### PR TITLE
Add CSS blur-entrance dropdown for gaming hub layouts

### DIFF
--- a/submissions/examples/css-blur-entrance-dropdown-gaming/README.md
+++ b/submissions/examples/css-blur-entrance-dropdown-gaming/README.md
@@ -1,0 +1,27 @@
+# CSS Blur-Entrance Dropdown for Gaming Hubs
+
+A pure CSS dropdown menu styled for gaming hub and esports matchmaking layouts. The dropdown panel transitions from a heavily blurred and scaled-up state into full clarity as it opens, creating a focal entrance effect over HUD interfaces. No JavaScript required.
+
+## How it works
+
+Utilizes the pure CSS checkbox toggle pattern (`#ease-blur-dropdown-toggle`). When unopened, the menu container holds `filter: blur(10px)`, `opacity: 0`, and `transform: scale(1.05)`. Toggling the checkbox smoothly animates `filter`, `transform`, and `opacity` down to rest values (`blur(0)` and `scale(1)`), producing a sharpening entrance effect.
+
+## Files
+
+`demo.html`, `style.css`, `README.md`
+
+## Custom properties
+
+- `--ease-dropdown-duration`: Speed of the blur-to-focus animation (`0.4s`)
+- `--ease-dropdown-radius`: Corner radius for trigger and menu (`10px`)
+- `--ease-dropdown-bg`: Dark HUD background color (`#12131a`)
+- `--ease-dropdown-border`: Subtle panel outline color (`#232736`)
+- `--ease-dropdown-text`: Primary text color (`#f3f4f6`)
+- `--ease-dropdown-muted-text`: Muted description text color (`#8b92a5`)
+- `--ease-dropdown-accent`: Cyan gaming accent color (`#06b6d4`)
+- `--ease-dropdown-blur`: Starting blur magnitude (`10px`)
+
+## Accessibility & Performance
+
+- Blur intensity is kept at a performant 10px threshold to prevent GPU rendering lag.
+- Complete support for `@media (prefers-reduced-motion: reduce)` which disables `filter` and `transform` animations, defaulting to a direct opacity fade.

