### PR TITLE
Add ease-film-strip-advance component

### DIFF
--- a/submissions/examples/ease-film-strip-advance-ij/README.md
+++ b/submissions/examples/ease-film-strip-advance-ij/README.md
@@ -1,0 +1,7 @@
+# ease-film-strip-advance
+A 35 mm film strip whose frames march through the projector gate.
+## Run
+Open `demo.html` directly in a browser to watch the frames advance.
+## Notes
+- The sprocket holes step past the rails.
+- Each frame carries its own scene color.

--- a/submissions/examples/ease-film-strip-advance-ij/demo.html
+++ b/submissions/examples/ease-film-strip-advance-ij/demo.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-film-strip-advance demo</title>
+</head>
+<body>
+<div class="fm-app">
+  <div class="fm-head">
+    <span class="fm-name">REEL REVIEW</span>
+    <span class="fm-badge">35 MM</span>
+  </div>
+  <div class="fm-stage">
+    <div class="fm-gate">
+      <div class="fm-strip">
+        <span class="fm-frame fm-frame-1"><b>1</b></span>
+        <span class="fm-frame fm-frame-2"><b>2</b></span>
+        <span class="fm-frame fm-frame-3"><b>3</b></span>
+        <span class="fm-frame fm-frame-4"><b>4</b></span>
+        <span class="fm-frame fm-frame-5"><b>5</b></span>
+        <span class="fm-frame fm-frame-6"><b>6</b></span>
+      </div>
+      <span class="fm-sprocket fm-sprocket-1">
+        <span class="fm-hole"></span>
+        <span class="fm-hole"></span>
+        <span class="fm-hole"></span>
+        <span class="fm-hole"></span>
+      </span>
+      <span class="fm-sprocket fm-sprocket-2">
+        <span class="fm-hole"></span>
+        <span class="fm-hole"></span>
+        <span class="fm-hole"></span>
+        <span class="fm-hole"></span>
+      </span>
+    </div>
+  </div>
+  <div class="fm-foot">FRAME 24 FPS</div>
+</div>
+</body>
+</html>

--- a/submissions/examples/ease-film-strip-advance-ij/style.css
+++ b/submissions/examples/ease-film-strip-advance-ij/style.css
@@ -1,0 +1,35 @@
+:root{
+--fm-ink:#14181e;
+--fm-frame:#d8c9a8;
+--fm-gate:#0b0d12;
+--fm-gold:#c9a25e;
+--fm-wood:#4a3018;
+}
+*::before,*::after,*{box-sizing:border-box;margin:0;padding:0}
+body{display:flex;align-items:center;justify-content:center;min-height:100vh;background:radial-gradient(circle at 50% 28%,hsl(30,24%,20%),hsl(36,32%,10%));font-family:'Georgia',serif}
+.fm-app{width:372px;padding:16px;border-radius:16px;background:linear-gradient(180deg,#3a2c1c,#221a10);box-shadow:0 0 0 3px #5a4220,0 14px 34px rgba(0,0,0,0.65)}
+.fm-head{display:flex;justify-content:space-between;align-items:center;padding:2px 6px 12px}
+.fm-name{color:#f0e4c8;font-size:18px;letter-spacing:3px;font-weight:bold}
+.fm-badge{color:#ffc46a;font-size:11px;font-weight:bold;padding:3px 8px;border-radius:9px;background:#2a1c08;animation:frame-blink-film-strip-advance 1.6s ease-in-out infinite}
+.fm-stage{position:relative;height:260px;background:radial-gradient(circle at 50% 45%,#3a2c1a,#1c140c);border-radius:12px;overflow:hidden}
+.fm-gate{position:absolute;left:50%;top:14px;width:170px;height:232px;margin-left:-85px;border-radius:10px;background:var(--fm-gate);border:4px solid #2e2010;box-shadow:0 10px 18px rgba(0,0,0,0.5);overflow:hidden}
+.fm-strip{position:absolute;left:22px;top:0;width:126px;height:432px;animation:strip-advance-film-strip-advance 4s linear infinite}
+.fm-frame{position:absolute;left:0;width:126px;height:72px;border-radius:4px;background:linear-gradient(160deg,var(--fm-frame),#b8a47c);box-shadow:inset 0 0 0 2px #8a6a3a;display:flex;align-items:center;justify-content:center}
+.fm-frame b{font-size:18px;color:#6a4a26}
+.fm-frame-1{top:0;background:linear-gradient(160deg,#8fc4d8,#5a94b0)}
+.fm-frame-2{top:72px;background:linear-gradient(160deg,#e0b25c,#b8822c)}
+.fm-frame-3{top:144px;background:linear-gradient(160deg,#8fd8a4,#4a945e)}
+.fm-frame-4{top:216px;background:linear-gradient(160deg,#c78fc8,#8a4a8a)}
+.fm-frame-5{top:288px;background:linear-gradient(160deg,#e08c8c,#a04a4a)}
+.fm-frame-6{top:360px;background:linear-gradient(160deg,#8ca4e0,#4a6aa0)}
+.fm-sprocket{position:absolute;top:0;bottom:0;width:16px;background:#10141a}
+.fm-sprocket-1{left:0}
+.fm-sprocket-2{right:0}
+.fm-hole{position:absolute;left:3px;width:10px;height:9px;border-radius:2px;background:#f0e4c8;animation:sprocket-step-film-strip-advance 0.5s steps(1) infinite}
+.fm-sprocket .fm-hole:nth-child(1){top:12px}
+.fm-sprocket .fm-hole:nth-child(2){top:84px;animation-delay:0.12s}
+.fm-sprocket .fm-hole:nth-child(3){top:156px;animation-delay:0.24s}
+.fm-sprocket .fm-hole:nth-child(4){top:228px;animation-delay:0.36s}
+.fm-foot{color:#d8c9a8;font-size:11px;letter-spacing:2px;text-align:center;padding:10px 6px 2px;font-weight:bold}
+@keyframes strip-advance-film-strip-advance{from{transform:translateY(0)}to{transform:translateY(-432px)}}
+@keyframes sprocket-step-film-strip-advance{0%{transform:translateY(0)}100%{transform:translateY(72px)}}


### PR DESCRIPTION
## Component: ease-film-strip-advance — strip advances, frames march, and sprockets turn

**Closes #60491**

### What this adds
A 35 mm film strip: frames that march through the projector gate, sprocket holes that step past the rails, and a counter that blinks each frame while the reel badge holds.

### Acceptance Criteria covered
- Frames march through the gate
- Sprocket holes step past the rails
- Counter blinks at each frame

### Files
- submissions/examples/ease-film-strip-advance-ij/demo.html
- submissions/examples/ease-film-strip-advance-ij/style.css
- submissions/examples/ease-film-strip-advance-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the frames advance through the gate.