### PR TITLE
docs: add reference fix for reveal.js no-IntersectionObserver fallback

### DIFF
--- a/submissions/docs/reveal-fallback-scroll-check-aaniya22/README.md
+++ b/submissions/docs/reveal-fallback-scroll-check-aaniya22/README.md
@@ -1,0 +1,45 @@
+# Fix: reveal.js fallback reveals all elements instantly
+
+## Track
+Core & Docs Showcase (`submissions/docs/`) — this is a reference
+implementation only. No files under `core/` are modified by this
+submission.
+
+## Bug
+
+In `core/reveal.js`, when `IntersectionObserver` is unavailable, the
+fallback branch does this:
+
+```js
+var readyFallback = function () {
+  var els = document.querySelectorAll('.' + revealClass);
+  Array.prototype.forEach.call(els, function (el) {
+    el.classList.add(activeClass);
+  });
+};
+```
+
+This adds `activeClass` to every `.reveal-el` on page load, regardless
+of whether the element is actually visible. The result: on browsers
+without `IntersectionObserver`, scroll-reveal animations don't play at
+all — everything just appears active immediately.
+
+## Fix
+
+`demo.js` in this folder replaces that logic with a throttled
+scroll/resize listener that checks each element's bounding rect and
+only adds the active class once the element has entered the viewport.
+It uses `requestAnimationFrame` to avoid layout thrashing on scroll.
+
+## How to verify
+
+1. Open `demo.html` in a browser.
+2. Note the three `.reveal-el` blocks are not active on load.
+3. Scroll down — each block fades/slides in only once it enters view,
+   instead of all being active immediately.
+
+## Suggested integration
+
+A maintainer can port the `checkAndReveal` / `onScroll` / `readyFallback`
+logic in `demo.js` directly into the `else` branch of
+`core/reveal.js`, replacing the current instant-activation fallback.

--- a/submissions/docs/reveal-fallback-scroll-check-aaniya22/demo.html
+++ b/submissions/docs/reveal-fallback-scroll-check-aaniya22/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Reveal Fallback — Scroll-Check Fix</title>
+  <style>
+    body {
+      font-family: sans-serif;
+      margin: 0;
+      padding: 0 20px;
+    }
+    .spacer {
+      height: 90vh;
+    }
+    .reveal-el {
+      opacity: 0;
+      transform: translateY(30px);
+      transition: opacity 0.5s ease, transform 0.5s ease;
+      background: #eef3ff;
+      border: 1px solid #c3d4ff;
+      border-radius: 8px;
+      padding: 24px;
+      margin: 40px auto;
+      max-width: 500px;
+      text-align: center;
+    }
+    .reveal-el.is-active {
+      opacity: 1;
+      transform: translateY(0);
+    }
+    .note {
+      max-width: 500px;
+      margin: 20px auto;
+      font-size: 14px;
+      color: #555;
+    }
+  </style>
+</head>
+<body>
+  <div class="note">
+    <strong>Bug being demonstrated:</strong> in browsers without
+    <code>IntersectionObserver</code>, the current fallback in
+    <code>core/reveal.js</code> adds the active class to every
+    <code>.reveal-el</code> immediately on load, so nothing actually
+    animates on scroll. This demo simulates that environment and
+    shows the fixed behavior instead: each block only activates once
+    it scrolls into view.
+  </div>
+
+  <div class="spacer"></div>
+
+  <div class="reveal-el">Block 1 — reveals on scroll</div>
+  <div class="spacer"></div>
+  <div class="reveal-el">Block 2 — reveals on scroll</div>
+  <div class="spacer"></div>
+  <div class="reveal-el">Block 3 — reveals on scroll</div>
+  <div class="spacer"></div>
+
+  <script src="demo.js"></script>
+</body>
+</html>

--- a/submissions/docs/reveal-fallback-scroll-check-aaniya22/demo.js
+++ b/submissions/docs/reveal-fallback-scroll-check-aaniya22/demo.js
@@ -1,0 +1,55 @@
+/**
+ * Reference implementation for the core/reveal.js no-IntersectionObserver
+ * fallback fix. Standalone — does not modify core/reveal.js.
+ *
+ * Original bug: the fallback branch added the active class to every
+ * .reveal-el element immediately, regardless of scroll position.
+ *
+ * Fix: throttled scroll/resize listener that checks each element's
+ * position and only activates it once it's actually in view.
+ */
+
+(function () {
+  var revealClass = 'reveal-el';
+  var activeClass = 'is-active';
+
+  function isCentered(el) {
+    var rect = el.getBoundingClientRect();
+    var viewportHeight = window.innerHeight || document.documentElement.clientHeight;
+    // Consider "in view" once the element has entered the bottom
+    // 90% of the viewport, matching core/reveal.js's IO threshold intent.
+    return rect.top < viewportHeight * 0.9 && rect.bottom > 0;
+  }
+
+  var throttled = false;
+
+  var checkAndReveal = function () {
+    var els = document.querySelectorAll('.' + revealClass + ':not(.' + activeClass + ')');
+    Array.prototype.forEach.call(els, function (el) {
+      if (isCentered(el)) {
+        el.classList.add(activeClass);
+      }
+    });
+  };
+
+  var onScroll = function () {
+    if (throttled) return;
+    throttled = true;
+    window.requestAnimationFrame(function () {
+      checkAndReveal();
+      throttled = false;
+    });
+  };
+
+  var readyFallback = function () {
+    checkAndReveal();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('resize', onScroll);
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', readyFallback);
+  } else {
+    readyFallback();
+  }
+})();


### PR DESCRIPTION
Fixes fallback branch in core/reveal.js that immediately activates all .reveal-el elements instead of checking scroll position when IntersectionObserver is unavailable. Reference implementation only, per contribution guide (no core/ edits) — submitted under submissions/docs/ for maintainer to port into core/reveal.js.

## Pull Request Description
Adds a reference implementation demonstrating the fix for a dead-on-arrival fallback in core/reveal.js: when IntersectionObserver isn't available, the fallback branch currently activates every .reveal-el element immediately on load instead of checking scroll position, so scroll-reveal never actually plays for those browsers.

---

## Type of Change
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/docs/reveal-fallback-scroll-check-aaniya22/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [ ] Includes `style.css` — N/A, this is a JS-behavior fix (Core & Docs Showcase track), not a visual/CSS feature — see Notes below
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A standalone reference fix (`demo.js`) for the no-IntersectionObserver fallback path in `core/reveal.js`, so reveal animations trigger on actual scroll position instead of firing all at once on page load.

**How does a developer use it?**
```html
<div class="reveal-el">Content that reveals on scroll</div>
<script src="demo.js"></script>
```

**Why does it fit EaseMotion CSS?**
It restores the intended scroll-reveal behavior for browsers without `IntersectionObserver`, keeping the library's animation-first behavior consistent across environments rather than silently degrading to "everything visible immediately."

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
This is a Core & Docs Showcase submission (`submissions/docs/`), not a standard CSS example — per the contribution guide, core/ fixes go through this track as a reference implementation for the maintainer to port in, rather than editing core/reveal.js directly. There's no `style.css` because this fixes JS behavior, not visual styling; happy to add a minimal one if you'd prefer every docs submission to include it regardless.