### PR TITLE
Add ease-cash-register-drawer component

### DIFF
--- a/submissions/examples/cash-register-drawer-ij/README.md
+++ b/submissions/examples/cash-register-drawer-ij/README.md
@@ -1,0 +1,10 @@
+# ease-cash-register-drawer
+
+A cash register whose drawer slides out on the sale while the display ticks the total and a receipt feeds out.
+
+## Run
+Open `demo.html` directly in a browser to watch the drawer pop open.
+
+## Notes
+- Keys press as items are keyed in.
+- The display shows the running total.

--- a/submissions/examples/cash-register-drawer-ij/demo.html
+++ b/submissions/examples/cash-register-drawer-ij/demo.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-cash-register-drawer demo</title>
+</head>
+<body>
+<div class="cr-app">
+  <span class="cr-title">CASH REGISTER</span>
+  <div class="cr-display"><span class="cr-digits">$4.50</span></div>
+  <div class="cr-keys">
+    <span class="cr-key cr-key-1"></span>
+    <span class="cr-key cr-key-2"></span>
+    <span class="cr-key cr-key-3"></span>
+    <span class="cr-key cr-key-4"></span>
+    <span class="cr-key cr-key-5"></span>
+    <span class="cr-key cr-key-6"></span>
+    <span class="cr-key cr-key-7"></span>
+    <span class="cr-key cr-key-8"></span>
+    <span class="cr-key cr-key-9"></span>
+    <span class="cr-key cr-key-10"></span>
+    <span class="cr-key cr-key-11"></span>
+    <span class="cr-key cr-key-12"></span>
+  </div>
+  <div class="cr-drawer">
+    <span class="cr-bill cr-bill-1"></span>
+    <span class="cr-bill cr-bill-2"></span>
+    <span class="cr-bill cr-bill-3"></span>
+    <span class="cr-bill cr-bill-4"></span>
+  </div>
+  <div class="cr-receipt"></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/cash-register-drawer-ij/style.css
+++ b/submissions/examples/cash-register-drawer-ij/style.css
@@ -1,0 +1,31 @@
+:root{--cr-dark:#2e3238;--cr-gold:#d8b84a;--cr-cream:#eef0e8}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#dedbd4,#a8a49c);font-family:'Segoe UI',sans-serif}
+.cr-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#ece9e2,#c2beb4);box-shadow:0 16px 36px rgba(0,0,0,0.3)}
+.cr-title{position:absolute;top:14px;left:0;right:0;text-align:center;font-size:14px;font-weight:800;letter-spacing:7px;color:#5a564c}
+.cr-display{position:absolute;top:60px;left:74px;width:224px;height:44px;border-radius:8px;background:var(--cr-dark);box-shadow:inset 0 0 0 5px #14161a;display:flex;align-items:center;justify-content:flex-end;padding-right:14px}
+.cr-digits{color:#e8d84a;font-size:22px;font-weight:700;letter-spacing:2px;animation:blink-display-cash-register-drawer 8s steps(1) infinite}
+.cr-keys{position:absolute;top:124px;left:74px;width:224px;height:88px;display:grid;grid-template-columns:repeat(4,1fr);gap:10px}
+.cr-key{border-radius:6px;background:var(--cr-cream);box-shadow:inset 0 0 0 4px #c8c8be;animation:press-key-cash-register-drawer 4s ease-in-out infinite}
+.cr-key-2{animation-delay:0.4s}
+.cr-key-3{animation-delay:0.8s}
+.cr-key-4{animation-delay:1.2s}
+.cr-key-5{animation-delay:1.6s}
+.cr-key-6{animation-delay:2s}
+.cr-key-7{animation-delay:2.4s}
+.cr-key-8{animation-delay:2.8s}
+.cr-key-9{animation-delay:3.2s}
+.cr-key-10{animation-delay:3.6s}
+.cr-key-11{animation-delay:0.2s}
+.cr-key-12{animation-delay:0.6s}
+.cr-drawer{position:absolute;bottom:52px;left:64px;width:244px;height:64px;border-radius:0 0 10px 10px;background:var(--cr-gold);box-shadow:inset 0 0 0 6px #b8982a;animation:slide-drawer-cash-register-drawer 8s ease-in-out infinite}
+.cr-bill{position:absolute;bottom:14px;width:34px;height:34px;border-radius:4px;background:#5ac06a}
+.cr-bill-1{left:20px}
+.cr-bill-2{left:62px;background:#4a90c8}
+.cr-bill-3{left:104px;background:#d8a03a}
+.cr-bill-4{left:146px;background:#e8d84a;animation:pop-cash-cash-register-drawer 8s ease-in-out infinite}
+.cr-receipt{position:absolute;top:196px;left:118px;width:14px;height:60px;background:#f4f0e4;transform-origin:top center;animation:feed-receipt-cash-register-drawer 8s ease-in-out infinite}
+@keyframes slide-drawer-cash-register-drawer{0%,30%{transform:translateY(0)}44%{transform:translateY(26px)}70%{transform:translateY(26px)}84%{transform:translateY(0)}100%{transform:translateY(0)}}
+@keyframes pop-cash-cash-register-drawer{0%,42%{transform:translateY(0)}52%{transform:translateY(-10px)}66%{transform:translateY(0)}100%{transform:translateY(0)}}
+@keyframes press-key-cash-register-drawer{0%,90%{transform:translateY(0)}96%{transform:translateY(3px)}100%{transform:translateY(0)}}
+@keyframes blink-display-cash-register-drawer{0%,100%{opacity:1}55%{opacity:1}68%{opacity:0.25}100%{opacity:1}}
+@keyframes feed-receipt-cash-register-drawer{0%,40%{transform:translateY(0)}50%{transform:translateY(-14px)}80%{transform:translateY(-14px)}92%{transform:translateY(0)}100%{transform:translateY(0)}}


### PR DESCRIPTION
## Component: ease-cash-register-drawer — drawer slides, keys press, and total ticks

**Closes #62458**

### What this adds
A cash register: the display ticks up a running total, number keys press as items are keyed in, the drawer slides out on the sale, and a receipt feeds out.

### Acceptance Criteria covered
- Drawer slides out on the sale
- Display shows the running total
- Receipt feeds out of the slot

### Files
- submissions/examples/cash-register-drawer-ij/demo.html
- submissions/examples/cash-register-drawer-ij/style.css
- submissions/examples/cash-register-drawer-ij/README.md

### How to review
Open `demo.html` in a browser and watch the drawer pop open.