### PR TITLE
Add ease-submarine-periscope component

### DIFF
--- a/submissions/examples/submarine-periscope-ij/README.md
+++ b/submissions/examples/submarine-periscope-ij/README.md
@@ -1,0 +1,10 @@
+# ease-submarine-periscope
+
+A submarine whose periscope rises and pans above the conning tower.
+
+## Run
+Open `demo.html` directly in a browser to watch the scope rise.
+
+## Notes
+- The tube extends upward out of the tower.
+- The tower pans side to side on watch.

--- a/submissions/examples/submarine-periscope-ij/demo.html
+++ b/submissions/examples/submarine-periscope-ij/demo.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-submarine-periscope demo</title>
+</head>
+<body>
+<div class="sp-app">
+  <span class="sp-title">SUBMARINE</span>
+  <span class="sp-bubble sp-bubble-1"></span>
+  <span class="sp-bubble sp-bubble-2"></span>
+  <div class="sp-hull"><span class="sp-finsta"></span></div>
+  <div class="sp-tower">
+    <span class="sp-scope"><span class="sp-eyepiece"></span><span class="sp-lens"></span></span>
+    <span class="sp-light"></span>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/submarine-periscope-ij/style.css
+++ b/submissions/examples/submarine-periscope-ij/style.css
@@ -1,0 +1,18 @@
+:root{--sp-sea:#0e3a5c;--sp-dark:#16304a;--sp-steel:#8a98a8;--sp-brass:#d8b84a}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#b8d8e8,#7aa8c4);font-family:'Segoe UI',sans-serif}
+.sp-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#124a74,#08263e);box-shadow:0 16px 36px rgba(0,0,0,0.45)}
+.sp-title{position:absolute;top:14px;left:0;right:0;text-align:center;font-size:13px;font-weight:700;letter-spacing:7px;color:#9ad8f4}
+.sp-bubble{position:absolute;width:10px;height:10px;border-radius:50%;background:rgba(180,230,250,0.4);animation:rise-bubble-submarine-periscope 3.4s ease-in-out infinite}
+.sp-bubble-1{bottom:36px;left:70px}
+.sp-bubble-2{bottom:60px;right:60px;animation-delay:1.6s}
+.sp-hull{position:absolute;left:56px;right:56px;bottom:34px;height:54px;border-radius:50% 50% 30px 30px;background:var(--sp-dark);box-shadow:inset 0 0 0 6px #0c2036}
+.sp-finsta{position:absolute;right:-26px;top:12px;width:44px;height:14px;border-radius:4px;background:var(--sp-dark)}
+.sp-tower{position:absolute;left:130px;bottom:86px;width:112px;height:66px;border-radius:8px 8px 4px 4px;background:var(--sp-dark);box-shadow:inset 0 0 0 6px #0c2036;transform-origin:center bottom;animation:pan-tower-submarine-periscope 7s ease-in-out infinite}
+.sp-scope{position:absolute;left:50px;top:-86px;width:12px;height:120px;border-radius:4px;background:var(--sp-steel);box-shadow:inset 0 0 0 3px #66727e;transform-origin:center bottom;animation:rise-periscope-submarine-periscope 5s ease-in-out infinite}
+.sp-eyepiece{position:absolute;top:-6px;left:-8px;width:28px;height:18px;border-radius:50%;background:var(--sp-steel);box-shadow:inset 0 0 0 3px #66727e}
+.sp-lens{position:absolute;bottom:-8px;left:-7px;width:26px;height:12px;border-radius:4px;background:var(--sp-brass);box-shadow:inset 0 0 0 3px #a8882c}
+.sp-light{position:absolute;top:8px;right:8px;width:10px;height:10px;border-radius:50%;background:#d8584a;box-shadow:0 0 10px #d8584a;animation:blink-light-submarine-periscope 1.2s steps(2) infinite}
+@keyframes rise-periscope-submarine-periscope{0%,100%{transform:translateY(0)}45%{transform:translateY(-46px)}70%{transform:translateY(-46px)}}
+@keyframes pan-tower-submarine-periscope{0%,100%{transform:rotate(-16deg)}50%{transform:rotate(16deg)}}
+@keyframes rise-bubble-submarine-periscope{0%{transform:translateY(0);opacity:0}30%{opacity:1}100%{transform:translateY(-120px);opacity:0}}
+@keyframes blink-light-submarine-periscope{0%,100%{opacity:1}50%{opacity:0.2}}


### PR DESCRIPTION
## Component: ease-submarine-periscope — scope rises, tower pans, and light blinks

**Closes #61582**

### What this adds
A submarine on patrol: the periscope tube extends up from the conning tower and pans side to side while a red signal light blinks and bubbles drift up through the sea.

### Acceptance Criteria covered
- Periscope extends upward
- Tower pans side to side
- Signal light blinks

### Files
- submissions/examples/submarine-periscope-ij/demo.html
- submissions/examples/submarine-periscope-ij/style.css
- submissions/examples/submarine-periscope-ij/README.md

### How to review
Open `demo.html` in a browser and watch the periscope rise.