### PR TITLE
feat: add Kbd React component with platform-aware modifiers (#61723)

### DIFF
--- a/submissions/react/kbd-ad/Kbd.jsx
+++ b/submissions/react/kbd-ad/Kbd.jsx
@@ -1,0 +1,139 @@
+/**
+ * EaseMotion CSS — Kbd
+ * ============================================================
+ * Renders a keyboard shortcut as a row of styled key caps.
+ *
+ * Two things this handles that hand-rolled `<kbd>` markup usually does not:
+ *
+ *  1. Platform modifiers. `mod` resolves to ⌘ on Apple platforms and Ctrl
+ *     everywhere else, so a single shortcut definition is correct on both
+ *     rather than needing two branches at every call site.
+ *
+ *  2. Screen reader output. A row of separate <kbd> elements is announced as
+ *     disconnected glyphs — "command, shift, P" at best, and at worst the
+ *     symbol characters read as nothing at all. The whole shortcut is
+ *     exposed as a single readable label instead, with the visual caps
+ *     hidden from the accessibility tree.
+ *
+ * Styling comes from EaseMotion utility classes plus the accompanying
+ * style.css; no CSS-in-JS, no runtime style injection.
+ * ============================================================
+ */
+
+import { useMemo } from 'react';
+
+/** Glyph + spoken name for each recognised key token. */
+const KEY_MAP = {
+  mod: { mac: '⌘', other: 'Ctrl', label: { mac: 'Command', other: 'Control' } },
+  cmd: { mac: '⌘', other: '⌘', label: { mac: 'Command', other: 'Command' } },
+  ctrl: { mac: '⌃', other: 'Ctrl', label: { mac: 'Control', other: 'Control' } },
+  alt: { mac: '⌥', other: 'Alt', label: { mac: 'Option', other: 'Alt' } },
+  shift: { mac: '⇧', other: 'Shift', label: { mac: 'Shift', other: 'Shift' } },
+  enter: { mac: '↵', other: '↵', label: { mac: 'Enter', other: 'Enter' } },
+  esc: { mac: 'Esc', other: 'Esc', label: { mac: 'Escape', other: 'Escape' } },
+  tab: { mac: '⇥', other: 'Tab', label: { mac: 'Tab', other: 'Tab' } },
+  space: { mac: '␣', other: 'Space', label: { mac: 'Space', other: 'Space' } },
+  backspace: { mac: '⌫', other: '⌫', label: { mac: 'Backspace', other: 'Backspace' } },
+  up: { mac: '↑', other: '↑', label: { mac: 'Up arrow', other: 'Up arrow' } },
+  down: { mac: '↓', other: '↓', label: { mac: 'Down arrow', other: 'Down arrow' } },
+  left: { mac: '←', other: '←', label: { mac: 'Left arrow', other: 'Left arrow' } },
+  right: { mac: '→', other: '→', label: { mac: 'Right arrow', other: 'Right arrow' } },
+};
+
+/**
+ * Detect an Apple platform.
+ *
+ * Guarded for `window` being undefined so the component is safe to render
+ * during server-side rendering — without the guard this throws at import
+ * time in any SSR framework.
+ *
+ * Prefers `navigator.userAgentData.platform`, since `navigator.platform`
+ * is deprecated and increasingly frozen by browsers.
+ */
+function detectApplePlatform() {
+  if (typeof window === 'undefined' || typeof navigator === 'undefined') {
+    return false;
+  }
+
+  const modern = navigator.userAgentData?.platform;
+  if (typeof modern === 'string' && modern.length > 0) {
+    return /mac/i.test(modern);
+  }
+
+  return /mac|iphone|ipad|ipod/i.test(navigator.platform || navigator.userAgent || '');
+}
+
+/**
+ * @param {object}   props
+ * @param {string[]} props.keys      Key tokens, e.g. ['mod', 'shift', 'p'].
+ * @param {'sm'|'md'|'lg'} [props.size='md']
+ * @param {boolean}  [props.separator=false]  Render a '+' between caps.
+ * @param {boolean}  [props.isApple]  Override platform detection. Pass this
+ *                                    when rendering on a server so the
+ *                                    markup matches what the client expects.
+ * @param {string}   [props.className]
+ */
+export default function Kbd({
+  keys = [],
+  size = 'md',
+  separator = false,
+  isApple,
+  className = '',
+  ...rest
+}) {
+  const apple = useMemo(
+    () => (typeof isApple === 'boolean' ? isApple : detectApplePlatform()),
+    [isApple],
+  );
+
+  const resolved = useMemo(
+    () =>
+      keys.filter(Boolean).map((raw) => {
+        const token = String(raw).toLowerCase();
+        const entry = KEY_MAP[token];
+
+        if (!entry) {
+          // Unknown tokens are single characters like 'p' — uppercase the
+          // glyph for legibility but keep the spoken label as-is.
+          const glyph = String(raw).length === 1 ? String(raw).toUpperCase() : String(raw);
+          return { glyph, spoken: glyph };
+        }
+
+        return {
+          glyph: apple ? entry.mac : entry.other,
+          spoken: apple ? entry.label.mac : entry.label.other,
+        };
+      }),
+    [keys, apple],
+  );
+
+  if (resolved.length === 0) {
+    return null;
+  }
+
+  // One readable string for assistive tech; the caps themselves are hidden.
+  const spokenLabel = resolved.map((k) => k.spoken).join(' plus ');
+
+  const classes = ['ease-kbd-ad', `ease-kbd-ad--${size}`, className]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <span className={classes} {...rest}>
+      <span className="ease-kbd-ad__sr">{spokenLabel}</span>
+
+      <span className="ease-kbd-ad__caps" aria-hidden="true">
+        {resolved.map((key, index) => (
+          // Index is a safe key here: the list is derived positionally from
+          // `keys` and is never reordered or filtered after render.
+          <span className="ease-kbd-ad__group" key={`${key.glyph}-${index}`}>
+            {separator && index > 0 && (
+              <span className="ease-kbd-ad__sep">+</span>
+            )}
+            <kbd className="ease-kbd-ad__cap">{key.glyph}</kbd>
+          </span>
+        ))}
+      </span>
+    </span>
+  );
+}

