### PR TITLE
feat: add CSS fade-in pricing table for gaming hub layouts (#59146)

### DIFF
--- a/submissions/examples/fade-in-pricing-table-aa/README.md
+++ b/submissions/examples/fade-in-pricing-table-aa/README.md
@@ -1,0 +1,31 @@
+# fade-in-pricing-table-aa
+
+**What does this do?**
+A pure CSS pricing table for gaming hub layouts — three plan cards fade in and slide up on page load with a staggered delay, with the featured tier scaled and highlighted, no JavaScript required.
+
+**How is it used?**
+```html
+<div class="fpt-grid">
+  <div class="fpt-card">
+    <h3 class="fpt-tier">Starter</h3>
+    <p class="fpt-price">$0<span>/mo</span></p>
+    <ul class="fpt-features">
+      <li>5 game servers</li>
+    </ul>
+    <button class="fpt-cta">Get Started</button>
+  </div>
+
+  <div class="fpt-card fpt-card--featured">
+    <span class="fpt-badge">Most Popular</span>
+    <h3 class="fpt-tier">Pro Gamer</h3>
+    <p class="fpt-price">$19<span>/mo</span></p>
+    <ul class="fpt-features">
+      <li>Unlimited servers</li>
+    </ul>
+    <button class="fpt-cta">Get Started</button>
+  </div>
+</div>
+```
+
+**Why is it useful?**
+Pure CSS/HTML — no JS frameworks — using `@keyframes` with per-card `animation-delay` for a staggered fade-in-up entrance, and a `fpt-card--featured` modifier for a scaled, highlighted plan card with a glow shadow. Fully responsive (collapses to a single column below 820px, with the featured scale reset to avoid overflow), and includes a `prefers-reduced-motion` fallback that disables the animation and shows cards in their final state immediately — matching EaseMotion's animation-first, accessible philosophy.

--- a/submissions/examples/fade-in-pricing-table-aa/demo.html
+++ b/submissions/examples/fade-in-pricing-table-aa/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Fade-In Pricing Table</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="fpt-hub">
+    <div class="fpt-grid">
+
+      <div class="fpt-card">
+        <h3 class="fpt-tier">Starter</h3>
+        <p class="fpt-price">$0<span>/mo</span></p>
+        <ul class="fpt-features">
+          <li>5 game servers</li>
+          <li>Community support</li>
+          <li>Basic analytics</li>
+        </ul>
+        <button class="fpt-cta">Get Started</button>
+      </div>
+
+      <div class="fpt-card fpt-card--featured">
+        <span class="fpt-badge">Most Popular</span>
+        <h3 class="fpt-tier">Pro Gamer</h3>
+        <p class="fpt-price">$19<span>/mo</span></p>
+        <ul class="fpt-features">
+          <li>Unlimited servers</li>
+          <li>Priority support</li>
+          <li>Advanced analytics</li>
+          <li>Custom mods</li>
+        </ul>
+        <button class="fpt-cta">Get Started</button>
+      </div>
+
+      <div class="fpt-card">
+        <h3 class="fpt-tier">Guild</h3>
+        <p class="fpt-price">$49<span>/mo</span></p>
+        <ul class="fpt-features">
+          <li>Everything in Pro</li>
+          <li>Dedicated hosting</li>
+          <li>24/7 support</li>
+        </ul>
+        <button class="fpt-cta">Get Started</button>
+      </div>
+
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/fade-in-pricing-table-aa/style.css
+++ b/submissions/examples/fade-in-pricing-table-aa/style.css
@@ -1,0 +1,161 @@
+.fpt-hub {
+  min-height: 100vh;
+  padding: 60px 24px;
+  background: radial-gradient(circle at top, #1a1035 0%, #0a0714 70%);
+  font-family: system-ui, sans-serif;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.fpt-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(220px, 280px));
+  gap: 24px;
+}
+
+.fpt-card {
+  position: relative;
+  background: #15102b;
+  border: 1px solid #2e2455;
+  border-radius: 16px;
+  padding: 32px 24px;
+  text-align: center;
+  color: #e5e0ff;
+  opacity: 0;
+  transform: translateY(24px);
+  animation: fpt-fade-in 0.6s ease forwards;
+}
+
+.fpt-card:nth-child(1) { animation-delay: 0.1s; }
+.fpt-card:nth-child(2) { animation-delay: 0.3s; }
+.fpt-card:nth-child(3) { animation-delay: 0.5s; }
+
+@keyframes fpt-fade-in {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.fpt-card--featured {
+  background: #1e1440;
+  border-color: #8b5cf6;
+  box-shadow: 0 0 32px rgba(139, 92, 246, 0.25);
+  transform: translateY(24px) scale(1.03);
+}
+
+.fpt-card--featured.fpt-card { animation-name: fpt-fade-in-featured; }
+
+@keyframes fpt-fade-in-featured {
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1.03);
+  }
+}
+
+.fpt-badge {
+  position: absolute;
+  top: -12px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #8b5cf6;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  padding: 4px 12px;
+  border-radius: 999px;
+}
+
+.fpt-tier {
+  margin: 0 0 8px;
+  font-size: 18px;
+  font-weight: 700;
+  color: #fff;
+}
+
+.fpt-price {
+  margin: 0 0 20px;
+  font-size: 34px;
+  font-weight: 800;
+  color: #a78bfa;
+}
+
+.fpt-price span {
+  font-size: 14px;
+  font-weight: 500;
+  color: #8f88b0;
+}
+
+.fpt-features {
+  list-style: none;
+  margin: 0 0 24px;
+  padding: 0;
+  text-align: left;
+}
+
+.fpt-features li {
+  padding: 8px 0;
+  font-size: 14px;
+  color: #cfc9ea;
+  border-bottom: 1px solid #241c47;
+}
+
+.fpt-features li:last-child {
+  border-bottom: none;
+}
+
+.fpt-features li::before {
+  content: "✓ ";
+  color: #8b5cf6;
+  font-weight: 700;
+}
+
+.fpt-cta {
+  width: 100%;
+  padding: 12px 0;
+  border: none;
+  border-radius: 10px;
+  background: #7c3aed;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.15s ease;
+}
+
+.fpt-cta:hover {
+  background: #8b5cf6;
+}
+
+.fpt-cta:active {
+  transform: scale(0.97);
+}
+
+@media (max-width: 820px) {
+  .fpt-grid {
+    grid-template-columns: minmax(220px, 320px);
+  }
+  .fpt-card--featured {
+    transform: translateY(24px) scale(1);
+  }
+  @keyframes fpt-fade-in-featured {
+    to {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fpt-card {
+    animation: none;
+    opacity: 1;
+    transform: translateY(0);
+  }
+  .fpt-card--featured {
+    transform: translateY(0) scale(1.03);
+  }
+}


### PR DESCRIPTION
Closes #59146
## Pull Request Description
Adds a pure CSS pricing table for gaming hub layouts. Three plan cards fade in and slide up on page load with a staggered delay, with the featured tier scaled and highlighted — no JavaScript required.

---
## Type of Change
- [x] 🧩 New component

---
## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/fade-in-pricing-table-aa/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
A 3-tier pricing table with a staggered fade-in-up entrance animation and a highlighted featured plan, suited to gaming hub UI patterns.

**How does a developer use it?**
```html
<div class="fpt-grid">
  <div class="fpt-card">
    <h3 class="fpt-tier">Starter</h3>
    <p class="fpt-price">$0<span>/mo</span></p>
    <ul class="fpt-features">
      <li>5 game servers</li>
    </ul>
    <button class="fpt-cta">Get Started</button>
  </div>
  <div class="fpt-card fpt-card--featured">
    <span class="fpt-badge">Most Popular</span>
    <h3 class="fpt-tier">Pro Gamer</h3>
    <p class="fpt-price">$19<span>/mo</span></p>
    <ul class="fpt-features">
      <li>Unlimited servers</li>
    </ul>
    <button class="fpt-cta">Get Started</button>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
Pure CSS/HTML — no JS frameworks — using `@keyframes` with per-card `animation-delay` for a staggered fade-in-up entrance, and a `fpt-card--featured` modifier for a scaled, highlighted plan card. Fully responsive (collapses to a single column below 820px), with a `prefers-reduced-motion` fallback that disables the animation and shows cards in their final state immediately, in line with the project's animation-first, accessible philosophy.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---
## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---
## Notes for Maintainer
Implements #59146 (fade-in pricing table for gaming hub layouts).