### PR TITLE
fix(core): document alert focus clip fix (fixes #59730)

### DIFF
--- a/submissions/docs/alert-focus-clip-fix-bh/README.md
+++ b/submissions/docs/alert-focus-clip-fix-bh/README.md
@@ -1,0 +1,28 @@
+# ease-alert Focus Outline Clipping Fix
+
+## Bug Description
+
+The `ease-alert` component has its focus ring clipped when placed inside containers with `overflow: hidden`.
+
+## Solution
+
+Replace outline with inset box-shadow:
+
+```css
+.ease-alert:focus-visible {
+  box-shadow: inset 0 0 0 2px var(--ease-color-primary);
+  outline: none;
+}
+```
+
+## Files Affected
+
+| File | Lines | Change |
+|------|-------|--------|
+| `core/alert.css` | ~60-70 | Replace outline with inset box-shadow |
+
+## Testing Checklist
+
+- [ ] Alert in normal container shows focus ring
+- [ ] Alert in overflow: hidden container shows focus ring
+- [ ] Focus is visible for keyboard navigation

--- a/submissions/docs/alert-focus-clip-fix-bh/demo.html
+++ b/submissions/docs/alert-focus-clip-fix-bh/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Alert Focus Clip Fix - EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../core/easemotion.min.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>ease-alert Focus Clip Fix</h1>
+      <p class="subtitle">Focus ring visible in overflow: hidden containers</p>
+    </header>
+
+    <main>
+      <section class="demo-section">
+        <h2>Alert in overflow: hidden</h2>
+        <div class="overflow-container">
+          <div class="ease-alert" role="alert" tabindex="0">
+            <strong>Warning!</strong> This is an alert message.
+          </div>
+        </div>
+        <p class="note">Tab to focus - inset shadow is visible</p>
+      </section>
+
+      <section class="demo-section">
+        <h2>Alert Variants</h2>
+        <div class="overflow-container">
+          <div class="ease-alert ease-alert-success" tabindex="0">Success Alert</div>
+          <div class="ease-alert ease-alert-error" tabindex="0">Error Alert</div>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <p>Fix submitted for issue #59730</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/submissions/docs/alert-focus-clip-fix-bh/style.css
+++ b/submissions/docs/alert-focus-clip-fix-bh/style.css
@@ -1,0 +1,110 @@
+/* Alert Focus Clip Fix Demo Styles */
+@import "../../../core/variables.css";
+@import "../../../core/utilities.css";
+
+@layer easemotion-docs {
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: var(--ease-font-sans, system-ui, sans-serif);
+  background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+  color: #f8fafc;
+  margin: 0;
+  padding: 2rem;
+  min-height: 100vh;
+}
+
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+h1 {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+  background: linear-gradient(135deg, #6c63ff, #a78bfa);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.subtitle {
+  color: #94a3b8;
+}
+
+main {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.demo-section {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+h2 {
+  font-size: 1rem;
+  color: #f4f4f5;
+  margin: 0 0 1rem 0;
+}
+
+.overflow-container {
+  background: #0f172a;
+  border-radius: 0.75rem;
+  padding: 2rem;
+  overflow: hidden;
+}
+
+.note {
+  color: #94a3b8;
+  font-size: 0.875rem;
+  margin: 1rem 0 0 0;
+  text-align: center;
+}
+
+/* Alert styles */
+.ease-alert {
+  padding: 1rem 1.5rem;
+  border-radius: 0.5rem;
+  background: #6c63ff;
+  color: white;
+  cursor: pointer;
+}
+
+.ease-alert-success {
+  background: #10b981;
+}
+
+.ease-alert-error {
+  background: #ef4444;
+}
+
+.ease-alert:focus-visible {
+  outline: 3px solid currentColor;
+  outline-offset: 3px;
+}
+
+.ease-alert.fixed:focus-visible {
+  box-shadow: inset 0 0 0 3px currentColor;
+  outline: none;
+}
+
+footer {
+  text-align: center;
+  color: #64748b;
+  padding-top: 2rem;
+  font-size: 0.875rem;
+}
+
+}

--- a/submissions/docs/avatar-focus-clip-fix-bh/README.md
+++ b/submissions/docs/avatar-focus-clip-fix-bh/README.md
@@ -1,0 +1,40 @@
+# ease-avatar Focus Outline Clipping Fix
+
+## Bug Description
+
+The `ease-avatar` component has its focus ring clipped when placed inside containers with `overflow: hidden` or `overflow: auto`.
+
+## The Problem
+
+```css
+/* Original avatar focus styles */
+.ease-avatar:focus-visible {
+  outline: 2px solid var(--ease-color-primary);
+  outline-offset: 2px; /* Gets clipped by overflow: hidden parent */
+}
+```
+
+## Solution: Inset Box-Shadow
+
+Replace outline with inset box-shadow:
+
+```css
+.ease-avatar:focus-visible {
+  box-shadow: inset 0 0 0 2px var(--ease-color-primary);
+  outline: none;
+}
+```
+
+## Files Affected
+
+| File | Lines | Change |
+|------|-------|--------|
+| `core/avatar.css` | ~80-90 | Replace outline with inset box-shadow |
+
+## Testing Checklist
+
+- [ ] Avatar in normal container shows focus ring
+- [ ] Avatar in `overflow: hidden` container shows focus ring
+- [ ] Avatar in `overflow: auto` container shows focus ring
+- [ ] Focus is visible for keyboard navigation
+- [ ] No visual regression on existing avatar styles

--- a/submissions/docs/avatar-focus-clip-fix-bh/demo.html
+++ b/submissions/docs/avatar-focus-clip-fix-bh/demo.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Avatar Focus Clip Fix - EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../core/easemotion.min.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>ease-avatar Focus Clip Fix</h1>
+      <p class="subtitle">Focus ring visible in overflow: hidden containers</p>
+    </header>
+
+    <main>
+      <section class="demo-section">
+        <h2>Avatar in overflow: hidden</h2>
+        <div class="overflow-container">
+          <div class="ease-avatar" tabindex="0" style="background: linear-gradient(135deg, #6c63ff, #a78bfa);">
+            <span>AS</span>
+          </div>
+        </div>
+        <p class="note">Tab to focus - inset shadow is visible</p>
+      </section>
+
+      <section class="demo-section">
+        <h2>Avatar Variants</h2>
+        <div class="overflow-container">
+          <div class="ease-avatar fixed" tabindex="0" style="background: #6c63ff;">A</div>
+          <div class="ease-avatar fixed" tabindex="0" style="background: #10b981;">B</div>
+          <div class="ease-avatar fixed" tabindex="0" style="background: #f59e0b;">C</div>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <p>Fix submitted for issue #59732</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/submissions/docs/avatar-focus-clip-fix-bh/style.css
+++ b/submissions/docs/avatar-focus-clip-fix-bh/style.css
@@ -1,0 +1,111 @@
+/* Avatar Focus Clip Fix Demo Styles */
+@import "../../../core/variables.css";
+@import "../../../core/utilities.css";
+
+@layer easemotion-docs {
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: var(--ease-font-sans, system-ui, sans-serif);
+  background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+  color: #f8fafc;
+  margin: 0;
+  padding: 2rem;
+  min-height: 100vh;
+}
+
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+h1 {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+  background: linear-gradient(135deg, #6c63ff, #a78bfa);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.subtitle {
+  color: #94a3b8;
+}
+
+main {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.demo-section {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+h2 {
+  font-size: 1rem;
+  color: #f4f4f5;
+  margin: 0 0 1rem 0;
+}
+
+.overflow-container {
+  background: #0f172a;
+  border-radius: 0.75rem;
+  padding: 2rem;
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.note {
+  color: #94a3b8;
+  font-size: 0.875rem;
+  margin: 1rem 0 0 0;
+  text-align: center;
+}
+
+/* Avatar styles */
+.ease-avatar {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  font-weight: 600;
+  font-size: 1.25rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.ease-avatar:focus-visible {
+  outline: 3px solid #6c63ff;
+  outline-offset: 3px;
+}
+
+.ease-avatar.fixed:focus-visible {
+  box-shadow: inset 0 0 0 3px #6c63ff;
+  outline: none;
+}
+
+footer {
+  text-align: center;
+  color: #64748b;
+  padding-top: 2rem;
+  font-size: 0.875rem;
+}
+
+}

--- a/submissions/docs/button-focus-clip-fix-bh/README.md
+++ b/submissions/docs/button-focus-clip-fix-bh/README.md
@@ -1,0 +1,86 @@
+# ease-button Focus Outline Clipping Fix
+
+## Bug Description
+
+The `ease-button` component has its focus ring (outline or box-shadow) clipped when placed inside a container with `overflow: hidden` or `overflow: auto`.
+
+## The Problem
+
+```css
+/* Original button focus styles */
+.ease-button:focus-visible {
+  outline: 2px solid var(--ease-color-primary);
+  outline-offset: 2px; /* Gets clipped by overflow: hidden parent */
+}
+```
+
+When the button is inside a container with `overflow: hidden`, the focus ring extends outside the button's bounding box and gets clipped.
+
+## Solutions
+
+### Solution 1: Inset Box-Shadow (Recommended)
+
+Use `box-shadow` with inset instead of `outline`:
+
+```css
+.ease-button:focus-visible {
+  /* Inset shadow doesn't extend outside the element */
+  box-shadow: inset 0 0 0 2px var(--ease-color-primary);
+  outline: none; /* Remove outline to avoid clipping */
+}
+```
+
+### Solution 2: Negative Outline Offset (Alternative)
+
+```css
+.ease-button:focus-visible {
+  outline: 2px solid var(--ease-color-primary);
+  outline-offset: -4px; /* Negative offset pulls ring inward */
+}
+```
+
+### Solution 3: Pseudo-Element Focus Ring
+
+```css
+.ease-button:focus-visible::after {
+  content: '';
+  position: absolute;
+  inset: -4px;
+  border: 2px solid var(--ease-color-primary);
+  border-radius: inherit;
+  pointer-events: none;
+}
+```
+
+## Recommended Fix for core/button.css
+
+Replace the current focus styles:
+
+```css
+/* BEFORE (problematic) */
+.ease-button:focus-visible {
+  outline: 2px solid var(--ease-color-primary);
+  outline-offset: 2px;
+}
+
+/* AFTER (fixed) */
+.ease-button:focus-visible {
+  box-shadow: inset 0 0 0 2px var(--ease-color-primary);
+  outline: none;
+}
+```
+
+## Files Affected
+
+| File | Lines | Change |
+|------|-------|--------|
+| `core/button.css` | ~120-130 | Replace outline with inset box-shadow |
+
+## Testing Checklist
+
+- [ ] Button in normal container shows focus ring
+- [ ] Button in `overflow: hidden` container shows focus ring
+- [ ] Button in `overflow: auto` container shows focus ring
+- [ ] Focus is visible for keyboard navigation
+- [ ] No visual regression on existing button styles
+- [ ] Works with all button variants (primary, secondary, etc.)

--- a/submissions/docs/button-focus-clip-fix-bh/demo.html
+++ b/submissions/docs/button-focus-clip-fix-bh/demo.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Button Focus Clip Fix - EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../core/easemotion.min.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <header class="ease-fade-in">
+      <h1>ease-button Focus Clip Fix</h1>
+      <p class="subtitle">Fix for focus ring being clipped by overflow: hidden containers</p>
+    </header>
+
+    <main class="ease-slide-up">
+      <!-- Before: Original problematic style -->
+      <section class="demo-section">
+        <h2>BEFORE (with outline - gets clipped)</h2>
+        <div class="overflow-container">
+          <button class="ease-button ease-button-primary" id="btn-before">
+            Click Me (Outline)
+          </button>
+        </div>
+        <p class="note">Focus on this button - outline gets clipped by overflow: hidden</p>
+      </section>
+
+      <!-- After: Fixed style with inset shadow -->
+      <section class="demo-section">
+        <h2>AFTER (with inset box-shadow - visible)</h2>
+        <div class="overflow-container">
+          <button class="ease-button ease-button-primary fixed" id="btn-after">
+            Click Me (Inset Shadow)
+          </button>
+        </div>
+        <p class="note">Focus on this button - inset shadow is visible inside container</p>
+      </section>
+
+      <!-- Multiple buttons demo -->
+      <section class="demo-section">
+        <h2>Fixed Button Variants</h2>
+        <div class="overflow-container">
+          <button class="ease-button ease-button-primary fixed">Primary Button</button>
+          <button class="ease-button ease-button-secondary fixed">Secondary Button</button>
+          <button class="ease-button ease-button-outline fixed">Outline Button</button>
+        </div>
+        <p class="note">All button variants work correctly with inset shadow focus</p>
+      </section>
+
+      <!-- In auto overflow container -->
+      <section class="demo-section">
+        <h2>In overflow: auto Container</h2>
+        <div class="overflow-container overflow-auto">
+          <button class="ease-button ease-button-primary fixed">Button in Auto Container</button>
+        </div>
+        <p class="note">Focus ring is visible even in scrollable containers</p>
+      </section>
+    </main>
+
+    <footer class="ease-fade-in">
+      <p>Fix submitted for issue #59738</p>
+      <p class="hint">Use Tab key to focus on buttons and see the difference</p>
+    </footer>
+  </div>
+
+  <script>
+    // Add visual toggle for before/after comparison
+    const btnBefore = document.getElementById('btn-before');
+    const btnAfter = document.getElementById('btn-after');
+    
+    btnBefore.addEventListener('focus', () => {
+      btnBefore.style.outline = '3px solid #6c63ff';
+      btnBefore.style.outlineOffset = '3px';
+    });
+    
+    btnBefore.addEventListener('blur', () => {
+      btnBefore.style.outline = '';
+      btnBefore.style.outlineOffset = '';
+    });
+  </script>
+</body>
+</html>

--- a/submissions/docs/button-focus-clip-fix-bh/style.css
+++ b/submissions/docs/button-focus-clip-fix-bh/style.css
@@ -1,0 +1,153 @@
+/* Button Focus Clip Fix Demo Styles */
+@import "../../../core/variables.css";
+@import "../../../core/utilities.css";
+
+@layer easemotion-docs {
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: var(--ease-font-sans, system-ui, sans-serif);
+  background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+  color: #f8fafc;
+  margin: 0;
+  padding: 2rem;
+  min-height: 100vh;
+}
+
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+  background: linear-gradient(135deg, #6c63ff, #a78bfa);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.subtitle {
+  color: #94a3b8;
+  font-size: 1rem;
+}
+
+main {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.demo-section {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+h2 {
+  font-size: 1.1rem;
+  color: #f4f4f5;
+  margin: 0 0 1rem 0;
+}
+
+/* Overflow container - the key to reproducing the bug */
+.overflow-container {
+  background: #0f172a;
+  border-radius: 0.75rem;
+  padding: 2rem;
+  margin-bottom: 1rem;
+  /* This is the problematic CSS that causes clipping */
+  overflow: hidden;
+}
+
+.overflow-auto {
+  overflow: auto;
+  max-height: 100px;
+}
+
+.note {
+  color: #94a3b8;
+  font-size: 0.875rem;
+  margin: 0;
+}
+
+/* Base button styles */
+.ease-button {
+  padding: 0.75rem 1.5rem;
+  border-radius: var(--ease-radius-lg, 0.5rem);
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border: 2px solid transparent;
+  font-size: 1rem;
+  font-family: inherit;
+  position: relative;
+}
+
+.ease-button-primary {
+  background: linear-gradient(135deg, #6c63ff 0%, #8b5cf6 100%);
+  color: white;
+}
+
+.ease-button-secondary {
+  background: rgba(255, 255, 255, 0.1);
+  color: #e2e8f0;
+}
+
+.ease-button-outline {
+  background: transparent;
+  border-color: #6c63ff;
+  color: #6c63ff;
+}
+
+/* PROBLEMATIC: Original focus with outline (gets clipped) */
+.ease-button:focus-visible {
+  outline: 3px solid #6c63ff;
+  outline-offset: 3px;
+}
+
+/* FIXED: Use inset box-shadow instead */
+.ease-button.fixed:focus-visible {
+  /* Inset shadow doesn't extend outside the element */
+  box-shadow: inset 0 0 0 3px #6c63ff;
+  outline: none;
+}
+
+/* Hover states */
+.ease-button:hover:not(:focus-visible) {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(108, 99, 255, 0.3);
+}
+
+.ease-button-primary:hover:not(:focus-visible) {
+  box-shadow: 0 4px 12px rgba(108, 99, 255, 0.4);
+}
+
+/* Footer */
+footer {
+  text-align: center;
+  color: #64748b;
+  padding-top: 2rem;
+}
+
+footer p {
+  margin: 0.25rem 0;
+}
+
+.hint {
+  color: #6c63ff;
+  font-size: 0.875rem;
+}
+
+}


### PR DESCRIPTION
## Summary
Documents the ease-alert focus outline clipping bug and provides the fix.

## Bug Description
The ease-alert focus ring gets clipped when placed inside containers with overflow: hidden.

## Fix
Replace outline with inset box-shadow:


## Files
- README.md: Documentation
- demo.html: Interactive demo
- style.css: Styling

Closes #59730