### PR TITLE
feat: add CSS 3D-Flip Toast for Gaming Hub Layouts (#59105)

### DIFF
--- a/submissions/examples/css-3d-flip-toast-gaming/README.md
+++ b/submissions/examples/css-3d-flip-toast-gaming/README.md
@@ -1,0 +1,43 @@
+# 3D-Flip Toast for Gaming Hub Layouts
+
+Toast notifications that flip in using CSS 3D perspective transforms, designed for gaming dashboards.
+
+## What does this do?
+
+Displays animated toast notifications that flip into view using `rotateX` perspective transforms, with a countdown progress bar and type-specific accent colors for achievements, XP gains, loot drops, and streaks.
+
+## How is it used?
+
+```html
+<div class="toast-stack" aria-live="polite">
+  <div class="toast toast--achievement" role="alert">
+    <span class="toast__icon">🏆</span>
+    <div class="toast__body">
+      <strong class="toast__title">Achievement Unlocked!</strong>
+      <p class="toast__msg">First Blood — Eliminated 1 enemy</p>
+    </div>
+    <button class="toast__close" aria-label="Dismiss">&times;</button>
+  </div>
+</div>
+```
+
+## Why is it useful?
+
+Gaming UIs need flashy, snappy feedback that matches the energy of gameplay. These toasts use pure CSS 3D transforms (`perspective` + `rotateX`) for a card-flip entrance that feels tactile and game-like, without any JS animation library.
+
+## CSS Custom Properties
+
+| Property            | Description        | Default   |
+| ------------------- | ------------------ | --------- |
+| `--toast-width`     | Toast card width   | `340px`   |
+| `--clr-achievement` | Achievement accent | `#f0b429` |
+| `--clr-xp`          | XP accent          | `#58a6ff` |
+| `--clr-loot`        | Loot accent        | `#bc8cff` |
+| `--clr-streak`      | Streak accent      | `#f97583` |
+
+## Browser Support
+
+- Chrome 90+
+- Firefox 88+
+- Safari 14+
+- Edge 90+

--- a/submissions/examples/css-3d-flip-toast-gaming/demo.html
+++ b/submissions/examples/css-3d-flip-toast-gaming/demo.html
@@ -1,0 +1,185 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>3D-Flip Toast — Gaming Hub</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="gaming-hub">
+      <header class="hub-header">
+        <h1 class="hub-title">GameVault</h1>
+        <p class="hub-subtitle">Your gaming dashboard</p>
+      </header>
+
+      <div class="hub-actions">
+        <button class="btn btn--achievement" id="btnAchievement">
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+          >
+            <circle cx="12" cy="8" r="7" />
+            <polyline points="8.21 13.89 7 23 12 20 17 23 15.79 13.88" />
+          </svg>
+          Unlock Achievement
+        </button>
+        <button class="btn btn--xp" id="btnXp">
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+          >
+            <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />
+          </svg>
+          Gain XP
+        </button>
+        <button class="btn btn--loot" id="btnLoot">
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+          >
+            <path
+              d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"
+            />
+          </svg>
+          Open Loot Box
+        </button>
+        <button class="btn btn--streak" id="btnStreak">
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+          >
+            <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" />
+          </svg>
+          Daily Streak
+        </button>
+      </div>
+
+      <div
+        class="toast-stack"
+        id="toastStack"
+        aria-live="polite"
+        aria-atomic="true"
+      ></div>
+    </div>
+
+    <script>
+      var stack = document.getElementById("toastStack");
+      var counter = 0;
+
+      var toasts = [
+        {
+          type: "achievement",
+          title: "Achievement Unlocked!",
+          msg: "First Blood — Eliminated 1 enemy in ranked match",
+          icon: "🏆",
+        },
+        {
+          type: "xp",
+          title: "+250 XP Gained",
+          msg: "Side quest completed: Find the hidden shrine",
+          icon: "⚡",
+        },
+        {
+          type: "loot",
+          title: "Legendary Drop!",
+          msg: 'You received the "Dragon\'s Fang" sword',
+          icon: "🎁",
+        },
+        {
+          type: "streak",
+          title: "7-Day Streak!",
+          msg: "Keep it up — 2x bonus XP active today",
+          icon: "🔥",
+        },
+        {
+          type: "achievement",
+          title: "Speed Runner",
+          msg: "Completed level 5 in under 2 minutes",
+          icon: "🏅",
+        },
+        {
+          type: "xp",
+          title: "+500 XP Bonus",
+          msg: "Team victory — MVP performance",
+          icon: "✨",
+        },
+      ];
+
+      function createToast(data) {
+        counter++;
+        var el = document.createElement("div");
+        el.className = "toast toast--" + data.type;
+        el.setAttribute("role", "alert");
+        el.innerHTML =
+          '<span class="toast__icon">' +
+          data.icon +
+          "</span>" +
+          '<div class="toast__body">' +
+          '<strong class="toast__title">' +
+          data.title +
+          "</strong>" +
+          '<p class="toast__msg">' +
+          data.msg +
+          "</p>" +
+          "</div>" +
+          '<button class="toast__close" aria-label="Dismiss">&times;</button>';
+
+        stack.appendChild(el);
+
+        // trigger reflow then add visible class
+        void el.offsetWidth;
+        el.classList.add("toast--visible");
+
+        el.querySelector(".toast__close").addEventListener(
+          "click",
+          function () {
+            dismissToast(el);
+          }
+        );
+
+        setTimeout(function () {
+          dismissToast(el);
+        }, 5000);
+      }
+
+      function dismissToast(el) {
+        if (!el.parentNode) return;
+        el.classList.remove("toast--visible");
+        el.classList.add("toast--exit");
+        setTimeout(function () {
+          if (el.parentNode) el.parentNode.removeChild(el);
+        }, 400);
+      }
+
+      var idx = 0;
+      function showToast() {
+        createToast(toasts[idx % toasts.length]);
+        idx++;
+      }
+
+      document
+        .getElementById("btnAchievement")
+        .addEventListener("click", showToast);
+      document.getElementById("btnXp").addEventListener("click", showToast);
+      document.getElementById("btnLoot").addEventListener("click", showToast);
+      document.getElementById("btnStreak").addEventListener("click", showToast);
+    </script>
+  </body>
+</html>

--- a/submissions/examples/css-3d-flip-toast-gaming/style.css
+++ b/submissions/examples/css-3d-flip-toast-gaming/style.css
@@ -1,0 +1,372 @@
+/* ===================================================
+   3D-Flip Toast — Gaming Hub Layouts
+   Toast notifications with perspective flip animation
+   =================================================== */
+
+:root {
+  --toast-width: 340px;
+  --toast-gap: 12px;
+  --toast-radius: 12px;
+
+  /* gaming palette */
+  --clr-bg: #0d1117;
+  --clr-surface: #161b22;
+  --clr-border: #30363d;
+  --clr-text: #e6edf3;
+  --clr-text-dim: #8b949e;
+
+  --clr-achievement: #f0b429;
+  --clr-xp: #58a6ff;
+  --clr-loot: #bc8cff;
+  --clr-streak: #f97583;
+}
+
+/* reset */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family:
+    "Segoe UI",
+    system-ui,
+    -apple-system,
+    sans-serif;
+  background: var(--clr-bg);
+  color: var(--clr-text);
+  min-height: 100vh;
+}
+
+/* hub layout */
+.gaming-hub {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem;
+}
+
+.hub-header {
+  text-align: center;
+  margin-bottom: 2.5rem;
+}
+
+.hub-title {
+  font-size: 2rem;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  background: linear-gradient(135deg, #f0b429, #f97583, #bc8cff);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.hub-subtitle {
+  color: var(--clr-text-dim);
+  margin-top: 0.375rem;
+  font-size: 0.9375rem;
+}
+
+/* action buttons */
+.hub-actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+  margin-bottom: 2rem;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.8rem 1rem;
+  border-radius: 10px;
+  border: 1px solid var(--clr-border);
+  background: var(--clr-surface);
+  color: var(--clr-text);
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    border-color 0.2s,
+    transform 0.15s,
+    box-shadow 0.2s;
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+}
+
+.btn:active {
+  transform: translateY(0);
+}
+
+.btn--achievement:hover {
+  border-color: var(--clr-achievement);
+}
+.btn--xp:hover {
+  border-color: var(--clr-xp);
+}
+.btn--loot:hover {
+  border-color: var(--clr-loot);
+}
+.btn--streak:hover {
+  border-color: var(--clr-streak);
+}
+
+/* toast stack */
+.toast-stack {
+  position: fixed;
+  top: 1.5rem;
+  right: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: var(--toast-gap);
+  z-index: 999;
+  width: var(--toast-width);
+  max-width: calc(100vw - 3rem);
+  perspective: 800px;
+}
+
+/* single toast */
+.toast {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-radius: var(--toast-radius);
+  background: var(--clr-surface);
+  border: 1px solid var(--clr-border);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  position: relative;
+  overflow: hidden;
+
+  /* start hidden — flipped on Y axis */
+  opacity: 0;
+  transform: rotateX(-90deg) translateY(-20px);
+  transform-origin: top center;
+  transition:
+    opacity 0.35s ease,
+    transform 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.toast--visible {
+  opacity: 1;
+  transform: rotateX(0deg) translateY(0);
+}
+
+.toast--exit {
+  opacity: 0;
+  transform: rotateX(90deg) scale(0.9);
+  transition:
+    opacity 0.25s ease,
+    transform 0.4s cubic-bezier(0.36, 0, 0.66, -0.56);
+}
+
+/* accent stripe on left */
+.toast::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 4px;
+  height: 100%;
+  border-radius: 4px 0 0 4px;
+}
+
+.toast--achievement::before {
+  background: var(--clr-achievement);
+}
+.toast--xp::before {
+  background: var(--clr-xp);
+}
+.toast--loot::before {
+  background: var(--clr-loot);
+}
+.toast--streak::before {
+  background: var(--clr-streak);
+}
+
+/* icon */
+.toast__icon {
+  font-size: 1.5rem;
+  line-height: 1;
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.toast--achievement .toast__icon {
+  color: var(--clr-achievement);
+}
+.toast--xp .toast__icon {
+  color: var(--clr-xp);
+}
+.toast--loot .toast__icon {
+  color: var(--clr-loot);
+}
+.toast--streak .toast__icon {
+  color: var(--clr-streak);
+}
+
+/* body text */
+.toast__body {
+  flex: 1;
+  min-width: 0;
+}
+
+.toast__title {
+  display: block;
+  font-size: 0.875rem;
+  font-weight: 700;
+  margin-bottom: 0.2rem;
+  line-height: 1.3;
+}
+
+.toast__msg {
+  font-size: 0.8125rem;
+  color: var(--clr-text-dim);
+  line-height: 1.4;
+}
+
+/* close btn */
+.toast__close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  width: 24px;
+  height: 24px;
+  border: none;
+  background: transparent;
+  color: var(--clr-text-dim);
+  font-size: 1.125rem;
+  border-radius: 6px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    background 0.15s,
+    color 0.15s;
+  line-height: 1;
+}
+
+.toast__close:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--clr-text);
+}
+
+/* progress bar */
+.toast::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  height: 3px;
+  width: 100%;
+  background: rgba(255, 255, 255, 0.15);
+  transform-origin: left;
+  animation: toastTimer 5s linear forwards;
+}
+
+.toast--achievement::after {
+  background: var(--clr-achievement);
+  opacity: 0.5;
+}
+.toast--xp::after {
+  background: var(--clr-xp);
+  opacity: 0.5;
+}
+.toast--loot::after {
+  background: var(--clr-loot);
+  opacity: 0.5;
+}
+.toast--streak::after {
+  background: var(--clr-streak);
+  opacity: 0.5;
+}
+
+@keyframes toastTimer {
+  from {
+    transform: scaleX(1);
+  }
+  to {
+    transform: scaleX(0);
+  }
+}
+
+/* stagger toasts */
+.toast:nth-child(2) {
+  transition-delay: 0.06s;
+}
+.toast:nth-child(3) {
+  transition-delay: 0.12s;
+}
+.toast:nth-child(4) {
+  transition-delay: 0.18s;
+}
+
+/* reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .toast {
+    transition-duration: 0.01ms !important;
+    transform: none !important;
+    opacity: 1;
+  }
+
+  .toast--exit {
+    opacity: 0;
+    transition-duration: 0.01ms !important;
+    transform: none !important;
+  }
+
+  .toast::after {
+    animation: none;
+  }
+}
+
+/* high contrast */
+@media (prefers-contrast: high) {
+  .toast {
+    border-width: 2px;
+  }
+  .btn {
+    border-width: 2px;
+  }
+}
+
+/* mobile */
+@media (max-width: 480px) {
+  .toast-stack {
+    right: 0.75rem;
+    left: 0.75rem;
+    width: auto;
+  }
+
+  .hub-actions {
+    grid-template-columns: 1fr;
+  }
+
+  .gaming-hub {
+    padding: 2rem 1rem;
+  }
+}
+
+/* print */
+@media print {
+  .toast-stack {
+    display: none;
+  }
+  .btn {
+    display: none;
+  }
+}


### PR DESCRIPTION
Adds toast notifications with CSS 3D perspective flip animation for gaming dashboard interfaces.

Closes #59105

---

## Type of Change

- [x] ✨ New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/css-3d-flip-toast-gaming/`
- [x] Includes `demo.html` — self-contained, opens in browser
- [x] Includes `style.css` — raw CSS with 3D flip animation
- [x] Includes `README.md` — what, how, why
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Toast notifications that flip into view using `perspective` and `rotateX(−90deg → 0)` for a card-flip entrance effect. Includes 4 toast types (achievement, XP, loot, streak) with color-coded accents and an auto-dismiss progress bar.

**How does a developer use it?**

```html
<div class="toast-stack" aria-live="polite">
  <div class="toast toast--achievement" role="alert">
    <span class="toast__icon">🏆</span>
    <div class="toast__body">
      <strong class="toast__title">Achievement Unlocked!</strong>
      <p class="toast__msg">First Blood</p>
    </div>
  </div>
</div>