### PR TITLE
Add ease-drum-kit-beat component

### DIFF
--- a/submissions/examples/ease-drum-kit-beat-ij/README.md
+++ b/submissions/examples/ease-drum-kit-beat-ij/README.md
@@ -1,0 +1,7 @@
+# ease-drum-kit-beat
+A rock drum kit whose sticks strike the snare and hi-hat on the beat.
+## Run
+Open `demo.html` directly in a browser to watch the sticks strike.
+## Notes
+- The kick drum thumps while the crash cymbal shakes.
+- The tom holds the middle of the kit.

--- a/submissions/examples/ease-drum-kit-beat-ij/demo.html
+++ b/submissions/examples/ease-drum-kit-beat-ij/demo.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-drum-kit-beat demo</title>
+</head>
+<body>
+<div class="dk-app">
+  <div class="dk-head">
+    <span class="dk-name">ROCK STAGE</span>
+    <span class="dk-badge">4/4 TIME</span>
+  </div>
+  <div class="dk-stage">
+    <div class="dk-kit">
+      <div class="dk-kick">
+        <span class="dk-kick-head"></span>
+        <span class="dk-kick-logo">ROCK</span>
+      </div>
+      <div class="dk-snare"></div>
+      <div class="dk-hihat"><span class="dk-cymbal"></span><span class="dk-hat-stack"></span></div>
+      <div class="dk-crash"><span class="dk-cymbal"></span></div>
+      <div class="dk-tom"></div>
+      <span class="dk-stick dk-stick-1"></span>
+      <span class="dk-stick dk-stick-2"></span>
+    </div>
+  </div>
+  <div class="dk-foot">HIT HARD</div>
+</div>
+</body>
+</html>

--- a/submissions/examples/ease-drum-kit-beat-ij/style.css
+++ b/submissions/examples/ease-drum-kit-beat-ij/style.css
@@ -1,0 +1,36 @@
+:root{
+--dk-red:#b03a2e;
+--dk-shell:#e8dcc0;
+--dk-ink:#10141a;
+--dk-cymbal:#d9b25c;
+--dk-stage:#1c140c;
+}
+*,*::after,*::before{margin:0;padding:0;box-sizing:border-box}
+body{display:flex;align-items:center;justify-content:center;min-height:100vh;background:radial-gradient(circle at 50% 24%,hsl(270,24%,16%),hsl(280,30%,7%));font-family:'Arial',sans-serif}
+.dk-app{width:372px;padding:16px;border-radius:16px;background:linear-gradient(180deg,#2a1636,#180c20);box-shadow:0 0 0 3px #4a2f6a,0 14px 34px rgba(0,0,0,0.7)}
+.dk-head{display:flex;justify-content:space-between;align-items:center;padding:2px 6px 12px}
+.dk-name{color:#f0e4c8;font-size:18px;letter-spacing:3px;font-weight:bold}
+.dk-badge{color:#ff8a8a;font-size:11px;font-weight:bold;padding:3px 8px;border-radius:9px;background:#33152b;animation:beat-blink-drum-kit-beat 0.7s steps(2) infinite}
+.dk-stage{position:relative;height:250px;background:radial-gradient(circle at 50% 40%,#332046,#1c1230);border-radius:12px;overflow:hidden}
+.dk-kit{position:absolute;left:50%;top:26px;width:300px;height:200px;margin-left:-150px}
+.dk-kick{position:absolute;left:110px;top:96px;width:84px;height:84px;border-radius:50%;background:linear-gradient(180deg,var(--dk-shell),#b8a47c);box-shadow:inset 0 0 0 14px #e8dcc0,0 8px 14px rgba(0,0,0,0.5);animation:kick-thump-drum-kit-beat 1s ease-in-out infinite}
+.dk-kick-head{position:absolute;inset:14px;border-radius:50%;background:var(--dk-ink)}
+.dk-kick-logo{position:absolute;left:0;right:0;top:50%;margin-top:-7px;text-align:center;font-size:12px;font-weight:bold;color:var(--dk-red);letter-spacing:1px}
+.dk-snare{position:absolute;left:36px;top:120px;width:70px;height:20px;border-radius:6px;background:linear-gradient(180deg,#c9c4b8,#9a9488);box-shadow:0 5px 0 #6a6458;animation:snare-hit-drum-kit-beat 1s ease-in-out infinite}
+.dk-hihat{position:relative;position:absolute;left:220px;top:76px;width:6px;height:90px;background:#8a8478}
+.dk-hihat .dk-cymbal{position:absolute;left:50%;top:0;margin-left:-26px}
+.dk-cymbal{width:52px;height:16px;border-radius:50%;background:radial-gradient(circle at 35% 30%,var(--dk-cymbal),#8a5f2e);animation:cymbal-shake-drum-kit-beat 1s ease-in-out infinite;transform-origin:50% 100%}
+.dk-hat-stack{position:absolute;left:50%;top:20px;width:40px;height:8px;margin-left:-20px;border-radius:4px;background:#c9b25c}
+.dk-crash{position:relative;position:absolute;left:246px;top:16px;width:6px;height:74px;background:#8a8478}
+.dk-crash .dk-cymbal{position:absolute;left:50%;top:0;margin-left:-26px}
+.dk-tom{position:absolute;left:170px;top:78px;width:56px;height:18px;border-radius:6px;background:linear-gradient(180deg,var(--dk-shell),#b8a47c);box-shadow:0 5px 0 #6a6458}
+.dk-stick{position:absolute;width:8px;height:64px;border-radius:4px;background:#d9b25c;transform-origin:50% 90%}
+.dk-stick-1{left:60px;top:44px;animation:stick-hit-right-drum-kit-beat 1s ease-in-out infinite}
+.dk-stick-2{left:206px;top:40px;animation:stick-hit-left-drum-kit-beat 1s ease-in-out infinite}
+.dk-foot{color:#c8b8ee;font-size:11px;letter-spacing:3px;text-align:center;padding:10px 6px 2px;font-weight:bold}
+@keyframes kick-thump-drum-kit-beat{0%,100%{transform:scale(1)}50%{transform:scale(1.07)}}
+@keyframes snare-hit-drum-kit-beat{0%,100%{transform:translateY(0)}50%{transform:translateY(3px)}}
+@keyframes cymbal-shake-drum-kit-beat{0%,100%{transform:rotate(0deg)}50%{transform:rotate(-6deg)}}
+@keyframes stick-hit-right-drum-kit-beat{0%,100%{transform:rotate(24deg)}50%{transform:rotate(-10deg)}}
+@keyframes stick-hit-left-drum-kit-beat{0%,100%{transform:rotate(-24deg)}50%{transform:rotate(10deg)}}
+@keyframes beat-blink-drum-kit-beat{0%,49%{opacity:1}50%,100%{opacity:0}}


### PR DESCRIPTION
## Component: ease-drum-kit-beat — kick thumps, cymbals shake, and sticks strike

**Closes #60483**

### What this adds
A rock drum kit: a kick drum that thumps, a snare and hi-hat that catch the sticks, a crash cymbal that shakes, and a tom that holds the beat while the sticks strike in turn.

### Acceptance Criteria covered
- Kick drum thumps on the beat
- Sticks strike snare and hi-hat
- Crash cymbal shakes at the top

### Files
- submissions/examples/ease-drum-kit-beat-ij/demo.html
- submissions/examples/ease-drum-kit-beat-ij/style.css
- submissions/examples/ease-drum-kit-beat-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the sticks strike the kit.