### PR TITLE
feat: add blur entrance tabs example

### DIFF
--- a/submissions/examples/blur-entrance-tabs-v/README.md
+++ b/submissions/examples/blur-entrance-tabs-v/README.md
@@ -1,0 +1,25 @@
+# Blur-Entrance Tabs
+
+A responsive fintech dashboard tab component featuring a smooth
+blur-and-fade entrance animation.
+
+## Features
+
+- Pure HTML and CSS
+- No JavaScript
+- No external dependencies
+- Blur + fade entrance animation
+- CSS-only tab switching
+- Responsive desktop, tablet, and mobile layouts
+- CSS custom properties for easy customization
+- Accessible reduced-motion support
+- Fintech dashboard styling
+- Keyboard-friendly native radio controls
+
+## Files
+
+```text
+blur-entrance-tabs/
+├── demo.html
+├── style.css
+└── README.md

--- a/submissions/examples/blur-entrance-tabs-v/demo.html
+++ b/submissions/examples/blur-entrance-tabs-v/demo.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta
+    name="description"
+    content="Blur-Entrance Tabs for fintech dashboard layouts"
+  >
+  <title>Blur-Entrance Tabs | EaseMotion CSS</title>
+
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+  <main class="dashboard">
+    <section class="dashboard-header">
+      <div>
+        <p class="eyebrow">FINTECH DASHBOARD</p>
+        <h1>Financial Overview</h1>
+        <p class="subtitle">
+          Track your financial activity with a smooth blur-entrance tab interface.
+        </p>
+      </div>
+
+      <div class="balance">
+        <span>Total Balance</span>
+        <strong>$24,680.50</strong>
+      </div>
+    </section>
+
+    <section class="tabs-demo" aria-labelledby="tabs-title">
+      <h2 id="tabs-title">Account Activity</h2>
+
+      <div class="tab-list" role="tablist" aria-label="Financial information">
+        <input
+          type="radio"
+          name="finance-tab"
+          id="overview"
+          checked
+        >
+        <label class="tab" for="overview" role="tab">
+          Overview
+        </label>
+
+        <input
+          type="radio"
+          name="finance-tab"
+          id="transactions"
+        >
+        <label class="tab" for="transactions" role="tab">
+          Transactions
+        </label>
+
+        <input
+          type="radio"
+          name="finance-tab"
+          id="analytics"
+        >
+        <label class="tab" for="analytics" role="tab">
+          Analytics
+        </label>
+
+        <input
+          type="radio"
+          name="finance-tab"
+          id="payments"
+        >
+        <label class="tab" for="payments" role="tab">
+          Payments
+        </label>
+      </div>
+
+      <div class="tab-panels">
+
+        <article class="tab-panel panel-overview">
+          <div class="panel-heading">
+            <div>
+              <span class="panel-label">Current Balance</span>
+              <h3>$24,680.50</h3>
+            </div>
+            <span class="status positive">+12.8%</span>
+          </div>
+
+          <div class="stats">
+            <div class="stat-card">
+              <span>Income</span>
+              <strong>$8,420</strong>
+              <small>+8.4% this month</small>
+            </div>
+
+            <div class="stat-card">
+              <span>Expenses</span>
+              <strong>$3,180</strong>
+              <small>-4.2% this month</small>
+            </div>
+
+            <div class="stat-card">
+              <span>Savings</span>
+              <strong>$5,240</strong>
+              <small>+15.6% this month</small>
+            </div>
+          </div>
+
+          <div class="chart">
+            <div class="chart-line"></div>
+            <div class="chart-grid"></div>
+          </div>
+        </article>
+
+        <article class="tab-panel panel-transactions">
+          <div class="panel-heading">
+            <div>
+              <span class="panel-label">Recent Transactions</span>
+              <h3>Activity</h3>
+            </div>
+            <span class="status neutral">12 Items</span>
+          </div>
+
+          <div class="transactions">
+            <div class="transaction">
+              <div class="transaction-icon">S</div>
+              <div>
+                <strong>Salary Credit</strong>
+                <span>Today, 09:30 AM</span>
+              </div>
+              <b class="income">+$4,200</b>
+            </div>
+
+            <div class="transaction">
+              <div class="transaction-icon">A</div>
+              <div>
+                <strong>Amazon Purchase</strong>
+                <span>Yesterday, 05:42 PM</span>
+              </div>
+              <b class="expense">-$128</b>
+            </div>
+
+            <div class="transaction">
+              <div class="transaction-icon">N</div>
+              <div>
+                <strong>Netflix Subscription</strong>
+                <span>Aug 02, 08:15 PM</span>
+              </div>
+              <b class="expense">-$18</b>
+            </div>
+          </div>
+        </article>
+
+        <article class="tab-panel panel-analytics">
+          <div class="panel-heading">
+            <div>
+              <span class="panel-label">Financial Analytics</span>
+              <h3>Monthly Performance</h3>
+            </div>
+            <span class="status positive">Healthy</span>
+          </div>
+
+          <div class="analytics">
+            <div class="metric">
+              <span>Net Growth</span>
+              <strong>18.4%</strong>
+              <div class="metric-bar">
+                <i style="width: 82%"></i>
+              </div>
+            </div>
+
+            <div class="metric">
+              <span>Savings Rate</span>
+              <strong>64%</strong>
+              <div class="metric-bar">
+                <i style="width: 64%"></i>
+              </div>
+            </div>
+
+            <div class="metric">
+              <span>Investment Return</span>
+              <strong>27.6%</strong>
+              <div class="metric-bar">
+                <i style="width: 76%"></i>
+              </div>
+            </div>
+          </div>
+        </article>
+
+        <article class="tab-panel panel-payments">
+          <div class="panel-heading">
+            <div>
+              <span class="panel-label">Payment Methods</span>
+              <h3>Connected Accounts</h3>
+            </div>
+          </div>
+
+          <div class="payment-grid">
+            <div class="payment-card">
+              <span class="payment-type">VISA</span>
+              <strong>•••• 4821</strong>
+              <small>Primary card</small>
+            </div>
+
+            <div class="payment-card">
+              <span class="payment-type">BANK</span>
+              <strong>•••• 9034</strong>
+              <small>Checking account</small>
+            </div>
+
+            <div class="payment-card">
+              <span class="payment-type">UPI</span>
+              <strong>srujana@upi</strong>
+              <small>Connected</small>
+            </div>
+          </div>
+        </article>
+
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/blur-entrance-tabs-v/style.css
+++ b/submissions/examples/blur-entrance-tabs-v/style.css
@@ -1,0 +1,493 @@
+:root {
+    --ease-bg: #08111f;
+    --ease-surface: #101c2d;
+    --ease-surface-light: #17253a;
+    --ease-border: rgba(255, 255, 255, 0.09);
+    --ease-text: #f4f7fb;
+    --ease-muted: #8d9aab;
+    --ease-primary: #5b8cff;
+    --ease-success: #39d98a;
+    --ease-danger: #ff6b7a;
+  
+    --ease-radius: 18px;
+    --ease-speed-fast: 180ms;
+    --ease-speed-medium: 400ms;
+    --ease-speed-slow: 700ms;
+    --ease-easing: cubic-bezier(0.22, 1, 0.36, 1);
+  }
+  
+  * {
+    box-sizing: border-box;
+  }
+  
+  body {
+    margin: 0;
+    min-height: 100vh;
+    font-family:
+      Inter,
+      ui-sans-serif,
+      system-ui,
+      -apple-system,
+      BlinkMacSystemFont,
+      "Segoe UI",
+      sans-serif;
+    background:
+      radial-gradient(circle at top right, #172c4a, transparent 35%),
+      var(--ease-bg);
+    color: var(--ease-text);
+  }
+  
+  .dashboard {
+    width: min(1100px, calc(100% - 32px));
+    margin: 0 auto;
+    padding: 64px 0;
+  }
+  
+  .dashboard-header {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 32px;
+    margin-bottom: 36px;
+    animation: blur-entrance var(--ease-speed-slow) var(--ease-easing) both;
+  }
+  
+  .eyebrow {
+    margin: 0 0 8px;
+    color: var(--ease-primary);
+    font-size: 0.75rem;
+    font-weight: 800;
+    letter-spacing: 0.16em;
+  }
+  
+  h1,
+  h2,
+  h3,
+  p {
+    margin-top: 0;
+  }
+  
+  h1 {
+    margin-bottom: 10px;
+    font-size: clamp(2rem, 5vw, 3.5rem);
+    line-height: 1;
+  }
+  
+  .subtitle {
+    max-width: 580px;
+    margin-bottom: 0;
+    color: var(--ease-muted);
+    line-height: 1.7;
+  }
+  
+  .balance {
+    min-width: 210px;
+    padding: 20px;
+    border: 1px solid var(--ease-border);
+    border-radius: var(--ease-radius);
+    background: rgba(16, 28, 45, 0.8);
+    backdrop-filter: blur(12px);
+  }
+  
+  .balance span,
+  .panel-label,
+  .stat-card span,
+  .metric span {
+    display: block;
+    color: var(--ease-muted);
+    font-size: 0.8rem;
+  }
+  
+  .balance strong {
+    display: block;
+    margin-top: 8px;
+    font-size: 1.7rem;
+  }
+  
+  .tabs-demo {
+    overflow: hidden;
+    border: 1px solid var(--ease-border);
+    border-radius: 24px;
+    background: rgba(16, 28, 45, 0.88);
+    box-shadow: 0 30px 80px rgba(0, 0, 0, 0.25);
+    animation: blur-entrance 800ms var(--ease-easing) 100ms both;
+  }
+  
+  .tabs-demo > h2 {
+    padding: 28px 28px 0;
+    margin-bottom: 22px;
+    font-size: 1.25rem;
+  }
+  
+  .tab-list {
+    display: flex;
+    gap: 6px;
+    padding: 0 28px;
+    border-bottom: 1px solid var(--ease-border);
+  }
+  
+  .tab-list input {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+  }
+  
+  .tab {
+    position: relative;
+    padding: 14px 18px;
+    color: var(--ease-muted);
+    cursor: pointer;
+    font-size: 0.9rem;
+    font-weight: 700;
+    transition:
+      color var(--ease-speed-fast) ease,
+      background var(--ease-speed-fast) ease;
+  }
+  
+  .tab:hover {
+    color: var(--ease-text);
+  }
+  
+  .tab::after {
+    content: "";
+    position: absolute;
+    right: 14px;
+    bottom: -1px;
+    left: 14px;
+    height: 2px;
+    background: var(--ease-primary);
+    transform: scaleX(0);
+    transition: transform var(--ease-speed-medium) var(--ease-easing);
+  }
+  
+  .tab-panels {
+    position: relative;
+    min-height: 400px;
+  }
+  
+  .tab-panel {
+    display: none;
+    padding: 32px;
+  }
+  
+  #overview:checked ~ .tab-panels .panel-overview,
+  #transactions:checked ~ .tab-panels .panel-transactions,
+  #analytics:checked ~ .tab-panels .panel-analytics,
+  #payments:checked ~ .tab-panels .panel-payments {
+    display: block;
+    animation: blur-entrance var(--ease-speed-medium) var(--ease-easing) both;
+  }
+  
+  #overview:checked + .tab,
+  #transactions:checked + .tab,
+  #analytics:checked + .tab,
+  #payments:checked + .tab {
+    color: var(--ease-text);
+  }
+  
+  #overview:checked + .tab::after,
+  #transactions:checked + .tab::after,
+  #analytics:checked + .tab::after,
+  #payments:checked + .tab::after {
+    transform: scaleX(1);
+  }
+  
+  .panel-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 20px;
+    margin-bottom: 28px;
+  }
+  
+  .panel-heading h3 {
+    margin: 7px 0 0;
+    font-size: 1.8rem;
+  }
+  
+  .status {
+    padding: 7px 12px;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 800;
+  }
+  
+  .positive {
+    color: var(--ease-success);
+    background: rgba(57, 217, 138, 0.1);
+  }
+  
+  .neutral {
+    color: var(--ease-muted);
+    background: rgba(255, 255, 255, 0.06);
+  }
+  
+  .stats {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 16px;
+  }
+  
+  .stat-card {
+    padding: 22px;
+    border: 1px solid var(--ease-border);
+    border-radius: 14px;
+    background: var(--ease-surface-light);
+  }
+  
+  .stat-card strong {
+    display: block;
+    margin: 8px 0;
+    font-size: 1.5rem;
+  }
+  
+  .stat-card small {
+    color: var(--ease-success);
+  }
+  
+  .chart {
+    position: relative;
+    height: 150px;
+    margin-top: 24px;
+    overflow: hidden;
+    border-radius: 14px;
+    background:
+      linear-gradient(
+        to bottom,
+        transparent 24%,
+        var(--ease-border) 25%,
+        transparent 26%,
+        transparent 49%,
+        var(--ease-border) 50%,
+        transparent 51%,
+        transparent 74%,
+        var(--ease-border) 75%,
+        transparent 76%
+      );
+  }
+  
+  .chart-line {
+    position: absolute;
+    inset: 30px 0 20px;
+    background: linear-gradient(
+      135deg,
+      transparent 0 10%,
+      var(--ease-primary) 10% 11%,
+      transparent 11% 22%,
+      var(--ease-primary) 22% 23%,
+      transparent 23% 36%,
+      var(--ease-primary) 36% 37%,
+      transparent 37% 49%,
+      var(--ease-primary) 49% 50%,
+      transparent 50% 65%,
+      var(--ease-primary) 65% 66%,
+      transparent 66% 79%,
+      var(--ease-primary) 79% 80%,
+      transparent 80%
+    );
+    clip-path: polygon(
+      0 80%,
+      10% 70%,
+      22% 62%,
+      36% 68%,
+      49% 40%,
+      65% 55%,
+      79% 25%,
+      100% 5%,
+      100% 100%,
+      0 100%
+    );
+    opacity: 0.85;
+  }
+  
+  .transactions {
+    display: grid;
+    gap: 12px;
+  }
+  
+  .transaction {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 14px;
+    padding: 16px;
+    border: 1px solid var(--ease-border);
+    border-radius: 14px;
+    background: var(--ease-surface-light);
+  }
+  
+  .transaction-icon {
+    display: grid;
+    width: 42px;
+    height: 42px;
+    place-items: center;
+    border-radius: 12px;
+    background: rgba(91, 140, 255, 0.12);
+    color: var(--ease-primary);
+    font-weight: 800;
+  }
+  
+  .transaction strong,
+  .transaction span {
+    display: block;
+  }
+  
+  .transaction span {
+    margin-top: 4px;
+    color: var(--ease-muted);
+    font-size: 0.75rem;
+  }
+  
+  .income {
+    color: var(--ease-success);
+  }
+  
+  .expense {
+    color: var(--ease-danger);
+  }
+  
+  .analytics {
+    display: grid;
+    gap: 22px;
+  }
+  
+  .metric {
+    padding: 20px;
+    border: 1px solid var(--ease-border);
+    border-radius: 14px;
+    background: var(--ease-surface-light);
+  }
+  
+  .metric strong {
+    display: block;
+    margin: 8px 0 14px;
+    font-size: 1.4rem;
+  }
+  
+  .metric-bar {
+    height: 8px;
+    overflow: hidden;
+    border-radius: 99px;
+    background: rgba(255, 255, 255, 0.08);
+  }
+  
+  .metric-bar i {
+    display: block;
+    height: 100%;
+    border-radius: inherit;
+    background: var(--ease-primary);
+    transform-origin: left;
+    animation: progress-entrance 600ms var(--ease-easing) both;
+  }
+  
+  .payment-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 16px;
+  }
+  
+  .payment-card {
+    display: grid;
+    gap: 12px;
+    min-height: 150px;
+    padding: 22px;
+    border: 1px solid var(--ease-border);
+    border-radius: 16px;
+    background:
+      linear-gradient(
+        135deg,
+        rgba(91, 140, 255, 0.15),
+        var(--ease-surface-light)
+      );
+  }
+  
+  .payment-type {
+    color: var(--ease-primary);
+    font-size: 0.75rem;
+    font-weight: 900;
+    letter-spacing: 0.1em;
+  }
+  
+  .payment-card strong {
+    align-self: center;
+    font-size: 1.1rem;
+  }
+  
+  .payment-card small {
+    color: var(--ease-muted);
+  }
+  
+  @keyframes blur-entrance {
+    from {
+      opacity: 0;
+      filter: blur(14px);
+      transform: translateY(14px);
+    }
+  
+    to {
+      opacity: 1;
+      filter: blur(0);
+      transform: translateY(0);
+    }
+  }
+  
+  @keyframes progress-entrance {
+    from {
+      transform: scaleX(0);
+    }
+  
+    to {
+      transform: scaleX(1);
+    }
+  }
+  
+  @media (max-width: 760px) {
+    .dashboard {
+      width: min(100% - 20px, 680px);
+      padding: 30px 0;
+    }
+  
+    .dashboard-header {
+      align-items: stretch;
+      flex-direction: column;
+    }
+  
+    .balance {
+      width: 100%;
+    }
+  
+    .tab-list {
+      overflow-x: auto;
+      padding: 0 14px;
+    }
+  
+    .tab {
+      flex: 0 0 auto;
+      padding: 14px;
+    }
+  
+    .tab-panel {
+      padding: 22px;
+    }
+  
+    .stats,
+    .payment-grid {
+      grid-template-columns: 1fr;
+    }
+  
+    .panel-heading {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+  }
+  
+  @media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+      scroll-behavior: auto !important;
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+    }
+  }


### PR DESCRIPTION
## Description

Implemented the CSS Blur-Entrance Tabs for Fintech Dashboard Layouts.

### Changes

- Added `demo.html`
- Added `style.css`
- Added `README.md`
- Added CSS-only tab switching
- Added blur-entrance animation
- Added responsive layouts
- Added CSS custom properties
- Added `prefers-reduced-motion` support
- No JavaScript or external frameworks used

Closes #59227