### PR TITLE
Add ease-loading-progress-skeleton component

### DIFF
--- a/submissions/examples/loading-progress-skeleton-ij/README.md
+++ b/submissions/examples/loading-progress-skeleton-ij/README.md
@@ -1,0 +1,10 @@
+# ease-loading-progress-skeleton
+
+A loading skeleton whose cards shimmer while the progress bar fills and the percent readout ticks.
+
+## Run
+Open `demo.html` directly in a browser to watch the load complete.
+
+## Notes
+- Two profile cards shimmer in place.
+- The progress bar fills toward full.

--- a/submissions/examples/loading-progress-skeleton-ij/demo.html
+++ b/submissions/examples/loading-progress-skeleton-ij/demo.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-loading-progress-skeleton demo</title>
+</head>
+<body>
+<div class="sk-app">
+  <span class="sk-title">LOADING</span>
+  <div class="sk-card">
+    <span class="sk-avatar"></span>
+    <div class="sk-copy">
+      <span class="sk-line sk-line-1"></span>
+      <span class="sk-line sk-line-2"></span>
+      <span class="sk-line sk-line-3"></span>
+    </div>
+  </div>
+  <div class="sk-card">
+    <span class="sk-avatar"></span>
+    <div class="sk-copy">
+      <span class="sk-line sk-line-1"></span>
+      <span class="sk-line sk-line-2"></span>
+      <span class="sk-line sk-line-3"></span>
+    </div>
+  </div>
+  <div class="sk-progress">
+    <span class="sk-fill"></span>
+  </div>
+  <span class="sk-percent">64%</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/loading-progress-skeleton-ij/style.css
+++ b/submissions/examples/loading-progress-skeleton-ij/style.css
@@ -1,0 +1,20 @@
+:root{--sk-accent:#4a8fe8;--sk-soft:#8fa6c8}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#26313a,#141b21);font-family:'Segoe UI',sans-serif}
+.sk-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#1c242c,#10161c);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.sk-title{position:absolute;top:14px;left:0;right:0;text-align:center;font-size:14px;font-weight:800;letter-spacing:7px;color:#8fa6c8}
+.sk-card{position:absolute;left:34px;width:304px;height:64px;border-radius:10px;background:#131b23;box-shadow:inset 0 0 0 3px #1b2632;display:flex;padding:10px}
+.sk-card-1{top:58px}
+.sk-card-2{top:134px}
+.sk-avatar{width:42px;height:42px;border-radius:50%;background:#223247;animation:shimmer-avatar-loading-progress-skeleton 1.8s ease-in-out infinite}
+.sk-copy{flex:1;display:flex;flex-direction:column;gap:8px;padding-left:12px;justify-content:center}
+.sk-line{height:10px;border-radius:5px;background:#223247}
+.sk-line-1{width:76%;animation:shimmer-line-loading-progress-skeleton 1.8s ease-in-out infinite}
+.sk-line-2{width:54%;animation:shimmer-line-loading-progress-skeleton 1.8s ease-in-out infinite 0.2s}
+.sk-line-3{width:66%;animation:shimmer-line-loading-progress-skeleton 1.8s ease-in-out infinite 0.4s}
+.sk-progress{position:absolute;top:222px;left:34px;width:304px;height:12px;border-radius:6px;background:#131b23;box-shadow:inset 0 0 0 3px #1b2632;overflow:hidden}
+.sk-fill{display:block;height:100%;border-radius:6px;background:linear-gradient(90deg,var(--sk-accent),#7ab8ff);animation:fill-progress-loading-progress-skeleton 3.2s ease-in-out infinite}
+.sk-percent{position:absolute;top:248px;left:0;right:0;text-align:center;font-size:15px;font-weight:800;color:var(--sk-soft);animation:tic-percent-loading-progress-skeleton 3.2s steps(1) infinite}
+@keyframes shimmer-line-loading-progress-skeleton{0%,100%{opacity:0.35}50%{opacity:1}}
+@keyframes shimmer-avatar-loading-progress-skeleton{0%,100%{opacity:0.35}50%{opacity:1}}
+@keyframes fill-progress-loading-progress-skeleton{0%{width:4%}30%{width:38%}60%{width:66%}100%{width:96%}}
+@keyframes tic-percent-loading-progress-skeleton{0%{color:var(--sk-soft)}50%{color:#fff}100%{color:var(--sk-soft)}}


### PR DESCRIPTION
## Component: ease-loading-progress-skeleton — skeleton cards shimmer, progress bar fills, and percent ticks

**Closes #62645**

### What this adds
A loading skeleton: profile cards shimmer in place, the progress bar fills from empty to full, and the percent readout ticks upward while content loads.

### Acceptance Criteria covered
- Skeleton cards shimmer in place
- Progress bar fills toward full
- Percent readout ticks upward

### Files
- submissions/examples/loading-progress-skeleton-ij/demo.html
- submissions/examples/loading-progress-skeleton-ij/style.css
- submissions/examples/loading-progress-skeleton-ij/README.md

### How to review
Open `demo.html` in a browser and watch the load complete.