### PR TITLE
Add ease-photocopier-scan-beam component

### DIFF
--- a/submissions/examples/photocopier-scan-beam-ij/README.md
+++ b/submissions/examples/photocopier-scan-beam-ij/README.md
@@ -1,0 +1,10 @@
+# ease-photocopier-scan-beam
+
+A photocopier whose scanning beam sweeps across the glass while a copy slides into the output tray.
+
+## Run
+Open `demo.html` directly in a browser to watch the beam scan the document.
+
+## Notes
+- The ready lamp blinks after each pass.
+- Copy sheets feed out in sync with the scan.

--- a/submissions/examples/photocopier-scan-beam-ij/demo.html
+++ b/submissions/examples/photocopier-scan-beam-ij/demo.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-photocopier-scan-beam demo</title>
+</head>
+<body>
+<div class="pc-app">
+  <span class="pc-title">PHOTOCOPIER</span>
+  <div class="pc-lid"></div>
+  <div class="pc-glass">
+    <span class="pc-line pc-line-1"></span>
+    <span class="pc-line pc-line-2"></span>
+    <span class="pc-line pc-line-3"></span>
+    <span class="pc-beam"></span>
+  </div>
+  <div class="pc-body">
+    <div class="pc-panel">
+      <span class="pc-btn pc-btn-1"></span>
+      <span class="pc-btn pc-btn-2"></span>
+      <span class="pc-btn pc-btn-3"></span>
+      <span class="pc-ready"></span>
+    </div>
+    <div class="pc-tray"><span class="pc-copy"></span></div>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/photocopier-scan-beam-ij/style.css
+++ b/submissions/examples/photocopier-scan-beam-ij/style.css
@@ -1,0 +1,22 @@
+:root{--pc-white:#f2f5f7;--pc-dark:#3a4250;--pc-beam:#3ad8e8}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#cfd8e0,#8f9aa6);font-family:'Segoe UI',sans-serif}
+.pc-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#e8eef2,#b6c0ca);box-shadow:0 16px 36px rgba(0,0,0,0.3)}
+.pc-title{position:absolute;top:14px;left:0;right:0;text-align:center;font-size:14px;font-weight:800;letter-spacing:7px;color:var(--pc-dark)}
+.pc-lid{position:absolute;top:70px;left:52px;width:268px;height:34px;border-radius:8px 8px 0 0;background:var(--pc-dark);box-shadow:inset 0 0 0 5px #2a3038}
+.pc-glass{position:absolute;top:104px;left:52px;width:268px;height:120px;background:#9fd8e8;box-shadow:inset 0 0 0 6px #7fb8cc;overflow:hidden}
+.pc-line{position:absolute;left:26px;height:8px;border-radius:4px;background:#4a5260}
+.pc-line-1{top:30px;width:160px}
+.pc-line-2{top:52px;width:200px}
+.pc-line-3{top:74px;width:130px}
+.pc-beam{position:absolute;top:0;left:0;width:10px;height:120px;background:var(--pc-beam);box-shadow:0 0 16px var(--pc-beam);animation:sweep-beam-photocopier-scan-beam 3s ease-in-out infinite}
+.pc-body{position:absolute;top:224px;left:52px;width:268px;height:110px;border-radius:0 0 10px 10px;background:var(--pc-white);box-shadow:inset 0 0 0 6px #c8ced4}
+.pc-panel{position:absolute;top:16px;left:22px;width:226px;height:40px;display:flex;align-items:center;gap:12px}
+.pc-btn{width:18px;height:18px;border-radius:4px;background:#e8b84a}
+.pc-btn-2{background:#d8604a}
+.pc-btn-3{background:#5ac06a}
+.pc-ready{width:12px;height:12px;border-radius:50%;background:#5ac06a;box-shadow:0 0 8px #5ac06a;animation:blink-ready-photocopier-scan-beam 1s steps(2) infinite}
+.pc-tray{position:absolute;bottom:16px;left:34px;width:200px;height:18px;border-radius:4px;background:#d8d2c4;overflow:hidden}
+.pc-copy{position:absolute;left:24px;width:64px;height:18px;background:#f4f0e4;animation:feed-copy-photocopier-scan-beam 3s ease-in infinite}
+@keyframes sweep-beam-photocopier-scan-beam{0%,100%{left:0}50%{left:258px}}
+@keyframes blink-ready-photocopier-scan-beam{0%,100%{opacity:1}50%{opacity:0.2}}
+@keyframes feed-copy-photocopier-scan-beam{0%{transform:translateX(0)}50%{transform:translateX(120px)}100%{transform:translateX(120px)}}


### PR DESCRIPTION
## Component: ease-photocopier-scan-beam — beam sweeps the glass, lamp blinks, and copies feed out

**Closes #61874**

### What this adds
A photocopier: the scanning beam sweeps across the glass bed over a document, the ready lamp blinks after each pass, and copy sheets slide out into the output tray.

### Acceptance Criteria covered
- Scan beam sweeps the glass
- Ready lamp blinks after a pass
- Copy sheets feed out the tray

### Files
- submissions/examples/photocopier-scan-beam-ij/demo.html
- submissions/examples/photocopier-scan-beam-ij/style.css
- submissions/examples/photocopier-scan-beam-ij/README.md

### How to review
Open `demo.html` in a browser and watch the beam scan the document.