### PR TITLE
feat: add CommandHint React component with description-list semantics (#63565)

### DIFF
--- a/submissions/react/command-hint-ad/CommandHint.jsx
+++ b/submissions/react/command-hint-ad/CommandHint.jsx
@@ -1,0 +1,138 @@
+/**
+ * EaseMotion CSS — CommandHint
+ * ============================================================
+ * Hint rows pairing an action label with its keyboard shortcut.
+ *
+ * The accessibility trap here is subtle. The obvious markup is a <table>
+ * or a row of divs, but a hint list is semantically a description list:
+ * each shortcut DESCRIBES an action. Using <dl>/<dt>/<dd> means a screen
+ * reader announces the pairing ("Search, Command K") rather than reading
+ * two unrelated columns top to bottom, which is what a div grid produces.
+ *
+ * Shortcut glyphs are rendered inside the <dd> with an accessible text
+ * form alongside, because the symbol characters (⌘, ⇧, ⌥) are frequently
+ * announced as nothing at all.
+ * ============================================================
+ */
+
+import { useId, useMemo } from 'react';
+
+/** Glyph + spoken name per key token, resolved per platform. */
+const KEYS = {
+  mod: { mac: '⌘', other: 'Ctrl', say: { mac: 'Command', other: 'Control' } },
+  shift: { mac: '⇧', other: 'Shift', say: { mac: 'Shift', other: 'Shift' } },
+  alt: { mac: '⌥', other: 'Alt', say: { mac: 'Option', other: 'Alt' } },
+  ctrl: { mac: '⌃', other: 'Ctrl', say: { mac: 'Control', other: 'Control' } },
+  enter: { mac: '↵', other: '↵', say: { mac: 'Enter', other: 'Enter' } },
+  esc: { mac: 'Esc', other: 'Esc', say: { mac: 'Escape', other: 'Escape' } },
+  tab: { mac: '⇥', other: 'Tab', say: { mac: 'Tab', other: 'Tab' } },
+  up: { mac: '↑', other: '↑', say: { mac: 'Up arrow', other: 'Up arrow' } },
+  down: { mac: '↓', other: '↓', say: { mac: 'Down arrow', other: 'Down arrow' } },
+};
+
+function isApplePlatform() {
+  if (typeof navigator === 'undefined') return false;
+
+  const modern = navigator.userAgentData?.platform;
+  if (typeof modern === 'string' && modern.length > 0) {
+    return /mac/i.test(modern);
+  }
+
+  return /mac|iphone|ipad|ipod/i.test(navigator.platform || navigator.userAgent || '');
+}
+
+/**
+ * @param {object} props
+ * @param {Array<{label: string, keys: string[]}>} props.items
+ * @param {string}  [props.heading]   Optional group heading.
+ * @param {'sm'|'md'} [props.size='md']
+ * @param {boolean} [props.isApple]   Override platform detection (SSR).
+ * @param {string}  [props.className]
+ */
+export default function CommandHint({
+  items = [],
+  heading,
+  size = 'md',
+  isApple,
+  className = '',
+  ...rest
+}) {
+  const headingId = useId();
+
+  const apple = useMemo(
+    () => (typeof isApple === 'boolean' ? isApple : isApplePlatform()),
+    [isApple],
+  );
+
+  const rows = useMemo(
+    () =>
+      items
+        .filter((item) => item && typeof item === 'object' && item.label)
+        .map((item) => {
+          const keys = Array.isArray(item.keys) ? item.keys.filter(Boolean) : [];
+
+          const resolved = keys.map((raw) => {
+            const token = String(raw).toLowerCase();
+            const entry = KEYS[token];
+
+            if (!entry) {
+              const glyph = String(raw).length === 1 ? String(raw).toUpperCase() : String(raw);
+              return { glyph, say: glyph };
+            }
+
+            return {
+              glyph: apple ? entry.mac : entry.other,
+              say: apple ? entry.say.mac : entry.say.other,
+            };
+          });
+
+          return {
+            label: item.label,
+            glyphs: resolved.map((k) => k.glyph),
+            spoken: resolved.map((k) => k.say).join(' plus '),
+          };
+        }),
+    [items, apple],
+  );
+
+  if (rows.length === 0) {
+    return null;
+  }
+
+  const classes = ['ease-hint-ad', `ease-hint-ad--${size}`, className]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div className={classes} {...rest}>
+      {heading && (
+        <p className="ease-hint-ad__heading" id={headingId}>
+          {heading}
+        </p>
+      )}
+
+      {/* A description list, not a grid: each shortcut describes an action,
+          so the pairing is announced rather than read as two columns. */}
+      <dl
+        className="ease-hint-ad__list"
+        aria-labelledby={heading ? headingId : undefined}
+      >
+        {rows.map((row, index) => (
+          <div className="ease-hint-ad__row" key={`${row.label}-${index}`}>
+            <dt className="ease-hint-ad__label">{row.label}</dt>
+            <dd className="ease-hint-ad__keys">
+              <span className="ease-hint-ad__sr">{row.spoken}</span>
+              <span className="ease-hint-ad__caps" aria-hidden="true">
+                {row.glyphs.map((glyph, i) => (
+                  <kbd className="ease-hint-ad__cap" key={`${glyph}-${i}`}>
+                    {glyph}
+                  </kbd>
+                ))}
+              </span>
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}

--- a/submissions/react/command-hint-ad/README.md
+++ b/submissions/react/command-hint-ad/README.md
@@ -1,0 +1,43 @@
+# CommandHint — command palette hint rows
+
+> Issue: [#63565](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/63565)
+
+Hint rows pairing an action label with its keyboard shortcut, for command palettes, empty states and help footers.
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `items` | `Array<{ label, keys }>` | `[]` | Hint rows. Entries without a `label` are skipped. Renders `null` if none remain. |
+| `heading` | `string` | — | Optional group heading, wired to the list via `aria-labelledby`. |
+| `size` | `'sm' \| 'md'` | `'md'` | Label and cap size. |
+| `isApple` | `boolean` | auto-detected | Override platform detection. Pass when server-rendering. |
+| `className` | `string` | `''` | Merged onto the root. |
+
+Recognised key tokens: `mod` · `shift` · `alt` · `ctrl` · `enter` · `esc` · `tab` · `up` · `down`. Anything else is a literal key.
+
+## Usage
+
+```jsx
+import CommandHint from './CommandHint';
+import './style.css';
+
+<CommandHint
+  heading="Shortcuts"
+  items={[
+    { label: 'Open command palette', keys: ['mod', 'k'] },
+    { label: 'Search', keys: ['mod', 'shift', 'f'] },
+    { label: 'Dismiss', keys: ['esc'] },
+  ]}
+/>
+```
+
+## Why it fits EaseMotion
+
+**The markup is a description list, and that is the whole point.** The obvious choice is a grid of divs or a `<table>`, but a hint list is semantically `<dl>`: each shortcut *describes* an action. With `<dt>`/`<dd>` a screen reader announces the pairing — "Search, Command plus Shift plus F" — whereas a div grid is read as two unrelated columns top to bottom, leaving the listener to reassemble which key belongs to which action.
+
+Shortcut glyphs sit inside the `<dd>` with an accessible text form alongside, because the symbol characters (⌘, ⇧, ⌥) are frequently announced as nothing at all. The visual caps are `aria-hidden`; the spoken form carries the meaning.
+
+`mod` resolves to ⌘ on Apple platforms and Ctrl elsewhere, so one definition is correct on both. Detection prefers `navigator.userAgentData.platform` over the deprecated `navigator.platform`, is guarded for `navigator` being undefined under SSR, and `isApple` is exposed so server-rendered output can match the client.
+
+Labels truncate with an ellipsis rather than wrapping. A wrapped label pushes its keys onto a second line and visually breaks the pairing the `<dl>` is there to express.

--- a/submissions/react/command-hint-ad/style.css
+++ b/submissions/react/command-hint-ad/style.css
@@ -34,10 +34,10 @@
     min-width: 0;
 }
 
+/* Long action names truncate rather than wrapping under the keys, which
+   would break the visual pairing the <dl> encodes. */
 .ease-hint-ad__label {
     color: var(--hint-text-ad);
-    /* Long action names truncate rather than wrapping under the keys,
-       which would break the visual pairing the <dl> encodes. */
     min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/submissions/react/command-hint-ad/style.css
+++ b/submissions/react/command-hint-ad/style.css
@@ -1,0 +1,109 @@
+/* ==========================================================================
+   EaseMotion CSS — CommandHint component styles
+   Issue #63565
+   ========================================================================== */
+
+.ease-hint-ad {
+    --hint-text-ad: #94a3b8;
+    --hint-strong-ad: #f1f5f9;
+    --hint-cap-bg-ad: rgba(30, 41, 59, 0.9);
+    --hint-cap-border-ad: rgba(148, 163, 184, 0.26);
+}
+
+.ease-hint-ad__heading {
+    color: var(--hint-strong-ad);
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    margin: 0 0 0.6rem;
+    text-transform: uppercase;
+}
+
+.ease-hint-ad__list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    margin: 0;
+}
+
+.ease-hint-ad__row {
+    align-items: center;
+    display: flex;
+    gap: 1rem;
+    justify-content: space-between;
+    min-width: 0;
+}
+
+.ease-hint-ad__label {
+    color: var(--hint-text-ad);
+    /* Long action names truncate rather than wrapping under the keys,
+       which would break the visual pairing the <dl> encodes. */
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.ease-hint-ad__keys {
+    flex: 0 0 auto;
+    margin: 0;
+}
+
+.ease-hint-ad__sr {
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+}
+
+.ease-hint-ad__caps {
+    align-items: center;
+    display: inline-flex;
+    gap: 0.2rem;
+}
+
+.ease-hint-ad__cap {
+    align-items: center;
+    background: var(--hint-cap-bg-ad);
+    border: 1px solid var(--hint-cap-border-ad);
+    border-bottom-width: 2px;
+    border-radius: 5px;
+    color: var(--hint-strong-ad);
+    display: inline-flex;
+    font-family: "JetBrains Mono", ui-monospace, monospace;
+    font-weight: 550;
+    justify-content: center;
+    line-height: 1;
+}
+
+/* -- Sizes -- */
+.ease-hint-ad--sm .ease-hint-ad__label,
+.ease-hint-ad--sm .ease-hint-ad__cap {
+    font-size: 0.72rem;
+}
+
+.ease-hint-ad--sm .ease-hint-ad__cap {
+    min-width: 1.2rem;
+    padding: 0.12rem 0.28rem;
+}
+
+.ease-hint-ad--md .ease-hint-ad__label,
+.ease-hint-ad--md .ease-hint-ad__cap {
+    font-size: 0.8rem;
+}
+
+.ease-hint-ad--md .ease-hint-ad__cap {
+    min-width: 1.45rem;
+    padding: 0.18rem 0.36rem;
+}
+
+@media (forced-colors: active) {
+    .ease-hint-ad__cap {
+        background: Canvas;
+        border: 1px solid CanvasText;
+        color: CanvasText;
+    }
+}


### PR DESCRIPTION
Fixes #63565

**What was added**

Command palette hint rows, under `submissions/react/command-hint-ad/`.

- `CommandHint.jsx` — a 9-token key map with per-platform glyphs and spoken names, SSR-safe detection, memoised resolution, and `<dl>`-based markup.
- `style.css` — heading, row, label and cap styling in two sizes, plus forced-colors handling.
- `README.md` — props table, recognised tokens, usage, and rationale.

**What is the problem**

The obvious markup for a hint list is a grid of divs or a `<table>`. Both lose the pairing: a screen reader reads two unrelated columns top to bottom, and the listener has to reassemble which key belongs to which action. On a list of eight shortcuts that is effectively unusable.

Separately, the shortcut glyphs themselves (⌘, ⇧, ⌥) are frequently announced as **nothing at all**, so even correct structure can yield "Search, blank".

**Why this approach**

A hint list is semantically a description list — each shortcut *describes* an action — so the markup is `<dl>` / `<dt>` / `<dd>`. Assistive tech then announces the pairing directly: "Search, Command plus Shift plus F".

The glyphs sit inside the `<dd>` with an accessible text form alongside. The visual caps are `aria-hidden`; the spoken form carries the meaning, so the symbol-announcement problem cannot bite.

`mod` resolves to ⌘ on Apple platforms and Ctrl elsewhere, so one definition is correct on both. Detection prefers `navigator.userAgentData.platform` over the deprecated `navigator.platform`, guards for `navigator` being undefined under SSR, and exposes `isApple` so server output can match the client.

Labels truncate rather than wrap: a wrapped label pushes its keys onto a second line and visually breaks the very pairing the `<dl>` exists to express.

**How to test**

1. Pull this branch and drop `command-hint-ad/` into any React app (React 18+ — uses `useId`).
2. Render:
   ```jsx
   <CommandHint heading="Shortcuts" items={[
     { label: 'Open command palette', keys: ['mod', 'k'] },
     { label: 'Search', keys: ['mod', 'shift', 'f'] },
     { label: 'Dismiss', keys: ['esc'] },
   ]} />
   ```
3. Inspect the DOM — confirm `<dl>`, `<dt>` and `<dd>` are used, not divs.
4. **Run a screen reader over the list.** Each row must be announced as a pair ("Search, Command plus Shift plus F"), not as two separate columns.
5. On macOS confirm `mod` renders ⌘; on Windows/Linux confirm `Ctrl`. Force the other with `isApple`.
6. Put a very long label in a narrow container — it must truncate with an ellipsis, keeping the keys on the same line.
7. Confirm the heading is wired to the list via `aria-labelledby`.
8. Render `items={[]}` and confirm it returns `null`.
9. Pass an item with no `label` and confirm it is skipped rather than rendering an empty row.

**Edge cases covered**

- `<dl>` semantics preserve the label↔shortcut pairing for assistive tech.
- Glyphs are `aria-hidden` with a spoken form alongside, so unannounced symbol characters cannot produce a silent row.
- Items without a `label`, and non-object entries, are filtered out.
- A missing or non-array `keys` yields a row with no caps rather than throwing.
- Unknown key tokens fall through as literals; single characters are uppercased for display but keep their spoken form.
- `navigator` guard makes the component safe under SSR; `isApple` avoids a hydration mismatch.
- Deprecated `navigator.platform` is only a fallback.
- Labels truncate rather than wrapping, preserving the visual pairing.
- `aria-labelledby` is only set when a heading exists, rather than pointing at a missing id.
- `useId` keeps heading ids unique across multiple instances on one page.
- `forced-colors: active` gives caps system colours.

**Verification**

- `CommandHint.jsx` parses cleanly through esbuild's JSX loader — zero errors or warnings.
- `npx stylelint style.css` against the repo's own config — zero errors.
- All component classes referenced in the JSX are defined in `style.css`.
- Description-list markup verified programmatically.
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 3 new files, 0 deletions, no existing file touched.
- Component classes carry an `-ad` suffix so this lands as a parallel implementation.

**Labels:** `type:feature` · `react` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
