### PR TITLE
add scroll progress bar top page

### DIFF
--- a/submissions/examples/animated-scroll-progress-bar-top-page/README.md
+++ b/submissions/examples/animated-scroll-progress-bar-top-page/README.md
@@ -1,0 +1,16 @@
+# ease-scroll-progress
+
+A fixed top-of-page scroll progress bar for **EaseMotion CSS** — the "reading progress" indicator common on blogs and docs sites.
+
+## Usage
+
+```html
+<div class="scroll-progress"></div>
+
+<script>
+  document.addEventListener('scroll', () => {
+    const h = document.documentElement;
+    const percent = h.scrollTop / (h.scrollHeight - h.clientHeight);
+    document.querySelector('.scroll-progress').style.setProperty('--scroll-percent', percent);
+  });
+</script>

--- a/submissions/examples/animated-scroll-progress-bar-top-page/demo.html
+++ b/submissions/examples/animated-scroll-progress-bar-top-page/demo.html
@@ -1,0 +1,38 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-scroll-progress Demo</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body { font-family: system-ui, sans-serif; background: #0f172a; color: #f1f5f9; padding: 40px; line-height: 1.7; }
+  .content { max-width: 640px; margin: 0 auto; }
+  h2 { margin-top: 60px; }
+</style>
+</head>
+<body>
+  <div class="scroll-progress"></div>
+
+  <div class="content">
+    <h1>ease-scroll-progress</h1>
+    <p>Scroll down this page to watch the bar at the top fill up.</p>
+    <h2>Section 1</h2>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+    <h2>Section 2</h2>
+    <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+    <h2>Section 3</h2>
+    <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
+    <h2>Section 4</h2>
+    <p style="margin-bottom: 800px;">Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+  </div>
+
+  <script>
+    document.addEventListener('scroll', () => {
+      const h = document.documentElement;
+      const percent = h.scrollTop / (h.scrollHeight - h.clientHeight);
+      document.querySelector('.scroll-progress').style.setProperty('--scroll-percent', percent);
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/animated-scroll-progress-bar-top-page/style.css
+++ b/submissions/examples/animated-scroll-progress-bar-top-page/style.css
@@ -1,0 +1,28 @@
+/* ==========================================================
+   ease-scroll-progress — Scroll Progress Bar
+   ========================================================== */
+
+.scroll-progress {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 4px;
+  background: transparent;
+  z-index: 1000;
+}
+
+.scroll-progress::before {
+  content: '';
+  display: block;
+  height: 100%;
+  width: 100%;
+  transform-origin: left;
+  transform: scaleX(var(--scroll-percent, 0));
+  background: linear-gradient(90deg, #3b82f6, #8b5cf6);
+  transition: transform 0.1s linear;
+}
+
+/* Color variants */
+.scroll-progress.success::before { background: linear-gradient(90deg, #22c55e, #4ade80); }
+.scroll-progress.danger::before  { background: linear-gradient(90deg, #ef4444, #f87171); }


### PR DESCRIPTION
### PR Description
```markdown
## Summary
Adds `ease-scroll-progress`, a fixed top-of-page reading progress bar, per issue #24.

## What's included
- `submissions/ease-scroll-progress/style.css`
- `submissions/ease-scroll-progress/demo.html`
- `submissions/ease-scroll-progress/readme.md`

## Implementation notes
- Fill driven by `transform: scaleX(var(--scroll-percent))` for GPU-accelerated performance vs. animating `width`.
- Single JS scroll listener sets the `--scroll-percent` custom property; all rendering is CSS.
- Includes `.success` / `.danger` gradient color variants.

## Testing checklist
- [x] Verified bar fills accurately from 0 to 100% across full page scroll
- [x] Verified smooth performance on long content pages
- [x] Verified color variants render correctly
- [x] Placed only inside `submissions/`

Closes #24