### PR TITLE
feat: add CSS Skew-Active Toast for Gaming Hub Layouts (#59099)

### DIFF
--- a/submissions/examples/skew-active-toast-gaming/README.md
+++ b/submissions/examples/skew-active-toast-gaming/README.md
@@ -1,0 +1,44 @@
+# Skew-Active Toast for Gaming Hub Layouts
+
+Toast notifications that enter with a skew transform, designed for gaming dashboards.
+
+## What does this do?
+
+Displays toast messages that slide in with a `skewY` skew effect and snap straight, giving a quick, punchy entrance that fits gaming UIs.
+
+## How is it used?
+
+```html
+<div class="toast-container" aria-live="polite">
+  <div class="toast toast--win toast--active" role="alert">
+    <div class="toast__inner">
+      <div class="toast__head">
+        <span class="toast__title">Victory!</span>
+        <button class="toast__x" aria-label="Close">&times;</button>
+      </div>
+      <p class="toast__body">Your team won the ranked match.</p>
+    </div>
+  </div>
+</div>
+```
+
+## Why is it useful?
+
+Quick, lightweight toast with a skewed entrance that feels snappy and game-like. No JS animation library needed — pure CSS transform and transition.
+
+## CSS Custom Properties
+
+| Property       | Description     | Default   |
+| -------------- | --------------- | --------- |
+| `--st-win`     | Win accent      | `#22c55e` |
+| `--st-warn`    | Warning accent  | `#f59e0b` |
+| `--st-info`    | Info accent     | `#6366f1` |
+| `--st-surface` | Card background | `#1c1f26` |
+| `--st-radius`  | Border radius   | `10px`    |
+
+## Browser Support
+
+- Chrome 90+
+- Firefox 88+
+- Safari 14+
+- Edge 90+

--- a/submissions/examples/skew-active-toast-gaming/demo.html
+++ b/submissions/examples/skew-active-toast-gaming/demo.html
@@ -1,0 +1,121 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Skew-Active Toast — Gaming Hub</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="gaming-panel">
+      <div class="panel-header">
+        <h1 class="panel-title">GameVault</h1>
+        <p class="panel-desc">Skew-Active Toast Notifications</p>
+      </div>
+
+      <div class="btn-row">
+        <button class="skew-btn skew-btn--win" id="btnWin">Victory</button>
+        <button class="skew-btn skew-btn--warn" id="btnWarn">Alert</button>
+        <button class="skew-btn skew-btn--info" id="btnInfo">Info</button>
+      </div>
+
+      <div
+        class="toast-container"
+        id="toastContainer"
+        aria-live="polite"
+        aria-relevant="additions"
+      ></div>
+    </div>
+
+    <script>
+      var container = document.getElementById("toastContainer");
+      var msgs = {
+        win: [
+          {
+            title: "Victory!",
+            body: "Your team won the ranked match. +500 XP",
+          },
+          { title: "Clutch Play", body: "Last kill secured the win. Amazing!" },
+          { title: "MVP Award", body: "You earned Most Valuable Player" },
+        ],
+        warn: [
+          {
+            title: "Low Health",
+            body: "Find a health pack before the next fight",
+          },
+          { title: "Zone Shrinking", body: "Move to safe zone in 10 seconds" },
+          { title: "Ammo Low", body: "Reload or switch weapons" },
+        ],
+        info: [
+          { title: "New Quest", body: "Side mission available: Hidden Temple" },
+          { title: "Friend Online", body: "xX_Shadow_Xx is now playing" },
+          {
+            title: "Daily Bonus",
+            body: "Log in 5 more days for a legendary crate",
+          },
+        ],
+      };
+
+      function pickMsg(type) {
+        var arr = msgs[type];
+        return arr[Math.floor(Math.random() * arr.length)];
+      }
+
+      function makeToast(type) {
+        var data = pickMsg(type);
+        var el = document.createElement("div");
+        el.className = "toast toast--" + type;
+        el.setAttribute("role", "alert");
+        el.innerHTML =
+          '<div class="toast__inner">' +
+          '<div class="toast__head">' +
+          '<span class="toast__title">' +
+          data.title +
+          "</span>" +
+          '<button class="toast__x" aria-label="Close">&times;</button>' +
+          "</div>" +
+          '<p class="toast__body">' +
+          data.body +
+          "</p>" +
+          '<div class="toast__bar"><div class="toast__bar-fill"></div></div>' +
+          "</div>";
+
+        container.prepend(el);
+
+        // kick off the skew-in
+        requestAnimationFrame(function () {
+          requestAnimationFrame(function () {
+            el.classList.add("toast--active");
+          });
+        });
+
+        el.querySelector(".toast__x").onclick = function () {
+          dismiss(el);
+        };
+
+        setTimeout(function () {
+          dismiss(el);
+        }, 4000);
+      }
+
+      function dismiss(el) {
+        if (!el.parentNode) return;
+        el.classList.remove("toast--active");
+        el.classList.add("toast--leaving");
+        setTimeout(function () {
+          if (el.parentNode) el.parentNode.removeChild(el);
+        }, 350);
+      }
+
+      document.getElementById("btnWin").onclick = function () {
+        makeToast("win");
+      };
+      document.getElementById("btnWarn").onclick = function () {
+        makeToast("warn");
+      };
+      document.getElementById("btnInfo").onclick = function () {
+        makeToast("info");
+      };
+    </script>
+  </body>
+</html>

--- a/submissions/examples/skew-active-toast-gaming/style.css
+++ b/submissions/examples/skew-active-toast-gaming/style.css
@@ -1,0 +1,293 @@
+/* ===================================================
+   Skew-Active Toast — Gaming Hub Layouts
+   Toast notifications with skew transition on enter
+   =================================================== */
+
+:root {
+  --st-bg: #111318;
+  --st-surface: #1c1f26;
+  --st-border: #2c3040;
+  --st-text: #e8eaed;
+  --st-text-dim: #8a8f9d;
+  --st-win: #22c55e;
+  --st-warn: #f59e0b;
+  --st-info: #6366f1;
+  --st-radius: 10px;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
+  background: var(--st-bg);
+  color: var(--st-text);
+  min-height: 100vh;
+}
+
+/* ---- panel ---- */
+.gaming-panel {
+  max-width: 520px;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+}
+
+.panel-header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.panel-title {
+  font-size: 1.75rem;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+}
+
+.panel-desc {
+  color: var(--st-text-dim);
+  font-size: 0.875rem;
+  margin-top: 0.25rem;
+}
+
+/* ---- trigger buttons ---- */
+.btn-row {
+  display: flex;
+  gap: 0.625rem;
+  justify-content: center;
+  margin-bottom: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.skew-btn {
+  padding: 0.6rem 1.25rem;
+  border-radius: 8px;
+  border: 1px solid var(--st-border);
+  background: var(--st-surface);
+  color: var(--st-text);
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    transform 0.2s ease,
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.skew-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+.skew-btn--win:hover {
+  border-color: var(--st-win);
+}
+.skew-btn--warn:hover {
+  border-color: var(--st-warn);
+}
+.skew-btn--info:hover {
+  border-color: var(--st-info);
+}
+
+/* ---- toast container ---- */
+.toast-container {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  perspective: 600px;
+}
+
+/* ---- single toast ---- */
+.toast {
+  opacity: 0;
+  /* start skewed + shifted — skewed axis is roughly the left edge */
+  transform: skewY(-6deg) translateX(40px) scale(0.95);
+  transform-origin: left center;
+  transition:
+    opacity 0.3s ease,
+    transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.toast--active {
+  opacity: 1;
+  transform: skewY(0deg) translateX(0) scale(1);
+}
+
+.toast--leaving {
+  opacity: 0;
+  transform: skewY(4deg) translateX(-30px) scale(0.95);
+  transition:
+    opacity 0.2s ease,
+    transform 0.35s cubic-bezier(0.36, 0, 0.66, -0.56);
+}
+
+.toast__inner {
+  background: var(--st-surface);
+  border: 1px solid var(--st-border);
+  border-radius: var(--st-radius);
+  padding: 0.85rem 1rem 0.7rem;
+  position: relative;
+  overflow: hidden;
+}
+
+/* left accent */
+.toast__inner::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 3px;
+  height: 100%;
+}
+
+.toast--win .toast__inner::before {
+  background: var(--st-win);
+}
+.toast--warn .toast__inner::before {
+  background: var(--st-warn);
+}
+.toast--info .toast__inner::before {
+  background: var(--st-info);
+}
+
+.toast__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.2rem;
+}
+
+.toast__title {
+  font-size: 0.875rem;
+  font-weight: 700;
+}
+
+.toast__x {
+  width: 22px;
+  height: 22px;
+  border: none;
+  background: transparent;
+  color: var(--st-text-dim);
+  font-size: 1.1rem;
+  border-radius: 5px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    background 0.15s,
+    color 0.15s;
+}
+
+.toast__x:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--st-text);
+}
+
+.toast__body {
+  font-size: 0.8125rem;
+  color: var(--st-text-dim);
+  line-height: 1.45;
+}
+
+/* progress bar */
+.toast__bar {
+  height: 3px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 2px;
+  margin-top: 0.65rem;
+  overflow: hidden;
+}
+
+.toast__bar-fill {
+  height: 100%;
+  width: 100%;
+  border-radius: 2px;
+  transform-origin: left;
+  animation: st-countdown 4s linear forwards;
+}
+
+.toast--win .toast__bar-fill {
+  background: var(--st-win);
+  opacity: 0.55;
+}
+.toast--warn .toast__bar-fill {
+  background: var(--st-warn);
+  opacity: 0.55;
+}
+.toast--info .toast__bar-fill {
+  background: var(--st-info);
+  opacity: 0.55;
+}
+
+@keyframes st-countdown {
+  from {
+    transform: scaleX(1);
+  }
+  to {
+    transform: scaleX(0);
+  }
+}
+
+/* stagger */
+.toast:nth-child(2) {
+  transition-delay: 0.04s;
+}
+.toast:nth-child(3) {
+  transition-delay: 0.08s;
+}
+
+/* ---- reduced motion ---- */
+@media (prefers-reduced-motion: reduce) {
+  .toast,
+  .toast--active,
+  .toast--leaving {
+    transition-duration: 0.01ms !important;
+    transform: none !important;
+    opacity: 1;
+  }
+  .toast--leaving {
+    opacity: 0;
+  }
+  .toast__bar-fill {
+    animation: none;
+  }
+}
+
+/* ---- high contrast ---- */
+@media (prefers-contrast: high) {
+  .toast__inner {
+    border-width: 2px;
+  }
+  .skew-btn {
+    border-width: 2px;
+  }
+}
+
+/* ---- mobile ---- */
+@media (max-width: 480px) {
+  .gaming-panel {
+    padding: 2rem 1rem;
+  }
+  .btn-row {
+    flex-direction: column;
+  }
+  .skew-btn {
+    width: 100%;
+  }
+}
+
+/* ---- print ---- */
+@media print {
+  .toast-container,
+  .btn-row {
+    display: none;
+  }
+}


### PR DESCRIPTION
Adds toast notifications with CSS skew transform entrance for gaming dashboard interfaces.

Closes #59099

---

## Type of Change

- [x] ✨ New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/skew-active-toast-gaming/`
- [x] Includes `demo.html` — self-contained, opens in browser
- [x] Includes `style.css` — raw CSS with skew animation
- [x] Includes `README.md` — what, how, why
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Toast notifications that enter with a `skewY(-6deg)` transform and snap to normal, giving a punchy, game-like entrance. Includes win/warn/info variants with color-coded accents and auto-dismiss progress bar.

**How does a developer use it?**

```html
<div class="toast toast--win toast--active" role="alert">
  <div class="toast__inner">
    <span class="toast__title">Victory!</span>
    <p class="toast__body">Your team won the match.</p>
  </div>
</div>