### PR TITLE
feat: add CSS Slide-Up Carousel for Fintech Dashboard Layouts (#59208)

### DIFF
--- a/submissions/examples/slide-up-carousel-fintech/README.md
+++ b/submissions/examples/slide-up-carousel-fintech/README.md
@@ -1,0 +1,43 @@
+# Slide-Up Carousel for Fintech Dashboard Layouts
+
+A horizontal carousel where cards slide up into view with staggered timing, designed for fintech dashboards.
+
+## What does this do?
+
+Displays financial metric cards in a horizontally scrollable carousel. Each card slides up from below with staggered delays on page load, giving a smooth cascading entrance.
+
+## How is it used?
+
+```html
+<div class="su-carousel">
+  <div class="su-carousel__track">
+    <article class="su-card">
+      <div class="su-card__icon su-card__icon--indigo">💰</div>
+      <h3 class="su-card__label">Total Balance</h3>
+      <p class="su-card__value">$847,293</p>
+      <span class="su-card__delta su-card__delta--up">+4.2%</span>
+    </article>
+  </div>
+</div>
+```
+
+## Why is it useful?
+
+Fintech dashboards need to present multiple metrics cleanly. The slide-up entrance draws attention to each card without being distracting, and the carousel keeps the layout compact on smaller screens.
+
+## CSS Custom Properties
+
+| Property       | Description     | Default   |
+| -------------- | --------------- | --------- |
+| `--su-indigo`  | Primary accent  | `#635bff` |
+| `--su-emerald` | Positive change | `#16a34a` |
+| `--su-amber`   | Neutral change  | `#d97706` |
+| `--su-card`    | Card background | `#ffffff` |
+| `--su-radius`  | Card radius     | `14px`    |
+
+## Browser Support
+
+- Chrome 90+
+- Firefox 88+
+- Safari 14+
+- Edge 90+

--- a/submissions/examples/slide-up-carousel-fintech/demo.html
+++ b/submissions/examples/slide-up-carousel-fintech/demo.html
@@ -1,0 +1,144 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Slide-Up Carousel — Fintech Dashboard</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="fin-dash">
+      <div class="fin-dash__head">
+        <h1 class="fin-dash__title">Wealth Summary</h1>
+        <div class="fin-dash__nav">
+          <button class="fin-nav" id="prevBtn" aria-label="Previous">
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2.5"
+            >
+              <polyline points="15 18 9 12 15 6" />
+            </svg>
+          </button>
+          <button class="fin-nav" id="nextBtn" aria-label="Next">
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2.5"
+            >
+              <polyline points="9 18 15 12 9 6" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      <div class="su-carousel" id="carousel">
+        <div class="su-carousel__track">
+          <article class="su-card">
+            <div class="su-card__icon su-card__icon--indigo">💰</div>
+            <h3 class="su-card__label">Total Balance</h3>
+            <p class="su-card__value">$847,293</p>
+            <span class="su-card__delta su-card__delta--up"
+              >+4.2% this month</span
+            >
+          </article>
+
+          <article class="su-card">
+            <div class="su-card__icon su-card__icon--emerald">📈</div>
+            <h3 class="su-card__label">Investments</h3>
+            <p class="su-card__value">$512,840</p>
+            <span class="su-card__delta su-card__delta--up">+7.8% YTD</span>
+          </article>
+
+          <article class="su-card">
+            <div class="su-card__icon su-card__icon--amber">🏦</div>
+            <h3 class="su-card__label">Savings</h3>
+            <p class="su-card__value">$198,452</p>
+            <span class="su-card__delta su-card__delta--up">+1.2% APY</span>
+          </article>
+
+          <article class="su-card">
+            <div class="su-card__icon su-card__icon--rose">💳</div>
+            <h3 class="su-card__label">Pending</h3>
+            <p class="su-card__value">$12,500</p>
+            <span class="su-card__delta su-card__delta--down"
+              >3 transactions</span
+            >
+          </article>
+
+          <article class="su-card">
+            <div class="su-card__icon su-card__icon--sky">📊</div>
+            <h3 class="su-card__label">Returns</h3>
+            <p class="su-card__value">+23.4%</p>
+            <span class="su-card__delta su-card__delta--up">vs benchmark</span>
+          </article>
+        </div>
+      </div>
+
+      <div class="su-dots" id="dots" role="tablist" aria-label="Carousel pages">
+        <button
+          class="su-dot su-dot--active"
+          role="tab"
+          aria-selected="true"
+          aria-label="Page 1"
+        ></button>
+        <button
+          class="su-dot"
+          role="tab"
+          aria-selected="false"
+          aria-label="Page 2"
+        ></button>
+        <button
+          class="su-dot"
+          role="tab"
+          aria-selected="false"
+          aria-label="Page 3"
+        ></button>
+      </div>
+    </div>
+
+    <script>
+      (function () {
+        var track = document.querySelector(".su-carousel__track");
+        var cards = document.querySelectorAll(".su-card");
+        var dots = document.querySelectorAll(".su-dot");
+        var page = 0;
+        var perPage = 3;
+
+        function getPages() {
+          return Math.ceil(cards.length / perPage);
+        }
+
+        function show(p) {
+          page = Math.max(0, Math.min(p, getPages() - 1));
+          var offset = page * perPage * (cards[0].offsetWidth + 16);
+          track.style.transform = "translateX(-" + offset + "px)";
+
+          dots.forEach(function (d, i) {
+            d.classList.toggle("su-dot--active", i === page);
+            d.setAttribute("aria-selected", i === page ? "true" : "false");
+          });
+        }
+
+        document.getElementById("prevBtn").onclick = function () {
+          show(page - 1);
+        };
+        document.getElementById("nextBtn").onclick = function () {
+          show(page + 1);
+        };
+
+        dots.forEach(function (d, i) {
+          d.onclick = function () {
+            show(i);
+          };
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/submissions/examples/slide-up-carousel-fintech/style.css
+++ b/submissions/examples/slide-up-carousel-fintech/style.css
@@ -1,0 +1,300 @@
+/* ===================================================
+   Slide-Up Carousel — Fintech Dashboard Layouts
+   Cards that slide up into the carousel viewport
+   =================================================== */
+
+:root {
+  --su-bg: #f5f6fa;
+  --su-card: #ffffff;
+  --su-border: #e4e7ee;
+  --su-text: #1a1f36;
+  --su-dim: #697386;
+  --su-indigo: #635bff;
+  --su-emerald: #16a34a;
+  --su-amber: #d97706;
+  --su-rose: #e11d48;
+  --su-sky: #0284c7;
+  --su-radius: 14px;
+  --su-gap: 16px;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
+  background: var(--su-bg);
+  color: var(--su-text);
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
+}
+
+/* ---- dashboard ---- */
+.fin-dash {
+  width: 100%;
+  max-width: 720px;
+}
+
+.fin-dash__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.25rem;
+}
+
+.fin-dash__title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.fin-dash__nav {
+  display: flex;
+  gap: 0.5rem;
+}
+
+/* ---- nav buttons ---- */
+.fin-nav {
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  border: 1px solid var(--su-border);
+  background: var(--su-card);
+  color: var(--su-text);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    border-color 0.2s,
+    box-shadow 0.2s;
+}
+
+.fin-nav:hover {
+  border-color: var(--su-indigo);
+  box-shadow: 0 2px 8px rgba(99, 91, 255, 0.15);
+}
+
+/* ---- carousel ---- */
+.su-carousel {
+  overflow: hidden;
+  border-radius: var(--su-radius);
+}
+
+.su-carousel__track {
+  display: flex;
+  gap: var(--su-gap);
+  transition: transform 0.45s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* ---- card ---- */
+.su-card {
+  flex: 0 0 calc(33.333% - 11px);
+  min-width: 180px;
+  background: var(--su-card);
+  border: 1px solid var(--su-border);
+  border-radius: var(--su-radius);
+  padding: 1.125rem;
+  transition:
+    box-shadow 0.2s ease,
+    transform 0.2s ease;
+
+  /* slide-up entrance */
+  opacity: 0;
+  transform: translateY(28px);
+  transition:
+    opacity 0.4s ease,
+    transform 0.5s cubic-bezier(0.34, 1.56, 0.64, 1),
+    box-shadow 0.2s ease;
+}
+
+.su-card.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.su-card:nth-child(1) {
+  transition-delay: 0.04s, 0.04s;
+}
+.su-card:nth-child(2) {
+  transition-delay: 0.1s, 0.1s;
+}
+.su-card:nth-child(3) {
+  transition-delay: 0.16s, 0.16s;
+}
+.su-card:nth-child(4) {
+  transition-delay: 0.22s, 0.22s;
+}
+.su-card:nth-child(5) {
+  transition-delay: 0.28s, 0.28s;
+}
+
+.su-card:hover {
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.08);
+  transform: translateY(-2px);
+}
+
+/* ---- icon ---- */
+.su-card__icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  margin-bottom: 0.75rem;
+}
+
+.su-card__icon--indigo {
+  background: rgba(99, 91, 255, 0.1);
+}
+.su-card__icon--emerald {
+  background: rgba(22, 163, 74, 0.1);
+}
+.su-card__icon--amber {
+  background: rgba(217, 119, 6, 0.1);
+}
+.su-card__icon--rose {
+  background: rgba(225, 29, 72, 0.1);
+}
+.su-card__icon--sky {
+  background: rgba(2, 132, 199, 0.1);
+}
+
+/* ---- content ---- */
+.su-card__label {
+  font-size: 0.8125rem;
+  color: var(--su-dim);
+  font-weight: 500;
+  margin-bottom: 0.25rem;
+}
+
+.su-card__value {
+  font-size: 1.375rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+}
+
+.su-card__delta {
+  display: inline-block;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  margin-top: 0.5rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 99px;
+}
+
+.su-card__delta--up {
+  background: rgba(22, 163, 74, 0.08);
+  color: var(--su-emerald);
+}
+
+.su-card__delta--down {
+  background: rgba(217, 119, 6, 0.08);
+  color: var(--su-amber);
+}
+
+/* ---- dots ---- */
+.su-dots {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.su-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 99px;
+  border: none;
+  background: var(--su-border);
+  cursor: pointer;
+  transition:
+    background 0.2s,
+    width 0.3s;
+}
+
+.su-dot:hover {
+  background: var(--su-dim);
+}
+
+.su-dot--active {
+  background: var(--su-indigo);
+  width: 20px;
+}
+
+/* ---- reduced motion ---- */
+@media (prefers-reduced-motion: reduce) {
+  .su-carousel__track {
+    transition-duration: 0.01ms;
+  }
+
+  .su-card {
+    transition-delay: 0s !important;
+    transition-duration: 0.01ms !important;
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* ---- high contrast ---- */
+@media (prefers-contrast: high) {
+  .su-card {
+    border-width: 2px;
+  }
+  .fin-nav {
+    border-width: 2px;
+  }
+}
+
+/* ---- mobile ---- */
+@media (max-width: 640px) {
+  .su-card {
+    flex: 0 0 calc(50% - 8px);
+    min-width: 150px;
+  }
+
+  .fin-dash__title {
+    font-size: 1.25rem;
+  }
+}
+
+@media (max-width: 420px) {
+  .su-card {
+    flex: 0 0 100%;
+    min-width: 0;
+  }
+}
+
+/* ---- print ---- */
+@media print {
+  body {
+    background: #fff;
+    padding: 1rem;
+  }
+  .fin-dash__nav,
+  .su-dots {
+    display: none;
+  }
+  .su-card {
+    opacity: 1;
+    transform: none;
+  }
+  .su-carousel__track {
+    transform: none !important;
+    flex-wrap: wrap;
+  }
+}


### PR DESCRIPTION
Closes #59208

## Summary
Adds a CSS Slide-Up Carousel component for fintech dashboard layouts with smooth slide-up transitions between slides.

## Changes
- submissions/examples/slide-up-carousel-fintech/demo.html
- submissions/examples/slide-up-carousel-fintech/style.css
- submissions/examples/slide-up-carousel-fintech/README.md