### PR TITLE
feat: add breadcrumb component with arrow separators (#60864)

### DIFF
--- a/submissions/examples/ease-breadcrumb/README.md
+++ b/submissions/examples/ease-breadcrumb/README.md
@@ -1,0 +1,14 @@
+# Breadcrumb with Arrow Separators (`ease-breadcrumb`)
+
+A clean, semantic breadcrumb navigation trail featuring arrow separators generated purely via CSS `::after` pseudo-elements and smooth animated hover underlines.
+
+## Features
+- **Zero Extra DOM Markup**: Separators are generated purely through CSS pseudo-elements (`::after`).
+- **Animated Underline**: Smooth scale-origin underline hover effect on interactive links.
+- **Accessible & Lightweight**: Semantic navigation container with current-page highlight styling.
+
+## Structure
+`submissions/examples/ease-breadcrumb/`
+├── demo.html
+├── style.css
+└── README.md

--- a/submissions/examples/ease-breadcrumb/demo.html
+++ b/submissions/examples/ease-breadcrumb/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Breadcrumb with Arrow Separators Demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      margin: 0;
+      background-color: #f8fafc;
+    }
+  </style>
+</head>
+<body>
+
+  <!-- Breadcrumb Navigation Component -->
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <a href="#" class="breadcrumb-item">Home</a>
+    <a href="#" class="breadcrumb-item">Products</a>
+    <a href="#" class="breadcrumb-item">Shoes</a>
+    <span class="breadcrumb-item breadcrumb-current">Running Shoes</span>
+  </nav>
+
+</body>
+</html>

--- a/submissions/examples/ease-breadcrumb/style.css
+++ b/submissions/examples/ease-breadcrumb/style.css
@@ -1,0 +1,61 @@
+/* Breadcrumb Container */
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: 0.95rem;
+}
+
+/* Breadcrumb Items */
+.breadcrumb-item {
+  position: relative;
+  text-decoration: none;
+  color: #475569;
+  display: inline-flex;
+  align-items: center;
+  transition: color 0.2s ease;
+}
+
+/* Hover State & Animated Underline for Links */
+a.breadcrumb-item {
+  padding-bottom: 2px;
+}
+
+a.breadcrumb-item::before {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  background-color: #2563eb;
+  transform: scaleX(0);
+  transform-origin: bottom right;
+  transition: transform 0.25s ease-out;
+}
+
+a.breadcrumb-item:hover {
+  color: #2563eb;
+}
+
+a.breadcrumb-item:hover::before {
+  transform: scaleX(1);
+  transform-origin: bottom left;
+}
+
+/* Arrow Separator via ::after pseudo-element */
+.breadcrumb-item:not(:last-child)::after {
+  content: '>';
+  margin-left: 8px;
+  color: #94a3b8;
+  font-weight: 600;
+  pointer-events: none;
+}
+
+/* Current Active Page */
+.breadcrumb-current {
+  color: #0f172a;
+  font-weight: 600;
+}


### PR DESCRIPTION
### Contributor
- **Feature Name:** Breadcrumb with Arrow Separators
- **Folder Path:** `submissions/examples/ease-breadcrumb/`

### Description
Added a CSS-only breadcrumb navigation component using `::after` pseudo-elements for arrow separators and interactive link hover-underline animations.

### Checklist
- [x] Closes #60864
- [x] Files added inside `submissions/examples/ease-breadcrumb/`
- [x] Included `demo.html`, `style.css`, and `README.md`