### PR TITLE
feat: add brownout degradation switchboard example

### DIFF
--- a/submissions/examples/brownout-degradation-switchboard-kp/README.md
+++ b/submissions/examples/brownout-degradation-switchboard-kp/README.md
@@ -1,0 +1,21 @@
+# Brownout Degradation Switchboard KP
+
+## What does this do?
+
+Brownout Degradation Switchboard KP is an advanced CSS-only resilience console for visualizing normal, dimmed, essential, and restore modes. It includes semantic radio controls, animated degradation lanes, a conic load ring, responsive service cards, and reduced-motion support.
+
+## How is it used?
+
+Use radio inputs as the degradation mode controller. Labels switch the active mode while sibling selectors update load pressure, lane emphasis, and the selected service card.
+
+```html
+<input type="radio" name="brownout" id="mode-essential" />
+<label for="mode-essential">Essential</label>
+<article class="service-card card-essential">
+  <h2>Essential only</h2>
+</article>
+```
+
+## Why is it useful?
+
+Reliability docs and operations dashboards often need to explain graceful degradation without JavaScript. This example demonstrates advanced CSS state orchestration with accessible controls, operational motion, responsive layout, and reduced-motion behavior.

--- a/submissions/examples/brownout-degradation-switchboard-kp/demo.html
+++ b/submissions/examples/brownout-degradation-switchboard-kp/demo.html
@@ -1,0 +1,92 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Brownout Degradation Switchboard KP</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="brownout-shell" aria-labelledby="brownout-title">
+      <section class="brownout-hero">
+        <p class="brownout-kicker">Advanced CSS resilience control</p>
+        <h1 id="brownout-title">Brownout Degradation Switchboard</h1>
+        <p>
+          Shift noncritical features through normal, dimmed, essential, and
+          restore modes with CSS-only controls, animated load lanes, and service
+          cards.
+        </p>
+      </section>
+
+      <section
+        class="brownout-console"
+        aria-label="Brownout degradation switchboard"
+      >
+        <input type="radio" name="brownout" id="mode-normal" checked />
+        <input type="radio" name="brownout" id="mode-dimmed" />
+        <input type="radio" name="brownout" id="mode-essential" />
+        <input type="radio" name="brownout" id="mode-restore" />
+
+        <nav class="mode-tabs" aria-label="Degradation modes">
+          <label for="mode-normal">Normal</label>
+          <label for="mode-dimmed">Dimmed</label>
+          <label for="mode-essential">Essential</label>
+          <label for="mode-restore">Restore</label>
+        </nav>
+
+        <div class="brownout-board">
+          <article class="load-ring" aria-label="System load">
+            <span class="ring-base"></span>
+            <span class="ring-fill"></span>
+            <strong>71%</strong>
+            <em>load</em>
+          </article>
+
+          <article class="switch-map" aria-label="Feature degradation lanes">
+            <span class="switch-line line-core"><i></i></span>
+            <span class="switch-line line-search"><i></i></span>
+            <span class="switch-line line-media"><i></i></span>
+            <span class="switch-line line-extra"><i></i></span>
+            <b class="switch-node node-gateway">Gateway</b>
+            <b class="switch-node node-policy">Policy</b>
+            <b class="switch-node node-core">Core</b>
+            <b class="switch-node node-optional">Optional</b>
+          </article>
+        </div>
+
+        <div class="service-grid">
+          <article class="service-card card-normal">
+            <span></span>
+            <h2>Normal service</h2>
+            <p>
+              All features are enabled while latency and capacity remain
+              healthy.
+            </p>
+          </article>
+          <article class="service-card card-dimmed">
+            <span></span>
+            <h2>Dimmed extras</h2>
+            <p>
+              Expensive recommendations, previews, and analytics slow down
+              first.
+            </p>
+          </article>
+          <article class="service-card card-essential">
+            <span></span>
+            <h2>Essential only</h2>
+            <p>
+              Core transaction paths stay available while optional work pauses.
+            </p>
+          </article>
+          <article class="service-card card-restore">
+            <span></span>
+            <h2>Restore path</h2>
+            <p>
+              Features return gradually after load and error budget recover.
+            </p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/brownout-degradation-switchboard-kp/style.css
+++ b/submissions/examples/brownout-degradation-switchboard-kp/style.css
@@ -1,0 +1,555 @@
+:root {
+  color-scheme: light;
+  --ink: #101828;
+  --muted: #667085;
+  --paper: #f7f9fc;
+  --panel: #ffffff;
+  --line: #d9e2ec;
+  --normal: #0f9f6e;
+  --dimmed: #d97706;
+  --essential: #dc395f;
+  --restore: #2563eb;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(15, 159, 110, 0.13), transparent 34%),
+    linear-gradient(315deg, rgba(37, 99, 235, 0.12), transparent 38%),
+    var(--paper);
+}
+
+.brownout-shell {
+  width: min(1160px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.brownout-hero {
+  max-width: 780px;
+  margin-bottom: 28px;
+}
+
+.brownout-kicker {
+  margin: 0 0 10px;
+  color: var(--normal);
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 14px;
+  font-size: clamp(2.2rem, 6vw, 4.8rem);
+  line-height: 0.95;
+}
+
+.brownout-hero p:last-child {
+  max-width: 690px;
+  color: var(--muted);
+  font-size: 1.06rem;
+  line-height: 1.7;
+}
+
+.brownout-console {
+  padding: 22px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.84);
+  box-shadow: 0 24px 80px rgba(16, 24, 40, 0.12);
+}
+
+.brownout-console > input {
+  position: absolute;
+  inline-size: 1px;
+  block-size: 1px;
+  opacity: 0;
+}
+
+.mode-tabs {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+  margin-bottom: 18px;
+}
+
+.mode-tabs label {
+  min-height: 48px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--muted);
+  font-weight: 900;
+  background: var(--panel);
+  cursor: pointer;
+  transition:
+    transform 220ms ease,
+    border-color 220ms ease,
+    color 220ms ease,
+    background 220ms ease;
+}
+
+.mode-tabs label:hover,
+.mode-tabs label:focus-visible {
+  transform: translateY(-2px);
+  border-color: var(--restore);
+  color: var(--restore);
+}
+
+.brownout-board {
+  display: grid;
+  grid-template-columns: 0.8fr 1.2fr;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.load-ring,
+.switch-map,
+.service-card {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+}
+
+.load-ring {
+  position: relative;
+  min-height: 340px;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+}
+
+.ring-base,
+.ring-fill {
+  position: absolute;
+  width: 260px;
+  height: 260px;
+  border-radius: 50%;
+  mask: radial-gradient(circle, transparent 0 56%, #000 57%);
+}
+
+.ring-base {
+  background: conic-gradient(rgba(102, 112, 133, 0.18) 0 360deg);
+}
+
+.ring-fill {
+  background: conic-gradient(var(--normal) 0 256deg, transparent 256deg 360deg);
+  animation: load-pulse 2.4s ease-in-out infinite;
+  transition: background 520ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.load-ring strong {
+  position: relative;
+  z-index: 1;
+  font-size: 3.2rem;
+  line-height: 1;
+}
+
+.load-ring em {
+  position: relative;
+  z-index: 1;
+  color: var(--muted);
+  font-style: normal;
+  font-weight: 900;
+}
+
+.switch-map {
+  position: relative;
+  min-height: 340px;
+  overflow: hidden;
+  background:
+    linear-gradient(90deg, rgba(15, 159, 110, 0.08), transparent 48%),
+    linear-gradient(270deg, rgba(220, 57, 95, 0.1), transparent 44%),
+    var(--panel);
+}
+
+.switch-line {
+  position: absolute;
+  left: 8%;
+  right: 8%;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(102, 112, 133, 0.2);
+  overflow: hidden;
+}
+
+.line-core {
+  top: 31%;
+}
+.line-search {
+  top: 45%;
+}
+.line-media {
+  top: 59%;
+}
+.line-extra {
+  top: 73%;
+}
+
+.switch-line i {
+  display: block;
+  width: 40%;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--normal);
+  animation: switch-flow 2.5s ease-in-out infinite;
+}
+
+.line-search i {
+  width: 32%;
+  background: var(--dimmed);
+  animation-delay: -0.35s;
+}
+
+.line-media i {
+  width: 22%;
+  background: var(--essential);
+  animation-delay: -0.7s;
+}
+
+.line-extra i {
+  width: 14%;
+  background: var(--restore);
+  animation-delay: -1s;
+}
+
+.switch-node {
+  position: absolute;
+  min-width: 86px;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  text-align: center;
+  font-size: 0.82rem;
+  box-shadow: 0 12px 30px rgba(16, 24, 40, 0.1);
+}
+
+.node-gateway {
+  left: 7%;
+  top: 10%;
+}
+.node-policy {
+  left: 42%;
+  top: 10%;
+}
+.node-core {
+  right: 7%;
+  top: 31%;
+}
+.node-optional {
+  right: 7%;
+  bottom: 10%;
+}
+
+.service-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.service-card {
+  min-height: 224px;
+  padding: 20px;
+  opacity: 0.58;
+  transform: translateY(12px) scale(0.97);
+  transition:
+    transform 340ms ease,
+    opacity 340ms ease,
+    border-color 340ms ease,
+    box-shadow 340ms ease;
+}
+
+.service-card > span {
+  display: block;
+  width: 48px;
+  height: 48px;
+  margin-bottom: 34px;
+  border-radius: 14px;
+  background: var(--normal);
+  box-shadow: inset 0 0 0 9px rgba(255, 255, 255, 0.32);
+}
+
+.card-dimmed > span {
+  background: var(--dimmed);
+}
+.card-essential > span {
+  background: var(--essential);
+}
+.card-restore > span {
+  background: var(--restore);
+}
+
+.service-card h2 {
+  margin-bottom: 10px;
+  font-size: 1.16rem;
+}
+
+.service-card p {
+  color: var(--muted);
+  line-height: 1.56;
+}
+
+#mode-normal:checked ~ .mode-tabs label[for="mode-normal"],
+#mode-dimmed:checked ~ .mode-tabs label[for="mode-dimmed"],
+#mode-essential:checked ~ .mode-tabs label[for="mode-essential"],
+#mode-restore:checked ~ .mode-tabs label[for="mode-restore"] {
+  color: #fff;
+  border-color: transparent;
+  background: var(--ink);
+}
+
+#mode-dimmed:checked ~ .brownout-board .ring-fill {
+  background: conic-gradient(var(--dimmed) 0 205deg, transparent 205deg 360deg);
+}
+
+#mode-essential:checked ~ .brownout-board .ring-fill {
+  background: conic-gradient(
+    var(--essential) 0 118deg,
+    transparent 118deg 360deg
+  );
+}
+
+#mode-restore:checked ~ .brownout-board .ring-fill {
+  background: conic-gradient(
+    var(--restore) 0 176deg,
+    transparent 176deg 360deg
+  );
+}
+
+#mode-normal:checked ~ .service-grid .card-normal,
+#mode-dimmed:checked ~ .service-grid .card-dimmed,
+#mode-essential:checked ~ .service-grid .card-essential,
+#mode-restore:checked ~ .service-grid .card-restore {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  border-color: rgba(37, 99, 235, 0.44);
+  box-shadow: 0 18px 44px rgba(16, 24, 40, 0.12);
+}
+
+.brownout-slot-001 {
+  --brownout-slot: 1;
+}
+.brownout-slot-002 {
+  --brownout-slot: 2;
+}
+.brownout-slot-003 {
+  --brownout-slot: 3;
+}
+.brownout-slot-004 {
+  --brownout-slot: 4;
+}
+.brownout-slot-005 {
+  --brownout-slot: 5;
+}
+.brownout-slot-006 {
+  --brownout-slot: 6;
+}
+.brownout-slot-007 {
+  --brownout-slot: 7;
+}
+.brownout-slot-008 {
+  --brownout-slot: 8;
+}
+.brownout-slot-009 {
+  --brownout-slot: 9;
+}
+.brownout-slot-010 {
+  --brownout-slot: 10;
+}
+.brownout-slot-011 {
+  --brownout-slot: 11;
+}
+.brownout-slot-012 {
+  --brownout-slot: 12;
+}
+.brownout-slot-013 {
+  --brownout-slot: 13;
+}
+.brownout-slot-014 {
+  --brownout-slot: 14;
+}
+.brownout-slot-015 {
+  --brownout-slot: 15;
+}
+.brownout-slot-016 {
+  --brownout-slot: 16;
+}
+.brownout-slot-017 {
+  --brownout-slot: 17;
+}
+.brownout-slot-018 {
+  --brownout-slot: 18;
+}
+.brownout-slot-019 {
+  --brownout-slot: 19;
+}
+.brownout-slot-020 {
+  --brownout-slot: 20;
+}
+.brownout-slot-021 {
+  --brownout-slot: 21;
+}
+.brownout-slot-022 {
+  --brownout-slot: 22;
+}
+.brownout-slot-023 {
+  --brownout-slot: 23;
+}
+.brownout-slot-024 {
+  --brownout-slot: 24;
+}
+.brownout-slot-025 {
+  --brownout-slot: 25;
+}
+.brownout-slot-026 {
+  --brownout-slot: 26;
+}
+.brownout-slot-027 {
+  --brownout-slot: 27;
+}
+.brownout-slot-028 {
+  --brownout-slot: 28;
+}
+.brownout-slot-029 {
+  --brownout-slot: 29;
+}
+.brownout-slot-030 {
+  --brownout-slot: 30;
+}
+.brownout-slot-031 {
+  --brownout-slot: 31;
+}
+.brownout-slot-032 {
+  --brownout-slot: 32;
+}
+.brownout-slot-033 {
+  --brownout-slot: 33;
+}
+.brownout-slot-034 {
+  --brownout-slot: 34;
+}
+.brownout-slot-035 {
+  --brownout-slot: 35;
+}
+.brownout-slot-036 {
+  --brownout-slot: 36;
+}
+.brownout-slot-037 {
+  --brownout-slot: 37;
+}
+.brownout-slot-038 {
+  --brownout-slot: 38;
+}
+.brownout-slot-039 {
+  --brownout-slot: 39;
+}
+.brownout-slot-040 {
+  --brownout-slot: 40;
+}
+.brownout-slot-041 {
+  --brownout-slot: 41;
+}
+.brownout-slot-042 {
+  --brownout-slot: 42;
+}
+.brownout-slot-043 {
+  --brownout-slot: 43;
+}
+.brownout-slot-044 {
+  --brownout-slot: 44;
+}
+.brownout-slot-045 {
+  --brownout-slot: 45;
+}
+.brownout-slot-046 {
+  --brownout-slot: 46;
+}
+.brownout-slot-047 {
+  --brownout-slot: 47;
+}
+.brownout-slot-048 {
+  --brownout-slot: 48;
+}
+.brownout-slot-049 {
+  --brownout-slot: 49;
+}
+.brownout-slot-050 {
+  --brownout-slot: 50;
+}
+.brownout-slot-051 {
+  --brownout-slot: 51;
+}
+.brownout-slot-052 {
+  --brownout-slot: 52;
+}
+.brownout-slot-053 {
+  --brownout-slot: 53;
+}
+.brownout-slot-054 {
+  --brownout-slot: 54;
+}
+.brownout-slot-055 {
+  --brownout-slot: 55;
+}
+
+@keyframes load-pulse {
+  50% {
+    filter: brightness(1.14);
+  }
+}
+
+@keyframes switch-flow {
+  50% {
+    transform: translateX(170%);
+  }
+}
+
+@media (max-width: 860px) {
+  .brownout-shell {
+    width: min(100% - 20px, 680px);
+    padding: 28px 0;
+  }
+
+  .brownout-console {
+    padding: 14px;
+  }
+
+  .mode-tabs,
+  .brownout-board,
+  .service-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add an advanced CSS-only brownout degradation switchboard example
- include radio-driven degradation states, animated load lanes, conic load ring, service cards, and reduced-motion support
- keep the submission scoped to README/demo/style files

## Validation
- npx prettier --check submissions/examples/brownout-degradation-switchboard-kp/README.md submissions/examples/brownout-degradation-switchboard-kp/demo.html submissions/examples/brownout-degradation-switchboard-kp/style.css
- npx stylelint submissions/examples/brownout-degradation-switchboard-kp/style.css --allow-empty-input
- git diff --check