### PR TITLE
add confetti burst button

### DIFF
--- a/submissions/examples/animated-confettii-burst-button/README.md
+++ b/submissions/examples/animated-confettii-burst-button/README.md
@@ -1,0 +1,16 @@
+# ease-confetti-btn
+
+A celebratory confetti-burst button for **EaseMotion CSS** — great for subscribe/submit/success actions.
+
+## Usage
+
+```html
+<button class="confetti-btn" onclick="
+  this.classList.remove('burst');
+  void this.offsetWidth; /* force reflow to allow re-triggering */
+  this.classList.add('burst');
+">
+  Subscribe
+  <span class="confetti-particle" style="--x:-40px; --y:-60px; --c:#f87171;"></span>
+  <!-- add 4-8 more particles with varied --x/--y/--c -->
+</button>

--- a/submissions/examples/animated-confettii-burst-button/demo.html
+++ b/submissions/examples/animated-confettii-burst-button/demo.html
@@ -1,0 +1,27 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-confetti-btn Demo</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body { font-family: system-ui, sans-serif; background: #0f172a; display: flex; align-items: center; justify-content: center; height: 100vh; }
+</style>
+</head>
+<body>
+  <button class="confetti-btn" onclick="
+    this.classList.remove('burst');
+    void this.offsetWidth;
+    this.classList.add('burst');
+  ">
+    🎉 Subscribe
+    <span class="confetti-particle" style="--x:-40px; --y:-60px; --c:#f87171;"></span>
+    <span class="confetti-particle" style="--x:30px; --y:-70px; --c:#60a5fa;"></span>
+    <span class="confetti-particle" style="--x:-20px; --y:-50px; --c:#facc15;"></span>
+    <span class="confetti-particle" style="--x:45px; --y:-40px; --c:#4ade80;"></span>
+    <span class="confetti-particle" style="--x:0px; --y:-75px; --c:#c084fc;"></span>
+    <span class="confetti-particle" style="--x:-55px; --y:-30px; --c:#fb923c;"></span>
+  </button>
+</body>
+</html>

--- a/submissions/examples/animated-confettii-burst-button/style.css
+++ b/submissions/examples/animated-confettii-burst-button/style.css
@@ -1,0 +1,42 @@
+/* ==========================================================
+   ease-confetti-btn — Confetti Burst Button
+   ========================================================== */
+
+.confetti-btn {
+  position: relative;
+  padding: 12px 24px;
+  border-radius: 8px;
+  border: none;
+  background: #2563eb;
+  color: #fff;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  overflow: visible;
+  transition: background 0.2s ease;
+}
+
+.confetti-btn:hover {
+  background: #1d4ed8;
+}
+
+.confetti-particle {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 6px;
+  height: 6px;
+  background: var(--c, #60a5fa);
+  border-radius: 2px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.confetti-btn.burst .confetti-particle {
+  animation: confetti-fly 0.8s ease-out forwards;
+}
+
+@keyframes confetti-fly {
+  0% { transform: translate(0, 0) rotate(0deg); opacity: 1; }
+  100% { transform: translate(var(--x), var(--y)) rotate(360deg); opacity: 0; }
+}


### PR DESCRIPTION
### PR Description
```markdown
## Summary
Adds `ease-confetti-btn`, a multi-particle confetti burst button micro-interaction, per issue #19.

## What's included
- `submissions/ease-confetti-btn/style.css`
- `submissions/ease-confetti-btn/demo.html`
- `submissions/ease-confetti-btn/readme.md`

## Implementation notes
- Each particle is a `<span>` with per-instance `--x`/`--y`/`--c` custom properties driving one shared `@keyframes` — no per-particle CSS duplication.
- Click handler uses the remove-reflow-readd pattern to allow the animation to replay on repeated clicks.
- Fully CSS-animated; JS only toggles the trigger class.

## Testing checklist
- [x] Verified confetti burst plays correctly on first click
- [x] Verified animation correctly replays on repeated clicks
- [x] Verified particles don't get clipped by button `overflow`
- [x] Placed only inside `submissions/`

Closes #19