### PR TITLE
feat: add CSS 3D-flip tooltip for product catalog layout

### DIFF
--- a/submissions/examples/css-3d-flip-tooltip-catalog-62289/README.md
+++ b/submissions/examples/css-3d-flip-tooltip-catalog-62289/README.md
@@ -1,0 +1,25 @@
+# CSS 3D-Flip Tooltip for Product Catalog Layouts
+
+A responsive product catalog with a **3D-flip tooltip** effect using pure CSS. Hovering over a product card flips it to reveal details, while a tooltip animates in with a 3D rotateX transform.
+
+## Features
+
+- 3D card flip on hover using `transform-style: preserve-3d`
+- 3D flip-in tooltip with `rotateX` animation
+- Fully responsive grid layout
+- `prefers-reduced-motion` support
+- No JavaScript dependencies
+
+## Usage
+
+1. Open `demo.html` in a browser.
+2. Hover over any product card to see the flip and tooltip effect.
+
+## Accessibility
+
+- Respects `prefers-reduced-motion: reduce` by disabling transitions.
+- All semantic HTML elements used for structure.
+
+## Author
+
+GSSoC 2026 Contribution

--- a/submissions/examples/css-3d-flip-tooltip-catalog-62289/demo.html
+++ b/submissions/examples/css-3d-flip-tooltip-catalog-62289/demo.html
@@ -1,0 +1,149 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>3D-Flip Tooltip - Product Catalog</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="catalog">
+      <h1 class="catalog__title">Product Catalog</h1>
+      <p class="catalog__subtitle">Hover over a product to see details</p>
+
+      <div class="catalog__grid">
+        <div class="product">
+          <div class="product__card">
+            <div class="product__front">
+              <span class="product__emoji">&#127822;</span>
+              <h3 class="product__name">Organic Apples</h3>
+              <p class="product__price">$4.99 / lb</p>
+            </div>
+            <div class="product__back">
+              <h4 class="product__detail-title">Details</h4>
+              <p class="product__detail">Fresh from local farms. Rich in fiber and vitamins.</p>
+              <span class="product__tag">In Stock</span>
+            </div>
+          </div>
+          <div class="tooltip">
+            <div class="tooltip__body">
+              <strong>Organic Apples</strong><br />
+              Farm-fresh, crisp texture. Great for snacking or baking.
+            </div>
+            <div class="tooltip__arrow"></div>
+          </div>
+        </div>
+
+        <div class="product">
+          <div class="product__card">
+            <div class="product__front">
+              <span class="product__emoji">&#129472;</span>
+              <h3 class="product__name">Sourdough Bread</h3>
+              <p class="product__price">$6.50</p>
+            </div>
+            <div class="product__back">
+              <h4 class="product__detail-title">Details</h4>
+              <p class="product__detail">Handcrafted with a 48-hour fermentation process.</p>
+              <span class="product__tag">Limited</span>
+            </div>
+          </div>
+          <div class="tooltip">
+            <div class="tooltip__body">
+              <strong>Sourdough Bread</strong><br />
+              Artisan loaf with a crispy crust and soft interior.
+            </div>
+            <div class="tooltip__arrow"></div>
+          </div>
+        </div>
+
+        <div class="product">
+          <div class="product__card">
+            <div class="product__front">
+              <span class="product__emoji">&#129361;</span>
+              <h3 class="product__name">Avocados</h3>
+              <p class="product__price">$2.99 each</p>
+            </div>
+            <div class="product__back">
+              <h4 class="product__detail-title">Details</h4>
+              <p class="product__detail">Perfectly ripe Hass avocados, sourced from Mexico.</p>
+              <span class="product__tag">In Stock</span>
+            </div>
+          </div>
+          <div class="tooltip">
+            <div class="tooltip__body">
+              <strong>Avocados</strong><br />
+              Creamy and nutrient-dense. Ideal for toast or guacamole.
+            </div>
+            <div class="tooltip__arrow"></div>
+          </div>
+        </div>
+
+        <div class="product">
+          <div class="product__card">
+            <div class="product__front">
+              <span class="product__emoji">&#127846;</span>
+              <h3 class="product__name">Artisan Cheese</h3>
+              <p class="product__price">$12.00 / wedge</p>
+            </div>
+            <div class="product__back">
+              <h4 class="product__detail-title">Details</h4>
+              <p class="product__detail">Aged for 12 months. Bold, nutty flavor profile.</p>
+              <span class="product__tag">Premium</span>
+            </div>
+          </div>
+          <div class="tooltip">
+            <div class="tooltip__body">
+              <strong>Artisan Cheese</strong><br />
+              Small-batch, aged cheddar from a family-run dairy.
+            </div>
+            <div class="tooltip__arrow"></div>
+          </div>
+        </div>
+
+        <div class="product">
+          <div class="product__card">
+            <div class="product__front">
+              <span class="product__emoji">&#127819;</span>
+              <h3 class="product__name">Mixed Berries</h3>
+              <p class="product__price">$5.99 / pint</p>
+            </div>
+            <div class="product__back">
+              <h4 class="product__detail-title">Details</h4>
+              <p class="product__detail">Blueberries, raspberries, and blackberries. Organic.</p>
+              <span class="product__tag">Seasonal</span>
+            </div>
+          </div>
+          <div class="tooltip">
+            <div class="tooltip__body">
+              <strong>Mixed Berries</strong><br />
+              Hand-picked blend of organic berries, perfect for smoothies.
+            </div>
+            <div class="tooltip__arrow"></div>
+          </div>
+        </div>
+
+        <div class="product">
+          <div class="product__card">
+            <div class="product__front">
+              <span class="product__emoji">&#129379;</span>
+              <h3 class="product__name">Greek Yogurt</h3>
+              <p class="product__price">$3.49</p>
+            </div>
+            <div class="product__back">
+              <h4 class="product__detail-title">Details</h4>
+              <p class="product__detail">Thick, creamy, and high in protein. No added sugar.</p>
+              <span class="product__tag">In Stock</span>
+            </div>
+          </div>
+          <div class="tooltip">
+            <div class="tooltip__body">
+              <strong>Greek Yogurt</strong><br />
+              Strained for 24 hours. Smooth texture with tangy finish.
+            </div>
+            <div class="tooltip__arrow"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/css-3d-flip-tooltip-catalog-62289/style.css
+++ b/submissions/examples/css-3d-flip-tooltip-catalog-62289/style.css
@@ -1,0 +1,194 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background: #f5f5f5;
+  min-height: 100vh;
+  padding: 2rem;
+}
+
+.catalog {
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.catalog__title {
+  font-size: 1.75rem;
+  color: #222;
+  text-align: center;
+}
+
+.catalog__subtitle {
+  color: #666;
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.catalog__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 2rem;
+}
+
+/* ---- Product card flip ---- */
+
+.product {
+  position: relative;
+  perspective: 800px;
+}
+
+.product__card {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 3 / 4;
+  transform-style: preserve-3d;
+  transition: transform 0.6s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.product:hover .product__card {
+  transform: rotateY(180deg);
+}
+
+.product__front,
+.product__back {
+  position: absolute;
+  inset: 0;
+  backface-visibility: hidden;
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  text-align: center;
+}
+
+.product__front {
+  background: #fff;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+}
+
+.product__back {
+  background: #1a1a2e;
+  color: #fff;
+  transform: rotateY(180deg);
+}
+
+.product__emoji {
+  font-size: 3.5rem;
+  margin-bottom: 1rem;
+}
+
+.product__name {
+  font-size: 1.1rem;
+  color: #333;
+  margin-bottom: 0.5rem;
+}
+
+.product__price {
+  color: #0d6efd;
+  font-weight: 600;
+}
+
+.product__detail-title {
+  font-size: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.product__detail {
+  font-size: 0.9rem;
+  line-height: 1.4;
+  opacity: 0.85;
+  margin-bottom: 1rem;
+}
+
+.product__tag {
+  background: #28a745;
+  color: #fff;
+  font-size: 0.75rem;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+}
+
+/* ---- 3-D flip tooltip ---- */
+
+.tooltip {
+  position: absolute;
+  bottom: calc(100% + 12px);
+  left: 50%;
+  transform: translateX(-50%) rotateX(90deg);
+  transform-origin: bottom center;
+  opacity: 0;
+  pointer-events: none;
+  transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1),
+              opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  z-index: 10;
+  width: 220px;
+}
+
+.product:hover .tooltip {
+  transform: translateX(-50%) rotateX(0deg);
+  opacity: 1;
+}
+
+.tooltip__body {
+  background: #1a1a2e;
+  color: #fff;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  font-size: 0.85rem;
+  line-height: 1.45;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.25);
+}
+
+.tooltip__arrow {
+  width: 12px;
+  height: 12px;
+  background: #1a1a2e;
+  position: absolute;
+  bottom: -5px;
+  left: 50%;
+  transform: translateX(-50%) rotate(45deg);
+}
+
+/* ---- Responsive tweaks ---- */
+
+@media (max-width: 600px) {
+  .catalog__grid {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+
+  .product__card {
+    aspect-ratio: 4 / 5;
+  }
+
+  .tooltip {
+    width: 180px;
+    font-size: 0.8rem;
+  }
+}
+
+/* ---- Reduced-motion preference ---- */
+
+@media (prefers-reduced-motion: reduce) {
+  .product__card,
+  .tooltip {
+    transition: none;
+  }
+
+  .product:hover .product__card {
+    transform: rotateY(180deg);
+  }
+
+  .product:hover .tooltip {
+    transform: translateX(-50%) rotateX(0deg);
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
Closes #62289

Added a pure CSS 3D-flip tooltip for product catalog layouts. Hovering over a product card triggers a 3D flip to reveal details, and a tooltip animates in from above using a rotateX transform.

Features:
- 3D card flip with preserve-3d and backface-visibility
- 3D tooltip entrance animation with rotateX
- Responsive grid with auto-fill and minmax
- prefers-reduced-motion support
- No JavaScript

Files added:
- submissions/examples/css-3d-flip-tooltip-catalog-62289/demo.html
- submissions/examples/css-3d-flip-tooltip-catalog-62289/style.css
- submissions/examples/css-3d-flip-tooltip-catalog-62289/README.md