### PR TITLE
feat: add fluid-type SCSS function with solved-slope clamp (#63555)

### DIFF
--- a/submissions/scss/fluid-type-ad/README.md
+++ b/submissions/scss/fluid-type-ad/README.md
@@ -1,0 +1,48 @@
+# Fluid Type function
+
+> Issue: [#63555](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/63555)
+
+Generates `clamp()` type scales that hit their bounds at exactly the viewport widths you specify.
+
+## Functions
+
+### `fluid-type($min-size, $max-size, $min-vw, $max-vw)`
+
+```scss
+.title { font-size: fluid-type(1.5rem, 2.5rem, 400px, 1200px); }
+// → clamp(1.5rem, 1rem + 2vw, 2.5rem)
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `$min-size` | `Number` | — | Size at and below `$min-vw`. px or rem. |
+| `$max-size` | `Number` | — | Size at and above `$max-vw`. |
+| `$min-vw` | `Number` | `400px` | Where scaling starts. |
+| `$max-vw` | `Number` | `1200px` | Where scaling stops. |
+
+### `fluid-space(...)`
+
+Same arithmetic, named for spacing tokens.
+
+### `fluid-type-scale($steps, $prefix, $min-vw, $max-vw)`
+
+```scss
+@include fluid-type-scale((sm: (0.875rem, 1rem), lg: (1.5rem, 2.5rem)));
+// → :root { --fs-sm: clamp(...); --fs-lg: clamp(...); }
+```
+
+## Configuration
+
+```scss
+@use "fluid-type" with ($fluid-type-root: 16px);
+```
+
+## Why it fits EaseMotion
+
+**The arithmetic is the point.** A clamp built by eye — `clamp(1.5rem, 4vw, 2.5rem)` — hits its bounds at arbitrary viewport widths that have nothing to do with the breakpoints the design specified. This solves for the slope of the line through `(min-vw, min-size)` and `(max-vw, max-size)`, so the type reaches exactly `$max` at exactly `$max-vw`.
+
+You can verify it by hand: `fluid-type(1.5rem, 2.5rem, 400px, 1200px)` yields `clamp(1.5rem, 1rem + 2vw, 2.5rem)`. At a 400px viewport (25rem), `1rem + 2vw` = `1rem + 0.5rem` = **1.5rem**. At 1200px (75rem), `1rem + 1.5rem` = **2.5rem**.
+
+**The `rem` term is not optional.** A pure `vw` preferred value ignores the user's browser font-size setting entirely, so text can no longer be resized to 200% — a WCAG 1.4.4 failure. Keeping a `rem` intercept in the expression preserves user zoom.
+
+Inverted `$min-size` / `$max-size` raises a build error rather than emitting a valid-looking clamp that makes text **shrink as the viewport grows**. That is almost always transposed arguments, and it is the kind of bug that survives review because the CSS is syntactically fine.

--- a/submissions/scss/fluid-type-ad/_fluid-type.scss
+++ b/submissions/scss/fluid-type-ad/_fluid-type.scss
@@ -1,0 +1,117 @@
+// ==========================================================================
+// EaseMotion CSS — Fluid Type function
+// Issue #63555
+// --------------------------------------------------------------------------
+// Generates `clamp()` type scales that interpolate smoothly between a
+// minimum and maximum viewport width.
+//
+// The arithmetic is the part worth getting right. A clamp built by eye —
+// `clamp(1.5rem, 4vw, 2.5rem)` — hits its bounds at arbitrary viewport
+// widths that have nothing to do with the breakpoints you designed for.
+// Solving for the slope makes the type reach exactly `$max` at exactly
+// `$max-vw`, which is what the design actually specified.
+//
+// The `rem` term in the preferred value is not optional. A pure `vw`
+// preferred value ignores the user's browser font-size setting entirely,
+// which fails WCAG 1.4.4 — text can no longer be resized to 200%.
+// ==========================================================================
+
+@use "sass:list";
+@use "sass:math";
+@use "sass:meta";
+
+$fluid-type-root: 16px !default;
+
+// --------------------------------------------------------------------------
+// strip-unit
+// --------------------------------------------------------------------------
+@function strip-unit($value) {
+    @if meta.type-of($value) != "number" {
+        @error "strip-unit(): expected a number, got `#{$value}`.";
+    }
+
+    @return math.div($value, ($value * 0 + 1));
+}
+
+// --------------------------------------------------------------------------
+// to-rem — normalise px or rem to rem.
+// --------------------------------------------------------------------------
+@function to-rem($value, $root: $fluid-type-root) {
+    @if math.unit($value) == "rem" {
+        @return $value;
+    }
+
+    @if math.unit($value) == "px" {
+        @return math.div(strip-unit($value), strip-unit($root)) * 1rem;
+    }
+
+    @error "to-rem(): expected px or rem, got `#{$value}`.";
+}
+
+// --------------------------------------------------------------------------
+// fluid-type
+//
+// @param {Number} $min-size  Size at (and below) $min-vw.
+// @param {Number} $max-size  Size at (and above) $max-vw.
+// @param {Number} $min-vw    Viewport width where scaling starts.
+// @param {Number} $max-vw    Viewport width where scaling stops.
+// @return {String} A `clamp()` expression.
+// --------------------------------------------------------------------------
+@function fluid-type($min-size, $max-size, $min-vw: 400px, $max-vw: 1200px) {
+    @if strip-unit($min-vw) >= strip-unit($max-vw) {
+        @error "fluid-type(): $min-vw (#{$min-vw}) must be less than $max-vw (#{$max-vw}).";
+    }
+
+    @if strip-unit($min-size) > strip-unit($max-size) {
+        // Inverted sizes produce type that SHRINKS as the viewport grows.
+        // Almost always a transposed argument, so it fails loudly.
+        @error "fluid-type(): $min-size (#{$min-size}) must not exceed "
+             + "$max-size (#{$max-size}) — this would shrink text as the "
+             + "viewport grows. Check the argument order.";
+    }
+
+    $min-rem: to-rem($min-size);
+    $max-rem: to-rem($max-size);
+    $min-vw-rem: to-rem($min-vw);
+    $max-vw-rem: to-rem($max-vw);
+
+    // Slope of the line through (min-vw, min-size) and (max-vw, max-size).
+    $slope: math.div(
+        strip-unit($max-rem) - strip-unit($min-rem),
+        strip-unit($max-vw-rem) - strip-unit($min-vw-rem)
+    );
+
+    $intercept: strip-unit($min-rem) - ($slope * strip-unit($min-vw-rem));
+
+    // `rem` intercept keeps the value responsive to user font-size settings.
+    @return clamp(
+        #{$min-rem},
+        #{$intercept * 1rem} + #{$slope * 100}vw,
+        #{$max-rem}
+    );
+}
+
+// --------------------------------------------------------------------------
+// fluid-space — same maths for spacing tokens.
+// --------------------------------------------------------------------------
+@function fluid-space($min-size, $max-size, $min-vw: 400px, $max-vw: 1200px) {
+    @return fluid-type($min-size, $max-size, $min-vw, $max-vw);
+}
+
+// --------------------------------------------------------------------------
+// fluid-type-scale
+//
+// Emit a whole type scale from a map of step => (min, max).
+// --------------------------------------------------------------------------
+@mixin fluid-type-scale($steps, $prefix: "fs", $min-vw: 400px, $max-vw: 1200px) {
+    :root {
+        @each $name, $pair in $steps {
+            --#{$prefix}-#{$name}: #{fluid-type(
+                list.nth($pair, 1),
+                list.nth($pair, 2),
+                $min-vw,
+                $max-vw
+            )};
+        }
+    }
+}


