### PR TITLE
feat: add 3d stacked perspective card deck showcase

### DIFF
--- a/submissions/examples/gssoc-2026-3d-perspective-card-deck-bb/README.md
+++ b/submissions/examples/gssoc-2026-3d-perspective-card-deck-bb/README.md
@@ -1,0 +1,13 @@
+# 3D Perspective Card Deck Showcase
+
+A stacked **3D Perspective Card Deck** component with depth offsets, card cycling animations, and 3D transform layers.
+
+## 🌟 Key Features
+
+- **3D Transform Depth**: Uses CSS `translateZ`, `translateY`, and `scale` to render physical layer depth.
+- **Card Cycling**: Interactive JavaScript button rotates array indices for smooth front-to-back card cycling.
+- **Glassmorphism Backdrop**: Dark theme card panels with backdrop blur filters.
+
+## 🚀 Usage
+
+Open `demo.html` in your browser.

--- a/submissions/examples/gssoc-2026-3d-perspective-card-deck-bb/card-deck.spec.js
+++ b/submissions/examples/gssoc-2026-3d-perspective-card-deck-bb/card-deck.spec.js
@@ -1,0 +1,14 @@
+// Unit specification test for 3D Perspective Card Deck
+describe('3D Perspective Card Deck Component', () => {
+  it('should render 3 deck cards in stack', () => {
+    const cards = document.querySelectorAll('.deck-card');
+    expect(cards.length).toBe(3);
+  });
+
+  it('should cycle top card on button click', () => {
+    const cycleBtn = document.getElementById('cycleBtn');
+    const cards = document.querySelectorAll('.deck-card');
+    cycleBtn.click();
+    expect(cards[0].classList.contains('card-bot')).toBe(true);
+  });
+});

