### PR TITLE
Add CSS elastic-slide dropdown for fintech dashboard layouts

### DIFF
--- a/submissions/examples/css-elastic-slide-dropdown/README.md
+++ b/submissions/examples/css-elastic-slide-dropdown/README.md
@@ -1,0 +1,25 @@
+# CSS Elastic-Slide Dropdown
+
+A pure CSS dropdown menu styled as an account selector for a fintech dashboard, with a springy elastic slide-down when opened. No JavaScript, no dependencies.
+
+## How it works
+
+The dropdown uses the checkbox hack: a hidden checkbox paired with a label trigger. When checked, the menu — absolutely positioned below the trigger — becomes visible and plays a dedicated `@keyframes` animation on open. Rather than a plain linear slide, the keyframe overshoots slightly past its resting position before settling, giving an elastic drop rather than a flat glide.
+
+The menu uses `visibility` with a delayed transition on close, so it doesn't intercept clicks while invisible or mid-fade-out — the same pattern used in the framework's modal submission.
+
+## Files
+- `demo.html` – an account-selector dropdown with 3 account options
+- `style.css` – all styling, custom properties, and the elastic-slide keyframe
+- `README.md` – this file
+
+## Custom properties
+- `--ease-dropdown-duration`, `--ease-dropdown-easing` – open animation timing/curve
+- `--ease-dropdown-radius` – corner radius
+- `--ease-dropdown-bg`, `--ease-dropdown-border` – surface colors
+- `--ease-dropdown-text`, `--ease-dropdown-muted-text` – text colors
+- `--ease-dropdown-accent` – eyebrow and highlight color
+
+## Notes
+- Fully responsive
+- Respects `prefers-reduced-motion` — the elastic keyframe is disabled, the menu simply fades in

