### PR TITLE
Add ease-cinema-film-projector component

### DIFF
--- a/submissions/examples/ease-cinema-film-projector-ij/README.md
+++ b/submissions/examples/ease-cinema-film-projector-ij/README.md
@@ -1,0 +1,7 @@
+# ease-cinema-film-projector
+A projector that whirs and throws a flickering beam.
+## Run
+Open `demo.html` directly in a browser to watch the reel spin.
+## Notes
+- The reel turns as the film advances.
+- The beam flickers toward the screen.

--- a/submissions/examples/ease-cinema-film-projector-ij/demo.html
+++ b/submissions/examples/ease-cinema-film-projector-ij/demo.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-cinema-film-projector demo</title>
+</head>
+<body>
+<div class="cf-app">
+  <div class="cf-wall"></div>
+  <div class="cf-table"></div>
+  <div class="cf-body">
+    <div class="cf-reel">
+      <div class="cf-hub"></div>
+      <div class="cf-sprocket"></div>
+    </div>
+    <div class="cf-lens"></div>
+    <div class="cf-bulb"></div>
+    <div class="cf-switch"></div>
+    <div class="cf-film"></div>
+  </div>
+  <div class="cf-beam"></div>
+  <div class="cf-screen"></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/ease-cinema-film-projector-ij/style.css
+++ b/submissions/examples/ease-cinema-film-projector-ij/style.css
@@ -1,0 +1,21 @@
+:root{--cf-dark:#1a1428;--cf-amber:#ffc86a;--cf-gold:#c8a64a}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#2a2044,#0e0a1e);font-family:'Courier New',monospace}
+.cf-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#241a3a,#100c22);box-shadow:0 16px 36px rgba(0,0,0,0.6)}
+.cf-wall{position:absolute;inset:0;background:repeating-linear-gradient(0deg,rgba(255,255,255,0.03) 0 18px,transparent 18px 36px)}
+.cf-table{position:absolute;left:20px;right:20px;bottom:70px;height:14px;border-radius:6px;background:#3a2a5a;box-shadow:inset 0 0 0 3px #241a3a}
+.cf-body{position:absolute;left:30px;bottom:84px;width:160px;height:96px;border-radius:14px;background:var(--cf-dark);box-shadow:inset 0 0 0 6px #2a2044,0 10px 20px rgba(0,0,0,0.5);animation:rattle-body-cinema-film-projector 1.6s steps(2) infinite}
+.cf-reel{position:absolute;top:-22px;left:20px;width:64px;height:64px;border-radius:50%;background:var(--cf-gold);box-shadow:inset 0 0 0 8px #a8842e;animation:spin-reel-cinema-film-projector 1.4s linear infinite}
+.cf-hub{position:absolute;top:50%;left:50%;width:14px;height:14px;margin:-7px;border-radius:50%;background:#5a4400}
+.cf-sprocket{position:absolute;top:-4px;left:50%;width:10px;height:10px;margin-left:-5px;border-radius:3px;background:#5a4400}
+.cf-lens{position:absolute;top:34px;right:22px;width:34px;height:26px;border-radius:8px;background:#3a4452;box-shadow:inset 0 0 0 4px #1a1428}
+.cf-bulb{position:absolute;top:-12px;right:30px;width:18px;height:18px;border-radius:50%;background:var(--cf-amber);box-shadow:0 0 22px var(--cf-amber);animation:glow-bulb-cinema-film-projector 1.6s ease-in-out infinite}
+.cf-switch{position:absolute;bottom:14px;left:26px;width:14px;height:22px;border-radius:4px;background:#5a6678}
+.cf-film{position:absolute;top:-6px;right:-4px;width:6px;height:120px;background:repeating-linear-gradient(180deg,#1a1428 0 8px,#3a4452 8px 10px);transform-origin:top;animation:advance-film-cinema-film-projector 1.6s linear infinite}
+.cf-beam{position:absolute;top:60px;left:190px;width:150px;height:20px;border-radius:10px;background:linear-gradient(90deg,rgba(255,200,106,0.9),rgba(255,200,106,0));clip-path:polygon(0 20%,100% 0,100% 100%,0 80%);animation:flicker-beam-cinema-film-projector 0.4s steps(2) infinite}
+.cf-screen{position:absolute;right:16px;top:44px;width:20px;height:64px;border-radius:4px;background:var(--cf-amber);box-shadow:0 0 24px var(--cf-amber);animation:flicker-screen-cinema-film-projector 0.4s steps(2) infinite}
+@keyframes spin-reel-cinema-film-projector{0%{transform:rotate(0deg)}100%{transform:rotate(360deg)}}
+@keyframes rattle-body-cinema-film-projector{0%,100%{transform:translateY(0)}50%{transform:translateY(1px)}}
+@keyframes flicker-beam-cinema-film-projector{0%,100%{opacity:1}50%{opacity:0.6}}
+@keyframes flicker-screen-cinema-film-projector{0%,100%{opacity:0.95}50%{opacity:0.6}}
+@keyframes glow-bulb-cinema-film-projector{0%,100%{opacity:1;transform:scale(1)}50%{opacity:0.7;transform:scale(0.9)}}
+@keyframes advance-film-cinema-film-projector{0%,100%{transform:translateY(0)}50%{transform:translateY(18px)}}


### PR DESCRIPTION
## Component: ease-cinema-film-projector — reel turns, beam flickers, and film advances

**Closes #61012**

### What this adds
A dim movie house with a brass projector: the reel turns as the film strip advances, the lens throws a flickering amber beam toward the screen, and the lamp glows inside the machine.

### Acceptance Criteria covered
- Reel turns on the projector
- Beam flickers toward the screen
- Film advances through the gate

### Files
- submissions/examples/ease-cinema-film-projector-ij/demo.html
- submissions/examples/ease-cinema-film-projector-ij/style.css
- submissions/examples/ease-cinema-film-projector-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the reel spin.