### PR TITLE
docs: demonstrate throttled scroll fallback fix for reveal.js 

### DIFF
--- a/submissions/docs/reveal-fallback-scroll-aaniya/README.md
+++ b/submissions/docs/reveal-fallback-scroll-aaniya/README.md
@@ -1,0 +1,68 @@
+# Fix: Fallback Scroll Reveals Activate All Items Instantly (#6085)
+
+## Issue
+In `core/reveal.js`, when `IntersectionObserver` isn't supported, the
+fallback branch (`readyFallback`) immediately adds the active class to
+every `.ease-reveal` element on page load:
+
+```js
+} else {
+  var readyFallback = function () {
+    var els = document.querySelectorAll('.' + revealClass);
+    Array.prototype.forEach.call(els, function (el) {
+      el.classList.add(activeClass);
+    });
+  };
+  ...
+}
+```
+
+This completely bypasses scroll-based reveal behavior — every element
+becomes visible at once instead of progressively as the user scrolls,
+breaking the intended entrance-animation effect in legacy environments.
+
+## Expected Behavior
+The script should fall back to a throttled/debounced scroll listener
+that checks each element's position on scroll (and resize) and adds the
+active class only once the element enters the viewport — mirroring what
+`IntersectionObserver` does, rather than short-circuiting it.
+
+## Investigation
+Confirmed directly in `core/reveal.js`:
+- `supportsObserver` gates between the `IntersectionObserver` path and
+  the fallback path.
+- The fallback path has no scroll/resize listener at all — it fires once
+  on `DOMContentLoaded` (or immediately if the document is already
+  loaded) and activates everything unconditionally.
+- The existing `isCentered(el)` helper (used in the observer path to
+  eagerly reveal already-visible elements) could be reused as the
+  viewport check in the fallback path instead of writing new geometry
+  logic.
+
+## Recommended Fix
+Since this submission can't edit `core/reveal.js` directly:
+
+1. Replace the fallback's one-time `forEach` with a `revealVisible()`
+   function that checks each un-activated `.ease-reveal` element against
+   `isCentered()` (or equivalent) and adds the active class only for
+   elements currently in view.
+2. Attach `revealVisible` to `scroll` and `resize` via a throttle
+   wrapper (~100ms) so it doesn't run on every scroll event.
+3. Run `revealVisible()` once on load to catch elements already in the
+   viewport, matching the observer path's eager-reveal behavior.
+4. Stop checking an element once it's been activated (skip elements that
+   already have `activeClass`) to avoid unnecessary work on later scroll
+   events.
+
+## Files
+- `style.css` — reveal/active state styling for the demo cards
+- `demo.html` — self-contained fallback scroll listener reproducing the
+  recommended fix; scroll down to see cards reveal progressively instead
+  of all at once
+
+## Testing
+1. Open `demo.html` in a browser.
+2. Scroll down slowly and confirm each card fades/slides in only once it
+   enters the viewport, rather than all three appearing on load.
+3. Resize the window and confirm newly-visible cards still reveal
+   correctly.

--- a/submissions/docs/reveal-fallback-scroll-aaniya/demo.html
+++ b/submissions/docs/reveal-fallback-scroll-aaniya/demo.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Scroll Reveal Fallback Fix — Issue #6085</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body style="font-family: sans-serif; padding: 2rem; background: #fafafa; margin: 0;">
+
+  <div style="padding: 2rem;">
+    <h2 style="text-align:center;">Fallback Scroll Reveal Demo</h2>
+    <p class="demo-note">
+      In <code>core/reveal.js</code>, browsers without <code>IntersectionObserver</code>
+      currently activate every <code>.ease-reveal</code> element instantly on load.
+      This demo instead uses a throttled scroll listener to reveal each card
+      progressively as it enters the viewport &mdash; scroll down to see it work.
+    </p>
+  </div>
+
+  <div class="demo-spacer"></div>
+
+  <div class="demo-reveal demo-card">Card 1</div>
+  <div class="demo-spacer"></div>
+
+  <div class="demo-reveal demo-card">Card 2</div>
+  <div class="demo-spacer"></div>
+
+  <div class="demo-reveal demo-card">Card 3</div>
+  <div class="demo-spacer"></div>
+
+  <script>
+    (function () {
+      'use strict';
+
+      var revealClass = 'demo-reveal';
+      var activeClass = 'demo-reveal-active';
+      var els = document.querySelectorAll('.' + revealClass);
+
+      function isInViewport(el) {
+        var rect = el.getBoundingClientRect();
+        var vh = window.innerHeight;
+        return rect.top < vh * 0.85 && rect.bottom > 0;
+      }
+
+      function revealVisible() {
+        Array.prototype.forEach.call(els, function (el) {
+          if (!el.classList.contains(activeClass) && isInViewport(el)) {
+            el.classList.add(activeClass);
+          }
+        });
+      }
+
+      // Throttle helper — recommended fallback pattern for #6085
+      function throttle(fn, wait) {
+        var lastCall = 0;
+        var timeout = null;
+        return function () {
+          var now = Date.now();
+          var remaining = wait - (now - lastCall);
+          if (remaining <= 0) {
+            lastCall = now;
+            fn();
+          } else if (!timeout) {
+            timeout = setTimeout(function () {
+              lastCall = Date.now();
+              timeout = null;
+              fn();
+            }, remaining);
+          }
+        };
+      }
+
+      var throttledReveal = throttle(revealVisible, 100);
+
+      window.addEventListener('scroll', throttledReveal, { passive: true });
+      window.addEventListener('resize', throttledReveal);
+
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', revealVisible);
+      } else {
+        revealVisible();
+      }
+    })();
+  </script>
+
+</body>
+</html>

