### PR TITLE
feat: add easing-curve SCSS token function with build-time validation (#61719)

### DIFF
--- a/submissions/scss/easing-curve-ad/README.md
+++ b/submissions/scss/easing-curve-ad/README.md
@@ -1,0 +1,85 @@
+# Easing Curve function
+
+> Issue: [#61719](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/61719)
+
+A SCSS map plus accessor functions exposing EaseMotion's easing vocabulary as named tokens, with build-time validation.
+
+## What it does
+
+Resolves names like `spring`, `snap` and `decelerate` to their `cubic-bezier()` values, and fails the build on an unknown name.
+
+That last part is the whole point. A typo'd easing keyword in raw CSS — `transition: transform 300ms ease-ouy` — causes the browser to discard the **entire declaration**. The transition silently does not happen, and nothing in the build output or the console tells you. Resolving easings through a function converts that silent runtime failure into a loud build failure.
+
+Curve values mirror `EASING_MAP` in `easemotion/engine/parser.js`, so SCSS consumers and the runtime engine stay in agreement rather than drifting apart.
+
+## Functions
+
+### `easing-curve($name)`
+
+```scss
+.panel {
+    transition: transform 320ms easing-curve(spring);
+}
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `$name` | `String` | Token name, quoted or unquoted. Unknown names raise a build error listing every valid token. |
+
+Returns a `cubic-bezier()` value, or `linear`.
+
+### `has-easing($name)` → `Bool`
+
+Non-throwing membership test, for callers that prefer a fallback over a build failure.
+
+```scss
+$curve: if(has-easing($input), easing-curve($input), easing-curve(ease-out));
+```
+
+### `easing-names()` → `List`
+
+Every registered token name — useful for generating docs tables or utility classes.
+
+## Mixins
+
+### `register-easing($name, $curve)`
+
+Adds a project-specific easing. Refuses to overwrite an existing token, because silently shadowing `ease-out` project-wide from inside a partial is a debugging problem nobody enjoys.
+
+```scss
+@include register-easing("overshoot", cubic-bezier(0.2, 1.6, 0.4, 1));
+```
+
+### `easing-utilities($prefix: "ease-fn")`
+
+Emits one utility class per registered token.
+
+```scss
+@include easing-utilities("ease-fn");
+// → .ease-fn-spring { transition-timing-function: cubic-bezier(0.34, 1.56, 0.64, 1); }
+```
+
+## Available tokens
+
+| Token | Value |
+|---|---|
+| `ease` | `cubic-bezier(0.4, 0, 0.2, 1)` |
+| `ease-in` | `cubic-bezier(0.4, 0, 1, 1)` |
+| `ease-out` | `cubic-bezier(0, 0, 0.2, 1)` |
+| `ease-in-out` | `cubic-bezier(0.4, 0, 0.2, 1)` |
+| `linear` | `linear` |
+| `spring` | `cubic-bezier(0.34, 1.56, 0.64, 1)` |
+| `bounce` | `cubic-bezier(0.34, 1.56, 0.64, 1)` |
+| `snap` | `cubic-bezier(0.77, 0, 0.175, 1)` |
+| `decelerate` | `cubic-bezier(0.16, 1, 0.3, 1)` |
+| `accelerate` | `cubic-bezier(0.55, 0, 1, 0.45)` |
+
+## Configuration
+
+```scss
+@use "easing-curve" with ($easing-curves: ("ease-out": cubic-bezier(0, 0, 0.2, 1)));
+```
+
+## Why it fits EaseMotion
+
+EaseMotion is built on the idea that motion should be human-readable — `em="fade-in spring"` rather than a raw bezier. This brings the same vocabulary to SCSS consumers, so a stylesheet and an `em=""` attribute describing the same motion use the same word, and a mistyped word stops the build rather than silently dropping the animation.

--- a/submissions/scss/easing-curve-ad/_easing-curve.scss
+++ b/submissions/scss/easing-curve-ad/_easing-curve.scss
@@ -1,0 +1,108 @@
+// ==========================================================================
+// EaseMotion CSS — Easing Curve function
+// Issue #61719
+// --------------------------------------------------------------------------
+// Exposes EaseMotion's easing vocabulary as named SCSS tokens that resolve
+// to `cubic-bezier()` values, with build-time validation.
+//
+// The point of the `@error` is not tidiness. A typo'd easing keyword in raw
+// CSS — `transition: transform 300ms ease-ouy` — makes the browser discard
+// the entire declaration. The transition silently does not happen, and
+// nothing in the build or the console says so. Resolving easings through a
+// function turns that into a build failure instead.
+// ==========================================================================
+
+@use "sass:map";
+@use "sass:list";
+
+// --------------------------------------------------------------------------
+// Token map
+//
+// Values mirror the easings already used across the EaseMotion engine
+// (see easemotion/engine/parser.js EASING_MAP), so SCSS consumers and the
+// runtime engine stay in agreement rather than drifting apart.
+// --------------------------------------------------------------------------
+$easing-curves: (
+    "ease": cubic-bezier(0.4, 0, 0.2, 1),
+    "ease-in": cubic-bezier(0.4, 0, 1, 1),
+    "ease-out": cubic-bezier(0, 0, 0.2, 1),
+    "ease-in-out": cubic-bezier(0.4, 0, 0.2, 1),
+    "linear": linear,
+    "spring": cubic-bezier(0.34, 1.56, 0.64, 1),
+    "bounce": cubic-bezier(0.34, 1.56, 0.64, 1),
+    "snap": cubic-bezier(0.77, 0, 0.175, 1),
+    "decelerate": cubic-bezier(0.16, 1, 0.3, 1),
+    "accelerate": cubic-bezier(0.55, 0, 1, 0.45),
+) !default;
+
+// --------------------------------------------------------------------------
+// easing-curve($name)
+//
+// Resolve a named easing token to its CSS value.
+//
+// @param  {String} $name  Token name, quoted or unquoted.
+// @return {String}        A `cubic-bezier()` value or `linear`.
+// @throw  If the token is not defined.
+// --------------------------------------------------------------------------
+@function easing-curve($name) {
+    // Accept both quoted and unquoted tokens by normalising to a string.
+    $key: "#{$name}";
+
+    @if not map.has-key($easing-curves, $key) {
+        @error "easing-curve(): unknown easing `#{$key}`. "
+             + "Available: #{list.join((), map.keys($easing-curves), $separator: comma)}.";
+    }
+
+    @return map.get($easing-curves, $key);
+}
+
+// --------------------------------------------------------------------------
+// easing-names()
+//
+// @return {List} Every registered token name. Useful for generating
+//                utility classes or documentation tables.
+// --------------------------------------------------------------------------
+@function easing-names() {
+    @return map.keys($easing-curves);
+}
+
+// --------------------------------------------------------------------------
+// has-easing($name)
+//
+// Non-throwing membership test, for callers that want to fall back rather
+// than fail the build.
+//
+// @return {Bool}
+// --------------------------------------------------------------------------
+@function has-easing($name) {
+    @return map.has-key($easing-curves, "#{$name}");
+}
+
+// --------------------------------------------------------------------------
+// register-easing($name, $curve)
+//
+// Add a project-specific easing at build time. Refuses to silently clobber
+// an existing token — shadowing `ease-out` project-wide from a partial is a
+// debugging problem nobody enjoys.
+// --------------------------------------------------------------------------
+@mixin register-easing($name, $curve) {
+    @if map.has-key($easing-curves, $name) {
+        @error "register-easing(): `#{$name}` is already defined as "
+             + "#{map.get($easing-curves, $name)}. Pick a different name.";
+    }
+
+    $easing-curves: map.set($easing-curves, $name, $curve) !global;
+}
+
+// --------------------------------------------------------------------------
+// easing-utilities($prefix)
+//
+// Emit one utility class per registered token, e.g. `.ease-fn-spring`.
+// --------------------------------------------------------------------------
+@mixin easing-utilities($prefix: "ease-fn") {
+    @each $name, $curve in $easing-curves {
+        .#{$prefix}-#{$name} {
+            transition-timing-function: $curve;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #61719

**What was added**

A SCSS easing token map with accessor functions and build-time validation, under `submissions/scss/easing-curve-ad/`.

- `_easing-curve.scss` — a 10-token `$easing-curves` map, `easing-curve()` / `has-easing()` / `easing-names()` functions, plus `register-easing()` and `easing-utilities()` mixins.
- `README.md` — parameter tables, the full token table, configuration, and rationale.

**What is the problem**

A typo'd easing keyword in raw CSS causes the browser to discard the **entire declaration**:

```css
transition: transform 300ms ease-ouy;   /* the whole transition is dropped */
```

The animation silently does not happen. Nothing in the build output, and nothing in the console, reports it. This is a genuinely nasty class of bug because the failure is invisible at exactly the moment you would want to catch it.

Resolving easings through a function converts that silent runtime failure into a build failure that names the problem and lists every valid token.

**Why this approach**

Curve values deliberately mirror `EASING_MAP` in `easemotion/engine/parser.js`. SCSS consumers and the runtime engine therefore describe the same motion with the same word and get the same bezier, rather than drifting apart over time — `em="fade-in spring"` and `easing-curve(spring)` resolve identically.

`register-easing()` refuses to overwrite an existing token rather than merging silently. Shadowing `ease-out` project-wide from inside a partial is a debugging problem nobody enjoys, and an explicit error is cheaper than tracking that down later.

`has-easing()` exists as a non-throwing companion so callers taking dynamic input can fall back instead of failing the build — the strict path is the default, but it is not the only path.

**How to test**

1. Pull this branch.
2. Compile against a test stylesheet:
   ```scss
   @use "submissions/scss/easing-curve-ad/easing-curve" as ec;
   .panel { transition: transform 320ms ec.easing-curve(spring); }
   .fade  { transition: opacity 200ms ec.easing-curve("ease-out"); }
   @include ec.easing-utilities("ease-fn");
   ```
   ```bash
   npx sass --no-source-map test.scss test.css
   ```
3. Confirm `.panel` resolves to `cubic-bezier(0.34, 1.56, 0.64, 1)` and `.fade` to `cubic-bezier(0, 0, 0.2, 1)` — proving both unquoted and quoted tokens work.
4. Confirm ten `.ease-fn-*` utility classes are emitted.
5. Introduce a typo and confirm the build fails:
   ```scss
   .x { transition-timing-function: ec.easing-curve(ease-ouy); }
   ```
   Expected: `Error: "easing-curve(): unknown easing 'ease-ouy'. Available: ease, ease-in, ease-out, ease-in-out, linear, spring, bounce, snap, decelerate, accelerate."`
6. Confirm the compile emits **zero deprecation warnings**.

**Edge cases covered**

- Unknown token raises a build error that lists every valid name, so the fix is immediate.
- Both quoted (`"ease-out"`) and unquoted (`spring`) tokens resolve, via string normalisation.
- `register-easing()` errors on collision rather than silently shadowing an existing token.
- `has-easing()` provides a non-throwing path for dynamic input.
- `linear` is stored as the bare keyword, not wrapped in a bezier, so it stays a valid `transition-timing-function` value.
- Uses the `sass:map` / `sass:list` module system rather than deprecated global functions.
- Avoids Sass's deprecated `if()` function entirely — the submission compiles with zero deprecation warnings against the repo's current Dart Sass version.
- `$easing-curves` is `!default`, so consumers can override the whole map via `@use ... with`.

**Verification**

- Compiled with the repo's own `sass` dependency — output verified value by value.
- Zero deprecation warnings (an earlier draft used `if()`; replaced with string interpolation).
- `@error` path verified to fail the build with the intended message.
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 2 new files, 0 deletions, no existing file touched.
- Folder carries an `-ad` suffix so this lands as a parallel implementation without overwriting existing contributor work.

**Labels:** `type:feature` · `scss` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
