### PR TITLE
feat: add claymorphism press kit (#63231)

### DIFF
--- a/submissions/examples/claymorphism-press-kit-sk/README.md
+++ b/submissions/examples/claymorphism-press-kit-sk/README.md
@@ -1,0 +1,17 @@
+# Claymorphism Soft Press Controls
+
+## What does this do?
+
+A claymorphism button/toggle kit with fat borders and press-in depth.
+
+## How is it used?
+
+```html
+<button class="clay-btn" type="button">Continue</button>
+```
+
+Open `demo.html` in a browser to try it.
+
+## Why is it useful?
+
+Tactile soft-press language that expands beyond flat/glass looks.

--- a/submissions/examples/claymorphism-press-kit-sk/demo.html
+++ b/submissions/examples/claymorphism-press-kit-sk/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Claymorphism Soft Press Controls</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0; min-height: 100vh; display: flex; flex-direction: column;
+      align-items: center; justify-content: center; gap: 1rem; padding: 24px;
+      background: linear-gradient(160deg, #f8fafc, #eef2ff 55%, #f8fafc);
+      color: #111827; font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+      
+    }
+    h1 { margin: 0; font-size: 1.25rem; text-align: center; }
+    .note { margin: 0; max-width: 420px; text-align: center; color: #4b5563; font-size: 0.92rem; line-height: 1.45; }
+  </style>
+</head>
+<body>
+  <h1>Claymorphism Soft Press Controls</h1>
+  
+  <div><button class="clay-btn" type="button">Continue</button>
+<label class="clay-toggle"><input type="checkbox" /><span>Soft toggle</span></label></div>
+  
+</body>
+</html>

--- a/submissions/examples/claymorphism-press-kit-sk/style.css
+++ b/submissions/examples/claymorphism-press-kit-sk/style.css
@@ -1,0 +1,8 @@
+.clay-btn{border:3px solid #111;border-radius:16px;padding:12px 18px;background:#ffd6a5;font-weight:800;box-shadow:4px 4px 0 #111, inset 0 2px 0 rgb(255 255 255/.5);cursor:pointer;transition:transform 120ms ease,box-shadow 120ms ease}
+.clay-btn:active{transform:translate(2px,2px);box-shadow:2px 2px 0 #111}
+.clay-toggle{display:inline-flex;align-items:center;gap:10px;margin-left:12px;font-weight:700}
+.clay-toggle input{appearance:none;width:52px;height:30px;border:3px solid #111;border-radius:999px;background:#fdba74;position:relative;box-shadow:3px 3px 0 #111;cursor:pointer}
+.clay-toggle input::after{content:"";position:absolute;top:2px;left:2px;width:18px;height:18px;border-radius:50%;background:#111;transition:transform 160ms ease}
+.clay-toggle input:checked{background:#86efac}
+.clay-toggle input:checked::after{transform:translateX(22px)}
+@media (prefers-reduced-motion:reduce){.clay-btn,.clay-toggle input::after{transition:none}}


### PR DESCRIPTION
## Pull Request Description

Adds `Claymorphism Soft Press Controls` under `submissions/examples/claymorphism-press-kit-sk/` for #63231.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> PRs that fail this checklist will be closed without review.

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A claymorphism button/toggle kit with fat borders and press-in depth.

**How does a developer use it?**

```html
<button class="clay-btn" type="button">Continue</button>
```

**Why does it fit EaseMotion CSS?**

Tactile soft-press language that expands beyond flat/glass looks.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #63231.
