### PR TITLE
feat: add shimmer image skeleton placeholder showcase

### DIFF
--- a/submissions/examples/gssoc-2026-shimmer-image-placeholder-bb/README.md
+++ b/submissions/examples/gssoc-2026-shimmer-image-placeholder-bb/README.md
@@ -1,0 +1,13 @@
+# Shimmer Image Skeleton Placeholder Showcase
+
+An animated **Shimmer Image Skeleton Placeholder** component providing seamless loading states without cumulative layout shifts (CLS).
+
+## 🌟 Key Features
+
+- **Linear Wave Animation**: 200% background-size sweep gradient simulating image & block content loading.
+- **Zero Layout Shifts**: Pre-allocated skeleton dimension constraints matching production media containers.
+- **Simulated Media Toggle**: Interactive JS button demonstrating transition from skeleton state to rendered media.
+
+## 🚀 Usage
+
+Open `demo.html` in your browser.

--- a/submissions/examples/gssoc-2026-shimmer-image-placeholder-bb/demo.html
+++ b/submissions/examples/gssoc-2026-shimmer-image-placeholder-bb/demo.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Shimmer Image Skeleton Placeholder - EaseMotion CSS Showcase</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="shimmer-container">
+    <header class="shimmer-header">
+      <h1 class="shimmer-title">Shimmer Image Skeleton Placeholder</h1>
+      <p class="shimmer-subtitle">Linear gradient wave animation transitioning to loaded media content.</p>
+    </header>
+
+    <div class="media-card-grid">
+      <div class="skeleton-card" id="card1">
+        <div class="shimmer-img-box shimmer-wave"></div>
+        <div class="card-body-skeleton">
+          <div class="shimmer-line title-line shimmer-wave"></div>
+          <div class="shimmer-line text-line shimmer-wave"></div>
+          <div class="shimmer-line short-line shimmer-wave"></div>
+        </div>
+      </div>
+
+      <div class="skeleton-card" id="card2">
+        <div class="shimmer-img-box shimmer-wave"></div>
+        <div class="card-body-skeleton">
+          <div class="shimmer-line title-line shimmer-wave"></div>
+          <div class="shimmer-line text-line shimmer-wave"></div>
+          <div class="shimmer-line short-line shimmer-wave"></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="shimmer-controls">
+      <button class="shimmer-btn" id="toggleLoadBtn">Simulate Media Loading Complete</button>
+    </div>
+  </div>
+
+  <script>
+    const toggleBtn = document.getElementById('toggleLoadBtn');
+    const cards = document.querySelectorAll('.skeleton-card');
+    let loaded = false;
+
+    toggleBtn.addEventListener('click', () => {
+      loaded = !loaded;
+      cards.forEach((card, idx) => {
+        if (loaded) {
+          card.classList.add('loaded');
+          card.innerHTML = `
+            <div class="real-img-box img-${idx + 1}">🎨 Rendered Media ${idx + 1}</div>
+            <div class="card-body-real">
+              <h3>EaseMotion Showcase ${idx + 1}</h3>
+              <p>Media asset loaded cleanly without cumulative layout shifts.</p>
+            </div>
+          `;
+          toggleBtn.textContent = 'Reset to Skeleton Placeholder';
+        } else {
+          location.reload();
+        }
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/gssoc-2026-shimmer-image-placeholder-bb/shimmer.spec.js
+++ b/submissions/examples/gssoc-2026-shimmer-image-placeholder-bb/shimmer.spec.js
@@ -1,0 +1,14 @@
+// Unit specification test for Shimmer Image Skeleton Placeholder
+describe('Shimmer Image Skeleton Placeholder Component', () => {
+  it('should render skeleton cards with shimmer wave elements', () => {
+    const shimmerWaves = document.querySelectorAll('.shimmer-wave');
+    expect(shimmerWaves.length).toBeGreaterThan(0);
+  });
+
+  it('should transition to real media when button is clicked', () => {
+    const toggleBtn = document.getElementById('toggleLoadBtn');
+    const card1 = document.getElementById('card1');
+    toggleBtn.click();
+    expect(card1.classList.contains('loaded')).toBe(true);
+  });
+});

--- a/submissions/examples/gssoc-2026-shimmer-image-placeholder-bb/style.css
+++ b/submissions/examples/gssoc-2026-shimmer-image-placeholder-bb/style.css
@@ -1,0 +1,124 @@
+/* Shimmer Image Skeleton Placeholder Showcase Styles */
+:root {
+  --shimmer-bg: #0b0f19;
+  --card-bg: rgba(30, 41, 59, 0.7);
+  --border-color: rgba(255, 255, 255, 0.1);
+  --shimmer-base: rgba(255, 255, 255, 0.05);
+  --shimmer-highlight: rgba(255, 255, 255, 0.15);
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family: system-ui, -apple-system, sans-serif;
+  background-color: var(--shimmer-bg);
+  color: #f8fafc;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.shimmer-container {
+  width: 90%;
+  max-width: 680px;
+  padding: 2rem 0;
+  text-align: center;
+}
+
+.shimmer-header { margin-bottom: 3rem; }
+.shimmer-title {
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a5b4fc, #38bdf8);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.shimmer-subtitle { color: #94a3b8; }
+
+.media-card-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.skeleton-card {
+  background: var(--card-bg);
+  backdrop-filter: blur(12px);
+  border: 1px solid var(--border-color);
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: 0 15px 30px rgba(0, 0, 0, 0.4);
+}
+
+.shimmer-img-box {
+  width: 100%;
+  height: 160px;
+}
+
+.card-body-skeleton {
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.shimmer-line {
+  height: 12px;
+  border-radius: 6px;
+}
+
+.title-line { width: 70%; height: 16px; }
+.text-line { width: 95%; }
+.short-line { width: 45%; }
+
+.shimmer-wave {
+  background: linear-gradient(
+    90deg,
+    var(--shimmer-base) 0%,
+    var(--shimmer-highlight) 50%,
+    var(--shimmer-base) 100%
+  );
+  background-size: 200% 100%;
+  animation: shimmerAnim 1.6s infinite linear;
+}
+
+@keyframes shimmerAnim {
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+
+.real-img-box {
+  width: 100%;
+  height: 160px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 1.1rem;
+}
+
+.img-1 { background: linear-gradient(135deg, #6366f1, #a855f7); }
+.img-2 { background: linear-gradient(135deg, #06b6d4, #3b82f6); }
+
+.card-body-real { padding: 1.25rem; text-align: left; }
+.card-body-real h3 { margin: 0 0 0.5rem 0; font-size: 1.1rem; }
+.card-body-real p { color: #94a3b8; font-size: 0.85rem; margin: 0; }
+
+.shimmer-btn {
+  padding: 0.8rem 1.6rem;
+  background: #38bdf8;
+  color: #0f172a;
+  border: none;
+  border-radius: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.shimmer-btn:hover { transform: translateY(-2px); }
+
+@media (max-width: 640px) {
+  .media-card-grid { grid-template-columns: 1fr; }
+}

--- a/submissions/examples/gssoc-2026-shimmer-image-placeholder-bb/tokens.json
+++ b/submissions/examples/gssoc-2026-shimmer-image-placeholder-bb/tokens.json
@@ -1,0 +1,10 @@
+{
+  "component": "shimmer-image-placeholder",
+  "version": "1.0.0",
+  "tokens": {
+    "shimmerDuration": "1.6s",
+    "baseColor": "rgba(255, 255, 255, 0.05)",
+    "highlightColor": "rgba(255, 255, 255, 0.15)",
+    "theme": "skeleton-dark"
+  }
+}


### PR DESCRIPTION
# 🚀 GSSoC_2026: Add Shimmer Image Skeleton Placeholder Showcase

## 📝 Summary of Changes
Adds the **Shimmer Image Skeleton Placeholder** showcase under `submissions/examples/gssoc-2026-shimmer-image-placeholder-bb/`.

### Key Features
- **Continuous Sweep Gradient**: 200% background size linear gradient keyframes.
- **CLS Prevention**: Dedicated skeleton dimension wrappers preventing layout jumps.
- **Interactive State Simulation**: Button toggling between skeleton placeholder and rendered image state.

## 🔒 Code Integrity Policy Verification
- **Deletions**: `0`
- **Modified Existing Files**: `0`
- **Created Files**: `5`

Closes #60740 