### PR TITLE
feat: add toast notification stack component (#60856)

### DIFF
--- a/submissions/examples/toast-notification-stack-aaniya22/README.md
+++ b/submissions/examples/toast-notification-stack-aaniya22/README.md
@@ -1,0 +1,48 @@
+# Toast Notification Stack (`ease-toast`)
+
+Closes #60856
+
+A stack of dismissible toast notifications built with **pure CSS** — no JavaScript. Toasts slide/fade in on load, stack vertically in the bottom-right corner, and collapse with a fade + slide-out animation when dismissed.
+
+## What does this add?
+
+- `.toast-stack` — fixed-position container that stacks toasts vertically with consistent spacing
+- `.toast` — individual toast card with entrance animation
+- `.toast-success` / `.toast-error` / `.toast-info` — color-coded left-border variants
+- `.toast-icon` — leading icon slot
+- `.toast-message` — message text
+- `.toast-close` — dismiss control (a `<label>` bound to a hidden checkbox)
+
+## How does a developer use it?
+
+Each toast needs a hidden checkbox (checked = visible) placed **before** `.toast-stack` in the DOM, and a `.toast-close` label pointing at that checkbox's `id`:
+
+```html
+<input type="checkbox" id="toast-1" class="toast-toggle" checked />
+
+<div class="toast-stack">
+  <div class="toast toast-success">
+    <span class="toast-icon">✔</span>
+    <span class="toast-message">Changes saved successfully.</span>
+    <label for="toast-1" class="toast-close">&times;</label>
+  </div>
+</div>
+```
+
+Clicking the `×` unchecks the box, which drives the exit animation via a `:not(:checked) ~` sibling selector — no JS required. Toast order in the markup must match checkbox order (`#toast-1` → 1st `.toast`, `#toast-2` → 2nd, etc.), since plain CSS can't target an arbitrary toast by ID match alone without repeating the selector per position.
+
+## Why does it fit EaseMotion CSS?
+
+- Matches the issue's requirement of pure CSS entry/exit animation with checkbox-hack dismissal
+- No JS, no dependencies, self-contained
+- Respects `prefers-reduced-motion`
+- Responsive: stack goes full-width with tighter padding under 480px
+- Uses the suggested class names (`toast-stack`, `toast`, `toast-success`, `toast-error`, `toast-icon`, `toast-message`, `toast-close`) directly, so it can be dropped into the component library largely as-is
+
+## Known limitation
+
+Because this is a pure-CSS approach, a dismissed toast can't be "re-shown" without a page reload or reset of the checkbox state (there's no JS to flip it back). This matches the constraint of the checkbox-hack pattern generally and is consistent with how the issue scoped the feature (no JS).
+
+## Browser support
+
+Relies on `:checked`, the general sibling combinator (`~`), and `:not()` — all broadly supported in evergreen browsers. No experimental features used.

