### PR TITLE
feat: add state machine orchestrator example

### DIFF
--- a/submissions/examples/state-machine-orchestrator-kp/README.md
+++ b/submissions/examples/state-machine-orchestrator-kp/README.md
@@ -1,0 +1,26 @@
+# State Machine Orchestrator KP
+
+## What does this do?
+
+State Machine Orchestrator KP adds a CSS-only workflow control surface for visualizing a release pipeline. It uses radio inputs, animated timeline progress, active nodes, and focused state cards to show queue, validation, execution, and recovery phases.
+
+## How is it used?
+
+Use semantic radio controls with labels to switch the workflow state. The timeline runner and cards respond entirely through sibling selectors.
+
+```html
+<input type="radio" name="machine-state" id="state-execute" />
+
+<nav class="state-tabs" aria-label="Workflow states">
+  <label for="state-execute">Execute</label>
+</nav>
+
+<div class="timeline" aria-hidden="true">
+  <span class="runner"></span>
+  <span class="node node-execute"></span>
+</div>
+```
+
+## Why is it useful?
+
+Complex products often need to explain state transitions, retries, and rollback routes without adding JavaScript to every documentation page. This example demonstrates advanced CSS state orchestration, responsive timeline direction changes, clear focus states, and reduced-motion support while keeping the markup portable.

