### PR TITLE
Add ease-dartboard-hit component

### DIFF
--- a/submissions/examples/dartboard-hit-ij/README.md
+++ b/submissions/examples/dartboard-hit-ij/README.md
@@ -1,0 +1,10 @@
+# ease-dartboard-hit
+
+A dartboard where the dart flies across the room and sticks while the board quivers.
+
+## Run
+Open `demo.html` directly in a browser to watch the dart stick.
+
+## Notes
+- The dart lands in the treble ring.
+- The BULL score flashes on the readout.

--- a/submissions/examples/dartboard-hit-ij/demo.html
+++ b/submissions/examples/dartboard-hit-ij/demo.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-dartboard-hit demo</title>
+</head>
+<body>
+<div class="dt-app">
+  <span class="dt-title">DARTS</span>
+  <div class="dt-board">
+    <span class="dt-ring dt-ring-1"></span>
+    <span class="dt-ring dt-ring-2"></span>
+    <span class="dt-ring dt-ring-3"></span>
+    <span class="dt-slice dt-slice-1"></span>
+    <span class="dt-slice dt-slice-2"></span>
+    <span class="dt-slice dt-slice-3"></span>
+    <span class="dt-slice dt-slice-4"></span>
+    <span class="dt-bull"></span>
+    <span class="dt-dart"></span>
+  </div>
+  <div class="dt-score">BULL</div>
+</div>
+</body>
+</html>

--- a/submissions/examples/dartboard-hit-ij/style.css
+++ b/submissions/examples/dartboard-hit-ij/style.css
@@ -1,0 +1,21 @@
+:root{--dt-green:#1e6a3a;--dt-red:#c23a2e;--dt-dark:#161c22}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#3a3430,#201c18);font-family:'Segoe UI',sans-serif}
+.dt-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#2c2622,#16120e);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.dt-title{position:absolute;top:14px;left:0;right:0;text-align:center;font-size:14px;font-weight:800;letter-spacing:7px;color:#b8a890}
+.dt-board{position:absolute;top:58px;left:76px;width:220px;height:220px;border-radius:50%;background:var(--dt-green);box-shadow:0 0 0 12px #2a2e34,inset 0 0 0 6px #145024;animation:quiver-board-dartboard-hit 6s ease-in-out infinite}
+.dt-ring{position:absolute;left:50%;top:50%;border-radius:50%;transform:translate(-50%,-50%)}
+.dt-ring-1{width:200px;height:200px;border:8px solid var(--dt-red)}
+.dt-ring-2{width:150px;height:150px;border:8px solid #f4f0e4}
+.dt-ring-3{width:96px;height:96px;border:8px solid var(--dt-red)}
+.dt-slice{position:absolute;left:50%;top:50%;width:12px;height:104px;margin:-52px 0 0 -6px;background:#f4f0e4;transform-origin:6px 52px;animation:spin-board-dartboard-hit 12s linear infinite}
+.dt-slice-1{transform:rotate(0deg) translateY(-6px)}
+.dt-slice-2{transform:rotate(90deg) translateY(-6px)}
+.dt-slice-3{transform:rotate(180deg) translateY(-6px)}
+.dt-slice-4{transform:rotate(270deg) translateY(-6px)}
+.dt-bull{position:absolute;top:100px;left:100px;width:20px;height:20px;border-radius:50%;background:var(--dt-red);box-shadow:0 0 0 6px #f4f0e4}
+.dt-dart{position:absolute;top:34px;left:86px;width:6px;height:96px;border-radius:3px;background:#c8ced4;transform-origin:3px 8px;animation:fly-dart-dartboard-hit 6s ease-in-out infinite}
+.dt-score{position:absolute;bottom:26px;left:116px;width:140px;height:32px;border-radius:6px;background:#2a2e34;box-shadow:inset 0 0 0 4px #1e2228;color:var(--dt-red);font-size:14px;font-weight:800;letter-spacing:4px;text-align:center;line-height:32px;animation:flash-score-dartboard-hit 6s steps(1) infinite}
+@keyframes fly-dart-dartboard-hit{0%,40%{transform:translate(0,0) rotate(0deg);opacity:1}50%{transform:translate(118px,92px) rotate(6deg);opacity:1}62%{transform:translate(118px,92px) rotate(6deg);opacity:1}72%{transform:translate(0,0) rotate(0deg);opacity:1}100%{transform:translate(0,0) rotate(0deg);opacity:1}}
+@keyframes quiver-board-dartboard-hit{0%,48%{transform:rotate(0deg)}56%{transform:rotate(4deg)}60%{transform:rotate(-4deg)}64%{transform:rotate(3deg)}68%{transform:rotate(0deg)}100%{transform:rotate(0deg)}}
+@keyframes spin-board-dartboard-hit{to{transform:rotate(360deg) translateY(-6px)}}
+@keyframes flash-score-dartboard-hit{0%,50%{color:var(--dt-red)}56%{color:#fff}60%{color:var(--dt-red)}64%{color:#fff}100%{color:var(--dt-red)}}


### PR DESCRIPTION
## Component: ease-dartboard-hit — dart flies, board quivers, and score flashes

**Closes #62610**

### What this adds
A dartboard: the dart flies across the room and sticks in the treble ring, the board quivers on the wall, and the BULL score flashes on the readout.

### Acceptance Criteria covered
- Dart flies to the board
- Board quivers on impact
- Score flashes on the readout

### Files
- submissions/examples/dartboard-hit-ij/demo.html
- submissions/examples/dartboard-hit-ij/style.css
- submissions/examples/dartboard-hit-ij/README.md

### How to review
Open `demo.html` in a browser and watch the dart stick.