### PR TITLE
feat(carousel): add CSS Zoom-In Carousel for Product Catalogs

### DIFF
--- a/submissions/examples/zoom-in-carousel-product-catalog/README.md
+++ b/submissions/examples/zoom-in-carousel-product-catalog/README.md
@@ -1,0 +1,27 @@
+# Zoom-In Carousel for Product Catalogs
+
+A lightweight, responsive product carousel built using pure HTML and CSS.
+
+This showcase demonstrates a Zoom-In animation suitable for e-commerce
+product catalog layouts.
+
+## Features
+
+- Pure HTML and CSS
+- No JavaScript required
+- Zoom-In carousel animation
+- Staggered product cards
+- Responsive across desktop, tablet, and mobile
+- CSS custom properties
+- Smooth CSS keyframe animations
+- Keyboard focus support
+- `prefers-reduced-motion` support
+- Works by opening `demo.html` directly in a browser
+
+## Folder Structure
+
+```text
+zoom-in-carousel-product-catalog/
+├── demo.html
+├── style.css
+└── README.md

--- a/submissions/examples/zoom-in-carousel-product-catalog/demo.html
+++ b/submissions/examples/zoom-in-carousel-product-catalog/demo.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta
+    name="description"
+    content="CSS Zoom-In Carousel for Product Catalog Layouts"
+  >
+  <title>Zoom-In Product Carousel</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="catalog-demo">
+
+    <header class="catalog-header">
+      <p class="eyebrow">EaseMotion CSS</p>
+      <h1>Featured Products</h1>
+      <p class="subtitle">
+        A lightweight CSS-only Zoom-In Carousel for modern product catalogs.
+      </p>
+    </header>
+
+    <section class="product-carousel" aria-label="Featured products">
+
+      <article class="product-card">
+        <span class="product-badge">New</span>
+
+        <div class="product-visual">
+          <div class="product-icon">⌚</div>
+        </div>
+
+        <div class="product-content">
+          <p class="product-category">Accessories</p>
+          <h2>Smart Watch</h2>
+          <p class="product-description">
+            A modern smartwatch with useful features and a lightweight design.
+          </p>
+
+          <div class="product-footer">
+            <strong>$129</strong>
+            <button type="button">View Product</button>
+          </div>
+        </div>
+      </article>
+
+      <article class="product-card">
+        <span class="product-badge">Popular</span>
+
+        <div class="product-visual">
+          <div class="product-icon">🎧</div>
+        </div>
+
+        <div class="product-content">
+          <p class="product-category">Audio</p>
+          <h2>Wireless Headphones</h2>
+          <p class="product-description">
+            Comfortable wireless headphones designed for everyday listening.
+          </p>
+
+          <div class="product-footer">
+            <strong>$89</strong>
+            <button type="button">View Product</button>
+          </div>
+        </div>
+      </article>
+
+      <article class="product-card">
+        <span class="product-badge">Featured</span>
+
+        <div class="product-visual">
+          <div class="product-icon">📷</div>
+        </div>
+
+        <div class="product-content">
+          <p class="product-category">Photography</p>
+          <h2>Compact Camera</h2>
+          <p class="product-description">
+            Capture sharp photos with a compact and portable camera.
+          </p>
+
+          <div class="product-footer">
+            <strong>$249</strong>
+            <button type="button">View Product</button>
+          </div>
+        </div>
+      </article>
+
+    </section>
+
+    <div class="carousel-controls" aria-label="Carousel indicators">
+      <span class="control-dot active"></span>
+      <span class="control-dot"></span>
+      <span class="control-dot"></span>
+    </div>
+
+    <p class="animation-note">
+      Zoom-In animation • Pure HTML & CSS
+    </p>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/zoom-in-carousel-product-catalog/style.css
+++ b/submissions/examples/zoom-in-carousel-product-catalog/style.css
@@ -1,0 +1,408 @@
+:root {
+    --zi-primary: #6c5ce7;
+    --zi-primary-dark: #5546c7;
+    --zi-background: #f4f5fb;
+    --zi-surface: #ffffff;
+    --zi-text: #20212b;
+    --zi-muted: #6d7080;
+    --zi-border: #e4e5ed;
+    --zi-radius: 22px;
+  
+    --zi-duration: 6s;
+    --zi-easing: cubic-bezier(0.65, 0, 0.35, 1);
+  }
+  
+  * {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+  }
+  
+  body {
+    min-height: 100vh;
+    font-family: Arial, Helvetica, sans-serif;
+    background: var(--zi-background);
+    color: var(--zi-text);
+  }
+  
+  button {
+    font: inherit;
+  }
+  
+  .catalog-demo {
+    width: min(1100px, 92%);
+    margin: 0 auto;
+    padding: 70px 0;
+  }
+  
+  /* Header */
+  
+  .catalog-header {
+    text-align: center;
+    margin-bottom: 42px;
+  }
+  
+  .eyebrow {
+    color: var(--zi-primary);
+    font-size: 0.8rem;
+    font-weight: 700;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    margin-bottom: 10px;
+  }
+  
+  .catalog-header h1 {
+    font-size: clamp(2rem, 5vw, 3.4rem);
+    margin-bottom: 12px;
+  }
+  
+  .subtitle {
+    max-width: 620px;
+    margin: 0 auto;
+    color: var(--zi-muted);
+    line-height: 1.7;
+  }
+  
+  /* Carousel */
+  
+  .product-carousel {
+    position: relative;
+    min-height: 530px;
+    display: grid;
+    place-items: center;
+    overflow: hidden;
+    border-radius: 30px;
+    background: var(--zi-surface);
+    border: 1px solid var(--zi-border);
+    padding: 35px;
+  }
+  
+  /* Product Card */
+  
+  .product-card {
+    position: absolute;
+    width: min(430px, 85%);
+    overflow: hidden;
+  
+    background: var(--zi-surface);
+    border: 1px solid var(--zi-border);
+    border-radius: var(--zi-radius);
+  
+    box-shadow: 0 20px 50px rgba(35, 35, 60, 0.12);
+  
+    opacity: 0;
+    transform: scale(0.65);
+  
+    animation:
+      zoomIn var(--zi-duration)
+      var(--zi-easing)
+      infinite;
+  }
+  
+  /*
+    Stagger each card to create the carousel effect.
+  */
+  
+  .product-card:nth-child(1) {
+    animation-delay: 0s;
+  }
+  
+  .product-card:nth-child(2) {
+    animation-delay: 2s;
+  }
+  
+  .product-card:nth-child(3) {
+    animation-delay: 4s;
+  }
+  
+  /* Badge */
+  
+  .product-badge {
+    position: absolute;
+    top: 18px;
+    right: 18px;
+    z-index: 2;
+  
+    padding: 7px 12px;
+    border-radius: 999px;
+  
+    background: var(--zi-primary);
+    color: #ffffff;
+  
+    font-size: 0.75rem;
+    font-weight: 700;
+  }
+  
+  /* Product visual */
+  
+  .product-visual {
+    height: 210px;
+  
+    display: grid;
+    place-items: center;
+  
+    background: linear-gradient(
+      135deg,
+      #eeeaff,
+      #f8f8ff
+    );
+  }
+  
+  .product-icon {
+    width: 120px;
+    height: 120px;
+  
+    display: grid;
+    place-items: center;
+  
+    border-radius: 50%;
+    background: #ffffff;
+  
+    font-size: 4rem;
+  
+    box-shadow:
+      0 15px 35px rgba(40, 40, 70, 0.12);
+  
+    transition:
+      transform 250ms ease,
+      box-shadow 250ms ease;
+  }
+  
+  /* Product content */
+  
+  .product-content {
+    padding: 26px;
+  }
+  
+  .product-category {
+    color: var(--zi-primary);
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 8px;
+  }
+  
+  .product-content h2 {
+    font-size: 1.55rem;
+    margin-bottom: 10px;
+  }
+  
+  .product-description {
+    color: var(--zi-muted);
+    line-height: 1.6;
+    font-size: 0.95rem;
+  }
+  
+  /* Footer */
+  
+  .product-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 15px;
+  
+    margin-top: 24px;
+  }
+  
+  .product-footer strong {
+    font-size: 1.4rem;
+  }
+  
+  .product-footer button {
+    border: 0;
+    border-radius: 10px;
+  
+    padding: 11px 17px;
+  
+    background: var(--zi-primary);
+    color: #ffffff;
+  
+    cursor: pointer;
+  
+    transition:
+      background 180ms ease,
+      transform 180ms ease;
+  }
+  
+  .product-footer button:hover {
+    background: var(--zi-primary-dark);
+    transform: translateY(-2px);
+  }
+  
+  .product-footer button:focus-visible {
+    outline: 3px solid rgba(108, 92, 231, 0.35);
+    outline-offset: 3px;
+  }
+  
+  /* Zoom effect on card hover */
+  
+  .product-card:hover .product-icon {
+    transform: scale(1.08);
+    box-shadow:
+      0 20px 40px rgba(40, 40, 70, 0.18);
+  }
+  
+  /* Carousel indicators */
+  
+  .carousel-controls {
+    display: flex;
+    justify-content: center;
+    gap: 8px;
+  
+    margin-top: 24px;
+  }
+  
+  .control-dot {
+    width: 9px;
+    height: 9px;
+  
+    border-radius: 50%;
+    background: #c8c9d5;
+  }
+  
+  .control-dot.active {
+    width: 25px;
+    border-radius: 10px;
+    background: var(--zi-primary);
+  }
+  
+  .animation-note {
+    margin-top: 18px;
+  
+    text-align: center;
+  
+    color: var(--zi-muted);
+    font-size: 0.8rem;
+  }
+  
+  /*
+    Zoom-In animation
+  
+    0-10%   = hidden and small
+    10-25%  = zoom in
+    25-60%  = visible
+    60-75%  = zoom out
+    75-100% = hidden
+  */
+  
+  @keyframes zoomIn {
+    0% {
+      opacity: 0;
+      transform: scale(0.65);
+    }
+  
+    10% {
+      opacity: 1;
+      transform: scale(1);
+    }
+  
+    25% {
+      opacity: 1;
+      transform: scale(1);
+    }
+  
+    60% {
+      opacity: 1;
+      transform: scale(1);
+    }
+  
+    75% {
+      opacity: 0;
+      transform: scale(1.15);
+    }
+  
+    100% {
+      opacity: 0;
+      transform: scale(1.15);
+    }
+  }
+  
+  /* Tablet */
+  
+  @media (max-width: 768px) {
+    .catalog-demo {
+      padding: 50px 0;
+    }
+  
+    .product-carousel {
+      min-height: 510px;
+      padding: 25px;
+    }
+  
+    .product-card {
+      width: min(410px, 88%);
+    }
+  
+    .product-visual {
+      height: 190px;
+    }
+  }
+  
+  /* Mobile */
+  
+  @media (max-width: 480px) {
+    .catalog-demo {
+      width: 94%;
+      padding: 35px 0;
+    }
+  
+    .catalog-header {
+      margin-bottom: 28px;
+    }
+  
+    .product-carousel {
+      min-height: 500px;
+      padding: 15px;
+    }
+  
+    .product-card {
+      width: 90%;
+    }
+  
+    .product-visual {
+      height: 165px;
+    }
+  
+    .product-icon {
+      width: 95px;
+      height: 95px;
+      font-size: 3rem;
+    }
+  
+    .product-content {
+      padding: 20px;
+    }
+  
+    .product-content h2 {
+      font-size: 1.3rem;
+    }
+  
+    .product-footer {
+      align-items: stretch;
+      flex-direction: column;
+    }
+  
+    .product-footer button {
+      width: 100%;
+    }
+  }
+  
+  /* Accessibility */
+  
+  @media (prefers-reduced-motion: reduce) {
+    .product-card {
+      animation: none;
+      opacity: 1;
+      transform: none;
+    }
+  
+    .product-card:not(:first-child) {
+      display: none;
+    }
+  
+    .product-icon,
+    .product-footer button {
+      transition: none;
+    }
+  }


### PR DESCRIPTION
## Pull Request Description

Adds a pure CSS Zoom-In Carousel for Product Catalog layouts as requested in #62181.

The component provides a responsive product showcase with staggered zoom-in
animations using only HTML and CSS.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained and opens directly in a browser
- [x] Includes `style.css` — pure CSS animation
- [x] Includes `README.md` — usage and documentation
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

### What does this add?

A responsive CSS-only Zoom-In Carousel designed for e-commerce product
catalog layouts.

### How does a developer use it?

```html
<article class="product-card">
  <div class="product-visual">
    <div class="product-icon">⌚</div>
  </div>

  <div class="product-content">
    <h2>Smart Watch</h2>
  </div>
</article>