### PR TITLE
feat: add CSS fade-in popover for SaaS showcase layouts (#59492)

### DIFF
--- a/submissions/examples/59492-css-fade-in-popover-saas-showcase-ad/README.md
+++ b/submissions/examples/59492-css-fade-in-popover-saas-showcase-ad/README.md
@@ -1,0 +1,46 @@
+# CSS Fade-In Popover for SaaS Showcase Layouts
+
+> Issue: [#59492](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/59492)
+
+Anchored popovers that fade in on focus, holding genuinely interactive content. Three placements, an attached arrow, and no JavaScript.
+
+## What it does
+
+Provides `--bottom`, `--top` and `--bottom-end` placements sharing one panel component. Each fades in while drifting toward its trigger. Panels contain real buttons and lists — not just text — and stay open while focus is inside them.
+
+## How it is used
+
+```html
+<span class="po-ad">
+    <button class="po-btn-ad" type="button" aria-expanded="false">Plan usage</button>
+    <div class="po-ad__panel po-ad__panel--bottom" role="dialog" aria-label="Plan usage">
+        <p class="po-ad__panel-title">Current cycle</p>
+        <ul class="po-ad__panel-list">
+            <li>Seats used <span class="po-ad__panel-num">42 / 50</span></li>
+        </ul>
+        <div class="po-ad__panel-actions">
+            <button class="po-btn-ad po-btn-ad--sm po-btn-ad--primary" type="button">Upgrade</button>
+        </div>
+    </div>
+</span>
+```
+
+The panel **must be a child of `.po-ad`**, alongside the trigger — that containment is what makes `:focus-within` stay true when focus moves into the panel.
+
+## Key CSS custom properties
+
+```css
+--po-duration-ad: 220ms;
+--po-travel-ad:      7px;  /* drift toward trigger */
+--po-gap-ad:        12px;  /* trigger-to-panel distance */
+--po-width-ad:     280px;
+--po-accent-ad: #2dd4bf;
+```
+
+## Why it fits EaseMotion
+
+Opening is bound to `:focus-within` rather than `:hover`. This is the central decision: a popover holds interactive content, and a hover-driven panel closes the moment the pointer crosses the gap between trigger and panel — making the buttons inside effectively unreachable. Because the panel is a sibling of the trigger *inside* `.po-ad`, focus moving into it keeps `:focus-within` true, so the panel survives and its actions are clickable.
+
+It also means keyboard and pointer behaviour are the same mechanism rather than two code paths, and dismissal is free — clicking away or tabbing out blurs the subtree and closes the panel.
+
+`visibility` is transitioned alongside opacity, delayed by the fade duration on close and `0s` on open, so closed panels stay out of the tab order without `display: none` (which would break the fade). The `--bottom-end` variant right-aligns to the trigger so a popover on a trailing toolbar button cannot overflow the viewport, and below 560px the width clamps to `min(280px, 100vw - 2.5rem)`.

--- a/submissions/examples/59492-css-fade-in-popover-saas-showcase-ad/demo.html
+++ b/submissions/examples/59492-css-fade-in-popover-saas-showcase-ad/demo.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Fade-In Popover — SaaS Showcase Layouts</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="po-shell-ad">
+        <header class="po-head-ad">
+            <p class="po-head-ad__eyebrow">Workspace</p>
+            <h1 class="po-head-ad__title">Anchored Popovers</h1>
+            <p class="po-head-ad__lede">
+                Popovers open on <code>:focus-within</code>, not hover — so they hold
+                interactive content and survive the pointer travelling from the trigger
+                into the panel. Click a button, then click away or press Tab to dismiss.
+            </p>
+        </header>
+
+        <section class="po-panel-ad">
+            <h2 class="po-panel-ad__title">Placements</h2>
+            <div class="po-row-ad">
+                <span class="po-ad">
+                    <button class="po-btn-ad" type="button" aria-expanded="false">Plan usage</button>
+                    <div class="po-ad__panel po-ad__panel--bottom" role="dialog" aria-label="Plan usage">
+                        <p class="po-ad__panel-title">Current cycle</p>
+                        <ul class="po-ad__panel-list">
+                            <li>Seats used <span class="po-ad__panel-num">42 / 50</span></li>
+                            <li>API calls <span class="po-ad__panel-num">1.8M</span></li>
+                            <li>Storage <span class="po-ad__panel-num">318 GB</span></li>
+                        </ul>
+                        <div class="po-ad__panel-actions">
+                            <button class="po-btn-ad po-btn-ad--sm" type="button">Details</button>
+                            <button class="po-btn-ad po-btn-ad--sm po-btn-ad--primary" type="button">Upgrade</button>
+                        </div>
+                    </div>
+                </span>
+
+                <span class="po-ad">
+                    <button class="po-btn-ad" type="button" aria-expanded="false">Share workspace</button>
+                    <div class="po-ad__panel po-ad__panel--top" role="dialog" aria-label="Share workspace">
+                        <p class="po-ad__panel-title">Invite a teammate</p>
+                        <p class="po-ad__panel-copy">
+                            Members inherit workspace-level roles. Guests are scoped to the
+                            projects you pick.
+                        </p>
+                        <div class="po-ad__panel-actions">
+                            <button class="po-btn-ad po-btn-ad--sm" type="button">Copy link</button>
+                            <button class="po-btn-ad po-btn-ad--sm po-btn-ad--primary" type="button">Invite</button>
+                        </div>
+                    </div>
+                </span>
+
+                <span class="po-ad">
+                    <button class="po-btn-ad" type="button" aria-expanded="false">Account</button>
+                    <div class="po-ad__panel po-ad__panel--bottom-end" role="dialog" aria-label="Account menu">
+                        <p class="po-ad__panel-title">Signed in as Priya</p>
+                        <p class="po-ad__panel-copy">
+                            Owner · Northwind workspace. Billing renews on the 1st.
+                        </p>
+                        <div class="po-ad__panel-actions">
+                            <button class="po-btn-ad po-btn-ad--sm" type="button">Settings</button>
+                            <button class="po-btn-ad po-btn-ad--sm" type="button">Sign out</button>
+                        </div>
+                    </div>
+                </span>
+            </div>
+        </section>
+
+        <section class="po-panel-ad">
+            <h2 class="po-panel-ad__title">Inline in a toolbar</h2>
+            <div class="po-row-ad">
+                <span class="po-ad">
+                    <button class="po-btn-ad" type="button" aria-expanded="false">Filters</button>
+                    <div class="po-ad__panel po-ad__panel--bottom" role="dialog" aria-label="Filters">
+                        <p class="po-ad__panel-title">Active filters</p>
+                        <ul class="po-ad__panel-list">
+                            <li>Status <span class="po-ad__panel-num">Open</span></li>
+                            <li>Owner <span class="po-ad__panel-num">Any</span></li>
+                            <li>Updated <span class="po-ad__panel-num">7d</span></li>
+                        </ul>
+                        <div class="po-ad__panel-actions">
+                            <button class="po-btn-ad po-btn-ad--sm" type="button">Reset</button>
+                            <button class="po-btn-ad po-btn-ad--sm po-btn-ad--primary" type="button">Apply</button>
+                        </div>
+                    </div>
+                </span>
+                <button class="po-btn-ad po-btn-ad--primary" type="button">New project</button>
+            </div>
+        </section>
+
+        <p class="po-note-ad">
+            Because the panel sits inside the same element as the trigger, focus moving
+            into it keeps <code>:focus-within</code> true — so buttons inside the popover
+            are fully clickable without the panel closing underneath the pointer.
+        </p>
+    </div>
+</body>
+</html>

--- a/submissions/examples/59492-css-fade-in-popover-saas-showcase-ad/style.css
+++ b/submissions/examples/59492-css-fade-in-popover-saas-showcase-ad/style.css
@@ -1,0 +1,409 @@
+/* ==========================================================================
+   CSS Fade-In Popover – SaaS Showcase Layouts
+   EaseMotion CSS · Issue #59492
+   Click-anchored popovers with fade-in entrance and focus-within persistence
+   ========================================================================== */
+
+/* ==========================================================================
+   Section 1: Custom Properties & Token Architecture
+   ========================================================================== */
+:root {
+    /* -- Surfaces -- */
+    --po-root-ad: #060a12;
+    --po-panel-ad: rgba(15, 23, 40, 0.9);
+    --po-pop-ad: #182339;
+    --po-inset-ad: rgba(6, 11, 21, 0.6);
+
+    /* -- Accents -- */
+    --po-accent-ad: #2dd4bf;
+    --po-accent-2-ad: #a78bfa;
+    --po-accent-soft-ad: rgba(45, 212, 191, 0.14);
+    --po-accent-line-ad: rgba(45, 212, 191, 0.42);
+
+    /* -- Text -- */
+    --po-text-strong-ad: #f1f5f9;
+    --po-text-body-ad: #94a3b8;
+    --po-text-muted-ad: #64748b;
+
+    /* -- Lines -- */
+    --po-line-ad: rgba(148, 163, 184, 0.14);
+    --po-pop-line-ad: rgba(148, 163, 184, 0.24);
+
+    /* -- Geometry -- */
+    --po-radius-ad: 14px;
+    --po-radius-sm-ad: 9px;
+    --po-gap-ad: 12px;
+    --po-arrow-ad: 7px;
+    --po-width-ad: 280px;
+
+    /* -- Motion -- */
+    --po-duration-ad: 220ms;
+    --po-travel-ad: 7px;
+    --po-ease-ad: cubic-bezier(0.16, 1, 0.3, 1);
+
+    /* -- Type -- */
+    --po-font-ad: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+    --po-mono-ad: "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+}
+
+/* ==========================================================================
+   Section 2: Base
+   ========================================================================== */
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+body {
+    background:
+        radial-gradient(circle at 88% 4%, rgba(45, 212, 191, 0.1), transparent 42%),
+        radial-gradient(circle at 8% 88%, rgba(167, 139, 250, 0.08), transparent 40%),
+        var(--po-root-ad);
+    color: var(--po-text-body-ad);
+    font-family: var(--po-font-ad);
+    font-size: 15px;
+    line-height: 1.6;
+    margin: 0;
+    min-height: 100vh;
+    padding: 3rem 1.25rem 8rem;
+}
+
+.po-shell-ad {
+    margin: 0 auto;
+    max-width: 940px;
+}
+
+/* ==========================================================================
+   Section 3: Header
+   ========================================================================== */
+.po-head-ad {
+    margin-bottom: 2.25rem;
+}
+
+.po-head-ad__eyebrow {
+    color: var(--po-accent-ad);
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.15em;
+    margin: 0 0 0.45rem;
+    text-transform: uppercase;
+}
+
+.po-head-ad__title {
+    color: var(--po-text-strong-ad);
+    font-size: clamp(1.55rem, 3.6vw, 2.15rem);
+    font-weight: 650;
+    letter-spacing: -0.02em;
+    margin: 0 0 0.4rem;
+}
+
+.po-head-ad__lede {
+    margin: 0;
+    max-width: 58ch;
+}
+
+/* ==========================================================================
+   Section 4: Popover Root
+   --------------------------------------------------------------------------
+   Opens on :focus-within rather than :hover. A popover holds interactive
+   content, so it must survive the pointer travelling from trigger to panel
+   — a hover-based popover would close in the gap between them.
+   ========================================================================== */
+.po-ad {
+    display: inline-block;
+    position: relative;
+}
+
+.po-ad__panel {
+    background: var(--po-pop-ad);
+    border: 1px solid var(--po-pop-line-ad);
+    border-radius: var(--po-radius-sm-ad);
+    box-shadow: 0 18px 38px -18px rgba(0, 0, 0, 0.92);
+    opacity: 0;
+    padding: 0.9rem 1rem;
+    position: absolute;
+    text-align: left;
+    visibility: hidden;
+    width: var(--po-width-ad);
+    z-index: 30;
+    transition:
+        opacity var(--po-duration-ad) var(--po-ease-ad),
+        transform var(--po-duration-ad) var(--po-ease-ad),
+        visibility 0s linear var(--po-duration-ad);
+}
+
+.po-ad:focus-within .po-ad__panel {
+    opacity: 1;
+    visibility: visible;
+    transition:
+        opacity var(--po-duration-ad) var(--po-ease-ad),
+        transform var(--po-duration-ad) var(--po-ease-ad),
+        visibility 0s linear 0s;
+}
+
+/* Arrow inherits the panel surface so it stays visually attached */
+.po-ad__panel::after {
+    background: var(--po-pop-ad);
+    border: 1px solid var(--po-pop-line-ad);
+    content: "";
+    height: calc(var(--po-arrow-ad) * 2);
+    position: absolute;
+    transform: rotate(45deg);
+    width: calc(var(--po-arrow-ad) * 2);
+}
+
+/* ==========================================================================
+   Section 5: Placement Variants
+   ========================================================================== */
+.po-ad__panel--bottom {
+    left: 50%;
+    top: calc(100% + var(--po-gap-ad));
+    transform: translateX(-50%) translateY(calc(var(--po-travel-ad) * -1));
+}
+
+.po-ad:focus-within .po-ad__panel--bottom {
+    transform: translateX(-50%) translateY(0);
+}
+
+.po-ad__panel--bottom::after {
+    border-bottom: 0;
+    border-right: 0;
+    left: 50%;
+    margin-left: calc(var(--po-arrow-ad) * -1);
+    top: calc(var(--po-arrow-ad) * -1);
+}
+
+.po-ad__panel--top {
+    bottom: calc(100% + var(--po-gap-ad));
+    left: 50%;
+    transform: translateX(-50%) translateY(var(--po-travel-ad));
+}
+
+.po-ad:focus-within .po-ad__panel--top {
+    transform: translateX(-50%) translateY(0);
+}
+
+.po-ad__panel--top::after {
+    border-left: 0;
+    border-top: 0;
+    bottom: calc(var(--po-arrow-ad) * -1);
+    left: 50%;
+    margin-left: calc(var(--po-arrow-ad) * -1);
+}
+
+/* Right-aligned: keeps the panel inside the viewport for trailing triggers */
+.po-ad__panel--bottom-end {
+    right: 0;
+    top: calc(100% + var(--po-gap-ad));
+    transform: translateY(calc(var(--po-travel-ad) * -1));
+}
+
+.po-ad:focus-within .po-ad__panel--bottom-end {
+    transform: translateY(0);
+}
+
+.po-ad__panel--bottom-end::after {
+    border-bottom: 0;
+    border-right: 0;
+    right: 1.15rem;
+    top: calc(var(--po-arrow-ad) * -1);
+}
+
+/* ==========================================================================
+   Section 6: Panel Content
+   ========================================================================== */
+.po-ad__panel-title {
+    color: var(--po-text-strong-ad);
+    font-size: 0.85rem;
+    font-weight: 620;
+    margin: 0 0 0.35rem;
+}
+
+.po-ad__panel-copy {
+    font-size: 0.82rem;
+    margin: 0 0 0.75rem;
+}
+
+.po-ad__panel-list {
+    list-style: none;
+    margin: 0 0 0.75rem;
+    padding: 0;
+}
+
+.po-ad__panel-list li {
+    border-bottom: 1px solid var(--po-line-ad);
+    display: flex;
+    font-size: 0.8rem;
+    gap: 0.75rem;
+    justify-content: space-between;
+    padding: 0.4rem 0;
+}
+
+.po-ad__panel-list li:last-child {
+    border-bottom: 0;
+}
+
+.po-ad__panel-num {
+    color: var(--po-accent-ad);
+    font-family: var(--po-mono-ad);
+}
+
+.po-ad__panel-actions {
+    display: flex;
+    gap: 0.45rem;
+}
+
+/* ==========================================================================
+   Section 7: Buttons
+   ========================================================================== */
+.po-btn-ad {
+    background: var(--po-inset-ad);
+    border: 1px solid var(--po-line-ad);
+    border-radius: var(--po-radius-sm-ad);
+    color: var(--po-text-strong-ad);
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.84rem;
+    font-weight: 550;
+    padding: 0.55rem 1rem;
+    transition:
+        background-color 180ms var(--po-ease-ad),
+        border-color 180ms var(--po-ease-ad);
+}
+
+.po-btn-ad:hover {
+    background: var(--po-accent-soft-ad);
+    border-color: var(--po-accent-line-ad);
+}
+
+.po-btn-ad:focus-visible {
+    outline: 2px solid var(--po-accent-ad);
+    outline-offset: 2px;
+}
+
+.po-btn-ad--sm {
+    flex: 1 1 auto;
+    font-size: 0.78rem;
+    padding: 0.4rem 0.7rem;
+}
+
+.po-btn-ad--primary {
+    background: linear-gradient(135deg, var(--po-accent-ad), var(--po-accent-2-ad));
+    border-color: transparent;
+    color: #041614;
+}
+
+.po-btn-ad--primary:hover {
+    color: #041614;
+    filter: brightness(1.08);
+}
+
+/* ==========================================================================
+   Section 8: Layout Blocks
+   ========================================================================== */
+.po-panel-ad {
+    background: var(--po-panel-ad);
+    border: 1px solid var(--po-line-ad);
+    border-radius: var(--po-radius-ad);
+    margin-bottom: 1.5rem;
+    padding: 1.5rem;
+}
+
+.po-panel-ad__title {
+    color: var(--po-text-strong-ad);
+    font-size: 0.78rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    margin: 0 0 1.15rem;
+    text-transform: uppercase;
+}
+
+.po-row-ad {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    justify-content: space-between;
+}
+
+.po-note-ad {
+    border-top: 1px solid var(--po-line-ad);
+    color: var(--po-text-muted-ad);
+    font-size: 0.8rem;
+    margin-top: 2.5rem;
+    padding-top: 1.25rem;
+}
+
+.po-note-ad code {
+    background: var(--po-inset-ad);
+    border-radius: 4px;
+    font-family: var(--po-mono-ad);
+    font-size: 0.78rem;
+    padding: 0.15rem 0.4rem;
+}
+
+/* ==========================================================================
+   Section 9: Responsive
+   --------------------------------------------------------------------------
+   The panel is clamped to the viewport on narrow screens, since a fixed
+   280px popover anchored to an edge trigger would otherwise overflow.
+   ========================================================================== */
+@media (max-width: 560px) {
+    body {
+        padding: 2.25rem 1rem 6rem;
+    }
+
+    .po-ad__panel {
+        --po-width-ad: min(280px, calc(100vw - 2.5rem));
+    }
+
+    .po-panel-ad {
+        padding: 1.2rem 1.1rem;
+    }
+
+    .po-row-ad {
+        align-items: stretch;
+        flex-direction: column;
+    }
+}
+
+/* ==========================================================================
+   Section 10: Reduced Motion
+   ========================================================================== */
+@media (prefers-reduced-motion: reduce) {
+    .po-ad__panel,
+    .po-ad:focus-within .po-ad__panel,
+    .po-btn-ad {
+        transition-duration: 1ms;
+    }
+
+    .po-ad__panel--bottom,
+    .po-ad__panel--top {
+        transform: translateX(-50%);
+    }
+
+    .po-ad__panel--bottom-end {
+        transform: none;
+    }
+}
+
+/* ==========================================================================
+   Section 11: Forced Colors
+   ========================================================================== */
+@media (forced-colors: active) {
+    .po-ad__panel {
+        background: Canvas;
+        border: 1px solid CanvasText;
+    }
+
+    .po-ad__panel::after {
+        background: Canvas;
+        border: 1px solid CanvasText;
+    }
+
+    .po-btn-ad,
+    .po-panel-ad {
+        border: 1px solid CanvasText;
+    }
+}


### PR DESCRIPTION
Fixes #59492

**What was added**

A pure CSS fade-in popover system for SaaS showcase layouts, under `submissions/examples/`.

- `style.css` — 354 non-empty lines across 11 documented sections: token architecture, base, header, popover root, three placement variants with arrow geometry, panel content, buttons, layout blocks, responsive clamping, reduced-motion, and forced-colors.
- `demo.html` — 95-line self-contained demo: four popovers across two panels, including a trailing toolbar button using the right-aligned placement.
- `README.md` — markup pattern, custom-property reference, and the containment requirement.

**Why this approach**

Opening is bound to `:focus-within`, not `:hover`. This is the central decision and it is a correctness issue, not a preference. A popover holds interactive content; a hover-driven panel closes the moment the pointer crosses the gap between trigger and panel, which makes the buttons inside effectively unreachable. Because the panel is a sibling of the trigger *inside* `.po-ad`, focus moving into the panel keeps `:focus-within` true, so the panel survives and its actions are genuinely clickable.

It also collapses keyboard and pointer interaction into one mechanism rather than two code paths, and dismissal comes for free: clicking away or tabbing out blurs the subtree and closes the panel.

The `--bottom-end` variant right-aligns to its trigger so a popover on a trailing toolbar button cannot overflow the viewport — a fixed centre-anchored 280px panel would.

**How to test**

1. Pull this branch.
2. Open `submissions/examples/59492-css-fade-in-popover-saas-showcase-ad/demo.html` directly in a browser — no server, no build, no CDN.
3. Click "Plan usage" — the panel fades in below the trigger, drifting 7px upward into place.
4. **Move the pointer down into the open panel and click "Upgrade".** The panel must stay open the whole way. This is the specific failure a hover-based popover has.
5. Click "Share workspace" — its panel opens above the trigger with the arrow flipped to the bottom edge.
6. Click "Account" (the trailing trigger) — its panel right-aligns rather than centring, staying inside the viewport.
7. Click anywhere outside, or press Tab until focus leaves — the panel fades out.
8. Tab through the page — every trigger opens its panel on focus, and panel buttons are reachable in sequence.
9. Resize below 560px — panels clamp to `min(280px, 100vw - 2.5rem)` and rows stack.
10. Enable OS-level "reduce motion" — panels appear instantly with no drift.

**Edge cases covered**

- `:focus-within` keeps the panel open while the pointer travels from trigger to panel, so interactive panel content actually works.
- Closed panels are `visibility: hidden`, keeping them out of the tab order without `display: none` (which would break the fade).
- `visibility` transition delay is matched to the fade on close and zeroed on open, so a panel never becomes hittable before it is visible.
- The right-aligned `--bottom-end` variant prevents overflow for triggers near the trailing edge.
- Panel width clamps to the viewport below 560px, so a fixed 280px panel cannot cause horizontal scroll on a phone.
- The arrow inherits the panel's own surface and border, staying attached across all three placements, with borders recomputed per direction.
- Extra bottom padding on `body` guarantees room for downward-opening panels at the end of the page.
- Panels carry `role="dialog"` and `aria-label`; triggers carry `aria-expanded`.
- `forced-colors: active` gives the panel and arrow system colours so they stay legible in high contrast.

**Verification**

- `npx stylelint style.css` against the repo's own config — zero errors.
- All 22 classes used in `demo.html` are defined in `style.css`.
- Counts verified: 4 popover roots / 4 placement-modified panels / 4 `role="dialog"`.
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 3 new files, 555 insertions, 0 deletions, no existing file touched.
- Component classes carry an `-ad` suffix so this lands as a parallel implementation without overwriting existing contributor work.

**Labels:** `type:feature` · `level:easy` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
