### PR TITLE
Add ease-typewriter-carriage-return component

### DIFF
--- a/submissions/examples/typewriter-carriage-return-ij/README.md
+++ b/submissions/examples/typewriter-carriage-return-ij/README.md
@@ -1,0 +1,10 @@
+# ease-typewriter-carriage-return
+
+A classic typewriter whose carriage returns while the keys press.
+
+## Run
+Open `demo.html` directly in a browser to watch the carriage slide.
+
+## Notes
+- The carriage slides back across the page.
+- Letters reveal on the paper with a caret.

--- a/submissions/examples/typewriter-carriage-return-ij/demo.html
+++ b/submissions/examples/typewriter-carriage-return-ij/demo.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-typewriter-carriage-return demo</title>
+</head>
+<body>
+<div class="tw-app">
+  <span class="tw-brand">CORONA</span>
+  <div class="tw-paper"><span class="tw-typed">The quick brown fox jumps</span><span class="tw-caret"></span></div>
+  <div class="tw-carriage"><span class="tw-platen"></span><span class="tw-handle"></span></div>
+  <div class="tw-body">
+    <div class="tw-keys">
+      <button class="tw-key">Q</button>
+      <button class="tw-key">W</button>
+      <button class="tw-key">E</button>
+      <button class="tw-key">R</button>
+      <button class="tw-key">T</button>
+      <button class="tw-key">Y</button>
+      <button class="tw-key">U</button>
+    </div>
+    <button class="tw-space">space</button>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/typewriter-carriage-return-ij/style.css
+++ b/submissions/examples/typewriter-carriage-return-ij/style.css
@@ -1,0 +1,24 @@
+:root{--tw-gray:#6a7078;--tw-ink:#2e3238;--tw-paper:#f4f0e4;--tw-key:#d8d2c4}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#dcd8cc,#b4ae9e);font-family:'Segoe UI',sans-serif}
+.tw-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#efeae0,#c8c2b4);box-shadow:0 16px 36px rgba(0,0,0,0.3)}
+.tw-brand{position:absolute;top:14px;left:0;right:0;text-align:center;font-size:14px;font-weight:800;letter-spacing:9px;color:var(--tw-ink)}
+.tw-paper{position:absolute;top:36px;left:98px;width:176px;height:110px;border-radius:4px;background:var(--tw-paper);box-shadow:0 4px 0 rgba(0,0,0,0.1)}
+.tw-typed{position:absolute;left:14px;top:18px;overflow:hidden;white-space:nowrap;font-family:'Consolas',monospace;font-size:13px;color:#3a4250;animation:type-text-typewriter-carriage-return 4s steps(18) infinite}
+.tw-caret{position:absolute;left:14px;top:38px;width:8px;height:2px;background:#c8404a;animation:blink-caret-typewriter-carriage-return 4s steps(2) infinite}
+.tw-carriage{position:absolute;top:122px;left:76px;width:220px;height:26px;border-radius:5px;background:var(--tw-gray);box-shadow:inset 0 0 0 3px #4c525a;animation:return-carriage-typewriter-carriage-return 4s ease-in-out infinite}
+.tw-platen{position:absolute;left:10px;top:5px;width:8px;height:16px;border-radius:3px;background:#3a3e44}
+.tw-handle{position:absolute;right:8px;top:6px;width:26px;height:14px;border-radius:3px;background:#2e3238}
+.tw-body{position:absolute;bottom:34px;left:46px;width:284px;height:150px;border-radius:10px;background:var(--tw-gray);box-shadow:inset 0 0 0 6px #4c525a}
+.tw-keys{position:absolute;top:26px;left:22px;right:22px;display:flex;flex-wrap:wrap;gap:8px}
+.tw-key{width:30px;height:24px;border:0;border-radius:3px;background:var(--tw-key);color:#3a3a34;font-family:'Consolas',monospace;font-size:11px;font-weight:700;cursor:pointer;box-shadow:0 3px 0 #a8a294;animation:press-key-typewriter-carriage-return 4s ease-in-out infinite}
+.tw-key:nth-child(2){animation-delay:0.2s}
+.tw-key:nth-child(3){animation-delay:0.4s}
+.tw-key:nth-child(4){animation-delay:0.6s}
+.tw-key:nth-child(5){animation-delay:0.8s}
+.tw-key:nth-child(6){animation-delay:1s}
+.tw-key:nth-child(7){animation-delay:1.2s}
+.tw-space{position:absolute;bottom:18px;left:76px;width:120px;height:16px;border:0;border-radius:3px;background:var(--tw-key);box-shadow:0 3px 0 #a8a294;cursor:pointer;animation:press-key-typewriter-carriage-return 4s ease-in-out infinite;animation-delay:1.4s}
+@keyframes return-carriage-typewriter-carriage-return{0%,100%{transform:translateX(0)}60%{transform:translateX(0)}72%{transform:translateX(-92px)}92%{transform:translateX(-92px)}}
+@keyframes type-text-typewriter-carriage-return{0%{width:0}58%{width:148px}88%{width:148px}100%{width:0}}
+@keyframes press-key-typewriter-carriage-return{0%,100%{transform:translateY(0)}50%{transform:translateY(3px)}}
+@keyframes blink-caret-typewriter-carriage-return{0%,46%{opacity:1}50%,96%{opacity:0}100%{opacity:1}}


### PR DESCRIPTION
## Component: ease-typewriter-carriage-return — carriage slides, keys press, and text types

**Closes #61566**

### What this adds
A classic typewriter: the carriage slides back across the page after each line, the platen and handle move with it, the letter keys press in turn, and the typed text appears on the paper with a blinking caret.

### Acceptance Criteria covered
- Carriage returns across the page
- Letter keys press in turn
- Typed text reveals with a caret

### Files
- submissions/examples/typewriter-carriage-return-ij/demo.html
- submissions/examples/typewriter-carriage-return-ij/style.css
- submissions/examples/typewriter-carriage-return-ij/README.md

### How to review
Open `demo.html` in a browser and watch the carriage return.