### PR TITLE
add animated card tilt on mouse

### DIFF
--- a/submissions/examples/animated-card-tilt-on-mouse/README.md
+++ b/submissions/examples/animated-card-tilt-on-mouse/README.md
@@ -1,0 +1,15 @@
+# Card Tilt on Mouse
+
+A card that tilts in 3D toward the cursor as it moves across the surface, giving a subtle parallax "hover" depth effect.
+
+## What it does
+A `mousemove` listener maps cursor position within the card to `--rx`/`--ry` custom properties, which drive a `perspective()` + `rotateX/rotateY` transform with a smooth transition. Resets flat on `mouseleave`.
+
+## How to use it
+Add `tilt` class and `data-tilt` attribute to any card element, wrap the page (or parent) in a container with `perspective` for stronger depth, and include the movement listener.
+
+```html
+<div class="card tilt" data-tilt>
+  <h3>Tilt Card</h3>
+  <p>Move your cursor across this card.</p>
+</div>

--- a/submissions/examples/animated-card-tilt-on-mouse/demo.html
+++ b/submissions/examples/animated-card-tilt-on-mouse/demo.html
@@ -1,0 +1,38 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Card Tilt on Mouse — Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-wrap">
+    <h1>Card Tilt on Mouse</h1>
+    <p class="sub">Move your cursor across the card below.</p>
+
+    <div class="tilt-stage">
+      <div class="card tilt" data-tilt>
+        <h3>3D Tilt Card</h3>
+        <p>Hover and move across this surface to feel the depth.</p>
+      </div>
+    </div>
+  </main>
+
+  <script>
+    document.querySelectorAll('[data-tilt]').forEach(card => {
+      card.addEventListener('mousemove', (e) => {
+        const r = card.getBoundingClientRect();
+        const px = (e.clientX - r.left) / r.width - 0.5;
+        const py = (e.clientY - r.top) / r.height - 0.5;
+        card.style.setProperty('--rx', `${px * 16}deg`);
+        card.style.setProperty('--ry', `${-py * 16}deg`);
+      });
+      card.addEventListener('mouseleave', () => {
+        card.style.setProperty('--rx', '0deg');
+        card.style.setProperty('--ry', '0deg');
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/animated-card-tilt-on-mouse/style.css
+++ b/submissions/examples/animated-card-tilt-on-mouse/style.css
@@ -1,0 +1,38 @@
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #f6f7f9;
+  color: #1a1a1a;
+  display: flex;
+  justify-content: center;
+  padding: 100px 16px;
+}
+
+.demo-wrap { max-width: 420px; width: 100%; text-align: center; }
+h1 { font-size: 22px; margin-bottom: 4px; }
+.sub { color: #666; font-size: 14px; margin-bottom: 40px; }
+
+.tilt-stage {
+  perspective: 800px;
+  display: flex;
+  justify-content: center;
+}
+
+.card {
+  width: 280px;
+  background: white;
+  border-radius: 14px;
+  padding: 28px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.12);
+}
+
+.tilt {
+  transform: perspective(600px) rotateX(var(--ry, 0deg)) rotateY(var(--rx, 0deg));
+  transition: transform 0.15s ease-out;
+  transform-style: preserve-3d;
+}
+
+.card h3 { margin: 0 0 8px; }
+.card p { margin: 0; color: #666; font-size: 14px; line-height: 1.5; }


### PR DESCRIPTION
### PR Description
```markdown
## Pull Request Description

Adds a 3D card tilt effect that responds to cursor position within the card bounds, using `perspective`/`rotateX`/`rotateY` driven by CSS custom properties. Closes #<issue-number>.

---
## Type of Change
- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---
## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/card-tilt/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description

**What does this add?**
A pointer-responsive 3D tilt effect for cards using `--rx`/`--ry` custom properties updated on `mousemove`.

**How does a developer use it?**
\`\`\`html
<div class="card tilt" data-tilt>
  <h3>Tilt Card</h3>
</div>
\`\`\`