### PR TITLE
feat: add truncate-clamp SCSS mixin with max-height fallback (#61722)

### DIFF
--- a/submissions/scss/truncate-clamp-ad/README.md
+++ b/submissions/scss/truncate-clamp-ad/README.md
@@ -1,0 +1,65 @@
+# Truncate Clamp mixin
+
+> Issue: [#61722](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/61722)
+
+Multi-line text truncation with a real fallback, an optional gradient fade, and a responsive variant.
+
+## What it does
+
+Clamps text to a line count using `-webkit-line-clamp`, backed by a `max-height` ceiling derived from line-height so unsupported engines still bound the text instead of letting it overflow.
+
+## Mixins
+
+### `truncate-clamp($lines, $line-height, $fade)`
+
+```scss
+.card__copy {
+    @include truncate-clamp($lines: 3);
+}
+
+.card__title {
+    @include truncate-clamp($lines: 1);   // single-line ellipsis path
+}
+
+.card__copy--faded {
+    @include truncate-clamp($lines: 2, $fade: #101a2c);
+}
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `$lines` | `Number` | `3` | Lines to keep. `1` switches to the single-line ellipsis path. Must be positive. |
+| `$line-height` | `Number` | `1.5` | **Unitless.** Used to compute the `max-height` fallback; errors if a unit is supplied. |
+| `$fade` | `Color` | `transparent` | Set to your surface colour to enable the gradient fade. |
+
+### `truncate-clamp-responsive($map, $line-height)`
+
+```scss
+.card__copy {
+    @include truncate-clamp-responsive((
+        default: 2,
+        640px: 3,
+        1024px: 4
+    ));
+}
+```
+
+Emits the full rule set once for `default`, then only the line count and ceiling at each breakpoint — re-declaring the whole mixin per breakpoint would re-emit every fallback rule.
+
+## Configuration
+
+```scss
+@use "truncate-clamp" with ($truncate-clamp-line-height: 1.6);
+```
+
+## Why it fits EaseMotion
+
+**`-webkit-line-clamp` has a hard failure mode.** Where it is unsupported the declaration is ignored entirely and the text simply overflows its container, breaking the surrounding layout. Pairing it with a `max-height` ceiling means the text is bounded either way.
+
+The ordering is deliberate: `max-height` is declared *first*, then released inside `@supports (-webkit-line-clamp: 1)`. Where the real clamp works it does a better job — a fixed `max-height` can slice a descender on the final line — so the ceiling is only kept as the fallback path.
+
+The gradient fade is scoped the same way. It exists to make the hard `max-height` cut read as intentional; with a working clamp the ellipsis already signals truncation, so the fade is switched off rather than left dimming perfectly readable text.
+
+`$line-height` is required to be unitless and errors otherwise, because the `em`-based ceiling arithmetic is only correct for a unitless multiplier — silently accepting `24px` would produce a `36em` max-height and a wildly wrong result.
+
+Worth knowing: the clamp path requires `display: -webkit-box`, which resets the element's formatting context. If the clamped element also needs to be flex or grid, wrap the text in an inner element and clamp that instead.

--- a/submissions/scss/truncate-clamp-ad/_truncate-clamp.scss
+++ b/submissions/scss/truncate-clamp-ad/_truncate-clamp.scss
@@ -1,0 +1,123 @@
+// ==========================================================================
+// EaseMotion CSS — Truncate Clamp mixin
+// Issue #61722
+// --------------------------------------------------------------------------
+// Multi-line text truncation with a graceful fallback.
+//
+// `-webkit-line-clamp` is the standard approach and it has a hard failure
+// mode: where it is unsupported, the declaration is ignored entirely and the
+// text simply overflows its container, breaking the surrounding layout. It
+// also silently requires `display: -webkit-box`, which resets the element's
+// formatting context — a detail that catches people out when the clamped
+// element also needed to be flex or grid.
+//
+// This mixin pairs the clamp with a `max-height` ceiling derived from
+// line-height, so unsupported engines still bound the text, plus an optional
+// gradient fade so the cut reads as intentional rather than as a glitch.
+// ==========================================================================
+
+@use "sass:math";
+@use "sass:meta";
+
+$truncate-clamp-line-height: 1.5 !default;
+$truncate-clamp-fade-color: transparent !default;
+
+// --------------------------------------------------------------------------
+// truncate-clamp
+//
+// @param {Number} $lines        Number of lines to keep. `1` uses the
+//                               single-line ellipsis path instead.
+// @param {Number} $line-height  Unitless line-height, used to compute the
+//                               fallback max-height.
+// @param {Color}  $fade         Colour to fade into. Set to a real colour
+//                               (matching the surface) to enable the fade.
+// --------------------------------------------------------------------------
+@mixin truncate-clamp(
+    $lines: 3,
+    $line-height: $truncate-clamp-line-height,
+    $fade: $truncate-clamp-fade-color
+) {
+    @if meta.type-of($lines) != "number" or $lines < 1 {
+        @error "truncate-clamp(): $lines must be a positive number, got `#{$lines}`.";
+    }
+
+    @if math.is-unitless($line-height) == false {
+        @error "truncate-clamp(): $line-height must be unitless so the "
+             + "max-height fallback can be computed. Got `#{$line-height}`.";
+    }
+
+    line-height: $line-height;
+    overflow: hidden;
+
+    @if $lines == 1 {
+        // Single line does not need the box model at all, and ellipsis
+        // support is effectively universal.
+        white-space: nowrap;
+        text-overflow: ellipsis;
+    } @else {
+        // Fallback ceiling: applied first so it holds even when the clamp
+        // below is ignored. `em` keeps it tied to the element's own size.
+        max-height: #{$lines * $line-height}em;
+
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: $lines;
+
+        // Where the clamp IS supported, the max-height ceiling can cut a
+        // descender on the final line. Releasing it avoids that.
+        @supports (-webkit-line-clamp: 1) {
+            max-height: none;
+        }
+
+        @if $fade != transparent {
+            position: relative;
+
+            &::after {
+                background: linear-gradient(to right, rgba(0, 0, 0, 0), $fade 85%);
+                bottom: 0;
+                content: "";
+                height: #{$line-height}em;
+                pointer-events: none;
+                position: absolute;
+                right: 0;
+                width: 45%;
+            }
+
+            // The fade is only needed for the hard max-height cut. With a
+            // real clamp the ellipsis already signals truncation, so the
+            // gradient would just dim readable text.
+            @supports (-webkit-line-clamp: 1) {
+                &::after {
+                    display: none;
+                }
+            }
+        }
+    }
+}
+
+// --------------------------------------------------------------------------
+// truncate-clamp-responsive
+//
+// Different line counts per breakpoint — a card that shows three lines on
+// desktop usually wants two on mobile, and re-declaring the whole mixin at
+// each breakpoint re-emits every fallback rule.
+//
+// @param {Map} $map  Breakpoint (min-width) => line count. The `default`
+//                    key is emitted outside any media query.
+// --------------------------------------------------------------------------
+@mixin truncate-clamp-responsive($map, $line-height: $truncate-clamp-line-height) {
+    @each $breakpoint, $lines in $map {
+        @if $breakpoint == default {
+            @include truncate-clamp($lines, $line-height);
+        } @else {
+            @media (min-width: $breakpoint) {
+                -webkit-line-clamp: $lines;
+                max-height: #{$lines * $line-height}em;
+
+                @supports (-webkit-line-clamp: 1) {
+                    max-height: none;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #61722

**What was added**

Multi-line truncation mixins with a real fallback path, under `submissions/scss/truncate-clamp-ad/`.

- `_truncate-clamp.scss` — `truncate-clamp()` and `truncate-clamp-responsive()` mixins, two configurable `!default` variables, and argument validation.
- `README.md` — parameter tables, `@include` examples, configuration, and a formatting-context caveat.

**What is the problem**

`-webkit-line-clamp` has a hard failure mode: where it is unsupported the declaration is ignored **entirely**, and the text simply overflows its container. That does not degrade to "slightly too much text" — it breaks the surrounding layout, pushing siblings out of position.

It also silently requires `display: -webkit-box`, which resets the element's formatting context. If the clamped element also needed to be flex or grid, that quietly stops working, and the cause is not obvious from the symptom.

**Why this approach**

The mixin declares a `max-height` ceiling derived from line-height *first*, then releases it inside `@supports (-webkit-line-clamp: 1)`. Order matters: unsupported engines keep the ceiling and stay bounded; supporting engines drop it, because a fixed `max-height` can slice a descender on the final line and the real clamp handles that correctly.

The gradient fade is scoped the same way. It exists to make the hard `max-height` cut read as intentional rather than as a rendering glitch. With a working clamp the ellipsis already signals truncation, so the fade is switched off rather than left dimming perfectly readable text.

`$lines: 1` takes a different path entirely — `white-space: nowrap` plus `text-overflow: ellipsis`. A single line does not need the box model at all, and avoiding `-webkit-box` there means the formatting-context reset never applies to the most common case.

`$line-height` is required to be unitless and errors otherwise, because the `em`-based ceiling arithmetic is only correct for a unitless multiplier. Silently accepting `24px` would compute a `36em` max-height — a wildly wrong result that would look like a mixin bug rather than a caller mistake.

**How to test**

1. Pull this branch.
2. Compile against a test stylesheet:
   ```scss
   @use "submissions/scss/truncate-clamp-ad/truncate-clamp" as tc;
   .copy   { @include tc.truncate-clamp($lines: 3); }
   .title  { @include tc.truncate-clamp($lines: 1); }
   .faded  { @include tc.truncate-clamp($lines: 2, $fade: #101a2c); }
   .resp   { @include tc.truncate-clamp-responsive((default: 2, 640px: 3, 1024px: 4)); }
   ```
   ```bash
   npx sass --no-source-map test.scss test.css
   ```
3. Confirm `.copy` emits `max-height: 4.5em` (3 × 1.5) followed by a `@supports` block releasing it to `none`.
4. Confirm `.title` emits the `nowrap` + `ellipsis` path with **no** `-webkit-box`.
5. Confirm `.faded` emits the `::after` gradient plus a `@supports` block hiding it.
6. Confirm `.resp` emits the full rule set once, then only line-count and ceiling per breakpoint.
7. Pass a unit'd line-height and confirm the build fails:
   ```scss
   .x { @include tc.truncate-clamp($lines: 2, $line-height: 24px); }
   ```
8. Confirm the compile emits **zero deprecation warnings**.

**Edge cases covered**

- `max-height` ceiling keeps text bounded where `-webkit-line-clamp` is unsupported, preventing layout-breaking overflow.
- Ceiling is released under `@supports`, so the real clamp is not fighting a fixed height that could slice descenders.
- `$lines: 1` avoids `-webkit-box` entirely, so the formatting-context reset never applies to the single-line case.
- Gradient fade is suppressed where the real clamp works, so it never dims readable text.
- Unit'd `$line-height` raises a build error rather than producing silently wrong arithmetic.
- Non-positive or non-numeric `$lines` raises a build error.
- The responsive variant emits fallback rules once rather than per breakpoint.
- The fade `::after` is `pointer-events: none`, so it never blocks text selection.
- Uses `sass:math` / `sass:meta` module functions rather than deprecated globals.

**Verification**

- Compiled with the repo's own `sass` dependency — all four call paths verified declaration by declaration.
- Zero deprecation warnings.
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 2 new files, 0 deletions, no existing file touched.
- Folder carries an `-ad` suffix so this lands as a parallel implementation without overwriting existing contributor work.

**Labels:** `type:feature` · `scss` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
