### PR TITLE
feat: add CSS Slide-Up Stepper for Gaming Hub Layouts (#59178)

### DIFF
--- a/submissions/examples/slide-up-stepper-gaming/README.md
+++ b/submissions/examples/slide-up-stepper-gaming/README.md
@@ -1,0 +1,56 @@
+# Slide-Up Stepper for Gaming Hub Layouts
+
+A vertical stepper that slides up each step with staggered timing, designed for gaming quest/mission trackers.
+
+## What does this do?
+
+Renders a vertical step-by-step progress tracker where each step slides up from below with a staggered delay, using CSS transitions and spring easing for a snappy entrance.
+
+## How is it used?
+
+```html
+<div class="stepper" role="list" aria-label="Quest steps">
+  <div class="step step--done" role="listitem">
+    <div class="step__marker">
+      <svg
+        class="step__check"
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="3"
+      >
+        <polyline points="20 6 9 17 4 12" />
+      </svg>
+      <span class="step__num">1</span>
+    </div>
+    <div class="step__content">
+      <h3 class="step__title">Step Title</h3>
+      <p class="step__desc">Step description</p>
+    </div>
+    <span class="step__badge step__badge--done">Done</span>
+  </div>
+</div>
+```
+
+## Why is it useful?
+
+Gaming hubs need clear visual progression for quests and missions. The slide-up stagger creates a satisfying reveal that matches the reward-driven feel of gaming UIs, without any JS animation library.
+
+## CSS Custom Properties
+
+| Property       | Description       | Default   |
+| -------------- | ----------------- | --------- |
+| `--su-accent`  | Active step color | `#6d5cff` |
+| `--su-done`    | Completed color   | `#22c55e` |
+| `--su-surface` | Card background   | `#181b23` |
+| `--su-border`  | Border color      | `#272c3a` |
+| `--su-radius`  | Card radius       | `12px`    |
+
+## Browser Support
+
+- Chrome 90+
+- Firefox 88+
+- Safari 14+
+- Edge 90+

--- a/submissions/examples/slide-up-stepper-gaming/demo.html
+++ b/submissions/examples/slide-up-stepper-gaming/demo.html
@@ -1,0 +1,143 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Slide-Up Stepper — Gaming Hub</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="quest-hub">
+      <div class="quest-hub__header">
+        <h1 class="quest-hub__title">Quest Tracker</h1>
+        <p class="quest-hub__sub">Complete each step to unlock the reward</p>
+      </div>
+
+      <div class="stepper" role="list" aria-label="Quest steps">
+        <!-- step 1 — done -->
+        <div class="step step--done" role="listitem">
+          <div class="step__marker">
+            <svg
+              class="step__check"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="3"
+            >
+              <polyline points="20 6 9 17 4 12" />
+            </svg>
+            <span class="step__num">1</span>
+          </div>
+          <div class="step__content">
+            <h3 class="step__title">Create Account</h3>
+            <p class="step__desc">Sign up and verify your email address</p>
+          </div>
+          <span class="step__badge step__badge--done">Done</span>
+        </div>
+
+        <!-- step 2 — done -->
+        <div class="step step--done" role="listitem">
+          <div class="step__marker">
+            <svg
+              class="step__check"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="3"
+            >
+              <polyline points="20 6 9 17 4 12" />
+            </svg>
+            <span class="step__num">2</span>
+          </div>
+          <div class="step__content">
+            <h3 class="step__title">First Purchase</h3>
+            <p class="step__desc">Buy any in-game item from the store</p>
+          </div>
+          <span class="step__badge step__badge--done">Done</span>
+        </div>
+
+        <!-- step 3 — active -->
+        <div class="step step--active" role="listitem" aria-current="step">
+          <div class="step__marker">
+            <svg
+              class="step__check"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="3"
+            >
+              <polyline points="20 6 9 17 4 12" />
+            </svg>
+            <span class="step__num">3</span>
+          </div>
+          <div class="step__content">
+            <h3 class="step__title">Win 5 Matches</h3>
+            <p class="step__desc">Compete in ranked mode and win 5 games</p>
+            <div class="step__progress">
+              <div class="step__progress-bar" style="--su-pct: 60%"></div>
+            </div>
+            <span class="step__progress-label">3 / 5 wins</span>
+          </div>
+          <span class="step__badge step__badge--active">In Progress</span>
+        </div>
+
+        <!-- step 4 — upcoming -->
+        <div class="step step--upcoming" role="listitem">
+          <div class="step__marker">
+            <svg
+              class="step__check"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="3"
+            >
+              <polyline points="20 6 9 17 4 12" />
+            </svg>
+            <span class="step__num">4</span>
+          </div>
+          <div class="step__content">
+            <h3 class="step__title">Reach Level 25</h3>
+            <p class="step__desc">Level up your profile to rank 25</p>
+          </div>
+          <span class="step__badge">Locked</span>
+        </div>
+
+        <!-- step 5 — upcoming -->
+        <div class="step step--upcoming" role="listitem">
+          <div class="step__marker">
+            <svg
+              class="step__check"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="3"
+            >
+              <polyline points="20 6 9 17 4 12" />
+            </svg>
+            <span class="step__num">5</span>
+          </div>
+          <div class="step__content">
+            <h3 class="step__title">Claim Reward</h3>
+            <p class="step__desc">Collect your legendary loot crate</p>
+          </div>
+          <span class="step__badge">Locked</span>
+        </div>
+      </div>
+
+      <div class="quest-hub__footer">
+        <span class="quest-hub__streak">🔥 7-Day Streak Active</span>
+        <span class="quest-hub__xp">+2,400 XP Earned</span>
+      </div>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/slide-up-stepper-gaming/style.css
+++ b/submissions/examples/slide-up-stepper-gaming/style.css
@@ -1,0 +1,335 @@
+/* ===================================================
+   Slide-Up Stepper — Gaming Hub Layouts
+   Vertical stepper with slide-up entrance animation
+   =================================================== */
+
+:root {
+  --su-bg: #0e1015;
+  --su-surface: #181b23;
+  --su-border: #272c3a;
+  --su-text: #eaedf3;
+  --su-text-dim: #7c8298;
+  --su-accent: #6d5cff;
+  --su-accent-soft: rgba(109, 92, 255, 0.15);
+  --su-done: #22c55e;
+  --su-done-soft: rgba(34, 197, 94, 0.12);
+  --su-active-glow: rgba(109, 92, 255, 0.25);
+  --su-radius: 12px;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
+  background: var(--su-bg);
+  color: var(--su-text);
+  min-height: 100vh;
+}
+
+/* ---- hub ---- */
+.quest-hub {
+  max-width: 520px;
+  margin: 0 auto;
+  padding: 3rem 1.25rem 2rem;
+}
+
+.quest-hub__title {
+  font-size: 1.625rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.quest-hub__sub {
+  color: var(--su-text-dim);
+  font-size: 0.875rem;
+  margin-top: 0.25rem;
+  margin-bottom: 2rem;
+}
+
+/* ---- stepper ---- */
+.stepper {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  position: relative;
+  padding-left: 22px;
+}
+
+/* vertical connector line */
+.stepper::before {
+  content: "";
+  position: absolute;
+  top: 20px;
+  bottom: 20px;
+  left: 11px;
+  width: 2px;
+  background: var(--su-border);
+  border-radius: 2px;
+}
+
+/* ---- step ---- */
+.step {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.875rem;
+  padding: 0.85rem 0;
+  position: relative;
+
+  /* slide-up entrance */
+  opacity: 0;
+  transform: translateY(24px);
+  transition:
+    opacity 0.4s ease,
+    transform 0.45s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* stagger */
+.step:nth-child(1) {
+  transition-delay: 0.05s;
+}
+.step:nth-child(2) {
+  transition-delay: 0.12s;
+}
+.step:nth-child(3) {
+  transition-delay: 0.19s;
+}
+.step:nth-child(4) {
+  transition-delay: 0.26s;
+}
+.step:nth-child(5) {
+  transition-delay: 0.33s;
+}
+
+/* trigger */
+.step.is-visible,
+.step--done,
+.step--active,
+.step--upcoming {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* ---- marker ---- */
+.step__marker {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 2px solid var(--su-border);
+  background: var(--su-surface);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  position: relative;
+  z-index: 1;
+  transition:
+    border-color 0.25s ease,
+    background 0.25s ease,
+    box-shadow 0.25s ease;
+}
+
+.step__num {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  color: var(--su-text-dim);
+}
+
+.step__check {
+  display: none;
+}
+
+/* done marker */
+.step--done .step__marker {
+  border-color: var(--su-done);
+  background: var(--su-done);
+}
+
+.step--done .step__num {
+  display: none;
+}
+.step--done .step__check {
+  display: block;
+  color: #fff;
+}
+
+/* active marker */
+.step--active .step__marker {
+  border-color: var(--su-accent);
+  background: var(--su-surface);
+  box-shadow: 0 0 0 4px var(--su-active-glow);
+}
+
+.step--active .step__num {
+  color: var(--su-accent);
+}
+
+/* ---- content ---- */
+.step__content {
+  flex: 1;
+  min-width: 0;
+}
+
+.step__title {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.step--upcoming .step__title {
+  color: var(--su-text-dim);
+}
+
+.step__desc {
+  font-size: 0.8125rem;
+  color: var(--su-text-dim);
+  margin-top: 0.15rem;
+  line-height: 1.4;
+}
+
+/* ---- badge ---- */
+.step__badge {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  padding: 0.2rem 0.6rem;
+  border-radius: 99px;
+  background: var(--su-border);
+  color: var(--su-text-dim);
+  white-space: nowrap;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.step__badge--done {
+  background: var(--su-done-soft);
+  color: var(--su-done);
+}
+
+.step__badge--active {
+  background: var(--su-accent-soft);
+  color: var(--su-accent);
+}
+
+/* ---- progress (for active step) ---- */
+.step__progress {
+  height: 5px;
+  background: var(--su-border);
+  border-radius: 99px;
+  margin-top: 0.5rem;
+  overflow: hidden;
+}
+
+.step__progress-bar {
+  height: 100%;
+  width: var(--su-pct, 0%);
+  background: var(--su-accent);
+  border-radius: 99px;
+  transform-origin: left;
+  animation: su-progress-in 0.8s 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+@keyframes su-progress-in {
+  from {
+    transform: scaleX(0);
+  }
+  to {
+    transform: scaleX(1);
+  }
+}
+
+.step__progress-label {
+  font-size: 0.75rem;
+  color: var(--su-text-dim);
+  margin-top: 0.3rem;
+  display: block;
+}
+
+/* ---- footer ---- */
+.quest-hub__footer {
+  margin-top: 1.75rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--su-border);
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.8125rem;
+  font-weight: 600;
+}
+
+.quest-hub__streak {
+  color: #f59e0b;
+}
+
+.quest-hub__xp {
+  color: var(--su-accent);
+}
+
+/* ---- reduced motion ---- */
+@media (prefers-reduced-motion: reduce) {
+  .step {
+    transition-duration: 0.01ms !important;
+    transition-delay: 0s !important;
+    opacity: 1;
+    transform: none;
+  }
+
+  .step__progress-bar {
+    animation: none;
+    width: var(--su-pct);
+  }
+}
+
+/* ---- high contrast ---- */
+@media (prefers-contrast: high) {
+  .step__marker {
+    border-width: 3px;
+  }
+  .stepper::before {
+    width: 3px;
+  }
+}
+
+/* ---- mobile ---- */
+@media (max-width: 480px) {
+  .quest-hub {
+    padding: 2rem 1rem 1.5rem;
+  }
+
+  .step {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+  .step__badge {
+    margin-left: 32px;
+  }
+
+  .quest-hub__footer {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+}
+
+/* ---- print ---- */
+@media print {
+  body {
+    background: #fff;
+    color: #000;
+  }
+  .stepper::before {
+    background: #ccc;
+  }
+  .step {
+    opacity: 1;
+    transform: none;
+  }
+  .step__progress-bar {
+    animation: none;
+  }
+}


### PR DESCRIPTION
Adds a vertical stepper with CSS slide-up entrance animation for gaming quest trackers.

Closes #59178

---

## Type of Change

- [x] ✨ New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/slide-up-stepper-gaming/`
- [x] Includes `demo.html` — self-contained, opens in browser
- [x] Includes `style.css` — raw CSS with slide-up animation
- [x] Includes `README.md` — what, how, why
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A vertical step tracker where each step slides up from below with staggered timing. Steps have three states: done (green check), active (purple glow + progress bar), and upcoming (dimmed/locked). Spring easing gives a bouncy, game-like feel.

**How does a developer use it?**

```html
<div class="stepper" role="list" aria-label="Quest steps">
  <div class="step step--done" role="listitem">
    <div class="step__marker">
      <span class="step__num">1</span>
    </div>
    <div class="step__content">
      <h3 class="step__title">Step Title</h3>
      <p class="step__desc">Description</p>
    </div>
    <span class="step__badge step__badge--done">Done</span>
  </div>
</div>