### PR TITLE
Add ease-chess-timer-clock component

### DIFF
--- a/submissions/examples/chess-timer-clock-ij/README.md
+++ b/submissions/examples/chess-timer-clock-ij/README.md
@@ -1,0 +1,10 @@
+# ease-chess-timer-clock
+
+A tournament chess clock with two facing panels where the active side glows, its time blinks, and the red flag drops as the pressure builds.
+
+## Run
+Open `demo.html` directly in a browser to watch the turns alternate.
+
+## Notes
+- The active panel pulses gold.
+- The flag drops when time runs low.

--- a/submissions/examples/chess-timer-clock-ij/demo.html
+++ b/submissions/examples/chess-timer-clock-ij/demo.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-chess-timer-clock demo</title>
+</head>
+<body>
+<div class="ct-app">
+  <span class="ct-title">TOURNAMENT CLOCK</span>
+  <div class="ct-panel ct-panel-a">
+    <span class="ct-label">WHITE</span>
+    <span class="ct-time">03:48</span>
+    <span class="ct-flag"></span>
+  </div>
+  <div class="ct-panel ct-panel-b ct-active">
+    <span class="ct-label">BLACK</span>
+    <span class="ct-time">02:15</span>
+    <span class="ct-flag"></span>
+  </div>
+  <span class="ct-caption">PRESS TO END TURN</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/chess-timer-clock-ij/style.css
+++ b/submissions/examples/chess-timer-clock-ij/style.css
@@ -1,0 +1,15 @@
+:root{--ct-gold:#e8c36a;--ct-dark:#14100a}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#241c0f,#120e07);font-family:'Segoe UI',sans-serif}
+.ct-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#1d160c,#0f0b05);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.ct-title{position:absolute;top:16px;left:0;right:0;text-align:center;font-size:12px;font-weight:800;letter-spacing:6px;color:#e8c36a}
+.ct-panel{position:absolute;top:64px;width:138px;height:214px;border-radius:12px;background:#0a0805;box-shadow:inset 0 0 0 4px #33290f;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:14px}
+.ct-panel-a{left:36px}
+.ct-panel-b{right:36px}
+.ct-active{background:#1a1308;animation:turn-pulse-chess-timer-clock 2s ease-in-out infinite}
+.ct-label{font-size:13px;font-weight:800;letter-spacing:4px;color:#8a7440}
+.ct-time{font-size:28px;font-weight:900;color:#f2e5c2;font-variant-numeric:tabular-nums;animation:time-blink-chess-timer-clock 1.6s steps(1) infinite}
+.ct-flag{width:22px;height:26px;background:#d34a2f;clip-path:polygon(0 0,100% 30%,100% 70%,0 100%);animation:flag-drop-chess-timer-clock 2.4s ease-in-out infinite}
+.ct-caption{position:absolute;bottom:16px;left:0;right:0;text-align:center;font-size:10px;font-weight:700;letter-spacing:3px;color:#7a6838}
+@keyframes turn-pulse-chess-timer-clock{0%,100%{box-shadow:inset 0 0 0 4px #e8c36a,0 0 10px rgba(232,195,106,0.2)}50%{box-shadow:inset 0 0 0 4px #f5dd9a,0 0 30px rgba(232,195,106,0.55)}}
+@keyframes time-blink-chess-timer-clock{0%,100%{opacity:1}50%{opacity:0.4}}
+@keyframes flag-drop-chess-timer-clock{0%,20%{transform:translateY(0)}60%{transform:translateY(18px)}100%{transform:translateY(0)}}


### PR DESCRIPTION
## Component: ease-chess-timer-clock — turns alternate, times blink, and flags drop

**Closes #63435**

### What this adds
A tournament chess clock: the active side glows gold, its time blinks as the turn runs, and the red flag drops when the clock winds down.

### Acceptance Criteria covered
- Active side glows gold
- Time blinks on the running clock
- Red flag drops when time is low

### Files
- submissions/examples/chess-timer-clock-ij/demo.html
- submissions/examples/chess-timer-clock-ij/style.css
- submissions/examples/chess-timer-clock-ij/README.md

### How to review
Open `demo.html` in a browser and watch the turns alternate.