### PR TITLE
fix: add missing closing tags in rotate-click-tabs demo (fixes #60599)

### DIFF
--- a/submissions/examples/rotate-click-tabs-checkout-bhakkti/demo.html
+++ b/submissions/examples/rotate-click-tabs-checkout-bhakkti/demo.html
@@ -168,11 +168,10 @@
         </div>
       </div>
     </div>
-
     <div class="ease-demo-info">
       <p>💡 Click tabs to see rotate effect</p>
       <p>⌨️ Tab + Enter/Space for keyboard navigation</p>
       <p>🛒 Perfect for e-commerce checkout flows</p>
     </div>
-  </div>
-</body>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
Fixed corrupted HTML structure in the demo.html file that was missing proper closing tags.

## Changes
- Fixed missing closing tags at end of demo.html
- Restructured content to be properly inside body element
- Added proper </body></html> closing structure

## Issue
Issue #60599 reported missing closing </html> tag

Closes #60599