### PR TITLE
feat: add 3D cube tabs component for product catalogs

### DIFF
--- a/submissions/examples/ease-3d-cube-tabs-catalog/README.md
+++ b/submissions/examples/ease-3d-cube-tabs-catalog/README.md
@@ -1,0 +1,54 @@
+# Ease 3D Cube Tabs — Product Catalog
+
+## Description
+Unlike a typical flip-tabs pattern where individual content panels rotate independently, this component treats all three tab panels as literal **faces of one 3D cube**. Selecting a tab rotates the entire cube on its Y-axis to bring that face to the front — visually similar to a product spinning on a display pedestal, which fits a product catalog context especially well. Pure CSS, zero JavaScript.
+
+## How it's structurally different from a standard flip
+Standard flip-tab patterns animate each panel individually (`rotateY(90deg) → 0deg` per panel, with `backface-visibility` hiding the inactive one). Here, all three faces are positioned in fixed 3D space around a single shared cube element using `translateZ()` + `rotateY()` offsets (0°, 90°, 180°) — they never move relative to each other. Only the parent `.cube` element itself rotates, driven by which radio input is checked. This is a genuine cube carousel, not three independently-flipping panels.
+
+## Features
+- True 3D cube: 3 faces positioned via `rotateY()` + `translateZ()`, forming an actual box in 3D space
+- Selecting a tab rotates the whole cube (not the individual panel) to bring that face forward
+- Product catalog demo content: Details, Specs, Reviews
+- Fully keyboard accessible (native radio inputs, `role="tablist"`/`"tab"`/`"tabpanel"`)
+- Responsive (cube stage height increases on narrow viewports to fit reflowed content)
+- Fully customizable via CSS custom properties
+- Respects `prefers-reduced-motion`
+
+## Usage
+```html
+<div class="ease-cube-tabs" role="tablist" aria-label="Product information">
+  <input type="radio" name="cube-tab" id="ctab-details" class="tab-input" checked />
+  <input type="radio" name="cube-tab" id="ctab-specs" class="tab-input" />
+  <input type="radio" name="cube-tab" id="ctab-reviews" class="tab-input" />
+
+  <div class="tab-list">
+    <label for="ctab-details" class="tab-label" role="tab">Details</label>
+    <label for="ctab-specs" class="tab-label" role="tab">Specs</label>
+    <label for="ctab-reviews" class="tab-label" role="tab">Reviews</label>
+  </div>
+
+  <div class="cube-stage">
+    <div class="cube">
+      <div class="cube-face face-details" role="tabpanel">...</div>
+      <div class="cube-face face-specs" role="tabpanel">...</div>
+      <div class="cube-face face-reviews" role="tabpanel">...</div>
+    </div>
+  </div>
+</div>
+```
+Each face needs its `rotateY()` offset to match its position in the tab order (0°, 90°, 180° for a 3-face cube), and the corresponding `#idN:checked ~ .cube-stage .cube { transform: rotateY(-N * 90deg); }` rule to rotate the cube to face it.
+
+## Customization (CSS custom properties)
+| Property | Default | Description |
+|---|---|---|
+| `--cube-size` | `320px` | Cube width/height |
+| `--spin-duration` | `0.9s` | Cube rotation duration |
+| `--spin-easing` | `cubic-bezier(0.65, 0, 0.35, 1)` | Rotation timing function |
+| `--accent` | `#e11d48` | Active tab / title accent color |
+| `--radius` | `18px` | Face corner rounding |
+
+## Files
+- `demo.html` — live working example (product Details/Specs/Reviews cube)
+- `style.css` — component styles and cube rotation logic
+- `README.md` — this file

