### PR TITLE
Add ease-scoreboard-flip-count component

### DIFF
--- a/submissions/examples/ease-scoreboard-flip-count-ij/README.md
+++ b/submissions/examples/ease-scoreboard-flip-count-ij/README.md
@@ -1,0 +1,7 @@
+# ease-scoreboard-flip-count
+A scoreboard whose flip cards count upward.
+## Run
+Open `demo.html` directly in a browser to watch the flips.
+## Notes
+- The cards roll over one by one.
+- The red digits change each flip.

--- a/submissions/examples/ease-scoreboard-flip-count-ij/demo.html
+++ b/submissions/examples/ease-scoreboard-flip-count-ij/demo.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-scoreboard-flip-count demo</title>
+</head>
+<body>
+<div class="sb-app">
+  <div class="sb-board">
+    <div class="sb-label">HOME</div>
+    <div class="sb-card">
+      <div class="sb-card-top"></div>
+      <div class="sb-card-bottom"></div>
+      <div class="sb-fold"></div>
+    </div>
+    <div class="sb-card sb-card-away">
+      <div class="sb-card-top"></div>
+      <div class="sb-card-bottom"></div>
+      <div class="sb-fold"></div>
+    </div>
+    <div class="sb-tick"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/ease-scoreboard-flip-count-ij/style.css
+++ b/submissions/examples/ease-scoreboard-flip-count-ij/style.css
@@ -1,0 +1,13 @@
+:root{--sb-black:#14181e;--sb-red:#d82a2a;--sb-green:#2ab86a}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#2a3240,#141820);font-family:'Arial Black',sans-serif}
+.sb-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#202838,#141820);box-shadow:0 16px 36px rgba(0,0,0,0.5)}
+.sb-board{position:absolute;top:56px;left:50%;width:250px;height:190px;margin-left:-125px;border-radius:14px;background:#1c222c;box-shadow:inset 0 0 0 10px #3a4452,0 12px 24px rgba(0,0,0,0.5)}
+.sb-label{position:absolute;top:24px;left:0;right:0;text-align:center;font-size:16px;letter-spacing:6px;color:var(--sb-green)}
+.sb-card{position:absolute;top:60px;left:36px;width:64px;height:84px;border-radius:8px;background:var(--sb-black);box-shadow:inset 0 0 0 4px #2a3240;perspective:120px;animation:flip-card-scoreboard-flip-count 2s steps(2) infinite}
+.sb-card-away{right:36px;animation-delay:1s}
+.sb-card-top{position:absolute;top:0;left:0;right:0;height:40px;border-radius:8px 8px 0 0;background:var(--sb-red);box-shadow:inset 0 -2px 0 rgba(255,255,255,0.15)}
+.sb-card-bottom{position:absolute;bottom:0;left:0;right:0;height:40px;border-radius:0 0 8px 8px;background:var(--sb-red);box-shadow:inset 0 2px 0 rgba(255,255,255,0.15)}
+.sb-fold{position:absolute;top:38px;left:0;right:0;height:4px;background:#0a0c10}
+.sb-tick{position:absolute;bottom:18px;left:50%;width:10px;height:10px;margin-left:-5px;border-radius:50%;background:var(--sb-green);box-shadow:0 0 12px var(--sb-green);animation:blink-tick-scoreboard-flip-count 1s steps(2) infinite}
+@keyframes flip-card-scoreboard-flip-count{0%{transform:rotateX(0deg)}50%{transform:rotateX(90deg)}100%{transform:rotateX(0deg)}}
+@keyframes blink-tick-scoreboard-flip-count{0%,100%{opacity:1}50%{opacity:0.2}}


### PR DESCRIPTION
## Component: ease-scoreboard-flip-count — cards flip, digits roll, and light blinks

**Closes #61068**

### What this adds
A stadium scoreboard: the flip cards turn over to count up under the team label, the red digits change on each flip, and the status light blinks at the bottom of the board.

### Acceptance Criteria covered
- Flip cards roll over
- Red digits change each flip
- Status light blinks below

### Files
- submissions/examples/ease-scoreboard-flip-count-ij/demo.html
- submissions/examples/ease-scoreboard-flip-count-ij/style.css
- submissions/examples/ease-scoreboard-flip-count-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the cards flip.