### PR TITLE
feat: add visually-hidden SCSS mixin with skip-link variant (#63556)

### DIFF
--- a/submissions/scss/visually-hidden-ad/README.md
+++ b/submissions/scss/visually-hidden-ad/README.md
@@ -1,0 +1,50 @@
+# Visually Hidden mixin
+
+> Issue: [#63556](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/63556)
+
+Hides content visually while keeping it available to assistive technology, plus a complete skip-link implementation.
+
+## Mixins
+
+### `visually-hidden($focusable: false)`
+
+```scss
+.sr-only    { @include visually-hidden; }
+.skip       { @include visually-hidden($focusable: true); }
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `$focusable` | `Bool` | `false` | Reveal the element when it receives focus. Required for skip links. |
+
+### `visually-hidden-reset`
+
+Undoes the hiding — for when a utility is applied conditionally and must be neutralised at a breakpoint.
+
+### `skip-link($bg, $color, $accent, $offset)`
+
+A complete skip-to-content link: hidden until focused, then pinned to the top of the viewport.
+
+```scss
+.skip-to-content { @include skip-link; }
+```
+
+### `visually-hidden-utilities($prefix, $breakpoint)`
+
+Emits `.sr-only-ad`, `.sr-only-ad-focusable`, and a responsive `.sr-only-ad-until-{bp}` variant.
+
+## Why it fits EaseMotion
+
+This is a mixin rather than three copied lines because **every naive approach is subtly wrong**:
+
+| Approach | What breaks |
+|---|---|
+| `display: none` / `visibility: hidden` | Removes content from the accessibility tree too — the screen reader never sees it. |
+| `text-indent: -9999px` | Creates a 9999px layout overflow, and breaks entirely in RTL. |
+| `width: 0; height: 0` | Some engines skip zero-sized boxes when building the accessibility tree, so it can silently stop working. |
+
+The 1px box with `clip-path: inset(50%)` survives all three. `white-space: nowrap` is part of the pattern, not decoration: without it a long string wraps inside the 1px box, and some engines truncate what they announce.
+
+**The skip link uses `position: fixed`, not `absolute`.** This is the detail most implementations miss. An absolutely positioned skip link renders at the *document* top — so on a long page, by the time the user has scrolled and tabbed to it, the link appears somewhere far off-screen and seems to do nothing at all. `fixed` pins it to the viewport where it is actually visible.
+
+`:focus` and `:focus-visible` are both matched, because a skip link reached by <kbd>Tab</kbd> must appear even in engines where `:focus-visible` heuristics would suppress it.

--- a/submissions/scss/visually-hidden-ad/_visually-hidden.scss
+++ b/submissions/scss/visually-hidden-ad/_visually-hidden.scss
@@ -1,0 +1,132 @@
+// ==========================================================================
+// EaseMotion CSS — Visually Hidden mixin
+// Issue #63556
+// --------------------------------------------------------------------------
+// Hides content visually while keeping it available to assistive tech.
+//
+// Why this is a mixin and not three lines copied around: the naive
+// approaches are all subtly wrong.
+//
+//   display: none / visibility: hidden  — removes the content from the
+//       accessibility tree too. The screen reader never sees it.
+//   text-indent: -9999px  — creates a 9999px-wide layout overflow, and
+//       breaks completely in RTL.
+//   width/height: 0       — some engines skip zero-sized boxes when
+//       building the accessibility tree, so it can silently stop working.
+//
+// The 1px box plus `clip-path: inset(50%)` is the pattern that survives
+// all of those. `white-space: nowrap` matters too: without it a long
+// string wraps inside the 1px box and some engines truncate what they
+// announce.
+// ==========================================================================
+
+// --------------------------------------------------------------------------
+// visually-hidden
+//
+// @param {Bool} $focusable  When true, the element becomes visible on
+//                           focus — required for skip links, which must
+//                           be discoverable once tabbed to.
+// --------------------------------------------------------------------------
+@mixin visually-hidden($focusable: false) {
+    border: 0;
+    clip-path: inset(50%);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+
+    @if $focusable {
+        &:focus,
+        &:focus-visible {
+            clip-path: none;
+            height: auto;
+            margin: 0;
+            overflow: visible;
+            position: static;
+            white-space: normal;
+            width: auto;
+        }
+    }
+}
+
+// --------------------------------------------------------------------------
+// visually-hidden-reset
+//
+// Undo the hiding. Needed when a utility class is applied conditionally
+// and has to be neutralised at a breakpoint — e.g. a label hidden on
+// mobile but shown on desktop.
+// --------------------------------------------------------------------------
+@mixin visually-hidden-reset {
+    clip-path: none;
+    height: auto;
+    margin: 0;
+    overflow: visible;
+    position: static;
+    white-space: normal;
+    width: auto;
+}
+
+// --------------------------------------------------------------------------
+// skip-link
+//
+// A complete skip-to-content link. Hidden until focused, then pinned to
+// the top of the viewport.
+//
+// `position: fixed` rather than absolute: on a long page an absolutely
+// positioned skip link renders at the document top, which may be far
+// off-screen by the time it is focused, so it appears to do nothing.
+// --------------------------------------------------------------------------
+@mixin skip-link(
+    $bg: #0b1120,
+    $color: #f1f5f9,
+    $accent: #38bdf8,
+    $offset: 0.75rem
+) {
+    @include visually-hidden;
+
+    &:focus,
+    &:focus-visible {
+        background: $bg;
+        border-radius: 8px;
+        box-shadow: 0 0 0 2px $accent;
+        clip-path: none;
+        color: $color;
+        height: auto;
+        left: $offset;
+        margin: 0;
+        overflow: visible;
+        padding: 0.65rem 1rem;
+        position: fixed;
+        text-decoration: none;
+        top: $offset;
+        white-space: normal;
+        width: auto;
+        z-index: 9999;
+    }
+}
+
+// --------------------------------------------------------------------------
+// visually-hidden-utilities
+//
+// Emit reusable utility classes, including a responsive reset variant.
+// --------------------------------------------------------------------------
+@mixin visually-hidden-utilities($prefix: "sr-only-ad", $breakpoint: 768px) {
+    .#{$prefix} {
+        @include visually-hidden;
+    }
+
+    .#{$prefix}-focusable {
+        @include visually-hidden($focusable: true);
+    }
+
+    .#{$prefix}-until-#{$breakpoint} {
+        @include visually-hidden;
+
+        @media (min-width: $breakpoint) {
+            @include visually-hidden-reset;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #63556

**What was added**

Screen-reader-only utilities, under `submissions/scss/visually-hidden-ad/`.

- `_visually-hidden.scss` — `visually-hidden()`, `visually-hidden-reset()`, `skip-link()` and `visually-hidden-utilities()`.
- `README.md` — parameter tables, a comparison table of failing approaches, and rationale.

**What is the problem**

Visually-hidden text is usually implemented inline, and **every naive approach is subtly wrong**:

| Approach | What breaks |
|---|---|
| `display: none` / `visibility: hidden` | Removes content from the accessibility tree too — the screen reader never sees it, so the "accessible" label does nothing. |
| `text-indent: -9999px` | Creates a 9999px layout overflow, and breaks entirely in RTL where the text slides into view. |
| `width: 0; height: 0` | Some engines skip zero-sized boxes when building the accessibility tree, so it silently stops working. |

All three *look* correct in a browser, which is why they persist.

**Why this approach**

The 1px box with `clip-path: inset(50%)` keeps the element in the accessibility tree, in flow-adjacent positioning, and non-zero-sized — surviving all three failure modes.

`white-space: nowrap` is part of the pattern rather than decoration: without it a long string wraps inside the 1px box, and some engines truncate what they announce.

**The skip link uses `position: fixed`, not `absolute`** — this is the detail most implementations miss. An absolutely positioned skip link renders at the *document* top, so on a long page, by the time a user has scrolled and tabbed to it, the link appears far off-screen and seems to do nothing. `fixed` pins it to the viewport where it is actually visible.

Both `:focus` and `:focus-visible` are matched, because a skip link reached by Tab must appear even where `:focus-visible` heuristics would suppress it.

**How to test**

1. Pull this branch and compile:
   ```scss
   @use "submissions/scss/visually-hidden-ad/visually-hidden" as vh;
   .sr   { @include vh.visually-hidden; }
   .skip { @include vh.skip-link; }
   @include vh.visually-hidden-utilities;
   ```
2. Confirm `clip-path: inset(50%)` and `white-space: nowrap` are present, and that no `display: none` appears anywhere.
3. In a browser, put text in a `.sr` element — it must be invisible but announced by a screen reader.
4. Add `.skip` as the first link on a **long** page. Scroll to the middle, press Tab — the link must appear pinned at the top of the *viewport*, not somewhere off-screen.
5. Confirm the utilities mixin emits `.sr-only-ad`, `.sr-only-ad-focusable` and `.sr-only-ad-until-768px`.
6. Resize past 768px and confirm the `-until-` variant reveals its content.
7. Confirm the compile emits **zero deprecation warnings**.

**Edge cases covered**

- Content stays in the accessibility tree — the failure mode of `display: none`.
- Non-zero-sized box — the failure mode of `width/height: 0`.
- No layout overflow and RTL-safe — the failure mode of `text-indent: -9999px`.
- `white-space: nowrap` prevents wrapping inside the 1px box, which truncates announcement in some engines.
- Skip link uses `position: fixed` so it is visible regardless of scroll position.
- Both `:focus` and `:focus-visible` are matched, so the skip link cannot be suppressed by focus heuristics.
- `visually-hidden-reset` exists specifically so the pattern can be undone at a breakpoint without duplicating the declarations.
- `z-index: 9999` on the focused skip link keeps it above sticky headers.
- No dependencies on Sass built-in modules, so nothing to deprecate.

**Verification**

- Compiled with the repo's own `sass` dependency; presence of the pattern properties and `position: fixed` verified in the output.
- Zero deprecation warnings.
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 2 new files, 0 deletions, no existing file touched.
- Folder and emitted class names carry an `-ad` suffix so this lands as a parallel implementation.

**Labels:** `type:feature` · `scss` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
