### PR TITLE
fix: resolve ease-modal focus outline clipping issue #59779

### DIFF
--- a/submissions/examples/ease-modal-focus-outline-clipped-59779/README.md
+++ b/submissions/examples/ease-modal-focus-outline-clipped-59779/README.md
@@ -1,0 +1,14 @@
+# Fix: ease-modal focus outline is clipped by parent overflow
+
+### Description
+The `ease-modal` component suffers from a clipping issue where its focus ring (outline or box-shadow) is cut off if placed inside a container with `overflow: hidden` or `overflow: auto`. This degrades the accessibility experience.
+
+### Expected Behavior
+The focus ring should be fully visible, either by using a negative outline offset or an inset box-shadow, so it is contained within the element's bounding box and avoids clipping from a parent container.
+
+### Implementation
+- `style.css`: Uses `outline-offset: -2px` on `:focus-visible` to ensure the focus outline is rendered inward and is not clipped by any parent `overflow` container.
+- `demo.html`: Demonstrates the `ease-modal` component inside an `overflow: hidden` wrapper.
+
+### Testing
+Open `demo.html` in a browser and press `Tab` to focus the modal. Verify that the focus outline is completely visible and not truncated.

--- a/submissions/examples/ease-modal-focus-outline-clipped-59779/demo.html
+++ b/submissions/examples/ease-modal-focus-outline-clipped-59779/demo.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-modal Focus Outline Fix - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+        font-family: system-ui, -apple-system, sans-serif;
+        padding: 2rem;
+        background-color: #f9fafb;
+        margin: 0;
+    }
+    .demo-container {
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+        max-width: 800px;
+        margin: 0 auto;
+    }
+    .overflow-container {
+        overflow: hidden;
+        border: 1px solid #ccc;
+        border-radius: 8px;
+        background-color: #e5e7eb;
+        /* Constrain dimensions to show clipping issue if not fixed */
+        height: 400px;
+        position: relative; /* For modal overlay positioning within container for demo purposes */
+    }
+    .instructions {
+        background: #eff6ff;
+        padding: 1.5rem;
+        border-left: 4px solid #3b82f6;
+        border-radius: 0 8px 8px 0;
+        margin-bottom: 2rem;
+    }
+    /* Scoping overlay for the demo container */
+    .ease-modal-overlay {
+        position: absolute; /* Changed from fixed for demo purposes so it stays in container */
+    }
+  </style>
+</head>
+<body>
+  <main class="demo-container">
+    <h1>Focus Outline Clipping Fix for ease-modal</h1>
+    
+    <div class="instructions">
+      <p><strong>Steps to Reproduce:</strong></p>
+      <ol>
+        <li>Click inside the gray container or use the <code>Tab</code> key to focus the modal component.</li>
+        <li>Notice that the focus ring is fully visible and not clipped by the <code>overflow: hidden</code> container, due to the negative outline-offset.</li>
+      </ol>
+    </div>
+
+    <div class="overflow-container">
+      <div class="ease-modal-overlay">
+        <!-- The ease-modal is what receives focus in this scenario -->
+        <div class="ease-modal" tabindex="0" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+          <h2 id="modal-title" class="ease-modal-title">Delete Account</h2>
+          <div class="ease-modal-body">
+            <p>Are you sure you want to delete your account? All of your data will be permanently removed. This action cannot be undone.</p>
+          </div>
+          <div class="ease-modal-actions">
+            <button class="ease-btn">Cancel</button>
+            <button class="ease-btn ease-btn-primary">Delete</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-modal-focus-outline-clipped-59779/style.css
+++ b/submissions/examples/ease-modal-focus-outline-clipped-59779/style.css
@@ -1,0 +1,68 @@
+/* 
+ * Fix for ease-modal focus outline clipping
+ * Issue: When .ease-modal is placed in a container with overflow: hidden or auto,
+ * the standard outline is clipped.
+ * Solution: Using negative outline-offset or inset box-shadow.
+ */
+
+.ease-modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.ease-modal {
+    background-color: #ffffff;
+    border-radius: 8px;
+    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    width: 100%;
+    max-width: 500px;
+    padding: 2rem;
+    position: relative;
+    /* Adding transition for smooth focus appearance */
+    transition: outline 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ease-modal-title {
+    margin-top: 0;
+    font-size: 1.5rem;
+    color: #111827;
+}
+
+.ease-modal-body {
+    color: #4b5563;
+    margin-bottom: 1.5rem;
+    line-height: 1.5;
+}
+
+.ease-modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 1rem;
+}
+
+.ease-btn {
+    padding: 0.5rem 1rem;
+    border-radius: 6px;
+    border: none;
+    font-weight: 500;
+    cursor: pointer;
+}
+
+.ease-btn-primary {
+    background-color: #3b82f6;
+    color: #ffffff;
+}
+
+/* Ensure focus outline is drawn inward to prevent clipping */
+.ease-modal:focus-visible {
+    outline: 2px solid #3b82f6;
+    outline-offset: -2px; /* Pulls the outline inward to be contained within the bounding box */
+}


### PR DESCRIPTION
## Pull Request Description

This PR provides a solution for issue #59779, where the `ease-modal` component experiences focus outline clipping when placed inside a container with `overflow: hidden` or `overflow: auto`. The submission adds a demo that rectifies this by applying a negative `outline-offset`, keeping the focus ring contained within the element's bounding box. 

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A fix for the `ease-modal` component's focus outline clipping issue using an inward-drawn `outline-offset`.

**How does a developer use it?**

```html
<!-- Simply ensure your ease-modal is focusable and the updated CSS will handle the focus state seamlessly -->
<div class="ease-modal" tabindex="0" role="dialog" aria-modal="true" aria-labelledby="modal-title">
  <!-- Modal Content -->
</div>
