### PR TITLE
fix: ease-divider focus outline clipped by parent overflow (#59755)

### DIFF
--- a/submissions/examples/fix-ease-divider-focus-clip-59755-ak/README.md
+++ b/submissions/examples/fix-ease-divider-focus-clip-59755-ak/README.md
@@ -1,0 +1,27 @@
+# Fix: ease-divider Focus Outline Clipped by Parent Overflow
+
+## Description
+Fixes #59755 — the `.ease-divider` component's focus ring (outline/box-shadow) was
+partially or fully clipped when the component was placed inside a wrapper with
+`overflow: hidden` or `overflow: auto`, since the default outline is drawn *outside*
+the element's border box.
+
+## Fix
+- Replaced the external outline with a **negative `outline-offset`** so the outline
+  renders *inside* the element's bounding box.
+- Layered an **inset `box-shadow`** on top for stronger visibility and as a fallback
+  for environments where `outline` rendering is suppressed or overridden.
+- Verified against both light and dark color schemes.
+
+## Usage
+Include `style.css` and add `tabindex="0"` to make the divider keyboard-focusable
+(see `demo.html`). No JavaScript required.
+
+## Accessibility Compliance
+Ensures the focus indicator remains fully visible per WCAG 2.1 Success Criterion
+2.4.7 (Focus Visible), even when the component is nested inside a container that
+clips overflowing content.
+
+## Testing
+Open `demo.html` in a browser, press `Tab` to focus the divider inside the
+`overflow: hidden` wrapper, and confirm the focus ring is fully visible and not cut off.

--- a/submissions/examples/fix-ease-divider-focus-clip-59755-ak/demo.html
+++ b/submissions/examples/fix-ease-divider-focus-clip-59755-ak/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-divider — Focus Outline Clipping Fix (#59755)</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      max-width: 640px;
+      margin: 3rem auto;
+      padding: 0 1.5rem;
+      line-height: 1.6;
+      color: #111827;
+    }
+    h1 { font-size: 1.5rem; }
+    h2 { font-size: 1.1rem; margin-top: 2rem; }
+    p.hint {
+      font-size: 0.9rem;
+      color: #6b7280;
+    }
+    code {
+      background: #f3f4f6;
+      padding: 0.15rem 0.4rem;
+      border-radius: 4px;
+      font-size: 0.85em;
+    }
+  </style>
+</head>
+<body>
+  <h1>ease-divider: Focus Outline Clipping Fix</h1>
+  <p>Fixes <a href="https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/59755">#59755</a> —
+     the focus ring on <code>.ease-divider</code> was clipped when placed inside a
+     parent with <code>overflow: hidden</code> or <code>overflow: auto</code>.</p>
+
+  <h2>Reproduction: divider inside <code>overflow: hidden</code></h2>
+  <p class="hint">Press <kbd>Tab</kbd> to focus the divider below. The focus ring stays
+     fully visible because it is drawn inward via a negative
+     <code>outline-offset</code> and reinforced with an inset <code>box-shadow</code>.</p>
+
+  <div class="clip-demo-wrapper">
+    <div class="ease-divider" tabindex="0">
+      Focus me with Tab — the ring should stay fully visible
+    </div>
+  </div>
+
+  <h2>Same component, no overflow constraint (for comparison)</h2>
+  <div class="ease-divider" tabindex="0">
+    Focus me with Tab — baseline behavior outside a clipping container
+  </div>
+</body>
+</html>

--- a/submissions/examples/fix-ease-divider-focus-clip-59755-ak/style.css
+++ b/submissions/examples/fix-ease-divider-focus-clip-59755-ak/style.css
@@ -1,0 +1,68 @@
+/*
+ * Fix: ease-divider focus outline clipped by parent overflow
+ * Issue: #59755
+ *
+ * Problem:
+ *   When an .ease-divider is placed inside a wrapper with
+ *   overflow: hidden or overflow: auto, the default focus outline
+ *   (drawn outside the element's border box) gets clipped by the
+ *   parent, making it partially or fully invisible on keyboard focus.
+ *
+ * Fix:
+ *   Replace the external outline with a negative outline-offset so
+ *   the outline is drawn INSIDE the element's box, which keeps it
+ *   within the parent's clipping bounds. An inset box-shadow is
+ *   layered on top for extra visibility and Windows High Contrast
+ *   Mode fallback support.
+ */
+
+.ease-divider {
+  position: relative;
+  box-sizing: border-box;
+  display: block;
+  padding: 0.75rem 1rem;
+  border-radius: var(--ease-radius-md, 4px);
+  background-color: var(--ease-bg-surface, #ffffff);
+  border: 1px solid var(--ease-border-subtle, #e5e7eb);
+  color: var(--ease-text-primary, #111827);
+  transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out;
+}
+
+.ease-divider:hover {
+  background-color: var(--ease-bg-hover, #f3f4f6);
+  border-color: var(--ease-border-hover, #d1d5db);
+}
+
+/*
+ * CRITICAL ACCESSIBILITY FIX (#59755)
+ * Keeps the focus indicator fully inside the element's bounding box
+ * so it is never clipped by an ancestor's overflow: hidden/auto.
+ */
+.ease-divider:focus-visible {
+  outline: 3px solid var(--ease-color-primary, #2563eb);
+  outline-offset: -3px;
+  box-shadow: inset 0 0 0 3px var(--ease-color-primary, #2563eb);
+}
+
+@media (prefers-color-scheme: dark) {
+  .ease-divider {
+    background-color: #1f2937;
+    border-color: #374151;
+    color: #f9fafb;
+  }
+
+  .ease-divider:focus-visible {
+    outline-color: var(--ease-color-primary-dark, #60a5fa);
+    box-shadow: inset 0 0 0 3px var(--ease-color-primary-dark, #60a5fa);
+  }
+}
+
+/* Demo-only helper: the overflow:hidden wrapper that reproduces the bug */
+.clip-demo-wrapper {
+  overflow: hidden;
+  border: 2px dashed var(--ease-border-hover, #d1d5db);
+  border-radius: 8px;
+  padding: 1.5rem;
+  max-width: 420px;
+  margin: 1.5rem 0;
+}


### PR DESCRIPTION
## Pull Request Description
Fixes #59755 — `.ease-divider`'s focus ring was drawn outside the element's border box, so it got clipped when the component sat inside a wrapper with `overflow: hidden` or `overflow: auto`. Replaces the external outline with a negative outline-offset + inset box-shadow so the focus ring stays inside the element's bounding box and is never clipped by an ancestor's overflow.

## Type of Change
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/fix-ease-divider-focus-clip-59755-ak/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

## Feature Description

**What does this add?**
An accessibility fix ensuring `.ease-divider`'s keyboard focus ring stays fully visible even when the component is nested inside an `overflow: hidden`/`auto` container.

**How does a developer use it?**
```html
<div style="overflow: hidden;">
  <div class="ease-divider" tabindex="0">
    Content
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It's a pure CSS accessibility fix with no JS dependency, matching the framework's human-readable, drop-in class philosophy — and it fixes a real WCAG 2.1 Focus Visible violation.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

## Notes for Maintainer
This addresses issue #59755 specifically — reproduces the exact bug scenario (divider inside an `overflow: hidden` wrapper) and shows a side-by-side comparison against the unconstrained case in `demo.html`. Note there's a related but separate submission (`fix-divider-focus-clip`) that fixes the same underlying pattern for a different issue (#38003); this PR is scoped to #59755's specific repro case.