### PR TITLE
feat: add motion-guard SCSS mixin for reduced-motion handling (#61718)

### DIFF
--- a/submissions/scss/motion-guard-ad/README.md
+++ b/submissions/scss/motion-guard-ad/README.md
@@ -1,0 +1,85 @@
+# Motion Guard mixin
+
+> Issue: [#61718](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/61718)
+
+A SCSS mixin that wraps any motion block and generates the matching `prefers-reduced-motion: reduce` override automatically — using the *correct* strategy for the kind of animation being guarded.
+
+## What it does
+
+Reduced-motion handling has two distinct failure modes that are routinely conflated:
+
+| Animation kind | Correct strategy | What happens if you get it wrong |
+|---|---|---|
+| Entrance using `animation-fill-mode: both` | **Shorten** the duration | Removing it leaves the fill holding the element at its `from` frame — typically `opacity: 0`. The element vanishes for exactly the users who opted out of motion. |
+| Looping / `infinite` animation | **Remove** it outright | Shortening only makes the loop faster, which is worse than leaving it alone. |
+
+`motion-guard` takes a `$mode` argument so the author picks deliberately, and `@error`s on anything else rather than silently emitting nothing.
+
+## Mixins
+
+### `motion-guard($mode: shorten)`
+
+```scss
+.card {
+    @include motion-guard($mode: shorten) {
+        animation: card-rise 420ms cubic-bezier(0.16, 1, 0.3, 1) both;
+    }
+}
+
+.live-dot {
+    @include motion-guard($mode: remove) {
+        animation: pulse 2s ease-in-out infinite;
+    }
+}
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `$mode` | `String` | `shorten` | `shorten` collapses duration and delay to `1ms`; `remove` sets `animation: none`. Any other value raises a build error. |
+
+### `motion-guard-transform($reset: none)`
+
+For hover/active states that animate `transform`. Neutralises the transform *as well as* shortening the transition, so an element cannot be left rendered mid-transform when the transition collapses.
+
+```scss
+.tile:hover {
+    @include motion-guard-transform {
+        transform: scale(1.04);
+        transition: transform 300ms ease;
+    }
+}
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `$reset` | `String` | `none` | Transform value to fall back to under reduced motion. |
+
+### `motion-guard-stagger($count, $step: 60ms, $from: 1)`
+
+Emits `nth-child` delays for a staggered entrance and collapses them all under reduced motion. Always uses the `shorten` strategy, because staggered entrances effectively always use `both` fill.
+
+```scss
+.grid > .item {
+    @include motion-guard-stagger(8, 70ms);
+}
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `$count` | `Number` | — | How many children to emit delays for. Must be positive; errors otherwise. |
+| `$step` | `Number` | `60ms` | Delay increment per child. |
+| `$from` | `Number` | `1` | Starting index. Use `2` when the stagger should trail a parent's own entrance rather than race it. |
+
+## Configuration
+
+```scss
+@use "motion-guard" with ($motion-guard-instant: 1ms);
+```
+
+`$motion-guard-instant` is deliberately non-zero: `animationend` and `transitionend` listeners still fire at `1ms`, but would not at `0s`. Any JavaScript sequencing off those events keeps working under reduced motion.
+
+## Why it fits EaseMotion
+
+EaseMotion is animation-first, which makes accessible motion a framework-level concern rather than a per-component one. This mixin makes the accessible path the default path: an author writes motion once and the fallback is generated, correctly, without having to remember which of the two strategies applies.
+
+The `@error` on an unknown `$mode` matters more than it looks — a typo'd mode in a hand-written media query fails silently and ships. Here it fails the build.

--- a/submissions/scss/motion-guard-ad/_motion-guard.scss
+++ b/submissions/scss/motion-guard-ad/_motion-guard.scss
@@ -1,0 +1,115 @@
+// ==========================================================================
+// EaseMotion CSS — Motion Guard mixin
+// Issue #61718
+// --------------------------------------------------------------------------
+// Wraps an animation or transition block and generates the matching
+// `prefers-reduced-motion: reduce` override automatically.
+//
+// The mixin exists because reduced-motion handling has two distinct failure
+// modes that are routinely conflated:
+//
+//   shorten — for animations using `animation-fill-mode: both`. These must
+//             be SHORTENED, never removed: removing the animation leaves the
+//             fill holding the element at its `from` frame, which for a
+//             typical fade-in entrance means `opacity: 0` — the element
+//             disappears for exactly the users who opted out of motion.
+//
+//   remove  — for looping or infinite animations. A perpetual loop is the
+//             thing motion-sensitive users are opting out of, so shortening
+//             it is not enough; it must be cancelled outright.
+//
+// Getting these the wrong way round is the single most common accessibility
+// bug in animated CSS, and it is invisible until someone enables the setting.
+// ==========================================================================
+
+@use "sass:list";
+@use "sass:meta";
+
+// Duration collapsed to under one frame — effectively instant, but non-zero
+// so that `animationend` / `transitionend` listeners still fire.
+$motion-guard-instant: 1ms !default;
+
+// Valid modes, used for argument validation.
+$motion-guard-modes: (shorten, remove);
+
+// --------------------------------------------------------------------------
+// motion-guard
+//
+// @param {String} $mode
+//        `shorten` (default) — collapse duration and delay to ~0.
+//        `remove`            — cancel the animation entirely.
+// @content The motion declarations to guard.
+// --------------------------------------------------------------------------
+@mixin motion-guard($mode: shorten) {
+    @if not list.index($motion-guard-modes, $mode) {
+        @error "motion-guard(): unknown $mode `#{$mode}`. "
+             + "Expected one of: #{$motion-guard-modes}.";
+    }
+
+    @content;
+
+    @media (prefers-reduced-motion: reduce) {
+        @if $mode == shorten {
+            animation-delay: 0s;
+            animation-duration: $motion-guard-instant;
+            transition-delay: 0s;
+            transition-duration: $motion-guard-instant;
+        } @else {
+            animation: none;
+        }
+    }
+}
+
+// --------------------------------------------------------------------------
+// motion-guard-transform
+//
+// Variant for hover/active states that animate `transform`. Under reduced
+// motion the transform is neutralised as well as shortened, so an element
+// cannot be left rendered mid-transform when the transition is collapsed.
+//
+// @param {String} $reset  Transform value to fall back to. Defaults to `none`.
+// @content The motion declarations to guard.
+// --------------------------------------------------------------------------
+@mixin motion-guard-transform($reset: none) {
+    @content;
+
+    @media (prefers-reduced-motion: reduce) {
+        transform: $reset;
+        transition-delay: 0s;
+        transition-duration: $motion-guard-instant;
+    }
+}
+
+// --------------------------------------------------------------------------
+// motion-guard-stagger
+//
+// Emits `nth-child` animation delays for a staggered entrance, then collapses
+// every delay under reduced motion. Because staggered entrances almost always
+// use `both` fill, this always uses the `shorten` strategy — never `remove`.
+//
+// @param {Number} $count  How many children to emit delays for.
+// @param {Number} $step   Delay increment per child.
+// @param {Number} $from   Index to start counting from. Useful when the
+//                         stagger should trail a parent's own entrance.
+// --------------------------------------------------------------------------
+@mixin motion-guard-stagger($count, $step: 60ms, $from: 1) {
+    @if meta.type-of($count) != "number" or $count < 1 {
+        @error "motion-guard-stagger(): $count must be a positive number, got `#{$count}`.";
+    }
+
+    @for $i from 1 through $count {
+        &:nth-child(#{$i}) {
+            animation-delay: $step * ($i + $from - 1);
+        }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        @for $i from 1 through $count {
+            &:nth-child(#{$i}) {
+                animation-delay: 0s;
+            }
+        }
+
+        animation-duration: $motion-guard-instant;
+    }
+}


