### PR TITLE
Add ease-pinball-flipper-flick component

### DIFF
--- a/submissions/examples/pinball-flipper-flick-ij/README.md
+++ b/submissions/examples/pinball-flipper-flick-ij/README.md
@@ -1,0 +1,10 @@
+# ease-pinball-flipper-flick
+
+A pinball table whose flippers flick and bounce a silver ball between the bumpers.
+
+## Run
+Open `demo.html` directly in a browser to watch the flippers flick.
+
+## Notes
+- The ball hops between the three bumpers.
+- Lanterns blink across the backglass.

--- a/submissions/examples/pinball-flipper-flick-ij/demo.html
+++ b/submissions/examples/pinball-flipper-flick-ij/demo.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-pinball-flipper-flick demo</title>
+</head>
+<body>
+<div class="pf-app">
+  <span class="pf-title">PINBALL</span>
+  <div class="pf-backglass">
+    <div class="pf-lantern pf-lantern-1"></div>
+    <div class="pf-lantern pf-lantern-2"></div>
+    <div class="pf-lantern pf-lantern-3"></div>
+    <div class="pf-lantern pf-lantern-4"></div>
+    <div class="pf-lantern pf-lantern-5"></div>
+  </div>
+  <div class="pf-bumper pf-bumper-1"></div>
+  <div class="pf-bumper pf-bumper-2"></div>
+  <div class="pf-bumper pf-bumper-3"></div>
+  <div class="pf-star pf-star-1"></div>
+  <div class="pf-star pf-star-2"></div>
+  <div class="pf-target pf-target-1"></div>
+  <div class="pf-target pf-target-2"></div>
+  <div class="pf-target pf-target-3"></div>
+  <div class="pf-ball"></div>
+  <div class="pf-flipper pf-flipper-l"></div>
+  <div class="pf-flipper pf-flipper-r"></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/pinball-flipper-flick-ij/style.css
+++ b/submissions/examples/pinball-flipper-flick-ij/style.css
@@ -1,0 +1,33 @@
+:root{--pf-dark:#14182a;--pf-neon:#3ad8c8;--pf-red:#e84a4a;--pf-gold:#f0c83a}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#1c2040,#0e1020);font-family:'Segoe UI',sans-serif}
+.pf-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#22264a,#12162e);box-shadow:0 16px 36px rgba(0,0,0,0.5)}
+.pf-title{position:absolute;top:12px;left:0;right:0;text-align:center;font-size:15px;font-weight:800;letter-spacing:8px;color:var(--pf-neon);text-shadow:0 0 10px rgba(58,216,200,0.8)}
+.pf-backglass{position:absolute;top:40px;left:24px;right:24px;height:74px;border-radius:8px;background:linear-gradient(180deg,#2a3060,#1a1e3e);box-shadow:inset 0 0 0 4px #3a4060}
+.pf-lantern{position:absolute;top:58px;width:10px;height:10px;border-radius:50%;background:var(--pf-red);box-shadow:0 0 8px rgba(232,74,74,0.9);animation:blink-lantern-pinball-flipper-flick 1.2s ease-in-out infinite}
+.pf-lantern-1{left:44px}
+.pf-lantern-2{left:112px;animation-delay:0.3s;background:var(--pf-gold);box-shadow:0 0 8px rgba(240,200,58,0.9)}
+.pf-lantern-3{left:184px;animation-delay:0.6s;background:var(--pf-neon);box-shadow:0 0 8px rgba(58,216,200,0.9)}
+.pf-lantern-4{left:252px;animation-delay:0.9s;background:var(--pf-gold);box-shadow:0 0 8px rgba(240,200,58,0.9)}
+.pf-lantern-5{left:318px;animation-delay:1.1s}
+.pf-bumper{position:absolute;width:34px;height:34px;border-radius:50%;background:var(--pf-red);box-shadow:inset 0 0 0 6px #b83232,0 0 14px rgba(232,74,74,0.7);animation:flash-bumper-pinball-flipper-flick 1.8s ease-in-out infinite}
+.pf-bumper-1{top:150px;left:64px}
+.pf-bumper-2{top:140px;left:169px;animation-delay:0.6s;background:var(--pf-gold);box-shadow:inset 0 0 0 6px #c8a024,0 0 14px rgba(240,200,58,0.7)}
+.pf-bumper-3{top:150px;left:274px;animation-delay:1.2s}
+.pf-star{position:absolute;width:16px;height:16px;background:var(--pf-neon);clip-path:polygon(50% 0,61% 38%,100% 50%,61% 62%,50% 100%,39% 62%,0 50%,39% 38%);animation:twinkle-star-pinball-flipper-flick 1.8s ease-in-out infinite}
+.pf-star-1{top:118px;left:140px;animation-delay:0.4s}
+.pf-star-2{top:124px;left:216px;animation-delay:1s}
+.pf-target{position:absolute;top:104px;width:6px;height:34px;border-radius:3px;background:var(--pf-gold);animation:flash-target-pinball-flipper-flick 1.8s ease-in-out infinite}
+.pf-target-1{left:88px;animation-delay:0.2s}
+.pf-target-2{left:186px;animation-delay:0.8s}
+.pf-target-3{left:284px;animation-delay:1.4s}
+.pf-ball{position:absolute;top:238px;left:132px;width:14px;height:14px;border-radius:50%;background:radial-gradient(circle at 35% 30%,#f8f8f8,#a8a8b0 60%,#707080);box-shadow:0 0 8px rgba(255,255,255,0.5);animation:bump-ball-pinball-flipper-flick 1.8s ease-in-out infinite}
+.pf-flipper{position:absolute;top:318px;width:88px;height:12px;border-radius:6px;background:var(--pf-red);box-shadow:inset 0 0 0 3px #b83232;animation-duration:1.8s;animation-timing-function:ease-in-out;animation-iteration-count:infinite}
+.pf-flipper-l{left:36px;transform-origin:left 6px;animation-name:flick-flipper-l-pinball-flipper-flick}
+.pf-flipper-r{right:36px;transform-origin:right 6px;animation-name:flick-flipper-r-pinball-flipper-flick}
+@keyframes flick-flipper-l-pinball-flipper-flick{0%,100%{transform:rotate(0deg)}50%{transform:rotate(-28deg)}}
+@keyframes flick-flipper-r-pinball-flipper-flick{0%,100%{transform:rotate(0deg)}50%{transform:rotate(28deg)}}
+@keyframes bump-ball-pinball-flipper-flick{0%,100%{transform:translate(0,0)}25%{transform:translate(60px,-30px)}50%{transform:translate(-46px,-52px)}75%{transform:translate(24px,-16px)}}
+@keyframes blink-lantern-pinball-flipper-flick{0%,100%{opacity:0.25}50%{opacity:1}}
+@keyframes flash-bumper-pinball-flipper-flick{0%,100%{transform:scale(1)}50%{transform:scale(1.25)}}
+@keyframes twinkle-star-pinball-flipper-flick{0%,100%{opacity:0.2;transform:scale(0.7)}50%{opacity:1;transform:scale(1.3)}}
+@keyframes flash-target-pinball-flipper-flick{0%,100%{opacity:0.3}50%{opacity:1}}


### PR DESCRIPTION
## Component: ease-pinball-flipper-flick — flippers flick, ball bounces, and bumpers blink

**Closes #61525**

### What this adds
A pinball table under the glass: the two flippers flick up to nudge a silver ball that bounces between the star bumpers, the rollover targets flash, and the lantern lights blink in a row on the backglass.

### Acceptance Criteria covered
- Flippers flick up in turn
- Ball bounces off the bumpers
- Lanterns blink on the backglass

### Files
- submissions/examples/pinball-flipper-flick-ij/demo.html
- submissions/examples/pinball-flipper-flick-ij/style.css
- submissions/examples/pinball-flipper-flick-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the flippers flick.