### PR TITLE
feat: add CSS zoom-in carousel for SaaS showcase layouts (#59464)

### DIFF
--- a/submissions/examples/59464-css-zoom-in-carousel-saas-showcase-ad/README.md
+++ b/submissions/examples/59464-css-zoom-in-carousel-saas-showcase-ad/README.md
@@ -1,0 +1,48 @@
+# CSS Zoom-In Carousel for SaaS Showcase Layouts
+
+> Issue: [#59464](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/59464)
+
+A testimonial carousel where the active slide zooms forward from `0.9` scale while the outgoing slide recedes. Driven by radio inputs — no JavaScript.
+
+## What it does
+
+Four testimonial slides stacked in a single grid cell. Selecting a radio promotes its slide to full scale and opacity; the previous slide scales back down and fades. The indicator dot for the active slide widens into a pill.
+
+## How it is used
+
+```html
+<section class="cz-ad" aria-roledescription="carousel">
+    <input class="cz-ad__radio" type="radio" name="cz-slides-ad" id="cz-s1-ad" checked>
+    <input class="cz-ad__radio" type="radio" name="cz-slides-ad" id="cz-s2-ad">
+
+    <div class="cz-ad__stage">
+        <article class="cz-ad__slide">…</article>
+        <article class="cz-ad__slide">…</article>
+    </div>
+
+    <div class="cz-ad__dots">
+        <label class="cz-ad__dot" for="cz-s1-ad" aria-label="Show testimonial 1"></label>
+        <label class="cz-ad__dot" for="cz-s2-ad" aria-label="Show testimonial 2"></label>
+    </div>
+</section>
+```
+
+The radios **must precede** both the stage and the dots — each pairing is matched with `:nth-of-type(n):checked ~ …:nth-of-type(n)`. To add a fifth slide, extend the selector lists in sections 5 and 7.
+
+## Key CSS custom properties
+
+```css
+--cz-zoom-duration-ad: 520ms;
+--cz-zoom-rest-ad:       0.9;  /* inactive slide scale */
+--cz-zoom-active-ad:       1;
+--cz-slide-h-ad:       340px;  /* stage height */
+--cz-accent-ad:      #c084fc;
+```
+
+## Why it fits EaseMotion
+
+Slides share one grid cell via `grid-area: 1 / 1` rather than absolute positioning. The stage therefore keeps a real, stable box and never reflows between transitions, and slides stay in normal flow for sizing purposes.
+
+Using radios rather than `:target` means arrow-key navigation works for free — a radio group is natively keyboard-operable, and the URL is never mutated. The focus ring is mirrored from each hidden radio onto its visible label.
+
+`visibility` is transitioned alongside opacity, delayed by the zoom duration when leaving and `0s` when entering, so inactive slides are removed from the tab order and hit-testing without `display: none` — which would kill the transition. Under `prefers-reduced-motion` the resting scale is neutralised to `none` as well as shortening the transition, so no slide can be caught mid-transform.

--- a/submissions/examples/59464-css-zoom-in-carousel-saas-showcase-ad/demo.html
+++ b/submissions/examples/59464-css-zoom-in-carousel-saas-showcase-ad/demo.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Zoom-In Carousel — SaaS Showcase Layouts</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="cz-shell-ad">
+        <header class="cz-head-ad">
+            <p class="cz-head-ad__eyebrow">Customers</p>
+            <h1 class="cz-head-ad__title">What Teams Say</h1>
+            <p class="cz-head-ad__lede">
+                A radio-driven carousel. The active slide zooms forward from 0.9 scale
+                while the outgoing one recedes. Click a dot, or tab to one and use the
+                arrow keys — native radio behaviour handles it.
+            </p>
+        </header>
+
+        <section class="cz-ad" aria-label="Customer testimonials" aria-roledescription="carousel">
+            <!-- Radios must precede stage and dots: both are matched via `~`. -->
+            <input class="cz-ad__radio" type="radio" name="cz-slides-ad" id="cz-s1-ad" checked>
+            <input class="cz-ad__radio" type="radio" name="cz-slides-ad" id="cz-s2-ad">
+            <input class="cz-ad__radio" type="radio" name="cz-slides-ad" id="cz-s3-ad">
+            <input class="cz-ad__radio" type="radio" name="cz-slides-ad" id="cz-s4-ad">
+
+            <div class="cz-ad__stage">
+                <article class="cz-ad__slide">
+                    <span class="cz-ad__badge">Reconciliation</span>
+                    <p class="cz-ad__quote">
+                        “We closed the month in four hours instead of three days. The
+                        exceptions surfaced before the cut-off, not after it.”
+                    </p>
+                    <div class="cz-ad__meta">
+                        <span class="cz-ad__who">Priya Raghavan</span>
+                        <span class="cz-ad__role">Head of Treasury · Northwind</span>
+                    </div>
+                    <span class="cz-ad__stat">CLOSE TIME −82%</span>
+                </article>
+
+                <article class="cz-ad__slide">
+                    <span class="cz-ad__badge">Routing</span>
+                    <p class="cz-ad__quote">
+                        “Multi-rail routing cut our per-payment cost without anyone
+                        rewriting a single integration.”
+                    </p>
+                    <div class="cz-ad__meta">
+                        <span class="cz-ad__who">Daniel Osei</span>
+                        <span class="cz-ad__role">VP Payments · Corvus</span>
+                    </div>
+                    <span class="cz-ad__stat">COST PER TXN −31%</span>
+                </article>
+
+                <article class="cz-ad__slide">
+                    <span class="cz-ad__badge">Compliance</span>
+                    <p class="cz-ad__quote">
+                        “The audit trail answered every question our examiners asked,
+                        with no engineering time spent pulling reports.”
+                    </p>
+                    <div class="cz-ad__meta">
+                        <span class="cz-ad__who">Mara Lindqvist</span>
+                        <span class="cz-ad__role">Chief Compliance Officer · Meridian</span>
+                    </div>
+                    <span class="cz-ad__stat">AUDIT PREP −60 HRS</span>
+                </article>
+
+                <article class="cz-ad__slide">
+                    <span class="cz-ad__badge">Forecasting</span>
+                    <p class="cz-ad__quote">
+                        “A rolling thirty-day view we actually trust. We stopped keeping
+                        a parallel spreadsheet within the first week.”
+                    </p>
+                    <div class="cz-ad__meta">
+                        <span class="cz-ad__who">Tomás Herrera</span>
+                        <span class="cz-ad__role">Finance Director · Atlas Freight</span>
+                    </div>
+                    <span class="cz-ad__stat">FORECAST VARIANCE ±2.1%</span>
+                </article>
+            </div>
+
+            <div class="cz-ad__dots">
+                <label class="cz-ad__dot" for="cz-s1-ad" aria-label="Show testimonial 1"></label>
+                <label class="cz-ad__dot" for="cz-s2-ad" aria-label="Show testimonial 2"></label>
+                <label class="cz-ad__dot" for="cz-s3-ad" aria-label="Show testimonial 3"></label>
+                <label class="cz-ad__dot" for="cz-s4-ad" aria-label="Show testimonial 4"></label>
+            </div>
+        </section>
+
+        <p class="cz-note-ad">
+            Slides share one grid cell via <code>grid-area: 1 / 1</code>, so the stage
+            never reflows between transitions and no absolute positioning is needed.
+        </p>
+    </div>
+</body>
+</html>

--- a/submissions/examples/59464-css-zoom-in-carousel-saas-showcase-ad/style.css
+++ b/submissions/examples/59464-css-zoom-in-carousel-saas-showcase-ad/style.css
@@ -1,0 +1,353 @@
+/* ==========================================================================
+   CSS Zoom-In Carousel – SaaS Showcase Layouts
+   EaseMotion CSS · Issue #59464
+   Radio-driven carousel where the active slide zooms forward
+   ========================================================================== */
+
+/* ==========================================================================
+   Section 1: Custom Properties & Token Architecture
+   ========================================================================== */
+:root {
+    /* -- Surfaces -- */
+    --cz-root-ad: #070610;
+    --cz-stage-ad: rgba(18, 16, 38, 0.86);
+    --cz-slide-ad: rgba(28, 25, 56, 0.95);
+    --cz-inset-ad: rgba(10, 8, 22, 0.62);
+
+    /* -- Accents -- */
+    --cz-accent-ad: #c084fc;
+    --cz-accent-2-ad: #38bdf8;
+    --cz-accent-soft-ad: rgba(192, 132, 252, 0.15);
+    --cz-accent-line-ad: rgba(192, 132, 252, 0.45);
+
+    /* -- Text -- */
+    --cz-text-strong-ad: #f5f3ff;
+    --cz-text-body-ad: #a5a0c0;
+    --cz-text-muted-ad: #6f6a92;
+
+    /* -- Lines -- */
+    --cz-line-ad: rgba(165, 160, 192, 0.15);
+
+    /* -- Geometry -- */
+    --cz-radius-ad: 18px;
+    --cz-radius-sm-ad: 9px;
+    --cz-slide-h-ad: 340px;
+
+    /* -- Motion -- */
+    --cz-zoom-duration-ad: 520ms;
+    --cz-zoom-rest-ad: 0.9;
+    --cz-zoom-active-ad: 1;
+    --cz-dim-rest-ad: 0.38;
+    --cz-ease-ad: cubic-bezier(0.16, 1, 0.3, 1);
+
+    /* -- Type -- */
+    --cz-font-ad: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+    --cz-mono-ad: "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+}
+
+/* ==========================================================================
+   Section 2: Base
+   ========================================================================== */
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+body {
+    background:
+        radial-gradient(circle at 20% 0%, rgba(192, 132, 252, 0.13), transparent 44%),
+        radial-gradient(circle at 84% 8%, rgba(56, 189, 248, 0.09), transparent 40%),
+        var(--cz-root-ad);
+    color: var(--cz-text-body-ad);
+    font-family: var(--cz-font-ad);
+    font-size: 15px;
+    line-height: 1.6;
+    margin: 0;
+    min-height: 100vh;
+    padding: 3rem 1.25rem 5rem;
+}
+
+.cz-shell-ad {
+    margin: 0 auto;
+    max-width: 1000px;
+}
+
+/* ==========================================================================
+   Section 3: Header
+   ========================================================================== */
+.cz-head-ad {
+    margin-bottom: 2.25rem;
+    text-align: center;
+}
+
+.cz-head-ad__eyebrow {
+    color: var(--cz-accent-ad);
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.15em;
+    margin: 0 0 0.5rem;
+    text-transform: uppercase;
+}
+
+.cz-head-ad__title {
+    color: var(--cz-text-strong-ad);
+    font-size: clamp(1.65rem, 4vw, 2.3rem);
+    font-weight: 650;
+    letter-spacing: -0.02em;
+    margin: 0 0 0.5rem;
+}
+
+.cz-head-ad__lede {
+    margin: 0 auto;
+    max-width: 56ch;
+}
+
+/* ==========================================================================
+   Section 4: Carousel Root
+   --------------------------------------------------------------------------
+   Radio inputs hold the active index. They sit before the stage so slides
+   and indicators can both be matched with the sibling combinator.
+   ========================================================================== */
+.cz-ad {
+    position: relative;
+}
+
+.cz-ad__radio {
+    height: 0;
+    opacity: 0;
+    pointer-events: none;
+    position: absolute;
+    width: 0;
+}
+
+.cz-ad__stage {
+    background: var(--cz-stage-ad);
+    border: 1px solid var(--cz-line-ad);
+    border-radius: var(--cz-radius-ad);
+    display: grid;
+    height: var(--cz-slide-h-ad);
+    overflow: hidden;
+    position: relative;
+}
+
+/* ==========================================================================
+   Section 5: Slides — zoom-in on activation
+   --------------------------------------------------------------------------
+   All slides occupy the same grid cell. Inactive slides rest at a smaller
+   scale and low opacity; the checked radio promotes its slide to full size.
+   ========================================================================== */
+.cz-ad__slide {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    grid-area: 1 / 1;
+    justify-content: center;
+    opacity: 0;
+    padding: 2.25rem 2rem;
+    pointer-events: none;
+    text-align: center;
+    transform: scale(var(--cz-zoom-rest-ad));
+    visibility: hidden;
+    transition:
+        opacity var(--cz-zoom-duration-ad) var(--cz-ease-ad),
+        transform var(--cz-zoom-duration-ad) var(--cz-ease-ad),
+        visibility 0s linear var(--cz-zoom-duration-ad);
+}
+
+.cz-ad__radio:nth-of-type(1):checked ~ .cz-ad__stage .cz-ad__slide:nth-of-type(1),
+.cz-ad__radio:nth-of-type(2):checked ~ .cz-ad__stage .cz-ad__slide:nth-of-type(2),
+.cz-ad__radio:nth-of-type(3):checked ~ .cz-ad__stage .cz-ad__slide:nth-of-type(3),
+.cz-ad__radio:nth-of-type(4):checked ~ .cz-ad__stage .cz-ad__slide:nth-of-type(4) {
+    opacity: 1;
+    pointer-events: auto;
+    transform: scale(var(--cz-zoom-active-ad));
+    visibility: visible;
+    transition:
+        opacity var(--cz-zoom-duration-ad) var(--cz-ease-ad),
+        transform var(--cz-zoom-duration-ad) var(--cz-ease-ad),
+        visibility 0s linear 0s;
+}
+
+/* ==========================================================================
+   Section 6: Slide Content
+   ========================================================================== */
+.cz-ad__badge {
+    background: var(--cz-accent-soft-ad);
+    border-radius: 999px;
+    color: var(--cz-accent-ad);
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    margin-bottom: 1rem;
+    padding: 0.3rem 0.75rem;
+    text-transform: uppercase;
+}
+
+.cz-ad__quote {
+    color: var(--cz-text-strong-ad);
+    font-size: clamp(1.05rem, 2.4vw, 1.35rem);
+    font-weight: 500;
+    letter-spacing: -0.01em;
+    line-height: 1.5;
+    margin: 0 0 1.25rem;
+    max-width: 46ch;
+}
+
+.cz-ad__meta {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+}
+
+.cz-ad__who {
+    color: var(--cz-text-strong-ad);
+    font-size: 0.88rem;
+    font-weight: 600;
+}
+
+.cz-ad__role {
+    color: var(--cz-text-muted-ad);
+    font-size: 0.78rem;
+}
+
+.cz-ad__stat {
+    background: var(--cz-inset-ad);
+    border: 1px solid var(--cz-line-ad);
+    border-radius: var(--cz-radius-sm-ad);
+    color: var(--cz-accent-2-ad);
+    font-family: var(--cz-mono-ad);
+    font-size: 0.8rem;
+    margin-top: 1.15rem;
+    padding: 0.45rem 0.85rem;
+}
+
+/* ==========================================================================
+   Section 7: Indicators
+   ========================================================================== */
+.cz-ad__dots {
+    display: flex;
+    gap: 0.55rem;
+    justify-content: center;
+    margin-top: 1.35rem;
+}
+
+.cz-ad__dot {
+    background: var(--cz-line-ad);
+    border-radius: 999px;
+    cursor: pointer;
+    height: 8px;
+    width: 8px;
+    transition:
+        background-color 260ms var(--cz-ease-ad),
+        width 260ms var(--cz-ease-ad);
+}
+
+.cz-ad__dot:hover {
+    background: var(--cz-accent-line-ad);
+}
+
+.cz-ad__radio:nth-of-type(1):checked ~ .cz-ad__dots .cz-ad__dot:nth-of-type(1),
+.cz-ad__radio:nth-of-type(2):checked ~ .cz-ad__dots .cz-ad__dot:nth-of-type(2),
+.cz-ad__radio:nth-of-type(3):checked ~ .cz-ad__dots .cz-ad__dot:nth-of-type(3),
+.cz-ad__radio:nth-of-type(4):checked ~ .cz-ad__dots .cz-ad__dot:nth-of-type(4) {
+    background: var(--cz-accent-ad);
+    width: 24px;
+}
+
+/* Focus ring mirrored from the hidden radio onto its label */
+.cz-ad__radio:nth-of-type(1):focus-visible ~ .cz-ad__dots .cz-ad__dot:nth-of-type(1),
+.cz-ad__radio:nth-of-type(2):focus-visible ~ .cz-ad__dots .cz-ad__dot:nth-of-type(2),
+.cz-ad__radio:nth-of-type(3):focus-visible ~ .cz-ad__dots .cz-ad__dot:nth-of-type(3),
+.cz-ad__radio:nth-of-type(4):focus-visible ~ .cz-ad__dots .cz-ad__dot:nth-of-type(4) {
+    outline: 2px solid var(--cz-accent-ad);
+    outline-offset: 3px;
+}
+
+/* ==========================================================================
+   Section 8: Footnote
+   ========================================================================== */
+.cz-note-ad {
+    border-top: 1px solid var(--cz-line-ad);
+    color: var(--cz-text-muted-ad);
+    font-size: 0.8rem;
+    margin-top: 2.75rem;
+    padding-top: 1.25rem;
+    text-align: center;
+}
+
+.cz-note-ad code {
+    background: var(--cz-inset-ad);
+    border-radius: 4px;
+    font-family: var(--cz-mono-ad);
+    font-size: 0.78rem;
+    padding: 0.15rem 0.4rem;
+}
+
+/* ==========================================================================
+   Section 9: Responsive
+   ========================================================================== */
+@media (max-width: 720px) {
+    body {
+        padding: 2.25rem 1rem 4rem;
+    }
+
+    .cz-ad__stage {
+        --cz-slide-h-ad: 400px;
+    }
+
+    .cz-ad__slide {
+        padding: 1.75rem 1.25rem;
+    }
+}
+
+@media (max-width: 460px) {
+    .cz-ad__stage {
+        --cz-slide-h-ad: 440px;
+    }
+
+    .cz-ad__dot {
+        height: 10px;
+        width: 10px;
+    }
+}
+
+/* ==========================================================================
+   Section 10: Reduced Motion
+   --------------------------------------------------------------------------
+   Slides still change, but without the zoom. The resting scale is
+   neutralised so an inactive slide cannot be caught mid-transform.
+   ========================================================================== */
+@media (prefers-reduced-motion: reduce) {
+    .cz-ad__slide {
+        transform: none;
+        transition-duration: 1ms;
+    }
+
+    .cz-ad__radio:nth-of-type(1):checked ~ .cz-ad__stage .cz-ad__slide:nth-of-type(1),
+    .cz-ad__radio:nth-of-type(2):checked ~ .cz-ad__stage .cz-ad__slide:nth-of-type(2),
+    .cz-ad__radio:nth-of-type(3):checked ~ .cz-ad__stage .cz-ad__slide:nth-of-type(3),
+    .cz-ad__radio:nth-of-type(4):checked ~ .cz-ad__stage .cz-ad__slide:nth-of-type(4) {
+        transform: none;
+        transition-duration: 1ms;
+    }
+
+    .cz-ad__dot {
+        transition-duration: 1ms;
+    }
+}
+
+/* ==========================================================================
+   Section 11: Forced Colors
+   ========================================================================== */
+@media (forced-colors: active) {
+    .cz-ad__stage,
+    .cz-ad__stat {
+        border: 1px solid CanvasText;
+    }
+
+    .cz-ad__dot {
+        background: CanvasText;
+    }
+}


### PR DESCRIPTION
Fixes #59464

**What was added**

A pure CSS zoom-in testimonial carousel for SaaS showcase layouts, under `submissions/examples/`.

- `style.css` — 311 non-empty lines across 11 documented sections: token architecture, base, header, carousel root with radio state, zoom-in slide transitions, slide content, indicators with focus mirroring, footnote, responsive, reduced-motion, and forced-colors.
- `demo.html` — 89-line self-contained demo: four customer testimonials with badges, attribution and result stats.
- `README.md` — markup pattern, custom-property reference, and instructions for adding a fifth slide.

**Why this approach**

Slides share a single grid cell via `grid-area: 1 / 1` rather than absolute positioning. The stage therefore keeps a real, stable box that never reflows between transitions, and slides remain in normal flow for sizing — no `position: absolute` height collapse to work around.

Radio inputs were chosen over `:target` for two concrete reasons: a radio group is natively keyboard-operable, so arrow-key navigation between slides works with no extra code; and the URL is never mutated, so the carousel does not hijack browser history or break the back button.

`visibility` is transitioned alongside opacity — delayed by the zoom duration when leaving, `0s` when entering. Inactive slides are therefore removed from the tab order and from hit-testing without `display: none`, which is not interpolatable and would kill the zoom.

**How to test**

1. Pull this branch.
2. Open `submissions/examples/59464-css-zoom-in-carousel-saas-showcase-ad/demo.html` directly in a browser — no server, no build, no CDN.
3. Click each indicator dot — the incoming slide zooms from 0.9 to full scale while the outgoing one recedes and fades. The active dot widens into a pill.
4. Tab to the indicator row, then press the arrow keys — slides advance via native radio-group behaviour, with the focus ring mirrored onto the visible dot.
5. Confirm the URL never changes and the back button is unaffected.
6. Tab through the page while slide 1 is active — content in slides 2–4 must not receive focus.
7. Resize below 720px, then below 460px — the stage grows to 400px and 440px so longer quotes are not clipped, and dots enlarge for touch targets.
8. Enable OS-level "reduce motion" — slides still change, instantly, with no zoom and no slide caught mid-transform.

**Edge cases covered**

- Inactive slides are `visibility: hidden` + `pointer-events: none`, so they are untabbable and unhittable while still transitionable.
- Stage height grows at two breakpoints so longer testimonials do not overflow on narrow viewports.
- Reduced motion neutralises the resting `scale(0.9)` to `none` in addition to shortening the transition — shortening alone could leave a slide rendered mid-transform.
- The first radio carries `checked`, so the carousel has a defined initial state rather than an empty stage.
- Focus ring is mirrored from each hidden radio to its label, so keyboard position is always visible despite the input being visually hidden.
- Hidden radios use `opacity: 0` + zero size rather than `display: none`, which would make them unfocusable and break arrow-key navigation entirely.
- Dots carry `aria-label`; the section carries `aria-roledescription="carousel"`.
- `forced-colors: active` gives the stage, stat chip and dots system colours.

**Verification**

- `npx stylelint style.css` against the repo's own config — zero errors.
- All 18 classes used in `demo.html` are defined in `style.css`.
- Counts verified balanced: 4 radios / 4 slides / 4 dots, matching the `:nth-of-type` selector lists; zero dead `for=` targets; a default `checked` radio is present.
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 3 new files, 0 deletions, no existing file touched.
- Component classes carry an `-ad` suffix so this lands as a parallel implementation without overwriting existing contributor work.

**Labels:** `type:feature` · `level:easy` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
