### PR TITLE
feat: add CSS morph-glow tabs example

### DIFF
--- a/submissions/examples/morph-glow-tabs-pb/README.md
+++ b/submissions/examples/morph-glow-tabs-pb/README.md
@@ -1,0 +1,32 @@
+# Morph-Glow Tabs
+
+## What does this do?
+
+A tab component with a glowing, morphing active state. The active tab's border-radius shifts through several shapes while a blue-to-dark-purple glow pulses behind it. Tab switching uses minimal vanilla JS; the animation itself is pure CSS.
+
+## How is it used?
+
+Add `.tab` to each button and `.active` to the one that should start selected. Each button calls `change(this.id)` on click, which toggles `.active` and shows the matching `.content` block.
+
+```html
+<div class="morph-tabs">
+  <button
+    class="tab active"
+    id="1"
+    aria-selected="true"
+    onclick="change(this.id)"
+  >
+    Overview
+  </button>
+  <button class="tab" id="2" aria-selected="false" onclick="change(this.id)">
+    Analytics
+  </button>
+</div>
+
+<div class="content" id="tab1">...</div>
+<div class="content" id="tab2" hidden>...</div>
+```
+
+## Why is it useful?
+
+It's a lightweight way to make tabs feel alive, with no animation library. The glow pauses on hover so it doesn't distract while reading. Buttons stack responsively on small screens. All motion is disabled under `prefers-reduced-motion`.

--- a/submissions/examples/morph-glow-tabs-pb/demo.html
+++ b/submissions/examples/morph-glow-tabs-pb/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Morph-Glow Tabs</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+    <main class="showcase">
+        <h1 class="title">Morph Glow Tabs for SaaS Layouts</h1>
+
+        <div class="morph-tabs">
+            <button class="tab active" id="1" aria-selected="true" onclick="change(this.id)">Overview</button>
+            <button class="tab" id="2" aria-selected="false" onclick="change(this.id)">Analytics</button>
+            <button class="tab" id="3" aria-selected="false" onclick="change(this.id)">Security</button>
+            <button class="tab" id="4" aria-selected="false" onclick="change(this.id)">Contact Us</button>
+        </div>
+
+        <div class="content" id="tab1">Welcome to the Overview tab. Here you can find a summary of our
+            services and offerings.</div>
+        <div class="content" id="tab2" hidden>Welcome to the Analytics tab. Here you can find detailed insights into
+            our performance and metrics.</div>
+        <div class="content" id="tab3" hidden>Welcome to the Security tab. Here you can find information about our
+            security measures and protocols.</div>
+        <div class="content" id="tab4" hidden>Welcome to the Contact Us tab. Here you can find our contact
+            information and reach out to us.</div>
+
+
+    </main>
+
+    <script>
+        const tabs = document.querySelectorAll(".tab");
+
+        function change(id) {
+            tabs.forEach((tab) => {
+                const curr_id = tab.getAttribute("id");
+                const isActive = curr_id === id;
+
+                tab.setAttribute("aria-selected", isActive ? "true" : "false");
+                tab.classList.toggle("active", isActive);
+
+                const cont = document.getElementById("tab" + curr_id);
+                cont.hidden = !isActive;
+            });
+        }
+
+    </script>
+
+</body>
+
+</html>

