### PR TITLE
Fix #59757: ease-drawer focus outline clipped by parent overflow

### DIFF
--- a/submissions/examples/ease-drawer-focus-bug-fix-59757/README.md
+++ b/submissions/examples/ease-drawer-focus-bug-fix-59757/README.md
@@ -1,0 +1,18 @@
+# Ease Drawer Focus Bug Fix (#59757)
+
+## What it does
+This submission provides a fix for Issue #59757, where the `ease-drawer` component's focus outline gets clipped if it is placed inside a container with `overflow: hidden` or `overflow: auto`.
+
+## How to use it
+To fix the clipping issue, apply a negative `outline-offset` to the `:focus` and `:focus-visible` states of the drawer. 
+
+```css
+.ease-drawer:focus,
+.ease-drawer:focus-visible {
+    outline: 4px solid var(--primary);
+    outline-offset: -4px; /* Prevents clipping by drawing the outline inside the element's bounding box */
+}
+```
+
+## Why it fits EaseMotion CSS
+Accessibility should never compromise visual aesthetics. By using a negative outline offset, we retain the highly visible native focus ring ensuring great accessibility, while preventing unwanted visual clipping from parent containers. This provides a clean, polished experience that aligns perfectly with EaseMotion's standards.

--- a/submissions/examples/ease-drawer-focus-bug-fix-59757/demo.html
+++ b/submissions/examples/ease-drawer-focus-bug-fix-59757/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ease Drawer Focus Bug Fix #59757</title>
+    <link rel="stylesheet" href="style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div class="showcase-container">
+        <header>
+            <h1>Ease Drawer Focus Outline Fix</h1>
+            <p>Issue #59757: Focus outline is clipped by parent overflow.</p>
+        </header>
+        
+        <main>
+            <section class="demo-section">
+                <h2>Before (Buggy Behavior Simulation)</h2>
+                <div class="drawer-wrapper wrapper-buggy">
+                    <div class="ease-drawer drawer-buggy" tabindex="0">
+                        <h3>Drawer Content</h3>
+                        <p>Focus me (Tab)! The outline is clipped by the hidden overflow.</p>
+                    </div>
+                </div>
+            </section>
+
+            <section class="demo-section">
+                <h2>After (Fixed Behavior)</h2>
+                <div class="drawer-wrapper wrapper-fixed">
+                    <div class="ease-drawer drawer-fixed" tabindex="0">
+                        <h3>Drawer Content</h3>
+                        <p>Focus me (Tab)! The outline is fully visible inside the box.</p>
+                    </div>
+                </div>
+            </section>
+        </main>
+    </div>
+</body>
+</html>

--- a/submissions/examples/ease-drawer-focus-bug-fix-59757/style.css
+++ b/submissions/examples/ease-drawer-focus-bug-fix-59757/style.css
@@ -1,0 +1,103 @@
+:root {
+    --primary: #3b82f6;
+    --primary-focus: #2563eb;
+    --bg: #f8fafc;
+    --text: #0f172a;
+    --drawer-bg: #ffffff;
+    --drawer-border: #e2e8f0;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: 'Inter', sans-serif;
+    background-color: var(--bg);
+    color: var(--text);
+    padding: 2rem;
+    line-height: 1.5;
+}
+
+.showcase-container {
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+header {
+    margin-bottom: 2rem;
+    text-align: center;
+}
+
+h1 {
+    font-size: 2rem;
+    margin-bottom: 0.5rem;
+}
+
+p {
+    color: #475569;
+}
+
+.demo-section {
+    background: #ffffff;
+    padding: 2rem;
+    border-radius: 12px;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+    margin-bottom: 2rem;
+}
+
+h2 {
+    font-size: 1.25rem;
+    margin-bottom: 1.5rem;
+    border-bottom: 1px solid var(--drawer-border);
+    padding-bottom: 0.5rem;
+}
+
+/* Wrapper to simulate the overflow issue */
+.drawer-wrapper {
+    width: 100%;
+    height: 150px;
+    background: #f1f5f9;
+    border: 1px dashed #cbd5e1;
+    border-radius: 8px;
+    position: relative;
+    overflow: hidden; /* This causes the clipping */
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+/* Base Drawer Styles */
+.ease-drawer {
+    width: 300px;
+    height: 100%;
+    max-height: 120px;
+    background: var(--drawer-bg);
+    border: 1px solid var(--drawer-border);
+    border-radius: 8px;
+    padding: 1rem;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+}
+
+.ease-drawer h3 {
+    margin-bottom: 0.5rem;
+    font-size: 1.1rem;
+}
+
+/* Focus Styles - Buggy (Default Outline) */
+.drawer-buggy:focus,
+.drawer-buggy:focus-visible {
+    outline: 4px solid var(--primary);
+    /* No outline-offset or inset box-shadow, so it gets clipped by .drawer-wrapper's hidden overflow */
+}
+
+/* Focus Styles - Fixed (Negative Outline Offset) */
+.drawer-fixed:focus,
+.drawer-fixed:focus-visible {
+    outline: 4px solid var(--primary);
+    outline-offset: -4px; /* Fix: Pulls the outline inside the element's bounding box */
+}


### PR DESCRIPTION
## Pull Request Description

This PR provides a fix for Issue #59757, where the `ease-drawer` component's focus outline is partially or entirely clipped when it is placed inside a wrapper `div` with `overflow: hidden` or `overflow: auto`. The solution demonstrates using a negative `outline-offset` to keep the focus ring entirely contained within the element's bounding box.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

It resolves accessibility visual regressions by using negative outline-offset to stop focus rings from getting cut off by overflowing parent containers.

**How does a developer use it?**

```css
/* Apply the negative outline-offset to focus and focus-visible states */
.ease-drawer:focus,
.ease-drawer:focus-visible {
    outline: 4px solid var(--primary);
    outline-offset: -4px; 
}
