### PR TITLE
Add ease-plane-propeller-spin component

### DIFF
--- a/submissions/examples/plane-propeller-spin-ij/README.md
+++ b/submissions/examples/plane-propeller-spin-ij/README.md
@@ -1,0 +1,7 @@
+# ease-plane-propeller-spin
+A plane whose propeller spins as it climbs.
+## Run
+Open `demo.html` directly in a browser to watch the propeller spin.
+## Notes
+- The nose propeller blurs with speed.
+- Clouds drift past the wings.

--- a/submissions/examples/plane-propeller-spin-ij/demo.html
+++ b/submissions/examples/plane-propeller-spin-ij/demo.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-plane-propeller-spin demo</title>
+</head>
+<body>
+<div class="pl-app">
+  <div class="pl-sky">
+    <div class="pl-cloud pl-cloud-1"></div>
+    <div class="pl-cloud pl-cloud-2"></div>
+  </div>
+  <div class="pl-plane">
+    <div class="pl-nose"></div>
+    <div class="pl-prop"></div>
+    <div class="pl-body"></div>
+    <div class="pl-cockpit"></div>
+    <div class="pl-wing pl-wing-1"></div>
+    <div class="pl-wing pl-wing-2"></div>
+    <div class="pl-tail"></div>
+    <div class="pl-rudder"></div>
+  </div>
+  <div class="pl-wind pl-wind-1"></div>
+  <div class="pl-wind pl-wind-2"></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/plane-propeller-spin-ij/style.css
+++ b/submissions/examples/plane-propeller-spin-ij/style.css
@@ -1,0 +1,24 @@
+:root{--pl-white:#e8e0d8;--pl-blue:#3a6ab8;--pl-red:#d84a3a}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#c0e0f4,#7aa8c8);font-family:'Consolas',monospace}
+.pl-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#7ab8e8,#3a6ab8);box-shadow:0 16px 36px rgba(0,0,0,0.35)}
+.pl-sky{position:absolute;top:0;left:0;right:0;bottom:0;z-index:0}
+.pl-cloud{position:absolute;width:90px;height:26px;border-radius:14px;background:rgba(232,224,216,0.85);animation:drift-cloud-plane-propeller-spin 6s linear infinite}
+.pl-cloud-1{top:30px;left:-90px}
+.pl-cloud-2{top:90px;left:-120px;animation-delay:3s}
+.pl-plane{position:absolute;top:150px;left:70px;width:210px;height:60px;animation:bob-plane-plane-propeller-spin 2.4s ease-in-out infinite}
+.pl-body{position:absolute;top:22px;left:20px;width:170px;height:24px;border-radius:12px;background:var(--pl-white);box-shadow:inset 0 0 0 4px rgba(0,0,0,0.08)}
+.pl-nose{position:absolute;top:22px;left:0;width:26px;height:24px;border-radius:12px 0 0 12px;background:var(--pl-red)}
+.pl-prop{position:absolute;top:16px;left:-6px;width:34px;height:34px;border-radius:50%;background:rgba(232,224,216,0.6);box-shadow:0 0 0 3px rgba(232,224,216,0.8);animation:spin-prop-plane-propeller-spin 0.12s linear infinite}
+.pl-cockpit{position:absolute;top:16px;left:48px;width:26px;height:14px;border-radius:8px;background:#a8e0f6;box-shadow:inset 0 0 0 3px #5a8ab8}
+.pl-wing{position:absolute;width:44px;height:12px;border-radius:6px;background:var(--pl-blue)}
+.pl-wing-1{top:32px;left:70px}
+.pl-wing-2{top:20px;right:40px}
+.pl-tail{position:absolute;top:34px;right:6px;width:10px;height:22px;background:var(--pl-red)}
+.pl-rudder{position:absolute;top:12px;right:6px;width:10px;height:16px;border-radius:4px;background:var(--pl-blue)}
+.pl-wind{position:absolute;top:30px;height:4px;border-radius:2px;background:rgba(255,255,255,0.7);animation:streak-wind-plane-propeller-spin 2.4s ease-in-out infinite}
+.pl-wind-1{left:120px;width:60px}
+.pl-wind-2{left:120px;top:44px;width:40px;animation-delay:1.2s}
+@keyframes spin-prop-plane-propeller-spin{0%{transform:rotate(0deg) scaleY(0.2)}50%{transform:rotate(180deg) scaleY(1)}100%{transform:rotate(360deg) scaleY(0.2)}}
+@keyframes bob-plane-plane-propeller-spin{0%,100%{transform:translateY(0) rotate(0deg)}50%{transform:translateY(-8px) rotate(2deg)}}
+@keyframes drift-cloud-plane-propeller-spin{0%{transform:translateX(0)}100%{transform:translateX(484px)}}
+@keyframes streak-wind-plane-propeller-spin{0%{transform:translateX(0);opacity:0}30%{opacity:1}100%{transform:translateX(90px);opacity:0}}


### PR DESCRIPTION
## Component: ease-plane-propeller-spin — propeller spins, plane bobs, and clouds drift

**Closes #61229**

### What this adds
A small propeller plane climbing through the sky: the nose propeller spins into a blur, the red-and-blue plane bobs on the breeze, white clouds drift past, and wind streaks trail behind.

### Acceptance Criteria covered
- Propeller spins into a blur
- Plane bobs on the breeze
- Clouds drift across the sky

### Files
- submissions/examples/plane-propeller-spin-ij/demo.html
- submissions/examples/plane-propeller-spin-ij/style.css
- submissions/examples/plane-propeller-spin-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the propeller spin.