### PR TITLE
feat: add CSS scale-hover badge for fintech dashboard layouts (#59330)

### DIFF
--- a/submissions/examples/fintech-scale-hover-badge-ak/README.md
+++ b/submissions/examples/fintech-scale-hover-badge-ak/README.md
@@ -1,0 +1,53 @@
+# CSS Scale-Hover Badge for Fintech Dashboard Layouts
+
+## Description
+Fixes #59330 — a lightweight, pure CSS badge component designed for fintech
+dashboard UIs (status indicators, percentage changes, stat pills), with a
+smooth scale-up interaction on hover and keyboard focus.
+
+## Usage
+```html
+<span class="ease-badge ease-badge--live" tabindex="0">
+  <span class="ease-badge__dot"></span> Live
+</span>
+
+<span class="ease-badge ease-badge--positive" tabindex="0">+2.4%</span>
+<span class="ease-badge ease-badge--negative" tabindex="0">-0.8%</span>
+<span class="ease-badge ease-badge--pending" tabindex="0">
+  <span class="ease-badge__dot"></span> Pending
+</span>
+<span class="ease-badge ease-badge--neutral" tabindex="0">$12.4K</span>
+```
+
+Group multiple badges with `.ease-badge-group` for consistent spacing:
+```html
+<div class="ease-badge-group">
+  <!-- badges here -->
+</div>
+```
+
+## Variants
+| Class | Use case |
+|---|---|
+| `.ease-badge--live` | Active/live status, green |
+| `.ease-badge--pending` | Pending/in-progress status, amber |
+| `.ease-badge--positive` | Positive stat change (e.g. gains), blue |
+| `.ease-badge--negative` | Negative stat change (e.g. losses), red |
+| `.ease-badge--neutral` | Neutral value display (e.g. balances), gray |
+
+## Custom Properties
+Uses `--ease-color-primary` (falls back to `#2563eb`) for the keyboard focus
+outline color, matching the framework's existing custom property convention.
+
+## Features
+- Pure CSS/HTML — no JavaScript required
+- Smooth spring-like scale transform (`cubic-bezier(0.34, 1.56, 0.64, 1)`) on hover and `:focus-visible`
+- Fully keyboard accessible (`tabindex="0"` + visible focus ring)
+- Responsive — badges shrink slightly below 480px viewports
+- Dark mode support via `prefers-color-scheme: dark`
+- Respects `prefers-reduced-motion: reduce` — disables the scale transform, keeps a subtle shadow-only affordance instead
+
+## Testing
+Open `demo.html` in a browser. Hover or Tab through each badge to see the
+scale interaction, resize the window to check responsive behavior, and
+toggle your OS "reduce motion" setting to verify the fallback.

--- a/submissions/examples/fintech-scale-hover-badge-ak/demo.html
+++ b/submissions/examples/fintech-scale-hover-badge-ak/demo.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Scale-Hover Badge — Fintech Dashboard (#59330)</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      max-width: 720px;
+      margin: 3rem auto;
+      padding: 0 1.5rem;
+      line-height: 1.6;
+      color: #111827;
+      background: #f9fafb;
+    }
+    h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    h2 { font-size: 1.05rem; margin-top: 2.5rem; color: #374151; }
+    p.sub { color: #6b7280; margin-top: 0; }
+    .dashboard-card {
+      background: #ffffff;
+      border: 1px solid #e5e7eb;
+      border-radius: 12px;
+      padding: 1.5rem;
+      margin-top: 1rem;
+    }
+    .row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 0.6rem 0;
+      border-bottom: 1px solid #f3f4f6;
+    }
+    .row:last-child { border-bottom: none; }
+    .row span { font-weight: 500; }
+  </style>
+</head>
+<body>
+  <h1>CSS Scale-Hover Badge</h1>
+  <p class="sub">Pure CSS badge component for fintech dashboard layouts — issue #59330</p>
+
+  <h2>Standalone badges</h2>
+  <p>Hover or Tab-focus each badge to see the scale interaction.</p>
+  <div class="ease-badge-group">
+    <span class="ease-badge ease-badge--live" tabindex="0">
+      <span class="ease-badge__dot"></span> Live
+    </span>
+    <span class="ease-badge ease-badge--pending" tabindex="0">
+      <span class="ease-badge__dot"></span> Pending
+    </span>
+    <span class="ease-badge ease-badge--positive" tabindex="0">+2.4%</span>
+    <span class="ease-badge ease-badge--negative" tabindex="0">-0.8%</span>
+    <span class="ease-badge ease-badge--neutral" tabindex="0">$12.4K</span>
+  </div>
+
+  <h2>In a dashboard context</h2>
+  <div class="dashboard-card">
+    <div class="row">
+      <span>Portfolio Status</span>
+      <span class="ease-badge ease-badge--live" tabindex="0">
+        <span class="ease-badge__dot"></span> Live
+      </span>
+    </div>
+    <div class="row">
+      <span>Monthly Return</span>
+      <span class="ease-badge ease-badge--positive" tabindex="0">+2.4%</span>
+    </div>
+    <div class="row">
+      <span>Pending Settlement</span>
+      <span class="ease-badge ease-badge--pending" tabindex="0">
+        <span class="ease-badge__dot"></span> Pending
+      </span>
+    </div>
+    <div class="row">
+      <span>Daily P/L</span>
+      <span class="ease-badge ease-badge--negative" tabindex="0">-0.8%</span>
+    </div>
+  </div>
+
+  <h2>Reduced motion &amp; responsive</h2>
+  <p class="sub">
+    Resize the window below ~480px to see the badges shrink slightly.
+    If your OS has "reduce motion" enabled, the scale transform is
+    automatically disabled and only a subtle shadow/background change
+    signals the hover/focus state.
+  </p>
+</body>
+</html>

--- a/submissions/examples/fintech-scale-hover-badge-ak/style.css
+++ b/submissions/examples/fintech-scale-hover-badge-ak/style.css
@@ -1,0 +1,147 @@
+/*
+ * CSS Scale-Hover Badge — Fintech Dashboard Layouts
+ * Issue: #59330
+ *
+ * Pure CSS badge component with a smooth scale-up hover/focus
+ * interaction, designed for status and stat indicators on
+ * fintech dashboards (e.g. "Live", "+2.4%", "$12.4K").
+ */
+
+.ease-badge-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.ease-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.85rem;
+  border-radius: 999px;
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  cursor: default;
+  user-select: none;
+  border: 1px solid transparent;
+  transition: transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1),
+              box-shadow 0.2s ease-out,
+              background-color 0.2s ease-out;
+  will-change: transform;
+}
+
+/* Scale-hover interaction (mouse + keyboard) */
+.ease-badge:hover,
+.ease-badge:focus-visible {
+  transform: scale(1.08);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.12);
+}
+
+.ease-badge:focus-visible {
+  outline: 2px solid var(--ease-color-primary, #2563eb);
+  outline-offset: 2px;
+}
+
+.ease-badge:active {
+  transform: scale(1.02);
+}
+
+/* Status dot, used by status-variant badges */
+.ease-badge__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+/* ── Variants ─────────────────────────────────────────── */
+
+.ease-badge--live {
+  background-color: #dcfce7;
+  color: #166534;
+  border-color: #bbf7d0;
+}
+.ease-badge--live .ease-badge__dot {
+  background-color: #22c55e;
+}
+
+.ease-badge--pending {
+  background-color: #fef9c3;
+  color: #854d0e;
+  border-color: #fef08a;
+}
+.ease-badge--pending .ease-badge__dot {
+  background-color: #eab308;
+}
+
+.ease-badge--positive {
+  background-color: #dbeafe;
+  color: #1e40af;
+  border-color: #bfdbfe;
+}
+
+.ease-badge--negative {
+  background-color: #fee2e2;
+  color: #991b1b;
+  border-color: #fecaca;
+}
+
+.ease-badge--neutral {
+  background-color: #f3f4f6;
+  color: #374151;
+  border-color: #e5e7eb;
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+  .ease-badge--live {
+    background-color: rgba(34, 197, 94, 0.15);
+    color: #4ade80;
+    border-color: rgba(34, 197, 94, 0.3);
+  }
+  .ease-badge--pending {
+    background-color: rgba(234, 179, 8, 0.15);
+    color: #facc15;
+    border-color: rgba(234, 179, 8, 0.3);
+  }
+  .ease-badge--positive {
+    background-color: rgba(59, 130, 246, 0.15);
+    color: #60a5fa;
+    border-color: rgba(59, 130, 246, 0.3);
+  }
+  .ease-badge--negative {
+    background-color: rgba(239, 68, 68, 0.15);
+    color: #f87171;
+    border-color: rgba(239, 68, 68, 0.3);
+  }
+  .ease-badge--neutral {
+    background-color: rgba(156, 163, 175, 0.15);
+    color: #d1d5db;
+    border-color: rgba(156, 163, 175, 0.3);
+  }
+}
+
+/* Reduced motion: disable the scale transform, keep a subtle
+   shadow-only affordance so hover/focus state is still visible */
+@media (prefers-reduced-motion: reduce) {
+  .ease-badge {
+    transition: box-shadow 0.15s ease-out, background-color 0.15s ease-out;
+  }
+  .ease-badge:hover,
+  .ease-badge:focus-visible {
+    transform: none;
+  }
+}
+
+/* Responsive: shrink padding/font slightly on narrow viewports */
+@media (max-width: 480px) {
+  .ease-badge {
+    padding: 0.35rem 0.7rem;
+    font-size: 0.78rem;
+  }
+  .ease-badge-group {
+    gap: 0.5rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a CSS scale-hover badge component for fintech dashboard layouts, closing #59330. Pure CSS/HTML badge with a spring-like scale transform on hover and keyboard focus. Includes status (Live/Pending) and stat (percentage/currency) variants, dark mode, responsive sizing below 480px, and prefers-reduced-motion support.

## Type of Change
- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/fintech-scale-hover-badge-ak/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

## Feature Description

**What does this add?**
A pure CSS badge component with status and stat variants (Live, Pending, +/- percentage, currency), featuring a smooth scale-up interaction on hover and keyboard focus — built for fintech dashboard UIs.

**How does a developer use it?**
```html
<div class="ease-badge-group">
  <span class="ease-badge ease-badge--live" tabindex="0">
    <span class="ease-badge__dot"></span> Live
  </span>
  <span class="ease-badge ease-badge--positive" tabindex="0">+2.4%</span>
  <span class="ease-badge ease-badge--negative" tabindex="0">-0.8%</span>
</div>
```

**Why does it fit EaseMotion CSS?**
It's a drop-in, class-based component with no JS dependency, matching the framework's human-readable naming convention (`ease-*`). The scale interaction uses a spring-like cubic-bezier easing consistent with the framework's animation-first philosophy, and it respects `prefers-reduced-motion` per the framework's accessibility standards.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

## Notes for Maintainer
Badge content/variants (Live, Pending, +/-%, currency) were chosen as a representative but non-exhaustive set for fintech dashboards per issue #59330 — happy to add more variants (e.g. "Closed", "Failed") if useful.