### PR TITLE
Add ease-swing-set-arc component

### DIFF
--- a/submissions/examples/swing-set-arc-ij/README.md
+++ b/submissions/examples/swing-set-arc-ij/README.md
@@ -1,0 +1,10 @@
+# ease-swing-set-arc
+
+A playground swing whose seat arcs forward and back on its ropes.
+
+## Run
+Open `demo.html` directly in a browser to watch the seat swing.
+
+## Notes
+- The seat swings as a pendulum from the beam.
+- The PLAY tag sways with the ride.

--- a/submissions/examples/swing-set-arc-ij/demo.html
+++ b/submissions/examples/swing-set-arc-ij/demo.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-swing-set-arc demo</title>
+</head>
+<body>
+<div class="sw-app">
+  <span class="sw-label">PLAY</span>
+  <div class="sw-grass"></div>
+  <div class="sw-frame">
+    <div class="sw-beam"></div>
+    <div class="sw-leg sw-leg-l"></div>
+    <div class="sw-leg sw-leg-r"></div>
+  </div>
+  <div class="sw-rope sw-rope-1"></div>
+  <div class="sw-rope sw-rope-2"></div>
+  <div class="sw-seat"></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/swing-set-arc-ij/style.css
+++ b/submissions/examples/swing-set-arc-ij/style.css
@@ -1,0 +1,16 @@
+:root{--sw-metal:#8a96a4;--sw-wood:#a06a3a;--sw-grass:#6aa84c}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#dcecd2,#a8c48e);font-family:'Segoe UI',sans-serif}
+.sw-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#c8e0b8,#88aa66);box-shadow:0 16px 36px rgba(0,0,0,0.3)}
+.sw-label{position:absolute;top:12px;left:0;right:0;text-align:center;font-size:14px;font-weight:800;letter-spacing:7px;color:#f4f8ec;text-shadow:0 2px 4px rgba(0,0,0,0.3);animation:sway-label-swing-set-arc 2.2s ease-in-out infinite}
+.sw-grass{position:absolute;bottom:0;left:0;right:0;height:74px;background:linear-gradient(180deg,#74b452,#4a8a34)}
+.sw-frame{position:absolute;top:96px;left:0;right:0}
+.sw-beam{position:absolute;top:0;left:36px;right:36px;height:10px;border-radius:5px;background:var(--sw-metal);box-shadow:inset 0 0 0 3px #6a7684}
+.sw-leg{position:absolute;top:10px;width:8px;height:176px;background:var(--sw-metal);transform-origin:top center;border-radius:4px}
+.sw-leg-l{left:40px;transform:rotate(8deg)}
+.sw-leg-r{right:40px;transform:rotate(-8deg)}
+.sw-rope{position:absolute;top:106px;width:3px;height:146px;background:#c8ccd2;transform-origin:top center;animation:arc-swing-swing-set-arc 2.2s ease-in-out infinite}
+.sw-rope-1{left:166px}
+.sw-rope-2{left:196px}
+.sw-seat{position:absolute;top:250px;left:152px;width:68px;height:12px;border-radius:6px;background:var(--sw-wood);box-shadow:0 3px 0 rgba(0,0,0,0.25);transform-origin:center -144px;animation:arc-swing-swing-set-arc 2.2s ease-in-out infinite}
+@keyframes arc-swing-swing-set-arc{0%,100%{transform:rotate(-26deg)}50%{transform:rotate(26deg)}}
+@keyframes sway-label-swing-set-arc{0%,100%{transform:rotate(-2deg)}50%{transform:rotate(2deg)}}


### PR DESCRIPTION
## Component: ease-swing-set-arc — seat arcs, ropes swing, and frame holds

**Closes #61555**

### What this adds
A playground swing set: the wooden seat arcs forward and back on its ropes from the metal beam, the frame legs hold steady on the grass, and the PLAY tag sways with the ride.

### Acceptance Criteria covered
- Seat arcs forward and back
- Ropes swing from the beam
- Frame legs hold on the grass

### Files
- submissions/examples/swing-set-arc-ij/demo.html
- submissions/examples/swing-set-arc-ij/style.css
- submissions/examples/swing-set-arc-ij/README.md

### How to review
Open `demo.html` directly in a browser and watch the seat swing.