### PR TITLE
Fix: ease-list focus outline clipped by parent overflow #59773

### DIFF
--- a/submissions/examples/ease-list-focus-outline-clipped-59773/README.md
+++ b/submissions/examples/ease-list-focus-outline-clipped-59773/README.md
@@ -1,0 +1,14 @@
+# Fix: ease-list focus outline is clipped by parent overflow
+
+### Description
+The `ease-list` component suffers from a clipping issue where its focus ring (outline or box-shadow) is cut off if placed inside a container with `overflow: hidden` or `overflow: auto`. This degrades the accessibility experience.
+
+### Expected Behavior
+The focus ring should be fully visible, either by using a negative outline offset or an inset box-shadow, so it is contained within the element's bounding box and avoids clipping from a parent container.
+
+### Implementation
+- `style.css`: Uses `outline-offset: -2px` on `:focus-visible` to ensure the focus outline is rendered inward and is not clipped by any parent `overflow` container.
+- `demo.html`: Demonstrates the `ease-list` component inside an `overflow: hidden` wrapper.
+
+### Testing
+Open `demo.html` in a browser and press `Tab` to focus the list. Verify that the focus outline is completely visible and not truncated.

--- a/submissions/examples/ease-list-focus-outline-clipped-59773/demo.html
+++ b/submissions/examples/ease-list-focus-outline-clipped-59773/demo.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-list Focus Outline Fix - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+        font-family: system-ui, -apple-system, sans-serif;
+        padding: 2rem;
+        background-color: #f9fafb;
+    }
+    .demo-container {
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+        max-width: 600px;
+        margin: 0 auto;
+    }
+    .overflow-container {
+        overflow: hidden;
+        border: 1px solid #ccc;
+        padding: 1rem;
+        border-radius: 8px;
+        background-color: #fff;
+        /* Constrain dimensions to show clipping issue if not fixed */
+        height: auto;
+    }
+    .instructions {
+        background: #eff6ff;
+        padding: 1.5rem;
+        border-left: 4px solid #3b82f6;
+        border-radius: 0 8px 8px 0;
+        margin-bottom: 2rem;
+    }
+  </style>
+</head>
+<body>
+  <main class="demo-container">
+    <h1>Focus Outline Clipping Fix for ease-list</h1>
+    
+    <div class="instructions">
+      <p><strong>Steps to Reproduce:</strong></p>
+      <ol>
+        <li>Click inside the container or use the <code>Tab</code> key to focus the list component.</li>
+        <li>Notice that the focus ring is fully visible and not clipped by the <code>overflow: hidden</code> container, due to the negative outline-offset.</li>
+      </ol>
+    </div>
+
+    <div class="overflow-container">
+      <ul class="ease-list" tabindex="0">
+        <li class="ease-list-item">Item 1</li>
+        <li class="ease-list-item">Item 2</li>
+        <li class="ease-list-item">Item 3</li>
+      </ul>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-list-focus-outline-clipped-59773/style.css
+++ b/submissions/examples/ease-list-focus-outline-clipped-59773/style.css
@@ -1,0 +1,45 @@
+/* 
+ * Fix for ease-list focus outline clipping
+ * Issue: When .ease-list is placed in a container with overflow: hidden or auto,
+ * the standard outline is clipped.
+ * Solution: Using negative outline-offset or inset box-shadow.
+ */
+
+.ease-list {
+    display: flex;
+    flex-direction: column;
+    padding: 1rem;
+    margin: 0;
+    list-style: none;
+    background-color: #ffffff;
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+    width: 250px;
+    /* Adding transition for smooth focus appearance */
+    transition: outline 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ease-list-item {
+    padding: 0.75rem 1rem;
+    color: #374151;
+    text-decoration: none;
+    border-radius: 4px;
+    transition: background-color 0.2s;
+    cursor: pointer;
+    border-bottom: 1px solid #f3f4f6;
+}
+
+.ease-list-item:last-child {
+    border-bottom: none;
+}
+
+.ease-list-item:hover {
+    background-color: #f3f4f6;
+}
+
+/* Ensure focus outline is drawn inward to prevent clipping */
+.ease-list:focus-visible {
+    outline: 2px solid #3b82f6;
+    outline-offset: -2px; /* Pulls the outline inward to be contained within the bounding box */
+}


### PR DESCRIPTION
## Pull Request Description

This submission provides a fix for issue #59773 where the `ease-list` component suffers from a clipping issue. When placed inside a container with `overflow: hidden` or `overflow: auto`, its focus ring gets cut off, which degrades the accessibility experience. The proposed solution uses `outline-offset: -2px` to pull the focus outline inward so it remains fully visible within its bounding box.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other (describe below)
  - Bug fix demonstration for the `ease-list` component clipping issue (#59773).

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

It provides a CSS enhancement for `ease-list` to ensure its focus outline is completely visible and never clipped by parent container overflow settings.

**How does a developer use it?**

```html
<div style="overflow: hidden;">
  <ul class="ease-list" tabindex="0">
    <li class="ease-list-item">Item 1</li>
    <li class="ease-list-item">Item 2</li>
    <li class="ease-list-item">Item 3</li>
  </ul>
</div>
