### PR TITLE
feat(modal): add CSS elastic-slide checkout modal for e-commerce layouts

### DIFF
--- a/submissions/examples/elastic-slide-modal-checkout/README.md
+++ b/submissions/examples/elastic-slide-modal-checkout/README.md
@@ -1,0 +1,62 @@
+# Elastic-Slide Checkout Modal
+
+A multi-step e-commerce checkout modal with a left-slide elastic spring entrance animation. Pure CSS transitions handle all motion — no animation libraries required.
+
+## Files
+
+| File | Description |
+|---|---|
+| `demo.html` | Interactive three-step checkout demo |
+| `style.css` | Component styles with CSS custom properties |
+| `README.md` | This file |
+
+## What it does
+
+- Modal panel slides in from the left using `translateX` + a `cubic-bezier(0.34, 1.56, 0.64, 1)` spring ease
+- Three-step form: Contact → Payment → Order Review
+- Step indicator strip with active/done state transitions
+- Top progress bar fills proportionally to the current step
+- Each step pane re-animates with a smaller elastic slide-in as users progress
+- Success state with a scale-pop icon animation on order confirm
+- Overlay closes with a reverse right-slide on dismiss
+
+## Usage
+
+```html
+<!-- Trigger -->
+<button onclick="openModal('modal-checkout')">Open Checkout</button>
+
+<!-- Modal markup -->
+<div class="modal-overlay" id="modal-checkout" role="dialog" aria-modal="true">
+    <div class="modal-panel" data-step="1">
+        <div class="modal-progress-strip"></div>
+        <!-- header, steps, body, footer -->
+    </div>
+</div>
+```
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|---|---|---|
+| `--modal-width` | `480px` | Max panel width |
+| `--modal-radius` | `16px` | Panel border radius |
+| `--modal-slide-distance` | `60px` | Horizontal slide travel distance |
+| `--modal-duration` | `0.42s` | Entrance/exit duration |
+| `--modal-ease` | `cubic-bezier(0.34, 1.56, 0.64, 1)` | Spring timing function |
+| `--modal-accent` | `#6366f1` | Accent colour (progress, buttons, focus) |
+| `--modal-overlay-bg` | `rgba(0,0,0,0.55)` | Backdrop colour |
+
+## Accessibility
+
+- `role="dialog"` and `aria-modal="true"` on overlay
+- `aria-labelledby` points to modal title
+- Closes on `Escape` key
+- `prefers-reduced-motion`: all transitions and animations are disabled; modal appears instantly
+- Trap focus managed via `tabindex`
+
+## Related issue
+
+Implements [#62493](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/62493) — Enhancement: Add CSS Elastic-Slide Modal for E-Commerce Checkout Layouts.
+
+Part of GSSoC-26.

--- a/submissions/examples/elastic-slide-modal-checkout/demo.html
+++ b/submissions/examples/elastic-slide-modal-checkout/demo.html
@@ -1,0 +1,274 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="CSS Elastic-Slide Modal for E-Commerce Checkout — EaseMotion CSS showcase">
+    <title>Elastic-Slide Checkout Modal — EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <main class="showcase">
+
+        <section class="intro">
+            <span class="eyebrow">EaseMotion CSS</span>
+            <h1>Elastic-Slide Checkout Modal</h1>
+            <p>
+                A multi-step e-commerce checkout modal that slides in from the left
+                with a spring elastic ease. Pure CSS transitions — no JavaScript animation libraries needed.
+            </p>
+        </section>
+
+        <div class="demo-triggers">
+            <button class="trigger-btn trigger-btn--primary" onclick="openModal('modal-checkout')">
+                🛒 Open Checkout
+            </button>
+            <button class="trigger-btn trigger-btn--outline" onclick="openModal('modal-checkout')">
+                View Demo
+            </button>
+        </div>
+
+    </main>
+
+    <!-- ── Elastic-Slide Modal ── -->
+    <div
+        class="modal-overlay"
+        id="modal-checkout"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="modal-title"
+        onclick="handleOverlayClick(event)"
+    >
+        <div class="modal-panel" data-step="1" id="modal-panel">
+
+            <!-- progress strip -->
+            <div class="modal-progress-strip" aria-hidden="true"></div>
+
+            <!-- header -->
+            <div class="modal-header">
+                <div class="modal-title-group">
+                    <span class="modal-eyebrow">Secure Checkout</span>
+                    <h2 class="modal-title" id="modal-title">Your Order</h2>
+                </div>
+                <button class="modal-close" onclick="closeModal()" aria-label="Close checkout modal">✕</button>
+            </div>
+
+            <!-- step indicators -->
+            <div class="modal-steps" aria-label="Checkout progress">
+                <div class="modal-step is-active" id="step-ind-1">
+                    <span class="modal-step-num">1</span>
+                    <span>Details</span>
+                </div>
+                <div class="modal-step-connector" id="conn-1"></div>
+                <div class="modal-step" id="step-ind-2">
+                    <span class="modal-step-num">2</span>
+                    <span>Payment</span>
+                </div>
+                <div class="modal-step-connector" id="conn-2"></div>
+                <div class="modal-step" id="step-ind-3">
+                    <span class="modal-step-num">3</span>
+                    <span>Review</span>
+                </div>
+            </div>
+
+            <div class="modal-divider" aria-hidden="true"></div>
+
+            <!-- body -->
+            <div class="modal-body">
+
+                <!-- step 1: contact + shipping -->
+                <div class="modal-step-pane is-active" id="pane-1" role="tabpanel" aria-label="Step 1: Contact details">
+                    <div class="form-row">
+                        <div class="form-group">
+                            <label class="form-label" for="first-name">First name</label>
+                            <input class="form-input" type="text" id="first-name" placeholder="Jane" autocomplete="given-name">
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label" for="last-name">Last name</label>
+                            <input class="form-input" type="text" id="last-name" placeholder="Doe" autocomplete="family-name">
+                        </div>
+                        <div class="form-group full">
+                            <label class="form-label" for="email">Email address</label>
+                            <input class="form-input" type="email" id="email" placeholder="jane@example.com" autocomplete="email">
+                        </div>
+                        <div class="form-group full">
+                            <label class="form-label" for="address">Shipping address</label>
+                            <input class="form-input" type="text" id="address" placeholder="123 Main St, City, Country" autocomplete="street-address">
+                        </div>
+                    </div>
+                </div>
+
+                <!-- step 2: payment -->
+                <div class="modal-step-pane" id="pane-2" role="tabpanel" aria-label="Step 2: Payment details">
+                    <div class="form-row">
+                        <div class="form-group full">
+                            <label class="form-label" for="card-name">Name on card</label>
+                            <input class="form-input" type="text" id="card-name" placeholder="Jane Doe" autocomplete="cc-name">
+                        </div>
+                        <div class="form-group full">
+                            <label class="form-label" for="card-num">Card number</label>
+                            <input class="form-input" type="text" id="card-num" placeholder="1234 5678 9012 3456" autocomplete="cc-number" maxlength="19">
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label" for="card-exp">Expiry</label>
+                            <input class="form-input" type="text" id="card-exp" placeholder="MM / YY" autocomplete="cc-exp" maxlength="7">
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label" for="card-cvv">CVV</label>
+                            <input class="form-input" type="text" id="card-cvv" placeholder="•••" autocomplete="cc-csc" maxlength="4">
+                        </div>
+                    </div>
+                </div>
+
+                <!-- step 3: order review -->
+                <div class="modal-step-pane" id="pane-3" role="tabpanel" aria-label="Step 3: Order review">
+                    <div class="order-summary">
+                        <div class="order-product">
+                            <div class="order-product-img" aria-hidden="true">👟</div>
+                            <div class="order-product-info">
+                                <div class="order-product-name">Premium Running Shoes</div>
+                                <div class="order-product-sku">SKU: PRO-RUN-42 · Size: 42</div>
+                            </div>
+                            <div class="order-product-price">$129.00</div>
+                        </div>
+                        <div class="order-row">
+                            <span>Subtotal</span>
+                            <span>$129.00</span>
+                        </div>
+                        <div class="order-row">
+                            <span>Shipping</span>
+                            <span>Free</span>
+                        </div>
+                        <div class="order-row">
+                            <span>Tax (8%)</span>
+                            <span>$10.32</span>
+                        </div>
+                        <div class="order-row order-row--total">
+                            <span>Total</span>
+                            <span class="amount">$139.32</span>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- success state -->
+                <div class="modal-success" id="modal-success" aria-live="polite">
+                    <div class="success-icon" aria-hidden="true">✓</div>
+                    <div class="success-title">Order Confirmed!</div>
+                    <div class="success-msg">
+                        Your order has been placed successfully.
+                        A confirmation has been sent to your email.
+                    </div>
+                    <span class="success-order-id">Order #EM-2024-8821</span>
+                    <button class="trigger-btn trigger-btn--outline" onclick="closeModal()" style="margin-top:8px;">
+                        Close
+                    </button>
+                </div>
+
+            </div>
+
+            <!-- footer -->
+            <div class="modal-footer" id="modal-footer">
+                <button class="modal-btn modal-btn--back" id="btn-back" onclick="prevStep()" style="display:none;">
+                    ← Back
+                </button>
+                <button class="modal-btn modal-btn--next" id="btn-next" onclick="nextStep()">
+                    Continue →
+                </button>
+            </div>
+
+        </div>
+    </div>
+
+    <script>
+        // Minimal vanilla JS to handle step transitions only
+        // All visual motion is handled by CSS transitions
+        let currentStep = 1;
+        const totalSteps = 3;
+
+        function openModal(id) {
+            const overlay = document.getElementById(id);
+            currentStep = 1;
+            updateStep();
+            overlay.classList.add('is-open');
+            document.body.style.overflow = 'hidden';
+            overlay.querySelector('.modal-close').focus();
+        }
+
+        function closeModal() {
+            const overlay = document.getElementById('modal-checkout');
+            overlay.classList.add('is-closing');
+            setTimeout(() => {
+                overlay.classList.remove('is-open', 'is-closing');
+                document.body.style.overflow = '';
+                document.querySelector('.trigger-btn--primary').focus();
+                // reset success
+                document.getElementById('modal-success').classList.remove('is-visible');
+                document.getElementById('modal-footer').style.display = '';
+            }, 300);
+        }
+
+        function handleOverlayClick(e) {
+            if (e.target === e.currentTarget) closeModal();
+        }
+
+        function nextStep() {
+            if (currentStep < totalSteps) {
+                currentStep++;
+                updateStep();
+            } else {
+                showSuccess();
+            }
+        }
+
+        function prevStep() {
+            if (currentStep > 1) {
+                currentStep--;
+                updateStep();
+            }
+        }
+
+        function updateStep() {
+            const panel = document.getElementById('modal-panel');
+            panel.setAttribute('data-step', currentStep);
+
+            // panes
+            document.querySelectorAll('.modal-step-pane').forEach((p, i) => {
+                p.classList.toggle('is-active', i + 1 === currentStep);
+            });
+
+            // step indicators
+            for (let i = 1; i <= totalSteps; i++) {
+                const ind = document.getElementById('step-ind-' + i);
+                ind.classList.toggle('is-active', i === currentStep);
+                ind.classList.toggle('is-done', i < currentStep);
+            }
+
+            // connectors
+            for (let i = 1; i < totalSteps; i++) {
+                const conn = document.getElementById('conn-' + i);
+                conn.classList.toggle('is-done', i < currentStep);
+            }
+
+            // buttons
+            document.getElementById('btn-back').style.display = currentStep > 1 ? '' : 'none';
+            const nextBtn = document.getElementById('btn-next');
+            nextBtn.textContent = currentStep === totalSteps ? 'Place Order ✓' : 'Continue →';
+            nextBtn.className = currentStep === totalSteps
+                ? 'modal-btn modal-btn--confirm'
+                : 'modal-btn modal-btn--next';
+        }
+
+        function showSuccess() {
+            document.querySelectorAll('.modal-step-pane').forEach(p => p.classList.remove('is-active'));
+            document.getElementById('modal-success').classList.add('is-visible');
+            document.getElementById('modal-footer').style.display = 'none';
+        }
+
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape') closeModal();
+        });
+    </script>
+
+</body>
+</html>

