### PR TITLE
add before after new image slider

### DIFF
--- a/submissions/examples/animated-before-after-image-slider/README.md
+++ b/submissions/examples/animated-before-after-image-slider/README.md
@@ -1,0 +1,15 @@
+# ease-compare-slider
+
+A draggable before/after image comparison slider for **EaseMotion CSS**, powered by a native range input for full accessibility.
+
+## Usage
+
+```html
+<div class="compare-slider">
+  <img class="compare-slider-after" src="after.jpg" alt="After">
+  <div class="compare-slider-before-wrap">
+    <img class="compare-slider-before" src="before.jpg" alt="Before">
+  </div>
+  <div class="compare-slider-handle"></div>
+  <input type="range" class="compare-slider-input" min="0" max="100" value="50">
+</div>

--- a/submissions/examples/animated-before-after-image-slider/demo.html
+++ b/submissions/examples/animated-before-after-image-slider/demo.html
@@ -1,0 +1,28 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-compare-slider Demo</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body { font-family: system-ui, sans-serif; background: #0f172a; color: #f1f5f9; display: flex; flex-direction: column; align-items: center; gap: 20px; padding: 60px; }
+</style>
+</head>
+<body>
+  <h1>ease-compare-slider</h1>
+
+  <div class="compare-slider">
+    <img class="compare-slider-after" src="https://picsum.photos/id/1015/600/338" alt="After">
+    <div class="compare-slider-before-wrap">
+      <img class="compare-slider-before" src="https://picsum.photos/id/1015/600/338?grayscale" alt="Before">
+    </div>
+    <div class="compare-slider-handle"></div>
+    <input type="range" class="compare-slider-input" min="0" max="100" value="50"
+      oninput="
+        this.previousElementSibling.style.left = this.value + '%';
+        this.parentElement.querySelector('.compare-slider-before-wrap').style.clipPath = `inset(0 ${100-this.value}% 0 0)`;
+      ">
+  </div>
+</body>
+</html>

--- a/submissions/examples/animated-before-after-image-slider/style.css
+++ b/submissions/examples/animated-before-after-image-slider/style.css
@@ -1,0 +1,69 @@
+/* ==========================================================
+   ease-compare-slider — Before/After Image Comparison Slider
+   ========================================================== */
+
+.compare-slider {
+  position: relative;
+  width: 100%;
+  max-width: 600px;
+  aspect-ratio: 16/9;
+  overflow: hidden;
+  border-radius: 8px;
+  user-select: none;
+}
+
+.compare-slider-after,
+.compare-slider-before {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  pointer-events: none;
+}
+
+.compare-slider-before-wrap {
+  position: absolute;
+  inset: 0;
+  clip-path: inset(0 50% 0 0);
+}
+
+.compare-slider-handle {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 3px;
+  height: 100%;
+  background: #fff;
+  box-shadow: 0 0 4px rgba(0,0,0,0.4);
+  transform: translateX(-50%);
+  pointer-events: none;
+}
+
+.compare-slider-handle::after {
+  content: '⇔';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: #fff;
+  color: #1e293b;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.9rem;
+}
+
+.compare-slider-input {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  opacity: 0;
+  cursor: ew-resize;
+  -webkit-appearance: none;
+}


### PR DESCRIPTION
### PR Description
```markdown
## Summary
Adds `ease-compare-slider`, an accessible before/after image comparison slider, per issue #19.

## What's included
- `submissions/ease-compare-slider/style.css`
- `submissions/ease-compare-slider/demo.html`
- `submissions/ease-compare-slider/readme.md`

## Implementation notes
- Reveal effect via `clip-path: inset()` on the "before" image wrapper.
- Draggable via a hidden native `<input type="range">` layered on top — free keyboard/touch/screen-reader support, no custom pointer-event JS.
- Handle indicator with `⇔` icon tracks the slider position via inline `left` update.

## Testing checklist
- [x] Verified drag updates clip-path smoothly on mouse and touch
- [x] Verified keyboard arrow keys move the slider (native range behavior)
- [x] Verified handle stays visually aligned with slider value
- [x] Placed only inside `submissions/`

Closes #19