### PR TITLE
Add ease-xylophone-mallet-strike component

### DIFF
--- a/submissions/examples/ease-xylophone-mallet-strike-ij/README.md
+++ b/submissions/examples/ease-xylophone-mallet-strike-ij/README.md
@@ -1,0 +1,7 @@
+# ease-xylophone-mallet-strike
+A concert xylophone where two mallets play across the bars.
+## Run
+Open `demo.html` directly in a browser to watch the mallets play.
+## Notes
+- The graduated bars ring on impact.
+- The wooden frame stands on its legs.

--- a/submissions/examples/ease-xylophone-mallet-strike-ij/demo.html
+++ b/submissions/examples/ease-xylophone-mallet-strike-ij/demo.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-xylophone-mallet-strike demo</title>
+</head>
+<body>
+<div class="xy-app">
+  <div class="xy-stand">
+    <div class="xy-frame">
+      <div class="xy-bar xy-bar-1"></div>
+      <div class="xy-bar xy-bar-2"></div>
+      <div class="xy-bar xy-bar-3"></div>
+      <div class="xy-bar xy-bar-4"></div>
+      <div class="xy-bar xy-bar-5"></div>
+    </div>
+    <div class="xy-mallet xy-mallet-1">
+      <div class="xy-head xy-head-1"></div>
+    </div>
+    <div class="xy-mallet xy-mallet-2">
+      <div class="xy-head xy-head-2"></div>
+    </div>
+    <div class="xy-leg xy-leg-1"></div>
+    <div class="xy-leg xy-leg-2"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/ease-xylophone-mallet-strike-ij/style.css
+++ b/submissions/examples/ease-xylophone-mallet-strike-ij/style.css
@@ -1,0 +1,21 @@
+:root{--xy-wood:#8a5a34;--xy-bar:#e8d6a8;--xy-ink:#2a2438}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#5a6a7a,#28323e);font-family:'Georgia',serif}
+.xy-app{position:relative;width:372px;height:372px;border-radius:18px;background:linear-gradient(180deg,#7a8a9a,#3a4a58);box-shadow:0 16px 36px rgba(0,0,0,0.5);display:flex;align-items:flex-end;justify-content:center}
+.xy-stand{position:relative;width:230px;height:240px}
+.xy-frame{position:absolute;top:0;left:0;right:0;height:70px;border-radius:8px;background:var(--xy-wood);box-shadow:0 8px 0 rgba(0,0,0,0.25)}
+.xy-bar{position:absolute;top:16px;height:22px;border-radius:4px;background:var(--xy-bar);box-shadow:inset 0 0 0 2px #c8b28a,0 3px 0 rgba(0,0,0,0.2);transform-origin:center;animation:ring-bar-xylophone-mallet-strike 1.2s ease-in-out infinite}
+.xy-bar-1{left:14px;width:34px}
+.xy-bar-2{left:56px;width:40px;animation-delay:0.24s}
+.xy-bar-3{left:98px;width:46px;animation-delay:0.48s}
+.xy-bar-4{left:140px;width:52px;animation-delay:0.72s}
+.xy-bar-5{left:182px;width:58px;animation-delay:0.96s}
+.xy-mallet{position:absolute;top:44px;width:10px;height:150px;border-radius:5px;background:var(--xy-wood);transform-origin:top center;animation:bounce-mallet-xylophone-mallet-strike 1.2s ease-in-out infinite}
+.xy-mallet-1{left:44px;transform:rotate(18deg)}
+.xy-mallet-2{right:44px;transform:rotate(-18deg);animation-delay:0.6s}
+.xy-head{position:absolute;bottom:0;left:50%;width:22px;height:18px;margin-left:-11px;border-radius:8px;background:#d8583a;box-shadow:0 2px 0 rgba(0,0,0,0.3)}
+.xy-head-2{background:#3a7fd8}
+.xy-leg{position:absolute;bottom:0;width:10px;height:170px;border-radius:5px;background:var(--xy-wood)}
+.xy-leg-1{left:20px}
+.xy-leg-2{right:20px}
+@keyframes ring-bar-xylophone-mallet-strike{0%,100%{transform:scaleY(1)}15%{transform:scaleY(1.2)}30%{transform:scaleY(1)}}
+@keyframes bounce-mallet-xylophone-mallet-strike{0%,100%{transform:rotate(18deg)}30%{transform:rotate(-26deg)}45%{transform:rotate(-26deg)}60%{transform:rotate(18deg)}}


### PR DESCRIPTION
## Component: ease-xylophone-mallet-strike — mallets strike, bars ring, and frame stands

**Closes #60667**

### What this adds
A concert xylophone: two mallets bounce in turn across the graduated bars while each bar rings on impact, and the wooden frame stands on its legs above the floor.

### Acceptance Criteria covered
- Mallets bounce across the bars
- Graduated bars ring on impact
- Wooden frame stands on its legs

### Files
- submissions/examples/ease-xylophone-mallet-strike-ij/demo.html
- submissions/examples/ease-xylophone-mallet-strike-ij/style.css
- submissions/examples/ease-xylophone-mallet-strike-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the mallets play.