### PR TITLE
add animated scroll trigger reveal

### DIFF
--- a/submissions/examples/animated-scroll-triggered-reveal/README.md
+++ b/submissions/examples/animated-scroll-triggered-reveal/README.md
@@ -1,0 +1,24 @@
+# ease-reveal-on-scroll
+
+A scroll-triggered reveal utility for **EaseMotion CSS**. Pairs with any existing entrance animation class (`ease-fade-in`, `ease-slide-up`, etc.) to defer it until the element scrolls into view.
+
+## Usage
+
+```html
+<div class="ease-reveal-on-scroll ease-fade-in">
+  Content
+</div>
+
+<script>
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('ease-in-view');
+        observer.unobserve(entry.target);
+      }
+    });
+  }, { threshold: 0.15 });
+
+  document.querySelectorAll('.ease-reveal-on-scroll')
+    .forEach(el => observer.observe(el));
+</script>

--- a/submissions/examples/animated-scroll-triggered-reveal/demo.html
+++ b/submissions/examples/animated-scroll-triggered-reveal/demo.html
@@ -1,0 +1,41 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-reveal-on-scroll Demo</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body { font-family: system-ui, sans-serif; background: #0f172a; color: #f1f5f9; margin: 0; }
+  .spacer { height: 90vh; display: flex; align-items: center; justify-content: center; color: #64748b; }
+  section { max-width: 500px; margin: 0 auto 200px; text-align: center; padding: 40px; background: #1e293b; border-radius: 12px; }
+</style>
+</head>
+<body>
+  <div class="spacer">↓ Scroll down to trigger the reveal ↓</div>
+
+  <section class="ease-reveal-on-scroll ease-fade-in">
+    <h2>Fade In on Scroll</h2>
+    <p>This section was invisible until it entered the viewport.</p>
+  </section>
+
+  <section class="ease-reveal-on-scroll ease-slide-up">
+    <h2>Slide Up on Scroll</h2>
+    <p>Same trigger mechanism, different animation.</p>
+  </section>
+
+  <script>
+    const observer = new IntersectionObserver(entries => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('ease-in-view');
+          observer.unobserve(entry.target);
+        }
+      });
+    }, { threshold: 0.15 });
+
+    document.querySelectorAll('.ease-reveal-on-scroll')
+      .forEach(el => observer.observe(el));
+  </script>
+</body>
+</html>

--- a/submissions/examples/animated-scroll-triggered-reveal/style.css
+++ b/submissions/examples/animated-scroll-triggered-reveal/style.css
@@ -1,0 +1,31 @@
+/* ==========================================================
+   ease-reveal-on-scroll — Scroll-triggered Reveal Utility
+   Pairs with any existing ease-* entrance animation.
+   ========================================================== */
+
+.ease-reveal-on-scroll {
+  opacity: 0;
+  transition: opacity 0.1s linear;
+}
+
+.ease-reveal-on-scroll.ease-in-view {
+  opacity: 1;
+}
+
+/* Demo-only fallback keyframes for fade/slide, in case core classes aren't loaded */
+.ease-in-view.ease-fade-in {
+  animation: demo-fade 0.6s ease forwards;
+}
+.ease-in-view.ease-slide-up {
+  animation: demo-slide-up 0.6s ease forwards;
+}
+
+@keyframes demo-fade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes demo-slide-up {
+  from { opacity: 0; transform: translateY(40px); }
+  to { opacity: 1; transform: translateY(0); }
+}


### PR DESCRIPTION
### PR Description
```markdown
## Pull Request Description

Adds `ease-reveal-on-scroll`, a scroll-triggered reveal utility that defers any existing EaseMotion entrance animation until the element enters the viewport, using a single reusable `IntersectionObserver` snippet. Closes #[ISSUE_NUMBER].

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/reveal-on-scroll/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

### What does this add?

A utility class that hides an element (`opacity: 0`) until it scrolls into the viewport, at which point a single shared `IntersectionObserver` adds `.ease-in-view`, allowing any already-shipped EaseMotion entrance animation (fade, slide, zoom, etc.) to play on it.

### How does a developer use it?

```html
<div class="ease-reveal-on-scroll ease-fade-in">
  Content
</div>