### PR TITLE
Add ease-piano-key-press component

### DIFF
--- a/submissions/examples/piano-key-press-ij/README.md
+++ b/submissions/examples/piano-key-press-ij/README.md
@@ -1,0 +1,10 @@
+# ease-piano-key-press
+
+A grand piano whose keys press in a ripple while hammers strike the strings.
+
+## Run
+Open `demo.html` directly in a browser to watch the keys press.
+
+## Notes
+- White and black keys press in sequence.
+- Music notes float above the lid.

--- a/submissions/examples/piano-key-press-ij/demo.html
+++ b/submissions/examples/piano-key-press-ij/demo.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-piano-key-press demo</title>
+</head>
+<body>
+<div class="pi-app">
+  <span class="pi-brand">GRAND</span>
+  <div class="pi-body">
+    <div class="pi-key pi-key-1"></div>
+    <div class="pi-key pi-key-2"></div>
+    <div class="pi-key pi-key-3"></div>
+    <div class="pi-key pi-key-4"></div>
+    <div class="pi-key pi-key-5"></div>
+    <div class="pi-key pi-key-6"></div>
+    <div class="pi-key pi-key-7"></div>
+    <div class="pi-black pi-black-1"></div>
+    <div class="pi-black pi-black-2"></div>
+    <div class="pi-black pi-black-3"></div>
+    <div class="pi-black pi-black-4"></div>
+    <div class="pi-black pi-black-5"></div>
+  </div>
+  <div class="pi-hammer pi-hammer-1"></div>
+  <div class="pi-hammer pi-hammer-2"></div>
+  <div class="pi-note pi-note-1">&#9834;</div>
+  <div class="pi-note pi-note-2">&#9835;</div>
+</div>
+</body>
+</html>

--- a/submissions/examples/piano-key-press-ij/style.css
+++ b/submissions/examples/piano-key-press-ij/style.css
@@ -1,0 +1,28 @@
+:root{--pi-wood:#4a3424;--pi-ivory:#f4f0e6;--pi-black:#26222a}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#efe4d2,#c8b48e);font-family:'Segoe UI',sans-serif}
+.pi-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#f4ead8,#d0bc94);box-shadow:0 16px 36px rgba(0,0,0,0.3)}
+.pi-brand{position:absolute;top:18px;left:0;right:0;text-align:center;font-size:13px;font-weight:700;letter-spacing:8px;color:#6a4a2a}
+.pi-body{position:absolute;bottom:46px;left:34px;width:304px;height:104px;border-radius:12px 12px 6px 6px;background:var(--pi-wood);box-shadow:inset 0 0 0 6px #2c1e12}
+.pi-key{position:absolute;bottom:14px;width:34px;height:70px;border-radius:3px 3px 6px 6px;background:var(--pi-ivory);box-shadow:inset 0 -8px 0 rgba(0,0,0,0.08);transform-origin:bottom;animation:press-key-piano-key-press 2.4s ease-in-out infinite}
+.pi-key-1{left:16px}
+.pi-key-2{left:54px;animation-delay:0.3s}
+.pi-key-3{left:92px;animation-delay:0.6s}
+.pi-key-4{left:130px;animation-delay:0.9s}
+.pi-key-5{left:168px;animation-delay:1.2s}
+.pi-key-6{left:206px;animation-delay:1.5s}
+.pi-key-7{left:244px;animation-delay:1.8s}
+.pi-black{position:absolute;bottom:70px;width:20px;height:44px;border-radius:0 0 4px 4px;background:var(--pi-black);animation:press-key-piano-key-press 2.4s ease-in-out infinite}
+.pi-black-1{left:44px;animation-delay:0.4s}
+.pi-black-2{left:120px;animation-delay:1s}
+.pi-black-3{left:158px;animation-delay:1.3s}
+.pi-black-4{left:196px;animation-delay:1.6s}
+.pi-black-5{left:272px;animation-delay:0.7s}
+.pi-hammer{position:absolute;width:4px;height:16px;border-radius:2px;background:#8a8a92;transform-origin:bottom;animation:strike-hammer-piano-key-press 2.4s ease-in-out infinite}
+.pi-hammer-1{top:6px;left:30px;animation-delay:0.3s}
+.pi-hammer-2{top:6px;left:120px;animation-delay:0.9s}
+.pi-note{position:absolute;font-size:18px;color:#6a4a2a;animation:float-note-piano-key-press 2.4s ease-in-out infinite}
+.pi-note-1{top:56px;left:96px}
+.pi-note-2{top:56px;left:220px;animation-delay:1.2s}
+@keyframes press-key-piano-key-press{0%,100%{transform:scaleY(1)}35%{transform:scaleY(0.92) translateY(3px)}}
+@keyframes strike-hammer-piano-key-press{0%,100%{transform:rotate(0deg)}35%{transform:rotate(14deg)}}
+@keyframes float-note-piano-key-press{0%{transform:translateY(0);opacity:0}25%{opacity:1}100%{transform:translateY(-46px);opacity:0}}


### PR DESCRIPTION
## Component: ease-piano-key-press — keys press, hammers strike, and notes float

**Closes #61400**

### What this adds
A grand piano in profile: the white and black keys press down in a ripple as the hammers strike the strings, and music notes float up over the raised lid.

### Acceptance Criteria covered
- Keys press in a ripple
- Hammers strike the strings
- Notes float above the lid

### Files
- submissions/examples/piano-key-press-ij/demo.html
- submissions/examples/piano-key-press-ij/style.css
- submissions/examples/piano-key-press-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the keys press.