### PR TITLE
Fix ease-breadcrumb focus outline clipping issue

### DIFF
--- a/submissions/examples/ease-breadcrumb-focus-outline-clipped-59736/README.md
+++ b/submissions/examples/ease-breadcrumb-focus-outline-clipped-59736/README.md
@@ -1,0 +1,18 @@
+# Ease Breadcrumb Focus Outline Fix
+
+This submission provides a fix for the focus outline clipping issue in the `ease-breadcrumb` component (#59736).
+
+## What it does
+
+When the breadcrumb links are placed inside a container with `overflow: hidden` or `overflow: auto`, the standard focus outline can be clipped because it extends outside the bounding box.
+
+This fix uses `outline-offset: -2px` to pull the focus ring inward, ensuring it remains fully visible regardless of the parent container's overflow settings.
+
+## How to use it
+
+1. Include the styles for `.ease-breadcrumb-link:focus-visible` in your CSS.
+2. The focus outline will automatically be rendered correctly inside the element's bounding box without being clipped.
+
+## Why it fits EaseMotion CSS
+
+EaseMotion CSS focuses on polished, highly accessible components. An obscured focus ring negatively impacts the accessibility experience for keyboard users. By applying this simple adjustment, we maintain a beautiful default focus state while enhancing accessibility and resilience to different layouts.

--- a/submissions/examples/ease-breadcrumb-focus-outline-clipped-59736/demo.html
+++ b/submissions/examples/ease-breadcrumb-focus-outline-clipped-59736/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-breadcrumb Focus Outline Fix - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+        font-family: system-ui, -apple-system, sans-serif;
+        padding: 2rem;
+        background-color: #f9fafb;
+    }
+    .demo-container {
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+        max-width: 600px;
+        margin: 0 auto;
+    }
+    .overflow-container {
+        overflow: hidden;
+        border: 1px solid #ccc;
+        padding: 1rem;
+        border-radius: 8px;
+        background-color: #fff;
+    }
+    .instructions {
+        background: #eff6ff;
+        padding: 1.5rem;
+        border-left: 4px solid #3b82f6;
+        border-radius: 0 8px 8px 0;
+        margin-bottom: 2rem;
+    }
+  </style>
+</head>
+<body>
+  <main class="demo-container">
+    <h1>Focus Outline Clipping Fix for Breadcrumb</h1>
+    
+    <div class="instructions">
+      <p><strong>Steps to Reproduce:</strong></p>
+      <ol>
+        <li>Focus the breadcrumb links below using the <code>Tab</code> key.</li>
+        <li>Notice that the focus ring is fully visible and not clipped by the <code>overflow: hidden</code> container.</li>
+      </ol>
+    </div>
+
+    <div class="overflow-container">
+      <ul class="ease-breadcrumb">
+        <li class="ease-breadcrumb-item">
+          <a href="#" class="ease-breadcrumb-link">Home</a>
+        </li>
+        <li class="ease-breadcrumb-item">
+          <a href="#" class="ease-breadcrumb-link">Library</a>
+        </li>
+        <li class="ease-breadcrumb-item active">
+          <a href="#" class="ease-breadcrumb-link" aria-current="page">Data</a>
+        </li>
+      </ul>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-breadcrumb-focus-outline-clipped-59736/style.css
+++ b/submissions/examples/ease-breadcrumb-focus-outline-clipped-59736/style.css
@@ -1,0 +1,50 @@
+/* 
+ * Fix for ease-breadcrumb focus outline clipping
+ * Issue: When .ease-breadcrumb or its focusable elements are placed in a container with overflow: hidden or auto,
+ * the standard outline is clipped.
+ * Solution: Using negative outline-offset or inset box-shadow.
+ */
+
+.ease-breadcrumb {
+    display: flex;
+    align-items: center;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    font-family: system-ui, -apple-system, sans-serif;
+}
+
+.ease-breadcrumb-item {
+    display: flex;
+    align-items: center;
+}
+
+.ease-breadcrumb-item:not(:last-child)::after {
+    content: "/";
+    margin: 0 0.5rem;
+    color: #6b7280;
+}
+
+.ease-breadcrumb-link {
+    text-decoration: none;
+    color: #374151;
+    padding: 0.25rem 0.5rem;
+    border-radius: 4px;
+    transition: background-color 0.2s, color 0.2s;
+}
+
+.ease-breadcrumb-link:hover {
+    background-color: #f3f4f6;
+    color: #111827;
+}
+
+/* Ensure focus outline is drawn inward to prevent clipping */
+.ease-breadcrumb-link:focus-visible {
+    outline: 2px solid #2563eb;
+    outline-offset: -2px; /* Pulls the outline inward */
+}
+
+.ease-breadcrumb-item.active .ease-breadcrumb-link {
+    color: #9ca3af;
+    pointer-events: none;
+}


### PR DESCRIPTION
## Pull Request Description

This PR fixes a bug (#59736) where the `ease-breadcrumb` component's focus outline is clipped when placed inside a parent container with `overflow: hidden` or `overflow: auto`. I have added an example in the `submissions/examples` directory demonstrating the problem and the CSS fix.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

It applies `outline-offset: -2px` to the `.ease-breadcrumb-link:focus-visible` state so the focus ring is drawn inward and avoids being clipped by parent overflow boundaries.

**How does a developer use it?**

```html
<!-- The fix applies automatically when styling breadcrumb links, just add the CSS class to your breadcrumb link elements -->
<a href="#" class="ease-breadcrumb-link">Home</a>
