### PR TITLE
feat: add CSS fade-in drawer for fintech dashboard layouts

### DIFF
--- a/submissions/examples/fintech-fade-drawer/README.md
+++ b/submissions/examples/fintech-fade-drawer/README.md
@@ -1,0 +1,83 @@
+# Fade-In Drawer for Fintech Dashboard Layouts
+
+A pure CSS/HTML slide-in drawer for surfacing transaction, account, or
+settings detail without leaving the dashboard view. Built for EaseMotion CSS
+— no JavaScript required.
+
+## Demo
+
+Open `demo.html` in a browser and click **View Transaction Details** to see
+the drawer slide in from the right with a fading backdrop and a staggered
+reveal of each content block.
+
+## How it works
+
+The component uses the **checkbox hack**: a hidden `<input type="checkbox">`
+tracks open/close state, and `<label for="...">` elements toggle it — one on
+the trigger button, one on the backdrop, and one on the close icon. CSS
+sibling combinators (`~`) react to `:checked` to animate the panel in and
+out. No JS, no external dependencies.
+
+```html
+<label for="em-drawer-1" class="em-trigger">Open</label>
+<input type="checkbox" id="em-drawer-1" class="em-drawer-toggle">
+
+<div class="em-drawer">
+  <label for="em-drawer-1" class="em-drawer__backdrop"></label>
+  <div class="em-drawer__panel">
+    ...
+  </div>
+</div>
+```
+
+Each `.em-drawer__block` inside the panel animates in with a short delay
+after the drawer opens, so content reveals in sequence rather than popping
+in all at once.
+
+## Multiple drawers on one page
+
+Duplicate the checkbox + trigger + `.em-drawer` markup with a new `id`
+(e.g. `em-drawer-2`) and point the matching `label` elements at it. Each
+instance is fully independent.
+
+## CSS custom properties
+
+All visual tokens are defined on `:root` in `style.css` so the drawer can be
+retheme'd without touching component rules.
+
+| Property | Default | Purpose |
+|---|---|---|
+| `--em-drawer-width` | `380px` | Panel width on desktop |
+| `--em-drawer-bg` | `#0f172a` | Panel background |
+| `--em-drawer-surface` | `#16213a` | Card/block background inside panel |
+| `--em-drawer-border` | `#253251` | Border color throughout |
+| `--em-drawer-text` | `#e7ebf5` | Primary text color |
+| `--em-drawer-muted` | `#94a3b8` | Secondary/label text color |
+| `--em-drawer-accent` | `#22c55e` | Positive values, primary action, trigger button |
+| `--em-drawer-accent-soft` | `rgba(34,197,94,.14)` | Accent badge background |
+| `--em-drawer-negative` | `#f87171` | Negative values, pending badge |
+| `--em-drawer-negative-soft` | `rgba(248,113,113,.14)` | Negative badge background |
+| `--em-drawer-radius` | `14px` | Corner radius for content blocks |
+| `--em-drawer-backdrop` | `rgba(4,8,20,.6)` | Overlay behind the panel |
+| `--em-duration-fast` | `180ms` | Hover/focus transitions |
+| `--em-duration-base` | `320ms` | Backdrop fade, block stagger |
+| `--em-duration-slow` | `420ms` | Panel slide-in/out |
+| `--em-ease` | `cubic-bezier(0.22, 1, 0.36, 1)` | Shared easing curve |
+
+## Features
+
+- Pure CSS/HTML, zero JavaScript and zero external frameworks
+- Smooth panel slide + backdrop fade using CSS transitions
+- Staggered `@keyframes` reveal for content blocks
+- Fully responsive: fixed-width panel on desktop, narrower on tablet,
+  full-width sheet on mobile (`≤600px`)
+- Closes via backdrop click or the close icon (both are `<label>` elements
+  wired to the same checkbox)
+- Keyboard-focusable trigger and close control with visible focus states
+- Respects `prefers-reduced-motion`: transitions are effectively instant and
+  the staggered block animation is disabled for users who request less motion
+
+## Browser support
+
+Works anywhere the checkbox hack and CSS transitions are supported —
+all evergreen browsers (Chrome, Firefox, Safari, Edge).

