### PR TITLE
fix(ease-dialog): prevent focus outline clipping by parent overflow (…

### DIFF
--- a/submissions/examples/ease-dialog-focus-outline-clipped-59752/README.md
+++ b/submissions/examples/ease-dialog-focus-outline-clipped-59752/README.md
@@ -1,0 +1,10 @@
+# ease-dialog Focus Outline Fix
+
+### Issue Description
+The `ease-dialog` component suffers from a clipping issue where its focus ring (outline or box-shadow) is cut off if placed inside a container with `overflow: hidden` or `overflow: auto`. This degrades the accessibility experience. (Issue #59752)
+
+### Solution
+This example demonstrates a fix by ensuring the focus ring is contained within the element's bounding box. We achieve this by using `outline-offset: -2px` on the `:focus-visible` pseudo-class.
+
+### Usage
+Open `demo.html` in your browser and use the `Tab` key to focus the dialog. You'll observe that the focus ring is completely visible and not clipped by the parent container.

--- a/submissions/examples/ease-dialog-focus-outline-clipped-59752/demo.html
+++ b/submissions/examples/ease-dialog-focus-outline-clipped-59752/demo.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-dialog Focus Outline Fix - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+        font-family: system-ui, -apple-system, sans-serif;
+        padding: 2rem;
+        background-color: #f9fafb;
+    }
+    .demo-container {
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+        max-width: 600px;
+        margin: 0 auto;
+    }
+    .overflow-container {
+        overflow: hidden;
+        border: 1px solid #ccc;
+        padding: 1rem;
+        border-radius: 8px;
+        background-color: #fff;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        height: 200px; /* Small height to test focus ring clipping */
+    }
+    .instructions {
+        background: #eff6ff;
+        padding: 1.5rem;
+        border-left: 4px solid #3b82f6;
+        border-radius: 0 8px 8px 0;
+        margin-bottom: 2rem;
+    }
+  </style>
+</head>
+<body>
+  <main class="demo-container">
+    <h1>Focus Outline Clipping Fix for ease-dialog</h1>
+    
+    <div class="instructions">
+      <p><strong>Steps to Reproduce:</strong></p>
+      <ol>
+        <li>Focus the dialog component below using the <code>Tab</code> key.</li>
+        <li>Notice that the focus ring is fully visible and not clipped by the <code>overflow: hidden</code> container.</li>
+      </ol>
+    </div>
+
+    <div class="overflow-container">
+      <dialog class="ease-dialog" open tabindex="0">
+        <h2>Dialog Title</h2>
+        <p>This is a sample dialog content to demonstrate the focus ring.</p>
+        <button>Close</button>
+      </dialog>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-dialog-focus-outline-clipped-59752/style.css
+++ b/submissions/examples/ease-dialog-focus-outline-clipped-59752/style.css
@@ -1,0 +1,25 @@
+/* 
+ * Fix for ease-dialog focus outline clipping
+ * Issue: When .ease-dialog is placed in a container with overflow: hidden or auto,
+ * the standard outline is clipped.
+ * Solution: Using negative outline-offset or inset box-shadow.
+ */
+
+.ease-dialog {
+    display: block;
+    position: relative;
+    padding: 1.5rem;
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    background-color: #fff;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+    color: #1f2937;
+    margin: 0;
+    max-width: 100%;
+}
+
+/* Ensure focus outline is drawn inward to prevent clipping */
+.ease-dialog:focus-visible {
+    outline: 2px solid #3b82f6;
+    outline-offset: -2px; /* Pulls the outline inward */
+}


### PR DESCRIPTION
## Pull Request Description

This PR fixes a clipping issue with the `ease-dialog` component (Issue #59752) where its focus ring (outline) gets cut off when placed inside a container with `overflow: hidden` or `overflow: auto`. The fix introduces a negative `outline-offset` when the component receives `:focus-visible`, ensuring the outline is drawn inwards and remains fully visible.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

It ensures the `ease-dialog` focus ring is fully visible and accessible even when constrained by a parent element's overflow boundaries.

**How does a developer use it?**

```html
<div style="overflow: hidden;">
  <!-- Focus the dialog with Tab to see the corrected focus ring -->
  <dialog class="ease-dialog" open tabindex="0">
    <h2>Dialog Title</h2>
    <p>Sample dialog content</p>
  </dialog>
</div>
