### PR TITLE
fix(dropdown): prevent focus ring clipping in overflow containers

### DIFF
--- a/submissions/examples/dropdown-focus-fix/README.md
+++ b/submissions/examples/dropdown-focus-fix/README.md
@@ -1,0 +1,12 @@
+# Fix: ease-dropdown focus ring clipping
+
+Fixes #59759
+
+## Problem
+Focus ring was getting clipped when `.ease-dropdown` was inside a container with `overflow: hidden` or `overflow: auto`.
+
+## Solution
+Replaced outline with an inset `box-shadow`, which stays within the element's bounding box and respects `border-radius`, so it never gets clipped by parent overflow.
+
+## How to test
+Open `demo.html`, press Tab to focus the button inside the overflow-hidden wrapper, and confirm the ring is fully visible.

--- a/submissions/examples/dropdown-focus-fix/demo.html
+++ b/submissions/examples/dropdown-focus-fix/demo.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Dropdown Focus Fix Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrapper">
+    <button class="ease-dropdown" tabindex="0">Select an option ▾</button>
+  </div>
+</body>
+</html>

--- a/submissions/examples/dropdown-focus-fix/style.css
+++ b/submissions/examples/dropdown-focus-fix/style.css
@@ -1,0 +1,16 @@
+.ease-dropdown {
+  position: relative;
+  display: inline-block;
+}
+
+.ease-dropdown:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px #2684FF;
+  border-radius: 4px;
+}
+
+.demo-wrapper {
+  overflow: hidden;
+  padding: 20px;
+  border: 1px solid #ccc;
+}


### PR DESCRIPTION
Fixes #59759

## Problem
Focus ring was getting clipped when `.ease-dropdown` was inside a container with `overflow: hidden` or `overflow: auto`.

## Solution
Replaced outline with an inset box-shadow, which stays within the element's bounding box and respects border-radius, so it never gets clipped by parent overflow.

## Testing
Tested locally — focus ring is fully visible on Tab focus inside overflow-hidden wrapper.