### PR TITLE
Add ease-piano-keys-wave component

### DIFF
--- a/submissions/examples/piano-keys-wave-ij/README.md
+++ b/submissions/examples/piano-keys-wave-ij/README.md
@@ -1,0 +1,10 @@
+# ease-piano-keys-wave
+
+A piano keyboard whose white keys press one after another while the black keys dip and note dots travel along the top.
+
+## Run
+Open `demo.html` directly in a browser to watch the keys press.
+
+## Notes
+- Each key has its own press delay.
+- Note dots travel along the track.

--- a/submissions/examples/piano-keys-wave-ij/demo.html
+++ b/submissions/examples/piano-keys-wave-ij/demo.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-piano-keys-wave demo</title>
+</head>
+<body>
+<div class="pn-app">
+  <span class="pn-title">PIANO</span>
+  <div class="pn-track">
+    <span class="pn-note pn-note-1"></span>
+    <span class="pn-note pn-note-2"></span>
+    <span class="pn-note pn-note-3"></span>
+    <span class="pn-note pn-note-4"></span>
+  </div>
+  <div class="pn-keys">
+    <span class="pn-white pn-w1"></span>
+    <span class="pn-black pn-b1"></span>
+    <span class="pn-white pn-w2"></span>
+    <span class="pn-black pn-b2"></span>
+    <span class="pn-white pn-w3"></span>
+    <span class="pn-white pn-w4"></span>
+    <span class="pn-black pn-b3"></span>
+    <span class="pn-white pn-w5"></span>
+    <span class="pn-black pn-b4"></span>
+    <span class="pn-white pn-w6"></span>
+    <span class="pn-black pn-b5"></span>
+    <span class="pn-white pn-w7"></span>
+    <span class="pn-white pn-w8"></span>
+    <span class="pn-black pn-b6"></span>
+    <span class="pn-white pn-w9"></span>
+  </div>
+  <span class="pn-caption">row 5 &mdash; the wave is playing</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/piano-keys-wave-ij/style.css
+++ b/submissions/examples/piano-keys-wave-ij/style.css
@@ -1,0 +1,21 @@
+:root{--pn-ivory:#f3f0e8;--pn-ebony:#181612;--pn-gold:#d9a13b}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#2a2012,#171008);font-family:'Segoe UI',sans-serif}
+.pn-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#221a0e,#130d05);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.pn-title{position:absolute;top:16px;left:0;right:0;text-align:center;font-size:13px;font-weight:800;letter-spacing:6px;color:#d9c28a}
+.pn-track{position:absolute;top:46px;left:40px;width:292px;height:34px;border-radius:8px;background:#0f0b04;box-shadow:inset 0 0 0 2px #332812;display:flex;align-items:center;justify-content:space-around}
+.pn-note{width:14px;height:14px;border-radius:50%;background:var(--pn-gold);box-shadow:0 0 12px rgba(217,161,59,0.7);opacity:0;animation:note-travel-piano-keys-wave 2.4s linear infinite}
+.pn-note-2{animation-delay:0.6s}
+.pn-note-3{animation-delay:1.2s}
+.pn-note-4{animation-delay:1.8s}
+.pn-keys{position:absolute;top:92px;left:40px;width:292px;height:196px;border-radius:10px;background:#0f0b04;box-shadow:inset 0 0 0 3px #332812;display:flex}
+.pn-white{flex:1;background:linear-gradient(180deg,var(--pn-ivory),#cfc9b6);border-right:2px solid #332812;border-radius:0 0 6px 6px;transform-origin:top;animation:white-press-piano-keys-wave 2.4s linear infinite}
+.pn-black{width:22px;margin:0 -11px;height:118px;background:linear-gradient(180deg,var(--pn-ebony),#050403);border-radius:0 0 4px 4px;z-index:2;transform-origin:top;animation:black-press-piano-keys-wave 2.4s linear infinite}
+.pn-w1{animation-delay:0.12s}.pn-b1{animation-delay:0.36s}
+.pn-w2{animation-delay:0.6s}.pn-b2{animation-delay:0.84s}
+.pn-w3{animation-delay:1.08s}.pn-w4{animation-delay:1.32s}
+.pn-b3{animation-delay:1.56s}.pn-w5{animation-delay:1.8s}
+.pn-b4{animation-delay:2.04s}
+.pn-caption{position:absolute;bottom:18px;left:0;right:0;text-align:center;font-size:12px;color:#a88f4e;letter-spacing:2px}
+@keyframes white-press-piano-keys-wave{0%,100%{transform:scaleY(1)}40%{transform:scaleY(0.94)}}
+@keyframes black-press-piano-keys-wave{0%,100%{transform:scaleY(1)}40%{transform:scaleY(0.9)}}
+@keyframes note-travel-piano-keys-wave{0%{opacity:0;transform:translateX(-120px)}12%{opacity:1}88%{opacity:1}100%{opacity:0;transform:translateX(120px)}}


### PR DESCRIPTION
## Component: ease-piano-keys-wave — white keys press, black keys dip, and note dots travel

**Closes #62857**

### What this adds
A piano keyboard: the white keys press down one after another, the black keys dip between them, and bright note dots travel along the top edge as the tune plays.

### Acceptance Criteria covered
- White keys press one after another
- Black keys dip between them
- Note dots travel along the top

### Files
- submissions/examples/piano-keys-wave-ij/demo.html
- submissions/examples/piano-keys-wave-ij/style.css
- submissions/examples/piano-keys-wave-ij/README.md

### How to review
Open `demo.html` in a browser and watch the keys press.