### PR TITLE
Add ease-skateboard-ollie-flip component

### DIFF
--- a/submissions/examples/skateboard-ollie-flip-ij/README.md
+++ b/submissions/examples/skateboard-ollie-flip-ij/README.md
@@ -1,0 +1,10 @@
+# ease-skateboard-ollie-flip
+
+A skateboard doing an ollie flip across the ramp while the trick meter fills and the rider bounces.
+
+## Run
+Open `demo.html` directly in a browser to watch the board flip.
+
+## Notes
+- The board flips a full 360 degrees.
+- The rider bounces with the board.

--- a/submissions/examples/skateboard-ollie-flip-ij/demo.html
+++ b/submissions/examples/skateboard-ollie-flip-ij/demo.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-skateboard-ollie-flip demo</title>
+</head>
+<body>
+<div class="sb-app">
+  <span class="sb-title">SKATE RAMP</span>
+  <div class="sb-ramp"></div>
+  <div class="sb-meter">
+    <span class="sb-bar"></span>
+    <span class="sb-trick">OLLIE</span>
+  </div>
+  <div class="sb-board">
+    <span class="sb-grip"></span>
+    <span class="sb-rider"></span>
+    <span class="sb-truck sb-truck-1"></span>
+    <span class="sb-truck sb-truck-2"></span>
+    <span class="sb-wheel sb-wheel-1"></span>
+    <span class="sb-wheel sb-wheel-2"></span>
+    <span class="sb-wheel sb-wheel-3"></span>
+    <span class="sb-wheel sb-wheel-4"></span>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/skateboard-ollie-flip-ij/style.css
+++ b/submissions/examples/skateboard-ollie-flip-ij/style.css
@@ -1,0 +1,24 @@
+:root{--sb-wood:#c98a4a;--sb-dark:#2e3238;--sb-teal:#3ac8b8}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#cfe0e4,#8fa8b0);font-family:'Segoe UI',sans-serif}
+.sb-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#e0eef0,#b0c8cc);box-shadow:0 16px 36px rgba(0,0,0,0.3)}
+.sb-title{position:absolute;top:14px;left:0;right:0;text-align:center;font-size:14px;font-weight:800;letter-spacing:7px;color:var(--sb-teal)}
+.sb-ramp{position:absolute;bottom:70px;left:40px;width:120px;height:56px;background:#7a8490;clip-path:polygon(0 100%,38% 34%,46% 0,54% 0,62% 34%,100% 100%)}
+.sb-meter{position:absolute;right:40px;top:66px;width:90px;height:40px;border-radius:8px;background:#2e3238;box-shadow:inset 0 0 0 5px #1e2228;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:4px}
+.sb-bar{width:56px;height:8px;border-radius:4px;background:#1a1e24;overflow:hidden}
+.sb-bar::after{content:'';display:block;width:30px;height:8px;background:#e8d84a;animation:fill-bar-skateboard-ollie-flip 5s ease-in-out infinite}
+.sb-trick{color:#f4f0e4;font-size:10px;font-weight:700;letter-spacing:3px}
+.sb-board{position:absolute;top:150px;left:20px;width:110px;height:14px;border-radius:7px 7px 3px 3px;background:var(--sb-wood);box-shadow:inset 0 0 0 4px #a86a34;animation:ollie-flip-skateboard-ollie-flip 5s ease-in-out infinite}
+.sb-grip{position:absolute;top:2px;left:0;right:0;height:4px;border-radius:3px;background:#2e3238}
+.sb-rider{position:absolute;top:-44px;left:30px;width:34px;height:46px;border-radius:10px 10px 6px 6px;background:#3a6ad8;animation:bounce-rider-skateboard-ollie-flip 5s ease-in-out infinite}
+.sb-truck{position:absolute;bottom:-10px;width:20px;height:10px;border-radius:4px;background:#6c7684}
+.sb-truck-1{left:16px}
+.sb-truck-2{right:16px}
+.sb-wheel{position:absolute;bottom:-16px;width:12px;height:12px;border-radius:50%;background:#2e3238;box-shadow:inset 0 0 0 3px #1a1e24;animation:spin-wheel-skateboard-ollie-flip 1s linear infinite}
+.sb-wheel-1{left:20px}
+.sb-wheel-2{left:38px}
+.sb-wheel-3{right:38px}
+.sb-wheel-4{right:20px}
+@keyframes ollie-flip-skateboard-ollie-flip{0%,30%{transform:translate(0,0) rotate(0deg)}42%{transform:translate(150px,-30px) rotate(180deg)}54%{transform:translate(150px,0) rotate(360deg)}70%{transform:translate(150px,0) rotate(360deg)}84%{transform:translate(0,0) rotate(0deg)}100%{transform:translate(0,0) rotate(0deg)}}
+@keyframes bounce-rider-skateboard-ollie-flip{0%,30%{transform:translateY(0)}42%{transform:translateY(-20px)}54%{transform:translateY(-10px)}70%{transform:translateY(0)}100%{transform:translateY(0)}}
+@keyframes spin-wheel-skateboard-ollie-flip{to{transform:rotate(360deg)}}
+@keyframes fill-bar-skateboard-ollie-flip{0%,30%{transform:translateX(0)}54%{transform:translateX(26px)}70%{transform:translateX(26px)}84%{transform:translateX(0)}100%{transform:translateX(0)}}


### PR DESCRIPTION
## Component: ease-skateboard-ollie-flip — board flips, wheels spin, and meter fills

**Closes #61942**

### What this adds
A skatepark ramp: the skateboard ollies across the ramp and flips a full rotation while its wheels spin, the rider bounces, and the trick meter fills.

### Acceptance Criteria covered
- Board ollie-flips across the ramp
- Wheels spin under the board
- Trick meter fills with the move

### Files
- submissions/examples/skateboard-ollie-flip-ij/demo.html
- submissions/examples/skateboard-ollie-flip-ij/style.css
- submissions/examples/skateboard-ollie-flip-ij/README.md

### How to review
Open `demo.html` in a browser and watch the board flip.