### PR TITLE
 add sticky header shrink on scroll

### DIFF
--- a/submissions/examples/animated-sticky-header-shrink-on-scroll/README.md
+++ b/submissions/examples/animated-sticky-header-shrink-on-scroll/README.md
@@ -1,0 +1,14 @@
+# Sticky Header Shrink-on-Scroll
+
+A sticky header that shrinks its padding and gains a shadow once the user scrolls past a threshold, then expands back at the top.
+
+## What it does
+A `scroll` listener toggles an `is-scrolled` class on the header once `window.scrollY` passes a threshold (40px by default). CSS transitions handle the smooth padding/shadow change — no layout jump.
+
+## How to use it
+Add `header-shrink` class and `data-header-shrink` attribute to your `<header>`, make it `position: sticky; top: 0;`, and include the scroll listener.
+
+```html
+<header class="site-header header-shrink" data-header-shrink>
+  <span class="logo">EaseMotion</span>
+</header>

--- a/submissions/examples/animated-sticky-header-shrink-on-scroll/demo.html
+++ b/submissions/examples/animated-sticky-header-shrink-on-scroll/demo.html
@@ -1,0 +1,29 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Sticky Header Shrink-on-Scroll — Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="site-header header-shrink" data-header-shrink>
+    <span class="logo">⚡ EaseMotion</span>
+    <nav>Docs&nbsp;&nbsp;·&nbsp;&nbsp;GitHub</nav>
+  </header>
+
+  <main class="demo-wrap">
+    <p class="sub">Scroll down to see the header shrink and gain a shadow.</p>
+    <div class="filler"></div>
+    <div class="filler"></div>
+    <div class="filler"></div>
+  </main>
+
+  <script>
+    const header = document.querySelector('[data-header-shrink]');
+    window.addEventListener('scroll', () => {
+      header.classList.toggle('is-scrolled', window.scrollY > 40);
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/animated-sticky-header-shrink-on-scroll/style.css
+++ b/submissions/examples/animated-sticky-header-shrink-on-scroll/style.css
@@ -1,0 +1,53 @@
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #f6f7f9;
+  color: #1a1a1a;
+}
+
+.header-shrink {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: white;
+  padding: 24px 32px;
+  transition: padding 0.25s ease, box-shadow 0.25s ease;
+}
+
+.header-shrink.is-scrolled {
+  padding: 12px 32px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.logo {
+  font-weight: 700;
+  font-size: 18px;
+  color: #6c63ff;
+}
+
+.header-shrink nav {
+  color: #555;
+  font-size: 14px;
+}
+
+.demo-wrap {
+  max-width: 700px;
+  margin: 0 auto;
+  padding: 32px 16px;
+  text-align: center;
+}
+
+.sub { color: #666; font-size: 14px; margin-bottom: 40px; }
+
+.filler {
+  height: 60vh;
+  background: white;
+  border-radius: 12px;
+  margin-bottom: 24px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.04);
+}


### PR DESCRIPTION
### PR Description
```markdown
## Pull Request Description

Adds a sticky header that shrinks its padding and gains a shadow on scroll, driven by a scroll-position class toggle with CSS handling the transition. Closes #<issue-number>.

---
## Type of Change
- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---
## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/header-shrink/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description

**What does this add?**
A sticky header shrink-on-scroll effect toggled via an `is-scrolled` class, with all visual transition handled by CSS.

**How does a developer use it?**
\`\`\`html
<header class="site-header header-shrink" data-header-shrink>...</header>
\`\`\`