### PR TITLE
feat: add CSS zoom-in toast for gaming hub layouts (#59103)

### DIFF
--- a/submissions/examples/gaming-hub-zoomin-toast/README.md
+++ b/submissions/examples/gaming-hub-zoomin-toast/README.md
@@ -1,0 +1,37 @@
+# Gaming Hub - Zoom-In Toast
+
+A pure CSS/HTML showcase component: game cards in a responsive grid where a centered toast panel zooms in from the middle of the card on hover or keyboard focus, showing the game title and description.
+
+## Features
+
+- Toast zooms in from `scale(0.6)` to `scale(1)` with a bouncy easing curve
+- Card image dims and blurs slightly when the toast is active
+- Fully keyboard accessible via `tabindex="0"` and `:focus-within`
+- Responsive grid (`auto-fit`, `minmax`) — collapses to a single column on mobile
+- Respects `prefers-reduced-motion` by disabling the toast transition
+- No external JS or frameworks — pure CSS/HTML
+
+## Usage
+
+1. Copy `demo.html` and `style.css` into your project.
+2. Replace the `.game-cover` image `src` and `.toast-title` / `.toast-desc` text with your own content.
+3. Reuse `.game-card` inside any `.hub-grid` to add more cards.
+
+## CSS Custom Properties
+
+| Property | Purpose |
+|---|---|
+| `--hub-bg` | Page background color |
+| `--card-bg` | Card background color |
+| `--toast-bg` | Toast panel background |
+| `--accent` | Focus outline accent color |
+| `--text-primary` | Primary text color |
+| `--text-secondary` | Secondary/description text color |
+| `--card-radius` | Border radius for cards |
+| `--transition-speed` | Duration for the toast zoom transition |
+
+## Accessibility
+
+- Cards are keyboard-focusable (`tabindex="0"`), so the toast reveal works with both mouse hover and keyboard focus.
+- A visible `:focus-visible` outline is included for keyboard users.
+- The zoom transition is disabled under `prefers-reduced-motion: reduce`.

--- a/submissions/examples/gaming-hub-zoomin-toast/demo.html
+++ b/submissions/examples/gaming-hub-zoomin-toast/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Gaming Hub - Zoom-In Toast</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="gaming-hub">
+    <h1 class="hub-title">Gaming Hub</h1>
+
+    <div class="hub-grid">
+
+      <div class="game-card" tabindex="0">
+        <img src="https://picsum.photos/seed/zoom1/400/240" alt="Game cover art" class="game-cover" />
+        <div class="game-toast">
+          <h2 class="toast-title">Nebula Raiders</h2>
+          <p class="toast-desc">Co-op space shooter, 4 players</p>
+        </div>
+      </div>
+
+      <div class="game-card" tabindex="0">
+        <img src="https://picsum.photos/seed/zoom2/400/240" alt="Game cover art" class="game-cover" />
+        <div class="game-toast">
+          <h2 class="toast-title">Iron Grove</h2>
+          <p class="toast-desc">Open-world survival crafting</p>
+        </div>
+      </div>
+
+      <div class="game-card" tabindex="0">
+        <img src="https://picsum.photos/seed/zoom3/400/240" alt="Game cover art" class="game-cover" />
+        <div class="game-toast">
+          <h2 class="toast-title">Skyline Drift</h2>
+          <p class="toast-desc">Arcade racing, career mode</p>
+        </div>
+      </div>
+
+      <div class="game-card" tabindex="0">
+        <img src="https://picsum.photos/seed/zoom4/400/240" alt="Game cover art" class="game-cover" />
+        <div class="game-toast">
+          <h2 class="toast-title">Ashen Keep</h2>
+          <p class="toast-desc">Dark fantasy RPG</p>
+        </div>
+      </div>
+
+      <div class="game-card" tabindex="0">
+        <img src="https://picsum.photos/seed/zoom5/400/240" alt="Game cover art" class="game-cover" />
+        <div class="game-toast">
+          <h2 class="toast-title">Puzzle Loom</h2>
+          <p class="toast-desc">Relaxing puzzle, no timers</p>
+        </div>
+      </div>
+
+      <div class="game-card" tabindex="0">
+        <img src="https://picsum.photos/seed/zoom6/400/240" alt="Game cover art" class="game-cover" />
+        <div class="game-toast">
+          <h2 class="toast-title">Voltage Arena</h2>
+          <p class="toast-desc">1v1 fighting tournament</p>
+        </div>
+      </div>
+
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/gaming-hub-zoomin-toast/style.css
+++ b/submissions/examples/gaming-hub-zoomin-toast/style.css
@@ -1,0 +1,112 @@
+:root {
+  --hub-bg: #0f1117;
+  --card-bg: #1a1d29;
+  --toast-bg: rgba(20, 22, 30, 0.94);
+  --accent: #ff5c8a;
+  --text-primary: #f4f4f8;
+  --text-secondary: #b7b9c6;
+  --card-radius: 14px;
+  --transition-speed: 0.3s;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  background: var(--hub-bg);
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  color: var(--text-primary);
+}
+
+.gaming-hub {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: clamp(1.5rem, 4vw, 3rem);
+}
+
+.hub-title {
+  font-size: clamp(1.5rem, 3vw, 2.25rem);
+  margin-bottom: 1.5rem;
+  letter-spacing: 0.02em;
+}
+
+.hub-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: clamp(1rem, 2vw, 1.75rem);
+}
+
+.game-card {
+  position: relative;
+  overflow: hidden;
+  border-radius: var(--card-radius);
+  background: var(--card-bg);
+  aspect-ratio: 5 / 3;
+  cursor: pointer;
+}
+
+.game-cover {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: filter var(--transition-speed) ease;
+}
+
+.game-card:hover .game-cover,
+.game-card:focus-within .game-cover {
+  filter: brightness(0.5) blur(1px);
+}
+
+.game-toast {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  padding: 1rem;
+  background: var(--toast-bg);
+  transform: scale(0.6);
+  opacity: 0;
+  transition: transform var(--transition-speed) cubic-bezier(0.34, 1.56, 0.64, 1),
+              opacity var(--transition-speed) ease;
+}
+
+.game-card:hover .game-toast,
+.game-card:focus-within .game-toast {
+  transform: scale(1);
+  opacity: 1;
+}
+
+.toast-title {
+  font-size: 1.1rem;
+  margin-bottom: 0.35rem;
+  color: var(--text-primary);
+}
+
+.toast-desc {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.game-card:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .game-toast {
+    transition: none !important;
+  }
+}
+
+@media (max-width: 480px) {
+  .hub-grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
Closes #59103
## Pull Request Description
Adds a pure CSS/HTML "zoom-in toast" component for gaming hub layouts — a centered toast panel that zooms in from the middle of the card on hover or keyboard focus, showing the game title and description, per issue #59103.

## Type of Change
- [x] ✨ New animation / hover effect

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/gaming-hub-zoomin-toast/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description
**What does this add?**
A centered toast panel that zooms in with a bouncy scale animation on hover/focus, over a dimmed and blurred game cover image.

**How does a developer use it?**
```html
<div class="game-card" tabindex="0">
  <img src="cover.jpg" class="game-cover" alt="Game cover art" />
  <div class="game-toast">
    <h2 class="toast-title">Game Name</h2>
    <p class="toast-desc">Short description</p>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
Uses only semantic class names and CSS transitions with a custom cubic-bezier easing — no JS, no build step — keeping with EaseMotion's human-readable, animation-first philosophy. Also respects `prefers-reduced-motion`.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer
This is a distinct visual treatment from the scale-hover toast (#59104) — here the card itself stays static and only the centered toast zooms in, rather than the whole card scaling up.