### PR TITLE
feat: add rotate-fade progress bar component for fintech dashboards

### DIFF
--- a/submissions/examples/ease-rotate-fade-progress-fintech/README.md
+++ b/submissions/examples/ease-rotate-fade-progress-fintech/README.md
@@ -1,0 +1,67 @@
+# Ease Rotate-Fade Progress Bar — Fintech Dashboard
+
+## Description
+A circular progress ring widget styled for fintech dashboard use cases — credit score, savings goals, and budget tracking. On load, the ring rotates + scales in while fading into view, the fill sweeps to its target value via `stroke-dashoffset`, and the center label, title, description, and a color-coded status badge fade in staggered afterward.
+
+## Features
+- Ring container enters with a combined `rotate` + `scale` + `opacity` animation
+- Progress fill sweeps in via `stroke-dashoffset`, using a gradient stroke
+- Staggered fade-in sequence: label → title → description → status badge
+- Status badge color reflects metric health (`good` green / `warning` amber)
+- Fully responsive (ring shrinks on narrow viewports)
+- Fully customizable via CSS custom properties
+- Respects `prefers-reduced-motion`
+
+## Usage
+```html
+<div class="ease-fintech-progress">
+  <div class="ring-wrap" style="--circumference: 345; --fill-offset: 51.75;">
+    <svg viewBox="0 0 130 130">
+      <defs>
+        <linearGradient id="fintech-ring-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+          <stop offset="0%" stop-color="#0d9488" />
+          <stop offset="100%" stop-color="#0891b2" />
+        </linearGradient>
+      </defs>
+      <circle class="ring-track" cx="65" cy="65" r="55"></circle>
+      <circle class="ring-fill" cx="65" cy="65" r="55"></circle>
+    </svg>
+    <div class="ring-label">
+      <span class="ring-value">785</span>
+      <span class="ring-sublabel">Credit Score</span>
+    </div>
+  </div>
+  <h3 class="widget-title">Excellent Standing</h3>
+  <p class="widget-desc">Top 15% of users</p>
+  <span class="status-badge good">↑ +12 this month</span>
+</div>
+```
+
+### Calculating `--fill-offset`
+For radius `r=55`, circumference = `2 × π × 55 ≈ 345`.
+`--fill-offset = circumference × (1 - percent / 100)`
+
+| Percent | fill-offset |
+|---|---|
+| 25% | 258.75 |
+| 50% | 172.5 |
+| 75% | 86.25 |
+| 100% | 0 |
+
+## Customization (CSS custom properties)
+| Property | Default | Description |
+|---|---|---|
+| `--ring-size` | `130px` | Ring diameter |
+| `--ring-stroke` | `10px` | Ring thickness |
+| `--rotate-duration` | `1.3s` | Ring entrance animation duration |
+| `--fade-duration` | `0.7s` | Label/title fade-in duration |
+| `--ring-color` / `--ring-color-2` | `#0d9488` / `#0891b2` | Gradient endpoints for the fill (teal → cyan) |
+| `--ring-track` | `#e2e8f0` | Empty track color |
+
+## Accessibility
+Respects `prefers-reduced-motion` by skipping directly to the final rotated/filled/faded-in state with no animation.
+
+## Files
+- `demo.html` — live working example with 3 fintech widgets (credit score, savings goal, budget usage)
+- `style.css` — component styles and all animations
+- `README.md` — this file

