### PR TITLE
Add ease-slot-machine-lever-pull component

### DIFF
--- a/submissions/examples/slot-machine-lever-pull-ij/README.md
+++ b/submissions/examples/slot-machine-lever-pull-ij/README.md
@@ -1,0 +1,10 @@
+# ease-slot-machine-lever-pull
+
+A casino slot machine whose reels spin as the lever pulls.
+
+## Run
+Open `demo.html` directly in a browser to watch the reels spin.
+
+## Notes
+- The lever pulls on the side.
+- Reels stop on their symbols.

--- a/submissions/examples/slot-machine-lever-pull-ij/demo.html
+++ b/submissions/examples/slot-machine-lever-pull-ij/demo.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-slot-machine-lever-pull demo</title>
+</head>
+<body>
+<div class="sm-app">
+  <span class="sm-title">JACKPOT</span>
+  <div class="sm-cab">
+    <div class="sm-screen">
+      <span class="sm-reel sm-reel-1"><span class="sm-sym">7</span><span class="sm-sym">BAR</span><span class="sm-sym">CH</span><span class="sm-sym">7</span></span>
+      <span class="sm-reel sm-reel-2"><span class="sm-sym">BAR</span><span class="sm-sym">CH</span><span class="sm-sym">7</span><span class="sm-sym">BAR</span></span>
+      <span class="sm-reel sm-reel-3"><span class="sm-sym">CH</span><span class="sm-sym">7</span><span class="sm-sym">BAR</span><span class="sm-sym">CH</span></span>
+    </div>
+    <div class="sm-panel">
+      <button class="sm-btn">SPIN</button>
+      <span class="sm-pay">PAYLINE</span>
+    </div>
+  </div>
+  <div class="sm-lever"><span class="sm-rod"></span><span class="sm-ball"></span></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/slot-machine-lever-pull-ij/style.css
+++ b/submissions/examples/slot-machine-lever-pull-ij/style.css
@@ -1,0 +1,22 @@
+:root{--sm-cab:#3a1c3a;--sm-gold:#e8b84a;--sm-red:#d8403a}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#1c1430,#100a20);font-family:'Segoe UI',sans-serif}
+.sm-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#241844,#160e2e);box-shadow:0 16px 36px rgba(0,0,0,0.5)}
+.sm-title{position:absolute;top:16px;left:0;right:0;text-align:center;font-size:16px;font-weight:800;letter-spacing:9px;color:var(--sm-gold);text-shadow:0 0 12px rgba(232,184,74,0.7)}
+.sm-cab{position:absolute;top:60px;left:70px;width:200px;height:240px;border-radius:12px;background:var(--sm-cab);box-shadow:inset 0 0 0 8px #241024}
+.sm-screen{position:absolute;top:22px;left:22px;right:22px;height:86px;border-radius:8px;background:#f4e8d0;box-shadow:inset 0 0 0 6px #b8a888;display:flex;justify-content:space-around;align-items:center}
+.sm-reel{width:44px;height:70px;border-radius:4px;background:#fff;box-shadow:inset 0 0 0 4px #d8d0c0;overflow:hidden;animation:spin-reel-slot-machine-lever-pull 3s steps(1) infinite}
+.sm-reel-2{animation-delay:0.3s}
+.sm-reel-3{animation-delay:0.6s}
+.sm-sym{display:flex;align-items:center;justify-content:center;height:70px;font-size:20px;font-weight:800;color:var(--sm-red)}
+.sm-reel-2 .sm-sym{color:#3a7a3a}
+.sm-reel-3 .sm-sym{color:#3a5aa8}
+.sm-panel{position:absolute;bottom:20px;left:22px;right:22px;height:74px;border-radius:8px;background:#2a142a;box-shadow:inset 0 0 0 5px #180c18;display:flex;align-items:center;justify-content:space-around}
+.sm-btn{width:60px;height:30px;border:0;border-radius:6px;background:var(--sm-gold);color:#4a3410;font-size:12px;font-weight:800;cursor:pointer;animation:press-btn-slot-machine-lever-pull 3s ease-in-out infinite}
+.sm-pay{font-size:11px;font-weight:800;letter-spacing:2px;color:var(--sm-gold);animation:blink-pay-slot-machine-lever-pull 1.4s steps(2) infinite}
+.sm-lever{position:absolute;top:60px;right:42px;width:20px;height:140px}
+.sm-rod{position:absolute;left:8px;top:0;width:4px;height:110px;border-radius:2px;background:#a8aeb8;animation:pull-lever-slot-machine-lever-pull 3s ease-in-out infinite}
+.sm-ball{position:absolute;top:102px;left:0;width:20px;height:20px;border-radius:50%;background:var(--sm-red);box-shadow:inset 0 0 0 4px #b82c2a;animation:pull-lever-slot-machine-lever-pull 3s ease-in-out infinite}
+@keyframes spin-reel-slot-machine-lever-pull{0%,24%{transform:translateY(0)}32%{transform:translateY(-70px)}40%{transform:translateY(-70px)}48%{transform:translateY(-140px)}56%{transform:translateY(-140px)}64%{transform:translateY(-210px)}100%{transform:translateY(-210px)}}
+@keyframes pull-lever-slot-machine-lever-pull{0%,20%{transform:translateY(0)}36%{transform:translateY(36px)}56%{transform:translateY(36px)}72%{transform:translateY(0)}100%{transform:translateY(0)}}
+@keyframes press-btn-slot-machine-lever-pull{0%,100%{transform:translateY(0)}50%{transform:translateY(3px)}}
+@keyframes blink-pay-slot-machine-lever-pull{0%,100%{opacity:1}50%{opacity:0.2}}


### PR DESCRIPTION
## Component: ease-slot-machine-lever-pull — lever pulls, reels spin, and payline blinks

**Closes #61686**

### What this adds
A casino slot machine: the side lever pulls down, the three reels spin and stop on their symbols one by one, the SPIN button presses, and the PAYLINE blinks below the screen.

### Acceptance Criteria covered
- Lever pulls on the side
- Reels spin and stop
- Payline blinks below

### Files
- submissions/examples/slot-machine-lever-pull-ij/demo.html
- submissions/examples/slot-machine-lever-pull-ij/style.css
- submissions/examples/slot-machine-lever-pull-ij/README.md

### How to review
Open `demo.html` in a browser and watch the reels spin.