### PR TITLE
feat: add CSS Zoom-In Progress Bar for Product Catalog Layouts (#62424)

### DIFF
--- a/submissions/examples/zoom-in-progress-bar-catalog/README.md
+++ b/submissions/examples/zoom-in-progress-bar-catalog/README.md
@@ -1,0 +1,46 @@
+# Zoom-In Progress Bar for Product Catalog Layouts
+
+Progress bars that scale up with a spring easing when they fill, designed for product catalog dashboards.
+
+## What does this do?
+
+Displays inventory/stock progress bars that enter with a `scaleX(0 → 1)` zoom animation triggered when the card scrolls into view, using Intersection Observer for performance.
+
+## How is it used?
+
+```html
+<article class="product-card">
+  <div class="product-card__head">
+    <span class="product-card__icon">👟</span>
+    <div>
+      <h3 class="product-card__name">Running Shoes</h3>
+      <span class="product-card__sku">SKU-4821</span>
+    </div>
+  </div>
+  <div class="product-card__bar-wrap">
+    <div class="product-card__bar" style="--zp-target: 92%"></div>
+  </div>
+  <span class="product-card__status product-card__status--ok">In Stock</span>
+</article>
+```
+
+## Why is it useful?
+
+Product catalogs need clear visual indicators of stock levels. The zoom-in animation draws attention to each bar as it enters the viewport, making inventory status immediately obvious without being distracting.
+
+## CSS Custom Properties
+
+| Property           | Description        | Default   |
+| ------------------ | ------------------ | --------- |
+| `--zp-fill`        | Default fill color | `#3b82f6` |
+| `--zp-fill-warn`   | Low stock color    | `#f59e0b` |
+| `--zp-fill-danger` | Critical color     | `#ef4444` |
+| `--zp-fill-ok`     | Full stock color   | `#22c55e` |
+| `--zp-track`       | Track background   | `#eef0f4` |
+
+## Browser Support
+
+- Chrome 90+
+- Firefox 88+
+- Safari 14+
+- Edge 90+

--- a/submissions/examples/zoom-in-progress-bar-catalog/demo.html
+++ b/submissions/examples/zoom-in-progress-bar-catalog/demo.html
@@ -1,0 +1,163 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Zoom-In Progress Bar — Product Catalog</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="catalog">
+      <div class="catalog__top">
+        <h1 class="catalog__title">Inventory Status</h1>
+        <p class="catalog__sub">Stock levels across product categories</p>
+      </div>
+
+      <div class="product-list" id="productList">
+        <article class="product-card" data-progress="92">
+          <div class="product-card__head">
+            <span class="product-card__icon">👟</span>
+            <div>
+              <h3 class="product-card__name">Running Shoes</h3>
+              <span class="product-card__sku">SKU-4821</span>
+            </div>
+          </div>
+          <div class="product-card__bar-wrap">
+            <div class="product-card__bar" style="--zp-target: 92%">
+              <span class="product-card__pct">92%</span>
+            </div>
+          </div>
+          <span class="product-card__status product-card__status--ok"
+            >In Stock</span
+          >
+        </article>
+
+        <article class="product-card" data-progress="67">
+          <div class="product-card__head">
+            <span class="product-card__icon">🎧</span>
+            <div>
+              <h3 class="product-card__name">Wireless Headphones</h3>
+              <span class="product-card__sku">SKU-1093</span>
+            </div>
+          </div>
+          <div class="product-card__bar-wrap">
+            <div class="product-card__bar" style="--zp-target: 67%">
+              <span class="product-card__pct">67%</span>
+            </div>
+          </div>
+          <span class="product-card__status product-card__status--ok"
+            >In Stock</span
+          >
+        </article>
+
+        <article class="product-card" data-progress="34">
+          <div class="product-card__head">
+            <span class="product-card__icon">⌚</span>
+            <div>
+              <h3 class="product-card__name">Smart Watch Pro</h3>
+              <span class="product-card__sku">SKU-7756</span>
+            </div>
+          </div>
+          <div class="product-card__bar-wrap">
+            <div
+              class="product-card__bar product-card__bar--warn"
+              style="--zp-target: 34%"
+            >
+              <span class="product-card__pct">34%</span>
+            </div>
+          </div>
+          <span class="product-card__status product-card__status--warn"
+            >Low Stock</span
+          >
+        </article>
+
+        <article class="product-card" data-progress="8">
+          <div class="product-card__head">
+            <span class="product-card__icon">🎮</span>
+            <div>
+              <h3 class="product-card__name">Gaming Controller</h3>
+              <span class="product-card__sku">SKU-3310</span>
+            </div>
+          </div>
+          <div class="product-card__bar-wrap">
+            <div
+              class="product-card__bar product-card__bar--danger"
+              style="--zp-target: 8%"
+            >
+              <span class="product-card__pct">8%</span>
+            </div>
+          </div>
+          <span class="product-card__status product-card__status--danger"
+            >Almost Gone</span
+          >
+        </article>
+
+        <article class="product-card" data-progress="100">
+          <div class="product-card__head">
+            <span class="product-card__icon">🧥</span>
+            <div>
+              <h3 class="product-card__name">Winter Jacket</h3>
+              <span class="product-card__sku">SKU-5502</span>
+            </div>
+          </div>
+          <div class="product-card__bar-wrap">
+            <div
+              class="product-card__bar product-card__bar--full"
+              style="--zp-target: 100%"
+            >
+              <span class="product-card__pct">100%</span>
+            </div>
+          </div>
+          <span class="product-card__status product-card__status--ok"
+            >Full Stock</span
+          >
+        </article>
+
+        <article class="product-card" data-progress="51">
+          <div class="product-card__head">
+            <span class="product-card__icon">📱</span>
+            <div>
+              <h3 class="product-card__name">Phone Case Ultra</h3>
+              <span class="product-card__sku">SKU-8864</span>
+            </div>
+          </div>
+          <div class="product-card__bar-wrap">
+            <div class="product-card__bar" style="--zp-target: 51%">
+              <span class="product-card__pct">51%</span>
+            </div>
+          </div>
+          <span class="product-card__status product-card__status--ok"
+            >In Stock</span
+          >
+        </article>
+      </div>
+    </div>
+
+    <script>
+      // trigger bars on scroll into view
+      (function () {
+        var cards = document.querySelectorAll(".product-card");
+        if (!("IntersectionObserver" in window)) {
+          cards.forEach(function (c) {
+            c.classList.add("is-visible");
+          });
+          return;
+        }
+        var obs = new IntersectionObserver(
+          function (entries) {
+            entries.forEach(function (e) {
+              if (e.isIntersecting) {
+                e.target.classList.add("is-visible");
+                obs.unobserve(e.target);
+              }
+            });
+          },
+          { threshold: 0.2 }
+        );
+        cards.forEach(function (c) {
+          obs.observe(c);
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/submissions/examples/zoom-in-progress-bar-catalog/style.css
+++ b/submissions/examples/zoom-in-progress-bar-catalog/style.css
@@ -1,0 +1,271 @@
+/* ===================================================
+   Zoom-In Progress Bar — Product Catalog Layouts
+   Progress bars that scale up when filling
+   =================================================== */
+
+:root {
+  --zp-bg: #f8f9fb;
+  --zp-card: #ffffff;
+  --zp-border: #e2e5ea;
+  --zp-text: #1a1d26;
+  --zp-text-dim: #6b7280;
+  --zp-track: #eef0f4;
+  --zp-fill: #3b82f6;
+  --zp-fill-warn: #f59e0b;
+  --zp-fill-danger: #ef4444;
+  --zp-fill-ok: #22c55e;
+  --zp-radius: 10px;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
+  background: var(--zp-bg);
+  color: var(--zp-text);
+  min-height: 100vh;
+}
+
+/* ---- catalog wrapper ---- */
+.catalog {
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 2.5rem 1.25rem;
+}
+
+.catalog__title {
+  font-size: 1.625rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.catalog__sub {
+  color: var(--zp-text-dim);
+  font-size: 0.875rem;
+  margin-top: 0.25rem;
+  margin-bottom: 1.75rem;
+}
+
+/* ---- product cards ---- */
+.product-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.product-card {
+  background: var(--zp-card);
+  border: 1px solid var(--zp-border);
+  border-radius: var(--zp-radius);
+  padding: 1rem 1.125rem;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto auto;
+  column-gap: 1rem;
+  row-gap: 0.625rem;
+  align-items: center;
+  transition: box-shadow 0.2s ease;
+}
+
+.product-card:hover {
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.06);
+}
+
+/* ---- card header ---- */
+.product-card__head {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  grid-column: 1;
+  grid-row: 1;
+}
+
+.product-card__icon {
+  font-size: 1.5rem;
+  width: 42px;
+  height: 42px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--zp-track);
+  border-radius: 10px;
+  flex-shrink: 0;
+}
+
+.product-card__name {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.product-card__sku {
+  font-size: 0.75rem;
+  color: var(--zp-text-dim);
+}
+
+/* ---- progress bar ---- */
+.product-card__bar-wrap {
+  grid-column: 1;
+  grid-row: 2;
+  height: 8px;
+  background: var(--zp-track);
+  border-radius: 99px;
+  overflow: hidden;
+  position: relative;
+}
+
+.product-card__bar {
+  height: 100%;
+  width: 0;
+  border-radius: 99px;
+  background: var(--zp-fill);
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  transform-origin: left center;
+  transform: scaleX(0);
+  transition: transform 0.7s cubic-bezier(0.34, 1.56, 0.64, 1);
+
+  /* label */
+  position: relative;
+}
+
+.product-card__pct {
+  position: absolute;
+  right: 0;
+  top: 0;
+  font-size: 0;
+  opacity: 0;
+}
+
+/* zoom-in when visible */
+.is-visible .product-card__bar {
+  transform: scaleX(1);
+  width: var(--zp-target);
+}
+
+/* variant colors */
+.product-card__bar--warn {
+  background: var(--zp-fill-warn);
+}
+.product-card__bar--danger {
+  background: var(--zp-fill-danger);
+}
+.product-card__bar--full {
+  background: var(--zp-fill-ok);
+}
+
+/* ---- status badge ---- */
+.product-card__status {
+  grid-column: 2;
+  grid-row: 1 / 3;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.3rem 0.65rem;
+  border-radius: 99px;
+  white-space: nowrap;
+  align-self: center;
+}
+
+.product-card__status--ok {
+  background: #dcfce7;
+  color: #166534;
+}
+.product-card__status--warn {
+  background: #fef3c7;
+  color: #92400e;
+}
+.product-card__status--danger {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+/* ---- card stagger ---- */
+.product-card:nth-child(1) {
+  transition-delay: 0s;
+}
+.product-card:nth-child(2) {
+  transition-delay: 0.06s;
+}
+.product-card:nth-child(3) {
+  transition-delay: 0.12s;
+}
+.product-card:nth-child(4) {
+  transition-delay: 0.18s;
+}
+.product-card:nth-child(5) {
+  transition-delay: 0.24s;
+}
+.product-card:nth-child(6) {
+  transition-delay: 0.3s;
+}
+
+/* ---- reduced motion ---- */
+@media (prefers-reduced-motion: reduce) {
+  .product-card__bar {
+    transition-duration: 0.01ms !important;
+  }
+
+  .product-card {
+    transition-delay: 0s !important;
+  }
+}
+
+/* ---- high contrast ---- */
+@media (prefers-contrast: high) {
+  .product-card {
+    border-width: 2px;
+  }
+  .product-card__bar-wrap {
+    height: 10px;
+  }
+}
+
+/* ---- mobile ---- */
+@media (max-width: 540px) {
+  .product-card {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto auto auto;
+    gap: 0.5rem;
+  }
+
+  .product-card__head {
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  .product-card__bar-wrap {
+    grid-column: 1;
+    grid-row: 2;
+  }
+
+  .product-card__status {
+    grid-column: 1;
+    grid-row: 3;
+    justify-self: start;
+  }
+
+  .catalog__title {
+    font-size: 1.375rem;
+  }
+}
+
+/* ---- print ---- */
+@media print {
+  .product-card__bar {
+    transition: none;
+    transform: scaleX(1);
+    width: var(--zp-target);
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+}


### PR DESCRIPTION
Adds progress bars with CSS zoom-in scale animation for product catalog dashboards.

Closes #62424

---

## Type of Change

- [x] ✨ New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/zoom-in-progress-bar-catalog/`
- [x] Includes `demo.html` — self-contained, opens in browser
- [x] Includes `style.css` — raw CSS with zoom animation
- [x] Includes `README.md` — what, how, why
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Progress bars that zoom in with `scaleX(0 → 1)` and spring easing when cards scroll into view. Uses CSS custom property `--zp-target` for width and Intersection Observer for scroll-triggered animation.

**How does a developer use it?**

```html
<div class="product-card__bar-wrap">
  <div class="product-card__bar" style="--zp-target: 92%">
    <span class="product-card__pct">92%</span>
  </div>
</div>