### PR TITLE
feat: add CSS-only testimonial carousel component (#60866)

### DIFF
--- a/submissions/examples/ease-carousel/README.md
+++ b/submissions/examples/ease-carousel/README.md
@@ -1,0 +1,14 @@
+# Testimonial Carousel (`ease-carousel`)
+
+A lightweight, zero-JavaScript horizontal testimonial carousel driven strictly by CSS radio inputs and transitions.
+
+## Features
+- **Pure CSS State**: Controls active slides and navigation dots using CSS `:checked` pseudo-selectors.
+- **Hardware-Accelerated Motion**: Uses CSS `transform: translateX()` for fluid slide transitions.
+- **Zero Dependencies**: Lightweight alternative to third-party JavaScript carousel libraries.
+
+## Structure
+`submissions/examples/ease-carousel/`
+├── demo.html
+├── style.css
+└── README.md

--- a/submissions/examples/ease-carousel/demo.html
+++ b/submissions/examples/ease-carousel/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS-only Testimonial Carousel Demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      margin: 0;
+      background-color: #f8fafc;
+    }
+  </style>
+</head>
+<body>
+
+  <!-- Pure CSS Testimonial Carousel -->
+  <div class="carousel">
+    <input type="radio" name="slide" id="slide1" class="carousel-radio" checked>
+    <input type="radio" name="slide" id="slide2" class="carousel-radio">
+    <input type="radio" name="slide" id="slide3" class="carousel-radio">
+
+    <div class="carousel-track">
+      <blockquote class="carousel-slide">"Absolutely love this product!" — Alex</blockquote>
+      <blockquote class="carousel-slide">"Changed how we work." — Priya</blockquote>
+      <blockquote class="carousel-slide">"Support team is fantastic." — Sam</blockquote>
+    </div>
+
+    <div class="carousel-dots">
+      <label for="slide1"></label>
+      <label for="slide2"></label>
+      <label for="slide3"></label>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-carousel/style.css
+++ b/submissions/examples/ease-carousel/style.css
@@ -1,0 +1,82 @@
+/* Container Layout */
+.carousel {
+  position: relative;
+  width: 100%;
+  max-width: 600px;
+  margin: 0 auto;
+  overflow: hidden;
+  background-color: #ffffff;
+  padding: 32px 24px;
+  border-radius: 12px;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+}
+
+/* Hide Radio Buttons Visually */
+.carousel-radio {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* Carousel Track */
+.carousel-track {
+  display: flex;
+  width: 300%;
+  transition: transform 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Individual Slides */
+.carousel-slide {
+  width: 33.333%;
+  margin: 0;
+  padding: 0 16px;
+  box-sizing: border-box;
+  text-align: center;
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: 1.125rem;
+  line-height: 1.75;
+  color: #334155;
+  font-style: italic;
+}
+
+/* Slide Positions based on Radio State */
+#slide1:checked ~ .carousel-track {
+  transform: translateX(0%);
+}
+
+#slide2:checked ~ .carousel-track {
+  transform: translateX(-33.333%);
+}
+
+#slide3:checked ~ .carousel-track {
+  transform: translateX(-66.666%);
+}
+
+/* Navigation Dots */
+.carousel-dots {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 24px;
+}
+
+.carousel-dots label {
+  width: 12px;
+  height: 12px;
+  border-radius: 9999px;
+  background-color: #cbd5e1;
+  cursor: pointer;
+  transition: background-color 0.3s ease, transform 0.3s ease;
+}
+
+.carousel-dots label:hover {
+  background-color: #94a3b8;
+}
+
+/* Active Dot Styling */
+#slide1:checked ~ .carousel-dots label[for="slide1"],
+#slide2:checked ~ .carousel-dots label[for="slide2"],
+#slide3:checked ~ .carousel-dots label[for="slide3"] {
+  background-color: #2563eb;
+  transform: scale(1.2);
+}


### PR DESCRIPTION
### Contributor
- **Feature Name:** Testimonial Carousel (CSS-only)
- **Folder Path:** `submissions/examples/ease-carousel/`

### Description
Added a zero-JavaScript testimonial carousel using radio buttons for state management and CSS transforms for smooth sliding transitions between quotes.

### Checklist
- [x] Closes #60866
- [x] Files added inside `submissions/examples/ease-carousel/`
- [x] Included `demo.html`, `style.css`, and `README.md`