### PR TITLE
feat: add CSS fade-in tooltip for fintech dashboard layouts (#59312)

### DIFF
--- a/submissions/examples/59312-css-fade-in-tooltip-fintech-dashboard-ad/README.md
+++ b/submissions/examples/59312-css-fade-in-tooltip-fintech-dashboard-ad/README.md
@@ -1,0 +1,42 @@
+# CSS Fade-In Tooltip for Fintech Dashboard Layouts
+
+> Issue: [#59312](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/59312)
+
+Four-directional tooltips that fade in after a short intent delay, with full hover and keyboard-focus parity. No JavaScript.
+
+## What it does
+
+Provides `--top`, `--bottom`, `--left` and `--right` placements sharing one bubble component. Each drifts a few pixels toward its trigger as it fades in. Tooltips open on `:hover` **or** `:focus-within`, so tabbing to a trigger shows the same tooltip a mouse user sees.
+
+## How it is used
+
+```html
+<span class="tt-ad">
+    <button class="tt-trigger-ad" type="button" aria-describedby="tt-top-ad">Top placement</button>
+    <span class="tt-ad__bubble tt-ad__bubble--top" id="tt-top-ad" role="tooltip">
+        <span class="tt-ad__bubble-title">Net Interest Margin</span>
+        Interest earned minus interest paid, over average earning assets.
+    </span>
+</span>
+```
+
+The bubble is a real sibling element, not a `::before` on the trigger — so it can hold rich markup and be referenced by `aria-describedby`.
+
+## Key CSS custom properties
+
+```css
+--tt-open-delay: 320ms;  /* intent filter before opening */
+--tt-fade-in:    180ms;
+--tt-fade-out:   120ms;  /* faster out than in */
+--tt-travel:       5px;  /* drift toward the trigger */
+--tt-gap:         10px;  /* trigger-to-bubble distance */
+--tt-bubble-max: 240px;
+```
+
+## Why it fits EaseMotion
+
+The open delay lives in `transition-delay` on the **open** state only, while the closed state has no delay. That asymmetry is the whole trick: tooltips wait 320ms before appearing, filtering out incidental pointer travel across a dense dashboard, but dismiss immediately when the pointer leaves.
+
+`visibility` is transitioned alongside opacity — delayed by the fade-out duration when closing, and by the open delay when opening. This keeps closed bubbles out of the accessibility tree and unhittable without `display: none`, which would break the fade entirely.
+
+Under `prefers-reduced-motion` the fade collapses to 1ms and the drift is removed, but **the open delay is deliberately kept** — it is an intent filter rather than decoration, and dropping it would make tooltips flicker on every incidental pointer movement. Below 620px the left/right placements re-point downward, since a side bubble would otherwise overflow a narrow viewport.

--- a/submissions/examples/59312-css-fade-in-tooltip-fintech-dashboard-ad/demo.html
+++ b/submissions/examples/59312-css-fade-in-tooltip-fintech-dashboard-ad/demo.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Fade-In Tooltip — Fintech Dashboard Layouts</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="tt-shell-ad">
+        <header class="tt-head-ad">
+            <p class="tt-head-ad__eyebrow">Reporting</p>
+            <h1 class="tt-head-ad__title">Metric Definitions</h1>
+            <p class="tt-head-ad__lede">
+                Four-directional tooltips that fade in after a short intent delay.
+                Hover a trigger, or tab to it — keyboard focus opens the same tooltip.
+            </p>
+        </header>
+
+        <section class="tt-board-ad" aria-label="Placement examples">
+            <span class="tt-ad">
+                <button class="tt-trigger-ad" type="button" aria-describedby="tt-top-ad">Top placement</button>
+                <span class="tt-ad__bubble tt-ad__bubble--top" id="tt-top-ad" role="tooltip">
+                    <span class="tt-ad__bubble-title">Net Interest Margin</span>
+                    Interest earned minus interest paid, over average earning assets.
+                </span>
+            </span>
+
+            <span class="tt-ad">
+                <button class="tt-trigger-ad" type="button" aria-describedby="tt-bottom-ad">Bottom placement</button>
+                <span class="tt-ad__bubble tt-ad__bubble--bottom" id="tt-bottom-ad" role="tooltip">
+                    <span class="tt-ad__bubble-title">Settlement Window</span>
+                    Rolling <span class="tt-ad__bubble-num">T+1</span> window measured from
+                    authorisation, not capture.
+                </span>
+            </span>
+
+            <span class="tt-ad">
+                <button class="tt-trigger-ad" type="button" aria-describedby="tt-left-ad">Left placement</button>
+                <span class="tt-ad__bubble tt-ad__bubble--left" id="tt-left-ad" role="tooltip">
+                    <span class="tt-ad__bubble-title">Chargeback Ratio</span>
+                    Disputes divided by settled volume for the same period.
+                </span>
+            </span>
+
+            <span class="tt-ad">
+                <button class="tt-trigger-ad" type="button" aria-describedby="tt-right-ad">Right placement</button>
+                <span class="tt-ad__bubble tt-ad__bubble--right" id="tt-right-ad" role="tooltip">
+                    <span class="tt-ad__bubble-title">Reserve Coverage</span>
+                    Liquid reserves as a percentage of the
+                    <span class="tt-ad__bubble-num">30-day</span> outflow forecast.
+                </span>
+            </span>
+        </section>
+
+        <table class="tt-table-ad">
+            <caption class="tt-head-ad__lede">Quarter-to-date performance</caption>
+            <thead>
+                <tr>
+                    <th scope="col">Metric</th>
+                    <th scope="col">
+                        <span class="tt-th-ad">
+                            Value
+                            <span class="tt-ad">
+                                <button class="tt-info-ad" type="button" aria-describedby="tt-val-ad" aria-label="About the Value column">i</button>
+                                <span class="tt-ad__bubble tt-ad__bubble--top" id="tt-val-ad" role="tooltip">
+                                    Values are unaudited and refresh every 15 minutes.
+                                </span>
+                            </span>
+                        </span>
+                    </th>
+                    <th scope="col">
+                        <span class="tt-th-ad">
+                            Variance
+                            <span class="tt-ad">
+                                <button class="tt-info-ad" type="button" aria-describedby="tt-var-ad" aria-label="About the Variance column">i</button>
+                                <span class="tt-ad__bubble tt-ad__bubble--left" id="tt-var-ad" role="tooltip">
+                                    Compared against the board-approved plan, not prior quarter.
+                                </span>
+                            </span>
+                        </span>
+                    </th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>Net interest margin</td>
+                    <td class="tt-table-ad__num">3.18%</td>
+                    <td class="tt-table-ad__num tt-table-ad__num--up">+0.24pp</td>
+                </tr>
+                <tr>
+                    <td>Settled volume</td>
+                    <td class="tt-table-ad__num">$48.2M</td>
+                    <td class="tt-table-ad__num tt-table-ad__num--up">+6.1%</td>
+                </tr>
+                <tr>
+                    <td>Chargeback ratio</td>
+                    <td class="tt-table-ad__num">0.42%</td>
+                    <td class="tt-table-ad__num tt-table-ad__num--warn">+0.09pp</td>
+                </tr>
+                <tr>
+                    <td>Reserve coverage</td>
+                    <td class="tt-table-ad__num">248%</td>
+                    <td class="tt-table-ad__num tt-table-ad__num--up">+11pp</td>
+                </tr>
+            </tbody>
+        </table>
+
+        <p class="tt-note-ad">
+            Bubbles open on <code>:hover</code> or <code>:focus-within</code>, so pointer and
+            keyboard users get identical behaviour. Below 620px the left and right
+            placements re-point downward to avoid overflowing the viewport.
+        </p>
+    </div>
+</body>
+</html>

--- a/submissions/examples/59312-css-fade-in-tooltip-fintech-dashboard-ad/style.css
+++ b/submissions/examples/59312-css-fade-in-tooltip-fintech-dashboard-ad/style.css
@@ -1,0 +1,506 @@
+/* ==========================================================================
+   CSS Fade-In Tooltip – Fintech Dashboard Layouts
+   EaseMotion CSS · Issue #59312
+   Four-directional tooltips with hover/focus parity and delayed fade-in
+   ========================================================================== */
+
+/* ==========================================================================
+   Section 1: Custom Properties & Token Architecture
+   ========================================================================== */
+:root {
+    /* -- Surfaces -- */
+    --tt-bg-root: #070b14;
+    --tt-panel: rgba(15, 23, 40, 0.9);
+    --tt-inset: rgba(6, 11, 21, 0.62);
+    --tt-bubble: #1b2740;
+
+    /* -- Accents -- */
+    --tt-accent: #f472b6;
+    --tt-accent-soft: rgba(244, 114, 182, 0.13);
+    --tt-cyan: #22d3ee;
+    --tt-emerald: #34d399;
+    --tt-amber: #fbbf24;
+
+    /* -- Text -- */
+    --tt-text-strong: #f1f5f9;
+    --tt-text-body: #94a3b8;
+    --tt-text-muted: #64748b;
+    --tt-bubble-text: #e8edf7;
+
+    /* -- Lines -- */
+    --tt-border: rgba(148, 163, 184, 0.14);
+    --tt-bubble-border: rgba(148, 163, 184, 0.24);
+
+    /* -- Geometry -- */
+    --tt-radius: 12px;
+    --tt-radius-sm: 8px;
+    --tt-gap: 10px;
+    --tt-arrow: 6px;
+    --tt-bubble-max: 240px;
+
+    /* -- Motion -- */
+    --tt-fade-in: 180ms;
+    --tt-fade-out: 120ms;
+    --tt-open-delay: 320ms;
+    --tt-travel: 5px;
+    --tt-ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+
+    /* -- Type -- */
+    --tt-font: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+    --tt-font-mono: "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+}
+
+/* ==========================================================================
+   Section 2: Base
+   ========================================================================== */
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+body {
+    background:
+        radial-gradient(circle at 85% 5%, rgba(244, 114, 182, 0.09), transparent 42%),
+        radial-gradient(circle at 10% 85%, rgba(34, 211, 238, 0.07), transparent 40%),
+        var(--tt-bg-root);
+    color: var(--tt-text-body);
+    font-family: var(--tt-font);
+    font-size: 15px;
+    line-height: 1.6;
+    margin: 0;
+    min-height: 100vh;
+    padding: 2.75rem 1.25rem 5rem;
+}
+
+.tt-shell-ad {
+    margin: 0 auto;
+    max-width: 980px;
+}
+
+/* ==========================================================================
+   Section 3: Header
+   ========================================================================== */
+.tt-head-ad {
+    margin-bottom: 2.25rem;
+}
+
+.tt-head-ad__eyebrow {
+    color: var(--tt-accent);
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.15em;
+    margin: 0 0 0.45rem;
+    text-transform: uppercase;
+}
+
+.tt-head-ad__title {
+    color: var(--tt-text-strong);
+    font-size: clamp(1.55rem, 3.6vw, 2.15rem);
+    font-weight: 650;
+    letter-spacing: -0.02em;
+    margin: 0 0 0.4rem;
+}
+
+.tt-head-ad__lede {
+    margin: 0;
+    max-width: 58ch;
+}
+
+/* ==========================================================================
+   Section 4: Tooltip Root
+   --------------------------------------------------------------------------
+   The trigger is the positioning context. The bubble is a sibling element
+   rather than a pseudo-element so it can hold rich markup (values, units)
+   and be exposed to assistive tech via role="tooltip".
+   ========================================================================== */
+.tt-ad {
+    display: inline-block;
+    position: relative;
+}
+
+.tt-ad__bubble {
+    background: var(--tt-bubble);
+    border: 1px solid var(--tt-bubble-border);
+    border-radius: var(--tt-radius-sm);
+    color: var(--tt-bubble-text);
+    font-size: 0.8rem;
+    font-weight: 450;
+    line-height: 1.45;
+    opacity: 0;
+    padding: 0.55rem 0.75rem;
+    pointer-events: none;
+    position: absolute;
+    text-align: left;
+    visibility: hidden;
+    width: max-content;
+    max-width: var(--tt-bubble-max);
+    z-index: 30;
+    box-shadow: 0 12px 28px -14px rgba(0, 0, 0, 0.9);
+    transition:
+        opacity var(--tt-fade-out) var(--tt-ease-out),
+        transform var(--tt-fade-out) var(--tt-ease-out),
+        visibility 0s linear var(--tt-fade-out);
+}
+
+/* Arrow — inherits the bubble surface so it stays visually attached */
+.tt-ad__bubble::after {
+    background: var(--tt-bubble);
+    border: 1px solid var(--tt-bubble-border);
+    content: "";
+    height: calc(var(--tt-arrow) * 2);
+    position: absolute;
+    transform: rotate(45deg);
+    width: calc(var(--tt-arrow) * 2);
+}
+
+/* -- Open state: hover on the root, or focus on the trigger -- */
+.tt-ad:hover .tt-ad__bubble,
+.tt-ad:focus-within .tt-ad__bubble {
+    opacity: 1;
+    visibility: visible;
+    transition:
+        opacity var(--tt-fade-in) var(--tt-ease-out) var(--tt-open-delay),
+        transform var(--tt-fade-in) var(--tt-ease-out) var(--tt-open-delay),
+        visibility 0s linear var(--tt-open-delay);
+}
+
+/* ==========================================================================
+   Section 5: Placement Variants
+   --------------------------------------------------------------------------
+   Each variant sets the resting transform (offset + travel) and the open
+   transform (offset only), so the bubble drifts toward its trigger.
+   ========================================================================== */
+
+/* -- Top -- */
+.tt-ad__bubble--top {
+    bottom: calc(100% + var(--tt-gap));
+    left: 50%;
+    transform: translateX(-50%) translateY(var(--tt-travel));
+}
+
+.tt-ad:hover .tt-ad__bubble--top,
+.tt-ad:focus-within .tt-ad__bubble--top {
+    transform: translateX(-50%) translateY(0);
+}
+
+.tt-ad__bubble--top::after {
+    border-left: 0;
+    border-top: 0;
+    bottom: calc(var(--tt-arrow) * -1);
+    left: 50%;
+    margin-left: calc(var(--tt-arrow) * -1);
+}
+
+/* -- Bottom -- */
+.tt-ad__bubble--bottom {
+    left: 50%;
+    top: calc(100% + var(--tt-gap));
+    transform: translateX(-50%) translateY(calc(var(--tt-travel) * -1));
+}
+
+.tt-ad:hover .tt-ad__bubble--bottom,
+.tt-ad:focus-within .tt-ad__bubble--bottom {
+    transform: translateX(-50%) translateY(0);
+}
+
+.tt-ad__bubble--bottom::after {
+    border-bottom: 0;
+    border-right: 0;
+    left: 50%;
+    margin-left: calc(var(--tt-arrow) * -1);
+    top: calc(var(--tt-arrow) * -1);
+}
+
+/* -- Left -- */
+.tt-ad__bubble--left {
+    right: calc(100% + var(--tt-gap));
+    top: 50%;
+    transform: translateY(-50%) translateX(var(--tt-travel));
+}
+
+.tt-ad:hover .tt-ad__bubble--left,
+.tt-ad:focus-within .tt-ad__bubble--left {
+    transform: translateY(-50%) translateX(0);
+}
+
+.tt-ad__bubble--left::after {
+    border-bottom: 0;
+    border-left: 0;
+    margin-top: calc(var(--tt-arrow) * -1);
+    right: calc(var(--tt-arrow) * -1);
+    top: 50%;
+}
+
+/* -- Right -- */
+.tt-ad__bubble--right {
+    left: calc(100% + var(--tt-gap));
+    top: 50%;
+    transform: translateY(-50%) translateX(calc(var(--tt-travel) * -1));
+}
+
+.tt-ad:hover .tt-ad__bubble--right,
+.tt-ad:focus-within .tt-ad__bubble--right {
+    transform: translateY(-50%) translateX(0);
+}
+
+.tt-ad__bubble--right::after {
+    border-right: 0;
+    border-top: 0;
+    left: calc(var(--tt-arrow) * -1);
+    margin-top: calc(var(--tt-arrow) * -1);
+    top: 50%;
+}
+
+/* ==========================================================================
+   Section 6: Bubble Content Helpers
+   ========================================================================== */
+.tt-ad__bubble-title {
+    color: var(--tt-text-strong);
+    display: block;
+    font-size: 0.78rem;
+    font-weight: 600;
+    margin-bottom: 0.2rem;
+}
+
+.tt-ad__bubble-num {
+    color: var(--tt-cyan);
+    font-family: var(--tt-font-mono);
+}
+
+/* ==========================================================================
+   Section 7: Triggers
+   ========================================================================== */
+.tt-trigger-ad {
+    background: var(--tt-inset);
+    border: 1px dashed var(--tt-border);
+    border-radius: var(--tt-radius-sm);
+    color: var(--tt-text-strong);
+    cursor: help;
+    font: inherit;
+    font-size: 0.86rem;
+    padding: 0.4rem 0.7rem;
+    transition: border-color 180ms var(--tt-ease-out);
+}
+
+.tt-trigger-ad:hover {
+    border-color: var(--tt-accent);
+}
+
+.tt-trigger-ad:focus-visible {
+    outline: 2px solid var(--tt-accent);
+    outline-offset: 2px;
+}
+
+/* Small circular info affordance used inside table headers */
+.tt-info-ad {
+    align-items: center;
+    background: var(--tt-accent-soft);
+    border: 0;
+    border-radius: 50%;
+    color: var(--tt-accent);
+    cursor: help;
+    display: inline-flex;
+    font-size: 0.68rem;
+    font-weight: 700;
+    height: 16px;
+    justify-content: center;
+    line-height: 1;
+    padding: 0;
+    width: 16px;
+}
+
+.tt-info-ad:focus-visible {
+    outline: 2px solid var(--tt-accent);
+    outline-offset: 2px;
+}
+
+/* ==========================================================================
+   Section 8: Placement Demo Board
+   ========================================================================== */
+.tt-board-ad {
+    background: var(--tt-panel);
+    border: 1px solid var(--tt-border);
+    border-radius: var(--tt-radius);
+    display: grid;
+    gap: 2.5rem 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    justify-items: center;
+    margin-bottom: 2rem;
+    padding: 3rem 1.5rem;
+}
+
+/* ==========================================================================
+   Section 9: Metrics Table
+   ========================================================================== */
+.tt-table-ad {
+    background: var(--tt-panel);
+    border: 1px solid var(--tt-border);
+    border-collapse: collapse;
+    border-radius: var(--tt-radius);
+    overflow: hidden;
+    width: 100%;
+}
+
+.tt-table-ad th,
+.tt-table-ad td {
+    border-bottom: 1px solid var(--tt-border);
+    padding: 0.8rem 1rem;
+    text-align: left;
+}
+
+.tt-table-ad tbody tr:last-child td {
+    border-bottom: 0;
+}
+
+.tt-table-ad th {
+    color: var(--tt-text-muted);
+    font-size: 0.74rem;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+}
+
+.tt-table-ad td {
+    color: var(--tt-text-strong);
+    font-size: 0.88rem;
+}
+
+.tt-table-ad__num {
+    font-family: var(--tt-font-mono);
+}
+
+.tt-table-ad__num--up {
+    color: var(--tt-emerald);
+}
+
+.tt-table-ad__num--warn {
+    color: var(--tt-amber);
+}
+
+.tt-th-ad {
+    align-items: center;
+    display: inline-flex;
+    gap: 0.4rem;
+}
+
+/* ==========================================================================
+   Section 10: Footnote
+   ========================================================================== */
+.tt-note-ad {
+    border-top: 1px solid var(--tt-border);
+    color: var(--tt-text-muted);
+    font-size: 0.8rem;
+    margin-top: 2.5rem;
+    padding-top: 1.25rem;
+}
+
+.tt-note-ad code {
+    background: var(--tt-inset);
+    border-radius: 4px;
+    font-family: var(--tt-font-mono);
+    font-size: 0.78rem;
+    padding: 0.15rem 0.4rem;
+}
+
+/* ==========================================================================
+   Section 11: Responsive
+   --------------------------------------------------------------------------
+   Side placements are re-pointed downward on narrow screens, where a
+   left/right bubble would otherwise overflow the viewport.
+   ========================================================================== */
+@media (max-width: 620px) {
+    body {
+        padding: 2rem 1rem 4rem;
+    }
+
+    .tt-board-ad {
+        gap: 2rem 1rem;
+        padding: 2.25rem 1rem;
+    }
+
+    .tt-ad__bubble {
+        --tt-bubble-max: 200px;
+    }
+
+    .tt-ad__bubble--left,
+    .tt-ad__bubble--right {
+        left: 50%;
+        right: auto;
+        top: calc(100% + var(--tt-gap));
+        transform: translateX(-50%) translateY(calc(var(--tt-travel) * -1));
+    }
+
+    .tt-ad:hover .tt-ad__bubble--left,
+    .tt-ad:focus-within .tt-ad__bubble--left,
+    .tt-ad:hover .tt-ad__bubble--right,
+    .tt-ad:focus-within .tt-ad__bubble--right {
+        transform: translateX(-50%) translateY(0);
+    }
+
+    .tt-ad__bubble--left::after,
+    .tt-ad__bubble--right::after {
+        border: 1px solid var(--tt-bubble-border);
+        border-bottom: 0;
+        border-right: 0;
+        left: 50%;
+        margin-left: calc(var(--tt-arrow) * -1);
+        margin-top: 0;
+        right: auto;
+        top: calc(var(--tt-arrow) * -1);
+    }
+
+    .tt-table-ad th,
+    .tt-table-ad td {
+        padding: 0.65rem 0.7rem;
+    }
+}
+
+/* ==========================================================================
+   Section 12: Reduced Motion
+   --------------------------------------------------------------------------
+   The open delay is preserved — it is an intent filter, not decoration, and
+   removing it would make tooltips flicker on incidental pointer movement.
+   ========================================================================== */
+@media (prefers-reduced-motion: reduce) {
+    .tt-ad__bubble,
+    .tt-ad:hover .tt-ad__bubble,
+    .tt-ad:focus-within .tt-ad__bubble {
+        transition-duration: 1ms;
+    }
+
+    .tt-ad__bubble--top,
+    .tt-ad__bubble--bottom {
+        transform: translateX(-50%);
+    }
+
+    .tt-ad__bubble--left,
+    .tt-ad__bubble--right {
+        transform: translateY(-50%);
+    }
+
+    .tt-trigger-ad {
+        transition-duration: 1ms;
+    }
+}
+
+/* ==========================================================================
+   Section 13: Forced Colors
+   ========================================================================== */
+@media (forced-colors: active) {
+    .tt-ad__bubble {
+        background: Canvas;
+        border: 1px solid CanvasText;
+        color: CanvasText;
+    }
+
+    .tt-ad__bubble::after {
+        background: Canvas;
+        border: 1px solid CanvasText;
+    }
+
+    .tt-trigger-ad,
+    .tt-table-ad {
+        border: 1px solid CanvasText;
+    }
+}


### PR DESCRIPTION
Fixes #59312

**What was added**

A pure CSS four-directional fade-in tooltip system for fintech dashboard layouts, under `submissions/examples/`.

- `style.css` — 442 non-empty lines across 13 documented sections: token architecture, base, tooltip root, four placement variants with arrow geometry, bubble content helpers, triggers, placement demo board, metrics table, footnote, responsive re-pointing, reduced-motion, and forced-colors.
- `demo.html` — 110-line self-contained demo: a placement board showing all four directions, plus a metrics table with inline info affordances in the column headers.
- `README.md` — markup pattern, custom-property reference, and the rationale for the asymmetric delay.

**Why this approach**

The open delay lives in `transition-delay` on the **open** state only; the closed state carries no delay. That asymmetry is the core of the component: tooltips wait 320ms before appearing, which filters out incidental pointer travel across a dense dashboard, but dismiss instantly when the pointer leaves. A symmetric delay would leave stale bubbles trailing the cursor.

The bubble is a real sibling element rather than a `::before` on the trigger. Pseudo-element tooltips cannot hold structured markup and — more importantly — cannot be referenced by `aria-describedby`, so they are invisible to screen readers. Every bubble here carries `role="tooltip"` and a resolving `aria-describedby`.

Opening is bound to `:hover` **or** `:focus-within`, giving pointer and keyboard users identical behaviour rather than treating keyboard access as an afterthought.

**How to test**

1. Pull this branch.
2. Open `submissions/examples/59312-css-fade-in-tooltip-fintech-dashboard-ad/demo.html` directly in a browser — no server, no build, no CDN.
3. Hover each of the four placement buttons — the bubble waits ~320ms, then fades in while drifting 5px toward its trigger.
4. Move the pointer away — dismissal is immediate, with no delay.
5. Sweep the pointer quickly across all four triggers without stopping — no tooltip should open. This is the intent filter working.
6. Tab through the page — every trigger, including the small `i` affordances in the table headers, opens its tooltip on focus.
7. Narrow below 620px — the left and right placements re-point downward, with their arrows flipped to match, instead of overflowing the viewport.
8. Enable OS-level "reduce motion" — the fade collapses but the open delay is deliberately preserved.

**Edge cases covered**

- Asymmetric delay: slow to open, instant to close, so bubbles never trail the cursor.
- Closed bubbles are `visibility: hidden` + `pointer-events: none`, keeping them out of the accessibility tree and unhittable, without `display: none` (which would break the fade).
- `visibility` transition delay is matched to the fade-out on close and to the open delay on open, so the bubble never becomes hittable before it is visible.
- Left/right placements re-point downward below 620px, with arrow borders and margins recomputed for the new direction.
- `max-width` on the bubble prevents long definitions from stretching into a single unreadable line; `width: max-content` keeps short ones tight.
- Reduced motion keeps the open delay — it is an intent filter, not decoration, and removing it would cause flicker on incidental pointer movement.
- The arrow inherits the bubble's own surface and border so it stays visually attached across all four directions.
- `forced-colors: active` gives the bubble and arrow system colours so they remain legible in high contrast.

**Verification**

- `npx stylelint style.css` against the repo's own config — zero errors.
- All 22 classes used in `demo.html` are defined in `style.css`.
- All 6 `aria-describedby` references resolve to a real element id; 6 elements carry `role="tooltip"`.
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 3 new files, 664 insertions, 0 deletions, no existing file touched.
- Component classes carry an `-ad` suffix so this lands as a parallel implementation without overwriting existing contributor work.

**Labels:** `type:feature` · `level:easy` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
