### PR TITLE
add animated ripple click effect

### DIFF
--- a/submissions/examples/animated-ripple-click-effect/README.md
+++ b/submissions/examples/animated-ripple-click-effect/README.md
@@ -1,0 +1,13 @@
+# Ripple Click Effect
+
+A Material-style ripple that expands from the exact click point on a button and fades out.
+
+## What it does
+On click, a small circle element is created at the pointer's position, animated to scale up and fade via CSS keyframes, then removed after the animation ends.
+
+## How to use it
+1. Add `ripple` class and `data-ripple` attribute to any button.
+2. Include the click-handler JS snippet — it works for any number of `[data-ripple]` elements.
+
+```html
+<button class="btn ripple" data-ripple>Click Me</button>

--- a/submissions/examples/animated-ripple-click-effect/demo.html
+++ b/submissions/examples/animated-ripple-click-effect/demo.html
@@ -1,0 +1,36 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Ripple Click Effect — Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-wrap">
+    <h1>Ripple Click Effect</h1>
+    <p class="sub">Click anywhere on the button to see the ripple originate from that point.</p>
+
+    <div class="card">
+      <button class="btn ripple" data-ripple>Click Me</button>
+      <button class="btn btn-outline ripple" data-ripple>Click Me Too</button>
+    </div>
+  </main>
+
+  <script>
+    document.querySelectorAll('[data-ripple]').forEach(btn => {
+      btn.addEventListener('click', (e) => {
+        const r = btn.getBoundingClientRect();
+        const circle = document.createElement('span');
+        const size = Math.max(r.width, r.height);
+        circle.className = 'ripple-circle';
+        circle.style.width = circle.style.height = `${size}px`;
+        circle.style.left = `${e.clientX - r.left - size / 2}px`;
+        circle.style.top = `${e.clientY - r.top - size / 2}px`;
+        btn.appendChild(circle);
+        circle.addEventListener('animationend', () => circle.remove());
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/animated-ripple-click-effect/style.css
+++ b/submissions/examples/animated-ripple-click-effect/style.css
@@ -1,0 +1,68 @@
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #f6f7f9;
+  color: #1a1a1a;
+  display: flex;
+  justify-content: center;
+  padding: 100px 16px;
+}
+
+.demo-wrap { max-width: 420px; width: 100%; text-align: center; }
+h1 { font-size: 22px; margin-bottom: 4px; }
+.sub { color: #666; font-size: 14px; margin-bottom: 32px; }
+
+.card {
+  background: white;
+  border-radius: 12px;
+  padding: 48px 24px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.06);
+  display: flex;
+  gap: 16px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.btn {
+  background: #6c63ff;
+  color: white;
+  border: none;
+  padding: 14px 28px;
+  border-radius: 10px;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.btn-outline {
+  background: transparent;
+  color: #6c63ff;
+  border: 2px solid #6c63ff;
+}
+
+.ripple {
+  position: relative;
+  overflow: hidden;
+}
+
+.ripple-circle {
+  position: absolute;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.55);
+  transform: scale(0);
+  animation: ripple-expand 0.6s ease-out forwards;
+  pointer-events: none;
+}
+
+.btn-outline .ripple-circle {
+  background: rgba(108, 99, 255, 0.25);
+}
+
+@keyframes ripple-expand {
+  to {
+    transform: scale(3);
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
### PR Description
```markdown
## Pull Request Description

Adds a click-triggered ripple effect that expands from the exact pointer position on any button and fades out, using a dynamically created span animated with CSS keyframes. Closes #<issue-number>.

---
## Type of Change
- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---
## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/ripple-click/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description

**What does this add?**
A ripple-from-click-point effect using a dynamically inserted, self-removing circle element animated via CSS `scale`/`opacity` keyframes.

**How does a developer use it?**
\`\`\`html
<button class="btn ripple" data-ripple>Click Me</button>
\`\`\`