### PR TITLE
Add CSS glitch-flicker dropdown for fintech dashboard layouts

### DIFF
--- a/submissions/examples/css-glitch-flicker-dropdown/README.md
+++ b/submissions/examples/css-glitch-flicker-dropdown/README.md
@@ -1,0 +1,16 @@
+# CSS Glitch-Flicker Dropdown
+
+A pure CSS dropdown styled as a session security menu, appearing with a rapid glitch-flicker rather than a smooth fade. No JavaScript.
+
+## How it works
+
+Instead of a `transition`, the menu's entrance is entirely `@keyframes`-driven with `steps(1, end)` timing — this makes each keyframe step snap instantly rather than interpolate, so the opacity and slight horizontal position jump abruptly between values, reading as a flicker rather than a glide.
+
+## Files
+`demo.html`, `style.css`, `README.md`
+
+## Custom properties
+`--ease-dropdown-radius`, `--ease-dropdown-bg`, `--ease-dropdown-border`, `--ease-dropdown-text`, `--ease-dropdown-muted-text`, `--ease-dropdown-accent`
+
+## Notes
+Respects `prefers-reduced-motion` — the menu appears instantly at full opacity, no glitch steps.

--- a/submissions/examples/css-glitch-flicker-dropdown/demo.html
+++ b/submissions/examples/css-glitch-flicker-dropdown/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Glitch-Flicker Dropdown — Fintech Dashboard</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="ease-container">
+    <p class="ease-eyebrow">Security</p>
+    <h1 class="ease-heading">Session Actions</h1>
+    <p class="ease-subtitle">The menu flickers into view rather than fading smoothly.</p>
+
+    <div class="ease-dropdown">
+      <input type="checkbox" id="ease-glitch-dropdown-toggle" class="ease-dropdown-input" />
+      <label for="ease-glitch-dropdown-toggle" class="ease-dropdown-trigger">
+        Session Options
+        <span class="ease-dropdown-arrow">▾</span>
+      </label>
+      <div class="ease-dropdown-menu">
+        <button class="ease-dropdown-item">View active devices</button>
+        <button class="ease-dropdown-item">Change security PIN</button>
+        <button class="ease-dropdown-item">Sign out everywhere</button>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/css-glitch-flicker-dropdown/style.css
+++ b/submissions/examples/css-glitch-flicker-dropdown/style.css
@@ -1,0 +1,105 @@
+:root {
+  --ease-dropdown-radius: 10px;
+  --ease-dropdown-bg: #16181d;
+  --ease-dropdown-border: #2a2d34;
+  --ease-dropdown-text: #f0f0f0;
+  --ease-dropdown-muted-text: #a8a8a8;
+  --ease-dropdown-accent: #22c55e;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0f1115;
+  color: var(--ease-dropdown-text);
+  padding: 3rem 1.5rem;
+}
+
+.ease-container { max-width: 400px; margin: 0 auto; }
+.ease-eyebrow { text-transform: uppercase; letter-spacing: 0.08em; font-size: 0.75rem; color: var(--ease-dropdown-accent); margin: 0 0 0.5rem; font-weight: 600; }
+.ease-heading { font-size: 1.6rem; margin: 0 0 0.5rem; }
+.ease-subtitle { color: #a0a0a0; margin: 0 0 2rem; font-size: 0.9rem; }
+
+.ease-dropdown { position: relative; }
+.ease-dropdown-input { position: absolute; opacity: 0; pointer-events: none; }
+
+.ease-dropdown-trigger {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 0.85rem 1.1rem;
+  background: var(--ease-dropdown-bg);
+  border: 1px solid var(--ease-dropdown-border);
+  border-radius: var(--ease-dropdown-radius);
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.ease-dropdown-arrow { transition: transform 0.25s ease; color: var(--ease-dropdown-muted-text); }
+.ease-dropdown-input:checked ~ .ease-dropdown-trigger .ease-dropdown-arrow { transform: rotate(180deg); }
+
+.ease-dropdown-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0; right: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--ease-dropdown-bg);
+  border: 1px solid var(--ease-dropdown-border);
+  border-radius: var(--ease-dropdown-radius);
+  padding: 0.4rem;
+  opacity: 0;
+  visibility: hidden;
+  transition: visibility 0s linear 0.3s;
+  z-index: 10;
+}
+
+/* glitch-flicker: instead of a smooth fade, the menu snaps through
+   several rapid opacity/position jumps before settling — no easing
+   curve involved, it's entirely keyframe-driven */
+.ease-dropdown-input:checked ~ .ease-dropdown-menu {
+  visibility: visible;
+  transition: none;
+  animation: ease-dropdown-glitch-in 0.4s steps(1, end) forwards;
+}
+
+@keyframes ease-dropdown-glitch-in {
+  0%   { opacity: 0;   transform: translateX(0); }
+  10%  { opacity: 1;   transform: translateX(-3px); }
+  20%  { opacity: 0.2; transform: translateX(2px); }
+  30%  { opacity: 1;   transform: translateX(0); }
+  45%  { opacity: 0.4; transform: translateX(-2px); }
+  60%  { opacity: 1;   transform: translateX(1px); }
+  100% { opacity: 1;   transform: translateX(0); }
+}
+
+.ease-dropdown-item {
+  width: 100%;
+  background: none;
+  border: none;
+  color: var(--ease-dropdown-text);
+  font-family: inherit;
+  font-size: 0.85rem;
+  padding: 0.65rem 0.75rem;
+  border-radius: 6px;
+  cursor: pointer;
+  text-align: left;
+  transition: background-color 0.15s ease;
+}
+
+.ease-dropdown-item:hover { background: rgba(255, 255, 255, 0.06); }
+
+@media (max-width: 480px) {
+  body { padding: 2rem 1rem; }
+  .ease-heading { font-size: 1.35rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-dropdown-menu {
+    animation: none !important;
+    opacity: 1;
+    visibility: visible;
+    transform: none !important;
+  }
+  .ease-dropdown-arrow { transition: none !important; }
+}


### PR DESCRIPTION
## Pull Request Description
Closes #59381

Adds a pure CSS/HTML dropdown menu styled as a session security menu, with a glitch-flicker entrance instead of a smooth fade.

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

## Submission Checklist
- [x] All changes inside `submissions/examples/css-glitch-flicker-dropdown/`
- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Feature Description
**What does this add?** A dropdown menu that appears via a `steps()`-timed keyframe animation, snapping through opacity/position jumps rather than interpolating smoothly.
**Why does it fit?** Same checkbox-hack dropdown base as other submissions, but demonstrates `steps()` timing for a distinctly different entrance feel from eased/spring transitions.

## Demo
- [x] Demo added
## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge

## Notes for Maintainer
`steps(1, end)` on the keyframe animation is what produces the snap/flicker rather than a smooth glide. Respects `prefers-reduced-motion`.