### PR TITLE
feat: add ticket tear stub (#63221)

### DIFF
--- a/submissions/examples/ticket-tear-stub-sk/README.md
+++ b/submissions/examples/ticket-tear-stub-sk/README.md
@@ -1,0 +1,17 @@
+# Perforated Ticket Tear Stub
+
+## What does this do?
+
+A boarding-pass ticket that tears along a perforation, leaving the stub behind.
+
+## How is it used?
+
+```html
+<div class="ticket"><div class="ticket__main">Gate B12</div><div class="ticket__stub">STUB</div></div>
+```
+
+Open `demo.html` in a browser to try it.
+
+## Why is it useful?
+
+Memorable redeem/check-in metaphor with staged motion.

--- a/submissions/examples/ticket-tear-stub-sk/demo.html
+++ b/submissions/examples/ticket-tear-stub-sk/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Perforated Ticket Tear Stub</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0; min-height: 100vh; display: flex; flex-direction: column;
+      align-items: center; justify-content: center; gap: 1rem; padding: 24px;
+      background: linear-gradient(160deg, #f8fafc, #eef2ff 55%, #f8fafc);
+      color: #111827; font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+      
+    }
+    h1 { margin: 0; font-size: 1.25rem; text-align: center; }
+    .note { margin: 0; max-width: 420px; text-align: center; color: #4b5563; font-size: 0.92rem; line-height: 1.45; }
+  </style>
+</head>
+<body>
+  <h1>Perforated Ticket Tear Stub</h1>
+  
+  <div>
+<div class="ticket">
+  <div class="ticket__main"><strong>Gate B12</strong><div>Seat 14A · Boarding 18:40</div></div>
+  <div class="ticket__perf" aria-hidden="true"></div>
+  <div class="ticket__stub">STUB</div>
+</div>
+<label class="ticket__tear-btn"><input class="ticket__tear" type="checkbox" hidden />Tear ticket</label>
+</div>
+  
+</body>
+</html>

--- a/submissions/examples/ticket-tear-stub-sk/style.css
+++ b/submissions/examples/ticket-tear-stub-sk/style.css
@@ -1,0 +1,8 @@
+.ticket{display:grid;grid-template-columns:1fr 12px auto;width:min(100%,420px);background:#fff;border-radius:12px;overflow:hidden;box-shadow:0 10px 28px rgb(0 0 0/.12);border:1px solid #e5e7eb}
+.ticket__main,.ticket__stub{padding:16px}
+.ticket__main{background:linear-gradient(135deg,#eff6ff,#fff)}
+.ticket__perf{background:repeating-linear-gradient(#fff 0 6px,#d1d5db 6px 8px);border-left:1px dashed #9ca3af;border-right:1px dashed #9ca3af}
+.ticket__stub{background:#111827;color:#fff;font-weight:800;display:grid;place-items:center}
+.ticket:has(.ticket__tear:checked) .ticket__main{transform:translate(-18px,-10px) rotate(-5deg);transition:transform 420ms cubic-bezier(.2,.8,.2,1);box-shadow:0 12px 24px rgb(0 0 0/.15)}
+.ticket__tear-btn{margin-top:12px;padding:8px 14px;border-radius:8px;border:1px solid #d1d5db;background:#fff;font-weight:700;cursor:pointer}
+@media (prefers-reduced-motion:reduce){.ticket__main{transition:none}}


### PR DESCRIPTION
## Pull Request Description

Adds `Perforated Ticket Tear Stub` under `submissions/examples/ticket-tear-stub-sk/` for #63221.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> PRs that fail this checklist will be closed without review.

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A boarding-pass ticket that tears along a perforation, leaving the stub behind.

**How does a developer use it?**

```html
<div class="ticket"><div class="ticket__main">Gate B12</div><div class="ticket__stub">STUB</div></div>
```

**Why does it fit EaseMotion CSS?**

Memorable redeem/check-in metaphor with staged motion.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #63221.
