### PR TITLE
fix(ease-carousel): add example for focus outline clipping bug #59742

### DIFF
--- a/submissions/examples/ease-carousel-focus-outline-clipped-59742/README.md
+++ b/submissions/examples/ease-carousel-focus-outline-clipped-59742/README.md
@@ -1,0 +1,21 @@
+# Ease Carousel Focus Outline Fix
+
+## Overview
+This submission provides a fix for the `ease-carousel` component focus outline clipping issue (Bug #59742). When the carousel component is placed inside a container with `overflow: hidden` or `overflow: auto`, the standard focus outline gets clipped, leading to a degraded accessibility experience. 
+
+## Solution
+The fix involves applying an `outline-offset: -2px` when the component receives `:focus-visible`. This pulls the focus ring inward, ensuring it remains fully visible within the component's bounding box and is not clipped by parent containers.
+
+## Usage
+Simply include the updated CSS class on your carousel container. Focus the element using keyboard navigation (`Tab`) to see the corrected focus ring.
+
+```html
+<div class="overflow-container" style="overflow: hidden;">
+  <div class="ease-carousel" tabindex="0">
+    Ease Carousel
+  </div>
+</div>
+```
+
+## Why it fits EaseMotion CSS
+Accessibility is a core part of great UI. Ensuring focus states are always clearly visible, regardless of layout constraints like overflow, fits perfectly with EaseMotion's philosophy of providing polished, accessible, and high-quality components.

--- a/submissions/examples/ease-carousel-focus-outline-clipped-59742/demo.html
+++ b/submissions/examples/ease-carousel-focus-outline-clipped-59742/demo.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-carousel Focus Outline Fix - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+        font-family: system-ui, -apple-system, sans-serif;
+        padding: 2rem;
+        background-color: #f9fafb;
+    }
+    .demo-container {
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+        max-width: 600px;
+        margin: 0 auto;
+    }
+    .overflow-container {
+        overflow: hidden;
+        border: 1px solid #ccc;
+        padding: 1rem;
+        border-radius: 8px;
+        background-color: #fff;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        /* Container styling to test clipping */
+    }
+    .instructions {
+        background: #eff6ff;
+        padding: 1.5rem;
+        border-left: 4px solid #3b82f6;
+        border-radius: 0 8px 8px 0;
+        margin-bottom: 2rem;
+    }
+  </style>
+</head>
+<body>
+  <main class="demo-container">
+    <h1>Focus Outline Clipping Fix for ease-carousel</h1>
+    
+    <div class="instructions">
+      <p><strong>Steps to Reproduce:</strong></p>
+      <ol>
+        <li>Focus the carousel component below using the <code>Tab</code> key.</li>
+        <li>Notice that the focus ring is fully visible and not clipped by the <code>overflow: hidden</code> container.</li>
+      </ol>
+    </div>
+
+    <div class="overflow-container">
+      <div class="ease-carousel" tabindex="0">
+        Ease Carousel
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-carousel-focus-outline-clipped-59742/style.css
+++ b/submissions/examples/ease-carousel-focus-outline-clipped-59742/style.css
@@ -1,0 +1,32 @@
+/* 
+ * Fix for ease-carousel focus outline clipping
+ * Issue: When .ease-carousel is placed in a container with overflow: hidden or auto,
+ * the standard outline is clipped.
+ * Solution: Using negative outline-offset or inset box-shadow.
+ */
+
+.ease-carousel {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 200px;
+    height: 100px;
+    font-size: 1rem;
+    font-weight: 500;
+    border-radius: 8px;
+    background-color: #e5e7eb;
+    color: #374151;
+    border: 1px solid transparent;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.ease-carousel:hover {
+    background-color: #d1d5db;
+}
+
+/* Ensure focus outline is drawn inward to prevent clipping */
+.ease-carousel:focus-visible {
+    outline: 2px solid #3b82f6;
+    outline-offset: -2px; /* Pulls the outline inward */
+}


### PR DESCRIPTION
## Pull Request Description

This PR fixes an accessibility bug (Issue #59742) where the `ease-carousel` component suffers from a clipping issue when placed inside a container with `overflow: hidden` or `overflow: auto`. The standard focus ring was being cut off, degrading the experience for keyboard navigation users.

To solve this, I've added a negative `outline-offset` when the `ease-carousel` is in a `:focus-visible` state, pulling the outline inward so it remains fully contained within the component's bounding box and is never clipped by the parent element.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Fixes the focus outline clipping issue on the `ease-carousel` component by implementing an inward-drawn outline offset.

**How does a developer use it?**

```html
<div class="overflow-container" style="overflow: hidden;">
  <div class="ease-carousel" tabindex="0">
    Ease Carousel
  </div>
</div>