--- a/submissions/examples/state-machine-orchestrator-kp/demo.html
+++ b/submissions/examples/state-machine-orchestrator-kp/demo.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>State Machine Orchestrator KP</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="orchestrator-shell" aria-labelledby="orchestrator-title">
+      <section class="intro-panel">
+        <p class="eyebrow">CSS workflow intelligence</p>
+        <h1 id="orchestrator-title">State Machine Orchestrator</h1>
+        <p>
+          Track queue intake, validation, execution, and rollback paths through
+          a motion-led control surface built without JavaScript.
+        </p>
+      </section>
+
+      <section
+        class="machine-board"
+        aria-label="Release workflow state machine"
+      >
+        <input type="radio" name="machine-state" id="state-queue" checked />
+        <input type="radio" name="machine-state" id="state-validate" />
+        <input type="radio" name="machine-state" id="state-execute" />
+        <input type="radio" name="machine-state" id="state-recover" />
+
+        <nav class="state-tabs" aria-label="Workflow states">
+          <label for="state-queue">Queue</label>
+          <label for="state-validate">Validate</label>
+          <label for="state-execute">Execute</label>
+          <label for="state-recover">Recover</label>
+        </nav>
+
+        <div class="timeline" aria-hidden="true">
+          <span class="rail"></span>
+          <span class="runner"></span>
+          <span class="node node-queue"></span>
+          <span class="node node-validate"></span>
+          <span class="node node-execute"></span>
+          <span class="node node-recover"></span>
+        </div>
+
+        <div class="state-grid">
+          <article class="state-card card-queue">
+            <span class="status">Queued</span>
+            <h2>Batch intake stabilized</h2>
+            <p>
+              New jobs are grouped by tenant, priority, and deadline window.
+            </p>
+          </article>
+          <article class="state-card card-validate">
+            <span class="status">Guarded</span>
+            <h2>Policy checks running</h2>
+            <p>Schema, quota, and dependency gates move in staggered layers.</p>
+          </article>
+          <article class="state-card card-execute">
+            <span class="status">Live</span>
+            <h2>Workers are deploying</h2>
+            <p>
+              Execution lanes pulse as each worker claims a safe unit of work.
+            </p>
+          </article>
+          <article class="state-card card-recover">
+            <span class="status">Fallback</span>
+            <h2>Rollback route armed</h2>
+            <p>Failed branches fold back into a clean retry checkpoint.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/state-machine-orchestrator-kp/style.css
+++ b/submissions/examples/state-machine-orchestrator-kp/style.css
@@ -1,0 +1,365 @@
+:root {
+  color-scheme: light;
+  --ink: #152033;
+  --muted: #667085;
+  --paper: #f6f8fb;
+  --panel: #ffffff;
+  --line: #d6dde8;
+  --blue: #2563eb;
+  --green: #12a36b;
+  --amber: #e59f12;
+  --rose: #dc4a5d;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(37, 99, 235, 0.12), transparent 38%),
+    linear-gradient(315deg, rgba(18, 163, 107, 0.14), transparent 42%),
+    var(--paper);
+}
+
+.orchestrator-shell {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.intro-panel {
+  max-width: 720px;
+  margin-bottom: 28px;
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: var(--blue);
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 14px;
+  font-size: clamp(2.1rem, 6vw, 4.6rem);
+  line-height: 0.95;
+}
+
+.intro-panel p:last-child {
+  max-width: 650px;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.machine-board {
+  padding: 22px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 22px 70px rgba(21, 32, 51, 0.12);
+}
+
+.machine-board > input {
+  position: absolute;
+  inline-size: 1px;
+  block-size: 1px;
+  opacity: 0;
+}
+
+.state-tabs {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+}
+
+.state-tabs label {
+  min-height: 48px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--muted);
+  font-weight: 800;
+  cursor: pointer;
+  background: var(--panel);
+  transition:
+    transform 220ms ease,
+    border-color 220ms ease,
+    color 220ms ease;
+}
+
+.state-tabs label:hover,
+.state-tabs label:focus-visible {
+  transform: translateY(-2px);
+  border-color: var(--blue);
+  color: var(--blue);
+}
+
+.timeline {
+  position: relative;
+  height: 96px;
+  margin: 16px 8px 10px;
+}
+
+.rail,
+.runner {
+  position: absolute;
+  top: 47px;
+  left: 5%;
+  right: 5%;
+  height: 6px;
+  border-radius: 999px;
+}
+
+.rail {
+  background: var(--line);
+}
+
+.runner {
+  right: auto;
+  width: 0;
+  background: linear-gradient(
+    90deg,
+    var(--blue),
+    var(--green),
+    var(--amber),
+    var(--rose)
+  );
+  animation: runner-breathe 1.8s ease-in-out infinite;
+  transition: width 520ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.node {
+  position: absolute;
+  top: 34px;
+  width: 32px;
+  height: 32px;
+  border: 6px solid var(--panel);
+  border-radius: 50%;
+  background: var(--line);
+  box-shadow: 0 0 0 1px var(--line);
+  transition:
+    transform 420ms ease,
+    background 420ms ease,
+    box-shadow 420ms ease;
+}
+
+.node-queue {
+  left: calc(5% - 16px);
+}
+.node-validate {
+  left: calc(35% - 16px);
+}
+.node-execute {
+  left: calc(65% - 16px);
+}
+.node-recover {
+  left: calc(95% - 16px);
+}
+
+.state-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.state-card {
+  min-height: 210px;
+  padding: 22px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  transform: translateY(12px) scale(0.97);
+  opacity: 0.58;
+  transition:
+    transform 420ms ease,
+    opacity 420ms ease,
+    border-color 420ms ease,
+    box-shadow 420ms ease;
+}
+
+.state-card h2 {
+  margin-bottom: 10px;
+  font-size: 1.2rem;
+}
+
+.state-card p {
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.status {
+  display: inline-flex;
+  margin-bottom: 34px;
+  padding: 7px 10px;
+  border-radius: 999px;
+  color: #fff;
+  font-size: 0.76rem;
+  font-weight: 900;
+}
+
+.card-queue .status {
+  background: var(--blue);
+}
+.card-validate .status {
+  background: var(--green);
+}
+.card-execute .status {
+  background: var(--amber);
+}
+.card-recover .status {
+  background: var(--rose);
+}
+
+#state-queue:checked ~ .state-tabs label[for="state-queue"],
+#state-validate:checked ~ .state-tabs label[for="state-validate"],
+#state-execute:checked ~ .state-tabs label[for="state-execute"],
+#state-recover:checked ~ .state-tabs label[for="state-recover"] {
+  color: #fff;
+  border-color: transparent;
+  background: var(--ink);
+}
+
+#state-queue:checked ~ .timeline .runner {
+  width: 0;
+}
+#state-validate:checked ~ .timeline .runner {
+  width: 30%;
+}
+#state-execute:checked ~ .timeline .runner {
+  width: 60%;
+}
+#state-recover:checked ~ .timeline .runner {
+  width: 90%;
+}
+
+#state-queue:checked ~ .timeline .node-queue,
+#state-validate:checked ~ .timeline .node-queue,
+#state-validate:checked ~ .timeline .node-validate,
+#state-execute:checked ~ .timeline .node-queue,
+#state-execute:checked ~ .timeline .node-validate,
+#state-execute:checked ~ .timeline .node-execute,
+#state-recover:checked ~ .timeline .node {
+  transform: scale(1.18);
+  background: var(--blue);
+  box-shadow: 0 0 0 8px rgba(37, 99, 235, 0.14);
+}
+
+#state-validate:checked ~ .timeline .node-validate {
+  background: var(--green);
+}
+#state-execute:checked ~ .timeline .node-execute {
+  background: var(--amber);
+}
+#state-recover:checked ~ .timeline .node-recover {
+  background: var(--rose);
+}
+
+#state-queue:checked ~ .state-grid .card-queue,
+#state-validate:checked ~ .state-grid .card-validate,
+#state-execute:checked ~ .state-grid .card-execute,
+#state-recover:checked ~ .state-grid .card-recover {
+  transform: translateY(0) scale(1);
+  opacity: 1;
+  border-color: rgba(37, 99, 235, 0.45);
+  box-shadow: 0 18px 44px rgba(21, 32, 51, 0.13);
+}
+
+@keyframes runner-breathe {
+  50% {
+    filter: brightness(1.16);
+  }
+}
+
+@media (max-width: 780px) {
+  .orchestrator-shell {
+    width: min(100% - 20px, 680px);
+    padding: 28px 0;
+  }
+
+  .machine-board {
+    padding: 14px;
+  }
+
+  .state-tabs,
+  .state-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .timeline {
+    height: 300px;
+    margin: 18px 0;
+  }
+
+  .rail,
+  .runner {
+    top: 5%;
+    bottom: 5%;
+    left: 50%;
+    right: auto;
+    width: 6px;
+    height: auto;
+    transform: translateX(-50%);
+  }
+
+  #state-validate:checked ~ .timeline .runner {
+    width: 6px;
+    height: 30%;
+  }
+  #state-execute:checked ~ .timeline .runner {
+    width: 6px;
+    height: 60%;
+  }
+  #state-recover:checked ~ .timeline .runner {
+    width: 6px;
+    height: 90%;
+  }
+
+  .node {
+    left: calc(50% - 16px);
+  }
+
+  .node-queue {
+    top: calc(5% - 16px);
+  }
+  .node-validate {
+    top: calc(35% - 16px);
+  }
+  .node-execute {
+    top: calc(65% - 16px);
+  }
+  .node-recover {
+    top: calc(95% - 16px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only state machine orchestrator example
- include responsive timeline state transitions and reduced-motion support
- document usage with semantic radio controls

## Validation
- npx prettier --check submissions/examples/state-machine-orchestrator-kp/README.md submissions/examples/state-machine-orchestrator-kp/demo.html submissions/examples/state-machine-orchestrator-kp/style.css
- git diff --check
- npx stylelint submissions/examples/state-machine-orchestrator-kp/style.css (repo config ignores submissions/)