### PR TITLE
feat: add fluid audio equalizer visualizer showcase

### DIFF
--- a/submissions/examples/gssoc-2026-fluid-audio-equalizer-bb/README.md
+++ b/submissions/examples/gssoc-2026-fluid-audio-equalizer-bb/README.md
@@ -1,0 +1,13 @@
+# Fluid Audio Equalizer Visualizer Showcase
+
+An animated **Fluid Audio Frequency Equalizer** featuring responsive spectrum bars and interactive play/pause controls.
+
+## 🌟 Key Features
+
+- **Animated Spectrum Bars**: Staggered keyframe animations simulating frequency spectrum data.
+- **Interactive State**: Toggle playback to pause bar animations and reset height states.
+- **Glassmorphism Player Card**: Complete with audio track progress bar and duration counter.
+
+## 🚀 Usage
+
+Open `demo.html` in your browser.

--- a/submissions/examples/gssoc-2026-fluid-audio-equalizer-bb/demo.html
+++ b/submissions/examples/gssoc-2026-fluid-audio-equalizer-bb/demo.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Fluid Audio Equalizer Visualizer - EaseMotion CSS Showcase</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="eq-demo-wrapper">
+    <header class="eq-header">
+      <h1 class="eq-title">Fluid Audio Frequency Equalizer</h1>
+      <p class="eq-subtitle">Dynamic spectrum bars animation &amp; glassmorphic audio player card.</p>
+    </header>
+
+    <div class="player-card">
+      <div class="track-info">
+        <span class="track-badge">NOW PLAYING</span>
+        <h2 class="track-name">Cybernetic Pulse Wave</h2>
+        <span class="artist-name">EaseMotion Soundscape Lab</span>
+      </div>
+
+      <div class="eq-spectrum-bars" id="eqSpectrum" aria-label="Audio frequency visualizer">
+        <span class="bar bar-1"></span>
+        <span class="bar bar-2"></span>
+        <span class="bar bar-3"></span>
+        <span class="bar bar-4"></span>
+        <span class="bar bar-5"></span>
+        <span class="bar bar-6"></span>
+        <span class="bar bar-7"></span>
+        <span class="bar bar-8"></span>
+      </div>
+
+      <div class="player-controls">
+        <button class="ctrl-btn play-pause-btn" id="playBtn" aria-label="Toggle Audio Playback">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+            <polygon points="5 3 19 12 5 21 5 3"></polygon>
+          </svg>
+        </button>
+        <div class="time-scrubber">
+          <span class="current-time">01:24</span>
+          <div class="progress-track"><div class="progress-fill"></div></div>
+          <span class="total-time">03:45</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const playBtn = document.getElementById('playBtn');
+    const eqSpectrum = document.getElementById('eqSpectrum');
+    let isPlaying = true;
+
+    playBtn.addEventListener('click', () => {
+      isPlaying = !isPlaying;
+      if (isPlaying) {
+        eqSpectrum.classList.remove('paused');
+        playBtn.innerHTML = '<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><polygon points="5 3 19 12 5 21 5 3"></polygon></svg>';
+      } else {
+        eqSpectrum.classList.add('paused');
+        playBtn.innerHTML = '<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><rect x="6" y="4" width="4" height="16"></rect><rect x="14" y="4" width="4" height="16"></rect></svg>';
+      }
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/gssoc-2026-fluid-audio-equalizer-bb/equalizer.spec.js
+++ b/submissions/examples/gssoc-2026-fluid-audio-equalizer-bb/equalizer.spec.js
@@ -1,0 +1,14 @@
+// Unit specification test for Fluid Audio Equalizer
+describe('Fluid Audio Equalizer Component', () => {
+  it('should render frequency bars', () => {
+    const bars = document.querySelectorAll('.bar');
+    expect(bars.length).toBe(8);
+  });
+
+  it('should pause animation when play button is clicked', () => {
+    const playBtn = document.getElementById('playBtn');
+    const eqSpectrum = document.getElementById('eqSpectrum');
+    playBtn.click();
+    expect(eqSpectrum.classList.contains('paused')).toBe(true);
+  });
+});

--- a/submissions/examples/gssoc-2026-fluid-audio-equalizer-bb/style.css
+++ b/submissions/examples/gssoc-2026-fluid-audio-equalizer-bb/style.css
@@ -1,0 +1,148 @@
+/* Fluid Audio Frequency Equalizer Showcase Styles */
+:root {
+  --player-bg: rgba(15, 23, 42, 0.8);
+  --player-border: rgba(255, 255, 255, 0.1);
+  --bar-color-1: #38bdf8;
+  --bar-color-2: #818cf8;
+  --bar-color-3: #c084fc;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family: system-ui, -apple-system, sans-serif;
+  background: radial-gradient(circle at 50% 50%, #0f172a 0%, #020617 100%);
+  color: #f8fafc;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.eq-demo-wrapper {
+  width: 90%;
+  max-width: 540px;
+  text-align: center;
+}
+
+.eq-title {
+  font-size: 2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #38bdf8, #c084fc);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  margin-bottom: 0.5rem;
+}
+
+.eq-subtitle {
+  color: #94a3b8;
+  margin-bottom: 2rem;
+}
+
+.player-card {
+  background: var(--player-bg);
+  backdrop-filter: blur(16px);
+  border: 1px solid var(--player-border);
+  border-radius: 20px;
+  padding: 2rem;
+  box-shadow: 0 20px 40px rgba(0,0,0,0.5);
+}
+
+.track-badge {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  color: #38bdf8;
+}
+
+.track-name {
+  font-size: 1.4rem;
+  margin: 0.25rem 0;
+}
+
+.artist-name {
+  color: #94a3b8;
+  font-size: 0.9rem;
+}
+
+.eq-spectrum-bars {
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  gap: 8px;
+  height: 80px;
+  margin: 2rem 0;
+}
+
+.bar {
+  width: 10px;
+  background: linear-gradient(to top, var(--bar-color-1), var(--bar-color-3));
+  border-radius: 6px;
+  animation: bounceBar 1.2s infinite ease-in-out alternate;
+}
+
+.bar-1 { height: 40%; animation-delay: 0.1s; }
+.bar-2 { height: 85%; animation-delay: 0.3s; }
+.bar-3 { height: 60%; animation-delay: 0.2s; }
+.bar-4 { height: 100%; animation-delay: 0.5s; }
+.bar-5 { height: 75%; animation-delay: 0.4s; }
+.bar-6 { height: 90%; animation-delay: 0.15s; }
+.bar-7 { height: 50%; animation-delay: 0.35s; }
+.bar-8 { height: 70%; animation-delay: 0.25s; }
+
+.eq-spectrum-bars.paused .bar {
+  animation-play-state: paused;
+  height: 20% !important;
+}
+
+@keyframes bounceBar {
+  0% { height: 25%; }
+  100% { height: 100%; }
+}
+
+.player-controls {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.ctrl-btn {
+  background: #38bdf8;
+  color: #0f172a;
+  border: none;
+  border-radius: 50%;
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.ctrl-btn:hover {
+  transform: scale(1.1);
+}
+
+.time-scrubber {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.8rem;
+  color: #94a3b8;
+}
+
+.progress-track {
+  flex: 1;
+  height: 4px;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.progress-fill {
+  width: 40%;
+  height: 100%;
+  background: #38bdf8;
+}

--- a/submissions/examples/gssoc-2026-fluid-audio-equalizer-bb/tokens.json
+++ b/submissions/examples/gssoc-2026-fluid-audio-equalizer-bb/tokens.json
@@ -1,0 +1,10 @@
+{
+  "component": "fluid-audio-equalizer",
+  "version": "1.0.0",
+  "tokens": {
+    "barsCount": 8,
+    "primaryColor": "#38bdf8",
+    "secondaryColor": "#c084fc",
+    "theme": "audio-dark"
+  }
+}


### PR DESCRIPTION
# 🚀 GSSoC_2026: Add Fluid Audio Equalizer Visualizer Showcase

## 📝 Summary of Changes
Adds the **Fluid Audio Frequency Equalizer** showcase under `submissions/examples/gssoc-2026-fluid-audio-equalizer-bb/`.

### Key Features
- **Staggered Keyframe Animation**: 8 spectrum bars oscillating with staggered delays.
- **Playback Control**: Interactive toggle button pausing animation keyframes dynamically.
- **Glassmorphic Audio Player Card**: Includes track info and scrubber progress bar.

## 🔒 Code Integrity Policy Verification
- **Deletions**: `0`
- **Modified Existing Files**: `0`
- **Created Files**: `5`

Closes #60727 