### PR TITLE
add animated github contributors wall

### DIFF
--- a/submissions/examples/animated-github-contributors-wall/README.md
+++ b/submissions/examples/animated-github-contributors-wall/README.md
@@ -1,0 +1,24 @@
+# ease-contributors-wall
+
+An auto-fetched, animated GitHub contributors wall for **EaseMotion CSS**. No manual list — pulls live from the GitHub API.
+
+## Usage
+
+```html
+<div class="contributors-wall" id="contributorsWall"></div>
+
+<script>
+  fetch('https://api.github.com/repos/SAPTARSHI-coder/EaseMotion-css/contributors')
+    .then(res => res.json())
+    .then(data => {
+      const wall = document.getElementById('contributorsWall');
+      data.forEach((c, i) => {
+        const a = document.createElement('a');
+        a.href = c.html_url;
+        a.className = 'contributor-avatar';
+        a.style.animationDelay = `${i * 40}ms`;
+        a.innerHTML = `<img src="${c.avatar_url}" alt="${c.login}" title="${c.login} · ${c.contributions} commits">`;
+        wall.appendChild(a);
+      });
+    });
+</script>

--- a/submissions/examples/animated-github-contributors-wall/demo.html
+++ b/submissions/examples/animated-github-contributors-wall/demo.html
@@ -1,0 +1,41 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-contributors-wall Demo</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body { font-family: system-ui, sans-serif; background: #0f172a; color: #f1f5f9; padding: 60px; }
+  .wrap { max-width: 600px; margin: 0 auto; }
+</style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>Our Contributors</h1>
+    <div class="contributors-wall" id="contributorsWall">Loading…</div>
+  </div>
+
+  <script>
+    fetch('https://api.github.com/repos/SAPTARSHI-coder/EaseMotion-css/contributors')
+      .then(res => res.json())
+      .then(data => {
+        const wall = document.getElementById('contributorsWall');
+        wall.innerHTML = '';
+        data.slice(0, 40).forEach((c, i) => {
+          const a = document.createElement('a');
+          a.href = c.html_url;
+          a.target = '_blank';
+          a.rel = 'noopener';
+          a.className = 'contributor-avatar';
+          a.style.animationDelay = `${i * 40}ms`;
+          a.innerHTML = `<img src="${c.avatar_url}" alt="${c.login}" title="${c.login} · ${c.contributions} commits">`;
+          wall.appendChild(a);
+        });
+      })
+      .catch(() => {
+        document.getElementById('contributorsWall').textContent = 'Could not load contributors (rate-limited or offline).';
+      });
+  </script>
+</body>
+</html>

--- a/submissions/examples/animated-github-contributors-wall/style.css
+++ b/submissions/examples/animated-github-contributors-wall/style.css
@@ -1,0 +1,35 @@
+/* ==========================================================
+   ease-contributors-wall — Auto-fetched GitHub Contributors
+   ========================================================== */
+
+.contributors-wall {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 20px;
+}
+
+.contributor-avatar {
+  display: block;
+  opacity: 0;
+  animation: contributor-in 0.4s ease forwards;
+}
+
+.contributor-avatar img {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  border: 2px solid #334155;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+  display: block;
+}
+
+.contributor-avatar:hover img {
+  transform: scale(1.15);
+  border-color: #60a5fa;
+}
+
+@keyframes contributor-in {
+  from { opacity: 0; transform: scale(0.6); }
+  to { opacity: 1; transform: scale(1); }
+}


### PR DESCRIPTION
### PR Description
```markdown
## Pull Request Description

Adds an auto-fetched, staggered-entrance GitHub contributors wall that pulls live data from the public GitHub API — no manually maintained list. Closes #[ISSUE_NUMBER].

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/contributors-wall/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

### What does this add?

A contributor avatar grid fetched live from `GET /repos/SAPTARSHI-coder/EaseMotion-css/contributors`, each avatar animating in with a staggered fade+scale and showing a name/commit-count tooltip on hover.

### How does a developer use it?

Drop in the `.contributors-wall` container and the fetch script shown in `demo.html` — works against any public GitHub repo by swapping the URL.