### PR TITLE
feat: add CSS fade-in modal for fintech dashboard layouts (#59252)

### DIFF
--- a/submissions/examples/59252-css-fade-in-modal-fintech-dashboard-ad/README.md
+++ b/submissions/examples/59252-css-fade-in-modal-fintech-dashboard-ad/README.md
@@ -1,0 +1,37 @@
+# CSS Fade-In Modal for Fintech Dashboard Layouts
+
+> Issue: [#59252](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/59252)
+
+A pure CSS modal system for fintech dashboards. Overlays fade in over a blurred backdrop and the dialog lifts into place, driven entirely by the `:target` pseudo-class — no JavaScript.
+
+## What it does
+
+Three modal variants (standard, wide, destructive confirm) layered over a mock treasury console. Opening is an anchor to the overlay `id`; closing is an anchor to `#`, with the backdrop doubling as a full-bleed dismiss link.
+
+## How it is used
+
+```html
+<a class="fm-trigger-ad" href="#fm-modal-payout-ad">Review payout batch</a>
+
+<div class="fm-overlay-ad" id="fm-modal-payout-ad" role="dialog" aria-modal="true">
+    <a class="fm-overlay-ad__dismiss" href="#" aria-label="Close dialog"></a>
+    <div class="fm-modal-ad">
+        <div class="fm-modal-ad__head">…</div>
+        <div class="fm-modal-ad__body">…</div>
+        <div class="fm-modal-ad__foot">…</div>
+    </div>
+</div>
+```
+
+## Key CSS custom properties
+
+```css
+--fm-fade-duration: 320ms;   /* overlay + dialog fade */
+--fm-fade-delay:     60ms;   /* dialog trails the backdrop */
+--fm-lift-distance:  14px;   /* dialog travel on entrance */
+--fm-accent:       #22d3ee;
+```
+
+## Why it fits EaseMotion
+
+The overlay stays inert with `visibility: hidden` + `pointer-events: none` rather than `display: none`, which keeps opacity interpolatable so the fade actually runs in both directions. Only `opacity` and `transform` are animated, so the entrance stays on the compositor. `backdrop-filter` is wrapped in `@supports` and degrades to a plain scrim. Full `prefers-reduced-motion: reduce` handling collapses all motion to 1ms while preserving the open/closed state change, and `forced-colors: active` restores borders for high-contrast users.

--- a/submissions/examples/59252-css-fade-in-modal-fintech-dashboard-ad/demo.html
+++ b/submissions/examples/59252-css-fade-in-modal-fintech-dashboard-ad/demo.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Fade-In Modal — Fintech Dashboard Layouts</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="fm-shell-ad">
+        <header class="fm-header-ad">
+            <div>
+                <p class="fm-header-ad__eyebrow">Treasury Console</p>
+                <h1 class="fm-header-ad__title">Settlement Overview</h1>
+                <p class="fm-header-ad__subtitle">
+                    Pure CSS fade-in modals driven by the <code>:target</code> pseudo-class.
+                    No JavaScript, no framework — open this file directly in a browser.
+                </p>
+            </div>
+            <span class="fm-header-ad__stamp">SYNCED 09:41 UTC</span>
+        </header>
+
+        <section class="fm-kpis-ad" aria-label="Key metrics">
+            <article class="fm-kpi-ad">
+                <p class="fm-kpi-ad__label">Net Settled</p>
+                <p class="fm-kpi-ad__value">$4.82M</p>
+                <p class="fm-kpi-ad__delta fm-kpi-ad__delta--up">▲ 6.4% vs. last cycle</p>
+            </article>
+            <article class="fm-kpi-ad">
+                <p class="fm-kpi-ad__label">Pending Holds</p>
+                <p class="fm-kpi-ad__value">$318K</p>
+                <p class="fm-kpi-ad__delta fm-kpi-ad__delta--down">▼ 2.1% vs. last cycle</p>
+            </article>
+            <article class="fm-kpi-ad">
+                <p class="fm-kpi-ad__label">Chargeback Rate</p>
+                <p class="fm-kpi-ad__value">0.42%</p>
+                <p class="fm-kpi-ad__delta fm-kpi-ad__delta--up">▲ 0.03pp vs. last cycle</p>
+            </article>
+            <article class="fm-kpi-ad">
+                <p class="fm-kpi-ad__label">Active Rails</p>
+                <p class="fm-kpi-ad__value">12</p>
+                <p class="fm-kpi-ad__delta">No change</p>
+            </article>
+        </section>
+
+        <div class="fm-actions-ad">
+            <a class="fm-trigger-ad fm-trigger-ad--primary" href="#fm-modal-payout-ad">Review payout batch</a>
+            <a class="fm-trigger-ad" href="#fm-modal-audit-ad">View audit trail</a>
+            <a class="fm-trigger-ad fm-trigger-ad--danger" href="#fm-modal-halt-ad">Halt settlement</a>
+        </div>
+
+        <p class="fm-footnote-ad">
+            Each modal is an <code>:target</code> overlay. Closing is handled by an anchor to
+            <code>#</code>, and the backdrop itself is a full-bleed dismiss link.
+        </p>
+    </div>
+
+    <!-- ── Modal 1: payout batch ─────────────────────────────────────────── -->
+    <div class="fm-overlay-ad" id="fm-modal-payout-ad" role="dialog" aria-modal="true" aria-labelledby="fm-payout-title-ad">
+        <a class="fm-overlay-ad__dismiss" href="#" aria-label="Close dialog"></a>
+        <div class="fm-modal-ad">
+            <div class="fm-modal-ad__head">
+                <div>
+                    <h2 class="fm-modal-ad__heading" id="fm-payout-title-ad">Payout batch #PB-40921</h2>
+                    <p class="fm-modal-ad__caption">Scheduled for release at 18:00 UTC</p>
+                </div>
+                <a class="fm-modal-ad__close" href="#" aria-label="Close dialog">&times;</a>
+            </div>
+            <div class="fm-modal-ad__body">
+                <div class="fm-ledger-ad">
+                    <div class="fm-ledger-ad__row">
+                        <span class="fm-ledger-ad__key">Recipients</span>
+                        <span class="fm-ledger-ad__val">1,284</span>
+                    </div>
+                    <div class="fm-ledger-ad__row">
+                        <span class="fm-ledger-ad__key">Gross amount</span>
+                        <span class="fm-ledger-ad__val">$1,940,220.00</span>
+                    </div>
+                    <div class="fm-ledger-ad__row">
+                        <span class="fm-ledger-ad__key">Processing fee</span>
+                        <span class="fm-ledger-ad__val">$4,850.55</span>
+                    </div>
+                    <div class="fm-ledger-ad__row">
+                        <span class="fm-ledger-ad__key">Net release</span>
+                        <span class="fm-ledger-ad__val fm-ledger-ad__val--positive">$1,935,369.45</span>
+                    </div>
+                </div>
+                <p class="fm-notice-ad">
+                    Funds clear on the ACH rail. Reversals are unavailable once the batch is released.
+                </p>
+            </div>
+            <div class="fm-modal-ad__foot">
+                <a class="fm-btn-ad" href="#">Cancel</a>
+                <a class="fm-btn-ad fm-btn-ad--confirm" href="#">Approve batch</a>
+            </div>
+        </div>
+    </div>
+
+    <!-- ── Modal 2: audit trail (wide) ───────────────────────────────────── -->
+    <div class="fm-overlay-ad" id="fm-modal-audit-ad" role="dialog" aria-modal="true" aria-labelledby="fm-audit-title-ad">
+        <a class="fm-overlay-ad__dismiss" href="#" aria-label="Close dialog"></a>
+        <div class="fm-modal-ad fm-modal-ad--wide">
+            <div class="fm-modal-ad__head">
+                <div>
+                    <h2 class="fm-modal-ad__heading" id="fm-audit-title-ad">Audit trail</h2>
+                    <p class="fm-modal-ad__caption">Last 5 state changes on this ledger</p>
+                </div>
+                <a class="fm-modal-ad__close" href="#" aria-label="Close dialog">&times;</a>
+            </div>
+            <div class="fm-modal-ad__body">
+                <div class="fm-ledger-ad">
+                    <div class="fm-ledger-ad__row">
+                        <span class="fm-ledger-ad__key">09:41 · reconciliation.completed</span>
+                        <span class="fm-ledger-ad__val fm-ledger-ad__val--positive">OK</span>
+                    </div>
+                    <div class="fm-ledger-ad__row">
+                        <span class="fm-ledger-ad__key">09:12 · rail.rebalanced</span>
+                        <span class="fm-ledger-ad__val">OK</span>
+                    </div>
+                    <div class="fm-ledger-ad__row">
+                        <span class="fm-ledger-ad__key">08:55 · hold.released</span>
+                        <span class="fm-ledger-ad__val">OK</span>
+                    </div>
+                    <div class="fm-ledger-ad__row">
+                        <span class="fm-ledger-ad__key">08:30 · limit.threshold_warning</span>
+                        <span class="fm-ledger-ad__val fm-ledger-ad__val--warning">REVIEW</span>
+                    </div>
+                    <div class="fm-ledger-ad__row">
+                        <span class="fm-ledger-ad__key">08:02 · session.authenticated</span>
+                        <span class="fm-ledger-ad__val">OK</span>
+                    </div>
+                </div>
+            </div>
+            <div class="fm-modal-ad__foot">
+                <a class="fm-btn-ad" href="#">Close</a>
+            </div>
+        </div>
+    </div>
+
+    <!-- ── Modal 3: destructive confirm ──────────────────────────────────── -->
+    <div class="fm-overlay-ad" id="fm-modal-halt-ad" role="alertdialog" aria-modal="true" aria-labelledby="fm-halt-title-ad">
+        <a class="fm-overlay-ad__dismiss" href="#" aria-label="Close dialog"></a>
+        <div class="fm-modal-ad">
+            <div class="fm-modal-ad__head">
+                <div>
+                    <h2 class="fm-modal-ad__heading" id="fm-halt-title-ad">Halt all settlement?</h2>
+                    <p class="fm-modal-ad__caption">This suspends every active rail immediately</p>
+                </div>
+                <a class="fm-modal-ad__close" href="#" aria-label="Close dialog">&times;</a>
+            </div>
+            <div class="fm-modal-ad__body">
+                <p>
+                    Halting stops 12 active rails and freezes $318K in pending holds. In-flight
+                    transfers already handed to the network will still complete.
+                </p>
+                <p class="fm-notice-ad fm-notice-ad--danger">
+                    Resuming settlement requires dual approval from two treasury operators.
+                </p>
+            </div>
+            <div class="fm-modal-ad__foot">
+                <a class="fm-btn-ad" href="#">Keep running</a>
+                <a class="fm-btn-ad fm-btn-ad--destructive" href="#">Halt settlement</a>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/59252-css-fade-in-modal-fintech-dashboard-ad/style.css
+++ b/submissions/examples/59252-css-fade-in-modal-fintech-dashboard-ad/style.css
@@ -1,0 +1,665 @@
+/* ==========================================================================
+   CSS Fade-In Modal – Fintech Dashboard Layouts
+   EaseMotion CSS · Issue #59252
+   Pure CSS :target modal with layered backdrop blur and fade-in entrance
+   ========================================================================== */
+
+/* ==========================================================================
+   Section 1: Custom Properties & Token Architecture
+   ========================================================================== */
+:root {
+    /* -- Surface Palette -- */
+    --fm-bg-root: #070b16;
+    --fm-bg-canvas: #0b1120;
+    --fm-surface-panel: rgba(15, 23, 42, 0.86);
+    --fm-surface-raised: rgba(23, 34, 58, 0.94);
+    --fm-surface-sunken: rgba(8, 13, 26, 0.72);
+
+    /* -- Accent Ramp -- */
+    --fm-accent: #22d3ee;
+    --fm-accent-soft: rgba(34, 211, 238, 0.16);
+    --fm-accent-line: rgba(34, 211, 238, 0.38);
+    --fm-positive: #34d399;
+    --fm-negative: #fb7185;
+    --fm-warning: #fbbf24;
+
+    /* -- Typography Colors -- */
+    --fm-text-strong: #f1f5f9;
+    --fm-text-body: #94a3b8;
+    --fm-text-muted: #64748b;
+
+    /* -- Borders & Dividers -- */
+    --fm-border: rgba(148, 163, 184, 0.14);
+    --fm-border-strong: rgba(148, 163, 184, 0.26);
+
+    /* -- Elevation -- */
+    --fm-shadow-panel: 0 18px 40px -24px rgba(2, 6, 23, 0.9);
+    --fm-shadow-modal:
+        0 32px 64px -24px rgba(2, 6, 23, 0.85),
+        0 0 0 1px rgba(148, 163, 184, 0.1);
+
+    /* -- Geometry -- */
+    --fm-radius-sm: 8px;
+    --fm-radius-md: 14px;
+    --fm-radius-lg: 20px;
+
+    /* -- Motion Tokens -- */
+    --fm-fade-duration: 320ms;
+    --fm-fade-delay: 60ms;
+    --fm-lift-distance: 14px;
+    --fm-ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+    --fm-ease-in: cubic-bezier(0.4, 0, 1, 1);
+
+    /* -- Typography -- */
+    --fm-font: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+    --fm-font-mono: "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+}
+
+/* ==========================================================================
+   Section 2: Base Reset & Page Shell
+   ========================================================================== */
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+html {
+    -webkit-text-size-adjust: 100%;
+}
+
+body {
+    margin: 0;
+    padding: 2.5rem 1.25rem 4rem;
+    background:
+        radial-gradient(circle at 12% 4%, rgba(34, 211, 238, 0.1), transparent 42%),
+        radial-gradient(circle at 88% 0%, rgba(129, 140, 248, 0.09), transparent 38%),
+        var(--fm-bg-root);
+    color: var(--fm-text-body);
+    font-family: var(--fm-font);
+    font-size: 15px;
+    line-height: 1.6;
+    min-height: 100vh;
+}
+
+.fm-shell-ad {
+    margin: 0 auto;
+    max-width: 1120px;
+}
+
+/* ==========================================================================
+   Section 3: Dashboard Header
+   ========================================================================== */
+.fm-header-ad {
+    align-items: flex-start;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.25rem;
+    justify-content: space-between;
+    margin-bottom: 2rem;
+}
+
+.fm-header-ad__eyebrow {
+    color: var(--fm-accent);
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.14em;
+    margin: 0 0 0.4rem;
+    text-transform: uppercase;
+}
+
+.fm-header-ad__title {
+    color: var(--fm-text-strong);
+    font-size: clamp(1.5rem, 3.4vw, 2.1rem);
+    font-weight: 650;
+    letter-spacing: -0.02em;
+    margin: 0 0 0.35rem;
+}
+
+.fm-header-ad__subtitle {
+    margin: 0;
+    max-width: 46ch;
+}
+
+.fm-header-ad__stamp {
+    background: var(--fm-surface-sunken);
+    border: 1px solid var(--fm-border);
+    border-radius: 999px;
+    color: var(--fm-text-muted);
+    font-family: var(--fm-font-mono);
+    font-size: 0.75rem;
+    padding: 0.45rem 0.9rem;
+    white-space: nowrap;
+}
+
+/* ==========================================================================
+   Section 4: KPI Strip (modal launch surface)
+   ========================================================================== */
+.fm-kpis-ad {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+    margin-bottom: 2rem;
+}
+
+.fm-kpi-ad {
+    background: var(--fm-surface-panel);
+    border: 1px solid var(--fm-border);
+    border-radius: var(--fm-radius-md);
+    box-shadow: var(--fm-shadow-panel);
+    padding: 1.15rem 1.25rem;
+}
+
+.fm-kpi-ad__label {
+    color: var(--fm-text-muted);
+    font-size: 0.74rem;
+    letter-spacing: 0.06em;
+    margin: 0 0 0.5rem;
+    text-transform: uppercase;
+}
+
+.fm-kpi-ad__value {
+    color: var(--fm-text-strong);
+    font-family: var(--fm-font-mono);
+    font-size: 1.6rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    margin: 0 0 0.35rem;
+}
+
+.fm-kpi-ad__delta {
+    font-size: 0.8rem;
+    font-weight: 550;
+    margin: 0;
+}
+
+.fm-kpi-ad__delta--up {
+    color: var(--fm-positive);
+}
+
+.fm-kpi-ad__delta--down {
+    color: var(--fm-negative);
+}
+
+/* ==========================================================================
+   Section 5: Trigger Buttons
+   ========================================================================== */
+.fm-actions-ad {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-bottom: 1.5rem;
+}
+
+.fm-trigger-ad {
+    background: var(--fm-surface-raised);
+    border: 1px solid var(--fm-border-strong);
+    border-radius: var(--fm-radius-sm);
+    color: var(--fm-text-strong);
+    cursor: pointer;
+    display: inline-block;
+    font-family: inherit;
+    font-size: 0.88rem;
+    font-weight: 550;
+    padding: 0.7rem 1.15rem;
+    text-decoration: none;
+    transition:
+        background-color 180ms var(--fm-ease-out),
+        border-color 180ms var(--fm-ease-out),
+        transform 180ms var(--fm-ease-out);
+}
+
+.fm-trigger-ad:hover {
+    background: rgba(34, 211, 238, 0.12);
+    border-color: var(--fm-accent-line);
+    transform: translateY(-1px);
+}
+
+.fm-trigger-ad:focus-visible {
+    outline: 2px solid var(--fm-accent);
+    outline-offset: 3px;
+}
+
+.fm-trigger-ad--primary {
+    background: linear-gradient(135deg, rgba(34, 211, 238, 0.22), rgba(59, 130, 246, 0.18));
+    border-color: var(--fm-accent-line);
+}
+
+.fm-trigger-ad--danger:hover {
+    background: rgba(251, 113, 133, 0.14);
+    border-color: rgba(251, 113, 133, 0.42);
+}
+
+/* ==========================================================================
+   Section 6: Modal Overlay — fade-in entrance
+   --------------------------------------------------------------------------
+   The overlay is always in the DOM but is inert (opacity 0 + pointer-events
+   none + visibility hidden) until its id matches the URL fragment. Using
+   visibility rather than display keeps the fade transition interpolatable.
+   ========================================================================== */
+.fm-overlay-ad {
+    align-items: center;
+    background: rgba(3, 7, 18, 0.72);
+    display: flex;
+    inset: 0;
+    justify-content: center;
+    opacity: 0;
+    padding: 1.25rem;
+    pointer-events: none;
+    position: fixed;
+    visibility: hidden;
+    z-index: 60;
+    transition:
+        opacity var(--fm-fade-duration) var(--fm-ease-in),
+        visibility 0s linear var(--fm-fade-duration),
+        backdrop-filter var(--fm-fade-duration) var(--fm-ease-in);
+}
+
+@supports (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px)) {
+    .fm-overlay-ad {
+        -webkit-backdrop-filter: blur(0);
+        backdrop-filter: blur(0);
+    }
+
+    .fm-overlay-ad:target {
+        -webkit-backdrop-filter: blur(9px);
+        backdrop-filter: blur(9px);
+    }
+}
+
+.fm-overlay-ad:target {
+    opacity: 1;
+    pointer-events: auto;
+    visibility: visible;
+    transition:
+        opacity var(--fm-fade-duration) var(--fm-ease-out),
+        visibility 0s linear 0s,
+        backdrop-filter var(--fm-fade-duration) var(--fm-ease-out);
+}
+
+/* Full-bleed click-catcher that closes the modal on backdrop press */
+.fm-overlay-ad__dismiss {
+    inset: 0;
+    position: absolute;
+    z-index: 0;
+}
+
+/* ==========================================================================
+   Section 7: Modal Dialog
+   ========================================================================== */
+.fm-modal-ad {
+    background: var(--fm-surface-raised);
+    border: 1px solid var(--fm-border-strong);
+    border-radius: var(--fm-radius-lg);
+    box-shadow: var(--fm-shadow-modal);
+    max-height: calc(100vh - 2.5rem);
+    max-width: 520px;
+    opacity: 0;
+    overflow-y: auto;
+    position: relative;
+    transform: translateY(var(--fm-lift-distance));
+    width: 100%;
+    z-index: 1;
+    transition:
+        opacity var(--fm-fade-duration) var(--fm-ease-in),
+        transform var(--fm-fade-duration) var(--fm-ease-in);
+}
+
+.fm-overlay-ad:target .fm-modal-ad {
+    opacity: 1;
+    transform: translateY(0);
+    transition:
+        opacity var(--fm-fade-duration) var(--fm-ease-out) var(--fm-fade-delay),
+        transform var(--fm-fade-duration) var(--fm-ease-out) var(--fm-fade-delay);
+}
+
+.fm-modal-ad--wide {
+    max-width: 660px;
+}
+
+/* -- Modal header -- */
+.fm-modal-ad__head {
+    align-items: flex-start;
+    border-bottom: 1px solid var(--fm-border);
+    display: flex;
+    gap: 1rem;
+    justify-content: space-between;
+    padding: 1.4rem 1.5rem 1.1rem;
+}
+
+.fm-modal-ad__heading {
+    color: var(--fm-text-strong);
+    font-size: 1.12rem;
+    font-weight: 620;
+    letter-spacing: -0.01em;
+    margin: 0 0 0.25rem;
+}
+
+.fm-modal-ad__caption {
+    font-size: 0.86rem;
+    margin: 0;
+}
+
+.fm-modal-ad__close {
+    align-items: center;
+    background: var(--fm-surface-sunken);
+    border: 1px solid var(--fm-border);
+    border-radius: 50%;
+    color: var(--fm-text-body);
+    display: flex;
+    flex: 0 0 auto;
+    height: 32px;
+    justify-content: center;
+    line-height: 1;
+    text-decoration: none;
+    width: 32px;
+    transition:
+        background-color 160ms var(--fm-ease-out),
+        color 160ms var(--fm-ease-out);
+}
+
+.fm-modal-ad__close:hover {
+    background: rgba(251, 113, 133, 0.16);
+    color: var(--fm-text-strong);
+}
+
+.fm-modal-ad__close:focus-visible {
+    outline: 2px solid var(--fm-accent);
+    outline-offset: 2px;
+}
+
+/* -- Modal body -- */
+.fm-modal-ad__body {
+    padding: 1.35rem 1.5rem;
+}
+
+.fm-modal-ad__body > p {
+    margin: 0 0 1rem;
+}
+
+.fm-modal-ad__body > p:last-child {
+    margin-bottom: 0;
+}
+
+/* -- Ledger rows inside the modal -- */
+.fm-ledger-ad {
+    border: 1px solid var(--fm-border);
+    border-radius: var(--fm-radius-md);
+    overflow: hidden;
+}
+
+.fm-ledger-ad__row {
+    align-items: center;
+    border-bottom: 1px solid var(--fm-border);
+    display: flex;
+    gap: 1rem;
+    justify-content: space-between;
+    padding: 0.8rem 1rem;
+}
+
+.fm-ledger-ad__row:last-child {
+    border-bottom: 0;
+}
+
+.fm-ledger-ad__key {
+    color: var(--fm-text-muted);
+    font-size: 0.82rem;
+}
+
+.fm-ledger-ad__val {
+    color: var(--fm-text-strong);
+    font-family: var(--fm-font-mono);
+    font-size: 0.88rem;
+}
+
+.fm-ledger-ad__val--positive {
+    color: var(--fm-positive);
+}
+
+.fm-ledger-ad__val--warning {
+    color: var(--fm-warning);
+}
+
+/* -- Inline notice -- */
+.fm-notice-ad {
+    background: var(--fm-accent-soft);
+    border-left: 3px solid var(--fm-accent);
+    border-radius: var(--fm-radius-sm);
+    color: var(--fm-text-body);
+    font-size: 0.84rem;
+    margin-top: 1.1rem;
+    padding: 0.8rem 1rem;
+}
+
+.fm-notice-ad--danger {
+    background: rgba(251, 113, 133, 0.12);
+    border-left-color: var(--fm-negative);
+}
+
+/* -- Modal footer -- */
+.fm-modal-ad__foot {
+    border-top: 1px solid var(--fm-border);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.65rem;
+    justify-content: flex-end;
+    padding: 1.1rem 1.5rem 1.35rem;
+}
+
+.fm-btn-ad {
+    background: transparent;
+    border: 1px solid var(--fm-border-strong);
+    border-radius: var(--fm-radius-sm);
+    color: var(--fm-text-body);
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.85rem;
+    font-weight: 550;
+    padding: 0.6rem 1.1rem;
+    text-decoration: none;
+    transition:
+        background-color 160ms var(--fm-ease-out),
+        color 160ms var(--fm-ease-out);
+}
+
+.fm-btn-ad:hover {
+    background: rgba(148, 163, 184, 0.1);
+    color: var(--fm-text-strong);
+}
+
+.fm-btn-ad:focus-visible {
+    outline: 2px solid var(--fm-accent);
+    outline-offset: 2px;
+}
+
+.fm-btn-ad--confirm {
+    background: linear-gradient(135deg, var(--fm-accent), #3b82f6);
+    border-color: transparent;
+    color: #041019;
+}
+
+.fm-btn-ad--confirm:hover {
+    color: #041019;
+    filter: brightness(1.08);
+}
+
+.fm-btn-ad--destructive {
+    background: rgba(251, 113, 133, 0.16);
+    border-color: rgba(251, 113, 133, 0.4);
+    color: #fecdd3;
+}
+
+/* ==========================================================================
+   Section 8: Staggered fade for modal body children
+   --------------------------------------------------------------------------
+   Children animate only while the overlay is targeted, so the keyframes
+   never run on page load for closed modals.
+   ========================================================================== */
+@keyframes fmFadeRise {
+    from {
+        opacity: 0;
+        transform: translateY(8px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.fm-overlay-ad:target .fm-modal-ad__head,
+.fm-overlay-ad:target .fm-modal-ad__body,
+.fm-overlay-ad:target .fm-modal-ad__foot {
+    animation: fmFadeRise var(--fm-fade-duration) var(--fm-ease-out) both;
+}
+
+.fm-overlay-ad:target .fm-modal-ad__head {
+    animation-delay: calc(var(--fm-fade-delay) + 40ms);
+}
+
+.fm-overlay-ad:target .fm-modal-ad__body {
+    animation-delay: calc(var(--fm-fade-delay) + 90ms);
+}
+
+.fm-overlay-ad:target .fm-modal-ad__foot {
+    animation-delay: calc(var(--fm-fade-delay) + 140ms);
+}
+
+/* ==========================================================================
+   Section 9: Scrollbar treatment inside modal
+   ========================================================================== */
+.fm-modal-ad::-webkit-scrollbar {
+    width: 10px;
+}
+
+.fm-modal-ad::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.fm-modal-ad::-webkit-scrollbar-thumb {
+    background: rgba(148, 163, 184, 0.22);
+    border: 3px solid transparent;
+    border-radius: 999px;
+    background-clip: content-box;
+}
+
+/* ==========================================================================
+   Section 10: Utility & Accessibility Helpers
+   ========================================================================== */
+.fm-visually-hidden-ad {
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+}
+
+.fm-footnote-ad {
+    border-top: 1px solid var(--fm-border);
+    color: var(--fm-text-muted);
+    font-size: 0.8rem;
+    margin-top: 2.5rem;
+    padding-top: 1.25rem;
+}
+
+.fm-footnote-ad code {
+    background: var(--fm-surface-sunken);
+    border-radius: 4px;
+    font-family: var(--fm-font-mono);
+    font-size: 0.78rem;
+    padding: 0.15rem 0.4rem;
+}
+
+/* ==========================================================================
+   Section 11: Responsive Breakpoints
+   ========================================================================== */
+@media (max-width: 720px) {
+    body {
+        padding: 1.75rem 1rem 3rem;
+    }
+
+    .fm-header-ad {
+        flex-direction: column;
+    }
+
+    .fm-modal-ad__head,
+    .fm-modal-ad__body,
+    .fm-modal-ad__foot {
+        padding-left: 1.15rem;
+        padding-right: 1.15rem;
+    }
+
+    .fm-modal-ad__foot .fm-btn-ad {
+        flex: 1 1 auto;
+        text-align: center;
+    }
+}
+
+@media (max-width: 480px) {
+    .fm-kpis-ad {
+        grid-template-columns: 1fr;
+    }
+
+    .fm-actions-ad .fm-trigger-ad {
+        flex: 1 1 100%;
+        text-align: center;
+    }
+
+    .fm-ledger-ad__row {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 0.25rem;
+    }
+}
+
+/* ==========================================================================
+   Section 12: Reduced Motion
+   --------------------------------------------------------------------------
+   Motion is removed but the open/closed state change is preserved, so the
+   modal remains fully operable for users who opt out of animation.
+   ========================================================================== */
+@media (prefers-reduced-motion: reduce) {
+    .fm-overlay-ad,
+    .fm-overlay-ad:target,
+    .fm-modal-ad,
+    .fm-overlay-ad:target .fm-modal-ad,
+    .fm-trigger-ad,
+    .fm-btn-ad,
+    .fm-modal-ad__close {
+        transition-duration: 1ms;
+        transition-delay: 0s;
+    }
+
+    .fm-overlay-ad:target .fm-modal-ad__head,
+    .fm-overlay-ad:target .fm-modal-ad__body,
+    .fm-overlay-ad:target .fm-modal-ad__foot {
+        animation-duration: 1ms;
+        animation-delay: 0s;
+    }
+
+    .fm-modal-ad {
+        transform: none;
+    }
+
+    .fm-trigger-ad:hover {
+        transform: none;
+    }
+}
+
+/* ==========================================================================
+   Section 13: Forced Colors / High Contrast
+   ========================================================================== */
+@media (forced-colors: active) {
+    .fm-modal-ad,
+    .fm-kpi-ad,
+    .fm-trigger-ad,
+    .fm-btn-ad {
+        border: 1px solid CanvasText;
+    }
+
+    .fm-overlay-ad {
+        background: Canvas;
+    }
+}


### PR DESCRIPTION
Fixes #59252

**What was added**

A pure CSS fade-in modal system for fintech dashboard layouts, submitted under `submissions/examples/` per the contribution guidelines.

- `submissions/examples/59252-css-fade-in-modal-fintech-dashboard-ad/style.css` — 577 non-empty lines across 13 documented sections: token architecture, dashboard shell, KPI strip, trigger buttons, `:target` overlay, dialog, staggered body fade, scrollbar treatment, a11y helpers, responsive breakpoints, reduced-motion, and forced-colors.
- `submissions/examples/59252-css-fade-in-modal-fintech-dashboard-ad/demo.html` — 161-line self-contained demo: a mock treasury console with three modal variants (standard payout batch, wide audit trail, destructive halt confirm).
- `submissions/examples/59252-css-fade-in-modal-fintech-dashboard-ad/README.md` — usage, markup pattern, and custom-property reference.

**Why this approach**

The overlay stays inert via `visibility: hidden` + `pointer-events: none` rather than `display: none`. That matters: `display` is not an interpolatable property, so a `display`-toggled modal cannot fade out at all — it snaps. Delaying `visibility` by the fade duration on close, and zeroing that delay on open, gives a real two-way transition while keeping the closed overlay untabbable.

Only `opacity` and `transform` are animated, so the entrance stays on the compositor and never triggers layout. The dialog trails the backdrop by `--fm-fade-delay` so the two surfaces read as depth rather than a single flat flash.

**How to test**

1. Pull this branch.
2. Open `submissions/examples/59252-css-fade-in-modal-fintech-dashboard-ad/demo.html` directly in a browser — no server, no build step, no CDN.
3. Click "Review payout batch" — the backdrop fades and blurs while the dialog lifts 14px into place.
4. Close via the × button, the "Cancel" action, or by clicking the backdrop itself. All three routes fade back out rather than snapping.
5. Enable OS-level "reduce motion" and repeat — modals open and close instantly with no animation, but remain fully operable.
6. Resize below 480px to confirm the KPI grid collapses to one column and footer actions go full-width.

**Edge cases covered**

- Closed overlays are `pointer-events: none` and `visibility: hidden`, so they never intercept clicks or receive tab focus.
- `backdrop-filter` is guarded by `@supports` and degrades to a plain scrim on browsers without it.
- `prefers-reduced-motion: reduce` collapses every transition and animation to 1ms and removes the transform, preserving the state change.
- `forced-colors: active` restores explicit borders so surfaces stay distinguishable in high-contrast mode.
- Long modal content scrolls internally via `max-height: calc(100vh - 2.5rem)` with a styled scrollbar, instead of overflowing the viewport.
- `:focus-visible` rings on every interactive element — triggers, close button, and footer actions.
- Dialogs carry `role="dialog"` / `role="alertdialog"`, `aria-modal`, and `aria-labelledby`; the backdrop dismiss link has an `aria-label`.

**Verification**

- `npx stylelint style.css` against the repo's own config — zero errors.
- All 39 classes used in `demo.html` are defined in `style.css`; zero dead anchor targets.
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 3 new files, 869 insertions, 0 deletions, no existing file touched.
- Component classes carry an `-ad` suffix so this lands as a parallel implementation without overwriting existing contributor work.

**Labels:** `type:feature` · `level:easy` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
