### PR TITLE
Add ease-password-strength-meter component

### DIFF
--- a/submissions/examples/password-strength-meter-ij/README.md
+++ b/submissions/examples/password-strength-meter-ij/README.md
@@ -1,0 +1,10 @@
+# ease-password-strength-meter
+
+A password strength meter whose field glows while the four segments fill and the verdict cycles.
+
+## Run
+Open `demo.html` directly in a browser to watch the meter fill.
+
+## Notes
+- The verdict passes through weak, mid, and strong.
+- The field glow follows the strength.

--- a/submissions/examples/password-strength-meter-ij/demo.html
+++ b/submissions/examples/password-strength-meter-ij/demo.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-password-strength-meter demo</title>
+</head>
+<body>
+<div class="ps-app">
+  <span class="ps-title">SECURITY</span>
+  <input type="password" class="ps-field" value="S3curePass!" placeholder="Type a password">
+  <div class="ps-bars">
+    <span class="ps-seg ps-seg-1"></span>
+    <span class="ps-seg ps-seg-2"></span>
+    <span class="ps-seg ps-seg-3"></span>
+    <span class="ps-seg ps-seg-4"></span>
+  </div>
+  <span class="ps-label">Strong</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/password-strength-meter-ij/style.css
+++ b/submissions/examples/password-strength-meter-ij/style.css
@@ -1,0 +1,14 @@
+:root{--ps-good:#4ad86a;--ps-mid:#e8c84a;--ps-bad:#e0533d}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#2a2733,#14121a);font-family:'Segoe UI',sans-serif}
+.ps-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#201d28,#110f16);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.ps-title{position:absolute;top:14px;left:0;right:0;text-align:center;font-size:14px;font-weight:800;letter-spacing:7px;color:#a898c8}
+.ps-field{position:absolute;top:112px;left:56px;width:260px;height:46px;border:none;border-radius:10px;background:#2a2440;color:#d8ccf0;font-size:15px;font-weight:700;padding:0 16px;box-sizing:border-box;animation:glow-field-password-strength-meter 3s ease-in-out infinite}
+.ps-bars{position:absolute;top:186px;left:56px;width:260px;display:flex;gap:6px}
+.ps-seg{flex:1;height:10px;border-radius:5px;background:#2a2440;animation:fill-segment-password-strength-meter 3s ease-in-out infinite}
+.ps-seg-2{animation-delay:0.2s}
+.ps-seg-3{animation-delay:0.4s}
+.ps-seg-4{animation-delay:0.6s}
+.ps-label{position:absolute;top:216px;left:0;right:0;text-align:center;font-size:15px;font-weight:800;color:var(--ps-good);animation:cycle-label-password-strength-meter 3s steps(1) infinite}
+@keyframes fill-segment-password-strength-meter{0%,100%{background:var(--ps-bad)}40%{background:var(--ps-mid)}70%,100%{background:var(--ps-good)}}
+@keyframes glow-field-password-strength-meter{0%,100%{box-shadow:0 0 0 3px rgba(224,83,61,0.4)}50%{box-shadow:0 0 0 3px rgba(74,216,106,0.6)}}
+@keyframes cycle-label-password-strength-meter{0%,30%{color:var(--ps-bad)}60%{color:var(--ps-mid)}90%,100%{color:var(--ps-good)}}


### PR DESCRIPTION
## Component: ease-password-strength-meter — field glows, segments fill, and label cycles

**Closes #62671**

### What this adds
A password strength meter: the input field glows as you type, the four strength segments fill in order, and the verdict label cycles through weak to strong.

### Acceptance Criteria covered
- Input field glows while typing
- Strength segments fill in order
- Verdict label cycles

### Files
- submissions/examples/password-strength-meter-ij/demo.html
- submissions/examples/password-strength-meter-ij/style.css
- submissions/examples/password-strength-meter-ij/README.md

### How to review
Open `demo.html` in a browser and watch the meter fill.