### PR TITLE
Add ease-gramophone-needle-track component

### DIFF
--- a/submissions/examples/ease-gramophone-needle-track-ij/README.md
+++ b/submissions/examples/ease-gramophone-needle-track-ij/README.md
@@ -1,0 +1,7 @@
+# ease-gramophone-needle-track
+A vintage gramophone whose record spins beneath the tonearm.
+## Run
+Open `demo.html` directly in a browser to watch the record turn.
+## Notes
+- The needle tracks the grooves as the record rotates.
+- The horn glints beside the polished base.

--- a/submissions/examples/ease-gramophone-needle-track-ij/demo.html
+++ b/submissions/examples/ease-gramophone-needle-track-ij/demo.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-gramophone-needle-track demo</title>
+</head>
+<body>
+<div class="gm-app">
+  <div class="gm-desk">
+    <div class="gm-base"></div>
+    <div class="gm-record">
+      <div class="gm-label"></div>
+      <span class="gm-groove gm-groove-1"></span>
+      <span class="gm-groove gm-groove-2"></span>
+      <span class="gm-groove gm-groove-3"></span>
+    </div>
+    <div class="gm-tonearm">
+      <div class="gm-head"></div>
+      <div class="gm-needle"></div>
+    </div>
+    <div class="gm-horn"></div>
+    <div class="gm-crank"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/ease-gramophone-needle-track-ij/style.css
+++ b/submissions/examples/ease-gramophone-needle-track-ij/style.css
@@ -1,0 +1,19 @@
+:root{--gm-wood:#7a5230;--gm-brass:#c8a64a;--gm-vinyl:#1c1c24}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#5a4432,#2e2016);font-family:'Georgia',serif}
+.gm-app{position:relative;width:372px;height:372px;border-radius:18px;background:linear-gradient(180deg,#6a4a32,#33241a);box-shadow:0 16px 36px rgba(0,0,0,0.55);padding:20px}
+.gm-desk{position:relative;height:332px;border-radius:12px;background:var(--gm-wood);box-shadow:inset 0 8px 0 rgba(255,255,255,0.08),0 8px 14px rgba(0,0,0,0.4)}
+.gm-base{position:absolute;bottom:0;left:0;right:0;height:18px;border-radius:0 0 12px 12px;background:#5a3a22;box-shadow:0 5px 0 rgba(0,0,0,0.3)}
+.gm-record{position:absolute;left:50%;bottom:44px;width:150px;height:150px;margin-left:-75px;border-radius:50%;background:var(--gm-vinyl);box-shadow:0 0 0 4px #2a2a34,0 8px 14px rgba(0,0,0,0.5);animation:spin-record-gramophone-needle-track 4s linear infinite}
+.gm-label{position:absolute;top:50%;left:50%;width:40px;height:40px;margin:-20px;border-radius:50%;background:#d8c9a8;box-shadow:0 0 0 3px #c8a64a}
+.gm-groove{position:absolute;top:50%;left:50%;width:0;height:0;border-radius:50%;box-shadow:0 0 0 1px rgba(200,166,74,0.25)}
+.gm-groove-1{width:100px;height:100px;margin:-50px;box-shadow:inset 0 0 0 2px rgba(200,166,74,0.3)}
+.gm-groove-2{width:120px;height:120px;margin:-60px;box-shadow:inset 0 0 0 2px rgba(200,166,74,0.3)}
+.gm-groove-3{width:140px;height:140px;margin:-70px;box-shadow:inset 0 0 0 2px rgba(200,166,74,0.3)}
+.gm-tonearm{position:absolute;top:40px;right:46px;width:14px;height:130px;border-radius:7px;background:var(--gm-brass);transform-origin:top center;transform:rotate(24deg);animation:sway-tonearm-gramophone-needle-track 4s ease-in-out infinite}
+.gm-head{position:absolute;bottom:-6px;left:50%;margin-left:-12px;width:24px;height:16px;border-radius:6px;background:#8a6a2e}
+.gm-needle{position:absolute;bottom:-20px;left:50%;margin-left:-3px;width:6px;height:18px;border-radius:3px;background:#5a4a2e}
+.gm-horn{position:absolute;top:44px;left:34px;width:0;height:0;border-top:60px solid transparent;border-bottom:60px solid transparent;border-right:86px solid var(--gm-brass);filter:drop-shadow(2px 4px 4px rgba(0,0,0,0.35));animation:glint-horn-gramophone-needle-track 4s ease-in-out infinite}
+.gm-crank{position:absolute;bottom:22px;left:40px;width:10px;height:10px;border-radius:50%;background:#8a6a2e;box-shadow:14px 0 0 #5a3a22,28px 0 0 #8a6a2e}
+@keyframes spin-record-gramophone-needle-track{0%{transform:rotate(0deg)}100%{transform:rotate(360deg)}}
+@keyframes sway-tonearm-gramophone-needle-track{0%,100%{transform:rotate(24deg)}50%{transform:rotate(20deg)}}
+@keyframes glint-horn-gramophone-needle-track{0%,100%{opacity:1}50%{opacity:0.6}}


### PR DESCRIPTION
## Component: ease-gramophone-needle-track — record spins, arm sways, and horn glints

**Closes #60650**

### What this adds
A vintage gramophone: the record spins under the tonearm while the needle tracks the grooves, the horn flares beside it with a metal glint, and the crank waits at the front of the polished base.

### Acceptance Criteria covered
- Record spins under the tonearm
- Needle tracks across the grooves
- Horn glints beside the base

### Files
- submissions/examples/ease-gramophone-needle-track-ij/demo.html
- submissions/examples/ease-gramophone-needle-track-ij/style.css
- submissions/examples/ease-gramophone-needle-track-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the record turn.