### PR TITLE
Add ease-film-reel-advance component

### DIFF
--- a/submissions/examples/film-reel-advance-ij/README.md
+++ b/submissions/examples/film-reel-advance-ij/README.md
@@ -1,0 +1,10 @@
+# ease-film-reel-advance
+
+A film projector whose supply reel spins the film strip frame by frame while the lens lamp glows.
+
+## Run
+Open `demo.html` directly in a browser to watch the frames march by.
+
+## Notes
+- Frames advance across the strip in steps.
+- The take-up reel turns the opposite way.

--- a/submissions/examples/film-reel-advance-ij/demo.html
+++ b/submissions/examples/film-reel-advance-ij/demo.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-film-reel-advance demo</title>
+</head>
+<body>
+<div class="fr-app">
+  <span class="fr-title">FILM REEL</span>
+  <div class="fr-reel">
+    <span class="fr-spoke fr-spoke-1"></span>
+    <span class="fr-spoke fr-spoke-2"></span>
+    <span class="fr-spoke fr-spoke-3"></span>
+    <span class="fr-spoke fr-spoke-4"></span>
+    <span class="fr-spoke fr-spoke-5"></span>
+    <span class="fr-spoke fr-spoke-6"></span>
+    <span class="fr-hub"></span>
+  </div>
+  <span class="fr-lens"></span>
+  <span class="fr-glow"></span>
+  <div class="fr-strip">
+    <span class="fr-frame fr-frame-1"></span>
+    <span class="fr-frame fr-frame-2"></span>
+    <span class="fr-frame fr-frame-3"></span>
+    <span class="fr-frame fr-frame-4"></span>
+  </div>
+  <div class="fr-takeup"><span class="fr-hub2"></span></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/film-reel-advance-ij/style.css
+++ b/submissions/examples/film-reel-advance-ij/style.css
@@ -1,0 +1,28 @@
+:root{--fr-dark:#2a2e34;--fr-gold:#d8b84a;--fr-lamp:#ffe8a8}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#3a3038,#1c141c);font-family:'Segoe UI',sans-serif}
+.fr-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#2e242c,#160e16);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.fr-title{position:absolute;top:14px;left:0;right:0;text-align:center;font-size:14px;font-weight:800;letter-spacing:7px;color:#b8a8b8}
+.fr-reel{position:absolute;top:76px;left:44px;width:150px;height:150px;border-radius:50%;background:#20242a;box-shadow:inset 0 0 0 10px #383c44;animation:spin-reel-film-reel-advance 2.4s linear infinite}
+.fr-spoke{position:absolute;top:71px;left:71px;width:8px;height:74px;border-radius:4px;background:var(--fr-gold);transform-origin:4px 4px}
+.fr-spoke-1{transform:rotate(0deg)}
+.fr-spoke-2{transform:rotate(60deg)}
+.fr-spoke-3{transform:rotate(120deg)}
+.fr-spoke-4{transform:rotate(180deg)}
+.fr-spoke-5{transform:rotate(240deg)}
+.fr-spoke-6{transform:rotate(300deg)}
+.fr-hub{position:absolute;top:68px;left:68px;width:14px;height:14px;border-radius:50%;background:var(--fr-gold)}
+.fr-lens{position:absolute;top:122px;right:70px;width:30px;height:30px;border-radius:50%;background:#4a90c8;box-shadow:0 0 22px #4a90c8;animation:flicker-lens-film-reel-advance 1.4s steps(2) infinite}
+.fr-glow{position:absolute;top:120px;right:40px;width:90px;height:36px;border-radius:50%;background:var(--fr-lamp);filter:blur(20px);opacity:0.35;animation:pulse-glow-film-reel-advance 2.4s ease-in-out infinite}
+.fr-strip{position:absolute;top:252px;left:30px;width:312px;height:64px;border-radius:8px;background:#e8e0d0;box-shadow:inset 0 0 0 6px #b8b0a0;overflow:hidden}
+.fr-frame{position:absolute;top:12px;width:34px;height:40px;border-radius:3px;background:#2a2e34;animation:advance-strip-film-reel-advance 2.4s steps(1) infinite}
+.fr-frame-1{left:24px;background:#4a90c8}
+.fr-frame-2{left:86px;background:#d8604a;animation-delay:0.6s}
+.fr-frame-3{left:148px;background:#5ac06a;animation-delay:1.2s}
+.fr-frame-4{left:210px;background:#e8b84a;animation-delay:1.8s}
+.fr-takeup{position:absolute;top:76px;right:66px;width:54px;height:54px;border-radius:50%;background:#20242a;box-shadow:inset 0 0 0 8px #383c44;animation:spin-takeup-film-reel-advance 2.4s linear infinite}
+.fr-hub2{position:absolute;top:23px;left:23px;width:8px;height:8px;border-radius:50%;background:var(--fr-gold)}
+@keyframes spin-reel-film-reel-advance{to{transform:rotate(360deg)}}
+@keyframes spin-takeup-film-reel-advance{to{transform:rotate(-360deg)}}
+@keyframes advance-strip-film-reel-advance{0%,20%{transform:translateX(0)}32%{transform:translateX(62px)}48%{transform:translateX(62px)}60%{transform:translateX(124px)}76%{transform:translateX(124px)}88%{transform:translateX(186px)}100%{transform:translateX(186px)}}
+@keyframes flicker-lens-film-reel-advance{0%,100%{opacity:1}50%{opacity:0.35}}
+@keyframes pulse-glow-film-reel-advance{0%,100%{opacity:0.25}50%{opacity:0.5}}


### PR DESCRIPTION
## Component: ease-film-reel-advance — reel spins, frames advance, and the lamp glows

**Closes #62058**

### What this adds
A film projector: the supply reel spins as the film strip advances frame by frame, the lens lamp glows, and the take-up reel turns the other way.

### Acceptance Criteria covered
- Supply reel spins the film
- Film strip advances frame by frame
- Lens lamp glows on the projector

### Files
- submissions/examples/film-reel-advance-ij/demo.html
- submissions/examples/film-reel-advance-ij/style.css
- submissions/examples/film-reel-advance-ij/README.md

### How to review
Open `demo.html` in a browser and watch the frames march by.