### PR TITLE
fix: add missing closing </html> tag (fixes #60599)

### DIFF
--- a/submissions/examples/rotate-click-tabs-checkout-bhakkti/demo.html
+++ b/submissions/examples/rotate-click-tabs-checkout-bhakkti/demo.html
@@ -175,4 +175,4 @@
       <p>🛒 Perfect for e-commerce checkout flows</p>
     </div>
   </div>
-</body>
+</body></html>


### PR DESCRIPTION
## PR: Bug Fix #60599

### Bug Description
The demo.html file for rotate-click-tabs-checkout-bhakkti was missing the closing `</html>` tag.

### Fix Applied
Added the missing `</html>` closing tag to ensure valid HTML.

### Related Issues
Fixes #60599