### PR TITLE
Add ease-bullseye-target-ping component

### DIFF
--- a/submissions/examples/bullseye-target-ping-ij/README.md
+++ b/submissions/examples/bullseye-target-ping-ij/README.md
@@ -1,0 +1,10 @@
+# ease-bullseye-target-ping
+
+An archery target where the arrow strikes the center and the rings ping outward.
+
+## Run
+Open `demo.html` directly in a browser to watch the bullseye ping.
+
+## Notes
+- The arrow hits the center spot.
+- Points tick up to a perfect ten.

--- a/submissions/examples/bullseye-target-ping-ij/demo.html
+++ b/submissions/examples/bullseye-target-ping-ij/demo.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-bullseye-target-ping demo</title>
+</head>
+<body>
+<div class="be-app">
+  <span class="be-title">BULLSEYE</span>
+  <div class="be-target">
+    <span class="be-ring be-ring-1"></span>
+    <span class="be-ring be-ring-2"></span>
+    <span class="be-ring be-ring-3"></span>
+    <span class="be-ring be-ring-4"></span>
+    <span class="be-center"></span>
+    <span class="be-arrow"></span>
+    <span class="be-ping"></span>
+  </div>
+  <div class="be-score"><span class="be-pts">10</span></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/bullseye-target-ping-ij/style.css
+++ b/submissions/examples/bullseye-target-ping-ij/style.css
@@ -1,0 +1,19 @@
+:root{--be-red:#d8403a;--be-cream:#f4f0e4;--be-navy:#1a2240}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#2a3260,#141a34);font-family:'Segoe UI',sans-serif}
+.be-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#20284e,#0e1428);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.be-title{position:absolute;top:14px;left:0;right:0;text-align:center;font-size:14px;font-weight:800;letter-spacing:7px;color:#b8c4e8}
+.be-target{position:absolute;top:58px;left:86px;width:200px;height:200px;border-radius:50%;background:#c8b84a;box-shadow:0 0 0 14px #3a3a44}
+.be-ring{position:absolute;left:50%;top:50%;border-radius:50%;transform:translate(-50%,-50%)}
+.be-ring-1{width:190px;height:190px;border:10px solid var(--be-cream)}
+.be-ring-2{width:150px;height:150px;border:10px solid var(--be-red)}
+.be-ring-3{width:110px;height:110px;border:10px solid var(--be-cream)}
+.be-ring-4{width:70px;height:70px;border:10px solid var(--be-red)}
+.be-center{position:absolute;top:92px;left:92px;width:16px;height:16px;border-radius:50%;background:#3a3a44;animation:pulse-center-bullseye-target-ping 1s ease-in-out infinite}
+.be-arrow{position:absolute;top:20px;left:104px;width:8px;height:90px;border-radius:4px;background:var(--be-cream);transform-origin:4px 6px;animation:strike-arrow-bullseye-target-ping 4s ease-in-out infinite}
+.be-ping{position:absolute;top:76px;left:76px;width:48px;height:48px;border-radius:50%;border:3px solid #ffd86a;opacity:0;animation:ping-ring-bullseye-target-ping 4s ease-out infinite}
+.be-score{position:absolute;bottom:26px;left:116px;width:140px;height:34px;border-radius:8px;background:#141a34;box-shadow:inset 0 0 0 4px #1a2240;display:flex;align-items:center;justify-content:center}
+.be-pts{color:#ffd86a;font-size:18px;font-weight:800;animation:flick-score-bullseye-target-ping 4s steps(1) infinite}
+@keyframes strike-arrow-bullseye-target-ping{0%,46%{transform:translate(0,0) rotate(0deg)}56%{transform:translate(24px,92px) rotate(12deg)}66%{transform:translate(24px,92px) rotate(12deg)}76%{transform:translate(0,0) rotate(0deg)}100%{transform:translate(0,0) rotate(0deg)}}
+@keyframes ping-ring-bullseye-target-ping{0%,54%{opacity:0;transform:scale(0.4)}62%{opacity:1}70%{opacity:0;transform:scale(1.6)}100%{opacity:0}}
+@keyframes pulse-center-bullseye-target-ping{0%,100%{transform:scale(1)}50%{transform:scale(1.3)}}
+@keyframes flick-score-bullseye-target-ping{0%,54%{color:#ffd86a}60%{color:#fff}64%{color:#ffd86a}68%{color:#fff}100%{color:#ffd86a}}


### PR DESCRIPTION
## Component: ease-bullseye-target-ping — arrow strikes, rings ping, and points tick

**Closes #62613**

### What this adds
An archery target: the arrow strikes the center bullseye, the rings ping outward like ripples, and the points readout ticks up to a perfect ten.

### Acceptance Criteria covered
- Arrow strikes the center
- Rings ping outward
- Points readout ticks upward

### Files
- submissions/examples/bullseye-target-ping-ij/demo.html
- submissions/examples/bullseye-target-ping-ij/style.css
- submissions/examples/bullseye-target-ping-ij/README.md

### How to review
Open `demo.html` in a browser and watch the bullseye ping.