--- a/submissions/examples/gssoc-2026-3d-perspective-card-deck-bb/demo.html
+++ b/submissions/examples/gssoc-2026-3d-perspective-card-deck-bb/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>3D Perspective Card Deck - EaseMotion CSS Showcase</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="deck-wrapper">
+    <header class="deck-header">
+      <h1 class="deck-title">3D Stacked Perspective Card Deck</h1>
+      <p class="deck-subtitle">Depth offsets, perspective tilt &amp; card cycling spring physics.</p>
+    </header>
+
+    <div class="card-stack-viewport" id="cardViewport">
+      <div class="deck-card card-top" data-index="0">
+        <span class="card-badge">CARD 01</span>
+        <h2>Quantum Motion Tokens</h2>
+        <p>Spring easing parameters configured for ultra-responsive micro-animations across all viewport breakpoints.</p>
+      </div>
+
+      <div class="deck-card card-mid" data-index="1">
+        <span class="card-badge">CARD 02</span>
+        <h2>Glassmorphism Engine</h2>
+        <p>GPU-accelerated blur filters combined with dynamic light reflection layers for modern UI panels.</p>
+      </div>
+
+      <div class="deck-card card-bot" data-index="2">
+        <span class="card-badge">CARD 03</span>
+        <h2>Accessibility First</h2>
+        <p>Built-in reduced motion queries automatically disable perspective tilts when system preference is detected.</p>
+      </div>
+    </div>
+
+    <div class="deck-controls">
+      <button class="deck-btn" id="cycleBtn">Cycle Next Card &rarr;</button>
+    </div>
+  </div>
+
+  <script>
+    const cards = document.querySelectorAll('.deck-card');
+    const cycleBtn = document.getElementById('cycleBtn');
+    let order = [0, 1, 2];
+
+    function updateDeckPositions() {
+      const classes = ['card-top', 'card-mid', 'card-bot'];
+      cards.forEach((card, idx) => {
+        card.className = `deck-card ${classes[order[idx]]}`;
+      });
+    }
+
+    cycleBtn.addEventListener('click', () => {
+      order.unshift(order.pop());
+      updateDeckPositions();
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/gssoc-2026-3d-perspective-card-deck-bb/style.css
+++ b/submissions/examples/gssoc-2026-3d-perspective-card-deck-bb/style.css
@@ -1,0 +1,101 @@
+/* 3D Perspective Card Deck Showcase Styles */
+:root {
+  --deck-bg: #090d16;
+  --card-bg: rgba(30, 41, 59, 0.8);
+  --border-color: rgba(255, 255, 255, 0.12);
+  --accent-color: #6366f1;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family: system-ui, -apple-system, sans-serif;
+  background-color: var(--deck-bg);
+  color: #f8fafc;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  perspective: 1000px;
+}
+
+.deck-wrapper {
+  width: 90%;
+  max-width: 500px;
+  text-align: center;
+}
+
+.deck-header { margin-bottom: 3rem; }
+.deck-title {
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a5b4fc, #c084fc);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.deck-subtitle { color: #94a3b8; }
+
+.card-stack-viewport {
+  position: relative;
+  height: 280px;
+  margin-bottom: 2rem;
+}
+
+.deck-card {
+  position: absolute;
+  inset: 0;
+  background: var(--card-bg);
+  backdrop-filter: blur(16px);
+  border: 1px solid var(--border-color);
+  border-radius: 20px;
+  padding: 2rem;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.6);
+  transition: transform 0.5s cubic-bezier(0.34, 1.56, 0.64, 1), opacity 0.5s ease;
+  text-align: left;
+}
+
+.card-top {
+  transform: translateZ(0) translateY(0) scale(1);
+  z-index: 3;
+  opacity: 1;
+}
+
+.card-mid {
+  transform: translateZ(-50px) translateY(-20px) scale(0.92);
+  z-index: 2;
+  opacity: 0.8;
+}
+
+.card-bot {
+  transform: translateZ(-100px) translateY(-40px) scale(0.84);
+  z-index: 1;
+  opacity: 0.6;
+}
+
+.card-badge {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--accent-color);
+  background: rgba(99, 102, 241, 0.15);
+  padding: 2px 8px;
+  border-radius: 12px;
+  margin-bottom: 1rem;
+}
+
+.deck-card h2 { font-size: 1.4rem; margin: 0 0 0.5rem 0; }
+.deck-card p { color: #94a3b8; font-size: 0.95rem; line-height: 1.5; margin: 0; }
+
+.deck-btn {
+  padding: 0.8rem 1.6rem;
+  background: var(--accent-color);
+  color: #fff;
+  border: none;
+  border-radius: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 0 20px rgba(99, 102, 241, 0.4);
+  transition: transform 0.2s ease;
+}
+
+.deck-btn:hover { transform: translateY(-2px); }

--- a/submissions/examples/gssoc-2026-3d-perspective-card-deck-bb/tokens.json
+++ b/submissions/examples/gssoc-2026-3d-perspective-card-deck-bb/tokens.json
@@ -1,0 +1,10 @@
+{
+  "component": "3d-perspective-card-deck",
+  "version": "1.0.0",
+  "tokens": {
+    "perspective": "1000px",
+    "springCurve": "cubic-bezier(0.34, 1.56, 0.64, 1)",
+    "accentColor": "#6366f1",
+    "theme": "deck-dark"
+  }
+}


### PR DESCRIPTION
# 🚀 GSSoC_2026: Add 3D Stacked Perspective Card Deck Showcase

## 📝 Summary of Changes
Adds the **3D Stacked Perspective Card Deck** showcase under `submissions/examples/gssoc-2026-3d-perspective-card-deck-bb/`.

### Key Features
- **3D Depth Layers**: `perspective: 1000px` combined with staggered `translateZ` and `scale` values.
- **Card Cycle Button**: Interactive cycling rotating front card to back of stack.
- **Glassmorphic Finish**: Semi-transparent dark card panels.

## 🔒 Code Integrity Policy Verification
- **Deletions**: `0`
- **Modified Existing Files**: `0`
- **Created Files**: `5`

Closes #60738 