### PR TITLE
fix: prevent ease-input focus ring clipping via inset box-shadow (#59767)

### DIFF
--- a/submissions/examples/ease-input-focus-clip-aa/README.md
+++ b/submissions/examples/ease-input-focus-clip-aa/README.md
@@ -1,0 +1,10 @@
+# ease-input-focus-clip-aa
+
+**What does this do?**
+Fixes the focus ring on `ease-input` being clipped when placed inside a container with `overflow: hidden` or `overflow: auto`.
+
+**How is it used?**
+Apply the class to your input: `<input class="ease-input-focus-clip-aa" />`
+
+**Why is it useful?**
+Instead of an outer `outline`/`box-shadow` that can be cut off by a parent's overflow, this uses an `inset` box-shadow, which draws inside the element's own bounding box and is never clipped — fixing the accessibility issue in #59767.

--- a/submissions/examples/ease-input-focus-clip-aa/demo.html
+++ b/submissions/examples/ease-input-focus-clip-aa/demo.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-input focus clip fix</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="clip-wrapper">
+    <input type="text" class="ease-input-focus-clip-aa" placeholder="Tab into me" />
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-input-focus-clip-aa/style.css
+++ b/submissions/examples/ease-input-focus-clip-aa/style.css
@@ -1,0 +1,18 @@
+.clip-wrapper {
+  overflow: hidden;
+  padding: 20px;
+  border: 1px solid #ccc;
+}
+
+.ease-input-focus-clip-aa {
+  padding: 10px 14px;
+  border: 1px solid #999;
+  border-radius: 6px;
+  font-size: 14px;
+  outline: none;
+  transition: box-shadow 0.15s ease;
+}
+
+.ease-input-focus-clip-aa:focus {
+  box-shadow: inset 0 0 0 2px #4f46e5, inset 0 0 0 4px rgba(79,70,229,0.25);
+}


### PR DESCRIPTION
## Pull Request Description
Fixes #59767 — the ease-input focus ring was clipped when placed inside a container with overflow: hidden or overflow: auto. Replaces the outer outline/box-shadow with an inset box-shadow so it always draws inside the element's own bounds.

---

## Type of Change
- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist
- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description
**What does this add?**
An inset-box-shadow-based focus style for ease-input that is never clipped by a parent's overflow.

**How does a developer use it?**
```html
<input class="ease-input-focus-clip-aa" placeholder="Tab into me" />
```

**Why does it fit EaseMotion CSS?**
It's a minimal, readable fix that keeps the accessible focus indicator fully visible in real-world layouts (cards, modals, scroll containers) without changing the animation-first philosophy of the framework.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome

---

## Notes for Maintainer
Uses inset box-shadow instead of outline since outline/outer box-shadow gets clipped by overflow:hidden parents — inset shadows draw within the element's own bounding box so they're never cut off. Fixes #59767.