### PR TITLE
Add ease-bike-pedal-turn component

### DIFF
--- a/submissions/examples/bike-pedal-turn-ij/README.md
+++ b/submissions/examples/bike-pedal-turn-ij/README.md
@@ -1,0 +1,10 @@
+# ease-bike-pedal-turn
+
+A bicycle whose pedals turn the chainring while both wheels roll their spokes.
+
+## Run
+Open `demo.html` directly in a browser to watch the pedals turn.
+
+## Notes
+- Pedals spin in sync with the chainring.
+- Wheels roll their spokes in the opposite sense.

--- a/submissions/examples/bike-pedal-turn-ij/demo.html
+++ b/submissions/examples/bike-pedal-turn-ij/demo.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-bike-pedal-turn demo</title>
+</head>
+<body>
+<div class="bi-app">
+  <span class="bi-head">BICYCLE</span>
+  <span class="bi-speed">PEDALING</span>
+  <div class="bi-wheel bi-wheel-back">
+    <div class="bi-rim">
+      <div class="bi-spoke bi-spoke-a"></div>
+      <div class="bi-spoke bi-spoke-b"></div>
+      <div class="bi-spoke bi-spoke-c"></div>
+      <div class="bi-spoke bi-spoke-d"></div>
+      <div class="bi-hub"></div>
+    </div>
+  </div>
+  <div class="bi-frame"></div>
+  <div class="bi-chain"></div>
+  <div class="bi-seat"></div>
+  <div class="bi-handle"></div>
+  <div class="bi-crank">
+    <div class="bi-pedal bi-pedal-1"></div>
+    <div class="bi-pedal bi-pedal-2"></div>
+  </div>
+  <div class="bi-wheel bi-wheel-front">
+    <div class="bi-rim">
+      <div class="bi-spoke bi-spoke-a"></div>
+      <div class="bi-spoke bi-spoke-b"></div>
+      <div class="bi-spoke bi-spoke-c"></div>
+      <div class="bi-spoke bi-spoke-d"></div>
+      <div class="bi-hub"></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/bike-pedal-turn-ij/style.css
+++ b/submissions/examples/bike-pedal-turn-ij/style.css
@@ -1,0 +1,27 @@
+:root{--bi-body:#d8543a;--bi-tire:#2c3440;--bi-rim:#c8ced6;--bi-spoke:#8a94a4}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#f4efe6,#d8cdb8);font-family:'Segoe UI',sans-serif}
+.bi-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#f8f4ea,#d6c8ae);box-shadow:0 16px 36px rgba(0,0,0,0.3)}
+.bi-head{position:absolute;top:16px;left:0;right:0;text-align:center;font-size:14px;font-weight:700;letter-spacing:6px;color:#7a5a3a}
+.bi-speed{position:absolute;top:44px;left:150px;font-size:12px;font-weight:700;letter-spacing:4px;color:#a05a2a;animation:wave-speed-bike-pedal-turn 2s ease-in-out infinite}
+.bi-wheel{position:absolute;width:150px;height:150px;border-radius:50%;background:var(--bi-tire);box-shadow:inset 0 0 0 10px #1c222c}
+.bi-wheel-back{left:28px;bottom:52px}
+.bi-wheel-front{right:28px;bottom:52px}
+.bi-rim{position:absolute;top:14px;left:14px;width:122px;height:122px;border-radius:50%;background:var(--bi-rim);animation:roll-spoke-bike-pedal-turn 0.9s linear infinite}
+.bi-spoke{position:absolute;top:60px;left:10px;width:102px;height:2px;background:var(--bi-spoke)}
+.bi-spoke-a{transform:rotate(0deg)}
+.bi-spoke-b{transform:rotate(45deg)}
+.bi-spoke-c{transform:rotate(90deg)}
+.bi-spoke-d{transform:rotate(135deg)}
+.bi-hub{position:absolute;top:54px;left:54px;width:14px;height:14px;border-radius:50%;background:#2c3440}
+.bi-frame{position:absolute;top:104px;left:148px;width:4px;height:150px;background:var(--bi-body);transform:rotate(38deg);transform-origin:top;border-radius:3px}
+.bi-chain{position:absolute;top:236px;left:152px;width:68px;height:6px;background:repeating-linear-gradient(90deg,#8a94a4 0 5px,#3c4450 5px 9px);border-radius:4px;animation:flow-chain-bike-pedal-turn 0.45s linear infinite}
+.bi-seat{position:absolute;top:66px;left:186px;width:40px;height:10px;border-radius:5px;background:var(--bi-tire)}
+.bi-handle{position:absolute;top:46px;left:300px;width:48px;height:8px;border-radius:4px;background:var(--bi-tire)}
+.bi-crank{position:absolute;top:228px;left:176px;width:46px;height:46px;border-radius:50%;background:#c8ced6;box-shadow:inset 0 0 0 5px #8a94a4;animation:spin-crank-bike-pedal-turn 0.9s linear infinite}
+.bi-pedal{position:absolute;width:20px;height:7px;border-radius:3px;background:var(--bi-tire)}
+.bi-pedal-1{top:-6px;left:13px;transform:rotate(38deg)}
+.bi-pedal-2{bottom:-6px;left:13px;transform:rotate(38deg)}
+@keyframes spin-crank-bike-pedal-turn{from{transform:rotate(0deg)}to{transform:rotate(360deg)}}
+@keyframes roll-spoke-bike-pedal-turn{from{transform:rotate(0deg)}to{transform:rotate(-360deg)}}
+@keyframes flow-chain-bike-pedal-turn{from{background-position:0 0}to{background-position:-18px 0}}
+@keyframes wave-speed-bike-pedal-turn{0%,100%{transform:translateY(0)}50%{transform:translateY(-4px)}}


### PR DESCRIPTION
## Component: ease-bike-pedal-turn — pedals turn, spokes roll, and chain glides

**Closes #61351**

### What this adds
A bicycle in profile on a studio backdrop: the riderless pedals spin the chainring, both wheels roll their spokes around the rims, the chain glides along its run, and a speed banner waves above.

### Acceptance Criteria covered
- Pedals spin the chainring
- Wheel spokes roll around
- Speed banner waves above

### Files
- submissions/examples/bike-pedal-turn-ij/demo.html
- submissions/examples/bike-pedal-turn-ij/style.css
- submissions/examples/bike-pedal-turn-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the pedals turn.