### PR TITLE
feat: Add focus visible styles for keyboard navigation

### DIFF
--- a/submissions/examples/ease-focus-visible-bh/README.md
+++ b/submissions/examples/ease-focus-visible-bh/README.md
@@ -1,0 +1,25 @@
+# Focus Visible Styles
+
+## What does this do?
+Provides WCAG 2.1 AA compliant visible focus indicators for keyboard navigation.
+
+## How is it used?
+```css
+:focus-visible {
+  outline: 2px solid #6c63ff;
+  outline-offset: 2px;
+}
+
+:focus:not(:focus-visible) {
+  outline: none;
+}
+```
+
+## Why is it useful?
+- Accessibility for keyboard-only users
+- WCAG 2.1 Level AA compliance
+- Clean design without focus rings for mouse users
+
+## WCAG References
+- WCAG 2.1 2.4.7 (Level AA) - Focus Visible
+- WCAG 2.1 2.4.11 (Level AA) - Focus Not Obscured

--- a/submissions/examples/ease-focus-visible-bh/demo.html
+++ b/submissions/examples/ease-focus-visible-bh/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion CSS - Focus Visible Styles</title>
+  <link rel="stylesheet" href="../../easemotion.min.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <header class="ease-fade-in">
+      <h1>Focus Visible Styles</h1>
+      <p class="subtitle">WCAG 2.1 AA compliant focus indicators for keyboard navigation</p>
+    </header>
+
+    <section class="demo-section ease-slide-up">
+      <h2>Interactive Elements</h2>
+      <p>Use Tab key to navigate and see focus states:</p>
+      
+      <div class="interactive-demo">
+        <button class="focus-demo-button">Button</button>
+        <a href="#demo" class="focus-demo-link">Link</a>
+        <input type="text" placeholder="Input field" class="focus-demo-input">
+        <select class="focus-demo-select">
+          <option>Select option</option>
+          <option>Option 1</option>
+        </select>
+      </div>
+    </section>
+
+    <section class="code-section ease-zoom-in">
+      <h2>Usage</h2>
+      <pre><code>:focus-visible {
+  outline: 2px solid #6c63ff;
+  outline-offset: 2px;
+}
+
+:focus:not(:focus-visible) {
+  outline: none;
+}</code></pre>
+    </section>
+
+    <footer class="ease-fade-in">
+      <p>Built with EaseMotion CSS</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-focus-visible-bh/style.css
+++ b/submissions/examples/ease-focus-visible-bh/style.css
@@ -1,0 +1,127 @@
+/* Focus Visible Styles - WCAG 2.1 AA Compliant */
+
+body {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+  color: #e4e4e7;
+  min-height: 100vh;
+  margin: 0;
+  padding: 2rem;
+}
+
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+h1 {
+  font-size: 2.5rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+  background: linear-gradient(135deg, #6c63ff, #a78bfa);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.subtitle {
+  font-size: 1.1rem;
+  color: #a1a1aa;
+}
+
+.demo-section,
+.code-section {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 1rem;
+  padding: 2rem;
+  margin-bottom: 2rem;
+}
+
+h2 {
+  font-size: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #f4f4f5;
+}
+
+.interactive-demo {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  padding: 1.5rem;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 0.5rem;
+}
+
+.focus-demo-button,
+.focus-demo-link,
+.focus-demo-input,
+.focus-demo-select {
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  border: 2px solid transparent;
+  border-radius: 0.5rem;
+  transition: all 0.2s ease;
+}
+
+.focus-demo-button {
+  background: #6c63ff;
+  color: white;
+  border: none;
+  cursor: pointer;
+}
+
+.focus-demo-link {
+  background: transparent;
+  color: #a78bfa;
+  text-decoration: underline;
+}
+
+.focus-demo-input,
+.focus-demo-select {
+  background: rgba(255, 255, 255, 0.1);
+  color: white;
+  border: 2px solid rgba(255, 255, 255, 0.2);
+}
+
+:focus-visible {
+  outline: 2px solid #6c63ff;
+  outline-offset: 2px;
+}
+
+:focus:not(:focus-visible) {
+  outline: none;
+}
+
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+select:focus-visible {
+  outline: 2px solid #6c63ff;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px rgba(108, 99, 255, 0.2);
+}
+
+pre {
+  background: #0f0f0f;
+  padding: 1.5rem;
+  border-radius: 0.5rem;
+  overflow-x: auto;
+  font-family: 'Fira Code', monospace;
+  font-size: 0.875rem;
+  line-height: 1.6;
+}
+
+code {
+  color: #a78bfa;
+}
+
+footer {
+  text-align: center;
+  color: #71717a;
+  padding-top: 2rem;
+}


### PR DESCRIPTION
## Summary
Adds WCAG 2.1 AA compliant focus visible styles for keyboard navigation.

## Changes
- demo.html - Interactive demo with keyboard navigation
- style.css - Focus visible CSS using :focus-visible
- README.md - Documentation

## WCAG Compliance
- WCAG 2.1 2.4.7 (Level AA) - Focus Visible
- WCAG 2.1 2.4.11 (Level AA) - Focus Not Obscured

Closes #61609