### PR TITLE
fix: contain ease-icon focus ring within bounding box (#59763)

### DIFF
--- a/submissions/examples/ease-icon-focus-fix-ak/README.md
+++ b/submissions/examples/ease-icon-focus-fix-ak/README.md
@@ -1,0 +1,19 @@
+# ease-icon focus clip fix
+
+## What does this do?
+Fixes the `ease-icon` focus ring being clipped when the icon sits inside a parent with `overflow: hidden` or `overflow: auto`, by replacing the outside `outline` with an inset `box-shadow` that stays within the element's own bounding box.
+
+## How is it used?
+```html
+<button class="icon-btn fixed-icon" aria-label="Star">★</button>
+```
+```css
+.fixed-icon:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px #4f46e5,
+              inset 0 0 0 4px #ffffff;
+}
+```
+
+## Why is it useful?
+Keyboard users rely on a visible focus ring to know where they are on the page. An outline placed outside the element gets cut off by ancestor `overflow` rules, silently breaking accessibility. Since `box-shadow` (unlike `outline`) participates in the box's own layout, an inset shadow is never clipped by a parent's overflow — fixing the bug referenced in issue #59763 without needing to touch any ancestor CSS.

--- a/submissions/examples/ease-icon-focus-fix-ak/demo.html
+++ b/submissions/examples/ease-icon-focus-fix-ak/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-icon focus clip fix</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <h2>Before (clipped)</h2>
+  <div class="wrapper clipped">
+    <button class="icon-btn old-icon" aria-label="Star">★</button>
+  </div>
+
+  <h2>After (fixed)</h2>
+  <div class="wrapper clipped">
+    <button class="icon-btn fixed-icon" aria-label="Star">★</button>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-icon-focus-fix-ak/style.css
+++ b/submissions/examples/ease-icon-focus-fix-ak/style.css
@@ -1,0 +1,35 @@
+.wrapper {
+  display: inline-block;
+  margin: 24px;
+  padding: 12px;
+  border: 1px dashed #999;
+}
+
+.clipped {
+  overflow: hidden; /* reproduces the bug */
+}
+
+.icon-btn {
+  width: 48px;
+  height: 48px;
+  font-size: 20px;
+  border: none;
+  border-radius: 8px;
+  background: #f2f2f2;
+  cursor: pointer;
+}
+
+/* BEFORE: outline sits outside the box, so the parent's
+   overflow:hidden clips it off */
+.old-icon:focus-visible {
+  outline: 2px solid #4f46e5;
+  outline-offset: 2px;
+}
+
+/* AFTER: inset box-shadow stays inside the element's own
+   bounding box, so it's never clipped by an ancestor */
+.fixed-icon:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px #4f46e5,
+              inset 0 0 0 4px #ffffff;
+}


### PR DESCRIPTION
Closes #59763
## Pull Request Description

Fixes the ease-icon focus ring being clipped when placed inside a container with `overflow: hidden` or `overflow: auto`, by switching from an outline to an inset box-shadow that stays within the element's own bounding box.

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/ease-icon-focus-fix-ak/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

An accessible focus style for `ease-icon` that uses an inset box-shadow instead of an outline, so it's never clipped by an ancestor's overflow.

**How does a developer use it?**

```html
<button class="icon-btn fixed-icon" aria-label="Star">★</button>
```

**Why does it fit EaseMotion CSS?**

Keyboard accessibility is core to a usable UI framework — a focus indicator that gets silently clipped defeats its purpose. This fix keeps the visual cue intact everywhere the icon is used, in line with EaseMotion's human-readable, accessibility-first philosophy.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

`demo.html` shows both versions side by side — `.old-icon` (clipped, for comparison) and `.fixed-icon` (fixed). Tab through both to see the difference. Happy to rename classes to `ease-*` convention if preferred before merge.