### PR DESCRIPTION
Fixes #63555

**What was added**

Fluid typography functions, under `submissions/scss/fluid-type-ad/`.

- `_fluid-type.scss` — `fluid-type()`, `fluid-space()`, `to-rem()`, `strip-unit()` and a `fluid-type-scale()` mixin, with build-time validation.
- `README.md` — parameter tables, a worked example, and rationale.

**What is the problem**

Two things go wrong with hand-written fluid type.

**The bounds land in the wrong place.** A clamp built by eye — `clamp(1.5rem, 4vw, 2.5rem)` — reaches its minimum and maximum at arbitrary viewport widths that have nothing to do with the breakpoints the design specified. You end up nudging the `vw` figure until it looks close.

**Pure `vw` breaks user zoom.** A preferred value with no `rem` term ignores the browser font-size setting entirely, so text cannot be resized to 200%. That is a WCAG 1.4.4 failure, and it is invisible unless you specifically test with a raised default font size.

**Why this approach**

The function solves for the slope of the line through `(min-vw, min-size)` and `(max-vw, max-size)`, then emits intercept + slope form. The type therefore reaches exactly `$max` at exactly `$max-vw`.

This is verifiable by hand. `fluid-type(1.5rem, 2.5rem, 400px, 1200px)` returns `clamp(1.5rem, 1rem + 2vw, 2.5rem)`. At a 400px viewport (25rem): `1rem + 2vw` = `1rem + 0.5rem` = **1.5rem**. At 1200px (75rem): `1rem + 1.5rem` = **2.5rem**. Both endpoints hit exactly.

