### PR TITLE
feat: add CSS slide-up product stepper

### DIFF
--- a/submissions/examples/slide-up-stepper-v2/README.md
+++ b/submissions/examples/slide-up-stepper-v2/README.md
@@ -1,0 +1,155 @@
+# Slide-Up Stepper
+
+A lightweight, responsive **CSS Slide-Up Stepper** designed for product catalog layouts.
+
+This component is built using only semantic HTML and pure CSS. No JavaScript or external frameworks are required.
+
+## ✨ Features
+
+* Pure HTML and CSS
+* No JavaScript dependencies
+* Slide-up product detail animation
+* Hover interaction
+* Keyboard focus interaction
+* Responsive desktop, tablet and mobile layouts
+* CSS custom properties for easy customization
+* Uses `transform` and `opacity` for smooth animations
+* Accessible `prefers-reduced-motion` support
+* Semantic `<ol>` and `<li>` step structure
+* Responsive typography using CSS `clamp()`
+
+## 📁 Files
+
+```text
+slide-up-stepper/
+├── demo.html
+├── style.css
+└── README.md
+```
+
+## 🚀 Usage
+
+Copy the `demo.html` and `style.css` files into your project.
+
+Include the stylesheet:
+
+```html
+<link rel="stylesheet" href="style.css">
+```
+
+Then create the stepper using the following structure:
+
+```html
+<ol class="stepper">
+  <li class="stepper__item">
+    <article class="step" tabindex="0">
+      <div class="step__number">01</div>
+
+      <div class="step__content">
+        <span class="step__category">Category</span>
+        <h3>Product Name</h3>
+
+        <div class="step__details">
+          <p>Product description goes here.</p>
+
+          <a class="step__link" href="#">
+            View product
+            <span aria-hidden="true">→</span>
+          </a>
+        </div>
+      </div>
+    </article>
+  </li>
+</ol>
+```
+
+## 🎨 CSS Custom Properties
+
+The component exposes several CSS custom properties for customization.
+
+| Property                | Default                          | Purpose                 |
+| ----------------------- | -------------------------------- | ----------------------- |
+| `--stepper-bg`          | `#f5f5f2`                        | Page/stepper background |
+| `--step-bg`             | `#ffffff`                        | Step background         |
+| `--step-text`           | `#181818`                        | Primary text color      |
+| `--step-muted`          | `#6f6f6a`                        | Secondary text color    |
+| `--step-border`         | `#deded8`                        | Border color            |
+| `--step-accent`         | `#181818`                        | Focus/interaction color |
+| `--step-radius`         | `1.25rem`                        | Step border radius      |
+| `--step-gap`            | `0.75rem`                        | Space between steps     |
+| `--step-duration`       | `420ms`                          | Animation duration      |
+| `--step-ease`           | `cubic-bezier(0.22, 1, 0.36, 1)` | Animation easing        |
+| `--step-padding`        | `1.5rem`                         | Step inner spacing      |
+| `--step-details-offset` | `1.25rem`                        | Space before details    |
+
+### Example customization
+
+```css
+:root {
+  --step-bg: #f8f8f8;
+  --step-accent: #222;
+  --step-radius: 0.75rem;
+  --step-duration: 300ms;
+}
+```
+
+## ♿ Accessibility
+
+The component supports keyboard navigation using focusable step elements.
+
+Each step uses `tabindex="0"` so users navigating with a keyboard can trigger the same visual state using `:focus-visible`.
+
+The component also respects users who prefer reduced motion:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  /* Animations and transitions are reduced */
+}
+```
+
+On mobile layouts, product details remain visible instead of relying exclusively on hover.
+
+## 📱 Responsive Behavior
+
+### Desktop
+
+Four steps are displayed in a horizontal layout.
+
+### Tablet
+
+The layout changes to two columns.
+
+### Mobile
+
+Steps are displayed in a single column and product details remain visible for better touch accessibility.
+
+## ⚡ Performance
+
+The animation primarily uses:
+
+* `transform`
+* `opacity`
+
+These properties are generally preferable for smooth UI animations because they avoid repeatedly changing layout dimensions during the interaction.
+
+## 🧩 Customization
+
+The step content can be changed without modifying the animation logic.
+
+You can customize:
+
+* Product name
+* Product category
+* Description
+* Product metadata
+* Product links
+* Number of steps
+* Colors
+* Spacing
+* Border radius
+* Animation duration
+* Animation easing
+
+## 📄 License
+
+Part of the EaseMotion CSS project and follows the repository's licensing terms.

--- a/submissions/examples/slide-up-stepper-v2/demo.html
+++ b/submissions/examples/slide-up-stepper-v2/demo.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta
+    name="description"
+    content="CSS Slide-Up Stepper for product catalog layouts"
+  >
+  <title>Slide-Up Stepper | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+  <main class="demo">
+    <header class="demo__header">
+      <p class="demo__eyebrow">EaseMotion CSS</p>
+      <h1>Slide-Up Product Stepper</h1>
+      <p class="demo__description">
+        A lightweight, responsive product catalog stepper built entirely
+        with HTML and CSS.
+      </p>
+    </header>
+
+```
+<section class="catalog" aria-labelledby="catalog-title">
+  <div class="catalog__intro">
+    <div>
+      <span class="catalog__label">Product journey</span>
+      <h2 id="catalog-title">Explore the collection</h2>
+    </div>
+
+    <p>
+      Hover or focus on a step to reveal its product details.
+    </p>
+  </div>
+
+  <ol class="stepper">
+    <li class="stepper__item">
+      <article class="step" tabindex="0">
+        <div class="step__number" aria-hidden="true">01</div>
+
+        <div class="step__content">
+          <span class="step__category">Essentials</span>
+          <h3>Everyday Pack</h3>
+
+          <div class="step__details">
+            <p>
+              A lightweight everyday backpack designed for work,
+              study and travel.
+            </p>
+
+            <div class="step__meta">
+              <span>24L capacity</span>
+              <span>Water resistant</span>
+            </div>
+
+            <a class="step__link" href="#product-01">
+              View product
+              <span aria-hidden="true">→</span>
+            </a>
+          </div>
+        </div>
+      </article>
+    </li>
+
+    <li class="stepper__item">
+      <article class="step" tabindex="0">
+        <div class="step__number" aria-hidden="true">02</div>
+
+        <div class="step__content">
+          <span class="step__category">Travel</span>
+          <h3>Explorer Case</h3>
+
+          <div class="step__details">
+            <p>
+              A durable travel case with organized storage for
+              longer journeys.
+            </p>
+
+            <div class="step__meta">
+              <span>45L capacity</span>
+              <span>Impact resistant</span>
+            </div>
+
+            <a class="step__link" href="#product-02">
+              View product
+              <span aria-hidden="true">→</span>
+            </a>
+          </div>
+        </div>
+      </article>
+    </li>
+
+    <li class="stepper__item">
+      <article class="step" tabindex="0">
+        <div class="step__number" aria-hidden="true">03</div>
+
+        <div class="step__content">
+          <span class="step__category">Outdoor</span>
+          <h3>Trail Series</h3>
+
+          <div class="step__details">
+            <p>
+              Performance-focused outdoor gear made for demanding
+              trails and changing conditions.
+            </p>
+
+            <div class="step__meta">
+              <span>32L capacity</span>
+              <span>All-weather</span>
+            </div>
+
+            <a class="step__link" href="#product-03">
+              View product
+              <span aria-hidden="true">→</span>
+            </a>
+          </div>
+        </div>
+      </article>
+    </li>
+
+    <li class="stepper__item">
+      <article class="step" tabindex="0">
+        <div class="step__number" aria-hidden="true">04</div>
+
+        <div class="step__content">
+          <span class="step__category">Premium</span>
+          <h3>Signature Collection</h3>
+
+          <div class="step__details">
+            <p>
+              Refined materials and thoughtful details for a premium
+              everyday experience.
+            </p>
+
+            <div class="step__meta">
+              <span>Premium finish</span>
+              <span>Lifetime design</span>
+            </div>
+
+            <a class="step__link" href="#product-04">
+              View product
+              <span aria-hidden="true">→</span>
+            </a>
+          </div>
+        </div>
+      </article>
+    </li>
+  </ol>
+</section>
+```
+
+  </main>
+</body>
+</html>

--- a/submissions/examples/slide-up-stepper-v2/style.css
+++ b/submissions/examples/slide-up-stepper-v2/style.css
@@ -1,0 +1,350 @@
+:root {
+    --stepper-bg: #f5f5f2;
+    --step-bg: #ffffff;
+    --step-text: #181818;
+    --step-muted: #6f6f6a;
+    --step-border: #deded8;
+    --step-accent: #181818;
+    
+    --step-radius: 1.25rem;
+    --step-gap: 0.75rem;
+    
+    --step-duration: 420ms;
+    --step-ease: cubic-bezier(0.22, 1, 0.36, 1);
+    
+    --step-padding: 1.5rem;
+    --step-details-offset: 1.25rem;
+    }
+    
+    * {
+      box-sizing: border-box;
+      }
+    
+    html {
+    scroll-behavior: smooth;
+    }
+    
+    body {
+    margin: 0;
+    min-width: 320px;
+    background: var(--stepper-bg);
+    color: var(--step-text);
+    font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+    line-height: 1.5;
+    }
+    
+    a {
+    color: inherit;
+    }
+    
+    .demo {
+    width: min(1180px, calc(100% - 2rem));
+    margin: 0 auto;
+    padding: 5rem 0;
+    }
+    
+    .demo__header {
+    max-width: 680px;
+    margin-bottom: 3rem;
+    }
+    
+    .demo__eyebrow {
+    margin: 0 0 0.5rem;
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--step-muted);
+    }
+    
+    .demo__header h1 {
+    margin: 0;
+    font-size: clamp(2.25rem, 6vw, 4.5rem);
+    line-height: 0.98;
+    letter-spacing: -0.05em;
+    }
+    
+    .demo__description {
+    max-width: 580px;
+    margin: 1.25rem 0 0;
+    color: var(--step-muted);
+    font-size: 1.05rem;
+    }
+    
+    .catalog {
+    padding: clamp(1.25rem, 3vw, 2rem);
+    border: 1px solid var(--step-border);
+    border-radius: calc(var(--step-radius) + 0.5rem);
+    background: rgba(255, 255, 255, 0.45);
+    }
+    
+    .catalog__intro {
+    display: flex;
+    align-items: end;
+    justify-content: space-between;
+    gap: 2rem;
+    margin-bottom: 1.5rem;
+    }
+    
+    .catalog__label {
+    display: block;
+    margin-bottom: 0.35rem;
+    color: var(--step-muted);
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    }
+    
+    .catalog__intro h2 {
+    margin: 0;
+    font-size: clamp(1.5rem, 3vw, 2.25rem);
+    line-height: 1.1;
+    }
+    
+    .catalog__intro p {
+    max-width: 340px;
+    margin: 0;
+    color: var(--step-muted);
+    font-size: 0.9rem;
+    }
+    
+    .stepper {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: var(--step-gap);
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    }
+    
+    .stepper__item {
+    min-width: 0;
+    }
+    
+    .step {
+    --step-hover-padding: 2rem;
+    
+    position: relative;
+    display: flex;
+    min-height: 360px;
+    overflow: hidden;
+    isolation: isolate;
+    padding: var(--step-padding);
+    border: 1px solid var(--step-border);
+    border-radius: var(--step-radius);
+    background: var(--step-bg);
+    cursor: pointer;
+    
+    transition:
+    transform var(--step-duration) var(--step-ease),
+    box-shadow var(--step-duration) var(--step-ease),
+    border-color var(--step-duration) var(--step-ease);
+    }
+    
+    .step::before {
+    position: absolute;
+    z-index: -1;
+    inset: auto 0 0;
+    height: 42%;
+    background: linear-gradient(
+    to top,
+    rgba(0, 0, 0, 0.06),
+    transparent
+    );
+    content: "";
+    opacity: 0;
+    transition: opacity var(--step-duration) var(--step-ease);
+    }
+    
+    .step__number {
+    position: absolute;
+    top: var(--step-padding);
+    right: var(--step-padding);
+    color: var(--step-muted);
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    }
+    
+    .step__content {
+    align-self: end;
+    width: 100%;
+    }
+    
+    .step__category {
+    display: block;
+    margin-bottom: 0.5rem;
+    color: var(--step-muted);
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    }
+    
+    .step h3 {
+    margin: 0;
+    font-size: clamp(1.35rem, 2.4vw, 1.8rem);
+    line-height: 1.1;
+    letter-spacing: -0.03em;
+    
+    transition:
+    transform var(--step-duration) var(--step-ease);
+    }
+    
+    .step__details {
+    margin-top: var(--step-details-offset);
+    transform: translateY(45px);
+    opacity: 0;
+    
+    transition:
+    transform var(--step-duration) var(--step-ease),
+    opacity var(--step-duration) var(--step-ease);
+    }
+    
+    .step__details p {
+    margin: 0 0 1rem;
+    color: var(--step-muted);
+    font-size: 0.875rem;
+    }
+    
+    .step__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    margin-bottom: 1.25rem;
+    }
+    
+    .step__meta span {
+    padding: 0.3rem 0.55rem;
+    border: 1px solid var(--step-border);
+    border-radius: 999px;
+    color: var(--step-muted);
+    font-size: 0.7rem;
+    }
+    
+    .step__link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.8rem;
+    font-weight: 700;
+    text-decoration: none;
+    }
+    
+    .step__link span {
+    transition: transform 250ms ease;
+    }
+    
+    .step__link:hover span,
+    .step:focus-within .step__link span {
+    transform: translateX(4px);
+    }
+    
+    /* Slide-up interaction */
+    .step:hover,
+    .step:focus-visible {
+    transform: translateY(-8px);
+    border-color: var(--step-accent);
+    box-shadow: 0 1.25rem 2.5rem rgba(0, 0, 0, 0.08);
+    }
+    
+    .step:hover::before,
+    .step:focus-visible::before {
+    opacity: 1;
+    }
+    
+    .step:hover .step__details,
+    .step:focus-visible .step__details {
+    transform: translateY(0);
+    opacity: 1;
+    }
+    
+    .step:hover h3,
+    .step:focus-visible h3 {
+    transform: translateY(-4px);
+    }
+    
+    .step:focus-visible {
+    outline: 3px solid currentColor;
+    outline-offset: 3px;
+    }
+    
+    /* Tablet */
+    @media (max-width: 900px) {
+    .stepper {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+    
+    .step {
+    min-height: 330px;
+    }
+    }
+    
+    /* Mobile */
+    @media (max-width: 600px) {
+    .demo {
+    width: min(100% - 1rem, 540px);
+    padding: 3rem 0;
+    }
+    
+    .catalog__intro {
+    display: block;
+    }
+    
+    .catalog__intro p {
+    margin-top: 0.75rem;
+    }
+    
+    .stepper {
+    grid-template-columns: 1fr;
+    }
+    
+    .step {
+    min-height: 290px;
+    }
+    
+    .step__details {
+    transform: translateY(0);
+    opacity: 1;
+    }
+    }
+    
+    /* Reduced motion accessibility */
+    @media (prefers-reduced-motion: reduce) {
+    html {
+    scroll-behavior: auto;
+    }
+    
+    *,
+    *::before,
+    *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+    }
+    
+    .step__details {
+    transform: none;
+    opacity: 1;
+    }
+    
+    .step:hover,
+    .step:focus-visible {
+    transform: none;
+    }
+    
+    .step:hover h3,
+    .step:focus-visible h3 {
+    transform: none;
+    }
+    }
+    


### PR DESCRIPTION
## Summary

Adds a new CSS Slide-Up Stepper example for product catalog layouts.

### What was added

* `demo.html` — responsive product catalog stepper demo
* `style.css` — pure CSS slide-up interaction and responsive styling
* `README.md` — usage, customization, CSS custom properties and accessibility documentation

### Features

* Pure HTML/CSS
* No JavaScript dependencies
* Hover and keyboard focus interactions
* Smooth slide-up transitions
* Responsive desktop, tablet and mobile layouts
* CSS custom properties
* `prefers-reduced-motion` support
* Semantic HTML structure

### Testing

* Tested desktop layout
* Tested tablet layout
* Tested mobile layout
* Tested keyboard focus interaction
* Tested reduced-motion behavior
* Ran `git diff --check`

Closes #62408
