### PR TITLE
Add ease-domino-tumble-fall component

### DIFF
--- a/submissions/examples/domino-tumble-fall-ij/README.md
+++ b/submissions/examples/domino-tumble-fall-ij/README.md
@@ -1,0 +1,10 @@
+# ease-domino-tumble-fall
+
+A row of dominoes that topples over one after another on a wooden board.
+
+## Run
+Open `demo.html` directly in a browser to watch the tiles fall.
+
+## Notes
+- Each tile tips with a small delay after the one before.
+- White pips flash as the row falls.

--- a/submissions/examples/domino-tumble-fall-ij/demo.html
+++ b/submissions/examples/domino-tumble-fall-ij/demo.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-domino-tumble-fall demo</title>
+</head>
+<body>
+<div class="do-app">
+  <div class="do-board">
+    <div class="do-tile do-tile-1"><span class="do-pip do-pip-a"></span><span class="do-pip do-pip-b"></span></div>
+    <div class="do-tile do-tile-2"><span class="do-pip do-pip-a"></span><span class="do-pip do-pip-b"></span></div>
+    <div class="do-tile do-tile-3"><span class="do-pip do-pip-a"></span><span class="do-pip do-pip-b"></span></div>
+    <div class="do-tile do-tile-4"><span class="do-pip do-pip-a"></span><span class="do-pip do-pip-b"></span></div>
+    <div class="do-tile do-tile-5"><span class="do-pip do-pip-a"></span><span class="do-pip do-pip-b"></span></div>
+    <div class="do-tile do-tile-6"><span class="do-pip do-pip-a"></span><span class="do-pip do-pip-b"></span></div>
+    <div class="do-tile do-tile-7"><span class="do-pip do-pip-a"></span><span class="do-pip do-pip-b"></span></div>
+    <div class="do-tile do-tile-8"><span class="do-pip do-pip-a"></span><span class="do-pip do-pip-b"></span></div>
+    <div class="do-tile do-tile-9"><span class="do-pip do-pip-a"></span><span class="do-pip do-pip-b"></span></div>
+    <span class="do-status">TUMBLE!</span>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/domino-tumble-fall-ij/style.css
+++ b/submissions/examples/domino-tumble-fall-ij/style.css
@@ -1,0 +1,20 @@
+:root{--do-board:#b0885a;--do-tile:#1c2230;--do-pip:#f4f6f8}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#e8dcc8,#c8b494);font-family:'Segoe UI',sans-serif}
+.do-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#f0e6d2,#d2c09e);box-shadow:0 16px 36px rgba(0,0,0,0.3)}
+.do-board{position:absolute;bottom:76px;left:34px;width:304px;height:170px;border-radius:10px;background:var(--do-board);box-shadow:inset 0 0 0 8px #8a6440}
+.do-tile{position:absolute;bottom:132px;width:22px;height:64px;border-radius:5px;background:var(--do-tile);box-shadow:inset 0 0 0 3px #3a4254;transform-origin:bottom center;animation:tip-tile-domino-tumble-fall 3.2s ease-in-out infinite}
+.do-pip{position:absolute;left:8px;width:6px;height:6px;border-radius:50%;background:var(--do-pip)}
+.do-pip-a{top:10px}
+.do-pip-b{top:28px}
+.do-tile-1{left:34px}
+.do-tile-2{left:64px;animation-delay:0.12s}
+.do-tile-3{left:94px;animation-delay:0.24s}
+.do-tile-4{left:124px;animation-delay:0.36s}
+.do-tile-5{left:154px;animation-delay:0.48s}
+.do-tile-6{left:184px;animation-delay:0.6s}
+.do-tile-7{left:214px;animation-delay:0.72s}
+.do-tile-8{left:244px;animation-delay:0.84s}
+.do-tile-9{left:274px;animation-delay:0.96s}
+.do-status{position:absolute;bottom:28px;left:0;right:0;text-align:center;font-size:15px;font-weight:700;letter-spacing:6px;color:#7a4a22;animation:flash-status-domino-tumble-fall 3.2s ease-in-out infinite}
+@keyframes tip-tile-domino-tumble-fall{0%{transform:rotate(0deg)}30%{transform:rotate(0deg)}100%{transform:rotate(-88deg)}}
+@keyframes flash-status-domino-tumble-fall{0%,28%{opacity:1}32%,100%{opacity:0.2}}


### PR DESCRIPTION
## Component: ease-domino-tumble-fall — tiles tip, row falls, and chain topples

**Closes #61368**

### What this adds
A row of black dominoes on a wooden board: the first tile tips into the next, and the whole line topples over one after another while their white pips flash as they fall.

### Acceptance Criteria covered
- First tile tips into the row
- Whole line topples in turn
- White pips flash as they fall

### Files
- submissions/examples/domino-tumble-fall-ij/demo.html
- submissions/examples/domino-tumble-fall-ij/style.css
- submissions/examples/domino-tumble-fall-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the tiles fall.