### PR TITLE
add copy to clipboard button state

### DIFF
--- a/submissions/examples/animated-copy-to-clipboard-button-state/README.md
+++ b/submissions/examples/animated-copy-to-clipboard-button-state/README.md
@@ -1,0 +1,16 @@
+# ease-copy-btn
+
+A copy-to-clipboard button with an animated "copied!" state for **EaseMotion CSS**.
+
+## Usage
+
+```html
+<button class="copy-btn" onclick="
+  navigator.clipboard.writeText('text to copy');
+  this.classList.add('copy-btn-copied');
+  setTimeout(() => this.classList.remove('copy-btn-copied'), 2000);
+">
+  <span class="copy-btn-icon copy-btn-icon-default">📋</span>
+  <span class="copy-btn-icon copy-btn-icon-success">✔</span>
+  <span class="copy-btn-label">Copy</span>
+</button>

--- a/submissions/examples/animated-copy-to-clipboard-button-state/demo.html
+++ b/submissions/examples/animated-copy-to-clipboard-button-state/demo.html
@@ -1,0 +1,26 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-copy-btn Demo</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body { font-family: system-ui, sans-serif; background: #0f172a; color: #f1f5f9; display: flex; flex-direction: column; align-items: center; gap: 24px; padding: 80px; }
+</style>
+</head>
+<body>
+  <h1>ease-copy-btn</h1>
+
+  <button class="copy-btn" onclick="
+    navigator.clipboard.writeText('npm install easemotion-css');
+    this.classList.add('copy-btn-copied');
+    clearTimeout(this._t);
+    this._t = setTimeout(() => this.classList.remove('copy-btn-copied'), 2000);
+  ">
+    <span class="copy-btn-icon copy-btn-icon-default">📋</span>
+    <span class="copy-btn-icon copy-btn-icon-success">✔</span>
+    <span class="copy-btn-label">Copy install command</span>
+  </button>
+</body>
+</html>

--- a/submissions/examples/animated-copy-to-clipboard-button-state/style.css
+++ b/submissions/examples/animated-copy-to-clipboard-button-state/style.css
@@ -1,0 +1,49 @@
+/* ==========================================================
+   ease-copy-btn — Copy-to-Clipboard Button State
+   ========================================================== */
+
+.copy-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-radius: 8px;
+  border: 1px solid #334155;
+  background: #1e293b;
+  color: #f1f5f9;
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: border-color 0.2s ease;
+}
+
+.copy-btn:hover {
+  border-color: #60a5fa;
+}
+
+.copy-btn-icon {
+  display: inline-block;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.copy-btn-icon-success {
+  display: none;
+}
+
+.copy-btn.copy-btn-copied {
+  border-color: #16a34a;
+}
+
+.copy-btn.copy-btn-copied .copy-btn-icon-default {
+  display: none;
+}
+
+.copy-btn.copy-btn-copied .copy-btn-icon-success {
+  display: inline-block;
+  color: #22c55e;
+  animation: pop-in 0.3s ease;
+}
+
+@keyframes pop-in {
+  from { transform: scale(0.5); opacity: 0; }
+  to { transform: scale(1); opacity: 1; }
+}


### PR DESCRIPTION
### PR Description
```markdown
## Summary
Adds `ease-copy-btn`, a copy-to-clipboard button with animated success state, per issue #23.

## What's included
- `submissions/ease-copy-btn/style.css`
- `submissions/ease-copy-btn/demo.html`
- `submissions/ease-copy-btn/readme.md`

## Implementation notes
- Icon swap and pop-in animation driven entirely by `.copy-btn-copied` class toggle.
- The only JS required is the unavoidable `navigator.clipboard.writeText()` call plus the class toggle/timeout — no other logic.
- Border color shifts green on success for extra visual confirmation.

## Testing checklist
- [x] Verified icon swaps from clipboard to checkmark with pop-in animation
- [x] Verified state reverts to default after timeout
- [x] Verified `navigator.clipboard` copy actually works in demo
- [x] Placed only inside `submissions/`

Closes #23