### PR TITLE
[Bug]: Hidden scroll-reveal elements receive keyboard tab focus before appearing

### DIFF
--- a/submissions/examples/css-hidden-scroll-reveal-focus/README.md
+++ b/submissions/examples/css-hidden-scroll-reveal-focus/README.md
@@ -1,0 +1,90 @@
+# CSS Hidden Scroll-Reveal Keyboard Focus Fix
+
+A responsive pure HTML5 and CSS3 Scroll-Reveal component designed to prevent unrevealed animated elements from receiving premature keyboard `Tab` focus.
+
+## Overview
+
+When scroll-reveal elements are hidden using `opacity: 0` alone, assistive technologies and keyboard users can still navigate to interactive links and buttons inside the invisible elements via the `Tab` key. This component resolves the focus leak by combining `opacity: 0`, `visibility: hidden`, and `pointer-events: none` prior to activation, restoring full focusability only upon intersection activation (`visibility: visible; pointer-events: auto`).
+
+## Features
+
+- **Pure HTML5 & CSS3**: Zero JavaScript execution.
+- **Keyboard Focus Lock Fix**: `visibility: hidden` prevents `Tab` key focus on hidden elements.
+- **Pointer Event Protection**: `pointer-events: none` prevents accidental clicks on invisible cards.
+- **Smooth Reveal Physics**: `transform: translateY(0)` and `opacity: 1` transition upon activation.
+- **WCAG AA Compliance**: High-contrast dark mode colors (>4.5:1 ratio).
+- **Prefers-Reduced-Motion**: Disables translate motion for motion-sensitive users.
+
+## Folder Structure
+
+```
+css-hidden-scroll-reveal-focus/
+├── demo.html    # HTML structure with reveal cards & interactive links
+├── style.css    # CSS visibility lock rules, variables & animations
+└── README.md    # Component documentation
+```
+
+## Usage
+
+Include `style.css` in your HTML file:
+
+```html
+<link rel="stylesheet" href="style.css">
+```
+
+## HTML Example
+
+```html
+<article class="card reveal-card" id="reveal-1">
+  <div class="card-badge">Revealed Element 1</div>
+  <h2 class="card-title">Scroll Revealed Component 1</h2>
+  <p class="card-text">This element is properly hidden with visibility: hidden before activation.</p>
+  <a href="#" class="card-link">Revealed Action Button 1 &rarr;</a>
+</article>
+```
+
+## CSS Variables
+
+Customizable design tokens defined in `:root`:
+
+```css
+:root {
+  --bg-main: #0b0f19;
+  --bg-card: #151d30;
+  --text-main: #f8fafc;
+  --text-muted: #94a3b8;
+  --border-color: #334155;
+  --accent-cyan: #38bdf8;
+  --focus-ring: #38bdf8;
+
+  --radius-lg: 16px;
+}
+```
+
+## Customization
+
+Adjust reveal translate distance or animation timing:
+
+```css
+.reveal-card {
+  transform: translateY(40px); /* Custom entrance offset */
+}
+```
+
+## Accessibility
+
+- **Focus Lock Fix**: `visibility: hidden` ensures keyboard focus skips invisible elements.
+- **Focus Ring Indicators**: High-visibility focus indicators on interactive links.
+- **WCAG AA Compliance**: High text-to-background contrast ratios.
+
+## Responsive Behaviour
+
+- **Desktop (680px+)**: Centered card layout with 680px max width.
+- **Mobile (<480px)**: Fluid mobile layout scaling to small screens.
+
+## Browser Compatibility
+
+- Chrome / Edge 105+ (Supports `:has()` selector)
+- Firefox 121+
+- Safari 15.4+
+- iOS Safari / Android Chrome

