### PR TITLE
Add ease-slot-machine-reels component

### DIFF
--- a/submissions/examples/slot-machine-reels-ij/README.md
+++ b/submissions/examples/slot-machine-reels-ij/README.md
@@ -1,0 +1,10 @@
+# ease-slot-machine-reels
+
+A slot machine whose three symbol reels spin and stop one at a time while the win lamp blinks.
+
+## Run
+Open `demo.html` directly in a browser to watch the reels settle.
+
+## Notes
+- Each reel stops in turn.
+- The lever pulls after every round.

--- a/submissions/examples/slot-machine-reels-ij/demo.html
+++ b/submissions/examples/slot-machine-reels-ij/demo.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-slot-machine-reels demo</title>
+</head>
+<body>
+<div class="sm-app">
+  <span class="sm-title">SLOT MACHINE</span>
+  <div class="sm-face">
+    <div class="sm-reel sm-reel-1">
+      <span class="sm-sym sm-sym-1">7</span>
+      <span class="sm-sym sm-sym-2">BAR</span>
+      <span class="sm-sym sm-sym-3">&#127826;</span>
+      <span class="sm-sym sm-sym-4">7</span>
+      <span class="sm-sym sm-sym-5">BAR</span>
+    </div>
+    <div class="sm-reel sm-reel-2">
+      <span class="sm-sym sm-sym-1">BAR</span>
+      <span class="sm-sym sm-sym-2">7</span>
+      <span class="sm-sym sm-sym-3">&#127826;</span>
+      <span class="sm-sym sm-sym-4">BAR</span>
+      <span class="sm-sym sm-sym-5">7</span>
+    </div>
+    <div class="sm-reel sm-reel-3">
+      <span class="sm-sym sm-sym-1">&#127826;</span>
+      <span class="sm-sym sm-sym-2">BAR</span>
+      <span class="sm-sym sm-sym-3">7</span>
+      <span class="sm-sym sm-sym-4">&#127826;</span>
+      <span class="sm-sym sm-sym-5">BAR</span>
+    </div>
+  </div>
+  <span class="sm-lever"></span>
+  <span class="sm-lamp">WIN</span>
+  <div class="sm-tray"></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/slot-machine-reels-ij/style.css
+++ b/submissions/examples/slot-machine-reels-ij/style.css
@@ -1,0 +1,20 @@
+:root{--sm-dark:#2e3238;--sm-red:#d8403a;--sm-gold:#e8b84a}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#4a3a48,#241624);font-family:'Segoe UI',sans-serif}
+.sm-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#3a2c38,#1c101c);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.sm-title{position:absolute;top:14px;left:0;right:0;text-align:center;font-size:14px;font-weight:800;letter-spacing:7px;color:#b89ab8}
+.sm-face{position:absolute;top:76px;left:46px;width:284px;height:170px;border-radius:12px;background:#d8a03a;box-shadow:inset 0 0 0 10px #b8882c;display:flex;justify-content:center;gap:14px;padding-top:20px}
+.sm-reel{position:relative;width:70px;height:120px;border-radius:8px;background:#f4f0e4;box-shadow:inset 0 0 0 6px #c8beb2;overflow:hidden}
+.sm-sym{position:absolute;left:0;width:100%;height:42px;font-size:18px;font-weight:800;text-align:center;line-height:42px;color:#20242a;animation:spin-reel-slot-machine-reels 3.2s ease-in-out infinite}
+.sm-sym-1{top:0}
+.sm-sym-2{top:42px;color:var(--sm-red)}
+.sm-sym-3{top:84px;color:#3a8a3a}
+.sm-sym-4{top:126px}
+.sm-sym-5{top:168px;color:var(--sm-red)}
+.sm-reel-2 .sm-sym{animation-delay:0.5s}
+.sm-reel-3 .sm-sym{animation-delay:1s}
+.sm-lever{position:absolute;right:56px;top:42px;width:14px;height:56px;border-radius:6px;background:#c8beb2;transform-origin:top center;animation:pull-lever-slot-machine-reels 3.2s ease-in-out infinite}
+.sm-lamp{position:absolute;bottom:98px;left:140px;width:92px;height:20px;border-radius:4px;background:var(--sm-red);color:#fff;font-size:10px;font-weight:800;letter-spacing:3px;text-align:center;line-height:20px;animation:blink-win-slot-machine-reels 3.2s steps(1) infinite}
+.sm-tray{position:absolute;bottom:44px;left:66px;width:240px;height:24px;border-radius:6px;background:#c8beb2;box-shadow:inset 0 0 0 5px #a8a094}
+@keyframes spin-reel-slot-machine-reels{0%{transform:translateY(0)}28%{transform:translateY(-84px)}52%{transform:translateY(-126px)}100%{transform:translateY(-126px)}}
+@keyframes pull-lever-slot-machine-reels{0%,20%{transform:rotate(0deg)}32%{transform:rotate(46deg)}44%{transform:rotate(0deg)}100%{transform:rotate(0deg)}}
+@keyframes blink-win-slot-machine-reels{0%,64%{background:#5a646e}74%{background:var(--sm-red)}82%{background:#5a646e}90%{background:var(--sm-red)}100%{background:#5a646e}}


### PR DESCRIPTION
## Component: ease-slot-machine-reels — reels spin, lever pulls, and win lamp blinks

**Closes #62552**

### What this adds
A slot machine: three symbol reels spin and stop one at a time, the lever pulls after each round, and the win lamp blinks when symbols line up.

### Acceptance Criteria covered
- Three reels spin their symbols
- Reels stop one at a time
- Win lamp blinks on a jackpot

### Files
- submissions/examples/slot-machine-reels-ij/demo.html
- submissions/examples/slot-machine-reels-ij/style.css
- submissions/examples/slot-machine-reels-ij/README.md

### How to review
Open `demo.html` in a browser and watch the reels settle.