### PR TITLE
feat: add ease-print Print-Friendly Utility Classes (fixes #60391)

### DIFF
--- a/submissions/examples/ease-print-bh/README.md
+++ b/submissions/examples/ease-print-bh/README.md
@@ -1,0 +1,44 @@
+# ease-print Print-Friendly Utility Classes
+
+## What does this do?
+
+Provides CSS utility classes for controlling element visibility during printing, allowing developers to hide navigation/animations when printing while showing print-specific content like footers.
+
+## How is it used?
+
+```html
+<!-- Hide navigation when printing -->
+<nav class="ease-print-hide">
+  <a href="#">Home</a>
+  <a href="#">About</a>
+  <button class="ease-animate-pulse">Buy Now</button>
+</nav>
+
+<!-- Printable article content -->
+<article>
+  <h1>Article Title</h1>
+  <p>Article content here...</p>
+</article>
+
+<!-- Print-only footer -->
+<footer class="ease-print-only">
+  <p>Printed from example.com on August 5, 2026</p>
+</footer>
+```
+
+### CSS Classes
+
+| Class | Purpose |
+|-------|---------|
+| `.ease-print-hide` | Hides element only when printing |
+| `.ease-print-only` | Shows element only when printing |
+
+## Why is it useful?
+
+Real-world pages built with CSS frameworks eventually get printed (invoices, articles, receipts, docs). Animated or interactive elements like nav bars, buttons with hover states, and pulsing animations look broken or wasteful on paper. This utility:
+
+- ✅ Improves print readability by removing distractions
+- ✅ Adds professional print footers automatically
+- ✅ Zero JavaScript required
+- ✅ Tiny footprint, high utility
+- ✅ Complements EaseMotion's focus on polished user experiences

--- a/submissions/examples/ease-print-bh/demo.html
+++ b/submissions/examples/ease-print-bh/demo.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion CSS - Print-Friendly Utilities</title>
+  <link rel="stylesheet" href="../../core/easemotion.min.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <header class="ease-print-hide">
+      <h1>My Website</h1>
+      <nav>
+        <a href="#">Home</a>
+        <a href="#">Products</a>
+        <a href="#">About</a>
+        <a href="#">Contact</a>
+      </nav>
+      <button class="cta-button">Buy Now - Limited Offer!</button>
+    </header>
+
+    <main>
+      <article class="printable-content">
+        <h2>Article: Understanding CSS Print Styles</h2>
+        <p class="intro">
+          This article demonstrates how print-friendly utility classes work. 
+          Notice how the navigation, buttons, and animations are hidden when printing,
+          while the print-only footer appears.
+        </p>
+        
+        <h3>Why Print Styles Matter</h3>
+        <p>
+          Web pages often contain navigation menus, call-to-action buttons, 
+          and animated elements that serve no purpose on paper. In fact, 
+          they can make printed documents look unprofessional.
+        </p>
+        
+        <div class="demo-box ease-print-hide">
+          <p>🖨️ <strong>Demo Box</strong> - This animated box is hidden when printing</p>
+          <p class="hint">Press Ctrl+P (or Cmd+P) to see the print preview!</p>
+        </div>
+        
+        <h3>Solution</h3>
+        <p>
+          Use the <code>.ease-print-hide</code> class on elements that should 
+          not appear in print, and <code>.ease-print-only</code> on elements 
+          that should only appear when printing.
+        </p>
+        
+        <div class="code-example">
+          <pre><code>&lt;nav class="ease-print-hide"&gt;...&lt;/nav&gt;
+&lt;footer class="ease-print-only"&gt;Printed from example.com&lt;/footer&gt;</code></pre>
+        </div>
+      </article>
+    </main>
+
+    <footer class="ease-print-hide">
+      <p>© 2026 My Website. All rights reserved.</p>
+      <div class="social-links">
+        <a href="#">Facebook</a>
+        <a href="#">Twitter</a>
+        <a href="#">Instagram</a>
+      </div>
+    </footer>
+
+    <!-- Only visible when printing -->
+    <div class="print-footer ease-print-only">
+      <p>— End of Document —</p>
+      <p>Printed from My Website on <span id="print-date"></span></p>
+      <p>Page 1 of 1</p>
+    </div>
+  </div>
+
+  <script>
+    // Auto-fill print date
+    document.getElementById('print-date').textContent = new Date().toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric'
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-print-bh/style.css
+++ b/submissions/examples/ease-print-bh/style.css
@@ -1,0 +1,274 @@
+/* ============================================================
+   EaseMotion CSS Sandbox — ease-print/style.css
+   Print-Friendly Utility Classes
+   ============================================================ */
+
+/* Step back 3 levels out of submissions/examples/ease-print to pull root tokens */
+@import "../../../core/variables.css";
+@import "../../../core/utilities.css";
+
+@layer easemotion-components {
+
+/* ── Base Styles ─────────────────────────────────────────── */
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: var(--ease-font-sans, system-ui, sans-serif);
+  background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+  color: #f8fafc;
+  margin: 0;
+  padding: 2rem;
+  min-height: 100vh;
+  line-height: 1.6;
+}
+
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+/* ── Header (hidden when printing) ────────────────────────── */
+header {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  margin-bottom: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+header h1 {
+  font-size: 1.75rem;
+  margin: 0 0 1rem 0;
+  background: linear-gradient(135deg, #6c63ff, #a78bfa);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+nav {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+nav a {
+  color: #94a3b8;
+  text-decoration: none;
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  transition: all 0.2s ease;
+}
+
+nav a:hover {
+  background: rgba(108, 99, 255, 0.2);
+  color: #f8fafc;
+}
+
+.cta-button {
+  background: linear-gradient(135deg, #6c63ff 0%, #8b5cf6 100%);
+  color: white;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 0.5rem;
+  font-weight: 600;
+  cursor: pointer;
+  animation: pulse 2s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.05); }
+}
+
+/* ── Main Content ────────────────────────────────────────── */
+.printable-content {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 1rem;
+  padding: 2rem;
+  margin-bottom: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.printable-content h2 {
+  font-size: 1.5rem;
+  margin-top: 0;
+  color: #f8fafc;
+}
+
+.printable-content h3 {
+  font-size: 1.25rem;
+  margin-top: 1.5rem;
+  color: #a78bfa;
+}
+
+.printable-content p {
+  color: #cbd5e1;
+  margin-bottom: 1rem;
+}
+
+.intro {
+  font-size: 1.1rem;
+  color: #e2e8f0 !important;
+}
+
+code {
+  background: rgba(108, 99, 255, 0.2);
+  padding: 0.2em 0.4em;
+  border-radius: 0.25rem;
+  font-size: 0.9em;
+  color: #a78bfa;
+}
+
+/* ── Demo Box (hidden when printing) ─────────────────────── */
+.demo-box {
+  background: rgba(108, 99, 255, 0.1);
+  border: 2px dashed #6c63ff;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  margin: 1.5rem 0;
+  animation: glow 3s ease-in-out infinite;
+}
+
+@keyframes glow {
+  0%, 100% { box-shadow: 0 0 10px rgba(108, 99, 255, 0.3); }
+  50% { box-shadow: 0 0 25px rgba(108, 99, 255, 0.6); }
+}
+
+.demo-box p {
+  margin: 0.5rem 0;
+}
+
+.demo-box .hint {
+  color: #a78bfa;
+  font-style: italic;
+}
+
+/* ── Code Example ────────────────────────────────────────── */
+.code-example {
+  background: #0f172a;
+  border-radius: 0.75rem;
+  padding: 1rem;
+  margin: 1.5rem 0;
+  overflow-x: auto;
+}
+
+.code-example pre {
+  margin: 0;
+}
+
+.code-example code {
+  background: none;
+  padding: 0;
+  color: #e2e8f0;
+  font-family: 'Fira Code', monospace;
+  font-size: 0.85rem;
+}
+
+/* ── Footer (hidden when printing) ───────────────────────── */
+footer {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  text-align: center;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+footer p {
+  color: #64748b;
+  margin: 0 0 0.5rem 0;
+}
+
+.social-links {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.social-links a {
+  color: #64748b;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.social-links a:hover {
+  color: #6c63ff;
+}
+
+/* ── Print Footer (only shown when printing) ──────────────── */
+.print-footer {
+  text-align: center;
+  padding-top: 2rem;
+  margin-top: 2rem;
+}
+
+.print-footer p {
+  margin: 0.5rem 0;
+  color: #64748b;
+}
+
+/* ═══════════════════════════════════════════════════════════
+   PRINT UTILITIES — THE CORE FEATURE
+   ═══════════════════════════════════════════════════════════ */
+
+/* Hide elements when printing */
+.ease-print-hide {
+  /* Visible on screen */
+}
+
+/* Show elements only when printing */
+.ease-print-only {
+  display: none;
+}
+
+/* Print Media Query */
+@media print {
+  /* Hide navigation, buttons, animations when printing */
+  .ease-print-hide {
+    display: none !important;
+  }
+  
+  /* Show print-only content */
+  .ease-print-only {
+    display: block !important;
+  }
+  
+  /* Print-friendly body styles */
+  body {
+    background: white !important;
+    color: black !important;
+    padding: 0 !important;
+  }
+  
+  /* Print-friendly content */
+  .printable-content {
+    background: none !important;
+    border: none !important;
+    padding: 0 !important;
+    border-radius: 0 !important;
+  }
+  
+  .printable-content h2,
+  .printable-content h3 {
+    color: black !important;
+    page-break-after: avoid;
+  }
+  
+  .printable-content p {
+    color: #333 !important;
+  }
+  
+  /* Code blocks in print */
+  .code-example {
+    background: #f5f5f5 !important;
+    border: 1px solid #ddd !important;
+  }
+  
+  .code-example code {
+    color: #333 !important;
+  }
+}
+
+}


### PR DESCRIPTION
## Summary
Adds print-friendly utility classes to control element visibility during printing.

## What does this do?
Provides CSS utility classes for controlling element visibility during printing.

## How is it used?
```html
<nav class="ease-print-hide">...</nav>
<footer class="ease-print-only">Printed from example.com</footer>
```

## Why is it useful?
Real-world pages get printed (invoices, articles, receipts) and animated/interactive nav elements look broken on paper. This is a tiny, genuinely useful accessibility/real-world utility.

## Files Added
- **submissions/examples/ease-print-bh/README.md** - Documentation
- **submissions/examples/ease-print-bh/demo.html** - Interactive demo
- **submissions/examples/ease-print-bh/style.css** - Print utility CSS

## PR Checklist
- [x] Files placed in correct directory (submissions/examples/ease-print-bh/)
- [x] README.md answers: What, How, Why
- [x] Demo works by opening directly in browser
- [x] CSS is clean and follows conventions
- [x] Issue referenced in commit message

Closes #60391