### PR TITLE
add animated underline nav bar

### DIFF
--- a/submissions/examples/animated-inderline-nav-link/README.md
+++ b/submissions/examples/animated-inderline-nav-link/README.md
@@ -1,0 +1,11 @@
+# ease-nav-underline
+
+An animated center-out underline hover effect for nav links, for **EaseMotion CSS**.
+
+## Usage
+
+```html
+<nav>
+  <a href="#" class="nav-underline">Home</a>
+  <a href="#" class="nav-underline active">Docs</a>
+</nav>

--- a/submissions/examples/animated-inderline-nav-link/demo.html
+++ b/submissions/examples/animated-inderline-nav-link/demo.html
@@ -1,0 +1,21 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-nav-underline Demo</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body { font-family: system-ui, sans-serif; background: #0f172a; display: flex; align-items: center; justify-content: center; height: 100vh; }
+  nav { display: flex; gap: 32px; font-size: 1.05rem; }
+</style>
+</head>
+<body>
+  <nav>
+    <a href="#" class="nav-underline">Home</a>
+    <a href="#" class="nav-underline">Docs</a>
+    <a href="#" class="nav-underline active">Components</a>
+    <a href="#" class="nav-underline">GitHub</a>
+  </nav>
+</body>
+</html>

--- a/submissions/examples/animated-inderline-nav-link/style.css
+++ b/submissions/examples/animated-inderline-nav-link/style.css
@@ -1,0 +1,37 @@
+/* ==========================================================
+   ease-nav-underline — Animated Underline Nav Link
+   ========================================================== */
+
+.nav-underline {
+  position: relative;
+  text-decoration: none;
+  color: #cbd5e1;
+  padding-bottom: 4px;
+  transition: color 0.2s ease;
+}
+
+.nav-underline::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  bottom: 0;
+  width: 0%;
+  height: 2px;
+  background: #60a5fa;
+  transition: width 0.25s ease, left 0.25s ease;
+}
+
+.nav-underline:hover {
+  color: #f1f5f9;
+}
+
+.nav-underline:hover::after,
+.nav-underline.active::after {
+  width: 100%;
+  left: 0%;
+}
+
+.nav-underline.active {
+  color: #f1f5f9;
+  font-weight: 600;
+}


### PR DESCRIPTION
### PR Description
```markdown
## Summary
Adds `ease-nav-underline`, an animated center-out underline hover effect for nav links, per issue #17.

## What's included
- `submissions/ease-nav-underline/style.css`
- `submissions/ease-nav-underline/demo.html`
- `submissions/ease-nav-underline/readme.md`

## Implementation notes
- Underline grows via combined `width` + `left` transition on `::after`, producing a center-outward motion.
- `.active` modifier keeps the underline permanently shown for the current page link.

## Testing checklist
- [x] Verified underline grows smoothly from center on hover
- [x] Verified `.active` link shows underline without needing hover
- [x] Placed only inside `submissions/`

Closes #17