### PR TITLE
Add ease-pinball-flipper-snap component

### DIFF
--- a/submissions/examples/ease-pinball-flipper-snap-ij/README.md
+++ b/submissions/examples/ease-pinball-flipper-snap-ij/README.md
@@ -1,0 +1,7 @@
+# ease-pinball-flipper-snap
+A pinball table where the flippers snap up to bat the ball.
+## Run
+Open `demo.html` directly in a browser to watch the ball bounce.
+## Notes
+- The ball ricochets off the two bumpers.
+- Lamps flash around the playfield glass.

--- a/submissions/examples/ease-pinball-flipper-snap-ij/demo.html
+++ b/submissions/examples/ease-pinball-flipper-snap-ij/demo.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-pinball-flipper-snap demo</title>
+</head>
+<body>
+<div class="pb-app">
+  <div class="pb-back">
+    <div class="pb-score">2500</div>
+    <span class="pb-light pb-light-1"></span>
+    <span class="pb-light pb-light-2"></span>
+  </div>
+  <div class="pb-playfield">
+    <span class="pb-bumper pb-bumper-1"></span>
+    <span class="pb-bumper pb-bumper-2"></span>
+    <span class="pb-arrow"></span>
+    <div class="pb-ball"></div>
+    <div class="pb-flipper pb-flipper-left"></div>
+    <div class="pb-flipper pb-flipper-right"></div>
+    <div class="pb-plunger"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/ease-pinball-flipper-snap-ij/style.css
+++ b/submissions/examples/ease-pinball-flipper-snap-ij/style.css
@@ -1,0 +1,24 @@
+:root{--pb-dark:#10141a;--pb-red:#d84a3a;--pb-glow:#ffd76a}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#2a2a3a,#101018);font-family:'Courier New',monospace}
+.pb-app{position:relative;width:372px;height:372px;border-radius:18px;background:linear-gradient(180deg,#3a3a4a,#181820);box-shadow:0 16px 36px rgba(0,0,0,0.6);overflow:hidden;padding-top:18px}
+.pb-back{height:88px;border-radius:10px;background:linear-gradient(180deg,#2a3040,#10141a);border:3px solid #3a4452;display:flex;flex-direction:column;align-items:center;gap:6px;justify-content:center}
+.pb-score{color:#ffe08a;font-size:24px;font-weight:bold;letter-spacing:2px;text-shadow:0 0 10px rgba(255,224,138,0.6);animation:tick-score-pinball-flipper-snap 2.2s steps(4) infinite}
+.pb-light{width:16px;height:16px;border-radius:50%;background:var(--pb-red);box-shadow:0 0 10px var(--pb-red);animation:flash-light-pinball-flipper-snap 0.7s steps(2) infinite}
+.pb-light-2{animation-delay:0.35s}
+.pb-playfield{position:relative;height:230px;margin-top:12px;border-radius:10px;background:linear-gradient(180deg,#2a2a3a,#14141c);border:3px solid #3a4452;overflow:hidden}
+.pb-bumper{position:absolute;width:26px;height:26px;border-radius:50%;background:var(--pb-dark);border:4px solid #d8a83a;box-shadow:0 0 12px rgba(216,168,58,0.5);animation:bump-pinball-flipper-snap 1.1s ease-in-out infinite}
+.pb-bumper-1{top:34px;left:60px}
+.pb-bumper-2{top:34px;right:60px;animation-delay:0.55s}
+.pb-arrow{position:absolute;top:14px;left:50%;margin-left:-30px;width:0;height:0;border-left:30px solid transparent;border-right:30px solid transparent;border-top:22px solid #8a93a2;animation:bounce-arrow-pinball-flipper-snap 1.1s ease-in-out infinite}
+.pb-ball{position:absolute;top:70px;left:50%;width:14px;height:14px;margin-left:-7px;border-radius:50%;background:#d8dce2;box-shadow:0 0 8px #d8dce2;animation:roll-ball-pinball-flipper-snap 2.2s ease-in-out infinite}
+.pb-flipper{position:absolute;bottom:22px;width:84px;height:14px;border-radius:14px 4px 4px 14px;background:linear-gradient(180deg,#c8442f,#8a2a1a);box-shadow:0 3px 0 rgba(0,0,0,0.4);animation:snap-flipper-pinball-flipper-snap 1.1s ease-in-out infinite}
+.pb-flipper-left{left:8px;transform-origin:left center}
+.pb-flipper-right{right:8px;transform-origin:right center;animation-delay:0.55s}
+.pb-plunger{position:absolute;right:16px;top:10px;width:8px;height:34px;border-radius:4px;background:#8a93a2;animation:push-plunger-pinball-flipper-snap 2.2s ease-in-out infinite}
+@keyframes snap-flipper-pinball-flipper-snap{0%,100%{transform:rotate(0deg)}40%{transform:rotate(-34deg)}55%{transform:rotate(-34deg)}70%{transform:rotate(0deg)}}
+@keyframes roll-ball-pinball-flipper-snap{0%,100%{transform:translate(0,0)}25%{transform:translate(-70px,-30px)}50%{transform:translate(0,-56px)}75%{transform:translate(70px,-30px)}}
+@keyframes bump-pinball-flipper-snap{0%,100%{transform:scale(1)}50%{transform:scale(1.3)}}
+@keyframes bounce-arrow-pinball-flipper-snap{0%,100%{transform:translateY(0)}50%{transform:translateY(-8px)}}
+@keyframes flash-light-pinball-flipper-snap{0%,49%{opacity:0.2}50%,99%{opacity:1}}
+@keyframes tick-score-pinball-flipper-snap{0%,100%{transform:scale(1)}50%{transform:scale(1.1)}}
+@keyframes push-plunger-pinball-flipper-snap{0%,100%{transform:translateY(0)}50%{transform:translateY(-14px)}}


### PR DESCRIPTION
## Component: ease-pinball-flipper-snap — flippers snap, ball bounces, and lights flash

**Closes #60627**

### What this adds
A pinball table: the two flippers snap up in turn to bat the ball while it bounces off the bumpers, the scoreboard ticks in the backbox, and the lamps around the glass flash as the playfield lights up.

### Acceptance Criteria covered
- Flippers snap up to bat the ball
- Ball bounces off the bumpers
- Lamps flash around the playfield

### Files
- submissions/examples/ease-pinball-flipper-snap-ij/demo.html
- submissions/examples/ease-pinball-flipper-snap-ij/style.css
- submissions/examples/ease-pinball-flipper-snap-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the ball get batted around.