### PR TITLE
feat: add fade-in toast product catalog

### DIFF
--- a/submissions/examples/fade-in-toast-product-catalog/README.md
+++ b/submissions/examples/fade-in-toast-product-catalog/README.md
@@ -1,0 +1,29 @@
+# Fade-In Toast Product Catalog
+
+A lightweight product catalog showcase featuring a smooth CSS Fade-In Toast
+interaction.
+
+The component is built entirely with HTML and CSS and requires no JavaScript
+or external frameworks.
+
+## Features
+
+- Pure HTML and CSS
+- Smooth fade-in animation
+- CSS transitions
+- CSS keyframe animation
+- Responsive product grid
+- Desktop, tablet, and mobile layouts
+- Keyboard-accessible interaction
+- Visible focus states
+- CSS custom properties
+- `prefers-reduced-motion` support
+- No external dependencies
+
+## Files
+
+```text
+fade-in-toast-product-catalog/
+├── demo.html
+├── style.css
+└── README.md

--- a/submissions/examples/fade-in-toast-product-catalog/demo.html
+++ b/submissions/examples/fade-in-toast-product-catalog/demo.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta
+    name="description"
+    content="Pure CSS Fade-In Toast for Product Catalog Layouts."
+  >
+  <title>Fade-In Toast | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+  <main class="catalog-page">
+
+    <header class="catalog-header">
+      <p class="catalog-eyebrow">EaseMotion CSS</p>
+      <h1>Product Catalog</h1>
+      <p class="catalog-description">
+        A responsive product catalog featuring a smooth CSS fade-in toast
+        interaction.
+      </p>
+    </header>
+
+    <section class="product-grid" aria-label="Product catalog">
+
+      <article class="product-card">
+        <div class="product-visual product-visual--headphones" aria-hidden="true">
+          <span>Audio</span>
+        </div>
+
+        <div class="product-content">
+          <p class="product-category">Electronics</p>
+          <h2>Studio Headphones</h2>
+          <p class="product-price">$129</p>
+
+          <div class="product-action">
+            <button class="catalog-button" type="button">
+              Add to cart
+            </button>
+
+            <div class="toast" role="status" aria-live="polite">
+              <span class="toast-icon" aria-hidden="true">✓</span>
+              <span>Added to cart</span>
+            </div>
+          </div>
+        </div>
+      </article>
+
+      <article class="product-card">
+        <div class="product-visual product-visual--watch" aria-hidden="true">
+          <span>Wearable</span>
+        </div>
+
+        <div class="product-content">
+          <p class="product-category">Accessories</p>
+          <h2>Smart Watch</h2>
+          <p class="product-price">$199</p>
+
+          <div class="product-action">
+            <button class="catalog-button" type="button">
+              Add to cart
+            </button>
+
+            <div class="toast" role="status" aria-live="polite">
+              <span class="toast-icon" aria-hidden="true">✓</span>
+              <span>Added to cart</span>
+            </div>
+          </div>
+        </div>
+      </article>
+
+      <article class="product-card">
+        <div class="product-visual product-visual--camera" aria-hidden="true">
+          <span>Camera</span>
+        </div>
+
+        <div class="product-content">
+          <p class="product-category">Photography</p>
+          <h2>Compact Camera</h2>
+          <p class="product-price">$549</p>
+
+          <div class="product-action">
+            <button class="catalog-button" type="button">
+              Add to cart
+            </button>
+
+            <div class="toast" role="status" aria-live="polite">
+              <span class="toast-icon" aria-hidden="true">✓</span>
+              <span>Added to cart</span>
+            </div>
+          </div>
+        </div>
+      </article>
+
+      <article class="product-card">
+        <div class="product-visual product-visual--speaker" aria-hidden="true">
+          <span>Speaker</span>
+        </div>
+
+        <div class="product-content">
+          <p class="product-category">Audio</p>
+          <h2>Portable Speaker</h2>
+          <p class="product-price">$89</p>
+
+          <div class="product-action">
+            <button class="catalog-button" type="button">
+              Add to cart
+            </button>
+
+            <div class="toast" role="status" aria-live="polite">
+              <span class="toast-icon" aria-hidden="true">✓</span>
+              <span>Added to cart</span>
+            </div>
+          </div>
+        </div>
+      </article>
+
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/fade-in-toast-product-catalog/style.css
+++ b/submissions/examples/fade-in-toast-product-catalog/style.css
@@ -1,0 +1,374 @@
+:root {
+    --fade-duration: 420ms;
+    --fade-easing: ease-out;
+  
+    --catalog-background: #f4f6f8;
+    --card-background: #ffffff;
+    --text-primary: #17202a;
+    --text-secondary: #667085;
+    --accent: #2563eb;
+    --accent-dark: #1d4ed8;
+    --success: #15803d;
+    --border: #e3e7ec;
+  
+    --card-radius: 20px;
+    --toast-radius: 12px;
+  }
+  
+  * {
+    box-sizing: border-box;
+  }
+  
+  html {
+    scroll-behavior: smooth;
+  }
+  
+  body {
+    margin: 0;
+    min-height: 100vh;
+    font-family:
+      Inter,
+      ui-sans-serif,
+      system-ui,
+      -apple-system,
+      BlinkMacSystemFont,
+      "Segoe UI",
+      sans-serif;
+    color: var(--text-primary);
+    background: var(--catalog-background);
+  }
+  
+  .catalog-page {
+    width: min(1180px, calc(100% - 32px));
+    margin: 0 auto;
+    padding: 72px 0;
+  }
+  
+  .catalog-header {
+    max-width: 700px;
+    margin: 0 auto 48px;
+    text-align: center;
+  }
+  
+  .catalog-eyebrow {
+    margin: 0 0 10px;
+    color: var(--accent);
+    font-size: 0.78rem;
+    font-weight: 800;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+  }
+  
+  .catalog-header h1 {
+    margin: 0;
+    font-size: clamp(2rem, 5vw, 3.5rem);
+    line-height: 1.05;
+    letter-spacing: -0.04em;
+  }
+  
+  .catalog-description {
+    margin: 18px 0 0;
+    color: var(--text-secondary);
+    line-height: 1.7;
+  }
+  
+  /* Product grid */
+  
+  .product-grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 22px;
+  }
+  
+  .product-card {
+    overflow: hidden;
+    border: 1px solid var(--border);
+    border-radius: var(--card-radius);
+    background: var(--card-background);
+    box-shadow: 0 12px 35px rgb(23 32 42 / 7%);
+    transition:
+      transform 300ms ease,
+      box-shadow 300ms ease;
+  }
+  
+  .product-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 20px 45px rgb(23 32 42 / 12%);
+  }
+  
+  /* Product visual */
+  
+  .product-visual {
+    position: relative;
+    display: grid;
+    min-height: 190px;
+    place-items: center;
+    overflow: hidden;
+    isolation: isolate;
+  }
+  
+  .product-visual::before {
+    position: absolute;
+    width: 130px;
+    height: 130px;
+    border-radius: 50%;
+    background: rgb(255 255 255 / 20%);
+    content: "";
+  }
+  
+  .product-visual::after {
+    position: absolute;
+    width: 70px;
+    height: 70px;
+    border: 2px solid rgb(255 255 255 / 40%);
+    border-radius: 50%;
+    content: "";
+  }
+  
+  .product-visual span {
+    position: relative;
+    z-index: 1;
+    color: #ffffff;
+    font-size: 0.75rem;
+    font-weight: 800;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+  
+  .product-visual--headphones {
+    background: linear-gradient(135deg, #475569, #0f172a);
+  }
+  
+  .product-visual--watch {
+    background: linear-gradient(135deg, #7c3aed, #4338ca);
+  }
+  
+  .product-visual--camera {
+    background: linear-gradient(135deg, #0891b2, #155e75);
+  }
+  
+  .product-visual--speaker {
+    background: linear-gradient(135deg, #ea580c, #9a3412);
+  }
+  
+  /* Product content */
+  
+  .product-content {
+    padding: 22px;
+  }
+  
+  .product-category {
+    margin: 0 0 7px;
+    color: var(--accent);
+    font-size: 0.72rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+  
+  .product-content h2 {
+    margin: 0;
+    font-size: 1.15rem;
+    line-height: 1.3;
+  }
+  
+  .product-price {
+    margin: 9px 0 20px;
+    font-size: 1.15rem;
+    font-weight: 800;
+  }
+  
+  /* Action area */
+  
+  .product-action {
+    position: relative;
+    min-height: 42px;
+  }
+  
+  .catalog-button {
+    width: 100%;
+    padding: 11px 16px;
+    border: 0;
+    border-radius: 10px;
+    background: var(--accent);
+    color: #ffffff;
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.82rem;
+    font-weight: 750;
+    transition:
+      background-color 180ms ease,
+      transform 180ms ease;
+  }
+  
+  .catalog-button:hover {
+    background: var(--accent-dark);
+    transform: translateY(-1px);
+  }
+  
+  .catalog-button:focus-visible {
+    outline: 3px solid rgb(37 99 235 / 25%);
+    outline-offset: 3px;
+  }
+  
+  /* Fade-in toast */
+  
+  .toast {
+    position: absolute;
+    right: 0;
+    bottom: calc(100% + 12px);
+    z-index: 5;
+  
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  
+    width: max-content;
+    max-width: 100%;
+    padding: 10px 13px;
+  
+    border: 1px solid rgb(21 128 61 / 15%);
+    border-radius: var(--toast-radius);
+    background: #ffffff;
+    box-shadow: 0 12px 30px rgb(23 32 42 / 16%);
+  
+    color: var(--success);
+    font-size: 0.76rem;
+    font-weight: 750;
+  
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+  
+    transform: translateY(8px);
+  
+    transition:
+      opacity var(--fade-duration) var(--fade-easing),
+      transform var(--fade-duration) var(--fade-easing),
+      visibility var(--fade-duration) var(--fade-easing);
+  }
+  
+  /* Fade-in state */
+  
+  .product-action:hover .toast,
+  .product-action:focus-within .toast {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+  
+  /* Fade-in keyframe */
+  
+  @keyframes fade-in-toast {
+    from {
+      opacity: 0;
+      transform: translateY(8px);
+    }
+  
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+  
+  .product-action:hover .toast,
+  .product-action:focus-within .toast {
+    animation: fade-in-toast var(--fade-duration) var(--fade-easing);
+  }
+  
+  .toast-icon {
+    display: grid;
+    width: 20px;
+    height: 20px;
+    flex: 0 0 20px;
+    place-items: center;
+    border-radius: 50%;
+    background: #dcfce7;
+    font-size: 0.7rem;
+  }
+  
+  /* Tablet */
+  
+  @media (max-width: 1000px) {
+    .product-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+  
+  /* Mobile */
+  
+  @media (max-width: 600px) {
+    .catalog-page {
+      width: min(100% - 24px, 520px);
+      padding: 48px 0;
+    }
+  
+    .catalog-header {
+      margin-bottom: 32px;
+    }
+  
+    .catalog-description {
+      font-size: 0.92rem;
+    }
+  
+    .product-grid {
+      grid-template-columns: 1fr;
+      gap: 16px;
+    }
+  
+    .product-visual {
+      min-height: 170px;
+    }
+  
+    .product-content {
+      padding: 18px;
+    }
+  
+    .toast {
+      right: 50%;
+      transform: translate(50%, 8px);
+    }
+  
+    .product-action:hover .toast,
+    .product-action:focus-within .toast {
+      transform: translate(50%, 0);
+    }
+  
+    @keyframes fade-in-toast {
+      from {
+        opacity: 0;
+        transform: translate(50%, 8px);
+      }
+  
+      to {
+        opacity: 1;
+        transform: translate(50%, 0);
+      }
+    }
+  }
+  
+  /* Reduced motion */
+  
+  @media (prefers-reduced-motion: reduce) {
+    html {
+      scroll-behavior: auto;
+    }
+  
+    *,
+    *::before,
+    *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+    }
+  
+    .product-card:hover,
+    .catalog-button:hover {
+      transform: none;
+    }
+  
+    .toast {
+      animation: none !important;
+    }
+  }


### PR DESCRIPTION
## Description

Implemented the CSS Fade-In Toast for Product Catalog Layouts as requested in issue #62331.

### Changes Made

* Added a new `fade-in-toast-product-catalog` example under `submissions/examples/`
* Added `demo.html` with a responsive product catalog
* Added `style.css` with a pure CSS fade-in toast animation
* Added smooth opacity and transform transitions
* Added CSS keyframe animation for the fade-in effect
* Added CSS custom properties for animation and visual customization
* Added responsive layouts for desktop, tablet, and mobile
* Added keyboard focus support using `:focus-within`
* Added visible focus styles
* Added `role="status"` and `aria-live="polite"` to toast messages
* Added `prefers-reduced-motion` support
* No JavaScript or external frameworks used

### Files Added

```text id="q2x7mv"
submissions/examples/fade-in-toast-product-catalog/
├── demo.html
├── style.css
└── README.md
```

### Testing

* Tested the demo in a modern browser
* Verified fade-in toast animation
* Verified hover interaction
* Verified keyboard focus interaction
* Verified responsive layouts
* Verified reduced-motion fallback
* Verified status announcement markup

Closes #62331
