### PR TITLE
Add ease-traffic-light-cycle component

### DIFF
--- a/submissions/examples/traffic-light-cycle-ij/README.md
+++ b/submissions/examples/traffic-light-cycle-ij/README.md
@@ -1,0 +1,7 @@
+# ease-traffic-light-cycle
+A traffic light that cycles through its lamps.
+## Run
+Open `demo.html` directly in a browser to watch the lights cycle.
+## Notes
+- The lamps light in sequence.
+- The car waits then drives off.

--- a/submissions/examples/traffic-light-cycle-ij/demo.html
+++ b/submissions/examples/traffic-light-cycle-ij/demo.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-traffic-light-cycle demo</title>
+</head>
+<body>
+<div class="tl-app">
+  <div class="tl-sky">
+    <div class="tl-sun"></div>
+  </div>
+  <div class="tl-road"></div>
+  <div class="tl-pole"></div>
+  <div class="tl-box">
+    <div class="tl-lamp tl-red"></div>
+    <div class="tl-lamp tl-yellow"></div>
+    <div class="tl-lamp tl-green"></div>
+    <div class="tl-visor tl-visor-1"></div>
+    <div class="tl-visor tl-visor-2"></div>
+    <div class="tl-visor tl-visor-3"></div>
+  </div>
+  <div class="tl-car">
+    <div class="tl-car-body"></div>
+    <div class="tl-car-window"></div>
+    <div class="tl-car-wheel tl-car-wheel-1"></div>
+    <div class="tl-car-wheel tl-car-wheel-2"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/traffic-light-cycle-ij/style.css
+++ b/submissions/examples/traffic-light-cycle-ij/style.css
@@ -1,0 +1,26 @@
+:root{--tl-box:#3a4452;--tl-red:#ff4a3a;--tl-yellow:#ffd04a;--tl-green:#3ad84a}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#cfe6f0,#88aec6);font-family:'Impact',sans-serif}
+.tl-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#a4d4ec,#5886b4);box-shadow:0 16px 36px rgba(0,0,0,0.35)}
+.tl-sky{position:absolute;top:0;left:0;right:0;bottom:0}
+.tl-sun{position:absolute;top:24px;right:44px;width:40px;height:40px;border-radius:50%;background:#ffe08a;box-shadow:0 0 24px #ffe08a}
+.tl-road{position:absolute;left:0;right:0;bottom:0;height:90px;background:#4a5264;box-shadow:inset 0 8px 0 rgba(255,255,255,0.08)}
+.tl-pole{position:absolute;bottom:90px;left:84px;width:10px;height:120px;background:#5a6678}
+.tl-box{position:absolute;bottom:204px;left:56px;width:58px;height:170px;border-radius:14px;background:var(--tl-box);box-shadow:inset 0 0 0 6px #2a3240,0 10px 20px rgba(0,0,0,0.4)}
+.tl-lamp{position:absolute;left:50%;width:34px;height:34px;margin-left:-17px;border-radius:50%;background:#14181e}
+.tl-red{top:16px;animation:glow-red-traffic-light-cycle 9s steps(1) infinite}
+.tl-yellow{top:68px;animation:glow-yellow-traffic-light-cycle 9s steps(1) infinite}
+.tl-green{top:120px;animation:glow-green-traffic-light-cycle 9s steps(1) infinite}
+.tl-visor{position:absolute;left:-4px;width:66px;height:10px;border-radius:6px;background:#2a3240}
+.tl-visor-1{top:12px}
+.tl-visor-2{top:64px}
+.tl-visor-3{top:116px}
+.tl-car{position:absolute;right:30px;bottom:40px;width:110px;height:48px;animation:drive-car-traffic-light-cycle 9s ease-in-out infinite}
+.tl-car-body{position:absolute;top:0;left:0;right:0;height:34px;border-radius:10px;background:#e86a5a;box-shadow:inset 0 0 0 4px rgba(0,0,0,0.12)}
+.tl-car-window{position:absolute;top:6px;left:16px;width:26px;height:20px;border-radius:6px;background:#a8e0f6;box-shadow:inset 0 0 0 3px rgba(0,0,0,0.12)}
+.tl-car-wheel{position:absolute;bottom:0;width:20px;height:20px;border-radius:50%;background:#2a2438;box-shadow:inset 0 0 0 4px #8a93a2}
+.tl-car-wheel-1{left:14px}
+.tl-car-wheel-2{right:14px}
+@keyframes glow-red-traffic-light-cycle{0%,30%{background:var(--tl-red);box-shadow:0 0 24px var(--tl-red)}31%,100%{background:#14181e;box-shadow:none}}
+@keyframes glow-yellow-traffic-light-cycle{0%,29%{background:#14181e}30%,40%{background:var(--tl-yellow);box-shadow:0 0 24px var(--tl-yellow)}41%,100%{background:#14181e;box-shadow:none}}
+@keyframes glow-green-traffic-light-cycle{0%,40%{background:#14181e;box-shadow:none}41%,100%{background:var(--tl-green);box-shadow:0 0 24px var(--tl-green)}}
+@keyframes drive-car-traffic-light-cycle{0%,39%{transform:translateX(0)}70%,100%{transform:translateX(-240px)}}


### PR DESCRIPTION
## Component: ease-traffic-light-cycle — lamps cycle, visors shine, and car waits

**Closes #61237**

### What this adds
A street corner with a tall traffic light: the red, yellow, and green lamps light in turn under their visors, each casting a glow, while a small car waits at the line and drives off when the light turns green.

### Acceptance Criteria covered
- Lamps cycle red to green
- Each lamp casts a glow
- Car waits then drives off

### Files
- submissions/examples/traffic-light-cycle-ij/demo.html
- submissions/examples/traffic-light-cycle-ij/style.css
- submissions/examples/traffic-light-cycle-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the lights cycle.