--- a/submissions/examples/css-hidden-scroll-reveal-focus/demo.html
+++ b/submissions/examples/css-hidden-scroll-reveal-focus/demo.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Hidden Scroll-Reveal Keyboard Focus Fix</title>
+  <link rel="stylesheet" href="style.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <main class="container">
+    <header class="header">
+      <h1 class="title">Scroll-Reveal Focus Lock Fix</h1>
+      <p class="subtitle">Pure CSS scroll reveal elements styled with visibility: hidden before activation to prevent early keyboard Tab focus.</p>
+    </header>
+
+    <!-- State Controller to simulate Scroll Reveal trigger -->
+    <div class="trigger-panel" role="group" aria-label="Reveal Simulation Controls">
+      <input type="checkbox" id="reveal-toggle" class="trigger-checkbox" checked>
+      <label for="reveal-toggle" class="btn btn-primary" tabindex="0">
+        Toggle Scroll Reveal Activation
+      </label>
+    </div>
+
+    <!-- Always Visible Initial Card -->
+    <section class="card initial-card">
+      <h2 class="card-title">Initial Page Content</h2>
+      <p class="card-text">Try pressing <kbd>Tab</kbd> to navigate through interactive elements. When scroll-reveal elements are hidden, focus will not get stuck on unrevealed elements.</p>
+      <a href="#link-initial" class="card-link">Initial Focusable Link &rarr;</a>
+    </section>
+
+    <!-- Scroll Reveal Section -->
+    <section class="reveal-section">
+      
+      <!-- Reveal Card 1 -->
+      <article class="card reveal-card" id="reveal-1">
+        <div class="card-badge">Revealed Element 1</div>
+        <h2 class="card-title">Scroll Revealed Component 1</h2>
+        <p class="card-text">This element is properly hidden with visibility: hidden and pointer-events: none before activation.</p>
+        <a href="#link-reveal-1" class="card-link">Revealed Action Button 1 &rarr;</a>
+      </article>
+
+      <!-- Reveal Card 2 -->
+      <article class="card reveal-card" id="reveal-2">
+        <div class="card-badge">Revealed Element 2</div>
+        <h2 class="card-title">Scroll Revealed Component 2</h2>
+        <p class="card-text">Once activated, visibility transitions to visible, restoring full keyboard tab focus and interaction.</p>
+        <a href="#link-reveal-2" class="card-link">Revealed Action Button 2 &rarr;</a>
+      </article>
+
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/css-hidden-scroll-reveal-focus/style.css
+++ b/submissions/examples/css-hidden-scroll-reveal-focus/style.css
@@ -1,0 +1,183 @@
+/* ==========================================================================
+   CSS Hidden Scroll-Reveal Keyboard Focus Fix
+   Scroll reveal elements styled with visibility: hidden before activation.
+   ========================================================================== */
+
+:root {
+  --bg-main: #0b0f19;
+  --bg-card: #151d30;
+  --text-main: #f8fafc;
+  --text-muted: #94a3b8;
+  --border-color: #334155;
+  --accent-cyan: #38bdf8;
+  --focus-ring: #38bdf8;
+
+  --radius-lg: 16px;
+  --radius-sm: 8px;
+
+  --transition-speed: 0.4s;
+  --transition-ease: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  background-color: var(--bg-main);
+  color: var(--text-main);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+  line-height: 1.5;
+}
+
+.container {
+  width: 100%;
+  max-width: 680px;
+}
+
+/* Header */
+.header {
+  text-align: center;
+  margin-bottom: 2.5rem;
+}
+
+.title {
+  font-size: 2.25rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+
+.subtitle {
+  color: var(--text-muted);
+  font-size: 1rem;
+}
+
+/* Trigger Panel */
+.trigger-panel {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 2rem;
+}
+
+.trigger-checkbox {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.75rem 1.5rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: all var(--transition-speed) var(--transition-ease);
+}
+
+.btn-primary {
+  background: #2563eb;
+  color: #ffffff;
+}
+
+.btn-primary:hover {
+  background: #1d4ed8;
+}
+
+.trigger-checkbox:focus-visible + .btn {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+/* Cards */
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: 1.75rem;
+  margin-bottom: 1.5rem;
+  box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.4);
+}
+
+.card-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--accent-cyan);
+  margin-bottom: 0.5rem;
+}
+
+.card-text {
+  font-size: 0.925rem;
+  color: var(--text-muted);
+  margin-bottom: 1.25rem;
+}
+
+kbd {
+  background: var(--border-color);
+  color: var(--text-main);
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+}
+
+.card-link {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--accent-cyan);
+  text-decoration: none;
+  transition: color var(--transition-speed) var(--transition-ease);
+}
+
+.card-link:hover,
+.card-link:focus-visible {
+  color: #ffffff;
+  outline: 2px solid var(--focus-ring);
+  border-radius: 4px;
+}
+
+/* Scroll-Reveal Pre-Activation State (Fixes Keyboard Focus Leak) */
+.reveal-card {
+  opacity: 0;
+  visibility: hidden; /* Prevents Tab key focus on unrevealed elements */
+  pointer-events: none;
+  transform: translateY(30px);
+  transition: opacity var(--transition-speed) var(--transition-ease), transform var(--transition-speed) var(--transition-ease), visibility var(--transition-speed) var(--transition-ease);
+}
+
+.card-badge {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 700;
+  background: rgba(56, 189, 248, 0.15);
+  color: var(--accent-cyan);
+  padding: 0.25rem 0.65rem;
+  border-radius: 9999px;
+  margin-bottom: 0.75rem;
+}
+
+/* Activated State Rules */
+:has(#reveal-toggle:checked) .reveal-card {
+  opacity: 1;
+  visibility: visible; /* Restores focus & visibility when revealed */
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+/* Accessibility: Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+  .reveal-card {
+    transition: opacity 0.01ms;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Overview
This PR fixes the bug where scroll-reveal elements styled with opacity: 0 receive keyboard Tab focus before appearing on screen.

## Changes Made
- Added demo.html with interactive scroll reveal cards and action links.
- Added style.css combining opacity: 0, isibility: hidden, and pointer-events: none prior to activation, restoring visibility and focusability upon reveal.
- Added README.md with complete documentation.

Closes #60884