--- a/submissions/examples/fintech-fade-drawer/demo.html
+++ b/submissions/examples/fintech-fade-drawer/demo.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>EaseMotion CSS — Fade-In Drawer Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="em-page">
+
+  <h1 style="margin:0; font-size:1.4rem;">Fintech Dashboard — Fade-In Drawer</h1>
+  <p class="em-page__hint">
+    Click the button to open a transaction detail drawer. Built with pure CSS
+    using the checkbox toggle pattern, so it works with no JavaScript.
+  </p>
+
+  <label for="em-drawer-1" class="em-trigger">View Transaction Details</label>
+
+  <input type="checkbox" id="em-drawer-1" class="em-drawer-toggle">
+
+  <div class="em-drawer">
+    <label for="em-drawer-1" class="em-drawer__backdrop" aria-hidden="true"></label>
+
+    <div class="em-drawer__panel" role="dialog" aria-labelledby="em-drawer-1-title">
+      <div class="em-drawer__header">
+        <div>
+          <p class="em-drawer__title" id="em-drawer-1-title">Transaction Details</p>
+          <p class="em-drawer__subtitle">Ref #TXN-88213 · Aug 3, 2026</p>
+        </div>
+        <label for="em-drawer-1" class="em-drawer__close" aria-label="Close drawer">✕</label>
+      </div>
+
+      <div class="em-drawer__body">
+
+        <div class="em-drawer__block">
+          <div class="em-drawer__row">
+            <span class="em-drawer__label">Amount</span>
+            <span class="em-drawer__value em-drawer__value--positive">+$2,450.00</span>
+          </div>
+          <div class="em-drawer__row">
+            <span class="em-drawer__label">Status</span>
+            <span class="em-drawer__badge">Completed</span>
+          </div>
+        </div>
+
+        <div class="em-drawer__block">
+          <div class="em-drawer__row">
+            <span class="em-drawer__label">Merchant</span>
+            <span class="em-drawer__value">Nimbus Cloud Services</span>
+          </div>
+          <div class="em-drawer__row">
+            <span class="em-drawer__label">Category</span>
+            <span class="em-drawer__value">Subscriptions</span>
+          </div>
+          <div class="em-drawer__row">
+            <span class="em-drawer__label">Payment Method</span>
+            <span class="em-drawer__value">Visa •••• 4471</span>
+          </div>
+        </div>
+
+        <div class="em-drawer__block">
+          <div class="em-drawer__row">
+            <span class="em-drawer__label">Processing Fee</span>
+            <span class="em-drawer__value em-drawer__value--negative">-$12.40</span>
+          </div>
+          <div class="em-drawer__row">
+            <span class="em-drawer__label">Settlement</span>
+            <span class="em-drawer__badge em-drawer__badge--pending">Pending</span>
+          </div>
+        </div>
+
+        <div class="em-drawer__block">
+          <div class="em-drawer__row">
+            <span class="em-drawer__label">Account</span>
+            <span class="em-drawer__value">Business Checking ••82</span>
+          </div>
+          <div class="em-drawer__row">
+            <span class="em-drawer__label">Initiated By</span>
+            <span class="em-drawer__value">A. Sharma</span>
+          </div>
+        </div>
+
+      </div>
+
+      <div class="em-drawer__footer">
+        <a href="#" class="em-drawer__action">Download Receipt</a>
+        <a href="#" class="em-drawer__action em-drawer__action--primary">Dispute</a>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+</body>
+</html>

