### PR TITLE
 animated image ken burns pan zoom

### DIFF
--- a/submissions/examples/animated-image-ken-burns-pan-zoom/README.md
+++ b/submissions/examples/animated-image-ken-burns-pan-zoom/README.md
@@ -1,0 +1,14 @@
+# Image Ken Burns Pan/Zoom
+
+A slow, continuous zoom-and-pan animation for hero images and cover photos — the classic documentary "Ken Burns" effect, built purely in CSS.
+
+## What it does
+The image is scaled and translated across an 18s ease-in-out loop (alternating direction), while its container clips overflow via `overflow: hidden`, keeping the frame edges clean.
+
+## How to use it
+Wrap your `<img>` in a fixed-size, `overflow: hidden` container, and add the `image-kenburns` class to the image itself.
+
+```html
+<div class="image-frame">
+  <img class="image-kenburns" src="hero.jpg" alt="Hero">
+</div>

--- a/submissions/examples/animated-image-ken-burns-pan-zoom/demo.html
+++ b/submissions/examples/animated-image-ken-burns-pan-zoom/demo.html
@@ -1,0 +1,22 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Image Ken Burns Pan/Zoom — Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-wrap">
+    <h1>Image Ken Burns Pan/Zoom</h1>
+    <p class="sub">A slow, looping zoom-and-pan — watch for a few seconds.</p>
+
+    <div class="image-frame">
+      <img class="image-kenburns"
+           src="https://images.unsplash.com/photo-1519681393784-d120267933ba?w=900&q=80"
+           alt="Mountain landscape">
+      <div class="frame-caption">Animation First</div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/animated-image-ken-burns-pan-zoom/style.css
+++ b/submissions/examples/animated-image-ken-burns-pan-zoom/style.css
@@ -1,0 +1,49 @@
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #0f1117;
+  color: #f4f4f5;
+  display: flex;
+  justify-content: center;
+  padding: 60px 16px;
+}
+
+.demo-wrap { max-width: 560px; width: 100%; text-align: center; }
+h1 { font-size: 22px; margin-bottom: 4px; }
+.sub { color: #9ca3af; font-size: 14px; margin-bottom: 32px; }
+
+.image-frame {
+  position: relative;
+  overflow: hidden;
+  border-radius: 14px;
+  height: 320px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
+}
+
+.image-kenburns {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transform-origin: center;
+  animation: kenburns-pan 18s ease-in-out infinite alternate;
+  display: block;
+}
+
+@keyframes kenburns-pan {
+  0%   { transform: scale(1) translate(0, 0); }
+  100% { transform: scale(1.15) translate(-2%, -2%); }
+}
+
+.frame-caption {
+  position: absolute;
+  bottom: 16px;
+  left: 16px;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+  padding: 8px 14px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+}


### PR DESCRIPTION
### PR Description
```markdown
## Pull Request Description

Adds a Ken Burns style slow zoom/pan animation for hero and cover images, using a single looping `transform` keyframe animation inside an `overflow: hidden` frame. Closes #<issue-number>.

---
## Type of Change
- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---
## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/image-kenburns/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description

**What does this add?**
A looping, alternating Ken Burns zoom/pan animation applied to a cover image inside a clipped frame.

**How does a developer use it?**
\`\`\`html
<div class="image-frame">
  <img class="image-kenburns" src="hero.jpg" alt="Hero">
</div>
\`\`\`