### PR TITLE
add animated dark light toggle

### DIFF
--- a/submissions/examples/animated-dark-light-toggle/README.md
+++ b/submissions/examples/animated-dark-light-toggle/README.md
@@ -1,0 +1,14 @@
+# docs-theme-toggle
+
+A persisted dark/light mode toggle for the EaseMotion CSS docs site, built on `data-theme` custom properties + `localStorage`.
+
+## Usage
+
+```html
+<html data-theme="dark">
+<head>...</head>
+<body>
+  <button class="theme-toggle-btn" id="themeToggleBtn" aria-label="Toggle dark mode">🌙</button>
+  ...
+</body>
+</html>

--- a/submissions/examples/animated-dark-light-toggle/demo.html
+++ b/submissions/examples/animated-dark-light-toggle/demo.html
@@ -1,0 +1,37 @@
+
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="UTF-8">
+<title>docs-theme-toggle Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header style="display:flex; justify-content:space-between; align-items:center; padding:20px 40px;">
+    <strong>EaseMotion CSS</strong>
+    <button class="theme-toggle-btn" id="themeToggleBtn" aria-label="Toggle dark mode">🌙</button>
+  </header>
+
+  <main style="max-width:500px; margin: 60px auto; padding: 0 20px;">
+    <div style="background:var(--card-bg); padding:24px; border-radius:12px;">
+      <h2>Theme-aware Card</h2>
+      <p>This card's background and text color respond to the toggle above, and your choice is remembered next time you visit.</p>
+    </div>
+  </main>
+
+  <script>
+    const root = document.documentElement;
+    const btn = document.getElementById('themeToggleBtn');
+    const saved = localStorage.getItem('easemotion-theme') || 'dark';
+    root.setAttribute('data-theme', saved);
+    btn.textContent = saved === 'dark' ? '🌙' : '☀️';
+
+    btn.addEventListener('click', () => {
+      const next = root.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+      root.setAttribute('data-theme', next);
+      localStorage.setItem('easemotion-theme', next);
+      btn.textContent = next === 'dark' ? '🌙' : '☀️';
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/animated-dark-light-toggle/style.css
+++ b/submissions/examples/animated-dark-light-toggle/style.css
@@ -1,0 +1,40 @@
+/* ==========================================================
+   docs-theme-toggle — Dark/Light Mode Toggle (persisted)
+   ========================================================== */
+
+:root[data-theme="dark"] {
+  --bg: #0f172a;
+  --text: #f1f5f9;
+  --card-bg: #1e293b;
+  --muted: #94a3b8;
+}
+
+:root[data-theme="light"] {
+  --bg: #f8fafc;
+  --text: #0f172a;
+  --card-bg: #ffffff;
+  --muted: #475569;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: system-ui, sans-serif;
+  margin: 0;
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+.theme-toggle-btn {
+  border: none;
+  background: var(--card-bg);
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  font-size: 1.1rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.3s ease;
+}
+
+.theme-toggle-btn:hover {
+  transform: rotate(20deg) scale(1.1);
+}


### PR DESCRIPTION
### PR Description
```markdown
## Pull Request Description

Adds a persisted dark/light mode toggle for the docs site, using `data-theme` CSS custom properties and `localStorage` for cross-visit persistence. Closes #[ISSUE_NUMBER].

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/docs-theme-toggle/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

### What does this add?

A toggle button that swaps `data-theme="dark"`/`"light"` on `<html>`, driving all page colors via CSS custom properties, and persists the choice in `localStorage` across visits.

### How does a developer use it?

Add the toggle button + script from `demo.html`, and define your own `:root[data-theme="..."]` variable blocks matching your color palette.