### PR TITLE
Add ease-marquee-ticker-scroll component

### DIFF
--- a/submissions/examples/marquee-ticker-scroll-ij/README.md
+++ b/submissions/examples/marquee-ticker-scroll-ij/README.md
@@ -1,0 +1,10 @@
+# ease-marquee-ticker-scroll
+
+A news ticker whose headline ribbon scrolls across the viewport while stock quotes pass on the band below.
+
+## Run
+Open `demo.html` directly in a browser to watch the headlines run.
+
+## Notes
+- The ribbon scrolls on a continuous loop.
+- The BREAKING label flashes red.

--- a/submissions/examples/marquee-ticker-scroll-ij/demo.html
+++ b/submissions/examples/marquee-ticker-scroll-ij/demo.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-marquee-ticker-scroll demo</title>
+</head>
+<body>
+<div class="mk-app">
+  <span class="mk-label">BREAKING</span>
+  <div class="mk-viewport">
+    <div class="mk-track">
+      <span class="mk-item">Market rallies as tech leads gains</span>
+      <span class="mk-item">Storm watch issued for coastal cities</span>
+      <span class="mk-item">City opens a new transit line downtown</span>
+      <span class="mk-item">Science fair winners announced today</span>
+    </div>
+  </div>
+  <div class="mk-stocks">
+    <span class="mk-quote">INDEX &nbsp;+1.2%</span>
+    <span class="mk-quote">TECH &nbsp;+2.4%</span>
+    <span class="mk-quote">ENERGY &nbsp;-0.6%</span>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/marquee-ticker-scroll-ij/style.css
+++ b/submissions/examples/marquee-ticker-scroll-ij/style.css
@@ -1,0 +1,12 @@
+:root{--mk-red:#d8403a;--mk-ink:#e8eef4}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#2a2622,#171410);font-family:'Segoe UI',sans-serif}
+.mk-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#221e1a,#120f0c);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.mk-title{position:absolute;top:14px;left:0;right:0;text-align:center;font-size:14px;font-weight:800;letter-spacing:7px;color:#c8b090}
+.mk-label{position:absolute;top:58px;left:26px;background:var(--mk-red);color:#fff;font-size:11px;font-weight:800;letter-spacing:2px;padding:6px 12px;border-radius:4px;animation:flash-label-marquee-ticker-scroll 1.6s steps(1) infinite}
+.mk-viewport{position:absolute;top:56px;left:120px;width:228px;height:38px;border-radius:6px;background:#1a1714;box-shadow:inset 0 0 0 3px #261f18;overflow:hidden}
+.mk-track{display:flex;width:max-content;white-space:nowrap;height:38px;align-items:center;animation:scroll-track-marquee-ticker-scroll 11s linear infinite}
+.mk-item{font-size:13px;font-weight:700;color:var(--mk-ink);padding:0 24px}
+.mk-stocks{position:absolute;bottom:30px;left:36px;width:300px;height:34px;border-radius:6px;background:#1a1714;box-shadow:inset 0 0 0 3px #261f18;display:flex;align-items:center;padding:0 10px}
+.mk-quote{font-size:11px;font-weight:800;color:#7ad87a;margin-right:14px}
+@keyframes scroll-track-marquee-ticker-scroll{to{transform:translateX(-50%)}}
+@keyframes flash-label-marquee-ticker-scroll{0%,86%{background:var(--mk-red)}92%{background:#fff}100%{background:var(--mk-red)}}


### PR DESCRIPTION
## Component: ease-marquee-ticker-scroll — news headline scrolls, red label flashes, and stocks scroll by

**Closes #62642**

### What this adds
A news ticker: the headline ribbon scrolls across the viewport, the red BREAKING label flashes, and stock quotes scroll past on the lower band.

### Acceptance Criteria covered
- Headline ribbon scrolls across
- Red BREAKING label flashes
- Stock quotes scroll on the band

### Files
- submissions/examples/marquee-ticker-scroll-ij/demo.html
- submissions/examples/marquee-ticker-scroll-ij/style.css
- submissions/examples/marquee-ticker-scroll-ij/README.md

### How to review
Open `demo.html` in a browser and watch the headlines run.