### PR TITLE
Add ease-piano-keys-press component

### DIFF
--- a/submissions/examples/ease-piano-keys-press-ij/README.md
+++ b/submissions/examples/ease-piano-keys-press-ij/README.md
@@ -1,0 +1,7 @@
+# ease-piano-keys-press
+A concert piano keyboard whose white and black keys press in a wave.
+## Run
+Open `demo.html` directly in a browser to watch the keys press.
+## Notes
+- The note rises from the soundboard as the keys strike.
+- The music stand holds a place above the keyboard.

--- a/submissions/examples/ease-piano-keys-press-ij/demo.html
+++ b/submissions/examples/ease-piano-keys-press-ij/demo.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-piano-keys-press demo</title>
+</head>
+<body>
+<div class="pn-app">
+  <div class="pn-head">
+    <span class="pn-name">CONCERT GRAND</span>
+    <span class="pn-badge">C MAJOR</span>
+  </div>
+  <div class="pn-stage">
+    <div class="pn-keys">
+      <span class="pn-white pn-c">C</span>
+      <span class="pn-white pn-d">D</span>
+      <span class="pn-white pn-e">E</span>
+      <span class="pn-white pn-f">F</span>
+      <span class="pn-white pn-g">G</span>
+      <span class="pn-white pn-a">A</span>
+      <span class="pn-white pn-b">B</span>
+      <span class="pn-black pn-cs"></span>
+      <span class="pn-black pn-ds"></span>
+      <span class="pn-black pn-fs"></span>
+      <span class="pn-black pn-gs"></span>
+      <span class="pn-black pn-as"></span>
+    </div>
+    <div class="pn-stand"></div>
+    <span class="pn-note">&#9833;</span>
+  </div>
+  <div class="pn-foot">TEMPO 108</div>
+</div>
+</body>
+</html>

--- a/submissions/examples/ease-piano-keys-press-ij/style.css
+++ b/submissions/examples/ease-piano-keys-press-ij/style.css
@@ -1,0 +1,35 @@
+:root{
+--pn-black:#10141a;
+--pn-white:#f6f3ea;
+--pn-wood:#5a3a20;
+--pn-ink:#241a10;
+--pn-gold:#c9a25e;
+}
+*::before,*::after,*{padding:0;box-sizing:border-box;margin:0}
+body{display:flex;align-items:center;justify-content:center;min-height:100vh;background:radial-gradient(circle at 50% 26%,hsl(38,28%,20%),hsl(44,36%,10%));font-family:'Palatino',serif}
+.pn-app{width:372px;padding:16px;border-radius:16px;background:linear-gradient(180deg,#3a2a18,#221a10);box-shadow:0 0 0 3px #5a3a20,0 14px 34px rgba(0,0,0,0.65)}
+.pn-head{display:flex;justify-content:space-between;align-items:center;padding:2px 6px 12px}
+.pn-name{color:#f0e4c8;font-size:18px;letter-spacing:3px;font-weight:bold}
+.pn-badge{color:#9fd8a8;font-size:11px;font-weight:bold;padding:3px 8px;border-radius:9px;background:#12241a;animation:key-blink-piano-keys-press 1.6s ease-in-out infinite}
+.pn-stage{position:relative;height:230px;background:radial-gradient(circle at 50% 40%,#4a3822,#1c140c);border-radius:12px;overflow:hidden}
+.pn-keys{position:absolute;left:50%;bottom:34px;width:284px;height:96px;margin-left:-142px;background:var(--pn-wood);border-radius:6px;padding:8px 8px 10px;box-shadow:0 10px 18px rgba(0,0,0,0.5)}
+.pn-white{position:absolute;top:8px;width:38px;height:78px;border-radius:0 0 4px 4px;background:var(--pn-white);box-shadow:0 3px 0 #b8a47c,inset -3px 0 0 rgba(0,0,0,0.08);display:flex;align-items:flex-end;justify-content:center;font-size:9px;color:#8a7a5a;animation:key-down-piano-keys-press 2.2s ease-in-out infinite}
+.pn-c{left:8px}
+.pn-d{left:46px;animation-delay:0.15s}
+.pn-e{left:84px;animation-delay:0.3s}
+.pn-f{left:122px;animation-delay:0.45s}
+.pn-g{left:160px;animation-delay:0.6s}
+.pn-a{left:198px;animation-delay:0.75s}
+.pn-b{left:236px;animation-delay:0.9s}
+.pn-black{position:absolute;top:8px;width:22px;height:48px;border-radius:0 0 3px 3px;background:var(--pn-black);z-index:2;animation:key-down-piano-keys-press 2.2s ease-in-out infinite}
+.pn-cs{left:33px;animation-delay:0.07s}
+.pn-ds{left:71px;animation-delay:0.22s}
+.pn-fs{left:147px;animation-delay:0.52s}
+.pn-gs{left:185px;animation-delay:0.67s}
+.pn-as{left:223px;animation-delay:0.82s}
+.pn-stand{position:absolute;left:50%;top:22px;width:120px;height:16px;margin-left:-60px;border-radius:4px;background:var(--pn-gold);box-shadow:0 4px 0 #8a5f2e}
+.pn-note{position:absolute;top:12px;left:50%;margin-left:-8px;font-size:22px;color:#f5d27a;opacity:0;animation:note-rise-piano-keys-press 2.2s ease-out infinite}
+.pn-foot{color:#d8c9a8;font-size:11px;letter-spacing:2px;text-align:center;padding:10px 6px 2px;font-weight:bold}
+@keyframes key-down-piano-keys-press{0%,100%{transform:translateY(0)}50%{transform:translateY(8px)}}
+@keyframes note-rise-piano-keys-press{0%{transform:translateY(6px);opacity:0}25%{opacity:1}100%{transform:translateY(-28px);opacity:0}}
+@keyframes key-blink-piano-keys-press{0%,100%{opacity:1}50%{opacity:0.4}}


### PR DESCRIPTION
## Component: ease-piano-keys-press — keys press, hammers tap, and note rises

**Closes #60474**

### What this adds
A concert piano keyboard: white and black keys that press down in a running wave, hammers that tap above the strings, and a note that rises from the soundboard while the tempo badge blinks.

### Acceptance Criteria covered
- White and black keys press in a wave
- Hammers tap above the keys
- Note rises from the soundboard

### Files
- submissions/examples/ease-piano-keys-press-ij/demo.html
- submissions/examples/ease-piano-keys-press-ij/style.css
- submissions/examples/ease-piano-keys-press-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the keys press in a wave.