### PR TITLE
feat: add slide-up popover ecommerce example

### DIFF
--- a/submissions/examples/slide-up-popover-ecommerce/README.md
+++ b/submissions/examples/slide-up-popover-ecommerce/README.md
@@ -1,0 +1,24 @@
+# CSS Slide-Up Popover for E-Commerce Checkout Layouts
+
+A lightweight, responsive Slide-Up Popover interaction built entirely with HTML and CSS for the EaseMotion CSS collection.
+
+## Features
+
+- Pure HTML and CSS
+- No JavaScript or external frameworks
+- Smooth slide-up entrance animation
+- Opacity and scale transition
+- Hover and keyboard-focus interaction
+- Responsive desktop, tablet, and mobile layouts
+- CSS custom properties for easy customization
+- Accessible `:focus-visible` support
+- `prefers-reduced-motion` support
+- Suitable for checkout and e-commerce interfaces
+
+## Folder Structure
+
+```text
+slide-up-popover-ecommerce/
+├── demo.html
+├── style.css
+└── README.md

--- a/submissions/examples/slide-up-popover-ecommerce/demo.html
+++ b/submissions/examples/slide-up-popover-ecommerce/demo.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS Slide-Up Popover for E-Commerce Checkout Layouts">
+  <title>Slide-Up Popover | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+  <main class="checkout-page">
+    <header class="checkout-header">
+      <p class="eyebrow">EaseMotion CSS</p>
+      <h1>Checkout</h1>
+      <p class="subtitle">A lightweight CSS-only slide-up popover interaction.</p>
+    </header>
+
+    <section class="checkout-layout" aria-label="Checkout summary">
+      <article class="checkout-card">
+        <div class="product">
+          <div class="product-icon" aria-hidden="true">⌁</div>
+
+          <div class="product-info">
+            <h2>Premium Headphones</h2>
+            <p>Wireless · Noise Cancelling</p>
+            <span class="quantity">Qty: 1</span>
+          </div>
+
+          <strong class="price">$129</strong>
+        </div>
+
+        <div class="summary">
+          <div>
+            <span>Subtotal</span>
+            <strong>$129</strong>
+          </div>
+
+          <div>
+            <span>Shipping</span>
+            <strong>Free</strong>
+          </div>
+
+          <div class="total">
+            <span>Total</span>
+            <strong>$129</strong>
+          </div>
+        </div>
+
+        <div class="popover-wrapper">
+          <button class="checkout-button" type="button">
+            Place Order
+          </button>
+
+          <div class="slide-up-popover" role="status">
+            <div class="popover-handle" aria-hidden="true"></div>
+
+            <div class="popover-icon" aria-hidden="true">✓</div>
+
+            <div class="popover-content">
+              <strong>Order ready!</strong>
+              <p>
+                Your order is prepared for checkout. This popover
+                slides upward when the action is hovered or focused.
+              </p>
+            </div>
+          </div>
+        </div>
+      </article>
+    </section>
+
+    <p class="interaction-hint">
+      Hover or focus the <strong>Place Order</strong> button.
+    </p>
+  </main>
+</body>
+</html>

--- a/submissions/examples/slide-up-popover-ecommerce/style.css
+++ b/submissions/examples/slide-up-popover-ecommerce/style.css
@@ -1,0 +1,337 @@
+:root {
+    --em-bg: #f4f6fb;
+    --em-surface: #ffffff;
+    --em-text: #172033;
+    --em-muted: #697386;
+    --em-border: #e4e8f0;
+    --em-accent: #635bff;
+    --em-accent-dark: #5148e5;
+    --em-success: #16845b;
+    --em-radius: 20px;
+  
+    --em-popover-offset: 12px;
+    --em-popover-duration: 420ms;
+    --em-popover-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  }
+  
+  * {
+    box-sizing: border-box;
+  }
+  
+  html {
+    font-family:
+      Inter,
+      ui-sans-serif,
+      system-ui,
+      -apple-system,
+      BlinkMacSystemFont,
+      "Segoe UI",
+      sans-serif;
+  }
+  
+  body {
+    margin: 0;
+    min-height: 100vh;
+    background: var(--em-bg);
+    color: var(--em-text);
+  }
+  
+  button {
+    font: inherit;
+  }
+  
+  .checkout-page {
+    width: min(100% - 32px, 760px);
+    margin: 0 auto;
+    padding: 72px 0;
+  }
+  
+  .checkout-header {
+    margin-bottom: 32px;
+    text-align: center;
+  }
+  
+  .eyebrow {
+    margin: 0 0 8px;
+    color: var(--em-accent);
+    font-size: 0.78rem;
+    font-weight: 800;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+  }
+  
+  .checkout-header h1 {
+    margin: 0;
+    font-size: clamp(2rem, 5vw, 3.2rem);
+    line-height: 1.05;
+  }
+  
+  .subtitle {
+    margin: 14px auto 0;
+    max-width: 520px;
+    color: var(--em-muted);
+    line-height: 1.6;
+  }
+  
+  .checkout-layout {
+    display: grid;
+    place-items: center;
+  }
+  
+  .checkout-card {
+    position: relative;
+    width: 100%;
+    padding: clamp(22px, 4vw, 34px);
+    overflow: hidden;
+    border: 1px solid var(--em-border);
+    border-radius: var(--em-radius);
+    background: var(--em-surface);
+    box-shadow: 0 24px 70px rgba(23, 32, 51, 0.1);
+  }
+  
+  .product {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 16px;
+    padding-bottom: 26px;
+    border-bottom: 1px solid var(--em-border);
+  }
+  
+  .product-icon {
+    display: grid;
+    width: 58px;
+    height: 58px;
+    place-items: center;
+    border-radius: 16px;
+    background: #eeecff;
+    color: var(--em-accent);
+    font-size: 1.8rem;
+    font-weight: 800;
+  }
+  
+  .product-info h2 {
+    margin: 0 0 5px;
+    font-size: 1.05rem;
+  }
+  
+  .product-info p,
+  .quantity {
+    display: block;
+    margin: 0;
+    color: var(--em-muted);
+    font-size: 0.88rem;
+  }
+  
+  .quantity {
+    margin-top: 4px;
+  }
+  
+  .price {
+    font-size: 1.05rem;
+  }
+  
+  .summary {
+    display: grid;
+    gap: 14px;
+    padding: 26px 0;
+  }
+  
+  .summary > div {
+    display: flex;
+    justify-content: space-between;
+    gap: 20px;
+    color: var(--em-muted);
+  }
+  
+  .summary strong {
+    color: var(--em-text);
+  }
+  
+  .summary .total {
+    margin-top: 8px;
+    padding-top: 18px;
+    border-top: 1px solid var(--em-border);
+    color: var(--em-text);
+    font-size: 1.08rem;
+  }
+  
+  .popover-wrapper {
+    position: relative;
+    z-index: 2;
+    padding-top: 8px;
+  }
+  
+  .checkout-button {
+    position: relative;
+    z-index: 3;
+    width: 100%;
+    min-height: 54px;
+    border: 0;
+    border-radius: 14px;
+    background: var(--em-accent);
+    color: #fff;
+    cursor: pointer;
+    font-weight: 750;
+    transition:
+      background 180ms ease,
+      transform 180ms ease;
+  }
+  
+  .checkout-button:hover,
+  .checkout-button:focus-visible {
+    background: var(--em-accent-dark);
+    transform: translateY(-2px);
+  }
+  
+  .checkout-button:focus-visible {
+    outline: 3px solid rgba(99, 91, 255, 0.3);
+    outline-offset: 3px;
+  }
+  
+  /*
+   * Slide-Up Popover
+   *
+   * The popover remains in the document flow and is visually hidden
+   * using transform + opacity. It becomes visible when its trigger
+   * receives hover or keyboard focus.
+   */
+  .slide-up-popover {
+    position: absolute;
+    right: 16px;
+    bottom: calc(100% + var(--em-popover-offset));
+    left: 16px;
+  
+    display: flex;
+    align-items: center;
+    gap: 14px;
+  
+    padding: 18px;
+  
+    border: 1px solid var(--em-border);
+    border-radius: 16px;
+    background: var(--em-surface);
+    box-shadow: 0 18px 45px rgba(23, 32, 51, 0.16);
+  
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(28px) scale(0.98);
+  
+    transition:
+      opacity var(--em-popover-duration) var(--em-popover-ease),
+      transform var(--em-popover-duration) var(--em-popover-ease);
+  }
+  
+  .popover-wrapper:hover .slide-up-popover,
+  .popover-wrapper:focus-within .slide-up-popover {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0) scale(1);
+  }
+  
+  .popover-handle {
+    position: absolute;
+    top: 7px;
+    left: 50%;
+    width: 34px;
+    height: 3px;
+    border-radius: 99px;
+    background: var(--em-border);
+    transform: translateX(-50%);
+  }
+  
+  .popover-icon {
+    flex: 0 0 auto;
+    display: grid;
+    width: 42px;
+    height: 42px;
+    place-items: center;
+    border-radius: 50%;
+    background: #e8f7f0;
+    color: var(--em-success);
+    font-weight: 900;
+  }
+  
+  .popover-content strong {
+    display: block;
+    margin-bottom: 4px;
+  }
+  
+  .popover-content p {
+    margin: 0;
+    color: var(--em-muted);
+    font-size: 0.82rem;
+    line-height: 1.5;
+  }
+  
+  .interaction-hint {
+    margin: 22px 0 0;
+    color: var(--em-muted);
+    text-align: center;
+    font-size: 0.85rem;
+  }
+  
+  /* Tablet */
+  @media (max-width: 700px) {
+    .checkout-page {
+      padding: 48px 0;
+    }
+  
+    .checkout-card {
+      padding: 22px;
+    }
+  
+    .slide-up-popover {
+      right: 10px;
+      left: 10px;
+    }
+  }
+  
+  /* Mobile */
+  @media (max-width: 480px) {
+    .checkout-page {
+      width: min(100% - 20px, 760px);
+      padding: 32px 0;
+    }
+  
+    .product {
+      grid-template-columns: auto 1fr;
+    }
+  
+    .price {
+      grid-column: 2;
+    }
+  
+    .slide-up-popover {
+      align-items: flex-start;
+    }
+  
+    .popover-content p {
+      font-size: 0.78rem;
+    }
+  }
+  
+  /*
+   * Accessibility:
+   * Reduce animation for users who have requested
+   * reduced motion at the operating-system level.
+   */
+  @media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+      scroll-behavior: auto !important;
+      transition-duration: 0.01ms !important;
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+    }
+  
+    .checkout-button:hover,
+    .checkout-button:focus-visible {
+      transform: none;
+    }
+  
+    .slide-up-popover {
+      transform: none;
+    }
+  }


### PR DESCRIPTION
## Description

Adds a responsive, CSS-only Slide-Up Popover for E-Commerce Checkout layouts.

## Changes
- Added demo.html
- Added style.css
- Added README.md
- Added smooth slide-up animation
- Added responsive design
- Added keyboard focus support
- Added prefers-reduced-motion support

Closes #62469