### PR TITLE
docs: add showcase demo for loaders reduced-motion gap (#61569)

### DIFF
--- a/submissions/docs/reduced-motion-loaders-scroll-gallery-aaniya/README.md
+++ b/submissions/docs/reduced-motion-loaders-scroll-gallery-aaniya/README.md
@@ -1,0 +1,55 @@
+# Reduced-Motion Support for Loaders — Issue #61569
+
+## Scope correction
+
+Issue #61569 asks to expand `prefers-reduced-motion` support across
+marquee, scroll-gallery, typewriter, and loading spinners. After
+auditing `core/` and `components/`, the actual picture is different
+from the issue description:
+
+| Area | Status |
+|---|---|
+| `components/ease-marquee.css` | Already has a `prefers-reduced-motion` override (line 134). No change needed. |
+| `components/scroll-gallery.css` | Defines no `@keyframes` at all — pure scroll-snap CSS, no animation to disable. Out of scope for this fix. |
+| Typewriter | No central `components/*typewriter*.css` file exists. Every typewriter implementation lives inside individual `submissions/` folders (dozens of them, by many different contributors), so there's no single component file to patch. |
+| `components/loaders.css` | **Genuinely missing** reduced-motion coverage for `.ease-loader-spin`, `.ease-loader-pulse`, `.ease-loader-ping`, and `.ease-loader-dot`. This is the real, actionable gap. |
+
+The issue's own suggested code snippet references a class called
+`.ease-spinner`, which doesn't exist anywhere in this codebase — the
+actual loader classes are `.ease-loader-*`, as used in this demo.
+
+## Demo
+
+`demo.html` + `style.css` reproduce the three animated loader variants
+(spin, pulse, dots) using renamed `demo-loader-*` classes to avoid
+colliding with the live components, plus the missing
+`prefers-reduced-motion` block. Toggling OS-level reduced motion (or
+DevTools' Rendering emulation) stops all three from animating.
+
+## Recommended fix (for maintainer to apply in `components/loaders.css`)
+
+Add to `components/loaders.css`, inside the existing
+`@layer easemotion-components` block or immediately after it:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  .ease-loader-spin,
+  .ease-loader-pulse,
+  .ease-loader-ping,
+  .ease-loader-dot {
+    animation: none;
+  }
+}
+```
+
+No changes are needed in `ease-marquee.css` or `scroll-gallery.css`.
+Typewriter isn't addressable here since it has no central component
+file — that would need to be tracked as a separate, narrower issue
+once (if) a shared `components/typewriter.css` is introduced.
+
+## Why this is submitted as a docs showcase, not a direct edit
+
+Per `CONTRIBUTING.md`, PRs touching `core/` or `components/` are closed
+automatically. This submission documents the actual gap and demonstrates
+the fix so a maintainer can apply the two-line change directly to
+`components/loaders.css`.

--- a/submissions/docs/reduced-motion-loaders-scroll-gallery-aaniya/demo.html
+++ b/submissions/docs/reduced-motion-loaders-scroll-gallery-aaniya/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>prefers-reduced-motion — Loaders Fix Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main style="font-family: sans-serif; padding: 2rem; background: #f8f9fa;">
+    <h1>Issue #61569 — Expand prefers-reduced-motion support</h1>
+
+    <p>
+      <code>components/loaders.css</code> defines four animated loader
+      variants (<code>.ease-loader-spin</code>,
+      <code>.ease-loader-pulse</code>, <code>.ease-loader-ping</code>,
+      <code>.ease-loader-dot</code>) but has no
+      <code>prefers-reduced-motion</code> override today, unlike
+      <code>components/ease-marquee.css</code> which already handles it.
+    </p>
+
+    <div style="display: flex; gap: 2rem; align-items: center; margin: 2rem 0;">
+      <span class="demo-loader demo-loader-spin"></span>
+      <span class="demo-loader demo-loader-pulse"></span>
+      <span class="demo-loader-dots">
+        <span class="demo-loader-dot"></span>
+        <span class="demo-loader-dot"></span>
+        <span class="demo-loader-dot"></span>
+      </span>
+    </div>
+
+    <p class="demo-toggle-hint">
+      To verify: enable "Reduce motion" in your OS accessibility settings
+      (or emulate <code>prefers-reduced-motion: reduce</code> in
+      DevTools' Rendering tab) and reload — all three loaders above
+      should stop animating instead of running indefinitely.
+    </p>
+
+    <p style="margin-top: 2rem; color: #555;">
+      <strong>Scope note:</strong> <code>components/ease-marquee.css</code>
+      already covers reduced-motion (no change needed there). No central
+      typewriter component file exists — typewriter implementations only
+      live inside individual <code>submissions/</code> folders, so they're
+      out of scope for a <code>components/</code> fix. This demo does not
+      cover <code>scroll-gallery.css</code>, since it defines no
+      <code>@keyframes</code> at all — only native scroll-snap behavior.
+    </p>
+  </main>
+</body>
+</html>

--- a/submissions/docs/reduced-motion-loaders-scroll-gallery-aaniya/style.css
+++ b/submissions/docs/reduced-motion-loaders-scroll-gallery-aaniya/style.css
@@ -1,0 +1,76 @@
+/* Fix for issue #61569 — Expand prefers-reduced-motion support
+   -----------------------------------------------------------
+   Scope note: components/ease-marquee.css already has a
+   prefers-reduced-motion override (line 134), and there is no
+   central "typewriter" component file — typewriter only exists
+   inside individual contributor submissions/ folders, so it's
+   out of scope for a components/ fix.
+
+   The real gap is components/loaders.css, which defines four
+   animated loader variants with zero reduced-motion coverage:
+     .ease-loader-spin   -> ease-kf-rotate
+     .ease-loader-pulse  -> ease-kf-pulse
+     .ease-loader-ping   -> ease-kf-ping
+     .ease-loader-dot    -> ease-kf-bounce
+
+   Note the issue's suggested snippet references ".ease-spinner",
+   which doesn't exist in this codebase — the real classes are
+   ".ease-loader-*" as used below. */
+
+@keyframes demo-kf-rotate {
+  to { transform: rotate(360deg); }
+}
+@keyframes demo-kf-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+@keyframes demo-kf-bounce {
+  to { transform: translateY(-6px); }
+}
+
+.demo-loader {
+  display: inline-block;
+  width: 32px;
+  height: 32px;
+  border-radius: 9999px;
+}
+.demo-loader-spin {
+  border: 3px solid #e2e8f0;
+  border-top-color: #6366f1;
+  animation: demo-kf-rotate 0.8s linear infinite;
+}
+.demo-loader-pulse {
+  background-color: #6366f1;
+  animation: demo-kf-pulse 1.2s ease-in-out infinite;
+}
+.demo-loader-dots {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 12px;
+}
+.demo-loader-dot {
+  width: 8px;
+  height: 8px;
+  background-color: #6366f1;
+  border-radius: 9999px;
+  animation: demo-kf-bounce 1s infinite alternate;
+}
+.demo-loader-dot:nth-child(2) { animation-delay: 0.2s; }
+.demo-loader-dot:nth-child(3) { animation-delay: 0.4s; }
+
+/* Recommended fix — this block does not exist in loaders.css today */
+@media (prefers-reduced-motion: reduce) {
+  .demo-loader-spin,
+  .demo-loader-pulse,
+  .demo-loader-dot {
+    animation: none;
+  }
+}
+
+.demo-toggle-hint {
+  font-family: sans-serif;
+  font-size: 13px;
+  color: #555;
+  margin-top: 1.5rem;
+}


### PR DESCRIPTION
## Pull Request Description
Docs-showcase for issue #61569. Audited `core/` and `components/` and found the issue's scope was partly inaccurate — see the scope table below. The one real, actionable gap is `components/loaders.css`, which has no `prefers-reduced-motion` override for any of its four loader variants.

---

## Type of Change
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/docs/reduced-motion-loaders-scroll-gallery-aaniya/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A demo + writeup showing that `.ease-loader-spin`, `.ease-loader-pulse`, `.ease-loader-ping`, and `.ease-loader-dot` in `components/loaders.css` have no `prefers-reduced-motion` override, plus the exact two-line fix.

**How does a developer use it?**
```html
<span class="demo-loader demo-loader-spin"></span>
<span class="demo-loader demo-loader-pulse"></span>
<span class="demo-loader-dots">
  <span class="demo-loader-dot"></span>
  <span class="demo-loader-dot"></span>
  <span class="demo-loader-dot"></span>
</span>
```

**Why does it fit EaseMotion CSS?**
`components/ease-marquee.css` already respects reduced motion — this brings loaders in line with that same accessibility standard, closing a real gap rather than a cosmetic one.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Scope correction on the original issue, based on auditing `core/` and `components/`:
- `ease-marquee.css` already handles reduced motion (line 134) — no change needed.
- `scroll-gallery.css` defines no `@keyframes` at all, so there's nothing to disable.
- No central typewriter component file exists — every typewriter lives inside individual `submissions/` folders by different contributors, so it's not a `components/` fix.
- `loaders.css` is the real gap. The issue's suggested snippet also references `.ease-spinner`, which doesn't exist in this codebase — actual classes are `.ease-loader-*`.

Recommended fix to apply directly in `components/loaders.css`:
```css
@media (prefers-reduced-motion: reduce) {
  .ease-loader-spin,
  .ease-loader-pulse,
  .ease-loader-ping,
  .ease-loader-dot {
    animation: none;
  }
}
```