### PR TITLE
Add CSS blur-entrance dropdown for fintech dashboard layouts

### DIFF
--- a/submissions/examples/css-blur-entrance-dropdown/README.md
+++ b/submissions/examples/css-blur-entrance-dropdown/README.md
@@ -1,0 +1,16 @@
+# CSS Blur-Entrance Dropdown
+
+A pure CSS dropdown styled as an export-format menu, sharpening from blurred to fully in-focus as it opens. No JavaScript.
+
+## How it works
+
+Standard checkbox-hack dropdown. The menu starts at `filter: blur(10px)`, slightly scaled up, and hidden. On open, `filter`, `transform`, and `opacity` all transition together to their resting values, so the menu appears to come into focus rather than simply fading or sliding in.
+
+## Files
+`demo.html`, `style.css`, `README.md`
+
+## Custom properties
+`--ease-dropdown-duration`, `--ease-dropdown-radius`, `--ease-dropdown-bg`, `--ease-dropdown-border`, `--ease-dropdown-text`, `--ease-dropdown-muted-text`, `--ease-dropdown-accent`, `--ease-dropdown-blur` — how blurred the menu starts (10px)
+
+## Notes
+`filter: blur()` can be more GPU-intensive than opacity/transform alone; kept moderate for performance. Respects `prefers-reduced-motion` — the menu fades in without blur or scale.

--- a/submissions/examples/css-blur-entrance-dropdown/Style.css
+++ b/submissions/examples/css-blur-entrance-dropdown/Style.css
@@ -1,0 +1,105 @@
+:root {
+  --ease-dropdown-duration: 0.4s;
+  --ease-dropdown-radius: 10px;
+  --ease-dropdown-bg: #16181d;
+  --ease-dropdown-border: #2a2d34;
+  --ease-dropdown-text: #f0f0f0;
+  --ease-dropdown-muted-text: #a8a8a8;
+  --ease-dropdown-accent: #22c55e;
+  --ease-dropdown-blur: 10px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0f1115;
+  color: var(--ease-dropdown-text);
+  padding: 3rem 1.5rem;
+}
+
+.ease-container { max-width: 380px; margin: 0 auto; }
+.ease-eyebrow { text-transform: uppercase; letter-spacing: 0.08em; font-size: 0.75rem; color: var(--ease-dropdown-accent); margin: 0 0 0.5rem; font-weight: 600; }
+.ease-heading { font-size: 1.6rem; margin: 0 0 0.5rem; }
+.ease-subtitle { color: #a0a0a0; margin: 0 0 2rem; font-size: 0.9rem; }
+
+.ease-dropdown { position: relative; display: inline-block; }
+.ease-dropdown-input { position: absolute; opacity: 0; pointer-events: none; }
+
+.ease-dropdown-trigger {
+  display: flex; align-items: center; gap: 0.5rem;
+  padding: 0.7rem 1rem;
+  background: var(--ease-dropdown-bg);
+  border: 1px solid var(--ease-dropdown-border);
+  border-radius: var(--ease-dropdown-radius);
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.ease-dropdown-arrow { transition: transform 0.25s ease; color: var(--ease-dropdown-muted-text); }
+.ease-dropdown-input:checked ~ .ease-dropdown-trigger .ease-dropdown-arrow { transform: rotate(180deg); }
+
+/* blur-entrance: the menu starts blurred and slightly scaled up,
+   then sharpens to blur(0) at full clarity as it opens */
+.ease-dropdown-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  min-width: 170px;
+  display: flex;
+  flex-direction: column;
+  background: var(--ease-dropdown-bg);
+  border: 1px solid var(--ease-dropdown-border);
+  border-radius: var(--ease-dropdown-radius);
+  padding: 0.4rem;
+  opacity: 0;
+  visibility: hidden;
+  filter: blur(var(--ease-dropdown-blur));
+  transform: scale(1.05);
+  transition: opacity var(--ease-dropdown-duration) ease-out,
+              filter var(--ease-dropdown-duration) ease-out,
+              transform var(--ease-dropdown-duration) ease-out,
+              visibility 0s linear var(--ease-dropdown-duration);
+  z-index: 10;
+}
+
+.ease-dropdown-input:checked ~ .ease-dropdown-menu {
+  opacity: 1;
+  visibility: visible;
+  filter: blur(0);
+  transform: scale(1);
+  transition: opacity var(--ease-dropdown-duration) ease-out,
+              filter var(--ease-dropdown-duration) ease-out,
+              transform var(--ease-dropdown-duration) ease-out;
+}
+
+.ease-dropdown-item {
+  width: 100%;
+  background: none;
+  border: none;
+  color: var(--ease-dropdown-text);
+  font-family: inherit;
+  font-size: 0.85rem;
+  padding: 0.6rem 0.7rem;
+  border-radius: 6px;
+  cursor: pointer;
+  text-align: left;
+  transition: background-color 0.15s ease;
+}
+
+.ease-dropdown-item:hover { background: rgba(255, 255, 255, 0.06); }
+
+@media (max-width: 480px) {
+  body { padding: 2rem 1rem; }
+  .ease-heading { font-size: 1.35rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-dropdown-menu {
+    transition: opacity 0.15s ease !important;
+    filter: none !important;
+    transform: none !important;
+  }
+  .ease-dropdown-arrow { transition: none !important; }
+}

--- a/submissions/examples/css-blur-entrance-dropdown/demo.html
+++ b/submissions/examples/css-blur-entrance-dropdown/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Blur-Entrance Dropdown — Fintech Dashboard</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="ease-container">
+    <p class="ease-eyebrow">Reports</p>
+    <h1 class="ease-heading">Export Data</h1>
+    <p class="ease-subtitle">The export menu sharpens into focus as it opens.</p>
+
+    <div class="ease-dropdown">
+      <input type="checkbox" id="ease-blur-dropdown-toggle" class="ease-dropdown-input" />
+      <label for="ease-blur-dropdown-toggle" class="ease-dropdown-trigger">
+        Export as...
+        <span class="ease-dropdown-arrow">▾</span>
+      </label>
+      <div class="ease-dropdown-menu">
+        <button class="ease-dropdown-item">CSV Spreadsheet</button>
+        <button class="ease-dropdown-item">PDF Statement</button>
+        <button class="ease-dropdown-item">JSON (API)</button>
+      </div>
+    </div>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Pull Request Description
Closes #59377

Adds a pure CSS/HTML dropdown menu styled as an export-format selector, sharpening from blurred to fully in-focus as it opens.

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

## Submission Checklist
- [x] All changes inside `submissions/examples/css-blur-entrance-dropdown/`
- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Feature Description
**What does this add?** A dropdown menu that transitions from `blur(10px)` + slightly scaled to full clarity at rest scale as it opens, alongside opacity.
**Why does it fit?** Same checkbox-hack base as other dropdown submissions, demonstrating `filter: blur()` as an animatable property for a distinct "coming into focus" entrance.

## Demo
- [x] Demo added
## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge

## Notes for Maintainer
Blur amount kept moderate (10px) for GPU performance, documented in the README. Respects `prefers-reduced-motion` by disabling blur/scale and keeping a plain opacity fade.