### PR TITLE
feat: add CSS Fade-In Progress Bar for Gaming Hub Layouts (#59192)

### DIFF
--- a/submissions/examples/fade-in-progress-bar-gaming/README.md
+++ b/submissions/examples/fade-in-progress-bar-gaming/README.md
@@ -1,0 +1,38 @@
+# Fade-In Progress Bar for Gaming Hub Layouts
+
+Progress bars that fade in with opacity and scale on page load, designed for gaming stat dashboards.
+
+## What does this do?
+
+Displays multiple stat progress bars that fade in from `opacity: 0; scaleX(0)` with staggered delays, creating a smooth cascading reveal of player stats.
+
+## How is it used?
+
+```html
+<div class="fi-track">
+  <div class="fi-fill fi-fill--purple" style="--fi-pct: 78%"></div>
+</div>
+```
+
+Add `.is-visible` class to trigger animation (handled by JS observer in the demo).
+
+## Why is it useful?
+
+Gaming dashboards display lots of stats at once. The fade-in cascade gives a clean, polished entrance that draws the eye without being overwhelming. Pure CSS with GPU-composited transforms.
+
+## CSS Custom Properties
+
+| Property        | Description      | Default   |
+| --------------- | ---------------- | --------- |
+| `--fi-purple`   | Purple variant   | `#a78bfa` |
+| `--fi-green`    | Green variant    | `#34d399` |
+| `--fi-amber`    | Amber variant    | `#fbbf24` |
+| `--fi-red`      | Red variant      | `#f87171` |
+| `--fi-track-bg` | Track background | `#1f2433` |
+
+## Browser Support
+
+- Chrome 90+
+- Firefox 88+
+- Safari 14+
+- Edge 90+

--- a/submissions/examples/fade-in-progress-bar-gaming/demo.html
+++ b/submissions/examples/fade-in-progress-bar-gaming/demo.html
@@ -1,0 +1,109 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Fade-In Progress Bar — Gaming Hub</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="gaming-dash">
+      <div class="gaming-dash__header">
+        <h1 class="gaming-dash__title">Player Stats</h1>
+        <p class="gaming-dash__sub">Season 4 progression</p>
+      </div>
+
+      <div class="stat-cards">
+        <div class="stat-card">
+          <div class="stat-card__top">
+            <span class="stat-card__icon">⚔️</span>
+            <span class="stat-card__label">Battle Pass</span>
+            <span class="stat-card__lvl">Lvl 47</span>
+          </div>
+          <div class="fi-track">
+            <div class="fi-fill fi-fill--purple" style="--fi-pct: 78%"></div>
+          </div>
+          <div class="stat-card__bottom">
+            <span>7,800 / 10,000 XP</span>
+            <span>2,200 to go</span>
+          </div>
+        </div>
+
+        <div class="stat-card">
+          <div class="stat-card__top">
+            <span class="stat-card__icon">🏆</span>
+            <span class="stat-card__label">Win Rate</span>
+            <span class="stat-card__pct">64%</span>
+          </div>
+          <div class="fi-track">
+            <div class="fi-fill fi-fill--green" style="--fi-pct: 64%"></div>
+          </div>
+          <div class="stat-card__bottom">
+            <span>128 wins / 200 matches</span>
+            <span>Top 12%</span>
+          </div>
+        </div>
+
+        <div class="stat-card">
+          <div class="stat-card__top">
+            <span class="stat-card__icon">🎯</span>
+            <span class="stat-card__label">Accuracy</span>
+            <span class="stat-card__pct">41%</span>
+          </div>
+          <div class="fi-track">
+            <div class="fi-fill fi-fill--amber" style="--fi-pct: 41%"></div>
+          </div>
+          <div class="stat-card__bottom">
+            <span>3,412 headshots</span>
+            <span>Above avg</span>
+          </div>
+        </div>
+
+        <div class="stat-card">
+          <div class="stat-card__top">
+            <span class="stat-card__icon">🔥</span>
+            <span class="stat-card__label">Kill Streak</span>
+            <span class="stat-card__pct">15</span>
+          </div>
+          <div class="fi-track">
+            <div class="fi-fill fi-fill--red" style="--fi-pct: 90%"></div>
+          </div>
+          <div class="stat-card__bottom">
+            <span>Personal best: 23</span>
+            <span>Almost there</span>
+          </div>
+        </div>
+
+        <div class="stat-card">
+          <div class="stat-card__top">
+            <span class="stat-card__icon">📦</span>
+            <span class="stat-card__label">Loot Collected</span>
+            <span class="stat-card__pct">83%</span>
+          </div>
+          <div class="fi-track">
+            <div class="fi-fill fi-fill--cyan" style="--fi-pct: 83%"></div>
+          </div>
+          <div class="stat-card__bottom">
+            <span>249 / 300 items</span>
+            <span>51 remaining</span>
+          </div>
+        </div>
+
+        <div class="stat-card">
+          <div class="stat-card__top">
+            <span class="stat-card__icon">⏱️</span>
+            <span class="stat-card__label">Playtime</span>
+            <span class="stat-card__pct">142h</span>
+          </div>
+          <div class="fi-track">
+            <div class="fi-fill fi-fill--blue" style="--fi-pct: 56%"></div>
+          </div>
+          <div class="stat-card__bottom">
+            <span>142 / 254 hours</span>
+            <span>Season ends in 18d</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/fade-in-progress-bar-gaming/style.css
+++ b/submissions/examples/fade-in-progress-bar-gaming/style.css
@@ -1,0 +1,224 @@
+/* ===================================================
+   Fade-In Progress Bar — Gaming Hub Layouts
+   Progress bars with opacity + scale fade-in on load
+   =================================================== */
+
+:root {
+  --fi-bg: #0f1119;
+  --fi-card: #181c28;
+  --fi-border: #262d3d;
+  --fi-text: #e5e8ef;
+  --fi-dim: #6e7590;
+  --fi-purple: #a78bfa;
+  --fi-green: #34d399;
+  --fi-amber: #fbbf24;
+  --fi-red: #f87171;
+  --fi-cyan: #22d3ee;
+  --fi-blue: #60a5fa;
+  --fi-track-bg: #1f2433;
+  --fi-radius: 10px;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
+  background: var(--fi-bg);
+  color: var(--fi-text);
+  min-height: 100vh;
+}
+
+/* ---- dashboard ---- */
+.gaming-dash {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 2.5rem 1.25rem;
+}
+
+.gaming-dash__title {
+  font-size: 1.625rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.gaming-dash__sub {
+  color: var(--fi-dim);
+  font-size: 0.875rem;
+  margin-top: 0.25rem;
+  margin-bottom: 1.75rem;
+}
+
+/* ---- card grid ---- */
+.stat-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 0.875rem;
+}
+
+/* ---- stat card ---- */
+.stat-card {
+  background: var(--fi-card);
+  border: 1px solid var(--fi-border);
+  border-radius: var(--fi-radius);
+  padding: 1rem 1.125rem 0.85rem;
+  transition: box-shadow 0.2s ease;
+}
+
+.stat-card:hover {
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.35);
+}
+
+.stat-card__top {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.stat-card__icon {
+  font-size: 1.25rem;
+}
+
+.stat-card__label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  flex: 1;
+}
+
+.stat-card__lvl,
+.stat-card__pct {
+  font-size: 0.8125rem;
+  font-weight: 700;
+  color: var(--fi-purple);
+}
+
+.stat-card__bottom {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.6875rem;
+  color: var(--fi-dim);
+  margin-top: 0.5rem;
+}
+
+/* ---- progress track ---- */
+.fi-track {
+  height: 6px;
+  background: var(--fi-track-bg);
+  border-radius: 99px;
+  overflow: hidden;
+}
+
+/* ---- fill bar — fade-in ---- */
+.fi-fill {
+  height: 100%;
+  width: 0;
+  border-radius: 99px;
+  opacity: 0;
+  transform: scaleX(0);
+  transform-origin: left center;
+  transition:
+    opacity 0.5s ease,
+    transform 0.65s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.is-visible .fi-fill {
+  width: var(--fi-pct);
+  opacity: 1;
+  transform: scaleX(1);
+}
+
+/* ---- color variants ---- */
+.fi-fill--purple {
+  background: var(--fi-purple);
+}
+.fi-fill--green {
+  background: var(--fi-green);
+}
+.fi-fill--amber {
+  background: var(--fi-amber);
+}
+.fi-fill--red {
+  background: var(--fi-red);
+}
+.fi-fill--cyan {
+  background: var(--fi-cyan);
+}
+.fi-fill--blue {
+  background: var(--fi-blue);
+}
+
+/* ---- stagger cards ---- */
+.stat-card:nth-child(1) .fi-fill {
+  transition-delay: 0.05s;
+}
+.stat-card:nth-child(2) .fi-fill {
+  transition-delay: 0.12s;
+}
+.stat-card:nth-child(3) .fi-fill {
+  transition-delay: 0.19s;
+}
+.stat-card:nth-child(4) .fi-fill {
+  transition-delay: 0.26s;
+}
+.stat-card:nth-child(5) .fi-fill {
+  transition-delay: 0.33s;
+}
+.stat-card:nth-child(6) .fi-fill {
+  transition-delay: 0.4s;
+}
+
+/* ---- reduced motion ---- */
+@media (prefers-reduced-motion: reduce) {
+  .fi-fill {
+    transition-duration: 0.01ms !important;
+    transition-delay: 0s !important;
+    width: var(--fi-pct);
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* ---- high contrast ---- */
+@media (prefers-contrast: high) {
+  .stat-card {
+    border-width: 2px;
+  }
+  .fi-track {
+    height: 8px;
+  }
+}
+
+/* ---- mobile ---- */
+@media (max-width: 480px) {
+  .stat-cards {
+    grid-template-columns: 1fr;
+  }
+  .gaming-dash {
+    padding: 2rem 1rem;
+  }
+}
+
+/* ---- print ---- */
+@media print {
+  body {
+    background: #fff;
+    color: #000;
+  }
+  .fi-fill {
+    transition: none;
+    width: var(--fi-pct);
+    opacity: 1;
+    transform: none;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+}


### PR DESCRIPTION
Adds progress bars with CSS fade-in animation for gaming stat dashboards.

Closes #59192

---

## Type of Change

- [x] ✨ New animation / hover effect

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/fade-in-progress-bar-gaming/`
- [x] Includes `demo.html` — self-contained, opens in browser
- [x] Includes `style.css` — raw CSS with fade-in animation
- [x] Includes `README.md` — what, how, why
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Progress bars that fade in from `opacity: 0; scaleX(0)` with staggered delays. Uses CSS custom property `--fi-pct` for width and 6 color variants (purple, green, amber, red, cyan, blue).

**How does a developer use it?**

```html
<div class="fi-track">
  <div class="fi-fill fi-fill--purple" style="--fi-pct: 78%"></div>
</div>