### PR TITLE
feat: add moon phase cycle (#63225)

### DIFF
--- a/submissions/examples/moon-phase-cycle-sk/README.md
+++ b/submissions/examples/moon-phase-cycle-sk/README.md
@@ -1,0 +1,17 @@
+# Moon Phase Cycle Indicator
+
+## What does this do?
+
+A lunar phase control scrubbed by a range input via --phase.
+
+## How is it used?
+
+```html
+<div class="moon" style="--phase:.35"><div class="moon__sphere"></div></div>
+```
+
+Open `demo.html` in a browser to try it.
+
+## Why is it useful?
+
+Clear educational control for weather and astronomy UIs.

--- a/submissions/examples/moon-phase-cycle-sk/demo.html
+++ b/submissions/examples/moon-phase-cycle-sk/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Moon Phase Cycle Indicator</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0; min-height: 100vh; display: flex; flex-direction: column;
+      align-items: center; justify-content: center; gap: 1rem; padding: 24px;
+      background: linear-gradient(160deg, #f8fafc, #eef2ff 55%, #f8fafc);
+      color: #111827; font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+      
+    }
+    h1 { margin: 0; font-size: 1.25rem; text-align: center; }
+    .note { margin: 0; max-width: 420px; text-align: center; color: #4b5563; font-size: 0.92rem; line-height: 1.45; }
+  </style>
+</head>
+<body>
+  <h1>Moon Phase Cycle Indicator</h1>
+  
+  <div class="moon" id="moon" style="--phase: 0.35;"><div class="moon__sphere" aria-hidden="true"></div>
+<input type="range" min="0" max="100" value="35" aria-label="Moon phase" id="phase"/></div>
+  <script>
+var m=document.getElementById('moon'),p=document.getElementById('phase');p.addEventListener('input',function(){m.style.setProperty('--phase',(+p.value/100).toFixed(3))});
+</script>
+</body>
+</html>

--- a/submissions/examples/moon-phase-cycle-sk/style.css
+++ b/submissions/examples/moon-phase-cycle-sk/style.css
@@ -1,0 +1,8 @@
+.moon{display:grid;gap:12px;justify-items:center}
+.moon__sphere{width:96px;height:96px;border-radius:50%;background:#f5f0d8;position:relative;overflow:hidden;box-shadow:inset -8px -6px 16px rgb(0 0 0/.2)}
+.moon__sphere::after{content:"";position:absolute;inset:0;border-radius:50%;background:#0b1220;transform:translateX(calc((var(--phase) - .5)*200%))}
+.moon input{width:220px}
+
+/* state tokens */
+:root{--demo-gap:1rem}
+.demo-safe{min-width:0}


### PR DESCRIPTION
## Pull Request Description

Adds `Moon Phase Cycle Indicator` under `submissions/examples/moon-phase-cycle-sk/` for #63225.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> PRs that fail this checklist will be closed without review.

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A lunar phase control scrubbed by a range input via --phase.

**How does a developer use it?**

```html
<div class="moon" style="--phase:.35"><div class="moon__sphere"></div></div>
```

**Why does it fit EaseMotion CSS?**

Clear educational control for weather and astronomy UIs.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #63225.
