### PR TITLE
feat: add CSS blur-entrance carousel for fintech dashboard (#59212)

### DIFF
--- a/submissions/examples/blur-entrance-carousel-fintech/README.md
+++ b/submissions/examples/blur-entrance-carousel-fintech/README.md
@@ -1,0 +1,68 @@
+# CSS Blur-Entrance Carousel — Fintech Dashboard
+
+A **Blur-Entrance Carousel** for fintech dashboard layouts, built with pure **HTML, CSS and minimal JS**. Slides fade in from a blurred state to deliver a premium feel when navigating investment cards.
+
+---
+
+## Features
+
+- Smooth blur-to-clear entrance on each slide transition
+- Responsive design — stacks gracefully on mobile
+- CSS custom properties for quick theming
+- `prefers-reduced-motion` support
+- Semantic HTML with ARIA roles for screen readers
+- Lightweight — no external libraries
+
+---
+
+## Folder Structure
+
+```
+blur-entrance-carousel-fintech/
+├── demo.html
+├── style.css
+└── README.md
+```
+
+---
+
+## Usage
+
+1. Open `demo.html` in any modern browser.
+2. Use the **‹** / **›** buttons to navigate between slides.
+3. Adjust colours and timing via the CSS custom properties in `style.css`.
+
+---
+
+## Custom Properties
+
+```css
+--bg: #0a0e1a;
+--surface: #121829;
+--accent: #3b82f6;
+--positive: #22c55e;
+--negative: #ef4444;
+--radius: 20px;
+--speed: 0.55s;
+```
+
+---
+
+## Accessibility
+
+- `prefers-reduced-motion` disables all animations
+- ARIA `role="region"`, `aria-roledescription="carousel"` and per-slide labels
+- Keyboard-focusable navigation buttons
+- `:focus-visible` outlines on interactive elements
+
+---
+
+## Browser Support
+
+Chrome · Firefox · Edge · Safari (latest two versions)
+
+---
+
+## Technologies
+
+HTML5 · CSS3 · CSS Variables · Keyframe Animations · Vanilla JS

--- a/submissions/examples/blur-entrance-carousel-fintech/demo.html
+++ b/submissions/examples/blur-entrance-carousel-fintech/demo.html
@@ -1,0 +1,148 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Blur-Entrance Carousel — Fintech Dashboard</title>
+
+    <link rel="stylesheet" href="style.css" />
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <main class="dashboard">
+      <header class="dash-header">
+        <h1>Portfolio Overview</h1>
+        <p class="subtitle">
+          Track your investments with a smooth blur-entrance carousel
+        </p>
+      </header>
+
+      <div
+        class="carousel"
+        role="region"
+        aria-label="Investment portfolio carousel"
+        aria-roledescription="carousel"
+      >
+        <div class="carousel-track" role="list">
+          <article
+            class="slide"
+            role="listitem"
+            aria-roledescription="slide"
+            aria-label="1 of 4"
+          >
+            <div class="slide-icon">📈</div>
+            <span class="slide-label">Equities</span>
+            <h2 class="slide-value">$48,290</h2>
+            <span class="slide-change positive">+12.4%</span>
+            <p class="slide-desc">
+              Large-cap growth stocks performing above benchmark
+            </p>
+          </article>
+
+          <article
+            class="slide"
+            role="listitem"
+            aria-roledescription="slide"
+            aria-label="2 of 4"
+          >
+            <div class="slide-icon">🏦</div>
+            <span class="slide-label">Fixed Income</span>
+            <h2 class="slide-value">$31,750</h2>
+            <span class="slide-change positive">+3.8%</span>
+            <p class="slide-desc">
+              Government bonds yielding steady coupon payments
+            </p>
+          </article>
+
+          <article
+            class="slide"
+            role="listitem"
+            aria-roledescription="slide"
+            aria-label="3 of 4"
+          >
+            <div class="slide-icon">🪙</div>
+            <span class="slide-label">Crypto</span>
+            <h2 class="slide-value">$12,640</h2>
+            <span class="slide-change negative">−6.2%</span>
+            <p class="slide-desc">
+              Bitcoin and Ethereum positions trimmed this quarter
+            </p>
+          </article>
+
+          <article
+            class="slide"
+            role="listitem"
+            aria-roledescription="slide"
+            aria-label="4 of 4"
+          >
+            <div class="slide-icon">🏠</div>
+            <span class="slide-label">Real Estate</span>
+            <h2 class="slide-value">$27,800</h2>
+            <span class="slide-change positive">+5.1%</span>
+            <p class="slide-desc">
+              REIT holdings distributing quarterly dividends
+            </p>
+          </article>
+        </div>
+
+        <nav class="carousel-nav" aria-label="Carousel navigation">
+          <button class="nav-btn prev" aria-label="Previous slide" disabled>
+            ‹
+          </button>
+          <button class="nav-btn next" aria-label="Next slide">›</button>
+        </nav>
+      </div>
+
+      <section class="summary-bar">
+        <div class="summary-item">
+          <span class="summary-label">Total Value</span>
+          <span class="summary-value">$120,480</span>
+        </div>
+        <div class="summary-item">
+          <span class="summary-label">Day Change</span>
+          <span class="summary-value positive">+$1,340</span>
+        </div>
+        <div class="summary-item">
+          <span class="summary-label">YTD Return</span>
+          <span class="summary-value positive">+8.7%</span>
+        </div>
+      </section>
+    </main>
+
+    <script>
+      const track = document.querySelector(".carousel-track");
+      const slides = track.querySelectorAll(".slide");
+      const prevBtn = document.querySelector(".nav-btn.prev");
+      const nextBtn = document.querySelector(".nav-btn.next");
+      let current = 0;
+
+      function updateCarousel() {
+        track.style.transform = `translateX(-${current * 100}%)`;
+        slides.forEach((s, i) => s.classList.toggle("active", i === current));
+        prevBtn.disabled = current === 0;
+        nextBtn.disabled = current === slides.length - 1;
+      }
+
+      prevBtn.addEventListener("click", () => {
+        if (current > 0) {
+          current--;
+          updateCarousel();
+        }
+      });
+      nextBtn.addEventListener("click", () => {
+        if (current < slides.length - 1) {
+          current++;
+          updateCarousel();
+        }
+      });
+
+      updateCarousel();
+    </script>
+  </body>
+</html>

--- a/submissions/examples/blur-entrance-carousel-fintech/style.css
+++ b/submissions/examples/blur-entrance-carousel-fintech/style.css
@@ -1,0 +1,303 @@
+:root {
+  --bg: #0a0e1a;
+  --surface: #121829;
+  --surface-2: #1a2236;
+
+  --text: #e8ecf4;
+  --muted: #7b8ba5;
+
+  --accent: #3b82f6;
+  --accent-glow: rgba(59, 130, 246, 0.2);
+  --positive: #22c55e;
+  --negative: #ef4444;
+
+  --radius: 20px;
+  --speed: 0.55s;
+  --ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: "DM Sans", sans-serif;
+  background:
+    radial-gradient(ellipse at 20% 0%, #1e40af22, transparent 50%),
+    radial-gradient(ellipse at 80% 100%, #7c3aed18, transparent 50%), var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  line-height: 1.6;
+}
+
+/* ── dashboard shell ── */
+.dashboard {
+  max-width: 1060px;
+  margin: 0 auto;
+  padding: 60px 24px;
+}
+
+.dash-header {
+  margin-bottom: 48px;
+}
+
+.dash-header h1 {
+  font-size: clamp(1.9rem, 4vw, 2.8rem);
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.subtitle {
+  color: var(--muted);
+  font-size: 1.05rem;
+}
+
+/* ── carousel ── */
+.carousel {
+  position: relative;
+  overflow: hidden;
+  border-radius: var(--radius);
+  background: var(--surface);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: 0 12px 48px rgba(0, 0, 0, 0.35);
+}
+
+.carousel-track {
+  display: flex;
+  transition: transform var(--speed) var(--ease);
+}
+
+/* ── individual slide ── */
+.slide {
+  min-width: 100%;
+  padding: 48px 52px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  opacity: 0;
+  filter: blur(14px);
+  transform: scale(0.94);
+  transition:
+    opacity var(--speed) var(--ease),
+    filter var(--speed) var(--ease),
+    transform var(--speed) var(--ease);
+}
+
+.slide.active {
+  opacity: 1;
+  filter: blur(0);
+  transform: scale(1);
+}
+
+.slide-icon {
+  font-size: 2.2rem;
+  margin-bottom: 4px;
+}
+
+.slide-label {
+  color: var(--muted);
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+}
+
+.slide-value {
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.slide-change {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.slide-change.positive {
+  color: var(--positive);
+}
+.slide-change.negative {
+  color: var(--negative);
+}
+
+.slide-desc {
+  color: var(--muted);
+  max-width: 420px;
+  font-size: 0.95rem;
+}
+
+/* ── navigation buttons ── */
+.carousel-nav {
+  position: absolute;
+  bottom: 22px;
+  right: 28px;
+  display: flex;
+  gap: 10px;
+}
+
+.nav-btn {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: var(--surface-2);
+  color: var(--text);
+  font-size: 1.3rem;
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  transition:
+    background 0.25s,
+    border-color 0.25s;
+}
+
+.nav-btn:hover:not(:disabled) {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.nav-btn:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+/* ── summary bar ── */
+.summary-bar {
+  margin-top: 28px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+
+.summary-item {
+  background: var(--surface);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 14px;
+  padding: 22px 26px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  animation: blurSlideUp var(--speed) var(--ease) backwards;
+}
+
+.summary-item:nth-child(1) {
+  animation-delay: 0.1s;
+}
+.summary-item:nth-child(2) {
+  animation-delay: 0.2s;
+}
+.summary-item:nth-child(3) {
+  animation-delay: 0.3s;
+}
+
+.summary-label {
+  color: var(--muted);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 600;
+}
+
+.summary-value {
+  font-size: 1.45rem;
+  font-weight: 700;
+}
+
+.summary-value.positive {
+  color: var(--positive);
+}
+.summary-value.negative {
+  color: var(--negative);
+}
+
+@keyframes blurSlideUp {
+  from {
+    opacity: 0;
+    filter: blur(10px);
+    transform: translateY(18px);
+  }
+  to {
+    opacity: 1;
+    filter: blur(0);
+    transform: translateY(0);
+  }
+}
+
+/* ── responsive ── */
+@media (max-width: 768px) {
+  .dashboard {
+    padding: 40px 16px;
+  }
+
+  .slide {
+    padding: 36px 28px;
+  }
+
+  .summary-bar {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 480px) {
+  .slide {
+    padding: 28px 20px;
+  }
+
+  .carousel-nav {
+    bottom: 14px;
+    right: 16px;
+  }
+
+  .nav-btn {
+    width: 36px;
+    height: 36px;
+    font-size: 1.1rem;
+  }
+}
+
+/* ── accessibility ── */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+
+  .slide {
+    opacity: 1;
+    filter: none;
+    transform: none;
+  }
+
+  .summary-item {
+    opacity: 1;
+    filter: none;
+    transform: none;
+  }
+}
+
+.slide:focus-within {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+}
+
+/* ── scrollbar ── */
+::-webkit-scrollbar {
+  width: 9px;
+}
+::-webkit-scrollbar-track {
+  background: var(--bg);
+}
+::-webkit-scrollbar-thumb {
+  background: linear-gradient(180deg, var(--accent), #7c3aed);
+  border-radius: 999px;
+}
+
+::selection {
+  background: rgba(59, 130, 246, 0.3);
+  color: #fff;
+}


### PR DESCRIPTION
Closes #59212

### What this PR adds
A blur-entrance carousel component for fintech dashboard layouts — slides transition from a blurred, scaled-down state to a crisp full view, giving a premium feel when browsing investment cards.

### Key features
- Blur-to-clear entrance on each slide transition
- Responsive design (desktop → tablet → mobile)
- CSS custom properties for easy theming
- `prefers-reduced-motion` support
- Semantic HTML with ARIA roles for accessibility
- Pure HTML, CSS, and minimal vanilla JS

### Files
- `submissions/examples/blur-entrance-carousel-fintech/demo.html`
- `submissions/examples/blur-entrance-carousel-fintech/style.css`
- `submissions/examples/blur-entrance-carousel-fintech/README.md`