### PR TITLE
add animated friendly stylesheet

### DIFF
--- a/submissions/examples/animated-friendly-stylesheet/README.md
+++ b/submissions/examples/animated-friendly-stylesheet/README.md
@@ -1,0 +1,17 @@
+# Print-Friendly Utility Classes
+
+## What does this do?
+Adds .ease-print-hide (hidden only when printing) and .ease-print-only
+(visible only when printing) utility classes, plus a global rule that
+strips animations/transitions/shadows from the print output.
+
+## How is it used?
+Add .ease-print-hide to navs, buttons, or decorative animated elements
+you don't want on paper. Add .ease-print-only to elements meant only for
+the printed version (e.g. a footer citation line).
+
+## Why is it useful?
+- Any real page eventually gets printed (invoices, articles, receipts)
+- Animated/interactive elements look broken or wasteful on paper
+- Currently zero print-related utilities exist in the framework
+- Tiny, self-contained, single-file addition

--- a/submissions/examples/animated-friendly-stylesheet/demo.html
+++ b/submissions/examples/animated-friendly-stylesheet/demo.html
@@ -1,0 +1,21 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Print Utility Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav class="ease-print-hide">🧭 Site Navigation (hidden when printed)</nav>
+
+  <article class="demo-wrap">
+    <h1>Article Title</h1>
+    <p>This paragraph and heading print normally. Open your browser's Print
+    Preview (Ctrl/Cmd+P) to see the nav disappear and the print-only footer
+    appear.</p>
+  </article>
+
+  <footer class="ease-print-only">Printed from easemotion-css.dev on demo day</footer>
+</body>
+</html>

--- a/submissions/examples/animated-friendly-stylesheet/style.css
+++ b/submissions/examples/animated-friendly-stylesheet/style.css
@@ -1,0 +1,14 @@
+body { font-family: system-ui, sans-serif; background: #f8fafc; padding: 0; margin: 0; }
+nav { background: #0f172a; color: #fff; padding: 14px 24px; }
+.demo-wrap { max-width: 600px; margin: 40px auto; background: #fff; padding: 24px; border-radius: 12px; }
+.ease-print-only { display: none; text-align: center; padding: 12px; font-size: 12px; color: #94a3b8; }
+
+@media print {
+  .ease-print-hide { display: none !important; }
+  .ease-print-only { display: block !important; }
+  * {
+    animation: none !important;
+    transition: none !important;
+    box-shadow: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `.ease-print-hide` / `.ease-print-only` utility classes plus a global `@media print` rule stripping animations, transitions, and shadows from printed output. Closes #<issue-number>.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other (describe below): New CSS utility category (print)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/print-utilities-xx/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Two new utility classes (`.ease-print-hide`, `.ease-print-only`) scoped
inside `@media print`, plus a blanket rule disabling animation/transition/
shadow properties in print output for cleaner paper results.

**How does a developer use it?**

\`\`\`html
<nav class="ease-print-hide">...</nav>
<footer class="ease-print-only">Printed from example.com</footer>
\`\`\`