### PR TITLE
feature: added visible keyboard focus styles for breadcrumb links

### DIFF
--- a/submissions/examples/keyboard-focus-styled-links-cs-/README.md
+++ b/submissions/examples/keyboard-focus-styled-links-cs-/README.md
@@ -1,0 +1,69 @@
+# Visible Focus State for Breadcrumb Links
+
+A small accessibility enhancement demonstrating a visible keyboard focus state for EaseMotion CSS breadcrumb links.
+
+## Feature
+
+The component adds a visible `:focus-visible` state to `.ease-breadcrumb-link`.
+
+```css
+.ease-breadcrumb-link:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+  text-decoration: underline;
+}
+```
+
+This provides visual feedback when users navigate breadcrumb links with a keyboard.
+
+## Usage
+
+Use the standard EaseMotion breadcrumb structure:
+
+```html
+<nav class="ease-breadcrumb" aria-label="Breadcrumb">
+  <ol class="ease-breadcrumb-list">
+    <li class="ease-breadcrumb-item">
+      <a href="/" class="ease-breadcrumb-link">
+        Home
+      </a>
+
+      <span class="ease-breadcrumb-separator" aria-hidden="true">
+        /
+      </span>
+    </li>
+
+    <li class="ease-breadcrumb-item">
+      <a href="/components" class="ease-breadcrumb-link">
+        Components
+      </a>
+
+      <span class="ease-breadcrumb-separator" aria-hidden="true">
+        /
+      </span>
+    </li>
+
+    <li class="ease-breadcrumb-item">
+      <span
+        class="ease-breadcrumb-active"
+        aria-current="page"
+      >
+        Breadcrumb
+      </span>
+    </li>
+  </ol>
+</nav>
+```
+
+## Accessibility
+
+The `:focus-visible` pseudo-class provides a visible focus indicator when the breadcrumb link receives keyboard focus.
+
+The enhancement:
+
+- Improves keyboard navigation visibility
+- Preserves existing hover behavior
+- Does not require JavaScript
+- Uses a visible outline with `outline-offset`
+- Adds an underline to reinforce the focused state
+- Does not remove or override the browser's focus indication

--- a/submissions/examples/keyboard-focus-styled-links-cs-/demo.html
+++ b/submissions/examples/keyboard-focus-styled-links-cs-/demo.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta
+    name="viewport"
+    content="width=device-width, initial-scale=1"
+  >
+  <title>Breadcrumb Keyboard Focus | EaseMotion CSS</title>
+
+  <link rel="stylesheet" href="../../../easemotion.min.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+  <a class="skip-link-bcf" href="#breadcrumb-demo-bcf">
+    Skip to breadcrumb demo
+  </a>
+
+  <main class="page-bcf">
+    <h1>Breadcrumb Keyboard Focus</h1>
+
+    <p>
+      Use the <kbd>Tab</kbd> key to move through the breadcrumb links
+      and view the visible keyboard focus state.
+    </p>
+
+    <nav
+      id="breadcrumb-demo-bcf"
+      class="ease-breadcrumb"
+      aria-label="Breadcrumb"
+    >
+      <ol class="ease-breadcrumb-list">
+        <li class="ease-breadcrumb-item">
+          <a href="/" class="ease-breadcrumb-link">
+            Home
+          </a>
+          <span
+            class="ease-breadcrumb-separator"
+            aria-hidden="true"
+          >/</span>
+        </li>
+
+        <li class="ease-breadcrumb-item">
+          <a href="/components" class="ease-breadcrumb-link">
+            Components
+          </a>
+          <span
+            class="ease-breadcrumb-separator"
+            aria-hidden="true"
+          >/</span>
+        </li>
+
+        <li class="ease-breadcrumb-item">
+          <span
+            class="ease-breadcrumb-active"
+            aria-current="page"
+          >
+            Breadcrumb
+          </span>
+        </li>
+      </ol>
+    </nav>
+  </main>
+</body>
+</html>

--- a/submissions/examples/keyboard-focus-styled-links-cs-/style.css
+++ b/submissions/examples/keyboard-focus-styled-links-cs-/style.css
@@ -1,0 +1,74 @@
+:root {
+  --bcf-page: #f7f8fa;
+  --bcf-surface: #ffffff;
+  --bcf-text: #172033;
+  --bcf-muted: #667085;
+  --bcf-border: #d9dee7;
+  --bcf-focus-offset: 2px;
+  --bcf-focus-width: 2px;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--bcf-text);
+  background: var(--bcf-page);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.skip-link-bcf {
+  position: fixed;
+  top: 1rem;
+  left: 1rem;
+  z-index: 10;
+  padding: 0.6rem 0.9rem;
+  border-radius: 0.5rem;
+  color: #ffffff;
+  background: var(--bcf-text);
+  transform: translateY(-150%);
+}
+
+.skip-link-bcf:focus-visible {
+  transform: translateY(0);
+}
+
+.page-bcf {
+  width: min(60rem, calc(100% - 2rem));
+  margin-inline: auto;
+  padding-block: 4rem;
+}
+
+.page-bcf h1 {
+  margin-top: 0;
+}
+
+.page-bcf p {
+  color: var(--bcf-muted);
+}
+
+.ease-breadcrumb {
+  margin-top: 2rem;
+  padding: 1.25rem;
+  border: 1px solid var(--bcf-border);
+  border-radius: 0.75rem;
+  background: var(--bcf-surface);
+}
+
+.ease-breadcrumb-link:focus-visible {
+  outline: var(--bcf-focus-width) solid currentColor;
+  outline-offset: var(--bcf-focus-offset);
+  text-decoration: underline;
+}


### PR DESCRIPTION

Closes #59919
 
## Summary

Adds a visible keyboard focus state for EaseMotion breadcrumb links.

This enhancement improves keyboard accessibility by providing clear visual feedback when users navigate `.ease-breadcrumb-link` elements using keyboard input.

## Changes

- Added a breadcrumb focus-state example under `submissions/`
- Added a visible `:focus-visible` style for `.ease-breadcrumb-link`
- Added a 2px focus outline using `currentColor`
- Added `outline-offset` for improved visibility
- Added underline styling to reinforce the focused state
- Preserved existing hover behavior
- Added a minimal HTML demonstration using standard EaseMotion breadcrumb classes
- Added documentation covering usage and accessibility

## Accessibility

- [x] Provides a visible keyboard focus state
- [x] Uses `:focus-visible` instead of applying focus styling to every interaction
- [x] Preserves browser focus indication
- [x] Uses semantic breadcrumb navigation
- [x] Uses `aria-label="Breadcrumb"`
- [x] Uses `aria-current="page"` for the current breadcrumb
- [x] Marks visual separators as `aria-hidden`
- [x] Includes a keyboard-accessible skip link
- [x] Requires no JavaScript