--- a/submissions/examples/css-blur-entrance-dropdown-gaming/demo.html
+++ b/submissions/examples/css-blur-entrance-dropdown-gaming/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Blur-Entrance Dropdown — Gaming Hub</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="ease-container">
+    <p class="ease-eyebrow">Matchmaking Mode</p>
+    <h1 class="ease-heading">Select Playlist</h1>
+    <p class="ease-subtitle">The menu sharpens into focus as it opens over the gaming HUD.</p>
+
+    <div class="ease-dropdown">
+      <input type="checkbox" id="ease-blur-dropdown-toggle" class="ease-dropdown-input" />
+      <label for="ease-blur-dropdown-toggle" class="ease-dropdown-trigger">
+        <span class="ease-dropdown-label">Ranked Arena (5v5)</span>
+        <span class="ease-dropdown-arrow">▾</span>
+      </label>
+      <div class="ease-dropdown-menu">
+        <button class="ease-dropdown-item">
+          <span>Ranked Arena (5v5)</span>
+          <span class="ease-mode-badge">Competitive</span>
+        </button>
+        <button class="ease-dropdown-item">
+          <span>Battle Royale (Solo)</span>
+          <span class="ease-mode-badge">Survival</span>
+        </button>
+        <button class="ease-dropdown-item">
+          <span>Custom Deathmatch</span>
+          <span class="ease-mode-badge">Casual</span>
+        </button>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/css-blur-entrance-dropdown-gaming/style.css
+++ b/submissions/examples/css-blur-entrance-dropdown-gaming/style.css
@@ -1,0 +1,173 @@
+:root {
+  --ease-dropdown-duration: 0.4s;
+  --ease-dropdown-radius: 10px;
+  --ease-dropdown-bg: #12131a;
+  --ease-dropdown-border: #232736;
+  --ease-dropdown-text: #f3f4f6;
+  --ease-dropdown-muted-text: #8b92a5;
+  --ease-dropdown-accent: #06b6d4;
+  --ease-dropdown-blur: 10px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #090a0f;
+  color: var(--ease-dropdown-text);
+  padding: 3rem 1.5rem;
+}
+
+.ease-container {
+  max-width: 380px;
+  margin: 0 auto;
+}
+
+.ease-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--ease-dropdown-accent);
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
+.ease-heading {
+  font-size: 1.6rem;
+  margin: 0 0 0.5rem;
+}
+
+.ease-subtitle {
+  color: var(--ease-dropdown-muted-text);
+  margin: 0 0 2rem;
+  font-size: 0.9rem;
+}
+
+.ease-dropdown {
+  position: relative;
+  display: inline-block;
+  width: 100%;
+}
+
+.ease-dropdown-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* Dropdown Trigger */
+.ease-dropdown-trigger {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.8rem 1rem;
+  background: var(--ease-dropdown-bg);
+  border: 1px solid var(--ease-dropdown-border);
+  border-radius: var(--ease-dropdown-radius);
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: border-color var(--ease-dropdown-duration) ease;
+}
+
+.ease-dropdown-trigger:hover {
+  border-color: var(--ease-dropdown-accent);
+}
+
+.ease-dropdown-arrow {
+  transition: transform 0.25s ease;
+  color: var(--ease-dropdown-muted-text);
+}
+
+.ease-dropdown-input:checked ~ .ease-dropdown-trigger .ease-dropdown-arrow {
+  transform: rotate(180deg);
+  color: var(--ease-dropdown-accent);
+}
+
+/* Dropdown Menu - Blur Entrance Effect */
+.ease-dropdown-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  background: var(--ease-dropdown-bg);
+  border: 1px solid var(--ease-dropdown-border);
+  border-radius: var(--ease-dropdown-radius);
+  padding: 0.4rem;
+  opacity: 0;
+  visibility: hidden;
+  filter: blur(var(--ease-dropdown-blur));
+  transform: scale(1.05);
+  transition: opacity var(--ease-dropdown-duration) ease-out,
+              filter var(--ease-dropdown-duration) ease-out,
+              transform var(--ease-dropdown-duration) ease-out,
+              visibility 0s linear var(--ease-dropdown-duration);
+  z-index: 10;
+}
+
+.ease-dropdown-input:checked ~ .ease-dropdown-menu {
+  opacity: 1;
+  visibility: visible;
+  filter: blur(0);
+  transform: scale(1);
+  border-color: rgba(6, 182, 212, 0.4);
+  transition: opacity var(--ease-dropdown-duration) ease-out,
+              filter var(--ease-dropdown-duration) ease-out,
+              transform var(--ease-dropdown-duration) ease-out;
+}
+
+/* Dropdown Items */
+.ease-dropdown-item {
+  width: 100%;
+  background: none;
+  border: none;
+  color: var(--ease-dropdown-text);
+  font-family: inherit;
+  font-size: 0.85rem;
+  padding: 0.65rem 0.8rem;
+  border-radius: 6px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  transition: background-color 0.15s ease;
+}
+
+.ease-dropdown-item:hover {
+  background: rgba(6, 182, 212, 0.12);
+}
+
+.ease-mode-badge {
+  font-size: 0.75rem;
+  color: var(--ease-dropdown-accent);
+  background: rgba(6, 182, 212, 0.1);
+  padding: 0.2rem 0.5rem;
+  border-radius: 12px;
+  font-weight: 600;
+}
+
+@media (max-width: 480px) {
+  body {
+    padding: 2rem 1rem;
+  }
+  .ease-heading {
+    font-size: 1.35rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-dropdown-menu {
+    transition: opacity 0.15s ease !important;
+    filter: none !important;
+    transform: none !important;
+  }
+  .ease-dropdown-arrow {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Closes #59121

Adds a pure CSS/HTML dropdown component styled for Gaming Hub matchmaking layouts, transitioning from a blurred, scaled state to full clarity upon opening.

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

## Submission Checklist
- [x] All changes inside `submissions/examples/css-blur-entrance-dropdown-gaming/`
- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Feature Description
**What does this add?** A playlist dropdown selector that uses `filter: blur()` alongside opacity and scaling transitions to create a "sharpening into focus" entrance.
**Why does it fit?** Expands EaseMotion CSS showcase dropdown options for gaming dashboard themes without relying on external JavaScript.

## Demo
- [x] Demo added

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge

## Notes for Maintainer
Includes full `prefers-reduced-motion` fallbacks (disabling filter blur and scaling) and keeps the blur radius optimized for rendering performance.