### PR TITLE
feat: add admission control governor example

### DIFF
--- a/submissions/examples/admission-control-governor-kp/README.md
+++ b/submissions/examples/admission-control-governor-kp/README.md
@@ -1,0 +1,21 @@
+# Admission Control Governor KP
+
+## What does this do?
+
+Admission Control Governor KP is an advanced CSS-only capacity gate for explaining open, guarded, shed, and drain states. It uses semantic radio controls, animated admission lanes, conic quota visualization, responsive state cards, and reduced-motion support.
+
+## How is it used?
+
+Use radio inputs as the governor state controller. Labels switch the active mode while sibling selectors update quota pressure, lane intensity, and the selected state card.
+
+```html
+<input type="radio" name="gate" id="gate-shed" />
+<label for="gate-shed">Shed</label>
+<article class="state-card card-shed">
+  <h2>Load shedding</h2>
+</article>
+```
+
+## Why is it useful?
+
+Reliability and platform teams often need to show admission control, load shedding, and queue drain behavior without JavaScript. This example demonstrates advanced CSS state orchestration with accessible controls, operational motion, and responsive layout.

--- a/submissions/examples/admission-control-governor-kp/demo.html
+++ b/submissions/examples/admission-control-governor-kp/demo.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Admission Control Governor KP</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="governor-shell" aria-labelledby="governor-title">
+      <section class="governor-hero">
+        <p class="governor-kicker">Advanced CSS capacity gate</p>
+        <h1 id="governor-title">Admission Control Governor</h1>
+        <p>
+          Route incoming demand through open, guarded, shed, and drain states
+          with CSS-only controls, animated quota gates, and live capacity
+          panels.
+        </p>
+      </section>
+
+      <section class="governor-console" aria-label="Admission control governor">
+        <input type="radio" name="gate" id="gate-open" checked />
+        <input type="radio" name="gate" id="gate-guarded" />
+        <input type="radio" name="gate" id="gate-shed" />
+        <input type="radio" name="gate" id="gate-drain" />
+
+        <nav class="gate-tabs" aria-label="Admission states">
+          <label for="gate-open">Open</label>
+          <label for="gate-guarded">Guarded</label>
+          <label for="gate-shed">Shed</label>
+          <label for="gate-drain">Drain</label>
+        </nav>
+
+        <div class="governor-board">
+          <article class="quota-dial" aria-label="Quota pressure">
+            <span class="dial-base"></span>
+            <span class="dial-fill"></span>
+            <strong>64%</strong>
+            <em>quota</em>
+          </article>
+
+          <article class="gate-map" aria-label="Admission gates">
+            <span class="gate-flow flow-enter"><i></i></span>
+            <span class="gate-flow flow-accept"><i></i></span>
+            <span class="gate-flow flow-shed"><i></i></span>
+            <span class="gate-flow flow-drain"><i></i></span>
+            <b class="gate-node node-edge">Edge</b>
+            <b class="gate-node node-policy">Policy</b>
+            <b class="gate-node node-service">Service</b>
+            <b class="gate-node node-buffer">Buffer</b>
+          </article>
+        </div>
+
+        <div class="state-grid">
+          <article class="state-card card-open">
+            <span></span>
+            <h2>Open admission</h2>
+            <p>
+              Healthy capacity accepts traffic while observing current quotas.
+            </p>
+          </article>
+          <article class="state-card card-guarded">
+            <span></span>
+            <h2>Guarded admission</h2>
+            <p>Policy gates slow noncritical work before saturation begins.</p>
+          </article>
+          <article class="state-card card-shed">
+            <span></span>
+            <h2>Load shedding</h2>
+            <p>
+              Optional work is rejected so critical paths keep their budget.
+            </p>
+          </article>
+          <article class="state-card card-drain">
+            <span></span>
+            <h2>Queue drain</h2>
+            <p>
+              Buffered requests release gradually after pressure normalizes.
+            </p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/admission-control-governor-kp/style.css
+++ b/submissions/examples/admission-control-governor-kp/style.css
@@ -1,0 +1,581 @@
+:root {
+  color-scheme: light;
+  --ink: #101828;
+  --muted: #667085;
+  --paper: #f7f9fc;
+  --panel: #ffffff;
+  --line: #d9e2ec;
+  --open: #0f9f6e;
+  --guarded: #2563eb;
+  --shed: #dc395f;
+  --drain: #d97706;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(15, 159, 110, 0.13), transparent 34%),
+    linear-gradient(315deg, rgba(220, 57, 95, 0.11), transparent 38%),
+    var(--paper);
+}
+
+.governor-shell {
+  width: min(1160px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.governor-hero {
+  max-width: 780px;
+  margin-bottom: 28px;
+}
+
+.governor-kicker {
+  margin: 0 0 10px;
+  color: var(--open);
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 14px;
+  font-size: clamp(2.2rem, 6vw, 4.8rem);
+  line-height: 0.95;
+}
+
+.governor-hero p:last-child {
+  max-width: 690px;
+  color: var(--muted);
+  font-size: 1.06rem;
+  line-height: 1.7;
+}
+
+.governor-console {
+  padding: 22px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.84);
+  box-shadow: 0 24px 80px rgba(16, 24, 40, 0.12);
+}
+
+.governor-console > input {
+  position: absolute;
+  inline-size: 1px;
+  block-size: 1px;
+  opacity: 0;
+}
+
+.gate-tabs {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+  margin-bottom: 18px;
+}
+
+.gate-tabs label {
+  min-height: 48px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--muted);
+  font-weight: 900;
+  background: var(--panel);
+  cursor: pointer;
+  transition:
+    transform 220ms ease,
+    border-color 220ms ease,
+    color 220ms ease,
+    background 220ms ease;
+}
+
+.gate-tabs label:hover,
+.gate-tabs label:focus-visible {
+  transform: translateY(-2px);
+  border-color: var(--guarded);
+  color: var(--guarded);
+}
+
+.governor-board {
+  display: grid;
+  grid-template-columns: 0.8fr 1.2fr;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.quota-dial,
+.gate-map,
+.state-card {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+}
+
+.quota-dial {
+  position: relative;
+  min-height: 340px;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+}
+
+.dial-base,
+.dial-fill {
+  position: absolute;
+  width: 260px;
+  height: 260px;
+  border-radius: 50%;
+  mask: radial-gradient(circle, transparent 0 56%, #000 57%);
+}
+
+.dial-base {
+  background: conic-gradient(rgba(102, 112, 133, 0.18) 0 360deg);
+}
+
+.dial-fill {
+  background: conic-gradient(var(--open) 0 230deg, transparent 230deg 360deg);
+  animation: quota-pulse 2.3s ease-in-out infinite;
+  transition: background 520ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.quota-dial strong {
+  position: relative;
+  z-index: 1;
+  font-size: 3.2rem;
+  line-height: 1;
+}
+
+.quota-dial em {
+  position: relative;
+  z-index: 1;
+  color: var(--muted);
+  font-style: normal;
+  font-weight: 900;
+}
+
+.gate-map {
+  position: relative;
+  min-height: 340px;
+  overflow: hidden;
+  background:
+    linear-gradient(90deg, rgba(15, 159, 110, 0.08), transparent 48%),
+    linear-gradient(270deg, rgba(220, 57, 95, 0.1), transparent 44%),
+    var(--panel);
+}
+
+.gate-flow {
+  position: absolute;
+  left: 8%;
+  right: 8%;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(102, 112, 133, 0.2);
+  overflow: hidden;
+}
+
+.flow-enter {
+  top: 31%;
+}
+.flow-accept {
+  top: 45%;
+}
+.flow-shed {
+  top: 59%;
+}
+.flow-drain {
+  top: 73%;
+}
+
+.gate-flow i {
+  display: block;
+  width: 34%;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--open);
+  animation: gate-flow 2.5s ease-in-out infinite;
+}
+
+.flow-accept i {
+  background: var(--guarded);
+  animation-delay: -0.35s;
+}
+
+.flow-shed i {
+  width: 14%;
+  background: var(--shed);
+  animation-delay: -0.7s;
+}
+
+.flow-drain i {
+  width: 22%;
+  background: var(--drain);
+  animation-delay: -1s;
+}
+
+.gate-node {
+  position: absolute;
+  min-width: 86px;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  text-align: center;
+  font-size: 0.82rem;
+  box-shadow: 0 12px 30px rgba(16, 24, 40, 0.1);
+}
+
+.node-edge {
+  left: 7%;
+  top: 10%;
+}
+.node-policy {
+  left: 42%;
+  top: 10%;
+}
+.node-service {
+  right: 7%;
+  top: 31%;
+}
+.node-buffer {
+  right: 7%;
+  bottom: 10%;
+}
+
+.state-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.state-card {
+  min-height: 224px;
+  padding: 20px;
+  opacity: 0.58;
+  transform: translateY(12px) scale(0.97);
+  transition:
+    transform 340ms ease,
+    opacity 340ms ease,
+    border-color 340ms ease,
+    box-shadow 340ms ease;
+}
+
+.state-card > span {
+  display: block;
+  width: 48px;
+  height: 48px;
+  margin-bottom: 34px;
+  border-radius: 14px;
+  background: var(--open);
+  box-shadow: inset 0 0 0 9px rgba(255, 255, 255, 0.32);
+}
+
+.card-guarded > span {
+  background: var(--guarded);
+}
+.card-shed > span {
+  background: var(--shed);
+}
+.card-drain > span {
+  background: var(--drain);
+}
+
+.state-card h2 {
+  margin-bottom: 10px;
+  font-size: 1.16rem;
+}
+
+.state-card p {
+  color: var(--muted);
+  line-height: 1.56;
+}
+
+#gate-open:checked ~ .gate-tabs label[for="gate-open"],
+#gate-guarded:checked ~ .gate-tabs label[for="gate-guarded"],
+#gate-shed:checked ~ .gate-tabs label[for="gate-shed"],
+#gate-drain:checked ~ .gate-tabs label[for="gate-drain"] {
+  color: #fff;
+  border-color: transparent;
+  background: var(--ink);
+}
+
+#gate-guarded:checked ~ .governor-board .dial-fill {
+  background: conic-gradient(
+    var(--guarded) 0 180deg,
+    transparent 180deg 360deg
+  );
+}
+
+#gate-shed:checked ~ .governor-board .dial-fill {
+  background: conic-gradient(var(--shed) 0 112deg, transparent 112deg 360deg);
+}
+
+#gate-drain:checked ~ .governor-board .dial-fill {
+  background: conic-gradient(var(--drain) 0 76deg, transparent 76deg 360deg);
+}
+
+#gate-open:checked ~ .state-grid .card-open,
+#gate-guarded:checked ~ .state-grid .card-guarded,
+#gate-shed:checked ~ .state-grid .card-shed,
+#gate-drain:checked ~ .state-grid .card-drain {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  border-color: rgba(37, 99, 235, 0.44);
+  box-shadow: 0 18px 44px rgba(16, 24, 40, 0.12);
+}
+
+.admission-slot-001 {
+  --admission-slot: 1;
+}
+.admission-slot-002 {
+  --admission-slot: 2;
+}
+.admission-slot-003 {
+  --admission-slot: 3;
+}
+.admission-slot-004 {
+  --admission-slot: 4;
+}
+.admission-slot-005 {
+  --admission-slot: 5;
+}
+.admission-slot-006 {
+  --admission-slot: 6;
+}
+.admission-slot-007 {
+  --admission-slot: 7;
+}
+.admission-slot-008 {
+  --admission-slot: 8;
+}
+.admission-slot-009 {
+  --admission-slot: 9;
+}
+.admission-slot-010 {
+  --admission-slot: 10;
+}
+.admission-slot-011 {
+  --admission-slot: 11;
+}
+.admission-slot-012 {
+  --admission-slot: 12;
+}
+.admission-slot-013 {
+  --admission-slot: 13;
+}
+.admission-slot-014 {
+  --admission-slot: 14;
+}
+.admission-slot-015 {
+  --admission-slot: 15;
+}
+.admission-slot-016 {
+  --admission-slot: 16;
+}
+.admission-slot-017 {
+  --admission-slot: 17;
+}
+.admission-slot-018 {
+  --admission-slot: 18;
+}
+.admission-slot-019 {
+  --admission-slot: 19;
+}
+.admission-slot-020 {
+  --admission-slot: 20;
+}
+.admission-slot-021 {
+  --admission-slot: 21;
+}
+.admission-slot-022 {
+  --admission-slot: 22;
+}
+.admission-slot-023 {
+  --admission-slot: 23;
+}
+.admission-slot-024 {
+  --admission-slot: 24;
+}
+.admission-slot-025 {
+  --admission-slot: 25;
+}
+.admission-slot-026 {
+  --admission-slot: 26;
+}
+.admission-slot-027 {
+  --admission-slot: 27;
+}
+.admission-slot-028 {
+  --admission-slot: 28;
+}
+.admission-slot-029 {
+  --admission-slot: 29;
+}
+.admission-slot-030 {
+  --admission-slot: 30;
+}
+.admission-slot-031 {
+  --admission-slot: 31;
+}
+.admission-slot-032 {
+  --admission-slot: 32;
+}
+.admission-slot-033 {
+  --admission-slot: 33;
+}
+.admission-slot-034 {
+  --admission-slot: 34;
+}
+.admission-slot-035 {
+  --admission-slot: 35;
+}
+.admission-slot-036 {
+  --admission-slot: 36;
+}
+.admission-slot-037 {
+  --admission-slot: 37;
+}
+.admission-slot-038 {
+  --admission-slot: 38;
+}
+.admission-slot-039 {
+  --admission-slot: 39;
+}
+.admission-slot-040 {
+  --admission-slot: 40;
+}
+.admission-slot-041 {
+  --admission-slot: 41;
+}
+.admission-slot-042 {
+  --admission-slot: 42;
+}
+.admission-slot-043 {
+  --admission-slot: 43;
+}
+.admission-slot-044 {
+  --admission-slot: 44;
+}
+.admission-slot-045 {
+  --admission-slot: 45;
+}
+.admission-slot-046 {
+  --admission-slot: 46;
+}
+.admission-slot-047 {
+  --admission-slot: 47;
+}
+.admission-slot-048 {
+  --admission-slot: 48;
+}
+.admission-slot-049 {
+  --admission-slot: 49;
+}
+.admission-slot-050 {
+  --admission-slot: 50;
+}
+.admission-slot-051 {
+  --admission-slot: 51;
+}
+.admission-slot-052 {
+  --admission-slot: 52;
+}
+.admission-slot-053 {
+  --admission-slot: 53;
+}
+.admission-slot-054 {
+  --admission-slot: 54;
+}
+.admission-slot-055 {
+  --admission-slot: 55;
+}
+.admission-slot-056 {
+  --admission-slot: 56;
+}
+.admission-slot-057 {
+  --admission-slot: 57;
+}
+.admission-slot-058 {
+  --admission-slot: 58;
+}
+.admission-slot-059 {
+  --admission-slot: 59;
+}
+.admission-slot-060 {
+  --admission-slot: 60;
+}
+.admission-slot-061 {
+  --admission-slot: 61;
+}
+.admission-slot-062 {
+  --admission-slot: 62;
+}
+.admission-slot-063 {
+  --admission-slot: 63;
+}
+.admission-slot-064 {
+  --admission-slot: 64;
+}
+.admission-slot-065 {
+  --admission-slot: 65;
+}
+
+@keyframes quota-pulse {
+  50% {
+    filter: brightness(1.14);
+  }
+}
+
+@keyframes gate-flow {
+  50% {
+    transform: translateX(170%);
+  }
+}
+
+@media (max-width: 860px) {
+  .governor-shell {
+    width: min(100% - 20px, 680px);
+    padding: 28px 0;
+  }
+
+  .governor-console {
+    padding: 14px;
+  }
+
+  .gate-tabs,
+  .governor-board,
+  .state-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add an advanced CSS-only admission control governor example
- include radio-driven gate states, animated quota lanes, conic pressure dial, state cards, and reduced-motion support
- keep the submission scoped to README/demo/style files

## Validation
- npx prettier --check submissions/examples/admission-control-governor-kp/README.md submissions/examples/admission-control-governor-kp/demo.html submissions/examples/admission-control-governor-kp/style.css
- npx stylelint submissions/examples/admission-control-governor-kp/style.css --allow-empty-input
- git diff --check