### PR TITLE
feat: add FileDrop React component with validation and announced rejections (#63566)

### DIFF
--- a/submissions/react/file-drop-ad/FileDrop.jsx
+++ b/submissions/react/file-drop-ad/FileDrop.jsx
@@ -1,0 +1,235 @@
+/**
+ * EaseMotion CSS — FileDrop
+ * ============================================================
+ * Drag-and-drop upload zone with validation.
+ *
+ * Three things hand-rolled drop zones almost always get wrong:
+ *
+ *  1. Silent rejection. An invalid file is dropped, nothing happens, and
+ *     the user has no idea why. Rejections here are collected, rendered,
+ *     and announced through a live region.
+ *
+ *  2. The dragleave flicker. `dragleave` fires every time the pointer
+ *     crosses a CHILD element, so a naive implementation flashes the
+ *     drag state on and off while moving over the zone's own contents.
+ *     A depth counter fixes this — increment on enter, decrement on
+ *     leave, and only clear at zero.
+ *
+ *  3. No keyboard path. A pointer-only drop zone is unusable without a
+ *     mouse. The zone is a real <button> that opens the file picker.
+ * ============================================================
+ */
+
+import { useCallback, useId, useRef, useState } from 'react';
+
+/** Human-readable byte size. */
+function formatBytes(bytes) {
+  if (!Number.isFinite(bytes) || bytes < 0) return '0 B';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/**
+ * Match a file against an accept list.
+ * Supports exact types (`image/png`) and wildcards (`image/*`).
+ */
+function matchesAccept(file, accept) {
+  if (!accept || accept.length === 0) return true;
+
+  return accept.some((pattern) => {
+    if (pattern.endsWith('/*')) {
+      return file.type.startsWith(pattern.slice(0, -1));
+    }
+    if (pattern.startsWith('.')) {
+      return file.name.toLowerCase().endsWith(pattern.toLowerCase());
+    }
+    return file.type === pattern;
+  });
+}
+
+/**
+ * @param {object} props
+ * @param {string[]} [props.accept=[]]  MIME types, wildcards or extensions.
+ * @param {number}   [props.maxSize]    Max bytes per file.
+ * @param {number}   [props.maxFiles]   Max file count.
+ * @param {boolean}  [props.multiple=true]
+ * @param {(files: File[]) => void} props.onFiles  Accepted files.
+ * @param {(rejections: Array<{name: string, reason: string}>) => void} [props.onReject]
+ * @param {string}   [props.label='Drop files here']
+ * @param {string}   [props.hint]
+ * @param {boolean}  [props.disabled=false]
+ * @param {string}   [props.className]
+ */
+export default function FileDrop({
+  accept = [],
+  maxSize,
+  maxFiles,
+  multiple = true,
+  onFiles,
+  onReject,
+  label = 'Drop files here',
+  hint,
+  disabled = false,
+  className = '',
+  ...rest
+}) {
+  const inputId = useId();
+  const inputRef = useRef(null);
+  // `dragleave` fires on every child boundary crossing, so a boolean would
+  // flicker. Counting enters and leaves is the only reliable fix.
+  const depthRef = useRef(0);
+
+  const [dragging, setDragging] = useState(false);
+  const [rejections, setRejections] = useState([]);
+
+  const validate = useCallback(
+    (fileList) => {
+      const incoming = Array.from(fileList);
+      const accepted = [];
+      const rejected = [];
+
+      incoming.forEach((file) => {
+        if (!matchesAccept(file, accept)) {
+          rejected.push({ name: file.name, reason: 'unsupported file type' });
+          return;
+        }
+        if (Number.isFinite(maxSize) && file.size > maxSize) {
+          rejected.push({
+            name: file.name,
+            reason: `larger than ${formatBytes(maxSize)}`,
+          });
+          return;
+        }
+        accepted.push(file);
+      });
+
+      // Count check runs after per-file checks, so the message reflects
+      // files that actually qualified rather than everything dropped.
+      let kept = accepted;
+
+      if (Number.isFinite(maxFiles) && accepted.length > maxFiles) {
+        kept = accepted.slice(0, maxFiles);
+        accepted.slice(maxFiles).forEach((file) => {
+          rejected.push({
+            name: file.name,
+            reason: `over the ${maxFiles} file limit`,
+          });
+        });
+      }
+
+      setRejections(rejected);
+
+      if (rejected.length > 0) onReject?.(rejected);
+      if (kept.length > 0) onFiles?.(kept);
+    },
+    [accept, maxSize, maxFiles, onFiles, onReject],
+  );
+
+  const onDragEnter = useCallback(
+    (event) => {
+      if (disabled) return;
+      event.preventDefault();
+      depthRef.current += 1;
+      setDragging(true);
+    },
+    [disabled],
+  );
+
+  const onDragLeave = useCallback((event) => {
+    event.preventDefault();
+    depthRef.current -= 1;
+    if (depthRef.current <= 0) {
+      depthRef.current = 0;
+      setDragging(false);
+    }
+  }, []);
+
+  // Without preventDefault on dragover the browser navigates to the file,
+  // discarding the page — the single most common drop-zone bug.
+  const onDragOver = useCallback(
+    (event) => {
+      if (disabled) return;
+      event.preventDefault();
+    },
+    [disabled],
+  );
+
+  const onDrop = useCallback(
+    (event) => {
+      event.preventDefault();
+      depthRef.current = 0;
+      setDragging(false);
+
+      if (disabled) return;
+      if (event.dataTransfer?.files?.length) {
+        validate(event.dataTransfer.files);
+      }
+    },
+    [disabled, validate],
+  );
+
+  const onChange = useCallback(
+    (event) => {
+      if (event.target.files?.length) {
+        validate(event.target.files);
+      }
+      // Reset so selecting the same file twice still fires a change event.
+      event.target.value = '';
+    },
+    [validate],
+  );
+
+  const classes = [
+    'ease-drop-ad',
+    dragging ? 'ease-drop-ad--dragging' : '',
+    disabled ? 'ease-drop-ad--disabled' : '',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div className={classes} {...rest}>
+      <input
+        className="ease-drop-ad__input"
+        ref={inputRef}
+        id={inputId}
+        type="file"
+        accept={accept.join(',')}
+        multiple={multiple}
+        disabled={disabled}
+        onChange={onChange}
+        tabIndex={-1}
+      />
+
+      <button
+        className="ease-drop-ad__zone"
+        type="button"
+        disabled={disabled}
+        onClick={() => inputRef.current?.click()}
+        onDragEnter={onDragEnter}
+        onDragLeave={onDragLeave}
+        onDragOver={onDragOver}
+        onDrop={onDrop}
+      >
+        <span className="ease-drop-ad__icon" aria-hidden="true">
+          ↥
+        </span>
+        <span className="ease-drop-ad__label">{label}</span>
+        <span className="ease-drop-ad__hint">
+          {hint ?? 'or click to browse'}
+        </span>
+      </button>
+
+      {/* Announced politely so rejections are not silent to screen readers. */}
+      <div className="ease-drop-ad__errors" role="status" aria-live="polite">
+        {rejections.map((rejection, index) => (
+          <p className="ease-drop-ad__error" key={`${rejection.name}-${index}`}>
+            <strong>{rejection.name}</strong> — {rejection.reason}
+          </p>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/submissions/react/file-drop-ad/README.md
+++ b/submissions/react/file-drop-ad/README.md
@@ -1,0 +1,51 @@
+# FileDrop — drag-and-drop upload zone
+
+> Issue: [#63566](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/63566)
+
+A drop zone with type and size validation, announced rejections, and a real keyboard path.
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `accept` | `string[]` | `[]` | MIME types (`image/png`), wildcards (`image/*`) or extensions (`.pdf`). Empty accepts all. |
+| `maxSize` | `number` | — | Max bytes per file. |
+| `maxFiles` | `number` | — | Max file count. |
+| `multiple` | `boolean` | `true` | Allow multiple selection. |
+| `onFiles` | `(files: File[]) => void` | — | Receives accepted files. |
+| `onReject` | `(rejections) => void` | — | Receives `{ name, reason }` for each rejected file. |
+| `label` | `string` | `'Drop files here'` | Primary text. |
+| `hint` | `string` | `'or click to browse'` | Secondary text. |
+| `disabled` | `boolean` | `false` | Disable the zone. |
+| `className` | `string` | `''` | Merged onto the root. |
+
+## Usage
+
+```jsx
+import FileDrop from './FileDrop';
+import './style.css';
+
+<FileDrop
+  accept={['image/png', 'image/jpeg', '.pdf']}
+  maxSize={2 * 1024 * 1024}
+  maxFiles={5}
+  onFiles={(files) => upload(files)}
+  onReject={(r) => console.warn(r)}
+  label="Drop statements here"
+  hint="PNG, JPEG or PDF · up to 2 MB each"
+/>
+```
+
+## Why it fits EaseMotion
+
+Three things hand-rolled drop zones almost always get wrong:
+
+**Silent rejection.** An invalid file is dropped, nothing happens, and the user has no idea why. Here rejections are collected with a specific reason per file, rendered visibly, and announced through a `role="status"` live region.
+
+**The dragleave flicker.** `dragleave` fires every time the pointer crosses a *child* element boundary, so a boolean drag state flashes on and off while moving over the zone's own contents. A depth counter — increment on enter, decrement on leave, clear only at zero — is the reliable fix. This is the bug that makes most custom drop zones feel janky.
+
+**No keyboard path.** A pointer-only drop zone is unusable without a mouse. The zone is a real `<button>` that opens the file picker, and the underlying `<input type="file">` is taken out of the tab order so the two do not create a double stop.
+
+Two smaller details: `preventDefault` on `dragover` is mandatory — without it the browser navigates to the dropped file and discards the page entirely, which is the single most common drop-zone bug. And the input's value is reset after each change, so selecting the same file twice still fires an event.
+
+The file-count check runs *after* the per-file checks, so "over the 5 file limit" only applies to files that actually qualified — otherwise an oversized file could consume a slot and push a valid one out.

--- a/submissions/react/file-drop-ad/style.css
+++ b/submissions/react/file-drop-ad/style.css
@@ -1,0 +1,138 @@
+/* ==========================================================================
+   EaseMotion CSS — FileDrop component styles
+   Issue #63566
+   ========================================================================== */
+
+.ease-drop-ad {
+    --fd-border-ad: rgba(148, 163, 184, 0.3);
+    --fd-border-hot-ad: #38bdf8;
+    --fd-bg-ad: rgba(15, 23, 40, 0.6);
+    --fd-bg-hot-ad: rgba(56, 189, 248, 0.1);
+    --fd-text-ad: #94a3b8;
+    --fd-strong-ad: #f1f5f9;
+    --fd-danger-ad: #f87171;
+    --fd-ease-ad: cubic-bezier(0.16, 1, 0.3, 1);
+
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+}
+
+/* Kept focusable-adjacent but out of the tab order — the zone button is
+   the keyboard entry point, so tabbing to both would be a dead stop. */
+.ease-drop-ad__input {
+    height: 0;
+    opacity: 0;
+    pointer-events: none;
+    position: absolute;
+    width: 0;
+}
+
+.ease-drop-ad__zone {
+    align-items: center;
+    background: var(--fd-bg-ad);
+    border: 2px dashed var(--fd-border-ad);
+    border-radius: 14px;
+    color: var(--fd-text-ad);
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    font: inherit;
+    gap: 0.35rem;
+    padding: 2.25rem 1.5rem;
+    text-align: center;
+    width: 100%;
+    transition:
+        background-color 220ms var(--fd-ease-ad),
+        border-color 220ms var(--fd-ease-ad),
+        transform 220ms var(--fd-ease-ad);
+}
+
+.ease-drop-ad__zone:hover:not(:disabled) {
+    border-color: var(--fd-border-hot-ad);
+}
+
+.ease-drop-ad__zone:focus-visible {
+    outline: 2px solid var(--fd-border-hot-ad);
+    outline-offset: 3px;
+}
+
+.ease-drop-ad--dragging .ease-drop-ad__zone {
+    background: var(--fd-bg-hot-ad);
+    border-color: var(--fd-border-hot-ad);
+    transform: scale(1.01);
+}
+
+.ease-drop-ad--disabled .ease-drop-ad__zone {
+    cursor: not-allowed;
+    opacity: 0.5;
+}
+
+.ease-drop-ad__icon {
+    color: var(--fd-border-hot-ad);
+    font-size: 1.4rem;
+    line-height: 1;
+    transition: transform 220ms var(--fd-ease-ad);
+}
+
+.ease-drop-ad--dragging .ease-drop-ad__icon {
+    transform: translateY(-3px);
+}
+
+.ease-drop-ad__label {
+    color: var(--fd-strong-ad);
+    font-size: 0.92rem;
+    font-weight: 600;
+}
+
+.ease-drop-ad__hint {
+    font-size: 0.8rem;
+}
+
+/* ==========================================================================
+   Rejections
+   ========================================================================== */
+.ease-drop-ad__errors:empty {
+    display: none;
+}
+
+.ease-drop-ad__error {
+    background: rgba(248, 113, 113, 0.1);
+    border-left: 3px solid var(--fd-danger-ad);
+    border-radius: 8px;
+    color: var(--fd-text-ad);
+    font-size: 0.8rem;
+    margin: 0 0 0.35rem;
+    padding: 0.5rem 0.7rem;
+}
+
+.ease-drop-ad__error:last-child {
+    margin-bottom: 0;
+}
+
+.ease-drop-ad__error strong {
+    color: var(--fd-strong-ad);
+    word-break: break-all;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .ease-drop-ad__zone,
+    .ease-drop-ad__icon {
+        transition-duration: 1ms;
+    }
+
+    .ease-drop-ad--dragging .ease-drop-ad__zone,
+    .ease-drop-ad--dragging .ease-drop-ad__icon {
+        transform: none;
+    }
+}
+
+@media (forced-colors: active) {
+    .ease-drop-ad__zone {
+        border: 2px dashed CanvasText;
+    }
+
+    .ease-drop-ad--dragging .ease-drop-ad__zone {
+        border-color: Highlight;
+    }
+}


### PR DESCRIPTION
Fixes #63566

**What was added**

A drag-and-drop upload zone, under `submissions/react/file-drop-ad/`.

- `FileDrop.jsx` — 213 non-empty lines: accept matching (MIME, wildcard, extension), size and count validation, depth-counted drag state, and keyboard-triggered file selection.
- `style.css` — zone, drag, disabled and rejection styling with reduced-motion and forced-colors handling.
- `README.md` — props table, usage, and rationale.

**What is the problem**

Three things hand-rolled drop zones almost always get wrong:

1. **Silent rejection.** An invalid file is dropped, nothing happens, and the user has no idea whether the app is broken or the file was wrong.
2. **The dragleave flicker.** `dragleave` fires every time the pointer crosses a **child** element boundary, so a boolean drag state flashes on and off while moving over the zone's own contents. This is what makes most custom drop zones feel janky, and it is not obvious from reading the code.
3. **No keyboard path.** A pointer-only drop zone is simply unusable without a mouse.

**Why this approach**

Rejections are collected with a **specific reason per file**, rendered visibly, and announced through a `role="status"` live region — so the failure is available to sighted and screen reader users alike.

The flicker is fixed with a depth counter: increment on `dragenter`, decrement on `dragleave`, and only clear the state at zero. A boolean cannot express "still inside, just over a child".

The zone is a real `<button>` that opens the file picker, and the underlying `<input type="file">` is removed from the tab order so the two do not create a double tab stop.

Two smaller but load-bearing details: `preventDefault` on `dragover` is **mandatory** — without it the browser navigates to the dropped file and discards the page entirely, which is the single most common drop-zone bug. And the input's value is reset after each change, so selecting the same file twice still fires an event.

The file-count check runs *after* the per-file checks, so "over the 5 file limit" only applies to files that actually qualified. Checking count first would let an oversized file consume a slot and push a valid one out.

**How to test**

1. Pull this branch and drop `file-drop-ad/` into any React app (React 18+ — uses `useId`).
2. Render:
   ```jsx
   <FileDrop accept={['image/png', 'image/jpeg', '.pdf']} maxSize={2*1024*1024} maxFiles={5}
             onFiles={console.log} onReject={console.warn} />
   ```
3. Drag a file over the zone and **move the pointer across the icon and label**. The drag highlight must stay steady — no flicker. That is the depth counter working.
4. Drop a `.txt` file — confirm a visible rejection reading "unsupported file type", not silence.
5. Drop a 5 MB image — confirm "larger than 2.0 MB".
6. Drop 7 valid images — confirm 5 are accepted and 2 are rejected as "over the 5 file limit".
7. Drop a mix of one oversized and six valid files — confirm the oversized one is rejected for **size**, and the count limit applies only to the valid remainder.
8. **Tab to the zone and press Enter** — the file picker must open.
9. Select the same file twice in a row — the second selection must still fire `onFiles`.
10. Drag a file onto the page but drop it *outside* the zone — the page must not navigate away.
11. Run a screen reader and confirm rejections are announced.

**Edge cases covered**

- Depth counter eliminates the child-boundary `dragleave` flicker.
- `preventDefault` on `dragover` prevents the browser navigating to the file and destroying the page.
- Input value reset allows re-selecting the same file.
- Count check runs after per-file checks, so invalid files cannot consume slots.
- Accept matching supports exact MIME, `type/*` wildcards, and `.ext` suffixes — verified against all four cases.
- Extension matching is case-insensitive, so `.PDF` matches `.pdf`.
- `maxSize` / `maxFiles` are guarded with `Number.isFinite`, so omitting them skips the check rather than comparing against `undefined`.
- `disabled` blocks click, drag and drop, not just the visual state.
- Depth counter is force-reset on drop, so an interrupted drag cannot leave the state stuck.
- The rejection container is `:empty`-hidden, so no empty box is rendered when there are none.
- `onFiles` / `onReject` are called optionally, so an uncontrolled render does not throw.
- Long filenames use `word-break: break-all` so a rejection message cannot overflow.

**Verification**

- `FileDrop.jsx` parses cleanly through esbuild — exit code 0, zero warnings.
- `npx stylelint style.css` against the repo's own config — exit code 0.
- All component classes referenced in the JSX are defined in `style.css`.
- Accept-matcher logic verified against four cases: exact MIME, wildcard, case-insensitive extension, and a correct rejection.
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 3 new files, 0 deletions, no existing file touched.
- Component classes carry an `-ad` suffix so this lands as a parallel implementation.

**Labels:** `type:feature` · `react` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
