### PR TITLE
Add ease-wifi-signal-strength component

### DIFF
--- a/submissions/examples/wifi-signal-strength-ij/README.md
+++ b/submissions/examples/wifi-signal-strength-ij/README.md
@@ -1,0 +1,10 @@
+# ease-wifi-signal-strength
+
+A wifi strength panel whose signal arcs pulse outward from the router while the device dot hops to connect.
+
+## Run
+Open `demo.html` directly in a browser to watch the wifi connect.
+
+## Notes
+- Four arcs pulse in sequence.
+- The status text blinks while linking.

--- a/submissions/examples/wifi-signal-strength-ij/demo.html
+++ b/submissions/examples/wifi-signal-strength-ij/demo.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-wifi-signal-strength demo</title>
+</head>
+<body>
+<div class="wf-app">
+  <span class="wf-title">WIFI PANEL</span>
+  <div class="wf-stage">
+    <span class="wf-arc wf-arc-1"></span>
+    <span class="wf-arc wf-arc-2"></span>
+    <span class="wf-arc wf-arc-3"></span>
+    <span class="wf-arc wf-arc-4"></span>
+    <span class="wf-dot"></span>
+    <span class="wf-router"></span>
+  </div>
+  <span class="wf-status">CONNECTING</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/wifi-signal-strength-ij/style.css
+++ b/submissions/examples/wifi-signal-strength-ij/style.css
@@ -1,0 +1,16 @@
+:root{--wf-blue:#3e9bff;--wf-ink:#10243c}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#10243c,#0a1622);font-family:'Segoe UI',sans-serif}
+.wf-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#0f2138,#091520);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.wf-title{position:absolute;top:16px;left:0;right:0;text-align:center;font-size:13px;font-weight:800;letter-spacing:6px;color:#7db9ff}
+.wf-stage{position:absolute;top:56px;left:58px;width:256px;height:256px;border-radius:50%;background:radial-gradient(circle,#0c1d31,#08131f);box-shadow:0 0 0 3px #17324f,inset 0 0 26px rgba(62,155,255,0.18)}
+.wf-arc{position:absolute;left:50%;top:50%;border:4px solid var(--wf-blue);border-radius:50%;transform:translate(-50%,-50%);opacity:0.35;animation:arc-pulse-wifi-signal-strength 2.2s ease-in-out infinite}
+.wf-arc-1{width:64px;height:64px;border-bottom-color:transparent;border-left-color:transparent}
+.wf-arc-2{width:104px;height:104px;border-bottom-color:transparent;border-left-color:transparent;animation-delay:0.18s}
+.wf-arc-3{width:144px;height:144px;border-bottom-color:transparent;border-left-color:transparent;animation-delay:0.36s}
+.wf-arc-4{width:184px;height:184px;border-bottom-color:transparent;border-left-color:transparent;animation-delay:0.54s}
+.wf-dot{position:absolute;left:50%;top:50%;width:22px;height:22px;margin:-11px 0 0 -11px;border-radius:50%;background:#dbefff;box-shadow:0 0 18px var(--wf-blue);animation:dot-pulse-wifi-signal-strength 2.2s ease-in-out infinite}
+.wf-router{position:absolute;left:50%;top:50%;width:56px;height:56px;margin:-28px 0 0 -28px;border-radius:50%;background:radial-gradient(circle,#1c3f66,#0f2238);box-shadow:0 0 0 4px #17324f}
+.wf-status{position:absolute;bottom:22px;left:0;right:0;text-align:center;font-size:14px;font-weight:800;letter-spacing:5px;color:#7db9ff;animation:status-blink-wifi-signal-strength 1.4s steps(1) infinite}
+@keyframes arc-pulse-wifi-signal-strength{0%,100%{opacity:0.22}50%{opacity:0.9}}
+@keyframes dot-pulse-wifi-signal-strength{0%,100%{transform:scale(0.7);box-shadow:0 0 10px rgba(62,155,255,0.5)}50%{transform:scale(1.15);box-shadow:0 0 26px var(--wf-blue)}}
+@keyframes status-blink-wifi-signal-strength{0%,100%{opacity:1}50%{opacity:0.3}}


### PR DESCRIPTION
## Component: ease-wifi-signal-strength — signal arcs pulse, dot hops, and status blinks

**Closes #62854**

### What this adds
A wifi strength panel: the four signal arcs pulse outward from the router, the device dot hops between the arcs, and the connection status blinks while it links up.

### Acceptance Criteria covered
- Signal arcs pulse outward from the router
- Device dot hops between the arcs
- Connection status blinks while linking

### Files
- submissions/examples/wifi-signal-strength-ij/demo.html
- submissions/examples/wifi-signal-strength-ij/style.css
- submissions/examples/wifi-signal-strength-ij/README.md

### How to review
Open `demo.html` in a browser and watch the wifi connect.