### PR TITLE
feat: add keyframe-factory SCSS mixin for symmetric directional keyframes (#63557)

### DIFF
--- a/submissions/scss/keyframe-factory-ad/README.md
+++ b/submissions/scss/keyframe-factory-ad/README.md
@@ -1,0 +1,51 @@
+# Keyframe Factory mixin
+
+> Issue: [#63557](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/63557)
+
+Generates matched directional entrance and exit keyframes from a single definition, so a four-direction set stays symmetric.
+
+## Mixins
+
+### `keyframe-factory($name, $distance, $directions, $fade)`
+
+```scss
+@include keyframe-factory("slide-in-ad", $distance: 24px);
+// → @keyframes slide-in-ad-from-left  { … translate(-24px, 0) → translate(0, 0) }
+// → @keyframes slide-in-ad-from-right { … translate( 24px, 0) → translate(0, 0) }
+// → plus -from-top and -from-bottom
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `$name` | `String` | — | Base keyframe name. |
+| `$distance` | `Number` | `24px` | Travel distance. Errors if not a number. |
+| `$directions` | `List` | all four | Which directions to emit. |
+| `$fade` | `Bool` | `true` | Include an opacity ramp. |
+
+### `keyframe-factory-exit($name, ...)`
+
+Emits `<name>-to-<direction>` keyframes travelling outward.
+
+### `keyframe-factory-zoom($name, $scale, $fade)`
+
+Emits `<name>-zoom-in` / `<name>-zoom-out`, sharing the naming convention so zoom and slide compose in one utility set.
+
+### `keyframe-factory-utilities($name, $prefix, $duration, $easing, $directions)`
+
+Emits utility classes bound to the generated keyframes, with reduced-motion handling.
+
+## Configuration
+
+```scss
+@use "keyframe-factory" with ($keyframe-factory-distance: 32px);
+```
+
+## Why it fits EaseMotion
+
+**Hand-writing four directions means four chances to get a sign wrong.** The classic result is a `-from-left` and `-from-right` that travel different distances, or a `-from-top` that animates upward. Each looks fine in isolation and only reads as broken when two run side by side. Generating from one distance guarantees symmetry, and changing the travel becomes a one-line edit.
+
+The direction map encodes the semantics explicitly: `from-left` starts *left of* its resting position, so it is a negative X. That is worth stating, because it is exactly the convention people invert.
+
+**Exit keyframes are generated separately rather than reusing the entrance in reverse.** That shortcut is common and wrong: `animation-direction: reverse` on `slide-in-from-left` produces something that exits *rightward* while being named for left — the animation visually contradicts its own name. Here `-to-left` genuinely travels left.
+
+The utility classes apply `animation-fill-mode: both`, because entrance animations carry opacity — without it, an element with a delay flashes at full opacity before its animation starts. That is also why `prefers-reduced-motion` **shortens** the duration to 1ms rather than removing the animation: removing it would leave `both` fill holding every element at `opacity: 0`.

--- a/submissions/scss/keyframe-factory-ad/_keyframe-factory.scss
+++ b/submissions/scss/keyframe-factory-ad/_keyframe-factory.scss
@@ -1,0 +1,215 @@
+// ==========================================================================
+// EaseMotion CSS — Keyframe Factory mixin
+// Issue #63557
+// --------------------------------------------------------------------------
+// Generates matched directional entrance/exit keyframes from one definition.
+//
+// Hand-writing four directions means four chances to typo a sign. The
+// classic result is `slide-in-from-left` and `slide-in-from-right` that
+// travel different distances, or a `-from-top` that animates upward. It
+// looks fine in isolation and only reads as wrong when two of them run
+// side by side.
+//
+// Generating them from a single distance guarantees the set stays
+// symmetric, and makes changing the travel distance a one-line edit.
+// ==========================================================================
+
+@use "sass:map";
+@use "sass:list";
+@use "sass:meta";
+
+$keyframe-factory-distance: 24px !default;
+$keyframe-factory-scale: 0.94 !default;
+
+// Axis and sign per direction. Entrance starts offset in the direction
+// named and travels to zero — `from-left` starts LEFT of its resting
+// position, i.e. a negative X.
+$keyframe-factory-directions: (
+    "left": (x: -1, y: 0),
+    "right": (x: 1, y: 0),
+    "top": (x: 0, y: -1),
+    "bottom": (x: 0, y: 1),
+);
+
+// --------------------------------------------------------------------------
+// offset-for — resolve a direction to a translate() value.
+// --------------------------------------------------------------------------
+@function offset-for($direction, $distance) {
+    @if not map.has-key($keyframe-factory-directions, $direction) {
+        @error "keyframe-factory: unknown direction `#{$direction}`. "
+             + "Expected one of: #{list.join((), map.keys($keyframe-factory-directions), $separator: comma)}.";
+    }
+
+    $axis: map.get($keyframe-factory-directions, $direction);
+
+    @return translate(
+        map.get($axis, x) * $distance,
+        map.get($axis, y) * $distance
+    );
+}
+
+// --------------------------------------------------------------------------
+// keyframe-factory
+//
+// Emits `<name>-from-<direction>` keyframes for each requested direction.
+//
+// @param {String} $name        Base keyframe name.
+// @param {Number} $distance    Travel distance.
+// @param {List}   $directions  Directions to emit.
+// @param {Bool}   $fade        Include an opacity ramp.
+// --------------------------------------------------------------------------
+@mixin keyframe-factory(
+    $name,
+    $distance: $keyframe-factory-distance,
+    $directions: ("left", "right", "top", "bottom"),
+    $fade: true
+) {
+    @if meta.type-of($distance) != "number" {
+        @error "keyframe-factory(): $distance must be a number, got `#{$distance}`.";
+    }
+
+    @each $direction in $directions {
+        @keyframes #{$name}-from-#{$direction} {
+            from {
+                @if $fade {
+                    opacity: 0;
+                }
+
+                transform: offset-for($direction, $distance);
+            }
+
+            to {
+                @if $fade {
+                    opacity: 1;
+                }
+
+                transform: translate(0, 0);
+            }
+        }
+    }
+}
+
+// --------------------------------------------------------------------------
+// keyframe-factory-exit
+//
+// Exit keyframes travel the OPPOSITE way — content leaving toward the left
+// should exit leftward, not re-enter from it. Reusing the entrance
+// keyframes in reverse is the common shortcut and it produces exits that
+// visually contradict the direction they are named for.
+// --------------------------------------------------------------------------
+@mixin keyframe-factory-exit(
+    $name,
+    $distance: $keyframe-factory-distance,
+    $directions: ("left", "right", "top", "bottom"),
+    $fade: true
+) {
+    @each $direction in $directions {
+        @keyframes #{$name}-to-#{$direction} {
+            from {
+                @if $fade {
+                    opacity: 1;
+                }
+
+                transform: translate(0, 0);
+            }
+
+            to {
+                @if $fade {
+                    opacity: 0;
+                }
+
+                transform: offset-for($direction, $distance);
+            }
+        }
+    }
+}
+
+// --------------------------------------------------------------------------
+// keyframe-factory-zoom
+//
+// Scale-based entrance, sharing the same naming convention so zoom and
+// slide variants compose in the same utility set.
+// --------------------------------------------------------------------------
+@mixin keyframe-factory-zoom(
+    $name,
+    $scale: $keyframe-factory-scale,
+    $fade: true
+) {
+    @if $scale <= 0 {
+        @error "keyframe-factory-zoom(): $scale must be positive, got `#{$scale}`.";
+    }
+
+    @keyframes #{$name}-zoom-in {
+        from {
+            @if $fade {
+                opacity: 0;
+            }
+
+            transform: scale($scale);
+        }
+
+        to {
+            @if $fade {
+                opacity: 1;
+            }
+
+            transform: scale(1);
+        }
+    }
+
+    @keyframes #{$name}-zoom-out {
+        from {
+            @if $fade {
+                opacity: 1;
+            }
+
+            transform: scale(1);
+        }
+
+        to {
+            @if $fade {
+                opacity: 0;
+            }
+
+            transform: scale($scale);
+        }
+    }
+}
+
+// --------------------------------------------------------------------------
+// keyframe-factory-utilities
+//
+// Emit utility classes bound to the generated keyframes. `both` fill is
+// applied because entrance animations carry opacity — without it an
+// element with an animation-delay flashes at full opacity first.
+// --------------------------------------------------------------------------
+@mixin keyframe-factory-utilities(
+    $name,
+    $prefix: null,
+    $duration: 420ms,
+    $easing: cubic-bezier(0.16, 1, 0.3, 1),
+    $directions: ("left", "right", "top", "bottom")
+) {
+    $class-prefix: $name;
+
+    @if $prefix {
+        $class-prefix: $prefix;
+    }
+
+    @each $direction in $directions {
+        .#{$class-prefix}-from-#{$direction} {
+            animation: #{$name}-from-#{$direction} $duration $easing both;
+        }
+    }
+
+    // Shortened, never removed — `both` fill would otherwise strand every
+    // element at opacity 0.
+    @media (prefers-reduced-motion: reduce) {
+        @each $direction in $directions {
+            .#{$class-prefix}-from-#{$direction} {
+                animation-duration: 1ms;
+                animation-delay: 0s;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #63557

**What was added**

Directional keyframe generators, under `submissions/scss/keyframe-factory-ad/`.

- `_keyframe-factory.scss` — `keyframe-factory()`, `keyframe-factory-exit()`, `keyframe-factory-zoom()`, `keyframe-factory-utilities()`, an `offset-for()` helper and a direction map.
- `README.md` — parameter tables, usage, and rationale.

**What is the problem**

Hand-writing a four-direction entrance set means **four chances to get a sign wrong**. The classic results are a `-from-left` and `-from-right` that travel different distances, or a `-from-top` that animates upward. Each looks perfectly fine in isolation, and only reads as broken when two of them run side by side — so it survives review and ships.

Changing the travel distance later then means editing four blocks and hoping none is missed.

**Why this approach**

All directions derive from one `$distance` and a direction map that encodes the axis and sign explicitly. Symmetry is structural rather than something you have to check, and changing the travel is a one-line edit.

The map states the semantics deliberately: `from-left` starts *left of* its resting position, i.e. a negative X. That is precisely the convention people invert when writing these by hand.

**Exit keyframes are generated separately rather than reusing the entrance in reverse.** That shortcut is common and wrong: `animation-direction: reverse` on `slide-in-from-left` produces motion that exits *rightward* while carrying a name that says left — the animation contradicts itself. Here `-to-left` genuinely travels left.

The utility classes apply `animation-fill-mode: both`, since entrance animations carry opacity and without it a delayed element flashes at full opacity first. That is also why `prefers-reduced-motion` **shortens** to 1ms rather than removing the animation — removing it would leave `both` fill holding every element at `opacity: 0`.

**How to test**

1. Pull this branch and compile:
   ```scss
   @use "submissions/scss/keyframe-factory-ad/keyframe-factory" as kf;
   @include kf.keyframe-factory("slide-in-ad", $distance: 24px);
   @include kf.keyframe-factory-exit("slide-out-ad");
   @include kf.keyframe-factory-zoom("pop-ad");
   @include kf.keyframe-factory-utilities("slide-in-ad");
   ```
2. Confirm 10 `@keyframes` blocks are emitted (4 entrance + 4 exit + 2 zoom).
3. **Verify symmetry** in the output:
   - `-from-left` → `translate(-24px, 0px)`
   - `-from-right` → `translate(24px, 0px)`
   - `-from-top` → `translate(0px, -24px)`
   - `-from-bottom` → `translate(0px, 24px)`
   Opposite pairs must be exact negations.
4. Confirm `slide-out-ad-to-left` ends at a negative X — it travels left, rather than reversing an entrance.
5. Confirm the utility classes carry `both` fill, and that the reduced-motion block shortens rather than removes.
6. Pass an unknown direction and confirm a build error listing the valid ones.
7. Confirm the compile emits **zero deprecation warnings**.

**Edge cases covered**

- Opposite directions are exact negations by construction, so the set cannot drift.
- Distance changes propagate to all directions from one value.
- Exit keyframes travel outward rather than being a reversed entrance, so the name matches the motion.
- Unknown direction raises a build error listing valid values.
- Non-numeric `$distance` and non-positive `$scale` both raise build errors.
- `$fade: false` omits the opacity ramp entirely, for callers composing opacity separately.
- `$directions` is configurable, so a caller needing only two axes does not emit four blocks.
- Utility classes use `both` fill, preventing the pre-delay opacity flash.
- Reduced motion shortens rather than removes, so `both` fill cannot strand elements at `opacity: 0`.
- Uses `sass:map` / `sass:list` / `sass:meta` module functions, and avoids the deprecated `if()` syntax.

**Verification**

- Compiled with the repo's own `sass` dependency; all four direction offsets verified as exact negating pairs.
- Zero deprecation warnings (an earlier draft used `if()`; replaced with `@if`).
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 2 new files, 0 deletions, no existing file touched.
- Folder carries an `-ad` suffix, and keyframe names are caller-supplied, so nothing collides in the global keyframe namespace.

**Labels:** `type:feature` · `scss` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
