### PR TITLE
docs: add example for ease-checkbox focus outline clipping bug #59744

### DIFF
--- a/submissions/examples/ease-checkbox-focus-outline-59744/README.md
+++ b/submissions/examples/ease-checkbox-focus-outline-59744/README.md
@@ -1,0 +1,16 @@
+# Ease Checkbox Focus Outline Fix (#59744)
+
+This example provides a solution for issue #59744, where the focus outline of the `ease-checkbox` component gets clipped when placed inside a container with `overflow: hidden` or `overflow: auto`.
+
+## The Problem
+
+By default, the CSS `outline` property draws outside the element's bounding box. If a parent container has `overflow: hidden`, any part of the outline that extends beyond the parent's bounds will be clipped, resulting in a degraded accessibility experience.
+
+## The Solution
+
+To ensure the focus ring is always fully visible, we can use one of the following approaches:
+
+1. **Inset `box-shadow`**: By using an `inset` box-shadow, the focus ring is drawn *inside* the element's bounding box, preventing it from ever being clipped by a parent.
+2. **Negative `outline-offset`**: By setting a negative `outline-offset`, we can pull the standard outline inside the element's bounding box.
+
+This example implements the inset `box-shadow` approach as the primary solution, but the negative `outline-offset` alternative is also provided in the CSS comments.

--- a/submissions/examples/ease-checkbox-focus-outline-59744/demo.html
+++ b/submissions/examples/ease-checkbox-focus-outline-59744/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ease Checkbox Focus Outline Fix</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container">
+        <h2>Ease Checkbox Focus Outline Fix</h2>
+        <p>This example demonstrates how to prevent the focus outline of an ease-checkbox from being clipped by a parent container with <code>overflow: hidden</code>.</p>
+        
+        <div class="wrapper">
+            <input type="checkbox" id="checkbox1" class="ease-checkbox">
+            <label for="checkbox1">Fixed Checkbox</label>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/ease-checkbox-focus-outline-59744/style.css
+++ b/submissions/examples/ease-checkbox-focus-outline-59744/style.css
@@ -1,0 +1,83 @@
+/* Base styles */
+body {
+    font-family: 'Inter', 'Segoe UI', sans-serif;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    margin: 0;
+    background-color: #f5f5f5;
+}
+
+.container {
+    background-color: white;
+    padding: 2rem;
+    border-radius: 8px;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    max-width: 400px;
+}
+
+/* Wrapper with overflow hidden to reproduce the bug */
+.wrapper {
+    overflow: hidden; /* This causes clipping with standard outline */
+    padding: 10px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    margin-top: 20px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+/* Ease Checkbox Styles */
+.ease-checkbox {
+    appearance: none;
+    -webkit-appearance: none;
+    width: 20px;
+    height: 20px;
+    border: 2px solid #007bff;
+    border-radius: 4px;
+    margin: 0;
+    cursor: pointer;
+    position: relative;
+    outline: none; /* Remove default outline to apply custom fix */
+    background-color: white;
+    transition: all 0.2s ease;
+}
+
+.ease-checkbox:checked {
+    background-color: #007bff;
+}
+
+.ease-checkbox:checked::after {
+    content: '';
+    position: absolute;
+    top: 1px;
+    left: 5px;
+    width: 4px;
+    height: 9px;
+    border: solid white;
+    border-width: 0 2px 2px 0;
+    transform: rotate(45deg);
+}
+
+/* 
+ * FIX: Use inset box-shadow instead of standard outline.
+ * Standard outline expands outside the element's bounding box and gets 
+ * clipped by the parent's overflow: hidden. 
+ * An inset box-shadow is drawn inside the element, preventing clipping.
+ * Alternatively, outline-offset: -2px could be used if outline is preferred.
+ */
+.ease-checkbox:focus-visible {
+    /* Solution 1: Inset box-shadow */
+    box-shadow: inset 0 0 0 2px white, inset 0 0 0 4px #0056b3;
+    
+    /* Solution 2 (Alternative): Negative outline offset */
+    /* outline: 2px solid #0056b3;
+    outline-offset: -2px; */
+}
+
+/* Add an active state for good measure */
+.ease-checkbox:active {
+    background-color: #e6f2ff;
+}


### PR DESCRIPTION
## Pull Request Description

This PR provides an example that solves issue #59744, where the `ease-checkbox` focus outline is clipped when placed inside a container with `overflow: hidden` or `overflow: auto`. To maintain code integrity, the solution is submitted as a new example under the `submissions/examples/` directory. The example demonstrates using an `inset` `box-shadow` to draw the focus ring inside the bounding box, preventing any clipping.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

An accessibility bug fix for `ease-checkbox` to ensure the focus ring remains fully visible even when placed within an overflow-clipped container.

**How does a developer use it?**

```html
<div style="overflow: hidden;">
    <input type="checkbox" class="ease-checkbox">
</div>
