### PR TITLE
Add ease-barista-coffee-pour component

### DIFF
--- a/submissions/examples/barista-coffee-pour-ij/README.md
+++ b/submissions/examples/barista-coffee-pour-ij/README.md
@@ -1,0 +1,10 @@
+# ease-barista-coffee-pour
+
+A coffee bar where the barista tilts the pot and pours a stream into the cup while steam rises and coffee beans bob beside the counter.
+
+## Run
+Open `demo.html` directly in a browser to watch the pour.
+
+## Notes
+- The pour stream pulses in length.
+- The cup fill rises and drains.

--- a/submissions/examples/barista-coffee-pour-ij/demo.html
+++ b/submissions/examples/barista-coffee-pour-ij/demo.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-barista-coffee-pour demo</title>
+</head>
+<body>
+<div class="bc-app">
+  <span class="bc-brand">BREW BAR</span>
+  <div class="bc-pot">
+    <span class="bc-handle"></span>
+    <span class="bc-spout"></span>
+    <span class="bc-stream"></span>
+  </div>
+  <div class="bc-cup">
+    <span class="bc-fill"></span>
+    <span class="bc-handle-cup"></span>
+  </div>
+  <div class="bc-saucer"></div>
+  <span class="bc-steam bc-steam-1"></span>
+  <span class="bc-steam bc-steam-2"></span>
+  <span class="bc-bean bc-bean-1"></span>
+  <span class="bc-bean bc-bean-2"></span>
+</div>
+</body>
+</html>

--- a/submissions/examples/barista-coffee-pour-ij/style.css
+++ b/submissions/examples/barista-coffee-pour-ij/style.css
@@ -1,0 +1,22 @@
+:root{--bc-brown:#6b3a2a;--bc-dark:#24140e}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#33200f,#180e08);font-family:'Segoe UI',sans-serif}
+.bc-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#2b1b0d,#140c06);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.bc-brand{position:absolute;top:16px;left:0;right:0;text-align:center;font-size:12px;font-weight:800;letter-spacing:7px;color:#e0a15a}
+.bc-pot{position:absolute;top:96px;left:34px;width:132px;height:104px;border-radius:14px;background:linear-gradient(180deg,#3b2a1c,#241710);box-shadow:inset 0 0 0 4px #14100a;transform:rotate(-8deg)}
+.bc-handle{position:absolute;top:28px;right:-16px;width:34px;height:46px;border-radius:50%;border:6px solid #14100a;background:transparent}
+.bc-spout{position:absolute;bottom:-14px;right:10px;width:44px;height:24px;border-radius:0 0 12px 12px;background:#241710;clip-path:polygon(0 0,100% 0,72% 100%,28% 100%)}
+.bc-stream{position:absolute;top:112px;left:86px;width:8px;height:74px;border-radius:4px;background:linear-gradient(180deg,#8a4b2b,#5b2e1c);box-shadow:0 0 8px rgba(138,75,43,0.7);transform:rotate(6deg);animation:pour-stream-barista-coffee-pour 1.4s ease-in-out infinite}
+.bc-cup{position:absolute;top:210px;left:150px;width:92px;height:76px;border-radius:0 0 16px 16px;background:#f3eadb;box-shadow:inset 0 -16px 0 rgba(0,0,0,0.08),0 10px 16px rgba(0,0,0,0.4);overflow:hidden}
+.bc-fill{position:absolute;left:0;right:0;bottom:0;height:40%;background:linear-gradient(180deg,#7a4024,#4e2415);animation:fill-cup-barista-coffee-pour 3s ease-in-out infinite}
+.bc-handle-cup{position:absolute;top:16px;right:-20px;width:30px;height:34px;border-radius:50%;border:6px solid #f3eadb;background:transparent}
+.bc-saucer{position:absolute;top:286px;left:128px;width:138px;height:18px;border-radius:50%;background:#dfd2bd;box-shadow:0 6px 12px rgba(0,0,0,0.4)}
+.bc-steam{position:absolute;width:3px;height:34px;border-radius:3px;background:rgba(255,255,255,0.5);filter:blur(1px);animation:steam-rise-barista-coffee-pour 2.2s ease-out infinite}
+.bc-steam-1{top:188px;left:182px;animation-delay:0.6s}
+.bc-steam-2{top:196px;left:210px;animation-delay:1.4s}
+.bc-bean{position:absolute;width:12px;height:16px;border-radius:6px;background:#4a2c18;animation:bean-bob-barista-coffee-pour 2.6s ease-in-out infinite}
+.bc-bean-1{top:44px;right:70px}
+.bc-bean-2{top:70px;right:30px;animation-delay:1.3s}
+@keyframes pour-stream-barista-coffee-pour{0%,100%{opacity:1;height:74px}50%{opacity:0.7;height:58px}}
+@keyframes fill-cup-barista-coffee-pour{0%{height:14%}60%{height:56%}100%{height:14%}}
+@keyframes steam-rise-barista-coffee-pour{0%{transform:translateY(0);opacity:0}30%{opacity:0.7}100%{transform:translateY(-46px);opacity:0}}
+@keyframes bean-bob-barista-coffee-pour{0%,100%{transform:translateY(0) rotate(0deg)}50%{transform:translateY(-8px) rotate(20deg)}}


### PR DESCRIPTION
## Component: ease-barista-coffee-pour — stream pours, cup fills, and steam rises

**Closes #63388**

### What this adds
A coffee bar: the barista pot tilts and pours a stream into the cup, the coffee level rises and drains, and steam wisps rise while beans bob beside the counter.

### Acceptance Criteria covered
- Pot pours a stream into the cup
- Coffee level rises and drains
- Steam wisps rise above the cup

### Files
- submissions/examples/barista-coffee-pour-ij/demo.html
- submissions/examples/barista-coffee-pour-ij/style.css
- submissions/examples/barista-coffee-pour-ij/README.md

### How to review
Open `demo.html` in a browser and watch the pour.