### PR TITLE
feat: add scale-hover dropdown gaming example

### DIFF
--- a/submissions/examples/scale-hover-dropdown/README.md
+++ b/submissions/examples/scale-hover-dropdown/README.md
@@ -1,0 +1,23 @@
+# Scale-Hover Dropdown
+
+A responsive CSS-only dropdown component designed for modern gaming hub interfaces.
+
+## Features
+
+- Pure HTML and CSS
+- Scale-hover interaction
+- Smooth dropdown reveal
+- Keyboard-friendly focus behavior
+- Responsive desktop, tablet and mobile layouts
+- CSS custom properties for easy customization
+- GPU-friendly transform animations
+- `prefers-reduced-motion` accessibility support
+- No JavaScript or external dependencies
+
+## Files
+
+```text
+scale-hover-dropdown/
+├── demo.html
+├── style.css
+└── README.md

--- a/submissions/examples/scale-hover-dropdown/demo.html
+++ b/submissions/examples/scale-hover-dropdown/demo.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS Scale-Hover Dropdown for Gaming Hub layouts">
+  <title>Scale Hover Dropdown | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="gaming-page">
+    <header class="hero">
+      <p class="eyebrow">EASEMOTION CSS</p>
+      <h1>Gaming Hub</h1>
+      <p class="intro">
+        A lightweight CSS-only scale-hover dropdown designed for modern gaming interfaces.
+      </p>
+    </header>
+
+    <section class="demo-section" aria-labelledby="menu-title">
+      <h2 id="menu-title">Explore the Hub</h2>
+
+      <nav class="game-nav" aria-label="Gaming navigation">
+        <div class="dropdown">
+          <button class="dropdown-trigger" type="button">
+            Games
+            <span class="arrow" aria-hidden="true">⌄</span>
+          </button>
+
+          <div class="dropdown-menu">
+            <a href="#action">Action</a>
+            <a href="#rpg">RPG</a>
+            <a href="#racing">Racing</a>
+            <a href="#strategy">Strategy</a>
+          </div>
+        </div>
+
+        <div class="dropdown">
+          <button class="dropdown-trigger" type="button">
+            Community
+            <span class="arrow" aria-hidden="true">⌄</span>
+          </button>
+
+          <div class="dropdown-menu">
+            <a href="#players">Players</a>
+            <a href="#teams">Teams</a>
+            <a href="#events">Events</a>
+            <a href="#forums">Forums</a>
+          </div>
+        </div>
+
+        <div class="dropdown">
+          <button class="dropdown-trigger" type="button">
+            Discover
+            <span class="arrow" aria-hidden="true">⌄</span>
+          </button>
+
+          <div class="dropdown-menu">
+            <a href="#news">Gaming News</a>
+            <a href="#reviews">Reviews</a>
+            <a href="#guides">Guides</a>
+            <a href="#releases">New Releases</a>
+          </div>
+        </div>
+      </nav>
+    </section>
+
+    <section class="feature-grid" aria-label="Gaming features">
+      <article class="feature-card">
+        <span class="feature-icon">01</span>
+        <h3>Fast Interaction</h3>
+        <p>GPU-friendly transforms create a smooth scale-hover experience.</p>
+      </article>
+
+      <article class="feature-card">
+        <span class="feature-icon">02</span>
+        <h3>CSS Only</h3>
+        <p>No JavaScript or external frameworks are required.</p>
+      </article>
+
+      <article class="feature-card">
+        <span class="feature-icon">03</span>
+        <h3>Responsive</h3>
+        <p>The dropdown adapts cleanly across desktop, tablet and mobile.</p>
+      </article>
+    </section>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/scale-hover-dropdown/style.css
+++ b/submissions/examples/scale-hover-dropdown/style.css
@@ -1,0 +1,274 @@
+:root {
+    --bg: #090b14;
+    --surface: #111526;
+    --surface-hover: #191f35;
+    --text: #f5f7ff;
+    --muted: #9ca5c4;
+    --accent: #7c5cff;
+    --accent-soft: rgba(124, 92, 255, 0.18);
+    --border: rgba(255, 255, 255, 0.1);
+    --radius: 14px;
+    --transition: 220ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  }
+  
+  * {
+    box-sizing: border-box;
+  }
+  
+  html {
+    scroll-behavior: smooth;
+  }
+  
+  body {
+    margin: 0;
+    min-height: 100vh;
+    font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+      "Segoe UI", sans-serif;
+    color: var(--text);
+    background:
+      radial-gradient(circle at top, #171a35 0, var(--bg) 45%);
+  }
+  
+  button,
+  a {
+    font: inherit;
+  }
+  
+  button {
+    color: inherit;
+  }
+  
+  .gaming-page {
+    width: min(1100px, calc(100% - 32px));
+    margin: 0 auto;
+    padding: 72px 0;
+  }
+  
+  .hero {
+    max-width: 700px;
+    margin-bottom: 52px;
+  }
+  
+  .eyebrow {
+    margin: 0 0 10px;
+    color: var(--accent);
+    font-size: 0.78rem;
+    font-weight: 800;
+    letter-spacing: 0.18em;
+  }
+  
+  .hero h1 {
+    margin: 0;
+    font-size: clamp(2.5rem, 7vw, 5rem);
+    line-height: 0.95;
+    letter-spacing: -0.05em;
+  }
+  
+  .intro {
+    max-width: 580px;
+    margin-top: 20px;
+    color: var(--muted);
+    line-height: 1.7;
+  }
+  
+  .demo-section {
+    padding: 28px;
+    border: 1px solid var(--border);
+    border-radius: 20px;
+    background: rgba(17, 21, 38, 0.72);
+    backdrop-filter: blur(14px);
+  }
+  
+  .demo-section h2 {
+    margin-top: 0;
+    margin-bottom: 24px;
+    font-size: 1.15rem;
+  }
+  
+  .game-nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 14px;
+  }
+  
+  .dropdown {
+    position: relative;
+  }
+  
+  .dropdown-trigger {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    min-width: 150px;
+    padding: 13px 17px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--surface);
+    cursor: pointer;
+    font-weight: 700;
+    transition:
+      transform var(--transition),
+      background var(--transition),
+      border-color var(--transition),
+      box-shadow var(--transition);
+  }
+  
+  .dropdown-trigger:hover,
+  .dropdown-trigger:focus-visible {
+    transform: scale(1.04);
+    background: var(--surface-hover);
+    border-color: var(--accent);
+    box-shadow: 0 10px 30px var(--accent-soft);
+    outline: none;
+  }
+  
+  .arrow {
+    display: inline-block;
+    margin-left: auto;
+    transition: transform var(--transition);
+  }
+  
+  .dropdown:hover .arrow,
+  .dropdown:focus-within .arrow {
+    transform: rotate(180deg);
+  }
+  
+  .dropdown-menu {
+    position: absolute;
+    z-index: 10;
+    top: calc(100% + 10px);
+    left: 0;
+    min-width: 210px;
+    padding: 8px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: #111526;
+    box-shadow: 0 18px 45px rgba(0, 0, 0, 0.35);
+  
+    opacity: 0;
+    visibility: hidden;
+    transform: scale(0.92);
+    transform-origin: top left;
+    pointer-events: none;
+  
+    transition:
+      opacity var(--transition),
+      visibility var(--transition),
+      transform var(--transition);
+  }
+  
+  .dropdown:hover .dropdown-menu,
+  .dropdown:focus-within .dropdown-menu {
+    opacity: 1;
+    visibility: visible;
+    transform: scale(1);
+    pointer-events: auto;
+  }
+  
+  .dropdown-menu a {
+    display: block;
+    padding: 11px 13px;
+    border-radius: 9px;
+    color: var(--muted);
+    text-decoration: none;
+    transition:
+      transform var(--transition),
+      color var(--transition),
+      background var(--transition);
+  }
+  
+  .dropdown-menu a:hover,
+  .dropdown-menu a:focus-visible {
+    transform: scale(1.03);
+    color: var(--text);
+    background: var(--accent-soft);
+    outline: none;
+  }
+  
+  .feature-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 18px;
+    margin-top: 22px;
+  }
+  
+  .feature-card {
+    padding: 24px;
+    border: 1px solid var(--border);
+    border-radius: 18px;
+    background: var(--surface);
+    transition:
+      transform var(--transition),
+      border-color var(--transition);
+  }
+  
+  .feature-card:hover {
+    transform: translateY(-5px) scale(1.015);
+    border-color: var(--accent);
+  }
+  
+  .feature-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 42px;
+    height: 42px;
+    margin-bottom: 18px;
+    border-radius: 10px;
+    background: var(--accent-soft);
+    color: var(--accent);
+    font-weight: 800;
+  }
+  
+  .feature-card h3 {
+    margin: 0 0 8px;
+  }
+  
+  .feature-card p {
+    margin: 0;
+    color: var(--muted);
+    line-height: 1.6;
+  }
+  
+  @media (max-width: 700px) {
+    .gaming-page {
+      padding: 44px 0;
+    }
+  
+    .demo-section {
+      padding: 20px;
+    }
+  
+    .game-nav {
+      flex-direction: column;
+    }
+  
+    .dropdown-trigger {
+      width: 100%;
+    }
+  
+    .dropdown-menu {
+      position: static;
+      width: 100%;
+      margin-top: 8px;
+      transform-origin: top center;
+    }
+  
+    .feature-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+  
+  @media (prefers-reduced-motion: reduce) {
+    html {
+      scroll-behavior: auto;
+    }
+  
+    *,
+    *::before,
+    *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+    }
+  }


### PR DESCRIPTION
## Description

Implemented the CSS Scale-Hover Dropdown for Gaming Hub Layouts.

### Changes

* Added responsive `demo.html`
* Added pure CSS `style.css`
* Added component documentation in `README.md`
* Added smooth scale-hover dropdown interactions
* Added keyboard focus support
* Added responsive mobile layout
* Added `prefers-reduced-motion` support
* No JavaScript or external dependencies

Closes #59119

## Testing

* Tested desktop layout
* Tested mobile responsive layout
* Tested keyboard focus interaction
* Verified reduced-motion support
