### PR TITLE
Add ease-chess-board-tiles component

### DIFF
--- a/submissions/examples/chess-board-tiles-ij/README.md
+++ b/submissions/examples/chess-board-tiles-ij/README.md
@@ -1,0 +1,10 @@
+# ease-chess-board-tiles
+
+A chess board whose light and dark tiles form an eight-by-eight grid while the knight jumps across squares.
+
+## Run
+Open `demo.html` directly in a browser to watch the knight jump.
+
+## Notes
+- The board uses a classic two-tone pattern.
+- The knight hops to new squares on a loop.

--- a/submissions/examples/chess-board-tiles-ij/demo.html
+++ b/submissions/examples/chess-board-tiles-ij/demo.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-chess-board-tiles demo</title>
+</head>
+<body>
+<div class="cb-app">
+  <span class="cb-title">CHESS</span>
+  <div class="cb-board">
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-tile"></span>
+    <span class="cb-knight">&#9822;</span>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/chess-board-tiles-ij/style.css
+++ b/submissions/examples/chess-board-tiles-ij/style.css
@@ -1,0 +1,9 @@
+:root{--cb-light:#e8dcc8;--cb-dark:#6a4a2a;--cb-accent:#4ad86a}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#332c24,#191510);font-family:'Segoe UI',sans-serif}
+.cb-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#26201a,#131008);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.cb-title{position:absolute;top:14px;left:0;right:0;text-align:center;font-size:14px;font-weight:800;letter-spacing:7px;color:#c8b8a0}
+.cb-board{position:absolute;top:56px;left:36px;width:300px;height:300px;border-radius:8px;overflow:hidden;display:grid;grid-template-columns:repeat(8,1fr);grid-template-rows:repeat(8,1fr);box-shadow:0 0 0 10px #3a2c1e}
+.cb-tile:nth-child(odd){background:var(--cb-light)}
+.cb-tile:nth-child(even){background:var(--cb-dark)}
+.cb-knight{position:absolute;font-size:26px;line-height:1;color:#1a120a;z-index:2;text-shadow:0 0 6px rgba(0,0,0,0.4);animation:jump-knight-chess-board-tiles 6s ease-in-out infinite}
+@keyframes jump-knight-chess-board-tiles{0%{top:22px;left:36px;transform:rotate(0deg)}18%{top:22px;left:36px}22%{top:60px;left:112px;transform:rotate(10deg)}26%{top:98px;left:190px}30%{top:60px;left:268px}34%{top:22px;left:112px}38%{top:60px;left:36px}100%{top:22px;left:36px}}


### PR DESCRIPTION
## Component: ease-chess-board-tiles — board tiles check, knight jumps, and square highlights

**Closes #62693**

### What this adds
A chess board: the light and dark tiles form a real board, the knight piece jumps across the squares, and the destination square highlights before the move.

### Acceptance Criteria covered
- Light and dark tiles form a board
- Knight piece jumps across squares
- Destination square highlights

### Files
- submissions/examples/chess-board-tiles-ij/demo.html
- submissions/examples/chess-board-tiles-ij/style.css
- submissions/examples/chess-board-tiles-ij/README.md

### How to review
Open `demo.html` in a browser and watch the knight jump.