### PR TITLE
feat: add CSS fade-in pricing table for fintech dashboard layout

### DIFF
--- a/submissions/examples/fintech-fadein-pricing-table-ak/README.md
+++ b/submissions/examples/fintech-fadein-pricing-table-ak/README.md
@@ -1,0 +1,52 @@
+# CSS Fade-In Pricing Table for Fintech Dashboard Layouts
+
+## Description
+Fixes #59402 — a pure CSS pricing table for fintech dashboard plan/subscription
+pages, with a staggered fade-in-up entrance animation for each tier and a
+highlighted "recommended" middle tier.
+
+## Usage
+```html
+<div class="ease-pricing">
+  <div class="ease-pricing__tier">
+    <p class="ease-pricing__name">Basic</p>
+    <p class="ease-pricing__price">$0<span>/mo</span></p>
+    <p class="ease-pricing__desc">Short description.</p>
+    <ul class="ease-pricing__features">
+      <li>Feature one</li>
+      <li>Feature two</li>
+    </ul>
+    <button class="ease-pricing__cta" type="button">Get Started</button>
+  </div>
+
+  <div class="ease-pricing__tier ease-pricing__tier--featured">
+    <span class="ease-pricing__badge">Most Popular</span>
+    <p class="ease-pricing__name">Pro</p>
+    <p class="ease-pricing__price">$29<span>/mo</span></p>
+    <!-- ... -->
+  </div>
+</div>
+```
+
+Add `ease-pricing__tier--featured` to any tier to visually highlight it as
+recommended, with an optional `ease-pricing__badge` label.
+
+## Custom Properties
+Uses `--ease-color-primary` (falls back to `#2563eb`) for the featured tier
+accent, checkmarks, and CTA buttons — consistent with the framework's
+existing custom property convention.
+
+## Features
+- Pure CSS/HTML — no JavaScript required
+- Staggered fade-in-up entrance animation per tier (`nth-child` delays)
+- Featured/recommended tier with distinct styling and hover lift
+- Fully keyboard accessible (`:focus-visible` on CTA buttons)
+- Responsive — tiers stack vertically below 720px
+- Dark mode support via `prefers-color-scheme: dark`
+- Respects `prefers-reduced-motion: reduce` — skips the fade-in animation
+  entirely, tiers render at full opacity immediately
+
+## Testing
+Open `demo.html` in a browser and reload to see the staggered fade-in.
+Resize the window to check responsive stacking, and toggle your OS
+"reduce motion" setting to verify the fallback.

