### PR TITLE
Add ease-dartboard-hit component

### DIFF
--- a/submissions/examples/ease-dartboard-hit-ij/README.md
+++ b/submissions/examples/ease-dartboard-hit-ij/README.md
@@ -1,0 +1,7 @@
+# ease-dartboard-hit
+A pub dartboard with a dart that flies in and sticks beside the bullseye.
+## Run
+Open `demo.html` directly in a browser to watch the dart land.
+## Notes
+- The concentric rings and numbered segments frame the face.
+- The score readout waits beside the board.

--- a/submissions/examples/ease-dartboard-hit-ij/demo.html
+++ b/submissions/examples/ease-dartboard-hit-ij/demo.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-dartboard-hit demo</title>
+</head>
+<body>
+<div class="db-app">
+  <div class="db-head">
+    <span class="db-name">BULLSEYE CLUB</span>
+    <span class="db-badge">DOUBLE</span>
+  </div>
+  <div class="db-stage">
+    <div class="db-board">
+      <div class="db-ring db-ring-outer"></div>
+      <div class="db-ring db-ring-mid"></div>
+      <div class="db-ring db-ring-inner"></div>
+      <span class="db-seg db-s1">20</span>
+      <span class="db-seg db-s2">1</span>
+      <span class="db-seg db-s3">18</span>
+      <span class="db-seg db-s4">4</span>
+      <span class="db-seg db-s5">13</span>
+      <span class="db-seg db-s6">6</span>
+      <div class="db-bull"></div>
+      <div class="db-bull-eye"></div>
+    </div>
+    <span class="db-dart"></span>
+    <span class="db-wire"></span>
+    <div class="db-score">
+      <span class="db-label">LAST DART</span>
+      <span class="db-value">TRIPLE 20</span>
+    </div>
+  </div>
+  <div class="db-foot">THROW 3 OF 3</div>
+</div>
+</body>
+</html>

--- a/submissions/examples/ease-dartboard-hit-ij/style.css
+++ b/submissions/examples/ease-dartboard-hit-ij/style.css
@@ -1,0 +1,36 @@
+:root{
+--db-wood:#6a4a26;
+--db-face:#e8dcc0;
+--db-red:#b03a2e;
+--db-ink:#241a10;
+--db-gold:#c9a25e;
+}
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+body{display:flex;align-items:center;justify-content:center;min-height:100vh;background:radial-gradient(circle at 50% 30%,hsl(28,30%,26%),hsl(30,40%,12%));font-family:'Georgia',serif}
+.db-app{width:372px;padding:16px;border-radius:16px;background:linear-gradient(180deg,#3a2c1c,#221a10);box-shadow:0 0 0 3px #5a4220,0 14px 34px rgba(0,0,0,0.65)}
+.db-head{display:flex;justify-content:space-between;align-items:center;padding:2px 6px 12px}
+.db-name{color:#f0e4c8;font-size:18px;letter-spacing:3px;font-weight:bold}
+.db-badge{color:#ffc46a;font-size:11px;font-weight:bold;padding:3px 8px;border-radius:9px;background:#2a1c08;animation:turn-blink-dartboard-hit 1.6s ease-in-out infinite}
+.db-stage{position:relative;height:260px;background:radial-gradient(circle at 30% 40%,#4a3822,#241c10);border-radius:12px;overflow:hidden}
+.db-board{position:absolute;right:34px;top:30px;width:200px;height:200px;border-radius:50%;background:radial-gradient(circle at 50% 50%,var(--db-gold) 0 6%,var(--db-red) 6% 16%,var(--db-face) 16% 26%,var(--db-red) 26% 38%,var(--db-face) 38% 46%,#241a10 46%);box-shadow:0 10px 22px rgba(0,0,0,0.5),inset 0 0 0 5px #3a2c18}
+.db-ring{position:absolute;border-radius:50%;border:2px solid rgba(36,26,16,0.5)}
+.db-ring-outer{inset:18px}
+.db-ring-mid{inset:38px}
+.db-ring-inner{inset:52px}
+.db-seg{position:absolute;font-size:11px;font-weight:bold;color:var(--db-ink)}
+.db-s1{top:8px;left:50%;margin-left:-8px}
+.db-s2{top:36px;right:6px}
+.db-s3{top:92px;right:2px}
+.db-s4{bottom:34px;right:8px}
+.db-s5{bottom:8px;left:50%;margin-left:-8px}
+.db-s6{left:6px;top:92px}
+.db-bull{position:absolute;left:50%;top:50%;width:34px;height:34px;margin:-17px;border-radius:50%;background:var(--db-face);box-shadow:inset 0 0 0 4px var(--db-red)}
+.db-bull-eye{position:absolute;left:50%;top:50%;width:12px;height:12px;margin:-6px;border-radius:50%;background:var(--db-red)}
+.db-dart{position:absolute;left:10px;top:152px;width:0;height:0;border-left:16px solid #ffd23f;border-top:4px solid transparent;border-bottom:4px solid transparent;opacity:0;animation:dart-fly-hit-dartboard-hit 3.6s ease-in infinite}
+.db-wire{position:absolute;left:26px;top:154px;width:120px;height:2px;background:repeating-linear-gradient(90deg,rgba(255,255,255,0.6) 0 4px,transparent 4px 9px);opacity:0.5;transform:rotate(-20deg);transform-origin:0 50%}
+.db-score{position:absolute;left:16px;bottom:16px;padding:10px 14px;border-radius:10px;background:rgba(20,14,8,0.7)}
+.db-label{display:block;font-size:10px;letter-spacing:2px;color:#b8a47c}
+.db-value{display:block;font-size:13px;font-weight:bold;color:#f0e4c8}
+.db-foot{color:#d8c9a8;font-size:11px;letter-spacing:2px;text-align:center;padding:10px 6px 2px;font-weight:bold}
+@keyframes dart-fly-hit-dartboard-hit{0%{transform:translate(0,0);opacity:0}18%{opacity:1}44%{transform:translate(168px,-64px)}54%{transform:translate(168px,-64px) scaleX(0.7)}100%{transform:translate(0,0);opacity:0}}
+@keyframes turn-blink-dartboard-hit{0%,100%{opacity:1}50%{opacity:0.4}}


### PR DESCRIPTION
## Component: ease-dartboard-hit — dart flies, board holds, and score waits

**Closes #60457**

### What this adds
A pub dartboard: a numbered board with concentric scoring rings and a bullseye, a dart that flies in from the side and sticks in the face, and a readout that shows the last dart.

### Acceptance Criteria covered
- Dart flies in and sticks in the board
- Concentric rings and bullseye mark the face
- Score readout waits beside the board

### Files
- submissions/examples/ease-dartboard-hit-ij/demo.html
- submissions/examples/ease-dartboard-hit-ij/style.css
- submissions/examples/ease-dartboard-hit-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the dart hit the board.