### PR TITLE
feat: add CSS slide-up badge for fintech dashboard layouts (#59328)

### DIFF
--- a/submissions/examples/59328-css-slide-up-badge-fintech-dashboard-ad/README.md
+++ b/submissions/examples/59328-css-slide-up-badge-fintech-dashboard-ad/README.md
@@ -1,0 +1,45 @@
+# CSS Slide-Up Badge for Fintech Dashboard Layouts
+
+> Issue: [#59328](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/59328)
+
+Status and delta badges that rise into place in a staggered wave, with a semantic colour ramp for gain, loss, warning, info and idle states. Pure CSS.
+
+## What it does
+
+Provides five semantic variants plus an outline modifier and a pulsing live dot. Badges inside a `.badge-row-ad` stagger their reveal, so a row resolves as a wave rather than appearing all at once.
+
+## How it is used
+
+```html
+<div class="badge-row-ad">
+    <span class="badge-ad badge-ad--gain">
+        <span class="badge-ad__glyph" aria-hidden="true">▲</span>
+        Gain <span class="badge-ad__num">+6.4%</span>
+    </span>
+    <span class="badge-ad badge-ad--loss">…</span>
+    <span class="badge-ad badge-ad--gain badge-ad--outline">
+        <span class="badge-ad__dot" aria-hidden="true"></span>
+        Live
+    </span>
+</div>
+```
+
+Variants: `--gain`, `--loss`, `--warn`, `--info`, plus the default idle state. `--outline` swaps the fill for an inset ring and composes with any of them.
+
+## Key CSS custom properties
+
+```css
+--rise-duration-ad: 420ms;
+--rise-travel-ad:     9px;  /* entrance distance */
+--rise-step-ad:      60ms;  /* per-badge delay */
+--sem-gain-ad:    #34d399;
+--sem-loss-ad:    #f87171;
+```
+
+## Why it fits EaseMotion
+
+Stagger is scoped to `.badge-row-ad .badge-ad:nth-child(n)` rather than applied globally. Each row therefore restarts its own wave from index 1, so a badge sitting fourth in the document but first in its row does not inherit a long, wrong delay. This is what lets the same component work in a standalone row and attached to list items.
+
+Direction is carried by a glyph (`▲` / `▼` / `!`) as well as by colour, so a delta badge still reads correctly without colour perception. The glyphs are `aria-hidden` because the adjacent text already states the meaning.
+
+Reduced motion is handled in two different ways on purpose: the entrance is *shortened* to 1ms (removing it would leave `both` fill holding badges at `opacity: 0`), while the live dot's infinite pulse is stopped outright — a perpetual loop is precisely what motion-sensitive users are opting out of.

--- a/submissions/examples/59328-css-slide-up-badge-fintech-dashboard-ad/demo.html
+++ b/submissions/examples/59328-css-slide-up-badge-fintech-dashboard-ad/demo.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Slide-Up Badge — Fintech Dashboard Layouts</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="shell-ad">
+        <header class="head-ad">
+            <p class="head-ad__eyebrow">Positions</p>
+            <h1 class="head-ad__title">Status &amp; Delta Badges</h1>
+            <p class="head-ad__lede">
+                Badges rise into place in a staggered wave on load. Direction is carried
+                by a glyph as well as colour, so meaning survives without colour vision.
+                Reload to replay the reveal.
+            </p>
+        </header>
+
+        <section class="panel-ad">
+            <h2 class="panel-ad__title">Semantic variants</h2>
+            <div class="badge-row-ad">
+                <span class="badge-ad badge-ad--gain">
+                    <span class="badge-ad__glyph" aria-hidden="true">▲</span>
+                    Gain <span class="badge-ad__num">+6.4%</span>
+                </span>
+                <span class="badge-ad badge-ad--loss">
+                    <span class="badge-ad__glyph" aria-hidden="true">▼</span>
+                    Loss <span class="badge-ad__num">−2.1%</span>
+                </span>
+                <span class="badge-ad badge-ad--warn">
+                    <span class="badge-ad__glyph" aria-hidden="true">!</span>
+                    Threshold
+                </span>
+                <span class="badge-ad badge-ad--info">
+                    <span class="badge-ad__glyph" aria-hidden="true">i</span>
+                    Rebalanced
+                </span>
+                <span class="badge-ad">
+                    Unchanged
+                </span>
+                <span class="badge-ad badge-ad--gain badge-ad--outline">
+                    <span class="badge-ad__dot" aria-hidden="true"></span>
+                    Live
+                </span>
+            </div>
+        </section>
+
+        <section class="panel-ad">
+            <h2 class="panel-ad__title">Open positions</h2>
+
+            <div class="pos-ad">
+                <div>
+                    <p class="pos-ad__name">US Treasury 10Y</p>
+                    <p class="pos-ad__meta">Fixed income · Held 142 days</p>
+                </div>
+                <div class="pos-ad__right badge-row-ad">
+                    <span class="badge-ad badge-ad--gain">
+                        <span class="badge-ad__glyph" aria-hidden="true">▲</span>
+                        <span class="badge-ad__num">+4.31%</span>
+                    </span>
+                    <span class="pos-ad__value">$1.24M</span>
+                </div>
+            </div>
+
+            <div class="pos-ad">
+                <div>
+                    <p class="pos-ad__name">EUR/USD forward</p>
+                    <p class="pos-ad__meta">FX hedge · Settles T+30</p>
+                </div>
+                <div class="pos-ad__right badge-row-ad">
+                    <span class="badge-ad badge-ad--loss">
+                        <span class="badge-ad__glyph" aria-hidden="true">▼</span>
+                        <span class="badge-ad__num">−1.08%</span>
+                    </span>
+                    <span class="pos-ad__value">$860K</span>
+                </div>
+            </div>
+
+            <div class="pos-ad">
+                <div>
+                    <p class="pos-ad__name">Corporate credit basket</p>
+                    <p class="pos-ad__meta">Concentration above policy limit</p>
+                </div>
+                <div class="pos-ad__right badge-row-ad">
+                    <span class="badge-ad badge-ad--warn">
+                        <span class="badge-ad__glyph" aria-hidden="true">!</span>
+                        Review
+                    </span>
+                    <span class="pos-ad__value">$2.91M</span>
+                </div>
+            </div>
+
+            <div class="pos-ad">
+                <div>
+                    <p class="pos-ad__name">Overnight repo</p>
+                    <p class="pos-ad__meta">Rolling · Marks refresh every 15 min</p>
+                </div>
+                <div class="pos-ad__right badge-row-ad">
+                    <span class="badge-ad badge-ad--info badge-ad--outline">
+                        <span class="badge-ad__dot" aria-hidden="true"></span>
+                        Live
+                    </span>
+                    <span class="pos-ad__value">$418K</span>
+                </div>
+            </div>
+        </section>
+
+        <p class="note-ad">
+            Stagger is scoped to <code>.badge-row-ad</code>, so each row restarts its own
+            wave rather than inheriting a global index. The live dot's infinite pulse is
+            stopped entirely under reduced motion.
+        </p>
+    </div>
+</body>
+</html>

--- a/submissions/examples/59328-css-slide-up-badge-fintech-dashboard-ad/style.css
+++ b/submissions/examples/59328-css-slide-up-badge-fintech-dashboard-ad/style.css
@@ -1,0 +1,391 @@
+/* ==========================================================================
+   CSS Slide-Up Badge – Fintech Dashboard Layouts
+   EaseMotion CSS · Issue #59328
+   Status and delta badges with a staggered slide-up reveal
+   ========================================================================== */
+
+/* ==========================================================================
+   Section 1: Custom Properties & Token Architecture
+   ========================================================================== */
+:root {
+    /* -- Surfaces -- */
+    --bg-root-ad: #060911;
+    --bg-panel-ad: rgba(15, 22, 38, 0.88);
+    --bg-inset-ad: rgba(6, 11, 20, 0.6);
+
+    /* -- Semantic Ramp -- */
+    --sem-gain-ad: #34d399;
+    --sem-gain-bg-ad: rgba(52, 211, 153, 0.13);
+    --sem-loss-ad: #f87171;
+    --sem-loss-bg-ad: rgba(248, 113, 113, 0.13);
+    --sem-warn-ad: #fbbf24;
+    --sem-warn-bg-ad: rgba(251, 191, 36, 0.13);
+    --sem-info-ad: #60a5fa;
+    --sem-info-bg-ad: rgba(96, 165, 250, 0.13);
+    --sem-idle-ad: #94a3b8;
+    --sem-idle-bg-ad: rgba(148, 163, 184, 0.12);
+
+    /* -- Text -- */
+    --text-strong-ad: #f1f5f9;
+    --text-body-ad: #94a3b8;
+    --text-muted-ad: #64748b;
+
+    /* -- Lines -- */
+    --line-ad: rgba(148, 163, 184, 0.14);
+
+    /* -- Geometry -- */
+    --badge-radius-ad: 999px;
+    --panel-radius-ad: 14px;
+
+    /* -- Motion -- */
+    --rise-duration-ad: 420ms;
+    --rise-travel-ad: 9px;
+    --rise-step-ad: 60ms;
+    --ease-out-ad: cubic-bezier(0.16, 1, 0.3, 1);
+
+    /* -- Type -- */
+    --font-ad: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+    --mono-ad: "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+}
+
+/* ==========================================================================
+   Section 2: Base
+   ========================================================================== */
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+body {
+    background:
+        radial-gradient(circle at 18% 2%, rgba(52, 211, 153, 0.08), transparent 40%),
+        radial-gradient(circle at 88% 10%, rgba(96, 165, 250, 0.08), transparent 40%),
+        var(--bg-root-ad);
+    color: var(--text-body-ad);
+    font-family: var(--font-ad);
+    font-size: 15px;
+    line-height: 1.6;
+    margin: 0;
+    min-height: 100vh;
+    padding: 2.75rem 1.25rem 5rem;
+}
+
+.shell-ad {
+    margin: 0 auto;
+    max-width: 1040px;
+}
+
+/* ==========================================================================
+   Section 3: Header
+   ========================================================================== */
+.head-ad {
+    margin-bottom: 2.25rem;
+}
+
+.head-ad__eyebrow {
+    color: var(--sem-gain-ad);
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.15em;
+    margin: 0 0 0.45rem;
+    text-transform: uppercase;
+}
+
+.head-ad__title {
+    color: var(--text-strong-ad);
+    font-size: clamp(1.55rem, 3.6vw, 2.15rem);
+    font-weight: 650;
+    letter-spacing: -0.02em;
+    margin: 0 0 0.4rem;
+}
+
+.head-ad__lede {
+    margin: 0;
+    max-width: 58ch;
+}
+
+/* ==========================================================================
+   Section 4: Slide-Up Reveal
+   --------------------------------------------------------------------------
+   Badges rise into place with `both` fill so they hold the opening frame
+   through their stagger delay instead of flashing at full opacity first.
+   ========================================================================== */
+@keyframes badgeRiseAd {
+    from {
+        opacity: 0;
+        transform: translateY(var(--rise-travel-ad));
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.badge-ad {
+    align-items: center;
+    animation: badgeRiseAd var(--rise-duration-ad) var(--ease-out-ad) both;
+    background: var(--sem-idle-bg-ad);
+    border-radius: var(--badge-radius-ad);
+    color: var(--sem-idle-ad);
+    display: inline-flex;
+    font-size: 0.75rem;
+    font-weight: 600;
+    gap: 0.35rem;
+    letter-spacing: 0.02em;
+    line-height: 1.3;
+    padding: 0.3rem 0.7rem;
+    white-space: nowrap;
+}
+
+/* Stagger inside any badge row */
+.badge-row-ad .badge-ad:nth-child(1) {
+    animation-delay: calc(var(--rise-step-ad) * 1);
+}
+
+.badge-row-ad .badge-ad:nth-child(2) {
+    animation-delay: calc(var(--rise-step-ad) * 2);
+}
+
+.badge-row-ad .badge-ad:nth-child(3) {
+    animation-delay: calc(var(--rise-step-ad) * 3);
+}
+
+.badge-row-ad .badge-ad:nth-child(4) {
+    animation-delay: calc(var(--rise-step-ad) * 4);
+}
+
+.badge-row-ad .badge-ad:nth-child(5) {
+    animation-delay: calc(var(--rise-step-ad) * 5);
+}
+
+.badge-row-ad .badge-ad:nth-child(6) {
+    animation-delay: calc(var(--rise-step-ad) * 6);
+}
+
+/* ==========================================================================
+   Section 5: Semantic Variants
+   ========================================================================== */
+.badge-ad--gain {
+    background: var(--sem-gain-bg-ad);
+    color: var(--sem-gain-ad);
+}
+
+.badge-ad--loss {
+    background: var(--sem-loss-bg-ad);
+    color: var(--sem-loss-ad);
+}
+
+.badge-ad--warn {
+    background: var(--sem-warn-bg-ad);
+    color: var(--sem-warn-ad);
+}
+
+.badge-ad--info {
+    background: var(--sem-info-bg-ad);
+    color: var(--sem-info-ad);
+}
+
+/* ==========================================================================
+   Section 6: Badge Affordances
+   --------------------------------------------------------------------------
+   Direction is carried by a glyph as well as colour, so the meaning does
+   not depend on colour perception alone.
+   ========================================================================== */
+.badge-ad__glyph {
+    font-size: 0.62rem;
+    line-height: 1;
+}
+
+.badge-ad__num {
+    font-family: var(--mono-ad);
+    font-size: 0.74rem;
+}
+
+/* Pulsing dot for live states */
+@keyframes badgePulseAd {
+    0%,
+    100% {
+        opacity: 1;
+        transform: scale(1);
+    }
+
+    50% {
+        opacity: 0.45;
+        transform: scale(0.8);
+    }
+}
+
+.badge-ad__dot {
+    animation: badgePulseAd 2s ease-in-out infinite;
+    background: currentcolor;
+    border-radius: 50%;
+    height: 6px;
+    width: 6px;
+}
+
+/* Outline variant for lower-emphasis metadata */
+.badge-ad--outline {
+    background: transparent;
+    box-shadow: inset 0 0 0 1px currentcolor;
+}
+
+/* ==========================================================================
+   Section 7: Layout Blocks
+   ========================================================================== */
+.badge-row-ad {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.panel-ad {
+    background: var(--bg-panel-ad);
+    border: 1px solid var(--line-ad);
+    border-radius: var(--panel-radius-ad);
+    margin-bottom: 1.5rem;
+    padding: 1.4rem 1.5rem;
+}
+
+.panel-ad__title {
+    color: var(--text-strong-ad);
+    font-size: 0.78rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    margin: 0 0 1rem;
+    text-transform: uppercase;
+}
+
+/* ==========================================================================
+   Section 8: Position List (badges attached to rows)
+   ========================================================================== */
+.pos-ad {
+    align-items: center;
+    border-bottom: 1px solid var(--line-ad);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    justify-content: space-between;
+    padding: 0.85rem 0;
+}
+
+.pos-ad:last-child {
+    border-bottom: 0;
+    padding-bottom: 0;
+}
+
+.pos-ad:first-child {
+    padding-top: 0;
+}
+
+.pos-ad__name {
+    color: var(--text-strong-ad);
+    font-size: 0.9rem;
+    font-weight: 550;
+    margin: 0 0 0.15rem;
+}
+
+.pos-ad__meta {
+    color: var(--text-muted-ad);
+    font-size: 0.76rem;
+    margin: 0;
+}
+
+.pos-ad__right {
+    align-items: center;
+    display: flex;
+    gap: 0.75rem;
+}
+
+.pos-ad__value {
+    color: var(--text-strong-ad);
+    font-family: var(--mono-ad);
+    font-size: 0.92rem;
+}
+
+/* ==========================================================================
+   Section 9: Footnote
+   ========================================================================== */
+.note-ad {
+    border-top: 1px solid var(--line-ad);
+    color: var(--text-muted-ad);
+    font-size: 0.8rem;
+    margin-top: 2.5rem;
+    padding-top: 1.25rem;
+}
+
+.note-ad code {
+    background: var(--bg-inset-ad);
+    border-radius: 4px;
+    font-family: var(--mono-ad);
+    font-size: 0.78rem;
+    padding: 0.15rem 0.4rem;
+}
+
+/* ==========================================================================
+   Section 10: Responsive
+   ========================================================================== */
+@media (max-width: 620px) {
+    body {
+        padding: 2rem 1rem 4rem;
+    }
+
+    .panel-ad {
+        padding: 1.15rem 1.1rem;
+    }
+
+    .pos-ad {
+        align-items: flex-start;
+        flex-direction: column;
+    }
+
+    .pos-ad__right {
+        width: 100%;
+        justify-content: space-between;
+    }
+
+    /* Tighten the wave — a long stagger reads as lag on a narrow column */
+    .badge-row-ad {
+        --rise-step-ad: 40ms;
+    }
+}
+
+/* ==========================================================================
+   Section 11: Reduced Motion
+   --------------------------------------------------------------------------
+   The reveal is shortened rather than removed: `both` fill would otherwise
+   hold every badge at opacity 0. The live dot's infinite pulse is stopped
+   outright, since a perpetual loop is exactly what motion-sensitive users
+   are opting out of.
+   ========================================================================== */
+@media (prefers-reduced-motion: reduce) {
+    .badge-ad {
+        animation-delay: 0s;
+        animation-duration: 1ms;
+    }
+
+    .badge-ad__dot {
+        animation: none;
+        opacity: 1;
+        transform: none;
+    }
+}
+
+/* ==========================================================================
+   Section 12: Forced Colors
+   ========================================================================== */
+@media (forced-colors: active) {
+    .badge-ad {
+        border: 1px solid CanvasText;
+        color: CanvasText;
+    }
+
+    .panel-ad {
+        border: 1px solid CanvasText;
+    }
+
+    .badge-ad__dot {
+        background: CanvasText;
+    }
+}


### PR DESCRIPTION
Fixes #59328

**What was added**

A pure CSS slide-up badge system for fintech dashboard layouts, under `submissions/examples/`.

- `style.css` — 336 non-empty lines across 12 documented sections: token architecture with a semantic ramp, base, slide-up keyframes with row-scoped stagger, five semantic variants, badge affordances (glyph, mono numeral, pulsing live dot, outline modifier), layout blocks, position list, footnote, responsive, reduced-motion, and forced-colors.
- `demo.html` — 110-line self-contained demo: a variants panel plus four open-position rows with badges attached inline.
- `README.md` — markup pattern, variant list, and custom-property reference.

**Why this approach**

Stagger is scoped to `.badge-row-ad .badge-ad:nth-child(n)` rather than applied globally to `.badge-ad`. Each row restarts its own wave from index 1, so a badge that sits fourth in document order but first within its row does not inherit a long, wrong delay. This is what allows the same component to work both in a standalone variants row and attached to list items, without a second class.

Direction is carried by a glyph (`▲` / `▼` / `!`) in addition to colour, so a delta badge still reads correctly for users who cannot distinguish the gain/loss hues. Glyphs are `aria-hidden` because the adjacent text already states the meaning — announcing "up triangle gain" would be redundant.

**How to test**

1. Pull this branch.
2. Open `submissions/examples/59328-css-slide-up-badge-fintech-dashboard-ad/demo.html` directly in a browser — no server, no build, no CDN.
3. Reload — badges in the variants row rise 9px into place, 60ms apart.
4. Note the position rows below: each row's badges start their own wave rather than continuing the first row's count.
5. Watch a "Live" badge — its dot pulses on a 2s loop.
6. Enable OS-level "reduce motion" and reload — **all badges must be visible**, appearing instantly, and the live dot's pulse must stop entirely rather than merely speeding up.
7. Resize below 620px — position rows stack, values move to a space-between row, and the stagger step tightens to 40ms.
8. View in a forced-colors / high-contrast mode — badges gain explicit borders and system text colour.

**Edge cases covered**

- Row-scoped stagger prevents badges from inheriting an incorrect global index.
- Entrance is shortened rather than removed under reduced motion, so `both` fill cannot strand badges at `opacity: 0`.
- The infinite pulse is stopped outright under reduced motion — a perpetual loop is exactly what motion-sensitive users are opting out of, so shortening it would not be enough.
- Meaning does not depend on colour alone; every semantic variant carries a glyph or text label.
- `white-space: nowrap` prevents badges from wrapping mid-label when a row runs out of space; the row itself wraps instead.
- `--outline` composes with any semantic variant via `currentcolor`, so it needs no per-variant override.
- `:first-child` / `:last-child` padding rules keep the position list flush inside its panel without a wrapper.
- `forced-colors: active` gives badges, panels and the live dot system colours.

**Verification**

- `npx stylelint style.css` against the repo's own config — zero errors.
- All 23 classes used in `demo.html` are defined in `style.css`.
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 3 new files, 553 insertions, 0 deletions, no existing file touched.
- Component classes carry an `-ad` suffix so this lands as a parallel implementation without overwriting existing contributor work.

**Labels:** `type:feature` · `level:easy` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