Keeping a `rem` intercept in the expression is what preserves user zoom.

Inverted size arguments raise a build error rather than emitting a syntactically valid clamp that makes text **shrink as the viewport grows** — a bug that survives review precisely because the CSS looks fine.

**How to test**

1. Pull this branch and compile:
   ```scss
   @use "submissions/scss/fluid-type-ad/fluid-type" as ft;
   .title { font-size: ft.fluid-type(1.5rem, 2.5rem, 400px, 1200px); }
   .body  { font-size: ft.fluid-type(16px, 18px); }
   @include ft.fluid-type-scale((sm: (0.875rem, 1rem), lg: (1.5rem, 2.5rem)));
   ```
2. Confirm `.title` emits exactly `clamp(1.5rem, 1rem + 2vw, 2.5rem)`.
3. Verify the endpoints by hand at 400px and 1200px — both should land on the specified sizes.
4. Confirm `.body` accepts px input and emits rem output (`clamp(1rem, 0.9375rem + 0.25vw, 1.125rem)`).
5. Confirm the scale mixin emits `--fs-sm` and `--fs-lg` custom properties on `:root`.
6. In a browser, raise the default font size to 24px and confirm the fluid text scales with it — this is the `rem` term working.
7. Transpose the size arguments and confirm the build fails:
   ```scss
   ft.fluid-type(2.5rem, 1.5rem);
   ```
   Expected: an error naming both values and pointing at argument order.
8. Confirm the compile emits **zero deprecation warnings**.

**Edge cases covered**

- Endpoints land exactly on the specified sizes rather than approximately.
- The `rem` intercept preserves user font-size settings, avoiding a WCAG 1.4.4 failure.
- Inverted `$min-size`/`$max-size` raises an explicit build error naming the likely cause.
- `$min-vw >= $max-vw` raises an error rather than dividing by zero or producing a negative slope.
- Both `px` and `rem` inputs are accepted and normalised via `to-rem()`.
- Any other unit raises an error from `to-rem()` rather than producing nonsense arithmetic.
- Non-numeric input is caught in `strip-unit()`.
- `$fluid-type-root` is `!default`, so projects on a non-16px root can override it.
- `fluid-space()` reuses the same maths so spacing and type cannot drift apart.
- Uses `sass:list` / `sass:math` / `sass:meta` module functions rather than deprecated globals.

**Verification**

- Compiled with the repo's own `sass` dependency; endpoint arithmetic verified numerically at both bounds.
- Error path verified to fail the build with the intended message.
- Zero deprecation warnings (an earlier draft used global `nth()`; replaced with `list.nth()`).
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 2 new files, 0 deletions, no existing file touched.
- Folder carries an `-ad` suffix so this lands as a parallel implementation.

**Labels:** `type:feature` · `scss` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
