### PR TITLE
feat: add CSS glitch text effect

### DIFF
--- a/submissions/examples/ease-fab-menu-ag/submissions/examples/ease-pulse-badge-ag/submissions/examples/ease-glitch-text-ag/README.md
+++ b/submissions/examples/ease-fab-menu-ag/submissions/examples/ease-pulse-badge-ag/submissions/examples/ease-glitch-text-ag/README.md
@@ -1,0 +1,26 @@
+# CSS Glitch Text Effect
+
+A cyberpunk-style glitch text effect using CSS `clip-path` and layered pseudo-elements — pure CSS, no JavaScript.
+
+## 🚀 Demo
+Open `demo.html` in your browser.
+
+## ✨ Features
+- Layered RGB-split glitch using `::before`/`::after` and `clip-path`
+- No JavaScript dependencies
+- Works on any text element via `data-text` attribute
+- Fully CSS-animated
+
+## 📁 Files
+- `demo.html` — Demo page showing the effect
+- `style.css` — Glitch text styles and animation
+- `README.md` — This file
+
+## 🛠️ Usage
+```html
+<h1 class="glitch-text" data-text="Your Text Here">Your Text Here</h1>
+```
+> Note: `data-text` must match the visible text — it's used by the pseudo-elements for the glitch layers.
+
+## 👤 Author
+Contributed by [aaniya22](https://github.com/aaniya22) as part of GSSoC.

--- a/submissions/examples/ease-fab-menu-ag/submissions/examples/ease-pulse-badge-ag/submissions/examples/ease-glitch-text-ag/demo.html
+++ b/submissions/examples/ease-fab-menu-ag/submissions/examples/ease-pulse-badge-ag/submissions/examples/ease-glitch-text-ag/demo.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Glitch Text Effect</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body style="background:#0a0a0a; height:100vh; display:flex; align-items:center; justify-content:center;">
+  <h1 class="glitch-text" data-text="EaseMotion CSS">EaseMotion CSS</h1>
+</body>
+</html>

--- a/submissions/examples/ease-fab-menu-ag/submissions/examples/ease-pulse-badge-ag/submissions/examples/ease-glitch-text-ag/style.css
+++ b/submissions/examples/ease-fab-menu-ag/submissions/examples/ease-pulse-badge-ag/submissions/examples/ease-glitch-text-ag/style.css
@@ -1,0 +1,61 @@
+.glitch-text {
+  position: relative;
+  font-size: 48px;
+  font-weight: 700;
+  color: #fff;
+  letter-spacing: 2px;
+}
+
+.glitch-text::before,
+.glitch-text::after {
+  content: attr(data-text);
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: inherit;
+  overflow: hidden;
+}
+
+.glitch-text::before {
+  left: 2px;
+  text-shadow: -2px 0 #ff00c1;
+  clip-path: inset(0 0 0 0);
+  animation: glitch-top 2.5s infinite linear alternate-reverse;
+}
+
+.glitch-text::after {
+  left: -2px;
+  text-shadow: -2px 0 #00fff9;
+  clip-path: inset(0 0 0 0);
+  animation: glitch-bottom 2.5s infinite linear alternate-reverse;
+}
+
+@keyframes glitch-top {
+  0%   { clip-path: inset(0 0 90% 0); }
+  10%  { clip-path: inset(10% 0 60% 0); }
+  20%  { clip-path: inset(40% 0 30% 0); }
+  30%  { clip-path: inset(60% 0 10% 0); }
+  40%  { clip-path: inset(80% 0 0 0); }
+  50%  { clip-path: inset(20% 0 50% 0); }
+  60%  { clip-path: inset(50% 0 20% 0); }
+  70%  { clip-path: inset(5% 0 80% 0); }
+  80%  { clip-path: inset(70% 0 5% 0); }
+  90%  { clip-path: inset(30% 0 40% 0); }
+  100% { clip-path: inset(0 0 90% 0); }
+}
+
+@keyframes glitch-bottom {
+  0%   { clip-path: inset(90% 0 0 0); }
+  10%  { clip-path: inset(60% 0 10% 0); }
+  20%  { clip-path: inset(30% 0 40% 0); }
+  30%  { clip-path: inset(10% 0 60% 0); }
+  40%  { clip-path: inset(0 0 80% 0); }
+  50%  { clip-path: inset(50% 0 20% 0); }
+  60%  { clip-path: inset(20% 0 50% 0); }
+  70%  { clip-path: inset(80% 0 5% 0); }
+  80%  { clip-path: inset(5% 0 70% 0); }
+  90%  { clip-path: inset(40% 0 30% 0); }
+  100% { clip-path: inset(90% 0 0 0); }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a cyberpunk-style CSS glitch text effect using layered pseudo-elements and clip-path animation.
closes #61244

## Type of Change
- [x] ✨ New animation / hover effect

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/ease-glitch-text-ag/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

## Feature Description
**What does this add?**
A cyberpunk-style glitch text effect that splits text into RGB-shifted layers animated with `clip-path`.

**How does a developer use it?**
```html
<h1 class="glitch-text" data-text="Your Text Here">Your Text Here</h1>
```

**Why does it fit EaseMotion CSS?**
Pure CSS with no JS dependency, human-readable class name, and a single drop-in element — matches the animation-first, no-build-step philosophy of the library.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge

## Notes for Maintainer
The `data-text` attribute must mirror the element's visible text since it drives the pseudo-element glitch layers — happy to add a note about this to the main docs if useful. Animation timing/colors are easy to adjust if you'd like a different glitch intensity.