### PR TITLE
feat: add uptime availability bars (#63237)

### DIFF
--- a/submissions/examples/uptime-availability-bars-sk/README.md
+++ b/submissions/examples/uptime-availability-bars-sk/README.md
@@ -1,0 +1,17 @@
+# Status Uptime Availability Bars
+
+## What does this do?
+
+A compact uptime strip with day cells, color states, and entrance stagger.
+
+## How is it used?
+
+```html
+<div class="uptime"><span class="day is-up"></span></div>
+```
+
+Open `demo.html` in a browser to try it.
+
+## Why is it useful?
+
+Reusable status-page building block for reliability history.

--- a/submissions/examples/uptime-availability-bars-sk/demo.html
+++ b/submissions/examples/uptime-availability-bars-sk/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Status Uptime Availability Bars</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0; min-height: 100vh; display: flex; flex-direction: column;
+      align-items: center; justify-content: center; gap: 1rem; padding: 24px;
+      background: linear-gradient(160deg, #f8fafc, #eef2ff 55%, #f8fafc);
+      color: #111827; font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+      
+    }
+    h1 { margin: 0; font-size: 1.25rem; text-align: center; }
+    .note { margin: 0; max-width: 420px; text-align: center; color: #4b5563; font-size: 0.92rem; line-height: 1.45; }
+  </style>
+</head>
+<body>
+  <h1>Status Uptime Availability Bars</h1>
+  
+  <div class="uptime" aria-label="90 day uptime"><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-degraded" title="Degraded"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-degraded" title="Degraded"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-degraded" title="Degraded"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span><span class="day is-up" title="Operational"></span></div>
+  
+</body>
+</html>

--- a/submissions/examples/uptime-availability-bars-sk/style.css
+++ b/submissions/examples/uptime-availability-bars-sk/style.css
@@ -1,0 +1,6 @@
+.uptime{display:flex;gap:2px;width:min(100%,420px);flex-wrap:wrap}
+.day{width:8px;height:28px;border-radius:2px;background:#22c55e;transform-origin:bottom;animation:day-in .3s ease both}
+.day.is-degraded{background:#f59e0b}.day.is-down{background:#ef4444}
+.day:nth-child(3n){animation-delay:.03s}.day:nth-child(5n){animation-delay:.06s}
+@keyframes day-in{from{transform:scaleY(.2);opacity:0}}
+@media (prefers-reduced-motion:reduce){.day{animation:none}}


### PR DESCRIPTION
## Pull Request Description

Adds `Status Uptime Availability Bars` under `submissions/examples/uptime-availability-bars-sk/` for #63237.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> PRs that fail this checklist will be closed without review.

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A compact uptime strip with day cells, color states, and entrance stagger.

**How does a developer use it?**

```html
<div class="uptime"><span class="day is-up"></span></div>
```

**Why does it fit EaseMotion CSS?**

Reusable status-page building block for reliability history.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #63237.
