### PR TITLE
docs: add fix example for ease-card focus clipping (#59740)

### DIFF
--- a/submissions/examples/bug-59740-ease-card-focus-fix/README.md
+++ b/submissions/examples/bug-59740-ease-card-focus-fix/README.md
@@ -1,0 +1,19 @@
+# Ease-Card Focus Clipping Fix
+
+Demonstrates the fix for the `ease-card` focus outline being clipped by a parent container with `overflow: hidden` (Issue #59740).
+
+## What it does
+When an `ease-card` component is placed inside a container with `overflow: hidden`, the default focus outline gets clipped, which degrades accessibility. This example provides a simple CSS override to ensure the focus ring remains fully visible.
+
+## How to use it
+Apply a negative `outline-offset` to the `:focus-visible` state of the `ease-card`.
+
+```css
+.ease-card:focus-visible {
+    outline: 2px solid var(--primary-color);
+    outline-offset: -2px; /* Pulls the outline inside the element's bounding box */
+}
+```
+
+## Why it fits EaseMotion CSS
+Accessibility is a core part of great UI. Ensuring focus rings are always visible aligns with the goal of creating inclusive, high-quality, and reliable CSS components without complex workarounds.

--- a/submissions/examples/bug-59740-ease-card-focus-fix/demo.html
+++ b/submissions/examples/bug-59740-ease-card-focus-fix/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Bug Fix: Ease-Card Focus Clipping</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <main class="container">
+        <h1>Ease-Card Focus Fix (#59740)</h1>
+        <p class="desc">
+            This demonstrates the fix for the <code>ease-card</code> focus outline being clipped by a parent with <code>overflow: hidden</code>.
+        </p>
+
+        <section class="demo-section">
+            <h2>Demonstration</h2>
+            <div class="overflow-wrapper">
+                <article class="ease-card" tabindex="0">
+                    <h3>Focus Me</h3>
+                    <p>Press Tab to focus this card. The focus ring is fully visible and not clipped by the parent's overflow setting because it uses a negative outline offset.</p>
+                </article>
+            </div>
+        </section>
+    </main>
+</body>
+</html>

--- a/submissions/examples/bug-59740-ease-card-focus-fix/style.css
+++ b/submissions/examples/bug-59740-ease-card-focus-fix/style.css
@@ -1,0 +1,113 @@
+:root {
+    --primary-color: #2563eb;
+    --bg-color: #f8fafc;
+    --card-bg: #ffffff;
+    --text-color: #1e293b;
+    --text-muted: #64748b;
+    --border-color: #e2e8f0;
+}
+
+body {
+    font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    margin: 0;
+    padding: 2rem;
+    line-height: 1.6;
+}
+
+.container {
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+h1 {
+    font-size: 1.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.desc {
+    color: var(--text-muted);
+    margin-bottom: 2rem;
+}
+
+code {
+    background: #e2e8f0;
+    padding: 0.2rem 0.4rem;
+    border-radius: 4px;
+    font-size: 0.9em;
+}
+
+.demo-section {
+    background: #fff;
+    padding: 2rem;
+    border-radius: 12px;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+    border: 1px solid var(--border-color);
+}
+
+.demo-section h2 {
+    font-size: 1.25rem;
+    margin-top: 0;
+    margin-bottom: 1.5rem;
+}
+
+/* 
+  Parent container with overflow: hidden 
+  This mimics the environment where the bug occurs 
+*/
+.overflow-wrapper {
+    overflow: hidden;
+    padding: 1rem;
+    background: #f1f5f9;
+    border-radius: 8px;
+    border: 1px dashed #cbd5e1;
+}
+
+/* 
+  The ease-card component
+  Fix for #59740 implemented below.
+*/
+.ease-card {
+    background-color: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 1.5rem;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ease-card h3 {
+    margin-top: 0;
+    margin-bottom: 0.5rem;
+    font-size: 1.125rem;
+}
+
+.ease-card p {
+    margin: 0;
+    color: var(--text-muted);
+    font-size: 0.95rem;
+}
+
+.ease-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+}
+
+/*
+  ========================================
+  BUG FIX (#59740):
+  Use a negative outline-offset or an inset box-shadow 
+  so that the focus ring sits inside the element bounds 
+  and is not clipped by parent overflow: hidden
+  ========================================
+*/
+.ease-card:focus-visible {
+    /* Method 1: Negative outline offset */
+    outline: 2px solid var(--primary-color);
+    outline-offset: -2px;
+    
+    /* Method 2 (Alternative): Inset box-shadow */
+    /* outline: none; */
+    /* box-shadow: inset 0 0 0 2px var(--primary-color); */
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #59740. This submission adds an example demonstrating how to fix the focus clipping issue on the `ease-card` component when its parent container has `overflow: hidden`. It provides a clean, pure CSS solution using a negative outline offset to prevent the focus ring from being cut off.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

This adds a standalone example illustrating how a negative `outline-offset` resolves the focus ring clipping bug on the `ease-card` component when nested in strict layouts.

**How does a developer use it?**

```html
<div class="overflow-hidden-parent">
    <!-- Applying the fix to ease-card ensures focus-visible outline works within clipping containers -->
    <div class="ease-card" tabindex="0">
        <h3>Focusable Card</h3>
    </div>
</div>
