### PR TITLE
feat: add SegmentedControl React component with radiogroup semantics (#61726)

### DIFF
--- a/submissions/react/segmented-control-ad/README.md
+++ b/submissions/react/segmented-control-ad/README.md
@@ -1,0 +1,65 @@
+# SegmentedControl — animated segmented control
+
+> Issue: [#61726](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/61726)
+
+A React segmented control whose indicator slides between options, implemented as a WAI-ARIA radiogroup with full keyboard support.
+
+## Description
+
+Renders a track of options with a thumb that slides to the selected one. Arrow keys move selection, Home and End jump to the ends, and disabled options are skipped.
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `options` | `Array<{ value, label, disabled? }>` | `[]` | Options. Renders `null` if empty. |
+| `value` | `string` | — | Selected value. An unmatched value pins the indicator to the first slot. |
+| `onChange` | `(value: string) => void` | — | Called with the newly selected value. |
+| `size` | `'sm' \| 'md'` | `'md'` | Option padding and font size. |
+| `fullWidth` | `boolean` | `false` | Stretch to fill the container. |
+| `label` | `string` | `'View'` | Accessible group label. |
+| `className` | `string` | `''` | Merged onto the root. |
+
+Any other props are spread onto the root element.
+
+## Usage
+
+```jsx
+import SegmentedControl from './SegmentedControl';
+import './style.css';
+
+const [range, setRange] = useState('week');
+
+<SegmentedControl
+  label="Date range"
+  value={range}
+  onChange={setRange}
+  options={[
+    { value: 'day', label: 'Day' },
+    { value: 'week', label: 'Week' },
+    { value: 'month', label: 'Month' },
+    { value: 'year', label: 'Year', disabled: true },
+  ]}
+/>
+```
+
+## Keyboard
+
+| Key | Action |
+|---|---|
+| <kbd>Tab</kbd> | Enter/leave the group — **one** tab stop total |
+| <kbd>→</kbd> / <kbd>↓</kbd> | Next enabled option (wraps) |
+| <kbd>←</kbd> / <kbd>↑</kbd> | Previous enabled option (wraps) |
+| <kbd>Home</kbd> / <kbd>End</kbd> | First / last enabled option |
+
+## Why it fits EaseMotion
+
+**Radiogroup, not a button row.** A row of buttons puts every option in the tab sequence, so a keyboard user crossing a toolbar has to tab through all six range options to reach the next control. A radiogroup with roving `tabIndex` is a single tab stop, with arrow keys moving between options — which is also the interaction screen reader users are told to expect from the role.
+
+**The indicator needs no measurement.** Its width is `(100% - padding) / --seg-count-ad` and its offset is `translateX(100% × --seg-active-ad)` — position derived entirely from the option count and active index. No refs, no `getBoundingClientRect`, no `ResizeObserver`. It stays correct when the container resizes, when a webfont loads late and reflows the labels, and during server rendering where measurement is impossible.
+
+It is also transform-only, so sliding never triggers layout.
+
+**Forced-colors needs special handling.** The thumb is a background fill, and high-contrast mode discards backgrounds — the selected option would become indistinguishable from the rest. The `forced-colors` block swaps the fill for an `outline` on the indicator plus a `Highlight` text colour, both of which survive.
+
+The arrow-key walk skips disabled options and bails after a full loop, so an all-disabled option set cannot spin forever.

--- a/submissions/react/segmented-control-ad/SegmentedControl.jsx
+++ b/submissions/react/segmented-control-ad/SegmentedControl.jsx
@@ -1,0 +1,154 @@
+/**
+ * EaseMotion CSS — SegmentedControl
+ * ============================================================
+ * A segmented control with an indicator that slides between options.
+ *
+ * Implemented as a WAI-ARIA radiogroup rather than a row of buttons.
+ * That distinction is the point: a button row puts every option in the tab
+ * sequence, so a keyboard user tabbing through a toolbar has to pass
+ * through all six range options to reach the next control. A radiogroup
+ * takes ONE tab stop, and arrow keys move between options — which is also
+ * what screen reader users are told to expect from the role.
+ *
+ * The indicator is positioned with percentage transforms derived from the
+ * selected index, so it needs no measurement, no refs, and no resize
+ * observer — it stays correct when the container is resized, when fonts
+ * load late, and during SSR.
+ * ============================================================
+ */
+
+import { useCallback, useId, useRef } from 'react';
+
+/**
+ * @param {object} props
+ * @param {Array<{value: string, label: string, disabled?: boolean}>} props.options
+ * @param {string}   props.value
+ * @param {(value: string) => void} props.onChange
+ * @param {'sm'|'md'} [props.size='md']
+ * @param {boolean}  [props.fullWidth=false]
+ * @param {string}   [props.label='View'] Accessible group label.
+ * @param {string}   [props.className]
+ */
+export default function SegmentedControl({
+  options = [],
+  value,
+  onChange,
+  size = 'md',
+  fullWidth = false,
+  label = 'View',
+  className = '',
+  ...rest
+}) {
+  const groupId = useId();
+  const refs = useRef([]);
+
+  const selectedIndex = options.findIndex((o) => o.value === value);
+  // -1 would push the indicator off-canvas, so an unmatched value pins it
+  // to the first slot rather than rendering something visibly broken.
+  const activeIndex = selectedIndex >= 0 ? selectedIndex : 0;
+
+  /** Move selection to the next enabled option, wrapping at both ends. */
+  const move = useCallback(
+    (from, direction) => {
+      const count = options.length;
+      if (count === 0) return;
+
+      // Skip disabled options; bail after a full loop so an all-disabled
+      // set cannot spin forever.
+      for (let step = 1; step <= count; step += 1) {
+        const next = (from + direction * step + count * count) % count;
+        if (!options[next].disabled) {
+          onChange?.(options[next].value);
+          refs.current[next]?.focus();
+          return;
+        }
+      }
+    },
+    [options, onChange],
+  );
+
+  const handleKeyDown = useCallback(
+    (event) => {
+      switch (event.key) {
+        case 'ArrowRight':
+        case 'ArrowDown':
+          event.preventDefault();
+          move(activeIndex, 1);
+          break;
+        case 'ArrowLeft':
+        case 'ArrowUp':
+          event.preventDefault();
+          move(activeIndex, -1);
+          break;
+        case 'Home':
+          event.preventDefault();
+          move(-1, 1);
+          break;
+        case 'End':
+          event.preventDefault();
+          move(options.length, -1);
+          break;
+        default:
+          break;
+      }
+    },
+    [activeIndex, move, options.length],
+  );
+
+  if (options.length === 0) {
+    return null;
+  }
+
+  const classes = [
+    'ease-seg-ad',
+    `ease-seg-ad--${size}`,
+    fullWidth ? 'ease-seg-ad--full' : '',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div
+      className={classes}
+      role="radiogroup"
+      aria-label={label}
+      onKeyDown={handleKeyDown}
+      style={{ '--seg-count-ad': options.length }}
+      {...rest}
+    >
+      {/* Indicator is a sibling, not a child of any option, so it can slide
+          across the whole track independently of the labels. */}
+      <span
+        className="ease-seg-ad__indicator"
+        style={{ '--seg-active-ad': activeIndex }}
+        aria-hidden="true"
+      />
+
+      {options.map((option, index) => {
+        const isActive = index === activeIndex;
+
+        return (
+          <button
+            className="ease-seg-ad__option"
+            key={option.value}
+            id={`${groupId}-${option.value}`}
+            ref={(node) => {
+              refs.current[index] = node;
+            }}
+            type="button"
+            role="radio"
+            aria-checked={isActive}
+            disabled={option.disabled}
+            // Roving tabindex: only the selected option is tabbable, so the
+            // whole group is a single tab stop.
+            tabIndex={isActive ? 0 : -1}
+            onClick={() => !option.disabled && onChange?.(option.value)}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/submissions/react/segmented-control-ad/style.css
+++ b/submissions/react/segmented-control-ad/style.css
@@ -1,0 +1,125 @@
+/* ==========================================================================
+   EaseMotion CSS — SegmentedControl component styles
+   Issue #61726
+   ========================================================================== */
+
+.ease-seg-ad {
+    --seg-bg-ad: rgba(15, 23, 40, 0.9);
+    --seg-thumb-ad: rgba(51, 65, 92, 0.98);
+    --seg-border-ad: rgba(148, 163, 184, 0.18);
+    --seg-text-ad: #94a3b8;
+    --seg-text-on-ad: #f1f5f9;
+    --seg-accent-ad: #38bdf8;
+    --seg-radius-ad: 10px;
+    --seg-pad-ad: 3px;
+    --seg-ease-ad: cubic-bezier(0.16, 1, 0.3, 1);
+
+    background: var(--seg-bg-ad);
+    border: 1px solid var(--seg-border-ad);
+    border-radius: var(--seg-radius-ad);
+    display: inline-grid;
+    grid-auto-flow: column;
+    grid-auto-columns: 1fr;
+    padding: var(--seg-pad-ad);
+    position: relative;
+}
+
+.ease-seg-ad--full {
+    display: grid;
+    width: 100%;
+}
+
+/* ==========================================================================
+   Sliding indicator
+   --------------------------------------------------------------------------
+   Width is a fraction of the track and the offset is a multiple of its own
+   width, so position is derived entirely from the option count and active
+   index. No measurement, no refs, no ResizeObserver — it stays correct when
+   the container resizes or a webfont loads late.
+   ========================================================================== */
+.ease-seg-ad__indicator {
+    background: var(--seg-thumb-ad);
+    border-radius: calc(var(--seg-radius-ad) - var(--seg-pad-ad));
+    bottom: var(--seg-pad-ad);
+    left: var(--seg-pad-ad);
+    pointer-events: none;
+    position: absolute;
+    top: var(--seg-pad-ad);
+    width: calc((100% - var(--seg-pad-ad) * 2) / var(--seg-count-ad, 1));
+    transform: translateX(calc(100% * var(--seg-active-ad, 0)));
+    transition: transform 280ms var(--seg-ease-ad);
+}
+
+/* ==========================================================================
+   Options
+   ========================================================================== */
+.ease-seg-ad__option {
+    background: none;
+    border: 0;
+    border-radius: calc(var(--seg-radius-ad) - var(--seg-pad-ad));
+    color: var(--seg-text-ad);
+    cursor: pointer;
+    font: inherit;
+    font-weight: 550;
+    position: relative;
+    white-space: nowrap;
+    z-index: 1;
+    transition: color 200ms var(--seg-ease-ad);
+}
+
+.ease-seg-ad__option:hover:not([disabled]) {
+    color: var(--seg-text-on-ad);
+}
+
+.ease-seg-ad__option[aria-checked="true"] {
+    color: var(--seg-text-on-ad);
+}
+
+.ease-seg-ad__option:focus-visible {
+    outline: 2px solid var(--seg-accent-ad);
+    outline-offset: 2px;
+}
+
+.ease-seg-ad__option[disabled] {
+    cursor: not-allowed;
+    opacity: 0.42;
+}
+
+/* -- Sizes -- */
+.ease-seg-ad--sm .ease-seg-ad__option {
+    font-size: 0.78rem;
+    padding: 0.35rem 0.75rem;
+}
+
+.ease-seg-ad--md .ease-seg-ad__option {
+    font-size: 0.86rem;
+    padding: 0.5rem 1rem;
+}
+
+/* ==========================================================================
+   Motion & contrast
+   ========================================================================== */
+@media (prefers-reduced-motion: reduce) {
+    .ease-seg-ad__indicator,
+    .ease-seg-ad__option {
+        transition-duration: 1ms;
+    }
+}
+
+@media (forced-colors: active) {
+    .ease-seg-ad {
+        border: 1px solid CanvasText;
+    }
+
+    /* The thumb is a background fill, which high-contrast mode discards —
+       the selected option would become indistinguishable. An outline on the
+       indicator survives forced colors and preserves the selected state. */
+    .ease-seg-ad__indicator {
+        background: none;
+        outline: 2px solid Highlight;
+    }
+
+    .ease-seg-ad__option[aria-checked="true"] {
+        color: Highlight;
+    }
+}


### PR DESCRIPTION
Fixes #61726

**What was added**

A React segmented control with a sliding indicator, under `submissions/react/segmented-control-ad/`.

- `SegmentedControl.jsx` — 143 non-empty lines: radiogroup semantics, roving tabindex, arrow/Home/End key handling with disabled-option skipping, and measurement-free indicator positioning.
- `style.css` — 110 non-empty lines: track and thumb geometry derived from custom properties, two sizes, focus and disabled states, reduced-motion and forced-colors handling.
- `README.md` — props table, keyboard table, usage, and rationale.

**What is the problem**

Segmented controls are usually built as a row of `<button>` elements. That puts **every option in the tab sequence**, so a keyboard user crossing a toolbar has to tab through all six range options just to reach the next control. It also gives assistive tech no signal that the options are mutually exclusive.

The second problem is the indicator. The common implementation measures the active option with `getBoundingClientRect` and positions the thumb in a layout effect — which needs refs, a `ResizeObserver`, and still renders in the wrong place on first paint and during SSR.

**Why this approach**

Implemented as a WAI-ARIA `radiogroup` with roving `tabIndex`: only the selected option is tabbable, so the whole group is a **single tab stop** and arrow keys move between options. That is also the interaction screen reader users are told to expect from the role, so behaviour matches the announcement.

The indicator needs no measurement at all. Its width is `(100% - padding) / --seg-count-ad` and its offset is `translateX(100% × --seg-active-ad)` — position derived entirely from the option count and active index, both passed as custom properties. No refs, no `getBoundingClientRect`, no `ResizeObserver`. It is correct on first paint, stays correct when the container resizes or a webfont loads late and reflows the labels, and works under SSR where measurement is impossible.

It is transform-only, so sliding never triggers layout.

**How to test**

1. Pull this branch and drop `segmented-control-ad/` into any React app (React 18+ — the component uses `useId`).
2. Render with one disabled option:
   ```jsx
   <SegmentedControl label="Date range" value={range} onChange={setRange}
     options={[
       { value: 'day', label: 'Day' },
       { value: 'week', label: 'Week' },
       { value: 'month', label: 'Month' },
       { value: 'year', label: 'Year', disabled: true },
     ]} />
   ```
3. Click between options — the thumb slides rather than jumping.
4. **Tab into the control, then tab again** — focus must leave the group entirely rather than moving to the next option. This is the roving-tabindex behaviour.
5. With focus inside, press <kbd>→</kbd> repeatedly — selection advances, **skips the disabled "Year" option**, and wraps to the start.
6. Press <kbd>←</kbd> from the first option — selection wraps to the last enabled one.
7. Press <kbd>Home</kbd> / <kbd>End</kbd> — jumps to first / last enabled option.
8. Resize the container (or switch `fullWidth`) — the indicator stays aligned with no re-measure.
9. Pass a `value` that matches no option and confirm the indicator pins to slot 0 rather than sliding off-canvas.
10. View in a forced-colors / high-contrast mode — the selected option must remain visually distinguishable.

**Edge cases covered**

- Single tab stop via roving `tabIndex`, rather than one stop per option.
- Arrow navigation skips disabled options and bails after a full loop, so an all-disabled set cannot spin forever.
- Wrap-around uses `(from + dir*step + count*count) % count`, which stays positive for leftward movement where a plain `%` would yield a negative index.
- An unmatched `value` clamps to index 0 instead of `-1`, which would translate the indicator off-canvas.
- Empty `options` returns `null`.
- `onChange` is called optionally (`onChange?.()`), so an uncontrolled render does not throw.
- Disabled options ignore clicks as well as keyboard traversal.
- Indicator position survives container resize, late webfont load, and SSR because nothing is measured.
- `useId` generates collision-free option ids for multiple instances on one page.
- `forced-colors: active` replaces the thumb's background fill — which high-contrast mode discards — with an outline plus `Highlight` text colour, so the selected state survives.

**Verification**

- `SegmentedControl.jsx` parses cleanly through esbuild's JSX loader — zero errors or warnings.
- `npx stylelint style.css` against the repo's own config — zero errors.
- All component classes referenced in the JSX are defined in `style.css`.
- Wrap-around arithmetic verified numerically: moving left from index 0 in a 4-option set yields 3.
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 3 new files, 0 deletions, no existing file touched.
- Component classes carry an `-ad` suffix so this lands as a parallel implementation without overwriting existing contributor work.

**Labels:** `type:feature` · `react` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
