### PR TITLE
Add Tabs with Sliding Indicator (ease-tabs)

### DIFF
--- a/submissions/examples/ease-tabss/README.md
+++ b/submissions/examples/ease-tabss/README.md
@@ -1,0 +1,12 @@
+# Tabs with Sliding Indicator (`ease-tabs`)
+
+A pure-CSS tab navigation featuring a smooth sliding indicator under the active tab.
+
+## Features
+- **Pure CSS State**: Uses the CSS `:checked` radio hack without JavaScript.
+- **Performant Animation**: Smooth sliding transition using `transform: translateX()`.
+- **Flexible Setup**: Uses CSS Custom Property `--tab-count` for easy scaling.
+
+## Structure
+- `demo.html` — Live preview layout
+- `style.css` — Core animation and layout rules

--- a/submissions/examples/ease-tabss/demo.html
+++ b/submissions/examples/ease-tabss/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tabs with Sliding Indicator Demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      margin: 0;
+      background-color: #f8fafc;
+    }
+  </style>
+</head>
+<body>
+
+  <!-- Pure CSS Sliding Tabs Component -->
+  <div class="tabs" style="--tab-count: 3;">
+    <input type="radio" name="tab" id="tab1" checked>
+    <label for="tab1" class="tabs-item">Overview</label>
+
+    <input type="radio" name="tab" id="tab2">
+    <label for="tab2" class="tabs-item">Analytics</label>
+
+    <input type="radio" name="tab" id="tab3">
+    <label for="tab3" class="tabs-item">Settings</label>
+
+    <span class="tabs-indicator"></span>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-tabss/style,css
+++ b/submissions/examples/ease-tabss/style,css
@@ -1,0 +1,72 @@
+/* Parent Container Layout */
+.tabs {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: fit-content;
+  background-color: #f1f5f9;
+  padding: 4px;
+  border-radius: 8px;
+  user-select: none;
+}
+
+/* Hide radio inputs visually */
+.tabs input[type="radio"] {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* Tab Item Label */
+.tabs-item {
+  position: relative;
+  z-index: 2;
+  flex: 1;
+  padding: 8px 16px;
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+  color: #64748b;
+  text-align: center;
+  cursor: pointer;
+  transition: color 0.3s ease;
+}
+
+.tabs-item:hover {
+  color: #0f172a;
+}
+
+/* Active tab text style */
+.tabs input[type="radio"]:nth-of-type(1):checked ~ label:nth-of-type(1),
+.tabs input[type="radio"]:nth-of-type(2):checked ~ label:nth-of-type(2),
+.tabs input[type="radio"]:nth-of-type(3):checked ~ label:nth-of-type(3) {
+  color: #0f172a;
+  font-weight: 600;
+}
+
+/* Sliding Indicator */
+.tabs-indicator {
+  position: absolute;
+  top: 4px;
+  bottom: 4px;
+  left: 4px;
+  z-index: 1;
+  width: calc((100% - 8px) / var(--tab-count, 3));
+  background-color: #ffffff;
+  border-radius: 6px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1), 0 1px 2px rgba(0, 0, 0, 0.06);
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Indicator Movements */
+.tabs input[type="radio"]:nth-of-type(1):checked ~ .tabs-indicator {
+  transform: translateX(0%);
+}
+
+.tabs input[type="radio"]:nth-of-type(2):checked ~ .tabs-indicator {
+  transform: translateX(100%);
+}
+
+.tabs input[type="radio"]:nth-of-type(3):checked ~ .tabs-indicator {
+  transform: translateX(200%);
+}


### PR DESCRIPTION
### Contributor
- **Feature Name:** Tabs with Sliding Indicator
- **Folder Path:** `submissions/examples/ease-tabs/`

### Description
A horizontal tab navigation where an underline indicator smoothly slides beneath the active tab when selection changes, using the radio-button hack for pure-CSS state management and CSS transforms for smooth animation.

### Checklist
- [x] Closes #60863
- [x] Files added inside `submissions/examples/ease-tabs/`
- [x] Included `demo.html`, `style.css`, and `README.md`