### PR TITLE
feat(dropdown): add CSS Fade-In Dropdown for SaaS layouts

### DIFF
--- a/submissions/examples/fade-in-dropdown-saas/README.md
+++ b/submissions/examples/fade-in-dropdown-saas/README.md
@@ -1,0 +1,29 @@
+# CSS Fade-In Dropdown for SaaS Showcase Layouts
+
+A lightweight, responsive, pure CSS/HTML dropdown component designed for
+SaaS showcase layouts.
+
+The component provides a clean fade-in navigation menu with subtle
+translation and staggered item animations.
+
+## Features
+
+- Pure HTML and CSS
+- No JavaScript required
+- Smooth fade-in animation
+- Subtle slide-up entrance
+- Staggered dropdown items
+- Hover interaction
+- Keyboard focus support using `:focus-within`
+- Responsive desktop, tablet, and mobile layouts
+- CSS custom properties
+- `prefers-reduced-motion` support
+- Self-contained HTML demo
+
+## Files
+
+```text
+fade-in-dropdown-saas/
+├── demo.html
+├── style.css
+└── README.md

--- a/submissions/examples/fade-in-dropdown-saas/demo.html
+++ b/submissions/examples/fade-in-dropdown-saas/demo.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS Fade-In Dropdown for SaaS Showcase Layouts">
+  <title>Fade-In Dropdown | SaaS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <header class="site-header">
+    <nav class="navbar" aria-label="Main navigation">
+
+      <a href="#" class="logo">SaaSFlow</a>
+
+      <div class="nav-links">
+        <a href="#">Home</a>
+
+        <div class="dropdown">
+          <button class="dropdown-trigger" type="button">
+            Products
+            <span class="arrow" aria-hidden="true">⌄</span>
+          </button>
+
+          <div class="dropdown-menu">
+            <a href="#" class="dropdown-item">
+              <span class="item-icon">◆</span>
+              <span>
+                <strong>Analytics</strong>
+                <small>Understand your business data</small>
+              </span>
+            </a>
+
+            <a href="#" class="dropdown-item">
+              <span class="item-icon">●</span>
+              <span>
+                <strong>Automation</strong>
+                <small>Automate repetitive workflows</small>
+              </span>
+            </a>
+
+            <a href="#" class="dropdown-item">
+              <span class="item-icon">▲</span>
+              <span>
+                <strong>Integrations</strong>
+                <small>Connect your favorite services</small>
+              </span>
+            </a>
+          </div>
+        </div>
+
+        <a href="#">Pricing</a>
+        <a href="#">Resources</a>
+      </div>
+
+      <a href="#" class="nav-button">Get Started</a>
+
+    </nav>
+  </header>
+
+  <main>
+    <section class="hero">
+
+      <div class="hero-content">
+        <span class="eyebrow">SMARTER SAAS</span>
+
+        <h1>
+          Everything your team
+          <span>needs to grow.</span>
+        </h1>
+
+        <p>
+          Manage projects, automate workflows, and gain powerful insights
+          with a simple SaaS platform built for modern teams.
+        </p>
+
+        <div class="hero-actions">
+          <a href="#" class="primary-button">Start Free Trial</a>
+          <a href="#" class="secondary-button">Explore Platform</a>
+        </div>
+      </div>
+
+      <div class="dashboard-card">
+
+        <div class="dashboard-header">
+          <div>
+            <small>Overview</small>
+            <h2>Performance</h2>
+          </div>
+
+          <span class="live-status">● Live</span>
+        </div>
+
+        <div class="metrics">
+          <div class="metric">
+            <span>Revenue</span>
+            <strong>$48,290</strong>
+            <small class="positive">+18.6%</small>
+          </div>
+
+          <div class="metric">
+            <span>Customers</span>
+            <strong>8,420</strong>
+            <small class="positive">+12.4%</small>
+          </div>
+        </div>
+
+        <div class="chart">
+          <span style="height: 35%"></span>
+          <span style="height: 48%"></span>
+          <span style="height: 42%"></span>
+          <span style="height: 63%"></span>
+          <span style="height: 56%"></span>
+          <span style="height: 78%"></span>
+          <span style="height: 92%"></span>
+        </div>
+
+      </div>
+
+    </section>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/fade-in-dropdown-saas/style.css
+++ b/submissions/examples/fade-in-dropdown-saas/style.css
@@ -1,0 +1,592 @@
+:root {
+    --fi-primary: #635bff;
+    --fi-primary-dark: #5148e8;
+    --fi-background: #f6f7fb;
+    --fi-surface: #ffffff;
+    --fi-text: #181a2a;
+    --fi-muted: #707487;
+    --fi-border: #e5e7ef;
+    --fi-radius: 14px;
+    --fi-fade-duration: 280ms;
+    --fi-easing: ease-out;
+  }
+  
+  * {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+  }
+  
+  html {
+    scroll-behavior: smooth;
+  }
+  
+  body {
+    min-height: 100vh;
+    font-family:
+      Inter,
+      system-ui,
+      -apple-system,
+      BlinkMacSystemFont,
+      "Segoe UI",
+      sans-serif;
+  
+    color: var(--fi-text);
+    background: var(--fi-background);
+  }
+  
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
+  
+  /* Navigation */
+  
+  .site-header {
+    background: var(--fi-surface);
+    border-bottom: 1px solid var(--fi-border);
+  }
+  
+  .navbar {
+    width: min(1180px, calc(100% - 40px));
+    min-height: 76px;
+    margin: auto;
+  
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 30px;
+  }
+  
+  .logo {
+    font-size: 1.35rem;
+    font-weight: 800;
+    letter-spacing: -0.04em;
+  }
+  
+  .nav-links {
+    display: flex;
+    align-items: center;
+    gap: 28px;
+  }
+  
+  .nav-links > a,
+  .dropdown-trigger {
+    color: var(--fi-muted);
+    font-size: 0.95rem;
+    font-weight: 600;
+  }
+  
+  .nav-links > a {
+    transition:
+      color 180ms ease,
+      transform 180ms ease;
+  }
+  
+  .nav-links > a:hover {
+    color: var(--fi-primary);
+    transform: translateY(-1px);
+  }
+  
+  /* Fade-In Dropdown */
+  
+  .dropdown {
+    position: relative;
+  }
+  
+  .dropdown-trigger {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+  
+    padding: 12px 0;
+  
+    border: 0;
+    background: transparent;
+  
+    font-family: inherit;
+    cursor: pointer;
+  }
+  
+  .arrow {
+    transition: transform 180ms ease;
+  }
+  
+  .dropdown-menu {
+    position: absolute;
+    top: calc(100% + 12px);
+    left: 50%;
+    z-index: 20;
+  
+    width: 290px;
+    padding: 10px;
+  
+    background: var(--fi-surface);
+    border: 1px solid var(--fi-border);
+    border-radius: var(--fi-radius);
+  
+    box-shadow: 0 20px 50px rgba(25, 30, 60, 0.14);
+  
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+  
+    transform: translate(-50%, 8px);
+  
+    transition:
+      opacity var(--fi-fade-duration) var(--fi-easing),
+      transform var(--fi-fade-duration) var(--fi-easing),
+      visibility var(--fi-fade-duration) var(--fi-easing);
+  }
+  
+  /*
+   * Opens when the user hovers over the dropdown
+   * or focuses any element inside it.
+   */
+  
+  .dropdown:hover .dropdown-menu,
+  .dropdown:focus-within .dropdown-menu {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+    transform: translate(-50%, 0);
+  }
+  
+  .dropdown:hover .arrow,
+  .dropdown:focus-within .arrow {
+    transform: rotate(180deg);
+  }
+  
+  /* Dropdown Items */
+  
+  .dropdown-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  
+    padding: 13px;
+  
+    border-radius: 10px;
+  
+    opacity: 0;
+    transform: translateY(6px);
+  
+    transition:
+      opacity 220ms ease,
+      transform 220ms ease,
+      background 180ms ease;
+  }
+  
+  .dropdown:hover .dropdown-item,
+  .dropdown:focus-within .dropdown-item {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  
+  .dropdown:hover .dropdown-item:nth-child(1),
+  .dropdown:focus-within .dropdown-item:nth-child(1) {
+    transition-delay: 40ms;
+  }
+  
+  .dropdown:hover .dropdown-item:nth-child(2),
+  .dropdown:focus-within .dropdown-item:nth-child(2) {
+    transition-delay: 90ms;
+  }
+  
+  .dropdown:hover .dropdown-item:nth-child(3),
+  .dropdown:focus-within .dropdown-item:nth-child(3) {
+    transition-delay: 140ms;
+  }
+  
+  .dropdown-item:hover {
+    background: #f1f2ff;
+  }
+  
+  .item-icon {
+    width: 38px;
+    height: 38px;
+  
+    display: grid;
+    place-items: center;
+    flex-shrink: 0;
+  
+    color: var(--fi-primary);
+    background: #eef0ff;
+    border-radius: 10px;
+  }
+  
+  .dropdown-item strong {
+    display: block;
+    margin-bottom: 3px;
+    font-size: 0.9rem;
+  }
+  
+  .dropdown-item small {
+    display: block;
+    color: var(--fi-muted);
+    font-size: 0.76rem;
+    line-height: 1.4;
+  }
+  
+  /* Navigation Button */
+  
+  .nav-button {
+    padding: 11px 18px;
+  
+    color: white;
+    background: var(--fi-primary);
+    border-radius: 9px;
+  
+    font-size: 0.9rem;
+    font-weight: 700;
+  
+    transition:
+      background 180ms ease,
+      transform 180ms ease;
+  }
+  
+  .nav-button:hover {
+    background: var(--fi-primary-dark);
+    transform: translateY(-2px);
+  }
+  
+  /* Hero */
+  
+  .hero {
+    width: min(1180px, calc(100% - 40px));
+    min-height: calc(100vh - 77px);
+    margin: auto;
+  
+    display: grid;
+    grid-template-columns: 1.05fr 0.95fr;
+    align-items: center;
+    gap: 80px;
+  }
+  
+  .hero-content {
+    animation: fade-up 700ms ease-out both;
+  }
+  
+  .eyebrow {
+    display: inline-block;
+    margin-bottom: 18px;
+  
+    color: var(--fi-primary);
+  
+    font-size: 0.78rem;
+    font-weight: 800;
+    letter-spacing: 0.14em;
+  }
+  
+  h1 {
+    max-width: 650px;
+  
+    font-size: clamp(2.7rem, 6vw, 5rem);
+    line-height: 0.98;
+    letter-spacing: -0.065em;
+  }
+  
+  h1 span {
+    display: block;
+    color: var(--fi-primary);
+  }
+  
+  .hero-content > p {
+    max-width: 570px;
+    margin-top: 25px;
+  
+    color: var(--fi-muted);
+    font-size: 1.08rem;
+    line-height: 1.7;
+  }
+  
+  .hero-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-top: 32px;
+  }
+  
+  .primary-button,
+  .secondary-button {
+    padding: 13px 20px;
+    border-radius: 10px;
+    font-weight: 700;
+  
+    transition:
+      transform 180ms ease,
+      box-shadow 180ms ease;
+  }
+  
+  .primary-button {
+    color: white;
+    background: var(--fi-primary);
+  }
+  
+  .secondary-button {
+    background: white;
+    border: 1px solid var(--fi-border);
+  }
+  
+  .primary-button:hover,
+  .secondary-button:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 12px 25px rgba(30, 32, 55, 0.12);
+  }
+  
+  /* Dashboard */
+  
+  .dashboard-card {
+    padding: 25px;
+  
+    background: var(--fi-surface);
+    border: 1px solid var(--fi-border);
+    border-radius: 20px;
+  
+    box-shadow: 0 25px 70px rgba(30, 32, 55, 0.12);
+  
+    animation: fade-in 900ms ease-out 150ms both;
+  }
+  
+  .dashboard-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  
+    padding-bottom: 20px;
+    border-bottom: 1px solid var(--fi-border);
+  }
+  
+  .dashboard-header small {
+    display: block;
+    margin-bottom: 4px;
+    color: var(--fi-muted);
+  }
+  
+  .dashboard-header h2 {
+    font-size: 1.15rem;
+  }
+  
+  .live-status {
+    color: #1c9c5c;
+    font-size: 0.8rem;
+    font-weight: 700;
+  }
+  
+  .metrics {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 15px;
+    margin-top: 22px;
+  }
+  
+  .metric {
+    padding: 18px;
+    background: var(--fi-background);
+    border-radius: 12px;
+  }
+  
+  .metric > span {
+    display: block;
+    margin-bottom: 8px;
+    color: var(--fi-muted);
+    font-size: 0.82rem;
+  }
+  
+  .metric strong {
+    display: block;
+    margin-bottom: 6px;
+    font-size: 1.4rem;
+  }
+  
+  .metric .positive {
+    color: #1c9c5c;
+    font-size: 0.78rem;
+    font-weight: 700;
+  }
+  
+  .chart {
+    height: 170px;
+    margin-top: 20px;
+  
+    display: flex;
+    align-items: flex-end;
+    gap: 10px;
+  
+    padding: 20px;
+  
+    background: #f8f8fc;
+    border-radius: 12px;
+  }
+  
+  .chart span {
+    flex: 1;
+  
+    background: var(--fi-primary);
+    border-radius: 6px 6px 2px 2px;
+  
+    transform-origin: bottom;
+  
+    animation: chart-grow 800ms ease-out both;
+  }
+  
+  .chart span:nth-child(1) {
+    animation-delay: 100ms;
+  }
+  
+  .chart span:nth-child(2) {
+    animation-delay: 160ms;
+  }
+  
+  .chart span:nth-child(3) {
+    animation-delay: 220ms;
+  }
+  
+  .chart span:nth-child(4) {
+    animation-delay: 280ms;
+  }
+  
+  .chart span:nth-child(5) {
+    animation-delay: 340ms;
+  }
+  
+  .chart span:nth-child(6) {
+    animation-delay: 400ms;
+  }
+  
+  .chart span:nth-child(7) {
+    animation-delay: 460ms;
+  }
+  
+  /* Animations */
+  
+  @keyframes fade-in {
+    from {
+      opacity: 0;
+    }
+  
+    to {
+      opacity: 1;
+    }
+  }
+  
+  @keyframes fade-up {
+    from {
+      opacity: 0;
+      transform: translateY(25px);
+    }
+  
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+  
+  @keyframes chart-grow {
+    from {
+      transform: scaleY(0);
+    }
+  
+    to {
+      transform: scaleY(1);
+    }
+  }
+  
+  /* Responsive */
+  
+  @media (max-width: 850px) {
+    .navbar {
+      flex-wrap: wrap;
+      padding: 15px 0;
+    }
+  
+    .nav-links {
+      order: 3;
+      width: 100%;
+      justify-content: center;
+      gap: 20px;
+    }
+  
+    .hero {
+      grid-template-columns: 1fr;
+      gap: 45px;
+      padding: 70px 0;
+    }
+  
+    .hero-content {
+      text-align: center;
+    }
+  
+    .hero-content > p {
+      margin-left: auto;
+      margin-right: auto;
+    }
+  
+    .hero-actions {
+      justify-content: center;
+    }
+  }
+  
+  @media (max-width: 560px) {
+    .navbar {
+      width: calc(100% - 24px);
+    }
+  
+    .logo {
+      font-size: 1.15rem;
+    }
+  
+    .nav-button {
+      padding: 9px 12px;
+    }
+  
+    .nav-links {
+      gap: 14px;
+    }
+  
+    .nav-links > a,
+    .dropdown-trigger {
+      font-size: 0.82rem;
+    }
+  
+    .hero {
+      width: calc(100% - 24px);
+      padding: 50px 0;
+    }
+  
+    h1 {
+      font-size: clamp(2.35rem, 13vw, 3.5rem);
+    }
+  
+    .dashboard-card {
+      padding: 18px;
+    }
+  
+    .dropdown-menu {
+      left: 0;
+      width: min(290px, calc(100vw - 24px));
+  
+      transform: translate(0, 8px);
+    }
+  
+    .dropdown:hover .dropdown-menu,
+    .dropdown:focus-within .dropdown-menu {
+      transform: translate(0, 0);
+    }
+  }
+  
+  /* Reduced Motion */
+  
+  @media (prefers-reduced-motion: reduce) {
+    html {
+      scroll-behavior: auto;
+    }
+  
+    *,
+    *::before,
+    *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+    }
+  }


### PR DESCRIPTION
## Pull Request Description

Adds a pure CSS/HTML Fade-In Dropdown for SaaS Showcase Layouts as requested in #62087.

The component provides a responsive SaaS navigation dropdown with smooth
fade-in, slide-up, and staggered menu-item animations.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

### What does this add?

A responsive CSS-only Fade-In Dropdown for SaaS showcase navigation layouts.

### How does a developer use it?

```html
<div class="dropdown">
  <button class="dropdown-trigger" type="button">
    Products
  </button>

  <div class="dropdown-menu">
    <a href="#" class="dropdown-item">
      Analytics
    </a>
  </div>
</div>