--- a/submissions/examples/ease-3d-cube-tabs-catalog/demo.html
+++ b/submissions/examples/ease-3d-cube-tabs-catalog/demo.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ease 3D Cube Tabs — Product Catalog Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #f8fafc;
+      padding: 40px;
+      box-sizing: border-box;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="ease-cube-tabs" role="tablist" aria-label="Product information">
+    <input type="radio" name="cube-tab" id="ctab-details" class="tab-input" checked />
+    <input type="radio" name="cube-tab" id="ctab-specs" class="tab-input" />
+    <input type="radio" name="cube-tab" id="ctab-reviews" class="tab-input" />
+
+    <div class="tab-list">
+      <label for="ctab-details" class="tab-label" role="tab">Details</label>
+      <label for="ctab-specs" class="tab-label" role="tab">Specs</label>
+      <label for="ctab-reviews" class="tab-label" role="tab">Reviews</label>
+    </div>
+
+    <div class="cube-stage">
+      <div class="cube">
+        <div class="cube-face face-details" role="tabpanel">
+          <h3 class="face-title">Aether Running Shoes</h3>
+          <p class="face-desc">
+            Engineered for daily training, the Aether combines a responsive
+            foam midsole with a breathable knit upper for all-day comfort
+            on any terrain.
+          </p>
+          <p class="face-desc">
+            Available in 6 colorways. Free returns within 30 days.
+          </p>
+        </div>
+
+        <div class="cube-face face-specs" role="tabpanel">
+          <h3 class="face-title">Specifications</h3>
+          <div class="spec-row"><span>Weight</span><span>242g</span></div>
+          <div class="spec-row"><span>Drop</span><span>8mm</span></div>
+          <div class="spec-row"><span>Material</span><span>Recycled knit</span></div>
+          <div class="spec-row"><span>Sole</span><span>Rubber compound</span></div>
+          <div class="spec-row"><span>Sizes</span><span>US 6–13</span></div>
+        </div>
+
+        <div class="cube-face face-reviews" role="tabpanel">
+          <h3 class="face-title">Customer Reviews</h3>
+          <div class="review-item">
+            <div class="review-stars">★★★★★</div>
+            <p class="review-text">"Best running shoe I've owned. True to size and super light." — Alex R.</p>
+          </div>
+          <div class="review-item">
+            <div class="review-stars">★★★★☆</div>
+            <p class="review-text">"Great cushioning, took a few runs to break in." — Priya M.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-3d-cube-tabs-catalog/style.css
+++ b/submissions/examples/ease-3d-cube-tabs-catalog/style.css
@@ -1,0 +1,167 @@
+/* Ease 3D Cube Tabs — Product Catalog style.
+   Unlike a typical flip-tabs pattern where individual panels rotate,
+   here ALL panels are faces of a single 3D cube. Selecting a tab rotates
+   the entire cube on its Y axis to bring that face to the front —
+   like a product spinning on a display pedestal. Pure CSS, zero JS. */
+
+.ease-cube-tabs {
+  --cube-size: 320px;
+  --cube-depth: calc(var(--cube-size) / 2);
+  --spin-duration: 0.9s;
+  --spin-easing: cubic-bezier(0.65, 0, 0.35, 1);
+  --accent: #e11d48;
+  --face-bg: #ffffff;
+  --face-border: #e2e8f0;
+  --fg: #0f172a;
+  --muted: #64748b;
+  --radius: 18px;
+
+  width: min(var(--cube-size), 92vw);
+  font-family: system-ui, sans-serif;
+}
+
+.ease-cube-tabs .tab-input {
+  position: absolute;
+  width: 1px; height: 1px;
+  overflow: hidden;
+  clip: rect(0,0,0,0);
+}
+
+/* ---- tab pills control cube rotation ---- */
+.ease-cube-tabs .tab-list {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 20px;
+  justify-content: center;
+}
+
+.ease-cube-tabs .tab-label {
+  padding: 9px 18px;
+  border-radius: 999px;
+  border: 1px solid var(--face-border);
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--muted);
+  cursor: pointer;
+  user-select: none;
+  transition: color 0.3s ease, background 0.3s ease, border-color 0.3s ease;
+}
+
+.ease-cube-tabs .tab-label:hover {
+  color: var(--fg);
+}
+
+.ease-cube-tabs .tab-input:focus-visible + .tab-label {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.ease-cube-tabs .tab-input:checked + .tab-label {
+  color: #fff;
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+/* ---- the cube stage ---- */
+.ease-cube-tabs .cube-stage {
+  position: relative;
+  width: 100%;
+  height: 300px;
+  perspective: 1600px;
+}
+
+.ease-cube-tabs .cube {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transform-style: preserve-3d;
+  transition: transform var(--spin-duration) var(--spin-easing);
+  transform: rotateY(0deg);
+}
+
+/* each tab selection rotates the whole cube to bring that face forward */
+#ctab-details:checked  ~ .cube-stage .cube { transform: rotateY(0deg); }
+#ctab-specs:checked    ~ .cube-stage .cube { transform: rotateY(-90deg); }
+#ctab-reviews:checked  ~ .cube-stage .cube { transform: rotateY(-180deg); }
+
+.ease-cube-tabs .cube-face {
+  position: absolute;
+  inset: 0;
+  background: var(--face-bg);
+  border: 1px solid var(--face-border);
+  border-radius: var(--radius);
+  padding: 26px;
+  box-sizing: border-box;
+  color: var(--fg);
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+  backface-visibility: hidden;
+  overflow-y: auto;
+}
+
+/* positioned as actual faces of a cube using translateZ + rotateY,
+   each offset by depth so they form a real box in 3D space */
+.ease-cube-tabs .face-details { transform: rotateY(0deg) translateZ(var(--cube-depth)); }
+.ease-cube-tabs .face-specs   { transform: rotateY(90deg) translateZ(var(--cube-depth)); }
+.ease-cube-tabs .face-reviews { transform: rotateY(180deg) translateZ(var(--cube-depth)); }
+
+.ease-cube-tabs .face-title {
+  font-size: 1rem;
+  font-weight: 800;
+  margin: 0 0 14px;
+  color: var(--accent);
+}
+
+.ease-cube-tabs .face-desc {
+  font-size: 0.85rem;
+  line-height: 1.7;
+  color: var(--muted);
+  margin: 0 0 16px;
+}
+
+.ease-cube-tabs .spec-row {
+  display: flex;
+  justify-content: space-between;
+  padding: 8px 0;
+  border-bottom: 1px dashed var(--face-border);
+  font-size: 0.82rem;
+}
+
+.ease-cube-tabs .spec-row span:first-child {
+  color: var(--muted);
+}
+
+.ease-cube-tabs .spec-row span:last-child {
+  font-weight: 600;
+}
+
+.ease-cube-tabs .review-item {
+  padding: 10px 0;
+  border-bottom: 1px solid var(--face-border);
+}
+
+.ease-cube-tabs .review-item:last-child {
+  border-bottom: none;
+}
+
+.ease-cube-tabs .review-stars {
+  color: #facc15;
+  font-size: 0.85rem;
+  margin-bottom: 3px;
+}
+
+.ease-cube-tabs .review-text {
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-cube-tabs .cube {
+    transition: none;
+  }
+}
+
+@media (max-width: 400px) {
+  .ease-cube-tabs .cube-stage {
+    height: 340px;
+  }
+}


### PR DESCRIPTION
Closes #62198

## Pull Request Description
Adds a genuinely distinct take on 3D-flip tabs for product catalog layouts: instead of individual panels flipping independently, all three content panels are literal faces of a single 3D cube. Selecting a tab rotates the entire cube on its Y-axis to bring that face forward — like a product spinning on a display pedestal. Pure CSS, zero JavaScript.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All files placed under `submissions/examples/ease-3d-cube-tabs-catalog-savni/`
- [x] Includes `demo.html` — clean HTML5 showcase page
- [x] Includes `style.css` — pure CSS, smooth/performant transitions and keyframes
- [x] Includes `README.md` — usage, custom properties, and features documented
- [x] Pure CSS/HTML, no JS frameworks
- [x] Fully responsive
- [x] Respects `prefers-reduced-motion`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A structurally distinct 3D-flip tabs variant (`ease-cube-tabs`): rather than each panel independently rotating via `backface-visibility` swaps (the standard flip-tabs pattern), all three panels are positioned as fixed faces of one shared cube element (`rotateY()` + `translateZ()` offsets at 0°/90°/180°). Only the parent `.cube` rotates in response to the selected radio input, genuinely bringing a different face to the front — like a product spinning on a pedestal. Demo shows a product's Details, Specs, and Reviews.

**How does a developer use it?**
```html
<div class="ease-cube-tabs" role="tablist" aria-label="Product information">
  <input type="radio" name="cube-tab" id="ctab-details" class="tab-input" checked />
  <input type="radio" name="cube-tab" id="ctab-specs" class="tab-input" />
  <input type="radio" name="cube-tab" id="ctab-reviews" class="tab-input" />

  <div class="tab-list">
    <label for="ctab-details" class="tab-label" role="tab">Details</label>
    <label for="ctab-specs" class="tab-label" role="tab">Specs</label>
    <label for="ctab-reviews" class="tab-label" role="tab">Reviews</label>
  </div>

  <div class="cube-stage">
    <div class="cube">
      <div class="cube-face face-details" role="tabpanel">...</div>
      <div class="cube-face face-specs" role="tabpanel">...</div>
      <div class="cube-face face-reviews" role="tabpanel">...</div>
    </div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
Fully pure-CSS, zero-JavaScript state management using the hidden-radio + `:checked` sibling-selector pattern, with a genuine 3D cube built from `perspective`, `transform-style: preserve-3d`, and `backface-visibility: hidden` — a structurally different technique from a standard per-panel flip, avoiding duplication with the earlier fintech 3D-flip tabs (#59226). All timing/sizing/colors are exposed via CSS custom properties (`--cube-size`, `--spin-duration`, `--spin-easing`, `--accent`) without touching core rules, consistent with the framework's animation-first, zero-dependency philosophy. Built with `role="tablist"`/`"tab"`/`"tabpanel"` semantics on native, keyboard-operable radio inputs, and respects `prefers-reduced-motion`.

---

## Demo
- [x] Demo added (`demo.html` — product catalog cube with Details, Specs, and Reviews faces)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Deliberately implemented as a true 3D cube carousel rather than another per-panel flip variant, to keep this submission mechanically distinct from the earlier 3D-Flip Tabs for Fintech Dashboards (#59226) despite sharing the "3D-Flip" issue title pattern.