### PR TITLE
fix: resolve ease-loader focus outline clipping issue #59775

### DIFF
--- a/submissions/docs/loader-focus-fix-59775/README.md
+++ b/submissions/docs/loader-focus-fix-59775/README.md
@@ -1,0 +1,5 @@
+# Loader Focus Fix
+
+1. What does this do? Fixes an accessibility bug where the `ease-loader` focus ring is clipped when placed inside an `overflow: hidden` parent.
+2. How is it used? Apply `.loader-focus-fix` to the loader element.
+3. Why is it useful? It ensures that screen-reader and keyboard users can always see when a loader component is focused, complying with accessibility standards by containing the focus ring within the element's bounding box using a negative `outline-offset`.

--- a/submissions/docs/loader-focus-fix-59775/demo.html
+++ b/submissions/docs/loader-focus-fix-59775/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Loader Focus Fix</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <h2>Focus Ring Clipping Bug Fix</h2>
+  <p>Press <code>Tab</code> to focus the loaders.</p>
+
+  <div style="margin-bottom: 2rem;">
+    <h3>Without Fix (Clipped)</h3>
+    <div class="loader-container">
+      <div class="loader" tabindex="0" aria-label="Loading" aria-busy="true"></div>
+    </div>
+  </div>
+
+  <div>
+    <h3>With Fix (Visible)</h3>
+    <div class="loader-container">
+      <div class="loader loader-focus-fix" tabindex="0" aria-label="Loading" aria-busy="true"></div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/docs/loader-focus-fix-59775/style.css
+++ b/submissions/docs/loader-focus-fix-59775/style.css
@@ -1,0 +1,31 @@
+/* Container with overflow hidden to demonstrate clipping */
+.loader-container {
+  overflow: hidden;
+  display: inline-flex;
+  padding: 4px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background-color: #f9f9f9;
+}
+
+/* Base loader styles representing the ease-loader component */
+.loader {
+  display: inline-block;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 3px solid #e5e7eb;
+  border-top-color: #3b82f6;
+  animation: spin 0.8s linear infinite;
+}
+
+/* The fix: negative outline offset */
+.loader-focus-fix:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: -2px;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}


### PR DESCRIPTION
## Pull Request Description

This PR submits a bug fix demonstration for issue #59775, where the `ease-loader` component's focus outline is inadvertently clipped when placed inside a container with `overflow: hidden` or `overflow: auto`. The submission provides a self-contained fix that applies a negative `outline-offset` to ensure the focus ring remains fully visible and accessible within the element's bounding box.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other (describe below)
  - Core bug fix demonstration submitted in `submissions/docs/`

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Fixes an accessibility bug where the `ease-loader` focus ring is clipped by containing elements by applying a negative `outline-offset` to keep the ring inside the bounding box.

**How does a developer use it?**

```html
<div class="loader-container" style="overflow: hidden;">
  <div class="ease-loader loader-focus-fix" tabindex="0" aria-label="Loading" aria-busy="true"></div>
</div>
