### PR TITLE
Add ease-calendar-date-picker component

### DIFF
--- a/submissions/examples/calendar-date-picker-ij/README.md
+++ b/submissions/examples/calendar-date-picker-ij/README.md
@@ -1,0 +1,10 @@
+# ease-calendar-date-picker
+
+A date picker whose day tiles drop into the grid while the today tile glows with a ring.
+
+## Run
+Open `demo.html` directly in a browser to watch the days drop.
+
+## Notes
+- The grid shows a full August month.
+- The nav arrows pulse at the top.

--- a/submissions/examples/calendar-date-picker-ij/demo.html
+++ b/submissions/examples/calendar-date-picker-ij/demo.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-calendar-date-picker demo</title>
+</head>
+<body>
+<div class="cal-app">
+  <span class="cal-title">PICK A DATE</span>
+  <div class="cal-head">
+    <span class="cal-month">August 2026</span>
+    <button class="cal-nav cal-prev">&#8249;</button>
+    <button class="cal-nav cal-next">&#8250;</button>
+  </div>
+  <div class="cal-grid">
+    <span class="cal-day cal-dow">Mo</span>
+    <span class="cal-day cal-dow">Tu</span>
+    <span class="cal-day cal-dow">We</span>
+    <span class="cal-day cal-dow">Th</span>
+    <span class="cal-day cal-dow">Fr</span>
+    <span class="cal-day cal-dow">Sa</span>
+    <span class="cal-day cal-dow">Su</span>
+    <span class="cal-day">1</span>
+    <span class="cal-day">2</span>
+    <span class="cal-day">3</span>
+    <span class="cal-day">4</span>
+    <span class="cal-day">5</span>
+    <span class="cal-day">6</span>
+    <span class="cal-day">7</span>
+    <span class="cal-day">8</span>
+    <span class="cal-day">9</span>
+    <span class="cal-day">10</span>
+    <span class="cal-day">11</span>
+    <span class="cal-day">12</span>
+    <span class="cal-day">13</span>
+    <span class="cal-day">14</span>
+    <span class="cal-day cal-today">15</span>
+    <span class="cal-day">16</span>
+    <span class="cal-day">17</span>
+    <span class="cal-day">18</span>
+    <span class="cal-day">19</span>
+    <span class="cal-day">20</span>
+    <span class="cal-day">21</span>
+    <span class="cal-day">22</span>
+    <span class="cal-day">23</span>
+    <span class="cal-day">24</span>
+    <span class="cal-day">25</span>
+    <span class="cal-day">26</span>
+    <span class="cal-day">27</span>
+    <span class="cal-day">28</span>
+    <span class="cal-day">29</span>
+    <span class="cal-day">30</span>
+    <span class="cal-day">31</span>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/calendar-date-picker-ij/style.css
+++ b/submissions/examples/calendar-date-picker-ij/style.css
@@ -1,0 +1,47 @@
+:root{--cal-accent:#4a8fe8;--cal-gold:#e8c84a}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#2b3140,#151926);font-family:'Segoe UI',sans-serif}
+.cal-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#1d2536,#0f1420);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.cal-title{position:absolute;top:14px;left:0;right:0;text-align:center;font-size:14px;font-weight:800;letter-spacing:7px;color:#8fa6c8}
+.cal-head{position:absolute;top:54px;left:26px;width:320px;height:42px;display:flex;align-items:center;justify-content:center;gap:10px}
+.cal-month{font-size:15px;font-weight:800;color:#c0ccf0;letter-spacing:1px}
+.cal-nav{width:34px;height:34px;border:none;border-radius:50%;background:#26334c;color:#8fa6c8;font-size:18px;font-weight:800;cursor:pointer;animation:pulse-nav-calendar-date-picker 2s ease-in-out infinite}
+.cal-prev{order:-1}
+.cal-next{order:3;animation-delay:1s}
+.cal-grid{position:absolute;top:104px;left:26px;width:320px;display:grid;grid-template-columns:repeat(7,1fr);gap:4px}
+.cal-day{height:30px;border-radius:6px;background:#26334c;color:#c0ccf0;font-size:12px;font-weight:700;display:flex;align-items:center;justify-content:center;animation:drop-day-calendar-date-picker 0.5s ease-out backwards}
+.cal-dow{background:#1d2536;color:#6a7a9a;font-weight:800}
+.cal-today{background:var(--cal-accent);color:#fff;box-shadow:0 0 14px rgba(74,143,232,0.6);animation:glow-today-calendar-date-picker 1.2s ease-in-out infinite}
+.cal-day:nth-child(8){animation-delay:0.05s}
+.cal-day:nth-child(9){animation-delay:0.1s}
+.cal-day:nth-child(10){animation-delay:0.15s}
+.cal-day:nth-child(11){animation-delay:0.2s}
+.cal-day:nth-child(12){animation-delay:0.25s}
+.cal-day:nth-child(13){animation-delay:0.3s}
+.cal-day:nth-child(14){animation-delay:0.35s}
+.cal-day:nth-child(15){animation-delay:0.4s}
+.cal-day:nth-child(16){animation-delay:0.45s}
+.cal-day:nth-child(17){animation-delay:0.5s}
+.cal-day:nth-child(18){animation-delay:0.55s}
+.cal-day:nth-child(19){animation-delay:0.6s}
+.cal-day:nth-child(20){animation-delay:0.65s}
+.cal-day:nth-child(21){animation-delay:0.7s}
+.cal-day:nth-child(22){animation-delay:0.75s}
+.cal-day:nth-child(23){animation-delay:0.8s}
+.cal-day:nth-child(24){animation-delay:0.85s}
+.cal-day:nth-child(25){animation-delay:0.9s}
+.cal-day:nth-child(26){animation-delay:0.95s}
+.cal-day:nth-child(27){animation-delay:1s}
+.cal-day:nth-child(28){animation-delay:1.05s}
+.cal-day:nth-child(29){animation-delay:1.1s}
+.cal-day:nth-child(30){animation-delay:1.15s}
+.cal-day:nth-child(31){animation-delay:1.2s}
+.cal-day:nth-child(32){animation-delay:1.25s}
+.cal-day:nth-child(33){animation-delay:1.3s}
+.cal-day:nth-child(34){animation-delay:1.35s}
+.cal-day:nth-child(35){animation-delay:1.4s}
+.cal-day:nth-child(36){animation-delay:1.45s}
+.cal-day:nth-child(37){animation-delay:1.5s}
+.cal-day:nth-child(38){animation-delay:1.55s}
+@keyframes drop-day-calendar-date-picker{0%{opacity:0;transform:translateY(-14px)}100%{opacity:1;transform:translateY(0)}}
+@keyframes glow-today-calendar-date-picker{0%,100%{box-shadow:0 0 8px rgba(74,143,232,0.5)}50%{box-shadow:0 0 18px rgba(74,143,232,0.9)}}
+@keyframes pulse-nav-calendar-date-picker{0%,100%{transform:scale(1)}50%{transform:scale(1.14)}}


### PR DESCRIPTION
## Component: ease-calendar-date-picker — month grid drops, today tile glows, and nav arrows pulse

**Closes #62834**

### What this adds
A date picker: the calendar grid drops its day tiles into place, the today tile glows with a ring, and the month nav arrows pulse at the top.

### Acceptance Criteria covered
- Day tiles drop into the grid
- Today tile glows with a ring
- Month nav arrows pulse

### Files
- submissions/examples/calendar-date-picker-ij/demo.html
- submissions/examples/calendar-date-picker-ij/style.css
- submissions/examples/calendar-date-picker-ij/README.md

### How to review
Open `demo.html` in a browser and watch the days drop.