### PR TITLE
Add ease-ferris-wheel-cabin-rotate component

### DIFF
--- a/submissions/examples/ferris-wheel-cabin-rotate-ij/README.md
+++ b/submissions/examples/ferris-wheel-cabin-rotate-ij/README.md
@@ -1,0 +1,10 @@
+# ease-ferris-wheel-cabin-rotate
+
+A fairground ferris wheel whose ring spins while every cabin stays level.
+
+## Run
+Open `demo.html` directly in a browser to watch the cabins orbit.
+
+## Notes
+- The wheel rotates on its golden hub.
+- Each cabin counter-rotates to stay upright.

--- a/submissions/examples/ferris-wheel-cabin-rotate-ij/demo.html
+++ b/submissions/examples/ferris-wheel-cabin-rotate-ij/demo.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-ferris-wheel-cabin-rotate demo</title>
+</head>
+<body>
+<div class="fw-app">
+  <span class="fw-sign">FERRIS WHEEL</span>
+  <span class="fw-leg fw-leg-l"></span>
+  <span class="fw-leg fw-leg-r"></span>
+  <span class="fw-base"></span>
+  <div class="fw-wheel">
+    <span class="fw-hub"></span>
+    <span class="fw-spoke fw-spoke-1"></span>
+    <span class="fw-spoke fw-spoke-2"></span>
+    <span class="fw-spoke fw-spoke-3"></span>
+    <span class="fw-spoke fw-spoke-4"></span>
+    <span class="fw-spoke fw-spoke-5"></span>
+    <span class="fw-spoke fw-spoke-6"></span>
+    <span class="fw-cabin-hold fw-hold-1"><span class="fw-level"><span class="fw-cabin"></span></span></span>
+    <span class="fw-cabin-hold fw-hold-2"><span class="fw-level"><span class="fw-cabin"></span></span></span>
+    <span class="fw-cabin-hold fw-hold-3"><span class="fw-level"><span class="fw-cabin"></span></span></span>
+    <span class="fw-cabin-hold fw-hold-4"><span class="fw-level"><span class="fw-cabin"></span></span></span>
+    <span class="fw-cabin-hold fw-hold-5"><span class="fw-level"><span class="fw-cabin"></span></span></span>
+    <span class="fw-cabin-hold fw-hold-6"><span class="fw-level"><span class="fw-cabin"></span></span></span>
+  </div>
+  <span class="fw-tag">RIDE OPEN</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/ferris-wheel-cabin-rotate-ij/style.css
+++ b/submissions/examples/ferris-wheel-cabin-rotate-ij/style.css
@@ -1,0 +1,36 @@
+:root{--fw-red:#d84a52;--fw-gold:#e8b84a;--fw-sky:#26325c;--fw-cab:#3aa8d8}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#2c3a68,#141c34);font-family:'Segoe UI',sans-serif}
+.fw-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#33509e,#1a2547);box-shadow:0 16px 36px rgba(0,0,0,0.45)}
+.fw-sign{position:absolute;top:14px;left:0;right:0;text-align:center;font-size:16px;font-weight:800;letter-spacing:7px;color:#ffd35c;text-shadow:0 0 12px rgba(255,211,92,0.6);animation:blink-sign-ferris-wheel-cabin-rotate 1.6s steps(2) infinite}
+.fw-leg{position:absolute;top:186px;width:12px;height:150px;transform-origin:top center;background:#5a3a26}
+.fw-leg-l{left:176px;transform:rotate(-22deg)}
+.fw-leg-r{left:184px;transform:rotate(22deg)}
+.fw-base{position:absolute;bottom:26px;left:70px;width:232px;height:12px;border-radius:6px;background:#3e2a1c}
+.fw-wheel{position:absolute;left:76px;top:70px;width:220px;height:220px;border-radius:50%;border:6px solid var(--fw-red);box-shadow:0 0 0 3px rgba(216,74,82,0.3);animation:spin-wheel-ferris-wheel-cabin-rotate 6s linear infinite}
+.fw-hub{position:absolute;left:92px;top:92px;width:36px;height:36px;border-radius:50%;background:var(--fw-gold);box-shadow:inset 0 0 0 6px #b89034,0 0 14px rgba(232,184,74,0.7)}
+.fw-spoke{position:absolute;left:108px;top:108px;width:3px;height:102px;transform-origin:top center;background:rgba(232,184,74,0.85)}
+.fw-spoke-1{transform:rotate(0deg)}
+.fw-spoke-2{transform:rotate(60deg)}
+.fw-spoke-3{transform:rotate(120deg)}
+.fw-spoke-4{transform:rotate(180deg)}
+.fw-spoke-5{transform:rotate(240deg)}
+.fw-spoke-6{transform:rotate(300deg)}
+.fw-cabin-hold{position:absolute;left:110px;top:110px;width:0;height:0}
+.fw-hold-1{transform:rotate(0deg) translate(110px)}
+.fw-hold-2{transform:rotate(60deg) translate(110px)}
+.fw-hold-3{transform:rotate(120deg) translate(110px)}
+.fw-hold-4{transform:rotate(180deg) translate(110px)}
+.fw-hold-5{transform:rotate(240deg) translate(110px)}
+.fw-hold-6{transform:rotate(300deg) translate(110px)}
+.fw-level{transform:rotate(0deg)}
+.fw-hold-2 .fw-level{transform:rotate(-60deg)}
+.fw-hold-3 .fw-level{transform:rotate(-120deg)}
+.fw-hold-4 .fw-level{transform:rotate(-180deg)}
+.fw-hold-5 .fw-level{transform:rotate(-240deg)}
+.fw-hold-6 .fw-level{transform:rotate(-300deg)}
+.fw-cabin{position:absolute;left:-13px;top:0;width:26px;height:30px;border-radius:5px;background:var(--fw-cab);box-shadow:inset 0 0 0 3px #2a7aa0;animation:level-cabin-ferris-wheel-cabin-rotate 6s linear infinite}
+.fw-cabin::after{content:'';position:absolute;top:8px;left:5px;width:16px;height:4px;border-radius:2px;background:#eaf4fb}
+.fw-tag{position:absolute;bottom:14px;left:0;right:0;text-align:center;font-size:11px;font-weight:700;letter-spacing:5px;color:#ffd35c}
+@keyframes spin-wheel-ferris-wheel-cabin-rotate{from{transform:rotate(0deg)}to{transform:rotate(360deg)}}
+@keyframes level-cabin-ferris-wheel-cabin-rotate{from{transform:rotate(0deg)}to{transform:rotate(-360deg)}}
+@keyframes blink-sign-ferris-wheel-cabin-rotate{0%,100%{opacity:1}50%{opacity:0.3}}


### PR DESCRIPTION
## Component: ease-ferris-wheel-cabin-rotate — ring spins, cabins orbit, and sign blinks

**Closes #61559**

### What this adds
A fairground ferris wheel: the red ring spins around its golden hub while six colored cabins orbit the rim and stay level, and the FERRIS WHEEL sign blinks above the A-frame legs.

### Acceptance Criteria covered
- Ring spins around the hub
- Cabins orbit and stay level
- Sign blinks above the frame

### Files
- submissions/examples/ferris-wheel-cabin-rotate-ij/demo.html
- submissions/examples/ferris-wheel-cabin-rotate-ij/style.css
- submissions/examples/ferris-wheel-cabin-rotate-ij/README.md

### How to review
Open `demo.html` in a browser and watch the cabins orbit.