### PR TITLE
feat: add CSS 3D cube loader

### DIFF
--- a/submissions/examples/ease-3d-cube-loader-ag/README.md
+++ b/submissions/examples/ease-3d-cube-loader-ag/README.md
@@ -1,0 +1,51 @@
+# CSS 3D Cube Loader
+
+A pure CSS 3D spinning cube loader — no JavaScript required.
+
+## 🚀 Demo
+
+Open `demo.html` in your browser to see it in action.
+
+## ✨ Features
+
+- Built entirely with CSS `perspective` and `transform-style: preserve-3d`
+- Smooth infinite rotation animation
+- Six independently styled cube faces
+- No JavaScript dependencies
+- Easy to customize via the `--size` CSS variable
+
+## 📁 Files
+
+- `demo.html` — Demo page showing the loader
+- `style.css` — Cube loader styles and animation
+- `README.md` — This file
+
+## 🛠️ Usage
+
+1. Copy `style.css` into your project.
+2. Add the following markup wherever you want the loader:
+
+```html
+<div class="cube-loader">
+  <div class="cube">
+    <div class="cube__face cube__face--front"></div>
+    <div class="cube__face cube__face--back"></div>
+    <div class="cube__face cube__face--right"></div>
+    <div class="cube__face cube__face--left"></div>
+    <div class="cube__face cube__face--top"></div>
+    <div class="cube__face cube__face--bottom"></div>
+  </div>
+</div>
+```
+
+3. Adjust size by overriding `--size` on `.cube-loader`.
+
+## 🎨 Customization
+
+| Variable | Default | Description |
+|----------|---------|--------------|
+| `--size` | `60px` | Width/height of the cube |
+
+## 👤 Author
+
+Contributed by [aaniya22](https://github.com/aaniya22) as part of GSSoC.

--- a/submissions/examples/ease-3d-cube-loader-ag/demo.html
+++ b/submissions/examples/ease-3d-cube-loader-ag/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>3D Cube Loader</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body style="background:#111;">
+  <div class="cube-loader">
+    <div class="cube">
+      <div class="cube__face cube__face--front"></div>
+      <div class="cube__face cube__face--back"></div>
+      <div class="cube__face cube__face--right"></div>
+      <div class="cube__face cube__face--left"></div>
+      <div class="cube__face cube__face--top"></div>
+      <div class="cube__face cube__face--bottom"></div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-3d-cube-loader-ag/style.css
+++ b/submissions/examples/ease-3d-cube-loader-ag/style.css
@@ -1,0 +1,35 @@
+.cube-loader {
+  --size: 60px;
+  width: var(--size);
+  height: var(--size);
+  perspective: 800px;
+  margin: 100px auto;
+}
+
+.cube {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  transform-style: preserve-3d;
+  animation: rotateCube 3s infinite linear;
+}
+
+.cube__face {
+  position: absolute;
+  width: var(--size);
+  height: var(--size);
+  border: 2px solid #fff;
+  background: rgba(99, 102, 241, 0.6);
+}
+
+.cube__face--front  { transform: translateZ(calc(var(--size) / 2)); }
+.cube__face--back   { transform: rotateY(180deg) translateZ(calc(var(--size) / 2)); }
+.cube__face--right  { transform: rotateY(90deg) translateZ(calc(var(--size) / 2)); }
+.cube__face--left   { transform: rotateY(-90deg) translateZ(calc(var(--size) / 2)); }
+.cube__face--top    { transform: rotateX(90deg) translateZ(calc(var(--size) / 2)); }
+.cube__face--bottom { transform: rotateX(-90deg) translateZ(calc(var(--size) / 2)); }
+
+@keyframes rotateCube {
+  0%   { transform: rotateX(0deg) rotateY(0deg); }
+  100% { transform: rotateX(360deg) rotateY(360deg); }
+}


### PR DESCRIPTION
Closes #61238

## Pull Request Description
Adds a pure CSS 3D spinning cube loader for use as a loading indicator, closes #61238.

## Type of Change
- [x] 🧩 New component

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/ease-3d-cube-loader-ag/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

## Feature Description
**What does this add?**
A 3D spinning cube loader built entirely with CSS `perspective` and `transform-style: preserve-3d`, no JavaScript.

**How does a developer use it?**
```html
<div class="cube-loader">
  <div class="cube">
    <div class="cube__face cube__face--front"></div>
    <div class="cube__face cube__face--back"></div>
    <div class="cube__face cube__face--right"></div>
    <div class="cube__face cube__face--left"></div>
    <div class="cube__face cube__face--top"></div>
    <div class="cube__face cube__face--bottom"></div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
Pure CSS, human-readable class names, drop-in markup, no JS dependency — matches the animation-first, no-build-step philosophy of the library.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge

## Notes for Maintainer
Size is configurable via the `--size` CSS variable on `.cube-loader`. Rotation speed/direction can be tuned in the `rotateCube` keyframes if you'd like a different feel.