### PR TITLE
Add ease-cassette-tape-spin component

### DIFF
--- a/submissions/examples/cassette-tape-spin-ij/README.md
+++ b/submissions/examples/cassette-tape-spin-ij/README.md
@@ -1,0 +1,7 @@
+# ease-cassette-tape-spin
+A cassette whose reels spin in opposite directions.
+## Run
+Open `demo.html` directly in a browser to watch the reels spin.
+## Notes
+- The two reels turn opposite ways.
+- The play indicator blinks below.

--- a/submissions/examples/cassette-tape-spin-ij/demo.html
+++ b/submissions/examples/cassette-tape-spin-ij/demo.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-cassette-tape-spin demo</title>
+</head>
+<body>
+<div class="cs-app">
+  <div class="cs-shell">
+    <div class="cs-screw cs-screw-1"></div>
+    <div class="cs-screw cs-screw-2"></div>
+    <div class="cs-screw cs-screw-3"></div>
+    <div class="cs-screw cs-screw-4"></div>
+    <div class="cs-label"></div>
+    <div class="cs-window"></div>
+    <div class="cs-reel cs-reel-1"></div>
+    <div class="cs-reel cs-reel-2"></div>
+    <div class="cs-hub cs-hub-1"></div>
+    <div class="cs-hub cs-hub-2"></div>
+  </div>
+  <div class="cs-deck">
+    <div class="cs-play"></div>
+    <div class="cs-stop"></div>
+    <div class="cs-fwd"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/cassette-tape-spin-ij/style.css
+++ b/submissions/examples/cassette-tape-spin-ij/style.css
@@ -1,0 +1,24 @@
+:root{--cs-black:#1a1e28;--cs-white:#e8e0d8;--cs-red:#d82a2a}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#4a4a5a,#202028);font-family:'Courier New',monospace}
+.cs-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#3a3a4a,#181820);box-shadow:0 16px 36px rgba(0,0,0,0.5)}
+.cs-shell{position:absolute;top:64px;left:50%;width:250px;height:170px;margin-left:-125px;border-radius:14px;background:var(--cs-black);box-shadow:inset 0 0 0 8px #2a2e3a,0 12px 24px rgba(0,0,0,0.5)}
+.cs-screw{position:absolute;width:10px;height:10px;border-radius:50%;background:#4a4a5a}
+.cs-screw-1{top:10px;left:10px}
+.cs-screw-2{top:10px;right:10px}
+.cs-screw-3{bottom:10px;left:10px}
+.cs-screw-4{bottom:10px;right:10px}
+.cs-label{position:absolute;top:18px;left:50%;width:184px;height:44px;margin-left:-92px;border-radius:6px;background:var(--cs-white);box-shadow:inset 0 0 0 4px #c8c0b0}
+.cs-window{position:absolute;top:88px;left:50%;width:150px;height:36px;margin-left:-75px;border-radius:6px;background:#2a3240;overflow:hidden}
+.cs-reel{position:absolute;top:74px;width:72px;height:72px;border-radius:50%;background:#2a3240;box-shadow:inset 0 0 0 8px #c8a64a}
+.cs-reel-1{left:40px;animation:spin-reel-left-cassette-tape-spin 1.6s linear infinite}
+.cs-reel-2{right:40px;animation:spin-reel-right-cassette-tape-spin 1.6s linear infinite}
+.cs-hub{position:absolute;top:94px;width:16px;height:16px;border-radius:4px;background:#c8a64a;box-shadow:inset 0 0 0 3px #8a6a2e}
+.cs-hub-1{left:68px;animation:spin-reel-left-cassette-tape-spin 1.6s linear infinite}
+.cs-hub-2{right:68px;animation:spin-reel-right-cassette-tape-spin 1.6s linear infinite}
+.cs-deck{position:absolute;bottom:30px;left:50%;width:140px;height:44px;margin-left:-70px;border-radius:10px;background:#3a3a4a;box-shadow:inset 0 0 0 5px #1a1e28}
+.cs-play{position:absolute;top:8px;left:18px;width:0;height:0;border-left:16px solid #c8a64a;border-top:12px solid transparent;border-bottom:12px solid transparent;animation:blink-play-cassette-tape-spin 1s steps(2) infinite}
+.cs-stop{position:absolute;top:8px;left:64px;width:16px;height:26px;border-radius:3px;background:#c8442f}
+.cs-fwd{position:absolute;top:8px;right:18px;width:0;height:0;border-left:16px solid #5a8ab8;border-top:12px solid transparent;border-bottom:12px solid transparent}
+@keyframes spin-reel-left-cassette-tape-spin{0%{transform:rotate(0deg)}100%{transform:rotate(360deg)}}
+@keyframes spin-reel-right-cassette-tape-spin{0%{transform:rotate(0deg)}100%{transform:rotate(-360deg)}}
+@keyframes blink-play-cassette-tape-spin{0%,100%{opacity:1}50%{opacity:0.3}}


### PR DESCRIPTION
## Component: ease-cassette-tape-spin — reels spin, play blinks, and tape turns

**Closes #61196**

### What this adds
A classic audio cassette: the two brass reels spin opposite directions inside the black shell, the cream label sits at the top, and the play indicator blinks while the tape deck sits below.

### Acceptance Criteria covered
- Reels spin in opposite directions
- Play indicator blinks on the deck
- Label and screws frame the shell

### Files
- submissions/examples/cassette-tape-spin-ij/demo.html
- submissions/examples/cassette-tape-spin-ij/style.css
- submissions/examples/cassette-tape-spin-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the reels spin.