### PR TITLE
## feat(components): add ease-popover-modal — Native Popover API + @starting-style 

### DIFF
--- a/submissions/examples/ease-popover-modal/README.md
+++ b/submissions/examples/ease-popover-modal/README.md
@@ -1,0 +1,179 @@
+# ease-popover-modal
+
+> **Issue #61501** — Native Popover API + `@starting-style` enter/exit animations · Zero JavaScript
+
+---
+
+## What does this do?
+
+`ease-popover-modal` is a **fully-animated modal dialog** built entirely with the native [HTML Popover API](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/popover) and the CSS [`@starting-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/@starting-style) at-rule.
+
+**The problem it solves:**  
+When a browser toggles a popover from `display: none` to `display: block`, the element jumps instantly into view — there is no "before" state to transition from. `@starting-style` fixes this by letting you declare what the CSS values should be treated as *before* the first frame of the open state, giving the browser a genuine start point for the opening transition.
+
+The component delivers:
+
+- **Smooth entry** — modal scales from `scale(0.95)` + `opacity: 0` → `scale(1)` + `opacity: 1`, driven by `@starting-style`.
+- **Smooth exit** — the reverse plays out before the browser removes the element from the top layer, thanks to `allow-discrete` on `display` and `overlay`.
+- **Blurred backdrop** — `::backdrop` transitions its `opacity` in perfect synchrony using the same `@starting-style` technique.
+- **Zero JavaScript** — open, close, light-dismiss, and Escape handling are all provided by the browser natively.
+- **Accessibility built-in** — top-layer promotion, focus trapping, and `Escape` support are handled by the browser's Popover API.
+- **Motion-safe** — `prefers-reduced-motion: reduce` disables all transitions.
+
+---
+
+## How is it used?
+
+### 1. Add the trigger button
+
+```html
+<!-- popovertarget connects the button to the modal by ID -->
+<button popovertarget="ease-modal-demo" class="ease-btn">
+  Open Popover Modal
+</button>
+```
+
+### 2. Add the modal container
+
+```html
+<!-- popover attribute opts the element into the Popover API -->
+<div id="ease-modal-demo" popover class="ease-popover-modal">
+
+  <div class="modal-header">
+    <h2 class="modal-title">Modal Title</h2>
+
+    <!-- popovertargetaction="hide" closes the popover -->
+    <button
+      popovertarget="ease-modal-demo"
+      popovertargetaction="hide"
+      class="modal-close-x"
+      aria-label="Close"
+    >×</button>
+  </div>
+
+  <div class="modal-body">
+    <p>Modal content goes here.</p>
+  </div>
+
+  <div class="modal-footer">
+    <button
+      popovertarget="ease-modal-demo"
+      popovertargetaction="hide"
+      class="modal-btn-ghost"
+    >Close</button>
+
+    <button
+      popovertarget="ease-modal-demo"
+      popovertargetaction="hide"
+      class="modal-btn-primary"
+    >Confirm</button>
+  </div>
+
+</div>
+```
+
+### 3. Link the stylesheet
+
+```html
+<link rel="stylesheet" href="style.css" />
+```
+
+That's it — **no JavaScript needed**.
+
+---
+
+## Why is it useful?
+
+### The old way (JavaScript required)
+
+Before `@starting-style`, animating a modal's lifecycle required:
+
+```js
+// 1. Add a class to trigger CSS transition
+modal.classList.add('is-opening');
+
+// 2. Wait for transition to end before hiding
+modal.addEventListener('transitionend', () => {
+  modal.style.display = 'none';
+}, { once: true });
+
+// 3. Or use a setTimeout hack for the entry animation
+modal.style.display = 'block';
+setTimeout(() => modal.classList.add('is-visible'), 16); // ← the rAF/setTimeout hack
+```
+
+This pattern is fragile: timing depends on frame budget, `transitionend` can fire multiple times, and it forces developers to maintain JS-driven "animation state" (opening / open / closing / closed) alongside CSS state.
+
+### The new way (`@starting-style` + native Popover API)
+
+```css
+/* 1. Closed state — also the exit-end state */
+.ease-popover-modal {
+  opacity: 0;
+  transform: scale(0.95);
+  transition:
+    opacity   0.4s ease,
+    transform 0.4s ease,
+    overlay   0.4s allow-discrete,   /* keeps element in top layer during exit */
+    display   0.4s allow-discrete;   /* defers display:none until exit is done */
+}
+
+/* 2. Open state */
+.ease-popover-modal:popover-open {
+  opacity: 1;
+  transform: scale(1);
+}
+
+/* 3. Entry start — without this, the opening transition is skipped */
+@starting-style {
+  .ease-popover-modal:popover-open {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+}
+```
+
+**What `@starting-style` eliminates:**
+
+| Old JS approach | With `@starting-style` |
+|---|---|
+| `setTimeout` / `requestAnimationFrame` hacks to seed entry state | ✅ Handled by browser via `@starting-style` |
+| `transitionend` listeners to defer `display: none` | ✅ Handled by `allow-discrete` on `display` |
+| Manual "animation state machine" (opening/closing/open/closed) | ✅ Handled by `:popover-open` pseudo-class |
+| External libraries (e.g. Framer Motion, GSAP) for modal lifecycle | ✅ Pure CSS — no dependencies |
+| JS to manage focus trap + Escape key + backdrop dismiss | ✅ Native Popover API |
+
+The result is a **declarative, CSS-only modal** with production-quality enter/exit animations — no JS state management, no `setTimeout` hacks, no external libraries.
+
+---
+
+## Browser Support
+
+| Browser | Popover API | `@starting-style` |
+|---|---|---|
+| Chrome | 114+ | 117+ |
+| Edge | 114+ | 117+ |
+| Safari | 17+ | 17.5+ |
+| Firefox | 125+ | 129+ |
+
+For browsers without support, the modal falls back to instantly showing/hiding (no animation), which is still fully functional.
+
+---
+
+## Files
+
+| File | Description |
+|---|---|
+| [`demo.html`](./demo.html) | Self-contained demo — zero external dependencies, zero JS |
+| [`style.css`](./style.css) | Component stylesheet with `@starting-style`, `allow-discrete` transitions, and backdrop |
+| [`README.md`](./README.md) | This document |
+
+---
+
+## Related Resources
+
+- [MDN: HTML `popover` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/popover)
+- [MDN: CSS `@starting-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/@starting-style)
+- [MDN: `transition-behavior: allow-discrete`](https://developer.mozilla.org/en-US/docs/Web/CSS/transition-behavior)
+- [Chrome Developers: Popover API](https://developer.chrome.com/blog/introducing-popover-api)
+- [web.dev: Four new CSS features for smooth entry and exit animations](https://web.dev/blog/entry-exit-animations)

--- a/submissions/examples/ease-popover-modal/demo.html
+++ b/submissions/examples/ease-popover-modal/demo.html
@@ -1,0 +1,244 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="ease-popover-modal — a zero-JavaScript modal built with the native HTML Popover API and CSS @starting-style for smooth enter/exit transitions." />
+  <title>ease-popover-modal | EaseMotion CSS · Issue #61501</title>
+
+  <!-- Google Fonts: Inter -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Fira+Code:wght@400;600&display=swap" rel="stylesheet" />
+
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <!-- =====================================================================
+       PAGE HERO
+       ===================================================================== -->
+  <header class="page-hero" role="banner">
+
+    <div class="badge-group" aria-label="Component metadata">
+      <span class="badge">Issue #61501</span>
+      <span class="badge">Native Popover API</span>
+      <span class="badge">@starting-style</span>
+      <span class="badge">0 JavaScript</span>
+    </div>
+
+    <h1>ease&#8209;popover&#8209;modal</h1>
+
+    <p>
+      A fully animated modal built on the native HTML
+      <code style="font-family:inherit;font-size:inherit;color:#a5b4fc">popover</code> attribute —
+      smooth enter &amp; exit transitions via
+      <code style="font-family:inherit;font-size:inherit;color:#a5b4fc">@starting-style</code>,
+      no JavaScript required.
+    </p>
+
+    <!-- ── Trigger button ──────────────────────────────────────────────── -->
+    <button
+      id="open-ease-modal"
+      class="ease-btn"
+      popovertarget="ease-modal-demo"
+      aria-label="Open popover modal demo"
+    >
+      <svg
+        aria-hidden="true"
+        width="16" height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <rect x="3" y="3" width="18" height="18" rx="3"/>
+        <path d="M12 8v8M8 12h8"/>
+      </svg>
+      Open Popover Modal
+    </button>
+
+  </header>
+
+
+  <!-- =====================================================================
+       THE MODAL  — popover attribute enables native Popover API
+       ===================================================================== -->
+  <div
+    id="ease-modal-demo"
+    popover
+    class="ease-popover-modal"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="modal-heading"
+    aria-describedby="modal-desc"
+  >
+
+    <!-- Header -->
+    <div class="modal-header">
+
+      <div class="modal-icon" aria-hidden="true">✦</div>
+
+      <div class="modal-title-group">
+        <h2 id="modal-heading" class="modal-title">Native Popover Modal</h2>
+        <p class="modal-subtitle">Zero JS · CSS @starting-style transitions</p>
+      </div>
+
+      <!-- Close button (hide action) — no JS needed -->
+      <button
+        id="close-ease-modal-x"
+        class="modal-close-x"
+        popovertarget="ease-modal-demo"
+        popovertargetaction="hide"
+        aria-label="Close modal"
+      >×</button>
+
+    </div>
+
+    <!-- Body -->
+    <div class="modal-body" id="modal-desc">
+
+      <p>
+        This modal is opened and closed exclusively through the
+        <code class="code-pill">popover</code> HTML attribute and the
+        <code class="code-pill">popovertarget</code> button attribute —
+        <strong style="color:#f1f5f9">no JavaScript whatsoever</strong>.
+      </p>
+
+      <p>
+        The silky enter <em style="font-style:normal;color:#a5b4fc">and</em> exit animations
+        are powered by
+        <code class="code-pill">@starting-style</code>, which sets the
+        modal's initial CSS values <em>before</em> the browser renders the
+        first frame of the open state, allowing a transition from
+        <code class="code-pill">display:none</code>.
+      </p>
+
+      <ul class="modal-feature-list" aria-label="Key features">
+        <li>
+          <code class="code-pill">@starting-style</code> seeds the entry animation
+          without any JS timeout hacks
+        </li>
+        <li>
+          <code class="code-pill">allow-discrete</code> on
+          <code class="code-pill">display</code> &amp;
+          <code class="code-pill">overlay</code> keeps the element in the
+          top layer during the exit transition
+        </li>
+        <li>
+          Blurred &amp; dimmed <code class="code-pill">::backdrop</code>
+          transitions in sync with the modal
+        </li>
+        <li>
+          Full <code class="code-pill">prefers-reduced-motion</code> support
+          — transitions disabled for users who prefer it
+        </li>
+        <li>
+          Light-dismiss enabled: click outside or press
+          <kbd style="
+            font-family:inherit;
+            font-size:0.8em;
+            background:rgba(148,163,184,0.12);
+            border:1px solid rgba(148,163,184,0.25);
+            border-radius:4px;
+            padding:0.1em 0.4em;
+          ">Esc</kbd>
+          to close
+        </li>
+      </ul>
+
+    </div>
+
+    <!-- Footer -->
+    <div class="modal-footer">
+
+      <!-- Close (ghost) -->
+      <button
+        id="close-ease-modal-cancel"
+        class="modal-btn-ghost"
+        popovertarget="ease-modal-demo"
+        popovertargetaction="hide"
+      >Close</button>
+
+      <!-- Confirm (primary) — also hides the popover -->
+      <button
+        id="close-ease-modal-confirm"
+        class="modal-btn-primary"
+        popovertarget="ease-modal-demo"
+        popovertargetaction="hide"
+      >Got it!</button>
+
+    </div>
+
+  </div><!-- /#ease-modal-demo -->
+
+
+  <!-- =====================================================================
+       HOW IT WORKS PANEL
+       ===================================================================== -->
+  <aside class="docs-panel" aria-label="How it works">
+
+    <h2>How it works</h2>
+
+    <div class="docs-step">
+      <div class="step-num" aria-hidden="true">1</div>
+      <div>
+        <h3>HTML — zero JS wiring</h3>
+        <p>
+          Add <code class="code-pill">popover</code> to the modal element
+          and <code class="code-pill">popovertarget="id"</code> to any
+          button. The browser handles open, close, light-dismiss, and
+          top-layer promotion natively.
+        </p>
+      </div>
+    </div>
+
+    <div class="docs-step">
+      <div class="step-num" aria-hidden="true">2</div>
+      <div>
+        <h3>Entry — @starting-style</h3>
+        <p>
+          <code class="code-pill">@starting-style</code> declares the
+          values the browser should treat as "before open". Without it,
+          the element jumps from <code class="code-pill">display:none</code>
+          straight to the open state, skipping the transition entirely.
+        </p>
+      </div>
+    </div>
+
+    <div class="docs-step">
+      <div class="step-num" aria-hidden="true">3</div>
+      <div>
+        <h3>Exit — allow-discrete</h3>
+        <p>
+          <code class="code-pill">display</code> and
+          <code class="code-pill">overlay</code> are discrete properties
+          (they don't interpolate). Using
+          <code class="code-pill">allow-discrete</code> in the
+          transition shorthand defers hiding until the
+          <code class="code-pill">opacity</code> and
+          <code class="code-pill">transform</code> animations finish.
+        </p>
+      </div>
+    </div>
+
+    <div class="docs-step">
+      <div class="step-num" aria-hidden="true">4</div>
+      <div>
+        <h3>Backdrop in sync</h3>
+        <p>
+          <code class="code-pill">::backdrop</code> gets the same
+          treatment: <code class="code-pill">opacity: 0</code> closed,
+          <code class="code-pill">opacity: 1</code> open, seeded by
+          <code class="code-pill">@starting-style</code> — so it fades
+          in and out perfectly in step with the modal panel.
+        </p>
+      </div>
+    </div>
+
+  </aside>
+
+</body>
+</html>

--- a/submissions/examples/ease-popover-modal/style.css
+++ b/submissions/examples/ease-popover-modal/style.css
@@ -1,0 +1,542 @@
+/* ==========================================================================
+   ease-popover-modal — Native Popover API + @starting-style
+   Submission: ease-popover-modal  |  Issue #61501
+   Zero JavaScript · Zero dependencies · Pure CSS transitions
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Design Tokens
+   -------------------------------------------------------------------------- */
+
+:root {
+  /* Colors */
+  --pm-bg:            #0f172a;          /* page background */
+  --pm-surface:       #1e293b;          /* modal surface */
+  --pm-surface-hover: #263248;
+  --pm-border:        rgba(148, 163, 184, 0.18);
+  --pm-text:          #f1f5f9;
+  --pm-text-muted:    #94a3b8;
+  --pm-accent:        #6366f1;          /* indigo */
+  --pm-accent-hover:  #4f46e5;
+  --pm-accent-muted:  rgba(99, 102, 241, 0.12);
+  --pm-danger:        #f87171;
+
+  /* Spacing */
+  --pm-space-1: 0.25rem;
+  --pm-space-2: 0.5rem;
+  --pm-space-3: 0.75rem;
+  --pm-space-4: 1rem;
+  --pm-space-5: 1.25rem;
+  --pm-space-6: 1.5rem;
+  --pm-space-8: 2rem;
+
+  /* Radii */
+  --pm-radius:    0.875rem;
+  --pm-radius-sm: 0.5rem;
+  --pm-radius-xs: 0.25rem;
+
+  /* Shadows */
+  --pm-shadow:
+    0 0 0 1px rgba(148, 163, 184, 0.12),
+    0 8px 32px rgba(0, 0, 0, 0.55),
+    0 32px 64px rgba(0, 0, 0, 0.35);
+
+  /* Typography */
+  --pm-font: 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
+  --pm-font-mono: 'Fira Code', 'Cascadia Code', Consolas, monospace;
+}
+
+/* --------------------------------------------------------------------------
+   2. Base Reset
+   -------------------------------------------------------------------------- */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-family: var(--pm-font);
+  font-size: 100%;
+  scroll-behavior: smooth;
+}
+
+body {
+  background-color: var(--pm-bg);
+  color: var(--pm-text);
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: var(--pm-space-8) var(--pm-space-4);
+  line-height: 1.6;
+}
+
+/* --------------------------------------------------------------------------
+   3. Page Layout
+   -------------------------------------------------------------------------- */
+
+.page-hero {
+  text-align: center;
+  max-width: 600px;
+  margin-bottom: var(--pm-space-8);
+}
+
+.page-hero h1 {
+  font-size: clamp(1.75rem, 4vw, 2.5rem);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  line-height: 1.2;
+  margin-bottom: var(--pm-space-3);
+  background: linear-gradient(135deg, #e2e8f0 0%, #818cf8 50%, #6366f1 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.page-hero p {
+  color: var(--pm-text-muted);
+  font-size: 1.0625rem;
+  max-width: 480px;
+  margin: 0 auto var(--pm-space-6);
+}
+
+.badge-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--pm-space-2);
+  justify-content: center;
+  margin-bottom: var(--pm-space-6);
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.2em 0.7em;
+  border-radius: 9999px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-family: var(--pm-font-mono);
+  border: 1px solid var(--pm-border);
+  background: var(--pm-accent-muted);
+  color: #a5b4fc;
+}
+
+/* --------------------------------------------------------------------------
+   4. Trigger Button  (.ease-btn)
+   -------------------------------------------------------------------------- */
+
+.ease-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--pm-space-2);
+  padding: 0.75rem 1.75rem;
+  font-family: var(--pm-font);
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: #fff;
+  background: var(--pm-accent);
+  border: none;
+  border-radius: var(--pm-radius-sm);
+  cursor: pointer;
+  position: relative;
+  overflow: hidden;
+  transition:
+    background 0.2s ease,
+    transform  0.15s ease,
+    box-shadow 0.2s ease;
+  box-shadow: 0 0 0 0 rgba(99, 102, 241, 0);
+}
+
+.ease-btn::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(255,255,255,0.15) 0%, transparent 60%);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.ease-btn:hover {
+  background: var(--pm-accent-hover);
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(99, 102, 241, 0.4);
+}
+
+.ease-btn:hover::before {
+  opacity: 1;
+}
+
+.ease-btn:active {
+  transform: translateY(0);
+}
+
+.ease-btn:focus-visible {
+  outline: 2px solid #818cf8;
+  outline-offset: 3px;
+}
+
+/* --------------------------------------------------------------------------
+   5. .ease-popover-modal — Core Component
+   -------------------------------------------------------------------------- */
+
+/*
+ * Base / closed state.
+ * The element is display:none by default when [popover].
+ * We set opacity + scale here so that:
+ *   - The EXIT transition starts from the :popover-open values
+ *     and animates toward these closed values.
+ *   - The ENTRY transition is overridden by @starting-style below.
+ *
+ * `overlay` and `display` must use allow-discrete so the browser
+ * keeps the element in the top layer long enough for the exit
+ * transition to complete before hiding it.
+ */
+.ease-popover-modal {
+  /* Geometry & positioning */
+  position: fixed;
+  inset: 0;
+  margin: auto;
+  width: min(520px, calc(100vw - 2rem));
+
+  /* Appearance */
+  background: var(--pm-surface);
+  border: 1px solid var(--pm-border);
+  border-radius: var(--pm-radius);
+  box-shadow: var(--pm-shadow);
+  padding: 0;
+  color: var(--pm-text);
+
+  /* Closed / exit-end state */
+  opacity: 0;
+  transform: scale(0.95);
+
+  /* Transitions — including discrete props for enter/exit lifecycle */
+  transition:
+    opacity    0.4s ease,
+    transform  0.4s ease,
+    overlay    0.4s allow-discrete,
+    display    0.4s allow-discrete;
+}
+
+/* ---- Open state ---- */
+.ease-popover-modal:popover-open {
+  opacity: 1;
+  transform: scale(1);
+}
+
+/*
+ * @starting-style — entry animation starting point.
+ * Without this, the element snaps in from display:none
+ * and the opening transition is skipped entirely.
+ * This rule tells the browser: "Before the first frame of
+ * :popover-open, treat these as the initial values."
+ */
+@starting-style {
+  .ease-popover-modal:popover-open {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+}
+
+/* ---- Backdrop ---- */
+.ease-popover-modal::backdrop {
+  background-color: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+
+  /* Backdrop opacity transitions */
+  opacity: 0;
+  transition:
+    opacity  0.4s ease,
+    overlay  0.4s allow-discrete,
+    display  0.4s allow-discrete;
+}
+
+.ease-popover-modal:popover-open::backdrop {
+  opacity: 1;
+}
+
+@starting-style {
+  .ease-popover-modal:popover-open::backdrop {
+    opacity: 0;
+  }
+}
+
+/* Respect user motion preferences */
+@media (prefers-reduced-motion: reduce) {
+  .ease-popover-modal,
+  .ease-popover-modal::backdrop {
+    transition: none !important;
+  }
+}
+
+/* --------------------------------------------------------------------------
+   6. Modal Interior Layout
+   -------------------------------------------------------------------------- */
+
+.modal-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--pm-space-4);
+  padding: var(--pm-space-6) var(--pm-space-6) var(--pm-space-4);
+  border-bottom: 1px solid var(--pm-border);
+}
+
+.modal-icon {
+  flex-shrink: 0;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: var(--pm-radius-xs);
+  background: var(--pm-accent-muted);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.25rem;
+}
+
+.modal-title-group {
+  flex: 1;
+}
+
+.modal-title {
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: var(--pm-text);
+  letter-spacing: -0.01em;
+  line-height: 1.3;
+}
+
+.modal-subtitle {
+  font-size: 0.8125rem;
+  color: var(--pm-text-muted);
+  margin-top: 0.25rem;
+}
+
+.modal-close-x {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border: 1px solid var(--pm-border);
+  background: transparent;
+  border-radius: var(--pm-radius-xs);
+  color: var(--pm-text-muted);
+  font-size: 1.125rem;
+  line-height: 1;
+  cursor: pointer;
+  font-family: var(--pm-font);
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.modal-close-x:hover {
+  background: rgba(248, 113, 113, 0.1);
+  border-color: var(--pm-danger);
+  color: var(--pm-danger);
+}
+
+.modal-close-x:focus-visible {
+  outline: 2px solid #818cf8;
+  outline-offset: 2px;
+}
+
+.modal-body {
+  padding: var(--pm-space-5) var(--pm-space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--pm-space-4);
+}
+
+.modal-body p {
+  font-size: 0.9375rem;
+  color: var(--pm-text-muted);
+  line-height: 1.7;
+}
+
+.modal-feature-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--pm-space-2);
+}
+
+.modal-feature-list li {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--pm-space-3);
+  font-size: 0.875rem;
+  color: var(--pm-text-muted);
+  line-height: 1.5;
+}
+
+.modal-feature-list li::before {
+  content: '✦';
+  color: #818cf8;
+  font-size: 0.65rem;
+  margin-top: 0.35rem;
+  flex-shrink: 0;
+}
+
+.code-pill {
+  display: inline-block;
+  font-family: var(--pm-font-mono);
+  font-size: 0.8em;
+  background: rgba(99, 102, 241, 0.15);
+  color: #a5b4fc;
+  border-radius: var(--pm-radius-xs);
+  padding: 0.1em 0.4em;
+  border: 1px solid rgba(99, 102, 241, 0.25);
+}
+
+.modal-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--pm-space-3);
+  padding: var(--pm-space-4) var(--pm-space-6) var(--pm-space-6);
+  border-top: 1px solid var(--pm-border);
+}
+
+/* Secondary / ghost button inside modal */
+.modal-btn-ghost {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.55rem 1.25rem;
+  font-family: var(--pm-font);
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--pm-text-muted);
+  background: transparent;
+  border: 1px solid var(--pm-border);
+  border-radius: var(--pm-radius-xs);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.modal-btn-ghost:hover {
+  background: var(--pm-surface-hover);
+  color: var(--pm-text);
+  border-color: rgba(148, 163, 184, 0.35);
+}
+
+.modal-btn-ghost:focus-visible {
+  outline: 2px solid #818cf8;
+  outline-offset: 2px;
+}
+
+/* Primary confirm button inside modal */
+.modal-btn-primary {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.55rem 1.25rem;
+  font-family: var(--pm-font);
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #fff;
+  background: var(--pm-accent);
+  border: 1px solid transparent;
+  border-radius: var(--pm-radius-xs);
+  cursor: pointer;
+  transition: background 0.15s ease, transform 0.1s ease;
+}
+
+.modal-btn-primary:hover {
+  background: var(--pm-accent-hover);
+  transform: translateY(-1px);
+}
+
+.modal-btn-primary:active {
+  transform: translateY(0);
+}
+
+.modal-btn-primary:focus-visible {
+  outline: 2px solid #818cf8;
+  outline-offset: 2px;
+}
+
+/* --------------------------------------------------------------------------
+   7. Docs / How-It-Works Panel
+   -------------------------------------------------------------------------- */
+
+.docs-panel {
+  margin-top: var(--pm-space-8);
+  width: min(680px, calc(100vw - 2rem));
+  background: var(--pm-surface);
+  border: 1px solid var(--pm-border);
+  border-radius: var(--pm-radius);
+  padding: var(--pm-space-6);
+}
+
+.docs-panel h2 {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--pm-text);
+  margin-bottom: var(--pm-space-4);
+  letter-spacing: -0.01em;
+}
+
+.docs-step {
+  display: flex;
+  gap: var(--pm-space-4);
+  margin-bottom: var(--pm-space-5);
+}
+
+.docs-step:last-child {
+  margin-bottom: 0;
+}
+
+.step-num {
+  flex-shrink: 0;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 50%;
+  background: var(--pm-accent-muted);
+  color: #818cf8;
+  font-size: 0.8125rem;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 0.1rem;
+}
+
+.docs-step div {
+  flex: 1;
+}
+
+.docs-step h3 {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--pm-text);
+  margin-bottom: var(--pm-space-1);
+}
+
+.docs-step p {
+  font-size: 0.8375rem;
+  color: var(--pm-text-muted);
+  line-height: 1.6;
+}
+
+/* --------------------------------------------------------------------------
+   8. Responsive
+   -------------------------------------------------------------------------- */
+
+@media (max-width: 480px) {
+  .modal-footer {
+    flex-direction: column-reverse;
+    align-items: stretch;
+  }
+
+  .modal-btn-ghost,
+  .modal-btn-primary {
+    justify-content: center;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-popover-modal`, a fully animated modal component built on the **native HTML Popover API** with CSS `@starting-style` for smooth enter/exit transitions directly from `display: none` — zero JavaScript, zero dependencies.

 Closes #61501 

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (`submissions/examples/ease-popover-modal/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A zero-JavaScript modal component that uses the browser-native `popover` attribute and `@starting-style` to animate entry and exit transitions from `display: none` — replacing the `setTimeout` hacks and JS state machines traditionally required for modal lifecycle animations.

**How does a developer use it?**

```html
<!-- 1. Trigger button — no JS wiring needed -->
<button popovertarget="ease-modal-demo" class="ease-btn">
  Open Popover Modal
</button>

<!-- 2. Modal container — popover attribute does all the work -->
<div id="ease-modal-demo" popover class="ease-popover-modal">

  <div class="modal-header">
    <h2 class="modal-title">Modal Title</h2>
    <button
      popovertarget="ease-modal-demo"
      popovertargetaction="hide"
      class="modal-close-x"
      aria-label="Close"
    >×</button>
  </div>

  <div class="modal-body">
    <p>Modal content goes here.</p>
  </div>

  <div class="modal-footer">
    <button
      popovertarget="ease-modal-demo"
      popovertargetaction="hide"
      class="modal-btn-ghost"
    >Close</button>
    <button
      popovertarget="ease-modal-demo"
      popovertargetaction="hide"
      class="modal-btn-primary"
    >Confirm</button>
  </div>

</div>
```

**Why does it fit EaseMotion CSS?**

EaseMotion CSS is built on the principle that motion should be declarative, human-readable, and free of JavaScript overhead. `ease-popover-modal` is the natural expression of that philosophy applied to modals: the entire open/close/animate lifecycle is expressed in CSS — `@starting-style` seeds the entry, `allow-discrete` on `display` and `overlay` defers the exit, and the `::backdrop` fades in sync. A developer reads the CSS and immediately understands what happens and when, with no hidden JS state to untangle.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

- `@starting-style` and `allow-discrete` are supported in Chrome 117+, Edge 117+, Firefox 129+, and Safari 17.5+. In older browsers the modal still opens and closes correctly — just without the transition animation (graceful degradation).
- The `::backdrop` is transitioned separately using its own `@starting-style` block so it fades in/out in perfect sync with the modal panel; this is intentional and required because `::backdrop` is a separate pseudo-element in the top layer.
- Timing is currently `0.4s ease` — feel free to adjust to match the EaseMotion design token convention if one exists for modal durations.
- `prefers-reduced-motion: reduce` fully disables all transitions, so the component is safe for motion-sensitive users out of the box.

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
>
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
