### PR TITLE
feat: add zoom-in stepper for fintech dashboards (#59434)

### DIFF
--- a/submissions/examples/fintech-zoomin-stepper-ak/README.md
+++ b/submissions/examples/fintech-zoomin-stepper-ak/README.md
@@ -1,0 +1,47 @@
+# CSS Zoom-In Stepper for Fintech Dashboard Layouts
+
+## Description
+Fixes #59434 — a pure CSS horizontal stepper with a zoom-in pop animation
+on the active step, designed for fintech dashboard flows such as KYC,
+onboarding, transfer wizards, and loan applications.
+
+## Usage
+```html
+<div class="ease-stepper">
+  <div class="ease-stepper__step ease-stepper__step--completed">
+    <span class="ease-stepper__circle">✓</span>
+    <span class="ease-stepper__label">Account Details</span>
+  </div>
+  <div class="ease-stepper__step ease-stepper__step--active">
+    <span class="ease-stepper__circle">3</span>
+    <span class="ease-stepper__label">Fund Transfer</span>
+  </div>
+  <div class="ease-stepper__step">
+    <span class="ease-stepper__circle">4</span>
+    <span class="ease-stepper__label">Confirmation</span>
+  </div>
+</div>
+```
+
+Add `ease-stepper__step--completed` for finished steps and
+`ease-stepper__step--active` for the current step. Steps with neither
+modifier render as upcoming/inactive.
+
+## Custom Properties
+Uses `--ease-color-primary` (falls back to `#2563eb`) for the active/
+completed circle color, connector line, and label accent — consistent
+with the framework's existing custom property convention.
+
+## Features
+- Pure CSS/HTML — no JavaScript required
+- Zoom-in pop animation (`cubic-bezier` overshoot) on the active step's circle
+- Connector line between steps that fills in as steps are completed
+- Fully responsive — collapses to a vertical, left-aligned layout below 640px
+- Dark mode support via `prefers-color-scheme: dark`
+- Respects `prefers-reduced-motion: reduce` — disables the zoom-in animation
+
+## Testing
+Open `demo.html` in a browser and reload to see the active step's
+zoom-in animation. Resize the window below 640px to check the vertical
+responsive layout, and toggle your OS "reduce motion" setting to verify
+the fallback.

--- a/submissions/examples/fintech-zoomin-stepper-ak/demo.html
+++ b/submissions/examples/fintech-zoomin-stepper-ak/demo.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Zoom-In Stepper — Fintech Dashboard (#59434)</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      max-width: 900px;
+      margin: 3rem auto;
+      padding: 0 1.5rem;
+      line-height: 1.6;
+      color: #111827;
+      background: #f9fafb;
+    }
+    h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    p.sub { color: #6b7280; margin-top: 0; }
+    h2 { font-size: 1rem; margin-top: 2.5rem; color: #374151; }
+    .demo-block { margin-top: 2rem; padding: 2rem 1rem; background: #ffffff; border-radius: 12px; border: 1px solid #e5e7eb; }
+  </style>
+</head>
+<body>
+  <h1>CSS Zoom-In Stepper</h1>
+  <p class="sub">Pure CSS horizontal stepper for fintech dashboard flows — issue #59434</p>
+
+  <h2>Reload the page to replay the active step's zoom-in animation</h2>
+
+  <div class="demo-block">
+    <div class="ease-stepper">
+      <div class="ease-stepper__step ease-stepper__step--completed">
+        <span class="ease-stepper__circle">✓</span>
+        <span class="ease-stepper__label">Account Details</span>
+      </div>
+      <div class="ease-stepper__step ease-stepper__step--completed">
+        <span class="ease-stepper__circle">✓</span>
+        <span class="ease-stepper__label">KYC Verification</span>
+      </div>
+      <div class="ease-stepper__step ease-stepper__step--active">
+        <span class="ease-stepper__circle">3</span>
+        <span class="ease-stepper__label">Fund Transfer</span>
+      </div>
+      <div class="ease-stepper__step">
+        <span class="ease-stepper__circle">4</span>
+        <span class="ease-stepper__label">Confirmation</span>
+      </div>
+    </div>
+  </div>
+
+  <h2>Reduced motion &amp; responsive</h2>
+  <p class="sub">
+    Resize the window below ~640px to see the stepper stack vertically
+    with left-aligned labels. If your OS has "reduce motion" enabled,
+    the zoom-in pop on the active step is skipped.
+  </p>
+</body>
+</html>

--- a/submissions/examples/fintech-zoomin-stepper-ak/style.css
+++ b/submissions/examples/fintech-zoomin-stepper-ak/style.css
@@ -1,0 +1,147 @@
+/*
+ * CSS Zoom-In Stepper — Fintech Dashboard Layouts
+ * Issue: #59434
+ *
+ * Pure CSS horizontal stepper with a zoom-in pop animation on the
+ * active step, designed for fintech dashboard flows (KYC, onboarding,
+ * transfer wizards, loan applications, etc).
+ */
+
+.ease-stepper {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  width: 100%;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+.ease-stepper__step {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.6rem;
+  flex: 1;
+  position: relative;
+  text-align: center;
+}
+
+/* Connector line between steps */
+.ease-stepper__step:not(:last-child)::after {
+  content: '';
+  position: absolute;
+  top: 20px;
+  left: 55%;
+  width: 90%;
+  height: 3px;
+  background-color: #e5e7eb;
+  z-index: 0;
+  transition: background-color 0.4s ease-out;
+}
+
+.ease-stepper__step--completed:not(:last-child)::after {
+  background-color: var(--ease-color-primary, #2563eb);
+}
+
+.ease-stepper__circle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  background-color: #ffffff;
+  border: 3px solid #e5e7eb;
+  color: #9ca3af;
+  font-weight: 700;
+  font-size: 0.95rem;
+  z-index: 1;
+  transition: border-color 0.3s ease-out, color 0.3s ease-out, background-color 0.3s ease-out;
+}
+
+.ease-stepper__label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #6b7280;
+  transition: color 0.3s ease-out;
+}
+
+/* Completed step */
+.ease-stepper__step--completed .ease-stepper__circle {
+  background-color: var(--ease-color-primary, #2563eb);
+  border-color: var(--ease-color-primary, #2563eb);
+  color: #ffffff;
+}
+
+.ease-stepper__step--completed .ease-stepper__label {
+  color: #111827;
+}
+
+/* Active step — zoom-in pop */
+.ease-stepper__step--active .ease-stepper__circle {
+  border-color: var(--ease-color-primary, #2563eb);
+  color: var(--ease-color-primary, #2563eb);
+  animation: ease-stepper-zoom-in 0.45s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+.ease-stepper__step--active .ease-stepper__label {
+  color: var(--ease-color-primary, #2563eb);
+  font-weight: 700;
+}
+
+@keyframes ease-stepper-zoom-in {
+  0% {
+    transform: scale(0.6);
+    opacity: 0;
+  }
+  60% {
+    transform: scale(1.15);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+/* ── Dark mode ────────────────────────────────────────── */
+
+@media (prefers-color-scheme: dark) {
+  .ease-stepper__circle {
+    background-color: #1f2937;
+    border-color: #374151;
+    color: #9ca3af;
+  }
+  .ease-stepper__step:not(:last-child)::after {
+    background-color: #374151;
+  }
+  .ease-stepper__label { color: #9ca3af; }
+  .ease-stepper__step--completed .ease-stepper__label { color: #f9fafb; }
+}
+
+/* ── Reduced motion ───────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-stepper__step--active .ease-stepper__circle {
+    animation: none;
+  }
+}
+
+/* ── Responsive ───────────────────────────────────────── */
+
+@media (max-width: 640px) {
+  .ease-stepper {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1.25rem;
+  }
+  .ease-stepper__step {
+    flex-direction: row;
+    text-align: left;
+    width: 100%;
+  }
+  .ease-stepper__step:not(:last-child)::after {
+    display: none;
+  }
+  .ease-stepper__label {
+    margin-left: 0.75rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS horizontal stepper with a zoom-in pop animation on the active step, designed for fintech dashboard flows like KYC, onboarding, and transfer wizards. Fixes #59434.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/fintech-zoomin-stepper-ak/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A horizontal step-progress indicator where the currently active step "pops" into focus with a zoom-in animation.

**How does a developer use it?**
```html
<div class="ease-stepper">
  <div class="ease-stepper__step ease-stepper__step--completed">
    <span class="ease-stepper__circle">✓</span>
    <span class="ease-stepper__label">Account Details</span>
  </div>
  <div class="ease-stepper__step ease-stepper__step--active">
    <span class="ease-stepper__circle">3</span>
    <span class="ease-stepper__label">Fund Transfer</span>
  </div>
  <div class="ease-stepper__step">
    <span class="ease-stepper__circle">4</span>
    <span class="ease-stepper__label">Confirmation</span>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It's pure CSS/HTML with no JS dependency, uses clearly named, human-readable BEM-style classes (`ease-stepper__step`, `--completed`, `--active`), follows the framework's existing `--ease-color-primary` custom property convention, and respects `prefers-reduced-motion` — in line with EaseMotion's animation-first, accessibility-conscious philosophy.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Connector line between steps fills in color as steps are marked completed. The zoom-in uses a slight overshoot (`cubic-bezier(0.34, 1.56, 0.64, 1)`) for a "pop" feel — happy to tone it down if it's too bouncy for the design system.