### PR TITLE
feat: add aspect-media SCSS mixin with padding-hack fallback (#63553)

### DIFF
--- a/submissions/scss/aspect-media-ad/README.md
+++ b/submissions/scss/aspect-media-ad/README.md
@@ -1,0 +1,49 @@
+# Aspect Media mixin
+
+> Issue: [#63553](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/63553)
+
+Fixed-ratio media containers, so images and embeds reserve their space before loading instead of shifting the page when they arrive.
+
+## Mixins
+
+### `aspect-media($ratio, $fit, $radius)`
+
+```scss
+.thumb  { @include aspect-media(16 9); }
+.square { @include aspect-media(1, $radius: 12px); }
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `$ratio` | `List \| Number` | `16 9` | `16 9`, or a single number treated as `n:1`. Errors on a wrong-length list or non-positive values. |
+| `$fit` | `String` | `cover` | `object-fit` for the media child. |
+| `$radius` | `Number` | `0` | Corner radius; omitted entirely when `0`. |
+
+Applies to `img`, `video`, `iframe`, `picture`, and `.aspect-media-ad__inner`.
+
+### `aspect-media-responsive($map, $fit, $radius)`
+
+```scss
+.hero {
+    @include aspect-media-responsive((default: (4 3), 768px: (21 9)));
+}
+```
+
+A 21:9 cinematic ratio is unreadable on a phone; this lets it become 4:3 there without re-emitting the whole mixin per breakpoint.
+
+### `aspect-media-placeholder($color, $speed)` + `aspect-media-keyframes`
+
+A shimmer skeleton shown while media loads. Call `aspect-media-keyframes` **once** at the top level.
+
+```scss
+@include aspect-media-keyframes;
+.thumb { @include aspect-media(16 9); @include aspect-media-placeholder; }
+```
+
+## Why it fits EaseMotion
+
+**The two ratio strategies cannot simply be stacked.** The padding-top hack requires an absolutely positioned child, and that positioning must *not* apply on the modern path — otherwise the child escapes the flow for no reason, breaking anything that relied on it sizing normally. Scoping the legacy geometry inside `@supports not (aspect-ratio: 1)` means exactly one strategy is ever active.
+
+The placeholder sits **behind** the media child via `z-index`, so it disappears the moment the image paints — no load handler, no state, no JavaScript. Its infinite shimmer is cancelled outright under `prefers-reduced-motion`, since a perpetual loop is precisely what that setting opts out of.
+
+Ratio arguments are validated at build time: a list of the wrong length, a non-numeric ratio, or a zero/negative value all raise an error rather than emitting a division that silently produces `padding-top: 0%` and collapses the container.

--- a/submissions/scss/aspect-media-ad/_aspect-media.scss
+++ b/submissions/scss/aspect-media-ad/_aspect-media.scss
@@ -1,0 +1,176 @@
+// ==========================================================================
+// EaseMotion CSS — Aspect Media mixin
+// Issue #63553
+// --------------------------------------------------------------------------
+// Fixed-ratio media containers, so images and embeds reserve their space
+// before they load instead of shifting the page when they arrive.
+//
+// Uses `aspect-ratio` where available and the padding-top hack elsewhere.
+// The two cannot simply be stacked: the padding hack needs an absolutely
+// positioned child, and that positioning must be undone in the modern
+// path or the child escapes the flow for no reason. The `@supports not`
+// query scopes the legacy geometry so only one strategy is ever active.
+// ==========================================================================
+
+@use "sass:math";
+@use "sass:meta";
+@use "sass:list";
+
+$aspect-media-fit: cover !default;
+$aspect-media-radius: 0 !default;
+
+// --------------------------------------------------------------------------
+// aspect-media
+//
+// @param {List|Number} $ratio   `16 9`, or a single number (16/9).
+// @param {String}      $fit     object-fit for the media child.
+// @param {Number}      $radius  Corner radius applied to container + child.
+// --------------------------------------------------------------------------
+@mixin aspect-media(
+    $ratio: 16 9,
+    $fit: $aspect-media-fit,
+    $radius: $aspect-media-radius
+) {
+    $w: null;
+    $h: null;
+
+    @if meta.type-of($ratio) == "list" {
+        @if list.length($ratio) != 2 {
+            @error "aspect-media(): $ratio list must have exactly 2 values, got #{list.length($ratio)}.";
+        }
+        $w: list.nth($ratio, 1);
+        $h: list.nth($ratio, 2);
+    } @else if meta.type-of($ratio) == "number" {
+        $w: $ratio;
+        $h: 1;
+    } @else {
+        @error "aspect-media(): $ratio must be a list like `16 9` or a number, got `#{$ratio}`.";
+    }
+
+    @if $w <= 0 or $h <= 0 {
+        @error "aspect-media(): ratio values must be positive, got `#{$w} #{$h}`.";
+    }
+
+    display: block;
+    overflow: hidden;
+    position: relative;
+    width: 100%;
+    aspect-ratio: math.div($w, $h);
+
+    @if $radius != 0 {
+        border-radius: $radius;
+    }
+
+    // Legacy path only. Scoping to `@supports not` means the padding and
+    // absolute positioning never coexist with a working `aspect-ratio`.
+    @supports not (aspect-ratio: 1) {
+        height: 0;
+        padding-top: math.percentage(math.div($h, $w));
+
+        > img,
+        > video,
+        > iframe,
+        > picture,
+        > .aspect-media-ad__inner {
+            height: 100%;
+            left: 0;
+            position: absolute;
+            top: 0;
+            width: 100%;
+        }
+    }
+
+    > img,
+    > video,
+    > picture > img,
+    > .aspect-media-ad__inner {
+        display: block;
+        height: 100%;
+        object-fit: $fit;
+        width: 100%;
+    }
+
+    > iframe {
+        border: 0;
+        height: 100%;
+        width: 100%;
+    }
+}
+
+// --------------------------------------------------------------------------
+// aspect-media-responsive
+//
+// Different ratios per breakpoint — a 21:9 cinematic hero is unreadable on
+// a phone and usually wants to become 4:3 or square.
+//
+// @param {Map} $map  Breakpoint (min-width) => ratio. `default` is emitted
+//                    outside any media query.
+// --------------------------------------------------------------------------
+@mixin aspect-media-responsive($map, $fit: $aspect-media-fit, $radius: $aspect-media-radius) {
+    @each $breakpoint, $ratio in $map {
+        @if $breakpoint == default {
+            @include aspect-media($ratio, $fit, $radius);
+        } @else {
+            @media (min-width: $breakpoint) {
+                $w: list.nth($ratio, 1);
+                $h: list.nth($ratio, 2);
+
+                aspect-ratio: math.div($w, $h);
+
+                @supports not (aspect-ratio: 1) {
+                    padding-top: math.percentage(math.div($h, $w));
+                }
+            }
+        }
+    }
+}
+
+// --------------------------------------------------------------------------
+// aspect-media-placeholder
+//
+// Skeleton shimmer shown while the media loads. Sits behind the child, so
+// it disappears naturally the moment the image paints — no load handler,
+// no state, no JavaScript.
+// --------------------------------------------------------------------------
+@mixin aspect-media-placeholder($color: rgba(148, 163, 184, 0.1), $speed: 1.4s) {
+    background: $color;
+    position: relative;
+
+    &::before {
+        animation: aspect-media-shimmer-ad $speed ease-in-out infinite;
+        background: linear-gradient(
+            90deg,
+            transparent,
+            rgba(255, 255, 255, 0.06),
+            transparent
+        );
+        content: "";
+        inset: 0;
+        position: absolute;
+        z-index: 0;
+    }
+
+    > * {
+        position: relative;
+        z-index: 1;
+    }
+
+    // An infinite shimmer is exactly what reduced-motion opts out of.
+    @media (prefers-reduced-motion: reduce) {
+        &::before {
+            animation: none;
+        }
+    }
+}
+
+@mixin aspect-media-keyframes {
+    @keyframes aspect-media-shimmer-ad {
+        0% {
+            transform: translateX(-100%);
+        }
+
+        100% {
+            transform: translateX(100%);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #63553

**What was added**

Fixed-ratio media container mixins, under `submissions/scss/aspect-media-ad/`.

- `_aspect-media.scss` — `aspect-media()`, `aspect-media-responsive()`, `aspect-media-placeholder()` and `aspect-media-keyframes()`, with build-time ratio validation.
- `README.md` — parameter tables, usage, and rationale.

**What is the problem**

Images and embeds without a reserved box cause cumulative layout shift: content jumps as each asset arrives. The two available fixes — `aspect-ratio` and the padding-top hack — **cannot simply be stacked**, which is where hand-rolled versions go wrong.

The padding hack requires an absolutely positioned child. If that positioning is applied unconditionally, then on modern engines the child escapes normal flow for no reason, breaking anything relying on it sizing naturally. Conversely, applying `padding-top` alongside a working `aspect-ratio` double-counts the height.

**Why this approach**

The legacy geometry — `height: 0`, `padding-top`, and the absolute child positioning — is scoped entirely inside `@supports not (aspect-ratio: 1)`. Exactly one strategy is ever active, so neither engine gets the other's side effects.

The placeholder sits behind the media child via `z-index` rather than being toggled by a load handler, so it disappears the moment the image paints — no state, no JavaScript. Its infinite shimmer is cancelled outright under `prefers-reduced-motion`.

Ratio arguments are validated: a wrong-length list, a non-numeric value, or a zero/negative component raises a build error rather than emitting `padding-top: 0%` and silently collapsing the container.

**How to test**

1. Pull this branch and compile:
   ```scss
   @use "submissions/scss/aspect-media-ad/aspect-media" as am;
   @include am.aspect-media-keyframes;
   .thumb  { @include am.aspect-media(16 9); }
   .square { @include am.aspect-media(1, $radius: 12px); }
   .hero   { @include am.aspect-media-responsive((default: (4 3), 768px: (21 9))); }
   ```
2. Verify computed padding values: 16:9 → `56.25%`, 1:1 → `100%`, 4:3 → `75%`, 21:9 → `42.857%`.
3. Confirm every `padding-top` and absolute-positioning rule sits inside a `@supports not (aspect-ratio: 1)` block, and `aspect-ratio` sits outside it.
4. Load a slow image in a browser and confirm the container holds its height before the image arrives.
5. Pass `aspect-media(16 9 4)` and confirm a build error about list length.
6. Pass `aspect-media(0 9)` and confirm a build error about non-positive values.
7. Enable OS-level "reduce motion" — the placeholder shimmer must stop entirely.

**Edge cases covered**

- Legacy and modern strategies are mutually exclusive via `@supports not`, so neither leaks into the other.
- Wrong-length ratio lists, non-numeric ratios and zero/negative values all raise build errors.
- A single number is accepted as `n:1`, so `aspect-media(1)` gives a square.
- `$radius: 0` omits the `border-radius` declaration rather than emitting a no-op.
- `iframe` gets its own rule with `border: 0`, since `object-fit` does not apply to it.
- The responsive variant re-emits only the ratio per breakpoint, not the whole rule set.
- Placeholder shimmer is cancelled, not shortened, under reduced motion.
- Keyframes live in a separate top-level mixin so they are emitted once regardless of call-site count.

**Verification**

- Compiled with the repo's own `sass` dependency; all four ratio computations verified numerically.
- Zero deprecation warnings.
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 2 new files, 0 deletions, no existing file touched.
- Folder and keyframe names carry an `-ad` suffix so this lands as a parallel implementation.

**Labels:** `type:feature` · `scss` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
