### PR TITLE
Add CSS blur-entrance toast for SaaS showcase layouts

### DIFF
--- a/submissions/examples/css-blur-entrance-toast-saas/README.md
+++ b/submissions/examples/css-blur-entrance-toast-saas/README.md
@@ -1,0 +1,27 @@
+# CSS Blur-Entrance Toast for SaaS Showcase
+
+A pure CSS notification toast designed for modern SaaS release logs and admin notifications. Features a "sharpen into focus" entrance transition that smoothly resolves from a blurred, scaled-up initial state down to zero blur and crisp positioning. No JavaScript required.
+
+## How it works
+
+Utilizes the pure CSS checkbox toggle pattern (`#ease-saas-blur-toggle`) to control visibility. When hidden, the notification card holds `filter: blur(10px)`, `opacity: 0`, and `transform: translateY(10px) scale(1.03)`. Checking the toggle animates `filter`, `transform`, and `opacity` to resting baseline values (`blur(0)` and `scale(1)`), creating a camera-focus entrance effect.
+
+## Files
+
+`demo.html`, `style.css`, `README.md`
+
+## Custom properties
+
+- `--ease-toast-duration`: Speed of blur-to-focus animation (`0.4s`)
+- `--ease-toast-radius`: Corner radius for container (`12px`)
+- `--ease-toast-bg`: Dark surface background color (`#0f172a`)
+- `--ease-toast-border`: Card boundary border color (`#1e293b`)
+- `--ease-toast-text`: Primary headline text color (`#f8fafc`)
+- `--ease-toast-muted-text`: Subtitle description color (`#94a3b8`)
+- `--ease-toast-accent`: Primary sky-blue brand color (`#38bdf8`)
+- `--ease-toast-blur`: Starting blur magnitude (`10px`)
+
+## Accessibility & Performance
+
+- Blur threshold is constrained to a performant 10px limit to avoid browser paint delays.
+- Full support for `@media (prefers-reduced-motion: reduce)` which disables `filter` and `transform` animations in favor of direct opacity fades.

