### PR TITLE
Add ease-elevator-doors-slide component

### DIFF
--- a/submissions/examples/ease-elevator-doors-slide-ij/README.md
+++ b/submissions/examples/ease-elevator-doors-slide-ij/README.md
@@ -1,0 +1,7 @@
+# ease-elevator-doors-slide
+A building elevator whose steel doors slide open at each stop.
+## Run
+Open `demo.html` directly in a browser to watch the doors part.
+## Notes
+- The floor display ticks as the cab arrives.
+- The call buttons glow on the side panel.

--- a/submissions/examples/ease-elevator-doors-slide-ij/demo.html
+++ b/submissions/examples/ease-elevator-doors-slide-ij/demo.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-elevator-doors-slide demo</title>
+</head>
+<body>
+<div class="ev-app">
+  <div class="ev-shaft">
+    <div class="ev-cab">
+      <span class="ev-lamp"></span>
+      <span class="ev-floor">3</span>
+    </div>
+    <div class="ev-door ev-door-left"></div>
+    <div class="ev-door ev-door-right"></div>
+  </div>
+  <div class="ev-panel">
+    <button class="ev-btn ev-btn-up">&#9650;</button>
+    <button class="ev-btn ev-btn-down">&#9660;</button>
+    <span class="ev-dot ev-dot-1"></span>
+    <span class="ev-dot ev-dot-2"></span>
+    <span class="ev-dot ev-dot-3"></span>
+  </div>
+  <div class="ev-base"></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/ease-elevator-doors-slide-ij/style.css
+++ b/submissions/examples/ease-elevator-doors-slide-ij/style.css
@@ -1,0 +1,22 @@
+:root{--ev-steel:#8f9aa8;--ev-dark:#1c222c;--ev-glow:#6fd8a8}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#3a4252,#171c26);font-family:'Segoe UI',sans-serif}
+.ev-app{position:relative;width:372px;height:372px;border-radius:18px;background:linear-gradient(180deg,#454e60,#1f2632);box-shadow:0 16px 36px rgba(0,0,0,0.55);padding:20px}
+.ev-shaft{position:relative;height:240px;border-radius:12px;background:linear-gradient(180deg,#232a36,#14181f);border:3px solid #2a3342;overflow:hidden}
+.ev-cab{position:absolute;top:14px;left:0;right:0;height:212px;display:flex;flex-direction:column;align-items:center;gap:8px}
+.ev-lamp{width:34px;height:14px;border-radius:7px;background:var(--ev-glow);box-shadow:0 0 12px var(--ev-glow);animation:glow-lamp-elevator-doors-slide 1.8s ease-in-out infinite}
+.ev-floor{width:52px;height:52px;border-radius:10px;background:#10141a;border:2px solid #4a525e;display:grid;place-items:center;color:#e8ecf4;font-size:26px;font-weight:bold;animation:tick-floor-elevator-doors-slide 1.8s ease-in-out infinite}
+.ev-door{position:absolute;top:0;bottom:0;width:50%;background:linear-gradient(90deg,#9aa5b4,#5f6a78);box-shadow:inset 0 0 0 3px #3a4452;animation:slide-door-elevator-doors-slide 1.8s ease-in-out infinite}
+.ev-door-left{left:0}
+.ev-door-right{right:0;animation-delay:0s}
+.ev-panel{display:flex;align-items:center;gap:10px;margin-top:16px;padding:10px;border-radius:10px;background:#2a3342}
+.ev-btn{width:40px;height:40px;border:0;border-radius:8px;background:#10141a;color:#e8ecf4;font-size:14px;box-shadow:0 3px 0 #05070d;animation:glow-button-elevator-doors-slide 1.8s ease-in-out infinite}
+.ev-btn-down{animation-delay:0.9s}
+.ev-dot{width:12px;height:12px;border-radius:50%;background:#3a4452;animation:dot-fill-elevator-doors-slide 1.8s ease-in-out infinite}
+.ev-dot-2{animation-delay:0.6s}
+.ev-dot-3{animation-delay:1.2s}
+.ev-base{height:8px;margin-top:14px;border-radius:4px;background:#14181f}
+@keyframes slide-door-elevator-doors-slide{0%,100%{transform:translateX(0)}40%{transform:translateX(-78%)}55%{transform:translateX(-78%)}70%{transform:translateX(0)}}
+@keyframes tick-floor-elevator-doors-slide{0%,100%{transform:scale(1)}40%{transform:scale(1.15)}55%{transform:scale(1.15)}70%{transform:scale(1)}}
+@keyframes glow-lamp-elevator-doors-slide{0%,100%{opacity:0.4}50%{opacity:1}}
+@keyframes glow-button-elevator-doors-slide{0%,100%{background:#10141a;color:#8a93a2}50%{background:#1d5c3f;color:#e8ecf4}}
+@keyframes dot-fill-elevator-doors-slide{0%,100%{background:#3a4452}50%{background:var(--ev-glow)}}


### PR DESCRIPTION
## Component: ease-elevator-doors-slide — doors slide, floor ticks, and buttons glow

**Closes #60532**

### What this adds
A building elevator: two steel doors slide apart and together inside the shaft while the cab lamp glows, the floor display ticks between numbers, and the UP and DOWN call buttons blink beside the indicator dots.

### Acceptance Criteria covered
- Steel doors slide open and closed
- Floor display ticks upward
- Call buttons glow on the panel

### Files
- submissions/examples/ease-elevator-doors-slide-ij/demo.html
- submissions/examples/ease-elevator-doors-slide-ij/style.css
- submissions/examples/ease-elevator-doors-slide-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the doors part for each stop.