### PR TITLE
Add ease-telegraph-key-tap component

### DIFF
--- a/submissions/examples/ease-telegraph-key-tap-ij/README.md
+++ b/submissions/examples/ease-telegraph-key-tap-ij/README.md
@@ -1,0 +1,7 @@
+# ease-telegraph-key-tap
+A Morse telegraph desk where the brass key taps out a signal.
+## Run
+Open `demo.html` directly in a browser to watch the key tap.
+## Notes
+- The contact point sparks when the lever drops.
+- The SOS lamp blinks out a Morse pattern.

--- a/submissions/examples/ease-telegraph-key-tap-ij/demo.html
+++ b/submissions/examples/ease-telegraph-key-tap-ij/demo.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-telegraph-key-tap demo</title>
+</head>
+<body>
+<div class="tk-app">
+  <div class="tk-desk">
+    <div class="tk-key">
+      <div class="tk-knob"></div>
+      <div class="tk-lever"></div>
+      <div class="tk-hinge"></div>
+      <div class="tk-contact"></div>
+      <div class="tk-base"></div>
+    </div>
+    <div class="tk-coil">
+      <div class="tk-wire tk-wire-1"></div>
+      <div class="tk-wire tk-wire-2"></div>
+    </div>
+    <div class="tk-buzzer">
+      <div class="tk-hammer"></div>
+    </div>
+    <div class="tk-paper"></div>
+    <div class="tk-led">SOS</div>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/ease-telegraph-key-tap-ij/style.css
+++ b/submissions/examples/ease-telegraph-key-tap-ij/style.css
@@ -1,0 +1,22 @@
+:root{--tk-brass:#c8a64a;--tk-wood:#7a5230;--tk-ink:#3a2a18}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#6b5238,#2e1f16);font-family:'Courier New',monospace}
+.tk-app{position:relative;width:372px;height:372px;border-radius:18px;background:linear-gradient(180deg,#8a6840,#3a2a1a);box-shadow:0 16px 36px rgba(0,0,0,0.55);padding:26px}
+.tk-desk{position:relative;height:320px;border-radius:12px;background:var(--tk-wood);box-shadow:inset 0 8px 0 rgba(255,255,255,0.08),0 8px 14px rgba(0,0,0,0.4)}
+.tk-key{position:absolute;top:36px;left:24px;width:150px;height:96px}
+.tk-base{position:absolute;bottom:0;left:0;right:0;height:16px;border-radius:8px;background:var(--tk-brass);box-shadow:0 5px 0 rgba(0,0,0,0.3)}
+.tk-lever{position:absolute;top:30px;left:20px;right:16px;height:14px;border-radius:7px;background:var(--tk-brass);transform-origin:right center;box-shadow:0 3px 0 rgba(0,0,0,0.25);animation:tap-lever-telegraph-key-tap 1.6s ease-in-out infinite}
+.tk-knob{position:absolute;top:20px;left:22px;width:34px;height:34px;border-radius:50%;background:#e8d6a8;box-shadow:0 4px 0 rgba(0,0,0,0.3)}
+.tk-hinge{position:absolute;top:26px;right:4px;width:26px;height:22px;border-radius:6px;background:#9a7a2e}
+.tk-contact{position:absolute;top:52px;left:34px;width:12px;height:12px;border-radius:50%;background:#8a6a2e;box-shadow:0 0 10px rgba(255,220,120,0.9);animation:spark-contact-telegraph-key-tap 1.6s ease-in-out infinite}
+.tk-coil{position:absolute;top:40px;right:24px;width:70px;height:84px;border-radius:12px;background:linear-gradient(90deg,#c8a64a,#8a6a2e);box-shadow:0 6px 10px rgba(0,0,0,0.35)}
+.tk-wire{position:absolute;left:8px;right:8px;height:8px;border-radius:4px;background:#5a4a2e}
+.tk-wire-1{top:18px}
+.tk-wire-2{top:52px}
+.tk-buzzer{position:absolute;top:44px;right:112px;width:44px;height:60px;border-radius:10px;background:#4a3a22;border:3px solid #2e2012}
+.tk-hammer{position:absolute;top:-4px;left:50%;margin-left:-6px;width:12px;height:16px;border-radius:4px;background:var(--tk-brass);animation:hammer-buzz-telegraph-key-tap 1.6s ease-in-out infinite}
+.tk-paper{position:absolute;bottom:26px;left:24px;right:24px;height:70px;border-radius:4px;background:#f3ead8;box-shadow:inset 0 0 0 2px #d8cba8}
+.tk-led{position:absolute;bottom:30px;right:30px;width:70px;height:26px;border-radius:6px;background:#10141a;color:#ffd76a;font-size:12px;font-weight:bold;line-height:26px;text-align:center;box-shadow:inset 0 0 0 2px #2a3342;animation:blink-led-telegraph-key-tap 1.6s steps(2) infinite}
+@keyframes tap-lever-telegraph-key-tap{0%,100%{transform:rotate(0deg)}40%{transform:rotate(-22deg)}55%{transform:rotate(-22deg)}70%{transform:rotate(0deg)}}
+@keyframes spark-contact-telegraph-key-tap{0%,100%{opacity:0.2}40%{opacity:1}52%{opacity:1}66%{opacity:0.2}}
+@keyframes hammer-buzz-telegraph-key-tap{0%,100%{transform:translateY(0)}40%{transform:translateY(8px)}55%{transform:translateY(8px)}70%{transform:translateY(0)}}
+@keyframes blink-led-telegraph-key-tap{0%,100%{opacity:1}46%{opacity:0.2}54%{opacity:1}60%{opacity:0.2}66%{opacity:1}}


### PR DESCRIPTION
## Component: ease-telegraph-key-tap — key taps, coil sparks, and lamp blinks

**Closes #60592**

### What this adds
A Morse telegraph desk: the brass key lever taps against the contact points while a spark flashes at the gap, the coil sits beside it with wrapped wire, and the SOS lamp blinks out a pattern in Morse.

### Acceptance Criteria covered
- Brass key lever taps the contacts
- Coil and buzzer sit on the desk
- SOS lamp blinks in Morse code

### Files
- submissions/examples/ease-telegraph-key-tap-ij/demo.html
- submissions/examples/ease-telegraph-key-tap-ij/style.css
- submissions/examples/ease-telegraph-key-tap-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the key tap out a signal.