### PR TITLE
fix: add missing closing html tag in rotate-click-tabs-checkout demo …

### DIFF
--- a/submissions/examples/rotate-click-tabs-checkout-bhakkti/demo.html
+++ b/submissions/examples/rotate-click-tabs-checkout-bhakkti/demo.html
@@ -176,3 +176,4 @@
     </div>
   </div>
 </body>
+</html>


### PR DESCRIPTION
## Pull Request Description
Fixes a missing `</html>` closing tag in `submissions/examples/rotate-click-tabs-checkout-bhakkti/demo.html`. The file was missing its final closing tag, causing invalid/incomplete HTML.

---

## Type of Change
- [x] 🐛 Bug fix in an existing submission

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/rotate-click-tabs-checkout-bhakkti/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description
**What does this add?**
Not a new feature — this fixes invalid HTML in an existing submission by adding the missing closing `</html>` tag.

**How does a developer use it?**
N/A — no usage change, `demo.html` now simply has valid, complete HTML structure.

**Why does it fit EaseMotion CSS?**
N/A — bug fix only, no new styling or philosophy changes introduced.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Small one-line fix — added the missing `</html>` tag at the end of `demo.html`. No other content was changed.