### PR TITLE
 add animated cookie consent banner

### DIFF
--- a/submissions/examples/animated-cookie-consent-banner/README.md
+++ b/submissions/examples/animated-cookie-consent-banner/README.md
@@ -1,0 +1,17 @@
+# Cookie Consent Banner (Slide-Up)
+
+## What does this do?
+A bottom-fixed banner that slides up on first visit to request cookie
+consent, and stays dismissed on future visits via localStorage.
+
+## How is it used?
+Place .cookie-banner at the end of <body>. On load, a script checks
+localStorage for prior consent — if absent, it adds .visible to trigger
+the slide-up transition. Clicking "Accept" stores consent and removes the
+class to slide it back out.
+
+## Why is it useful?
+- Near-universal real-world requirement for public sites (GDPR/cookie law)
+- The project's own live demo/docs currently has no such banner
+- Combines EaseMotion's entrance-animation strength with minimal persistence logic
+- Fully self-contained, no external consent-management dependency

--- a/submissions/examples/animated-cookie-consent-banner/demo.html
+++ b/submissions/examples/animated-cookie-consent-banner/demo.html
@@ -1,0 +1,43 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Cookie Consent Banner Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrap">
+    <h2>Page content</h2>
+    <p>Open this file in a fresh/incognito window to see the banner slide
+    up from the bottom. Clicking "Accept" slides it away and remembers
+    your choice via localStorage.</p>
+    <button id="resetDemo">Reset demo (clear consent)</button>
+  </div>
+
+  <div class="cookie-banner" id="cookieBanner">
+    <p>We use cookies to improve your experience. <a href="#" style="color:#a78bfa;">Learn more</a></p>
+    <button id="acceptCookies">Accept</button>
+  </div>
+
+  <script>
+    const banner = document.getElementById('cookieBanner');
+    function showIfNeeded() {
+      if (!localStorage.getItem('cookieConsent')) {
+        requestAnimationFrame(() => banner.classList.add('visible'));
+      } else {
+        banner.classList.remove('visible');
+      }
+    }
+    document.getElementById('acceptCookies').onclick = () => {
+      localStorage.setItem('cookieConsent', 'true');
+      banner.classList.remove('visible');
+    };
+    document.getElementById('resetDemo').onclick = () => {
+      localStorage.removeItem('cookieConsent');
+      showIfNeeded();
+    };
+    showIfNeeded();
+  </script>
+</body>
+</html>

--- a/submissions/examples/animated-cookie-consent-banner/style.css
+++ b/submissions/examples/animated-cookie-consent-banner/style.css
@@ -1,0 +1,33 @@
+body { font-family: system-ui, sans-serif; background: #f8fafc; padding: 40px; margin: 0; }
+.demo-wrap { max-width: 500px; margin: 0 auto; background: #fff; padding: 24px; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,0.08); }
+#resetDemo { margin-top: 12px; padding: 6px 14px; border-radius: 6px; border: 1px solid #cbd5e1; background: #fff; cursor: pointer; }
+
+.cookie-banner {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 16px 24px;
+  transform: translateY(100%);
+  transition: transform 0.4s cubic-bezier(.4,0,.2,1);
+  z-index: 1000;
+}
+.cookie-banner.visible {
+  transform: translateY(0);
+}
+.cookie-banner p { margin: 0; font-size: 14px; }
+.cookie-banner button {
+  background: #7c3aed;
+  color: #fff;
+  border: none;
+  padding: 8px 20px;
+  border-radius: 8px;
+  cursor: pointer;
+  flex-shrink: 0;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a bottom-fixed, slide-up cookie consent banner with localStorage-based persistence so it only shows once per visitor. Closes #<issue-number>.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/cookie-consent-banner-xx/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A `.cookie-banner` component with a `.visible` state class driving a
`translateY` slide-up transition, plus a minimal script checking/writing
`localStorage.cookieConsent` to control first-visit-only display.

**How does a developer use it?**

\`\`\`html
<div class="cookie-banner" id="cookieBanner">
  <p>We use cookies to improve your experience.</p>
  <button id="acceptCookies">Accept</button>
</div>
\`\`\`