### PR TITLE
feat: add CSS scale-hover toast for gaming hub layouts (#59104)

### DIFF
--- a/submissions/examples/gaming-hub-scale-toast/README.md
+++ b/submissions/examples/gaming-hub-scale-toast/README.md
@@ -1,0 +1,37 @@
+# Gaming Hub - Scale Hover Toast
+
+A pure CSS/HTML showcase component: game cards in a responsive grid that scale up on hover and reveal a toast-style info panel with the game title and description.
+
+## Features
+
+- Smooth scale + shadow lift on hover/focus using CSS transitions
+- Toast panel slides up from the bottom with a fade-in
+- Fully keyboard accessible via `tabindex="0"` and `:focus-within`
+- Responsive grid (`auto-fit`, `minmax`) — collapses to a single column on mobile
+- Respects `prefers-reduced-motion` by disabling transforms/transitions
+- No external JS or frameworks — pure CSS/HTML
+
+## Usage
+
+1. Copy `demo.html` and `style.css` into your project.
+2. Replace the `.game-cover` image `src` and `.toast-title` / `.toast-desc` text with your own content.
+3. Reuse `.game-card` inside any `.hub-grid` to add more cards.
+
+## CSS Custom Properties
+
+| Property | Purpose |
+|---|---|
+| `--hub-bg` | Page background color |
+| `--card-bg` | Card background color |
+| `--toast-bg` | Toast panel background (with transparency for blur) |
+| `--accent` | Hover outline / focus accent color |
+| `--text-primary` | Primary text color |
+| `--text-secondary` | Secondary/description text color |
+| `--card-radius` | Border radius for cards |
+| `--transition-speed` | Duration for all hover/focus transitions |
+
+## Accessibility
+
+- Cards are keyboard-focusable (`tabindex="0"`), so the toast reveal works with both mouse hover and keyboard focus.
+- A visible `:focus-visible` outline is included for keyboard users.
+- All animation is disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/gaming-hub-scale-toast/demo.html
+++ b/submissions/examples/gaming-hub-scale-toast/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Gaming Hub - Scale Hover Toast</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="gaming-hub">
+    <h1 class="hub-title">Gaming Hub</h1>
+
+    <div class="hub-grid">
+
+      <div class="game-card" tabindex="0">
+        <img src="https://picsum.photos/seed/game1/400/240" alt="Game cover art" class="game-cover" />
+        <div class="game-toast">
+          <h2 class="toast-title">Nebula Raiders</h2>
+          <p class="toast-desc">Co-op space shooter, 4 players</p>
+        </div>
+      </div>
+
+      <div class="game-card" tabindex="0">
+        <img src="https://picsum.photos/seed/game2/400/240" alt="Game cover art" class="game-cover" />
+        <div class="game-toast">
+          <h2 class="toast-title">Iron Grove</h2>
+          <p class="toast-desc">Open-world survival crafting</p>
+        </div>
+      </div>
+
+      <div class="game-card" tabindex="0">
+        <img src="https://picsum.photos/seed/game3/400/240" alt="Game cover art" class="game-cover" />
+        <div class="game-toast">
+          <h2 class="toast-title">Skyline Drift</h2>
+          <p class="toast-desc">Arcade racing, career mode</p>
+        </div>
+      </div>
+
+      <div class="game-card" tabindex="0">
+        <img src="https://picsum.photos/seed/game4/400/240" alt="Game cover art" class="game-cover" />
+        <div class="game-toast">
+          <h2 class="toast-title">Ashen Keep</h2>
+          <p class="toast-desc">Dark fantasy RPG</p>
+        </div>
+      </div>
+
+      <div class="game-card" tabindex="0">
+        <img src="https://picsum.photos/seed/game5/400/240" alt="Game cover art" class="game-cover" />
+        <div class="game-toast">
+          <h2 class="toast-title">Puzzle Loom</h2>
+          <p class="toast-desc">Relaxing puzzle, no timers</p>
+        </div>
+      </div>
+
+      <div class="game-card" tabindex="0">
+        <img src="https://picsum.photos/seed/game6/400/240" alt="Game cover art" class="game-cover" />
+        <div class="game-toast">
+          <h2 class="toast-title">Voltage Arena</h2>
+          <p class="toast-desc">1v1 fighting tournament</p>
+        </div>
+      </div>
+
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/gaming-hub-scale-toast/style.css
+++ b/submissions/examples/gaming-hub-scale-toast/style.css
@@ -1,0 +1,124 @@
+:root {
+  --hub-bg: #0f1117;
+  --card-bg: #1a1d29;
+  --toast-bg: rgba(15, 17, 23, 0.92);
+  --accent: #7c5cff;
+  --text-primary: #f4f4f8;
+  --text-secondary: #b7b9c6;
+  --card-radius: 14px;
+  --transition-speed: 0.35s;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  background: var(--hub-bg);
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  color: var(--text-primary);
+}
+
+.gaming-hub {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: clamp(1.5rem, 4vw, 3rem);
+}
+
+.hub-title {
+  font-size: clamp(1.5rem, 3vw, 2.25rem);
+  margin-bottom: 1.5rem;
+  letter-spacing: 0.02em;
+}
+
+.hub-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: clamp(1rem, 2vw, 1.75rem);
+}
+
+.game-card {
+  position: relative;
+  overflow: hidden;
+  border-radius: var(--card-radius);
+  background: var(--card-bg);
+  aspect-ratio: 5 / 3;
+  cursor: pointer;
+  transition: transform var(--transition-speed) ease, box-shadow var(--transition-speed) ease;
+}
+
+.game-card:hover,
+.game-card:focus-within {
+  transform: scale(1.05);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.45), 0 0 0 1px var(--accent);
+  z-index: 2;
+}
+
+.game-cover {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: filter var(--transition-speed) ease;
+}
+
+.game-card:hover .game-cover,
+.game-card:focus-within .game-cover {
+  filter: brightness(0.55);
+}
+
+.game-toast {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  padding: 1rem 1.1rem;
+  background: var(--toast-bg);
+  backdrop-filter: blur(6px);
+  transform: translateY(100%);
+  opacity: 0;
+  transition: transform var(--transition-speed) ease, opacity var(--transition-speed) ease;
+}
+
+.game-card:hover .game-toast,
+.game-card:focus-within .game-toast {
+  transform: translateY(0);
+  opacity: 1;
+}
+
+.toast-title {
+  font-size: 1.05rem;
+  margin-bottom: 0.25rem;
+  color: var(--text-primary);
+}
+
+.toast-desc {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.game-card:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .game-card,
+  .game-cover,
+  .game-toast {
+    transition: none !important;
+  }
+
+  .game-card:hover,
+  .game-card:focus-within {
+    transform: none;
+  }
+}
+
+@media (max-width: 480px) {
+  .hub-grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
Closes #59104
## Pull Request Description
Adds a pure CSS/HTML "scale-hover toast" component for gaming hub layouts — game cards that scale up and reveal a toast panel with title/description on hover or keyboard focus, per issue #59104.

## Type of Change
- [x] ✨ New animation / hover effect

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/gaming-hub-scale-toast/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description
**What does this add?**
A responsive grid of game cards that scale up and reveal a bottom toast panel (title + description) on hover/focus.

**How does a developer use it?**
```html
<div class="game-card" tabindex="0">
  <img src="cover.jpg" class="game-cover" alt="Game cover art" />
  <div class="game-toast">
    <h2 class="toast-title">Game Name</h2>
    <p class="toast-desc">Short description</p>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
Uses only semantic class names and CSS transitions/keyframes — no JS, no build step — keeping with EaseMotion's human-readable, animation-first philosophy. Also respects `prefers-reduced-motion`.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer
Cards use `tabindex="0"` + `:focus-within` so the toast reveal is keyboard-accessible, not just mouse hover.