### PR TITLE
feat: add AvatarStack React component with full roster announcement (#61725)

### DIFF
--- a/submissions/react/avatar-stack-ad/AvatarStack.jsx
+++ b/submissions/react/avatar-stack-ad/AvatarStack.jsx
@@ -1,0 +1,142 @@
+/**
+ * EaseMotion CSS — AvatarStack
+ * ============================================================
+ * Overlapping avatar group that fans out on hover or focus.
+ *
+ * The accessibility problem this solves: an avatar stack that collapses to
+ * "+7" gives a screen reader user the number and nothing else. The seven
+ * people are visually present but semantically absent. Here the full member
+ * list is always exposed as readable text, and the visual stack — including
+ * the overflow chip — is hidden from the accessibility tree.
+ *
+ * Initials are derived rather than required, so a member with no avatar
+ * image still renders something meaningful instead of a broken <img>.
+ * ============================================================
+ */
+
+import { useMemo } from 'react';
+
+/**
+ * Derive up to two initials from a name.
+ * Falls back to '?' rather than an empty circle for unnamed members.
+ */
+function initialsFrom(name) {
+  if (typeof name !== 'string' || name.trim() === '') return '?';
+
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+/**
+ * Deterministic tone index from a name, so a given person keeps the same
+ * colour across renders and across pages. Math.random() would reshuffle on
+ * every render and make the list feel unstable.
+ */
+function toneFor(name, toneCount) {
+  const source = typeof name === 'string' ? name : '';
+  let hash = 0;
+
+  for (let i = 0; i < source.length; i += 1) {
+    hash = (hash * 31 + source.charCodeAt(i)) >>> 0;
+  }
+
+  return hash % toneCount;
+}
+
+const TONE_COUNT = 6;
+
+/**
+ * @param {object} props
+ * @param {Array<{id?: string|number, name: string, src?: string}>} props.members
+ * @param {number}  [props.max=4]     Avatars shown before collapsing to +N.
+ * @param {'sm'|'md'|'lg'} [props.size='md']
+ * @param {boolean} [props.fan=true]  Fan the stack out on hover/focus.
+ * @param {string}  [props.label='Team members']  Accessible group label.
+ * @param {string}  [props.className]
+ */
+export default function AvatarStack({
+  members = [],
+  max = 4,
+  size = 'md',
+  fan = true,
+  label = 'Team members',
+  className = '',
+  ...rest
+}) {
+  // A max below 1 would render only the overflow chip and hide everyone,
+  // so it is clamped rather than trusted.
+  const safeMax = Number.isFinite(max) && max >= 1 ? Math.floor(max) : 1;
+
+  const { shown, overflow, spokenList } = useMemo(() => {
+    const valid = members.filter((m) => m && typeof m === 'object');
+    const visible = valid.slice(0, safeMax);
+
+    return {
+      shown: visible,
+      overflow: Math.max(0, valid.length - visible.length),
+      spokenList: valid.map((m) => m.name || 'Unnamed member').join(', '),
+    };
+  }, [members, safeMax]);
+
+  if (shown.length === 0) {
+    return null;
+  }
+
+  const classes = [
+    'ease-avstack-ad',
+    `ease-avstack-ad--${size}`,
+    fan ? 'ease-avstack-ad--fan' : '',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div className={classes} {...rest}>
+      {/* The complete roster, always announced — not just the count. */}
+      <span className="ease-avstack-ad__sr">
+        {label}: {spokenList}
+      </span>
+
+      <span className="ease-avstack-ad__row" aria-hidden="true">
+        {shown.map((member, index) => (
+          <span
+            className="ease-avstack-ad__item"
+            key={member.id ?? `${member.name}-${index}`}
+            style={{ '--av-index-ad': index }}
+          >
+            {member.src ? (
+              <img
+                className="ease-avstack-ad__img"
+                src={member.src}
+                alt=""
+                loading="lazy"
+                decoding="async"
+              />
+            ) : (
+              <span
+                className={`ease-avstack-ad__initials ease-avstack-ad__initials--t${toneFor(
+                  member.name,
+                  TONE_COUNT,
+                )}`}
+              >
+                {initialsFrom(member.name)}
+              </span>
+            )}
+          </span>
+        ))}
+
+        {overflow > 0 && (
+          <span
+            className="ease-avstack-ad__item ease-avstack-ad__item--more"
+            style={{ '--av-index-ad': shown.length }}
+          >
+            <span className="ease-avstack-ad__initials">+{overflow}</span>
+          </span>
+        )}
+      </span>
+    </div>
+  );
+}

--- a/submissions/react/avatar-stack-ad/README.md
+++ b/submissions/react/avatar-stack-ad/README.md
@@ -1,0 +1,52 @@
+# AvatarStack — overlapping avatar group
+
+> Issue: [#61725](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/61725)
+
+A React component rendering an overlapping avatar group that fans out on hover or focus, collapsing past a `max` count into a `+N` chip.
+
+## Description
+
+Shows up to `max` avatars with a consistent overlap and separating ring. Members without an image get generated initials in a deterministic colour. Hovering or focusing the row spreads the stack so individual avatars become distinguishable.
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `members` | `Array<{ id?, name, src? }>` | `[]` | Member list. Renders `null` if empty. |
+| `max` | `number` | `4` | Avatars shown before collapsing. Clamped to a minimum of 1. |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | Avatar diameter and overlap. |
+| `fan` | `boolean` | `true` | Fan the stack out on hover/focus. |
+| `label` | `string` | `'Team members'` | Accessible group label, prefixed to the spoken roster. |
+| `className` | `string` | `''` | Merged onto the root. |
+
+Any other props are spread onto the root element.
+
+## Usage
+
+```jsx
+import AvatarStack from './AvatarStack';
+import './style.css';
+
+const team = [
+  { id: 1, name: 'Priya Raghavan', src: '/avatars/priya.jpg' },
+  { id: 2, name: 'Daniel Osei' },                    // renders "DO"
+  { id: 3, name: 'Mara Lindqvist', src: '/avatars/mara.jpg' },
+  { id: 4, name: 'Tomás Herrera' },
+  { id: 5, name: 'Ana Silva' },
+];
+
+<AvatarStack members={team} max={4} size="md" label="Project members" />
+// → four avatars + a "+1" chip
+```
+
+## Why it fits EaseMotion
+
+**The accessibility problem this exists to solve:** an avatar stack that collapses to "+7" gives a screen reader user the number and nothing else. The seven people are visually present but semantically absent. Here the entire roster — including collapsed members — is always exposed as readable text, and the visual row (chip included) is `aria-hidden`. Avatar images carry `alt=""` because the name is already announced; duplicating it would read every member twice.
+
+**Tone selection is deterministic**, hashed from the member's name rather than random. A given person keeps the same colour across renders and across pages. `Math.random()` would reshuffle on every render and make the list feel unstable.
+
+**The fan is index-driven.** Each avatar translates by `--av-fan-ad × --av-index-ad`, so the stack genuinely spreads rather than every avatar sliding the same distance. It is transform-only, so it never triggers layout.
+
+`z-index: calc(10 - var(--av-index-ad))` is required, not cosmetic — without it, DOM order makes later avatars stack *above* earlier ones, inverting the overlap direction and making the fan read backwards.
+
+A `@media (hover: none)` guard disables the fan on touch devices, where there is no hover-out event and the spread would latch open on first tap. `prefers-reduced-motion` removes the fan entirely, and `forced-colors: active` swaps the ring shadow for a real border, since `box-shadow` is dropped in high-contrast mode.

--- a/submissions/react/avatar-stack-ad/style.css
+++ b/submissions/react/avatar-stack-ad/style.css
@@ -1,0 +1,139 @@
+/* ==========================================================================
+   EaseMotion CSS — AvatarStack component styles
+   Issue #61725
+   ========================================================================== */
+
+.ease-avstack-ad {
+    --av-size-ad: 34px;
+    --av-overlap-ad: 10px;
+    --av-ring-ad: #0b1120;
+    --av-fan-ad: 4px;
+    --av-ease-ad: cubic-bezier(0.16, 1, 0.3, 1);
+
+    display: inline-block;
+}
+
+.ease-avstack-ad__sr {
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+}
+
+.ease-avstack-ad__row {
+    align-items: center;
+    display: inline-flex;
+}
+
+/* Negative margin creates the overlap; the ring separates neighbours.
+   `z-index` descends with the index so earlier avatars sit above later
+   ones — without it DOM order inverts the overlap and the fan reads
+   backwards. */
+.ease-avstack-ad__item {
+    border-radius: 50%;
+    box-shadow: 0 0 0 2px var(--av-ring-ad);
+    height: var(--av-size-ad);
+    position: relative;
+    width: var(--av-size-ad);
+    z-index: calc(10 - var(--av-index-ad, 0));
+    transition: transform 260ms var(--av-ease-ad);
+}
+
+.ease-avstack-ad__item + .ease-avstack-ad__item {
+    margin-left: calc(var(--av-overlap-ad) * -1);
+}
+
+.ease-avstack-ad__img,
+.ease-avstack-ad__initials {
+    border-radius: 50%;
+    display: block;
+    height: 100%;
+    object-fit: cover;
+    width: 100%;
+}
+
+.ease-avstack-ad__initials {
+    align-items: center;
+    background: rgba(148, 163, 184, 0.22);
+    color: #f1f5f9;
+    display: flex;
+    font-family: Inter, system-ui, sans-serif;
+    font-size: calc(var(--av-size-ad) * 0.36);
+    font-weight: 600;
+    justify-content: center;
+    letter-spacing: 0.01em;
+}
+
+/* Deterministic tone palette — index derived from the member's name. */
+.ease-avstack-ad__initials--t0 { background: rgba(129, 140, 248, 0.32); }
+.ease-avstack-ad__initials--t1 { background: rgba(34, 211, 238, 0.3); }
+.ease-avstack-ad__initials--t2 { background: rgba(52, 211, 153, 0.3); }
+.ease-avstack-ad__initials--t3 { background: rgba(251, 191, 36, 0.28); }
+.ease-avstack-ad__initials--t4 { background: rgba(244, 114, 182, 0.3); }
+.ease-avstack-ad__initials--t5 { background: rgba(167, 139, 250, 0.32); }
+
+.ease-avstack-ad__item--more .ease-avstack-ad__initials {
+    background: rgba(148, 163, 184, 0.16);
+    color: #94a3b8;
+    font-size: calc(var(--av-size-ad) * 0.32);
+}
+
+/* ==========================================================================
+   Fan-out
+   --------------------------------------------------------------------------
+   Each avatar shifts right by its own index, so the stack spreads instead
+   of every avatar moving the same distance. Transform only — no layout.
+   ========================================================================== */
+.ease-avstack-ad--fan .ease-avstack-ad__row:hover .ease-avstack-ad__item,
+.ease-avstack-ad--fan .ease-avstack-ad__row:focus-within .ease-avstack-ad__item {
+    transform: translateX(calc(var(--av-fan-ad) * var(--av-index-ad, 0)));
+}
+
+/* -- Sizes -- */
+.ease-avstack-ad--sm {
+    --av-size-ad: 26px;
+    --av-overlap-ad: 8px;
+}
+
+.ease-avstack-ad--md {
+    --av-size-ad: 34px;
+    --av-overlap-ad: 10px;
+}
+
+.ease-avstack-ad--lg {
+    --av-size-ad: 44px;
+    --av-overlap-ad: 13px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .ease-avstack-ad__item {
+        transition-duration: 1ms;
+    }
+
+    .ease-avstack-ad--fan .ease-avstack-ad__row:hover .ease-avstack-ad__item,
+    .ease-avstack-ad--fan .ease-avstack-ad__row:focus-within .ease-avstack-ad__item {
+        transform: none;
+    }
+}
+
+/* No hover-out event on touch, so the fan would latch open on first tap. */
+@media (hover: none) {
+    .ease-avstack-ad--fan .ease-avstack-ad__row:hover .ease-avstack-ad__item {
+        transform: none;
+    }
+}
+
+@media (forced-colors: active) {
+    .ease-avstack-ad__item {
+        border: 1px solid CanvasText;
+        box-shadow: none;
+    }
+
+    .ease-avstack-ad__initials {
+        background: Canvas;
+        color: CanvasText;
+    }
+}


### PR DESCRIPTION
Fixes #61725

**What was added**

A React overlapping avatar group, under `submissions/react/avatar-stack-ad/`.

- `AvatarStack.jsx` — 126 non-empty lines: initials derivation, a deterministic name-hash tone selector, memoised slicing and roster composition, and the render.
- `style.css` — 120 non-empty lines: overlap and ring geometry, six-tone palette, index-driven fan-out, three sizes, reduced-motion, `hover: none` and forced-colors handling.
- `README.md` — props table, usage, and rationale.

**What is the problem**

An avatar stack that collapses to "+7" gives a screen reader user **the number and nothing else**. The seven people are visually present but semantically absent — there is no way to find out who they are without leaving the page.

Secondary problem: implementations commonly assign avatar fallback colours randomly, so the same person changes colour on every render, and the group never becomes visually memorable.

**Why this approach**

The full roster — including every collapsed member — is always rendered as visually-hidden readable text, and the entire visual row (chip included) is `aria-hidden="true"`. Avatar images carry `alt=""` deliberately: the name is already announced in the roster, so a populated `alt` would read every member twice.

Tone selection hashes the member's name rather than using `Math.random()`, so a given person keeps the same colour across renders and across pages.

The fan is index-driven — each avatar translates by `--av-fan-ad × --av-index-ad`, so the stack genuinely spreads rather than every avatar sliding the same distance and preserving the overlap. Transform-only, so it never triggers layout.

`z-index: calc(10 - var(--av-index-ad))` is load-bearing, not cosmetic. Without it, DOM order puts later avatars *above* earlier ones, which inverts the overlap direction and makes the fan appear to spread backwards.

**How to test**

1. Pull this branch and drop `avatar-stack-ad/` into any React app (React 16.8+).
2. Render with more members than `max`:
   ```jsx
   <AvatarStack members={team} max={4} size="md" label="Project members" />
   ```
3. Confirm four avatars render plus a `+N` chip for the remainder.
4. Confirm members **without** a `src` render two-letter initials in a colour, and that reloading the page keeps each person's colour identical.
5. Hover the row — avatars spread apart progressively, not uniformly.
6. Inspect the DOM: a visually-hidden element must list **every** member including the collapsed ones; the visual row must be `aria-hidden="true"`.
7. Run a screen reader — the full roster should be announced, not "plus 1".
8. Pass `max={0}` and confirm it clamps to 1 rather than hiding everyone behind a chip.
9. Pass `members={[]}` and confirm it returns `null`.
10. Enable OS-level "reduce motion" — the fan is removed.

**Edge cases covered**

- Full roster is announced, including collapsed members — the core accessibility fix.
- `max` below 1, non-finite, or fractional is clamped and floored, so the component cannot render only an overflow chip.
- Empty or all-invalid `members` returns `null` rather than an empty ring.
- Members with no `name` fall back to `'?'` initials and `'Unnamed member'` in the roster, instead of an empty circle.
- Single-word names use the first two characters; multi-word names use first and last initial.
- Tone hashing is deterministic, so colours are stable across renders.
- `key` falls back to `name-index` when `id` is absent, rather than relying on array index alone.
- Images use `loading="lazy"` and `decoding="async"` so a large stack does not block render.
- `z-index` ordering keeps the overlap direction correct.
- `@media (hover: none)` disables the fan on touch, where there is no hover-out event and the spread would latch open.
- `forced-colors: active` swaps the ring `box-shadow` for a real border, since box-shadow is dropped entirely in high-contrast mode.

**Verification**

- `AvatarStack.jsx` parses cleanly through esbuild's JSX loader — zero errors or warnings.
- `npx stylelint style.css` against the repo's own config — zero errors (an initial run flagged a duplicate selector and quoted font name; both fixed).
- All component classes referenced in the JSX are defined in `style.css`.
- Tone parity verified: 6 `--t{n}` classes in CSS matches `TONE_COUNT = 6` in the JSX, so the hash can never select a missing class.
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 3 new files, 0 deletions, no existing file touched.
- Component classes carry an `-ad` suffix so this lands as a parallel implementation without overwriting existing contributor work.

**Labels:** `type:feature` · `react` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
