### PR TITLE
feat: add CSS ripple-wave popover for fintech dashboards (#59247)

### DIFF
--- a/submissions/examples/ripple-wave-popover-aa/README.md
+++ b/submissions/examples/ripple-wave-popover-aa/README.md
@@ -1,0 +1,24 @@
+# ripple-wave-popover-aa
+
+**What does this do?**
+A pure CSS ripple-wave popover for fintech dashboard layouts — clicking a trigger (e.g. "Account Balance") expands a ripple wave and reveals a popover with account details, with no JavaScript.
+
+**How is it used?**
+```html
+<div class="rwp-wrap">
+  <input type="checkbox" id="rwp-toggle" class="rwp-checkbox">
+  <label for="rwp-toggle" class="rwp-trigger">
+    Account Balance
+    <span class="rwp-ripple"></span>
+  </label>
+  <div class="rwp-popover">
+    <div class="rwp-popover-inner">
+      <h4>$48,203.12</h4>
+      <p>+2.4% this week</p>
+    </div>
+  </div>
+</div>
+```
+
+**Why is it useful?**
+Uses the checkbox-hack for pure CSS/HTML interactivity (no JS frameworks), a keyframe-driven ripple expansion on trigger, a spring-eased popover reveal, full responsiveness down to mobile widths, and a `prefers-reduced-motion` fallback that disables the ripple and shortens the transition — matching EaseMotion's animation-first, accessible philosophy.

--- a/submissions/examples/ripple-wave-popover-aa/demo.html
+++ b/submissions/examples/ripple-wave-popover-aa/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Ripple-Wave Popover</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="rwp-dashboard">
+    <div class="rwp-wrap">
+      <input type="checkbox" id="rwp-toggle" class="rwp-checkbox">
+      <label for="rwp-toggle" class="rwp-trigger">
+        Account Balance
+        <span class="rwp-ripple"></span>
+      </label>
+      <div class="rwp-popover">
+        <div class="rwp-popover-inner">
+          <h4>$48,203.12</h4>
+          <p>+2.4% this week</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ripple-wave-popover-aa/style.css
+++ b/submissions/examples/ripple-wave-popover-aa/style.css
@@ -1,0 +1,122 @@
+.rwp-dashboard {
+  min-height: 260px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px;
+  background: #0f1115;
+  font-family: system-ui, sans-serif;
+}
+
+.rwp-wrap {
+  position: relative;
+  display: inline-block;
+}
+
+.rwp-checkbox {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.rwp-trigger {
+  position: relative;
+  overflow: hidden;
+  display: inline-block;
+  padding: 14px 26px;
+  border-radius: 10px;
+  background: #4f46e5;
+  color: #fff;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  isolation: isolate;
+  transition: transform 0.15s ease;
+}
+
+.rwp-trigger:active {
+  transform: scale(0.97);
+}
+
+.rwp-ripple {
+  position: absolute;
+  inset: 0;
+  border-radius: 10px;
+}
+
+.rwp-ripple::before {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 0;
+  height: 0;
+  border-radius: 50%;
+  background: rgba(255,255,255,0.35);
+  transform: translate(-50%, -50%);
+  opacity: 0;
+}
+
+.rwp-checkbox:checked ~ .rwp-trigger .rwp-ripple::before {
+  animation: rwp-ripple-expand 0.6s ease-out;
+}
+
+@keyframes rwp-ripple-expand {
+  0%   { width: 0;    height: 0;    opacity: 0.6; }
+  100% { width: 260px; height: 260px; opacity: 0; }
+}
+
+.rwp-popover {
+  position: absolute;
+  top: calc(100% + 12px);
+  left: 50%;
+  transform: translateX(-50%) translateY(-8px) scale(0.92);
+  min-width: 220px;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.25s ease, transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1), visibility 0.25s;
+}
+
+.rwp-checkbox:checked ~ .rwp-popover {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.rwp-popover-inner {
+  background: #1a1d24;
+  border: 1px solid #2a2e37;
+  border-radius: 12px;
+  padding: 18px 20px;
+  box-shadow: 0 12px 32px rgba(0,0,0,0.4);
+  text-align: center;
+}
+
+.rwp-popover-inner h4 {
+  margin: 0 0 4px;
+  color: #fff;
+  font-size: 20px;
+}
+
+.rwp-popover-inner p {
+  margin: 0;
+  color: #22c55e;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+@media (max-width: 480px) {
+  .rwp-popover { min-width: 180px; }
+  .rwp-trigger { font-size: 14px; padding: 12px 20px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rwp-checkbox:checked ~ .rwp-trigger .rwp-ripple::before {
+    animation: none;
+  }
+  .rwp-popover {
+    transition: opacity 0.15s ease;
+  }
+}


### PR DESCRIPTION
Closes #59247
## Pull Request Description
Adds a pure CSS "ripple-wave popover" component for fintech-style dashboards. Clicking a trigger element (e.g. an account balance label) plays a ripple expansion animation and reveals a popover with detail content — no JavaScript required.

---
## Type of Change
- [x] 🧩 New component

---
## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/ripple-wave-popover-aa/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
A checkbox-hack-based popover trigger with a ripple-wave click animation, suited to fintech/dashboard UI patterns.

**How does a developer use it?**
```html
<div class="rwp-wrap">
  <input type="checkbox" id="rwp-toggle" class="rwp-checkbox">
  <label for="rwp-toggle" class="rwp-trigger">
    Account Balance
    <span class="rwp-ripple"></span>
  </label>
  <div class="rwp-popover">
    <div class="rwp-popover-inner">
      <h4>$48,203.12</h4>
      <p>+2.4% this week</p>
    </div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
Pure CSS/HTML — no JS frameworks — using the checkbox hack for interactivity, a keyframe-driven ripple, and a spring-eased popover reveal. Fully responsive down to mobile widths, with a `prefers-reduced-motion` fallback that disables the ripple and shortens the transition, in line with the project's animation-first, accessible philosophy.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---
## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---
## Notes for Maintainer
Recreated this branch from scratch after a local git mishap caused the original branch ref to lose its unique commit — content is otherwise unchanged from the original submission (#59247).