### PR TITLE
feat: add scroll-track SCSS mixin with cross-browser scrollbars and shadows (#63563)

### DIFF
--- a/submissions/scss/scroll-track-ad/README.md
+++ b/submissions/scss/scroll-track-ad/README.md
@@ -1,0 +1,44 @@
+# Scroll Track mixin
+
+> Issue: [#63563](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/63563)
+
+Cross-browser scrollbar styling, plus JavaScript-free scroll shadows.
+
+## Mixins
+
+### `scroll-track($thumb, $track, $size, $shadow, $surface)`
+
+```scss
+.panel { @include scroll-track($thumb: rgba(148, 163, 184, 0.3)); }
+.report { @include scroll-track($shadow: true, $surface: #0b1120); }
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `$thumb` | `Color` | `rgba(148,163,184,0.3)` | Thumb colour. |
+| `$track` | `Color` | `transparent` | Track colour. |
+| `$size` | `Number` | `10px` | Thickness (webkit only). |
+| `$shadow` | `Bool` | `false` | Emit scroll shadows. |
+| `$surface` | `Color` | `null` | **Required** when `$shadow` is true. |
+
+### `scroll-shadow($surface, $size, $shade)`
+
+Scroll shadows on their own.
+
+### `scroll-track-hide`
+
+Hides the scrollbar while keeping the element scrollable.
+
+### `scroll-snap-x($align, $padding)`
+
+Horizontal snap track.
+
+## Why it fits EaseMotion
+
+**Two independent scrollbar APIs exist and neither is a superset of the other.** `scrollbar-color` / `scrollbar-width` are the standard properties (Firefox, and more recently Chromium) but only accept colours and a coarse `thin`/`auto` width. `::-webkit-scrollbar-*` allows arbitrary sizing, radius and padding but is ignored by Firefox. Emitting both is the only way to cover the field, and they are ordered standard-first so the more capable pseudo-element rules win where an engine supports both.
+
+**The scroll shadow needs no JavaScript.** It layers four gradients: two pinned to the content via `background-attachment: local`, and two pinned to the container via `scroll`. Layer order is load-bearing — the `local` covers are listed *first* so they paint over the shadow gradients at the extremes. At the top of the scroll range the cover sits flush over the top shadow and hides it; as content scrolls away the cover moves with it and the shadow is revealed.
+
+`$surface` is **required** when shadows are enabled rather than defaulting to white, because the cover gradients must fade into the real background colour. Guessing wrong renders them as visible grey bars across the top and bottom of the container — so this fails the build instead.
+
+`scroll-track-hide` documents its own cost: hiding a scrollbar removes an affordance, so it should only be used where another cue (arrows, peeking content) signals that the area scrolls.

--- a/submissions/scss/scroll-track-ad/_scroll-track.scss
+++ b/submissions/scss/scroll-track-ad/_scroll-track.scss
@@ -1,0 +1,154 @@
+// ==========================================================================
+// EaseMotion CSS — Scroll Track mixin
+// Issue #63563
+// --------------------------------------------------------------------------
+// Cross-browser scrollbar styling, plus optional scroll shadows.
+//
+// Two independent APIs exist and neither is a superset of the other:
+//
+//   `scrollbar-color` / `scrollbar-width`  — the standard properties.
+//   Supported in Firefox and, more recently, Chromium. Only accepts a
+//   thumb and track colour and a coarse `thin` / `auto` width.
+//
+//   `::-webkit-scrollbar-*`  — the older pseudo-element family. Allows
+//   arbitrary sizing, radius and padding, but is ignored by Firefox.
+//
+// Emitting both is the only way to cover the field. They are ordered
+// standard-first so that where an engine supports both, the more capable
+// pseudo-element rules win.
+//
+// The scroll shadow uses the `background-attachment: local` technique:
+// two gradients pinned to the scroll container and two pinned to the
+// content, layered so the shadows are revealed only when there is content
+// out of view. No JavaScript and no scroll listener.
+// ==========================================================================
+
+@use "sass:meta";
+
+$scroll-track-thumb: rgba(148, 163, 184, 0.3) !default;
+$scroll-track-bg: transparent !default;
+$scroll-track-size: 10px !default;
+
+// --------------------------------------------------------------------------
+// scroll-track
+//
+// @param {Color}  $thumb   Thumb colour.
+// @param {Color}  $track   Track colour.
+// @param {Number} $size    Scrollbar thickness (webkit only).
+// @param {Bool}   $shadow  Emit scroll shadows.
+// @param {Color}  $surface Surface colour, required when $shadow is true —
+//                          the gradients must fade to the real background
+//                          or they read as grey bars.
+// --------------------------------------------------------------------------
+@mixin scroll-track(
+    $thumb: $scroll-track-thumb,
+    $track: $scroll-track-bg,
+    $size: $scroll-track-size,
+    $shadow: false,
+    $surface: null
+) {
+    @if meta.type-of($size) != "number" {
+        @error "scroll-track(): $size must be a number, got `#{$size}`.";
+    }
+
+    // Standard properties first.
+    scrollbar-color: $thumb $track;
+    scrollbar-width: thin;
+
+    // Webkit pseudo-elements second, so they win where both are supported.
+    &::-webkit-scrollbar {
+        height: $size;
+        width: $size;
+    }
+
+    &::-webkit-scrollbar-track {
+        background: $track;
+    }
+
+    &::-webkit-scrollbar-thumb {
+        background: $thumb;
+        background-clip: content-box;
+        // Transparent border inset the thumb without changing the hit area.
+        border: 3px solid transparent;
+        border-radius: 999px;
+    }
+
+    &::-webkit-scrollbar-thumb:hover {
+        background: rgba(148, 163, 184, 0.5);
+        background-clip: content-box;
+    }
+
+    // Prevents the corner square rendering as an opaque block where both
+    // axes scroll.
+    &::-webkit-scrollbar-corner {
+        background: transparent;
+    }
+
+    @if $shadow {
+        @if not $surface {
+            @error "scroll-track(): $surface is required when $shadow is true — "
+                 + "the shadow gradients must fade into the real background "
+                 + "colour or they render as grey bars.";
+        }
+
+        @include scroll-shadow($surface);
+    }
+}
+
+// --------------------------------------------------------------------------
+// scroll-shadow
+//
+// Vertical scroll shadows via `background-attachment: local`.
+//
+// Layer order matters and is not arbitrary: the two `local` cover
+// gradients are listed FIRST so they paint over the `scroll` shadow
+// gradients at the extremes. At the top of the scroll range the top cover
+// sits flush over the top shadow and hides it; as content scrolls away
+// the cover moves with it and the shadow is revealed.
+// --------------------------------------------------------------------------
+@mixin scroll-shadow($surface, $size: 26px, $shade: rgba(0, 0, 0, 0.28)) {
+    background:
+        // Covers — move with the content.
+        linear-gradient($surface 30%, rgba(255, 255, 255, 0)) top / 100% $size,
+        linear-gradient(rgba(255, 255, 255, 0), $surface 70%) bottom / 100% $size,
+        // Shadows — pinned to the container.
+        radial-gradient(farthest-side at 50% 0, $shade, rgba(0, 0, 0, 0)) top / 100% calc(#{$size} * 0.5),
+        radial-gradient(farthest-side at 50% 100%, $shade, rgba(0, 0, 0, 0)) bottom / 100% calc(#{$size} * 0.5);
+    background-attachment: local, local, scroll, scroll;
+    background-color: $surface;
+    background-repeat: no-repeat;
+}
+
+// --------------------------------------------------------------------------
+// scroll-track-hide
+//
+// Hide the scrollbar while keeping the element scrollable — for carousels
+// and chip rows where a visible bar is noise.
+//
+// Note: this hides an affordance. Only use it where another cue (arrows,
+// peeking content) tells the user the area scrolls.
+// --------------------------------------------------------------------------
+@mixin scroll-track-hide {
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+        display: none;
+    }
+}
+
+// --------------------------------------------------------------------------
+// scroll-snap-x
+//
+// Horizontal snap track. `scroll-padding` matters when the container has
+// sticky edges — without it a snapped item aligns under them.
+// --------------------------------------------------------------------------
+@mixin scroll-snap-x($align: start, $padding: 0) {
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    scroll-padding-inline: $padding;
+    -webkit-overflow-scrolling: touch;
+
+    > * {
+        scroll-snap-align: $align;
+    }
+}


### PR DESCRIPTION
Fixes #63563

**What was added**

Cross-browser scrollbar styling and scroll shadows, under `submissions/scss/scroll-track-ad/`.

- `_scroll-track.scss` — `scroll-track()`, `scroll-shadow()`, `scroll-track-hide()` and `scroll-snap-x()`.
- `README.md` — parameter tables, usage, and rationale.

**What is the problem**

**Two independent scrollbar APIs exist and neither is a superset of the other.** `scrollbar-color` / `scrollbar-width` are the standard properties but only accept colours and a coarse `thin`/`auto` width. `::-webkit-scrollbar-*` allows arbitrary sizing, radius and padding but is ignored by Firefox entirely. Picking one leaves a whole engine unstyled.

Separately, scroll shadows — the cue that tells a user there is more content above or below — are almost always implemented with a scroll listener, which means JavaScript, a re-render per frame, and a cleanup obligation.

**Why this approach**

Both APIs are emitted, ordered standard-first so the more capable pseudo-element rules win where an engine supports both.

The scroll shadow uses the `background-attachment: local` technique: four gradients, two pinned to the content and two to the container. **Layer order is load-bearing** — the `local` covers are listed first so they paint over the shadow gradients at the extremes. At the top of the scroll range the cover sits flush over the top shadow and hides it; as content scrolls away the cover moves with it and the shadow is revealed. No listener, no state, no cleanup.

`$surface` is **required** when shadows are enabled rather than defaulting to white, because the cover gradients must fade into the real background colour. Guessing wrong renders them as visible grey bars across the top and bottom of the container — a subtle enough artefact that it would ship, so the mixin fails the build instead.

**How to test**

1. Pull this branch and compile:
   ```scss
   @use "submissions/scss/scroll-track-ad/scroll-track" as st;
   .panel { @include st.scroll-track($thumb: rgba(148,163,184,0.3)); }
   .shady { @include st.scroll-track($shadow: true, $surface: #0b1120); }
   .chips { @include st.scroll-track-hide; @include st.scroll-snap-x(start, 1rem); }
   ```
2. Confirm both `scrollbar-color`/`scrollbar-width` **and** the `::-webkit-scrollbar-*` family are emitted, standard first.
3. Confirm `background-attachment: local, local, scroll, scroll` — the order must match the four gradients.
4. **In Firefox**, confirm `.panel` has a thin coloured scrollbar (standard properties path).
5. **In Chrome/Safari**, confirm the thumb is rounded and inset (pseudo-element path).
6. Scroll `.shady` and confirm a shadow appears at the top only once content has scrolled past, and disappears again at the top of the range.
7. Confirm `.chips` scrolls with no visible scrollbar and snaps to item starts.
8. Omit `$surface` while enabling `$shadow` and confirm the build fails with a message explaining why it is required.

**Edge cases covered**

- Both scrollbar APIs are emitted, so no engine is left unstyled.
- Standard properties are ordered first so pseudo-element rules win where both are supported.
- Gradient layer order matches `background-attachment` order — a mismatch would pin the wrong layers and break the effect.
- `$surface` is mandatory with shadows, preventing grey-bar artefacts from a guessed background.
- `background-clip: content-box` with a transparent border insets the thumb without shrinking its hit area.
- `::-webkit-scrollbar-corner` is set transparent, so a both-axes scroller does not show an opaque corner block.
- Non-numeric `$size` raises a build error.
- `scroll-track-hide` documents that it removes an affordance and should be paired with another scroll cue.
- `scroll-snap-x` exposes `scroll-padding-inline`, which is what keeps snapped items clear of sticky edges.
- `-webkit-overflow-scrolling: touch` retained for momentum scrolling on older iOS.

**Verification**

- Compiled with the repo's own `sass` dependency; both API families and the four-layer attachment order verified in output.
- Error path verified to fail the build with the intended message.
- Zero deprecation warnings.
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 2 new files, 0 deletions, no existing file touched.
- Folder carries an `-ad` suffix so this lands as a parallel implementation.

**Labels:** `type:feature` · `scss` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
