### PR TITLE
feat: add ios action sheet (#63250)

### DIFF
--- a/submissions/examples/ios-action-sheet-sk/README.md
+++ b/submissions/examples/ios-action-sheet-sk/README.md
@@ -1,0 +1,17 @@
+# iOS Action Sheet
+
+## What does this do?
+
+An iOS-style action sheet with grouped actions and a separated cancel button.
+
+## How is it used?
+
+```html
+<div class="action-sheet" role="dialog"><button>Save</button></div>
+```
+
+Open `demo.html` in a browser to try it.
+
+## Why is it useful?
+
+Essential mobile pattern with springy bottom ingress.

--- a/submissions/examples/ios-action-sheet-sk/demo.html
+++ b/submissions/examples/ios-action-sheet-sk/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>iOS Action Sheet</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0; min-height: 100vh; display: flex; flex-direction: column;
+      align-items: center; justify-content: center; gap: 1rem; padding: 24px;
+      background: linear-gradient(160deg, #f8fafc, #eef2ff 55%, #f8fafc);
+      color: #111827; font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+    }
+    h1 { margin: 0; font-size: 1.25rem; text-align: center; }
+    .note { margin: 0; max-width: 420px; text-align: center; color: #4b5563; font-size: 0.92rem; line-height: 1.45; }
+  </style>
+</head>
+<body>
+  <h1>iOS Action Sheet</h1>
+  
+  <div class="action-sheet" role="dialog" aria-modal="true"><div class="action-sheet__group"><button type="button">Save Image</button><button type="button">Copy Link</button><button type="button" class="is-destructive">Delete</button></div><button type="button" class="action-sheet__cancel">Cancel</button></div>
+  
+</body>
+</html>

--- a/submissions/examples/ios-action-sheet-sk/style.css
+++ b/submissions/examples/ios-action-sheet-sk/style.css
@@ -1,0 +1,8 @@
+.action-sheet{position:relative;width:min(100%,340px);display:grid;gap:8px;animation:sheet-up .32s cubic-bezier(.2,.8,.2,1)}
+.action-sheet__group{border-radius:14px;overflow:hidden;background:rgb(255 255 255/.9);border:1px solid #e5e7eb;backdrop-filter:blur(12px)}
+.action-sheet__group button,.action-sheet__cancel{width:100%;border:0;background:transparent;padding:14px;font-weight:700;cursor:pointer}
+.action-sheet__group button+button{border-top:1px solid #e5e7eb}
+.is-destructive{color:#dc2626}
+.action-sheet__cancel{border-radius:14px;background:#fff;border:1px solid #e5e7eb}
+@keyframes sheet-up{from{transform:translateY(24px);opacity:0}}
+@media (prefers-reduced-motion:reduce){.action-sheet{animation:none}}


### PR DESCRIPTION
## Pull Request Description

Adds `iOS Action Sheet` under `submissions/examples/ios-action-sheet-sk/` for #63250.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> PRs that fail this checklist will be closed without review.

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

An iOS-style action sheet with grouped actions and a separated cancel button.

**How does a developer use it?**

```html
<div class="action-sheet" role="dialog"><button>Save</button></div>
```

**Why does it fit EaseMotion CSS?**

Essential mobile pattern with springy bottom ingress.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #63250.
