### PR TITLE
feat: add split pane resize handle (#63236)

### DIFF
--- a/submissions/examples/split-pane-resize-handle-sk/README.md
+++ b/submissions/examples/split-pane-resize-handle-sk/README.md
@@ -1,0 +1,17 @@
+# Split-Pane Resize Handle
+
+## What does this do?
+
+A split view with a styled resize gutter using CSS resize.
+
+## How is it used?
+
+```html
+<div class="split"><div class="split__pane split__pane--left">Editor</div><div class="split__pane">Preview</div></div>
+```
+
+Open `demo.html` in a browser to try it.
+
+## Why is it useful?
+
+Discoverable pane resizing for editor/dashboard chrome.

--- a/submissions/examples/split-pane-resize-handle-sk/demo.html
+++ b/submissions/examples/split-pane-resize-handle-sk/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Split-Pane Resize Handle</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0; min-height: 100vh; display: flex; flex-direction: column;
+      align-items: center; justify-content: center; gap: 1rem; padding: 24px;
+      background: linear-gradient(160deg, #f8fafc, #eef2ff 55%, #f8fafc);
+      color: #111827; font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+      
+    }
+    h1 { margin: 0; font-size: 1.25rem; text-align: center; }
+    .note { margin: 0; max-width: 420px; text-align: center; color: #4b5563; font-size: 0.92rem; line-height: 1.45; }
+  </style>
+</head>
+<body>
+  <h1>Split-Pane Resize Handle</h1>
+  
+  <div class="split"><div class="split__pane split__pane--left">Editor<br/><small style="font-weight:500;color:#6b7280">Drag edge to resize</small></div><div class="split__gutter" aria-hidden="true"></div><div class="split__pane">Preview</div></div>
+  
+</body>
+</html>

--- a/submissions/examples/split-pane-resize-handle-sk/style.css
+++ b/submissions/examples/split-pane-resize-handle-sk/style.css
@@ -1,0 +1,6 @@
+.split{display:flex;width:min(100%,460px);min-height:180px;border:1px solid #e5e7eb;border-radius:12px;overflow:hidden;background:#fff}
+.split__pane{padding:12px;font-weight:700}
+.split__pane--left{resize:horizontal;overflow:auto;min-width:120px;max-width:75%;width:42%;border-right:1px solid #e5e7eb;background:#f8fafc}
+.split__gutter{width:8px;background:#e5e7eb;transition:background-color 160ms ease,width 160ms ease;cursor:col-resize}
+.split__gutter:hover{background:#2563eb;width:10px}
+@media (prefers-reduced-motion:reduce){.split__gutter{transition:none}}


### PR DESCRIPTION
## Pull Request Description

Adds `Split-Pane Resize Handle` under `submissions/examples/split-pane-resize-handle-sk/` for #63236.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> PRs that fail this checklist will be closed without review.

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A split view with a styled resize gutter using CSS resize.

**How does a developer use it?**

```html
<div class="split"><div class="split__pane split__pane--left">Editor</div><div class="split__pane">Preview</div></div>
```

**Why does it fit EaseMotion CSS?**

Discoverable pane resizing for editor/dashboard chrome.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #63236.