--- a/submissions/examples/css-elastic-slide-dropdown/demo.html
+++ b/submissions/examples/css-elastic-slide-dropdown/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Elastic-Slide Dropdown — Fintech Dashboard</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="ease-container">
+    <p class="ease-eyebrow">Account</p>
+    <h1 class="ease-heading">Portfolio Overview</h1>
+    <p class="ease-subtitle">Click the account selector to open a dropdown with an elastic slide-down.</p>
+
+    <div class="ease-dropdown">
+      <input type="checkbox" id="ease-dropdown-toggle" class="ease-dropdown-input" />
+      <label for="ease-dropdown-toggle" class="ease-dropdown-trigger">
+        Checking Account — •••• 4821
+        <span class="ease-dropdown-arrow">▾</span>
+      </label>
+
+      <div class="ease-dropdown-menu">
+        <button class="ease-dropdown-item">
+          <span>Checking Account</span>
+          <span class="ease-dropdown-item-meta">•••• 4821</span>
+        </button>
+        <button class="ease-dropdown-item">
+          <span>Savings Account</span>
+          <span class="ease-dropdown-item-meta">•••• 7734</span>
+        </button>
+        <button class="ease-dropdown-item">
+          <span>Investment Portfolio</span>
+          <span class="ease-dropdown-item-meta">•••• 1092</span>
+        </button>
+      </div>
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/css-elastic-slide-dropdown/style.css
+++ b/submissions/examples/css-elastic-slide-dropdown/style.css
@@ -1,0 +1,144 @@
+:root {
+  --ease-dropdown-duration: 0.5s;
+  --ease-dropdown-easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-dropdown-radius: 10px;
+  --ease-dropdown-bg: #16181d;
+  --ease-dropdown-border: #2a2d34;
+  --ease-dropdown-text: #f0f0f0;
+  --ease-dropdown-muted-text: #a8a8a8;
+  --ease-dropdown-accent: #22c55e;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0f1115;
+  color: var(--ease-dropdown-text);
+  padding: 3rem 1.5rem;
+}
+
+.ease-container { max-width: 420px; margin: 0 auto; }
+
+.ease-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--ease-dropdown-accent);
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
+.ease-heading { font-size: 1.6rem; margin: 0 0 0.5rem; }
+.ease-subtitle { color: #a0a0a0; margin: 0 0 2rem; font-size: 0.9rem; }
+
+.ease-dropdown { position: relative; }
+
+.ease-dropdown-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.ease-dropdown-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.85rem 1.1rem;
+  background: var(--ease-dropdown-bg);
+  border: 1px solid var(--ease-dropdown-border);
+  border-radius: var(--ease-dropdown-radius);
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.ease-dropdown-arrow {
+  transition: transform 0.25s ease;
+  color: var(--ease-dropdown-muted-text);
+}
+
+.ease-dropdown-input:checked ~ .ease-dropdown-trigger .ease-dropdown-arrow {
+  transform: rotate(180deg);
+}
+
+/* menu is absolutely positioned and hidden by default; visibility
+   is delayed on close so it doesn't intercept clicks mid-fade */
+.ease-dropdown-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  right: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--ease-dropdown-bg);
+  border: 1px solid var(--ease-dropdown-border);
+  border-radius: var(--ease-dropdown-radius);
+  padding: 0.4rem;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-8px);
+  transform-origin: top center;
+  transition: opacity 0.2s ease, visibility 0s linear 0.2s;
+  z-index: 10;
+}
+
+/* the elastic slide: a dedicated keyframe animation plays only
+   while the dropdown is open, giving the menu a springy overshoot
+   as it drops down, rather than a flat linear transition */
+.ease-dropdown-input:checked ~ .ease-dropdown-menu {
+  opacity: 1;
+  visibility: visible;
+  transition: opacity 0.2s ease;
+  animation: ease-dropdown-elastic-slide var(--ease-dropdown-duration) var(--ease-dropdown-easing) forwards;
+}
+
+@keyframes ease-dropdown-elastic-slide {
+  0%   { transform: translateY(-14px) scaleY(0.9); }
+  55%  { transform: translateY(4px) scaleY(1.03); }
+  75%  { transform: translateY(-2px) scaleY(0.99); }
+  100% { transform: translateY(0) scaleY(1); }
+}
+
+.ease-dropdown-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  background: none;
+  border: none;
+  color: var(--ease-dropdown-text);
+  font-family: inherit;
+  font-size: 0.85rem;
+  padding: 0.65rem 0.75rem;
+  border-radius: 6px;
+  cursor: pointer;
+  text-align: left;
+  transition: background-color 0.15s ease;
+}
+
+.ease-dropdown-item:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.ease-dropdown-item-meta {
+  font-size: 0.75rem;
+  color: var(--ease-dropdown-muted-text);
+}
+
+@media (max-width: 480px) {
+  body { padding: 2rem 1rem; }
+  .ease-heading { font-size: 1.35rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-dropdown-menu {
+    animation: none !important;
+    transition: opacity 0.15s ease !important;
+    transform: none !important;
+  }
+
+  .ease-dropdown-arrow {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Closes #59380

Adds a pure CSS/HTML dropdown menu styled as a fintech account selector, with a springy elastic slide-down entrance.

---
## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---
## Submission Checklist
- [x] All changes inside `submissions/examples/css-elastic-slide-dropdown/`
- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

---
## Feature Description
**What does this add?** A checkbox-driven dropdown menu that opens with a multi-step elastic overshoot keyframe rather than a flat linear slide.

**How does a developer use it?**
```html
<div class="ease-dropdown">
  <input type="checkbox" id="ease-dropdown-toggle" class="ease-dropdown-input" />
  <label for="ease-dropdown-toggle" class="ease-dropdown-trigger">Select...</label>
  <div class="ease-dropdown-menu">...</div>
</div>
```

**Why does it fit EaseMotion CSS?** Plain-English class names, zero dependencies, and the elastic drop is achieved through an explicit multi-step `@keyframes` timeline rather than easing alone, giving a genuinely springy feel.

---
## Demo
- [x] Demo added

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge

---
## Notes for Maintainer
Menu uses `visibility` with a delayed transition on close, same pattern as the framework's modal submission, so it doesn't intercept clicks while hidden. Respects `prefers-reduced-motion`.