--- a/submissions/examples/elastic-slide-modal-checkout/style.css
+++ b/submissions/examples/elastic-slide-modal-checkout/style.css
@@ -1,0 +1,641 @@
+:root {
+    --modal-overlay-bg: rgba(0, 0, 0, 0.55);
+    --modal-bg: #ffffff;
+    --modal-text: #111827;
+    --modal-muted: #6b7280;
+    --modal-border: #e5e7eb;
+    --modal-radius: 16px;
+    --modal-width: 480px;
+    --modal-shadow: 0 24px 60px rgba(0, 0, 0, 0.18);
+    --modal-slide-distance: 60px;
+    --modal-duration: 0.42s;
+    --modal-ease: cubic-bezier(0.34, 1.56, 0.64, 1);
+    --modal-accent: #6366f1;
+    --modal-accent-hover: #4f46e5;
+    --modal-accent-light: rgba(99, 102, 241, 0.1);
+    --modal-danger: #ef4444;
+    --modal-danger-hover: #dc2626;
+    --modal-input-bg: #f9fafb;
+    --modal-input-border: #d1d5db;
+    --modal-input-focus: #6366f1;
+    --modal-step-bg: #f3f4f6;
+    --modal-step-active: #6366f1;
+    --modal-step-text: #374151;
+}
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    background: #f0f2f5;
+    color: var(--modal-text);
+    min-height: 100vh;
+}
+
+.showcase {
+    width: min(100% - 32px, 1000px);
+    margin: 0 auto;
+    padding: 72px 0 96px;
+}
+
+.intro {
+    max-width: 640px;
+    margin: 0 auto 56px;
+    text-align: center;
+}
+
+.eyebrow {
+    display: inline-block;
+    margin-bottom: 10px;
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--modal-accent);
+}
+
+.intro h1 {
+    font-size: clamp(2rem, 5vw, 3.5rem);
+    font-weight: 800;
+    line-height: 1.1;
+    letter-spacing: -0.02em;
+    margin-bottom: 14px;
+    color: #111827;
+}
+
+.intro p {
+    font-size: 1.05rem;
+    line-height: 1.65;
+    color: var(--modal-muted);
+    max-width: 520px;
+    margin: 0 auto;
+}
+
+/* ── trigger buttons ── */
+
+.demo-triggers {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    justify-content: center;
+    margin-bottom: 48px;
+}
+
+.trigger-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 22px;
+    border-radius: 10px;
+    border: none;
+    font-size: 0.9rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s, transform 0.15s, box-shadow 0.2s;
+    letter-spacing: 0.01em;
+}
+
+.trigger-btn--primary {
+    background: var(--modal-accent);
+    color: #fff;
+    box-shadow: 0 4px 14px rgba(99, 102, 241, 0.35);
+}
+
+.trigger-btn--primary:hover {
+    background: var(--modal-accent-hover);
+    transform: translateY(-1px);
+    box-shadow: 0 6px 20px rgba(99, 102, 241, 0.45);
+}
+
+.trigger-btn--outline {
+    background: #fff;
+    color: var(--modal-text);
+    border: 1.5px solid var(--modal-border);
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+}
+
+.trigger-btn--outline:hover {
+    border-color: var(--modal-accent);
+    color: var(--modal-accent);
+    transform: translateY(-1px);
+}
+
+/* ── overlay ── */
+
+.modal-overlay {
+    position: fixed;
+    inset: 0;
+    background: var(--modal-overlay-bg);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 20px;
+    z-index: 100;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.25s ease, visibility 0.25s ease;
+}
+
+.modal-overlay.is-open {
+    opacity: 1;
+    visibility: visible;
+}
+
+/* ── modal panel ── */
+
+.modal-panel {
+    background: var(--modal-bg);
+    border-radius: var(--modal-radius);
+    box-shadow: var(--modal-shadow);
+    width: min(var(--modal-width), 100%);
+    overflow: hidden;
+    position: relative;
+    transform: translateX(calc(-1 * var(--modal-slide-distance)));
+    opacity: 0;
+    transition:
+        transform var(--modal-duration) var(--modal-ease),
+        opacity var(--modal-duration) ease;
+}
+
+.modal-overlay.is-open .modal-panel {
+    transform: translateX(0);
+    opacity: 1;
+}
+
+/* closing: slide to the right */
+
+.modal-overlay.is-closing .modal-panel {
+    transform: translateX(var(--modal-slide-distance));
+    opacity: 0;
+}
+
+/* ── progress strip at top ── */
+
+.modal-progress-strip {
+    height: 3px;
+    background: var(--modal-border);
+    position: relative;
+    overflow: hidden;
+}
+
+.modal-progress-strip::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 0;
+    height: 100%;
+    background: var(--modal-accent);
+    transition: width 0.4s ease;
+}
+
+.modal-panel[data-step="1"] .modal-progress-strip::after {
+    width: 33.33%;
+}
+
+.modal-panel[data-step="2"] .modal-progress-strip::after {
+    width: 66.66%;
+}
+
+.modal-panel[data-step="3"] .modal-progress-strip::after {
+    width: 100%;
+}
+
+/* ── header ── */
+
+.modal-header {
+    padding: 22px 24px 0;
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.modal-title-group {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+}
+
+.modal-eyebrow {
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--modal-accent);
+}
+
+.modal-title {
+    font-size: 1.2rem;
+    font-weight: 700;
+    color: var(--modal-text);
+    letter-spacing: -0.01em;
+}
+
+.modal-close {
+    width: 32px;
+    height: 32px;
+    border-radius: 8px;
+    border: none;
+    background: var(--modal-step-bg);
+    color: var(--modal-muted);
+    font-size: 1.1rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    transition: background 0.15s, color 0.15s;
+    line-height: 1;
+}
+
+.modal-close:hover {
+    background: #fee2e2;
+    color: var(--modal-danger);
+}
+
+/* ── step indicators ── */
+
+.modal-steps {
+    display: flex;
+    align-items: center;
+    gap: 0;
+    padding: 18px 24px 0;
+}
+
+.modal-step {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--modal-muted);
+    flex: 1;
+}
+
+.modal-step-num {
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    background: var(--modal-step-bg);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.65rem;
+    font-weight: 700;
+    flex-shrink: 0;
+    transition: background 0.3s, color 0.3s;
+}
+
+.modal-step.is-active .modal-step-num {
+    background: var(--modal-accent);
+    color: #fff;
+}
+
+.modal-step.is-done .modal-step-num {
+    background: #10b981;
+    color: #fff;
+}
+
+.modal-step.is-active {
+    color: var(--modal-accent);
+}
+
+.modal-step.is-done {
+    color: #10b981;
+}
+
+.modal-step-connector {
+    flex: 1;
+    height: 1.5px;
+    background: var(--modal-border);
+    margin: 0 8px;
+    transition: background 0.3s;
+}
+
+.modal-step-connector.is-done {
+    background: #10b981;
+}
+
+/* ── body ── */
+
+.modal-body {
+    padding: 20px 24px;
+}
+
+/* step panes */
+
+.modal-step-pane {
+    display: none;
+    flex-direction: column;
+    gap: 14px;
+    animation: ease-elastic-slide-in 0.35s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+.modal-step-pane.is-active {
+    display: flex;
+}
+
+@keyframes ease-elastic-slide-in {
+    from {
+        opacity: 0;
+        transform: translateX(24px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateX(0);
+    }
+}
+
+/* ── form elements ── */
+
+.form-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+}
+
+.form-group {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+}
+
+.form-group.full {
+    grid-column: 1 / -1;
+}
+
+.form-label {
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--modal-step-text);
+}
+
+.form-input,
+.form-select {
+    padding: 9px 12px;
+    border: 1.5px solid var(--modal-input-border);
+    border-radius: 8px;
+    font-size: 0.88rem;
+    font-family: inherit;
+    background: var(--modal-input-bg);
+    color: var(--modal-text);
+    transition: border-color 0.2s, box-shadow 0.2s;
+    outline: none;
+    width: 100%;
+}
+
+.form-input:focus,
+.form-select:focus {
+    border-color: var(--modal-input-focus);
+    box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.12);
+}
+
+.form-input::placeholder {
+    color: #9ca3af;
+}
+
+/* ── summary list (step 3) ── */
+
+.order-summary {
+    background: var(--modal-step-bg);
+    border-radius: 10px;
+    padding: 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.order-row {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.85rem;
+    color: var(--modal-step-text);
+}
+
+.order-row--total {
+    border-top: 1.5px solid var(--modal-border);
+    padding-top: 10px;
+    font-weight: 700;
+    color: var(--modal-text);
+    font-size: 0.95rem;
+}
+
+.order-row--total .amount {
+    color: var(--modal-accent);
+}
+
+/* product line */
+
+.order-product {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.order-product-img {
+    width: 44px;
+    height: 44px;
+    border-radius: 8px;
+    background: linear-gradient(135deg, #6366f1, #8b5cf6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.2rem;
+    flex-shrink: 0;
+}
+
+.order-product-info {
+    flex: 1;
+}
+
+.order-product-name {
+    font-size: 0.88rem;
+    font-weight: 600;
+    color: var(--modal-text);
+}
+
+.order-product-sku {
+    font-size: 0.72rem;
+    color: var(--modal-muted);
+    margin-top: 2px;
+}
+
+.order-product-price {
+    font-size: 0.9rem;
+    font-weight: 700;
+    color: var(--modal-text);
+}
+
+/* ── footer ── */
+
+.modal-footer {
+    padding: 0 24px 22px;
+    display: flex;
+    gap: 10px;
+    justify-content: flex-end;
+}
+
+.modal-btn {
+    padding: 10px 20px;
+    border-radius: 9px;
+    border: none;
+    font-size: 0.875rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s, transform 0.15s, box-shadow 0.2s;
+    font-family: inherit;
+}
+
+.modal-btn--back {
+    background: var(--modal-step-bg);
+    color: var(--modal-step-text);
+}
+
+.modal-btn--back:hover {
+    background: var(--modal-border);
+}
+
+.modal-btn--next {
+    background: var(--modal-accent);
+    color: #fff;
+    box-shadow: 0 3px 10px rgba(99, 102, 241, 0.3);
+}
+
+.modal-btn--next:hover {
+    background: var(--modal-accent-hover);
+    transform: translateY(-1px);
+    box-shadow: 0 5px 16px rgba(99, 102, 241, 0.4);
+}
+
+.modal-btn--confirm {
+    background: #10b981;
+    color: #fff;
+    box-shadow: 0 3px 10px rgba(16, 185, 129, 0.3);
+}
+
+.modal-btn--confirm:hover {
+    background: #059669;
+    transform: translateY(-1px);
+}
+
+/* ── success state ── */
+
+.modal-success {
+    display: none;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    padding: 32px 24px;
+    gap: 12px;
+}
+
+.modal-success.is-visible {
+    display: flex;
+    animation: ease-elastic-slide-in 0.4s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+.success-icon {
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #10b981, #059669);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.8rem;
+    box-shadow: 0 8px 24px rgba(16, 185, 129, 0.35);
+    animation: ease-elastic-pop 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) 0.1s both;
+}
+
+@keyframes ease-elastic-pop {
+    from {
+        transform: scale(0.4);
+        opacity: 0;
+    }
+
+    to {
+        transform: scale(1);
+        opacity: 1;
+    }
+}
+
+.success-title {
+    font-size: 1.2rem;
+    font-weight: 700;
+    color: var(--modal-text);
+}
+
+.success-msg {
+    font-size: 0.9rem;
+    color: var(--modal-muted);
+    line-height: 1.6;
+    max-width: 320px;
+}
+
+.success-order-id {
+    background: var(--modal-accent-light);
+    color: var(--modal-accent);
+    font-size: 0.78rem;
+    font-weight: 600;
+    padding: 5px 12px;
+    border-radius: 99px;
+    letter-spacing: 0.04em;
+}
+
+/* ── divider ── */
+
+.modal-divider {
+    height: 1px;
+    background: var(--modal-border);
+    margin: 4px 24px 0;
+}
+
+/* ── reduced motion ── */
+
+@media (prefers-reduced-motion: reduce) {
+    .modal-overlay,
+    .modal-panel,
+    .modal-step-pane,
+    .modal-btn,
+    .trigger-btn,
+    .success-icon {
+        transition: none !important;
+        animation: none !important;
+    }
+
+    .modal-overlay.is-open {
+        opacity: 1;
+        visibility: visible;
+    }
+
+    .modal-overlay.is-open .modal-panel {
+        transform: none;
+        opacity: 1;
+    }
+}
+
+/* ── responsive ── */
+
+@media (max-width: 520px) {
+    .form-row {
+        grid-template-columns: 1fr;
+    }
+
+    .modal-footer {
+        flex-direction: column-reverse;
+    }
+
+    .modal-btn {
+        width: 100%;
+        text-align: center;
+    }
+}


### PR DESCRIPTION
﻿## Pull Request Description

Adds a CSS elastic-slide multi-step checkout modal as requested in #62493.

The modal slides in from the left with a spring cubic-bezier(0.34, 1.56, 0.64, 1) ease, walks the user through three steps (Contact → Payment → Review), and shows a success state on confirm.

## How the animation works

The panel starts at 	ranslateX(-60px) with opacity: 0. Adding .is-open to the overlay transitions it to 	ranslateX(0) and opacity: 1:

`css
.modal-panel {
    transform: translateX(-60px);
    opacity: 0;
    transition: transform 0.42s cubic-bezier(0.34, 1.56, 0.64, 1), opacity 0.42s ease;
}
.modal-overlay.is-open .modal-panel {
    transform: translateX(0);
    opacity: 1;
}
`

The cubic-bezier values (0.34, 1.56, 0.64, 1) push past 1.0 on y, creating the elastic overshoot with no extra JS. Each step pane also re-enters with a smaller elastic slide via @keyframes ease-elastic-slide-in.

The top progress bar uses ::after width controlled by [data-step] attribute selectors:

`css
.modal-panel[data-step="1"] .modal-progress-strip::after { width: 33.33%; }
.modal-panel[data-step="2"] .modal-progress-strip::after { width: 66.66%; }
.modal-panel[data-step="3"] .modal-progress-strip::after { width: 100%; }
`

## Submission Checklist

- [x] Files inside submissions/examples/elastic-slide-modal-checkout/
- [x] demo.html — valid HTML5 with DOCTYPE, head, body
- [x] style.css — 641 lines of hand-written CSS
- [x] README.md — usage, custom properties table, accessibility notes
- [x] No changes to core/, components/, or .github/
- [x] One feature per PR
- [x] prefers-reduced-motion support included
- [x] ole="dialog", ria-modal, ria-labelledby on overlay
- [x] Responsive: mobile single-column layout

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component

Closes #62493 — GSSoC-26