--- a/submissions/examples/morph-glow-tabs-pb/style.css
+++ b/submissions/examples/morph-glow-tabs-pb/style.css
@@ -1,0 +1,133 @@
+:root {
+    --gt-bg: #0a0b10;
+    --gt-surface: #14161f;
+    --gt-border: #23263a;
+    --gt-text: #edeff5;
+    --gt-blue: #2563eb;
+    --gt-purple-dark: #4c1d95;
+    --gt-radius: 18px;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 48px 20px;
+    background: var(--gt-bg);
+    color: var(--gt-text);
+    font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+}
+
+.tab {
+    position: relative;
+    isolation: isolate;
+    border-radius: 14px;
+    border: 1px solid white;
+    padding: 15px;
+    color: var(--gt-text);
+    font-size: 14px;
+    font-weight: bold;
+    background-color: var(--gt-bg);
+    cursor: pointer;
+    transition: color 0.35s ease;
+}
+
+.tab::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    border-radius: 14px;
+    opacity: 0;
+    transform: scale(0.6);
+    background: radial-gradient(circle at 50% 50%, var(--gt-blue), var(--gt-purple-dark) 140%);
+    transition: opacity 0.4s ease, transform 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.tab.active {
+    border-color: transparent;
+}
+
+.tab.active::before {
+    opacity: 1;
+    transform: scale(1);
+    animation: gt-morph 4s ease-in-out infinite, gt-glow-pulse 2.6s ease-in-out infinite;
+}
+
+.tab.active:hover::before {
+    animation-play-state: paused;
+}
+
+.morph-tabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    justify-content: center;
+}
+
+.content {
+    padding-top: 10px;
+    margin: 10px;
+}
+
+@media (max-width: 560px) {
+    .morph-tabs {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        justify-content: center;
+    }
+
+    .tab {
+        flex: 1 1 calc(50% - 10px);
+        padding: 12px;
+        font-size: 13px;
+    }
+}
+
+@media (max-width: 360px) {
+    .tab {
+        flex: 1 1 100%;
+    }
+}
+
+@keyframes gt-morph {
+    0%,
+    100% {
+        border-radius: 14px;
+    }
+    25% {
+        border-radius: 42% 58% 63% 37% / 41% 44% 56% 59%;
+    }
+    50% {
+        border-radius: 50%;
+    }
+    75% {
+        border-radius: 8px 28px 8px 28px;
+    }
+}
+
+@keyframes gt-glow-pulse {
+    0%,
+    100% {
+        box-shadow: 0 0 18px 2px rgba(76, 29, 149, 0.55);
+    }
+    50% {
+        box-shadow: 0 0 30px 6px rgba(37, 99, 235, 0.6);
+    }
+}
+
+/* ---------- reduced motion ---------- */
+
+@media (prefers-reduced-motion: reduce) {
+    .tab::before {
+        transition: none !important;
+        animation: none !important;
+    }
+}


### PR DESCRIPTION
Closes #59488

## Pull Request Description

Adds a CSS Morph-Glow Tabs example for SaaS showcase layouts.

This enhancement gives tab components a distinctive animated active state — the glow behind the active tab morphs through several shapes and pulses in a blue-to-dark-purple gradient — instead of a plain static highlight.

## Changes

- Added a morph-glow tabs example under `submissions/examples/`
- Added `.tab` and `.tab.active` styles with a morphing `::before` glow layer
- Added `gt-morph` keyframes to cycle the glow through several border-radius shapes
- Added `gt-glow-pulse` keyframes for the blue-to-dark-purple glow animation
- Added hover pause via `animation-play-state: paused` on the active tab
- Added responsive stacking for tabs on small screens
- Added minimal vanilla JS to toggle the active tab and matching content panel
- Added documentation covering usage and how it fits EaseMotion CSS

## Accessibility

- [x] Preserves keyboard-usable native `<button>` elements for tabs
- [x] Uses `aria-selected` to reflect the active tab state
- [x] Disables all animation under `prefers-reduced-motion: reduce`
- [x] Pauses the glow animation on hover so it doesn't distract while reading
- [x] Fully responsive down to mobile viewports
- [x] Requires no JavaScript framework
---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A tab component with a glowing, morphing active state. The active tab's border-radius shifts through several shapes while a blue-to-dark-purple glow pulses behind it. Tab switching uses minimal vanilla JS; the animation itself is pure CSS.

**How does a developer use it?**
Add `.tab` to each button and `.active` to the one that should start selected. Each button calls `change(this.id)` on click, which toggles `.active` and shows the matching `.content` block.

```html
<div class="morph-tabs">
  <button class="tab active"  id="1"  aria-selected="true"  onclick="change(this.id)"> Overview  </button>
  <button class="tab" id="2" aria-selected="false" onclick="change(this.id)">  Analytics  </button>
</div>
<div class="content" id="tab1">...</div>
<div class="content" id="tab2" hidden>...</div>
```

**Why does it fit EaseMotion CSS?**
It's a lightweight way to make tabs feel alive, with no animation library. The glow pauses on hover so it doesn't distract while reading. Buttons stack responsively on small screens. All motion is disabled under `prefers-reduced-motion`.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Shapes cycle through border-radius keyframes rather than a single sliding indicator — feel free to adjust timing/easing if it feels too fast/slow.
<!-- Anything the maintainer should know when reviewing or integrating.
     e.g. "I wasn't sure about the timing — feel free to adjust."
     e.g. "Inspired by Material UI's shimmer effect." -->

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
