### PR TITLE
feat: add progressive canary delivery example

### DIFF
--- a/submissions/examples/progressive-canary-delivery-kp/README.md
+++ b/submissions/examples/progressive-canary-delivery-kp/README.md
@@ -1,0 +1,21 @@
+# Progressive Canary Delivery KP
+
+## What does this do?
+
+Progressive Canary Delivery KP is an advanced CSS-only release control example for explaining gradual rollout stages. It uses semantic radio controls, animated traffic lanes, a conic rollout gauge, stateful health cards, responsive layout, and reduced-motion support.
+
+## How is it used?
+
+Use radio inputs as the rollout controller. Labels switch the active stage, while sibling selectors update the traffic gauge, lane animation, and active health card.
+
+```html
+<input type="radio" name="rollout" id="rollout-50" />
+<label for="rollout-50">50%</label>
+<article class="health-card card-balance">
+  <h2>Balanced split</h2>
+</article>
+```
+
+## Why is it useful?
+
+Release notes, platform docs, and internal dashboards often need to show staged rollout behavior without shipping JavaScript. This example demonstrates advanced CSS orchestration for progressive delivery, health gates, traffic splitting, and rollback visibility.

--- a/submissions/examples/progressive-canary-delivery-kp/demo.html
+++ b/submissions/examples/progressive-canary-delivery-kp/demo.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Progressive Canary Delivery KP</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="canary-shell" aria-labelledby="canary-title">
+      <section class="canary-hero">
+        <p class="canary-kicker">Advanced CSS release control</p>
+        <h1 id="canary-title">Progressive Canary Delivery</h1>
+        <p>
+          Visualize 5%, 25%, 50%, and full rollout phases with CSS-only
+          controls, animated traffic flow, health gates, and rollback-aware
+          status panels.
+        </p>
+      </section>
+
+      <section class="canary-console" aria-label="Progressive rollout console">
+        <input type="radio" name="rollout" id="rollout-5" checked />
+        <input type="radio" name="rollout" id="rollout-25" />
+        <input type="radio" name="rollout" id="rollout-50" />
+        <input type="radio" name="rollout" id="rollout-100" />
+
+        <nav class="rollout-tabs" aria-label="Rollout stages">
+          <label for="rollout-5">5%</label>
+          <label for="rollout-25">25%</label>
+          <label for="rollout-50">50%</label>
+          <label for="rollout-100">100%</label>
+        </nav>
+
+        <div class="traffic-board">
+          <article class="release-ring" aria-label="Traffic split">
+            <span class="ring-track"></span>
+            <span class="ring-fill"></span>
+            <strong>5%</strong>
+            <em>canary</em>
+          </article>
+
+          <article class="lane-map" aria-label="Service lane map">
+            <span class="lane stable-lane"><i></i></span>
+            <span class="lane canary-lane"><i></i></span>
+            <span class="lane rollback-lane"><i></i></span>
+            <b class="node node-users">Users</b>
+            <b class="node node-stable">Stable</b>
+            <b class="node node-canary">Canary</b>
+            <b class="node node-guard">Guard</b>
+          </article>
+        </div>
+
+        <div class="health-grid">
+          <article class="health-card card-sample">
+            <span></span>
+            <h2>Sample cohort</h2>
+            <p>
+              Small traffic slice confirms baseline latency and error budget.
+            </p>
+          </article>
+          <article class="health-card card-expand">
+            <span></span>
+            <h2>Expand cohort</h2>
+            <p>
+              More regions join after health gates stay inside the release
+              policy.
+            </p>
+          </article>
+          <article class="health-card card-balance">
+            <span></span>
+            <h2>Balanced split</h2>
+            <p>
+              Canary and stable lanes share load while rollback remains hot.
+            </p>
+          </article>
+          <article class="health-card card-complete">
+            <span></span>
+            <h2>Complete rollout</h2>
+            <p>
+              The stable pool flips to the new version after final guard
+              approval.
+            </p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/progressive-canary-delivery-kp/style.css
+++ b/submissions/examples/progressive-canary-delivery-kp/style.css
@@ -1,0 +1,576 @@
+:root {
+  color-scheme: light;
+  --ink: #101828;
+  --muted: #667085;
+  --paper: #f7f9fc;
+  --panel: #ffffff;
+  --line: #d9e2ec;
+  --stable: #2563eb;
+  --canary: #0f9f6e;
+  --warn: #d97706;
+  --rollback: #dc395f;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(37, 99, 235, 0.12), transparent 34%),
+    linear-gradient(315deg, rgba(15, 159, 110, 0.14), transparent 38%),
+    var(--paper);
+}
+
+.canary-shell {
+  width: min(1160px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.canary-hero {
+  max-width: 780px;
+  margin-bottom: 28px;
+}
+
+.canary-kicker {
+  margin: 0 0 10px;
+  color: var(--canary);
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 14px;
+  font-size: clamp(2.2rem, 6vw, 4.8rem);
+  line-height: 0.95;
+}
+
+.canary-hero p:last-child {
+  max-width: 690px;
+  color: var(--muted);
+  font-size: 1.06rem;
+  line-height: 1.7;
+}
+
+.canary-console {
+  padding: 22px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.84);
+  box-shadow: 0 24px 80px rgba(16, 24, 40, 0.12);
+}
+
+.canary-console > input {
+  position: absolute;
+  inline-size: 1px;
+  block-size: 1px;
+  opacity: 0;
+}
+
+.rollout-tabs {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+  margin-bottom: 18px;
+}
+
+.rollout-tabs label {
+  min-height: 48px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--muted);
+  font-weight: 900;
+  background: var(--panel);
+  cursor: pointer;
+  transition:
+    transform 220ms ease,
+    border-color 220ms ease,
+    color 220ms ease,
+    background 220ms ease;
+}
+
+.rollout-tabs label:hover,
+.rollout-tabs label:focus-visible {
+  transform: translateY(-2px);
+  border-color: var(--stable);
+  color: var(--stable);
+}
+
+.traffic-board {
+  display: grid;
+  grid-template-columns: 0.8fr 1.2fr;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.release-ring,
+.lane-map,
+.health-card {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+}
+
+.release-ring {
+  position: relative;
+  min-height: 340px;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+}
+
+.ring-track,
+.ring-fill {
+  position: absolute;
+  width: 260px;
+  height: 260px;
+  border-radius: 50%;
+}
+
+.ring-track {
+  background: conic-gradient(rgba(102, 112, 133, 0.18) 0 360deg);
+  mask: radial-gradient(circle, transparent 0 56%, #000 57%);
+}
+
+.ring-fill {
+  background: conic-gradient(var(--canary) 0 18deg, transparent 18deg 360deg);
+  mask: radial-gradient(circle, transparent 0 56%, #000 57%);
+  animation: ring-glow 2.4s ease-in-out infinite;
+  transition: background 520ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.release-ring strong {
+  position: relative;
+  z-index: 1;
+  font-size: 3.2rem;
+  line-height: 1;
+}
+
+.release-ring em {
+  position: relative;
+  z-index: 1;
+  color: var(--muted);
+  font-style: normal;
+  font-weight: 900;
+}
+
+.lane-map {
+  position: relative;
+  min-height: 340px;
+  overflow: hidden;
+  background:
+    linear-gradient(90deg, rgba(37, 99, 235, 0.08), transparent 48%),
+    linear-gradient(270deg, rgba(15, 159, 110, 0.1), transparent 44%),
+    var(--panel);
+}
+
+.lane {
+  position: absolute;
+  left: 8%;
+  right: 8%;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(102, 112, 133, 0.2);
+  overflow: hidden;
+}
+
+.stable-lane {
+  top: 38%;
+}
+
+.canary-lane {
+  top: 52%;
+}
+
+.rollback-lane {
+  top: 66%;
+}
+
+.lane i {
+  display: block;
+  width: 38%;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--stable);
+  animation: traffic-flow 2.6s ease-in-out infinite;
+}
+
+.canary-lane i {
+  width: 12%;
+  background: var(--canary);
+  animation-delay: -0.4s;
+  transition: width 520ms ease;
+}
+
+.rollback-lane i {
+  width: 6%;
+  background: var(--rollback);
+  animation-delay: -0.8s;
+}
+
+.node {
+  position: absolute;
+  min-width: 84px;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  text-align: center;
+  font-size: 0.82rem;
+  box-shadow: 0 12px 30px rgba(16, 24, 40, 0.1);
+}
+
+.node-users {
+  left: 7%;
+  top: 12%;
+}
+
+.node-stable {
+  right: 7%;
+  top: 29%;
+}
+
+.node-canary {
+  right: 7%;
+  top: 48%;
+}
+
+.node-guard {
+  right: 7%;
+  bottom: 12%;
+}
+
+.health-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.health-card {
+  min-height: 224px;
+  padding: 20px;
+  opacity: 0.58;
+  transform: translateY(12px) scale(0.97);
+  transition:
+    transform 340ms ease,
+    opacity 340ms ease,
+    border-color 340ms ease,
+    box-shadow 340ms ease;
+}
+
+.health-card > span {
+  display: block;
+  width: 48px;
+  height: 48px;
+  margin-bottom: 34px;
+  border-radius: 14px;
+  background: var(--stable);
+  box-shadow: inset 0 0 0 9px rgba(255, 255, 255, 0.32);
+}
+
+.card-expand > span {
+  background: var(--canary);
+}
+
+.card-balance > span {
+  background: var(--warn);
+}
+
+.card-complete > span {
+  background: var(--rollback);
+}
+
+.health-card h2 {
+  margin-bottom: 10px;
+  font-size: 1.16rem;
+}
+
+.health-card p {
+  color: var(--muted);
+  line-height: 1.56;
+}
+
+#rollout-5:checked ~ .rollout-tabs label[for="rollout-5"],
+#rollout-25:checked ~ .rollout-tabs label[for="rollout-25"],
+#rollout-50:checked ~ .rollout-tabs label[for="rollout-50"],
+#rollout-100:checked ~ .rollout-tabs label[for="rollout-100"] {
+  color: #fff;
+  border-color: transparent;
+  background: var(--ink);
+}
+
+#rollout-25:checked ~ .traffic-board .ring-fill {
+  background: conic-gradient(var(--canary) 0 90deg, transparent 90deg 360deg);
+}
+
+#rollout-50:checked ~ .traffic-board .ring-fill {
+  background: conic-gradient(var(--canary) 0 180deg, transparent 180deg 360deg);
+}
+
+#rollout-100:checked ~ .traffic-board .ring-fill {
+  background: conic-gradient(var(--canary) 0 360deg);
+}
+
+#rollout-25:checked ~ .traffic-board .canary-lane i {
+  width: 25%;
+}
+
+#rollout-50:checked ~ .traffic-board .canary-lane i {
+  width: 50%;
+}
+
+#rollout-100:checked ~ .traffic-board .canary-lane i {
+  width: 100%;
+}
+
+#rollout-5:checked ~ .health-grid .card-sample,
+#rollout-25:checked ~ .health-grid .card-expand,
+#rollout-50:checked ~ .health-grid .card-balance,
+#rollout-100:checked ~ .health-grid .card-complete {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  border-color: rgba(37, 99, 235, 0.44);
+  box-shadow: 0 18px 44px rgba(16, 24, 40, 0.12);
+}
+
+.rollout-shard-001 {
+  --rollout-shard: 1;
+}
+.rollout-shard-002 {
+  --rollout-shard: 2;
+}
+.rollout-shard-003 {
+  --rollout-shard: 3;
+}
+.rollout-shard-004 {
+  --rollout-shard: 4;
+}
+.rollout-shard-005 {
+  --rollout-shard: 5;
+}
+.rollout-shard-006 {
+  --rollout-shard: 6;
+}
+.rollout-shard-007 {
+  --rollout-shard: 7;
+}
+.rollout-shard-008 {
+  --rollout-shard: 8;
+}
+.rollout-shard-009 {
+  --rollout-shard: 9;
+}
+.rollout-shard-010 {
+  --rollout-shard: 10;
+}
+.rollout-shard-011 {
+  --rollout-shard: 11;
+}
+.rollout-shard-012 {
+  --rollout-shard: 12;
+}
+.rollout-shard-013 {
+  --rollout-shard: 13;
+}
+.rollout-shard-014 {
+  --rollout-shard: 14;
+}
+.rollout-shard-015 {
+  --rollout-shard: 15;
+}
+.rollout-shard-016 {
+  --rollout-shard: 16;
+}
+.rollout-shard-017 {
+  --rollout-shard: 17;
+}
+.rollout-shard-018 {
+  --rollout-shard: 18;
+}
+.rollout-shard-019 {
+  --rollout-shard: 19;
+}
+.rollout-shard-020 {
+  --rollout-shard: 20;
+}
+.rollout-shard-021 {
+  --rollout-shard: 21;
+}
+.rollout-shard-022 {
+  --rollout-shard: 22;
+}
+.rollout-shard-023 {
+  --rollout-shard: 23;
+}
+.rollout-shard-024 {
+  --rollout-shard: 24;
+}
+.rollout-shard-025 {
+  --rollout-shard: 25;
+}
+.rollout-shard-026 {
+  --rollout-shard: 26;
+}
+.rollout-shard-027 {
+  --rollout-shard: 27;
+}
+.rollout-shard-028 {
+  --rollout-shard: 28;
+}
+.rollout-shard-029 {
+  --rollout-shard: 29;
+}
+.rollout-shard-030 {
+  --rollout-shard: 30;
+}
+.rollout-shard-031 {
+  --rollout-shard: 31;
+}
+.rollout-shard-032 {
+  --rollout-shard: 32;
+}
+.rollout-shard-033 {
+  --rollout-shard: 33;
+}
+.rollout-shard-034 {
+  --rollout-shard: 34;
+}
+.rollout-shard-035 {
+  --rollout-shard: 35;
+}
+.rollout-shard-036 {
+  --rollout-shard: 36;
+}
+.rollout-shard-037 {
+  --rollout-shard: 37;
+}
+.rollout-shard-038 {
+  --rollout-shard: 38;
+}
+.rollout-shard-039 {
+  --rollout-shard: 39;
+}
+.rollout-shard-040 {
+  --rollout-shard: 40;
+}
+.rollout-shard-041 {
+  --rollout-shard: 41;
+}
+.rollout-shard-042 {
+  --rollout-shard: 42;
+}
+.rollout-shard-043 {
+  --rollout-shard: 43;
+}
+.rollout-shard-044 {
+  --rollout-shard: 44;
+}
+.rollout-shard-045 {
+  --rollout-shard: 45;
+}
+.rollout-shard-046 {
+  --rollout-shard: 46;
+}
+.rollout-shard-047 {
+  --rollout-shard: 47;
+}
+.rollout-shard-048 {
+  --rollout-shard: 48;
+}
+.rollout-shard-049 {
+  --rollout-shard: 49;
+}
+.rollout-shard-050 {
+  --rollout-shard: 50;
+}
+.rollout-shard-051 {
+  --rollout-shard: 51;
+}
+.rollout-shard-052 {
+  --rollout-shard: 52;
+}
+.rollout-shard-053 {
+  --rollout-shard: 53;
+}
+.rollout-shard-054 {
+  --rollout-shard: 54;
+}
+.rollout-shard-055 {
+  --rollout-shard: 55;
+}
+.rollout-shard-056 {
+  --rollout-shard: 56;
+}
+.rollout-shard-057 {
+  --rollout-shard: 57;
+}
+.rollout-shard-058 {
+  --rollout-shard: 58;
+}
+.rollout-shard-059 {
+  --rollout-shard: 59;
+}
+.rollout-shard-060 {
+  --rollout-shard: 60;
+}
+
+@keyframes ring-glow {
+  50% {
+    filter: brightness(1.14);
+  }
+}
+
+@keyframes traffic-flow {
+  50% {
+    transform: translateX(160%);
+  }
+}
+
+@media (max-width: 860px) {
+  .canary-shell {
+    width: min(100% - 20px, 680px);
+    padding: 28px 0;
+  }
+
+  .canary-console {
+    padding: 14px;
+  }
+
+  .rollout-tabs,
+  .traffic-board,
+  .health-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add an advanced CSS-only progressive canary delivery example
- include radio-driven rollout stages, animated traffic lanes, conic rollout gauge, health cards, and reduced-motion support
- keep the submission scoped to README/demo/style files

## Validation
- npx prettier --check submissions/examples/progressive-canary-delivery-kp/README.md submissions/examples/progressive-canary-delivery-kp/demo.html submissions/examples/progressive-canary-delivery-kp/style.css
- npx stylelint submissions/examples/progressive-canary-delivery-kp/style.css --allow-empty-input
- git diff --check