### PR TITLE
fix: ease-chip focus outline is clipped by parent overflow (#59746)

### DIFF
--- a/submissions/examples/ease-chip-focus-outline-clipped-59746/README.md
+++ b/submissions/examples/ease-chip-focus-outline-clipped-59746/README.md
@@ -1,0 +1,10 @@
+# ease-chip Focus Outline Fix
+
+### Issue Description
+The `ease-chip` component suffers from a clipping issue where its focus ring (outline or box-shadow) is cut off if placed inside a container with `overflow: hidden` or `overflow: auto`. This degrades the accessibility experience. (Issue #59746)
+
+### Solution
+This example demonstrates a fix by ensuring the focus ring is contained within the element's bounding box. We achieve this by using `outline-offset: -2px` on the `:focus-visible` pseudo-class.
+
+### Usage
+Open `demo.html` in your browser and use the `Tab` key to focus the chip. You'll observe that the focus ring is completely visible and not clipped by the parent container.

--- a/submissions/examples/ease-chip-focus-outline-clipped-59746/demo.html
+++ b/submissions/examples/ease-chip-focus-outline-clipped-59746/demo.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-chip Focus Outline Fix - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+        font-family: system-ui, -apple-system, sans-serif;
+        padding: 2rem;
+        background-color: #f9fafb;
+    }
+    .demo-container {
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+        max-width: 600px;
+        margin: 0 auto;
+    }
+    .overflow-container {
+        overflow: hidden;
+        border: 1px solid #ccc;
+        padding: 1rem;
+        border-radius: 8px;
+        background-color: #fff;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        /* Container styling to test clipping */
+    }
+    .instructions {
+        background: #eff6ff;
+        padding: 1.5rem;
+        border-left: 4px solid #3b82f6;
+        border-radius: 0 8px 8px 0;
+        margin-bottom: 2rem;
+    }
+  </style>
+</head>
+<body>
+  <main class="demo-container">
+    <h1>Focus Outline Clipping Fix for ease-chip</h1>
+    
+    <div class="instructions">
+      <p><strong>Steps to Reproduce:</strong></p>
+      <ol>
+        <li>Focus the chip component below using the <code>Tab</code> key.</li>
+        <li>Notice that the focus ring is fully visible and not clipped by the <code>overflow: hidden</code> container.</li>
+      </ol>
+    </div>
+
+    <div class="overflow-container">
+      <button class="ease-chip" tabindex="0">
+        Ease Chip
+      </button>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-chip-focus-outline-clipped-59746/style.css
+++ b/submissions/examples/ease-chip-focus-outline-clipped-59746/style.css
@@ -1,0 +1,30 @@
+/* 
+ * Fix for ease-chip focus outline clipping
+ * Issue: When .ease-chip is placed in a container with overflow: hidden or auto,
+ * the standard outline is clipped.
+ * Solution: Using negative outline-offset or inset box-shadow.
+ */
+
+.ease-chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.25rem 0.75rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    border-radius: 9999px;
+    background-color: #e5e7eb;
+    color: #374151;
+    border: 1px solid transparent;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.ease-chip:hover {
+    background-color: #d1d5db;
+}
+
+/* Ensure focus outline is drawn inward to prevent clipping */
+.ease-chip:focus-visible {
+    outline: 2px solid #3b82f6;
+    outline-offset: -2px; /* Pulls the outline inward */
+}


### PR DESCRIPTION
## Pull Request Description

This PR provides a solution for Issue #59746 where the `ease-chip` focus ring gets clipped when placed inside a container with `overflow: hidden` or `overflow: auto`. The submission includes a new example demonstrating the fix utilizing an inward-drawn outline (`outline-offset: -2px`) to ensure the focus ring remains fully visible and accessible within the bounding box of the element. 

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

It provides a fix for the `ease-chip` component to prevent its focus outline from being clipped by containers with restrictive overflow properties.

**How does a developer use it?**

```html
<div style="overflow: hidden;">
  <button class="ease-chip" tabindex="0">
    Ease Chip
  </button>
</div>
