### PR TITLE
feat: add theme-contrast SCSS function for build-time WCAG checks (#63558)

### DIFF
--- a/submissions/scss/theme-contrast-ad/README.md
+++ b/submissions/scss/theme-contrast-ad/README.md
@@ -1,0 +1,61 @@
+# Theme Contrast function
+
+> Issue: [#63558](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/63558)
+
+Computes WCAG 2.1 contrast ratios at build time and warns when a token pair falls below threshold.
+
+## Functions
+
+### `contrast-ratio($fg, $bg)` → `Number`
+
+Returns the WCAG contrast ratio, 1–21.
+
+```scss
+contrast-ratio(#ffffff, #000000)  // → 21
+contrast-ratio(#767676, #ffffff)  // → 4.54
+```
+
+### `meets-contrast($fg, $bg, $level)` → `Bool`
+
+| `$level` | Threshold |
+|---|---|
+| `"AA"` (default) | 4.5 |
+| `"AA-large"` | 3 |
+| `"AAA"` | 7 |
+
+### `contrast-safe($col, $on, $level, $label)` → `Color`
+
+Returns the colour unchanged, emitting a build **warning** if it fails.
+
+```scss
+.muted { color: contrast-safe(#334155, $on: #0b1120, $label: "muted"); }
+// WARNING: Contrast AA FAIL — muted: ratio 1.82:1.
+```
+
+### `pick-contrast($bg, $light, $dark)` → `Color`
+
+Picks whichever candidate contrasts better — for text on a dynamic accent colour where neither light nor dark is always right.
+
+### `contrast-audit($tokens, $on, $level)`
+
+Audits a whole token map in one pass.
+
+```scss
+@include contrast-audit((muted: #64748b, body: #94a3b8), #0b1120);
+```
+
+## Configuration
+
+```scss
+@use "theme-contrast" with ($theme-contrast-aa: 4.5);
+```
+
+## Why it fits EaseMotion
+
+**The value is timing.** Contrast problems are normally found in a manual audit, long after the tokens have spread through a codebase — at which point fixing one muted-grey value means re-checking every surface it appears on. Computing the ratio where the token is *defined* moves the finding to the moment the mistake is made.
+
+The implementation follows WCAG 2.1 exactly. The sRGB linearisation threshold `0.03928` is the specified constant, not an approximation, and the luminance coefficients (`0.2126` / `0.7152` / `0.0722`) are the spec values. You can check it against the two reference points: white on black returns exactly `21`, and `#767676` on white returns `4.54` — the canonical minimum-passing grey.
+
+**`contrast-safe` warns rather than errors, deliberately.** Contrast is a judgement call at the margins — disabled text, decorative dividers, and placeholder copy all legitimately sit below AA. Failing the build on those would push people to stop using the function entirely, which loses the checking everywhere else. A warning is visible in CI without being a hard block.
+
+`$label` exists because the default message identifies a failure by hex pair, which is not obviously actionable in a large theme. Passing the token name makes the warning point at the thing you need to edit.

--- a/submissions/scss/theme-contrast-ad/_theme-contrast.scss
+++ b/submissions/scss/theme-contrast-ad/_theme-contrast.scss
@@ -1,0 +1,142 @@
+// ==========================================================================
+// EaseMotion CSS — Theme Contrast function
+// Issue #63558
+// --------------------------------------------------------------------------
+// Computes WCAG 2.1 contrast ratios at build time and warns when a token
+// pair falls below the required threshold.
+//
+// The value here is timing. Contrast problems are normally found during a
+// manual audit, long after the tokens have spread through a codebase — at
+// which point fixing one muted-grey value means re-checking every surface
+// it appears on. Computing the ratio where the token is defined moves the
+// finding to the moment the mistake is made.
+//
+// The relative-luminance formula is from WCAG 2.1 §Relative luminance, and
+// the sRGB linearisation threshold (0.03928) is the specified constant —
+// it is not an approximation and should not be rounded.
+// ==========================================================================
+
+@use "sass:color";
+@use "sass:math";
+@use "sass:meta";
+
+$theme-contrast-aa: 4.5 !default;
+$theme-contrast-aa-large: 3 !default;
+$theme-contrast-aaa: 7 !default;
+
+// --------------------------------------------------------------------------
+// channel-luminance — linearise one sRGB channel (0-255).
+// --------------------------------------------------------------------------
+@function channel-luminance($channel) {
+    $c: math.div($channel, 255);
+
+    @if $c <= 0.03928 {
+        @return math.div($c, 12.92);
+    }
+
+    // WCAG uses ((c + 0.055) / 1.055) ^ 2.4. Sass has no arbitrary power
+    // operator, so this uses math.pow, available since Dart Sass 1.25.
+    @return math.pow(math.div($c + 0.055, 1.055), 2.4);
+}
+
+// --------------------------------------------------------------------------
+// relative-luminance — WCAG relative luminance of a colour.
+// --------------------------------------------------------------------------
+@function relative-luminance($col) {
+    @if meta.type-of($col) != "color" {
+        @error "relative-luminance(): expected a color, got `#{$col}`.";
+    }
+
+    @return 0.2126 * channel-luminance(color.channel($col, "red", $space: rgb))
+        + 0.7152 * channel-luminance(color.channel($col, "green", $space: rgb))
+        + 0.0722 * channel-luminance(color.channel($col, "blue", $space: rgb));
+}
+
+// --------------------------------------------------------------------------
+// contrast-ratio — WCAG contrast ratio between two colours. 1 to 21.
+// --------------------------------------------------------------------------
+@function contrast-ratio($fg, $bg) {
+    $l1: relative-luminance($fg);
+    $l2: relative-luminance($bg);
+
+    $lighter: math.max($l1, $l2);
+    $darker: math.min($l1, $l2);
+
+    @return math.div($lighter + 0.05, $darker + 0.05);
+}
+
+// --------------------------------------------------------------------------
+// meets-contrast — boolean threshold test.
+//
+// @param {String} $level  "AA", "AA-large" or "AAA".
+// --------------------------------------------------------------------------
+@function meets-contrast($fg, $bg, $level: "AA") {
+    $required: $theme-contrast-aa;
+
+    @if $level == "AA-large" {
+        $required: $theme-contrast-aa-large;
+    } @else if $level == "AAA" {
+        $required: $theme-contrast-aaa;
+    } @else if $level != "AA" {
+        @error "meets-contrast(): unknown $level `#{$level}`. "
+             + "Expected AA, AA-large or AAA.";
+    }
+
+    @return contrast-ratio($fg, $bg) >= $required;
+}
+
+// --------------------------------------------------------------------------
+// contrast-safe
+//
+// Returns the colour unchanged, but emits a build WARNING if it fails the
+// threshold against $on.
+//
+// Deliberately @warn rather than @error: contrast is a judgement call at
+// the margins (disabled text, decorative dividers), and failing the build
+// on those would push people to stop using the function entirely. A
+// warning is visible in CI without being a hard block.
+// --------------------------------------------------------------------------
+@function contrast-safe($col, $on, $level: "AA", $label: null) {
+    @if not meets-contrast($col, $on, $level) {
+        $ratio: contrast-ratio($col, $on);
+        $name: $label;
+
+        @if not $name {
+            $name: "#{$col} on #{$on}";
+        }
+
+        @warn "Contrast #{$level} FAIL — #{$name}: ratio "
+            + "#{math.div(math.round($ratio * 100), 100)}:1.";
+    }
+
+    @return $col;
+}
+
+// --------------------------------------------------------------------------
+// pick-contrast
+//
+// Choose whichever of two candidates contrasts better with $bg. Useful for
+// text on a dynamic accent colour, where neither light nor dark is always
+// correct.
+// --------------------------------------------------------------------------
+@function pick-contrast($bg, $light: #ffffff, $dark: #000000) {
+    @if contrast-ratio($light, $bg) >= contrast-ratio($dark, $bg) {
+        @return $light;
+    }
+
+    @return $dark;
+}
+
+// --------------------------------------------------------------------------
+// contrast-audit
+//
+// Audit a whole token map against one background in a single pass, so a
+// theme can be checked as a unit rather than token by token.
+//
+// @param {Map} $tokens  name => color
+// --------------------------------------------------------------------------
+@mixin contrast-audit($tokens, $on, $level: "AA") {
+    @each $name, $col in $tokens {
+        $ignored: contrast-safe($col, $on, $level, $name);
+    }
+}


### PR DESCRIPTION
Fixes #63558

**What was added**

Build-time WCAG contrast checking, under `submissions/scss/theme-contrast-ad/`.

- `_theme-contrast.scss` — `contrast-ratio()`, `relative-luminance()`, `channel-luminance()`, `meets-contrast()`, `contrast-safe()`, `pick-contrast()` and a `contrast-audit()` mixin.
- `README.md` — function reference, thresholds, and rationale.

**What is the problem**

Contrast failures are normally found in a manual audit, long after the tokens have spread through a codebase. By then, fixing one muted-grey value means re-checking every surface it appears on — so the cheap fix at definition time becomes an expensive sweep.

**Why this approach**

Computing the ratio where the token is *defined* moves the finding to the moment the mistake is made, which is the only point at which it is cheap to fix.

The implementation follows WCAG 2.1 exactly. The sRGB linearisation threshold `0.03928` is the specified constant rather than an approximation, and the luminance coefficients (`0.2126` / `0.7152` / `0.0722`) are the spec values. `math.pow` is used for the 2.4 exponent rather than an approximation.

**`contrast-safe` warns rather than errors, deliberately.** Contrast is a judgement call at the margins — disabled text, decorative dividers and placeholder copy all legitimately sit below AA. Failing the build on those would push people to stop using the function altogether, which loses the checking everywhere else. A warning is visible in CI without being a hard block.

`$label` exists because the default message identifies a failure by hex pair, which is not actionable in a large theme. Passing the token name makes the warning point at the thing to edit.

**How to test**

1. Pull this branch and compile:
   ```scss
   @use "submissions/scss/theme-contrast-ad/theme-contrast" as tc;
   .a { --r1: #{tc.contrast-ratio(#ffffff, #000000)}; }
   .b { --r2: #{tc.contrast-ratio(#767676, #ffffff)}; }
   .c { --pick: #{tc.pick-contrast(#38bdf8)}; }
   .d { color: tc.contrast-safe(#94a3b8, $on: #0b1120); }
   .e { color: tc.contrast-safe(#334155, $on: #0b1120, $label: "muted"); }
   ```
2. **Verify against WCAG reference values.** White on black must return exactly `21` — the theoretical maximum. `#767676` on white must return `4.54`, the canonical minimum-passing grey used in the WCAG examples. If either is off, the luminance maths is wrong.
3. Confirm `pick-contrast(#38bdf8)` returns `#000000` — black contrasts better against a light blue than white does.
4. Confirm `.d` (a passing pair) emits **no warning**, and `.e` (a failing pair) emits `WARNING: Contrast AA FAIL — muted: ratio 1.82:1.`
5. Confirm the warning names the token (`muted`) rather than a hex pair.
6. Confirm the build still **succeeds** despite the failure — this is a warning, not an error.
7. Pass an invalid `$level` and confirm a build error listing AA / AA-large / AAA.
8. Confirm the compile emits **zero deprecation warnings**.

**Edge cases covered**

- Ratio is order-independent: `math.max`/`math.min` on the two luminances means `contrast-ratio($a, $b)` equals `contrast-ratio($b, $a)`.
- The `0.03928` linearisation branch is implemented rather than approximated, so very dark colours are correct.
- Non-colour input raises a build error from `relative-luminance()`.
- Unknown `$level` raises a build error listing valid values.
- Warning rather than error, so legitimately-low-contrast decorative tokens do not break the build.
- `$label` falls back to the hex pair when omitted, so the function is still usable without it.
- `pick-contrast` compares both candidates rather than thresholding on luminance, so it stays correct for mid-tone backgrounds where a simple light/dark split fails.
- `contrast-audit` assigns to a discarded variable, since Sass has no statement-position function call.
- Uses `color.channel(..., $space: rgb)` rather than the deprecated `red()`/`green()`/`blue()` globals.

**Verification**

- Compiled with the repo's own `sass` dependency and checked against two independent WCAG reference values (21:1 and 4.54:1) — both exact.
- Warning fires for the failing pair and stays silent for the passing one.
- Zero deprecation warnings.
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 2 new files, 0 deletions, no existing file touched.
- Folder carries an `-ad` suffix so this lands as a parallel implementation.

**Labels:** `type:feature` · `scss` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
