### PR TITLE
Add ease-postal-stamp-lick component

### DIFF
--- a/submissions/examples/ease-postal-stamp-lick-ij/README.md
+++ b/submissions/examples/ease-postal-stamp-lick-ij/README.md
@@ -1,0 +1,7 @@
+# ease-postal-stamp-lick
+A letter desk where the brush licks the envelope flap.
+## Run
+Open `demo.html` directly in a browser to watch the seal.
+## Notes
+- The brush glides from the paste pot.
+- The stamp glues to the corner.

--- a/submissions/examples/ease-postal-stamp-lick-ij/demo.html
+++ b/submissions/examples/ease-postal-stamp-lick-ij/demo.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-postal-stamp-lick demo</title>
+</head>
+<body>
+<div class="ps-app">
+  <div class="ps-desk">
+    <div class="ps-envelope">
+      <div class="ps-flap"></div>
+      <div class="ps-address ps-address-1"></div>
+      <div class="ps-address ps-address-2"></div>
+      <div class="ps-stamp">
+        <div class="ps-stamp-mark ps-stamp-mark-1"></div>
+        <div class="ps-stamp-mark ps-stamp-mark-2"></div>
+      </div>
+    </div>
+    <div class="ps-brush">
+      <div class="ps-bristle ps-bristle-1"></div>
+      <div class="ps-bristle ps-bristle-2"></div>
+      <div class="ps-bristle ps-bristle-3"></div>
+      <div class="ps-handle"></div>
+    </div>
+    <div class="ps-pot"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/ease-postal-stamp-lick-ij/style.css
+++ b/submissions/examples/ease-postal-stamp-lick-ij/style.css
@@ -1,0 +1,23 @@
+:root{--ps-cream:#f8f0e0;--ps-red:#c8442f;--ps-wood:#8a5a34}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#c8b28a,#7a5a3a);font-family:'Courier New',monospace}
+.ps-app{position:relative;width:372px;height:372px;border-radius:18px;background:linear-gradient(180deg,#b89a6a,#6a4a32);box-shadow:0 16px 36px rgba(0,0,0,0.5);padding:26px}
+.ps-desk{position:relative;height:320px;border-radius:12px;background:var(--ps-wood);box-shadow:inset 0 10px 0 rgba(255,255,255,0.08),0 10px 16px rgba(0,0,0,0.4)}
+.ps-envelope{position:absolute;left:50%;top:60px;width:170px;height:110px;margin-left:-85px;border-radius:10px;background:var(--ps-cream);box-shadow:0 10px 16px rgba(0,0,0,0.35);animation:wiggle-flap-postal-stamp-lick 3s ease-in-out infinite}
+.ps-flap{position:absolute;top:0;left:50%;width:0;height:0;margin-left:-60px;border-top:52px solid #e8dcc8;border-left:60px solid transparent;border-right:60px solid transparent;transform-origin:top;animation:lift-flap-postal-stamp-lick 3s ease-in-out infinite}
+.ps-address{position:absolute;left:22px;height:5px;border-radius:3px;background:#8a7a6a}
+.ps-address-1{top:52px;width:60px}
+.ps-address-2{top:66px;width:44px}
+.ps-stamp{position:absolute;top:16px;right:16px;width:40px;height:46px;border-radius:4px;background:var(--ps-red);box-shadow:0 0 0 2px #8f2a1e;animation:lick-stamp-postal-stamp-lick 3s ease-in-out infinite}
+.ps-stamp-mark{position:absolute;background:#f8f0e0;border-radius:2px}
+.ps-stamp-mark-1{top:10px;left:8px;width:24px;height:4px}
+.ps-stamp-mark-2{top:20px;left:8px;width:16px;height:4px}
+.ps-brush{position:absolute;left:60px;top:220px;width:22px;height:90px;transform-origin:top center;transform:rotate(-32deg);animation:lick-brush-postal-stamp-lick 3s ease-in-out infinite}
+.ps-bristle{position:absolute;bottom:0;left:50%;width:6px;height:26px;margin-left:-3px;border-radius:3px;background:#f3d0a8}
+.ps-bristle-1{transform:translateX(-6px)}
+.ps-bristle-2{transform:translateX(6px)}
+.ps-handle{position:absolute;top:0;left:50%;width:10px;height:64px;margin-left:-5px;border-radius:5px;background:#5a4a2e}
+.ps-pot{position:absolute;right:52px;top:230px;width:40px;height:34px;border-radius:8px;background:#3a7fd8;box-shadow:inset 0 -8px 0 rgba(0,0,0,0.15)}
+@keyframes lick-brush-postal-stamp-lick{0%,100%{transform:rotate(-32deg)}45%{transform:rotate(24deg)}60%{transform:rotate(24deg)}75%{transform:rotate(-32deg)}}
+@keyframes lift-flap-postal-stamp-lick{0%,100%{transform:rotate(0deg)}45%{transform:rotate(-24deg)}60%{transform:rotate(-24deg)}75%{transform:rotate(0deg)}}
+@keyframes wiggle-flap-postal-stamp-lick{0%,100%{transform:translateY(0)}45%{transform:translateY(-3px)}60%{transform:translateY(-3px)}75%{transform:translateY(0)}}
+@keyframes lick-stamp-postal-stamp-lick{0%,100%{opacity:1}45%{opacity:0.55}60%{opacity:0.55}75%{opacity:1}}


### PR DESCRIPTION
## Component: ease-postal-stamp-lick — brush licks, flap lifts, and stamp glues

**Closes #60710**

### What this adds
A letter-writing desk: the brush dips toward the paste pot and licks the envelope flap while the flap lifts, the stamp glues to the corner, and the address lines wait on the cream paper.

### Acceptance Criteria covered
- Brush licks the envelope flap
- Flap lifts and settles back
- Stamp glues to the corner

### Files
- submissions/examples/ease-postal-stamp-lick-ij/demo.html
- submissions/examples/ease-postal-stamp-lick-ij/style.css
- submissions/examples/ease-postal-stamp-lick-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the envelope get sealed.