### PR TITLE
Add ease-campfire-crackle component

### DIFF
--- a/submissions/examples/campfire-crackle-ij/README.md
+++ b/submissions/examples/campfire-crackle-ij/README.md
@@ -1,0 +1,7 @@
+# ease-campfire-crackle
+A campfire that flickers and crackles in the night.
+## Run
+Open `demo.html` directly in a browser to watch the fire crackle.
+## Notes
+- The flames dance over the logs.
+- Embers rise into the dark.

--- a/submissions/examples/campfire-crackle-ij/demo.html
+++ b/submissions/examples/campfire-crackle-ij/demo.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-campfire-crackle demo</title>
+</head>
+<body>
+<div class="ca-app">
+  <div class="ca-sky">
+    <div class="ca-moon"></div>
+    <div class="ca-star ca-star-1"></div>
+    <div class="ca-star ca-star-2"></div>
+  </div>
+  <div class="ca-ground"></div>
+  <div class="ca-stone ca-stone-1"></div>
+  <div class="ca-stone ca-stone-2"></div>
+  <div class="ca-stone ca-stone-3"></div>
+  <div class="ca-stone ca-stone-4"></div>
+  <div class="ca-log ca-log-1"></div>
+  <div class="ca-log ca-log-2"></div>
+  <div class="ca-flame ca-flame-1"></div>
+  <div class="ca-flame ca-flame-2"></div>
+  <div class="ca-flame ca-flame-3"></div>
+  <div class="ca-spark ca-spark-1"></div>
+  <div class="ca-spark ca-spark-2"></div>
+  <div class="ca-spark ca-spark-3"></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/campfire-crackle-ij/style.css
+++ b/submissions/examples/campfire-crackle-ij/style.css
@@ -1,0 +1,28 @@
+:root{--ca-night:#1a2240;--ca-ember:#ff8a2e;--ca-wood:#5a3a22}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#2a3050,#141830);font-family:'Verdana',sans-serif}
+.ca-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#222c52,#10162e);box-shadow:0 16px 36px rgba(0,0,0,0.5)}
+.ca-sky{position:absolute;top:0;left:0;right:0;bottom:0;pointer-events:none}
+.ca-moon{position:absolute;top:26px;right:44px;width:34px;height:34px;border-radius:50%;background:#f3ead8;box-shadow:0 0 22px #f3ead8}
+.ca-star{position:absolute;width:6px;height:6px;border-radius:50%;background:#ffe08a;animation:twinkle-star-campfire-crackle 1.8s ease-in-out infinite}
+.ca-star-1{top:40px;left:60px}
+.ca-star-2{top:20px;left:150px;animation-delay:0.9s}
+.ca-ground{position:absolute;left:0;right:0;bottom:0;height:64px;background:#3a2a1e;box-shadow:inset 0 6px 0 rgba(0,0,0,0.3)}
+.ca-stone{position:absolute;bottom:56px;width:26px;height:20px;border-radius:8px;background:#5a6678;box-shadow:inset 0 0 0 4px #3a4452}
+.ca-stone-1{left:120px}
+.ca-stone-2{left:148px;bottom:64px}
+.ca-stone-3{right:120px}
+.ca-stone-4{right:148px;bottom:64px}
+.ca-log{position:absolute;bottom:58px;width:60px;height:16px;border-radius:8px;background:var(--ca-wood);box-shadow:inset 0 0 0 4px #3a2416}
+.ca-log-1{left:132px;transform:rotate(14deg)}
+.ca-log-2{right:132px;transform:rotate(-14deg)}
+.ca-flame{position:absolute;bottom:64px;width:26px;height:46px;border-radius:50% 50% 8px 8px;background:linear-gradient(180deg,#ffe08a,#ff8a2e);transform-origin:bottom center;animation:flicker-flame-campfire-crackle 0.4s ease-in-out infinite}
+.ca-flame-1{left:150px}
+.ca-flame-2{left:170px;height:36px;animation-delay:0.12s}
+.ca-flame-3{left:190px;height:40px;animation-delay:0.24s}
+.ca-spark{position:absolute;bottom:100px;width:8px;height:8px;border-radius:50%;background:var(--ca-ember);box-shadow:0 0 12px var(--ca-ember);animation:rise-spark-campfire-crackle 1.4s ease-out infinite}
+.ca-spark-1{left:162px}
+.ca-spark-2{left:178px;animation-delay:0.46s}
+.ca-spark-3{left:186px;animation-delay:0.92s}
+@keyframes flicker-flame-campfire-crackle{0%,100%{transform:scaleY(1) scaleX(1)}50%{transform:scaleY(1.25) scaleX(0.9)}}
+@keyframes rise-spark-campfire-crackle{0%{transform:translateY(0) scale(0.6);opacity:0.9}100%{transform:translateY(-90px) scale(1.4);opacity:0}}
+@keyframes twinkle-star-campfire-crackle{0%,100%{opacity:1}50%{opacity:0.2}}


### PR DESCRIPTION
## Component: ease-campfire-crackle — flames flicker, sparks rise, and stars twinkle

**Closes #61314**

### What this adds
A nighttime campfire circled by stones: the orange flames flicker and crackle over the crossed logs, embers rise into the dark, and two stars twinkle beside the moon.

### Acceptance Criteria covered
- Flames flicker over the logs
- Embers rise into the night
- Stones circle the fire pit

### Files
- submissions/examples/campfire-crackle-ij/demo.html
- submissions/examples/campfire-crackle-ij/style.css
- submissions/examples/campfire-crackle-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the fire crackle.