### PR TITLE
feat: add ease-ken-burns-bh CSS Ken Burns Pan/Zoom Effect (fixes #60802)

### DIFF
--- a/submissions/examples/ease-ken-burns-bh/README.md
+++ b/submissions/examples/ease-ken-burns-bh/README.md
@@ -1,0 +1,16 @@
+# ease-ken-burns-bh
+
+Pure CSS Ken Burns pan/zoom effect for images.
+
+## What does this do?
+Creates a cinematic Ken Burns effect where images slowly pan and zoom, adding visual interest to hero sections and galleries.
+
+## How is it used?
+```html
+<div class="ease-ken-burns-bh">
+  <img src="image.jpg" alt="Description">
+</div>
+```
+
+## Why is it useful?
+Adds dynamic, cinematic movement to static images without requiring JavaScript or video encoding.

--- a/submissions/examples/ease-ken-burns-bh/demo.html
+++ b/submissions/examples/ease-ken-burns-bh/demo.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-ken-burns-bh</title>
+  <link rel="stylesheet" href="style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'Inter', sans-serif; background: #0f172a; min-height: 100vh; padding: 2rem; color: #f1f5f9; }
+    .container { max-width: 1200px; margin: 0 auto; }
+    header { text-align: center; margin-bottom: 3rem; padding: 2rem; background: rgba(30, 41, 59, 0.8); border-radius: 1rem; }
+    header h1 { font-size: 2rem; font-weight: 700; background: linear-gradient(135deg, #22d3ee, #06b6d4); -webkit-background-clip: text; -webkit-text-fill-color: transparent; margin-bottom: 0.5rem; }
+    header p { color: #94a3b8; }
+    .demo-section { background: rgba(30, 41, 59, 0.8); border: 1px solid rgba(148, 163, 184, 0.1); border-radius: 1rem; padding: 2rem; margin-bottom: 2rem; }
+    .demo-section h2 { font-size: 1.25rem; margin-bottom: 1.5rem; color: #e2e8f0; }
+    .demo-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1.5rem; }
+    .demo-item { position: relative; height: 200px; border-radius: 0.75rem; overflow: hidden; }
+    .demo-item h3 { font-size: 0.875rem; color: #94a3b8; margin-bottom: 0.75rem; }
+    .code-block { background: #1e293b; padding: 0.75rem; border-radius: 0.5rem; font-family: 'Courier New', monospace; font-size: 0.75rem; margin-top: 0.75rem; overflow-x: auto; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>ease-ken-burns-bh</h1>
+      <p>Pure CSS Ken Burns Pan/Zoom Effect for Images</p>
+    </header>
+    
+    <section class="demo-section">
+      <h2>Ken Burns Effect Examples</h2>
+      <div class="demo-grid">
+        <div>
+          <h3>Zoom In</h3>
+          <div class="demo-item ease-ken-burns-bh ease-ken-burns-bh-zoom-in">
+            <img src="https://picsum.photos/400/300?random=1" alt="Demo image">
+          </div>
+          <div class="code-block">class="ease-ken-burns-bh ease-ken-burns-bh-zoom-in"</div>
+        </div>
+        
+        <div>
+          <h3>Pan Left</h3>
+          <div class="demo-item ease-ken-burns-bh ease-ken-burns-bh-pan-left">
+            <img src="https://picsum.photos/400/300?random=2" alt="Demo image">
+          </div>
+          <div class="code-block">class="ease-ken-burns-bh ease-ken-burns-bh-pan-left"</div>
+        </div>
+        
+        <div>
+          <h3>Pan Up</h3>
+          <div class="demo-item ease-ken-burns-bh ease-ken-burns-bh-pan-up">
+            <img src="https://picsum.photos/400/300?random=3" alt="Demo image">
+          </div>
+          <div class="code-block">class="ease-ken-burns-bh ease-ken-burns-bh-pan-up"</div>
+        </div>
+        
+        <div>
+          <h3>Diagonal</h3>
+          <div class="demo-item ease-ken-burns-bh ease-ken-burns-bh-diagonal">
+            <img src="https://picsum.photos/400/300?random=4" alt="Demo image">
+          </div>
+          <div class="code-block">class="ease-ken-burns-bh ease-ken-burns-bh-diagonal"</div>
+        </div>
+      </div>
+    </section>
+    
+    <section class="demo-section">
+      <h2>Usage</h2>
+      <div class="code-block" style="font-size: 0.875rem;">
+&lt;div class="ease-ken-burns-bh ease-ken-burns-bh-zoom-in"&gt;<br>
+&nbsp;&nbsp;&lt;img src="your-image.jpg" alt="Description"&gt;<br>
+&lt;/div&gt;
+      </div>
+    </section>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-ken-burns-bh/style.css
+++ b/submissions/examples/ease-ken-burns-bh/style.css
@@ -1,0 +1,112 @@
+/* ease-ken-burns-bh */
+:root {
+  --ease-ken-burns-duration: 20s;
+  --ease-ken-burns-scale: 1.1;
+}
+
+.ease-ken-burns-bh {
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+  height: 100%;
+}
+
+.ease-ken-burns-bh img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform var(--ease-ken-burns-duration) ease-in-out;
+}
+
+.ease-ken-burns-bh:hover img {
+  transform: scale(var(--ease-ken-burns-scale));
+}
+
+/* Zoom In */
+.ease-ken-burns-bh-zoom-in img {
+  animation: ease-ken-burns-zoom-in var(--ease-ken-burns-duration) ease-in-out infinite alternate;
+}
+
+@keyframes ease-ken-burns-zoom-in {
+  from { transform: scale(1) translate(0, 0); }
+  to { transform: scale(var(--ease-ken-burns-scale)) translate(-2%, -2%); }
+}
+
+/* Zoom Out */
+.ease-ken-burns-bh-zoom-out img {
+  animation: ease-ken-burns-zoom-out var(--ease-ken-burns-duration) ease-in-out infinite alternate;
+}
+
+@keyframes ease-ken-burns-zoom-out {
+  from { transform: scale(var(--ease-ken-burns-scale)); }
+  to { transform: scale(1); }
+}
+
+/* Pan Left */
+.ease-ken-burns-bh-pan-left img {
+  animation: ease-ken-burns-pan-left var(--ease-ken-burns-duration) ease-in-out infinite alternate;
+}
+
+@keyframes ease-ken-burns-pan-left {
+  from { transform: scale(var(--ease-ken-burns-scale)) translate(5%, 0); }
+  to { transform: scale(1) translate(-5%, 0); }
+}
+
+/* Pan Right */
+.ease-ken-burns-bh-pan-right img {
+  animation: ease-ken-burns-pan-right var(--ease-ken-burns-duration) ease-in-out infinite alternate;
+}
+
+@keyframes ease-ken-burns-pan-right {
+  from { transform: scale(var(--ease-ken-burns-scale)) translate(-5%, 0); }
+  to { transform: scale(1) translate(5%, 0); }
+}
+
+/* Pan Up */
+.ease-ken-burns-bh-pan-up img {
+  animation: ease-ken-burns-pan-up var(--ease-ken-burns-duration) ease-in-out infinite alternate;
+}
+
+@keyframes ease-ken-burns-pan-up {
+  from { transform: scale(var(--ease-ken-burns-scale)) translate(0, 5%); }
+  to { transform: scale(1) translate(0, -5%); }
+}
+
+/* Pan Down */
+.ease-ken-burns-bh-pan-down img {
+  animation: ease-ken-burns-pan-down var(--ease-ken-burns-duration) ease-in-out infinite alternate;
+}
+
+@keyframes ease-ken-burns-pan-down {
+  from { transform: scale(var(--ease-ken-burns-scale)) translate(0, -5%); }
+  to { transform: scale(1) translate(0, 5%); }
+}
+
+/* Diagonal Pan */
+.ease-ken-burns-bh-diagonal img {
+  animation: ease-ken-burns-diagonal var(--ease-ken-burns-duration) ease-in-out infinite alternate;
+}
+
+@keyframes ease-ken-burns-diagonal {
+  from { transform: scale(var(--ease-ken-burns-scale)) translate(5%, 5%); }
+  to { transform: scale(1) translate(-5%, -5%); }
+}
+
+/* Rotate Zoom */
+.ease-ken-burns-bh-rotate img {
+  animation: ease-ken-burns-rotate var(--ease-ken-burns-duration) ease-in-out infinite alternate;
+}
+
+@keyframes ease-ken-burns-rotate {
+  from { transform: scale(var(--ease-ken-burns-scale)) rotate(-2deg); }
+  to { transform: scale(1) rotate(2deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-ken-burns-bh img,
+  .ease-ken-burns-bh:hover img {
+    animation: none;
+    transform: none;
+    transition: none;
+  }
+}


### PR DESCRIPTION
## PR: ease-ken-burns-bh

Pure CSS Ken Burns pan/zoom effect for images.

### What does this do?
Creates a cinematic Ken Burns effect where images slowly pan and zoom, adding visual interest to hero sections and galleries.

### How is it used?
```html
<div class="ease-ken-burns-bh ease-ken-burns-bh-zoom-in">
  <img src="image.jpg" alt="Description">
</div>
```

### Why is it useful?
Adds dynamic, cinematic movement to static images without requiring JavaScript or video encoding.

### Features
- Multiple animation variants (zoom-in, zoom-out, pan-left, pan-right, pan-up, pan-down, diagonal, rotate)
- Smooth, continuous animation loop
- CSS custom properties for duration and scale
- Accessibility support via prefers-reduced-motion
- Pure CSS - no JavaScript required

### CSS Custom Properties
- `--ease-ken-burns-duration` - Animation duration (default: 20s)
- `--ease-ken-burns-scale` - Zoom scale factor (default: 1.1)

### Related Issues
Fixes #60802