### PR TITLE
add animated back to top floating button

### DIFF
--- a/submissions/examples/animated-back-to-top-floating-button/README.md
+++ b/submissions/examples/animated-back-to-top-floating-button/README.md
@@ -1,0 +1,17 @@
+# ease-back-to-top
+
+A floating "back to top" button for **EaseMotion CSS** that fades/scales in past a scroll threshold and smoothly scrolls the page to top on click.
+
+## Usage
+
+```html
+<button class="back-to-top" aria-label="Back to top" onclick="window.scrollTo({top: 0, behavior: 'smooth'})">
+  ↑
+</button>
+
+<script>
+  window.addEventListener('scroll', () => {
+    document.querySelector('.back-to-top')
+      .classList.toggle('visible', window.scrollY > 300);
+  });
+</script>

--- a/submissions/examples/animated-back-to-top-floating-button/demo.html
+++ b/submissions/examples/animated-back-to-top-floating-button/demo.html
@@ -1,0 +1,30 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-back-to-top Demo</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body { font-family: system-ui, sans-serif; background: #0f172a; color: #f1f5f9; padding: 40px; }
+  .filler { height: 1400px; max-width: 600px; margin: 0 auto; line-height: 1.7; }
+</style>
+</head>
+<body>
+  <div class="filler">
+    <h1>ease-back-to-top</h1>
+    <p>Scroll down 300px to reveal the floating button in the bottom-right corner.</p>
+  </div>
+
+  <button class="back-to-top" aria-label="Back to top" onclick="window.scrollTo({top: 0, behavior: 'smooth'})">
+    ↑
+  </button>
+
+  <script>
+    window.addEventListener('scroll', () => {
+      document.querySelector('.back-to-top')
+        .classList.toggle('visible', window.scrollY > 300);
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/animated-back-to-top-floating-button/style.css
+++ b/submissions/examples/animated-back-to-top-floating-button/style.css
@@ -1,0 +1,43 @@
+/* ==========================================================
+   ease-back-to-top — Back-to-Top Floating Button
+   ========================================================== */
+
+html {
+  scroll-behavior: smooth;
+}
+
+.back-to-top {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: none;
+  background: #2563eb;
+  color: #fff;
+  font-size: 1.2rem;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+  opacity: 0;
+  transform: translateY(20px) scale(0.8);
+  pointer-events: none;
+  transition: opacity 0.3s ease, transform 0.3s ease, background 0.2s ease;
+  z-index: 999;
+}
+
+.back-to-top.visible {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.back-to-top:hover {
+  background: #1d4ed8;
+  transform: translateY(-3px) scale(1.05);
+}
+
+.back-to-top:focus-visible {
+  outline: 2px solid #93c5fd;
+  outline-offset: 3px;
+}


### PR DESCRIPTION
### PR Description
```markdown
## Summary
Adds `ease-back-to-top`, a floating scroll-to-top button, per issue #25.

## What's included
- `submissions/ease-back-to-top/style.css`
- `submissions/ease-back-to-top/demo.html`
- `submissions/ease-back-to-top/readme.md`

## Implementation notes
- Visibility toggle (`opacity` + `transform`) driven by `.visible` class based on scroll position.
- Smooth scroll uses native `scroll-behavior: smooth`, not JS-animated scrolling.
- Includes `:focus-visible` outline for keyboard accessibility and `aria-label` for screen readers.

## Testing checklist
- [x] Verified button fades/scales in only after scrolling past threshold
- [x] Verified click scrolls smoothly to top
- [x] Verified keyboard focus ring and screen reader label work
- [x] Placed only inside `submissions/`

Closes #25