### PR TITLE
feat: add EmptyState React component with variant-scoped ARIA (#61724)

### DIFF
--- a/submissions/react/empty-state-ad/EmptyState.jsx
+++ b/submissions/react/empty-state-ad/EmptyState.jsx
@@ -1,0 +1,120 @@
+/**
+ * EaseMotion CSS — EmptyState
+ * ============================================================
+ * The placeholder shown when a data view has nothing to render.
+ *
+ * The reason this is a component rather than ad-hoc markup: "empty",
+ * "no results" and "error" look nearly identical in most implementations
+ * but mean completely different things to the user, and each needs a
+ * different next action.
+ *
+ *   empty       — nothing exists yet. The action should CREATE something.
+ *   no-results  — things exist, the filter excluded them. The action should
+ *                 CLEAR the filter. Telling someone to "create your first
+ *                 project" when they have forty and mistyped a search is
+ *                 actively unhelpful.
+ *   error       — the fetch failed. The action should RETRY, and this one
+ *                 must be announced assertively because it is unexpected.
+ *
+ * Announcement is scoped to match: `role="alert"` for errors so it
+ * interrupts, `role="status"` otherwise so routine states do not.
+ * ============================================================
+ */
+
+import { useMemo } from 'react';
+
+/** Per-variant defaults: glyph, tone class, and ARIA wiring. */
+const VARIANTS = {
+  empty: {
+    glyph: '◇',
+    tone: 'empty',
+    role: 'status',
+    live: 'polite',
+    fallbackTitle: 'Nothing here yet',
+  },
+  'no-results': {
+    glyph: '⌕',
+    tone: 'neutral',
+    role: 'status',
+    live: 'polite',
+    fallbackTitle: 'No matching results',
+  },
+  error: {
+    glyph: '⚠',
+    tone: 'danger',
+    role: 'alert',
+    live: 'assertive',
+    fallbackTitle: 'Something went wrong',
+  },
+};
+
+/**
+ * @param {object} props
+ * @param {'empty'|'no-results'|'error'} [props.variant='empty']
+ * @param {string}    [props.title]        Falls back to a per-variant default.
+ * @param {string}    [props.description]
+ * @param {React.ReactNode} [props.icon]   Custom icon; replaces the glyph.
+ * @param {React.ReactNode} [props.action] Primary action node.
+ * @param {React.ReactNode} [props.secondaryAction]
+ * @param {'sm'|'md'} [props.size='md']
+ * @param {boolean}   [props.animate=true] Set false to skip the entrance.
+ * @param {string}    [props.className]
+ */
+export default function EmptyState({
+  variant = 'empty',
+  title,
+  description,
+  icon,
+  action,
+  secondaryAction,
+  size = 'md',
+  animate = true,
+  className = '',
+  ...rest
+}) {
+  // Unknown variants fall back to `empty` rather than crashing on an
+  // undefined lookup — a typo'd prop should degrade, not white-screen.
+  const config = VARIANTS[variant] ?? VARIANTS.empty;
+
+  const classes = useMemo(
+    () =>
+      [
+        'ease-empty-ad',
+        `ease-empty-ad--${size}`,
+        `ease-empty-ad--${config.tone}`,
+        animate ? 'ease-empty-ad--animate' : '',
+        className,
+      ]
+        .filter(Boolean)
+        .join(' '),
+    [size, config.tone, animate, className],
+  );
+
+  const heading = title ?? config.fallbackTitle;
+
+  return (
+    <div
+      className={classes}
+      role={config.role}
+      aria-live={config.live}
+      {...rest}
+    >
+      <div className="ease-empty-ad__icon" aria-hidden="true">
+        {icon ?? config.glyph}
+      </div>
+
+      <p className="ease-empty-ad__title">{heading}</p>
+
+      {description && (
+        <p className="ease-empty-ad__desc">{description}</p>
+      )}
+
+      {(action || secondaryAction) && (
+        <div className="ease-empty-ad__actions">
+          {action}
+          {secondaryAction}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/submissions/react/empty-state-ad/README.md
+++ b/submissions/react/empty-state-ad/README.md
@@ -1,0 +1,74 @@
+# EmptyState — empty state placeholder
+
+> Issue: [#61724](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/61724)
+
+A React component for the empty case of a data view, with a staggered entrance and variant-appropriate ARIA announcement.
+
+## Description
+
+Three variants that look similar but mean very different things — and each needs a different next action:
+
+| Variant | Meaning | The action should |
+|---|---|---|
+| `empty` | Nothing exists yet | **Create** something |
+| `no-results` | Things exist; the filter excluded them | **Clear** the filter |
+| `error` | The fetch failed | **Retry** |
+
+Collapsing these into one generic "no data" block is why users get told to "create your first project" when they have forty and mistyped a search.
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `variant` | `'empty' \| 'no-results' \| 'error'` | `'empty'` | Sets tone, glyph, fallback title and ARIA role. Unknown values fall back to `empty`. |
+| `title` | `string` | per-variant default | Heading text. |
+| `description` | `string` | — | Supporting copy. Omitted entirely if not passed. |
+| `icon` | `ReactNode` | per-variant glyph | Custom icon, replaces the default glyph. |
+| `action` | `ReactNode` | — | Primary action node. |
+| `secondaryAction` | `ReactNode` | — | Secondary action node. |
+| `size` | `'sm' \| 'md'` | `'md'` | Padding and icon scale. |
+| `animate` | `boolean` | `true` | Set `false` to skip the staggered entrance. |
+| `className` | `string` | `''` | Merged onto the root. |
+
+Any other props are spread onto the root element.
+
+## Usage
+
+```jsx
+import EmptyState from './EmptyState';
+import './style.css';
+
+// Nothing created yet
+<EmptyState
+  variant="empty"
+  title="No projects yet"
+  description="Create your first project to get started."
+  action={<button onClick={create}>New project</button>}
+/>
+
+// Filter excluded everything
+<EmptyState
+  variant="no-results"
+  title="No transactions match those filters"
+  description="Try widening the date range."
+  action={<button onClick={reset}>Reset filters</button>}
+/>
+
+// Fetch failed
+<EmptyState
+  variant="error"
+  description="We could not load your balances."
+  action={<button onClick={retry}>Retry</button>}
+  secondaryAction={<button onClick={contact}>Contact support</button>}
+/>
+```
+
+## Why it fits EaseMotion
+
+The entrance is applied to `> *:nth-child(n)` rather than to per-part classes, so icon, title, description and actions stagger correctly **regardless of which of them are actually rendered**. Because `description` and the action row are conditional, a class-per-part approach would leave gaps in the sequence whenever a part is omitted.
+
+ARIA announcement is scoped to the variant: `role="alert"` with `aria-live="assertive"` for errors, so a failed fetch interrupts; `role="status"` with `aria-live="polite"` otherwise, so a routine empty list does not. Announcing every empty view assertively trains users to ignore the alerts that matter.
+
+The entrance uses `animation-fill-mode: both`, so under `prefers-reduced-motion` it is **shortened to 1ms rather than removed** — removing it would leave the fill holding every child at `opacity: 0`, making the empty state invisible to exactly the users who opted out of motion.
+
+An unknown `variant` falls back to `empty` rather than crashing on an undefined lookup: a typo'd prop should degrade, not white-screen the view.

--- a/submissions/react/empty-state-ad/style.css
+++ b/submissions/react/empty-state-ad/style.css
@@ -1,0 +1,147 @@
+/* ==========================================================================
+   EaseMotion CSS — EmptyState component styles
+   Issue #61724
+   ========================================================================== */
+
+.ease-empty-ad {
+    --es-icon-ad: #64748b;
+    --es-icon-bg-ad: rgba(148, 163, 184, 0.1);
+    --es-title-ad: #f1f5f9;
+    --es-desc-ad: #94a3b8;
+    --es-step-ad: 70ms;
+    --es-ease-ad: cubic-bezier(0.16, 1, 0.3, 1);
+
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    text-align: center;
+}
+
+/* -- Tones -- */
+.ease-empty-ad--empty {
+    --es-icon-ad: #818cf8;
+    --es-icon-bg-ad: rgba(129, 140, 248, 0.12);
+}
+
+.ease-empty-ad--neutral {
+    --es-icon-ad: #64748b;
+    --es-icon-bg-ad: rgba(148, 163, 184, 0.1);
+}
+
+.ease-empty-ad--danger {
+    --es-icon-ad: #f87171;
+    --es-icon-bg-ad: rgba(248, 113, 113, 0.12);
+}
+
+/* -- Sizes -- */
+.ease-empty-ad--sm {
+    gap: 0.5rem;
+    padding: 1.75rem 1.25rem;
+}
+
+.ease-empty-ad--md {
+    gap: 0.65rem;
+    padding: 3rem 1.5rem;
+}
+
+.ease-empty-ad--sm .ease-empty-ad__icon {
+    font-size: 1.15rem;
+    height: 38px;
+    width: 38px;
+}
+
+.ease-empty-ad--md .ease-empty-ad__icon {
+    font-size: 1.5rem;
+    height: 52px;
+    width: 52px;
+}
+
+/* -- Parts -- */
+.ease-empty-ad__icon {
+    align-items: center;
+    background: var(--es-icon-bg-ad);
+    border-radius: 50%;
+    color: var(--es-icon-ad);
+    display: flex;
+    justify-content: center;
+    line-height: 1;
+    margin-bottom: 0.35rem;
+}
+
+.ease-empty-ad__title {
+    color: var(--es-title-ad);
+    font-size: 1rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    margin: 0;
+}
+
+.ease-empty-ad__desc {
+    color: var(--es-desc-ad);
+    font-size: 0.88rem;
+    margin: 0;
+    max-width: 42ch;
+}
+
+.ease-empty-ad__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    justify-content: center;
+    margin-top: 0.65rem;
+}
+
+/* ==========================================================================
+   Staggered entrance
+   --------------------------------------------------------------------------
+   Scoped to the --animate modifier so consumers can opt out entirely, and
+   applied to children by position so no extra classes are needed per part.
+   ========================================================================== */
+@keyframes easeEmptyRiseAd {
+    from {
+        opacity: 0;
+        transform: translateY(10px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.ease-empty-ad--animate > * {
+    animation: easeEmptyRiseAd 460ms var(--es-ease-ad) both;
+}
+
+.ease-empty-ad--animate > *:nth-child(1) {
+    animation-delay: calc(var(--es-step-ad) * 1);
+}
+
+.ease-empty-ad--animate > *:nth-child(2) {
+    animation-delay: calc(var(--es-step-ad) * 2);
+}
+
+.ease-empty-ad--animate > *:nth-child(3) {
+    animation-delay: calc(var(--es-step-ad) * 3);
+}
+
+.ease-empty-ad--animate > *:nth-child(4) {
+    animation-delay: calc(var(--es-step-ad) * 4);
+}
+
+/* The entrance uses `both` fill, so it is SHORTENED rather than removed —
+   removing it would hold every child at opacity 0 and render the empty
+   state invisible to exactly the users who opted out of motion. */
+@media (prefers-reduced-motion: reduce) {
+    .ease-empty-ad--animate > * {
+        animation-delay: 0s;
+        animation-duration: 1ms;
+    }
+}
+
+@media (forced-colors: active) {
+    .ease-empty-ad__icon {
+        border: 1px solid CanvasText;
+        color: CanvasText;
+    }
+}


### PR DESCRIPTION
Fixes #61724

**What was added**

A React empty-state component, under `submissions/react/empty-state-ad/`.

- `EmptyState.jsx` — 111 non-empty lines: a three-variant config map carrying glyph, tone, ARIA role and fallback title, memoised class composition, and conditional rendering of description and actions.
- `style.css` — 125 non-empty lines: three tones, two sizes, positional staggered entrance, reduced-motion and forced-colors handling.
- `README.md` — props table, a variant-semantics table, three usage examples, and rationale.

**What is the problem**

"Empty", "no results" and "error" look nearly identical in most implementations but mean completely different things, and each needs a **different next action**:

- `empty` — nothing exists yet; the action should **create**.
- `no-results` — things exist, the filter excluded them; the action should **clear the filter**.
- `error` — the fetch failed; the action should **retry**.

Collapsing them into one generic "no data" block is why users get told to "create your first project" when they have forty and simply mistyped a search.

**Why this approach**

The entrance is applied to `> *:nth-child(n)` rather than to per-part classes. This matters because `description` and the action row are **conditionally rendered** — with a class-per-part approach, omitting the description would leave a gap in the delay sequence and the stagger would visibly stutter. Positional selectors stay correct for every combination of rendered parts.

ARIA announcement is scoped to the variant: `role="alert"` + `aria-live="assertive"` for errors so a failed fetch interrupts, and `role="status"` + `aria-live="polite"` otherwise so a routine empty list does not. Announcing every empty view assertively trains users to ignore the alerts that actually matter.

An unknown `variant` falls back to `empty` via `??` rather than crashing on an undefined property lookup — a typo'd prop should degrade, not white-screen the view.

**How to test**

1. Pull this branch and drop `empty-state-ad/` into any React app (React 16.8+).
2. Render all three variants:
   ```jsx
   <EmptyState variant="empty" title="No projects yet" action={<button>New project</button>} />
   <EmptyState variant="no-results" description="Try widening the date range." action={<button>Reset filters</button>} />
   <EmptyState variant="error" action={<button>Retry</button>} secondaryAction={<button>Contact support</button>} />
   ```
3. Confirm each renders a distinct tone and glyph, and that omitting `title` produces a sensible per-variant default.
4. Inspect the DOM: the `error` variant must carry `role="alert"` / `aria-live="assertive"`; the others `role="status"` / `aria-live="polite"`.
5. Render one **without** a `description` and confirm the stagger has no gap — this is what the positional selectors buy.
6. Render with `animate={false}` and confirm no entrance animation is applied at all.
7. Pass `variant="bogus"` and confirm it degrades to the `empty` variant rather than throwing.
8. Enable OS-level "reduce motion" — **every child must still be visible**, appearing instantly.

**Edge cases covered**

- Positional `nth-child` stagger stays correct when description and/or actions are omitted.
- Unknown `variant` falls back to `empty` instead of throwing on an undefined lookup.
- Missing `title` falls back to a per-variant default rather than rendering an empty heading.
- The actions row is omitted entirely when neither action prop is passed, so no empty flex container is left behind.
- Reduced motion shortens rather than removes the entrance — `both` fill would otherwise hold every child at `opacity: 0` and render the component invisible.
- `animate={false}` skips the animation class entirely, for consumers who compose their own transitions.
- The icon is `aria-hidden`, since the title already carries the meaning.
- Extra props are spread onto the root; `className` is merged rather than replacing component classes.
- `forced-colors: active` gives the icon a system colour and an explicit border.

**Verification**

- `EmptyState.jsx` parses cleanly through esbuild's JSX loader — zero errors or warnings.
- `npx stylelint style.css` against the repo's own config — zero errors.
- All component classes referenced in the JSX are defined in `style.css`.
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 3 new files, 0 deletions, no existing file touched.
- Component classes carry an `-ad` suffix so this lands as a parallel implementation without overwriting existing contributor work.

**Labels:** `type:feature` · `react` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
