### PR TITLE
Add ease-subway-door-close component

### DIFF
--- a/submissions/examples/subway-door-close-ij/README.md
+++ b/submissions/examples/subway-door-close-ij/README.md
@@ -1,0 +1,10 @@
+# ease-subway-door-close
+
+A subway car whose two doors slide shut with a warning strip while the red light blinks and the STAND CLEAR sign flashes.
+
+## Run
+Open `demo.html` directly in a browser to watch the doors close.
+
+## Notes
+- Both doors slide in opposite directions.
+- The warning light blinks during the cycle.

--- a/submissions/examples/subway-door-close-ij/demo.html
+++ b/submissions/examples/subway-door-close-ij/demo.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-subway-door-close demo</title>
+</head>
+<body>
+<div class="sd-app">
+  <span class="sd-line">LINE 4</span>
+  <div class="sd-car">
+    <div class="sd-door sd-door-l">
+      <span class="sd-window"></span>
+      <span class="sd-strip"></span>
+    </div>
+    <div class="sd-door sd-door-r">
+      <span class="sd-window"></span>
+      <span class="sd-strip"></span>
+    </div>
+    <span class="sd-track"></span>
+  </div>
+  <span class="sd-sign">STAND CLEAR</span>
+  <span class="sd-light"></span>
+</div>
+</body>
+</html>

--- a/submissions/examples/subway-door-close-ij/style.css
+++ b/submissions/examples/subway-door-close-ij/style.css
@@ -1,0 +1,17 @@
+:root{--sd-amber:#ffb443;--sd-dark:#0c1016}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#16202c,#0a0e14);font-family:'Segoe UI',sans-serif}
+.sd-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#101826,#080c11);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.sd-line{position:absolute;top:16px;left:0;right:0;text-align:center;font-size:12px;font-weight:800;letter-spacing:8px;color:#ffb443}
+.sd-car{position:absolute;top:64px;left:36px;width:300px;height:210px;border-radius:16px;background:linear-gradient(180deg,#24313f,#161f2a);box-shadow:inset 0 0 0 4px #33445a;overflow:hidden}
+.sd-door{position:absolute;top:12px;bottom:12px;width:130px;border-radius:8px;background:linear-gradient(180deg,#3d5063,#263442);box-shadow:inset 0 0 0 3px #4c627a;overflow:hidden}
+.sd-door-l{left:16px;animation:door-slide-l-subway-door-close 4.4s ease-in-out infinite}
+.sd-door-r{right:16px;animation:door-slide-r-subway-door-close 4.4s ease-in-out infinite}
+.sd-window{position:absolute;top:18px;left:50%;transform:translateX(-50%);width:64px;height:76px;border-radius:8px;background:#0b1219;box-shadow:inset 0 0 0 3px #4c627a}
+.sd-strip{position:absolute;bottom:14px;left:10px;right:10px;height:8px;border-radius:4px;background:repeating-linear-gradient(90deg,#ffb443 0 12px,#2c1c0a 12px 24px)}
+.sd-track{position:absolute;left:0;right:0;bottom:0;height:26px;background:linear-gradient(180deg,#0a0e14,#05070a)}
+.sd-sign{position:absolute;bottom:34px;left:0;right:0;text-align:center;font-size:11px;font-weight:800;letter-spacing:3px;color:#ffb443;animation:sign-flash-subway-door-close 1s steps(1) infinite}
+.sd-light{position:absolute;top:34px;left:50%;transform:translateX(-50%);width:14px;height:14px;border-radius:50%;background:#ff4040;box-shadow:0 0 12px #ff4040;animation:warn-blink-subway-door-close 0.8s steps(1) infinite}
+@keyframes door-slide-l-subway-door-close{0%,24%{transform:translateX(0)}36%{transform:translateX(86px)}48%{transform:translateX(86px)}60%{transform:translateX(0)}100%{transform:translateX(0)}}
+@keyframes door-slide-r-subway-door-close{0%,24%{transform:translateX(0)}36%{transform:translateX(-86px)}48%{transform:translateX(-86px)}60%{transform:translateX(0)}100%{transform:translateX(0)}}
+@keyframes warn-blink-subway-door-close{0%,49%{opacity:1}50%,100%{opacity:0.15}}
+@keyframes sign-flash-subway-door-close{0%,49%{opacity:1}50%,100%{opacity:0.3}}


### PR DESCRIPTION
## Component: ease-subway-door-close — doors slide, lights blink, and signs flash

**Closes #63395**

### What this adds
A subway car: the two doors slide shut with a warning strip, the red light blinks overhead, and the STAND CLEAR sign flashes while the train waits.

### Acceptance Criteria covered
- Both doors slide in opposite directions
- Red warning light blinks overhead
- STAND CLEAR sign flashes

### Files
- submissions/examples/subway-door-close-ij/demo.html
- submissions/examples/subway-door-close-ij/style.css
- submissions/examples/subway-door-close-ij/README.md

### How to review
Open `demo.html` in a browser and watch the doors close.