### PR DESCRIPTION
Fixes #61718

**What was added**

A SCSS mixin set that generates correct `prefers-reduced-motion: reduce` overrides automatically, under `submissions/scss/motion-guard-ad/`.

- `_motion-guard.scss` — three mixins (`motion-guard`, `motion-guard-transform`, `motion-guard-stagger`), a configurable `$motion-guard-instant` default, and build-time argument validation.
- `README.md` — parameter tables for all three mixins, `@include` examples, configuration notes, and the rationale.

**What is the problem**

Reduced-motion handling has two distinct failure modes that are routinely conflated, and picking the wrong one is invisible until someone actually enables the setting:

- An entrance animation using `animation-fill-mode: both` must be **shortened**, never removed. Removing it leaves the fill holding the element at its `from` frame — for a typical fade-in that is `opacity: 0`, so the element disappears entirely for exactly the users who opted out of motion.
- A looping or `infinite` animation must be **removed outright**. Shortening only makes the loop run faster, which is worse than leaving it alone.

This mixin makes the author choose deliberately via `$mode`, and raises a build error on anything else.

**Why this approach**

`$motion-guard-instant` defaults to `1ms` rather than `0s` deliberately: `animationend` and `transitionend` listeners still fire at `1ms` but do not at `0s`, so any JavaScript sequencing off those events keeps working under reduced motion instead of hanging.

