### PR TITLE
Add ease-jukebox-record-drop component

### DIFF
--- a/submissions/examples/ease-jukebox-record-drop-ij/README.md
+++ b/submissions/examples/ease-jukebox-record-drop-ij/README.md
@@ -1,0 +1,7 @@
+# ease-jukebox-record-drop
+A neon jukebox where a record drops onto the spinning platter.
+## Run
+Open `demo.html` directly in a browser to watch the record drop.
+## Notes
+- The tone arm swings over the grooves.
+- Bubble tubes rise beside the selector buttons.

--- a/submissions/examples/ease-jukebox-record-drop-ij/demo.html
+++ b/submissions/examples/ease-jukebox-record-drop-ij/demo.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-jukebox-record-drop demo</title>
+</head>
+<body>
+<div class="jb-app">
+  <div class="jb-head">
+    <span class="jb-name">ROCK-O-LA</span>
+    <span class="jb-badge">NOW PLAYING</span>
+  </div>
+  <div class="jb-stage">
+    <div class="jb-cabinet">
+      <div class="jb-bubbles">
+        <span class="jb-bubble jb-bubble-1"></span>
+        <span class="jb-bubble jb-bubble-2"></span>
+        <span class="jb-bubble jb-bubble-3"></span>
+      </div>
+      <div class="jb-stack">
+        <span class="jb-record"></span>
+        <span class="jb-record"></span>
+        <span class="jb-record"></span>
+      </div>
+      <div class="jb-turntable">
+        <span class="jb-platter"></span>
+        <span class="jb-drop"></span>
+      </div>
+      <div class="jb-arm"><span class="jb-arm-pivot"></span></div>
+      <div class="jb-panel">
+        <button class="jb-select jb-select-1" type="button">A1</button>
+        <button class="jb-select jb-select-2" type="button">B2</button>
+        <button class="jb-select jb-select-3" type="button">C3</button>
+      </div>
+    </div>
+  </div>
+  <div class="jb-foot">3 PLAYS LEFT</div>
+</div>
+</body>
+</html>

