### PR TITLE
Add expandable-card-accordion-menu component

### DIFF
--- a/submissions/examples/expandable-card-accordion-menu/README.md
+++ b/submissions/examples/expandable-card-accordion-menu/README.md
@@ -1,0 +1,8 @@
+﻿# expandable-card-accordion-menu
+
+A compact card accordion layout that expands and collapses details without script dependencies.
+
+## Features
+- Pure CSS layout logic.
+- Light and dark theme adaptable.
+- Clean semantic HTML structure.

--- a/submissions/examples/expandable-card-accordion-menu/demo.html
+++ b/submissions/examples/expandable-card-accordion-menu/demo.html
@@ -1,0 +1,27 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>expandable-card-accordion-menu</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Expandable Card Accordion Menu</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="expand-card">
+    <input type="checkbox" id="ec-menu">
+    <label for="ec-menu">Accordion Header</label>
+    <div class="ec-body">
+      <p>This is the inner content revealed gracefully using transition heights.</p>
+    </div>
+  </div>
+</body>
+</html>
+</body>
+</html>

--- a/submissions/examples/expandable-card-accordion-menu/style.css
+++ b/submissions/examples/expandable-card-accordion-menu/style.css
@@ -1,0 +1,37 @@
+﻿body {
+  margin: 0;
+  padding: 0;
+  background-color: #0b0f19;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  font-family: system-ui, sans-serif;
+}
+.expand-card {
+  width: 280px;
+  background: #1e293b;
+  border-radius: 8px;
+  overflow: hidden;
+}
+.expand-card input {
+  display: none;
+}
+.expand-card label {
+  display: block;
+  padding: 15px;
+  color: #fff;
+  cursor: pointer;
+  background: #334155;
+}
+.ec-body {
+  max-height: 0;
+  padding: 0 15px;
+  color: #cbd5e1;
+  overflow: hidden;
+  transition: max-height 0.3s, padding 0.3s;
+}
+.expand-card input:checked ~ .ec-body {
+  max-height: 100px;
+  padding: 15px;
+}


### PR DESCRIPTION
Adds the new expandable-card-accordion-menu component under submissions/examples/.