### PR TITLE
feat: add fade-in progress bar component for product catalogs

### DIFF
--- a/submissions/examples/ease-fade-in-progress-catalog/README.md
+++ b/submissions/examples/ease-fade-in-progress-catalog/README.md
@@ -1,0 +1,54 @@
+# Ease Fade-In Progress Bar — Product Catalog
+
+## Description
+Product catalog cards where the card itself, its stock-level bar, and its rating bar each fade in with a staggered sequence — cards appear first, then stock bars fade+fill shortly after, then rating bars fade+fill last. Color-coded stock status (green in-stock, amber low-stock, gray sold-out). Pure CSS, zero JavaScript.
+
+## Features
+- Staggered multi-layer fade-in: card → stock bar → rating bar, each with incremental delay
+- Color-coded stock level bar (`in-stock` / `low-stock` / `sold-out` variants)
+- Star-rating style fill bar with numeric label
+- Grid layout with `auto-fit`/`minmax` for natural responsive wrapping
+- Fully customizable via CSS custom properties
+- Respects `prefers-reduced-motion`
+
+## Usage
+```html
+<div class="ease-catalog-progress">
+  <div class="product-card">
+    <p class="product-name">Product Name</p>
+    <p class="product-price">$XX.XX</p>
+
+    <div class="stock-row">
+      <div class="stock-label-row">
+        <span class="stock-label">Stock</span>
+        <span class="stock-status in-stock">In Stock</span>
+      </div>
+      <div class="stock-track">
+        <div class="stock-fill in-stock" style="--fill-scale: 0.85;"></div>
+      </div>
+    </div>
+
+    <div class="rating-row">
+      <div class="rating-track">
+        <div class="rating-fill" style="--rating-scale: 0.9;"></div>
+      </div>
+      <span class="rating-text">4.5</span>
+    </div>
+  </div>
+</div>
+```
+Set `--fill-scale`/`--rating-scale` to a decimal (0–1) representing the bar's fill percentage. Use `.stock-status`/`.stock-fill` modifier classes `in-stock`, `low-stock`, or `sold-out` to match the desired state.
+
+## Customization (CSS custom properties)
+| Property | Default | Description |
+|---|---|---|
+| `--fade-duration` | `0.6s` | Card/bar fade-in duration |
+| `--fade-easing` | `cubic-bezier(0.16, 1, 0.3, 1)` | Timing function |
+| `--stagger` | `0.15s` | Delay increment between cards |
+| `--bar-height` | `8px` | Stock bar thickness |
+| `--track-bg` | `#f1f5f9` | Empty bar track background |
+
+## Files
+- `demo.html` — live working example with 4 product cards (in-stock, low-stock, sold-out states)
+- `style.css` — component styles and all fade-in animations
+- `README.md` — this file

