### PR TITLE
add animated slidebar drawer

### DIFF
--- a/submissions/examples/animated-slidebar-slide-in-drawer/README.md
+++ b/submissions/examples/animated-slidebar-slide-in-drawer/README.md
@@ -1,0 +1,16 @@
+# ease-drawer
+
+A pure-CSS off-canvas slide-in drawer for **EaseMotion CSS**, built on the checkbox hack.
+
+## Usage
+
+```html
+<div class="drawer">
+  <input type="checkbox" id="drawerToggle" class="drawer-checkbox">
+  <label for="drawerToggle" class="drawer-backdrop"></label>
+  <nav class="drawer-panel">
+    <a href="#">Home</a>
+    <a href="#">About</a>
+  </nav>
+  <label for="drawerToggle" class="drawer-open-btn">☰ Menu</label>
+</div>

--- a/submissions/examples/animated-slidebar-slide-in-drawer/demo.html
+++ b/submissions/examples/animated-slidebar-slide-in-drawer/demo.html
@@ -1,0 +1,27 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-drawer Demo</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body { font-family: system-ui, sans-serif; background: #0f172a; color: #f1f5f9; }
+  .drawer-open-btn { display: inline-block; margin: 30px; padding: 10px 16px; background: #2563eb; color: #fff; border-radius: 8px; cursor: pointer; }
+  .drawer-panel a { color: #f1f5f9; text-decoration: none; padding: 12px 0; border-bottom: 1px solid #334155; }
+</style>
+</head>
+<body>
+  <div class="drawer">
+    <input type="checkbox" id="drawerToggle" class="drawer-checkbox">
+    <label for="drawerToggle" class="drawer-backdrop"></label>
+    <nav class="drawer-panel">
+      <a href="#">Home</a>
+      <a href="#">Docs</a>
+      <a href="#">Components</a>
+      <a href="#">GitHub</a>
+    </nav>
+    <label for="drawerToggle" class="drawer-open-btn">☰ Menu</label>
+  </div>
+</body>
+</html>

--- a/submissions/examples/animated-slidebar-slide-in-drawer/style.css
+++ b/submissions/examples/animated-slidebar-slide-in-drawer/style.css
@@ -1,0 +1,57 @@
+/* ==========================================================
+   ease-drawer — Sidebar Slide-in Drawer
+   Pure CSS via checkbox hack, no JS required.
+   ========================================================== */
+
+.drawer-checkbox { display: none; }
+
+.drawer-panel {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 260px;
+  background: #1e293b;
+  transform: translateX(-100%);
+  transition: transform 0.3s ease;
+  z-index: 200;
+  display: flex;
+  flex-direction: column;
+  padding: 24px;
+  box-shadow: 4px 0 24px rgba(0,0,0,0.3);
+}
+
+.drawer-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.5);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+  z-index: 190;
+  cursor: pointer;
+}
+
+.drawer-checkbox:checked ~ .drawer-backdrop {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.drawer-checkbox:checked ~ .drawer-panel {
+  transform: translateX(0);
+}
+
+.drawer-open-btn {
+  cursor: pointer;
+}
+
+/* Right-side variant */
+.drawer.drawer-right .drawer-panel {
+  left: auto;
+  right: 0;
+  transform: translateX(100%);
+  box-shadow: -4px 0 24px rgba(0,0,0,0.3);
+}
+.drawer.drawer-right .drawer-checkbox:checked ~ .drawer-panel {
+  transform: translateX(0);
+}


### PR DESCRIPTION
### PR Description
```markdown
## Summary
Adds `ease-drawer`, a pure-CSS off-canvas slide-in drawer, per issue #16.

## What's included
- `submissions/ease-drawer/style.css`
- `submissions/ease-drawer/demo.html`
- `submissions/ease-drawer/readme.md`

## Implementation notes
- Entirely checkbox-hack driven — open, close via backdrop click, and dim/slide transitions are zero-JS.
- Backdrop click-to-close works because it's also a `<label for="drawerToggle">`, toggling the same checkbox off.
- Includes a `.drawer-right` modifier for right-side slide-in.

## Testing checklist
- [x] Verified drawer slides in/out smoothly on toggle
- [x] Verified backdrop dims in sync and closes drawer on click
- [x] Verified `.drawer-right` variant slides from the correct side
- [x] Placed only inside `submissions/`

Closes #16