### PR TITLE
fix: add missing closing html tag (fixes #60599)

### DIFF
--- a/submissions/examples/rotate-click-tabs-checkout-bhakkti/demo.html
+++ b/submissions/examples/rotate-click-tabs-checkout-bhakkti/demo.html
@@ -175,4 +175,4 @@
       <p>🛒 Perfect for e-commerce checkout flows</p>
     </div>
   </div>
-</body>
+</body></html>


### PR DESCRIPTION
## Description
Add missing closing `</html>` tag to submissions/examples/rotate-click-tabs-checkout-bhakkti/demo.html

## Changes
- Added closing `</html>` tag to complete the HTML document

## Issue
Closes #60599