### PR TITLE
Add ease-parachute-descent component

### DIFF
--- a/submissions/examples/ease-parachute-descent-ij/README.md
+++ b/submissions/examples/ease-parachute-descent-ij/README.md
@@ -1,0 +1,7 @@
+# ease-parachute-descent
+A parachute that descends through the sky toward a landing field.
+## Run
+Open `demo.html` directly in a browser to watch the chute drop.
+## Notes
+- The canopy sways as the jumper swings beneath.
+- Clouds drift past while the ground rises up.

--- a/submissions/examples/ease-parachute-descent-ij/demo.html
+++ b/submissions/examples/ease-parachute-descent-ij/demo.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-parachute-descent demo</title>
+</head>
+<body>
+<div class="pc-app">
+  <div class="pc-sky">
+    <span class="pc-cloud pc-cloud-1"></span>
+    <span class="pc-cloud pc-cloud-2"></span>
+    <div class="pc-chute">
+      <div class="pc-gore pc-gore-1"></div>
+      <div class="pc-gore pc-gore-2"></div>
+      <div class="pc-gore pc-gore-3"></div>
+      <div class="pc-line pc-line-1"></div>
+      <div class="pc-line pc-line-2"></div>
+      <div class="pc-jumper"></div>
+    </div>
+    <div class="pc-ground"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/ease-parachute-descent-ij/style.css
+++ b/submissions/examples/ease-parachute-descent-ij/style.css
@@ -1,0 +1,20 @@
+:root{--pc-canopy:#d8583a;--pc-dark:#8f3a22;--pc-jumper:#3a414b}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#8fc3e0,#d8ecf6);font-family:'Verdana',sans-serif}
+.pc-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#a8d2ea,#e8f4fa);box-shadow:0 16px 36px rgba(0,0,0,0.3)}
+.pc-sky{position:absolute;inset:0}
+.pc-cloud{position:absolute;width:90px;height:30px;border-radius:50%;background:rgba(255,255,255,0.85);animation:drift-cloud-parachute-descent 7s linear infinite}
+.pc-cloud-1{top:30px;left:20px}
+.pc-cloud-2{top:66px;right:30px;animation-delay:3.5s}
+.pc-chute{position:absolute;top:0;left:50%;margin-left:-54px;width:108px;height:230px;animation:descend-chute-parachute-descent 5s ease-in-out infinite}
+.pc-gore{position:absolute;top:0;width:0;height:0;border-top:64px solid var(--pc-canopy);opacity:0.95}
+.pc-gore-1{left:0;border-left:54px solid transparent}
+.pc-gore-2{left:50%;margin-left:-54px;border-left:54px solid transparent;border-top-color:var(--pc-dark)}
+.pc-gore-3{right:0;border-right:54px solid transparent}
+.pc-line{position:absolute;top:58px;width:2px;height:110px;background:#d8dce2}
+.pc-line-1{left:26px;transform:rotate(8deg)}
+.pc-line-2{right:26px;transform:rotate(-8deg)}
+.pc-jumper{position:absolute;top:150px;left:50%;margin-left:-10px;width:20px;height:40px;border-radius:8px 8px 6px 6px;background:var(--pc-jumper);box-shadow:inset 0 -8px 0 #242a30;animation:swing-jumper-parachute-descent 5s ease-in-out infinite}
+.pc-ground{position:absolute;left:0;right:0;bottom:0;height:40px;background:linear-gradient(180deg,#7a9a5a,#4a6a3a);border-radius:18px 18px 0 0}
+@keyframes descend-chute-parachute-descent{0%,100%{transform:translateY(0)}50%{transform:translateY(120px)}}
+@keyframes swing-jumper-parachute-descent{0%,100%{transform:rotate(6deg)}50%{transform:rotate(-6deg)}}
+@keyframes drift-cloud-parachute-descent{0%{transform:translateX(0)}50%{transform:translateX(60px)}100%{transform:translateX(0)}}


### PR DESCRIPTION
## Component: ease-parachute-descent — canopy drops, lines sway, and jumper swings

**Closes #60600**

### What this adds
A parachute over a landing field: the scalloped canopy descends through drifting clouds while the shroud lines sway, the jumper swings gently beneath, and the ground rises to meet the drop zone.

### Acceptance Criteria covered
- Canopy descends through the clouds
- Shroud lines sway in the air
- Jumper swings beneath the canopy

### Files
- submissions/examples/ease-parachute-descent-ij/demo.html
- submissions/examples/ease-parachute-descent-ij/style.css
- submissions/examples/ease-parachute-descent-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the chute drift down.