### PR TITLE
feat(badge): add CSS zoom-in badge for product catalog

### DIFF
--- a/submissions/examples/zoom-in-badge-product-catalog/README.md
+++ b/submissions/examples/zoom-in-badge-product-catalog/README.md
@@ -1,0 +1,23 @@
+# CSS Zoom-In Badge for Product Catalog Layouts
+
+A lightweight, pure CSS Zoom-In Badge animation designed for product
+catalog interfaces.
+
+## Features
+
+- Pure HTML and CSS
+- No JavaScript or external libraries
+- Smooth zoom-in badge animation
+- CSS custom properties for easy customization
+- Responsive product-card layout
+- Hover interaction
+- `prefers-reduced-motion` accessibility support
+- Works by opening `demo.html` directly in a browser
+
+## Files
+
+```text
+zoom-in-badge-product-catalog/
+├── demo.html
+├── style.css
+└── README.md

--- a/submissions/examples/zoom-in-badge-product-catalog/demo.html
+++ b/submissions/examples/zoom-in-badge-product-catalog/demo.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS Zoom-In Badge for Product Catalog Layouts">
+  <title>Zoom-In Badge | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="catalog">
+    <header class="catalog__header">
+      <p class="catalog__eyebrow">EaseMotion CSS</p>
+      <h1>Product Catalog</h1>
+      <p class="catalog__description">
+        A pure CSS Zoom-In Badge animation for product cards.
+      </p>
+    </header>
+
+    <section class="product-grid" aria-label="Product catalog">
+
+      <article class="product-card">
+        <div class="product-card__visual">
+          <span class="zoom-badge">NEW</span>
+          <div class="product-icon" aria-hidden="true">⌚</div>
+        </div>
+
+        <div class="product-card__content">
+          <p class="product-card__category">Accessories</p>
+          <h2>Smart Watch</h2>
+          <p class="product-card__price">$129</p>
+        </div>
+      </article>
+
+      <article class="product-card">
+        <div class="product-card__visual">
+          <span class="zoom-badge">SALE</span>
+          <div class="product-icon" aria-hidden="true">🎧</div>
+        </div>
+
+        <div class="product-card__content">
+          <p class="product-card__category">Audio</p>
+          <h2>Wireless Headphones</h2>
+          <p class="product-card__price">$89</p>
+        </div>
+      </article>
+
+      <article class="product-card">
+        <div class="product-card__visual">
+          <span class="zoom-badge">HOT</span>
+          <div class="product-icon" aria-hidden="true">👟</div>
+        </div>
+
+        <div class="product-card__content">
+          <p class="product-card__category">Footwear</p>
+          <h2>Running Shoes</h2>
+          <p class="product-card__price">$99</p>
+        </div>
+      </article>
+
+    </section>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/zoom-in-badge-product-catalog/style.css
+++ b/submissions/examples/zoom-in-badge-product-catalog/style.css
@@ -1,0 +1,222 @@
+:root {
+    --zoom-badge-duration: 700ms;
+    --zoom-badge-scale: 1.18;
+    --zoom-badge-easing: cubic-bezier(0.22, 1, 0.36, 1);
+  
+    --page-bg: #f4f6f8;
+    --card-bg: #ffffff;
+    --text-primary: #17202a;
+    --text-secondary: #697586;
+    --accent: #2563eb;
+    --badge-text: #ffffff;
+    --border: #e5e7eb;
+  }
+  
+  * {
+    box-sizing: border-box;
+  }
+  
+  html {
+    scroll-behavior: smooth;
+  }
+  
+  body {
+    margin: 0;
+    min-height: 100vh;
+    font-family:
+      Inter,
+      ui-sans-serif,
+      system-ui,
+      -apple-system,
+      BlinkMacSystemFont,
+      "Segoe UI",
+      sans-serif;
+    background: var(--page-bg);
+    color: var(--text-primary);
+  }
+  
+  .catalog {
+    width: min(1100px, 92%);
+    margin: 0 auto;
+    padding: 70px 0;
+  }
+  
+  .catalog__header {
+    max-width: 650px;
+    margin: 0 auto 45px;
+    text-align: center;
+  }
+  
+  .catalog__eyebrow {
+    margin: 0 0 10px;
+    font-size: 0.8rem;
+    font-weight: 800;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    color: var(--accent);
+  }
+  
+  .catalog__header h1 {
+    margin: 0 0 12px;
+    font-size: clamp(2rem, 5vw, 3.5rem);
+    line-height: 1.05;
+  }
+  
+  .catalog__description {
+    margin: 0;
+    color: var(--text-secondary);
+    line-height: 1.7;
+  }
+  
+  .product-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 24px;
+  }
+  
+  .product-card {
+    overflow: hidden;
+    background: var(--card-bg);
+    border: 1px solid var(--border);
+    border-radius: 20px;
+    box-shadow: 0 10px 30px rgba(23, 32, 42, 0.07);
+    transition:
+      transform 250ms ease,
+      box-shadow 250ms ease;
+  }
+  
+  .product-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 18px 40px rgba(23, 32, 42, 0.12);
+  }
+  
+  .product-card__visual {
+    position: relative;
+    display: grid;
+    min-height: 220px;
+    place-items: center;
+    background: linear-gradient(135deg, #eef3ff, #f8fafc);
+  }
+  
+  .product-icon {
+    font-size: 5rem;
+    line-height: 1;
+  }
+  
+  .zoom-badge {
+    position: absolute;
+    top: 18px;
+    right: 18px;
+    z-index: 2;
+  
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  
+    min-width: 62px;
+    min-height: 32px;
+    padding: 7px 12px;
+  
+    border-radius: 999px;
+    background: var(--accent);
+    color: var(--badge-text);
+  
+    font-size: 0.72rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+  
+    transform: scale(1);
+    transform-origin: center;
+    will-change: transform;
+  }
+  
+  .product-card:hover .zoom-badge {
+    animation: zoom-in-badge
+      var(--zoom-badge-duration)
+      var(--zoom-badge-easing)
+      both;
+  }
+  
+  .product-card__content {
+    padding: 22px;
+  }
+  
+  .product-card__category {
+    margin: 0 0 7px;
+    color: var(--text-secondary);
+    font-size: 0.78rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+  
+  .product-card__content h2 {
+    margin: 0;
+    font-size: 1.25rem;
+  }
+  
+  .product-card__price {
+    margin: 12px 0 0;
+    font-size: 1.15rem;
+    font-weight: 800;
+  }
+  
+  @keyframes zoom-in-badge {
+    0% {
+      opacity: 0.65;
+      transform: scale(0.72);
+    }
+  
+    60% {
+      opacity: 1;
+      transform: scale(var(--zoom-badge-scale));
+    }
+  
+    100% {
+      opacity: 1;
+      transform: scale(1);
+    }
+  }
+  
+  @media (max-width: 800px) {
+    .product-grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  
+    .catalog {
+      padding: 50px 0;
+    }
+  }
+  
+  @media (max-width: 540px) {
+    .product-grid {
+      grid-template-columns: 1fr;
+    }
+  
+    .product-card__visual {
+      min-height: 190px;
+    }
+  
+    .catalog {
+      width: min(92%, 420px);
+      padding: 40px 0;
+    }
+  }
+  
+  @media (prefers-reduced-motion: reduce) {
+    html {
+      scroll-behavior: auto;
+    }
+  
+    *,
+    *::before,
+    *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+    }
+  
+    .product-card:hover {
+      transform: none;
+    }
+  }


### PR DESCRIPTION
## Pull Request Description

Added a pure CSS Zoom-In Badge for Product Catalog Layouts as requested in #62302.

The submission includes a responsive product catalog demo with a reusable
Zoom-In Badge animation implemented using CSS keyframes and custom properties.

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

### What does this add?

A responsive CSS Zoom-In Badge animation for product catalog cards.

### How does a developer use it?

```html
<span class="zoom-badge">NEW</span>