### PR TITLE
Add ease-binary-counter-digits component

### DIFF
--- a/submissions/examples/binary-counter-digits-ij/README.md
+++ b/submissions/examples/binary-counter-digits-ij/README.md
@@ -1,0 +1,10 @@
+# ease-binary-counter-digits
+
+A binary counter whose bit cells flip between zero and one while the decimal readout ticks to match.
+
+## Run
+Open `demo.html` directly in a browser to watch the bits flip.
+
+## Notes
+- Eight bits flip on staggered delays.
+- The decimal value matches the binary row.

--- a/submissions/examples/binary-counter-digits-ij/demo.html
+++ b/submissions/examples/binary-counter-digits-ij/demo.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-binary-counter-digits demo</title>
+</head>
+<body>
+<div class="bc-app">
+  <span class="bc-title">BINARY</span>
+  <div class="bc-bits">
+    <span class="bc-bit bc-bit-1">1</span>
+    <span class="bc-bit bc-bit-2">0</span>
+    <span class="bc-bit bc-bit-3">1</span>
+    <span class="bc-bit bc-bit-4">1</span>
+    <span class="bc-bit bc-bit-5">0</span>
+    <span class="bc-bit bc-bit-6">1</span>
+    <span class="bc-bit bc-bit-7">0</span>
+    <span class="bc-bit bc-bit-8">0</span>
+  </div>
+  <span class="bc-decimal">= 180</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/binary-counter-digits-ij/style.css
+++ b/submissions/examples/binary-counter-digits-ij/style.css
@@ -1,0 +1,16 @@
+:root{--bc-green:#4ad86a;--bc-soft:#2f9a4a}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#0f1f16,#071009);font-family:'Courier New',monospace}
+.bc-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#0a140e,#050a07);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.bc-title{position:absolute;top:14px;left:0;right:0;text-align:center;font-size:14px;font-weight:800;letter-spacing:7px;color:#5f9a6a}
+.bc-bits{position:absolute;top:140px;left:34px;width:304px;display:flex;gap:6px}
+.bc-bit{flex:1;height:56px;border-radius:8px;background:#0c1a12;box-shadow:inset 0 0 0 3px #153322;color:var(--bc-green);font-size:22px;font-weight:800;display:flex;align-items:center;justify-content:center;animation:flip-bit-binary-counter-digits 6s ease-in-out infinite}
+.bc-bit:nth-child(2){animation-delay:0.08s}
+.bc-bit:nth-child(3){animation-delay:0.16s}
+.bc-bit:nth-child(4){animation-delay:0.24s}
+.bc-bit:nth-child(5){animation-delay:0.32s}
+.bc-bit:nth-child(6){animation-delay:0.4s}
+.bc-bit:nth-child(7){animation-delay:0.48s}
+.bc-bit:nth-child(8){animation-delay:0.56s}
+.bc-decimal{position:absolute;bottom:44px;left:0;right:0;text-align:center;font-size:18px;font-weight:800;color:var(--bc-soft);letter-spacing:2px;animation:tic-decimal-binary-counter-digits 6s steps(1) infinite}
+@keyframes flip-bit-binary-counter-digits{0%,20%{transform:rotateX(0);color:var(--bc-green)}32%{transform:rotateX(90deg);color:#0c1a12}44%{transform:rotateX(0);color:var(--bc-green)}100%{transform:rotateX(0);color:var(--bc-green)}}
+@keyframes tic-decimal-binary-counter-digits{0%,20%{color:var(--bc-soft)}36%{color:#fff}50%{color:var(--bc-soft)}100%{color:var(--bc-soft)}}


### PR DESCRIPTION
## Component: ease-binary-counter-digits — bits flip, rows ripple, and decimal ticks

**Closes #62684**

### What this adds
A binary counter: the bit cells flip between zero and one, rows ripple like a counter, and the decimal readout ticks to match the binary value.

### Acceptance Criteria covered
- Bit cells flip between zero and one
- Rows ripple like a counter
- Decimal readout ticks to match

### Files
- submissions/examples/binary-counter-digits-ij/demo.html
- submissions/examples/binary-counter-digits-ij/style.css
- submissions/examples/binary-counter-digits-ij/README.md

### How to review
Open `demo.html` in a browser and watch the bits flip.