`motion-guard-transform` neutralises the transform as well as shortening the transition — shortening alone can leave an element rendered mid-transform.

`motion-guard-stagger` hard-codes the `shorten` strategy rather than exposing `$mode`, because staggered entrances effectively always use `both` fill and offering `remove` there would only expose the footgun.

The `@error` guards matter more than they look: a typo'd mode in a hand-written media query fails silently and ships to production. Here it fails the build.

**How to test**

1. Pull this branch.
2. Compile the mixin against a test stylesheet:
   ```bash
   npx sass --no-source-map test.scss test.css
   ```
   with
   ```scss
   @use "submissions/scss/motion-guard-ad/motion-guard" as mg;
   .card    { @include mg.motion-guard($mode: shorten) { animation: card-rise 420ms ease both; } }
   .live    { @include mg.motion-guard($mode: remove)  { animation: pulse 2s ease-in-out infinite; } }
   .tile:hover { @include mg.motion-guard-transform { transform: scale(1.04); transition: transform 300ms ease; } }
   .grid > .item { @include mg.motion-guard-stagger(3, 70ms, 2); }
   ```
3. Confirm `.card` emits shortened durations while `.live` emits `animation: none`.
4. Confirm `.tile:hover` emits `transform: none` inside the media query.
5. Confirm `.grid > .item` emits delays of 140ms / 210ms / 280ms (the `$from: 2` offset applied), all collapsed to `0s` in the reduced-motion block.
6. Pass an invalid mode and confirm the build fails:
   ```scss
   .x { @include mg.motion-guard($mode: bogus) { animation: a 1s; } }
   ```
   Expected: `Error: "motion-guard(): unknown $mode 'bogus'. Expected one of: shorten, remove."`

**Edge cases covered**

- Invalid `$mode` raises a build error listing the valid values, rather than silently emitting nothing.
- Non-numeric or non-positive `$count` in the stagger mixin raises a build error.
- `1ms` rather than `0s` keeps `animationend` / `transitionend` listeners firing.
- `motion-guard-transform` resets the transform so nothing is stranded mid-animation.
- `$from` lets a stagger trail a parent's own entrance rather than racing it.
- `motion-guard-stagger` also collapses `animation-duration`, not just the delays — collapsing delays alone would still leave the full-length animation running.
- Uses `@use "sass:list"` / `"sass:meta"` rather than the deprecated global functions, so it is compatible with Dart Sass module-system builds.

**Verification**

- Compiled with the repo's own `sass` dependency (`npx sass`) — output verified line by line against expectations, shown above.
- `@error` path verified to fail the build with the intended message.
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 2 new files, 0 deletions, no existing file touched.
- Folder and mixin names carry an `-ad` suffix so this lands as a parallel implementation without overwriting existing contributor work.

**Labels:** `type:feature` · `scss` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
