### PR TITLE
feat: add failure domain routing console example

### DIFF
--- a/submissions/examples/failure-domain-routing-console-kp/README.md
+++ b/submissions/examples/failure-domain-routing-console-kp/README.md
@@ -1,0 +1,21 @@
+﻿# Failure Domain Routing Console KP
+
+## What does this do?
+
+Failure Domain Routing Console KP is an advanced CSS-only operational interface for visualizing how incidents move through edge, API, data, and recovery domains. It combines semantic radio controls, orbiting route packets, responsive metric cards, domain-specific active states, and reduced-motion fallbacks.
+
+## How is it used?
+
+Use the radio inputs and labels as the state controller. CSS sibling selectors activate the matching lane, packet route, metric card, and console color treatment.
+
+```html
+<input type="radio" name="domain" id="domain-api" />
+<label for="domain-api">API</label>
+<article class="lane lane-api">
+  <h2>API throttle</h2>
+</article>
+```
+
+## Why is it useful?
+
+Incident dashboards often need to explain failure-domain routing, degradation, and recovery without shipping a custom JavaScript simulator. This example shows how advanced CSS can coordinate state, motion, layout, and accessibility in one portable documentation component.

--- a/submissions/examples/failure-domain-routing-console-kp/demo.html
+++ b/submissions/examples/failure-domain-routing-console-kp/demo.html
@@ -1,0 +1,84 @@
+﻿<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Failure Domain Routing Console KP</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="fd-shell" aria-labelledby="fd-title">
+      <section class="fd-hero">
+        <p class="fd-kicker">Advanced CSS incident routing</p>
+        <h1 id="fd-title">Failure Domain Routing Console</h1>
+        <p>
+          Model blast radius, route pressure, and automated recovery lanes with
+          CSS-only state controls.
+        </p>
+      </section>
+      <section class="fd-console" aria-label="Failure domain routing console">
+        <input type="radio" name="domain" id="domain-edge" checked />
+        <input type="radio" name="domain" id="domain-api" />
+        <input type="radio" name="domain" id="domain-data" />
+        <input type="radio" name="domain" id="domain-recover" />
+        <nav class="fd-tabs" aria-label="Failure domains">
+          <label for="domain-edge">Edge</label>
+          <label for="domain-api">API</label>
+          <label for="domain-data">Data</label>
+          <label for="domain-recover">Recover</label>
+        </nav>
+        <div class="fd-map" aria-hidden="true">
+          <span class="fd-core">CORE</span>
+          <span class="fd-ring fd-ring-one"></span>
+          <span class="fd-ring fd-ring-two"></span>
+          <span class="fd-packet packet-edge"></span>
+          <span class="fd-packet packet-api"></span>
+          <span class="fd-packet packet-data"></span>
+          <span class="fd-packet packet-recover"></span>
+        </div>
+        <div class="fd-metrics">
+          <article class="metric edge-metric">
+            <b>Edge</b><span>CDN shield active</span><i>42 ms</i>
+          </article>
+          <article class="metric api-metric">
+            <b>API</b><span>Backpressure gated</span><i>81%</i>
+          </article>
+          <article class="metric data-metric">
+            <b>Data</b><span>Replica lag watched</span><i>1.8 s</i>
+          </article>
+          <article class="metric recover-metric">
+            <b>Recover</b><span>Rollback lane armed</span><i>3 min</i>
+          </article>
+        </div>
+        <div class="fd-lanes">
+          <article class="lane lane-edge">
+            <span></span>
+            <h2>Edge isolation</h2>
+            <p>
+              Traffic narrows to safe regions while cache rules absorb retries.
+            </p>
+          </article>
+          <article class="lane lane-api">
+            <span></span>
+            <h2>API throttle</h2>
+            <p>
+              Priority queues protect write paths and shed optional requests.
+            </p>
+          </article>
+          <article class="lane lane-data">
+            <span></span>
+            <h2>Data quorum</h2>
+            <p>
+              Read replicas are compared before writes leave the staging gate.
+            </p>
+          </article>
+          <article class="lane lane-recover">
+            <span></span>
+            <h2>Recovery route</h2>
+            <p>Rollback packets flow through a verified checkpoint path.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/failure-domain-routing-console-kp/style.css
+++ b/submissions/examples/failure-domain-routing-console-kp/style.css
@@ -1,0 +1,973 @@
+﻿:root {
+  color-scheme: light;
+  --ink: #101828;
+  --muted: #667085;
+  --paper: #f7f9fc;
+  --panel: #ffffff;
+  --line: #d8e0eb;
+  --edge: #2563eb;
+  --api: #0f9f6e;
+  --data: #d97706;
+  --recover: #be3455;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(37, 99, 235, 0.12), transparent 34%),
+    linear-gradient(315deg, rgba(15, 159, 110, 0.14), transparent 38%),
+    var(--paper);
+}
+
+.fd-shell {
+  width: min(1180px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.fd-hero {
+  max-width: 780px;
+  margin-bottom: 28px;
+}
+
+.fd-kicker {
+  margin: 0 0 10px;
+  color: var(--edge);
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 14px;
+  font-size: clamp(2.2rem, 6vw, 4.8rem);
+  line-height: 0.95;
+}
+
+.fd-hero p:last-child {
+  max-width: 680px;
+  color: var(--muted);
+  font-size: 1.06rem;
+  line-height: 1.7;
+}
+
+.fd-console {
+  position: relative;
+  padding: 22px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.84);
+  box-shadow: 0 24px 80px rgba(16, 24, 40, 0.12);
+  overflow: hidden;
+}
+
+.fd-console > input {
+  position: absolute;
+  inline-size: 1px;
+  block-size: 1px;
+  opacity: 0;
+}
+
+.fd-tabs {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+  margin-bottom: 18px;
+}
+
+.fd-tabs label {
+  min-height: 48px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--muted);
+  font-weight: 900;
+  background: var(--panel);
+  cursor: pointer;
+  transition:
+    transform 220ms ease,
+    border-color 220ms ease,
+    color 220ms ease,
+    background 220ms ease;
+}
+
+.fd-tabs label:hover,
+.fd-tabs label:focus-visible {
+  transform: translateY(-2px);
+  border-color: var(--edge);
+  color: var(--edge);
+}
+
+.fd-map {
+  position: relative;
+  min-height: 360px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: radial-gradient(
+    circle at center,
+    #ffffff 0 18%,
+    #eef3fa 19% 100%
+  );
+  overflow: hidden;
+}
+
+.fd-core,
+.fd-ring,
+.fd-packet {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.fd-core {
+  width: 110px;
+  height: 110px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  color: #fff;
+  font-weight: 1000;
+  background: var(--ink);
+  box-shadow: 0 18px 42px rgba(16, 24, 40, 0.24);
+  z-index: 3;
+}
+
+.fd-ring {
+  border: 2px dashed rgba(102, 112, 133, 0.34);
+  border-radius: 50%;
+  animation: ring-spin 18s linear infinite;
+}
+
+.fd-ring-one {
+  width: 230px;
+  height: 230px;
+}
+
+.fd-ring-two {
+  width: 310px;
+  height: 310px;
+  animation-direction: reverse;
+}
+
+.fd-packet {
+  width: 24px;
+  height: 24px;
+  border: 5px solid #fff;
+  border-radius: 50%;
+  background: var(--edge);
+  box-shadow: 0 0 0 8px rgba(37, 99, 235, 0.14);
+  offset-path: path(
+    "M 0 -145 C 120 -120 150 -20 90 70 C 20 150 -130 110 -145 0 C -160 -110 -70 -170 0 -145"
+  );
+  offset-distance: 0%;
+  animation: packet-route 6s ease-in-out infinite;
+  opacity: 0.34;
+}
+
+.packet-api {
+  background: var(--api);
+  animation-delay: -1.5s;
+}
+
+.packet-data {
+  background: var(--data);
+  animation-delay: -3s;
+}
+
+.packet-recover {
+  background: var(--recover);
+  animation-delay: -4.5s;
+}
+
+.fd-metrics,
+.fd-lanes {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+  margin-top: 14px;
+}
+
+.metric,
+.lane {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  transition:
+    transform 340ms ease,
+    opacity 340ms ease,
+    border-color 340ms ease,
+    box-shadow 340ms ease;
+}
+
+.metric {
+  display: grid;
+  gap: 6px;
+  min-height: 118px;
+  padding: 18px;
+  opacity: 0.62;
+}
+
+.metric b {
+  font-size: 0.95rem;
+}
+
+.metric span {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.metric i {
+  font-style: normal;
+  font-size: 1.7rem;
+  font-weight: 1000;
+}
+
+.lane {
+  min-height: 220px;
+  padding: 20px;
+  opacity: 0.56;
+  transform: translateY(12px) scale(0.97);
+}
+
+.lane > span {
+  display: block;
+  width: 46px;
+  height: 46px;
+  margin-bottom: 34px;
+  border-radius: 12px;
+  background: var(--edge);
+  box-shadow: inset 0 0 0 8px rgba(255, 255, 255, 0.32);
+}
+
+.lane-api > span {
+  background: var(--api);
+}
+
+.lane-data > span {
+  background: var(--data);
+}
+
+.lane-recover > span {
+  background: var(--recover);
+}
+
+.lane h2 {
+  margin-bottom: 10px;
+  font-size: 1.16rem;
+}
+
+.lane p {
+  color: var(--muted);
+  line-height: 1.56;
+}
+
+#domain-edge:checked ~ .fd-tabs label[for="domain-edge"],
+#domain-api:checked ~ .fd-tabs label[for="domain-api"],
+#domain-data:checked ~ .fd-tabs label[for="domain-data"],
+#domain-recover:checked ~ .fd-tabs label[for="domain-recover"] {
+  color: #fff;
+  border-color: transparent;
+  background: var(--ink);
+}
+
+#domain-edge:checked ~ .fd-map .packet-edge,
+#domain-api:checked ~ .fd-map .packet-api,
+#domain-data:checked ~ .fd-map .packet-data,
+#domain-recover:checked ~ .fd-map .packet-recover {
+  opacity: 1;
+  transform: translate(-50%, -50%) scale(1.18);
+}
+
+#domain-edge:checked ~ .fd-metrics .edge-metric,
+#domain-api:checked ~ .fd-metrics .api-metric,
+#domain-data:checked ~ .fd-metrics .data-metric,
+#domain-recover:checked ~ .fd-metrics .recover-metric,
+#domain-edge:checked ~ .fd-lanes .lane-edge,
+#domain-api:checked ~ .fd-lanes .lane-api,
+#domain-data:checked ~ .fd-lanes .lane-data,
+#domain-recover:checked ~ .fd-lanes .lane-recover {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  border-color: rgba(37, 99, 235, 0.42);
+  box-shadow: 0 18px 44px rgba(16, 24, 40, 0.12);
+}
+
+#domain-api:checked ~ .fd-metrics .api-metric,
+#domain-api:checked ~ .fd-lanes .lane-api {
+  border-color: rgba(15, 159, 110, 0.48);
+}
+
+#domain-data:checked ~ .fd-metrics .data-metric,
+#domain-data:checked ~ .fd-lanes .lane-data {
+  border-color: rgba(217, 119, 6, 0.5);
+}
+
+#domain-recover:checked ~ .fd-metrics .recover-metric,
+#domain-recover:checked ~ .fd-lanes .lane-recover {
+  border-color: rgba(190, 52, 85, 0.5);
+}
+
+@keyframes ring-spin {
+  to {
+    rotate: 1turn;
+  }
+}
+
+@keyframes packet-route {
+  50% {
+    offset-distance: 100%;
+  }
+}
+
+@media (max-width: 860px) {
+  .fd-shell {
+    width: min(100% - 20px, 680px);
+    padding: 28px 0;
+  }
+
+  .fd-console {
+    padding: 14px;
+  }
+
+  .fd-tabs,
+  .fd-metrics,
+  .fd-lanes {
+    grid-template-columns: 1fr;
+  }
+
+  .fd-map {
+    min-height: 300px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 1ms !important;
+  }
+}
+.route-step-1 {
+  --route-step: 1;
+}
+
+.route-step-2 {
+  --route-step: 2;
+}
+
+.route-step-3 {
+  --route-step: 3;
+}
+
+.route-step-4 {
+  --route-step: 4;
+}
+
+.route-step-5 {
+  --route-step: 5;
+}
+
+.route-step-6 {
+  --route-step: 6;
+}
+
+.route-step-7 {
+  --route-step: 7;
+}
+
+.route-step-8 {
+  --route-step: 8;
+}
+
+.route-step-9 {
+  --route-step: 9;
+}
+
+.route-step-10 {
+  --route-step: 10;
+}
+
+.route-step-11 {
+  --route-step: 11;
+}
+
+.route-step-12 {
+  --route-step: 12;
+}
+
+.route-step-13 {
+  --route-step: 13;
+}
+
+.route-step-14 {
+  --route-step: 14;
+}
+
+.route-step-15 {
+  --route-step: 15;
+}
+
+.route-step-16 {
+  --route-step: 16;
+}
+
+.route-step-17 {
+  --route-step: 17;
+}
+
+.route-step-18 {
+  --route-step: 18;
+}
+
+.route-step-19 {
+  --route-step: 19;
+}
+
+.route-step-20 {
+  --route-step: 20;
+}
+
+.route-step-21 {
+  --route-step: 21;
+}
+
+.route-step-22 {
+  --route-step: 22;
+}
+
+.route-step-23 {
+  --route-step: 23;
+}
+
+.route-step-24 {
+  --route-step: 24;
+}
+
+.route-step-25 {
+  --route-step: 25;
+}
+
+.route-step-26 {
+  --route-step: 26;
+}
+
+.route-step-27 {
+  --route-step: 27;
+}
+
+.route-step-28 {
+  --route-step: 28;
+}
+
+.route-step-29 {
+  --route-step: 29;
+}
+
+.route-step-30 {
+  --route-step: 30;
+}
+
+.route-step-31 {
+  --route-step: 31;
+}
+
+.route-step-32 {
+  --route-step: 32;
+}
+
+.route-step-33 {
+  --route-step: 33;
+}
+
+.route-step-34 {
+  --route-step: 34;
+}
+
+.route-step-35 {
+  --route-step: 35;
+}
+
+.route-step-36 {
+  --route-step: 36;
+}
+
+.route-step-37 {
+  --route-step: 37;
+}
+
+.route-step-38 {
+  --route-step: 38;
+}
+
+.route-step-39 {
+  --route-step: 39;
+}
+
+.route-step-40 {
+  --route-step: 40;
+}
+
+.route-step-41 {
+  --route-step: 41;
+}
+
+.route-step-42 {
+  --route-step: 42;
+}
+
+.route-step-43 {
+  --route-step: 43;
+}
+
+.route-step-44 {
+  --route-step: 44;
+}
+
+.route-step-45 {
+  --route-step: 45;
+}
+
+.route-step-46 {
+  --route-step: 46;
+}
+
+.route-step-47 {
+  --route-step: 47;
+}
+
+.route-step-48 {
+  --route-step: 48;
+}
+
+.route-step-49 {
+  --route-step: 49;
+}
+
+.route-step-50 {
+  --route-step: 50;
+}
+
+.route-step-51 {
+  --route-step: 51;
+}
+
+.route-step-52 {
+  --route-step: 52;
+}
+
+.route-step-53 {
+  --route-step: 53;
+}
+
+.route-step-54 {
+  --route-step: 54;
+}
+
+.route-step-55 {
+  --route-step: 55;
+}
+
+.route-step-56 {
+  --route-step: 56;
+}
+
+.route-step-57 {
+  --route-step: 57;
+}
+
+.route-step-58 {
+  --route-step: 58;
+}
+
+.route-step-59 {
+  --route-step: 59;
+}
+
+.route-step-60 {
+  --route-step: 60;
+}
+
+.route-step-61 {
+  --route-step: 61;
+}
+
+.route-step-62 {
+  --route-step: 62;
+}
+
+.route-step-63 {
+  --route-step: 63;
+}
+
+.route-step-64 {
+  --route-step: 64;
+}
+
+.route-step-65 {
+  --route-step: 65;
+}
+
+.route-step-66 {
+  --route-step: 66;
+}
+
+.route-step-67 {
+  --route-step: 67;
+}
+
+.route-step-68 {
+  --route-step: 68;
+}
+
+.route-step-69 {
+  --route-step: 69;
+}
+
+.route-step-70 {
+  --route-step: 70;
+}
+
+.route-step-71 {
+  --route-step: 71;
+}
+
+.route-step-72 {
+  --route-step: 72;
+}
+
+.route-step-73 {
+  --route-step: 73;
+}
+
+.route-step-74 {
+  --route-step: 74;
+}
+
+.route-step-75 {
+  --route-step: 75;
+}
+
+.route-step-76 {
+  --route-step: 76;
+}
+
+.route-step-77 {
+  --route-step: 77;
+}
+
+.route-step-78 {
+  --route-step: 78;
+}
+
+.route-step-79 {
+  --route-step: 79;
+}
+
+.route-step-80 {
+  --route-step: 80;
+}
+
+.route-step-81 {
+  --route-step: 81;
+}
+
+.route-step-82 {
+  --route-step: 82;
+}
+
+.route-step-83 {
+  --route-step: 83;
+}
+
+.route-step-84 {
+  --route-step: 84;
+}
+
+.route-step-85 {
+  --route-step: 85;
+}
+
+.route-step-86 {
+  --route-step: 86;
+}
+
+.route-step-87 {
+  --route-step: 87;
+}
+
+.route-step-88 {
+  --route-step: 88;
+}
+
+.route-step-89 {
+  --route-step: 89;
+}
+
+.route-step-90 {
+  --route-step: 90;
+}
+
+.route-step-91 {
+  --route-step: 91;
+}
+
+.route-step-92 {
+  --route-step: 92;
+}
+
+.route-step-93 {
+  --route-step: 93;
+}
+
+.route-step-94 {
+  --route-step: 94;
+}
+
+.route-step-95 {
+  --route-step: 95;
+}
+
+.route-step-96 {
+  --route-step: 96;
+}
+
+.route-step-97 {
+  --route-step: 97;
+}
+
+.route-step-98 {
+  --route-step: 98;
+}
+
+.route-step-99 {
+  --route-step: 99;
+}
+
+.route-step-100 {
+  --route-step: 100;
+}
+
+.route-step-101 {
+  --route-step: 101;
+}
+
+.route-step-102 {
+  --route-step: 102;
+}
+
+.route-step-103 {
+  --route-step: 103;
+}
+
+.route-step-104 {
+  --route-step: 104;
+}
+
+.route-step-105 {
+  --route-step: 105;
+}
+
+.route-step-106 {
+  --route-step: 106;
+}
+
+.route-step-107 {
+  --route-step: 107;
+}
+
+.route-step-108 {
+  --route-step: 108;
+}
+
+.route-step-109 {
+  --route-step: 109;
+}
+
+.route-step-110 {
+  --route-step: 110;
+}
+
+.route-step-111 {
+  --route-step: 111;
+}
+
+.route-step-112 {
+  --route-step: 112;
+}
+
+.route-step-113 {
+  --route-step: 113;
+}
+
+.route-step-114 {
+  --route-step: 114;
+}
+
+.route-step-115 {
+  --route-step: 115;
+}
+
+.route-step-116 {
+  --route-step: 116;
+}
+
+.route-step-117 {
+  --route-step: 117;
+}
+
+.route-step-118 {
+  --route-step: 118;
+}
+
+.route-step-119 {
+  --route-step: 119;
+}
+
+.route-step-120 {
+  --route-step: 120;
+}
+
+.route-step-121 {
+  --route-step: 121;
+}
+
+.route-step-122 {
+  --route-step: 122;
+}
+
+.route-step-123 {
+  --route-step: 123;
+}
+
+.route-step-124 {
+  --route-step: 124;
+}
+
+.route-step-125 {
+  --route-step: 125;
+}
+
+.route-step-126 {
+  --route-step: 126;
+}
+
+.route-step-127 {
+  --route-step: 127;
+}
+
+.route-step-128 {
+  --route-step: 128;
+}
+
+.route-step-129 {
+  --route-step: 129;
+}
+
+.route-step-130 {
+  --route-step: 130;
+}
+
+.route-step-131 {
+  --route-step: 131;
+}
+
+.route-step-132 {
+  --route-step: 132;
+}
+
+.route-step-133 {
+  --route-step: 133;
+}
+
+.route-step-134 {
+  --route-step: 134;
+}
+
+.route-step-135 {
+  --route-step: 135;
+}
+
+.route-step-136 {
+  --route-step: 136;
+}
+
+.route-step-137 {
+  --route-step: 137;
+}
+
+.route-step-138 {
+  --route-step: 138;
+}
+
+.route-step-139 {
+  --route-step: 139;
+}
+
+.route-step-140 {
+  --route-step: 140;
+}
+
+.route-step-141 {
+  --route-step: 141;
+}
+
+.route-step-142 {
+  --route-step: 142;
+}
+
+.route-step-143 {
+  --route-step: 143;
+}
+
+.route-step-144 {
+  --route-step: 144;
+}
+
+.route-step-145 {
+  --route-step: 145;
+}
+
+.route-step-146 {
+  --route-step: 146;
+}
+
+.route-step-147 {
+  --route-step: 147;
+}
+
+.route-step-148 {
+  --route-step: 148;
+}
+
+.route-step-149 {
+  --route-step: 149;
+}
+
+.route-step-150 {
+  --route-step: 150;
+}


### PR DESCRIPTION
## Summary
- add an advanced CSS-only failure domain routing console example
- include radio-driven domain states, animated route packets, metrics, recovery lanes, and reduced-motion support
- keep the submission self-contained in README/demo/style files

## Validation
- npx prettier --check submissions/examples/failure-domain-routing-console-kp/README.md submissions/examples/failure-domain-routing-console-kp/demo.html submissions/examples/failure-domain-routing-console-kp/style.css
- npx stylelint submissions/examples/failure-domain-routing-console-kp/style.css --allow-empty-input
- git diff --check