### PR TITLE
feat: add sticker corner peel (#63220)

### DIFF
--- a/submissions/examples/sticker-corner-peel-sk/README.md
+++ b/submissions/examples/sticker-corner-peel-sk/README.md
@@ -1,0 +1,17 @@
+# Sticker Corner Peel Reveal
+
+## What does this do?
+
+A sticker card whose corner peels back on hover or when locked open.
+
+## How is it used?
+
+```html
+<label class="sticker"><input type="checkbox"/><div class="sticker__face">20% OFF</div></label>
+```
+
+Open `demo.html` in a browser to try it.
+
+## Why is it useful?
+
+Tangible reveal affordance for coupons and promotional cards.

--- a/submissions/examples/sticker-corner-peel-sk/demo.html
+++ b/submissions/examples/sticker-corner-peel-sk/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sticker Corner Peel Reveal</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0; min-height: 100vh; display: flex; flex-direction: column;
+      align-items: center; justify-content: center; gap: 1rem; padding: 24px;
+      background: linear-gradient(160deg, #f8fafc, #eef2ff 55%, #f8fafc);
+      color: #111827; font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+      
+    }
+    h1 { margin: 0; font-size: 1.25rem; text-align: center; }
+    .note { margin: 0; max-width: 420px; text-align: center; color: #4b5563; font-size: 0.92rem; line-height: 1.45; }
+  </style>
+</head>
+<body>
+  <h1>Sticker Corner Peel Reveal</h1>
+  <p class="note">Hover or click to peel.</p>
+  <label class="sticker">
+  <input type="checkbox" />
+  <div class="sticker__face">20% OFF</div>
+  <div class="sticker__peel" aria-hidden="true"></div>
+</label>
+  
+</body>
+</html>

--- a/submissions/examples/sticker-corner-peel-sk/style.css
+++ b/submissions/examples/sticker-corner-peel-sk/style.css
@@ -1,0 +1,6 @@
+.sticker{position:relative;display:inline-block;cursor:pointer}
+.sticker input{position:absolute;opacity:0}
+.sticker__face{width:180px;height:120px;display:grid;place-items:center;border-radius:12px;background:#fef3c7;border:2px solid #f59e0b;font-weight:800;font-size:1.2rem;box-shadow:0 8px 20px rgb(245 158 11/.25)}
+.sticker__peel{position:absolute;right:0;top:0;width:46%;height:46%;background:linear-gradient(135deg,transparent 49.5%,#fff7ed 50%);transform-origin:100% 0;transition:transform 280ms ease;filter:drop-shadow(-2px 2px 2px rgb(0 0 0/.15))}
+.sticker:hover .sticker__peel,.sticker:has(:checked) .sticker__peel{transform:rotate(-18deg) translate(6px,-4px)}
+@media (prefers-reduced-motion:reduce){.sticker__peel{transition:none}}


### PR DESCRIPTION
## Pull Request Description

Adds `Sticker Corner Peel Reveal` under `submissions/examples/sticker-corner-peel-sk/` for #63220.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> PRs that fail this checklist will be closed without review.

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A sticker card whose corner peels back on hover or when locked open.

**How does a developer use it?**

```html
<label class="sticker"><input type="checkbox"/><div class="sticker__face">20% OFF</div></label>
```

**Why does it fit EaseMotion CSS?**

Tangible reveal affordance for coupons and promotional cards.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #63220.
