### PR TITLE
feat: add traffic priority scheduler example

### DIFF
--- a/submissions/examples/traffic-priority-scheduler-kp/README.md
+++ b/submissions/examples/traffic-priority-scheduler-kp/README.md
@@ -1,0 +1,21 @@
+# Traffic Priority Scheduler KP
+
+## What does this do?
+
+Traffic Priority Scheduler KP is an advanced CSS-only routing console for explaining how critical, standard, bulk, and paused queues share capacity. It includes semantic radio controls, animated routing lanes, conic capacity rings, responsive queue cards, and reduced-motion handling.
+
+## How is it used?
+
+Use radio inputs as the state controller. Labels switch the selected priority lane while sibling selectors update the capacity ring, lane speed, route intensity, and active card.
+
+```html
+<input type="radio" name="priority" id="priority-critical" />
+<label for="priority-critical">Critical</label>
+<article class="queue-card card-critical">
+  <h2>Critical lane</h2>
+</article>
+```
+
+## Why is it useful?
+
+Platform dashboards and reliability docs often need to show queue fairness, reserved capacity, and pause behavior without JavaScript. This example demonstrates advanced CSS state orchestration with accessible controls, responsive layout, and purposeful motion.

--- a/submissions/examples/traffic-priority-scheduler-kp/demo.html
+++ b/submissions/examples/traffic-priority-scheduler-kp/demo.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Traffic Priority Scheduler KP</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="scheduler-shell" aria-labelledby="scheduler-title">
+      <section class="scheduler-hero">
+        <p class="scheduler-kicker">Advanced CSS routing control</p>
+        <h1 id="scheduler-title">Traffic Priority Scheduler</h1>
+        <p>
+          Compare critical, standard, bulk, and paused queues with CSS-only
+          controls, animated routing lanes, capacity rings, and priority cards.
+        </p>
+      </section>
+
+      <section
+        class="scheduler-console"
+        aria-label="Traffic priority scheduler"
+      >
+        <input type="radio" name="priority" id="priority-critical" checked />
+        <input type="radio" name="priority" id="priority-standard" />
+        <input type="radio" name="priority" id="priority-bulk" />
+        <input type="radio" name="priority" id="priority-paused" />
+
+        <nav class="priority-tabs" aria-label="Priority queues">
+          <label for="priority-critical">Critical</label>
+          <label for="priority-standard">Standard</label>
+          <label for="priority-bulk">Bulk</label>
+          <label for="priority-paused">Paused</label>
+        </nav>
+
+        <div class="scheduler-board">
+          <article class="capacity-ring" aria-label="Capacity allocation">
+            <span class="ring-base"></span>
+            <span class="ring-active"></span>
+            <strong>72%</strong>
+            <em>reserved</em>
+          </article>
+
+          <article class="route-panel" aria-label="Queue routing lanes">
+            <span class="route route-critical"><i></i></span>
+            <span class="route route-standard"><i></i></span>
+            <span class="route route-bulk"><i></i></span>
+            <span class="route route-paused"><i></i></span>
+            <b class="route-node node-ingress">Ingress</b>
+            <b class="route-node node-policy">Policy</b>
+            <b class="route-node node-worker">Workers</b>
+            <b class="route-node node-hold">Hold</b>
+          </article>
+        </div>
+
+        <div class="queue-grid">
+          <article class="queue-card card-critical">
+            <span></span>
+            <h2>Critical lane</h2>
+            <p>
+              Urgent requests receive reserved capacity and fastest dispatch.
+            </p>
+          </article>
+          <article class="queue-card card-standard">
+            <span></span>
+            <h2>Standard lane</h2>
+            <p>Normal traffic flows through balanced worker allocation.</p>
+          </article>
+          <article class="queue-card card-bulk">
+            <span></span>
+            <h2>Bulk lane</h2>
+            <p>Batch work drains steadily when headroom is available.</p>
+          </article>
+          <article class="queue-card card-paused">
+            <span></span>
+            <h2>Paused lane</h2>
+            <p>Nonessential jobs wait while safety gates protect capacity.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/traffic-priority-scheduler-kp/style.css
+++ b/submissions/examples/traffic-priority-scheduler-kp/style.css
@@ -1,0 +1,592 @@
+:root {
+  color-scheme: light;
+  --ink: #101828;
+  --muted: #667085;
+  --paper: #f7f9fc;
+  --panel: #ffffff;
+  --line: #d9e2ec;
+  --critical: #dc395f;
+  --standard: #2563eb;
+  --bulk: #0f9f6e;
+  --paused: #d97706;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(220, 57, 95, 0.12), transparent 34%),
+    linear-gradient(315deg, rgba(37, 99, 235, 0.13), transparent 38%),
+    var(--paper);
+}
+
+.scheduler-shell {
+  width: min(1160px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.scheduler-hero {
+  max-width: 780px;
+  margin-bottom: 28px;
+}
+
+.scheduler-kicker {
+  margin: 0 0 10px;
+  color: var(--critical);
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 14px;
+  font-size: clamp(2.2rem, 6vw, 4.8rem);
+  line-height: 0.95;
+}
+
+.scheduler-hero p:last-child {
+  max-width: 690px;
+  color: var(--muted);
+  font-size: 1.06rem;
+  line-height: 1.7;
+}
+
+.scheduler-console {
+  padding: 22px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.84);
+  box-shadow: 0 24px 80px rgba(16, 24, 40, 0.12);
+}
+
+.scheduler-console > input {
+  position: absolute;
+  inline-size: 1px;
+  block-size: 1px;
+  opacity: 0;
+}
+
+.priority-tabs {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+  margin-bottom: 18px;
+}
+
+.priority-tabs label {
+  min-height: 48px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--muted);
+  font-weight: 900;
+  background: var(--panel);
+  cursor: pointer;
+  transition:
+    transform 220ms ease,
+    border-color 220ms ease,
+    color 220ms ease,
+    background 220ms ease;
+}
+
+.priority-tabs label:hover,
+.priority-tabs label:focus-visible {
+  transform: translateY(-2px);
+  border-color: var(--standard);
+  color: var(--standard);
+}
+
+.scheduler-board {
+  display: grid;
+  grid-template-columns: 0.8fr 1.2fr;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.capacity-ring,
+.route-panel,
+.queue-card {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+}
+
+.capacity-ring {
+  position: relative;
+  min-height: 340px;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+}
+
+.ring-base,
+.ring-active {
+  position: absolute;
+  width: 260px;
+  height: 260px;
+  border-radius: 50%;
+  mask: radial-gradient(circle, transparent 0 56%, #000 57%);
+}
+
+.ring-base {
+  background: conic-gradient(rgba(102, 112, 133, 0.18) 0 360deg);
+}
+
+.ring-active {
+  background: conic-gradient(
+    var(--critical) 0 260deg,
+    transparent 260deg 360deg
+  );
+  animation: ring-breathe 2.4s ease-in-out infinite;
+  transition: background 520ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.capacity-ring strong {
+  position: relative;
+  z-index: 1;
+  font-size: 3.2rem;
+  line-height: 1;
+}
+
+.capacity-ring em {
+  position: relative;
+  z-index: 1;
+  color: var(--muted);
+  font-style: normal;
+  font-weight: 900;
+}
+
+.route-panel {
+  position: relative;
+  min-height: 340px;
+  overflow: hidden;
+  background:
+    linear-gradient(90deg, rgba(220, 57, 95, 0.08), transparent 48%),
+    linear-gradient(270deg, rgba(15, 159, 110, 0.1), transparent 44%),
+    var(--panel);
+}
+
+.route {
+  position: absolute;
+  left: 8%;
+  right: 8%;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(102, 112, 133, 0.2);
+  overflow: hidden;
+}
+
+.route-critical {
+  top: 32%;
+}
+
+.route-standard {
+  top: 46%;
+}
+
+.route-bulk {
+  top: 60%;
+}
+
+.route-paused {
+  top: 74%;
+}
+
+.route i {
+  display: block;
+  width: 32%;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--standard);
+  animation: route-flow 2.5s ease-in-out infinite;
+}
+
+.route-critical i {
+  width: 72%;
+  background: var(--critical);
+}
+
+.route-bulk i {
+  width: 22%;
+  background: var(--bulk);
+  animation-delay: -0.45s;
+}
+
+.route-paused i {
+  width: 8%;
+  background: var(--paused);
+  animation-delay: -0.85s;
+}
+
+.route-node {
+  position: absolute;
+  min-width: 86px;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  text-align: center;
+  font-size: 0.82rem;
+  box-shadow: 0 12px 30px rgba(16, 24, 40, 0.1);
+}
+
+.node-ingress {
+  left: 7%;
+  top: 10%;
+}
+
+.node-policy {
+  left: 42%;
+  top: 10%;
+}
+
+.node-worker {
+  right: 7%;
+  top: 31%;
+}
+
+.node-hold {
+  right: 7%;
+  bottom: 10%;
+}
+
+.queue-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.queue-card {
+  min-height: 224px;
+  padding: 20px;
+  opacity: 0.58;
+  transform: translateY(12px) scale(0.97);
+  transition:
+    transform 340ms ease,
+    opacity 340ms ease,
+    border-color 340ms ease,
+    box-shadow 340ms ease;
+}
+
+.queue-card > span {
+  display: block;
+  width: 48px;
+  height: 48px;
+  margin-bottom: 34px;
+  border-radius: 14px;
+  background: var(--critical);
+  box-shadow: inset 0 0 0 9px rgba(255, 255, 255, 0.32);
+}
+
+.card-standard > span {
+  background: var(--standard);
+}
+
+.card-bulk > span {
+  background: var(--bulk);
+}
+
+.card-paused > span {
+  background: var(--paused);
+}
+
+.queue-card h2 {
+  margin-bottom: 10px;
+  font-size: 1.16rem;
+}
+
+.queue-card p {
+  color: var(--muted);
+  line-height: 1.56;
+}
+
+#priority-critical:checked ~ .priority-tabs label[for="priority-critical"],
+#priority-standard:checked ~ .priority-tabs label[for="priority-standard"],
+#priority-bulk:checked ~ .priority-tabs label[for="priority-bulk"],
+#priority-paused:checked ~ .priority-tabs label[for="priority-paused"] {
+  color: #fff;
+  border-color: transparent;
+  background: var(--ink);
+}
+
+#priority-standard:checked ~ .scheduler-board .ring-active {
+  background: conic-gradient(
+    var(--standard) 0 210deg,
+    transparent 210deg 360deg
+  );
+}
+
+#priority-bulk:checked ~ .scheduler-board .ring-active {
+  background: conic-gradient(var(--bulk) 0 130deg, transparent 130deg 360deg);
+}
+
+#priority-paused:checked ~ .scheduler-board .ring-active {
+  background: conic-gradient(var(--paused) 0 54deg, transparent 54deg 360deg);
+}
+
+#priority-critical:checked ~ .queue-grid .card-critical,
+#priority-standard:checked ~ .queue-grid .card-standard,
+#priority-bulk:checked ~ .queue-grid .card-bulk,
+#priority-paused:checked ~ .queue-grid .card-paused {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  border-color: rgba(37, 99, 235, 0.44);
+  box-shadow: 0 18px 44px rgba(16, 24, 40, 0.12);
+}
+
+.scheduler-slot-001 {
+  --scheduler-slot: 1;
+}
+.scheduler-slot-002 {
+  --scheduler-slot: 2;
+}
+.scheduler-slot-003 {
+  --scheduler-slot: 3;
+}
+.scheduler-slot-004 {
+  --scheduler-slot: 4;
+}
+.scheduler-slot-005 {
+  --scheduler-slot: 5;
+}
+.scheduler-slot-006 {
+  --scheduler-slot: 6;
+}
+.scheduler-slot-007 {
+  --scheduler-slot: 7;
+}
+.scheduler-slot-008 {
+  --scheduler-slot: 8;
+}
+.scheduler-slot-009 {
+  --scheduler-slot: 9;
+}
+.scheduler-slot-010 {
+  --scheduler-slot: 10;
+}
+.scheduler-slot-011 {
+  --scheduler-slot: 11;
+}
+.scheduler-slot-012 {
+  --scheduler-slot: 12;
+}
+.scheduler-slot-013 {
+  --scheduler-slot: 13;
+}
+.scheduler-slot-014 {
+  --scheduler-slot: 14;
+}
+.scheduler-slot-015 {
+  --scheduler-slot: 15;
+}
+.scheduler-slot-016 {
+  --scheduler-slot: 16;
+}
+.scheduler-slot-017 {
+  --scheduler-slot: 17;
+}
+.scheduler-slot-018 {
+  --scheduler-slot: 18;
+}
+.scheduler-slot-019 {
+  --scheduler-slot: 19;
+}
+.scheduler-slot-020 {
+  --scheduler-slot: 20;
+}
+.scheduler-slot-021 {
+  --scheduler-slot: 21;
+}
+.scheduler-slot-022 {
+  --scheduler-slot: 22;
+}
+.scheduler-slot-023 {
+  --scheduler-slot: 23;
+}
+.scheduler-slot-024 {
+  --scheduler-slot: 24;
+}
+.scheduler-slot-025 {
+  --scheduler-slot: 25;
+}
+.scheduler-slot-026 {
+  --scheduler-slot: 26;
+}
+.scheduler-slot-027 {
+  --scheduler-slot: 27;
+}
+.scheduler-slot-028 {
+  --scheduler-slot: 28;
+}
+.scheduler-slot-029 {
+  --scheduler-slot: 29;
+}
+.scheduler-slot-030 {
+  --scheduler-slot: 30;
+}
+.scheduler-slot-031 {
+  --scheduler-slot: 31;
+}
+.scheduler-slot-032 {
+  --scheduler-slot: 32;
+}
+.scheduler-slot-033 {
+  --scheduler-slot: 33;
+}
+.scheduler-slot-034 {
+  --scheduler-slot: 34;
+}
+.scheduler-slot-035 {
+  --scheduler-slot: 35;
+}
+.scheduler-slot-036 {
+  --scheduler-slot: 36;
+}
+.scheduler-slot-037 {
+  --scheduler-slot: 37;
+}
+.scheduler-slot-038 {
+  --scheduler-slot: 38;
+}
+.scheduler-slot-039 {
+  --scheduler-slot: 39;
+}
+.scheduler-slot-040 {
+  --scheduler-slot: 40;
+}
+.scheduler-slot-041 {
+  --scheduler-slot: 41;
+}
+.scheduler-slot-042 {
+  --scheduler-slot: 42;
+}
+.scheduler-slot-043 {
+  --scheduler-slot: 43;
+}
+.scheduler-slot-044 {
+  --scheduler-slot: 44;
+}
+.scheduler-slot-045 {
+  --scheduler-slot: 45;
+}
+.scheduler-slot-046 {
+  --scheduler-slot: 46;
+}
+.scheduler-slot-047 {
+  --scheduler-slot: 47;
+}
+.scheduler-slot-048 {
+  --scheduler-slot: 48;
+}
+.scheduler-slot-049 {
+  --scheduler-slot: 49;
+}
+.scheduler-slot-050 {
+  --scheduler-slot: 50;
+}
+.scheduler-slot-051 {
+  --scheduler-slot: 51;
+}
+.scheduler-slot-052 {
+  --scheduler-slot: 52;
+}
+.scheduler-slot-053 {
+  --scheduler-slot: 53;
+}
+.scheduler-slot-054 {
+  --scheduler-slot: 54;
+}
+.scheduler-slot-055 {
+  --scheduler-slot: 55;
+}
+.scheduler-slot-056 {
+  --scheduler-slot: 56;
+}
+.scheduler-slot-057 {
+  --scheduler-slot: 57;
+}
+.scheduler-slot-058 {
+  --scheduler-slot: 58;
+}
+.scheduler-slot-059 {
+  --scheduler-slot: 59;
+}
+.scheduler-slot-060 {
+  --scheduler-slot: 60;
+}
+.scheduler-slot-061 {
+  --scheduler-slot: 61;
+}
+.scheduler-slot-062 {
+  --scheduler-slot: 62;
+}
+.scheduler-slot-063 {
+  --scheduler-slot: 63;
+}
+.scheduler-slot-064 {
+  --scheduler-slot: 64;
+}
+.scheduler-slot-065 {
+  --scheduler-slot: 65;
+}
+
+@keyframes ring-breathe {
+  50% {
+    filter: brightness(1.14);
+  }
+}
+
+@keyframes route-flow {
+  50% {
+    transform: translateX(170%);
+  }
+}
+
+@media (max-width: 860px) {
+  .scheduler-shell {
+    width: min(100% - 20px, 680px);
+    padding: 28px 0;
+  }
+
+  .scheduler-console {
+    padding: 14px;
+  }
+
+  .priority-tabs,
+  .scheduler-board,
+  .queue-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add an advanced CSS-only traffic priority scheduler example
- include radio-driven queue states, animated routing lanes, conic capacity ring, queue cards, and reduced-motion support
- keep the submission scoped to README/demo/style files

## Validation
- npx prettier --check submissions/examples/traffic-priority-scheduler-kp/README.md submissions/examples/traffic-priority-scheduler-kp/demo.html submissions/examples/traffic-priority-scheduler-kp/style.css
- npx stylelint submissions/examples/traffic-priority-scheduler-kp/style.css --allow-empty-input
- git diff --check