### PR TITLE
fix: remove dead code in core/modal.js (fixes #60595)

### DIFF
--- a/core/modal.js
+++ b/core/modal.js
@@ -25,10 +25,6 @@
 
           const modal = overlay.querySelector('.ease-modal');
           if (modal) {
-            if (!overlay.classList.contains('is-active')) {
-              previousFocusedElement = document.activeElement;
-            }
-
             modal.setAttribute('tabindex', '-1');
             modal.focus();
           }


### PR DESCRIPTION
## Description
Remove dead code in core/modal.js - redundant `is-active` class check that always evaluates to false after the class is added.

## Changes
- Removed lines 27-30 in core/modal.js that checked for `is-active` class AFTER adding it
- The `previousFocusedElement` assignment is already done correctly before `classList.add()`

## Issue
Closes #60595