### PR TITLE
feat: add ease-compare Before/After Image Comparison Slider (fixes #60390)

### DIFF
--- a/submissions/examples/ease-compare-bh/README.md
+++ b/submissions/examples/ease-compare-bh/README.md
@@ -1,0 +1,35 @@
+# ease-compare Before/After Image Comparison Slider
+
+## What does this do?
+
+A draggable slider component that reveals an "after" image over a "before" image using CSS `clip-path`, controlled by a native range input for full accessibility and no complex JS drag math.
+
+## How is it used?
+
+```html
+<div class="ease-compare">
+  <img class="ease-compare-after" src="after.jpg" alt="After">
+  <img class="ease-compare-before" src="before.jpg" alt="Before">
+  <input type="range" class="ease-compare-slider" min="0" max="100" value="50"
+    oninput="this.previousElementSibling.style.clipPath='inset(0 '+(100-this.value)+'% 0 0)'">
+</div>
+```
+
+### CSS Classes
+
+| Class | Purpose |
+|-------|---------|
+| `.ease-compare` | Container for the comparison component |
+| `.ease-compare-before` | The "before" image (visible by default) |
+| `.ease-compare-after` | The "after" image (revealed by slider) |
+| `.ease-compare-slider` | Range input that controls the reveal |
+
+## Why is it useful?
+
+Common in portfolio sites, photo editing tools, redesign showcases, and product comparisons. Driving the reveal with a native range input (instead of manual pointer-drag JS) keeps it consistent with EaseMotion's "minimal JS, CSS does the work" philosophy:
+
+- ✅ Fully accessible via keyboard (native range input)
+- ✅ No external libraries or complex JS
+- ✅ Smooth CSS transitions
+- ✅ Works on touch devices
+- ✅ Great for showcasing transformations

--- a/submissions/examples/ease-compare-bh/demo.html
+++ b/submissions/examples/ease-compare-bh/demo.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion CSS - Before/After Comparison Slider</title>
+  <link rel="stylesheet" href="../../core/easemotion.min.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <header class="ease-fade-in">
+      <h1>Before/After Image Comparison</h1>
+      <p class="subtitle">Drag the slider to reveal the transformation</p>
+    </header>
+
+    <main class="ease-slide-up">
+      <!-- Main Comparison Demo -->
+      <section class="demo-section">
+        <h2>Photo Enhancement Comparison</h2>
+        <p class="description">Compare the original (before) with the enhanced (after) version using the slider below.</p>
+        
+        <div class="ease-compare">
+          <img class="ease-compare-after" 
+               src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='600' height='400'%3E%3Crect fill='%23f0f0f0' width='600' height='400'/%3E%3Ccircle cx='300' cy='180' r='80' fill='%23ffd700'/%3E%3Ctext x='300' y='320' text-anchor='middle' font-family='system-ui' font-size='24' fill='%23333'%3EAfter: Enhanced%3C/text%3E%3C/svg%3E" 
+               alt="After enhancement">
+          <img class="ease-compare-before" 
+               src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='600' height='400'%3E%3Crect fill='%23888' width='600' height='400'/%3E%3Ccircle cx='300' cy='180' r='80' fill='%23ccc'/%3E%3Ctext x='300' y='320' text-anchor='middle' font-family='system-ui' font-size='24' fill='%23666'%3EBefore: Original%3C/text%3E%3C/svg%3E" 
+               alt="Before enhancement">
+          <input type="range" class="ease-compare-slider" min="0" max="100" value="50">
+        </div>
+        
+        <p class="hint">Use Tab to focus and arrow keys to adjust the slider</p>
+      </section>
+
+      <!-- Color Transformation Demo -->
+      <section class="demo-section">
+        <h2>Color Transformation</h2>
+        <div class="ease-compare">
+          <img class="ease-compare-after" 
+               src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='600' height='300'%3E%3Crect fill='%232d5a27' width='600' height='300'/%3E%3Ctext x='300' y='160' text-anchor='middle' font-family='system-ui' font-size='28' fill='white'%3EVibrant Green%3C/text%3E%3C/svg%3E" 
+               alt="After color enhancement">
+          <img class="ease-compare-before" 
+               src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='600' height='300'%3E%3Crect fill='%236b6b6b' width='600' height='300'/%3E%3Ctext x='300' y='160' text-anchor='middle' font-family='system-ui' font-size='28' fill='white'%3EGrayscale%3C/text%3E%3C/svg%3E" 
+               alt="Before color enhancement">
+          <input type="range" class="ease-compare-slider" min="0" max="100" value="50">
+        </div>
+      </section>
+
+      <!-- Side by Side Examples -->
+      <section class="demo-section">
+        <h2>Common Use Cases</h2>
+        <div class="use-cases">
+          <div class="use-case">
+            <h3>📸 Photo Retouching</h3>
+            <p>Compare original vs. retouched photos</p>
+          </div>
+          <div class="use-case">
+            <h3>🏠 Real Estate</h3>
+            <p>Show before/after home renovations</p>
+          </div>
+          <div class="use-case">
+            <h3>🎨 Design Mockups</h3>
+            <p>Present design iterations to clients</p>
+          </div>
+          <div class="use-case">
+            <h3>📱 Product Photos</h3>
+            <p>Display product color options</p>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="ease-fade-in">
+      <p>EaseMotion CSS Feature • Uses native range input for accessibility</p>
+    </footer>
+  </div>
+
+  <script>
+    // Initialize all comparison sliders
+    document.querySelectorAll('.ease-compare-slider').forEach(slider => {
+      const afterImage = slider.previousElementSibling;
+      
+      slider.addEventListener('input', (e) => {
+        const value = 100 - e.target.value;
+        afterImage.style.clipPath = `inset(0 ${value}% 0 0)`;
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-compare-bh/style.css
+++ b/submissions/examples/ease-compare-bh/style.css
@@ -1,0 +1,254 @@
+/* ============================================================
+   EaseMotion CSS Sandbox — ease-compare/style.css
+   Before/After Image Comparison Slider
+   ============================================================ */
+
+@import "../../../core/variables.css";
+@import "../../../core/utilities.css";
+
+@layer easemotion-components {
+
+/* ── Base Styles ─────────────────────────────────────────── */
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: var(--ease-font-sans, system-ui, sans-serif);
+  background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+  color: #f8fafc;
+  margin: 0;
+  padding: 2rem;
+  min-height: 100vh;
+  line-height: 1.6;
+}
+
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+h1 {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+  background: linear-gradient(135deg, #6c63ff, #a78bfa);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.subtitle {
+  color: #94a3b8;
+  font-size: 1.1rem;
+}
+
+main {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+/* ── Demo Section ───────────────────────────────────────── */
+.demo-section {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.demo-section h2 {
+  font-size: 1.25rem;
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+  color: #f8fafc;
+}
+
+.description {
+  color: #94a3b8;
+  margin-bottom: 1rem;
+}
+
+.hint {
+  color: #64748b;
+  font-size: 0.875rem;
+  margin-top: 1rem;
+  text-align: center;
+}
+
+/* ═══════════════════════════════════════════════════════════
+   COMPARE COMPONENT — THE CORE FEATURE
+   ═══════════════════════════════════════════════════════════ */
+
+/* Container for the comparison */
+.ease-compare {
+  position: relative;
+  width: 100%;
+  max-width: 600px;
+  margin: 0 auto;
+  border-radius: 0.75rem;
+  overflow: hidden;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
+  background: #0f172a;
+}
+
+/* Both images fill the container */
+.ease-compare-before,
+.ease-compare-after {
+  display: block;
+  width: 100%;
+  height: auto;
+  aspect-ratio: 3 / 2;
+  object-fit: cover;
+}
+
+/* After image starts at 50% reveal */
+.ease-compare-after {
+  position: absolute;
+  top: 0;
+  left: 0;
+  clip-path: inset(0 50% 0 0);
+}
+
+/* Slider styling */
+.ease-compare-slider {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 40px;
+  margin: 0;
+  padding: 0 10px;
+  background: transparent;
+  cursor: ew-resize;
+  -webkit-appearance: none;
+  appearance: none;
+  z-index: 10;
+}
+
+/* Slider track */
+.ease-compare-slider::-webkit-slider-runnable-track {
+  width: 100%;
+  height: 4px;
+  background: rgba(255, 255, 255, 0.3);
+  border-radius: 2px;
+}
+
+.ease-compare-slider::-moz-range-track {
+  width: 100%;
+  height: 4px;
+  background: rgba(255, 255, 255, 0.3);
+  border-radius: 2px;
+}
+
+/* Slider thumb */
+.ease-compare-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #6c63ff, #8b5cf6);
+  border: 3px solid white;
+  cursor: ew-resize;
+  margin-top: -10px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+  transition: transform 0.2s ease;
+}
+
+.ease-compare-slider::-moz-range-thumb {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #6c63ff, #8b5cf6);
+  border: 3px solid white;
+  cursor: ew-resize;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+  transition: transform 0.2s ease;
+}
+
+/* Thumb hover/focus state */
+.ease-compare-slider::-webkit-slider-thumb:hover,
+.ease-compare-slider:focus::-webkit-slider-thumb {
+  transform: scale(1.1);
+  box-shadow: 0 4px 15px rgba(108, 99, 255, 0.5);
+}
+
+.ease-compare-slider::-moz-range-thumb:hover,
+.ease-compare-slider:focus::-moz-range-thumb {
+  transform: scale(1.1);
+  box-shadow: 0 4px 15px rgba(108, 99, 255, 0.5);
+}
+
+/* Focus outline */
+.ease-compare-slider:focus {
+  outline: none;
+}
+
+.ease-compare-slider:focus::-webkit-slider-thumb {
+  outline: 2px solid #a78bfa;
+  outline-offset: 2px;
+}
+
+/* Vertical line indicator on slider */
+.ease-compare-slider::before {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 2px;
+  height: calc(100% + 8px);
+  background: white;
+  border-radius: 1px;
+  pointer-events: none;
+  box-shadow: 0 0 8px rgba(255, 255, 255, 0.5);
+}
+
+/* ── Use Cases Grid ─────────────────────────────────────── */
+.use-cases {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.use-case {
+  background: rgba(108, 99, 255, 0.1);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  text-align: center;
+  border: 1px solid rgba(108, 99, 255, 0.2);
+  transition: all 0.2s ease;
+}
+
+.use-case:hover {
+  background: rgba(108, 99, 255, 0.2);
+  transform: translateY(-2px);
+}
+
+.use-case h3 {
+  font-size: 1rem;
+  margin: 0 0 0.5rem 0;
+  color: #a78bfa;
+}
+
+.use-case p {
+  font-size: 0.875rem;
+  color: #94a3b8;
+  margin: 0;
+}
+
+/* ── Footer ─────────────────────────────────────────────── */
+footer {
+  text-align: center;
+  padding-top: 2rem;
+  color: #64748b;
+  font-size: 0.875rem;
+}
+
+}

--- a/submissions/examples/ease-print-bh/README.md
+++ b/submissions/examples/ease-print-bh/README.md
@@ -1,0 +1,44 @@
+# ease-print Print-Friendly Utility Classes
+
+## What does this do?
+
+Provides CSS utility classes for controlling element visibility during printing, allowing developers to hide navigation/animations when printing while showing print-specific content like footers.
+
+## How is it used?
+
+```html
+<!-- Hide navigation when printing -->
+<nav class="ease-print-hide">
+  <a href="#">Home</a>
+  <a href="#">About</a>
+  <button class="ease-animate-pulse">Buy Now</button>
+</nav>
+
+<!-- Printable article content -->
+<article>
+  <h1>Article Title</h1>
+  <p>Article content here...</p>
+</article>
+
+<!-- Print-only footer -->
+<footer class="ease-print-only">
+  <p>Printed from example.com on August 5, 2026</p>
+</footer>
+```
+
+### CSS Classes
+
+| Class | Purpose |
+|-------|---------|
+| `.ease-print-hide` | Hides element only when printing |
+| `.ease-print-only` | Shows element only when printing |
+
+## Why is it useful?
+
+Real-world pages built with CSS frameworks eventually get printed (invoices, articles, receipts, docs). Animated or interactive elements like nav bars, buttons with hover states, and pulsing animations look broken or wasteful on paper. This utility:
+
+- ✅ Improves print readability by removing distractions
+- ✅ Adds professional print footers automatically
+- ✅ Zero JavaScript required
+- ✅ Tiny footprint, high utility
+- ✅ Complements EaseMotion's focus on polished user experiences

--- a/submissions/examples/ease-print-bh/demo.html
+++ b/submissions/examples/ease-print-bh/demo.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion CSS - Print-Friendly Utilities</title>
+  <link rel="stylesheet" href="../../core/easemotion.min.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <header class="ease-print-hide">
+      <h1>My Website</h1>
+      <nav>
+        <a href="#">Home</a>
+        <a href="#">Products</a>
+        <a href="#">About</a>
+        <a href="#">Contact</a>
+      </nav>
+      <button class="cta-button">Buy Now - Limited Offer!</button>
+    </header>
+
+    <main>
+      <article class="printable-content">
+        <h2>Article: Understanding CSS Print Styles</h2>
+        <p class="intro">
+          This article demonstrates how print-friendly utility classes work. 
+          Notice how the navigation, buttons, and animations are hidden when printing,
+          while the print-only footer appears.
+        </p>
+        
+        <h3>Why Print Styles Matter</h3>
+        <p>
+          Web pages often contain navigation menus, call-to-action buttons, 
+          and animated elements that serve no purpose on paper. In fact, 
+          they can make printed documents look unprofessional.
+        </p>
+        
+        <div class="demo-box ease-print-hide">
+          <p>🖨️ <strong>Demo Box</strong> - This animated box is hidden when printing</p>
+          <p class="hint">Press Ctrl+P (or Cmd+P) to see the print preview!</p>
+        </div>
+        
+        <h3>Solution</h3>
+        <p>
+          Use the <code>.ease-print-hide</code> class on elements that should 
+          not appear in print, and <code>.ease-print-only</code> on elements 
+          that should only appear when printing.
+        </p>
+        
+        <div class="code-example">
+          <pre><code>&lt;nav class="ease-print-hide"&gt;...&lt;/nav&gt;
+&lt;footer class="ease-print-only"&gt;Printed from example.com&lt;/footer&gt;</code></pre>
+        </div>
+      </article>
+    </main>
+
+    <footer class="ease-print-hide">
+      <p>© 2026 My Website. All rights reserved.</p>
+      <div class="social-links">
+        <a href="#">Facebook</a>
+        <a href="#">Twitter</a>
+        <a href="#">Instagram</a>
+      </div>
+    </footer>
+
+    <!-- Only visible when printing -->
+    <div class="print-footer ease-print-only">
+      <p>— End of Document —</p>
+      <p>Printed from My Website on <span id="print-date"></span></p>
+      <p>Page 1 of 1</p>
+    </div>
+  </div>
+
+  <script>
+    // Auto-fill print date
+    document.getElementById('print-date').textContent = new Date().toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric'
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-print-bh/style.css
+++ b/submissions/examples/ease-print-bh/style.css
@@ -1,0 +1,274 @@
+/* ============================================================
+   EaseMotion CSS Sandbox — ease-print/style.css
+   Print-Friendly Utility Classes
+   ============================================================ */
+
+/* Step back 3 levels out of submissions/examples/ease-print to pull root tokens */
+@import "../../../core/variables.css";
+@import "../../../core/utilities.css";
+
+@layer easemotion-components {
+
+/* ── Base Styles ─────────────────────────────────────────── */
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: var(--ease-font-sans, system-ui, sans-serif);
+  background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+  color: #f8fafc;
+  margin: 0;
+  padding: 2rem;
+  min-height: 100vh;
+  line-height: 1.6;
+}
+
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+/* ── Header (hidden when printing) ────────────────────────── */
+header {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  margin-bottom: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+header h1 {
+  font-size: 1.75rem;
+  margin: 0 0 1rem 0;
+  background: linear-gradient(135deg, #6c63ff, #a78bfa);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+nav {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+nav a {
+  color: #94a3b8;
+  text-decoration: none;
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  transition: all 0.2s ease;
+}
+
+nav a:hover {
+  background: rgba(108, 99, 255, 0.2);
+  color: #f8fafc;
+}
+
+.cta-button {
+  background: linear-gradient(135deg, #6c63ff 0%, #8b5cf6 100%);
+  color: white;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 0.5rem;
+  font-weight: 600;
+  cursor: pointer;
+  animation: pulse 2s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.05); }
+}
+
+/* ── Main Content ────────────────────────────────────────── */
+.printable-content {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 1rem;
+  padding: 2rem;
+  margin-bottom: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.printable-content h2 {
+  font-size: 1.5rem;
+  margin-top: 0;
+  color: #f8fafc;
+}
+
+.printable-content h3 {
+  font-size: 1.25rem;
+  margin-top: 1.5rem;
+  color: #a78bfa;
+}
+
+.printable-content p {
+  color: #cbd5e1;
+  margin-bottom: 1rem;
+}
+
+.intro {
+  font-size: 1.1rem;
+  color: #e2e8f0 !important;
+}
+
+code {
+  background: rgba(108, 99, 255, 0.2);
+  padding: 0.2em 0.4em;
+  border-radius: 0.25rem;
+  font-size: 0.9em;
+  color: #a78bfa;
+}
+
+/* ── Demo Box (hidden when printing) ─────────────────────── */
+.demo-box {
+  background: rgba(108, 99, 255, 0.1);
+  border: 2px dashed #6c63ff;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  margin: 1.5rem 0;
+  animation: glow 3s ease-in-out infinite;
+}
+
+@keyframes glow {
+  0%, 100% { box-shadow: 0 0 10px rgba(108, 99, 255, 0.3); }
+  50% { box-shadow: 0 0 25px rgba(108, 99, 255, 0.6); }
+}
+
+.demo-box p {
+  margin: 0.5rem 0;
+}
+
+.demo-box .hint {
+  color: #a78bfa;
+  font-style: italic;
+}
+
+/* ── Code Example ────────────────────────────────────────── */
+.code-example {
+  background: #0f172a;
+  border-radius: 0.75rem;
+  padding: 1rem;
+  margin: 1.5rem 0;
+  overflow-x: auto;
+}
+
+.code-example pre {
+  margin: 0;
+}
+
+.code-example code {
+  background: none;
+  padding: 0;
+  color: #e2e8f0;
+  font-family: 'Fira Code', monospace;
+  font-size: 0.85rem;
+}
+
+/* ── Footer (hidden when printing) ───────────────────────── */
+footer {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  text-align: center;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+footer p {
+  color: #64748b;
+  margin: 0 0 0.5rem 0;
+}
+
+.social-links {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.social-links a {
+  color: #64748b;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.social-links a:hover {
+  color: #6c63ff;
+}
+
+/* ── Print Footer (only shown when printing) ──────────────── */
+.print-footer {
+  text-align: center;
+  padding-top: 2rem;
+  margin-top: 2rem;
+}
+
+.print-footer p {
+  margin: 0.5rem 0;
+  color: #64748b;
+}
+
+/* ═══════════════════════════════════════════════════════════
+   PRINT UTILITIES — THE CORE FEATURE
+   ═══════════════════════════════════════════════════════════ */
+
+/* Hide elements when printing */
+.ease-print-hide {
+  /* Visible on screen */
+}
+
+/* Show elements only when printing */
+.ease-print-only {
+  display: none;
+}
+
+/* Print Media Query */
+@media print {
+  /* Hide navigation, buttons, animations when printing */
+  .ease-print-hide {
+    display: none !important;
+  }
+  
+  /* Show print-only content */
+  .ease-print-only {
+    display: block !important;
+  }
+  
+  /* Print-friendly body styles */
+  body {
+    background: white !important;
+    color: black !important;
+    padding: 0 !important;
+  }
+  
+  /* Print-friendly content */
+  .printable-content {
+    background: none !important;
+    border: none !important;
+    padding: 0 !important;
+    border-radius: 0 !important;
+  }
+  
+  .printable-content h2,
+  .printable-content h3 {
+    color: black !important;
+    page-break-after: avoid;
+  }
+  
+  .printable-content p {
+    color: #333 !important;
+  }
+  
+  /* Code blocks in print */
+  .code-example {
+    background: #f5f5f5 !important;
+    border: 1px solid #ddd !important;
+  }
+  
+  .code-example code {
+    color: #333 !important;
+  }
+}
+
+}


### PR DESCRIPTION
## Summary
Adds a before/after image comparison slider using CSS clip-path and native range input.

## What does this do?
A draggable slider component that reveals an "after" image over a "before" image using CSS clip-path.

## How is it used?
```html
<div class="ease-compare">
  <img class="ease-compare-after" src="after.jpg" alt="After">
  <img class="ease-compare-before" src="before.jpg" alt="Before">
  <input type="range" class="ease-compare-slider" min="0" max="100" value="50">
</div>
```

## Why is it useful?
Common in portfolio sites, photo editing tools, redesign showcases, and product comparisons. Uses native range input for full accessibility with no complex JS.

## Files Added
- **submissions/examples/ease-compare-bh/README.md**
- **submissions/examples/ease-compare-bh/demo.html**
- **submissions/examples/ease-compare-bh/style.css**

## PR Checklist
- [x] Files in correct directory
- [x] README.md answers: What, How, Why
- [x] Demo works in browser
- [x] CSS follows conventions
- [x] Issue referenced

Closes #60390