### PR TITLE
Add ease-cash-register-ding component

### DIFF
--- a/submissions/examples/cash-register-ding-ij/README.md
+++ b/submissions/examples/cash-register-ding-ij/README.md
@@ -1,0 +1,10 @@
+# ease-cash-register-ding
+
+A classic cash register whose keys tap and drawer slides open with a ding.
+
+## Run
+Open `demo.html` directly in a browser to watch the keys tap.
+
+## Notes
+- Keys press one after another around the dial.
+- The DING flag pops up as the drawer opens.

--- a/submissions/examples/cash-register-ding-ij/demo.html
+++ b/submissions/examples/cash-register-ding-ij/demo.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-cash-register-ding demo</title>
+</head>
+<body>
+<div class="cr-app">
+  <div class="cr-display"><span class="cr-total">$12.40</span></div>
+  <div class="cr-crank"></div>
+  <div class="cr-flag"><span class="cr-flag-text">DING!</span></div>
+  <div class="cr-keys">
+    <button class="cr-key cr-key-1">1</button>
+    <button class="cr-key cr-key-2">2</button>
+    <button class="cr-key cr-key-3">3</button>
+    <button class="cr-key cr-key-4">4</button>
+    <button class="cr-key cr-key-5">5</button>
+    <button class="cr-key cr-key-6">6</button>
+    <button class="cr-key cr-key-7">7</button>
+    <button class="cr-key cr-key-8">8</button>
+    <button class="cr-key cr-key-9">9</button>
+    <button class="cr-key cr-key-0">0</button>
+    <button class="cr-key cr-key-plus">+</button>
+    <button class="cr-key cr-key-cash">$</button>
+  </div>
+  <div class="cr-drawer"><span class="cr-drawer-label">CASH</span></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/cash-register-ding-ij/style.css
+++ b/submissions/examples/cash-register-ding-ij/style.css
@@ -1,0 +1,29 @@
+:root{--cr-body:#8a5a32;--cr-dark:#4a2e1a;--cr-face:#f0e4d0;--cr-gold:#d8b64a}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#e8dcc6,#c0aa86);font-family:'Segoe UI',sans-serif}
+.cr-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#f0e4ce,#d0b892);box-shadow:0 16px 36px rgba(0,0,0,0.3)}
+.cr-display{position:absolute;top:22px;left:84px;width:204px;height:40px;border-radius:6px;background:#1c2430;box-shadow:inset 0 0 0 4px #3a4450;animation:flash-total-cash-register-ding 2.4s ease-in-out infinite}
+.cr-total{position:absolute;top:6px;left:0;right:0;text-align:center;font-size:19px;font-weight:700;color:#7fe07a;font-family:'Consolas',monospace}
+.cr-crank{position:absolute;top:34px;right:32px;width:14px;height:14px;border-radius:50%;background:var(--cr-gold);box-shadow:inset 0 0 0 4px #a8882c;animation:turn-crank-cash-register-ding 2.4s ease-in-out infinite}
+.cr-flag{position:absolute;top:74px;left:120px;width:132px;height:34px;border-radius:6px;background:var(--cr-gold);transform-origin:bottom center;animation:ding-flag-cash-register-ding 2.4s ease-in-out infinite}
+.cr-flag-text{position:absolute;left:0;right:0;top:7px;text-align:center;font-size:15px;font-weight:800;letter-spacing:3px;color:#4a2e1a}
+.cr-keys{position:absolute;top:122px;left:44px;width:284px;height:130px;border-radius:8px;background:var(--cr-body);box-shadow:inset 0 0 0 5px var(--cr-dark)}
+.cr-key{position:absolute;width:44px;height:28px;border:0;border-radius:5px;background:var(--cr-face);color:#4a2e1a;font-size:13px;font-weight:700;box-shadow:0 3px 0 #a08860;cursor:pointer;animation:press-key-cash-register-ding 2.4s ease-in-out infinite}
+.cr-key-1{left:16px;top:14px}
+.cr-key-2{left:66px;top:14px;animation-delay:0.2s}
+.cr-key-3{left:116px;top:14px;animation-delay:0.4s}
+.cr-key-4{left:166px;top:14px;animation-delay:0.6s}
+.cr-key-5{left:216px;top:14px;animation-delay:0.8s}
+.cr-key-6{left:16px;top:52px;animation-delay:1s}
+.cr-key-7{left:66px;top:52px;animation-delay:1.2s}
+.cr-key-8{left:116px;top:52px;animation-delay:1.4s}
+.cr-key-9{left:166px;top:52px;animation-delay:1.6s}
+.cr-key-0{left:216px;top:52px;animation-delay:1.8s}
+.cr-key-plus{left:16px;top:90px;animation-delay:2s}
+.cr-key-cash{left:66px;top:90px;animation-delay:2.2s}
+.cr-drawer{position:absolute;bottom:26px;left:56px;width:260px;height:54px;border-radius:6px;background:var(--cr-dark);box-shadow:inset 0 0 0 4px #33200e;animation:slide-drawer-cash-register-ding 2.4s ease-in-out infinite}
+.cr-drawer-label{position:absolute;left:0;right:0;top:17px;text-align:center;font-size:12px;font-weight:700;letter-spacing:6px;color:var(--cr-gold)}
+@keyframes press-key-cash-register-ding{0%,100%{transform:translateY(0)}50%{transform:translateY(3px)}}
+@keyframes ding-flag-cash-register-ding{0%,100%{transform:translateY(0)}20%{transform:translateY(-34px)}60%{transform:translateY(-34px)}}
+@keyframes flash-total-cash-register-ding{0%,100%{opacity:1}50%{opacity:0.4}}
+@keyframes turn-crank-cash-register-ding{0%,100%{transform:rotate(0deg)}50%{transform:rotate(120deg)}}
+@keyframes slide-drawer-cash-register-ding{0%,100%{transform:translateX(0)}20%{transform:translateX(30px)}60%{transform:translateX(30px)}}


### PR DESCRIPTION
## Component: ease-cash-register-ding — keys tap, drawer slides, and total dings

**Closes #61528**

### What this adds
A classic cash register: the number keys tap in sequence, the price total flashes on the display, the crank turns on the side, and a DING flag pops up as the cash drawer slides open.

### Acceptance Criteria covered
- Number keys tap in sequence
- Total flashes on the display
- Drawer slides open with a ding

### Files
- submissions/examples/cash-register-ding-ij/demo.html
- submissions/examples/cash-register-ding-ij/style.css
- submissions/examples/cash-register-ding-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the keys tap.