### PR TITLE
feat: add saturation window governor example

### DIFF
--- a/submissions/examples/saturation-window-governor-kp/README.md
+++ b/submissions/examples/saturation-window-governor-kp/README.md
@@ -1,0 +1,21 @@
+﻿# Saturation Window Governor KP
+
+## What does this do?
+
+Saturation Window Governor KP is an advanced CSS-only resilience console for visualizing observe, buffer, saturation, and shaping modes. It includes semantic radio controls, animated saturation lanes, a conic load ring, responsive service cards, and reduced-motion support.
+
+## How is it used?
+
+Use radio inputs as the saturation mode controller. Labels switch the active mode while sibling selectors update load pressure, lane emphasis, and the selected service card.
+
+```html
+<input type="radio" name="saturation" id="mode-saturation" />
+<label for="mode-saturation">Saturation</label>
+<article class="service-card card-saturation">
+  <h2>Confirm saturation</h2>
+</article>
+```
+
+## Why is it useful?
+
+Reliability docs and operations dashboards often need to explain saturation windows without JavaScript. This example demonstrates advanced CSS state orchestration with accessible controls, operational motion, responsive layout, and reduced-motion behavior.

--- a/submissions/examples/saturation-window-governor-kp/demo.html
+++ b/submissions/examples/saturation-window-governor-kp/demo.html
@@ -1,0 +1,88 @@
+﻿<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Saturation Window Governor KP</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="saturation-shell" aria-labelledby="saturation-title">
+      <section class="saturation-hero">
+        <p class="saturation-kicker">Advanced CSS resilience control</p>
+        <h1 id="saturation-title">Saturation Window Governor</h1>
+        <p>
+          Route service load windows through observe, buffer, saturation, and
+          shaping modes with CSS-only controls, animated load lanes, and service
+          cards.
+        </p>
+      </section>
+
+      <section
+        class="saturation-console"
+        aria-label="Saturation window switchboard"
+      >
+        <input type="radio" name="saturation" id="mode-observe" checked />
+        <input type="radio" name="saturation" id="mode-buffer" />
+        <input type="radio" name="saturation" id="mode-saturation" />
+        <input type="radio" name="saturation" id="mode-throttle" />
+
+        <nav class="mode-tabs" aria-label="Saturation modes">
+          <label for="mode-observe">Observe</label>
+          <label for="mode-buffer">Buffer</label>
+          <label for="mode-saturation">Saturation</label>
+          <label for="mode-throttle">Throttle</label>
+        </nav>
+
+        <div class="saturation-board">
+          <article class="load-ring" aria-label="System load">
+            <span class="ring-base"></span>
+            <span class="ring-fill"></span>
+            <strong>71%</strong>
+            <em>load</em>
+          </article>
+
+          <article class="switch-map" aria-label="Saturation window lanes">
+            <span class="switch-line line-core"><i></i></span>
+            <span class="switch-line line-search"><i></i></span>
+            <span class="switch-line line-media"><i></i></span>
+            <span class="switch-line line-extra"><i></i></span>
+            <b class="switch-node node-ingress">Ingress</b>
+            <b class="switch-node node-policy">Observe</b>
+            <b class="switch-node node-core">Worker</b>
+            <b class="switch-node node-optional">Governor</b>
+          </article>
+        </div>
+
+        <div class="service-grid">
+          <article class="service-card card-observe">
+            <span></span>
+            <h2>Observe window</h2>
+            <p>
+              Requests stay inside the observed capacity window while worker
+              load remains healthy.
+            </p>
+          </article>
+          <article class="service-card card-buffer">
+            <span></span>
+            <h2>Buffer load</h2>
+            <p>
+              Workers receive time buffers while queue depth and load pressure
+              are tracked.
+            </p>
+          </article>
+          <article class="service-card card-saturation">
+            <span></span>
+            <h2>Confirm saturation</h2>
+            <p>Saturation spikes and tail load spikes are highlighted.</p>
+          </article>
+          <article class="service-card card-throttle">
+            <span></span>
+            <h2>Throttle traffic</h2>
+            <p>New work is throttled once saturation checks turn unstable.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/saturation-window-governor-kp/style.css
+++ b/submissions/examples/saturation-window-governor-kp/style.css
@@ -1,0 +1,558 @@
+﻿:root {
+  color-scheme: light;
+  --ink: #101828;
+  --muted: #667085;
+  --paper: #f7f9fc;
+  --panel: #ffffff;
+  --line: #d9e2ec;
+  --observe: #0f9f6e;
+  --buffer: #d97706;
+  --saturation: #dc395f;
+  --throttle: #2563eb;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(15, 159, 110, 0.13), transparent 34%),
+    linear-gradient(315deg, rgba(37, 99, 235, 0.12), transparent 38%),
+    var(--paper);
+}
+
+.saturation-shell {
+  width: min(1160px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.saturation-hero {
+  max-width: 780px;
+  margin-bottom: 28px;
+}
+
+.saturation-kicker {
+  margin: 0 0 10px;
+  color: var(--observe);
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 14px;
+  font-size: clamp(2.2rem, 6vw, 4.8rem);
+  line-height: 0.95;
+}
+
+.saturation-hero p:last-child {
+  max-width: 690px;
+  color: var(--muted);
+  font-size: 1.06rem;
+  line-height: 1.7;
+}
+
+.saturation-console {
+  padding: 22px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.84);
+  box-shadow: 0 24px 80px rgba(16, 24, 40, 0.12);
+}
+
+.saturation-console > input {
+  position: absolute;
+  inline-size: 1px;
+  block-size: 1px;
+  opacity: 0;
+}
+
+.mode-tabs {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+  margin-bottom: 18px;
+}
+
+.mode-tabs label {
+  min-height: 48px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--muted);
+  font-weight: 900;
+  background: var(--panel);
+  cursor: pointer;
+  transition:
+    transform 220ms ease,
+    border-color 220ms ease,
+    color 220ms ease,
+    background 220ms ease;
+}
+
+.mode-tabs label:hover,
+.mode-tabs label:focus-visible {
+  transform: translateY(-2px);
+  border-color: var(--throttle);
+  color: var(--throttle);
+}
+
+.saturation-board {
+  display: grid;
+  grid-template-columns: 0.8fr 1.2fr;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.load-ring,
+.switch-map,
+.service-card {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+}
+
+.load-ring {
+  position: relative;
+  min-height: 340px;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+}
+
+.ring-base,
+.ring-fill {
+  position: absolute;
+  width: 260px;
+  height: 260px;
+  border-radius: 50%;
+  mask: radial-gradient(circle, transparent 0 56%, #000 57%);
+}
+
+.ring-base {
+  background: conic-gradient(rgba(102, 112, 133, 0.18) 0 360deg);
+}
+
+.ring-fill {
+  background: conic-gradient(
+    var(--observe) 0 256deg,
+    transparent 256deg 360deg
+  );
+  animation: load-pulse 2.4s ease-in-out infinite;
+  transition: background 520ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.load-ring strong {
+  position: relative;
+  z-index: 1;
+  font-size: 3.2rem;
+  line-height: 1;
+}
+
+.load-ring em {
+  position: relative;
+  z-index: 1;
+  color: var(--muted);
+  font-style: normal;
+  font-weight: 900;
+}
+
+.switch-map {
+  position: relative;
+  min-height: 340px;
+  overflow: hidden;
+  background:
+    linear-gradient(90deg, rgba(15, 159, 110, 0.08), transparent 48%),
+    linear-gradient(270deg, rgba(220, 57, 95, 0.1), transparent 44%),
+    var(--panel);
+}
+
+.switch-line {
+  position: absolute;
+  left: 8%;
+  right: 8%;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(102, 112, 133, 0.2);
+  overflow: hidden;
+}
+
+.line-core {
+  top: 31%;
+}
+.line-search {
+  top: 45%;
+}
+.line-media {
+  top: 59%;
+}
+.line-extra {
+  top: 73%;
+}
+
+.switch-line i {
+  display: block;
+  width: 40%;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--observe);
+  animation: switch-flow 2.5s ease-in-out infinite;
+}
+
+.line-search i {
+  width: 32%;
+  background: var(--buffer);
+  animation-delay: -0.35s;
+}
+
+.line-media i {
+  width: 22%;
+  background: var(--saturation);
+  animation-delay: -0.7s;
+}
+
+.line-extra i {
+  width: 14%;
+  background: var(--throttle);
+  animation-delay: -1s;
+}
+
+.switch-node {
+  position: absolute;
+  min-width: 86px;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  text-align: center;
+  font-size: 0.82rem;
+  box-shadow: 0 12px 30px rgba(16, 24, 40, 0.1);
+}
+
+.node-ingress {
+  left: 7%;
+  top: 10%;
+}
+.node-policy {
+  left: 42%;
+  top: 10%;
+}
+.node-core {
+  right: 7%;
+  top: 31%;
+}
+.node-optional {
+  right: 7%;
+  bottom: 10%;
+}
+
+.service-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.service-card {
+  min-height: 224px;
+  padding: 20px;
+  opacity: 0.58;
+  transform: translateY(12px) scale(0.97);
+  transition:
+    transform 340ms ease,
+    opacity 340ms ease,
+    border-color 340ms ease,
+    box-shadow 340ms ease;
+}
+
+.service-card > span {
+  display: block;
+  width: 48px;
+  height: 48px;
+  margin-bottom: 34px;
+  border-radius: 14px;
+  background: var(--observe);
+  box-shadow: inset 0 0 0 9px rgba(255, 255, 255, 0.32);
+}
+
+.card-buffer > span {
+  background: var(--buffer);
+}
+.card-saturation > span {
+  background: var(--saturation);
+}
+.card-throttle > span {
+  background: var(--throttle);
+}
+
+.service-card h2 {
+  margin-bottom: 10px;
+  font-size: 1.16rem;
+}
+
+.service-card p {
+  color: var(--muted);
+  line-height: 1.56;
+}
+
+#mode-observe:checked ~ .mode-tabs label[for="mode-observe"],
+#mode-buffer:checked ~ .mode-tabs label[for="mode-buffer"],
+#mode-saturation:checked ~ .mode-tabs label[for="mode-saturation"],
+#mode-throttle:checked ~ .mode-tabs label[for="mode-throttle"] {
+  color: #fff;
+  border-color: transparent;
+  background: var(--ink);
+}
+
+#mode-buffer:checked ~ .saturation-board .ring-fill {
+  background: conic-gradient(var(--buffer) 0 205deg, transparent 205deg 360deg);
+}
+
+#mode-saturation:checked ~ .saturation-board .ring-fill {
+  background: conic-gradient(
+    var(--saturation) 0 118deg,
+    transparent 118deg 360deg
+  );
+}
+
+#mode-throttle:checked ~ .saturation-board .ring-fill {
+  background: conic-gradient(
+    var(--throttle) 0 176deg,
+    transparent 176deg 360deg
+  );
+}
+
+#mode-observe:checked ~ .service-grid .card-observe,
+#mode-buffer:checked ~ .service-grid .card-buffer,
+#mode-saturation:checked ~ .service-grid .card-saturation,
+#mode-throttle:checked ~ .service-grid .card-throttle {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  border-color: rgba(37, 99, 235, 0.44);
+  box-shadow: 0 18px 44px rgba(16, 24, 40, 0.12);
+}
+
+.saturation-slot-001 {
+  --saturation-slot: 1;
+}
+.saturation-slot-002 {
+  --saturation-slot: 2;
+}
+.saturation-slot-003 {
+  --saturation-slot: 3;
+}
+.saturation-slot-004 {
+  --saturation-slot: 4;
+}
+.saturation-slot-005 {
+  --saturation-slot: 5;
+}
+.saturation-slot-006 {
+  --saturation-slot: 6;
+}
+.saturation-slot-007 {
+  --saturation-slot: 7;
+}
+.saturation-slot-008 {
+  --saturation-slot: 8;
+}
+.saturation-slot-009 {
+  --saturation-slot: 9;
+}
+.saturation-slot-010 {
+  --saturation-slot: 10;
+}
+.saturation-slot-011 {
+  --saturation-slot: 11;
+}
+.saturation-slot-012 {
+  --saturation-slot: 12;
+}
+.saturation-slot-013 {
+  --saturation-slot: 13;
+}
+.saturation-slot-014 {
+  --saturation-slot: 14;
+}
+.saturation-slot-015 {
+  --saturation-slot: 15;
+}
+.saturation-slot-016 {
+  --saturation-slot: 16;
+}
+.saturation-slot-017 {
+  --saturation-slot: 17;
+}
+.saturation-slot-018 {
+  --saturation-slot: 18;
+}
+.saturation-slot-019 {
+  --saturation-slot: 19;
+}
+.saturation-slot-020 {
+  --saturation-slot: 20;
+}
+.saturation-slot-021 {
+  --saturation-slot: 21;
+}
+.saturation-slot-022 {
+  --saturation-slot: 22;
+}
+.saturation-slot-023 {
+  --saturation-slot: 23;
+}
+.saturation-slot-024 {
+  --saturation-slot: 24;
+}
+.saturation-slot-025 {
+  --saturation-slot: 25;
+}
+.saturation-slot-026 {
+  --saturation-slot: 26;
+}
+.saturation-slot-027 {
+  --saturation-slot: 27;
+}
+.saturation-slot-028 {
+  --saturation-slot: 28;
+}
+.saturation-slot-029 {
+  --saturation-slot: 29;
+}
+.saturation-slot-030 {
+  --saturation-slot: 30;
+}
+.saturation-slot-031 {
+  --saturation-slot: 31;
+}
+.saturation-slot-032 {
+  --saturation-slot: 32;
+}
+.saturation-slot-033 {
+  --saturation-slot: 33;
+}
+.saturation-slot-034 {
+  --saturation-slot: 34;
+}
+.saturation-slot-035 {
+  --saturation-slot: 35;
+}
+.saturation-slot-036 {
+  --saturation-slot: 36;
+}
+.saturation-slot-037 {
+  --saturation-slot: 37;
+}
+.saturation-slot-038 {
+  --saturation-slot: 38;
+}
+.saturation-slot-039 {
+  --saturation-slot: 39;
+}
+.saturation-slot-040 {
+  --saturation-slot: 40;
+}
+.saturation-slot-041 {
+  --saturation-slot: 41;
+}
+.saturation-slot-042 {
+  --saturation-slot: 42;
+}
+.saturation-slot-043 {
+  --saturation-slot: 43;
+}
+.saturation-slot-044 {
+  --saturation-slot: 44;
+}
+.saturation-slot-045 {
+  --saturation-slot: 45;
+}
+.saturation-slot-046 {
+  --saturation-slot: 46;
+}
+.saturation-slot-047 {
+  --saturation-slot: 47;
+}
+.saturation-slot-048 {
+  --saturation-slot: 48;
+}
+.saturation-slot-049 {
+  --saturation-slot: 49;
+}
+.saturation-slot-050 {
+  --saturation-slot: 50;
+}
+.saturation-slot-051 {
+  --saturation-slot: 51;
+}
+.saturation-slot-052 {
+  --saturation-slot: 52;
+}
+.saturation-slot-053 {
+  --saturation-slot: 53;
+}
+.saturation-slot-054 {
+  --saturation-slot: 54;
+}
+.saturation-slot-055 {
+  --saturation-slot: 55;
+}
+
+@keyframes load-pulse {
+  50% {
+    filter: brightness(1.14);
+  }
+}
+
+@keyframes switch-flow {
+  50% {
+    transform: translateX(170%);
+  }
+}
+
+@media (max-width: 860px) {
+  .saturation-shell {
+    width: min(100% - 20px, 680px);
+    padding: 28px 0;
+  }
+
+  .saturation-console {
+    padding: 14px;
+  }
+
+  .mode-tabs,
+  .saturation-board,
+  .service-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only saturation window governor with observe, buffer, saturation, and throttle modes
- include animated load ring, saturation lanes, responsive cards, and reduced-motion handling

## Validation
- npx prettier --check submissions/examples/saturation-window-governor-kp/README.md submissions/examples/saturation-window-governor-kp/demo.html submissions/examples/saturation-window-governor-kp/style.css
- npx stylelint submissions/examples/saturation-window-governor-kp/style.css --allow-empty-input
- git diff --check