### PR TITLE
feat: add CSS bounce-pulse carousel for fintech dashboard layouts

### DIFF
--- a/submissions/examples/bounce-pulse-carousel-fintech-59214/README.md
+++ b/submissions/examples/bounce-pulse-carousel-fintech-59214/README.md
@@ -1,0 +1,44 @@
+# Bounce-Pulse Carousel for Fintech Dashboard Layouts
+
+A horizontal carousel where fintech metric cards bounce into view with staggered timing and a single pulse ring effect, designed for dashboard interfaces.
+
+## What does this do?
+
+Displays financial metric cards in a horizontally scrollable carousel. Each card bounces in from a scaled-down state with staggered delays on page load, and a one-shot pulse ring expands outward from the card center for added visual emphasis.
+
+## How is it used?
+
+```html
+<div class="bp-carousel">
+  <div class="bp-carousel__track">
+    <article class="bp-card bp-card--delay-1">
+      <div class="bp-card__pulse"></div>
+      <div class="bp-card__icon bp-card__icon--violet">💰</div>
+      <h3 class="bp-card__label">Net Worth</h3>
+      <p class="bp-card__value">$1,247,830</p>
+      <span class="bp-card__delta bp-card__delta--up">+5.6% MTD</span>
+    </article>
+  </div>
+</div>
+```
+
+## Why is it useful?
+
+Fintech dashboards benefit from attention-grabbing but non-disruptive animations. The bounce entrance draws the eye to each metric card on load, while the subtle pulse ring adds depth without competing with the data itself.
+
+## CSS Custom Properties
+
+| Property     | Description      | Default   |
+| ------------ | ---------------- | --------- |
+| `--bp-violet`| Primary accent   | `#7c5cfc` |
+| `--bp-teal`  | Positive change  | `#0ea5a0` |
+| `--bp-orange`| Neutral change   | `#e88c30` |
+| `--bp-card`  | Card background  | `#ffffff` |
+| `--bp-radius`| Card radius      | `14px`    |
+
+## Browser Support
+
+- Chrome 90+
+- Firefox 88+
+- Safari 14+
+- Edge 90+