--- a/submissions/docs/reveal-fallback-scroll-aaniya/style.css
+++ b/submissions/docs/reveal-fallback-scroll-aaniya/style.css
@@ -1,0 +1,49 @@
+/* Fix for issue #6085 — Fallback scroll reveals activate all items instantly
+   ----------------------------------------------------------------------------
+   Confirmed in core/reveal.js: when IntersectionObserver is unsupported,
+   the fallback branch (readyFallback) immediately adds the active class
+   to every .ease-reveal element on load, completely bypassing scroll-based
+   reveal behavior.
+
+   This submission cannot edit core/reveal.js directly, so it demonstrates
+   the recommended fix: a throttled/debounced scroll listener that checks
+   each element's position and progressively activates it as it enters
+   the viewport, matching the IntersectionObserver behavior instead of
+   short-circuiting it.
+*/
+
+.demo-reveal {
+  opacity: 0;
+  transform: translateY(40px);
+  transition: opacity 0.7s ease, transform 0.7s ease;
+}
+
+.demo-reveal.demo-reveal-active {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.demo-card {
+  width: 100%;
+  max-width: 320px;
+  padding: 1.5rem;
+  margin: 0 auto 4rem auto;
+  border-radius: 10px;
+  background-color: #6366f1;
+  color: #fff;
+  font-family: sans-serif;
+  text-align: center;
+}
+
+.demo-spacer {
+  height: 90vh;
+}
+
+.demo-note {
+  font-family: sans-serif;
+  font-size: 13px;
+  color: #555;
+  max-width: 480px;
+  margin: 0 auto 2rem auto;
+  text-align: center;
+}


### PR DESCRIPTION
Closes #60850
## Pull Request Description
Addresses issue #6085 — in `core/reveal.js`, the fallback branch used when `IntersectionObserver` isn't supported activates every `.ease-reveal` element instantly on load, completely bypassing scroll-based reveal behavior. Since submission PRs can't edit `core/` directly, this adds a docs submission demonstrating the recommended fix: a throttled scroll/resize listener that progressively reveals elements as they enter the viewport, matching what the observer path already does.

---
## Type of Change
- [x] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission

---
## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/docs/reveal-fallback-scroll-aaniya/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---
## Feature Description
**What does this add?**
A demo reproducing `core/reveal.js`'s fallback path with a throttled scroll listener instead of an instant-activate loop, plus a README documenting the exact fix.

**How does a developer use it?**
```html
<div class="demo-reveal demo-card">Card content</div>
<!-- Scroll listener in demo.html adds .demo-reveal-active
     once the element enters the viewport -->
```

**Why does it fit EaseMotion CSS?**
Scroll reveal is meant to be a progressive entrance effect. In legacy environments the fallback currently defeats that entirely by showing everything at once — this restores the intended behavior for browsers without `IntersectionObserver` support.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---
## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

---
## Notes for Maintainer
This is docs-only since I can't edit `core/reveal.js` directly. Recommended fix: replace `readyFallback`'s one-time `forEach` with a `revealVisible()` function reusing the existing `isCentered()` helper, throttle it (~100ms) on `scroll`/`resize`, run it once on load, and skip elements that already have `activeClass` to avoid redundant checks on later scroll events.