### PR TITLE
Add ease-bowling-pin-tumble component

### DIFF
--- a/submissions/examples/bowling-pin-tumble-ij/README.md
+++ b/submissions/examples/bowling-pin-tumble-ij/README.md
@@ -1,0 +1,10 @@
+# ease-bowling-pin-tumble
+
+A bowling lane where the ball rolls down the boards and sends the pins tumbling.
+
+## Run
+Open `demo.html` directly in a browser to watch the pins scatter.
+
+## Notes
+- The ball rolls in a straight shot.
+- The rack resets after the strike.

--- a/submissions/examples/bowling-pin-tumble-ij/demo.html
+++ b/submissions/examples/bowling-pin-tumble-ij/demo.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-bowling-pin-tumble demo</title>
+</head>
+<body>
+<div class="bw-app">
+  <span class="bw-title">BOWLING</span>
+  <div class="bw-lane">
+    <span class="bw-gutter bw-gutter-1"></span>
+    <span class="bw-gutter bw-gutter-2"></span>
+    <span class="bw-board"></span>
+    <span class="bw-pin bw-pin-1"></span>
+    <span class="bw-pin bw-pin-2"></span>
+    <span class="bw-pin bw-pin-3"></span>
+    <span class="bw-pin bw-pin-4"></span>
+    <span class="bw-pin bw-pin-5"></span>
+    <span class="bw-pin bw-pin-6"></span>
+    <span class="bw-pin bw-pin-7"></span>
+    <span class="bw-pin bw-pin-8"></span>
+    <span class="bw-pin bw-pin-9"></span>
+    <span class="bw-pin bw-pin-10"></span>
+    <span class="bw-ball"></span>
+  </div>
+  <span class="bw-score">STRIKE</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/bowling-pin-tumble-ij/style.css
+++ b/submissions/examples/bowling-pin-tumble-ij/style.css
@@ -1,0 +1,25 @@
+:root{--bw-wood:#c98a4a;--bw-dark:#4c3a28;--bw-red:#d8403a}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#e8dcc8,#b8a488);font-family:'Segoe UI',sans-serif}
+.bw-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#f0e4d0,#c4b08e);box-shadow:0 16px 36px rgba(0,0,0,0.3)}
+.bw-title{position:absolute;top:14px;left:0;right:0;text-align:center;font-size:14px;font-weight:800;letter-spacing:7px;color:var(--bw-dark)}
+.bw-lane{position:absolute;top:64px;left:56px;width:260px;height:240px;border-radius:10px;background:var(--bw-wood);box-shadow:inset 0 0 0 6px #a86a34;overflow:hidden}
+.bw-gutter{position:absolute;top:0;bottom:0;width:22px;background:#3a4650}
+.bw-gutter-1{left:0}
+.bw-gutter-2{right:0}
+.bw-board{position:absolute;top:0;left:22px;right:22px;height:240px;background:repeating-linear-gradient(180deg,transparent 0 26px,rgba(0,0,0,0.12) 26px 28px)}
+.bw-pin{position:absolute;width:12px;height:30px;border-radius:6px 6px 3px 3px;background:#f4f0e4;box-shadow:inset 0 0 0 3px #c8c8be;transform-origin:center bottom;animation:tumble-pin-bowling-pin-tumble 7s ease-in-out infinite}
+.bw-pin-1{top:56px;left:120px}
+.bw-pin-2{top:56px;left:152px}
+.bw-pin-3{top:56px;left:184px}
+.bw-pin-4{top:76px;left:136px}
+.bw-pin-5{top:76px;left:168px}
+.bw-pin-6{top:96px;left:120px}
+.bw-pin-7{top:96px;left:152px}
+.bw-pin-8{top:96px;left:184px}
+.bw-pin-9{top:116px;left:136px}
+.bw-pin-10{top:116px;left:168px;animation-delay:0.2s}
+.bw-ball{position:absolute;top:200px;left:118px;width:34px;height:34px;border-radius:50%;background:var(--bw-red);box-shadow:inset 0 0 0 6px #b02a26;animation:roll-ball-bowling-pin-tumble 7s ease-in-out infinite}
+.bw-score{position:absolute;top:20px;right:40px;width:76px;height:22px;border-radius:5px;background:var(--bw-dark);color:var(--bw-red);font-size:11px;font-weight:800;letter-spacing:3px;text-align:center;line-height:22px;animation:flash-score-bowling-pin-tumble 7s steps(1) infinite}
+@keyframes roll-ball-bowling-pin-tumble{0%,52%{transform:translateX(0)}64%{transform:translateX(28px)}70%{transform:translateX(28px)}82%{transform:translateX(0)}100%{transform:translateX(0)}}
+@keyframes tumble-pin-bowling-pin-tumble{0%,62%{transform:rotate(0deg)}74%{transform:rotate(118deg) translateX(8px);opacity:0.5}86%{transform:rotate(118deg) translateX(8px);opacity:0.5}94%{transform:rotate(0deg);opacity:1}100%{transform:rotate(0deg)}}
+@keyframes flash-score-bowling-pin-tumble{0%,60%{opacity:1}66%{opacity:1}70%{opacity:0.2}74%{opacity:1}78%{opacity:0.2}82%{opacity:1}100%{opacity:1}}


### PR DESCRIPTION
## Component: ease-bowling-pin-tumble — ball rolls, pins tumble, and the score flashes

**Closes #62591**

### What this adds
A bowling lane: the ball rolls down the boards and smashes the pins, the pins tumble off their spots, and the STRIKE score flashes as the rack resets.

### Acceptance Criteria covered
- Ball rolls down the lane
- Pins tumble on impact
- Score flashes after the strike

### Files
- submissions/examples/bowling-pin-tumble-ij/demo.html
- submissions/examples/bowling-pin-tumble-ij/style.css
- submissions/examples/bowling-pin-tumble-ij/README.md

### How to review
Open `demo.html` in a browser and watch the pins scatter.