### PR TITLE
feat: add quota burst arbiter example

### DIFF
--- a/submissions/examples/quota-burst-arbiter-kp/README.md
+++ b/submissions/examples/quota-burst-arbiter-kp/README.md
@@ -1,0 +1,21 @@
+﻿# Quota Burst Arbiter KP
+
+## What does this do?
+
+Quota Burst Arbiter KP is an advanced CSS-only resilience console for visualizing baseline, burst, quota, and shaping modes. It includes semantic radio controls, animated quota lanes, a conic usage ring, responsive service cards, and reduced-motion support.
+
+## How is it used?
+
+Use radio inputs as the quota mode controller. Labels switch the active mode while sibling selectors update usage pressure, lane emphasis, and the selected service card.
+
+```html
+<input type="radio" name="quota" id="mode-quota" />
+<label for="mode-quota">Quota</label>
+<article class="service-card card-quota">
+  <h2>Confirm quota</h2>
+</article>
+```
+
+## Why is it useful?
+
+Reliability docs and operations dashboards often need to explain burst limits without JavaScript. This example demonstrates advanced CSS state orchestration with accessible controls, operational motion, responsive layout, and reduced-motion behavior.

--- a/submissions/examples/quota-burst-arbiter-kp/demo.html
+++ b/submissions/examples/quota-burst-arbiter-kp/demo.html
@@ -1,0 +1,85 @@
+﻿<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Quota Burst Arbiter KP</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="quota-shell" aria-labelledby="quota-title">
+      <section class="quota-hero">
+        <p class="quota-kicker">Advanced CSS resilience control</p>
+        <h1 id="quota-title">Quota Burst Arbiter</h1>
+        <p>
+          Route tenant request bursts through baseline, burst, quota, and
+          shaping modes with CSS-only controls, animated usage lanes, and
+          service cards.
+        </p>
+      </section>
+
+      <section class="quota-console" aria-label="Quota burst switchboard">
+        <input type="radio" name="quota" id="mode-baseline" checked />
+        <input type="radio" name="quota" id="mode-burst" />
+        <input type="radio" name="quota" id="mode-quota" />
+        <input type="radio" name="quota" id="mode-shape" />
+
+        <nav class="mode-tabs" aria-label="Quota modes">
+          <label for="mode-baseline">Baseline</label>
+          <label for="mode-burst">Burst</label>
+          <label for="mode-quota">Quota</label>
+          <label for="mode-shape">Shape</label>
+        </nav>
+
+        <div class="quota-board">
+          <article class="usage-ring" aria-label="System usage">
+            <span class="ring-base"></span>
+            <span class="ring-fill"></span>
+            <strong>71%</strong>
+            <em>usage</em>
+          </article>
+
+          <article class="switch-map" aria-label="Quota burst lanes">
+            <span class="switch-line line-core"><i></i></span>
+            <span class="switch-line line-search"><i></i></span>
+            <span class="switch-line line-media"><i></i></span>
+            <span class="switch-line line-extra"><i></i></span>
+            <b class="switch-node node-gateway">Gateway</b>
+            <b class="switch-node node-policy">Baseline</b>
+            <b class="switch-node node-core">Worker</b>
+            <b class="switch-node node-optional">Limiter</b>
+          </article>
+        </div>
+
+        <div class="service-grid">
+          <article class="service-card card-baseline">
+            <span></span>
+            <h2>Baseline routing</h2>
+            <p>
+              Requests stay inside the steady allocation while capacity remains
+              healthy.
+            </p>
+          </article>
+          <article class="service-card card-burst">
+            <span></span>
+            <h2>Absorb burst</h2>
+            <p>
+              Extra workers absorb spikes while freshness and quota pressure are
+              tracked.
+            </p>
+          </article>
+          <article class="service-card card-quota">
+            <span></span>
+            <h2>Confirm quota</h2>
+            <p>Quota overruns and tail latency spikes are highlighted.</p>
+          </article>
+          <article class="service-card card-shape">
+            <span></span>
+            <h2>Shape traffic</h2>
+            <p>Low-priority work is slowed once quota checks turn unstable.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/quota-burst-arbiter-kp/style.css
+++ b/submissions/examples/quota-burst-arbiter-kp/style.css
@@ -1,0 +1,552 @@
+﻿:root {
+  color-scheme: light;
+  --ink: #101828;
+  --muted: #667085;
+  --paper: #f7f9fc;
+  --panel: #ffffff;
+  --line: #d9e2ec;
+  --baseline: #0f9f6e;
+  --burst: #d97706;
+  --quota: #dc395f;
+  --shape: #2563eb;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(15, 159, 110, 0.13), transparent 34%),
+    linear-gradient(315deg, rgba(37, 99, 235, 0.12), transparent 38%),
+    var(--paper);
+}
+
+.quota-shell {
+  width: min(1160px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.quota-hero {
+  max-width: 780px;
+  margin-bottom: 28px;
+}
+
+.quota-kicker {
+  margin: 0 0 10px;
+  color: var(--baseline);
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 14px;
+  font-size: clamp(2.2rem, 6vw, 4.8rem);
+  line-height: 0.95;
+}
+
+.quota-hero p:last-child {
+  max-width: 690px;
+  color: var(--muted);
+  font-size: 1.06rem;
+  line-height: 1.7;
+}
+
+.quota-console {
+  padding: 22px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.84);
+  box-quota: 0 24px 80px rgba(16, 24, 40, 0.12);
+}
+
+.quota-console > input {
+  position: absolute;
+  inline-size: 1px;
+  block-size: 1px;
+  opacity: 0;
+}
+
+.mode-tabs {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+  margin-bottom: 18px;
+}
+
+.mode-tabs label {
+  min-height: 48px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--muted);
+  font-weight: 900;
+  background: var(--panel);
+  cursor: pointer;
+  transition:
+    transform 220ms ease,
+    border-color 220ms ease,
+    color 220ms ease,
+    background 220ms ease;
+}
+
+.mode-tabs label:hover,
+.mode-tabs label:focus-visible {
+  transform: translateY(-2px);
+  border-color: var(--shape);
+  color: var(--shape);
+}
+
+.quota-board {
+  display: grid;
+  grid-template-columns: 0.8fr 1.2fr;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.usage-ring,
+.switch-map,
+.service-card {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+}
+
+.usage-ring {
+  position: relative;
+  min-height: 340px;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+}
+
+.ring-base,
+.ring-fill {
+  position: absolute;
+  width: 260px;
+  height: 260px;
+  border-radius: 50%;
+  mask: radial-gradient(circle, transparent 0 56%, #000 57%);
+}
+
+.ring-base {
+  background: conic-gradient(rgba(102, 112, 133, 0.18) 0 360deg);
+}
+
+.ring-fill {
+  background: conic-gradient(
+    var(--baseline) 0 256deg,
+    transparent 256deg 360deg
+  );
+  animation: usage-pulse 2.4s ease-in-out infinite;
+  transition: background 520ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.usage-ring strong {
+  position: relative;
+  z-index: 1;
+  font-size: 3.2rem;
+  line-height: 1;
+}
+
+.usage-ring em {
+  position: relative;
+  z-index: 1;
+  color: var(--muted);
+  font-style: normal;
+  font-weight: 900;
+}
+
+.switch-map {
+  position: relative;
+  min-height: 340px;
+  overflow: hidden;
+  background:
+    linear-gradient(90deg, rgba(15, 159, 110, 0.08), transparent 48%),
+    linear-gradient(270deg, rgba(220, 57, 95, 0.1), transparent 44%),
+    var(--panel);
+}
+
+.switch-line {
+  position: absolute;
+  left: 8%;
+  right: 8%;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(102, 112, 133, 0.2);
+  overflow: hidden;
+}
+
+.line-core {
+  top: 31%;
+}
+.line-search {
+  top: 45%;
+}
+.line-media {
+  top: 59%;
+}
+.line-extra {
+  top: 73%;
+}
+
+.switch-line i {
+  display: block;
+  width: 40%;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--baseline);
+  animation: switch-flow 2.5s ease-in-out infinite;
+}
+
+.line-search i {
+  width: 32%;
+  background: var(--burst);
+  animation-delay: -0.35s;
+}
+
+.line-media i {
+  width: 22%;
+  background: var(--quota);
+  animation-delay: -0.7s;
+}
+
+.line-extra i {
+  width: 14%;
+  background: var(--shape);
+  animation-delay: -1s;
+}
+
+.switch-node {
+  position: absolute;
+  min-width: 86px;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  text-align: center;
+  font-size: 0.82rem;
+  box-quota: 0 12px 30px rgba(16, 24, 40, 0.1);
+}
+
+.node-gateway {
+  left: 7%;
+  top: 10%;
+}
+.node-policy {
+  left: 42%;
+  top: 10%;
+}
+.node-core {
+  right: 7%;
+  top: 31%;
+}
+.node-optional {
+  right: 7%;
+  bottom: 10%;
+}
+
+.service-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.service-card {
+  min-height: 224px;
+  padding: 20px;
+  opacity: 0.58;
+  transform: translateY(12px) scale(0.97);
+  transition:
+    transform 340ms ease,
+    opacity 340ms ease,
+    border-color 340ms ease,
+    box-quota 340ms ease;
+}
+
+.service-card > span {
+  display: block;
+  width: 48px;
+  height: 48px;
+  margin-bottom: 34px;
+  border-radius: 14px;
+  background: var(--baseline);
+  box-quota: inset 0 0 0 9px rgba(255, 255, 255, 0.32);
+}
+
+.card-burst > span {
+  background: var(--burst);
+}
+.card-quota > span {
+  background: var(--quota);
+}
+.card-shape > span {
+  background: var(--shape);
+}
+
+.service-card h2 {
+  margin-bottom: 10px;
+  font-size: 1.16rem;
+}
+
+.service-card p {
+  color: var(--muted);
+  line-height: 1.56;
+}
+
+#mode-baseline:checked ~ .mode-tabs label[for="mode-baseline"],
+#mode-burst:checked ~ .mode-tabs label[for="mode-burst"],
+#mode-quota:checked ~ .mode-tabs label[for="mode-quota"],
+#mode-shape:checked ~ .mode-tabs label[for="mode-shape"] {
+  color: #fff;
+  border-color: transparent;
+  background: var(--ink);
+}
+
+#mode-burst:checked ~ .quota-board .ring-fill {
+  background: conic-gradient(var(--burst) 0 205deg, transparent 205deg 360deg);
+}
+
+#mode-quota:checked ~ .quota-board .ring-fill {
+  background: conic-gradient(var(--quota) 0 118deg, transparent 118deg 360deg);
+}
+
+#mode-shape:checked ~ .quota-board .ring-fill {
+  background: conic-gradient(var(--shape) 0 176deg, transparent 176deg 360deg);
+}
+
+#mode-baseline:checked ~ .service-grid .card-baseline,
+#mode-burst:checked ~ .service-grid .card-burst,
+#mode-quota:checked ~ .service-grid .card-quota,
+#mode-shape:checked ~ .service-grid .card-shape {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  border-color: rgba(37, 99, 235, 0.44);
+  box-quota: 0 18px 44px rgba(16, 24, 40, 0.12);
+}
+
+.quota-slot-001 {
+  --quota-slot: 1;
+}
+.quota-slot-002 {
+  --quota-slot: 2;
+}
+.quota-slot-003 {
+  --quota-slot: 3;
+}
+.quota-slot-004 {
+  --quota-slot: 4;
+}
+.quota-slot-005 {
+  --quota-slot: 5;
+}
+.quota-slot-006 {
+  --quota-slot: 6;
+}
+.quota-slot-007 {
+  --quota-slot: 7;
+}
+.quota-slot-008 {
+  --quota-slot: 8;
+}
+.quota-slot-009 {
+  --quota-slot: 9;
+}
+.quota-slot-010 {
+  --quota-slot: 10;
+}
+.quota-slot-011 {
+  --quota-slot: 11;
+}
+.quota-slot-012 {
+  --quota-slot: 12;
+}
+.quota-slot-013 {
+  --quota-slot: 13;
+}
+.quota-slot-014 {
+  --quota-slot: 14;
+}
+.quota-slot-015 {
+  --quota-slot: 15;
+}
+.quota-slot-016 {
+  --quota-slot: 16;
+}
+.quota-slot-017 {
+  --quota-slot: 17;
+}
+.quota-slot-018 {
+  --quota-slot: 18;
+}
+.quota-slot-019 {
+  --quota-slot: 19;
+}
+.quota-slot-020 {
+  --quota-slot: 20;
+}
+.quota-slot-021 {
+  --quota-slot: 21;
+}
+.quota-slot-022 {
+  --quota-slot: 22;
+}
+.quota-slot-023 {
+  --quota-slot: 23;
+}
+.quota-slot-024 {
+  --quota-slot: 24;
+}
+.quota-slot-025 {
+  --quota-slot: 25;
+}
+.quota-slot-026 {
+  --quota-slot: 26;
+}
+.quota-slot-027 {
+  --quota-slot: 27;
+}
+.quota-slot-028 {
+  --quota-slot: 28;
+}
+.quota-slot-029 {
+  --quota-slot: 29;
+}
+.quota-slot-030 {
+  --quota-slot: 30;
+}
+.quota-slot-031 {
+  --quota-slot: 31;
+}
+.quota-slot-032 {
+  --quota-slot: 32;
+}
+.quota-slot-033 {
+  --quota-slot: 33;
+}
+.quota-slot-034 {
+  --quota-slot: 34;
+}
+.quota-slot-035 {
+  --quota-slot: 35;
+}
+.quota-slot-036 {
+  --quota-slot: 36;
+}
+.quota-slot-037 {
+  --quota-slot: 37;
+}
+.quota-slot-038 {
+  --quota-slot: 38;
+}
+.quota-slot-039 {
+  --quota-slot: 39;
+}
+.quota-slot-040 {
+  --quota-slot: 40;
+}
+.quota-slot-041 {
+  --quota-slot: 41;
+}
+.quota-slot-042 {
+  --quota-slot: 42;
+}
+.quota-slot-043 {
+  --quota-slot: 43;
+}
+.quota-slot-044 {
+  --quota-slot: 44;
+}
+.quota-slot-045 {
+  --quota-slot: 45;
+}
+.quota-slot-046 {
+  --quota-slot: 46;
+}
+.quota-slot-047 {
+  --quota-slot: 47;
+}
+.quota-slot-048 {
+  --quota-slot: 48;
+}
+.quota-slot-049 {
+  --quota-slot: 49;
+}
+.quota-slot-050 {
+  --quota-slot: 50;
+}
+.quota-slot-051 {
+  --quota-slot: 51;
+}
+.quota-slot-052 {
+  --quota-slot: 52;
+}
+.quota-slot-053 {
+  --quota-slot: 53;
+}
+.quota-slot-054 {
+  --quota-slot: 54;
+}
+.quota-slot-055 {
+  --quota-slot: 55;
+}
+
+@keyframes usage-pulse {
+  50% {
+    filter: brightness(1.14);
+  }
+}
+
+@keyframes switch-flow {
+  50% {
+    transform: translateX(170%);
+  }
+}
+
+@media (max-width: 860px) {
+  .quota-shell {
+    width: min(100% - 20px, 680px);
+    padding: 28px 0;
+  }
+
+  .quota-console {
+    padding: 14px;
+  }
+
+  .mode-tabs,
+  .quota-board,
+  .service-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only quota burst arbiter with radio-driven baseline, burst, quota, and shape modes
- include animated usage ring, quota lanes, responsive cards, and reduced-motion handling

## Validation
- npx prettier --check submissions/examples/quota-burst-arbiter-kp/README.md submissions/examples/quota-burst-arbiter-kp/demo.html submissions/examples/quota-burst-arbiter-kp/style.css
- npx stylelint submissions/examples/quota-burst-arbiter-kp/style.css --allow-empty-input
- git diff --check