--- a/submissions/examples/fintech-fadein-pricing-table-ak/demo.html
+++ b/submissions/examples/fintech-fadein-pricing-table-ak/demo.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Fade-In Pricing Table — Fintech Dashboard (#59402)</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      max-width: 960px;
+      margin: 3rem auto;
+      padding: 0 1.5rem;
+      line-height: 1.6;
+      color: #111827;
+      background: #f9fafb;
+    }
+    h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    p.sub { color: #6b7280; margin-top: 0; }
+    h2 { font-size: 1rem; margin-top: 2.5rem; color: #374151; }
+  </style>
+</head>
+<body>
+  <h1>CSS Fade-In Pricing Table</h1>
+  <p class="sub">Pure CSS pricing table for fintech dashboard layouts — issue #59402</p>
+
+  <h2>Reload the page to replay the staggered fade-in animation</h2>
+
+  <div class="ease-pricing">
+    <div class="ease-pricing__tier">
+      <p class="ease-pricing__name">Basic</p>
+      <p class="ease-pricing__price">$0<span>/mo</span></p>
+      <p class="ease-pricing__desc">For individuals getting started with portfolio tracking.</p>
+      <ul class="ease-pricing__features">
+        <li>Up to 3 linked accounts</li>
+        <li>Daily portfolio snapshot</li>
+        <li>Basic performance charts</li>
+        <li>Email support</li>
+      </ul>
+      <button class="ease-pricing__cta" type="button">Get Started</button>
+    </div>
+
+    <div class="ease-pricing__tier ease-pricing__tier--featured">
+      <span class="ease-pricing__badge">Most Popular</span>
+      <p class="ease-pricing__name">Pro</p>
+      <p class="ease-pricing__price">$29<span>/mo</span></p>
+      <p class="ease-pricing__desc">For active investors who need real-time insight.</p>
+      <ul class="ease-pricing__features">
+        <li>Unlimited linked accounts</li>
+        <li>Real-time market data</li>
+        <li>Advanced risk analytics</li>
+        <li>Priority support</li>
+        <li>Custom alerts</li>
+      </ul>
+      <button class="ease-pricing__cta" type="button">Start Free Trial</button>
+    </div>
+
+    <div class="ease-pricing__tier">
+      <p class="ease-pricing__name">Enterprise</p>
+      <p class="ease-pricing__price">Custom</p>
+      <p class="ease-pricing__desc">For teams and institutions with advanced needs.</p>
+      <ul class="ease-pricing__features">
+        <li>Everything in Pro</li>
+        <li>Dedicated account manager</li>
+        <li>API access</li>
+        <li>Custom integrations</li>
+        <li>SLA-backed uptime</li>
+      </ul>
+      <button class="ease-pricing__cta" type="button">Contact Sales</button>
+    </div>
+  </div>
+
+  <h2>Reduced motion &amp; responsive</h2>
+  <p class="sub">
+    Resize the window below ~720px to see the tiers stack vertically.
+    If your OS has "reduce motion" enabled, the fade-in-up animation is
+    skipped and tiers appear immediately at full opacity.
+  </p>
+</body>
+</html>

--- a/submissions/examples/fintech-fadein-pricing-table-ak/style.css
+++ b/submissions/examples/fintech-fadein-pricing-table-ak/style.css
@@ -1,0 +1,203 @@
+/*
+ * CSS Fade-In Pricing Table — Fintech Dashboard Layouts
+ * Issue: #59402
+ *
+ * Pure CSS pricing table with a staggered fade-in-up entrance
+ * animation for each tier, designed for fintech dashboard
+ * plan/subscription pages.
+ */
+
+.ease-pricing {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  align-items: stretch;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+.ease-pricing__tier {
+  flex: 1 1 240px;
+  display: flex;
+  flex-direction: column;
+  padding: 2rem 1.75rem;
+  border-radius: 18px;
+  background-color: #ffffff;
+  border: 1px solid #e5e7eb;
+  opacity: 0;
+  transform: translateY(16px);
+  animation: ease-pricing-fade-in 0.5s ease-out forwards;
+  transition: transform 0.25s ease-out, box-shadow 0.25s ease-out;
+}
+
+.ease-pricing__tier:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.08);
+}
+
+/* Staggered entrance delays */
+.ease-pricing__tier:nth-child(1) { animation-delay: 0s; }
+.ease-pricing__tier:nth-child(2) { animation-delay: 0.12s; }
+.ease-pricing__tier:nth-child(3) { animation-delay: 0.24s; }
+.ease-pricing__tier:nth-child(4) { animation-delay: 0.36s; }
+
+@keyframes ease-pricing-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* ── Highlighted / recommended tier ──────────────────────── */
+
+.ease-pricing__tier--featured {
+  border-color: var(--ease-color-primary, #2563eb);
+  background: linear-gradient(180deg, #eff6ff 0%, #ffffff 100%);
+  box-shadow: 0 8px 24px rgba(37, 99, 235, 0.12);
+  position: relative;
+}
+
+.ease-pricing__tier--featured:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 16px 32px rgba(37, 99, 235, 0.18);
+}
+
+.ease-pricing__badge {
+  position: absolute;
+  top: -0.75rem;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 0.3rem 0.9rem;
+  border-radius: 999px;
+  background-color: var(--ease-color-primary, #2563eb);
+  color: #ffffff;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+/* ── Tier content ─────────────────────────────────────── */
+
+.ease-pricing__name {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #6b7280;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin: 0 0 0.5rem;
+}
+
+.ease-pricing__price {
+  font-size: 2.25rem;
+  font-weight: 800;
+  color: #111827;
+  margin: 0;
+}
+
+.ease-pricing__price span {
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: #6b7280;
+}
+
+.ease-pricing__desc {
+  font-size: 0.9rem;
+  color: #6b7280;
+  margin: 0.5rem 0 1.5rem;
+}
+
+.ease-pricing__features {
+  list-style: none;
+  margin: 0 0 1.75rem;
+  padding: 0;
+  flex-grow: 1;
+}
+
+.ease-pricing__features li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.88rem;
+  color: #374151;
+  padding: 0.4rem 0;
+}
+
+.ease-pricing__features li::before {
+  content: "✓";
+  color: var(--ease-color-primary, #2563eb);
+  font-weight: 700;
+}
+
+.ease-pricing__cta {
+  display: inline-block;
+  text-align: center;
+  padding: 0.75rem 1rem;
+  border-radius: 10px;
+  border: 1.5px solid var(--ease-color-primary, #2563eb);
+  background-color: transparent;
+  color: var(--ease-color-primary, #2563eb);
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease-out, color 0.2s ease-out;
+}
+
+.ease-pricing__cta:hover,
+.ease-pricing__cta:focus-visible {
+  background-color: var(--ease-color-primary, #2563eb);
+  color: #ffffff;
+}
+
+.ease-pricing__tier--featured .ease-pricing__cta {
+  background-color: var(--ease-color-primary, #2563eb);
+  color: #ffffff;
+}
+
+.ease-pricing__tier--featured .ease-pricing__cta:hover,
+.ease-pricing__tier--featured .ease-pricing__cta:focus-visible {
+  background-color: #1d4ed8;
+}
+
+/* ── Dark mode ────────────────────────────────────────── */
+
+@media (prefers-color-scheme: dark) {
+  .ease-pricing__tier {
+    background-color: #1f2937;
+    border-color: #374151;
+  }
+  .ease-pricing__tier--featured {
+    background: linear-gradient(180deg, #1e293b 0%, #1f2937 100%);
+  }
+  .ease-pricing__price { color: #f9fafb; }
+  .ease-pricing__features li { color: #d1d5db; }
+}
+
+/* ── Reduced motion ───────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-pricing__tier {
+    animation: none;
+    opacity: 1;
+    transform: none;
+    transition: box-shadow 0.15s ease-out;
+  }
+  .ease-pricing__tier:hover,
+  .ease-pricing__tier--featured:hover {
+    transform: none;
+  }
+}
+
+/* ── Responsive ───────────────────────────────────────── */
+
+@media (max-width: 720px) {
+  .ease-pricing {
+    flex-direction: column;
+  }
+  .ease-pricing__tier {
+    flex: 1 1 auto;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a CSS fade-in pricing table for fintech dashboard layouts, closing #59402. Pure CSS/HTML pricing table with staggered fade-in-up entrance animation per tier and a highlighted 'recommended' middle tier. Includes dark mode, responsive stacking below 720px, and prefers-reduced-motion support.

## Type of Change
- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/fintech-fadein-pricing-table-ak/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

## Feature Description

**What does this add?**
A pure CSS pricing table with a staggered fade-in-up entrance animation for each tier, plus a highlighted "recommended" tier variant — built for fintech dashboard plan/subscription pages.

**How does a developer use it?**
```html
<div class="ease-pricing">
  <div class="ease-pricing__tier">
    <p class="ease-pricing__name">Basic</p>
    <p class="ease-pricing__price">$0<span>/mo</span></p>
    <ul class="ease-pricing__features">
      <li>Feature one</li>
    </ul>
    <button class="ease-pricing__cta" type="button">Get Started</button>
  </div>
  <div class="ease-pricing__tier ease-pricing__tier--featured">
    <span class="ease-pricing__badge">Most Popular</span>
    <p class="ease-pricing__name">Pro</p>
    <p class="ease-pricing__price">$29<span>/mo</span></p>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It's a drop-in, class-based component with no JS dependency, following the framework's `ease-*` naming convention. The staggered `nth-child` fade-in-up entrance is a classic EaseMotion-style choreographed animation, and it respects `prefers-reduced-motion` per the framework's accessibility standards.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

## Notes for Maintainer
Third in a small fintech-dashboard series alongside the scale-hover badge (#59330) and hero section (#59390) I submitted earlier — all three use the same `--ease-color-primary` custom property and could compose into a cohesive dashboard demo if useful.