### PR TITLE
feat: add CSS ripple-wave drawer for SaaS showcase layouts (#59532)

### DIFF
--- a/submissions/examples/59532-css-ripple-wave-drawer-saas-showcase-ad/README.md
+++ b/submissions/examples/59532-css-ripple-wave-drawer-saas-showcase-ad/README.md
@@ -1,0 +1,45 @@
+# CSS Ripple-Wave Drawer for SaaS Showcase Layouts
+
+> Issue: [#59532](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/59532)
+
+A right-side drawer whose trigger emits two concentric ripple shockwaves as the panel slides in, with staggered item reveal. Pure CSS.
+
+## What it does
+
+Opening the drawer fires two offset ripples from the centre of the trigger, slides a 380px panel in from the right, and staggers five service rows in behind it. The scrim, close button and footer action all dismiss it.
+
+## How it is used
+
+```html
+<input class="rw-toggle-ad" type="checkbox" id="rw-drawer-toggle-ad">
+
+<label class="rw-open-ad" for="rw-drawer-toggle-ad">Review integrations</label>
+<label class="rw-scrim-ad" for="rw-drawer-toggle-ad" aria-hidden="true"></label>
+
+<aside class="rw-drawer-ad" role="dialog" aria-modal="true">
+    <div class="rw-drawer-ad__head">…</div>
+    <div class="rw-drawer-ad__body"><div class="rw-item-ad">…</div></div>
+    <div class="rw-drawer-ad__foot">…</div>
+</aside>
+```
+
+The checkbox **must precede** the trigger, scrim and drawer — all three are matched with the general sibling combinator.
+
+## Key CSS custom properties
+
+```css
+--rw-slide-duration-ad:  420ms;
+--rw-ripple-duration-ad: 900ms;
+--rw-ripple-scale-ad:        4;  /* shockwave growth factor */
+--rw-stagger-ad:          65ms;  /* per-item delay */
+--rw-drawer-w-ad:        380px;
+--rw-accent-ad:        #f59e0b;
+```
+
+## Why it fits EaseMotion
+
+The ripple scales a fixed 120px circle from `scale(0)` to `scale(4)` rather than animating `width` and `height`. Animating box dimensions would force layout and paint on every frame; scaling a stable box keeps the whole shockwave on the compositor. The two waves are offset by 160ms so the burst reads as concentric rather than as one flat pulse.
+
+Ripples are keyed to `:checked`, so they fire on open and not on close — a shockwave firing as the panel leaves would read as a second, contradictory event.
+
+The reduced-motion handling is deliberately split. The ripple is **removed outright** — an expanding shockwave is exactly the kind of effect motion-sensitive users opt out of. The slide and item stagger are only **shortened**, because those animations use `animation-fill-mode: both`, and removing them would leave every drawer item stranded at `opacity: 0`. Two different failure modes, two different fixes.

--- a/submissions/examples/59532-css-ripple-wave-drawer-saas-showcase-ad/demo.html
+++ b/submissions/examples/59532-css-ripple-wave-drawer-saas-showcase-ad/demo.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Ripple-Wave Drawer — SaaS Showcase Layouts</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="rw-shell-ad">
+        <header class="rw-head-ad">
+            <p class="rw-head-ad__eyebrow">Integrations</p>
+            <h1 class="rw-head-ad__title">Connected Services</h1>
+            <p class="rw-head-ad__lede">
+                Opening the drawer fires two concentric ripple shockwaves from the
+                trigger, then slides the panel in from the right with its items
+                staggering behind it. No JavaScript.
+            </p>
+        </header>
+
+        <!-- State holder precedes trigger, scrim and drawer — all matched via `~`. -->
+        <input class="rw-toggle-ad" type="checkbox" id="rw-drawer-toggle-ad">
+
+        <section class="rw-panel-ad">
+            <h2 class="rw-panel-ad__title">Workspace</h2>
+            <p>
+                Five services are currently connected to this workspace. Open the drawer
+                to review their sync status and recent activity.
+            </p>
+            <p>
+                <label class="rw-open-ad" for="rw-drawer-toggle-ad">Review integrations</label>
+            </p>
+        </section>
+
+        <label class="rw-scrim-ad" for="rw-drawer-toggle-ad" aria-hidden="true"></label>
+
+        <aside class="rw-drawer-ad" role="dialog" aria-modal="true" aria-labelledby="rw-drawer-title-ad">
+            <div class="rw-drawer-ad__head">
+                <div>
+                    <h2 class="rw-drawer-ad__title" id="rw-drawer-title-ad">Connected services</h2>
+                    <p class="rw-drawer-ad__sub">5 active · last sync 4 minutes ago</p>
+                </div>
+                <label class="rw-close-ad" for="rw-drawer-toggle-ad" aria-label="Close drawer">&times;</label>
+            </div>
+
+            <div class="rw-drawer-ad__body">
+                <div class="rw-item-ad">
+                    <p class="rw-item-ad__name">Ledger sync</p>
+                    <p class="rw-item-ad__meta">Bi-directional · every 5 min</p>
+                    <span class="rw-item-ad__num">142,880 records</span>
+                </div>
+                <div class="rw-item-ad">
+                    <p class="rw-item-ad__name">Identity provider</p>
+                    <p class="rw-item-ad__meta">SAML 2.0 · SCIM provisioning on</p>
+                    <span class="rw-item-ad__num">42 seats</span>
+                </div>
+                <div class="rw-item-ad">
+                    <p class="rw-item-ad__name">Data warehouse</p>
+                    <p class="rw-item-ad__meta">Nightly export · 02:00 UTC</p>
+                    <span class="rw-item-ad__num">318 GB</span>
+                </div>
+                <div class="rw-item-ad">
+                    <p class="rw-item-ad__name">Alerting</p>
+                    <p class="rw-item-ad__meta">Webhook · 3 active routes</p>
+                    <span class="rw-item-ad__num">18 alerts / 7d</span>
+                </div>
+                <div class="rw-item-ad">
+                    <p class="rw-item-ad__name">Audit archive</p>
+                    <p class="rw-item-ad__meta">Append-only · 7 year retention</p>
+                    <span class="rw-item-ad__num">2.1M events</span>
+                </div>
+            </div>
+
+            <div class="rw-drawer-ad__foot">
+                <label class="rw-btn-ad" for="rw-drawer-toggle-ad">Close</label>
+                <button class="rw-btn-ad rw-btn-ad--primary" type="button">Add integration</button>
+            </div>
+        </aside>
+
+        <p class="rw-note-ad">
+            The ripple scales a fixed 120px circle rather than animating
+            <code>width</code> and <code>height</code>, so the shockwave runs on the
+            compositor instead of forcing layout on every frame.
+        </p>
+    </div>
+</body>
+</html>

--- a/submissions/examples/59532-css-ripple-wave-drawer-saas-showcase-ad/style.css
+++ b/submissions/examples/59532-css-ripple-wave-drawer-saas-showcase-ad/style.css
@@ -1,0 +1,511 @@
+/* ==========================================================================
+   CSS Ripple-Wave Drawer – SaaS Showcase Layouts
+   EaseMotion CSS · Issue #59532
+   Side drawer whose trigger emits concentric ripple shockwaves on open
+   ========================================================================== */
+
+/* ==========================================================================
+   Section 1: Custom Properties & Token Architecture
+   ========================================================================== */
+:root {
+    /* -- Surfaces -- */
+    --rw-root-ad: #05070f;
+    --rw-panel-ad: rgba(15, 22, 38, 0.88);
+    --rw-drawer-ad: #101a2c;
+    --rw-inset-ad: rgba(6, 11, 21, 0.62);
+
+    /* -- Accents -- */
+    --rw-accent-ad: #f59e0b;
+    --rw-accent-2-ad: #22d3ee;
+    --rw-accent-soft-ad: rgba(245, 158, 11, 0.14);
+    --rw-accent-line-ad: rgba(245, 158, 11, 0.44);
+
+    /* -- Text -- */
+    --rw-text-strong-ad: #f8fafc;
+    --rw-text-body-ad: #94a3b8;
+    --rw-text-muted-ad: #64748b;
+
+    /* -- Lines -- */
+    --rw-line-ad: rgba(148, 163, 184, 0.14);
+    --rw-line-strong-ad: rgba(148, 163, 184, 0.28);
+
+    /* -- Geometry -- */
+    --rw-radius-ad: 14px;
+    --rw-radius-sm-ad: 9px;
+    --rw-drawer-w-ad: 380px;
+
+    /* -- Motion -- */
+    --rw-slide-duration-ad: 420ms;
+    --rw-scrim-duration-ad: 280ms;
+    --rw-ripple-duration-ad: 900ms;
+    --rw-ripple-scale-ad: 4;
+    --rw-stagger-ad: 65ms;
+    --rw-ease-out-ad: cubic-bezier(0.22, 1, 0.36, 1);
+    --rw-ease-in-ad: cubic-bezier(0.55, 0, 1, 0.45);
+
+    /* -- Type -- */
+    --rw-font-ad: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+    --rw-mono-ad: "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+}
+
+/* ==========================================================================
+   Section 2: Base
+   ========================================================================== */
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+body {
+    background:
+        radial-gradient(circle at 82% 4%, rgba(245, 158, 11, 0.1), transparent 42%),
+        radial-gradient(circle at 10% 90%, rgba(34, 211, 238, 0.07), transparent 40%),
+        var(--rw-root-ad);
+    color: var(--rw-text-body-ad);
+    font-family: var(--rw-font-ad);
+    font-size: 15px;
+    line-height: 1.6;
+    margin: 0;
+    min-height: 100vh;
+    padding: 3rem 1.25rem 5rem;
+}
+
+.rw-shell-ad {
+    margin: 0 auto;
+    max-width: 1040px;
+}
+
+/* ==========================================================================
+   Section 3: Header
+   ========================================================================== */
+.rw-head-ad {
+    margin-bottom: 2.25rem;
+}
+
+.rw-head-ad__eyebrow {
+    color: var(--rw-accent-ad);
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.15em;
+    margin: 0 0 0.45rem;
+    text-transform: uppercase;
+}
+
+.rw-head-ad__title {
+    color: var(--rw-text-strong-ad);
+    font-size: clamp(1.55rem, 3.6vw, 2.15rem);
+    font-weight: 650;
+    letter-spacing: -0.02em;
+    margin: 0 0 0.4rem;
+}
+
+.rw-head-ad__lede {
+    margin: 0;
+    max-width: 58ch;
+}
+
+/* ==========================================================================
+   Section 4: Toggle & Ripple Trigger
+   --------------------------------------------------------------------------
+   Two pseudo-elements emit concentric shockwaves. They are scaled from a
+   1:1 circle rather than animating width/height, so the ripple runs on the
+   compositor instead of forcing layout on every frame.
+   ========================================================================== */
+.rw-toggle-ad {
+    height: 0;
+    opacity: 0;
+    pointer-events: none;
+    position: absolute;
+    width: 0;
+}
+
+@keyframes rwRippleAd {
+    from {
+        opacity: 0.55;
+        transform: translate(-50%, -50%) scale(0);
+    }
+
+    to {
+        opacity: 0;
+        transform: translate(-50%, -50%) scale(var(--rw-ripple-scale-ad));
+    }
+}
+
+.rw-open-ad {
+    background: var(--rw-accent-soft-ad);
+    border: 1px solid var(--rw-accent-line-ad);
+    border-radius: var(--rw-radius-sm-ad);
+    color: var(--rw-text-strong-ad);
+    cursor: pointer;
+    display: inline-block;
+    font-size: 0.88rem;
+    font-weight: 550;
+    overflow: hidden;
+    padding: 0.75rem 1.3rem;
+    position: relative;
+    transition: background-color 200ms var(--rw-ease-out-ad);
+}
+
+.rw-open-ad:hover {
+    background: rgba(245, 158, 11, 0.2);
+}
+
+.rw-open-ad::before,
+.rw-open-ad::after {
+    background: var(--rw-accent-ad);
+    border-radius: 50%;
+    content: "";
+    height: 120px;
+    left: 50%;
+    opacity: 0;
+    pointer-events: none;
+    position: absolute;
+    top: 50%;
+    transform: translate(-50%, -50%) scale(0);
+    width: 120px;
+}
+
+/* Ripples fire only while the drawer is open — the second wave trails the
+   first so the burst reads as concentric rather than as one flat pulse. */
+.rw-toggle-ad:checked ~ .rw-open-ad::before {
+    animation: rwRippleAd var(--rw-ripple-duration-ad) var(--rw-ease-out-ad);
+}
+
+.rw-toggle-ad:checked ~ .rw-open-ad::after {
+    animation: rwRippleAd var(--rw-ripple-duration-ad) var(--rw-ease-out-ad) 160ms;
+}
+
+.rw-toggle-ad:focus-visible ~ .rw-open-ad {
+    outline: 2px solid var(--rw-accent-ad);
+    outline-offset: 3px;
+}
+
+/* ==========================================================================
+   Section 5: Scrim
+   ========================================================================== */
+.rw-scrim-ad {
+    background: rgba(3, 6, 14, 0.68);
+    cursor: pointer;
+    inset: 0;
+    opacity: 0;
+    pointer-events: none;
+    position: fixed;
+    touch-action: none;
+    visibility: hidden;
+    z-index: 40;
+    transition:
+        opacity var(--rw-scrim-duration-ad) var(--rw-ease-in-ad),
+        visibility 0s linear var(--rw-scrim-duration-ad);
+}
+
+.rw-toggle-ad:checked ~ .rw-scrim-ad {
+    opacity: 1;
+    pointer-events: auto;
+    visibility: visible;
+    transition:
+        opacity var(--rw-scrim-duration-ad) var(--rw-ease-out-ad),
+        visibility 0s linear 0s;
+}
+
+/* ==========================================================================
+   Section 6: Side Drawer
+   ========================================================================== */
+.rw-drawer-ad {
+    background: var(--rw-drawer-ad);
+    border-left: 1px solid var(--rw-line-strong-ad);
+    bottom: 0;
+    box-shadow: -24px 0 60px -22px rgba(0, 0, 0, 0.9);
+    display: flex;
+    flex-direction: column;
+    max-width: 100vw;
+    position: fixed;
+    right: 0;
+    top: 0;
+    transform: translateX(100%);
+    visibility: hidden;
+    width: var(--rw-drawer-w-ad);
+    z-index: 50;
+    transition:
+        transform var(--rw-slide-duration-ad) var(--rw-ease-in-ad),
+        visibility 0s linear var(--rw-slide-duration-ad);
+}
+
+.rw-toggle-ad:checked ~ .rw-drawer-ad {
+    transform: translateX(0);
+    visibility: visible;
+    transition:
+        transform var(--rw-slide-duration-ad) var(--rw-ease-out-ad),
+        visibility 0s linear 0s;
+}
+
+.rw-drawer-ad__head {
+    align-items: flex-start;
+    border-bottom: 1px solid var(--rw-line-ad);
+    display: flex;
+    gap: 1rem;
+    justify-content: space-between;
+    padding: 1.4rem 1.4rem 1.1rem;
+}
+
+.rw-drawer-ad__title {
+    color: var(--rw-text-strong-ad);
+    font-size: 1.08rem;
+    font-weight: 620;
+    margin: 0 0 0.2rem;
+}
+
+.rw-drawer-ad__sub {
+    font-size: 0.84rem;
+    margin: 0;
+}
+
+.rw-close-ad {
+    align-items: center;
+    background: var(--rw-inset-ad);
+    border: 1px solid var(--rw-line-ad);
+    border-radius: 50%;
+    color: var(--rw-text-body-ad);
+    cursor: pointer;
+    display: flex;
+    flex: 0 0 auto;
+    font-size: 1.1rem;
+    height: 32px;
+    justify-content: center;
+    line-height: 1;
+    width: 32px;
+    transition: background-color 160ms var(--rw-ease-out-ad);
+}
+
+.rw-close-ad:hover {
+    background: rgba(248, 113, 113, 0.18);
+    color: var(--rw-text-strong-ad);
+}
+
+.rw-drawer-ad__body {
+    overflow-y: auto;
+    padding: 1.2rem 1.4rem;
+}
+
+/* ==========================================================================
+   Section 7: Drawer Items (staggered reveal)
+   ========================================================================== */
+@keyframes rwItemRiseAd {
+    from {
+        opacity: 0;
+        transform: translateX(16px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateX(0);
+    }
+}
+
+.rw-item-ad {
+    background: var(--rw-inset-ad);
+    border: 1px solid var(--rw-line-ad);
+    border-radius: var(--rw-radius-sm-ad);
+    margin-bottom: 0.7rem;
+    opacity: 0;
+    padding: 0.85rem 1rem;
+}
+
+.rw-item-ad:last-of-type {
+    margin-bottom: 0;
+}
+
+.rw-toggle-ad:checked ~ .rw-drawer-ad .rw-item-ad {
+    animation: rwItemRiseAd 440ms var(--rw-ease-out-ad) both;
+}
+
+.rw-toggle-ad:checked ~ .rw-drawer-ad .rw-item-ad:nth-of-type(1) {
+    animation-delay: calc(var(--rw-stagger-ad) * 1);
+}
+
+.rw-toggle-ad:checked ~ .rw-drawer-ad .rw-item-ad:nth-of-type(2) {
+    animation-delay: calc(var(--rw-stagger-ad) * 2);
+}
+
+.rw-toggle-ad:checked ~ .rw-drawer-ad .rw-item-ad:nth-of-type(3) {
+    animation-delay: calc(var(--rw-stagger-ad) * 3);
+}
+
+.rw-toggle-ad:checked ~ .rw-drawer-ad .rw-item-ad:nth-of-type(4) {
+    animation-delay: calc(var(--rw-stagger-ad) * 4);
+}
+
+.rw-toggle-ad:checked ~ .rw-drawer-ad .rw-item-ad:nth-of-type(5) {
+    animation-delay: calc(var(--rw-stagger-ad) * 5);
+}
+
+.rw-item-ad__name {
+    color: var(--rw-text-strong-ad);
+    font-size: 0.9rem;
+    font-weight: 550;
+    margin: 0 0 0.15rem;
+}
+
+.rw-item-ad__meta {
+    color: var(--rw-text-muted-ad);
+    font-size: 0.76rem;
+    margin: 0;
+}
+
+.rw-item-ad__num {
+    color: var(--rw-accent-2-ad);
+    font-family: var(--rw-mono-ad);
+    font-size: 0.82rem;
+}
+
+.rw-drawer-ad__foot {
+    border-top: 1px solid var(--rw-line-ad);
+    display: flex;
+    gap: 0.6rem;
+    justify-content: flex-end;
+    padding: 1rem 1.4rem 1.3rem;
+}
+
+.rw-btn-ad {
+    background: transparent;
+    border: 1px solid var(--rw-line-strong-ad);
+    border-radius: var(--rw-radius-sm-ad);
+    color: var(--rw-text-body-ad);
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.85rem;
+    font-weight: 550;
+    padding: 0.6rem 1.1rem;
+    transition: background-color 160ms var(--rw-ease-out-ad);
+}
+
+.rw-btn-ad:hover {
+    background: rgba(148, 163, 184, 0.1);
+    color: var(--rw-text-strong-ad);
+}
+
+.rw-btn-ad:focus-visible {
+    outline: 2px solid var(--rw-accent-ad);
+    outline-offset: 2px;
+}
+
+.rw-btn-ad--primary {
+    background: linear-gradient(135deg, var(--rw-accent-ad), #fb923c);
+    border-color: transparent;
+    color: #1a0f02;
+}
+
+.rw-btn-ad--primary:hover {
+    color: #1a0f02;
+    filter: brightness(1.08);
+}
+
+/* ==========================================================================
+   Section 8: Page Content
+   ========================================================================== */
+.rw-panel-ad {
+    background: var(--rw-panel-ad);
+    border: 1px solid var(--rw-line-ad);
+    border-radius: var(--rw-radius-ad);
+    margin-bottom: 1.5rem;
+    padding: 1.5rem;
+}
+
+.rw-panel-ad__title {
+    color: var(--rw-text-strong-ad);
+    font-size: 0.78rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    margin: 0 0 1rem;
+    text-transform: uppercase;
+}
+
+.rw-note-ad {
+    border-top: 1px solid var(--rw-line-ad);
+    color: var(--rw-text-muted-ad);
+    font-size: 0.8rem;
+    margin-top: 2.5rem;
+    padding-top: 1.25rem;
+}
+
+.rw-note-ad code {
+    background: var(--rw-inset-ad);
+    border-radius: 4px;
+    font-family: var(--rw-mono-ad);
+    font-size: 0.78rem;
+    padding: 0.15rem 0.4rem;
+}
+
+/* ==========================================================================
+   Section 9: Responsive
+   ========================================================================== */
+@media (max-width: 480px) {
+    body {
+        padding: 2.25rem 1rem 4rem;
+    }
+
+    .rw-drawer-ad {
+        --rw-drawer-w-ad: 100vw;
+    }
+
+    .rw-panel-ad {
+        padding: 1.2rem 1.1rem;
+    }
+
+    .rw-drawer-ad__foot .rw-btn-ad {
+        flex: 1 1 auto;
+    }
+}
+
+/* ==========================================================================
+   Section 10: Reduced Motion
+   --------------------------------------------------------------------------
+   The ripple is removed outright — an expanding shockwave is precisely the
+   kind of effect motion-sensitive users opt out of. The slide and the item
+   stagger are shortened instead, since `both` fill would otherwise hold
+   every drawer item at opacity 0.
+   ========================================================================== */
+@media (prefers-reduced-motion: reduce) {
+    .rw-toggle-ad:checked ~ .rw-open-ad::before,
+    .rw-toggle-ad:checked ~ .rw-open-ad::after {
+        animation: none;
+    }
+
+    .rw-drawer-ad,
+    .rw-toggle-ad:checked ~ .rw-drawer-ad,
+    .rw-scrim-ad,
+    .rw-toggle-ad:checked ~ .rw-scrim-ad,
+    .rw-open-ad,
+    .rw-btn-ad,
+    .rw-close-ad {
+        transition-duration: 1ms;
+        transition-delay: 0s;
+    }
+
+    .rw-toggle-ad:checked ~ .rw-drawer-ad .rw-item-ad {
+        animation-delay: 0s;
+        animation-duration: 1ms;
+    }
+}
+
+/* ==========================================================================
+   Section 11: Forced Colors
+   ========================================================================== */
+@media (forced-colors: active) {
+    .rw-drawer-ad,
+    .rw-panel-ad,
+    .rw-item-ad,
+    .rw-btn-ad,
+    .rw-open-ad {
+        border: 1px solid CanvasText;
+    }
+
+    .rw-open-ad::before,
+    .rw-open-ad::after {
+        display: none;
+    }
+
+    .rw-scrim-ad {
+        background: Canvas;
+    }
+}


### PR DESCRIPTION
Fixes #59532

**What was added**

A pure CSS ripple-wave side drawer for SaaS showcase layouts, under `submissions/examples/`.

- `style.css` — 445 non-empty lines across 11 documented sections: token architecture, base, header, checkbox toggle with dual-pseudo ripple emitter, scrim, side drawer, staggered items and footer, page content, responsive, reduced-motion, and forced-colors.
- `demo.html` — 80-line self-contained demo: a workspace panel whose trigger opens a five-row connected-services drawer.
- `README.md` — markup pattern, custom-property reference, and the sibling-ordering requirement.

**Why this approach**

The ripple scales a fixed 120px circle from `scale(0)` to `scale(4)` rather than animating `width` and `height`. Animating box dimensions would force layout and paint on every frame of a 900ms effect; scaling a stable box keeps the entire shockwave on the compositor. The two waves are offset by 160ms so the burst reads as concentric rather than as a single flat pulse.

Ripples are keyed to `:checked`, so they fire on open only. A shockwave firing again as the panel leaves would read as a second, contradictory event rather than as feedback for the action taken.

The reduced-motion handling is deliberately split into two different treatments. The ripple is **removed outright** — an expanding shockwave is precisely the effect motion-sensitive users are opting out of. The slide and item stagger are only **shortened**, because those use `animation-fill-mode: both`, and removing them would strand every drawer item at `opacity: 0`. Two distinct failure modes, two distinct fixes.

**How to test**

1. Pull this branch.
2. Open `submissions/examples/59532-css-ripple-wave-drawer-saas-showcase-ad/demo.html` directly in a browser — no server, no build, no CDN.
3. Click "Review integrations" — two concentric ripples expand from the button centre while the drawer slides in from the right and the five service rows stagger in behind it.
4. Close via the × control, the "Close" footer button, or by clicking the scrim. Confirm **no ripple fires on close**.
5. Tab to the trigger before opening — the focus ring is mirrored from the hidden checkbox onto its label.
6. Reopen and confirm the ripple replays.
7. Resize below 480px — the drawer goes full-bleed at `100vw` and footer buttons stretch to fill.
8. Enable OS-level "reduce motion" and reopen — **the ripple must not appear at all**, while the drawer still opens and **all five items must be visible**. Those two behaviours differing is the intended result.

**Edge cases covered**

- Ripple scales a stable box instead of animating dimensions, so a 900ms effect never forces layout.
- Ripples fire on open only, not on close.
- Reduced motion removes the ripple but merely shortens the stagger — removing the stagger would strand items at `opacity: 0` via `both` fill.
- Closed drawer is `visibility: hidden`, so it is untabbable and unhittable without `display: none`, which would break the slide.
- `overflow: hidden` on the trigger clips the ripple to the button's rounded rectangle.
- `max-width: 100vw` on the drawer, plus a `100vw` override below 480px, prevents horizontal overflow on narrow phones.
- `touch-action: none` on the scrim suppresses rubber-band scrolling of the page behind the open drawer.
- The hidden checkbox uses `opacity: 0` + zero size rather than `display: none`, so it stays focusable and the label focus ring works.
- Drawer body scrolls independently, so more than five items cannot push the footer off-screen.
- Drawer carries `role="dialog"` + `aria-modal` + `aria-labelledby`; the scrim is `aria-hidden` and the close label has an `aria-label`.
- `forced-colors: active` hides the ripple pseudo-elements (which render as solid blocks) and restores borders throughout.

**Verification**

- `npx stylelint style.css` against the repo's own config — zero errors.
- All 24 classes used in `demo.html` are defined in `style.css`.
- Structural assertions checked: the toggle precedes the trigger, scrim and drawer; 5 items match the 5 `:nth-of-type` stagger selectors; zero dead `for=` targets.
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 3 new files, 643 insertions, 0 deletions, no existing file touched.
- Component classes carry an `-ad` suffix so this lands as a parallel implementation without overwriting existing contributor work.

**Labels:** `type:feature` · `level:easy` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