--- a/submissions/examples/ease-fade-in-progress-catalog/demo.html
+++ b/submissions/examples/ease-fade-in-progress-catalog/demo.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ease Fade-In Progress Bar — Product Catalog Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0;
+      background: #f8fafc;
+      padding: 40px;
+      box-sizing: border-box;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="ease-catalog-progress">
+
+    <div class="product-card">
+      <p class="product-name">Wireless Headphones</p>
+      <p class="product-price">$249.00</p>
+
+      <div class="stock-row">
+        <div class="stock-label-row">
+          <span class="stock-label">Stock</span>
+          <span class="stock-status in-stock">In Stock</span>
+        </div>
+        <div class="stock-track">
+          <div class="stock-fill in-stock" style="--fill-scale: 0.85;"></div>
+        </div>
+      </div>
+
+      <div class="rating-row">
+        <div class="rating-track">
+          <div class="rating-fill" style="--rating-scale: 0.9;"></div>
+        </div>
+        <span class="rating-text">4.5</span>
+      </div>
+    </div>
+
+    <div class="product-card">
+      <p class="product-name">Mechanical Keyboard</p>
+      <p class="product-price">$129.00</p>
+
+      <div class="stock-row">
+        <div class="stock-label-row">
+          <span class="stock-label">Stock</span>
+          <span class="stock-status low-stock">Low Stock</span>
+        </div>
+        <div class="stock-track">
+          <div class="stock-fill low-stock" style="--fill-scale: 0.22;"></div>
+        </div>
+      </div>
+
+      <div class="rating-row">
+        <div class="rating-track">
+          <div class="rating-fill" style="--rating-scale: 0.76;"></div>
+        </div>
+        <span class="rating-text">3.8</span>
+      </div>
+    </div>
+
+    <div class="product-card">
+      <p class="product-name">4K Webcam</p>
+      <p class="product-price">$89.00</p>
+
+      <div class="stock-row">
+        <div class="stock-label-row">
+          <span class="stock-label">Stock</span>
+          <span class="stock-status sold-out">Sold Out</span>
+        </div>
+        <div class="stock-track">
+          <div class="stock-fill sold-out" style="--fill-scale: 0.02;"></div>
+        </div>
+      </div>
+
+      <div class="rating-row">
+        <div class="rating-track">
+          <div class="rating-fill" style="--rating-scale: 0.82;"></div>
+        </div>
+        <span class="rating-text">4.1</span>
+      </div>
+    </div>
+
+    <div class="product-card">
+      <p class="product-name">USB-C Hub</p>
+      <p class="product-price">$39.00</p>
+
+      <div class="stock-row">
+        <div class="stock-label-row">
+          <span class="stock-label">Stock</span>
+          <span class="stock-status in-stock">In Stock</span>
+        </div>
+        <div class="stock-track">
+          <div class="stock-fill in-stock" style="--fill-scale: 0.95;"></div>
+        </div>
+      </div>
+
+      <div class="rating-row">
+        <div class="rating-track">
+          <div class="rating-fill" style="--rating-scale: 0.94;"></div>
+        </div>
+        <span class="rating-text">4.7</span>
+      </div>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-fade-in-progress-catalog/style.css
+++ b/submissions/examples/ease-fade-in-progress-catalog/style.css
@@ -1,0 +1,174 @@
+/* Ease Fade-In Progress Bar — Product Catalog style, pure CSS, zero JS */
+
+.ease-catalog-progress {
+  --fade-duration: 0.6s;
+  --fade-easing: cubic-bezier(0.16, 1, 0.3, 1);
+  --stagger: 0.15s;
+  --bar-height: 8px;
+  --track-bg: #f1f5f9;
+  --radius: 999px;
+  --card-bg: #ffffff;
+  --card-border: #e2e8f0;
+  --fg: #0f172a;
+  --muted: #64748b;
+
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+  font-family: system-ui, sans-serif;
+}
+
+.ease-catalog-progress .product-card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 16px;
+  padding: 20px;
+  box-shadow: 0 2px 10px rgba(15, 23, 42, 0.05);
+
+  opacity: 0;
+  animation: card-fade-in var(--fade-duration) var(--fade-easing) forwards;
+}
+
+.ease-catalog-progress .product-card:nth-child(1) { animation-delay: calc(var(--stagger) * 0); }
+.ease-catalog-progress .product-card:nth-child(2) { animation-delay: calc(var(--stagger) * 1); }
+.ease-catalog-progress .product-card:nth-child(3) { animation-delay: calc(var(--stagger) * 2); }
+.ease-catalog-progress .product-card:nth-child(4) { animation-delay: calc(var(--stagger) * 3); }
+
+@keyframes card-fade-in {
+  from { opacity: 0; transform: translateY(10px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.ease-catalog-progress .product-name {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--fg);
+  margin: 0 0 4px;
+}
+
+.ease-catalog-progress .product-price {
+  font-size: 0.85rem;
+  color: var(--muted);
+  margin: 0 0 16px;
+}
+
+/* ---- stock level bar: fades + fills in after the card itself appears ---- */
+.ease-catalog-progress .stock-row {
+  margin-bottom: 14px;
+}
+
+.ease-catalog-progress .stock-label-row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.72rem;
+  margin-bottom: 6px;
+}
+
+.ease-catalog-progress .stock-label {
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.ease-catalog-progress .stock-status {
+  font-weight: 700;
+}
+
+.ease-catalog-progress .stock-status.in-stock { color: #16a34a; }
+.ease-catalog-progress .stock-status.low-stock { color: #d97706; }
+.ease-catalog-progress .stock-status.sold-out { color: #dc2626; }
+
+.ease-catalog-progress .stock-track {
+  height: var(--bar-height);
+  background: var(--track-bg);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.ease-catalog-progress .stock-fill {
+  height: 100%;
+  border-radius: var(--radius);
+
+  opacity: 0;
+  transform: scaleX(0);
+  transform-origin: left;
+  animation: stock-fade-fill var(--fade-duration) var(--fade-easing) forwards;
+}
+
+.ease-catalog-progress .product-card:nth-child(1) .stock-fill { animation-delay: calc(var(--stagger) * 0 + 0.3s); }
+.ease-catalog-progress .product-card:nth-child(2) .stock-fill { animation-delay: calc(var(--stagger) * 1 + 0.3s); }
+.ease-catalog-progress .product-card:nth-child(3) .stock-fill { animation-delay: calc(var(--stagger) * 2 + 0.3s); }
+.ease-catalog-progress .product-card:nth-child(4) .stock-fill { animation-delay: calc(var(--stagger) * 3 + 0.3s); }
+
+@keyframes stock-fade-fill {
+  from { opacity: 0; transform: scaleX(0); }
+  to   { opacity: 1; transform: scaleX(var(--fill-scale, 1)); }
+}
+
+.ease-catalog-progress .stock-fill.in-stock { background: linear-gradient(90deg, #22c55e, #16a34a); }
+.ease-catalog-progress .stock-fill.low-stock { background: linear-gradient(90deg, #f59e0b, #d97706); }
+.ease-catalog-progress .stock-fill.sold-out { background: #cbd5e1; }
+
+/* ---- rating bar: same fade-in pattern, different context ---- */
+.ease-catalog-progress .rating-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  opacity: 0;
+  animation: card-fade-in var(--fade-duration) ease forwards;
+}
+
+.ease-catalog-progress .product-card:nth-child(1) .rating-row { animation-delay: calc(var(--stagger) * 0 + 0.5s); }
+.ease-catalog-progress .product-card:nth-child(2) .rating-row { animation-delay: calc(var(--stagger) * 1 + 0.5s); }
+.ease-catalog-progress .product-card:nth-child(3) .rating-row { animation-delay: calc(var(--stagger) * 2 + 0.5s); }
+.ease-catalog-progress .product-card:nth-child(4) .rating-row { animation-delay: calc(var(--stagger) * 3 + 0.5s); }
+
+.ease-catalog-progress .rating-track {
+  flex: 1;
+  height: 6px;
+  background: var(--track-bg);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.ease-catalog-progress .rating-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #facc15, #f59e0b);
+  border-radius: var(--radius);
+  transform: scaleX(0);
+  transform-origin: left;
+  animation: rating-fill 0.8s var(--fade-easing) forwards;
+  animation-delay: 0.7s;
+}
+
+.ease-catalog-progress .product-card:nth-child(2) .rating-fill { animation-delay: 0.85s; }
+.ease-catalog-progress .product-card:nth-child(3) .rating-fill { animation-delay: 1s; }
+.ease-catalog-progress .product-card:nth-child(4) .rating-fill { animation-delay: 1.15s; }
+
+@keyframes rating-fill {
+  to { transform: scaleX(var(--rating-scale, 1)); }
+}
+
+.ease-catalog-progress .rating-text {
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--muted);
+  flex-shrink: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-catalog-progress .product-card,
+  .ease-catalog-progress .stock-fill,
+  .ease-catalog-progress .rating-row,
+  .ease-catalog-progress .rating-fill {
+    animation: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+  }
+  .ease-catalog-progress .stock-fill {
+    transform: scaleX(var(--fill-scale, 1)) !important;
+  }
+  .ease-catalog-progress .rating-fill {
+    transform: scaleX(var(--rating-scale, 1)) !important;
+  }
+}


### PR DESCRIPTION
Closes #62422

## Pull Request Description
Adds fade-in progress bars for product catalog layouts — each product card, its stock-level bar, and its rating bar fade in with a staggered sequence (card first, stock bar shortly after, rating bar last), with color-coded stock status (green in-stock, amber low-stock, gray sold-out). Pure CSS, zero JavaScript.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All files placed under `submissions/examples/ease-fade-in-progress-catalog-savni/`
- [x] Includes `demo.html` — clean HTML5 showcase page
- [x] Includes `style.css` — pure CSS, smooth/performant transitions and keyframes
- [x] Includes `README.md` — usage, custom properties, and features documented
- [x] Pure CSS/HTML, no JS frameworks
- [x] Fully responsive (`auto-fit`/`minmax` grid layout)
- [x] Respects `prefers-reduced-motion`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A product catalog component (`ease-catalog-progress`) with layered fade-in sequencing: each product card fades/slides in first, its stock-level bar fades and fills in shortly after (color-coded by stock status), and its star-rating bar fades and fills in last — all staggered per card for a cascading catalog-loading feel.

**How does a developer use it?**
```html
<div class="ease-catalog-progress">
  <div class="product-card">
    <p class="product-name">Product Name</p>
    <p class="product-price">$XX.XX</p>

    <div class="stock-row">
      <div class="stock-label-row">
        <span class="stock-label">Stock</span>
        <span class="stock-status in-stock">In Stock</span>
      </div>
      <div class="stock-track">
        <div class="stock-fill in-stock" style="--fill-scale: 0.85;"></div>
      </div>
    </div>

    <div class="rating-row">
      <div class="rating-track">
        <div class="rating-fill" style="--rating-scale: 0.9;"></div>
      </div>
      <span class="rating-text">4.5</span>
    </div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
All fade-in and fill animations use pure CSS `@keyframes` combining `opacity` and `transform: scaleX()` (avoiding layout thrashing), with per-card and per-element incremental delays creating a genuine multi-layer "fade-in" sequence rather than a single flat animation. All timing and sizing are exposed via CSS custom properties (`--fade-duration`, `--fade-easing`, `--stagger`, `--bar-height`) without touching core rules, consistent with the framework's animation-first, zero-dependency philosophy. Respects `prefers-reduced-motion` by disabling all animation while preserving each bar's correct final fill state.

---

## Demo
- [x] Demo added (`demo.html` — 4 product cards demonstrating in-stock, low-stock, and sold-out states)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Stock status uses three modifier classes (`in-stock`/`low-stock`/`sold-out`) applied to both `.stock-status` (text) and `.stock-fill` (bar color) for consistent color-coding — developers set the matching pair based on actual inventory data.