--- a/submissions/examples/ease-rotate-fade-progress-fintech/demo.html
+++ b/submissions/examples/ease-rotate-fade-progress-fintech/demo.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ease Rotate-Fade Progress Bar — Fintech Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 22px;
+      align-items: center;
+      justify-content: center;
+      padding: 40px;
+      background: #eef2f6;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="ease-fintech-progress">
+    <div class="ring-wrap" style="--circumference: 345; --fill-offset: 51.75;">
+      <svg viewBox="0 0 130 130">
+        <defs>
+          <linearGradient id="fintech-ring-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stop-color="#0d9488" />
+            <stop offset="100%" stop-color="#0891b2" />
+          </linearGradient>
+        </defs>
+        <circle class="ring-track" cx="65" cy="65" r="55"></circle>
+        <circle class="ring-fill" cx="65" cy="65" r="55"></circle>
+      </svg>
+      <div class="ring-label">
+        <span class="ring-value">785</span>
+        <span class="ring-sublabel">Credit Score</span>
+      </div>
+    </div>
+    <h3 class="widget-title">Excellent Standing</h3>
+    <p class="widget-desc">Top 15% of users</p>
+    <span class="status-badge good">↑ +12 this month</span>
+  </div>
+
+  <div class="ease-fintech-progress">
+    <div class="ring-wrap" style="--circumference: 345; --fill-offset: 172.5;">
+      <svg viewBox="0 0 130 130">
+        <defs>
+          <linearGradient id="fintech-ring-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stop-color="#0d9488" />
+            <stop offset="100%" stop-color="#0891b2" />
+          </linearGradient>
+        </defs>
+        <circle class="ring-track" cx="65" cy="65" r="55"></circle>
+        <circle class="ring-fill" cx="65" cy="65" r="55"></circle>
+      </svg>
+      <div class="ring-label">
+        <span class="ring-value">50%</span>
+        <span class="ring-sublabel">Savings Goal</span>
+      </div>
+    </div>
+    <h3 class="widget-title">Emergency Fund</h3>
+    <p class="widget-desc">$5,000 of $10,000</p>
+    <span class="status-badge good">On track</span>
+  </div>
+
+  <div class="ease-fintech-progress">
+    <div class="ring-wrap" style="--circumference: 345; --fill-offset: 62.1;">
+      <svg viewBox="0 0 130 130">
+        <defs>
+          <linearGradient id="fintech-ring-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stop-color="#d97706" />
+            <stop offset="100%" stop-color="#f59e0b" />
+          </linearGradient>
+        </defs>
+        <circle class="ring-track" cx="65" cy="65" r="55"></circle>
+        <circle class="ring-fill" cx="65" cy="65" r="55"></circle>
+      </svg>
+      <div class="ring-label">
+        <span class="ring-value">82%</span>
+        <span class="ring-sublabel">Budget Used</span>
+      </div>
+    </div>
+    <h3 class="widget-title">Monthly Spending</h3>
+    <p class="widget-desc">$2,460 of $3,000</p>
+    <span class="status-badge warning">Approaching limit</span>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-rotate-fade-progress-fintech/style.css
+++ b/submissions/examples/ease-rotate-fade-progress-fintech/style.css
@@ -1,0 +1,172 @@
+/* Ease Rotate-Fade Progress Bar — Fintech Dashboard style, pure CSS, zero JS */
+
+.ease-fintech-progress {
+  --ring-size: 130px;
+  --ring-stroke: 10px;
+  --ring-track: #e2e8f0;
+  --ring-color: #0d9488;
+  --ring-color-2: #0891b2;
+  --rotate-duration: 1.3s;
+  --fade-duration: 0.7s;
+  --rotate-easing: cubic-bezier(0.65, 0, 0.35, 1);
+  --card-bg: #ffffff;
+  --card-border: #e2e8f0;
+  --fg: #0f172a;
+  --muted: #64748b;
+
+  width: min(230px, 90vw);
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 18px;
+  padding: 24px;
+  font-family: system-ui, sans-serif;
+  text-align: center;
+  box-sizing: border-box;
+  box-shadow: 0 4px 16px rgba(15, 23, 42, 0.05);
+}
+
+.ease-fintech-progress .ring-wrap {
+  position: relative;
+  width: var(--ring-size);
+  height: var(--ring-size);
+  margin: 0 auto 14px;
+
+  opacity: 0;
+  transform: rotate(-90deg) scale(0.75);
+  animation: ring-rotate-fade-in var(--rotate-duration) var(--rotate-easing) forwards;
+}
+
+@keyframes ring-rotate-fade-in {
+  0%   { opacity: 0; transform: rotate(-90deg) scale(0.75); }
+  55%  { opacity: 1; }
+  100% { opacity: 1; transform: rotate(0deg) scale(1); }
+}
+
+.ease-fintech-progress svg {
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+}
+
+.ease-fintech-progress .ring-track {
+  fill: none;
+  stroke: var(--ring-track);
+  stroke-width: var(--ring-stroke);
+}
+
+.ease-fintech-progress .ring-fill {
+  fill: none;
+  stroke: url(#fintech-ring-gradient);
+  stroke-width: var(--ring-stroke);
+  stroke-linecap: round;
+  stroke-dasharray: var(--circumference);
+  stroke-dashoffset: var(--circumference);
+
+  animation: ring-fill-sweep 1.5s var(--rotate-easing) forwards;
+  animation-delay: 0.25s;
+}
+
+@keyframes ring-fill-sweep {
+  to { stroke-dashoffset: var(--fill-offset, 0); }
+}
+
+.ease-fintech-progress .ring-label {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  opacity: 0;
+  animation: label-fade-in var(--fade-duration) ease forwards;
+  animation-delay: 0.85s;
+}
+
+@keyframes label-fade-in {
+  from { opacity: 0; transform: scale(0.85); }
+  to   { opacity: 1; transform: scale(1); }
+}
+
+.ease-fintech-progress .ring-value {
+  font-size: 1.55rem;
+  font-weight: 800;
+  color: var(--fg);
+  font-variant-numeric: tabular-nums;
+}
+
+.ease-fintech-progress .ring-sublabel {
+  font-size: 0.65rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-top: 2px;
+}
+
+.ease-fintech-progress .widget-title {
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: var(--fg);
+  margin: 0 0 3px;
+
+  opacity: 0;
+  animation: label-fade-in var(--fade-duration) ease forwards;
+  animation-delay: 1.05s;
+}
+
+.ease-fintech-progress .widget-desc {
+  font-size: 0.72rem;
+  color: var(--muted);
+  margin: 0;
+
+  opacity: 0;
+  animation: label-fade-in var(--fade-duration) ease forwards;
+  animation-delay: 1.15s;
+}
+
+/* status badge, color reflects the metric's health (good/warning) */
+.ease-fintech-progress .status-badge {
+  display: inline-block;
+  margin-top: 10px;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  padding: 3px 10px;
+  border-radius: 999px;
+
+  opacity: 0;
+  animation: label-fade-in var(--fade-duration) ease forwards;
+  animation-delay: 1.25s;
+}
+
+.ease-fintech-progress .status-badge.good {
+  color: #16a34a;
+  background: rgba(22, 163, 74, 0.1);
+}
+
+.ease-fintech-progress .status-badge.warning {
+  color: #d97706;
+  background: rgba(217, 119, 6, 0.1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-fintech-progress .ring-wrap,
+  .ease-fintech-progress .ring-fill,
+  .ease-fintech-progress .ring-label,
+  .ease-fintech-progress .widget-title,
+  .ease-fintech-progress .widget-desc,
+  .ease-fintech-progress .status-badge {
+    animation: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+  }
+  .ease-fintech-progress .ring-fill {
+    stroke-dashoffset: var(--fill-offset, 0);
+  }
+}
+
+@media (max-width: 380px) {
+  .ease-fintech-progress {
+    --ring-size: 105px;
+  }
+}


### PR DESCRIPTION
Closes #59453

## Pull Request Description
Adds a circular progress ring widget styled for fintech dashboard use cases — credit score, savings goal, and budget tracking. On load, the ring rotates + scales in while fading into view, the fill sweeps to its target value, and the label, title, description, and a health-status badge fade in staggered afterward.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All files placed under `submissions/examples/ease-rotate-fade-progress-fintech-savni/`
- [x] Includes `demo.html` — clean HTML5 showcase page
- [x] Includes `style.css` — pure CSS, smooth/performant transitions and keyframes
- [x] Includes `README.md` — usage, custom properties, and features documented
- [x] Pure CSS/HTML, no JS frameworks
- [x] Fully responsive (ring shrinks on narrow viewports)
- [x] Respects `prefers-reduced-motion`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A dashboard progress widget (`ease-fintech-progress`) with a rotate-fade ring entrance, gradient `stroke-dashoffset` fill sweep, and a staggered reveal of value/title/description/status-badge — styled specifically for fintech data (credit score gauge, savings goal, budget usage), with a color-coded status badge (green "good" / amber "warning") reflecting metric health.

**How does a developer use it?**
```html
<div class="ease-fintech-progress">
  <div class="ring-wrap" style="--circumference: 345; --fill-offset: 51.75;">
    <svg viewBox="0 0 130 130">
      <defs>
        <linearGradient id="fintech-ring-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
          <stop offset="0%" stop-color="#0d9488" />
          <stop offset="100%" stop-color="#0891b2" />
        </linearGradient>
      </defs>
      <circle class="ring-track" cx="65" cy="65" r="55"></circle>
      <circle class="ring-fill" cx="65" cy="65" r="55"></circle>
    </svg>
    <div class="ring-label">
      <span class="ring-value">785</span>
      <span class="ring-sublabel">Credit Score</span>
    </div>
  </div>
  <h3 class="widget-title">Excellent Standing</h3>
  <p class="widget-desc">Top 15% of users</p>
  <span class="status-badge good">↑ +12 this month</span>
</div>
```
`--fill-offset` is calculated as `circumference × (1 - percent / 100)` — documented with a lookup table in the README.

**Why does it fit EaseMotion CSS?**
Entrance combines `rotate` + `scale` + `opacity` via `@keyframes`, layered with a gradient-stroked SVG fill sweep and staggered fades for label/title/badge — matching the "rotate-fade" transition requested in the issue title. All timing/size/color parameters are exposed via CSS custom properties (`--rotate-duration`, `--fade-duration`, `--ring-color/-2`, etc.) without touching core rules, consistent with the framework's animation-first, zero-dependency philosophy. Respects `prefers-reduced-motion` by jumping straight to the final settled state.

---

## Demo
- [x] Demo added (`demo.html` — 3 fintech widgets: Credit Score, Savings Goal, Budget Usage)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
This is a fintech-specific restyle/variant of the earlier dashboard rotate-fade progress bar (#54185) — same core rotate-fade + fill-sweep mechanic, but with distinct fintech content (credit score, savings, budget) and an added color-coded status badge not present in the original, per this issue's specific "Fintech Dashboard Layouts" framing.