### PR TITLE
Add ease-movie-clapper-snap component

### DIFF
--- a/submissions/examples/ease-movie-clapper-snap-ij/README.md
+++ b/submissions/examples/ease-movie-clapper-snap-ij/README.md
@@ -1,0 +1,7 @@
+# ease-movie-clapper-snap
+A film clapperboard whose striped stick snaps against the slate.
+## Run
+Open `demo.html` directly in a browser to watch the clapper snap.
+## Notes
+- The slate shakes with each take.
+- The flash glints beside the scene lettering.

--- a/submissions/examples/ease-movie-clapper-snap-ij/demo.html
+++ b/submissions/examples/ease-movie-clapper-snap-ij/demo.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-movie-clapper-snap demo</title>
+</head>
+<body>
+<div class="mc-app">
+  <div class="mc-board">
+    <div class="mc-stick">
+      <div class="mc-stripe mc-stripe-1"></div>
+      <div class="mc-stripe mc-stripe-2"></div>
+      <div class="mc-stripe mc-stripe-3"></div>
+    </div>
+    <div class="mc-title">SCENE 4</div>
+    <div class="mc-take">TAKE 2</div>
+    <div class="mc-bolt mc-bolt-1"></div>
+    <div class="mc-bolt mc-bolt-2"></div>
+    <div class="mc-bolt mc-bolt-3"></div>
+    <div class="mc-flash"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/ease-movie-clapper-snap-ij/style.css
+++ b/submissions/examples/ease-movie-clapper-snap-ij/style.css
@@ -1,0 +1,19 @@
+:root{--mc-slate:#10141a;--mc-cream:#f3ead8;--mc-stripe:#e8e2d0}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#3a4452,#10141a);font-family:'Courier New',monospace}
+.mc-app{position:relative;width:372px;height:372px;border-radius:18px;background:linear-gradient(180deg,#2a3342,#0c1015);box-shadow:0 16px 36px rgba(0,0,0,0.6);display:flex;align-items:center;justify-content:center}
+.mc-board{position:relative;width:230px;height:184px;border-radius:10px;background:var(--mc-slate);border:4px solid #3a4452;box-shadow:0 16px 26px rgba(0,0,0,0.5);animation:shake-board-movie-clapper-snap 1.4s ease-in-out infinite}
+.mc-stick{position:absolute;top:26px;left:-14px;width:248px;height:26px;background:var(--mc-cream);transform-origin:left center;border-radius:4px;animation:snap-stick-movie-clapper-snap 1.4s ease-in-out infinite}
+.mc-stripe{position:absolute;top:0;bottom:0;width:20px;background:repeating-linear-gradient(45deg,#2a3342 0 8px,#f3ead8 8px 16px);transform:skewX(-14deg)}
+.mc-stripe-1{left:44px}
+.mc-stripe-2{left:110px}
+.mc-stripe-3{left:176px}
+.mc-title{position:absolute;top:70px;left:24px;color:var(--mc-cream);font-size:20px;font-weight:bold;letter-spacing:2px}
+.mc-take{position:absolute;top:104px;left:24px;color:#9fd8d8;font-size:15px;font-weight:bold;letter-spacing:1px}
+.mc-bolt{position:absolute;width:12px;height:12px;border-radius:50%;background:#8a93a2;box-shadow:0 0 0 3px #5a646e}
+.mc-bolt-1{top:12px;left:12px}
+.mc-bolt-2{top:12px;right:12px}
+.mc-bolt-3{bottom:12px;right:12px}
+.mc-flash{position:absolute;top:70px;right:30px;width:0;height:0;border-top:20px solid transparent;border-bottom:20px solid transparent;border-right:30px solid #ffd76a;animation:glint-flash-movie-clapper-snap 1.4s ease-in-out infinite}
+@keyframes snap-stick-movie-clapper-snap{0%,100%{transform:rotate(0deg)}20%{transform:rotate(46deg)}32%{transform:rotate(46deg)}50%{transform:rotate(0deg)}}
+@keyframes shake-board-movie-clapper-snap{0%,100%{transform:translateX(0)}24%{transform:translateX(-6px)}28%{transform:translateX(6px)}32%{transform:translateX(-4px)}36%{transform:translateX(0)}}
+@keyframes glint-flash-movie-clapper-snap{0%,100%{opacity:1}30%{opacity:0.4}40%{opacity:1}}


### PR DESCRIPTION
## Component: ease-movie-clapper-snap — stick snaps, board shakes, and flash glints

**Closes #60670**

### What this adds
A film clapperboard: the striped stick snaps down against the slate and swings back up, the board shakes with each take, and the flash glints beside the SCENE 4 and TAKE 2 lettering.

### Acceptance Criteria covered
- Striped stick snaps down and up
- Slate shakes with each take
- Flash glints on the board

### Files
- submissions/examples/ease-movie-clapper-snap-ij/demo.html
- submissions/examples/ease-movie-clapper-snap-ij/style.css
- submissions/examples/ease-movie-clapper-snap-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the clapper snap.