### PR TITLE
add sticky header on scroll

### DIFF
--- a/submissions/examples/animated-sticky-header-on-scroll/README.md
+++ b/submissions/examples/animated-sticky-header-on-scroll/README.md
@@ -1,0 +1,18 @@
+# ease-sticky-header
+
+A sticky page header that shrinks and gains a shadow once scrolled, for **EaseMotion CSS**.
+
+## Usage
+
+```html
+<header class="sticky-header">
+  <div class="sticky-header-logo">Brand</div>
+  <nav>Nav links</nav>
+</header>
+
+<script>
+  window.addEventListener('scroll', () => {
+    document.querySelector('.sticky-header')
+      .classList.toggle('scrolled', window.scrollY > 40);
+  });
+</script>

--- a/submissions/examples/animated-sticky-header-on-scroll/demo.html
+++ b/submissions/examples/animated-sticky-header-on-scroll/demo.html
@@ -1,0 +1,30 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-sticky-header Demo</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body { font-family: system-ui, sans-serif; margin: 0; background: #0f172a; color: #f1f5f9; }
+  .filler { height: 1400px; padding: 40px; max-width: 640px; margin: 0 auto; line-height: 1.7; }
+</style>
+</head>
+<body>
+  <header class="sticky-header">
+    <div class="sticky-header-logo">EaseMotion</div>
+    <nav>Home · Docs · GitHub</nav>
+  </header>
+  <div class="filler">
+    <h1>ease-sticky-header</h1>
+    <p>Scroll down to see the header shrink and gain a shadow.</p>
+  </div>
+
+  <script>
+    window.addEventListener('scroll', () => {
+      document.querySelector('.sticky-header')
+        .classList.toggle('scrolled', window.scrollY > 40);
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/animated-sticky-header-on-scroll/style.css
+++ b/submissions/examples/animated-sticky-header-on-scroll/style.css
@@ -1,0 +1,31 @@
+/* ==========================================================
+   ease-sticky-header — Sticky Header with Shrink-on-Scroll
+   ========================================================== */
+
+.sticky-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 24px 32px;
+  background: #1e293b;
+  color: #f1f5f9;
+  transition: padding 0.25s ease, box-shadow 0.25s ease;
+}
+
+.sticky-header.scrolled {
+  padding: 12px 32px;
+  box-shadow: 0 2px 12px rgba(0,0,0,0.3);
+}
+
+.sticky-header-logo {
+  font-weight: 700;
+  font-size: 1.3rem;
+  transition: font-size 0.25s ease;
+}
+
+.sticky-header.scrolled .sticky-header-logo {
+  font-size: 1.05rem;
+}


### PR DESCRIPTION
### PR Description
```markdown
## Summary
Adds `ease-sticky-header`, a shrink-on-scroll sticky header, per issue #12.

## What's included
- `submissions/ease-sticky-header/style.css`
- `submissions/ease-sticky-header/demo.html`
- `submissions/ease-sticky-header/readme.md`

## Implementation notes
- Pinning via `position: sticky` (zero JS needed for the pin itself).
- Shrink/shadow effect via a single `.scrolled` class toggle set by one scroll listener line — minimal JS footprint.
- Logo font-size and header padding both transition together for a cohesive "compact" feel.

## Testing checklist
- [x] Verified header stays pinned correctly while scrolling
- [x] Verified shrink transition triggers at the documented threshold and reverts when scrolled back to top
- [x] Placed only inside `submissions/`

Closes #12