--- a/submissions/examples/bounce-pulse-carousel-fintech-59214/demo.html
+++ b/submissions/examples/bounce-pulse-carousel-fintech-59214/demo.html
@@ -1,0 +1,108 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Bounce-Pulse Carousel - Fintech Dashboard</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="bp-dash">
+      <div class="bp-dash__head">
+        <h1 class="bp-dash__title">Portfolio Overview</h1>
+        <div class="bp-dash__nav">
+          <button class="bp-nav" id="prevBtn" aria-label="Previous">&lsaquo;</button>
+          <button class="bp-nav" id="nextBtn" aria-label="Next">&rsaquo;</button>
+        </div>
+      </div>
+
+      <div class="bp-carousel" id="carousel">
+        <div class="bp-carousel__track">
+          <article class="bp-card bp-card--delay-1">
+            <div class="bp-card__pulse"></div>
+            <div class="bp-card__icon bp-card__icon--violet">&#128176;</div>
+            <h3 class="bp-card__label">Net Worth</h3>
+            <p class="bp-card__value">$1,247,830</p>
+            <span class="bp-card__delta bp-card__delta--up">+5.6% MTD</span>
+          </article>
+
+          <article class="bp-card bp-card--delay-2">
+            <div class="bp-card__pulse"></div>
+            <div class="bp-card__icon bp-card__icon--teal">&#128200;</div>
+            <h3 class="bp-card__label">Equity Holdings</h3>
+            <p class="bp-card__value">$683,210</p>
+            <span class="bp-card__delta bp-card__delta--up">+12.3% YTD</span>
+          </article>
+
+          <article class="bp-card bp-card--delay-3">
+            <div class="bp-card__pulse"></div>
+            <div class="bp-card__icon bp-card__icon--orange">&#127974;</div>
+            <h3 class="bp-card__label">Fixed Income</h3>
+            <p class="bp-card__value">$324,500</p>
+            <span class="bp-card__delta bp-card__delta--up">+3.1% APY</span>
+          </article>
+
+          <article class="bp-card bp-card--delay-4">
+            <div class="bp-card__pulse"></div>
+            <div class="bp-card__icon bp-card__icon--red">&#128179;</div>
+            <h3 class="bp-card__label">Pending Transfers</h3>
+            <p class="bp-card__value">$8,750</p>
+            <span class="bp-card__delta bp-card__delta--down">2 pending</span>
+          </article>
+
+          <article class="bp-card bp-card--delay-5">
+            <div class="bp-card__pulse"></div>
+            <div class="bp-card__icon bp-card__icon--blue">&#128202;</div>
+            <h3 class="bp-card__label">Crypto Assets</h3>
+            <p class="bp-card__value">$42,370</p>
+            <span class="bp-card__delta bp-card__delta--down">-1.8% 24h</span>
+          </article>
+        </div>
+      </div>
+
+      <div class="bp-dots" id="dots" role="tablist" aria-label="Carousel pages">
+        <button class="bp-dot bp-dot--active" role="tab" aria-selected="true" aria-label="Page 1"></button>
+        <button class="bp-dot" role="tab" aria-selected="false" aria-label="Page 2"></button>
+        <button class="bp-dot" role="tab" aria-selected="false" aria-label="Page 3"></button>
+      </div>
+    </div>
+
+    <script>
+      (function () {
+        var track = document.querySelector(".bp-carousel__track");
+        var cards = document.querySelectorAll(".bp-card");
+        var dots = document.querySelectorAll(".bp-dot");
+        var page = 0;
+        var perPage = 3;
+
+        function getPages() {
+          return Math.ceil(cards.length / perPage);
+        }
+
+        function show(p) {
+          page = Math.max(0, Math.min(p, getPages() - 1));
+          var offset = page * perPage * (cards[0].offsetWidth + 16);
+          track.style.transform = "translateX(-" + offset + "px)";
+
+          dots.forEach(function (d, i) {
+            d.classList.toggle("bp-dot--active", i === page);
+            d.setAttribute("aria-selected", i === page ? "true" : "false");
+          });
+        }
+
+        document.getElementById("prevBtn").onclick = function () {
+          show(page - 1);
+        };
+        document.getElementById("nextBtn").onclick = function () {
+          show(page + 1);
+        };
+
+        dots.forEach(function (d, i) {
+          d.onclick = function () {
+            show(i);
+          };
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/submissions/examples/bounce-pulse-carousel-fintech-59214/style.css
+++ b/submissions/examples/bounce-pulse-carousel-fintech-59214/style.css
@@ -1,0 +1,341 @@
+/* ===================================================
+   Bounce-Pulse Carousel - Fintech Dashboard Layouts
+   Cards that bounce and pulse on entrance
+   =================================================== */
+
+:root {
+  --bp-bg: #f4f5f9;
+  --bp-card: #ffffff;
+  --bp-border: #e2e5ee;
+  --bp-text: #1b2140;
+  --bp-dim: #6b7394;
+  --bp-violet: #7c5cfc;
+  --bp-teal: #0ea5a0;
+  --bp-orange: #e88c30;
+  --bp-red: #dc3561;
+  --bp-blue: #2b8bd6;
+  --bp-radius: 14px;
+  --bp-gap: 16px;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: var(--bp-bg);
+  color: var(--bp-text);
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
+}
+
+/* ---- dashboard ---- */
+.bp-dash {
+  width: 100%;
+  max-width: 720px;
+}
+
+.bp-dash__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.25rem;
+}
+
+.bp-dash__title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.bp-dash__nav {
+  display: flex;
+  gap: 0.5rem;
+}
+
+/* ---- nav buttons ---- */
+.bp-nav {
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  border: 1px solid var(--bp-border);
+  background: var(--bp-card);
+  color: var(--bp-text);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.bp-nav:hover {
+  border-color: var(--bp-violet);
+  box-shadow: 0 2px 8px rgba(124, 92, 252, 0.15);
+}
+
+/* ---- carousel ---- */
+.bp-carousel {
+  overflow: hidden;
+  border-radius: var(--bp-radius);
+}
+
+.bp-carousel__track {
+  display: flex;
+  gap: var(--bp-gap);
+  transition: transform 0.45s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* ---- keyframes ---- */
+@keyframes bp-bounce {
+  0% {
+    opacity: 0;
+    transform: scale(0.3) translateY(40px);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.05) translateY(-6px);
+  }
+  70% {
+    transform: scale(0.95) translateY(2px);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
+@keyframes bp-pulse {
+  0% {
+    transform: scale(1);
+    opacity: 0.6;
+  }
+  50% {
+    transform: scale(1.35);
+    opacity: 0;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 0;
+  }
+}
+
+/* ---- card ---- */
+.bp-card {
+  flex: 0 0 calc(33.333% - 11px);
+  min-width: 180px;
+  background: var(--bp-card);
+  border: 1px solid var(--bp-border);
+  border-radius: var(--bp-radius);
+  padding: 1.125rem;
+  position: relative;
+  overflow: hidden;
+
+  /* bounce entrance */
+  opacity: 0;
+  animation: bp-bounce 0.6s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+
+.bp-card--delay-1 {
+  animation-delay: 0.05s;
+}
+.bp-card--delay-2 {
+  animation-delay: 0.12s;
+}
+.bp-card--delay-3 {
+  animation-delay: 0.19s;
+}
+.bp-card--delay-4 {
+  animation-delay: 0.26s;
+}
+.bp-card--delay-5 {
+  animation-delay: 0.33s;
+}
+
+/* ---- pulse ring ---- */
+.bp-card__pulse {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 60px;
+  height: 60px;
+  margin-top: -30px;
+  margin-left: -30px;
+  border-radius: 50%;
+  border: 2px solid var(--bp-violet);
+  opacity: 0;
+  pointer-events: none;
+  animation: bp-pulse 1.8s ease-out 0.6s;
+}
+
+.bp-card:hover {
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.08);
+  transform: translateY(-2px);
+}
+
+/* ---- icon ---- */
+.bp-card__icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  margin-bottom: 0.75rem;
+}
+
+.bp-card__icon--violet {
+  background: rgba(124, 92, 252, 0.1);
+}
+.bp-card__icon--teal {
+  background: rgba(14, 165, 160, 0.1);
+}
+.bp-card__icon--orange {
+  background: rgba(232, 140, 48, 0.1);
+}
+.bp-card__icon--red {
+  background: rgba(220, 53, 97, 0.1);
+}
+.bp-card__icon--blue {
+  background: rgba(43, 139, 214, 0.1);
+}
+
+/* ---- content ---- */
+.bp-card__label {
+  font-size: 0.8125rem;
+  color: var(--bp-dim);
+  font-weight: 500;
+  margin-bottom: 0.25rem;
+}
+
+.bp-card__value {
+  font-size: 1.375rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+}
+
+.bp-card__delta {
+  display: inline-block;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  margin-top: 0.5rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 99px;
+}
+
+.bp-card__delta--up {
+  background: rgba(14, 165, 160, 0.08);
+  color: var(--bp-teal);
+}
+
+.bp-card__delta--down {
+  background: rgba(232, 140, 48, 0.08);
+  color: var(--bp-orange);
+}
+
+/* ---- dots ---- */
+.bp-dots {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.bp-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 99px;
+  border: none;
+  background: var(--bp-border);
+  cursor: pointer;
+  transition: background 0.2s, width 0.3s;
+}
+
+.bp-dot:hover {
+  background: var(--bp-dim);
+}
+
+.bp-dot--active {
+  background: var(--bp-violet);
+  width: 20px;
+}
+
+/* ---- reduced motion ---- */
+@media (prefers-reduced-motion: reduce) {
+  .bp-carousel__track {
+    transition-duration: 0.01ms;
+  }
+
+  .bp-card {
+    animation: none !important;
+    opacity: 1;
+    transform: none;
+  }
+
+  .bp-card__pulse {
+    animation: none !important;
+    display: none;
+  }
+}
+
+/* ---- high contrast ---- */
+@media (prefers-contrast: high) {
+  .bp-card {
+    border-width: 2px;
+  }
+  .bp-nav {
+    border-width: 2px;
+  }
+}
+
+/* ---- mobile ---- */
+@media (max-width: 640px) {
+  .bp-card {
+    flex: 0 0 calc(50% - 8px);
+    min-width: 150px;
+  }
+
+  .bp-dash__title {
+    font-size: 1.25rem;
+  }
+}
+
+@media (max-width: 420px) {
+  .bp-card {
+    flex: 0 0 100%;
+    min-width: 0;
+  }
+}
+
+/* ---- print ---- */
+@media print {
+  body {
+    background: #fff;
+    padding: 1rem;
+  }
+  .bp-dash__nav,
+  .bp-dots {
+    display: none;
+  }
+  .bp-card {
+    animation: none !important;
+    opacity: 1;
+    transform: none;
+  }
+  .bp-card__pulse {
+    display: none;
+  }
+  .bp-carousel__track {
+    transform: none !important;
+    flex-wrap: wrap;
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Adds a CSS bounce-pulse carousel component for fintech dashboard layouts under `submissions/examples/bounce-pulse-carousel-fintech-59214/`.

Cards bounce into the viewport with staggered timing using `@keyframes` and a pulse ring effect expands on load, giving a lively but non-distracting entrance for dashboard metric cards.

## Changes

- **demo.html** — Self-contained HTML5 showcase with ARIA attributes and minimal inline JS for carousel navigation
- **style.css** — Pure CSS with `@keyframes bp-bounce` and `@keyframes bp-pulse`, responsive breakpoints, `prefers-reduced-motion` and `prefers-contrast` support
- **README.md** — Usage docs, CSS custom properties table, browser support

## Checklist

- [x] Files placed inside `submissions/examples/bounce-pulse-carousel-fintech-59214/`
- [x] No files modified outside `submissions/`
- [x] Pure CSS/HTML, no external JS frameworks
- [x] Smooth CSS transitions and keyframe animations
- [x] Fully responsive (desktop, tablet, mobile)
- [x] `prefers-reduced-motion` support
- [x] `prefers-contrast` support
- [x] Print styles included

Closes #59214