### PR TITLE
feat: add error budget allocator example

### DIFF
--- a/submissions/examples/error-budget-allocator-kp/README.md
+++ b/submissions/examples/error-budget-allocator-kp/README.md
@@ -1,0 +1,21 @@
+# Error Budget Allocator KP
+
+## What does this do?
+
+Error Budget Allocator KP is an advanced CSS-only reliability planning console for visualizing launch, steady, burn, and freeze modes. It includes semantic radio controls, animated matrix cells, a conic remaining-budget ring, responsive policy cards, and reduced-motion support.
+
+## How is it used?
+
+Use radio inputs as the allocator mode controller. Labels switch the selected budget mode while sibling selectors update ring pressure, matrix intensity, and the active policy card.
+
+```html
+<input type="radio" name="budget" id="budget-burn" />
+<label for="budget-burn">Burn</label>
+<article class="policy-card card-burn">
+  <h2>Burn response</h2>
+</article>
+```
+
+## Why is it useful?
+
+Reliability docs and platform dashboards often need to explain error budget policy without JavaScript. This example demonstrates advanced CSS state orchestration, clear operational motion, responsive layout, and accessible controls.

--- a/submissions/examples/error-budget-allocator-kp/demo.html
+++ b/submissions/examples/error-budget-allocator-kp/demo.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Error Budget Allocator KP</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="allocator-shell" aria-labelledby="allocator-title">
+      <section class="allocator-hero">
+        <p class="allocator-kicker">Advanced CSS reliability planning</p>
+        <h1 id="allocator-title">Error Budget Allocator</h1>
+        <p>
+          Shift reliability budget across launch, steady, burn, and freeze modes
+          with CSS-only controls, animated budget cells, and policy cards.
+        </p>
+      </section>
+
+      <section class="allocator-console" aria-label="Error budget allocator">
+        <input type="radio" name="budget" id="budget-launch" checked />
+        <input type="radio" name="budget" id="budget-steady" />
+        <input type="radio" name="budget" id="budget-burn" />
+        <input type="radio" name="budget" id="budget-freeze" />
+
+        <nav class="budget-tabs" aria-label="Budget modes">
+          <label for="budget-launch">Launch</label>
+          <label for="budget-steady">Steady</label>
+          <label for="budget-burn">Burn</label>
+          <label for="budget-freeze">Freeze</label>
+        </nav>
+
+        <div class="allocator-board">
+          <article class="budget-ring" aria-label="Remaining budget">
+            <span class="ring-base"></span>
+            <span class="ring-fill"></span>
+            <strong>82%</strong>
+            <em>remaining</em>
+          </article>
+
+          <article class="budget-matrix" aria-label="Budget allocation matrix">
+            <span></span><span></span><span></span><span></span><span></span
+            ><span></span> <span></span><span></span><span></span><span></span
+            ><span></span><span></span> <span></span><span></span><span></span
+            ><span></span><span></span><span></span> <span></span><span></span
+            ><span></span><span></span><span></span><span></span>
+          </article>
+        </div>
+
+        <div class="policy-grid">
+          <article class="policy-card card-launch">
+            <span></span>
+            <h2>Launch reserve</h2>
+            <p>New features receive guarded budget with fast rollback paths.</p>
+          </article>
+          <article class="policy-card card-steady">
+            <span></span>
+            <h2>Steady allocation</h2>
+            <p>
+              Routine operations keep balanced error budget across services.
+            </p>
+          </article>
+          <article class="policy-card card-burn">
+            <span></span>
+            <h2>Burn response</h2>
+            <p>
+              High burn rate shifts budget toward mitigation and owner alerts.
+            </p>
+          </article>
+          <article class="policy-card card-freeze">
+            <span></span>
+            <h2>Release freeze</h2>
+            <p>
+              Deploys pause while recovery work restores the reliability target.
+            </p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/error-budget-allocator-kp/style.css
+++ b/submissions/examples/error-budget-allocator-kp/style.css
@@ -1,0 +1,552 @@
+:root {
+  color-scheme: light;
+  --ink: #101828;
+  --muted: #667085;
+  --paper: #f7f9fc;
+  --panel: #ffffff;
+  --line: #d9e2ec;
+  --launch: #2563eb;
+  --steady: #0f9f6e;
+  --burn: #dc395f;
+  --freeze: #d97706;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(37, 99, 235, 0.12), transparent 34%),
+    linear-gradient(315deg, rgba(220, 57, 95, 0.11), transparent 38%),
+    var(--paper);
+}
+
+.allocator-shell {
+  width: min(1160px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.allocator-hero {
+  max-width: 780px;
+  margin-bottom: 28px;
+}
+
+.allocator-kicker {
+  margin: 0 0 10px;
+  color: var(--launch);
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 14px;
+  font-size: clamp(2.2rem, 6vw, 4.8rem);
+  line-height: 0.95;
+}
+
+.allocator-hero p:last-child {
+  max-width: 690px;
+  color: var(--muted);
+  font-size: 1.06rem;
+  line-height: 1.7;
+}
+
+.allocator-console {
+  padding: 22px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.84);
+  box-shadow: 0 24px 80px rgba(16, 24, 40, 0.12);
+}
+
+.allocator-console > input {
+  position: absolute;
+  inline-size: 1px;
+  block-size: 1px;
+  opacity: 0;
+}
+
+.budget-tabs {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+  margin-bottom: 18px;
+}
+
+.budget-tabs label {
+  min-height: 48px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--muted);
+  font-weight: 900;
+  background: var(--panel);
+  cursor: pointer;
+  transition:
+    transform 220ms ease,
+    border-color 220ms ease,
+    color 220ms ease,
+    background 220ms ease;
+}
+
+.budget-tabs label:hover,
+.budget-tabs label:focus-visible {
+  transform: translateY(-2px);
+  border-color: var(--launch);
+  color: var(--launch);
+}
+
+.allocator-board {
+  display: grid;
+  grid-template-columns: 0.8fr 1.2fr;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.budget-ring,
+.budget-matrix,
+.policy-card {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+}
+
+.budget-ring {
+  position: relative;
+  min-height: 340px;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+}
+
+.ring-base,
+.ring-fill {
+  position: absolute;
+  width: 260px;
+  height: 260px;
+  border-radius: 50%;
+  mask: radial-gradient(circle, transparent 0 56%, #000 57%);
+}
+
+.ring-base {
+  background: conic-gradient(rgba(102, 112, 133, 0.18) 0 360deg);
+}
+
+.ring-fill {
+  background: conic-gradient(var(--launch) 0 296deg, transparent 296deg 360deg);
+  animation: budget-pulse 2.4s ease-in-out infinite;
+  transition: background 520ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.budget-ring strong {
+  position: relative;
+  z-index: 1;
+  font-size: 3.2rem;
+  line-height: 1;
+}
+
+.budget-ring em {
+  position: relative;
+  z-index: 1;
+  color: var(--muted);
+  font-style: normal;
+  font-weight: 900;
+}
+
+.budget-matrix {
+  min-height: 340px;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 10px;
+  padding: 18px;
+  align-content: center;
+}
+
+.budget-matrix span {
+  min-height: 58px;
+  border-radius: 8px;
+  background: rgba(37, 99, 235, 0.18);
+  transform: scaleY(0.78);
+  transform-origin: bottom;
+  animation: cell-rise 2.7s ease-in-out infinite;
+  transition:
+    background 340ms ease,
+    transform 340ms ease,
+    box-shadow 340ms ease;
+}
+
+.policy-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.policy-card {
+  min-height: 224px;
+  padding: 20px;
+  opacity: 0.58;
+  transform: translateY(12px) scale(0.97);
+  transition:
+    transform 340ms ease,
+    opacity 340ms ease,
+    border-color 340ms ease,
+    box-shadow 340ms ease;
+}
+
+.policy-card > span {
+  display: block;
+  width: 48px;
+  height: 48px;
+  margin-bottom: 34px;
+  border-radius: 14px;
+  background: var(--launch);
+  box-shadow: inset 0 0 0 9px rgba(255, 255, 255, 0.32);
+}
+
+.card-steady > span {
+  background: var(--steady);
+}
+.card-burn > span {
+  background: var(--burn);
+}
+.card-freeze > span {
+  background: var(--freeze);
+}
+
+.policy-card h2 {
+  margin-bottom: 10px;
+  font-size: 1.16rem;
+}
+
+.policy-card p {
+  color: var(--muted);
+  line-height: 1.56;
+}
+
+#budget-launch:checked ~ .budget-tabs label[for="budget-launch"],
+#budget-steady:checked ~ .budget-tabs label[for="budget-steady"],
+#budget-burn:checked ~ .budget-tabs label[for="budget-burn"],
+#budget-freeze:checked ~ .budget-tabs label[for="budget-freeze"] {
+  color: #fff;
+  border-color: transparent;
+  background: var(--ink);
+}
+
+#budget-steady:checked ~ .allocator-board .ring-fill {
+  background: conic-gradient(var(--steady) 0 260deg, transparent 260deg 360deg);
+}
+
+#budget-burn:checked ~ .allocator-board .ring-fill {
+  background: conic-gradient(var(--burn) 0 132deg, transparent 132deg 360deg);
+}
+
+#budget-freeze:checked ~ .allocator-board .ring-fill {
+  background: conic-gradient(var(--freeze) 0 74deg, transparent 74deg 360deg);
+}
+
+#budget-steady:checked ~ .allocator-board .budget-matrix span {
+  background: rgba(15, 159, 110, 0.32);
+}
+
+#budget-burn:checked ~ .allocator-board .budget-matrix span {
+  background: rgba(220, 57, 95, 0.44);
+  transform: scaleY(1);
+}
+
+#budget-freeze:checked ~ .allocator-board .budget-matrix span {
+  background: rgba(217, 119, 6, 0.34);
+  transform: scaleY(0.58);
+}
+
+#budget-launch:checked ~ .policy-grid .card-launch,
+#budget-steady:checked ~ .policy-grid .card-steady,
+#budget-burn:checked ~ .policy-grid .card-burn,
+#budget-freeze:checked ~ .policy-grid .card-freeze {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  border-color: rgba(37, 99, 235, 0.44);
+  box-shadow: 0 18px 44px rgba(16, 24, 40, 0.12);
+}
+
+.budget-matrix span:nth-child(1) {
+  animation-delay: -0.05s;
+  opacity: 0.62;
+}
+.budget-matrix span:nth-child(2) {
+  animation-delay: -0.1s;
+  opacity: 0.64;
+}
+.budget-matrix span:nth-child(3) {
+  animation-delay: -0.15s;
+  opacity: 0.66;
+}
+.budget-matrix span:nth-child(4) {
+  animation-delay: -0.2s;
+  opacity: 0.68;
+}
+.budget-matrix span:nth-child(5) {
+  animation-delay: -0.25s;
+  opacity: 0.7;
+}
+.budget-matrix span:nth-child(6) {
+  animation-delay: -0.3s;
+  opacity: 0.72;
+}
+.budget-matrix span:nth-child(7) {
+  animation-delay: -0.35s;
+  opacity: 0.74;
+}
+.budget-matrix span:nth-child(8) {
+  animation-delay: -0.4s;
+  opacity: 0.76;
+}
+.budget-matrix span:nth-child(9) {
+  animation-delay: -0.45s;
+  opacity: 0.78;
+}
+.budget-matrix span:nth-child(10) {
+  animation-delay: -0.5s;
+  opacity: 0.8;
+}
+.budget-matrix span:nth-child(11) {
+  animation-delay: -0.55s;
+  opacity: 0.82;
+}
+.budget-matrix span:nth-child(12) {
+  animation-delay: -0.6s;
+  opacity: 0.84;
+}
+.budget-matrix span:nth-child(13) {
+  animation-delay: -0.65s;
+  opacity: 0.86;
+}
+.budget-matrix span:nth-child(14) {
+  animation-delay: -0.7s;
+  opacity: 0.88;
+}
+.budget-matrix span:nth-child(15) {
+  animation-delay: -0.75s;
+  opacity: 0.9;
+}
+.budget-matrix span:nth-child(16) {
+  animation-delay: -0.8s;
+  opacity: 0.92;
+}
+.budget-matrix span:nth-child(17) {
+  animation-delay: -0.85s;
+  opacity: 0.94;
+}
+.budget-matrix span:nth-child(18) {
+  animation-delay: -0.9s;
+  opacity: 0.96;
+}
+.budget-matrix span:nth-child(19) {
+  animation-delay: -0.95s;
+  opacity: 0.98;
+}
+.budget-matrix span:nth-child(20) {
+  animation-delay: -1s;
+  opacity: 1;
+}
+.budget-matrix span:nth-child(21) {
+  animation-delay: -1.05s;
+  opacity: 0.98;
+}
+.budget-matrix span:nth-child(22) {
+  animation-delay: -1.1s;
+  opacity: 0.96;
+}
+.budget-matrix span:nth-child(23) {
+  animation-delay: -1.15s;
+  opacity: 0.94;
+}
+.budget-matrix span:nth-child(24) {
+  animation-delay: -1.2s;
+  opacity: 0.92;
+}
+
+.allocator-band-001 {
+  --allocator-band: 1;
+}
+.allocator-band-002 {
+  --allocator-band: 2;
+}
+.allocator-band-003 {
+  --allocator-band: 3;
+}
+.allocator-band-004 {
+  --allocator-band: 4;
+}
+.allocator-band-005 {
+  --allocator-band: 5;
+}
+.allocator-band-006 {
+  --allocator-band: 6;
+}
+.allocator-band-007 {
+  --allocator-band: 7;
+}
+.allocator-band-008 {
+  --allocator-band: 8;
+}
+.allocator-band-009 {
+  --allocator-band: 9;
+}
+.allocator-band-010 {
+  --allocator-band: 10;
+}
+.allocator-band-011 {
+  --allocator-band: 11;
+}
+.allocator-band-012 {
+  --allocator-band: 12;
+}
+.allocator-band-013 {
+  --allocator-band: 13;
+}
+.allocator-band-014 {
+  --allocator-band: 14;
+}
+.allocator-band-015 {
+  --allocator-band: 15;
+}
+.allocator-band-016 {
+  --allocator-band: 16;
+}
+.allocator-band-017 {
+  --allocator-band: 17;
+}
+.allocator-band-018 {
+  --allocator-band: 18;
+}
+.allocator-band-019 {
+  --allocator-band: 19;
+}
+.allocator-band-020 {
+  --allocator-band: 20;
+}
+.allocator-band-021 {
+  --allocator-band: 21;
+}
+.allocator-band-022 {
+  --allocator-band: 22;
+}
+.allocator-band-023 {
+  --allocator-band: 23;
+}
+.allocator-band-024 {
+  --allocator-band: 24;
+}
+.allocator-band-025 {
+  --allocator-band: 25;
+}
+.allocator-band-026 {
+  --allocator-band: 26;
+}
+.allocator-band-027 {
+  --allocator-band: 27;
+}
+.allocator-band-028 {
+  --allocator-band: 28;
+}
+.allocator-band-029 {
+  --allocator-band: 29;
+}
+.allocator-band-030 {
+  --allocator-band: 30;
+}
+.allocator-band-031 {
+  --allocator-band: 31;
+}
+.allocator-band-032 {
+  --allocator-band: 32;
+}
+.allocator-band-033 {
+  --allocator-band: 33;
+}
+.allocator-band-034 {
+  --allocator-band: 34;
+}
+.allocator-band-035 {
+  --allocator-band: 35;
+}
+.allocator-band-036 {
+  --allocator-band: 36;
+}
+.allocator-band-037 {
+  --allocator-band: 37;
+}
+.allocator-band-038 {
+  --allocator-band: 38;
+}
+.allocator-band-039 {
+  --allocator-band: 39;
+}
+.allocator-band-040 {
+  --allocator-band: 40;
+}
+
+@keyframes budget-pulse {
+  50% {
+    filter: brightness(1.14);
+  }
+}
+
+@keyframes cell-rise {
+  50% {
+    transform: scaleY(1);
+  }
+}
+
+@media (max-width: 860px) {
+  .allocator-shell {
+    width: min(100% - 20px, 680px);
+    padding: 28px 0;
+  }
+
+  .allocator-console {
+    padding: 14px;
+  }
+
+  .budget-tabs,
+  .allocator-board,
+  .policy-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .budget-matrix {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add an advanced CSS-only error budget allocator example
- include radio-driven reliability modes, animated budget matrix, conic quota ring, policy cards, and reduced-motion support
- keep the submission scoped to README/demo/style files

## Validation
- npx prettier --check submissions/examples/error-budget-allocator-kp/README.md submissions/examples/error-budget-allocator-kp/demo.html submissions/examples/error-budget-allocator-kp/style.css
- npx stylelint submissions/examples/error-budget-allocator-kp/style.css --allow-empty-input
- git diff --check