### PR TITLE
feat: add CSS zoom-in popover for fintech dashboards (#59239)

### DIFF
--- a/submissions/examples/zoom-in-popover-aa/README.md
+++ b/submissions/examples/zoom-in-popover-aa/README.md
@@ -1,0 +1,23 @@
+# zoom-in-popover-aa
+
+**What does this do?**
+A pure CSS "zoom-in" popover for fintech dashboard layouts — the popover scales in from small to full size with a spring ease when the trigger is activated, no JavaScript required.
+
+**How is it used?**
+```html
+<div class="zip-wrap">
+  <input type="checkbox" id="zip-toggle" class="zip-checkbox">
+  <label for="zip-toggle" class="zip-trigger">
+    Account Balance
+  </label>
+  <div class="zip-popover">
+    <div class="zip-popover-inner">
+      <h4>$48,203.12</h4>
+      <p>+2.4% this week</p>
+    </div>
+  </div>
+</div>
+```
+
+**Why is it useful?**
+Uses the checkbox-hack for pure CSS/HTML interactivity (no JS frameworks), with a `scale()` transform from a small `transform-origin: top center` anchor and a spring-eased cubic-bezier curve for a punchy zoom-in reveal. Fully responsive down to mobile widths, with a `prefers-reduced-motion` fallback that removes the scale animation and falls back to a simple fade — matching EaseMotion's animation-first, accessible philosophy.

--- a/submissions/examples/zoom-in-popover-aa/demo.html
+++ b/submissions/examples/zoom-in-popover-aa/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Zoom-In Popover</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="zip-dashboard">
+    <div class="zip-wrap">
+      <input type="checkbox" id="zip-toggle" class="zip-checkbox">
+      <label for="zip-toggle" class="zip-trigger">
+        Account Balance
+      </label>
+      <div class="zip-popover">
+        <div class="zip-popover-inner">
+          <h4>$48,203.12</h4>
+          <p>+2.4% this week</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/zoom-in-popover-aa/style.css
+++ b/submissions/examples/zoom-in-popover-aa/style.css
@@ -1,0 +1,100 @@
+.zip-dashboard {
+  min-height: 260px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px;
+  background: #0f1115;
+  font-family: system-ui, sans-serif;
+}
+
+.zip-wrap {
+  position: relative;
+  display: inline-block;
+}
+
+.zip-checkbox {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.zip-trigger {
+  position: relative;
+  display: inline-block;
+  padding: 14px 26px;
+  border-radius: 10px;
+  background: #4f46e5;
+  color: #fff;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, background 0.25s ease;
+}
+
+.zip-trigger:hover {
+  background: #4338ca;
+}
+
+.zip-trigger:active {
+  transform: scale(0.97);
+}
+
+.zip-popover {
+  position: absolute;
+  top: calc(100% + 12px);
+  left: 50%;
+  transform: translateX(-50%) scale(0.4);
+  transform-origin: top center;
+  min-width: 220px;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.3s ease,
+              transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1),
+              visibility 0.3s;
+}
+
+.zip-checkbox:checked ~ .zip-popover {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) scale(1);
+  pointer-events: auto;
+}
+
+.zip-popover-inner {
+  background: #1a1d24;
+  border: 1px solid #2a2e37;
+  border-radius: 12px;
+  padding: 18px 20px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.4);
+  text-align: center;
+}
+
+.zip-popover-inner h4 {
+  margin: 0 0 4px;
+  color: #fff;
+  font-size: 20px;
+}
+
+.zip-popover-inner p {
+  margin: 0;
+  color: #22c55e;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+@media (max-width: 480px) {
+  .zip-popover { min-width: 180px; }
+  .zip-trigger { font-size: 14px; padding: 12px 20px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .zip-popover {
+    transition: opacity 0.15s ease;
+    transform: translateX(-50%) scale(1);
+  }
+  .zip-checkbox:checked ~ .zip-popover {
+    transform: translateX(-50%) scale(1);
+  }
+}


### PR DESCRIPTION
Closes #59239
## Pull Request Description
Adds a pure CSS "zoom-in" popover for fintech-style dashboards. The popover scales in from small to full size with a spring ease when the trigger is activated — no JavaScript required.

---
## Type of Change
- [x] 🧩 New component

---
## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/zoom-in-popover-aa/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
A checkbox-hack-based popover trigger with a scale-based zoom-in reveal, suited to fintech/dashboard UI patterns.

**How does a developer use it?**
```html
<div class="zip-wrap">
  <input type="checkbox" id="zip-toggle" class="zip-checkbox">
  <label for="zip-toggle" class="zip-trigger">
    Account Balance
  </label>
  <div class="zip-popover">
    <div class="zip-popover-inner">
      <h4>$48,203.12</h4>
      <p>+2.4% this week</p>
    </div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
Pure CSS/HTML — no JS frameworks — using the checkbox hack for interactivity, with a `scale()` transform from `transform-origin: top center` and a spring-eased cubic-bezier curve for the reveal. Fully responsive down to mobile widths, with a `prefers-reduced-motion` fallback that removes the scale animation in favor of a simple fade, in line with the project's animation-first, accessible philosophy.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---
## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

---
## Notes for Maintainer
Implements #59239 (zoom-in popover).