### PR TITLE
add animated breadcrumb arrow separators

### DIFF
--- a/submissions/examples/animated-breadcrumb-arrow-separators/README.md
+++ b/submissions/examples/animated-breadcrumb-arrow-separators/README.md
@@ -1,0 +1,12 @@
+# ease-breadcrumb
+
+A breadcrumb navigation component for **EaseMotion CSS** with `::after`-generated arrow separators and an animated hover underline — zero extra markup.
+
+## Usage
+
+```html
+<nav class="breadcrumb" aria-label="Breadcrumb">
+  <a href="#" class="breadcrumb-item">Home</a>
+  <a href="#" class="breadcrumb-item">Products</a>
+  <span class="breadcrumb-item breadcrumb-current">Shoes</span>
+</nav>

--- a/submissions/examples/animated-breadcrumb-arrow-separators/demo.html
+++ b/submissions/examples/animated-breadcrumb-arrow-separators/demo.html
@@ -1,0 +1,22 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-breadcrumb Demo</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body { font-family: system-ui, sans-serif; background: #0f172a; color: #f1f5f9; padding: 60px; }
+</style>
+</head>
+<body>
+  <h1>ease-breadcrumb</h1>
+
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <a href="#" class="breadcrumb-item">Home</a>
+    <a href="#" class="breadcrumb-item">Products</a>
+    <a href="#" class="breadcrumb-item">Shoes</a>
+    <span class="breadcrumb-item breadcrumb-current">Running Shoes</span>
+  </nav>
+</body>
+</html>

--- a/submissions/examples/animated-breadcrumb-arrow-separators/style.css
+++ b/submissions/examples/animated-breadcrumb-arrow-separators/style.css
@@ -1,0 +1,47 @@
+/* ==========================================================
+   ease-breadcrumb — Breadcrumb with Arrow Separators
+   ========================================================== */
+
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  font-size: 0.9rem;
+  flex-wrap: wrap;
+}
+
+.breadcrumb-item {
+  position: relative;
+  color: #94a3b8;
+  text-decoration: none;
+  padding: 2px 0;
+}
+
+.breadcrumb-item:not(:last-child)::after {
+  content: '›';
+  margin: 0 8px;
+  color: #475569;
+}
+
+.breadcrumb-item:not(.breadcrumb-current)::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: -2px;
+  width: 0%;
+  height: 2px;
+  background: #60a5fa;
+  transition: width 0.25s ease;
+}
+
+.breadcrumb-item:not(.breadcrumb-current):hover {
+  color: #60a5fa;
+}
+
+.breadcrumb-item:not(.breadcrumb-current):hover::before {
+  width: 100%;
+}
+
+.breadcrumb-current {
+  color: #f1f5f9;
+  font-weight: 600;
+}


### PR DESCRIPTION
### PR Description
```markdown
## Summary
Adds `ease-breadcrumb`, a breadcrumb nav with CSS-generated arrow separators and animated underline, per issue #17.

## What's included
- `submissions/ease-breadcrumb/style.css`
- `submissions/ease-breadcrumb/demo.html`
- `submissions/ease-breadcrumb/readme.md`

## Implementation notes
- Arrow separators generated via `::after { content: '›' }` — no separator markup needed.
- Hover underline via `::before` pseudo-element with `width` transition.
- `.breadcrumb-current` marks the non-interactive final crumb.
- Includes `aria-label="Breadcrumb"` semantic wrapper for accessibility.

## Testing checklist
- [x] Verified separators appear between all items except the last
- [x] Verified hover underline animates smoothly, excludes current crumb
- [x] Verified screen reader announces breadcrumb landmark correctly
- [x] Placed only inside `submissions/`

Closes #17