--- a/submissions/examples/ease-jukebox-record-drop-ij/style.css
+++ b/submissions/examples/ease-jukebox-record-drop-ij/style.css
@@ -1,0 +1,38 @@
+:root{
+--jb-wood:#6a4326;
+--jb-neon:#ff5e8a;
+--jb-plat:#10141a;
+--jb-gold:#ffd23f;
+--jb-stage:#1c140c;
+}
+*::after,*::before,*{padding:0;margin:0;box-sizing:border-box}
+body{display:flex;align-items:center;justify-content:center;min-height:100vh;background:radial-gradient(circle at 50% 26%,hsl(330,30%,16%),hsl(340,40%,7%));font-family:'Courier New',monospace}
+.jb-app{width:372px;padding:16px;border-radius:16px;background:linear-gradient(180deg,#4a2440,#241220);box-shadow:0 0 0 3px #6a3a5e,0 14px 34px rgba(0,0,0,0.75)}
+.jb-head{display:flex;justify-content:space-between;align-items:center;padding:2px 6px 12px}
+.jb-name{color:#ffb8d0;font-size:18px;letter-spacing:3px;font-weight:bold;text-shadow:0 0 8px rgba(255,94,138,0.6)}
+.jb-badge{color:var(--jb-gold);font-size:10px;font-weight:bold;padding:2px 7px;border-radius:8px;background:#2a1a22;animation:play-blink-jukebox-record-drop 1.3s ease-in-out infinite}
+.jb-stage{position:relative;height:250px;background:radial-gradient(circle at 50% 45%,#332033,#1c101c);border-radius:12px;overflow:hidden}
+.jb-cabinet{position:absolute;left:50%;top:18px;width:250px;height:214px;margin-left:-125px;border-radius:16px;background:linear-gradient(180deg,#7a4f2e,#4a2c18);border:3px solid #2e1a0e;box-shadow:0 14px 26px rgba(0,0,0,0.5);overflow:hidden}
+.jb-bubbles{position:absolute;left:14px;top:10px;width:22px;height:120px;border-radius:10px;background:#3a2a1a;border:2px solid #2e1a0e;overflow:hidden}
+.jb-bubble{position:absolute;left:6px;width:8px;height:8px;border-radius:50%;background:var(--jb-neon);animation:bubble-rise-jukebox-record-drop 2.4s linear infinite}
+.jb-bubble-1{top:110px}
+.jb-bubble-2{top:110px;animation-delay:0.8s;background:#5ec8ff}
+.jb-bubble-3{top:110px;animation-delay:1.6s;background:var(--jb-gold)}
+.jb-stack{position:absolute;left:64px;top:16px;width:120px;height:56px}
+.jb-record{position:absolute;left:50%;width:120px;height:26px;margin-left:-60px;border-radius:50%;background:radial-gradient(circle at 50% 50%,var(--jb-gold) 0 8%,var(--jb-plat) 9% 70%,#c9a25e 100%);box-shadow:0 4px 6px rgba(0,0,0,0.4)}
+.jb-stack .jb-record:nth-child(1){top:0}
+.jb-stack .jb-record:nth-child(2){top:18px}
+.jb-stack .jb-record:nth-child(3){top:36px}
+.jb-turntable{position:relative;position:absolute;left:64px;bottom:16px;width:130px;height:64px;border-radius:8px;background:#3a2a1a;border:2px solid #2e1a0e}
+.jb-platter{position:absolute;left:50%;top:4px;width:116px;height:44px;margin-left:-58px;border-radius:50%;background:radial-gradient(circle at 50% 50%,#2a2f3a 0 60%,var(--jb-plat) 100%);box-shadow:inset 0 0 0 4px #4a4f5a;animation:platter-spin-jukebox-record-drop 1.4s linear infinite}
+.jb-drop{position:absolute;left:50%;top:2px;width:116px;height:44px;margin-left:-58px;border-radius:50%;background:radial-gradient(circle at 50% 50%,var(--jb-gold) 0 8%,var(--jb-plat) 9% 70%,#c9a25e 100%);z-index:2;animation:record-drop-jukebox-record-drop 3.2s ease-in infinite}
+.jb-arm{position:absolute;right:6px;top:104px;width:60px;height:8px;border-radius:4px;background:linear-gradient(180deg,#d9b25c,#8a5f2e);transform-origin:100% 50%;animation:arm-swing-jukebox-record-drop 3.2s ease-in-out infinite}
+.jb-arm-pivot{position:absolute;right:-4px;top:-5px;width:16px;height:16px;border-radius:50%;background:#c9a25e}
+.jb-panel{position:absolute;left:206px;top:26px;width:30px;height:120px;border-radius:6px;background:#3a2a1a;border:2px solid #2e1a0e}
+.jb-select{display:block;width:20px;height:20px;margin:8px auto 0;border:none;border-radius:50%;background:radial-gradient(circle at 35% 30%,#ffb8d0,var(--jb-neon));color:#fff;font-size:8px;font-weight:bold;cursor:pointer;box-shadow:0 2px 0 #7a2a4a}
+.jb-foot{color:#e8c9d8;font-size:11px;letter-spacing:2px;text-align:center;padding:10px 6px 2px;font-weight:bold}
+@keyframes record-drop-jukebox-record-drop{0%{transform:translateY(-150px);opacity:0}18%{opacity:1}46%{transform:translateY(0)}100%{transform:translateY(0)}}
+@keyframes platter-spin-jukebox-record-drop{from{transform:rotate(0deg)}to{transform:rotate(360deg)}}
+@keyframes arm-swing-jukebox-record-drop{0%,42%,100%{transform:rotate(-32deg)}62%{transform:rotate(4deg)}}
+@keyframes bubble-rise-jukebox-record-drop{0%{transform:translateY(0);opacity:0.9}100%{transform:translateY(-110px);opacity:0}}
+@keyframes play-blink-jukebox-record-drop{0%,100%{opacity:1}50%{opacity:0.4}}


### PR DESCRIPTION
## Component: ease-jukebox-record-drop — record drops, platter spins, and arm swings

**Closes #60487**

### What this adds
A neon jukebox: a 45 record that drops from the stack onto the spinning platter, a tone arm that swings over the grooves, and selector buttons beside rising bubble tubes.

### Acceptance Criteria covered
- Record drops onto the platter
- Platter spins under the record
- Tone arm swings over the grooves

### Files
- submissions/examples/ease-jukebox-record-drop-ij/demo.html
- submissions/examples/ease-jukebox-record-drop-ij/style.css
- submissions/examples/ease-jukebox-record-drop-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the record drop while the platter spins.