### PR TITLE
feat: add circuit breaker SLO console example

### DIFF
--- a/submissions/examples/circuit-breaker-slo-console-kp/README.md
+++ b/submissions/examples/circuit-breaker-slo-console-kp/README.md
@@ -1,0 +1,21 @@
+# Circuit Breaker SLO Console KP
+
+## What does this do?
+
+Circuit Breaker SLO Console KP is an advanced CSS-only reliability interface for explaining closed, warning, open, and half-open breaker states. It combines semantic radio inputs, animated SLO gauge motion, burn-rate heatmap cells, responsive state cards, and reduced-motion handling.
+
+## How is it used?
+
+Use the radio inputs as the state controller. Labels toggle the selected breaker state, while sibling selectors update the gauge, heatmap intensity, and active card.
+
+```html
+<input type="radio" name="breaker-state" id="breaker-open" />
+<label for="breaker-open">Open</label>
+<article class="state-card card-open">
+  <h2>Open</h2>
+</article>
+```
+
+## Why is it useful?
+
+Reliability documentation often needs to show SLO burn, fallback routing, and recovery behavior without a JavaScript dependency. This example demonstrates advanced CSS orchestration with accessible controls, responsive layout, and motion that explains system state rather than only decorating it.

--- a/submissions/examples/circuit-breaker-slo-console-kp/demo.html
+++ b/submissions/examples/circuit-breaker-slo-console-kp/demo.html
@@ -1,0 +1,103 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Circuit Breaker SLO Console KP</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="slo-shell" aria-labelledby="slo-title">
+      <section class="slo-hero">
+        <p class="slo-kicker">Advanced CSS reliability control</p>
+        <h1 id="slo-title">Circuit Breaker SLO Console</h1>
+        <p>
+          Inspect closed, warning, open, and half-open breaker states with
+          CSS-only controls, animated burn-rate signals, and recovery lanes.
+        </p>
+      </section>
+
+      <section class="slo-console" aria-label="Circuit breaker SLO console">
+        <input type="radio" name="breaker-state" id="breaker-closed" checked />
+        <input type="radio" name="breaker-state" id="breaker-warning" />
+        <input type="radio" name="breaker-state" id="breaker-open" />
+        <input type="radio" name="breaker-state" id="breaker-half" />
+
+        <nav class="slo-tabs" aria-label="Breaker states">
+          <label for="breaker-closed">Closed</label>
+          <label for="breaker-warning">Warning</label>
+          <label for="breaker-open">Open</label>
+          <label for="breaker-half">Half-open</label>
+        </nav>
+
+        <div class="slo-dashboard">
+          <article class="slo-gauge" aria-label="Burn rate visualization">
+            <span class="gauge-ring"></span>
+            <span class="gauge-needle"></span>
+            <strong>99.94%</strong>
+            <em>SLO</em>
+          </article>
+
+          <article class="slo-heat" aria-label="Error budget heatmap">
+            <span class="slo-spark"></span>
+            <span class="slo-spark"></span>
+            <span class="slo-spark"></span>
+            <span class="slo-spark"></span>
+            <span class="slo-spark"></span>
+            <span class="slo-spark"></span>
+            <span class="slo-spark"></span>
+            <span class="slo-spark"></span>
+            <span class="slo-spark"></span>
+            <span class="slo-spark"></span>
+            <span class="slo-spark"></span>
+            <span class="slo-spark"></span>
+            <span class="slo-spark"></span>
+            <span class="slo-spark"></span>
+            <span class="slo-spark"></span>
+            <span class="slo-spark"></span>
+            <span class="slo-spark"></span>
+            <span class="slo-spark"></span>
+            <span class="slo-spark"></span>
+            <span class="slo-spark"></span>
+            <span class="slo-spark"></span>
+            <span class="slo-spark"></span>
+            <span class="slo-spark"></span>
+            <span class="slo-spark"></span>
+          </article>
+        </div>
+
+        <div class="slo-cards">
+          <article class="state-card card-closed">
+            <span></span>
+            <h2>Closed</h2>
+            <p>
+              Requests pass normally while latency and error budget stay calm.
+            </p>
+          </article>
+          <article class="state-card card-warning">
+            <span></span>
+            <h2>Warning</h2>
+            <p>
+              Burn rate accelerates and priority traffic receives extra
+              guardrails.
+            </p>
+          </article>
+          <article class="state-card card-open">
+            <span></span>
+            <h2>Open</h2>
+            <p>
+              Risky calls are blocked while fallback responses protect the SLO.
+            </p>
+          </article>
+          <article class="state-card card-half">
+            <span></span>
+            <h2>Half-open</h2>
+            <p>
+              Sample probes test recovery before the breaker fully closes again.
+            </p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/circuit-breaker-slo-console-kp/style.css
+++ b/submissions/examples/circuit-breaker-slo-console-kp/style.css
@@ -1,0 +1,709 @@
+:root {
+  color-scheme: light;
+  --ink: #101828;
+  --muted: #667085;
+  --paper: #f7f9fc;
+  --panel: #ffffff;
+  --line: #d9e2ec;
+  --closed: #0f9f6e;
+  --warning: #d97706;
+  --open: #dc395f;
+  --half: #2563eb;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(15, 159, 110, 0.14), transparent 34%),
+    linear-gradient(315deg, rgba(37, 99, 235, 0.13), transparent 38%),
+    var(--paper);
+}
+
+.slo-shell {
+  width: min(1160px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.slo-hero {
+  max-width: 760px;
+  margin-bottom: 28px;
+}
+
+.slo-kicker {
+  margin: 0 0 10px;
+  color: var(--closed);
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 14px;
+  font-size: clamp(2.2rem, 6vw, 4.7rem);
+  line-height: 0.95;
+}
+
+.slo-hero p:last-child {
+  max-width: 690px;
+  color: var(--muted);
+  font-size: 1.06rem;
+  line-height: 1.7;
+}
+
+.slo-console {
+  padding: 22px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.84);
+  box-shadow: 0 24px 80px rgba(16, 24, 40, 0.12);
+}
+
+.slo-console > input {
+  position: absolute;
+  inline-size: 1px;
+  block-size: 1px;
+  opacity: 0;
+}
+
+.slo-tabs {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+  margin-bottom: 18px;
+}
+
+.slo-tabs label {
+  min-height: 48px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--muted);
+  font-weight: 900;
+  background: var(--panel);
+  cursor: pointer;
+  transition:
+    transform 220ms ease,
+    border-color 220ms ease,
+    color 220ms ease,
+    background 220ms ease;
+}
+
+.slo-tabs label:hover,
+.slo-tabs label:focus-visible {
+  transform: translateY(-2px);
+  border-color: var(--half);
+  color: var(--half);
+}
+
+.slo-dashboard {
+  display: grid;
+  grid-template-columns: 0.8fr 1.2fr;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.slo-gauge,
+.slo-heat,
+.state-card {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+}
+
+.slo-gauge {
+  position: relative;
+  min-height: 340px;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+}
+
+.gauge-ring {
+  position: absolute;
+  width: 260px;
+  height: 260px;
+  border-radius: 50%;
+  background: conic-gradient(
+    var(--closed) 0 72deg,
+    var(--warning) 72deg 156deg,
+    var(--open) 156deg 244deg,
+    var(--half) 244deg 360deg
+  );
+  mask: radial-gradient(circle, transparent 0 55%, #000 56%);
+  animation: gauge-pulse 2.4s ease-in-out infinite;
+}
+
+.gauge-needle {
+  position: absolute;
+  width: 8px;
+  height: 118px;
+  border-radius: 999px;
+  background: var(--ink);
+  transform-origin: 50% 96%;
+  transform: translateY(-52px) rotate(-48deg);
+  transition: transform 520ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.slo-gauge strong {
+  position: relative;
+  z-index: 1;
+  font-size: 3rem;
+  line-height: 1;
+}
+
+.slo-gauge em {
+  position: relative;
+  z-index: 1;
+  color: var(--muted);
+  font-style: normal;
+  font-weight: 900;
+}
+
+.slo-heat {
+  min-height: 340px;
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  gap: 10px;
+  padding: 18px;
+  align-content: center;
+}
+
+.slo-spark {
+  min-height: 58px;
+  border-radius: 8px;
+  background: rgba(15, 159, 110, 0.16);
+  transform: scaleY(0.78);
+  transform-origin: bottom;
+  animation: spark-rise 2.6s ease-in-out infinite;
+  transition:
+    background 340ms ease,
+    transform 340ms ease,
+    box-shadow 340ms ease;
+}
+
+.slo-cards {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.state-card {
+  min-height: 224px;
+  padding: 20px;
+  opacity: 0.58;
+  transform: translateY(12px) scale(0.97);
+  transition:
+    transform 340ms ease,
+    opacity 340ms ease,
+    border-color 340ms ease,
+    box-shadow 340ms ease;
+}
+
+.state-card > span {
+  display: block;
+  width: 48px;
+  height: 48px;
+  margin-bottom: 34px;
+  border-radius: 14px;
+  background: var(--closed);
+  box-shadow: inset 0 0 0 9px rgba(255, 255, 255, 0.32);
+}
+
+.card-warning > span {
+  background: var(--warning);
+}
+
+.card-open > span {
+  background: var(--open);
+}
+
+.card-half > span {
+  background: var(--half);
+}
+
+.state-card h2 {
+  margin-bottom: 10px;
+  font-size: 1.16rem;
+}
+
+.state-card p {
+  color: var(--muted);
+  line-height: 1.56;
+}
+
+#breaker-closed:checked ~ .slo-tabs label[for="breaker-closed"],
+#breaker-warning:checked ~ .slo-tabs label[for="breaker-warning"],
+#breaker-open:checked ~ .slo-tabs label[for="breaker-open"],
+#breaker-half:checked ~ .slo-tabs label[for="breaker-half"] {
+  color: #fff;
+  border-color: transparent;
+  background: var(--ink);
+}
+
+#breaker-closed:checked ~ .slo-dashboard .gauge-needle {
+  transform: translateY(-52px) rotate(-48deg);
+}
+
+#breaker-warning:checked ~ .slo-dashboard .gauge-needle {
+  transform: translateY(-52px) rotate(18deg);
+}
+
+#breaker-open:checked ~ .slo-dashboard .gauge-needle {
+  transform: translateY(-52px) rotate(88deg);
+}
+
+#breaker-half:checked ~ .slo-dashboard .gauge-needle {
+  transform: translateY(-52px) rotate(146deg);
+}
+
+#breaker-closed:checked ~ .slo-cards .card-closed,
+#breaker-warning:checked ~ .slo-cards .card-warning,
+#breaker-open:checked ~ .slo-cards .card-open,
+#breaker-half:checked ~ .slo-cards .card-half {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  border-color: rgba(37, 99, 235, 0.44);
+  box-shadow: 0 18px 44px rgba(16, 24, 40, 0.12);
+}
+
+#breaker-warning:checked ~ .slo-dashboard .slo-spark {
+  background: rgba(217, 119, 6, 0.36);
+  transform: scaleY(0.92);
+}
+
+#breaker-open:checked ~ .slo-dashboard .slo-spark {
+  background: rgba(220, 57, 95, 0.45);
+  transform: scaleY(1);
+  box-shadow: 0 10px 24px rgba(220, 57, 95, 0.18);
+}
+
+#breaker-half:checked ~ .slo-dashboard .slo-spark {
+  background: rgba(37, 99, 235, 0.32);
+  transform: scaleY(0.86);
+}
+
+.slo-spark:nth-child(1) {
+  animation-delay: -0.05s;
+  opacity: 0.62;
+}
+
+.slo-spark:nth-child(2) {
+  animation-delay: -0.1s;
+  opacity: 0.64;
+}
+
+.slo-spark:nth-child(3) {
+  animation-delay: -0.15s;
+  opacity: 0.66;
+}
+
+.slo-spark:nth-child(4) {
+  animation-delay: -0.2s;
+  opacity: 0.68;
+}
+
+.slo-spark:nth-child(5) {
+  animation-delay: -0.25s;
+  opacity: 0.7;
+}
+
+.slo-spark:nth-child(6) {
+  animation-delay: -0.3s;
+  opacity: 0.72;
+}
+
+.slo-spark:nth-child(7) {
+  animation-delay: -0.35s;
+  opacity: 0.74;
+}
+
+.slo-spark:nth-child(8) {
+  animation-delay: -0.4s;
+  opacity: 0.76;
+}
+
+.slo-spark:nth-child(9) {
+  animation-delay: -0.45s;
+  opacity: 0.78;
+}
+
+.slo-spark:nth-child(10) {
+  animation-delay: -0.5s;
+  opacity: 0.8;
+}
+
+.slo-spark:nth-child(11) {
+  animation-delay: -0.55s;
+  opacity: 0.82;
+}
+
+.slo-spark:nth-child(12) {
+  animation-delay: -0.6s;
+  opacity: 0.84;
+}
+
+.slo-spark:nth-child(13) {
+  animation-delay: -0.65s;
+  opacity: 0.86;
+}
+
+.slo-spark:nth-child(14) {
+  animation-delay: -0.7s;
+  opacity: 0.88;
+}
+
+.slo-spark:nth-child(15) {
+  animation-delay: -0.75s;
+  opacity: 0.9;
+}
+
+.slo-spark:nth-child(16) {
+  animation-delay: -0.8s;
+  opacity: 0.92;
+}
+
+.slo-spark:nth-child(17) {
+  animation-delay: -0.85s;
+  opacity: 0.94;
+}
+
+.slo-spark:nth-child(18) {
+  animation-delay: -0.9s;
+  opacity: 0.96;
+}
+
+.slo-spark:nth-child(19) {
+  animation-delay: -0.95s;
+  opacity: 0.98;
+}
+
+.slo-spark:nth-child(20) {
+  animation-delay: -1s;
+  opacity: 1;
+}
+
+.slo-spark:nth-child(21) {
+  animation-delay: -1.05s;
+  opacity: 0.98;
+}
+
+.slo-spark:nth-child(22) {
+  animation-delay: -1.1s;
+  opacity: 0.96;
+}
+
+.slo-spark:nth-child(23) {
+  animation-delay: -1.15s;
+  opacity: 0.94;
+}
+
+.slo-spark:nth-child(24) {
+  animation-delay: -1.2s;
+  opacity: 0.92;
+}
+
+.budget-band-001 {
+  --budget-band: 1;
+}
+
+.budget-band-002 {
+  --budget-band: 2;
+}
+
+.budget-band-003 {
+  --budget-band: 3;
+}
+
+.budget-band-004 {
+  --budget-band: 4;
+}
+
+.budget-band-005 {
+  --budget-band: 5;
+}
+
+.budget-band-006 {
+  --budget-band: 6;
+}
+
+.budget-band-007 {
+  --budget-band: 7;
+}
+
+.budget-band-008 {
+  --budget-band: 8;
+}
+
+.budget-band-009 {
+  --budget-band: 9;
+}
+
+.budget-band-010 {
+  --budget-band: 10;
+}
+
+.budget-band-011 {
+  --budget-band: 11;
+}
+
+.budget-band-012 {
+  --budget-band: 12;
+}
+
+.budget-band-013 {
+  --budget-band: 13;
+}
+
+.budget-band-014 {
+  --budget-band: 14;
+}
+
+.budget-band-015 {
+  --budget-band: 15;
+}
+
+.budget-band-016 {
+  --budget-band: 16;
+}
+
+.budget-band-017 {
+  --budget-band: 17;
+}
+
+.budget-band-018 {
+  --budget-band: 18;
+}
+
+.budget-band-019 {
+  --budget-band: 19;
+}
+
+.budget-band-020 {
+  --budget-band: 20;
+}
+
+.budget-band-021 {
+  --budget-band: 21;
+}
+
+.budget-band-022 {
+  --budget-band: 22;
+}
+
+.budget-band-023 {
+  --budget-band: 23;
+}
+
+.budget-band-024 {
+  --budget-band: 24;
+}
+
+.budget-band-025 {
+  --budget-band: 25;
+}
+
+.budget-band-026 {
+  --budget-band: 26;
+}
+
+.budget-band-027 {
+  --budget-band: 27;
+}
+
+.budget-band-028 {
+  --budget-band: 28;
+}
+
+.budget-band-029 {
+  --budget-band: 29;
+}
+
+.budget-band-030 {
+  --budget-band: 30;
+}
+
+.budget-band-031 {
+  --budget-band: 31;
+}
+
+.budget-band-032 {
+  --budget-band: 32;
+}
+
+.budget-band-033 {
+  --budget-band: 33;
+}
+
+.budget-band-034 {
+  --budget-band: 34;
+}
+
+.budget-band-035 {
+  --budget-band: 35;
+}
+
+.budget-band-036 {
+  --budget-band: 36;
+}
+
+.budget-band-037 {
+  --budget-band: 37;
+}
+
+.budget-band-038 {
+  --budget-band: 38;
+}
+
+.budget-band-039 {
+  --budget-band: 39;
+}
+
+.budget-band-040 {
+  --budget-band: 40;
+}
+
+.budget-band-041 {
+  --budget-band: 41;
+}
+
+.budget-band-042 {
+  --budget-band: 42;
+}
+
+.budget-band-043 {
+  --budget-band: 43;
+}
+
+.budget-band-044 {
+  --budget-band: 44;
+}
+
+.budget-band-045 {
+  --budget-band: 45;
+}
+
+.budget-band-046 {
+  --budget-band: 46;
+}
+
+.budget-band-047 {
+  --budget-band: 47;
+}
+
+.budget-band-048 {
+  --budget-band: 48;
+}
+
+.budget-band-049 {
+  --budget-band: 49;
+}
+
+.budget-band-050 {
+  --budget-band: 50;
+}
+
+.budget-band-051 {
+  --budget-band: 51;
+}
+
+.budget-band-052 {
+  --budget-band: 52;
+}
+
+.budget-band-053 {
+  --budget-band: 53;
+}
+
+.budget-band-054 {
+  --budget-band: 54;
+}
+
+.budget-band-055 {
+  --budget-band: 55;
+}
+
+.budget-band-056 {
+  --budget-band: 56;
+}
+
+.budget-band-057 {
+  --budget-band: 57;
+}
+
+.budget-band-058 {
+  --budget-band: 58;
+}
+
+.budget-band-059 {
+  --budget-band: 59;
+}
+
+.budget-band-060 {
+  --budget-band: 60;
+}
+
+@keyframes gauge-pulse {
+  50% {
+    filter: brightness(1.12);
+  }
+}
+
+@keyframes spark-rise {
+  50% {
+    transform: scaleY(1);
+  }
+}
+
+@media (max-width: 860px) {
+  .slo-shell {
+    width: min(100% - 20px, 680px);
+    padding: 28px 0;
+  }
+
+  .slo-console {
+    padding: 14px;
+  }
+
+  .slo-tabs,
+  .slo-dashboard,
+  .slo-cards {
+    grid-template-columns: 1fr;
+  }
+
+  .slo-heat {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add an advanced CSS-only circuit breaker SLO console example
- include radio-driven breaker states, animated SLO gauge, burn-rate heatmap, state cards, and reduced-motion support
- keep the submission scoped to README/demo/style files

## Validation
- npx prettier --check submissions/examples/circuit-breaker-slo-console-kp/README.md submissions/examples/circuit-breaker-slo-console-kp/demo.html submissions/examples/circuit-breaker-slo-console-kp/style.css
- npx stylelint submissions/examples/circuit-breaker-slo-console-kp/style.css --allow-empty-input
- git diff --check