### PR TITLE
Fix: add ease-navbar focus outline clip fix demo #59781

### DIFF
--- a/submissions/examples/ease-navbar-focus-fix-59781/README.md
+++ b/submissions/examples/ease-navbar-focus-fix-59781/README.md
@@ -1,0 +1,21 @@
+# Ease Navbar Focus Fix
+
+### Overview
+This example demonstrates a fix for the `ease-navbar` component where its focus outline was getting clipped by parent containers with `overflow: hidden` or `overflow: auto`. This clipping degraded the accessibility experience.
+
+### What it does
+It adds a simple `outline-offset: -2px` rule to the focus state (`:focus-visible`) of the navbar and its inner links. This ensures that the outline is pulled inwards and rendered fully within the element's bounding box, preventing any clipping from ancestor elements.
+
+### How to use it
+Incorporate the CSS fix into the component's base styles or as a utility override:
+
+```css
+.ease-navbar:focus-visible,
+.nav-link:focus-visible {
+    outline: 2px solid #38bdf8;
+    outline-offset: -2px; /* Fix for overflow hidden */
+}
+```
+
+### Why it fits EaseMotion CSS
+EaseMotion prioritizes high-quality, accessible UI components. Ensuring focus rings are always clearly visible, regardless of the component's container, is a core accessibility requirement and aligns with the project's standards.

--- a/submissions/examples/ease-navbar-focus-fix-59781/demo.html
+++ b/submissions/examples/ease-navbar-focus-fix-59781/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ease Navbar Focus Fix #59781</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Ease Navbar Focus Fix Demo</h1>
+    <p>This demo shows the <code>ease-navbar</code> component inside a container with <code>overflow: hidden</code>. The focus ring is customized to use a negative outline offset so it doesn't get clipped.</p>
+    
+    <div class="container">
+        <nav class="ease-navbar" tabindex="0" aria-label="Main Navigation">
+            <ul class="nav-list">
+                <li><a href="#" class="nav-link">Home</a></li>
+                <li><a href="#" class="nav-link">Features</a></li>
+                <li><a href="#" class="nav-link">Pricing</a></li>
+                <li><a href="#" class="nav-link">Contact</a></li>
+            </ul>
+        </nav>
+    </div>
+</body>
+</html>

--- a/submissions/examples/ease-navbar-focus-fix-59781/style.css
+++ b/submissions/examples/ease-navbar-focus-fix-59781/style.css
@@ -1,0 +1,84 @@
+/* Base reset for demo purposes */
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: system-ui, -apple-system, sans-serif;
+    padding: 2rem;
+    background-color: #f0f4f8;
+    color: #333;
+}
+
+h1 {
+    margin-bottom: 0.5rem;
+}
+
+p {
+    margin-bottom: 2rem;
+    color: #666;
+    max-width: 600px;
+}
+
+/* Container to reproduce the clipping issue */
+.container {
+    /* overflow: hidden causes outline to clip if it extends outside the bounding box */
+    overflow: hidden; 
+    
+    background-color: #ffffff;
+    border-radius: 8px;
+    padding: 1rem;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    max-width: 600px;
+}
+
+/* ease-navbar component styles */
+.ease-navbar {
+    display: block;
+    background-color: #1e293b;
+    border-radius: 6px;
+    padding: 0.5rem 1rem;
+}
+
+.nav-list {
+    list-style: none;
+    display: flex;
+    gap: 1rem;
+}
+
+.nav-link {
+    color: #f8fafc;
+    text-decoration: none;
+    font-weight: 500;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    display: inline-block;
+    transition: background-color 0.2s ease;
+}
+
+.nav-link:hover {
+    background-color: #334155;
+}
+
+/* 
+  THE BUG FIX: 
+  When the navbar or its children receive focus, the focus ring (outline) 
+  needs to be contained within the element's bounding box so it isn't 
+  clipped by a parent with `overflow: hidden` or `overflow: auto`.
+  
+  Using `outline-offset: -2px` pulls the outline inward, or 
+  `box-shadow: inset 0 0 0 2px <color>` can be used.
+*/
+
+.ease-navbar:focus-visible,
+.nav-link:focus-visible {
+    outline: 2px solid #38bdf8;
+    /* Negative outline-offset prevents clipping */
+    outline-offset: -2px;
+    
+    /* Alternatively, using inset box shadow: */
+    /* outline: none; */
+    /* box-shadow: inset 0 0 0 2px #38bdf8; */
+}


### PR DESCRIPTION
## Pull Request Description

This PR provides a fix for issue #59781 where the `ease-navbar` focus outline is clipped when placed inside a container with `overflow: hidden` or `overflow: auto`. It addresses this by providing an example using `outline-offset: -2px` to draw the focus ring inward, ensuring full visibility.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A fix to the `ease-navbar` that utilizes a negative `outline-offset` to keep the `:focus-visible` ring fully visible even inside containers with `overflow: hidden`.

**How does a developer use it?**

```html
<!-- The CSS fix makes sure standard usage remains accessible -->
<nav class="ease-navbar" tabindex="0" aria-label="Main Navigation">
    <ul class="nav-list">
        <li><a href="#" class="nav-link">Home</a></li>
        <li><a href="#" class="nav-link">Features</a></li>
    </ul>
</nav>
