### PR TITLE
Add ease-bus-arrival-board component

### DIFF
--- a/submissions/examples/bus-arrival-board-ij/README.md
+++ b/submissions/examples/bus-arrival-board-ij/README.md
@@ -1,0 +1,10 @@
+# ease-bus-arrival-board
+
+A transit departures board whose route pills flash as arrivals update, the minutes count down, and LATE tags blink.
+
+## Run
+Open `demo.html` directly in a browser to watch the board update.
+
+## Notes
+- Five routes are listed.
+- Delayed rows blink red.

--- a/submissions/examples/bus-arrival-board-ij/demo.html
+++ b/submissions/examples/bus-arrival-board-ij/demo.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-bus-arrival-board demo</title>
+</head>
+<body>
+<div class="bs-app">
+  <span class="bs-title">DEPARTURES</span>
+  <div class="bs-rows">
+    <div class="bs-row">
+      <span class="bs-route">14</span>
+      <span class="bs-dest">North Terminal</span>
+      <span class="bs-min">2</span>
+    </div>
+    <div class="bs-row">
+      <span class="bs-route">22</span>
+      <span class="bs-dest">City Center</span>
+      <span class="bs-min bs-min-late">LATE</span>
+    </div>
+    <div class="bs-row">
+      <span class="bs-route">37</span>
+      <span class="bs-dest">Harbor View</span>
+      <span class="bs-min">7</span>
+    </div>
+    <div class="bs-row">
+      <span class="bs-route">48</span>
+      <span class="bs-dest">Airport Loop</span>
+      <span class="bs-min bs-min-late">LATE</span>
+    </div>
+    <div class="bs-row">
+      <span class="bs-route">51</span>
+      <span class="bs-dest">East Station</span>
+      <span class="bs-min">11</span>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/bus-arrival-board-ij/style.css
+++ b/submissions/examples/bus-arrival-board-ij/style.css
@@ -1,0 +1,14 @@
+:root{--bs-amber:#ffc94a;--bs-ink:#1a1408}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#241f0c,#12100a);font-family:'Segoe UI',sans-serif}
+.bs-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#1d190b,#100d06);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.bs-title{position:absolute;top:16px;left:0;right:0;text-align:center;font-size:13px;font-weight:800;letter-spacing:6px;color:var(--bs-amber)}
+.bs-rows{position:absolute;top:52px;left:28px;width:316px;display:flex;flex-direction:column;gap:10px}
+.bs-row{height:44px;border-radius:8px;background:#241c08;box-shadow:inset 0 0 0 2px #3c3010;display:flex;align-items:center;padding:0 12px;gap:10px;animation:row-flash-bus-arrival-board 3s steps(1) infinite}
+.bs-row:nth-child(2n){animation-delay:1.5s}
+.bs-route{width:44px;height:28px;border-radius:6px;background:var(--bs-amber);color:var(--bs-ink);font-size:16px;font-weight:900;display:flex;align-items:center;justify-content:center}
+.bs-dest{flex:1;font-size:14px;font-weight:700;color:#f0e2b0}
+.bs-min{min-width:46px;text-align:right;font-size:15px;font-weight:900;color:var(--bs-amber);animation:min-tick-bus-arrival-board 1.2s ease-in-out infinite}
+.bs-min-late{color:#ff6b5b;animation:late-blink-bus-arrival-board 0.6s steps(1) infinite}
+@keyframes row-flash-bus-arrival-board{0%,100%{opacity:1}50%{opacity:0.6}}
+@keyframes min-tick-bus-arrival-board{0%,100%{transform:scale(1)}50%{transform:scale(1.18);color:#ffe08a}}
+@keyframes late-blink-bus-arrival-board{0%,100%{opacity:1}50%{opacity:0.2}}


### PR DESCRIPTION
## Component: ease-bus-arrival-board — routes flash, minutes tick, and late tags blink

**Closes #62871**

### What this adds
A transit board: the route pills flash as arrivals update, the minutes count down per row, and the LATE tags blink beside delayed buses.

### Acceptance Criteria covered
- Route pills flash as arrivals update
- Minutes count down per row
- LATE tags blink beside delays

### Files
- submissions/examples/bus-arrival-board-ij/demo.html
- submissions/examples/bus-arrival-board-ij/style.css
- submissions/examples/bus-arrival-board-ij/README.md

### How to review
Open `demo.html` in a browser and watch the board update.