### PR TITLE
add animated floating label input

### DIFF
--- a/submissions/examples/animated-label-input-floating/README.md
+++ b/submissions/examples/animated-label-input-floating/README.md
@@ -1,0 +1,11 @@
+# ease-float-label
+
+A pure-CSS Material-style floating label input for **EaseMotion CSS**. No JS required.
+
+## Usage
+
+```html
+<div class="float-label">
+  <input type="text" id="email" placeholder=" " required>
+  <label for="email">Email address</label>
+</div>

--- a/submissions/examples/animated-label-input-floating/demo.html
+++ b/submissions/examples/animated-label-input-floating/demo.html
@@ -1,0 +1,25 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-float-label Demo</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body { font-family: system-ui, sans-serif; background: #0f172a; color: #f1f5f9; display: flex; justify-content: center; padding: 80px; }
+  form { width: 280px; }
+</style>
+</head>
+<body>
+  <form>
+    <div class="float-label">
+      <input type="text" id="email" placeholder=" " required>
+      <label for="email">Email address</label>
+    </div>
+    <div class="float-label">
+      <input type="password" id="pass" placeholder=" " required>
+      <label for="pass">Password</label>
+    </div>
+  </form>
+</body>
+</html>

--- a/submissions/examples/animated-label-input-floating/style.css
+++ b/submissions/examples/animated-label-input-floating/style.css
@@ -1,0 +1,41 @@
+/* ==========================================================
+   ease-float-label — Floating Label Input
+   Pure CSS via :placeholder-shown, no JS required.
+   ========================================================== */
+
+.float-label {
+  position: relative;
+  margin-top: 20px;
+}
+
+.float-label input {
+  width: 100%;
+  padding: 14px 12px 6px;
+  background: #1e293b;
+  color: #f1f5f9;
+  border: 1px solid #475569;
+  border-radius: 8px;
+  font-size: 1rem;
+  box-sizing: border-box;
+}
+
+.float-label label {
+  position: absolute;
+  left: 12px;
+  top: 14px;
+  color: #94a3b8;
+  pointer-events: none;
+  transition: transform 0.2s ease, color 0.2s ease;
+  transform-origin: left top;
+}
+
+.float-label input:focus + label,
+.float-label input:not(:placeholder-shown) + label {
+  transform: translateY(-20px) scale(0.8);
+  color: #60a5fa;
+}
+
+.float-label input:focus {
+  outline: none;
+  border-color: #60a5fa;
+}


### PR DESCRIPTION
### PR Description
```markdown
## Summary
Adds `ease-float-label`, a pure-CSS floating label input, per issue #3.

## What's included
- `submissions/ease-float-label/style.css`
- `submissions/ease-float-label/demo.html`
- `submissions/ease-float-label/readme.md`

## Implementation notes
- Uses `:placeholder-shown` + a mandatory single-space placeholder to detect "has value" state without JS.
- Label animates via `transform: translateY() scale()` on both `:focus` and filled states.

## Testing checklist
- [x] Verified label floats on focus and stays floated after typing + blur
- [x] Verified label returns to rest position when field is cleared
- [x] Placed only inside `submissions/`

Closes #3