### PR TITLE
feat: add CSS slide-up drawer for fintech dashboard layouts (#59268)

### DIFF
--- a/submissions/examples/59268-css-slide-up-drawer-fintech-dashboard-ad/README.md
+++ b/submissions/examples/59268-css-slide-up-drawer-fintech-dashboard-ad/README.md
@@ -1,0 +1,45 @@
+# CSS Slide-Up Drawer for Fintech Dashboard Layouts
+
+> Issue: [#59268](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/59268)
+
+A bottom-sheet drawer that slides up from the viewport edge, holding its open state in a single hidden checkbox. No JavaScript.
+
+## What it does
+
+Presents a scrollable transfer feed in a bottom sheet over a mock accounts dashboard. Rows stagger in as the sheet settles. The scrim and the close button are both `<label>` elements bound to the same checkbox, so every dismiss route is pure CSS.
+
+## How it is used
+
+```html
+<input class="dr-toggle-ad" type="checkbox" id="dr-sheet-toggle-ad">
+<label class="dr-open-ad" for="dr-sheet-toggle-ad">Open recent movement</label>
+
+<label class="dr-scrim-ad" for="dr-sheet-toggle-ad" aria-hidden="true"></label>
+
+<aside class="dr-sheet-ad" role="dialog" aria-modal="true">
+    <div class="dr-sheet-ad__grip"></div>
+    <div class="dr-sheet-ad__head">…</div>
+    <div class="dr-sheet-ad__body"><div class="dr-row-ad">…</div></div>
+    <div class="dr-sheet-ad__foot">…</div>
+</aside>
+```
+
+The trigger, scrim and sheet must be **siblings** of the checkbox — the general sibling combinator (`~`) is what drives the open state.
+
+## Key CSS custom properties
+
+```css
+--dr-slide-duration: 380ms;  /* sheet travel */
+--dr-scrim-duration: 260ms;  /* scrim fade, deliberately shorter */
+--dr-stagger-step:    55ms;  /* per-row delay */
+--dr-sheet-max-h:     78vh;  /* clamps tall content */
+--dr-accent:       #a78bfa;
+```
+
+## Why it fits EaseMotion
+
+The sheet animates only `transform: translateY(100%)` → `translateY(0)` — a percentage translate, so it stays fully off-screen at any sheet height without hardcoding pixels. Nothing touches layout, so the slide runs entirely on the compositor.
+
+`visibility` is transitioned with a delay equal to the slide duration on close and `0s` on open. That keeps the closed sheet untabbable without using `display: none`, which would kill the transition outright.
+
+`prefers-reduced-motion: reduce` collapses the slide, the scrim fade and the row stagger to 1ms while preserving the open/closed state change, and `forced-colors: active` restores explicit borders for high-contrast users.

--- a/submissions/examples/59268-css-slide-up-drawer-fintech-dashboard-ad/demo.html
+++ b/submissions/examples/59268-css-slide-up-drawer-fintech-dashboard-ad/demo.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Slide-Up Drawer — Fintech Dashboard Layouts</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="dr-shell-ad">
+        <header class="dr-head-ad">
+            <p class="dr-head-ad__eyebrow">Accounts</p>
+            <h1 class="dr-head-ad__title">Balances &amp; Recent Movement</h1>
+            <p class="dr-head-ad__lede">
+                A bottom sheet that slides up from the viewport edge, toggled by a hidden
+                checkbox. Transform-only animation, no JavaScript.
+            </p>
+        </header>
+
+        <section class="dr-accounts-ad" aria-label="Account balances">
+            <article class="dr-account-ad">
+                <p class="dr-account-ad__name">Operating</p>
+                <p class="dr-account-ad__balance">$862,410</p>
+                <p class="dr-account-ad__meta dr-account-ad__meta--up">▲ $12,480 today</p>
+            </article>
+            <article class="dr-account-ad">
+                <p class="dr-account-ad__name">Reserve</p>
+                <p class="dr-account-ad__balance">$2,140,000</p>
+                <p class="dr-account-ad__meta">Unchanged</p>
+            </article>
+            <article class="dr-account-ad">
+                <p class="dr-account-ad__name">Payables</p>
+                <p class="dr-account-ad__balance">$318,205</p>
+                <p class="dr-account-ad__meta dr-account-ad__meta--down">▼ $6,120 today</p>
+            </article>
+        </section>
+
+        <!-- Hidden state holder. Trigger, scrim and sheet are all siblings. -->
+        <input class="dr-toggle-ad" type="checkbox" id="dr-sheet-toggle-ad">
+        <label class="dr-open-ad" for="dr-sheet-toggle-ad">Open recent movement</label>
+
+        <label class="dr-scrim-ad" for="dr-sheet-toggle-ad" aria-hidden="true"></label>
+
+        <aside class="dr-sheet-ad" role="dialog" aria-modal="true" aria-labelledby="dr-sheet-title-ad">
+            <div class="dr-sheet-ad__grip" aria-hidden="true"></div>
+
+            <div class="dr-sheet-ad__head">
+                <div>
+                    <h2 class="dr-sheet-ad__title" id="dr-sheet-title-ad">Recent movement</h2>
+                    <p class="dr-sheet-ad__sub">Last 5 transfers across all rails</p>
+                </div>
+                <label class="dr-close-ad" for="dr-sheet-toggle-ad" aria-label="Close drawer">&times;</label>
+            </div>
+
+            <div class="dr-sheet-ad__body">
+                <div class="dr-row-ad">
+                    <div>
+                        <p class="dr-row-ad__who">Northwind Logistics</p>
+                        <p class="dr-row-ad__when">Today · 09:41 · ACH</p>
+                    </div>
+                    <span class="dr-row-ad__amt dr-row-ad__amt--in">+$48,200.00</span>
+                </div>
+                <div class="dr-row-ad">
+                    <div>
+                        <p class="dr-row-ad__who">Payroll — March cycle</p>
+                        <p class="dr-row-ad__when">Today · 08:15 · SEPA</p>
+                    </div>
+                    <span class="dr-row-ad__amt dr-row-ad__amt--out">−$212,940.00</span>
+                </div>
+                <div class="dr-row-ad">
+                    <div>
+                        <p class="dr-row-ad__who">Corvus Analytics</p>
+                        <p class="dr-row-ad__when">Yesterday · 17:52 · Wire</p>
+                    </div>
+                    <span class="dr-row-ad__amt dr-row-ad__amt--in">+$9,750.00</span>
+                </div>
+                <div class="dr-row-ad">
+                    <div>
+                        <p class="dr-row-ad__who">Cloud infrastructure</p>
+                        <p class="dr-row-ad__when">Yesterday · 14:08 · Card</p>
+                    </div>
+                    <span class="dr-row-ad__amt dr-row-ad__amt--out">−$18,430.55</span>
+                </div>
+                <div class="dr-row-ad">
+                    <div>
+                        <p class="dr-row-ad__who">Meridian Capital</p>
+                        <p class="dr-row-ad__when">2 days ago · 11:20 · Wire</p>
+                    </div>
+                    <span class="dr-row-ad__amt dr-row-ad__amt--in">+$126,000.00</span>
+                </div>
+            </div>
+
+            <div class="dr-sheet-ad__foot">
+                <label class="dr-btn-ad" for="dr-sheet-toggle-ad">Dismiss</label>
+                <button class="dr-btn-ad dr-btn-ad--primary" type="button">Export statement</button>
+            </div>
+        </aside>
+
+        <p class="dr-note-ad">
+            State lives in a single <code>:checked</code> input. The scrim and the close
+            control are <code>&lt;label&gt;</code> elements pointing at the same checkbox,
+            so every dismiss route is pure CSS.
+        </p>
+    </div>
+</body>
+</html>

--- a/submissions/examples/59268-css-slide-up-drawer-fintech-dashboard-ad/style.css
+++ b/submissions/examples/59268-css-slide-up-drawer-fintech-dashboard-ad/style.css
@@ -1,0 +1,570 @@
+/* ==========================================================================
+   CSS Slide-Up Drawer – Fintech Dashboard Layouts
+   EaseMotion CSS · Issue #59268
+   Checkbox-toggled bottom sheet with transform-only slide-up entrance
+   ========================================================================== */
+
+/* ==========================================================================
+   Section 1: Custom Properties & Token Architecture
+   ========================================================================== */
+:root {
+    /* -- Surfaces -- */
+    --dr-bg-root: #06090f;
+    --dr-surface-card: rgba(17, 24, 39, 0.9);
+    --dr-surface-sheet: #111a2b;
+    --dr-surface-inset: rgba(6, 11, 20, 0.66);
+
+    /* -- Accents -- */
+    --dr-accent: #a78bfa;
+    --dr-accent-line: rgba(167, 139, 250, 0.42);
+    --dr-accent-soft: rgba(167, 139, 250, 0.14);
+    --dr-teal: #2dd4bf;
+    --dr-rose: #fb7185;
+
+    /* -- Text -- */
+    --dr-text-strong: #eef2ff;
+    --dr-text-body: #9aa5b8;
+    --dr-text-muted: #6b7789;
+
+    /* -- Lines -- */
+    --dr-border: rgba(148, 163, 184, 0.13);
+    --dr-border-strong: rgba(148, 163, 184, 0.28);
+
+    /* -- Elevation -- */
+    --dr-shadow-sheet: 0 -24px 60px -20px rgba(0, 0, 0, 0.85);
+    --dr-shadow-card: 0 14px 32px -22px rgba(0, 0, 0, 0.9);
+
+    /* -- Geometry -- */
+    --dr-radius-sheet: 22px;
+    --dr-radius-md: 12px;
+    --dr-radius-sm: 8px;
+    --dr-sheet-max-h: 78vh;
+
+    /* -- Motion -- */
+    --dr-slide-duration: 380ms;
+    --dr-scrim-duration: 260ms;
+    --dr-stagger-step: 55ms;
+    --dr-ease-out: cubic-bezier(0.22, 1, 0.36, 1);
+    --dr-ease-in: cubic-bezier(0.55, 0, 1, 0.45);
+
+    /* -- Type -- */
+    --dr-font: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+    --dr-font-mono: "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+}
+
+/* ==========================================================================
+   Section 2: Base & Page Shell
+   ========================================================================== */
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+body {
+    background:
+        radial-gradient(circle at 78% 6%, rgba(167, 139, 250, 0.12), transparent 44%),
+        radial-gradient(circle at 8% 90%, rgba(45, 212, 191, 0.08), transparent 40%),
+        var(--dr-bg-root);
+    color: var(--dr-text-body);
+    font-family: var(--dr-font);
+    font-size: 15px;
+    line-height: 1.6;
+    margin: 0;
+    min-height: 100vh;
+    padding: 2.5rem 1.25rem 5rem;
+}
+
+.dr-shell-ad {
+    margin: 0 auto;
+    max-width: 1040px;
+}
+
+/* ==========================================================================
+   Section 3: Header
+   ========================================================================== */
+.dr-head-ad {
+    margin-bottom: 2rem;
+}
+
+.dr-head-ad__eyebrow {
+    color: var(--dr-accent);
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.15em;
+    margin: 0 0 0.45rem;
+    text-transform: uppercase;
+}
+
+.dr-head-ad__title {
+    color: var(--dr-text-strong);
+    font-size: clamp(1.55rem, 3.6vw, 2.15rem);
+    font-weight: 650;
+    letter-spacing: -0.02em;
+    margin: 0 0 0.4rem;
+}
+
+.dr-head-ad__lede {
+    margin: 0;
+    max-width: 54ch;
+}
+
+/* ==========================================================================
+   Section 4: Account Cards
+   ========================================================================== */
+.dr-accounts-ad {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+    margin-bottom: 2rem;
+}
+
+.dr-account-ad {
+    background: var(--dr-surface-card);
+    border: 1px solid var(--dr-border);
+    border-radius: var(--dr-radius-md);
+    box-shadow: var(--dr-shadow-card);
+    padding: 1.15rem 1.2rem;
+}
+
+.dr-account-ad__name {
+    color: var(--dr-text-muted);
+    font-size: 0.75rem;
+    letter-spacing: 0.07em;
+    margin: 0 0 0.55rem;
+    text-transform: uppercase;
+}
+
+.dr-account-ad__balance {
+    color: var(--dr-text-strong);
+    font-family: var(--dr-font-mono);
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin: 0 0 0.3rem;
+}
+
+.dr-account-ad__meta {
+    font-size: 0.8rem;
+    margin: 0;
+}
+
+.dr-account-ad__meta--up {
+    color: var(--dr-teal);
+}
+
+.dr-account-ad__meta--down {
+    color: var(--dr-rose);
+}
+
+/* ==========================================================================
+   Section 5: Drawer Control
+   --------------------------------------------------------------------------
+   A visually hidden checkbox holds the open state. Labels act as triggers,
+   which keeps the whole drawer keyboard-operable with zero JavaScript.
+   ========================================================================== */
+.dr-toggle-ad {
+    height: 0;
+    opacity: 0;
+    pointer-events: none;
+    position: absolute;
+    width: 0;
+}
+
+.dr-open-ad {
+    background: linear-gradient(135deg, var(--dr-accent-soft), rgba(45, 212, 191, 0.12));
+    border: 1px solid var(--dr-accent-line);
+    border-radius: var(--dr-radius-sm);
+    color: var(--dr-text-strong);
+    cursor: pointer;
+    display: inline-block;
+    font-size: 0.88rem;
+    font-weight: 550;
+    padding: 0.72rem 1.2rem;
+    transition:
+        background-color 180ms var(--dr-ease-out),
+        transform 180ms var(--dr-ease-out);
+}
+
+.dr-open-ad:hover {
+    transform: translateY(-1px);
+}
+
+/* Focus ring is driven by the hidden input, mirrored onto its label */
+.dr-toggle-ad:focus-visible + .dr-open-ad {
+    outline: 2px solid var(--dr-accent);
+    outline-offset: 3px;
+}
+
+/* ==========================================================================
+   Section 6: Scrim
+   ========================================================================== */
+.dr-scrim-ad {
+    background: rgba(3, 6, 14, 0.66);
+    cursor: pointer;
+    inset: 0;
+    opacity: 0;
+    pointer-events: none;
+    position: fixed;
+    visibility: hidden;
+    z-index: 40;
+    transition:
+        opacity var(--dr-scrim-duration) var(--dr-ease-in),
+        visibility 0s linear var(--dr-scrim-duration);
+}
+
+/* `touch-action` suppresses rubber-band scroll of the page behind the sheet */
+.dr-toggle-ad:checked ~ .dr-scrim-ad {
+    opacity: 1;
+    pointer-events: auto;
+    touch-action: none;
+    visibility: visible;
+    transition:
+        opacity var(--dr-scrim-duration) var(--dr-ease-out),
+        visibility 0s linear 0s;
+}
+
+/* ==========================================================================
+   Section 7: Bottom Sheet — slide-up entrance
+   --------------------------------------------------------------------------
+   Only `transform` animates. The sheet is translated fully off-screen with
+   a percentage translate so it works at any sheet height.
+   ========================================================================== */
+.dr-sheet-ad {
+    background: var(--dr-surface-sheet);
+    border-radius: var(--dr-radius-sheet) var(--dr-radius-sheet) 0 0;
+    border-top: 1px solid var(--dr-border-strong);
+    bottom: 0;
+    box-shadow: var(--dr-shadow-sheet);
+    display: flex;
+    flex-direction: column;
+    left: 50%;
+    max-height: var(--dr-sheet-max-h);
+    max-width: 620px;
+    position: fixed;
+    transform: translateX(-50%) translateY(100%);
+    visibility: hidden;
+    width: 100%;
+    z-index: 50;
+    transition:
+        transform var(--dr-slide-duration) var(--dr-ease-in),
+        visibility 0s linear var(--dr-slide-duration);
+}
+
+.dr-toggle-ad:checked ~ .dr-sheet-ad {
+    transform: translateX(-50%) translateY(0);
+    visibility: visible;
+    transition:
+        transform var(--dr-slide-duration) var(--dr-ease-out),
+        visibility 0s linear 0s;
+}
+
+/* -- Grab handle -- */
+.dr-sheet-ad__grip {
+    display: flex;
+    justify-content: center;
+    padding: 0.75rem 0 0.25rem;
+}
+
+.dr-sheet-ad__grip::after {
+    background: var(--dr-border-strong);
+    border-radius: 999px;
+    content: "";
+    height: 4px;
+    width: 40px;
+}
+
+/* -- Sheet header -- */
+.dr-sheet-ad__head {
+    align-items: flex-start;
+    border-bottom: 1px solid var(--dr-border);
+    display: flex;
+    gap: 1rem;
+    justify-content: space-between;
+    padding: 0.6rem 1.4rem 1rem;
+}
+
+.dr-sheet-ad__title {
+    color: var(--dr-text-strong);
+    font-size: 1.1rem;
+    font-weight: 620;
+    margin: 0 0 0.2rem;
+}
+
+.dr-sheet-ad__sub {
+    font-size: 0.85rem;
+    margin: 0;
+}
+
+.dr-close-ad {
+    align-items: center;
+    background: var(--dr-surface-inset);
+    border: 1px solid var(--dr-border);
+    border-radius: 50%;
+    color: var(--dr-text-body);
+    cursor: pointer;
+    display: flex;
+    flex: 0 0 auto;
+    font-size: 1.1rem;
+    height: 32px;
+    justify-content: center;
+    line-height: 1;
+    width: 32px;
+    transition: background-color 160ms var(--dr-ease-out);
+}
+
+.dr-close-ad:hover {
+    background: rgba(251, 113, 133, 0.16);
+    color: var(--dr-text-strong);
+}
+
+/* -- Scrollable sheet body -- */
+.dr-sheet-ad__body {
+    overflow-y: auto;
+    padding: 1.2rem 1.4rem;
+}
+
+/* ==========================================================================
+   Section 8: Transfer Rows (staggered reveal)
+   ========================================================================== */
+@keyframes drRowRise {
+    from {
+        opacity: 0;
+        transform: translateY(14px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.dr-row-ad {
+    align-items: center;
+    background: var(--dr-surface-inset);
+    border: 1px solid var(--dr-border);
+    border-radius: var(--dr-radius-md);
+    display: flex;
+    gap: 1rem;
+    justify-content: space-between;
+    margin-bottom: 0.7rem;
+    opacity: 0;
+    padding: 0.85rem 1rem;
+}
+
+.dr-row-ad:last-of-type {
+    margin-bottom: 0;
+}
+
+.dr-toggle-ad:checked ~ .dr-sheet-ad .dr-row-ad {
+    animation: drRowRise 420ms var(--dr-ease-out) both;
+}
+
+.dr-toggle-ad:checked ~ .dr-sheet-ad .dr-row-ad:nth-of-type(1) {
+    animation-delay: calc(var(--dr-stagger-step) * 1);
+}
+
+.dr-toggle-ad:checked ~ .dr-sheet-ad .dr-row-ad:nth-of-type(2) {
+    animation-delay: calc(var(--dr-stagger-step) * 2);
+}
+
+.dr-toggle-ad:checked ~ .dr-sheet-ad .dr-row-ad:nth-of-type(3) {
+    animation-delay: calc(var(--dr-stagger-step) * 3);
+}
+
+.dr-toggle-ad:checked ~ .dr-sheet-ad .dr-row-ad:nth-of-type(4) {
+    animation-delay: calc(var(--dr-stagger-step) * 4);
+}
+
+.dr-toggle-ad:checked ~ .dr-sheet-ad .dr-row-ad:nth-of-type(5) {
+    animation-delay: calc(var(--dr-stagger-step) * 5);
+}
+
+.dr-row-ad__who {
+    color: var(--dr-text-strong);
+    font-size: 0.9rem;
+    font-weight: 550;
+    margin: 0 0 0.15rem;
+}
+
+.dr-row-ad__when {
+    color: var(--dr-text-muted);
+    font-size: 0.76rem;
+    margin: 0;
+}
+
+.dr-row-ad__amt {
+    color: var(--dr-text-strong);
+    font-family: var(--dr-font-mono);
+    font-size: 0.92rem;
+    white-space: nowrap;
+}
+
+.dr-row-ad__amt--in {
+    color: var(--dr-teal);
+}
+
+.dr-row-ad__amt--out {
+    color: var(--dr-rose);
+}
+
+/* ==========================================================================
+   Section 9: Sheet Footer
+   ========================================================================== */
+.dr-sheet-ad__foot {
+    border-top: 1px solid var(--dr-border);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.65rem;
+    justify-content: flex-end;
+    padding: 1rem 1.4rem 1.3rem;
+}
+
+.dr-btn-ad {
+    background: transparent;
+    border: 1px solid var(--dr-border-strong);
+    border-radius: var(--dr-radius-sm);
+    color: var(--dr-text-body);
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.85rem;
+    font-weight: 550;
+    padding: 0.6rem 1.1rem;
+    transition: background-color 160ms var(--dr-ease-out);
+}
+
+.dr-btn-ad:hover {
+    background: rgba(148, 163, 184, 0.1);
+    color: var(--dr-text-strong);
+}
+
+.dr-btn-ad:focus-visible {
+    outline: 2px solid var(--dr-accent);
+    outline-offset: 2px;
+}
+
+.dr-btn-ad--primary {
+    background: linear-gradient(135deg, var(--dr-accent), #6366f1);
+    border-color: transparent;
+    color: #0b0718;
+}
+
+.dr-btn-ad--primary:hover {
+    color: #0b0718;
+    filter: brightness(1.08);
+}
+
+/* ==========================================================================
+   Section 10: Scrollbar
+   ========================================================================== */
+.dr-sheet-ad__body::-webkit-scrollbar {
+    width: 10px;
+}
+
+.dr-sheet-ad__body::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.dr-sheet-ad__body::-webkit-scrollbar-thumb {
+    background: rgba(148, 163, 184, 0.22);
+    background-clip: content-box;
+    border: 3px solid transparent;
+    border-radius: 999px;
+}
+
+/* ==========================================================================
+   Section 11: Helpers
+   ========================================================================== */
+.dr-note-ad {
+    border-top: 1px solid var(--dr-border);
+    color: var(--dr-text-muted);
+    font-size: 0.8rem;
+    margin-top: 2.5rem;
+    padding-top: 1.25rem;
+}
+
+.dr-note-ad code {
+    background: var(--dr-surface-inset);
+    border-radius: 4px;
+    font-family: var(--dr-font-mono);
+    font-size: 0.78rem;
+    padding: 0.15rem 0.4rem;
+}
+
+/* ==========================================================================
+   Section 12: Responsive
+   ========================================================================== */
+@media (max-width: 720px) {
+    body {
+        padding: 1.75rem 1rem 4rem;
+    }
+
+    .dr-sheet-ad {
+        --dr-sheet-max-h: 86vh;
+    }
+
+    .dr-sheet-ad__head,
+    .dr-sheet-ad__body,
+    .dr-sheet-ad__foot {
+        padding-left: 1.1rem;
+        padding-right: 1.1rem;
+    }
+}
+
+@media (max-width: 480px) {
+    .dr-accounts-ad {
+        grid-template-columns: 1fr;
+    }
+
+    .dr-sheet-ad__foot .dr-btn-ad {
+        flex: 1 1 auto;
+        text-align: center;
+    }
+
+    .dr-row-ad {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 0.35rem;
+    }
+}
+
+/* ==========================================================================
+   Section 13: Reduced Motion
+   ========================================================================== */
+@media (prefers-reduced-motion: reduce) {
+    .dr-sheet-ad,
+    .dr-toggle-ad:checked ~ .dr-sheet-ad,
+    .dr-scrim-ad,
+    .dr-toggle-ad:checked ~ .dr-scrim-ad,
+    .dr-open-ad,
+    .dr-btn-ad,
+    .dr-close-ad {
+        transition-duration: 1ms;
+        transition-delay: 0s;
+    }
+
+    .dr-toggle-ad:checked ~ .dr-sheet-ad .dr-row-ad {
+        animation-duration: 1ms;
+        animation-delay: 0s;
+    }
+
+    .dr-open-ad:hover {
+        transform: none;
+    }
+}
+
+/* ==========================================================================
+   Section 14: Forced Colors
+   ========================================================================== */
+@media (forced-colors: active) {
+    .dr-sheet-ad,
+    .dr-account-ad,
+    .dr-row-ad,
+    .dr-btn-ad,
+    .dr-open-ad {
+        border: 1px solid CanvasText;
+    }
+
+    .dr-scrim-ad {
+        background: Canvas;
+    }
+}


### PR DESCRIPTION
Fixes #59268

**What was added**

A pure CSS slide-up bottom-sheet drawer for fintech dashboard layouts, under `submissions/examples/`.

- `style.css` — 495 non-empty lines across 14 documented sections: token architecture, page shell, account cards, checkbox drawer control, scrim, bottom sheet, staggered transfer rows, footer, scrollbar, helpers, responsive breakpoints, reduced-motion, and forced-colors.
- `demo.html` — 98-line self-contained demo: a mock accounts dashboard with a scrollable five-row transfer feed in the sheet.
- `README.md` — markup pattern, custom-property reference, and the sibling-combinator requirement.

**Why this approach**

State lives in one visually hidden checkbox; the trigger, scrim, close button and footer dismiss are all `<label for>` elements pointing at it. That makes every open and close route pure CSS and keyboard-operable, with no JavaScript and no `:target` hash pollution in the URL.

The sheet animates only `transform: translateY(100%)` → `translateY(0)`. Using a *percentage* translate rather than a pixel value means the sheet parks fully off-screen at any height, so `--dr-sheet-max-h` can change (it does, at the 720px breakpoint) without leaving a sliver visible. Nothing touches layout, so the slide stays on the compositor.

`visibility` is transitioned with a delay equal to the slide duration on close and `0s` on open. This keeps the closed sheet untabbable without `display: none`, which is not interpolatable and would make the sheet snap instead of slide.

**How to test**

1. Pull this branch.
2. Open `submissions/examples/59268-css-slide-up-drawer-fintech-dashboard-ad/demo.html` directly in a browser — no server, no build, no CDN.
3. Click "Open recent movement" — the scrim fades in over 260ms while the sheet slides up over 380ms, and the five transfer rows stagger in behind it.
4. Close via the × control, the "Dismiss" button, or by clicking the scrim. All three routes reverse the slide.
5. Tab to the trigger before opening — the focus ring is mirrored from the hidden input onto its label via `:focus-visible + label`.
6. Enable OS-level "reduce motion" and repeat — the sheet opens and closes instantly, still fully operable.
7. Resize below 480px — account cards collapse to one column, sheet height grows to 86vh, and rows stack vertically.

**Edge cases covered**

- Closed sheet is `visibility: hidden`, so it never receives tab focus or intercepts pointer events.
- Percentage translate keeps the sheet fully off-screen at any `--dr-sheet-max-h`, including the responsive override.
- Tall content scrolls inside `.dr-sheet-ad__body` with a styled scrollbar rather than overflowing the viewport.
- `touch-action: none` on the active scrim suppresses rubber-band scrolling of the page behind the sheet on touch devices.
- The hidden checkbox uses `opacity: 0` + zero size rather than `display: none`, so it stays focusable and the label focus ring works.
- `prefers-reduced-motion: reduce` collapses the slide, scrim fade and row stagger to 1ms and removes the hover lift.
- `forced-colors: active` restores explicit borders on sheet, cards, rows and buttons.
- Sheet carries `role="dialog"` + `aria-modal` + `aria-labelledby`; the scrim is `aria-hidden` and the close label has an `aria-label`.

**Verification**

- `npx stylelint style.css` against the repo's own config — zero errors.
- All 32 classes used in `demo.html` are defined in `style.css`; zero dead `for=` label targets.
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 3 new files, 721 insertions, 0 deletions, no existing file touched.
- Component classes carry an `-ad` suffix so this lands as a parallel implementation without overwriting existing contributor work.

**Labels:** `type:feature` · `level:easy` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
