### PR TITLE
docs: add reference fix for badge keyboard focus styles

### DIFF
--- a/submissions/docs/badge-focus-visible-aaniya22/README.md
+++ b/submissions/docs/badge-focus-visible-aaniya22/README.md
@@ -1,0 +1,73 @@
+# Badge Keyboard Focus Styles
+
+Submission for [#59916](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/59916)
+("[FEATURE] Add keyboard focus styles for badge components").
+
+## Track
+
+Core & Docs Showcase (`submissions/docs/`) — reference implementation only.
+No files under `core/` or `components/` are modified by this submission.
+
+## What
+
+`.ease-badge` (and `.em-badge`) components currently have no visible
+keyboard focus state when used as interactive elements (buttons or
+links), making keyboard navigation through badges inaccessible —
+there's no way to tell which badge is currently focused when tabbing.
+
+## Fix
+
+Add a `:focus-visible` outline, matching the CSS provided in the issue:
+
+```css
+.ease-badge:focus-visible,
+.em-badge:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+```
+
+`currentColor` is used so the outline automatically matches each
+badge variant's text color (success/danger/info/warning) without
+needing per-variant overrides.
+
+An additional small addition (not in the original issue snippet, but
+included here for completeness) suppresses the outline for
+mouse/touch clicks, since `:focus-visible` already isolates the
+keyboard-only case:
+
+```css
+.ease-badge:focus:not(:focus-visible),
+.em-badge:focus:not(:focus-visible) {
+  outline: none;
+}
+```
+
+Maintainer may drop this second block if the base badge styles
+already handle default focus suppression elsewhere.
+
+## Files
+
+- `demo.html` — standalone page with four interactive badges
+  (button and link variants) to tab through
+- `style.css` — includes a minimal standalone reimplementation of
+  `.ease-badge` base styles (since `core/`/`components/` can't be
+  imported directly per the contribution guide) plus the actual
+  focus-visible fix, clearly separated and labeled
+- `README.md` — this file
+
+## How to verify
+
+1. Open `demo.html` in a browser.
+2. Click anywhere on the page to ensure no element has focus.
+3. Press `Tab` repeatedly — each badge should show a colored outline
+   matching its variant as it receives focus.
+4. Click a badge with the mouse — no outline should appear (confirms
+   `:focus-visible` is correctly distinguishing keyboard vs. pointer
+   focus).
+
+## Why it fits EaseMotion CSS
+
+Improves accessibility for keyboard users without altering existing
+badge visuals, colors, or animations — purely additive, consistent
+with the issue's stated goal.

--- a/submissions/docs/badge-focus-visible-aaniya22/demo.html
+++ b/submissions/docs/badge-focus-visible-aaniya22/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion CSS — Badge Keyboard Focus Styles</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="ease-badge-demo">
+    <h1>Badge Keyboard Focus Styles</h1>
+    <p>
+      Tab through the badges below to see the visible focus outline.
+      Click anywhere on the page first to remove initial focus, then
+      press <kbd>Tab</kbd>.
+    </p>
+
+    <div class="ease-badge-demo__row">
+      <button class="ease-badge ease-badge-success">
+        New
+      </button>
+
+      <a href="#" class="ease-badge ease-badge-danger">
+        Alert
+      </a>
+
+      <button class="ease-badge ease-badge-info">
+        Beta
+      </button>
+
+      <a href="#" class="ease-badge ease-badge-warning">
+        Pending
+      </a>
+    </div>
+
+    <p class="ease-badge-demo__note">
+      Mouse/touch clicks do not show the outline — only keyboard
+      navigation triggers <code>:focus-visible</code>.
+    </p>
+  </main>
+
+</body>
+</html>

--- a/submissions/docs/badge-focus-visible-aaniya22/style.css
+++ b/submissions/docs/badge-focus-visible-aaniya22/style.css
@@ -1,0 +1,121 @@
+/* ==========================================================================
+   EaseMotion CSS — Badge Keyboard Focus Styles
+   Fixes #59916: badges used as interactive elements (buttons/links)
+   have no visible keyboard focus state.
+
+   NOTE: .ease-badge base styles below are a minimal standalone
+   reimplementation for this demo only (per contribution guide,
+   core/ and components/ cannot be imported/edited directly). The
+   actual fix a maintainer needs to port is isolated in the
+   ":focus-visible fix" section at the bottom.
+   ========================================================================== */
+
+body {
+  margin: 0;
+  padding: 48px 24px;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+}
+
+.ease-badge-demo {
+  max-width: 560px;
+  margin: 0 auto;
+}
+
+.ease-badge-demo h1 {
+  font-size: 22px;
+  margin-bottom: 8px;
+}
+
+.ease-badge-demo p {
+  color: #94a3b8;
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.ease-badge-demo__row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin: 24px 0;
+}
+
+.ease-badge-demo__note {
+  font-size: 13px;
+  color: #64748b;
+}
+
+kbd {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 12px;
+}
+
+code {
+  background: #1e293b;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 13px;
+}
+
+/* --------------------------------------------------------------------
+   Minimal standalone .ease-badge base styles (for demo purposes only)
+   -------------------------------------------------------------------- */
+
+.ease-badge {
+  display: inline-block;
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 600;
+  text-decoration: none;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ease-badge:hover {
+  transform: translateY(-1px);
+}
+
+.ease-badge-success {
+  background: rgba(31, 174, 107, 0.15);
+  color: #34d399;
+}
+
+.ease-badge-danger {
+  background: rgba(229, 72, 77, 0.15);
+  color: #f87171;
+}
+
+.ease-badge-info {
+  background: rgba(59, 130, 246, 0.15);
+  color: #60a5fa;
+}
+
+.ease-badge-warning {
+  background: rgba(245, 158, 11, 0.15);
+  color: #fbbf24;
+}
+
+/* --------------------------------------------------------------------
+   THE FIX — keyboard focus-visible styles for .ease-badge
+   This is the block to port into core/components as-is.
+   Matches the CSS snippet from issue #59916.
+   -------------------------------------------------------------------- */
+
+.ease-badge:focus-visible,
+.em-badge:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+
+/* Remove default browser outline for mouse/touch clicks, since
+   :focus-visible already handles the keyboard-only case. */
+.ease-badge:focus:not(:focus-visible),
+.em-badge:focus:not(:focus-visible) {
+  outline: none;
+}


### PR DESCRIPTION
Closes #59916
Adds :focus-visible outline for .ease-badge / .em-badge components used as interactive elements (buttons/links), per issue #59916. Reference implementation only, per contribution guide (no core/ or components/ edits) — submitted under submissions/docs/ for maintainer to port into the badge component styles.

## Pull Request Description
Adds `submissions/docs/badge-focus-visible-aaniya22/` — a reference fix demonstrating visible keyboard focus styles for `.ease-badge` components used as buttons/links, closing the accessibility gap described in #59916.

---

## Type of Change
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/docs/badge-focus-visible-aaniya22/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A visible `:focus-visible` outline for `.ease-badge`/`.em-badge` components when used as interactive elements, closing a keyboard-accessibility gap.

**How does a developer use it?**
```html
<button class="ease-badge ease-badge-success">New</button>
<a href="#" class="ease-badge ease-badge-danger">Alert</a>
```
The focus style applies automatically — no extra class needed. The maintainer would add this CSS block to the badge component styles:
```css
.ease-badge:focus-visible,
.em-badge:focus-visible {
  outline: 2px solid currentColor;
  outline-offset: 2px;
}
```

**Why does it fit EaseMotion CSS?**
Improves accessibility for keyboard users without changing any existing badge visuals, colors, or animations — purely additive, matching the issue's stated goal.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
This is a Core & Docs Showcase submission (`submissions/docs/`) since `.ease-badge` styles live in `core/`/`components/`, which contributors can't edit directly. `style.css` includes a minimal standalone reimplementation of the badge base styles (needed for the demo to render independently) — the actual fix to port is clearly labeled in its own section at the bottom of the file. I also added an optional `:focus:not(:focus-visible) { outline: none; }` rule beyond the issue's snippet to suppress the outline on mouse/touch clicks — happy to drop it if redundant with existing styles.