### PR TITLE
feat: add Callout React component with completing exit animation (#61727)

### DIFF
--- a/submissions/react/callout-ad/Callout.jsx
+++ b/submissions/react/callout-ad/Callout.jsx
@@ -1,0 +1,149 @@
+/**
+ * EaseMotion CSS — Callout
+ * ============================================================
+ * Inline callout / banner with an animated dismissal.
+ *
+ * Two details this gets right that most inline banners do not:
+ *
+ *  1. Announcement is scoped to severity. `role="alert"` interrupts the
+ *     screen reader immediately; `role="status"` waits for a pause. Marking
+ *     every callout as an alert trains users to ignore all of them, so only
+ *     `warning` and `danger` interrupt here.
+ *
+ *  2. Exit actually completes. Unmounting on click skips the animation
+ *     entirely — the element is gone before a frame renders. This keeps the
+ *     node mounted through an `exiting` phase and removes it on
+ *     `transitionend`, with a timeout fallback so a dropped or interrupted
+ *     transition event cannot strand the callout on screen forever.
+ * ============================================================
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/** Per-tone glyph and ARIA wiring. */
+const TONES = {
+  info: { glyph: 'i', role: 'status', live: 'polite' },
+  success: { glyph: '✓', role: 'status', live: 'polite' },
+  warning: { glyph: '!', role: 'alert', live: 'assertive' },
+  danger: { glyph: '⚠', role: 'alert', live: 'assertive' },
+};
+
+/** Must exceed the CSS exit duration; guards against a missed event. */
+const EXIT_FALLBACK_MS = 400;
+
+/**
+ * @param {object} props
+ * @param {'info'|'success'|'warning'|'danger'} [props.tone='info']
+ * @param {string}    [props.title]
+ * @param {React.ReactNode} props.children  Body content.
+ * @param {React.ReactNode} [props.icon]    Custom icon; replaces the glyph.
+ * @param {boolean}   [props.dismissible=false]
+ * @param {() => void} [props.onDismiss]    Called after the exit completes.
+ * @param {React.ReactNode} [props.action]
+ * @param {string}    [props.className]
+ */
+export default function Callout({
+  tone = 'info',
+  title,
+  children,
+  icon,
+  dismissible = false,
+  onDismiss,
+  action,
+  className = '',
+  ...rest
+}) {
+  const [exiting, setExiting] = useState(false);
+  const [removed, setRemoved] = useState(false);
+  const nodeRef = useRef(null);
+  const timerRef = useRef(null);
+
+  // Unknown tones degrade to `info` rather than throwing on an undefined
+  // property lookup.
+  const config = TONES[tone] ?? TONES.info;
+
+  const finish = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    setRemoved(true);
+    onDismiss?.();
+  }, [onDismiss]);
+
+  const handleDismiss = useCallback(() => {
+    if (exiting) return; // Ignore repeat clicks during the exit.
+    setExiting(true);
+  }, [exiting]);
+
+  useEffect(() => {
+    if (!exiting) return undefined;
+
+    const node = nodeRef.current;
+
+    // Only react to the element's OWN transition. Without this check a
+    // transition on any descendant (a hovered button inside the callout)
+    // would bubble up and remove the callout early.
+    const onEnd = (event) => {
+      if (event.target === node) finish();
+    };
+
+    node?.addEventListener('transitionend', onEnd);
+    timerRef.current = setTimeout(finish, EXIT_FALLBACK_MS);
+
+    return () => {
+      node?.removeEventListener('transitionend', onEnd);
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [exiting, finish]);
+
+  // Clear any pending timer if the component unmounts mid-exit.
+  useEffect(
+    () => () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    },
+    [],
+  );
+
+  if (removed) return null;
+
+  const classes = [
+    'ease-callout-ad',
+    `ease-callout-ad--${tone in TONES ? tone : 'info'}`,
+    exiting ? 'ease-callout-ad--exiting' : '',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div
+      className={classes}
+      ref={nodeRef}
+      role={config.role}
+      aria-live={config.live}
+      {...rest}
+    >
+      <span className="ease-callout-ad__icon" aria-hidden="true">
+        {icon ?? config.glyph}
+      </span>
+
+      <div className="ease-callout-ad__body">
+        {title && <p className="ease-callout-ad__title">{title}</p>}
+        {children && <div className="ease-callout-ad__copy">{children}</div>}
+        {action && <div className="ease-callout-ad__action">{action}</div>}
+      </div>
+
+      {dismissible && (
+        <button
+          className="ease-callout-ad__close"
+          type="button"
+          onClick={handleDismiss}
+          aria-label="Dismiss notification"
+        >
+          &times;
+        </button>
+      )}
+    </div>
+  );
+}

