### PR TITLE
feat(submissions): add jello wobble hover example

### DIFF
--- a/submissions/examples/jello-wobble-hover-ag/README.md
+++ b/submissions/examples/jello-wobble-hover-ag/README.md
@@ -1,0 +1,5 @@
+# Jello Wobble Hover
+
+1. What does this do? A playful, elastic wobble effect triggered on hover that mimics the physics of a block of jello.
+2. How is it used? Apply `.hover-wobble` to an element (like an image, icon, or card).
+3. Why is it useful? This adds a layer of micro-interaction and delight to user interfaces. It's fully modular and can be composed with utility classes to make a site feel alive and tactile.

--- a/submissions/examples/jello-wobble-hover-ag/demo.html
+++ b/submissions/examples/jello-wobble-hover-ag/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Jello Wobble Hover Demo</title>
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    body {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 100vh;
+      background-color: #1e293b;
+      margin: 0;
+      font-family: sans-serif;
+    }
+  </style>
+</head>
+<body>
+  <div class="hover-wobble" style="width: 100px; height: 100px; background-color: #6366f1; border-radius: 16px; display: flex; align-items: center; justify-content: center; color: white; font-weight: bold; cursor: pointer; box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);">
+    Hover Me
+  </div>
+</body>
+</html>

--- a/submissions/examples/jello-wobble-hover-ag/style.css
+++ b/submissions/examples/jello-wobble-hover-ag/style.css
@@ -1,0 +1,19 @@
+.hover-wobble {
+  display: inline-block;
+  transform-origin: center;
+  transition: transform 0.2s;
+}
+
+.hover-wobble:hover {
+  animation: jello-wobble 0.9s both;
+}
+
+@keyframes jello-wobble {
+  0% { transform: scale3d(1, 1, 1); }
+  30% { transform: scale3d(1.25, 0.75, 1); }
+  40% { transform: scale3d(0.75, 1.25, 1); }
+  50% { transform: scale3d(1.15, 0.85, 1); }
+  65% { transform: scale3d(0.95, 1.05, 1); }
+  75% { transform: scale3d(1.05, 0.95, 1); }
+  100% { transform: scale3d(1, 1, 1); }
+}


### PR DESCRIPTION
## Pull Request Description

This PR introduces a new "Jello Wobble Hover" effect to the standard examples track. It resolves **#62999** by adding a playful, elastic wobble effect triggered on hover. The element squishes and stretches dynamically before settling back into its original shape, mimicking the physics of a block of jello.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

It adds a playful, elastic wobble animation that squishes and stretches the element when hovered, mimicking the physics of a block of jello.

**How does a developer use it?**

```html
<img src="logo.png" class="hover-wobble" alt="Logo">
<!-- Or applied to a card/button -->
<div class="hover-wobble">Hover Me</div>
