### PR TITLE
add animated tooltip with arrow

### DIFF
--- a/submissions/examples/animated-tooltip-with-arrow/README.md
+++ b/submissions/examples/animated-tooltip-with-arrow/README.md
@@ -1,0 +1,8 @@
+# ease-tooltip
+
+A pure-CSS hover tooltip with a matching arrow for **EaseMotion CSS**. Content driven entirely by a `data-tooltip` attribute — no extra markup.
+
+## Usage
+
+```html
+<button class="tooltip" data-tooltip="Saves your changes">Save</button>

--- a/submissions/examples/animated-tooltip-with-arrow/demo.html
+++ b/submissions/examples/animated-tooltip-with-arrow/demo.html
@@ -1,0 +1,17 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-tooltip Demo</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body { font-family: system-ui, sans-serif; background: #0f172a; color: #f1f5f9; display: flex; gap: 20px; align-items: center; justify-content: center; height: 100vh; }
+  button { padding: 10px 18px; border-radius: 8px; border: none; background: #2563eb; color: #fff; cursor: pointer; }
+</style>
+</head>
+<body>
+  <button class="tooltip" data-tooltip="Saves your changes">Save</button>
+  <button class="tooltip tooltip-bottom" data-tooltip="Permanently deletes this item">Delete</button>
+</body>
+</html>

--- a/submissions/examples/animated-tooltip-with-arrow/style.css
+++ b/submissions/examples/animated-tooltip-with-arrow/style.css
@@ -1,0 +1,64 @@
+/* ==========================================================
+   ease-tooltip — Tooltip with Arrow
+   ========================================================== */
+
+.tooltip {
+  position: relative;
+}
+
+.tooltip::before,
+.tooltip::after {
+  position: absolute;
+  left: 50%;
+  bottom: 100%;
+  transform: translateX(-50%) translateY(4px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  z-index: 20;
+}
+
+.tooltip::before {
+  content: attr(data-tooltip);
+  margin-bottom: 8px;
+  padding: 6px 10px;
+  background: #0f172a;
+  color: #fff;
+  font-size: 0.8rem;
+  border-radius: 6px;
+  white-space: nowrap;
+}
+
+.tooltip::after {
+  content: '';
+  border: 5px solid transparent;
+  border-top-color: #0f172a;
+  margin-bottom: 3px;
+}
+
+.tooltip:hover::before,
+.tooltip:hover::after,
+.tooltip:focus-visible::before,
+.tooltip:focus-visible::after {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+/* Bottom-positioned variant */
+.tooltip-bottom::before,
+.tooltip-bottom::after {
+  top: 100%;
+  bottom: auto;
+  transform: translateX(-50%) translateY(-4px);
+}
+.tooltip-bottom::before { margin-top: 8px; margin-bottom: 0; }
+.tooltip-bottom::after {
+  border-top-color: transparent;
+  border-bottom-color: #0f172a;
+  margin-top: 3px;
+  margin-bottom: 0;
+}
+.tooltip-bottom:hover::before,
+.tooltip-bottom:hover::after {
+  transform: translateX(-50%) translateY(0);
+}


### PR DESCRIPTION
### PR Description
```markdown
## Summary
Adds `ease-tooltip`, an attribute-driven CSS tooltip with arrow, per issue #4.

## What's included
- `submissions/ease-tooltip/style.css`
- `submissions/ease-tooltip/demo.html`
- `submissions/ease-tooltip/readme.md`

## Implementation notes
- Tooltip text pulled from `data-tooltip` via `content: attr(...)` — zero extra DOM nodes.
- Arrow built from a bordered triangle `::after`, color-matched to the tooltip background.
- Shows on both `:hover` and `:focus-visible` for keyboard accessibility.
- Includes `.tooltip-bottom` positional variant.

## Testing checklist
- [x] Verified tooltip and arrow appear correctly positioned above/below trigger
- [x] Verified keyboard focus reveals the tooltip
- [x] Verified long tooltip text doesn't wrap awkwardly (white-space: nowrap)
- [x] Placed only inside `submissions/`

Closes #4