### PR TITLE
add animated number count up

### DIFF
--- a/submissions/examples/animated-number-count-up/README.md
+++ b/submissions/examples/animated-number-count-up/README.md
@@ -1,0 +1,12 @@
+# Number Count-Up
+
+An animated counter that ticks up from 0 to its target value once it scrolls into view — ideal for stat/metric cards.
+
+## What it does
+An `IntersectionObserver` detects when a `.count-up` element enters the viewport, then uses `requestAnimationFrame` to increment the displayed number from 0 to `data-target` over `data-duration` milliseconds. A small CSS "pop" plays on completion.
+
+## How to use it
+Add the `count-up` class to a `<span>`, set `data-target` (final number) and `data-duration` (ms), and include the observer script once per page.
+
+```html
+<span class="count-up" data-target="42" data-duration="1200">0</span>

--- a/submissions/examples/animated-number-count-up/demo.html
+++ b/submissions/examples/animated-number-count-up/demo.html
@@ -1,0 +1,54 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Number Count-Up — Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-wrap">
+    <h1>Number Count-Up</h1>
+    <p class="sub">Scroll down — the numbers animate into view.</p>
+
+    <div class="spacer"></div>
+
+    <div class="stat-row">
+      <div class="stat-card">
+        <span class="count-up" data-target="42" data-duration="1200">0</span>+
+        <p>Utilities</p>
+      </div>
+      <div class="stat-card">
+        <span class="count-up" data-target="12" data-duration="1000">0</span>
+        <p>Animations</p>
+      </div>
+      <div class="stat-card">
+        <span class="count-up" data-target="0" data-duration="600">0</span>
+        <p>Dependencies</p>
+      </div>
+    </div>
+  </main>
+
+  <script>
+    const counters = document.querySelectorAll('.count-up');
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (!entry.isIntersecting) return;
+        const el = entry.target;
+        const target = +el.dataset.target;
+        const duration = +el.dataset.duration || 1200;
+        const start = performance.now();
+        function tick(now) {
+          const progress = Math.min((now - start) / duration, 1);
+          el.textContent = Math.floor(progress * target);
+          if (progress < 1) requestAnimationFrame(tick);
+          else { el.textContent = target; el.classList.add('is-counting'); }
+        }
+        requestAnimationFrame(tick);
+        observer.unobserve(el);
+      });
+    }, { threshold: 0.5 });
+    counters.forEach(el => observer.observe(el));
+  </script>
+</body>
+</html>

--- a/submissions/examples/animated-number-count-up/style.css
+++ b/submissions/examples/animated-number-count-up/style.css
@@ -1,0 +1,58 @@
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #f6f7f9;
+  color: #1a1a1a;
+  display: flex;
+  justify-content: center;
+  padding: 40px 16px 120px;
+}
+
+.demo-wrap { max-width: 600px; width: 100%; text-align: center; }
+h1 { font-size: 22px; margin-bottom: 4px; }
+.sub { color: #666; font-size: 14px; margin-bottom: 24px; }
+
+.spacer { height: 60vh; }
+
+.stat-row {
+  display: flex;
+  gap: 16px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.stat-card {
+  background: white;
+  border-radius: 12px;
+  padding: 28px 32px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.06);
+  min-width: 140px;
+}
+
+.stat-card p {
+  margin: 6px 0 0;
+  color: #666;
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.count-up {
+  display: inline-block;
+  font-size: 34px;
+  font-weight: 800;
+  color: #6c63ff;
+  font-variant-numeric: tabular-nums;
+}
+
+.count-up.is-counting {
+  animation: count-pop 0.3s ease-out;
+}
+
+@keyframes count-pop {
+  0%   { transform: scale(1); }
+  50%  { transform: scale(1.15); }
+  100% { transform: scale(1); }
+}


### PR DESCRIPTION
### PR Description
```markdown
## Pull Request Description

Adds a scroll-triggered number count-up animation for stat cards, using `IntersectionObserver` + `requestAnimationFrame` with a CSS completion pulse. Closes #<issue-number>.

---
## Type of Change
- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---
## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/count-up/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description

**What does this add?**
A scroll-triggered count-up animation for numeric stats, driven by `IntersectionObserver` and `requestAnimationFrame`.

**How does a developer use it?**
\`\`\`html
<span class="count-up" data-target="42" data-duration="1200">0</span>
\`\`\`