--- a/submissions/react/kbd-ad/README.md
+++ b/submissions/react/kbd-ad/README.md
@@ -1,0 +1,65 @@
+# Kbd — keyboard shortcut hint
+
+> Issue: [#61723](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/61723)
+
+A React component that renders keyboard shortcuts as styled key caps, with platform-aware modifiers and a screen-reader-readable label.
+
+## Description
+
+Takes a list of key tokens and renders one `<kbd>` cap per key. The `mod` token resolves to ⌘ on Apple platforms and Ctrl elsewhere, so a single shortcut definition is correct on both without branching at the call site.
+
+The visual caps are `aria-hidden`, and the full shortcut is exposed separately as one readable string. A row of bare `<kbd>` elements is otherwise announced as disconnected glyphs — and symbol characters like ⌘ or ⇧ frequently read as nothing at all.
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `keys` | `string[]` | `[]` | Key tokens, e.g. `['mod', 'shift', 'p']`. Renders `null` if empty. |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | Cap size. |
+| `separator` | `boolean` | `false` | Render a `+` between caps. |
+| `isApple` | `boolean` | auto-detected | Override platform detection. Pass explicitly when server-rendering. |
+| `className` | `string` | `''` | Additional classes, merged onto the root. |
+
+Any other props are spread onto the root element.
+
+## Recognised tokens
+
+`mod` · `cmd` · `ctrl` · `alt` · `shift` · `enter` · `esc` · `tab` · `space` · `backspace` · `up` · `down` · `left` · `right`
+
+Anything else is treated as a literal key — single characters are uppercased for display.
+
+## Usage
+
+```jsx
+import Kbd from './Kbd';
+import './style.css';
+
+function CommandPalette() {
+  return (
+    <div>
+      <button type="button">
+        Open palette <Kbd keys={['mod', 'k']} size="sm" />
+      </button>
+
+      <p>Save the document with <Kbd keys={['mod', 's']} separator /></p>
+      <p>Dismiss with <Kbd keys={['esc']} /></p>
+    </div>
+  );
+}
+```
+
+### Server-side rendering
+
+Platform detection reads `navigator`, which does not exist on the server. The component guards for this and defaults to the non-Apple glyphs, but that means the server and client can render different markup and React will warn about a hydration mismatch. Pass `isApple` explicitly if you render on a server:
+
+```jsx
+<Kbd keys={['mod', 'k']} isApple={userAgentIsApple} />
+```
+
+## Why it fits EaseMotion
+
+Styling is entirely class-based — no CSS-in-JS and no runtime style injection — so it composes with the rest of the framework and can be restyled through the `--kbd-*` custom properties without touching the component.
+
+The press affordance is driven by `button:active .ease-kbd-ad__cap` rather than component state. The caps depress when the button documenting them is pressed, which is the behaviour you actually want, and it costs no re-renders.
+
+Platform detection prefers `navigator.userAgentData.platform` over the deprecated and increasingly frozen `navigator.platform`, falling back only when the modern API is unavailable. `prefers-reduced-motion` removes the press translation, and `forced-colors: active` gives caps system colours.

--- a/submissions/react/kbd-ad/style.css
+++ b/submissions/react/kbd-ad/style.css
@@ -1,0 +1,109 @@
+/* ==========================================================================
+   EaseMotion CSS — Kbd component styles
+   Issue #61723
+   ========================================================================== */
+
+.ease-kbd-ad {
+    --kbd-bg-ad: rgba(23, 34, 58, 0.95);
+    --kbd-face-ad: rgba(35, 48, 76, 0.98);
+    --kbd-border-ad: rgba(148, 163, 184, 0.28);
+    --kbd-text-ad: #e2e8f0;
+    --kbd-radius-ad: 6px;
+    --kbd-press-ad: 1px;
+
+    align-items: center;
+    display: inline-flex;
+    gap: 0.25rem;
+    line-height: 1;
+    vertical-align: middle;
+}
+
+/* Visually hidden but still announced — this carries the whole shortcut. */
+.ease-kbd-ad__sr {
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+}
+
+.ease-kbd-ad__caps {
+    align-items: center;
+    display: inline-flex;
+    gap: 0.25rem;
+}
+
+.ease-kbd-ad__group {
+    align-items: center;
+    display: inline-flex;
+    gap: 0.25rem;
+}
+
+.ease-kbd-ad__sep {
+    color: rgba(148, 163, 184, 0.7);
+    font-size: 0.72em;
+}
+
+.ease-kbd-ad__cap {
+    align-items: center;
+    background: linear-gradient(180deg, var(--kbd-face-ad), var(--kbd-bg-ad));
+    border: 1px solid var(--kbd-border-ad);
+    border-bottom-width: 2px;
+    border-radius: var(--kbd-radius-ad);
+    color: var(--kbd-text-ad);
+    display: inline-flex;
+    font-family: "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+    font-weight: 550;
+    justify-content: center;
+    transition:
+        border-bottom-width 90ms ease-out,
+        transform 90ms ease-out;
+}
+
+/* Press affordance — fires when an ancestor button is active, so the caps
+   depress along with the control they document. */
+button:active .ease-kbd-ad__cap,
+[role="button"]:active .ease-kbd-ad__cap {
+    border-bottom-width: 1px;
+    transform: translateY(var(--kbd-press-ad));
+}
+
+/* -- Sizes -- */
+.ease-kbd-ad--sm .ease-kbd-ad__cap {
+    font-size: 0.68rem;
+    min-width: 1.35rem;
+    padding: 0.15rem 0.3rem;
+}
+
+.ease-kbd-ad--md .ease-kbd-ad__cap {
+    font-size: 0.76rem;
+    min-width: 1.6rem;
+    padding: 0.22rem 0.4rem;
+}
+
+.ease-kbd-ad--lg .ease-kbd-ad__cap {
+    font-size: 0.88rem;
+    min-width: 1.9rem;
+    padding: 0.32rem 0.55rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .ease-kbd-ad__cap {
+        transition-duration: 1ms;
+    }
+
+    button:active .ease-kbd-ad__cap,
+    [role="button"]:active .ease-kbd-ad__cap {
+        transform: none;
+    }
+}
+
+@media (forced-colors: active) {
+    .ease-kbd-ad__cap {
+        background: Canvas;
+        border: 1px solid CanvasText;
+        color: CanvasText;
+    }
+}


### PR DESCRIPTION
Fixes #61723

**What was added**

A React keyboard-shortcut component, under `submissions/react/kbd-ad/`.

- `Kbd.jsx` — 125 non-empty lines: a 14-token key map with per-platform glyphs and spoken names, SSR-safe platform detection, memoised resolution, and the render.
- `style.css` — 95 non-empty lines: cap styling with a physical key face, three sizes, a press affordance, reduced-motion and forced-colors handling.
- `README.md` — props table, recognised tokens, usage, and an SSR caveat.

**What is the problem**

Two things hand-rolled `<kbd>` markup routinely gets wrong:

1. **Platform modifiers.** A shortcut is ⌘K on macOS and Ctrl+K everywhere else. Without a resolving layer, every call site needs its own branch — or, more commonly, ships one variant and is simply wrong for half the users.
2. **Screen reader output.** A row of separate `<kbd>` elements is announced as disconnected fragments, and the symbol characters (⌘, ⇧, ⌥, ⌫) frequently read as **nothing at all** — so the shortcut is silently invisible to screen reader users.

**Why this approach**

The visual caps are wrapped in `aria-hidden="true"` and the whole shortcut is exposed separately as one readable string ("Command plus Shift plus P"). This is the only reliable way to get correct announcement — hiding the glyphs and providing prose beats hoping the symbol font has accessible names.

Platform detection prefers `navigator.userAgentData.platform` over `navigator.platform`, which is deprecated and increasingly frozen or spoofed by browsers, falling back only when the modern API is absent.

Detection is guarded for `window`/`navigator` being undefined so the component does not throw at import time under SSR, and `isApple` is exposed as an explicit override so consumers can avoid a hydration mismatch. The README documents this rather than leaving it to be discovered.

The press affordance is `button:active .ease-kbd-ad__cap` — pure CSS, driven by the ancestor control rather than component state. The caps depress when the button documenting them is pressed, which is the behaviour you actually want, and it costs zero re-renders.

**How to test**

1. Pull this branch and drop `kbd-ad/` into any React app (React 16.8+ — the component uses hooks).
2. Render:
   ```jsx
   import Kbd from './Kbd';
   import './style.css';

   <button type="button">Open palette <Kbd keys={['mod', 'k']} size="sm" /></button>
   <p>Save with <Kbd keys={['mod', 's']} separator /></p>
   <p>Dismiss with <Kbd keys={['esc']} /></p>
   ```
3. On macOS confirm `mod` renders ⌘; on Windows/Linux confirm it renders `Ctrl`.
4. Force the other platform with `isApple={false}` / `isApple` and confirm the glyphs swap.
5. Inspect the DOM: the caps wrapper must be `aria-hidden="true"`, with a visually-hidden sibling containing the full spoken label.
6. Run a screen reader over it — the shortcut should be announced as one phrase, not as separate symbols.
7. Press and hold the containing button — the caps depress by 1px.
8. Render `<Kbd keys={[]} />` and confirm it returns `null` rather than an empty wrapper.
9. Enable OS-level "reduce motion" — the press translation is removed.

**Edge cases covered**

- Empty or all-falsy `keys` returns `null` instead of rendering an empty element.
- Unknown tokens fall through as literal keys; single characters are uppercased for display but keep their spoken form.
- `window` / `navigator` guards make the component safe to import under SSR rather than throwing at module scope.
- `isApple` override lets server-rendered output match the client and avoid a hydration mismatch.
- Deprecated `navigator.platform` is only a fallback, not the primary detection path.
- `useMemo` on both platform detection and key resolution keeps re-renders cheap.
- Extra props are spread onto the root, so callers can pass `id`, `title`, data attributes etc.
- `className` is merged rather than replaced, so consumer classes do not clobber component classes.
- Index-based React keys are used deliberately and the reason is documented inline — the list is positional and never reordered.
- `prefers-reduced-motion` removes the press translation; `forced-colors: active` gives caps system colours.

**Verification**

- `Kbd.jsx` parses cleanly through esbuild's JSX loader — zero errors or warnings.
- `npx stylelint style.css` against the repo's own config — zero errors.
- All 6 component classes referenced in the JSX are defined in `style.css`; all three size variants present.
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 3 new files, 0 deletions, no existing file touched.
- Component classes carry an `-ad` suffix so this lands as a parallel implementation without overwriting existing contributor work.

**Labels:** `type:feature` · `react` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
