### PR TITLE
fix: prevent focus ring clipping on ease-image in overflow containers

### DIFF
--- a/submissions/examples/image-focus-ring-koko/README.md
+++ b/submissions/examples/image-focus-ring-koko/README.md
@@ -1,0 +1,16 @@
+# Image Focus Ring Fix (image-focus-ring-koko)
+
+## What does this do?
+Fixes the clipping issue where the focus ring on `.ease-image` gets cut off when the image is inside a container with `overflow: hidden` or `overflow: auto`.
+
+## How is it used?
+Wrap your image inside a container and add the `.ease-image` class:
+
+\`\`\`html
+<div class="image-wrapper">
+  <img class="ease-image" src="your-image.jpg" tabindex="0" alt="description" />
+</div>
+\`\`\`
+
+## Why is it useful?
+Uses an inset `box-shadow` instead of an `outline`, so the focus ring stays fully visible inside the element's bounding box — even when the parent has `overflow: hidden`. Improves keyboard accessibility. Fixes issue #59765.

--- a/submissions/examples/image-focus-ring-koko/demo.html
+++ b/submissions/examples/image-focus-ring-koko/demo.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Image Focus Ring Fix Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="image-wrapper">
+  <img class="ease-image" src="https://picsum.photos/300/200" tabindex="0" alt="Sample image" />
+</div>
+
+</body>
+</html>

--- a/submissions/examples/image-focus-ring-koko/style.css
+++ b/submissions/examples/image-focus-ring-koko/style.css
@@ -1,0 +1,27 @@
+body {
+  font-family: sans-serif;
+  padding: 60px;
+  background: #f0f0f0;
+}
+
+.image-wrapper {
+  width: 300px;
+  overflow: hidden;
+  border-radius: 10px;
+  display: inline-block;
+}
+
+.ease-image {
+  display: block;
+  width: 100%;
+  height: auto;
+  border-radius: 10px;
+  outline: none;
+  box-shadow: 0 0 0 0 transparent;
+  transition: box-shadow 0.2s ease;
+}
+
+.ease-image:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px #4f46e5 inset;
+}


### PR DESCRIPTION
## Pull Request Description

Closes #59765

Fixed the focus ring clipping issue on .ease-image by replacing outline with an inset box-shadow, which stays contained within the element's bounding box even when the parent has overflow: hidden or overflow: auto. Improves keyboard accessibility.

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/` (submissions/examples/image-focus-ring-koko/)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A fix that keeps the focus ring on .ease-image fully visible even inside containers with overflow: hidden.

**How does a developer use it?**

```html
<div class="image-wrapper">
  <img class="ease-image" src="your-image.jpg" tabindex="0" alt="description" />
</div>
```

**Why does it fit EaseMotion CSS?**

Improves accessibility and keyboard navigation experience, aligning with EaseMotion CSS's usability-first philosophy.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome

---

## Notes for Maintainer

Tested locally with Live Server using keyboard Tab navigation — focus ring stays fully visible inside the overflow container.