--- a/submissions/react/callout-ad/README.md
+++ b/submissions/react/callout-ad/README.md
@@ -1,0 +1,65 @@
+# Callout — inline callout / banner
+
+> Issue: [#61727](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/61727)
+
+A React callout for inline messaging, with severity-scoped announcement and an exit animation that actually completes before unmount.
+
+## Description
+
+Four tones with matching glyphs and ARIA wiring. Dismissible callouts play a collapse-and-fade exit, then unmount — rather than vanishing instantly.
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `tone` | `'info' \| 'success' \| 'warning' \| 'danger'` | `'info'` | Sets colour, glyph and ARIA role. Unknown values degrade to `info`. |
+| `title` | `string` | — | Optional heading. |
+| `children` | `ReactNode` | — | Body content. |
+| `icon` | `ReactNode` | per-tone glyph | Custom icon. |
+| `dismissible` | `boolean` | `false` | Show a dismiss button. |
+| `onDismiss` | `() => void` | — | Called **after** the exit animation completes. |
+| `action` | `ReactNode` | — | Action node rendered under the copy. |
+| `className` | `string` | `''` | Merged onto the root. |
+
+Any other props are spread onto the root element.
+
+## Usage
+
+```jsx
+import Callout from './Callout';
+import './style.css';
+
+<Callout tone="info" title="Scheduled maintenance">
+  Settlement will pause on Sunday between 02:00 and 04:00 UTC.
+</Callout>
+
+<Callout
+  tone="warning"
+  title="Limit approaching"
+  dismissible
+  onDismiss={() => acknowledge('seats')}
+  action={<button onClick={upgrade}>Upgrade plan</button>}
+>
+  You have used 42 of 50 seats.
+</Callout>
+
+<Callout tone="danger" title="Payment failed" dismissible onDismiss={clear}>
+  We could not charge the card on file.
+</Callout>
+```
+
+## Why it fits EaseMotion
+
+**Announcement is scoped to severity.** `warning` and `danger` use `role="alert"` with `aria-live="assertive"`, so they interrupt the screen reader. `info` and `success` use `role="status"` with `aria-live="polite"`, so they wait for a pause. Marking every callout as an alert trains users to ignore all of them, including the one that mattered.
+
+**The exit actually completes.** Unmounting on click skips the animation entirely — the element is gone before a frame renders, so the collapse is never seen. This component keeps the node mounted through an `exiting` phase and removes it on `transitionend`.
+
+Three details make that reliable:
+
+- The `transitionend` handler checks `event.target === node`. Without it, a transition on any *descendant* — hovering a button inside the callout — bubbles up and removes the callout early.
+- A `setTimeout` fallback fires if the event never arrives, which happens when the element is off-screen, in a background tab, or the transition is interrupted. Without it a callout could be stranded on screen permanently.
+- `max-height` is bounded (`30rem`) rather than `auto`, because `auto` is not interpolatable and the collapse simply would not animate.
+
+`margin` and `padding` animate alongside `max-height`, or the surrounding layout would jump as the element is removed.
+
+Under `prefers-reduced-motion` the transition is **shortened rather than removed** — this one is not just an aesthetic choice. Removing the transition stops `transitionend` firing at all, and since unmount waits on that event, the callout would linger until the timeout fallback fired.

--- a/submissions/react/callout-ad/style.css
+++ b/submissions/react/callout-ad/style.css
@@ -1,0 +1,175 @@
+/* ==========================================================================
+   EaseMotion CSS — Callout component styles
+   Issue #61727
+   ========================================================================== */
+
+.ease-callout-ad {
+    --co-accent-ad: #60a5fa;
+    --co-bg-ad: rgba(96, 165, 250, 0.1);
+    --co-title-ad: #f1f5f9;
+    --co-text-ad: #94a3b8;
+    --co-radius-ad: 11px;
+    --co-ease-ad: cubic-bezier(0.16, 1, 0.3, 1);
+    --co-exit-ad: 260ms;
+
+    background: var(--co-bg-ad);
+    border-left: 3px solid var(--co-accent-ad);
+    border-radius: var(--co-radius-ad);
+    display: flex;
+    gap: 0.75rem;
+    padding: 0.9rem 1rem;
+
+    /* Bounded so the collapse has a real value to animate from — `auto`
+       is not interpolatable and the exit would not collapse at all. */
+    max-height: 30rem;
+    opacity: 1;
+    overflow: hidden;
+    transform: translateY(0);
+    transition:
+        max-height var(--co-exit-ad) var(--co-ease-ad),
+        margin var(--co-exit-ad) var(--co-ease-ad),
+        opacity var(--co-exit-ad) var(--co-ease-ad),
+        padding var(--co-exit-ad) var(--co-ease-ad),
+        transform var(--co-exit-ad) var(--co-ease-ad);
+}
+
+/* Collapse-and-fade exit. Margin and padding are animated too, or the
+   surrounding layout would jump as the element is removed. */
+.ease-callout-ad--exiting {
+    margin-bottom: 0;
+    margin-top: 0;
+    max-height: 0;
+    opacity: 0;
+    padding-bottom: 0;
+    padding-top: 0;
+    transform: translateY(-4px);
+}
+
+/* -- Tones -- */
+.ease-callout-ad--info {
+    --co-accent-ad: #60a5fa;
+    --co-bg-ad: rgba(96, 165, 250, 0.1);
+}
+
+.ease-callout-ad--success {
+    --co-accent-ad: #34d399;
+    --co-bg-ad: rgba(52, 211, 153, 0.1);
+}
+
+.ease-callout-ad--warning {
+    --co-accent-ad: #fbbf24;
+    --co-bg-ad: rgba(251, 191, 36, 0.1);
+}
+
+.ease-callout-ad--danger {
+    --co-accent-ad: #f87171;
+    --co-bg-ad: rgba(248, 113, 113, 0.1);
+}
+
+/* -- Parts -- */
+.ease-callout-ad__icon {
+    align-items: center;
+    background: var(--co-accent-ad);
+    border-radius: 50%;
+    color: #06101f;
+    display: flex;
+    flex: 0 0 auto;
+    font-size: 0.72rem;
+    font-weight: 700;
+    height: 20px;
+    justify-content: center;
+    line-height: 1;
+    margin-top: 0.12rem;
+    width: 20px;
+}
+
+.ease-callout-ad__body {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.ease-callout-ad__title {
+    color: var(--co-title-ad);
+    font-size: 0.9rem;
+    font-weight: 600;
+    margin: 0 0 0.2rem;
+}
+
+.ease-callout-ad__copy {
+    color: var(--co-text-ad);
+    font-size: 0.85rem;
+}
+
+.ease-callout-ad__copy > :first-child {
+    margin-top: 0;
+}
+
+.ease-callout-ad__copy > :last-child {
+    margin-bottom: 0;
+}
+
+.ease-callout-ad__action {
+    margin-top: 0.65rem;
+}
+
+.ease-callout-ad__close {
+    align-items: center;
+    background: none;
+    border: 0;
+    border-radius: 50%;
+    color: var(--co-text-ad);
+    cursor: pointer;
+    display: flex;
+    flex: 0 0 auto;
+    font-size: 1.1rem;
+    height: 24px;
+    justify-content: center;
+    line-height: 1;
+    padding: 0;
+    width: 24px;
+    transition: background-color 160ms var(--co-ease-ad);
+}
+
+.ease-callout-ad__close:hover {
+    background: rgba(148, 163, 184, 0.16);
+    color: var(--co-title-ad);
+}
+
+.ease-callout-ad__close:focus-visible {
+    outline: 2px solid var(--co-accent-ad);
+    outline-offset: 2px;
+}
+
+/* ==========================================================================
+   Motion & contrast
+   --------------------------------------------------------------------------
+   The exit transition is shortened, never removed. Removing it would stop
+   `transitionend` firing, and the component waits on that event to unmount
+   — the callout would sit there until the timeout fallback fired.
+   ========================================================================== */
+@media (prefers-reduced-motion: reduce) {
+    .ease-callout-ad {
+        transition-duration: 1ms;
+    }
+
+    .ease-callout-ad--exiting {
+        transform: none;
+    }
+
+    .ease-callout-ad__close {
+        transition-duration: 1ms;
+    }
+}
+
+@media (forced-colors: active) {
+    .ease-callout-ad {
+        border: 1px solid CanvasText;
+        border-left-width: 3px;
+    }
+
+    .ease-callout-ad__icon {
+        background: Canvas;
+        border: 1px solid CanvasText;
+        color: CanvasText;
+    }
+}


### PR DESCRIPTION
Fixes #61727

**What was added**

A React inline callout with an animated dismissal, under `submissions/react/callout-ad/`.

- `Callout.jsx` — 131 non-empty lines: four-tone config with per-severity ARIA wiring, a two-phase exit driven by `transitionend`, a timeout fallback, and full effect cleanup.
- `style.css` — 152 non-empty lines: four tones, collapse-and-fade exit, parts styling, reduced-motion and forced-colors handling.
- `README.md` — props table, three usage examples, and rationale.

**What is the problem**

Two things inline banners routinely get wrong.

**Announcement.** Marking every callout `role="alert"` makes routine information interrupt the screen reader, which trains users to ignore all of them — including the one that mattered. Severity has to be reflected in the role.

**The exit never plays.** The common implementation calls `setState(false)` on dismiss and unmounts immediately. React removes the node before a frame renders, so the exit animation is written, styled, and never seen once.

**Why this approach**

Announcement is scoped: `warning` and `danger` use `role="alert"` / `aria-live="assertive"` so they interrupt; `info` and `success` use `role="status"` / `aria-live="polite"` so they wait for a pause.

The exit keeps the node mounted through an `exiting` phase and removes it on `transitionend`. Three details make that reliable rather than flaky:

- The handler checks `event.target === node`. Without it, a transition on any **descendant** — hovering a button inside the callout — bubbles up and removes the callout early, mid-interaction.
- A `setTimeout` fallback (400ms, comfortably above the 260ms CSS exit) fires if the event never arrives. `transitionend` does not fire when the element is off-screen, in a background tab, or when the transition is interrupted — without the fallback a callout could be stranded on screen permanently.
- `max-height` is bounded at `30rem` rather than `auto`, because `auto` is not interpolatable and the collapse simply would not animate.

`margin` and `padding` animate alongside `max-height`, or the surrounding layout jumps as the element is removed.

Under `prefers-reduced-motion` the transition is **shortened, not removed** — and here that is a correctness requirement, not an aesthetic one. Removing the transition stops `transitionend` firing at all, and since unmount waits on that event, the callout would linger until the timeout fallback fired.

**How to test**

1. Pull this branch and drop `callout-ad/` into any React app (React 16.8+).
2. Render all four tones and confirm distinct colours and glyphs.
3. Inspect the DOM: `warning` and `danger` must carry `role="alert"` / `aria-live="assertive"`; `info` and `success` `role="status"` / `aria-live="polite"`.
4. Dismiss a `dismissible` callout — it should **collapse and fade over ~260ms**, then unmount. Confirm `onDismiss` fires *after* the animation, not on click.
5. Confirm the content below slides up smoothly rather than jumping — this is the margin/padding animation.
6. **Put an `action` button inside a callout, start the dismissal, and hover that button.** The callout must not disappear early — this is the `event.target === node` guard.
7. Click the dismiss button rapidly several times — only one exit should run.
8. Pass `tone="bogus"` and confirm it degrades to `info` rather than throwing.
9. Unmount the parent mid-exit and confirm no "setState on unmounted component" warning appears.
10. Enable OS-level "reduce motion" — the callout must still dismiss and unmount promptly.

**Edge cases covered**

- `transitionend` is filtered to the element itself, so descendant transitions cannot trigger an early unmount.
- Timeout fallback guarantees removal if `transitionend` never fires (off-screen, background tab, interrupted transition).
- Fallback duration is verified to exceed the CSS exit duration, so it never pre-empts the animation.
- Repeat dismiss clicks are ignored while `exiting` is already true.
- Timers are cleared both in the effect cleanup and in an unmount-only effect, so no state update lands on an unmounted component.
- `max-height` is bounded rather than `auto`, so the collapse is actually interpolatable.
- `margin` and `padding` animate too, preventing a layout jump on removal.
- Unknown `tone` degrades to `info` in both the config lookup and the class name.
- `title`, `children` and `action` are each conditional, so no empty elements are rendered.
- `min-width: 0` on the body lets long unbroken content shrink instead of overflowing the flex row.
- Reduced motion shortens rather than removes the transition, preserving the `transitionend` the unmount depends on.
- `forced-colors: active` gives the callout and icon explicit borders and system colours.

**Verification**

- `Callout.jsx` parses cleanly through esbuild's JSX loader — zero errors or warnings.
- `npx stylelint style.css` against the repo's own config — zero errors.
- All component classes referenced in the JSX are defined in `style.css`.
- All four tones in the JSX config have matching CSS modifier classes.
- Timeout ordering verified numerically: `EXIT_FALLBACK_MS` (400) > `--co-exit-ad` (260).
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 3 new files, 0 deletions, no existing file touched.
- Component classes carry an `-ad` suffix so this lands as a parallel implementation without overwriting existing contributor work.

**Labels:** `type:feature` · `react` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
