### PR TITLE
Add ease-mobile-pull-refresh-spinner component

### DIFF
--- a/submissions/examples/mobile-pull-refresh-spinner-ij/README.md
+++ b/submissions/examples/mobile-pull-refresh-spinner-ij/README.md
@@ -1,0 +1,10 @@
+# ease-mobile-pull-refresh-spinner
+
+A phone-style inbox whose circular spinner rotates with the pull distance.
+
+## Run
+Open `demo.html` directly in a browser and drag down on the message list.
+
+## Notes
+- Drag distance maps to a CSS progress variable.
+- Releasing past the threshold spins out a refresh cycle.

--- a/submissions/examples/mobile-pull-refresh-spinner-ij/demo.html
+++ b/submissions/examples/mobile-pull-refresh-spinner-ij/demo.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-mobile-pull-refresh-spinner demo</title>
+</head>
+<body>
+<div class="mpr-app">
+  <div class="mpr-bar"><span class="mpr-clock">9:41</span><span class="mpr-batt">100%</span></div>
+  <h1 class="mpr-head">MESSAGES</h1>
+  <div class="mpr-scroll" id="mprScroll">
+    <div class="mpr-pull">
+      <span class="mpr-spinner" aria-hidden="true"></span>
+      <span class="mpr-tip">pull to refresh</span>
+    </div>
+    <ul class="mpr-list">
+      <li class="mpr-row"><strong>Ada</strong><span class="mpr-pre">Meeting moved to noon</span></li>
+      <li class="mpr-row"><strong>Ben</strong><span class="mpr-pre">See you at the gate</span></li>
+      <li class="mpr-row"><strong>Cleo</strong><span class="mpr-pre">Deploy looks good</span></li>
+      <li class="mpr-row"><strong>Dara</strong><span class="mpr-pre">Milk and bread, please</span></li>
+      <li class="mpr-row"><strong>Eli</strong><span class="mpr-pre">Photo is uploaded</span></li>
+    </ul>
+  </div>
+</div>
+<script>
+(function () {
+  var app = document.querySelector('.mpr-app');
+  var scroll = document.querySelector('.mpr-scroll');
+  var pulling = false;
+  var startY = 0;
+  scroll.addEventListener('pointerdown', function (e) {
+    if (app.classList.contains('mpr-refreshing')) return;
+    pulling = true;
+    startY = e.clientY;
+    scroll.setPointerCapture(e.pointerId);
+  });
+  scroll.addEventListener('pointermove', function (e) {
+    if (!pulling) return;
+    var delta = e.clientY - startY;
+    if (delta < 0) delta = 0;
+    var progress = Math.min(delta / 72, 1.15);
+    app.style.setProperty('--pull-progress', progress.toFixed(2));
+  });
+  scroll.addEventListener('pointerup', function () {
+    if (!pulling) return;
+    pulling = false;
+    var progress = parseFloat(app.style.getPropertyValue('--pull-progress') || '0');
+    if (progress >= 1) {
+      app.classList.add('mpr-refreshing');
+      setTimeout(function () {
+        app.classList.remove('mpr-refreshing');
+        app.style.setProperty('--pull-progress', '0');
+      }, 1400);
+    } else {
+      app.style.setProperty('--pull-progress', '0');
+    }
+  });
+})();
+</script>
+</body>
+</html>

--- a/submissions/examples/mobile-pull-refresh-spinner-ij/style.css
+++ b/submissions/examples/mobile-pull-refresh-spinner-ij/style.css
@@ -1,0 +1,17 @@
+:root{--mpr-blue:#5a7bff;--mpr-ink:#2a2f3a;--mpr-paper:#f6f7fb;--mpr-line:#e2e6f0}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#e8edfb,#bcc6ea);font-family:'Segoe UI',sans-serif}
+.mpr-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:var(--mpr-paper);box-shadow:0 16px 36px rgba(0,0,0,0.25)}
+.mpr-bar{display:flex;justify-content:space-between;align-items:center;height:26px;padding:0 14px;font-size:11px;font-weight:600;color:var(--mpr-ink);background:#eef1fb}
+.mpr-head{position:absolute;top:26px;left:0;right:0;margin:0;padding:10px 0 8px;text-align:center;font-size:16px;font-weight:800;letter-spacing:6px;color:var(--mpr-blue)}
+.mpr-scroll{position:absolute;top:62px;bottom:0;left:0;right:0;overflow:hidden;touch-action:none}
+.mpr-pull{position:absolute;top:-48px;left:0;right:0;height:48px;display:flex;align-items:center;justify-content:center;gap:8px;transform:translateY(calc(var(--pull-progress,0)*48px))}
+.mpr-spinner{width:22px;height:22px;border-radius:50%;border:3px solid #c9d2f5;border-top-color:var(--mpr-blue);transform:rotate(calc(var(--pull-progress,0)*360deg));opacity:calc(0.3 + var(--pull-progress,0)*0.7)}
+.mpr-tip{font-size:11px;font-weight:600;letter-spacing:1px;color:#8892b8;opacity:calc(var(--pull-progress,0))}
+.mpr-list{list-style:none;margin:0;padding:48px 0 0;transform:translateY(calc(var(--pull-progress,0)*46px));transition:transform 0.25s ease-out}
+.mpr-row{display:flex;align-items:baseline;gap:10px;padding:11px 16px;border-bottom:1px solid var(--mpr-line)}
+.mpr-row strong{font-size:13px;color:var(--mpr-ink)}
+.mpr-pre{font-size:12px;color:#7c86a6;overflow:hidden;white-space:nowrap;text-overflow:ellipsis}
+.mpr-app.mpr-refreshing .mpr-pull{transform:translateY(48px)}
+.mpr-app.mpr-refreshing .mpr-spinner{animation:spin-refresh-mobile-pull-refresh-spinner 0.8s linear infinite;opacity:1}
+.mpr-app.mpr-refreshing .mpr-list{transform:translateY(46px)}
+@keyframes spin-refresh-mobile-pull-refresh-spinner{from{transform:rotate(0deg)}to{transform:rotate(360deg)}}


### PR DESCRIPTION
## Component: ease-mobile-pull-refresh-spinner — spinner spins with pull, list slides, and refresh resets

**Closes #61557**

### What this adds
A phone-style inbox: drag down on the list and the circular spinner rotates in step with the pull distance while the content slides down; release past the threshold and the spinner spins out a full refresh cycle.

### Acceptance Criteria covered
- Spinner rotates with pull distance
- List slides down with the gesture
- Release triggers a full spin cycle

### Files
- submissions/examples/mobile-pull-refresh-spinner-ij/demo.html
- submissions/examples/mobile-pull-refresh-spinner-ij/style.css
- submissions/examples/mobile-pull-refresh-spinner-ij/README.md

### How to review
Open `demo.html` in a browser and drag down on the message list.