### PR TITLE
docs: add error reference guide

### DIFF
--- a/submissions/docs/61708-error-reference-guide/README.md
+++ b/submissions/docs/61708-error-reference-guide/README.md
@@ -1,0 +1,162 @@
+# Error Reference Guide
+
+This guide provides a centralized reference for common errors that developers may encounter while using EaseMotion CSS. Each error includes a description, possible causes, and recommended solutions to simplify troubleshooting.
+
+---
+
+# Common Errors
+
+## 1. CSS File Not Loading
+
+**Description**
+
+Animations or styles are not applied to the page.
+
+**Possible Causes**
+
+- Incorrect file path
+- Missing stylesheet
+- Network loading issue
+
+**Recommended Solution**
+
+- Verify the stylesheet path.
+- Ensure the CSS file exists.
+- Check the browser's developer tools for failed requests.
+
+---
+
+## 2. Incorrect Stylesheet Import Order
+
+**Description**
+
+Animations behave unexpectedly or custom styles override framework styles.
+
+**Possible Causes**
+
+- Import sequence is incorrect.
+- Multiple stylesheets conflict.
+
+**Recommended Solution**
+
+- Load EaseMotion CSS before custom overrides.
+- Avoid importing duplicate stylesheets.
+
+---
+
+## 3. CDN Caching Issues
+
+**Description**
+
+Recent stylesheet changes are not visible.
+
+**Possible Causes**
+
+- Browser cache
+- CDN cache
+
+**Recommended Solution**
+
+- Refresh the browser cache.
+- Use cache invalidation or versioned assets.
+
+---
+
+## 4. Animations Not Working
+
+**Description**
+
+Animation classes are present but no animation is visible.
+
+**Possible Causes**
+
+- Missing animation class
+- CSS not loaded
+- Unsupported browser
+
+**Recommended Solution**
+
+- Confirm the stylesheet is loaded.
+- Verify the animation class name.
+- Test in a supported browser.
+
+---
+
+## 5. npm Installation Errors
+
+**Description**
+
+Installation fails or dependencies cannot be resolved.
+
+**Possible Causes**
+
+- Dependency conflicts
+- Unsupported Node.js or npm version
+
+**Recommended Solution**
+
+- Verify Node.js and npm versions.
+- Reinstall dependencies if necessary.
+
+---
+
+## 6. Framework Integration Issues
+
+Supported frameworks include React, Next.js, Vue, Astro, and Svelte.
+
+**Possible Causes**
+
+- Incorrect global stylesheet import
+- Project configuration issues
+
+**Recommended Solution**
+
+- Follow the framework integration guide.
+- Import the stylesheet in the correct entry point.
+
+---
+
+## 7. Browser Compatibility Problems
+
+**Description**
+
+Animations work differently across browsers.
+
+**Recommended Solution**
+
+- Test using supported browsers.
+- Keep browsers updated.
+
+---
+
+## 8. Missing Assets
+
+**Description**
+
+Resources such as fonts or images fail to load.
+
+**Possible Causes**
+
+- Incorrect file path
+- Missing files
+
+**Recommended Solution**
+
+- Verify asset locations.
+- Check relative and absolute paths.
+
+---
+
+# Best Practices
+
+- Verify stylesheet imports.
+- Keep dependencies updated.
+- Test on multiple browsers.
+- Review browser developer tools for errors.
+- Follow the official project documentation.
+
+---
+
+## Summary
+
+This Error Reference Guide helps developers quickly identify common issues, understand their causes, and apply recommended troubleshooting steps for a smoother development experience.

--- a/submissions/docs/61708-error-reference-guide/demo.html
+++ b/submissions/docs/61708-error-reference-guide/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Error Reference Guide</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="container">
+    <h1>Error Reference Guide</h1>
+
+    <div class="card">
+        <h2>Common Issues Covered</h2>
+
+        <ul>
+            <li>CSS file not loading</li>
+            <li>Import order issues</li>
+            <li>CDN caching</li>
+            <li>Animations not working</li>
+            <li>npm installation errors</li>
+            <li>Framework integration mistakes</li>
+            <li>Browser compatibility</li>
+            <li>Missing assets</li>
+        </ul>
+
+        <p>See <strong>README.md</strong> for complete troubleshooting guidance.</p>
+    </div>
+
+</div>
+
+</body>
+</html>

--- a/submissions/docs/61708-error-reference-guide/style.css
+++ b/submissions/docs/61708-error-reference-guide/style.css
@@ -1,0 +1,30 @@
+body{
+    margin:0;
+    padding:40px;
+    font-family:Arial,Helvetica,sans-serif;
+    background:#f5f7fb;
+}
+
+.container{
+    max-width:850px;
+    margin:auto;
+}
+
+.card{
+    background:#ffffff;
+    padding:30px;
+    border-radius:12px;
+    box-shadow:0 4px 12px rgba(0,0,0,.12);
+}
+
+h1{
+    color:#2c3e50;
+}
+
+h2{
+    color:#34495e;
+}
+
+ul{
+    line-height:1.8;
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds an **Error Reference Guide** under `submissions/docs/61708-error-reference-guide/`. It provides a centralized troubleshooting resource covering common setup and integration errors, their possible causes, and recommended solutions to help developers resolve issues more efficiently.

Fixes #61708

---

## Type of Change

- [x] 📝 Documentation improvement
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A centralized Error Reference Guide that documents common errors, their causes, and recommended troubleshooting steps.

**How does a developer use it?**

```html
<!-- Open demo.html directly in a browser -->
<link rel="stylesheet" href="style.css">
```

**Why does it fit EaseMotion CSS?**

It improves the documentation by reducing repetitive support questions, making troubleshooting easier, and helping new users integrate EaseMotion CSS more confidently.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

- Added a standalone documentation example under `submissions/docs/61708-error-reference-guide/`.
- Includes common setup, installation, integration, and browser-related troubleshooting guidance.
- No changes were made to the core framework or existing components.