### PR TITLE
feat: add glassmorphic pricing card toggle showcase

### DIFF
--- a/submissions/examples/gssoc-2026-glassmorphic-pricing-toggle-bb/README.md
+++ b/submissions/examples/gssoc-2026-glassmorphic-pricing-toggle-bb/README.md
@@ -1,0 +1,13 @@
+# Glassmorphic Pricing Card Toggle Showcase
+
+A modern **Glassmorphic SaaS Pricing Card Grid** with animated billing cycle toggle and feature highlighting.
+
+## 🌟 Key Features
+
+- **Billing Cycle Toggle**: Smooth spring transition switching between monthly and annual plans.
+- **Popular Card Shine**: Distinctive accent border glow and badge overlay for featured tier.
+- **Responsive Layout**: Adapts automatically for desktop and mobile viewports.
+
+## 🚀 Usage
+
+Open `demo.html` in your browser.

--- a/submissions/examples/gssoc-2026-glassmorphic-pricing-toggle-bb/demo.html
+++ b/submissions/examples/gssoc-2026-glassmorphic-pricing-toggle-bb/demo.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Glassmorphic Pricing Card Toggle - EaseMotion CSS Showcase</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="pricing-container">
+    <header class="pricing-header">
+      <h1 class="pricing-title">Glassmorphic SaaS Pricing</h1>
+      <p class="pricing-subtitle">Switch billing cycles with spring toggle animations.</p>
+      
+      <div class="billing-toggle-wrapper">
+        <span>Monthly</span>
+        <button class="toggle-switch" id="billingToggle" aria-checked="false" role="switch">
+          <span class="toggle-thumb"></span>
+        </button>
+        <span>Annual <span class="discount-pill">Save 20%</span></span>
+      </div>
+    </header>
+
+    <div class="pricing-grid">
+      <div class="pricing-card">
+        <h2 class="plan-name">Starter</h2>
+        <div class="plan-price"><span class="price-val" id="priceStarter">$19</span><span class="price-period">/mo</span></div>
+        <p class="plan-desc">Perfect for side projects and individual developers.</p>
+        <ul class="plan-features">
+          <li>✓ 5 Active Motion Presets</li>
+          <li>✓ Community Support</li>
+          <li>✓ Standard CSS Export</li>
+        </ul>
+        <button class="plan-btn secondary">Get Started</button>
+      </div>
+
+      <div class="pricing-card popular ease-popular-glow">
+        <div class="popular-badge">MOST POPULAR</div>
+        <h2 class="plan-name">Pro Studio</h2>
+        <div class="plan-price"><span class="price-val" id="pricePro">$49</span><span class="price-period">/mo</span></div>
+        <p class="plan-desc">For growing design teams requiring high-performance motion.</p>
+        <ul class="plan-features">
+          <li>✓ Unlimited Animation Tokens</li>
+          <li>✓ Priority GPU Rendering</li>
+          <li>✓ React &amp; SCSS Exporters</li>
+          <li>✓ 24/7 Dedicated Support</li>
+        </ul>
+        <button class="plan-btn primary">Upgrade to Pro</button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const toggle = document.getElementById('billingToggle');
+    const starterPrice = document.getElementById('priceStarter');
+    const proPrice = document.getElementById('pricePro');
+
+    toggle.addEventListener('click', () => {
+      const isAnnual = toggle.getAttribute('aria-checked') === 'true';
+      toggle.setAttribute('aria-checked', !isAnnual);
+      toggle.classList.toggle('annual', !isAnnual);
+
+      if (!isAnnual) {
+        starterPrice.textContent = '$15';
+        proPrice.textContent = '$39';
+      } else {
+        starterPrice.textContent = '$19';
+        proPrice.textContent = '$49';
+      }
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/gssoc-2026-glassmorphic-pricing-toggle-bb/pricing.spec.js
+++ b/submissions/examples/gssoc-2026-glassmorphic-pricing-toggle-bb/pricing.spec.js
@@ -1,0 +1,15 @@
+// Unit specification test for Glassmorphic Pricing Card Toggle
+describe('Glassmorphic Pricing Card Toggle Component', () => {
+  it('should render pricing cards', () => {
+    const cards = document.querySelectorAll('.pricing-card');
+    expect(cards.length).toBe(2);
+  });
+
+  it('should toggle annual pricing state on toggle click', () => {
+    const toggle = document.getElementById('billingToggle');
+    const starterPrice = document.getElementById('priceStarter');
+    toggle.click();
+    expect(toggle.getAttribute('aria-checked')).toBe('true');
+    expect(starterPrice.textContent).toBe('$15');
+  });
+});

--- a/submissions/examples/gssoc-2026-glassmorphic-pricing-toggle-bb/style.css
+++ b/submissions/examples/gssoc-2026-glassmorphic-pricing-toggle-bb/style.css
@@ -1,0 +1,154 @@
+/* Glassmorphic Pricing Card Toggle Showcase Styles */
+:root {
+  --pricing-bg: #090d16;
+  --card-bg: rgba(30, 41, 59, 0.6);
+  --border-color: rgba(255, 255, 255, 0.12);
+  --accent-color: #6366f1;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family: system-ui, -apple-system, sans-serif;
+  background-color: var(--pricing-bg);
+  color: #f8fafc;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.pricing-container {
+  width: 90%;
+  max-width: 800px;
+  padding: 2rem 0;
+}
+
+.pricing-header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.pricing-title {
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a5b4fc, #c084fc);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.pricing-subtitle {
+  color: #94a3b8;
+}
+
+.billing-toggle-wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.toggle-switch {
+  width: 56px;
+  height: 28px;
+  background: rgba(255, 255, 255, 0.15);
+  border: 1px solid var(--border-color);
+  border-radius: 20px;
+  padding: 3px;
+  cursor: pointer;
+  position: relative;
+  transition: background 0.3s ease;
+}
+
+.toggle-switch.annual {
+  background: var(--accent-color);
+}
+
+.toggle-thumb {
+  display: block;
+  width: 22px;
+  height: 22px;
+  background: #fff;
+  border-radius: 50%;
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.toggle-switch.annual .toggle-thumb {
+  transform: translateX(28px);
+}
+
+.discount-pill {
+  background: rgba(99, 102, 241, 0.2);
+  color: #818cf8;
+  border: 1px solid #818cf8;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 0.75rem;
+}
+
+.pricing-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 2rem;
+}
+
+.pricing-card {
+  position: relative;
+  background: var(--card-bg);
+  backdrop-filter: blur(12px);
+  border: 1px solid var(--border-color);
+  border-radius: 20px;
+  padding: 2rem;
+  box-shadow: 0 15px 30px rgba(0, 0, 0, 0.4);
+}
+
+.pricing-card.popular {
+  border-color: var(--accent-color);
+  box-shadow: 0 0 30px rgba(99, 102, 241, 0.3);
+}
+
+.popular-badge {
+  position: absolute;
+  top: -12px;
+  right: 24px;
+  background: var(--accent-color);
+  color: #fff;
+  padding: 4px 12px;
+  border-radius: 12px;
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+
+.plan-name { font-size: 1.4rem; margin: 0; }
+.plan-price { font-size: 2.5rem; font-weight: 800; margin: 0.5rem 0; color: #a5b4fc; }
+.price-period { font-size: 1rem; color: #94a3b8; font-weight: 400; }
+.plan-desc { color: #94a3b8; font-size: 0.9rem; }
+
+.plan-features {
+  list-style: none;
+  padding: 0;
+  margin: 1.5rem 0;
+  color: #cbd5e1;
+  font-size: 0.9rem;
+}
+
+.plan-features li { margin-bottom: 0.5rem; }
+
+.plan-btn {
+  width: 100%;
+  padding: 0.8rem;
+  border-radius: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+  transition: transform 0.2s ease;
+}
+
+.plan-btn.primary { background: var(--accent-color); color: #fff; }
+.plan-btn.secondary { background: rgba(255, 255, 255, 0.1); color: #fff; }
+.plan-btn:hover { transform: translateY(-2px); }
+
+@media (max-width: 640px) {
+  .pricing-grid { grid-template-columns: 1fr; }
+}

--- a/submissions/examples/gssoc-2026-glassmorphic-pricing-toggle-bb/tokens.json
+++ b/submissions/examples/gssoc-2026-glassmorphic-pricing-toggle-bb/tokens.json
@@ -1,0 +1,10 @@
+{
+  "component": "glassmorphic-pricing-toggle",
+  "version": "1.0.0",
+  "tokens": {
+    "discount": "20%",
+    "monthlyStarter": "$19",
+    "annualStarter": "$15",
+    "theme": "saas-pricing-dark"
+  }
+}


### PR DESCRIPTION
# 🚀 GSSoC_2026: Add Glassmorphic SaaS Pricing Card Toggle Showcase

## 📝 Summary of Changes
Adds the **Glassmorphic SaaS Pricing Card Toggle** showcase under `submissions/examples/gssoc-2026-glassmorphic-pricing-toggle-bb/`.

### Key Features
- **Billing Switch Transition**: Smooth spring thumb translation on billing toggle click.
- **Featured Tier Glow**: Outer accent box-shadow glow emphasizing popular tier.
- **Responsive Layout**: Switches between 2-column and 1-column layouts.

## 🔒 Code Integrity Policy Verification
- **Deletions**: `0`
- **Modified Existing Files**: `0`
- **Created Files**: `5`

Closes #60732 