--- a/submissions/examples/css-blur-entrance-toast-saas/demo.html
+++ b/submissions/examples/css-blur-entrance-toast-saas/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Blur-Entrance Toast — SaaS Showcase</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="ease-container">
+    <p class="ease-eyebrow">Deployment Pipeline</p>
+    <h1 class="ease-heading">Release Alert</h1>
+    <p class="ease-subtitle">Toggle or hover the notification to trigger the focus-blur entrance sequence.</p>
+
+    <div class="ease-toast-wrapper">
+      <input type="checkbox" id="ease-saas-blur-toggle" class="ease-toast-input" checked />
+
+      <label for="ease-saas-blur-toggle" class="ease-trigger-btn">
+        Toggle Release Toast
+      </label>
+
+      <div class="ease-toast">
+        <div class="ease-toast-icon">🚀</div>
+
+        <div class="ease-toast-content">
+          <p class="ease-toast-title">Version v2.4.0 Deployed</p>
+          <p class="ease-toast-message">All microservices active across production clusters.</p>
+        </div>
+
+        <label for="ease-saas-blur-toggle" class="ease-toast-close" title="Dismiss Alert">✕</label>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/css-blur-entrance-toast-saas/style.css
+++ b/submissions/examples/css-blur-entrance-toast-saas/style.css
@@ -1,0 +1,180 @@
+:root {
+  --ease-toast-duration: 0.4s;
+  --ease-toast-radius: 12px;
+  --ease-toast-bg: #0f172a;
+  --ease-toast-border: #1e293b;
+  --ease-toast-text: #f8fafc;
+  --ease-toast-muted-text: #94a3b8;
+  --ease-toast-accent: #38bdf8;
+  --ease-toast-blur: 10px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #020617;
+  color: var(--ease-toast-text);
+  padding: 3rem 1.5rem;
+}
+
+.ease-container {
+  max-width: 420px;
+  margin: 0 auto;
+}
+
+.ease-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--ease-toast-accent);
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
+.ease-heading {
+  font-size: 1.6rem;
+  margin: 0 0 0.5rem;
+  letter-spacing: -0.02em;
+}
+
+.ease-subtitle {
+  color: var(--ease-toast-muted-text);
+  margin: 0 0 2rem;
+  font-size: 0.9rem;
+}
+
+.ease-toast-wrapper {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  align-items: flex-start;
+}
+
+.ease-toast-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* Trigger Button */
+.ease-trigger-btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.7rem 1.2rem;
+  background: var(--ease-toast-bg);
+  border: 1px solid var(--ease-toast-border);
+  border-radius: var(--ease-toast-radius);
+  color: var(--ease-toast-text);
+  font-size: 0.88rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.ease-trigger-btn:hover {
+  border-color: rgba(56, 189, 248, 0.4);
+}
+
+/* Toast Container with Blur Entrance */
+.ease-toast {
+  position: relative;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 1.2rem;
+  background: var(--ease-toast-bg);
+  border: 1px solid var(--ease-toast-border);
+  border-left: 4px solid var(--ease-toast-accent);
+  border-radius: var(--ease-toast-radius);
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.5);
+  opacity: 0;
+  visibility: hidden;
+  filter: blur(var(--ease-toast-blur));
+  transform: translateY(10px) scale(1.03);
+  transition: opacity var(--ease-toast-duration) ease-out,
+              filter var(--ease-toast-duration) ease-out,
+              transform var(--ease-toast-duration) ease-out,
+              visibility 0s linear var(--ease-toast-duration);
+}
+
+.ease-toast-input:checked ~ .ease-toast {
+  opacity: 1;
+  visibility: visible;
+  filter: blur(0);
+  transform: translateY(0) scale(1);
+  border-color: rgba(56, 189, 248, 0.3);
+  transition: opacity var(--ease-toast-duration) ease-out,
+              filter var(--ease-toast-duration) ease-out,
+              transform var(--ease-toast-duration) ease-out;
+}
+
+/* Status Icon Badge */
+.ease-toast-icon {
+  width: 38px;
+  height: 38px;
+  border-radius: 8px;
+  background: rgba(56, 189, 248, 0.12);
+  border: 1px solid rgba(56, 189, 248, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  font-size: 1.1rem;
+}
+
+/* Content */
+.ease-toast-content {
+  flex: 1;
+}
+
+.ease-toast-title {
+  margin: 0 0 0.2rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--ease-toast-text);
+}
+
+.ease-toast-message {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--ease-toast-muted-text);
+}
+
+/* Close Button */
+.ease-toast-close {
+  color: var(--ease-toast-muted-text);
+  font-size: 0.9rem;
+  cursor: pointer;
+  padding: 0.2rem;
+  transition: color 0.15s ease;
+}
+
+.ease-toast-close:hover {
+  color: var(--ease-toast-text);
+}
+
+@media (max-width: 480px) {
+  body {
+    padding: 2rem 1rem;
+  }
+  .ease-heading {
+    font-size: 1.35rem;
+  }
+  .ease-toast {
+    padding: 0.85rem 1rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-toast {
+    transition: opacity 0.15s ease !important;
+    filter: none !important;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Closes #62077

Adds a pure CSS/HTML toast component styled for SaaS deployment alerts, featuring a blur-to-focus entrance sequence as the notification reveals.

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

## Submission Checklist
- [x] All changes inside `submissions/examples/css-blur-entrance-toast-saas/`
- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Feature Description
**What does this add?** A SaaS deployment release alert toast that transitions from `filter: blur(10px)` and scale `1.03` down to `blur(0)` and scale `1` when toggled.
**Why does it fit?** Expands EaseMotion CSS showcase components with focus/blur motion effects tailored to cloud dashboard alert mechanisms without JS dependencies.

## Demo
- [x] Demo added

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge

## Notes for Maintainer
Includes full `prefers-reduced-motion` accessibility fallbacks (disabling filter blur and scaling) and keeps the blur radius optimized for rendering performance.