### PR TITLE
# fix(a11y): disable badge pulse animation when prefers-reduced-motion is active (#61760)

### DIFF
--- a/components/badges.css
+++ b/components/badges.css
@@ -76,4 +76,12 @@
   .em-badge-success.em-badge-pulse::after {
     box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.7);
   }
+
+  /* Accessibility: Disable pulse animation for reduced motion preferences (#61760) */
+  @media (prefers-reduced-motion: reduce) {
+    .ease-badge-pulse::after,
+    .em-badge-pulse::after {
+      animation: none;
+    }
+  }
 }


### PR DESCRIPTION


## Pull Request Description

Adds a `@media (prefers-reduced-motion: reduce)` accessibility rule to the badge component. This ensures the `.ease-badge-pulse` animation respects user system preferences regarding motion sensitivity, resolving issue #61760.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Disables the continuous ping/pulse animation on pulsing badges when the user has enabled reduced motion preferences in their operating system settings.

**How does a developer use it?**

```html
<!-- Automatically respects system settings when using pulse badges -->
<span class="ease-badge ease-badge-pulse">1</span>