### PR TITLE
feat: add CSS skew-active popover for fintech dashboards (#59235)

### DIFF
--- a/submissions/examples/skew-active-popover-aa/README.md
+++ b/submissions/examples/skew-active-popover-aa/README.md
@@ -1,0 +1,23 @@
+# skew-active-popover-aa
+
+**What does this do?**
+A pure CSS "skew-active" popover for fintech dashboard layouts — the trigger skews on hover and activation, and the popover un-skews into place as it reveals, giving a snappy, editorial feel with no JavaScript required.
+
+**How is it used?**
+```html
+<div class="sap-wrap">
+  <input type="checkbox" id="sap-toggle" class="sap-checkbox">
+  <label for="sap-toggle" class="sap-trigger">
+    Account Balance
+  </label>
+  <div class="sap-popover">
+    <div class="sap-popover-inner">
+      <h4>$48,203.12</h4>
+      <p>+2.4% this week</p>
+    </div>
+  </div>
+</div>
+```
+
+**Why is it useful?**
+Uses the checkbox-hack for pure CSS/HTML interactivity (no JS frameworks). The trigger skews on hover (`skewX(-6deg)`) and skews further with a slight scale on activation, while the popover enters un-skewing from an offset angle with a spring-eased transition — matching EaseMotion's animation-first philosophy. Fully responsive down to mobile widths, with a `prefers-reduced-motion` fallback that removes all skew/transform effects and shortens transitions to a simple fade.

--- a/submissions/examples/skew-active-popover-aa/demo.html
+++ b/submissions/examples/skew-active-popover-aa/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Skew-Active Popover</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="sap-dashboard">
+    <div class="sap-wrap">
+      <input type="checkbox" id="sap-toggle" class="sap-checkbox">
+      <label for="sap-toggle" class="sap-trigger">
+        Account Balance
+      </label>
+      <div class="sap-popover">
+        <div class="sap-popover-inner">
+          <h4>$48,203.12</h4>
+          <p>+2.4% this week</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/skew-active-popover-aa/style.css
+++ b/submissions/examples/skew-active-popover-aa/style.css
@@ -1,0 +1,106 @@
+.sap-dashboard {
+  min-height: 260px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px;
+  background: #0f1115;
+  font-family: system-ui, sans-serif;
+}
+
+.sap-wrap {
+  position: relative;
+  display: inline-block;
+}
+
+.sap-checkbox {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.sap-trigger {
+  position: relative;
+  display: inline-block;
+  padding: 14px 26px;
+  border-radius: 10px;
+  background: #4f46e5;
+  color: #fff;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  transform-origin: center;
+  transition: transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1),
+              background 0.25s ease;
+}
+
+.sap-trigger:hover {
+  transform: skewX(-6deg);
+}
+
+.sap-checkbox:checked ~ .sap-trigger {
+  transform: skewX(-10deg) scale(1.03);
+  background: #4338ca;
+}
+
+.sap-popover {
+  position: absolute;
+  top: calc(100% + 12px);
+  left: 50%;
+  transform: translateX(-50%) skewX(8deg) translateY(-8px);
+  min-width: 220px;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.3s ease,
+              transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1),
+              visibility 0.3s;
+}
+
+.sap-checkbox:checked ~ .sap-popover {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) skewX(0deg) translateY(0);
+  pointer-events: auto;
+}
+
+.sap-popover-inner {
+  background: #1a1d24;
+  border: 1px solid #2a2e37;
+  border-radius: 12px;
+  padding: 18px 20px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.4);
+  text-align: center;
+}
+
+.sap-popover-inner h4 {
+  margin: 0 0 4px;
+  color: #fff;
+  font-size: 20px;
+}
+
+.sap-popover-inner p {
+  margin: 0;
+  color: #22c55e;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+@media (max-width: 480px) {
+  .sap-popover { min-width: 180px; }
+  .sap-trigger { font-size: 14px; padding: 12px 20px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sap-trigger,
+  .sap-popover {
+    transition: opacity 0.15s ease;
+  }
+  .sap-trigger:hover,
+  .sap-checkbox:checked ~ .sap-trigger {
+    transform: none;
+  }
+  .sap-checkbox:checked ~ .sap-popover {
+    transform: translateX(-50%) translateY(0);
+  }
+}


### PR DESCRIPTION
Closes #59235 
## Pull Request Description
Adds a pure CSS "skew-active" popover for fintech-style dashboards. The trigger skews on hover and activation, and the popover un-skews into place as it reveals — no JavaScript required.

---
## Type of Change
- [x] 🧩 New component

---
## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/skew-active-popover-aa/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
A checkbox-hack-based popover trigger with a skew-tilt animation on hover/activation, suited to fintech/dashboard UI patterns.

**How does a developer use it?**
```html
<div class="sap-wrap">
  <input type="checkbox" id="sap-toggle" class="sap-checkbox">
  <label for="sap-toggle" class="sap-trigger">
    Account Balance
  </label>
  <div class="sap-popover">
    <div class="sap-popover-inner">
      <h4>$48,203.12</h4>
      <p>+2.4% this week</p>
    </div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
Pure CSS/HTML — no JS frameworks — using the checkbox hack for interactivity, with a spring-eased skew transform on the trigger and popover reveal. Fully responsive down to mobile widths, with a `prefers-reduced-motion` fallback that removes all skew/transform effects, in line with the project's animation-first, accessible philosophy.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---
## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

---
## Notes for Maintainer
Implements #59235 (skew-active popover, not the earlier ripple-wave submission).