### PR TITLE
add animated command pallettte

### DIFF
--- a/submissions/examples/animated-animated-vcommandpallete/README.md
+++ b/submissions/examples/animated-animated-vcommandpallete/README.md
@@ -1,0 +1,14 @@
+# ease-command-palette
+
+A `Cmd/Ctrl+K` command palette for instantly searching EaseMotion CSS class names across the docs site.
+
+## Usage
+
+```html
+<button class="cmdk-trigger">Search classes… <kbd>⌘K</kbd></button>
+<div class="cmdk-overlay" hidden>
+  <div class="cmdk-panel">
+    <input type="text" class="cmdk-input" placeholder="Type a class name...">
+    <ul class="cmdk-results"></ul>
+  </div>
+</div>

--- a/submissions/examples/animated-animated-vcommandpallete/demo.html
+++ b/submissions/examples/animated-animated-vcommandpallete/demo.html
@@ -1,0 +1,54 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-command-palette Demo</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body { font-family: system-ui, sans-serif; background: #0f172a; color: #f1f5f9; display: flex; align-items: center; justify-content: center; height: 100vh; }
+  .cmdk-trigger { padding: 10px 16px; border-radius: 8px; border: 1px solid #334155; background: #1e293b; color: #cbd5e1; cursor: pointer; display: flex; gap: 10px; align-items: center; }
+  kbd { background: #334155; padding: 2px 6px; border-radius: 4px; font-size: 0.75rem; }
+</style>
+</head>
+<body>
+  <button class="cmdk-trigger" id="cmdkTrigger">Search classes… <kbd>⌘K</kbd></button>
+
+  <div class="cmdk-overlay" id="cmdkOverlay" hidden>
+    <div class="cmdk-panel">
+      <input type="text" class="cmdk-input" id="cmdkInput" placeholder="Type a class name...">
+      <ul class="cmdk-results" id="cmdkResults"></ul>
+    </div>
+  </div>
+
+  <script>
+    const CLASSES = ['ease-fade-in', 'ease-slide-up', 'ease-zoom-in', 'ease-hover-grow', 'ease-hover-glow', 'ease-btn-hover', 'ease-card-hover', 'ease-pulse', 'ease-bounce', 'ease-rotate'];
+    const overlay = document.getElementById('cmdkOverlay');
+    const input = document.getElementById('cmdkInput');
+    const results = document.getElementById('cmdkResults');
+
+    function open() {
+      overlay.hidden = false;
+      input.value = '';
+      render(CLASSES);
+      input.focus();
+    }
+    function close() { overlay.hidden = true; }
+
+    function render(list) {
+      results.innerHTML = list.map(c => `<li>${c}</li>`).join('');
+    }
+
+    document.getElementById('cmdkTrigger').addEventListener('click', open);
+    overlay.addEventListener('click', e => { if (e.target === overlay) close(); });
+    document.addEventListener('keydown', e => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') { e.preventDefault(); open(); }
+      if (e.key === 'Escape') close();
+    });
+    input.addEventListener('input', () => {
+      const q = input.value.toLowerCase();
+      render(CLASSES.filter(c => c.includes(q)));
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/animated-animated-vcommandpallete/style.css
+++ b/submissions/examples/animated-animated-vcommandpallete/style.css
@@ -1,0 +1,65 @@
+/* ==========================================================
+   ease-command-palette — Cmd+K Docs Search Overlay
+   ========================================================== */
+
+.cmdk-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.6);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 12vh;
+  z-index: 999;
+}
+
+.cmdk-panel {
+  width: 500px;
+  max-width: 90vw;
+  background: #1e293b;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 20px 60px rgba(0,0,0,0.4);
+  animation: cmdk-in 0.15s ease;
+}
+
+@keyframes cmdk-in {
+  from { transform: translateY(-10px); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
+}
+
+.cmdk-input {
+  width: 100%;
+  padding: 16px;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid #334155;
+  color: #f1f5f9;
+  font-size: 1rem;
+  outline: none;
+  box-sizing: border-box;
+}
+
+.cmdk-results {
+  list-style: none;
+  margin: 0;
+  padding: 8px;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.cmdk-results li {
+  padding: 10px 12px;
+  border-radius: 6px;
+  color: #cbd5e1;
+  cursor: pointer;
+  font-family: 'Courier New', monospace;
+  font-size: 0.9rem;
+  transition: background 0.1s ease;
+}
+
+.cmdk-results li:hover {
+  background: #2563eb;
+  color: #fff;
+}


### PR DESCRIPTION
### PR Description
```markdown
## Pull Request Description

Adds a `Cmd/Ctrl+K` command palette overlay for instantly searching and jumping to any EaseMotion CSS class documented on the site. Closes #[ISSUE_NUMBER].

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/command-palette/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

### What does this add?

A keyboard-triggered search overlay (`⌘K`/`Ctrl+K`) with a filterable list of class names, letting developers jump straight to any documented utility instead of scrolling the demo page.

### How does a developer use it?

Include the trigger button + overlay markup, then wire the open/close/filter logic shown in `demo.html` — swap the hardcoded class array for the site's real class list.