### PR TITLE
Add ease-bowling-pin-strike component

### DIFF
--- a/submissions/examples/bowling-pin-strike-ij/README.md
+++ b/submissions/examples/bowling-pin-strike-ij/README.md
@@ -1,0 +1,10 @@
+# ease-bowling-pin-strike
+
+A bowling lane where the ball rolls down and topples all ten pins.
+
+## Run
+Open `demo.html` directly in a browser to watch the pins fall.
+
+## Notes
+- Pins topple in a ripple from left to right.
+- The STRIKE banner flashes above the lane.

--- a/submissions/examples/bowling-pin-strike-ij/demo.html
+++ b/submissions/examples/bowling-pin-strike-ij/demo.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-bowling-pin-strike demo</title>
+</head>
+<body>
+<div class="bo-app">
+  <span class="bo-score">STRIKE</span>
+  <div class="bo-lane">
+    <div class="bo-arrow bo-arrow-1"></div>
+    <div class="bo-arrow bo-arrow-2"></div>
+    <div class="bo-arrow bo-arrow-3"></div>
+    <div class="bo-pin bo-pin-1"></div>
+    <div class="bo-pin bo-pin-2"></div>
+    <div class="bo-pin bo-pin-3"></div>
+    <div class="bo-pin bo-pin-4"></div>
+    <div class="bo-pin bo-pin-5"></div>
+    <div class="bo-pin bo-pin-6"></div>
+    <div class="bo-pin bo-pin-7"></div>
+    <div class="bo-pin bo-pin-8"></div>
+    <div class="bo-pin bo-pin-9"></div>
+    <div class="bo-pin bo-pin-10"></div>
+    <div class="bo-ball"></div>
+    <span class="bo-foul">FOUL LINE</span>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/bowling-pin-strike-ij/style.css
+++ b/submissions/examples/bowling-pin-strike-ij/style.css
@@ -1,0 +1,25 @@
+:root{--bo-lane:#d8a86a;--bo-pin:#f2f0ea;--bo-ball:#7a4a8a}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#eae2d2,#c8bc9e);font-family:'Segoe UI',sans-serif}
+.bo-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#f0e8d8,#d0c2a0);box-shadow:0 16px 36px rgba(0,0,0,0.3)}
+.bo-score{position:absolute;top:6px;left:0;right:0;text-align:center;font-size:17px;font-weight:800;letter-spacing:7px;color:#5a4a8a;animation:flash-strike-bowling-pin-strike 3s ease-in-out infinite}
+.bo-lane{position:absolute;top:30px;left:26px;width:320px;height:300px;border-radius:8px;background:var(--bo-lane);box-shadow:inset 0 0 0 8px #b0804e}
+.bo-arrow{position:absolute;top:216px;width:18px;height:26px;clip-path:polygon(50% 0,100% 100%,0 100%);background:#8a5a2a}
+.bo-arrow-1{left:72px}
+.bo-arrow-2{left:146px}
+.bo-arrow-3{left:230px}
+.bo-foul{position:absolute;top:188px;left:0;right:0;text-align:center;font-size:11px;letter-spacing:3px;color:#6a3a1a}
+.bo-pin{position:absolute;top:38px;width:16px;height:44px;border-radius:50% 50% 8px 8px;background:var(--bo-pin);box-shadow:inset 0 0 0 3px #c8c4ba;transform-origin:bottom center;animation:topple-pin-bowling-pin-strike 3s ease-in-out infinite}
+.bo-pin-1{left:44px}
+.bo-pin-2{left:84px;animation-delay:0.06s}
+.bo-pin-3{left:124px;animation-delay:0.12s}
+.bo-pin-4{left:164px;animation-delay:0.18s}
+.bo-pin-5{left:204px;animation-delay:0.24s}
+.bo-pin-6{left:244px;animation-delay:0.3s}
+.bo-pin-7{left:64px;top:26px;animation-delay:0.36s}
+.bo-pin-8{left:104px;top:26px;animation-delay:0.42s}
+.bo-pin-9{left:144px;top:26px;animation-delay:0.48s}
+.bo-pin-10{left:184px;top:26px;animation-delay:0.54s}
+.bo-ball{position:absolute;top:260px;left:152px;width:26px;height:26px;border-radius:50%;background:var(--bo-ball);animation:roll-ball-bowling-pin-strike 3s ease-in-out infinite}
+@keyframes roll-ball-bowling-pin-strike{0%,100%{transform:translateY(0)}55%{transform:translateY(-210px)}}
+@keyframes topple-pin-bowling-pin-strike{0%,52%{transform:rotate(0deg)}100%{transform:rotate(-90deg)}}
+@keyframes flash-strike-bowling-pin-strike{0%,50%{opacity:1}56%,100%{opacity:0.15}}


### PR DESCRIPTION
## Component: ease-bowling-pin-strike — ball rolls, pins topple, and score flashes

**Closes #61384**

### What this adds
A bowling lane from above: the striped ball rolls straight down the boards, all ten pins scatter and topple in its path, and the score display flashes STRIKE above the foul line.

### Acceptance Criteria covered
- Ball rolls down the lane
- Ten pins topple in the path
- Score flashes STRIKE

### Files
- submissions/examples/bowling-pin-strike-ij/demo.html
- submissions/examples/bowling-pin-strike-ij/style.css
- submissions/examples/bowling-pin-strike-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the pins fall.