### PR TITLE
feat: add replica quorum monitor example

### DIFF
--- a/submissions/examples/replica-quorum-monitor-kp/README.md
+++ b/submissions/examples/replica-quorum-monitor-kp/README.md
@@ -1,0 +1,21 @@
+﻿# Replica Quorum Monitor KP
+
+## What does this do?
+
+Replica Quorum Monitor KP is an advanced CSS-only resilience console for visualizing primary, replica, quorum, and promotion modes. It includes semantic radio controls, animated quorum lanes, a conic sync ring, responsive service cards, and reduced-motion support.
+
+## How is it used?
+
+Use radio inputs as the quorum mode controller. Labels switch the active mode while sibling selectors update sync pressure, lane emphasis, and the selected service card.
+
+```html
+<input type="radio" name="quorum" id="mode-quorum" />
+<label for="mode-quorum">Quorum</label>
+<article class="service-card card-quorum">
+  <h2>Confirm quorum</h2>
+</article>
+```
+
+## Why is it useful?
+
+Reliability docs and operations dashboards often need to explain replica agreement without JavaScript. This example demonstrates advanced CSS state orchestration with accessible controls, operational motion, responsive layout, and reduced-motion behavior.

--- a/submissions/examples/replica-quorum-monitor-kp/demo.html
+++ b/submissions/examples/replica-quorum-monitor-kp/demo.html
@@ -1,0 +1,84 @@
+﻿<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Replica Quorum Monitor KP</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="quorum-shell" aria-labelledby="quorum-title">
+      <section class="quorum-hero">
+        <p class="quorum-kicker">Advanced CSS resilience control</p>
+        <h1 id="quorum-title">Replica Quorum Monitor</h1>
+        <p>
+          Route replicated service writes through primary, replica, quorum, and
+          promotion modes with CSS-only controls, animated sync lanes, and
+          service cards.
+        </p>
+      </section>
+
+      <section class="quorum-console" aria-label="Replica quorum switchboard">
+        <input type="radio" name="quorum" id="mode-primary" checked />
+        <input type="radio" name="quorum" id="mode-replica" />
+        <input type="radio" name="quorum" id="mode-quorum" />
+        <input type="radio" name="quorum" id="mode-promote" />
+
+        <nav class="mode-tabs" aria-label="Quorum modes">
+          <label for="mode-primary">Primary</label>
+          <label for="mode-replica">Replica</label>
+          <label for="mode-quorum">Quorum</label>
+          <label for="mode-promote">Promote</label>
+        </nav>
+
+        <div class="quorum-board">
+          <article class="sync-ring" aria-label="System sync">
+            <span class="ring-base"></span>
+            <span class="ring-fill"></span>
+            <strong>71%</strong>
+            <em>sync</em>
+          </article>
+
+          <article class="switch-map" aria-label="Replica quorum lanes">
+            <span class="switch-line line-core"><i></i></span>
+            <span class="switch-line line-search"><i></i></span>
+            <span class="switch-line line-media"><i></i></span>
+            <span class="switch-line line-extra"><i></i></span>
+            <b class="switch-node node-gateway">Leader</b>
+            <b class="switch-node node-policy">Primary</b>
+            <b class="switch-node node-core">Follower</b>
+            <b class="switch-node node-optional">Witness</b>
+          </article>
+        </div>
+
+        <div class="service-grid">
+          <article class="service-card card-primary">
+            <span></span>
+            <h2>Primary routing</h2>
+            <p>
+              Writes stay on the elected leader while replicas remain healthy.
+            </p>
+          </article>
+          <article class="service-card card-replica">
+            <span></span>
+            <h2>Replicate state</h2>
+            <p>
+              Followers receive changes while lag, freshness, and capacity are
+              tracked.
+            </p>
+          </article>
+          <article class="service-card card-quorum">
+            <span></span>
+            <h2>Confirm quorum</h2>
+            <p>Agreement gaps and tail latency spikes are highlighted.</p>
+          </article>
+          <article class="service-card card-promote">
+            <span></span>
+            <h2>Promote leader</h2>
+            <p>The follower can lead once quorum checks remain stable.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/replica-quorum-monitor-kp/style.css
+++ b/submissions/examples/replica-quorum-monitor-kp/style.css
@@ -1,0 +1,558 @@
+﻿:root {
+  color-scheme: light;
+  --ink: #101828;
+  --muted: #667085;
+  --paper: #f7f9fc;
+  --panel: #ffffff;
+  --line: #d9e2ec;
+  --primary: #0f9f6e;
+  --replica: #d97706;
+  --quorum: #dc395f;
+  --promote: #2563eb;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(15, 159, 110, 0.13), transparent 34%),
+    linear-gradient(315deg, rgba(37, 99, 235, 0.12), transparent 38%),
+    var(--paper);
+}
+
+.quorum-shell {
+  width: min(1160px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.quorum-hero {
+  max-width: 780px;
+  margin-bottom: 28px;
+}
+
+.quorum-kicker {
+  margin: 0 0 10px;
+  color: var(--primary);
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 14px;
+  font-size: clamp(2.2rem, 6vw, 4.8rem);
+  line-height: 0.95;
+}
+
+.quorum-hero p:last-child {
+  max-width: 690px;
+  color: var(--muted);
+  font-size: 1.06rem;
+  line-height: 1.7;
+}
+
+.quorum-console {
+  padding: 22px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.84);
+  box-quorum: 0 24px 80px rgba(16, 24, 40, 0.12);
+}
+
+.quorum-console > input {
+  position: absolute;
+  inline-size: 1px;
+  block-size: 1px;
+  opacity: 0;
+}
+
+.mode-tabs {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+  margin-bottom: 18px;
+}
+
+.mode-tabs label {
+  min-height: 48px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--muted);
+  font-weight: 900;
+  background: var(--panel);
+  cursor: pointer;
+  transition:
+    transform 220ms ease,
+    border-color 220ms ease,
+    color 220ms ease,
+    background 220ms ease;
+}
+
+.mode-tabs label:hover,
+.mode-tabs label:focus-visible {
+  transform: translateY(-2px);
+  border-color: var(--promote);
+  color: var(--promote);
+}
+
+.quorum-board {
+  display: grid;
+  grid-template-columns: 0.8fr 1.2fr;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.sync-ring,
+.switch-map,
+.service-card {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+}
+
+.sync-ring {
+  position: relative;
+  min-height: 340px;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+}
+
+.ring-base,
+.ring-fill {
+  position: absolute;
+  width: 260px;
+  height: 260px;
+  border-radius: 50%;
+  mask: radial-gradient(circle, transparent 0 56%, #000 57%);
+}
+
+.ring-base {
+  background: conic-gradient(rgba(102, 112, 133, 0.18) 0 360deg);
+}
+
+.ring-fill {
+  background: conic-gradient(
+    var(--primary) 0 256deg,
+    transparent 256deg 360deg
+  );
+  animation: sync-pulse 2.4s ease-in-out infinite;
+  transition: background 520ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.sync-ring strong {
+  position: relative;
+  z-index: 1;
+  font-size: 3.2rem;
+  line-height: 1;
+}
+
+.sync-ring em {
+  position: relative;
+  z-index: 1;
+  color: var(--muted);
+  font-style: normal;
+  font-weight: 900;
+}
+
+.switch-map {
+  position: relative;
+  min-height: 340px;
+  overflow: hidden;
+  background:
+    linear-gradient(90deg, rgba(15, 159, 110, 0.08), transparent 48%),
+    linear-gradient(270deg, rgba(220, 57, 95, 0.1), transparent 44%),
+    var(--panel);
+}
+
+.switch-line {
+  position: absolute;
+  left: 8%;
+  right: 8%;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(102, 112, 133, 0.2);
+  overflow: hidden;
+}
+
+.line-core {
+  top: 31%;
+}
+.line-search {
+  top: 45%;
+}
+.line-media {
+  top: 59%;
+}
+.line-extra {
+  top: 73%;
+}
+
+.switch-line i {
+  display: block;
+  width: 40%;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--primary);
+  animation: switch-flow 2.5s ease-in-out infinite;
+}
+
+.line-search i {
+  width: 32%;
+  background: var(--replica);
+  animation-delay: -0.35s;
+}
+
+.line-media i {
+  width: 22%;
+  background: var(--quorum);
+  animation-delay: -0.7s;
+}
+
+.line-extra i {
+  width: 14%;
+  background: var(--promote);
+  animation-delay: -1s;
+}
+
+.switch-node {
+  position: absolute;
+  min-width: 86px;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  text-align: center;
+  font-size: 0.82rem;
+  box-quorum: 0 12px 30px rgba(16, 24, 40, 0.1);
+}
+
+.node-gateway {
+  left: 7%;
+  top: 10%;
+}
+.node-policy {
+  left: 42%;
+  top: 10%;
+}
+.node-core {
+  right: 7%;
+  top: 31%;
+}
+.node-optional {
+  right: 7%;
+  bottom: 10%;
+}
+
+.service-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.service-card {
+  min-height: 224px;
+  padding: 20px;
+  opacity: 0.58;
+  transform: translateY(12px) scale(0.97);
+  transition:
+    transform 340ms ease,
+    opacity 340ms ease,
+    border-color 340ms ease,
+    box-quorum 340ms ease;
+}
+
+.service-card > span {
+  display: block;
+  width: 48px;
+  height: 48px;
+  margin-bottom: 34px;
+  border-radius: 14px;
+  background: var(--primary);
+  box-quorum: inset 0 0 0 9px rgba(255, 255, 255, 0.32);
+}
+
+.card-replica > span {
+  background: var(--replica);
+}
+.card-quorum > span {
+  background: var(--quorum);
+}
+.card-promote > span {
+  background: var(--promote);
+}
+
+.service-card h2 {
+  margin-bottom: 10px;
+  font-size: 1.16rem;
+}
+
+.service-card p {
+  color: var(--muted);
+  line-height: 1.56;
+}
+
+#mode-primary:checked ~ .mode-tabs label[for="mode-primary"],
+#mode-replica:checked ~ .mode-tabs label[for="mode-replica"],
+#mode-quorum:checked ~ .mode-tabs label[for="mode-quorum"],
+#mode-promote:checked ~ .mode-tabs label[for="mode-promote"] {
+  color: #fff;
+  border-color: transparent;
+  background: var(--ink);
+}
+
+#mode-replica:checked ~ .quorum-board .ring-fill {
+  background: conic-gradient(
+    var(--replica) 0 205deg,
+    transparent 205deg 360deg
+  );
+}
+
+#mode-quorum:checked ~ .quorum-board .ring-fill {
+  background: conic-gradient(var(--quorum) 0 118deg, transparent 118deg 360deg);
+}
+
+#mode-promote:checked ~ .quorum-board .ring-fill {
+  background: conic-gradient(
+    var(--promote) 0 176deg,
+    transparent 176deg 360deg
+  );
+}
+
+#mode-primary:checked ~ .service-grid .card-primary,
+#mode-replica:checked ~ .service-grid .card-replica,
+#mode-quorum:checked ~ .service-grid .card-quorum,
+#mode-promote:checked ~ .service-grid .card-promote {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  border-color: rgba(37, 99, 235, 0.44);
+  box-quorum: 0 18px 44px rgba(16, 24, 40, 0.12);
+}
+
+.quorum-slot-001 {
+  --quorum-slot: 1;
+}
+.quorum-slot-002 {
+  --quorum-slot: 2;
+}
+.quorum-slot-003 {
+  --quorum-slot: 3;
+}
+.quorum-slot-004 {
+  --quorum-slot: 4;
+}
+.quorum-slot-005 {
+  --quorum-slot: 5;
+}
+.quorum-slot-006 {
+  --quorum-slot: 6;
+}
+.quorum-slot-007 {
+  --quorum-slot: 7;
+}
+.quorum-slot-008 {
+  --quorum-slot: 8;
+}
+.quorum-slot-009 {
+  --quorum-slot: 9;
+}
+.quorum-slot-010 {
+  --quorum-slot: 10;
+}
+.quorum-slot-011 {
+  --quorum-slot: 11;
+}
+.quorum-slot-012 {
+  --quorum-slot: 12;
+}
+.quorum-slot-013 {
+  --quorum-slot: 13;
+}
+.quorum-slot-014 {
+  --quorum-slot: 14;
+}
+.quorum-slot-015 {
+  --quorum-slot: 15;
+}
+.quorum-slot-016 {
+  --quorum-slot: 16;
+}
+.quorum-slot-017 {
+  --quorum-slot: 17;
+}
+.quorum-slot-018 {
+  --quorum-slot: 18;
+}
+.quorum-slot-019 {
+  --quorum-slot: 19;
+}
+.quorum-slot-020 {
+  --quorum-slot: 20;
+}
+.quorum-slot-021 {
+  --quorum-slot: 21;
+}
+.quorum-slot-022 {
+  --quorum-slot: 22;
+}
+.quorum-slot-023 {
+  --quorum-slot: 23;
+}
+.quorum-slot-024 {
+  --quorum-slot: 24;
+}
+.quorum-slot-025 {
+  --quorum-slot: 25;
+}
+.quorum-slot-026 {
+  --quorum-slot: 26;
+}
+.quorum-slot-027 {
+  --quorum-slot: 27;
+}
+.quorum-slot-028 {
+  --quorum-slot: 28;
+}
+.quorum-slot-029 {
+  --quorum-slot: 29;
+}
+.quorum-slot-030 {
+  --quorum-slot: 30;
+}
+.quorum-slot-031 {
+  --quorum-slot: 31;
+}
+.quorum-slot-032 {
+  --quorum-slot: 32;
+}
+.quorum-slot-033 {
+  --quorum-slot: 33;
+}
+.quorum-slot-034 {
+  --quorum-slot: 34;
+}
+.quorum-slot-035 {
+  --quorum-slot: 35;
+}
+.quorum-slot-036 {
+  --quorum-slot: 36;
+}
+.quorum-slot-037 {
+  --quorum-slot: 37;
+}
+.quorum-slot-038 {
+  --quorum-slot: 38;
+}
+.quorum-slot-039 {
+  --quorum-slot: 39;
+}
+.quorum-slot-040 {
+  --quorum-slot: 40;
+}
+.quorum-slot-041 {
+  --quorum-slot: 41;
+}
+.quorum-slot-042 {
+  --quorum-slot: 42;
+}
+.quorum-slot-043 {
+  --quorum-slot: 43;
+}
+.quorum-slot-044 {
+  --quorum-slot: 44;
+}
+.quorum-slot-045 {
+  --quorum-slot: 45;
+}
+.quorum-slot-046 {
+  --quorum-slot: 46;
+}
+.quorum-slot-047 {
+  --quorum-slot: 47;
+}
+.quorum-slot-048 {
+  --quorum-slot: 48;
+}
+.quorum-slot-049 {
+  --quorum-slot: 49;
+}
+.quorum-slot-050 {
+  --quorum-slot: 50;
+}
+.quorum-slot-051 {
+  --quorum-slot: 51;
+}
+.quorum-slot-052 {
+  --quorum-slot: 52;
+}
+.quorum-slot-053 {
+  --quorum-slot: 53;
+}
+.quorum-slot-054 {
+  --quorum-slot: 54;
+}
+.quorum-slot-055 {
+  --quorum-slot: 55;
+}
+
+@keyframes sync-pulse {
+  50% {
+    filter: brightness(1.14);
+  }
+}
+
+@keyframes switch-flow {
+  50% {
+    transform: translateX(170%);
+  }
+}
+
+@media (max-width: 860px) {
+  .quorum-shell {
+    width: min(100% - 20px, 680px);
+    padding: 28px 0;
+  }
+
+  .quorum-console {
+    padding: 14px;
+  }
+
+  .mode-tabs,
+  .quorum-board,
+  .service-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only replica quorum monitor example with radio-driven primary, replica, quorum, and promote modes
- include animated sync ring, quorum lanes, responsive service cards, and reduced-motion handling

## Validation
- npx prettier --check submissions/examples/replica-quorum-monitor-kp/README.md submissions/examples/replica-quorum-monitor-kp/demo.html submissions/examples/replica-quorum-monitor-kp/style.css
- npx stylelint submissions/examples/replica-quorum-monitor-kp/style.css --allow-empty-input
- git diff --check