### PR TITLE
feat: add pin passcode pad (#63244)

### DIFF
--- a/submissions/examples/pin-passcode-pad-sk/README.md
+++ b/submissions/examples/pin-passcode-pad-sk/README.md
@@ -1,0 +1,17 @@
+# PIN Passcode Digit Pad
+
+## What does this do?
+
+A PIN pad with press-depth keys and filling status dots.
+
+## How is it used?
+
+```html
+<div class="pin"><div class="pin__dots"></div><div class="pin__pad"><button>1</button></div></div>
+```
+
+Open `demo.html` in a browser to try it.
+
+## Why is it useful?
+
+Auth chrome microinteraction focused on pad feedback, not OTP boxes.

--- a/submissions/examples/pin-passcode-pad-sk/demo.html
+++ b/submissions/examples/pin-passcode-pad-sk/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>PIN Passcode Digit Pad</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0; min-height: 100vh; display: flex; flex-direction: column;
+      align-items: center; justify-content: center; gap: 1rem; padding: 24px;
+      background: linear-gradient(160deg, #f8fafc, #eef2ff 55%, #f8fafc);
+      color: #111827; font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+    }
+    h1 { margin: 0; font-size: 1.25rem; text-align: center; }
+    .note { margin: 0; max-width: 420px; text-align: center; color: #4b5563; font-size: 0.92rem; line-height: 1.45; }
+  </style>
+</head>
+<body>
+  <h1>PIN Passcode Digit Pad</h1>
+  
+  <div class="pin" id="pin"><div class="pin__dots" aria-live="polite"><span></span><span></span><span></span><span></span></div><div class="pin__pad"></div></div>
+  <script>
+var pin=document.getElementById('pin'),pad=pin.querySelector('.pin__pad'),dots=[].slice.call(pin.querySelectorAll('.pin__dots span'));
+var n=0;['1','2','3','4','5','6','7','8','9','','0','⌫'].forEach(function(label){var b=document.createElement('button');b.type='button';if(!label){b.disabled=true;b.style.visibility='hidden';}else{b.textContent=label;}pad.appendChild(b);b.addEventListener('click',function(){if(label==='⌫'){n=Math.max(0,n-1);}else if(n<4){n++;}dots.forEach(function(d,i){d.classList.toggle('is-filled',i<n)});pin.classList.remove('is-error');if(n===4){pin.classList.add('is-error');setTimeout(function(){n=0;dots.forEach(function(d){d.classList.remove('is-filled')});pin.classList.remove('is-error');},500);}});});
+</script>
+</body>
+</html>

--- a/submissions/examples/pin-passcode-pad-sk/style.css
+++ b/submissions/examples/pin-passcode-pad-sk/style.css
@@ -1,0 +1,10 @@
+.pin{width:220px;display:grid;gap:16px;justify-items:center}
+.pin__dots{display:flex;gap:10px}
+.pin__dots span{width:10px;height:10px;border-radius:50%;border:2px solid #111;transition:background-color 120ms ease}
+.pin__dots span.is-filled{background:#111}
+.pin__pad{display:grid;grid-template-columns:repeat(3,56px);gap:10px}
+.pin__pad button{width:56px;height:56px;border-radius:50%;border:0;background:#e5e7eb;font-weight:700;font-size:1.1rem;cursor:pointer;transition:transform 100ms ease,background-color 100ms ease}
+.pin__pad button:active{transform:scale(.94);background:#d1d5db}
+.pin.is-error{animation:pin-shake .3s ease}
+@keyframes pin-shake{25%{transform:translateX(-4px)}75%{transform:translateX(4px)}}
+@media (prefers-reduced-motion:reduce){.pin__pad button,.pin.is-error{transition:none;animation:none}}


### PR DESCRIPTION
## Pull Request Description

Adds `PIN Passcode Digit Pad` under `submissions/examples/pin-passcode-pad-sk/` for #63244.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> PRs that fail this checklist will be closed without review.

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A PIN pad with press-depth keys and filling status dots.

**How does a developer use it?**

```html
<div class="pin"><div class="pin__dots"></div><div class="pin__pad"><button>1</button></div></div>
```

**Why does it fit EaseMotion CSS?**

Auth chrome microinteraction focused on pad feedback, not OTP boxes.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #63244.
