### PR TITLE
Add CSS rotate-fade dropdown for fintech dashboard layouts

### DIFF
--- a/submissions/examples/css-rotate-fade-dropdown/README.md
+++ b/submissions/examples/css-rotate-fade-dropdown/README.md
@@ -1,0 +1,16 @@
+# CSS Rotate-Fade Dropdown
+
+A pure CSS dropdown styled as a currency selector for money transfers, rotating open around its top-left corner while fading in, like a page turning. No JavaScript.
+
+## How it works
+
+Standard checkbox-hack dropdown. The menu starts at `rotate(-8deg)` with `transform-origin: top left` and `opacity: 0`. On open, both `transform` and `opacity` transition to their resting values together, giving the impression of the menu swinging open from its anchored corner rather than a plain fade or straight slide.
+
+## Files
+`demo.html`, `style.css`, `README.md`
+
+## Custom properties
+`--ease-dropdown-duration`, `--ease-dropdown-radius`, `--ease-dropdown-bg`, `--ease-dropdown-border`, `--ease-dropdown-text`, `--ease-dropdown-muted-text`, `--ease-dropdown-accent`
+
+## Notes
+Respects `prefers-reduced-motion` — the menu fades in without the rotation.

--- a/submissions/examples/css-rotate-fade-dropdown/demo.html
+++ b/submissions/examples/css-rotate-fade-dropdown/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Rotate-Fade Dropdown — Fintech Dashboard</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="ease-container">
+    <p class="ease-eyebrow">Transfers</p>
+    <h1 class="ease-heading">Send Money</h1>
+    <p class="ease-subtitle">The currency menu rotates and fades in from its top corner.</p>
+
+    <div class="ease-dropdown">
+      <input type="checkbox" id="ease-rotate-dropdown-toggle" class="ease-dropdown-input" />
+      <label for="ease-rotate-dropdown-toggle" class="ease-dropdown-trigger">
+        USD ($)
+        <span class="ease-dropdown-arrow">▾</span>
+      </label>
+      <div class="ease-dropdown-menu">
+        <button class="ease-dropdown-item">USD ($)</button>
+        <button class="ease-dropdown-item">EUR (€)</button>
+        <button class="ease-dropdown-item">GBP (£)</button>
+        <button class="ease-dropdown-item">JPY (¥)</button>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/css-rotate-fade-dropdown/style.css
+++ b/submissions/examples/css-rotate-fade-dropdown/style.css
@@ -1,0 +1,98 @@
+:root {
+  --ease-dropdown-duration: 0.35s;
+  --ease-dropdown-radius: 10px;
+  --ease-dropdown-bg: #16181d;
+  --ease-dropdown-border: #2a2d34;
+  --ease-dropdown-text: #f0f0f0;
+  --ease-dropdown-muted-text: #a8a8a8;
+  --ease-dropdown-accent: #22c55e;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0f1115;
+  color: var(--ease-dropdown-text);
+  padding: 3rem 1.5rem;
+}
+
+.ease-container { max-width: 380px; margin: 0 auto; }
+.ease-eyebrow { text-transform: uppercase; letter-spacing: 0.08em; font-size: 0.75rem; color: var(--ease-dropdown-accent); margin: 0 0 0.5rem; font-weight: 600; }
+.ease-heading { font-size: 1.6rem; margin: 0 0 0.5rem; }
+.ease-subtitle { color: #a0a0a0; margin: 0 0 2rem; font-size: 0.9rem; }
+
+.ease-dropdown { position: relative; display: inline-block; }
+.ease-dropdown-input { position: absolute; opacity: 0; pointer-events: none; }
+
+.ease-dropdown-trigger {
+  display: flex; align-items: center; gap: 0.5rem;
+  padding: 0.7rem 1rem;
+  background: var(--ease-dropdown-bg);
+  border: 1px solid var(--ease-dropdown-border);
+  border-radius: var(--ease-dropdown-radius);
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.ease-dropdown-arrow { transition: transform 0.25s ease; color: var(--ease-dropdown-muted-text); }
+.ease-dropdown-input:checked ~ .ease-dropdown-trigger .ease-dropdown-arrow { transform: rotate(180deg); }
+
+/* rotate-fade: the menu rotates in around its top-left corner while
+   fading in, like a page turning open, rather than sliding straight
+   down or scaling from center */
+.ease-dropdown-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  min-width: 160px;
+  display: flex;
+  flex-direction: column;
+  background: var(--ease-dropdown-bg);
+  border: 1px solid var(--ease-dropdown-border);
+  border-radius: var(--ease-dropdown-radius);
+  padding: 0.4rem;
+  opacity: 0;
+  visibility: hidden;
+  transform: rotate(-8deg);
+  transform-origin: top left;
+  transition: opacity var(--ease-dropdown-duration) ease-out,
+              transform var(--ease-dropdown-duration) ease-out,
+              visibility 0s linear var(--ease-dropdown-duration);
+  z-index: 10;
+}
+
+.ease-dropdown-input:checked ~ .ease-dropdown-menu {
+  opacity: 1;
+  visibility: visible;
+  transform: rotate(0deg);
+  transition: opacity var(--ease-dropdown-duration) ease-out,
+              transform var(--ease-dropdown-duration) ease-out;
+}
+
+.ease-dropdown-item {
+  width: 100%;
+  background: none;
+  border: none;
+  color: var(--ease-dropdown-text);
+  font-family: inherit;
+  font-size: 0.85rem;
+  padding: 0.6rem 0.7rem;
+  border-radius: 6px;
+  cursor: pointer;
+  text-align: left;
+  transition: background-color 0.15s ease;
+}
+
+.ease-dropdown-item:hover { background: rgba(255, 255, 255, 0.06); }
+
+@media (max-width: 480px) {
+  body { padding: 2rem 1rem; }
+  .ease-heading { font-size: 1.35rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-dropdown-menu { transition: opacity 0.15s ease !important; transform: none !important; }
+  .ease-dropdown-arrow { transition: none !important; }
+}


### PR DESCRIPTION
## Pull Request Description
Closes #59378

Adds a pure CSS/HTML dropdown menu styled as a currency selector, rotating open from its top-left corner while fading in.

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

## Submission Checklist
- [x] All changes inside `submissions/examples/css-rotate-fade-dropdown/`
- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Feature Description
**What does this add?** A dropdown menu that rotates open around its top-left corner (`transform-origin: top left`) while fading in, rather than sliding or scaling from center.
**Why does it fit?** Same checkbox-hack base as other dropdown submissions, demonstrating a corner-anchored rotate transform paired with opacity for a distinct "page turning" entrance.

## Demo
- [x] Demo added
## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge

## Notes for Maintainer
`transform-origin: top left` is what makes the rotation feel anchored/hinged rather than spinning around center. Respects `prefers-reduced-motion`.