### PR TITLE
Add ease-traffic-lights component

### DIFF
--- a/submissions/examples/traffic-lights-ij/README.md
+++ b/submissions/examples/traffic-lights-ij/README.md
@@ -1,0 +1,10 @@
+# ease-traffic-lights
+
+A traffic signal whose three lamps cycle through red, amber, and green with fading glows.
+
+## Run
+Open `demo.html` directly in a browser to watch the lights cycle.
+
+## Notes
+- The state label swaps to match the lamp.
+- Each phase lasts a fixed slice of the cycle.

--- a/submissions/examples/traffic-lights-ij/demo.html
+++ b/submissions/examples/traffic-lights-ij/demo.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-traffic-lights demo</title>
+</head>
+<body>
+<div class="tl-app">
+  <span class="tl-title">INTERSECTION</span>
+  <div class="tl-pole">
+    <div class="tl-box">
+      <span class="tl-lamp tl-red"></span>
+      <span class="tl-lamp tl-amber"></span>
+      <span class="tl-lamp tl-green"></span>
+    </div>
+  </div>
+  <span class="tl-state">Go</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/traffic-lights-ij/style.css
+++ b/submissions/examples/traffic-lights-ij/style.css
@@ -1,0 +1,15 @@
+:root{--tl-red:#ff4d3d;--tl-amber:#ffd84a;--tl-green:#4ad86a;--tl-dark:#262a30}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#2a2f36,#13171c);font-family:'Segoe UI',sans-serif}
+.tl-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#20252b,#0e1216);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.tl-title{position:absolute;top:14px;left:0;right:0;text-align:center;font-size:14px;font-weight:800;letter-spacing:7px;color:#8f9aa8}
+.tl-pole{position:absolute;top:52px;left:164px;width:44px;height:268px;border-radius:8px;background:#262a30}
+.tl-box{position:absolute;top:20px;left:-14px;width:84px;height:196px;border-radius:14px;background:#16191e;box-shadow:inset 0 0 0 5px #2c3138;display:flex;flex-direction:column;align-items:center;justify-content:space-around}
+.tl-lamp{width:44px;height:44px;border-radius:50%;background:#2a2e34;animation:sequence-lamp-traffic-lights 8s ease-in-out infinite}
+.tl-red{animation-name:sequence-red-traffic-lights}
+.tl-amber{animation-name:sequence-amber-traffic-lights}
+.tl-green{animation-name:sequence-green-traffic-lights}
+.tl-state{position:absolute;bottom:28px;left:0;right:0;text-align:center;font-size:16px;font-weight:800;color:var(--tl-green);letter-spacing:3px;animation:swap-state-traffic-lights 8s steps(1) infinite}
+@keyframes sequence-red-traffic-lights{0%,36%{background:var(--tl-red);box-shadow:0 0 22px var(--tl-red)}44%,100%{background:#2a2e34;box-shadow:none}}
+@keyframes sequence-amber-traffic-lights{0%,36%{background:#2a2e34}40%,52%{background:var(--tl-amber);box-shadow:0 0 22px var(--tl-amber)}60%,100%{background:#2a2e34}}
+@keyframes sequence-green-traffic-lights{0%,52%{background:#2a2e34}56%,92%{background:var(--tl-green);box-shadow:0 0 22px var(--tl-green)}100%{background:#2a2e34}}
+@keyframes swap-state-traffic-lights{0%,36%{color:var(--tl-red)}40%,52%{color:var(--tl-amber)}56%,92%{color:var(--tl-green)}100%{color:var(--tl-red)}}


### PR DESCRIPTION
## Component: ease-traffic-lights — lamps cycle red, amber, green, and state text swaps

**Closes #62763**

### What this adds
A traffic signal: the three lamps cycle through red, amber, and green, each glow fading between phases, and the state label swaps to match the active lamp.

### Acceptance Criteria covered
- Lamps cycle red, amber, green
- Glow fades between phases
- State label swaps to match

### Files
- submissions/examples/traffic-lights-ij/demo.html
- submissions/examples/traffic-lights-ij/style.css
- submissions/examples/traffic-lights-ij/README.md

### How to review
Open `demo.html` in a browser and watch the lights cycle.