### PR TITLE
feat: add CSS 3D-flip pricing table for gaming hub layout (#59150)

### DIFF
--- a/submissions/examples/3d-flip-pricing-table/README.md
+++ b/submissions/examples/3d-flip-pricing-table/README.md
@@ -1,0 +1,35 @@
+# CSS 3D-Flip Pricing Table — Gaming Hub Layout
+
+A pure CSS/HTML pricing table for gaming platform layouts. Each plan card flips in 3D on hover to reveal its full feature list on the back face, with a highlighted "most popular" tier in the middle.
+
+## Files
+
+- `demo.html` — Clean HTML5 markup for the pricing section
+- `style.css` — All styling, 3D flip logic, and responsive rules
+- `README.md` — This file
+
+## Features
+
+- **3D card flip on hover**: front shows plan name and price, back reveals the full feature list using `transform-style: preserve-3d` and `backface-visibility: hidden`
+- **Featured plan highlight**: middle "Pro Gamer" tier has an accent border, glow, and a "Most popular" badge
+- **Checkmark feature list**: back-face features use a custom `::before` checkmark instead of default bullets
+- **Fully responsive**: 3-column grid collapses to a single centered column on smaller viewports
+- **Accessible motion fallback**: under `prefers-reduced-motion: reduce`, the flip animation is disabled and the back content is shown directly on hover instead, so features remain reachable without relying on 3D transforms
+
+## CSS Techniques Used
+
+- `perspective` on the grid container plus `transform-style: preserve-3d` on each card for the 3D flip effect
+- `backface-visibility: hidden` to hide the non-active face during rotation
+- `rotateY(180deg)` triggered on `:hover` of the card wrapper
+- `clamp()` for responsive heading sizing
+- A single `prefers-reduced-motion` block that swaps the 3D flip for a simple hover-reveal
+
+## Usage
+
+Open `demo.html` directly in a browser — no build step or dependencies required.
+
+## Customization
+
+- Update plan names, prices, and feature lists directly in `demo.html`
+- Change the accent gradient in `.featured-badge` and `.btn-primary` to match your brand
+- Adjust flip speed via the `transition` duration on `.flip-card-inner`

--- a/submissions/examples/3d-flip-pricing-table/demo.html
+++ b/submissions/examples/3d-flip-pricing-table/demo.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Gaming Hub - 3D Flip Pricing Table</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <section class="pricing-section">
+    <div class="pricing-header">
+      <span class="pricing-badge">Choose your plan</span>
+      <h1 class="pricing-title">Level up your access</h1>
+      <p class="pricing-subtitle">Hover a card to see what's inside</p>
+    </div>
+
+    <div class="pricing-grid">
+
+      <div class="flip-card">
+        <div class="flip-card-inner">
+          <div class="flip-card-front">
+            <span class="plan-name">Rookie</span>
+            <div class="plan-price"><span class="price-amount">$0</span><span class="price-period">/mo</span></div>
+            <p class="plan-tagline">Get started for free</p>
+            <span class="flip-hint">Hover to see features</span>
+          </div>
+          <div class="flip-card-back">
+            <h3 class="back-title">What's included</h3>
+            <ul class="feature-list">
+              <li>Access to public lobbies</li>
+              <li>Basic profile customization</li>
+              <li>Community chat access</li>
+              <li>Standard matchmaking</li>
+            </ul>
+            <button class="btn btn-outline">Get started</button>
+          </div>
+        </div>
+      </div>
+
+      <div class="flip-card featured">
+        <div class="flip-card-inner">
+          <div class="flip-card-front">
+            <span class="featured-badge">Most popular</span>
+            <span class="plan-name">Pro Gamer</span>
+            <div class="plan-price"><span class="price-amount">$12</span><span class="price-period">/mo</span></div>
+            <p class="plan-tagline">For serious competitors</p>
+            <span class="flip-hint">Hover to see features</span>
+          </div>
+          <div class="flip-card-back">
+            <h3 class="back-title">What's included</h3>
+            <ul class="feature-list">
+              <li>Everything in Rookie</li>
+              <li>Priority matchmaking</li>
+              <li>Custom emotes and badges</li>
+              <li>Tournament entry access</li>
+              <li>Ad-free experience</li>
+            </ul>
+            <button class="btn btn-primary">Upgrade now</button>
+          </div>
+        </div>
+      </div>
+
+      <div class="flip-card">
+        <div class="flip-card-inner">
+          <div class="flip-card-front">
+            <span class="plan-name">Legend</span>
+            <div class="plan-price"><span class="price-amount">$29</span><span class="price-period">/mo</span></div>
+            <p class="plan-tagline">Full hub, no limits</p>
+            <span class="flip-hint">Hover to see features</span>
+          </div>
+          <div class="flip-card-back">
+            <h3 class="back-title">What's included</h3>
+            <ul class="feature-list">
+              <li>Everything in Pro Gamer</li>
+              <li>Dedicated server slots</li>
+              <li>Early access to new features</li>
+              <li>1-on-1 coaching sessions</li>
+              <li>Exclusive Legend badge</li>
+            </ul>
+            <button class="btn btn-outline">Go Legend</button>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </section>
+</body>
+</html>

--- a/submissions/examples/3d-flip-pricing-table/style.css
+++ b/submissions/examples/3d-flip-pricing-table/style.css
@@ -1,0 +1,236 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Segoe UI', system-ui, sans-serif;
+  background: #0b0f19;
+  color: #ffffff;
+}
+
+.pricing-section {
+  min-height: 100vh;
+  padding: 4rem 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: radial-gradient(circle at 50% 0%, #1a1f35 0%, #0b0f19 60%);
+}
+
+.pricing-header {
+  text-align: center;
+  max-width: 600px;
+  margin-bottom: 3rem;
+}
+
+.pricing-badge {
+  display: inline-block;
+  padding: 0.4rem 1rem;
+  border-radius: 999px;
+  background: rgba(124, 58, 237, 0.15);
+  border: 1px solid rgba(124, 58, 237, 0.4);
+  color: #c4b5fd;
+  font-size: 0.85rem;
+  font-weight: 600;
+  margin-bottom: 1.25rem;
+}
+
+.pricing-title {
+  font-size: clamp(2rem, 5vw, 3rem);
+  font-weight: 800;
+  margin-bottom: 0.75rem;
+}
+
+.pricing-subtitle {
+  color: #9ca3af;
+  font-size: 1.05rem;
+}
+
+.pricing-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 280px));
+  gap: 2rem;
+  justify-content: center;
+  perspective: 1500px;
+}
+
+.flip-card {
+  height: 380px;
+}
+
+.flip-card-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transition: transform 0.7s cubic-bezier(0.4, 0.2, 0.2, 1);
+  transform-style: preserve-3d;
+}
+
+.flip-card:hover .flip-card-inner {
+  transform: rotateY(180deg);
+}
+
+.flip-card-front,
+.flip-card-back {
+  position: absolute;
+  inset: 0;
+  backface-visibility: hidden;
+  border-radius: 16px;
+  padding: 2rem 1.75rem;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: #131826;
+}
+
+.flip-card-front {
+  align-items: center;
+  text-align: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.flip-card-back {
+  transform: rotateY(180deg);
+  background: #171d30;
+}
+
+.featured .flip-card-front,
+.featured .flip-card-back {
+  border-color: #7c3aed;
+  box-shadow: 0 0 30px rgba(124, 58, 237, 0.25);
+}
+
+.featured-badge {
+  position: absolute;
+  top: 1rem;
+  padding: 0.25rem 0.75rem;
+  background: linear-gradient(90deg, #7c3aed, #ec4899);
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.plan-name {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: #c4b5fd;
+}
+
+.plan-price {
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+  margin: 0.5rem 0;
+}
+
+.price-amount {
+  font-size: 2.5rem;
+  font-weight: 800;
+}
+
+.price-period {
+  color: #9ca3af;
+  font-size: 0.95rem;
+}
+
+.plan-tagline {
+  color: #9ca3af;
+  font-size: 0.9rem;
+  margin-bottom: 1.5rem;
+}
+
+.flip-hint {
+  margin-top: auto;
+  font-size: 0.8rem;
+  color: #6b7280;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+}
+
+.back-title {
+  font-size: 1.05rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+  color: #c4b5fd;
+}
+
+.feature-list {
+  list-style: none;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.feature-list li {
+  font-size: 0.9rem;
+  color: #e5e7eb;
+  padding-left: 1.25rem;
+  position: relative;
+}
+
+.feature-list li::before {
+  content: "✓";
+  position: absolute;
+  left: 0;
+  color: #a78bfa;
+  font-weight: 700;
+}
+
+.btn {
+  margin-top: 1.25rem;
+  padding: 0.75rem 1rem;
+  border-radius: 10px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.btn-primary {
+  background: linear-gradient(90deg, #7c3aed, #ec4899);
+  color: #fff;
+}
+
+.btn-outline {
+  background: transparent;
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+}
+
+.btn:hover {
+  transform: translateY(-2px);
+}
+
+@media (max-width: 900px) {
+  .pricing-grid {
+    grid-template-columns: minmax(0, 320px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .flip-card-inner {
+    transition: none;
+  }
+  .flip-card:hover .flip-card-inner {
+    transform: none;
+  }
+  .flip-card-back {
+    position: relative;
+    transform: none;
+    display: none;
+  }
+  .flip-card:hover .flip-card-back {
+    display: flex;
+  }
+  .flip-card:hover .flip-card-front {
+    display: none;
+  }
+}


### PR DESCRIPTION
Adds a pure CSS/HTML pricing table with 3D card-flip hover effect revealing feature lists on the back face. Includes a highlighted featured plan and a prefers-reduced-motion fallback that swaps the flip for a simple hover-reveal.

Closes #59150

## Pull Request Description
Adds a CSS 3D-Flip Pricing Table for gaming hub layouts. Three plan cards sit in a responsive grid; hovering any card flips it in 3D to reveal its feature list on the back face. The middle "Pro Gamer" plan is highlighted as the featured tier with an accent glow and badge.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/3d-flip-pricing-table/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A 3D hover-flip pricing table where each card's back face reveals its full feature list.

**How does a developer use it?**
```html
<div class="flip-card">
  <div class="flip-card-inner">
    <div class="flip-card-front">
      <!-- plan name, price, tagline -->
    </div>
    <div class="flip-card-back">
      <!-- feature list, CTA button -->
    </div>
  </div>
</div>
```
Adding `featured` as a class on `.flip-card` applies the highlighted styling for a "most popular" plan.

**Why does it fit EaseMotion CSS?**
It's pure CSS/HTML with no JS dependencies, uses semantic, readable class names (`flip-card`, `flip-card-front`, `flip-card-back`), and follows an animation-first approach using `transform-style: preserve-3d` and `backface-visibility` rather than opacity toggling or JS-driven state.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
This is a resubmission of an earlier PR that was auto-closed for containing an empty `README.md`. All three files (`demo.html`, `style.css`, `README.md`) were verified with `wc -l` before commit this time to confirm nonzero content.