### PR TITLE
add animated typewrite text reveal

### DIFF
--- a/submissions/examples/animated-typewriter-text-reveal/README.md
+++ b/submissions/examples/animated-typewriter-text-reveal/README.md
@@ -1,0 +1,14 @@
+# Typewriter Text Reveal
+
+A pure-CSS typewriter effect: text reveals character-by-character with a blinking cursor, no JavaScript required.
+
+## What it does
+Uses `steps()` timing on an animated `width` property inside an `overflow: hidden` container, paired with a blinking `border-right` as the caret.
+
+## How to use it
+1. Add the `typewriter` class to any single-line text element.
+2. Set an inline `--chars` custom property equal to the character count of your text (controls animation step count).
+3. Optionally set a fixed `width` in `ch` units so the container doesn't reflow after the animation.
+
+```html
+<h1 class="typewriter" style="--chars: 20;">Build with EaseMotion</h1>

--- a/submissions/examples/animated-typewriter-text-reveal/demo.html
+++ b/submissions/examples/animated-typewriter-text-reveal/demo.html
@@ -1,0 +1,36 @@
+### demo.html
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Typewriter Text Reveal — Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-wrap">
+    <h1>Typewriter Text Reveal</h1>
+    <p class="sub">Click replay to restart the animation.</p>
+
+    <div class="card">
+      <h2 class="typewriter" id="line1" style="--chars: 20;">Build with EaseMotion</h2>
+      <p class="typewriter typewriter-sub" id="line2" style="--chars: 34;">Human-readable. Animation-first. Zero deps.</p>
+    </div>
+
+    <button id="replayBtn" class="replay-btn">↻ Replay Animation</button>
+  </main>
+
+  <script>
+    const btn = document.getElementById('replayBtn');
+    const lines = [document.getElementById('line1'), document.getElementById('line2')];
+
+    btn.addEventListener('click', () => {
+      lines.forEach(el => {
+        el.style.animation = 'none';
+        void el.offsetWidth; // force reflow
+        el.style.animation = '';
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/animated-typewriter-text-reveal/style.css
+++ b/submissions/examples/animated-typewriter-text-reveal/style.css
@@ -1,0 +1,76 @@
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #0f1117;
+  color: #f4f4f5;
+  display: flex;
+  justify-content: center;
+  padding: 64px 16px;
+}
+
+.demo-wrap { max-width: 520px; width: 100%; text-align: center; }
+
+h1 { font-size: 22px; margin-bottom: 4px; }
+.sub { color: #9ca3af; font-size: 14px; margin-bottom: 32px; }
+
+.card {
+  background: #1a1d27;
+  border-radius: 12px;
+  padding: 40px 24px;
+  border: 1px solid #2a2e3a;
+}
+
+.typewriter {
+  overflow: hidden;
+  white-space: nowrap;
+  margin: 0 auto;
+  border-right: 3px solid #6c63ff;
+  font-family: "Courier New", monospace;
+  animation:
+    typing 2.2s steps(var(--chars), end) forwards,
+    blink-caret 0.75s step-end infinite;
+}
+
+h2.typewriter {
+  font-size: 26px;
+  width: 20ch;
+  max-width: 100%;
+}
+
+.typewriter-sub {
+  font-size: 14px;
+  color: #a5a5b0;
+  width: 34ch;
+  max-width: 100%;
+  margin-top: 16px !important;
+  animation-delay: 2.2s, 2.2s;
+  animation-fill-mode: both;
+}
+
+@keyframes typing {
+  from { width: 0; }
+  to   { width: 100%; }
+}
+
+@keyframes blink-caret {
+  50% { border-color: transparent; }
+}
+
+.replay-btn {
+  margin-top: 28px;
+  background: #6c63ff;
+  color: white;
+  border: none;
+  padding: 10px 18px;
+  border-radius: 8px;
+  font-size: 14px;
+  cursor: pointer;
+  transition: transform 0.15s ease, background 0.2s ease;
+}
+
+.replay-btn:hover {
+  background: #5a52e0;
+  transform: translateY(-2px);
+}


### PR DESCRIPTION
### PR Description
```markdown
## Pull Request Description

Adds a pure-CSS typewriter text reveal effect with a blinking cursor, using `steps()` timing — no JavaScript required to run. Closes #<issue-number>.

---
## Type of Change
- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---
## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/typewriter-reveal/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description

**What does this add?**
A character-by-character text reveal animation with a blinking caret, driven entirely by CSS `steps()` timing.

**How does a developer use it?**
\`\`\`html
<h1 class="typewriter" style="--chars: 20;">Build with EaseMotion</h1>
\`\`\`