### PR TITLE
feat: add shadow traffic verifier example

### DIFF
--- a/submissions/examples/shadow-traffic-verifier-kp/README.md
+++ b/submissions/examples/shadow-traffic-verifier-kp/README.md
@@ -1,0 +1,21 @@
+﻿# Shadow Traffic Verifier KP
+
+## What does this do?
+
+Shadow Traffic Verifier KP is an advanced CSS-only resilience console for visualizing mirror, compare, drift, and approve modes. It includes semantic radio controls, animated verification lanes, a conic match ring, responsive service cards, and reduced-motion support.
+
+## How is it used?
+
+Use radio inputs as the verification mode controller. Labels switch the active mode while sibling selectors update match pressure, lane emphasis, and the selected service card.
+
+```html
+<input type="radio" name="shadow" id="mode-drift" />
+<label for="mode-drift">Drift</label>
+<article class="service-card card-drift">
+  <h2>Detect drift</h2>
+</article>
+```
+
+## Why is it useful?
+
+Reliability docs and operations dashboards often need to explain graceful verification without JavaScript. This example demonstrates advanced CSS state orchestration with accessible controls, operational motion, responsive layout, and reduced-motion behavior.

--- a/submissions/examples/shadow-traffic-verifier-kp/demo.html
+++ b/submissions/examples/shadow-traffic-verifier-kp/demo.html
@@ -1,0 +1,88 @@
+﻿<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Shadow Traffic Verifier KP</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="shadow-shell" aria-labelledby="shadow-title">
+      <section class="shadow-hero">
+        <p class="shadow-kicker">Advanced CSS resilience control</p>
+        <h1 id="shadow-title">Shadow Traffic Verifier</h1>
+        <p>
+          Shift mirrored production requests through mirror, compare, drift, and
+          approve modes with CSS-only controls, animated match lanes, and
+          service cards.
+        </p>
+      </section>
+
+      <section
+        class="shadow-console"
+        aria-label="Shadow verification switchboard"
+      >
+        <input type="radio" name="shadow" id="mode-mirror" checked />
+        <input type="radio" name="shadow" id="mode-compare" />
+        <input type="radio" name="shadow" id="mode-drift" />
+        <input type="radio" name="shadow" id="mode-approve" />
+
+        <nav class="mode-tabs" aria-label="Verification modes">
+          <label for="mode-mirror">Mirror</label>
+          <label for="mode-compare">Compare</label>
+          <label for="mode-drift">Drift</label>
+          <label for="mode-approve">Approve</label>
+        </nav>
+
+        <div class="shadow-board">
+          <article class="match-ring" aria-label="System match">
+            <span class="ring-base"></span>
+            <span class="ring-fill"></span>
+            <strong>71%</strong>
+            <em>match</em>
+          </article>
+
+          <article class="switch-map" aria-label="Shadow verification lanes">
+            <span class="switch-line line-core"><i></i></span>
+            <span class="switch-line line-search"><i></i></span>
+            <span class="switch-line line-media"><i></i></span>
+            <span class="switch-line line-extra"><i></i></span>
+            <b class="switch-node node-gateway">Ingress</b>
+            <b class="switch-node node-policy">Mirror</b>
+            <b class="switch-node node-core">Candidate</b>
+            <b class="switch-node node-optional">Verifier</b>
+          </article>
+        </div>
+
+        <div class="service-grid">
+          <article class="service-card card-mirror">
+            <span></span>
+            <h2>Mirror traffic</h2>
+            <p>
+              All features are enabled while latency and capacity remain
+              healthy.
+            </p>
+          </article>
+          <article class="service-card card-compare">
+            <span></span>
+            <h2>Compare responses</h2>
+            <p>
+              Expensive recommendations, previews, and analytics slow down
+              first.
+            </p>
+          </article>
+          <article class="service-card card-drift">
+            <span></span>
+            <h2>Detect drift</h2>
+            <p>Contract mismatches and tail latency spikes are highlighted.</p>
+          </article>
+          <article class="service-card card-approve">
+            <span></span>
+            <h2>Approve release</h2>
+            <p>The candidate can graduate once checks remain stable.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/shadow-traffic-verifier-kp/style.css
+++ b/submissions/examples/shadow-traffic-verifier-kp/style.css
@@ -1,0 +1,555 @@
+﻿:root {
+  color-scheme: light;
+  --ink: #101828;
+  --muted: #667085;
+  --paper: #f7f9fc;
+  --panel: #ffffff;
+  --line: #d9e2ec;
+  --mirror: #0f9f6e;
+  --compare: #d97706;
+  --drift: #dc395f;
+  --approve: #2563eb;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(15, 159, 110, 0.13), transparent 34%),
+    linear-gradient(315deg, rgba(37, 99, 235, 0.12), transparent 38%),
+    var(--paper);
+}
+
+.shadow-shell {
+  width: min(1160px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.shadow-hero {
+  max-width: 780px;
+  margin-bottom: 28px;
+}
+
+.shadow-kicker {
+  margin: 0 0 10px;
+  color: var(--mirror);
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 14px;
+  font-size: clamp(2.2rem, 6vw, 4.8rem);
+  line-height: 0.95;
+}
+
+.shadow-hero p:last-child {
+  max-width: 690px;
+  color: var(--muted);
+  font-size: 1.06rem;
+  line-height: 1.7;
+}
+
+.shadow-console {
+  padding: 22px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.84);
+  box-shadow: 0 24px 80px rgba(16, 24, 40, 0.12);
+}
+
+.shadow-console > input {
+  position: absolute;
+  inline-size: 1px;
+  block-size: 1px;
+  opacity: 0;
+}
+
+.mode-tabs {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+  margin-bottom: 18px;
+}
+
+.mode-tabs label {
+  min-height: 48px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--muted);
+  font-weight: 900;
+  background: var(--panel);
+  cursor: pointer;
+  transition:
+    transform 220ms ease,
+    border-color 220ms ease,
+    color 220ms ease,
+    background 220ms ease;
+}
+
+.mode-tabs label:hover,
+.mode-tabs label:focus-visible {
+  transform: translateY(-2px);
+  border-color: var(--approve);
+  color: var(--approve);
+}
+
+.shadow-board {
+  display: grid;
+  grid-template-columns: 0.8fr 1.2fr;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.match-ring,
+.switch-map,
+.service-card {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+}
+
+.match-ring {
+  position: relative;
+  min-height: 340px;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+}
+
+.ring-base,
+.ring-fill {
+  position: absolute;
+  width: 260px;
+  height: 260px;
+  border-radius: 50%;
+  mask: radial-gradient(circle, transparent 0 56%, #000 57%);
+}
+
+.ring-base {
+  background: conic-gradient(rgba(102, 112, 133, 0.18) 0 360deg);
+}
+
+.ring-fill {
+  background: conic-gradient(var(--mirror) 0 256deg, transparent 256deg 360deg);
+  animation: match-pulse 2.4s ease-in-out infinite;
+  transition: background 520ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.match-ring strong {
+  position: relative;
+  z-index: 1;
+  font-size: 3.2rem;
+  line-height: 1;
+}
+
+.match-ring em {
+  position: relative;
+  z-index: 1;
+  color: var(--muted);
+  font-style: mirror;
+  font-weight: 900;
+}
+
+.switch-map {
+  position: relative;
+  min-height: 340px;
+  overflow: hidden;
+  background:
+    linear-gradient(90deg, rgba(15, 159, 110, 0.08), transparent 48%),
+    linear-gradient(270deg, rgba(220, 57, 95, 0.1), transparent 44%),
+    var(--panel);
+}
+
+.switch-line {
+  position: absolute;
+  left: 8%;
+  right: 8%;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(102, 112, 133, 0.2);
+  overflow: hidden;
+}
+
+.line-core {
+  top: 31%;
+}
+.line-search {
+  top: 45%;
+}
+.line-media {
+  top: 59%;
+}
+.line-extra {
+  top: 73%;
+}
+
+.switch-line i {
+  display: block;
+  width: 40%;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--mirror);
+  animation: switch-flow 2.5s ease-in-out infinite;
+}
+
+.line-search i {
+  width: 32%;
+  background: var(--compare);
+  animation-delay: -0.35s;
+}
+
+.line-media i {
+  width: 22%;
+  background: var(--drift);
+  animation-delay: -0.7s;
+}
+
+.line-extra i {
+  width: 14%;
+  background: var(--approve);
+  animation-delay: -1s;
+}
+
+.switch-node {
+  position: absolute;
+  min-width: 86px;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  text-align: center;
+  font-size: 0.82rem;
+  box-shadow: 0 12px 30px rgba(16, 24, 40, 0.1);
+}
+
+.node-gateway {
+  left: 7%;
+  top: 10%;
+}
+.node-policy {
+  left: 42%;
+  top: 10%;
+}
+.node-core {
+  right: 7%;
+  top: 31%;
+}
+.node-optional {
+  right: 7%;
+  bottom: 10%;
+}
+
+.service-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.service-card {
+  min-height: 224px;
+  padding: 20px;
+  opacity: 0.58;
+  transform: translateY(12px) scale(0.97);
+  transition:
+    transform 340ms ease,
+    opacity 340ms ease,
+    border-color 340ms ease,
+    box-shadow 340ms ease;
+}
+
+.service-card > span {
+  display: block;
+  width: 48px;
+  height: 48px;
+  margin-bottom: 34px;
+  border-radius: 14px;
+  background: var(--mirror);
+  box-shadow: inset 0 0 0 9px rgba(255, 255, 255, 0.32);
+}
+
+.card-compare > span {
+  background: var(--compare);
+}
+.card-drift > span {
+  background: var(--drift);
+}
+.card-approve > span {
+  background: var(--approve);
+}
+
+.service-card h2 {
+  margin-bottom: 10px;
+  font-size: 1.16rem;
+}
+
+.service-card p {
+  color: var(--muted);
+  line-height: 1.56;
+}
+
+#mode-mirror:checked ~ .mode-tabs label[for="mode-mirror"],
+#mode-compare:checked ~ .mode-tabs label[for="mode-compare"],
+#mode-drift:checked ~ .mode-tabs label[for="mode-drift"],
+#mode-approve:checked ~ .mode-tabs label[for="mode-approve"] {
+  color: #fff;
+  border-color: transparent;
+  background: var(--ink);
+}
+
+#mode-compare:checked ~ .shadow-board .ring-fill {
+  background: conic-gradient(
+    var(--compare) 0 205deg,
+    transparent 205deg 360deg
+  );
+}
+
+#mode-drift:checked ~ .shadow-board .ring-fill {
+  background: conic-gradient(var(--drift) 0 118deg, transparent 118deg 360deg);
+}
+
+#mode-approve:checked ~ .shadow-board .ring-fill {
+  background: conic-gradient(
+    var(--approve) 0 176deg,
+    transparent 176deg 360deg
+  );
+}
+
+#mode-mirror:checked ~ .service-grid .card-mirror,
+#mode-compare:checked ~ .service-grid .card-compare,
+#mode-drift:checked ~ .service-grid .card-drift,
+#mode-approve:checked ~ .service-grid .card-approve {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  border-color: rgba(37, 99, 235, 0.44);
+  box-shadow: 0 18px 44px rgba(16, 24, 40, 0.12);
+}
+
+.shadow-slot-001 {
+  --shadow-slot: 1;
+}
+.shadow-slot-002 {
+  --shadow-slot: 2;
+}
+.shadow-slot-003 {
+  --shadow-slot: 3;
+}
+.shadow-slot-004 {
+  --shadow-slot: 4;
+}
+.shadow-slot-005 {
+  --shadow-slot: 5;
+}
+.shadow-slot-006 {
+  --shadow-slot: 6;
+}
+.shadow-slot-007 {
+  --shadow-slot: 7;
+}
+.shadow-slot-008 {
+  --shadow-slot: 8;
+}
+.shadow-slot-009 {
+  --shadow-slot: 9;
+}
+.shadow-slot-010 {
+  --shadow-slot: 10;
+}
+.shadow-slot-011 {
+  --shadow-slot: 11;
+}
+.shadow-slot-012 {
+  --shadow-slot: 12;
+}
+.shadow-slot-013 {
+  --shadow-slot: 13;
+}
+.shadow-slot-014 {
+  --shadow-slot: 14;
+}
+.shadow-slot-015 {
+  --shadow-slot: 15;
+}
+.shadow-slot-016 {
+  --shadow-slot: 16;
+}
+.shadow-slot-017 {
+  --shadow-slot: 17;
+}
+.shadow-slot-018 {
+  --shadow-slot: 18;
+}
+.shadow-slot-019 {
+  --shadow-slot: 19;
+}
+.shadow-slot-020 {
+  --shadow-slot: 20;
+}
+.shadow-slot-021 {
+  --shadow-slot: 21;
+}
+.shadow-slot-022 {
+  --shadow-slot: 22;
+}
+.shadow-slot-023 {
+  --shadow-slot: 23;
+}
+.shadow-slot-024 {
+  --shadow-slot: 24;
+}
+.shadow-slot-025 {
+  --shadow-slot: 25;
+}
+.shadow-slot-026 {
+  --shadow-slot: 26;
+}
+.shadow-slot-027 {
+  --shadow-slot: 27;
+}
+.shadow-slot-028 {
+  --shadow-slot: 28;
+}
+.shadow-slot-029 {
+  --shadow-slot: 29;
+}
+.shadow-slot-030 {
+  --shadow-slot: 30;
+}
+.shadow-slot-031 {
+  --shadow-slot: 31;
+}
+.shadow-slot-032 {
+  --shadow-slot: 32;
+}
+.shadow-slot-033 {
+  --shadow-slot: 33;
+}
+.shadow-slot-034 {
+  --shadow-slot: 34;
+}
+.shadow-slot-035 {
+  --shadow-slot: 35;
+}
+.shadow-slot-036 {
+  --shadow-slot: 36;
+}
+.shadow-slot-037 {
+  --shadow-slot: 37;
+}
+.shadow-slot-038 {
+  --shadow-slot: 38;
+}
+.shadow-slot-039 {
+  --shadow-slot: 39;
+}
+.shadow-slot-040 {
+  --shadow-slot: 40;
+}
+.shadow-slot-041 {
+  --shadow-slot: 41;
+}
+.shadow-slot-042 {
+  --shadow-slot: 42;
+}
+.shadow-slot-043 {
+  --shadow-slot: 43;
+}
+.shadow-slot-044 {
+  --shadow-slot: 44;
+}
+.shadow-slot-045 {
+  --shadow-slot: 45;
+}
+.shadow-slot-046 {
+  --shadow-slot: 46;
+}
+.shadow-slot-047 {
+  --shadow-slot: 47;
+}
+.shadow-slot-048 {
+  --shadow-slot: 48;
+}
+.shadow-slot-049 {
+  --shadow-slot: 49;
+}
+.shadow-slot-050 {
+  --shadow-slot: 50;
+}
+.shadow-slot-051 {
+  --shadow-slot: 51;
+}
+.shadow-slot-052 {
+  --shadow-slot: 52;
+}
+.shadow-slot-053 {
+  --shadow-slot: 53;
+}
+.shadow-slot-054 {
+  --shadow-slot: 54;
+}
+.shadow-slot-055 {
+  --shadow-slot: 55;
+}
+
+@keyframes match-pulse {
+  50% {
+    filter: brightness(1.14);
+  }
+}
+
+@keyframes switch-flow {
+  50% {
+    transform: translateX(170%);
+  }
+}
+
+@media (max-width: 860px) {
+  .shadow-shell {
+    width: min(100% - 20px, 680px);
+    padding: 28px 0;
+  }
+
+  .shadow-console {
+    padding: 14px;
+  }
+
+  .mode-tabs,
+  .shadow-board,
+  .service-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add an advanced CSS-only shadow traffic verifier example
- include radio-driven verification modes, animated shadow lanes, conic match ring, service cards, and reduced-motion support
- keep the submission scoped to README/demo/style files

## Validation
- npx prettier --check submissions/examples/shadow-traffic-verifier-kp/README.md submissions/examples/shadow-traffic-verifier-kp/demo.html submissions/examples/shadow-traffic-verifier-kp/style.css
- npx stylelint submissions/examples/shadow-traffic-verifier-kp/style.css --allow-empty-input
- git diff --check