### PR TITLE
feat: add gradient-border SCSS mixin with radius-aware masking (#61721)

### DIFF
--- a/submissions/scss/gradient-border-ad/README.md
+++ b/submissions/scss/gradient-border-ad/README.md
@@ -1,0 +1,68 @@
+# Gradient Border mixin
+
+> Issue: [#61721](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/61721)
+
+Animated and static gradient borders that respect `border-radius`, built with mask compositing rather than `border-image`.
+
+## What it does
+
+Paints a gradient into a border-width ring around an element, following the corner radius exactly. The animated variant sweeps the gradient continuously; the static variant emits no keyframes at all.
+
+## Setup
+
+Call the keyframes mixin **once**, at the top level of your stylesheet:
+
+```scss
+@include gradient-border-keyframes;
+```
+
+This emits the `@property` registration and the spin keyframes. It is separate from the border mixin so that using the border on twenty elements does not emit the keyframes twenty times.
+
+## Mixins
+
+### `gradient-border($width, $radius, $speed, $colors, $fallback)`
+
+```scss
+.feature-card {
+    @include gradient-border($width: 1px, $radius: 16px, $speed: 6s);
+}
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `$width` | `Number` | `1px` | Ring thickness. Errors if not a number. |
+| `$radius` | `Number` | `12px` | Corner radius. Should match the element's own. |
+| `$speed` | `Number` | `6s` | Rotation period. `0s` omits the animation entirely. |
+| `$colors` | `List` | cyan → indigo → pink → cyan | Gradient stops. Needs at least 2; first and last should match for a seamless loop. |
+| `$fallback` | `Color` | `rgba(148, 163, 184, 0.3)` | Solid colour used where mask compositing is unavailable. |
+
+### `gradient-border-static($width, $radius, $angle, $colors, $fallback)`
+
+Same ring, fixed angle, no animation and no keyframe dependency.
+
+```scss
+.chip {
+    @include gradient-border-static($width: 2px, $radius: 999px, $angle: 135deg);
+}
+```
+
+## Configuration
+
+```scss
+@use "gradient-border" with (
+    $gradient-border-speed: 8s,
+    $gradient-border-colors: (#34d399, #22d3ee, #34d399)
+);
+```
+
+## Why it fits EaseMotion
+
+**`border-image` is the obvious tool and the wrong one.** It ignores `border-radius` completely, so a gradient border on any rounded element renders as a hard-cornered rectangle. The mask approach fills both the border box and the padding box, then subtracts the padding box via `mask-composite: exclude` — leaving only the ring, which follows the radius exactly.
+
+**`@property` is what makes the animation possible at all.** Without registering `--gb-angle-ad` with `syntax: "<angle>"`, the browser treats it as an untyped string, and custom properties of unknown type are not interpolatable. The gradient would jump from `0deg` to `360deg` in a single step rather than sweeping. Registration is what turns it into a real animation.
+
+Animating the angle also avoids the common alternative — animating `background-position` across an oversized gradient image — which repaints a large surface every frame.
+
+The solid `border` is applied unconditionally *before* the `@supports` block, so the element is never border-less on engines without mask compositing; the enhanced path only sets `border-color: transparent` once it knows the ring will render.
+
+An infinitely rotating border is precisely the perpetual motion `prefers-reduced-motion` exists for, so it is **cancelled outright** rather than shortened — the gradient stays visible, it just stops moving. Under `forced-colors: active` the pseudo-element is dropped entirely, since high-contrast mode flattens gradients to solid blocks that would obscure the element.

--- a/submissions/scss/gradient-border-ad/_gradient-border.scss
+++ b/submissions/scss/gradient-border-ad/_gradient-border.scss
@@ -1,0 +1,174 @@
+// ==========================================================================
+// EaseMotion CSS — Gradient Border mixin
+// Issue #61721
+// --------------------------------------------------------------------------
+// Produces an animated gradient border using a mask-composited pseudo-element
+// rather than `border-image`.
+//
+// `border-image` is the obvious tool and the wrong one: it ignores
+// `border-radius` entirely, so a gradient border on any rounded element
+// renders as a hard-cornered rectangle. The mask approach paints the gradient
+// into a padding-box-subtracted ring, which follows the radius exactly.
+//
+// Animation is driven by rotating the gradient angle, not by animating
+// background-position on an oversized image, so nothing repaints a large
+// surface each frame.
+// ==========================================================================
+
+@use "sass:meta";
+@use "sass:list";
+
+$gradient-border-width: 1px !default;
+$gradient-border-radius: 12px !default;
+$gradient-border-speed: 6s !default;
+$gradient-border-colors: (#22d3ee, #818cf8, #f472b6, #22d3ee) !default;
+
+// --------------------------------------------------------------------------
+// gradient-border
+//
+// @param {Number} $width     Ring thickness.
+// @param {Number} $radius    Corner radius. Must match the element's own.
+// @param {Number} $speed     Rotation period. `0s` disables the animation.
+// @param {List}   $colors    Gradient stops. First and last should match for
+//                            a seamless loop.
+// @param {Color}  $fallback  Solid colour used where mask compositing is
+//                            unavailable.
+// --------------------------------------------------------------------------
+@mixin gradient-border(
+    $width: $gradient-border-width,
+    $radius: $gradient-border-radius,
+    $speed: $gradient-border-speed,
+    $colors: $gradient-border-colors,
+    $fallback: rgba(148, 163, 184, 0.3)
+) {
+    @if meta.type-of($width) != "number" {
+        @error "gradient-border(): $width must be a number, got `#{$width}`.";
+    }
+
+    @if list.length($colors) < 2 {
+        @error "gradient-border(): $colors needs at least 2 stops, got #{list.length($colors)}.";
+    }
+
+    border-radius: $radius;
+    position: relative;
+
+    // Baseline for engines without mask compositing — a plain solid border.
+    // Applied unconditionally so the element is never border-less.
+    border: $width solid $fallback;
+
+    @supports (mask-composite: exclude) or (-webkit-mask-composite: xor) {
+        border-color: transparent;
+
+        &::before {
+            border: $width solid transparent;
+            border-radius: inherit;
+            background: conic-gradient(from var(--gb-angle-ad, 0deg), $colors) border-box;
+            content: "";
+            inset: -$width;
+            pointer-events: none;
+            position: absolute;
+
+            // Paint only the ring: fill both boxes, then subtract the
+            // padding box, leaving the border box alone.
+            -webkit-mask:
+                linear-gradient(#000 0 0) padding-box,
+                linear-gradient(#000 0 0);
+            mask:
+                linear-gradient(#000 0 0) padding-box,
+                linear-gradient(#000 0 0);
+            -webkit-mask-composite: xor;
+            mask-composite: exclude;
+
+            @if $speed != 0s {
+                animation: gradient-border-spin-ad $speed linear infinite;
+            }
+        }
+    }
+
+    // An infinitely rotating border is exactly the kind of perpetual motion
+    // that `prefers-reduced-motion` exists for, so it is cancelled outright
+    // rather than shortened. The gradient itself remains visible.
+    @media (prefers-reduced-motion: reduce) {
+        &::before {
+            animation: none;
+        }
+    }
+
+    // High-contrast mode flattens gradients to solid blocks, which would
+    // obscure the element. Fall back to a system-coloured border.
+    @media (forced-colors: active) {
+        border-color: CanvasText;
+
+        &::before {
+            display: none;
+        }
+    }
+}
+
+// --------------------------------------------------------------------------
+// The angle is animated through a registered custom property. `@property`
+// is what makes an angle interpolatable at all — without registration the
+// browser treats `--gb-angle-ad` as an untyped string and the conic gradient
+// jumps from 0deg to 360deg instead of sweeping.
+// --------------------------------------------------------------------------
+@mixin gradient-border-keyframes {
+    @property --gb-angle-ad {
+        syntax: "<angle>";
+        inherits: false;
+        initial-value: 0deg;
+    }
+
+    @keyframes gradient-border-spin-ad {
+        to {
+            --gb-angle-ad: 360deg;
+        }
+    }
+}
+
+// --------------------------------------------------------------------------
+// gradient-border-static
+//
+// Non-animated variant for cases where a gradient outline is wanted without
+// any motion at all — avoids emitting the keyframes entirely.
+// --------------------------------------------------------------------------
+@mixin gradient-border-static(
+    $width: $gradient-border-width,
+    $radius: $gradient-border-radius,
+    $angle: 135deg,
+    $colors: $gradient-border-colors,
+    $fallback: rgba(148, 163, 184, 0.3)
+) {
+    border: $width solid $fallback;
+    border-radius: $radius;
+    position: relative;
+
+    @supports (mask-composite: exclude) or (-webkit-mask-composite: xor) {
+        border-color: transparent;
+
+        &::before {
+            border: $width solid transparent;
+            border-radius: inherit;
+            background: linear-gradient($angle, $colors) border-box;
+            content: "";
+            inset: -$width;
+            pointer-events: none;
+            position: absolute;
+            -webkit-mask:
+                linear-gradient(#000 0 0) padding-box,
+                linear-gradient(#000 0 0);
+            mask:
+                linear-gradient(#000 0 0) padding-box,
+                linear-gradient(#000 0 0);
+            -webkit-mask-composite: xor;
+            mask-composite: exclude;
+        }
+    }
+
+    @media (forced-colors: active) {
+        border-color: CanvasText;
+
+        &::before {
+            display: none;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #61721

**What was added**

Animated and static gradient-border mixins that respect `border-radius`, under `submissions/scss/gradient-border-ad/`.

- `_gradient-border.scss` — `gradient-border()`, `gradient-border-static()` and `gradient-border-keyframes()` mixins, four configurable `!default` variables, and argument validation.
- `README.md` — parameter tables, setup note, configuration, and rationale.

**What is the problem**

`border-image` is the obvious tool for a gradient border and it is the wrong one: **it ignores `border-radius` entirely**. A gradient border applied to any rounded card renders as a hard-cornered rectangle sitting behind the rounded content — visibly broken, and not fixable by tweaking values.

The workaround people reach for next — animating `background-position` across an oversized gradient image — repaints a large surface on every frame.

**Why this approach**

The ring is produced by filling both the border box and the padding box with a mask, then subtracting the padding box via `mask-composite: exclude`. What remains is exactly the border ring, and because it is a real box it follows `border-radius` precisely.

`@property` registration is what makes the animation work at all, not a nicety. Without declaring `--gb-angle-ad` with `syntax: "<angle>"`, the browser treats it as an untyped string, and custom properties of unknown type are **not interpolatable** — the conic gradient would jump from `0deg` to `360deg` in one step rather than sweeping. Registration turns a broken step into a real animation.

The keyframes and `@property` live in a **separate mixin** called once at the top level, so applying the border to twenty elements does not emit twenty copies of the keyframes.

The solid `border` is applied unconditionally *before* the `@supports` block, so the element is never border-less on engines without mask compositing. The enhanced path only sets `border-color: transparent` once it knows the ring will actually render — the ordering is what makes the fallback safe.

**How to test**

1. Pull this branch.
2. Compile against a test stylesheet:
   ```scss
   @use "submissions/scss/gradient-border-ad/gradient-border" as gb;
   @include gb.gradient-border-keyframes;
   .card { @include gb.gradient-border($width: 1px, $radius: 16px, $speed: 6s); }
   .chip { @include gb.gradient-border-static($width: 2px, $radius: 999px); }
   ```
   ```bash
   npx sass --no-source-map test.scss test.css
   ```
3. Confirm the `@property --gb-angle-ad` block and `@keyframes gradient-border-spin-ad` are emitted exactly once.
4. Confirm `.card` emits a solid fallback border *outside* the `@supports` block, and `border-color: transparent` *inside* it.
5. Render in a browser and confirm the gradient ring follows the 16px radius rather than squaring off at the corners.
6. Confirm the gradient sweeps smoothly rather than jumping — this is the `@property` registration working.
7. Confirm `.chip` emits no `animation` property and no keyframe reference.
8. Enable OS-level "reduce motion" — the gradient must remain visible but stop rotating.
9. Confirm the compile emits **zero deprecation warnings**.

**Edge cases covered**

- Ring follows `border-radius` exactly, which `border-image` cannot do.
- `@property` registration makes the angle interpolatable; without it the sweep would be a single jump.
- Keyframes are emitted once via a separate top-level mixin rather than per call site.
- Solid fallback border is applied before the `@supports` block, so the element is never border-less.
- `$speed: 0s` omits the `animation` declaration entirely rather than emitting a zero-duration animation.
- `gradient-border-static()` avoids the keyframe dependency completely for non-animated use.
- Non-numeric `$width` and fewer than two `$colors` both raise build errors.
- Reduced motion cancels the infinite rotation outright — shortening a loop only makes it faster.
- `forced-colors: active` drops the pseudo-element and restores a system-coloured border, since high-contrast flattens gradients to solid blocks.
- Both `-webkit-mask-composite: xor` and standard `mask-composite: exclude` are emitted for Safari compatibility.

**Verification**

- Compiled with the repo's own `sass` dependency — output verified declaration by declaration for both mixins.
- Zero deprecation warnings.
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 2 new files, 0 deletions, no existing file touched.
- Folder and keyframe/property names carry an `-ad` suffix so this lands as a parallel implementation without overwriting existing contributor work or colliding in the global keyframe namespace.

**Labels:** `type:feature` · `scss` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
