### PR TITLE
Add ease-hockey-puck-slide component

### DIFF
--- a/submissions/examples/hockey-puck-slide-ij/README.md
+++ b/submissions/examples/hockey-puck-slide-ij/README.md
@@ -1,0 +1,10 @@
+# ease-hockey-puck-slide
+
+An ice rink whose puck slides across the blue line toward the goal.
+
+## Run
+Open `demo.html` directly in a browser to watch the puck slide.
+
+## Notes
+- The puck glides toward the left goal.
+- The stick sweeps behind it.

--- a/submissions/examples/hockey-puck-slide-ij/demo.html
+++ b/submissions/examples/hockey-puck-slide-ij/demo.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-hockey-puck-slide demo</title>
+</head>
+<body>
+<div class="hk-app">
+  <span class="hk-label">FACE OFF</span>
+  <div class="hk-rink">
+    <div class="hk-line hk-line-blue"></div>
+    <div class="hk-line hk-line-red"></div>
+    <div class="hk-goal hk-goal-l"></div>
+    <div class="hk-goal hk-goal-r"></div>
+    <div class="hk-circle"></div>
+    <div class="hk-puck"></div>
+    <div class="hk-stick"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/hockey-puck-slide-ij/style.css
+++ b/submissions/examples/hockey-puck-slide-ij/style.css
@@ -1,0 +1,17 @@
+:root{--hk-ice:#d8ecf2;--hk-line:#3a5ab8;--hk-red:#c8302a;--hk-puck:#1c1c22}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#dfe6ea,#aab6c0);font-family:'Segoe UI',sans-serif}
+.hk-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#e6eef2,#c2ced6);box-shadow:0 16px 36px rgba(0,0,0,0.3)}
+.hk-label{position:absolute;top:12px;left:0;right:0;text-align:center;font-size:13px;font-weight:800;letter-spacing:6px;color:var(--hk-red);animation:blink-label-hockey-puck-slide 1.6s steps(2) infinite}
+.hk-rink{position:absolute;top:46px;left:26px;width:320px;height:286px;border-radius:12px;background:var(--hk-ice);box-shadow:inset 0 0 0 6px #9cb2bc}
+.hk-line{position:absolute;width:4px;top:0;bottom:0}
+.hk-line-blue{left:88px;background:rgba(58,90,184,0.6)}
+.hk-line-red{left:230px;background:var(--hk-red)}
+.hk-goal{position:absolute;top:118px;width:26px;height:50px;background:#c8d0d6;box-shadow:inset 0 0 0 4px #8a96a0}
+.hk-goal-l{left:6px}
+.hk-goal-r{right:6px}
+.hk-circle{position:absolute;top:128px;left:196px;width:30px;height:30px;border:2px solid var(--hk-red);border-radius:50%}
+.hk-puck{position:absolute;top:146px;left:128px;width:18px;height:18px;border-radius:50%;background:var(--hk-puck);box-shadow:inset 0 0 0 3px #3a3a44;animation:slide-puck-hockey-puck-slide 2.4s ease-in-out infinite}
+.hk-stick{position:absolute;top:172px;left:150px;width:110px;height:5px;border-radius:4px;background:#c8985a;transform-origin:left center;animation:swipe-stick-hockey-puck-slide 2.4s ease-in-out infinite}
+@keyframes slide-puck-hockey-puck-slide{0%,100%{transform:translate(0,0)}45%{transform:translate(-96px,4px)}}
+@keyframes swipe-stick-hockey-puck-slide{0%,100%{transform:rotate(0deg)}45%{transform:rotate(32deg)}}
+@keyframes blink-label-hockey-puck-slide{0%,100%{opacity:1}50%{opacity:0.3}}


### PR DESCRIPTION
## Component: ease-hockey-puck-slide — puck slides, stick sweeps, and goal flashes

**Closes #61545**

### What this adds
An ice rink from above: the black puck slides across the blue line toward the goal as the stick sweeps behind it, and the FACE OFF banner blinks above the boards.

### Acceptance Criteria covered
- Puck slides across the blue line
- Stick sweeps behind the puck
- FACE OFF banner blinks above

### Files
- submissions/examples/hockey-puck-slide-ij/demo.html
- submissions/examples/hockey-puck-slide-ij/style.css
- submissions/examples/hockey-puck-slide-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the puck slide.