### PR TITLE
Add ease-jukebox-record-spin component

### DIFF
--- a/submissions/examples/jukebox-record-spin-ij/README.md
+++ b/submissions/examples/jukebox-record-spin-ij/README.md
@@ -1,0 +1,10 @@
+# ease-jukebox-record-spin
+
+A vintage jukebox whose record spins while the tonearm rocks across it.
+
+## Run
+Open `demo.html` directly in a browser to watch the record spin.
+
+## Notes
+- The vinyl rotates under the tonearm.
+- Letter rows bob beside the cabinet.

--- a/submissions/examples/jukebox-record-spin-ij/demo.html
+++ b/submissions/examples/jukebox-record-spin-ij/demo.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-jukebox-record-spin demo</title>
+</head>
+<body>
+<div class="jk-app">
+  <span class="jk-title">HIT PARADE</span>
+  <div class="jk-cabinet">
+    <div class="jk-light jk-light-1"></div>
+    <div class="jk-light jk-light-2"></div>
+    <div class="jk-light jk-light-3"></div>
+    <div class="jk-light jk-light-4"></div>
+    <div class="jk-turntable">
+      <div class="jk-record">
+        <div class="jk-groove jk-groove-1"></div>
+        <div class="jk-groove jk-groove-2"></div>
+        <div class="jk-label"></div>
+      </div>
+      <div class="jk-tonearm"></div>
+    </div>
+    <div class="jk-row jk-row-1"><span class="jk-letter">A</span></div>
+    <div class="jk-row jk-row-2"><span class="jk-letter">B</span></div>
+    <div class="jk-row jk-row-3"><span class="jk-letter">C</span></div>
+    <div class="jk-row jk-row-4"><span class="jk-letter">D</span></div>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/jukebox-record-spin-ij/style.css
+++ b/submissions/examples/jukebox-record-spin-ij/style.css
@@ -1,0 +1,27 @@
+:root{--jk-wood:#6a4a32;--jk-dark:#241a10;--jk-gold:#e0b84a;--jk-vinyl:#16161c}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#e8dcc4,#c4a878);font-family:'Segoe UI',sans-serif}
+.jk-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#f0e4ca,#d0b082);box-shadow:0 16px 36px rgba(0,0,0,0.3)}
+.jk-title{position:absolute;top:12px;left:0;right:0;text-align:center;font-size:14px;font-weight:800;letter-spacing:6px;color:var(--jk-dark)}
+.jk-cabinet{position:absolute;top:44px;left:46px;width:284px;height:292px;border-radius:12px;background:linear-gradient(180deg,var(--jk-wood),#4e3420);box-shadow:inset 0 0 0 6px #3c2616}
+.jk-light{position:absolute;top:16px;width:12px;height:12px;border-radius:50%;background:var(--jk-gold);box-shadow:0 0 10px var(--jk-gold);animation:glow-light-jukebox-record-spin 1.2s ease-in-out infinite}
+.jk-light-1{left:22px}
+.jk-light-2{left:84px;animation-delay:0.3s}
+.jk-light-3{left:184px;animation-delay:0.6s}
+.jk-light-4{left:246px;animation-delay:0.9s}
+.jk-turntable{position:absolute;top:50px;left:64px;width:152px;height:152px;border-radius:50%;background:#1c1c22;box-shadow:inset 0 0 0 5px #3a3a44}
+.jk-record{position:absolute;top:16px;left:16px;width:120px;height:120px;border-radius:50%;background:var(--jk-vinyl);box-shadow:inset 0 0 0 6px #282830;animation:spin-record-jukebox-record-spin 2s linear infinite}
+.jk-groove{position:absolute;border:1px solid rgba(120,120,132,0.4);border-radius:50%}
+.jk-groove-1{top:22px;left:22px;width:76px;height:76px}
+.jk-groove-2{top:36px;left:36px;width:48px;height:48px}
+.jk-label{position:absolute;top:46px;left:40px;width:40px;height:28px;border-radius:4px;background:var(--jk-gold)}
+.jk-tonearm{position:absolute;top:-6px;left:120px;width:8px;height:64px;border-radius:4px;background:#c8ccd4;transform-origin:top center;animation:rock-tonearm-jukebox-record-spin 2s ease-in-out infinite}
+.jk-row{position:absolute;right:22px;width:44px;height:44px;border-radius:6px;background:var(--jk-dark);box-shadow:inset 0 0 0 3px #4a3a24;animation:slide-row-jukebox-record-spin 2.4s ease-in-out infinite}
+.jk-letter{position:absolute;left:0;right:0;top:10px;text-align:center;font-size:16px;font-weight:700;color:var(--jk-gold)}
+.jk-row-1{top:58px}
+.jk-row-2{top:116px;animation-delay:0.6s}
+.jk-row-3{top:174px;animation-delay:1.2s}
+.jk-row-4{top:232px;animation-delay:1.8s}
+@keyframes spin-record-jukebox-record-spin{from{transform:rotate(0deg)}to{transform:rotate(360deg)}}
+@keyframes rock-tonearm-jukebox-record-spin{0%,100%{transform:rotate(-12deg)}50%{transform:rotate(-4deg)}}
+@keyframes glow-light-jukebox-record-spin{0%,100%{opacity:0.25}50%{opacity:1}}
+@keyframes slide-row-jukebox-record-spin{0%,100%{transform:translateY(0)}50%{transform:translateY(-6px)}}


### PR DESCRIPTION
## Component: ease-jukebox-record-spin — record spins, tonearm rocks, and lights glow

**Closes #61548**

### What this adds
A vintage jukebox cabinet: the black record spins on its turntable while the tonearm rocks across it, the letter rows slide up and down, and the bulb lights glow in sequence.

### Acceptance Criteria covered
- Record spins on the turntable
- Tonearm rocks across the grooves
- Bulb lights glow in sequence

### Files
- submissions/examples/jukebox-record-spin-ij/demo.html
- submissions/examples/jukebox-record-spin-ij/style.css
- submissions/examples/jukebox-record-spin-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the record spin.