### PR TITLE
docs(modal): document dead-code fix in checkModal() (#60093)

### DIFF
--- a/submissions/docs/modal-dead-code-fix-aaniya22/README.md
+++ b/submissions/docs/modal-dead-code-fix-aaniya22/README.md
@@ -1,0 +1,71 @@
+# Dead Code Fix — checkModal() in core/modal.js
+
+Fixes [#60093](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/60093)
+
+## What
+
+`checkModal()` in `core/modal.js` (lines 28-30) contains an
+unreachable `if` block. It checks whether `overlay` does **not** have
+the `is-active` class, but `is-active` is added on line 24 —
+immediately before this check runs. The condition is therefore always
+`false`, and the block inside it never executes.
+
+## Why
+
+Dead code adds confusion for anyone reading or maintaining
+`checkModal()` later — it looks like conditional logic that matters,
+but it's a no-op. No functional bug exists today (nothing currently
+depends on the dead branch), so this is a clarity / maintainability
+fix, not a behavior change.
+
+## How
+
+Per the contribution guide, contributors cannot edit `core/` directly
+— that path is maintainer-only. This submission documents the exact
+change for the maintainer to apply, and includes a standalone demo
+that mirrors the **corrected** logic to prove the fix preserves
+existing modal-focus behavior.
+
+### Current code (buggy)
+
+\`\`\`js
+const modal = overlay.querySelector(".ease-modal");
+if (modal) {
+  if (!overlay.classList.contains("is-active")) { // ALWAYS FALSE
+    previousFocusedElement = document.activeElement;
+  }
+  modal.setAttribute("tabindex", "-1");
+  modal.focus();
+}
+\`\`\`
+
+### Suggested fix
+
+\`\`\`js
+const modal = overlay.querySelector(".ease-modal");
+if (modal) {
+  modal.setAttribute("tabindex", "-1");
+  modal.focus();
+}
+\`\`\`
+
+The unreachable inner `if` block is removed entirely. `previousFocusedElement`
+was only ever set inside that dead branch, so removing it does not
+change any currently-observable behavior — that assignment never ran.
+
+## Files
+
+- `README.md` — this file, with the exact before/after patch for `core/modal.js`.
+- `demo.html` — standalone repro showing the modal open/focus/close
+  cycle working correctly using the corrected `checkModal()` logic,
+  reimplemented locally (does not import the real `core/modal.js`,
+  per the no-core-edits rule).
+- `style.css` — minimal styling for the demo modal/overlay.
+
+## Testing
+
+1. Open `demo.html` in a browser.
+2. Click "Open Modal" — focus moves into the modal, tabindex is set.
+3. Close the modal (Escape or close button) — no console errors,
+   focus behavior matches current production behavior with the dead
+   branch removed.

--- a/submissions/docs/modal-dead-code-fix-aaniya22/demo.html
+++ b/submissions/docs/modal-dead-code-fix-aaniya22/demo.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>checkModal() dead code fix — demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      font-family: system-ui, sans-serif;
+      max-width: 640px;
+      margin: 3rem auto;
+      padding: 0 1.5rem;
+      line-height: 1.6;
+    }
+    h1 { font-size: 1.3rem; }
+    p.note { color: #555; font-size: 0.9rem; }
+  </style>
+</head>
+<body>
+  <h1>checkModal() — Dead Code Fix (#60093)</h1>
+  <p class="note">
+    This demo reimplements the <strong>corrected</strong> version of
+    <code>checkModal()</code> locally (the unreachable
+    <code>is-active</code> check has been removed). It does not import
+    or modify the real <code>core/modal.js</code>, per the
+    no-core-edits contribution rule — this is proof the corrected
+    logic preserves existing focus behavior.
+  </p>
+
+  <button id="openBtn">Open Modal</button>
+
+  <div class="demo-overlay" id="overlay">
+    <div class="ease-modal" id="modal" tabindex="-1">
+      <h2>Example Modal</h2>
+      <p>Focus was moved here via the corrected <code>checkModal()</code>.</p>
+      <button id="closeBtn">Close</button>
+    </div>
+  </div>
+
+  <script>
+    const overlay = document.getElementById("overlay");
+    const openBtn = document.getElementById("openBtn");
+    const closeBtn = document.getElementById("closeBtn");
+
+    function checkModal() {
+      const modal = overlay.querySelector(".ease-modal");
+      if (modal) {
+        modal.setAttribute("tabindex", "-1");
+        modal.focus();
+      }
+    }
+
+    function openModal() {
+      overlay.classList.add("is-active");
+      checkModal();
+    }
+
+    function closeModal() {
+      overlay.classList.remove("is-active");
+      openBtn.focus();
+    }
+
+    openBtn.addEventListener("click", openModal);
+    closeBtn.addEventListener("click", closeModal);
+    document.addEventListener("keydown", (e) => {
+      if (e.key === "Escape" && overlay.classList.contains("is-active")) {
+        closeModal();
+      }
+    });
+  </script>
+</body>
+</html>

--- a/submissions/docs/modal-dead-code-fix-aaniya22/style.css
+++ b/submissions/docs/modal-dead-code-fix-aaniya22/style.css
@@ -1,0 +1,44 @@
+.demo-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: none;
+  align-items: center;
+  justify-content: center;
+}
+
+.demo-overlay.is-active {
+  display: flex;
+}
+
+.ease-modal {
+  background: #fff;
+  border-radius: 10px;
+  padding: 1.5rem 1.75rem;
+  max-width: 360px;
+  width: 90%;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+}
+
+.ease-modal h2 {
+  margin-top: 0;
+  font-size: 1.1rem;
+}
+
+.ease-modal button {
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 6px;
+  background: #6c63ff;
+  color: #fff;
+  cursor: pointer;
+}
+
+#openBtn {
+  padding: 0.6rem 1.2rem;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  background: #fff;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Pull Request Description
Documents a fix for #60093 — `checkModal()` in `core/modal.js` contains
an unreachable `if` block (lines 28-30) checking `!overlay.classList.contains("is-active")`,
which is always false since `is-active` is added on line 24, just before
this check runs. This submission provides the exact before/after patch
and a standalone demo proving the corrected logic preserves existing
modal-focus behavior.

## Type of Change
- [x] Other (describe below)

**Other:** Documentation of a core bug fix. Per CONTRIBUTING.md,
contributors cannot edit `core/` directly, so this submission documents
the fix in `submissions/docs/` for the maintainer to apply.

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/docs/modal-dead-code-fix-aaniya22/`)
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description
**What does this add?**
A documented dead-code fix for `checkModal()` in `core/modal.js`.

**How does a developer use it?**
N/A — this is an internal logic fix, not a new class or component.

**Why does it fit EaseMotion CSS?**
Keeps core logic clean and maintainable, consistent with the framework's curated-quality philosophy.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer
The exact patch (before/after) is in `README.md`, ready to apply directly
to `core/modal.js` lines 28-30. `demo.html` reimplements the corrected
logic locally to confirm no behavior regression.