### PR TITLE
Add ease-metronome-tick-sway component

### DIFF
--- a/submissions/examples/ease-metronome-tick-sway-ij/README.md
+++ b/submissions/examples/ease-metronome-tick-sway-ij/README.md
@@ -1,0 +1,7 @@
+# ease-metronome-tick-sway
+A wooden metronome whose pendulum sways past the tempo window.
+## Run
+Open `demo.html` directly in a browser to watch the pendulum tick.
+## Notes
+- The weight rides up the rod as it swings.
+- The tempo scale marks 60, 120, and 208.

--- a/submissions/examples/ease-metronome-tick-sway-ij/demo.html
+++ b/submissions/examples/ease-metronome-tick-sway-ij/demo.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-metronome-tick-sway demo</title>
+</head>
+<body>
+<div class="mt-app">
+  <div class="mt-case">
+    <div class="mt-window"></div>
+    <div class="mt-pendulum">
+      <div class="mt-rod"></div>
+      <div class="mt-weight"></div>
+      <div class="mt-pivot"></div>
+    </div>
+    <span class="mt-scale mt-scale-1">60</span>
+    <span class="mt-scale mt-scale-2">120</span>
+    <span class="mt-scale mt-scale-3">208</span>
+    <div class="mt-base"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/ease-metronome-tick-sway-ij/style.css
+++ b/submissions/examples/ease-metronome-tick-sway-ij/style.css
@@ -1,0 +1,16 @@
+:root{--mt-wood:#8a5a34;--mt-dark:#5a3a22;--mt-steel:#c8ced8}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#6a7a8a,#2c3844);font-family:'Georgia',serif}
+.mt-app{position:relative;width:372px;height:372px;border-radius:18px;background:linear-gradient(180deg,#7a8a9a,#3a4a58);box-shadow:0 16px 36px rgba(0,0,0,0.5);display:flex;align-items:flex-end;justify-content:center}
+.mt-case{position:relative;width:120px;height:284px;border-radius:14px;background:linear-gradient(90deg,var(--mt-dark),var(--mt-wood),var(--mt-dark));box-shadow:inset 0 -10px 0 rgba(0,0,0,0.25),0 14px 24px rgba(0,0,0,0.45)}
+.mt-window{position:absolute;top:34px;left:50%;margin-left:-30px;width:60px;height:120px;border-radius:8px;background:#10141a;border:3px solid var(--mt-dark);overflow:hidden}
+.mt-pendulum{position:absolute;top:44px;left:50%;margin-left:-6px;width:12px;height:150px;transform-origin:top center;animation:tick-pendulum-metronome-tick-sway 1s ease-in-out infinite}
+.mt-rod{position:absolute;top:0;left:50%;width:4px;height:150px;margin-left:-2px;background:var(--mt-steel)}
+.mt-weight{position:absolute;top:60px;left:50%;width:34px;height:34px;margin-left:-17px;border-radius:8px;background:#c8a64a;box-shadow:0 4px 0 rgba(0,0,0,0.3);animation:slide-weight-metronome-tick-sway 2s ease-in-out infinite}
+.mt-pivot{position:absolute;top:-8px;left:50%;width:20px;height:20px;margin-left:-10px;border-radius:50%;background:#c8a64a;box-shadow:0 0 0 4px var(--mt-dark)}
+.mt-scale{position:absolute;right:10px;color:#f3ead8;font-size:10px;font-weight:bold;text-align:right}
+.mt-scale-1{top:64px}
+.mt-scale-2{top:100px}
+.mt-scale-3{top:136px}
+.mt-base{position:absolute;bottom:-12px;left:50%;margin-left:-52px;width:104px;height:16px;border-radius:8px;background:var(--mt-dark);box-shadow:0 5px 0 rgba(0,0,0,0.35)}
+@keyframes tick-pendulum-metronome-tick-sway{0%,100%{transform:rotate(-22deg)}50%{transform:rotate(22deg)}}
+@keyframes slide-weight-metronome-tick-sway{0%,100%{transform:translateX(0)}50%{transform:translateX(6px)}}


### PR DESCRIPTION
## Component: ease-metronome-tick-sway — pendulum ticks, weight slides, and scale glows

**Closes #60660**

### What this adds
A wooden metronome: the pendulum sways past the window while the sliding weight sits on the rod, the tempo scale shows 60, 120, and 208, and the base holds the pyramid steady on the stand.

### Acceptance Criteria covered
- Pendulum sways past the window
- Weight rides up the rod
- Tempo scale marks the case

### Files
- submissions/examples/ease-metronome-tick-sway-ij/demo.html
- submissions/examples/ease-metronome-tick-sway-ij/style.css
- submissions/examples/ease-metronome-tick-sway-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the pendulum tick.