### PR TITLE
feat: add hedged request latency example

### DIFF
--- a/submissions/examples/hedged-request-latency-kp/README.md
+++ b/submissions/examples/hedged-request-latency-kp/README.md
@@ -1,0 +1,21 @@
+# Hedged Request Latency KP
+
+## What does this do?
+
+Hedged Request Latency KP is an advanced CSS-only reliability example for visualizing primary, duplicate, winner, and cancel phases in a hedged request flow. It includes semantic radio controls, animated request lanes, a conic percentile ring, responsive phase cards, and reduced-motion support.
+
+## How is it used?
+
+Use radio inputs as the phase controller. Labels switch the active hedge phase while sibling selectors update the percentile ring, lane emphasis, and active response card.
+
+```html
+<input type="radio" name="hedge" id="hedge-winner" />
+<label for="hedge-winner">Winner</label>
+<article class="phase-card card-winner">
+  <h2>Fastest wins</h2>
+</article>
+```
+
+## Why is it useful?
+
+Distributed systems documentation often needs to explain tail latency mitigation without JavaScript. This example demonstrates advanced CSS state orchestration with accessible controls, operational motion, responsive layout, and clear reduced-motion behavior.

--- a/submissions/examples/hedged-request-latency-kp/demo.html
+++ b/submissions/examples/hedged-request-latency-kp/demo.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Hedged Request Latency KP</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="hedge-shell" aria-labelledby="hedge-title">
+      <section class="hedge-hero">
+        <p class="hedge-kicker">Advanced CSS latency control</p>
+        <h1 id="hedge-title">Hedged Request Latency</h1>
+        <p>
+          Compare primary, hedge, winner, and cancel phases with CSS-only
+          controls, animated request lanes, percentile rings, and response
+          cards.
+        </p>
+      </section>
+
+      <section
+        class="hedge-console"
+        aria-label="Hedged request latency console"
+      >
+        <input type="radio" name="hedge" id="hedge-primary" checked />
+        <input type="radio" name="hedge" id="hedge-duplicate" />
+        <input type="radio" name="hedge" id="hedge-winner" />
+        <input type="radio" name="hedge" id="hedge-cancel" />
+
+        <nav class="hedge-tabs" aria-label="Hedge phases">
+          <label for="hedge-primary">Primary</label>
+          <label for="hedge-duplicate">Hedge</label>
+          <label for="hedge-winner">Winner</label>
+          <label for="hedge-cancel">Cancel</label>
+        </nav>
+
+        <div class="hedge-board">
+          <article class="latency-ring" aria-label="P99 latency">
+            <span class="ring-base"></span>
+            <span class="ring-fill"></span>
+            <strong>138ms</strong>
+            <em>p99</em>
+          </article>
+
+          <article class="request-map" aria-label="Request lanes">
+            <span class="request-line line-primary"><i></i></span>
+            <span class="request-line line-hedge"><i></i></span>
+            <span class="request-line line-winner"><i></i></span>
+            <span class="request-line line-cancel"><i></i></span>
+            <b class="request-node node-client">Client</b>
+            <b class="request-node node-router">Router</b>
+            <b class="request-node node-replica">Replica</b>
+            <b class="request-node node-cache">Cancel</b>
+          </article>
+        </div>
+
+        <div class="phase-grid">
+          <article class="phase-card card-primary">
+            <span></span>
+            <h2>Primary request</h2>
+            <p>
+              The first request starts normally and records its latency budget.
+            </p>
+          </article>
+          <article class="phase-card card-duplicate">
+            <span></span>
+            <h2>Hedge duplicate</h2>
+            <p>A duplicate is sent only after the configured tail threshold.</p>
+          </article>
+          <article class="phase-card card-winner">
+            <span></span>
+            <h2>Fastest wins</h2>
+            <p>
+              The earliest healthy response returns while telemetry is
+              preserved.
+            </p>
+          </article>
+          <article class="phase-card card-cancel">
+            <span></span>
+            <h2>Cancel remainder</h2>
+            <p>
+              Late work is canceled to protect capacity and reduce queue
+              pressure.
+            </p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/hedged-request-latency-kp/style.css
+++ b/submissions/examples/hedged-request-latency-kp/style.css
@@ -1,0 +1,555 @@
+:root {
+  color-scheme: light;
+  --ink: #101828;
+  --muted: #667085;
+  --paper: #f7f9fc;
+  --panel: #ffffff;
+  --line: #d9e2ec;
+  --primary: #2563eb;
+  --duplicate: #d97706;
+  --winner: #0f9f6e;
+  --cancel: #dc395f;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(37, 99, 235, 0.12), transparent 34%),
+    linear-gradient(315deg, rgba(15, 159, 110, 0.13), transparent 38%),
+    var(--paper);
+}
+
+.hedge-shell {
+  width: min(1160px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.hedge-hero {
+  max-width: 780px;
+  margin-bottom: 28px;
+}
+
+.hedge-kicker {
+  margin: 0 0 10px;
+  color: var(--primary);
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 14px;
+  font-size: clamp(2.2rem, 6vw, 4.8rem);
+  line-height: 0.95;
+}
+
+.hedge-hero p:last-child {
+  max-width: 690px;
+  color: var(--muted);
+  font-size: 1.06rem;
+  line-height: 1.7;
+}
+
+.hedge-console {
+  padding: 22px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.84);
+  box-shadow: 0 24px 80px rgba(16, 24, 40, 0.12);
+}
+
+.hedge-console > input {
+  position: absolute;
+  inline-size: 1px;
+  block-size: 1px;
+  opacity: 0;
+}
+
+.hedge-tabs {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+  margin-bottom: 18px;
+}
+
+.hedge-tabs label {
+  min-height: 48px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--muted);
+  font-weight: 900;
+  background: var(--panel);
+  cursor: pointer;
+  transition:
+    transform 220ms ease,
+    border-color 220ms ease,
+    color 220ms ease,
+    background 220ms ease;
+}
+
+.hedge-tabs label:hover,
+.hedge-tabs label:focus-visible {
+  transform: translateY(-2px);
+  border-color: var(--primary);
+  color: var(--primary);
+}
+
+.hedge-board {
+  display: grid;
+  grid-template-columns: 0.8fr 1.2fr;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.latency-ring,
+.request-map,
+.phase-card {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+}
+
+.latency-ring {
+  position: relative;
+  min-height: 340px;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+}
+
+.ring-base,
+.ring-fill {
+  position: absolute;
+  width: 260px;
+  height: 260px;
+  border-radius: 50%;
+  mask: radial-gradient(circle, transparent 0 56%, #000 57%);
+}
+
+.ring-base {
+  background: conic-gradient(rgba(102, 112, 133, 0.18) 0 360deg);
+}
+
+.ring-fill {
+  background: conic-gradient(
+    var(--primary) 0 240deg,
+    transparent 240deg 360deg
+  );
+  animation: latency-pulse 2.4s ease-in-out infinite;
+  transition: background 520ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.latency-ring strong {
+  position: relative;
+  z-index: 1;
+  font-size: 3.1rem;
+  line-height: 1;
+}
+
+.latency-ring em {
+  position: relative;
+  z-index: 1;
+  color: var(--muted);
+  font-style: normal;
+  font-weight: 900;
+}
+
+.request-map {
+  position: relative;
+  min-height: 340px;
+  overflow: hidden;
+  background:
+    linear-gradient(90deg, rgba(37, 99, 235, 0.08), transparent 48%),
+    linear-gradient(270deg, rgba(15, 159, 110, 0.1), transparent 44%),
+    var(--panel);
+}
+
+.request-line {
+  position: absolute;
+  left: 8%;
+  right: 8%;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(102, 112, 133, 0.2);
+  overflow: hidden;
+}
+
+.line-primary {
+  top: 31%;
+}
+.line-hedge {
+  top: 45%;
+}
+.line-winner {
+  top: 59%;
+}
+.line-cancel {
+  top: 73%;
+}
+
+.request-line i {
+  display: block;
+  width: 34%;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--primary);
+  animation: request-flow 2.5s ease-in-out infinite;
+}
+
+.line-hedge i {
+  width: 24%;
+  background: var(--duplicate);
+  animation-delay: -0.35s;
+}
+
+.line-winner i {
+  width: 54%;
+  background: var(--winner);
+  animation-delay: -0.7s;
+}
+
+.line-cancel i {
+  width: 16%;
+  background: var(--cancel);
+  animation-delay: -1s;
+}
+
+.request-node {
+  position: absolute;
+  min-width: 86px;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  text-align: center;
+  font-size: 0.82rem;
+  box-shadow: 0 12px 30px rgba(16, 24, 40, 0.1);
+}
+
+.node-client {
+  left: 7%;
+  top: 10%;
+}
+.node-router {
+  left: 42%;
+  top: 10%;
+}
+.node-replica {
+  right: 7%;
+  top: 31%;
+}
+.node-cache {
+  right: 7%;
+  bottom: 10%;
+}
+
+.phase-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.phase-card {
+  min-height: 224px;
+  padding: 20px;
+  opacity: 0.58;
+  transform: translateY(12px) scale(0.97);
+  transition:
+    transform 340ms ease,
+    opacity 340ms ease,
+    border-color 340ms ease,
+    box-shadow 340ms ease;
+}
+
+.phase-card > span {
+  display: block;
+  width: 48px;
+  height: 48px;
+  margin-bottom: 34px;
+  border-radius: 14px;
+  background: var(--primary);
+  box-shadow: inset 0 0 0 9px rgba(255, 255, 255, 0.32);
+}
+
+.card-duplicate > span {
+  background: var(--duplicate);
+}
+.card-winner > span {
+  background: var(--winner);
+}
+.card-cancel > span {
+  background: var(--cancel);
+}
+
+.phase-card h2 {
+  margin-bottom: 10px;
+  font-size: 1.16rem;
+}
+
+.phase-card p {
+  color: var(--muted);
+  line-height: 1.56;
+}
+
+#hedge-primary:checked ~ .hedge-tabs label[for="hedge-primary"],
+#hedge-duplicate:checked ~ .hedge-tabs label[for="hedge-duplicate"],
+#hedge-winner:checked ~ .hedge-tabs label[for="hedge-winner"],
+#hedge-cancel:checked ~ .hedge-tabs label[for="hedge-cancel"] {
+  color: #fff;
+  border-color: transparent;
+  background: var(--ink);
+}
+
+#hedge-duplicate:checked ~ .hedge-board .ring-fill {
+  background: conic-gradient(
+    var(--duplicate) 0 190deg,
+    transparent 190deg 360deg
+  );
+}
+
+#hedge-winner:checked ~ .hedge-board .ring-fill {
+  background: conic-gradient(var(--winner) 0 118deg, transparent 118deg 360deg);
+}
+
+#hedge-cancel:checked ~ .hedge-board .ring-fill {
+  background: conic-gradient(var(--cancel) 0 74deg, transparent 74deg 360deg);
+}
+
+#hedge-primary:checked ~ .phase-grid .card-primary,
+#hedge-duplicate:checked ~ .phase-grid .card-duplicate,
+#hedge-winner:checked ~ .phase-grid .card-winner,
+#hedge-cancel:checked ~ .phase-grid .card-cancel {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  border-color: rgba(37, 99, 235, 0.44);
+  box-shadow: 0 18px 44px rgba(16, 24, 40, 0.12);
+}
+
+.latency-slot-001 {
+  --latency-slot: 1;
+}
+.latency-slot-002 {
+  --latency-slot: 2;
+}
+.latency-slot-003 {
+  --latency-slot: 3;
+}
+.latency-slot-004 {
+  --latency-slot: 4;
+}
+.latency-slot-005 {
+  --latency-slot: 5;
+}
+.latency-slot-006 {
+  --latency-slot: 6;
+}
+.latency-slot-007 {
+  --latency-slot: 7;
+}
+.latency-slot-008 {
+  --latency-slot: 8;
+}
+.latency-slot-009 {
+  --latency-slot: 9;
+}
+.latency-slot-010 {
+  --latency-slot: 10;
+}
+.latency-slot-011 {
+  --latency-slot: 11;
+}
+.latency-slot-012 {
+  --latency-slot: 12;
+}
+.latency-slot-013 {
+  --latency-slot: 13;
+}
+.latency-slot-014 {
+  --latency-slot: 14;
+}
+.latency-slot-015 {
+  --latency-slot: 15;
+}
+.latency-slot-016 {
+  --latency-slot: 16;
+}
+.latency-slot-017 {
+  --latency-slot: 17;
+}
+.latency-slot-018 {
+  --latency-slot: 18;
+}
+.latency-slot-019 {
+  --latency-slot: 19;
+}
+.latency-slot-020 {
+  --latency-slot: 20;
+}
+.latency-slot-021 {
+  --latency-slot: 21;
+}
+.latency-slot-022 {
+  --latency-slot: 22;
+}
+.latency-slot-023 {
+  --latency-slot: 23;
+}
+.latency-slot-024 {
+  --latency-slot: 24;
+}
+.latency-slot-025 {
+  --latency-slot: 25;
+}
+.latency-slot-026 {
+  --latency-slot: 26;
+}
+.latency-slot-027 {
+  --latency-slot: 27;
+}
+.latency-slot-028 {
+  --latency-slot: 28;
+}
+.latency-slot-029 {
+  --latency-slot: 29;
+}
+.latency-slot-030 {
+  --latency-slot: 30;
+}
+.latency-slot-031 {
+  --latency-slot: 31;
+}
+.latency-slot-032 {
+  --latency-slot: 32;
+}
+.latency-slot-033 {
+  --latency-slot: 33;
+}
+.latency-slot-034 {
+  --latency-slot: 34;
+}
+.latency-slot-035 {
+  --latency-slot: 35;
+}
+.latency-slot-036 {
+  --latency-slot: 36;
+}
+.latency-slot-037 {
+  --latency-slot: 37;
+}
+.latency-slot-038 {
+  --latency-slot: 38;
+}
+.latency-slot-039 {
+  --latency-slot: 39;
+}
+.latency-slot-040 {
+  --latency-slot: 40;
+}
+.latency-slot-041 {
+  --latency-slot: 41;
+}
+.latency-slot-042 {
+  --latency-slot: 42;
+}
+.latency-slot-043 {
+  --latency-slot: 43;
+}
+.latency-slot-044 {
+  --latency-slot: 44;
+}
+.latency-slot-045 {
+  --latency-slot: 45;
+}
+.latency-slot-046 {
+  --latency-slot: 46;
+}
+.latency-slot-047 {
+  --latency-slot: 47;
+}
+.latency-slot-048 {
+  --latency-slot: 48;
+}
+.latency-slot-049 {
+  --latency-slot: 49;
+}
+.latency-slot-050 {
+  --latency-slot: 50;
+}
+.latency-slot-051 {
+  --latency-slot: 51;
+}
+.latency-slot-052 {
+  --latency-slot: 52;
+}
+.latency-slot-053 {
+  --latency-slot: 53;
+}
+.latency-slot-054 {
+  --latency-slot: 54;
+}
+.latency-slot-055 {
+  --latency-slot: 55;
+}
+
+@keyframes latency-pulse {
+  50% {
+    filter: brightness(1.14);
+  }
+}
+
+@keyframes request-flow {
+  50% {
+    transform: translateX(170%);
+  }
+}
+
+@media (max-width: 860px) {
+  .hedge-shell {
+    width: min(100% - 20px, 680px);
+    padding: 28px 0;
+  }
+
+  .hedge-console {
+    padding: 14px;
+  }
+
+  .hedge-tabs,
+  .hedge-board,
+  .phase-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add an advanced CSS-only hedged request latency example
- include radio-driven hedge phases, animated request lanes, conic percentile ring, phase cards, and reduced-motion support
- keep the submission scoped to README/demo/style files

## Validation
- npx prettier --check submissions/examples/hedged-request-latency-kp/README.md submissions/examples/hedged-request-latency-kp/demo.html submissions/examples/hedged-request-latency-kp/style.css
- npx stylelint submissions/examples/hedged-request-latency-kp/style.css --allow-empty-input
- git diff --check