### PR TITLE
Add ease-typewriter-caret-blink component

### DIFF
--- a/submissions/examples/ease-typewriter-caret-blink-ij/README.md
+++ b/submissions/examples/ease-typewriter-caret-blink-ij/README.md
@@ -1,0 +1,7 @@
+# ease-typewriter-caret-blink
+A classic typewriter that types a letter onto the page with a blinking caret.
+## Run
+Open `demo.html` directly in a browser to watch the words punch in.
+## Notes
+- Words fade in one by one while the caret blinks.
+- The key row presses in sequence beneath the carriage.

--- a/submissions/examples/ease-typewriter-caret-blink-ij/demo.html
+++ b/submissions/examples/ease-typewriter-caret-blink-ij/demo.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-typewriter-caret-blink demo</title>
+</head>
+<body>
+<div class="tw-app">
+  <div class="tw-platen"></div>
+  <div class="tw-paper">
+    <span class="tw-word tw-word-1">Dear</span>
+    <span class="tw-word tw-word-2">Gretel,</span>
+    <span class="tw-word tw-word-3">the</span>
+    <span class="tw-word tw-word-4">hamster</span>
+    <span class="tw-word tw-word-5">escaped</span>
+    <span class="tw-caret"></span>
+  </div>
+  <div class="tw-carriage"></div>
+  <div class="tw-keys">
+    <button class="tw-key tw-key-1">Q</button>
+    <button class="tw-key tw-key-2">W</button>
+    <button class="tw-key tw-key-3">E</button>
+    <button class="tw-key tw-key-4">R</button>
+    <button class="tw-key tw-key-5">T</button>
+  </div>
+  <div class="tw-space"></div>
+  <div class="tw-base"></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/ease-typewriter-caret-blink-ij/style.css
+++ b/submissions/examples/ease-typewriter-caret-blink-ij/style.css
@@ -1,0 +1,25 @@
+:root{--tw-ink:#2a2438;--tw-key:#f6efe4;--tw-paper:#fdfaf2}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(160deg,#4b3f52,#241e2c);font-family:Georgia,serif}
+.tw-app{width:372px;padding:22px;border-radius:18px;background:linear-gradient(180deg,#5a4a62,#2e2737);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.tw-platen{height:14px;border-radius:7px;background:#3a2f42;margin-bottom:8px}
+.tw-paper{position:relative;min-height:96px;padding:16px 18px;background:var(--tw-paper);border-radius:4px;box-shadow:inset 0 0 0 2px #d9d2c2,0 6px 10px rgba(0,0,0,0.3)}
+.tw-word{display:inline-block;color:var(--tw-ink);font-size:22px;font-style:italic;opacity:0;animation:type-word-typewriter-caret-blink 2.4s ease-in infinite}
+.tw-word-1{animation-delay:0.1s}
+.tw-word-2{animation-delay:0.5s}
+.tw-word-3{animation-delay:0.9s}
+.tw-word-4{animation-delay:1.3s}
+.tw-word-5{animation-delay:1.7s}
+.tw-caret{display:inline-block;width:3px;height:26px;margin:0 4px;background:var(--tw-ink);vertical-align:-6px;animation:blink-caret-typewriter-caret-blink 0.9s steps(2) infinite}
+.tw-carriage{height:10px;margin-top:8px;border-radius:5px;background:#4a3c52;animation:thunk-carriage-typewriter-caret-blink 2.4s ease-in infinite}
+.tw-keys{display:flex;gap:8px;margin-top:12px;padding:10px;border-radius:10px;background:#3a2f42}
+.tw-key{flex:1;height:34px;border:0;border-radius:6px;background:var(--tw-key);color:#3a2f42;font-size:14px;font-weight:bold;box-shadow:0 4px 0 #cbbfa8;animation:press-key-typewriter-caret-blink 2.4s ease-in infinite}
+.tw-key-2{animation-delay:0.4s}
+.tw-key-3{animation-delay:0.8s}
+.tw-key-4{animation-delay:1.2s}
+.tw-key-5{animation-delay:1.6s}
+.tw-space{height:14px}
+.tw-base{height:8px;border-radius:4px;background:#241e2c}
+@keyframes type-word-typewriter-caret-blink{0%,100%{opacity:1}45%{opacity:1}50%{opacity:0}95%{opacity:0}}
+@keyframes blink-caret-typewriter-caret-blink{0%,49%{opacity:1}50%,99%{opacity:0}}
+@keyframes thunk-carriage-typewriter-caret-blink{0%,100%{transform:translateX(0)}48%{transform:translateX(26px)}52%{transform:translateX(-6px)}56%{transform:translateX(0)}}
+@keyframes press-key-typewriter-caret-blink{0%,100%{transform:translateY(0);box-shadow:0 4px 0 #cbbfa8}48%{transform:translateY(4px);box-shadow:0 0 0 #cbbfa8}52%{transform:translateY(4px)}}


### PR DESCRIPTION
## Component: ease-typewriter-caret-blink — words type, caret blinks, and keys press

**Closes #60511**

### What this adds
A classic typewriter: words punch onto the paper line by line while the caret blinks and skips across, the carriage thunks left on each return, and the QWERTY key row presses in sequence below.

### Acceptance Criteria covered
- Words type onto the paper
- Caret blinks as it advances
- Key row presses below the carriage

### Files
- submissions/examples/ease-typewriter-caret-blink-ij/demo.html
- submissions/examples/ease-typewriter-caret-blink-ij/style.css
- submissions/examples/ease-typewriter-caret-blink-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the words appear as the caret blinks.