### PR TITLE
fix(ease-badge): prevent focus outline clipping by parent overflow (#…

### DIFF
--- a/submissions/examples/ease-badge-focus-outline-clipped-59734/README.md
+++ b/submissions/examples/ease-badge-focus-outline-clipped-59734/README.md
@@ -1,0 +1,14 @@
+# Fix: ease-badge focus outline is clipped by parent overflow
+
+### Description
+The `ease-badge` component suffers from a clipping issue where its focus ring (outline or box-shadow) is cut off if placed inside a container with `overflow: hidden` or `overflow: auto`. This degrades the accessibility experience.
+
+### Expected Behavior
+The focus ring should be fully visible, either by using a negative outline offset or an inset box-shadow, so it is contained within the element's bounding box and avoids clipping from a parent container.
+
+### Implementation
+- `style.css`: Uses `outline-offset: -2px` on `:focus-visible` to ensure the focus outline is rendered inward and is not clipped by any parent `overflow` container.
+- `demo.html`: Demonstrates the `ease-badge` component inside an `overflow: hidden` wrapper.
+
+### Testing
+Open `demo.html` in a browser and press `Tab` to focus the badge. Verify that the focus outline is completely visible and not truncated.

--- a/submissions/examples/ease-badge-focus-outline-clipped-59734/demo.html
+++ b/submissions/examples/ease-badge-focus-outline-clipped-59734/demo.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-badge Focus Outline Fix - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+        font-family: system-ui, -apple-system, sans-serif;
+        padding: 2rem;
+        background-color: #f9fafb;
+    }
+    .demo-container {
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+        max-width: 600px;
+        margin: 0 auto;
+    }
+    .overflow-container {
+        overflow: hidden;
+        border: 1px solid #ccc;
+        padding: 1rem;
+        border-radius: 8px;
+        background-color: #fff;
+        /* Constrain dimensions to show clipping issue if not fixed */
+        height: auto;
+    }
+    .instructions {
+        background: #eff6ff;
+        padding: 1.5rem;
+        border-left: 4px solid #3b82f6;
+        border-radius: 0 8px 8px 0;
+        margin-bottom: 2rem;
+    }
+  </style>
+</head>
+<body>
+  <main class="demo-container">
+    <h1>Focus Outline Clipping Fix for ease-badge</h1>
+    
+    <div class="instructions">
+      <p><strong>Steps to Reproduce:</strong></p>
+      <ol>
+        <li>Click inside the container or use the <code>Tab</code> key to focus the badge component.</li>
+        <li>Notice that the focus ring is fully visible and not clipped by the <code>overflow: hidden</code> container, due to the negative outline-offset.</li>
+      </ol>
+    </div>
+
+    <div class="overflow-container">
+      <span class="ease-badge" tabindex="0">New Feature</span>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-badge-focus-outline-clipped-59734/style.css
+++ b/submissions/examples/ease-badge-focus-outline-clipped-59734/style.css
@@ -1,0 +1,28 @@
+/* 
+ * Fix for ease-badge focus outline clipping
+ * Issue: When .ease-badge is placed in a container with overflow: hidden or auto,
+ * the standard outline is clipped.
+ * Solution: Using negative outline-offset or inset box-shadow.
+ */
+
+.ease-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.25rem 0.5rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    line-height: 1.25rem;
+    color: #ffffff;
+    background-color: #3b82f6;
+    border-radius: 9999px;
+    border: none;
+    /* Adding transition for smooth focus appearance */
+    transition: outline 0.2s ease, box-shadow 0.2s ease;
+}
+
+/* Ensure focus outline is drawn inward to prevent clipping */
+.ease-badge:focus-visible {
+    outline: 2px solid #1d4ed8;
+    outline-offset: -2px; /* Pulls the outline inward to be contained within the bounding box */
+}


### PR DESCRIPTION
## Pull Request Description

This PR introduces an example fixing the clipping issue with the `ease-badge` component's focus ring. Previously, when the component was placed inside containers with `overflow: hidden` or `overflow: auto`, the outline was cut off. This degrades the accessibility experience. The issue is resolved by using a negative `outline-offset` to contain the focus ring entirely within the element's bounding box.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

It provides a solution for the `ease-badge` focus outline clipping bug by pulling the focus ring inward so it isn't hidden by parent containers.

**How does a developer use it?**

```html
<div style="overflow: hidden; border-radius: 8px;">
  <span class="ease-badge" tabindex="0">New Feature</span>
</div>
