### PR TITLE
feat: add overscroll edge glow (#63251)

### DIFF
--- a/submissions/examples/overscroll-edge-glow-sk/README.md
+++ b/submissions/examples/overscroll-edge-glow-sk/README.md
@@ -1,0 +1,17 @@
+# Overscroll Edge Glow
+
+## What does this do?
+
+A scroll container that shows edge glow cues at top/bottom bounds.
+
+## How is it used?
+
+```html
+<div class="scroll-glow"><div class="scroll-glow__content"></div></div>
+```
+
+Open `demo.html` in a browser to try it.
+
+## Why is it useful?
+
+Teaches scroll boundaries without layout jump.

--- a/submissions/examples/overscroll-edge-glow-sk/demo.html
+++ b/submissions/examples/overscroll-edge-glow-sk/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Overscroll Edge Glow</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0; min-height: 100vh; display: flex; flex-direction: column;
+      align-items: center; justify-content: center; gap: 1rem; padding: 24px;
+      background: linear-gradient(160deg, #f8fafc, #eef2ff 55%, #f8fafc);
+      color: #111827; font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+    }
+    h1 { margin: 0; font-size: 1.25rem; text-align: center; }
+    .note { margin: 0; max-width: 420px; text-align: center; color: #4b5563; font-size: 0.92rem; line-height: 1.45; }
+  </style>
+</head>
+<body>
+  <h1>Overscroll Edge Glow</h1>
+  
+  <div class="scroll-glow" id="glow"><div class="scroll-glow__content"><p>Scroll this panel.</p><p>Edge glow appears at the bounds.</p><p>More content.</p><p>Keep going.</p><p>Almost there.</p><p>End of list.</p><p>Last line.</p></div></div>
+  <script>
+var el=document.getElementById('glow');function sync(){var top=el.scrollTop<=0;var bottom=el.scrollTop+el.clientHeight>=el.scrollHeight-1;el.classList.toggle('is-top',top);el.classList.toggle('is-bottom',bottom);} el.addEventListener('scroll',sync);sync();
+</script>
+</body>
+</html>

--- a/submissions/examples/overscroll-edge-glow-sk/style.css
+++ b/submissions/examples/overscroll-edge-glow-sk/style.css
@@ -1,0 +1,6 @@
+.scroll-glow{width:min(100%,320px);max-height:180px;overflow:auto;border-radius:12px;border:1px solid #e5e7eb;background:#fff;position:relative}
+.scroll-glow__content{padding:14px;line-height:1.5}
+.scroll-glow.is-top{box-shadow:inset 0 18px 16px -16px rgb(37 99 235/.45)}
+.scroll-glow.is-bottom{box-shadow:inset 0 -18px 16px -16px rgb(37 99 235/.45)}
+.scroll-glow.is-top.is-bottom{box-shadow:inset 0 18px 16px -16px rgb(37 99 235/.45),inset 0 -18px 16px -16px rgb(37 99 235/.45)}
+@media (prefers-reduced-motion:reduce){.scroll-glow{box-shadow:none}}


### PR DESCRIPTION
## Pull Request Description

Adds `Overscroll Edge Glow` under `submissions/examples/overscroll-edge-glow-sk/` for #63251.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> PRs that fail this checklist will be closed without review.

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A scroll container that shows edge glow cues at top/bottom bounds.

**How does a developer use it?**

```html
<div class="scroll-glow"><div class="scroll-glow__content"></div></div>
```

**Why does it fit EaseMotion CSS?**

Teaches scroll boundaries without layout jump.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #63251.
