### PR TITLE
feat: add fix for ease-code-block focus outline clipping

### DIFF
--- a/submissions/examples/ease-code-block-focus-outline-clipped-59748/README.md
+++ b/submissions/examples/ease-code-block-focus-outline-clipped-59748/README.md
@@ -1,0 +1,14 @@
+# Fix: ease-code-block focus outline is clipped by parent overflow
+
+### Description
+The `ease-code-block` component suffers from a clipping issue where its focus ring (outline or box-shadow) is cut off if placed inside a container with `overflow: hidden` or `overflow: auto`. This degrades the accessibility experience.
+
+### Expected Behavior
+The focus ring should be fully visible, either by using a negative outline offset or an inset box-shadow, so it is contained within the element's bounding box and avoids clipping from a parent container.
+
+### Implementation
+- `style.css`: Uses `outline-offset: -2px` on `:focus-visible` to ensure the focus outline is rendered inward and is not clipped by any parent `overflow` container.
+- `demo.html`: Demonstrates the `ease-code-block` component inside an `overflow: hidden` wrapper.
+
+### Testing
+Open `demo.html` in a browser and press `Tab` to focus the code block. Verify that the focus outline is completely visible and not truncated.

--- a/submissions/examples/ease-code-block-focus-outline-clipped-59748/demo.html
+++ b/submissions/examples/ease-code-block-focus-outline-clipped-59748/demo.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-code-block Focus Outline Fix - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+        font-family: system-ui, -apple-system, sans-serif;
+        padding: 2rem;
+        background-color: #f9fafb;
+    }
+    .demo-container {
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+        max-width: 600px;
+        margin: 0 auto;
+    }
+    .overflow-container {
+        overflow: hidden;
+        border: 1px solid #ccc;
+        padding: 1rem;
+        border-radius: 8px;
+        background-color: #fff;
+        /* Constrain dimensions to show clipping issue if not fixed */
+        height: auto;
+    }
+    .instructions {
+        background: #eff6ff;
+        padding: 1.5rem;
+        border-left: 4px solid #3b82f6;
+        border-radius: 0 8px 8px 0;
+        margin-bottom: 2rem;
+    }
+  </style>
+</head>
+<body>
+  <main class="demo-container">
+    <h1>Focus Outline Clipping Fix for ease-code-block</h1>
+    
+    <div class="instructions">
+      <p><strong>Steps to Reproduce:</strong></p>
+      <ol>
+        <li>Click inside the container or use the <code>Tab</code> key to focus the code block component.</li>
+        <li>Notice that the focus ring is fully visible and not clipped by the <code>overflow: hidden</code> container, due to the negative outline-offset.</li>
+      </ol>
+    </div>
+
+    <div class="overflow-container">
+      <code class="ease-code-block" tabindex="0">const greet = () => {
+  console.log("Hello, world!");
+};</code>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-code-block-focus-outline-clipped-59748/style.css
+++ b/submissions/examples/ease-code-block-focus-outline-clipped-59748/style.css
@@ -1,0 +1,26 @@
+/* Base styles for ease-code-block to demonstrate the fix */
+.ease-code-block {
+  display: block;
+  padding: 1rem;
+  background-color: #1e1e1e;
+  color: #d4d4d4;
+  border-radius: 6px;
+  font-family: monospace;
+  font-size: 14px;
+  line-height: 1.5;
+  white-space: pre;
+  overflow-x: auto;
+  border: 1px solid #333;
+  margin: 0;
+  transition: outline 0.2s ease;
+}
+
+/* 
+  Fix: Apply a negative outline-offset on focus-visible
+  so the focus ring is drawn inside the element, preventing
+  it from being clipped by a parent with overflow: hidden.
+*/
+.ease-code-block:focus-visible {
+  outline: 2px solid #3b82f6;
+  outline-offset: -2px;
+}


### PR DESCRIPTION
## Pull Request Description

This PR fixes a bug in the `ease-code-block` component where its focus ring (outline) gets partially or entirely cut off if placed inside a container with `overflow: hidden` or `overflow: auto`. The solution applies a negative `outline-offset` to ensure the focus outline is rendered inward and remains fully visible, significantly improving accessibility. 
Resolves #59748.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Fixes the focus outline clipping issue for `ease-code-block` when placed inside an overflow container, ensuring accessibility compliance.

**How does a developer use it?**

```html
<div style="overflow: hidden;">
  <code class="ease-code-block" tabindex="0">const greet = () => {
  console.log("Hello, world!");
};</code>
</div>
