### PR TITLE
feat: add scroll-driven image reveal with clip-path morphing (#59070)

### DIFF
--- a/submissions/examples/scroll-driven-clip-path-reveal/README.md
+++ b/submissions/examples/scroll-driven-clip-path-reveal/README.md
@@ -1,0 +1,36 @@
+# Scroll-Driven Image Reveal with Clip-Path Morphing
+
+A pure CSS scroll-driven animation: each image morphs from a small diamond shape into its full rectangular frame as it scrolls into the viewport, using the native CSS `animation-timeline: view()` API — no JavaScript, no IntersectionObserver.
+
+## Features
+
+- Scroll progress directly drives the animation via `animation-timeline: view()`
+- `clip-path` morphs through an intermediate hexagon shape into the final rectangle
+- Fully responsive gallery layout
+- Graceful `@supports` fallback for browsers without scroll-driven animation support
+- Respects `prefers-reduced-motion` by disabling the effect entirely
+- No external JS or frameworks — pure CSS/HTML
+
+## Usage
+
+1. Copy `demo.html` and `style.css` into your project.
+2. Wrap any image (or block element) in a `.reveal-item` with an `.reveal-image` inside.
+3. Adjust `animation-range` on `.reveal-item` to control when the reveal starts/finishes relative to scroll position.
+
+## CSS Custom Properties
+
+| Property | Purpose |
+|---|---|
+| `--page-bg` | Page background color |
+| `--text-primary` | Primary text color |
+| `--text-secondary` | Secondary/subtitle text color |
+| `--caption-bg` | Caption overlay background |
+
+## Browser Support Note
+
+`animation-timeline: view()` is supported in current Chromium-based browsers. Firefox and Safari fall back via `@supports not (...)` to show images fully visible with no animation, so the content is never hidden on unsupported browsers.
+
+## Accessibility
+
+- All animation is disabled under `prefers-reduced-motion: reduce`, showing images immediately.
+- Unsupported browsers get the same non-animated fallback, so nothing is ever permanently hidden.

--- a/submissions/examples/scroll-driven-clip-path-reveal/demo.html
+++ b/submissions/examples/scroll-driven-clip-path-reveal/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Scroll-Driven Image Reveal with Clip-Path Morphing</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <header class="intro">
+    <h1>Scroll down to see the reveal</h1>
+    <p>Pure CSS scroll-driven animation — no JavaScript.</p>
+  </header>
+
+  <main class="reveal-gallery">
+
+    <figure class="reveal-item">
+      <img src="https://picsum.photos/seed/reveal1/800/500" alt="Landscape photo one" class="reveal-image" />
+      <figcaption class="reveal-caption">Mountain Ridge</figcaption>
+    </figure>
+
+    <figure class="reveal-item">
+      <img src="https://picsum.photos/seed/reveal2/800/500" alt="Landscape photo two" class="reveal-image" />
+      <figcaption class="reveal-caption">Coastal Drift</figcaption>
+    </figure>
+
+    <figure class="reveal-item">
+      <img src="https://picsum.photos/seed/reveal3/800/500" alt="Landscape photo three" class="reveal-image" />
+      <figcaption class="reveal-caption">Forest Path</figcaption>
+    </figure>
+
+  </main>
+
+  <footer class="outro">
+    <p>End of demo.</p>
+  </footer>
+
+</body>
+</html>

--- a/submissions/examples/scroll-driven-clip-path-reveal/style.css
+++ b/submissions/examples/scroll-driven-clip-path-reveal/style.css
@@ -1,0 +1,117 @@
+:root {
+  --page-bg: #0f1117;
+  --text-primary: #f4f4f8;
+  --text-secondary: #9aa0b4;
+  --caption-bg: rgba(15, 17, 23, 0.85);
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  background: var(--page-bg);
+  color: var(--text-primary);
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+}
+
+.intro,
+.outro {
+  min-height: 60vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 2rem;
+}
+
+.intro h1 {
+  font-size: clamp(1.5rem, 4vw, 2.25rem);
+  margin-bottom: 0.75rem;
+}
+
+.intro p,
+.outro p {
+  color: var(--text-secondary);
+}
+
+.reveal-gallery {
+  display: flex;
+  flex-direction: column;
+  gap: 40vh;
+  padding: 0 clamp(1rem, 6vw, 4rem);
+}
+
+.reveal-item {
+  position: relative;
+  max-width: 900px;
+  margin: 0 auto;
+  overflow: hidden;
+  border-radius: 18px;
+
+  /* Ties this element's animation progress to its own scroll visibility */
+  animation-name: clip-morph-reveal;
+  animation-timeline: view();
+  animation-range: entry 0% cover 40%;
+  animation-fill-mode: both;
+}
+
+.reveal-image {
+  width: 100%;
+  display: block;
+  aspect-ratio: 8 / 5;
+  object-fit: cover;
+}
+
+.reveal-caption {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  padding: 1rem 1.25rem;
+  background: var(--caption-bg);
+  font-size: 1.05rem;
+  letter-spacing: 0.02em;
+}
+
+/* Morphs from a small centered diamond into the full rectangle as the item scrolls into view */
+@keyframes clip-morph-reveal {
+  0% {
+    clip-path: polygon(50% 45%, 55% 50%, 50% 55%, 45% 50%);
+    opacity: 0;
+  }
+  50% {
+    clip-path: polygon(20% 0%, 80% 0%, 100% 50%, 80% 100%, 20% 100%, 0% 50%);
+    opacity: 1;
+  }
+  100% {
+    clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%);
+    opacity: 1;
+  }
+}
+
+/* Fallback for browsers without scroll-timeline support: show images plainly */
+@supports not (animation-timeline: view()) {
+  .reveal-item {
+    animation: none;
+    clip-path: none;
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reveal-item {
+    animation: none !important;
+    clip-path: none;
+    opacity: 1;
+  }
+}
+
+@media (max-width: 600px) {
+  .reveal-gallery {
+    gap: 25vh;
+  }
+}


### PR DESCRIPTION
Closes #59070
## Pull Request Description
Adds a pure CSS scroll-driven image reveal — each image morphs from a small diamond shape into its full frame as it scrolls into view, using the native `animation-timeline: view()` API. Closes #59070.

## Type of Change
- [x] ✨ New animation / hover effect

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/scroll-driven-clip-path-reveal/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description
**What does this add?**
A scroll-linked reveal where each image's `clip-path` morphs from a diamond into a hexagon into the full rectangle, driven purely by scroll position via `animation-timeline: view()`.

**How does a developer use it?**
```html
<figure class="reveal-item">
  <img src="photo.jpg" class="reveal-image" alt="Description" />
  <figcaption class="reveal-caption">Caption text</figcaption>
</figure>
```

**Why does it fit EaseMotion CSS?**
Uses only native CSS scroll-driven animations and `clip-path` keyframes — no JS, no IntersectionObserver, no build step — fully in line with EaseMotion's human-readable, animation-first philosophy. Includes an `@supports` fallback and respects `prefers-reduced-motion`.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer
`animation-timeline: view()` is Chromium-only right now — Firefox/Safari get a clean `@supports` fallback showing images fully visible, so nothing is ever hidden on unsupported browsers.