--- a/submissions/examples/fintech-fade-drawer/style.css
+++ b/submissions/examples/fintech-fade-drawer/style.css
@@ -1,0 +1,333 @@
+/* =========================================================
+   EaseMotion CSS — Fade-In Drawer for Fintech Dashboards
+   Pure CSS/HTML, no JS frameworks required.
+   ========================================================= */
+
+:root {
+  --em-drawer-width: 380px;
+  --em-drawer-bg: #0f172a;
+  --em-drawer-surface: #16213a;
+  --em-drawer-border: #253251;
+  --em-drawer-text: #e7ebf5;
+  --em-drawer-muted: #94a3b8;
+  --em-drawer-accent: #22c55e;
+  --em-drawer-accent-soft: rgba(34, 197, 94, 0.14);
+  --em-drawer-negative: #f87171;
+  --em-drawer-negative-soft: rgba(248, 113, 113, 0.14);
+  --em-drawer-radius: 14px;
+  --em-drawer-backdrop: rgba(4, 8, 20, 0.6);
+
+  --em-duration-fast: 180ms;
+  --em-duration-base: 320ms;
+  --em-duration-slow: 420ms;
+  --em-ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* -------------------- Demo page shell -------------------- */
+
+.em-page {
+  min-height: 100vh;
+  background: #0b1120;
+  color: var(--em-drawer-text);
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 24px;
+  padding: 32px 16px;
+  box-sizing: border-box;
+}
+
+.em-page__hint {
+  color: var(--em-drawer-muted);
+  font-size: 0.9rem;
+  text-align: center;
+  max-width: 420px;
+}
+
+.em-trigger {
+  background: var(--em-drawer-accent);
+  color: #06210f;
+  border: none;
+  font-weight: 600;
+  font-size: 0.95rem;
+  padding: 12px 22px;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: transform var(--em-duration-fast) var(--em-ease),
+              box-shadow var(--em-duration-fast) var(--em-ease);
+}
+
+.em-trigger:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 24px var(--em-drawer-accent-soft);
+}
+
+.em-trigger:focus-visible {
+  outline: 2px solid var(--em-drawer-accent);
+  outline-offset: 3px;
+}
+
+/* -------------------- Drawer mechanics -------------------- */
+/* Checkbox hack drives state so this stays pure CSS/HTML. */
+
+.em-drawer-toggle {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.em-drawer {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  visibility: hidden;
+}
+
+.em-drawer__backdrop {
+  position: absolute;
+  inset: 0;
+  background: var(--em-drawer-backdrop);
+  opacity: 0;
+  transition: opacity var(--em-duration-base) var(--em-ease);
+}
+
+.em-drawer__panel {
+  position: absolute;
+  top: 0;
+  right: 0;
+  height: 100%;
+  width: min(var(--em-drawer-width), 100%);
+  background: var(--em-drawer-bg);
+  border-left: 1px solid var(--em-drawer-border);
+  box-shadow: -24px 0 48px rgba(0, 0, 0, 0.35);
+  transform: translateX(100%);
+  opacity: 0;
+  transition: transform var(--em-duration-slow) var(--em-ease),
+              opacity var(--em-duration-base) var(--em-ease);
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+}
+
+/* Open state, toggled by the checkbox */
+.em-drawer-toggle:checked ~ .em-drawer {
+  visibility: visible;
+}
+
+.em-drawer-toggle:checked ~ .em-drawer .em-drawer__backdrop {
+  opacity: 1;
+}
+
+.em-drawer-toggle:checked ~ .em-drawer .em-drawer__panel {
+  transform: translateX(0);
+  opacity: 1;
+}
+
+/* -------------------- Panel content -------------------- */
+
+.em-drawer__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 22px 22px 16px;
+  border-bottom: 1px solid var(--em-drawer-border);
+}
+
+.em-drawer__title {
+  margin: 0 0 4px;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.em-drawer__subtitle {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--em-drawer-muted);
+}
+
+.em-drawer__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  color: var(--em-drawer-muted);
+  text-decoration: none;
+  font-size: 1.1rem;
+  line-height: 1;
+  transition: background var(--em-duration-fast) var(--em-ease),
+              color var(--em-duration-fast) var(--em-ease);
+}
+
+.em-drawer__close:hover {
+  background: var(--em-drawer-surface);
+  color: var(--em-drawer-text);
+}
+
+.em-drawer__close:focus-visible {
+  outline: 2px solid var(--em-drawer-accent);
+  outline-offset: 2px;
+}
+
+.em-drawer__body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 18px 22px 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+/* Staggered reveal for each content block, only while open */
+.em-drawer__block {
+  background: var(--em-drawer-surface);
+  border: 1px solid var(--em-drawer-border);
+  border-radius: var(--em-drawer-radius);
+  padding: 16px;
+  opacity: 0;
+  transform: translateY(10px);
+}
+
+.em-drawer-toggle:checked ~ .em-drawer .em-drawer__block {
+  animation: em-block-in var(--em-duration-base) var(--em-ease) forwards;
+}
+
+.em-drawer-toggle:checked ~ .em-drawer .em-drawer__block:nth-child(1) { animation-delay: 90ms; }
+.em-drawer-toggle:checked ~ .em-drawer .em-drawer__block:nth-child(2) { animation-delay: 150ms; }
+.em-drawer-toggle:checked ~ .em-drawer .em-drawer__block:nth-child(3) { animation-delay: 210ms; }
+.em-drawer-toggle:checked ~ .em-drawer .em-drawer__block:nth-child(4) { animation-delay: 270ms; }
+
+@keyframes em-block-in {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.em-drawer__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 0;
+}
+
+.em-drawer__row + .em-drawer__row {
+  border-top: 1px solid var(--em-drawer-border);
+}
+
+.em-drawer__label {
+  color: var(--em-drawer-muted);
+  font-size: 0.85rem;
+}
+
+.em-drawer__value {
+  font-weight: 600;
+  font-size: 0.92rem;
+}
+
+.em-drawer__value--positive {
+  color: var(--em-drawer-accent);
+}
+
+.em-drawer__value--negative {
+  color: var(--em-drawer-negative);
+}
+
+.em-drawer__badge {
+  display: inline-block;
+  font-size: 0.72rem;
+  font-weight: 600;
+  padding: 3px 10px;
+  border-radius: 999px;
+  background: var(--em-drawer-accent-soft);
+  color: var(--em-drawer-accent);
+}
+
+.em-drawer__badge--pending {
+  background: var(--em-drawer-negative-soft);
+  color: var(--em-drawer-negative);
+}
+
+.em-drawer__footer {
+  padding: 16px 22px;
+  border-top: 1px solid var(--em-drawer-border);
+  display: flex;
+  gap: 10px;
+}
+
+.em-drawer__action {
+  flex: 1;
+  text-align: center;
+  padding: 10px 14px;
+  border-radius: 10px;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-decoration: none;
+  border: 1px solid var(--em-drawer-border);
+  color: var(--em-drawer-text);
+  transition: background var(--em-duration-fast) var(--em-ease),
+              transform var(--em-duration-fast) var(--em-ease);
+}
+
+.em-drawer__action:hover {
+  background: var(--em-drawer-surface);
+  transform: translateY(-1px);
+}
+
+.em-drawer__action--primary {
+  background: var(--em-drawer-accent);
+  border-color: var(--em-drawer-accent);
+  color: #06210f;
+}
+
+.em-drawer__action--primary:hover {
+  background: #16b452;
+}
+
+/* -------------------- Responsive -------------------- */
+
+@media (max-width: 900px) {
+  :root {
+    --em-drawer-width: 340px;
+  }
+}
+
+@media (max-width: 600px) {
+  .em-drawer__panel {
+    width: 100%;
+    border-left: none;
+  }
+
+  .em-drawer__footer {
+    flex-direction: column;
+  }
+}
+
+/* -------------------- Reduced motion -------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .em-trigger,
+  .em-drawer__backdrop,
+  .em-drawer__panel,
+  .em-drawer__close,
+  .em-drawer__action {
+    transition-duration: 0.01ms !important;
+  }
+
+  .em-drawer-toggle:checked ~ .em-drawer .em-drawer__block {
+    animation: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+  }
+
+  .em-drawer__panel {
+    transform: none;
+  }
+
+  .em-drawer-toggle:checked ~ .em-drawer .em-drawer__panel {
+    transform: none;
+  }
+}


### PR DESCRIPTION
Closes #59267

## Pull Request Description
Adds a pure CSS/HTML fade-in drawer component for fintech dashboard layouts. The drawer slides in from the right with a fading backdrop and reveals its content blocks in a short staggered sequence, useful for transaction details, account info, or settings panels without navigating away from the dashboard.

## Type of Change
- [x] 🧩 New component

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/fintech-fade-drawer/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

## Feature Description

**What does this add?**
A slide-in "drawer" panel for surfacing detail content (e.g. a transaction record) over a dashboard, built entirely with CSS and the checkbox-toggle pattern.

**How does a developer use it?**
```html
<label for="em-drawer-1" class="em-trigger">Open</label>
<input type="checkbox" id="em-drawer-1" class="em-drawer-toggle">

<div class="em-drawer">
  <label for="em-drawer-1" class="em-drawer__backdrop"></label>
  <div class="em-drawer__panel">
    <!-- drawer content -->
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It's fully declarative and readable — no JS, no build step, just semantic HTML and CSS transitions/keyframes driving the motion. The animation timing and colors are exposed as CSS custom properties, matching the library's animation-first, easy-to-customize philosophy.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

## Notes for Maintainer
Used the checkbox-hack pattern to keep this pure CSS/HTML per the issue requirements. Timing values (`--em-duration-*`) and easing are exposed as custom properties so the drawer can be retimed or retheme'd without touching the component rules. Happy to adjust the stagger delay or add a left/bottom variant if useful.