--- a/submissions/examples/toast-notification-stack-aaniya22/demo.html
+++ b/submissions/examples/toast-notification-stack-aaniya22/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Toast Notification Stack — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="demo-wrap">
+    <h1>Toast Notification Stack</h1>
+    <p>Pure CSS toasts — no JavaScript. Click the &times; on any toast to dismiss it.</p>
+    <p class="demo-hint">Reload the page to reset the stack.</p>
+  </main>
+
+  <input type="checkbox" id="toast-1" class="toast-toggle" checked />
+  <input type="checkbox" id="toast-2" class="toast-toggle" checked />
+  <input type="checkbox" id="toast-3" class="toast-toggle" checked />
+
+  <div class="toast-stack" aria-live="polite">
+
+    <div class="toast toast-success">
+      <span class="toast-icon" aria-hidden="true">&#10003;</span>
+      <span class="toast-message">Changes saved successfully.</span>
+      <label for="toast-1" class="toast-close" aria-label="Dismiss notification">&times;</label>
+    </div>
+
+    <div class="toast toast-error">
+      <span class="toast-icon" aria-hidden="true">&#10007;</span>
+      <span class="toast-message">Something went wrong. Please try again.</span>
+      <label for="toast-2" class="toast-close" aria-label="Dismiss notification">&times;</label>
+    </div>
+
+    <div class="toast toast-info">
+      <span class="toast-icon" aria-hidden="true">&#8505;</span>
+      <span class="toast-message">A new update is available.</span>
+      <label for="toast-3" class="toast-close" aria-label="Dismiss notification">&times;</label>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/toast-notification-stack-aaniya22/style.css
+++ b/submissions/examples/toast-notification-stack-aaniya22/style.css
@@ -1,0 +1,168 @@
+/* =========================================================
+   Toast Notification Stack — ease-toast
+   Pure CSS, no JavaScript.
+   Dismissal via checkbox-hack: each toast is paired with a
+   hidden <input type="checkbox" checked> that lives BEFORE
+   the .toast-stack in the DOM. Unchecking it (via the label
+   used as the close button) collapses and fades that toast.
+   ========================================================= */
+
+/* ---- Demo page chrome (not part of the component) ---- */
+.demo-wrap {
+  max-width: 640px;
+  margin: 4rem auto;
+  padding: 0 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #1f2430;
+}
+.demo-wrap h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }
+.demo-wrap p { color: #5a6270; margin: 0.25rem 0; }
+.demo-hint { font-size: 0.85rem; color: #9aa1ad; }
+
+/* ---- Hide the checkbox drivers ---- */
+.toast-toggle {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* =========================================================
+   Component: ease-toast
+   ========================================================= */
+
+.toast-stack {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  width: min(360px, calc(100vw - 3rem));
+  z-index: 9999;
+  pointer-events: none; /* re-enabled per-toast below */
+}
+
+.toast {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  padding: 0.85rem 1rem;
+  border-radius: 10px;
+  background: #ffffff;
+  color: #1f2430;
+  box-shadow: 0 8px 24px rgba(20, 20, 30, 0.14), 0 1px 3px rgba(20, 20, 30, 0.08);
+  border-left: 4px solid #6b7280;
+  pointer-events: auto;
+
+  /* Entrance animation */
+  animation: toast-in 320ms cubic-bezier(0.21, 1.02, 0.73, 1) both;
+
+  /* Collapse state defaults (used when dismissed) */
+  max-height: 200px;
+  overflow: hidden;
+  transform-origin: top right;
+  transition:
+    opacity 260ms ease,
+    transform 260ms ease,
+    max-height 300ms ease 60ms,
+    padding 300ms ease 60ms,
+    margin 300ms ease 60ms;
+}
+
+.toast-icon {
+  flex-shrink: 0;
+  font-size: 1rem;
+  line-height: 1.4rem;
+  font-weight: 700;
+}
+
+.toast-message {
+  flex: 1;
+  font-size: 0.9rem;
+  line-height: 1.4rem;
+}
+
+.toast-close {
+  flex-shrink: 0;
+  cursor: pointer;
+  font-size: 1.1rem;
+  line-height: 1;
+  color: #9aa1ad;
+  padding: 0 0.15rem;
+  user-select: none;
+}
+.toast-close:hover { color: #1f2430; }
+
+/* ---- Variants ---- */
+.toast-success { border-left-color: #22c55e; }
+.toast-success .toast-icon { color: #22c55e; }
+
+.toast-error { border-left-color: #ef4444; }
+.toast-error .toast-icon { color: #ef4444; }
+
+.toast-info { border-left-color: #3b82f6; }
+.toast-info .toast-icon { color: #3b82f6; }
+
+/* =========================================================
+   Checkbox-hack wiring
+   Each #toast-N checkbox sits before .toast-stack in the DOM.
+   Unchecking it (via its <label class="toast-close">) drives
+   the exit animation on the matching .toast, in source order.
+   ========================================================= */
+
+#toast-1:not(:checked) ~ .toast-stack .toast:nth-of-type(1),
+#toast-2:not(:checked) ~ .toast-stack .toast:nth-of-type(2),
+#toast-3:not(:checked) ~ .toast-stack .toast:nth-of-type(3) {
+  animation: toast-out 260ms ease forwards;
+  max-height: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+  margin-top: -0.75rem; /* collapses the flex gap along with it */
+  border-width: 0;
+  pointer-events: none;
+}
+
+/* ---- Keyframes ---- */
+@keyframes toast-in {
+  from {
+    opacity: 0;
+    transform: translateX(16px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0) scale(1);
+  }
+}
+
+@keyframes toast-out {
+  from {
+    opacity: 1;
+    transform: translateX(0) scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: translateX(24px) scale(0.96);
+  }
+}
+
+/* ---- Reduced motion ---- */
+@media (prefers-reduced-motion: reduce) {
+  .toast {
+    animation: none !important;
+    transition: opacity 120ms linear, max-height 120ms linear !important;
+  }
+  @keyframes toast-in { from, to { opacity: 1; transform: none; } }
+}
+
+/* ---- Responsive ---- */
+@media (max-width: 480px) {
+  .toast-stack {
+    left: 1rem;
+    right: 1rem;
+    bottom: 1rem;
+    width: auto;
+  }
+  .toast { padding: 0.75rem 0.85rem; }
+}


### PR DESCRIPTION
Closes #60856
## Pull Request Description
Adds `submissions/examples/toast-notification-stack-aaniya22/` — a pure CSS toast notification stack (`ease-toast`) that slides/fades in, stacks vertically, and collapses out on dismiss, per issue #60856.

---

## Type of Change
- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/toast-notification-stack-aaniya22/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A stack of dismissible toast notifications (`toast-stack`, `toast`, `toast-success`/`toast-error`/`toast-info`) with pure CSS slide/fade entrance and collapse-on-dismiss exit, no JavaScript.

**How does a developer use it?**
```html
<input type="checkbox" id="toast-1" class="toast-toggle" checked />

<div class="toast-stack">
  <div class="toast toast-success">
    <span class="toast-icon">✔</span>
    <span class="toast-message">Changes saved successfully.</span>
    <label for="toast-1" class="toast-close">&times;</label>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
Uses only checkbox-hack + CSS animations for state and motion, matches the suggested class naming from the issue, respects `prefers-reduced-motion`, and is responsive down to mobile widths — consistent with the animation-first, dependency-free philosophy of the library.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
This is a pure-CSS implementation, so there's one inherent limitation worth flagging: a dismissed toast can't be re-shown without a page reload, since there's no JS to reset the checkbox state — this follows directly from the issue's no-JS constraint. Toast-to-checkbox pairing is done by DOM order (`#toast-1` → 1st `.toast`, etc.) since CSS can't match on ID alone without a selector per position; documented in the README. Happy to adjust animation timing/easing if it doesn't match the rest of the library's feel.