### PR TITLE
feat: add OtpInput React component with paste distribution (#63569)

### DIFF
--- a/submissions/react/otp-input-ad/OtpInput.jsx
+++ b/submissions/react/otp-input-ad/OtpInput.jsx
@@ -1,0 +1,202 @@
+/**
+ * EaseMotion CSS — OtpInput
+ * ============================================================
+ * Segmented one-time-code input.
+ *
+ * Segmented OTP inputs are notorious for being hostile to exactly the
+ * flow they exist to serve. The specific failures:
+ *
+ *  - Paste only fills the first box. The user copies a 6-digit code from
+ *    an SMS and gets "4" in box one. Paste is intercepted here and
+ *    distributed across every box.
+ *
+ *  - Backspace on an empty box does nothing, so correcting a typo means
+ *    clicking backwards. Backspace on an empty box moves focus back and
+ *    clears the previous value.
+ *
+ *  - `autocomplete="one-time-code"` is missing, so iOS never offers the
+ *    SMS code above the keyboard. It only works on the FIRST input, so
+ *    it is set there specifically rather than on all of them.
+ *
+ *  - `type="number"` is used, which brings spinners, allows `e` and `-`,
+ *    and breaks `maxLength`. `inputMode="numeric"` with a text type gives
+ *    the numeric keypad without any of that.
+ * ============================================================
+ */
+
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+
+/**
+ * @param {object} props
+ * @param {number}   [props.length=6]
+ * @param {string}   [props.value]        Controlled value.
+ * @param {(code: string) => void} [props.onChange]
+ * @param {(code: string) => void} [props.onComplete]  Fires when full.
+ * @param {boolean}  [props.disabled=false]
+ * @param {boolean}  [props.invalid=false]
+ * @param {string}   [props.label='One-time code']
+ * @param {string}   [props.className]
+ */
+export default function OtpInput({
+  length = 6,
+  value,
+  onChange,
+  onComplete,
+  disabled = false,
+  invalid = false,
+  label = 'One-time code',
+  className = '',
+  ...rest
+}) {
+  const groupId = useId();
+  const refs = useRef([]);
+  const completedRef = useRef(false);
+
+  const safeLength = Number.isFinite(length) && length > 0 ? Math.floor(length) : 6;
+
+  const [internal, setInternal] = useState('');
+  const controlled = typeof value === 'string';
+  const code = controlled ? value : internal;
+
+  const digits = useMemo(() => {
+    const chars = code.replace(/\D/g, '').slice(0, safeLength).split('');
+    return Array.from({ length: safeLength }, (_, i) => chars[i] ?? '');
+  }, [code, safeLength]);
+
+  const setCode = useCallback(
+    (next) => {
+      const clean = next.replace(/\D/g, '').slice(0, safeLength);
+      if (!controlled) setInternal(clean);
+      onChange?.(clean);
+      return clean;
+    },
+    [controlled, onChange, safeLength],
+  );
+
+  // Fire onComplete once per fill, not on every keystroke while full.
+  useEffect(() => {
+    const filled = code.replace(/\D/g, '').length === safeLength;
+
+    if (filled && !completedRef.current) {
+      completedRef.current = true;
+      onComplete?.(code.replace(/\D/g, ''));
+    } else if (!filled) {
+      completedRef.current = false;
+    }
+  }, [code, safeLength, onComplete]);
+
+  const focusBox = useCallback((index) => {
+    const target = refs.current[index];
+    if (target) {
+      target.focus();
+      target.select?.();
+    }
+  }, []);
+
+  const handleChange = useCallback(
+    (index, raw) => {
+      const digit = raw.replace(/\D/g, '');
+      if (digit === '') return;
+
+      const chars = digits.slice();
+      // Take only the last character typed, so overwriting a filled box
+      // replaces rather than appending.
+      chars[index] = digit[digit.length - 1];
+
+      setCode(chars.join(''));
+
+      if (index < safeLength - 1) focusBox(index + 1);
+    },
+    [digits, setCode, safeLength, focusBox],
+  );
+
+  const handleKeyDown = useCallback(
+    (index, event) => {
+      if (event.key === 'Backspace') {
+        event.preventDefault();
+        const chars = digits.slice();
+
+        if (chars[index]) {
+          chars[index] = '';
+          setCode(chars.join(''));
+        } else if (index > 0) {
+          // Empty box: step back and clear the previous one.
+          chars[index - 1] = '';
+          setCode(chars.join(''));
+          focusBox(index - 1);
+        }
+        return;
+      }
+
+      if (event.key === 'ArrowLeft' && index > 0) {
+        event.preventDefault();
+        focusBox(index - 1);
+      } else if (event.key === 'ArrowRight' && index < safeLength - 1) {
+        event.preventDefault();
+        focusBox(index + 1);
+      }
+    },
+    [digits, setCode, focusBox, safeLength],
+  );
+
+  const handlePaste = useCallback(
+    (event) => {
+      event.preventDefault();
+      const pasted = (event.clipboardData?.getData('text') ?? '').replace(/\D/g, '');
+      if (!pasted) return;
+
+      const clean = setCode(pasted.slice(0, safeLength));
+      // Land on the first empty box, or the last if the code filled it.
+      focusBox(Math.min(clean.length, safeLength - 1));
+    },
+    [setCode, focusBox, safeLength],
+  );
+
+  const classes = [
+    'ease-otp-ad',
+    invalid ? 'ease-otp-ad--invalid' : '',
+    disabled ? 'ease-otp-ad--disabled' : '',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div
+      className={classes}
+      role="group"
+      aria-label={label}
+      aria-describedby={`${groupId}-status`}
+      {...rest}
+    >
+      {digits.map((digit, index) => (
+        <input
+          className="ease-otp-ad__box"
+          key={index}
+          ref={(node) => {
+            refs.current[index] = node;
+          }}
+          // text + inputMode gives the numeric keypad without number-type
+          // spinners, `e`/`-` acceptance, or broken maxLength.
+          type="text"
+          inputMode="numeric"
+          pattern="[0-9]*"
+          maxLength={1}
+          // Only the first box carries this; iOS ignores it elsewhere.
+          autoComplete={index === 0 ? 'one-time-code' : 'off'}
+          aria-label={`Digit ${index + 1} of ${safeLength}`}
+          value={digit}
+          disabled={disabled}
+          onChange={(event) => handleChange(index, event.target.value)}
+          onKeyDown={(event) => handleKeyDown(index, event)}
+          onPaste={handlePaste}
+          onFocus={(event) => event.target.select()}
+        />
+      ))}
+
+      <span className="ease-otp-ad__sr" id={`${groupId}-status`} role="status" aria-live="polite">
+        {invalid ? 'The code entered is incorrect.' : ''}
+      </span>
+    </div>
+  );
+}

--- a/submissions/react/otp-input-ad/README.md
+++ b/submissions/react/otp-input-ad/README.md
@@ -1,0 +1,50 @@
+# OtpInput — one-time-code input
+
+> Issue: [#63569](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/63569)
+
+A segmented one-time-code input that handles paste, backspace traversal, and the SMS autofill affordance.
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `length` | `number` | `6` | Number of digits. Clamped to at least 1. |
+| `value` | `string` | — | Controlled value. Omit for uncontrolled. |
+| `onChange` | `(code: string) => void` | — | Fires on every change with the digits so far. |
+| `onComplete` | `(code: string) => void` | — | Fires **once** when all boxes are filled. |
+| `disabled` | `boolean` | `false` | Disable all boxes. |
+| `invalid` | `boolean` | `false` | Error state; announces politely. |
+| `label` | `string` | `'One-time code'` | Accessible group name. |
+| `className` | `string` | `''` | Merged onto the root. |
+
+## Keyboard
+
+| Key | Action |
+|---|---|
+| digit | Fill and advance |
+| <kbd>Backspace</kbd> | Clear box, or step back and clear if already empty |
+| <kbd>←</kbd> / <kbd>→</kbd> | Move between boxes |
+| <kbd>Cmd/Ctrl</kbd>+<kbd>V</kbd> | Distribute the whole code |
+
+## Usage
+
+```jsx
+import OtpInput from './OtpInput';
+import './style.css';
+
+<OtpInput length={6} onComplete={(code) => verify(code)} invalid={failed} />
+```
+
+## Why it fits EaseMotion
+
+Segmented OTP inputs are notorious for being hostile to exactly the flow they exist to serve. Four specific failures, all handled:
+
+**Paste only fills the first box.** The user copies a 6-digit code from an SMS and gets "4" in box one. Paste is intercepted and distributed across every box, then focus lands on the first empty one.
+
+**Backspace on an empty box does nothing**, so correcting a typo means clicking backwards. Here it steps back *and* clears the previous value in one press.
+
+**`autocomplete="one-time-code"` is missing**, so iOS never offers the SMS code above the keyboard. It is set on the **first** box only, because that is the only place iOS honours it — setting it on all six does nothing useful.
+
+**`type="number"` is used**, which brings spinner buttons, accepts `e` and `-`, and silently ignores `maxLength`. `type="text"` with `inputMode="numeric"` gives the numeric keypad without any of that.
+
+`onComplete` fires once per fill rather than on every keystroke while full — a completion handler that submits a form would otherwise fire repeatedly. A ref tracks the completed state and resets when the code is no longer full.

--- a/submissions/react/otp-input-ad/style.css
+++ b/submissions/react/otp-input-ad/style.css
@@ -1,0 +1,97 @@
+/* ==========================================================================
+   EaseMotion CSS — OtpInput component styles
+   Issue #63569
+   ========================================================================== */
+
+.ease-otp-ad {
+    --otp-bg-ad: rgba(15, 23, 40, 0.85);
+    --otp-border-ad: rgba(148, 163, 184, 0.3);
+    --otp-accent-ad: #38bdf8;
+    --otp-danger-ad: #f87171;
+    --otp-text-ad: #f1f5f9;
+    --otp-size-ad: 46px;
+    --otp-ease-ad: cubic-bezier(0.16, 1, 0.3, 1);
+
+    display: inline-flex;
+    gap: 0.45rem;
+}
+
+.ease-otp-ad__sr {
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+}
+
+.ease-otp-ad__box {
+    background: var(--otp-bg-ad);
+    border: 1px solid var(--otp-border-ad);
+    border-radius: 10px;
+    color: var(--otp-text-ad);
+    font-family: "JetBrains Mono", ui-monospace, monospace;
+    font-size: 1.25rem;
+    font-weight: 600;
+    height: var(--otp-size-ad);
+    text-align: center;
+    width: var(--otp-size-ad);
+    transition:
+        border-color 180ms var(--otp-ease-ad),
+        box-shadow 180ms var(--otp-ease-ad);
+}
+
+.ease-otp-ad__box:focus {
+    border-color: var(--otp-accent-ad);
+    box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.22);
+    outline: none;
+}
+
+/* A filled box is visibly distinct, so progress through the code is
+   readable at a glance rather than only from the caret position. */
+.ease-otp-ad__box:not(:placeholder-shown),
+.ease-otp-ad__box[value]:not([value=""]) {
+    border-color: rgba(56, 189, 248, 0.45);
+}
+
+.ease-otp-ad--invalid .ease-otp-ad__box {
+    border-color: var(--otp-danger-ad);
+}
+
+.ease-otp-ad--invalid .ease-otp-ad__box:focus {
+    box-shadow: 0 0 0 3px rgba(248, 113, 113, 0.22);
+}
+
+.ease-otp-ad--disabled .ease-otp-ad__box {
+    cursor: not-allowed;
+    opacity: 0.55;
+}
+
+@media (max-width: 400px) {
+    .ease-otp-ad {
+        --otp-size-ad: 38px;
+
+        gap: 0.3rem;
+    }
+
+    .ease-otp-ad__box {
+        font-size: 1.05rem;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .ease-otp-ad__box {
+        transition-duration: 1ms;
+    }
+}
+
+@media (forced-colors: active) {
+    .ease-otp-ad__box {
+        border: 1px solid CanvasText;
+    }
+
+    .ease-otp-ad--invalid .ease-otp-ad__box {
+        border-style: dashed;
+    }
+}


### PR DESCRIPTION
Fixes #63569

**What was added**

A segmented one-time-code input, under `submissions/react/otp-input-ad/`.

- `OtpInput.jsx` — 181 non-empty lines: paste distribution, backspace traversal, arrow navigation, controlled/uncontrolled support, and once-per-fill completion.
- `style.css` — box, focus, filled, invalid and disabled states, a narrow-viewport size step, reduced-motion and forced-colors handling.
- `README.md` — props table, keyboard table, usage, and rationale.

**What is the problem**

Segmented OTP inputs are notorious for being hostile to exactly the flow they exist to serve. Four specific failures:

1. **Paste only fills the first box.** The user copies a 6-digit code from an SMS and gets "4" in box one — then has to retype the rest from memory.
2. **Backspace on an empty box does nothing**, so correcting a typo means clicking backwards through the boxes.
3. **`autocomplete="one-time-code"` is missing**, so iOS never offers the SMS code above the keyboard — the single biggest convenience on the platform this UI is designed for.
4. **`type="number"` is used**, which brings spinner buttons, accepts `e` and `-`, and silently ignores `maxLength`.

**Why this approach**

Paste is intercepted and distributed across every box, with focus landing on the first empty one afterwards.

Backspace on an empty box steps back **and** clears the previous value in one press, so correcting a typo is a single keystroke.

`autocomplete="one-time-code"` is set on the **first box only**, because that is the only place iOS honours it — applying it to all six accomplishes nothing.

`type="text"` with `inputMode="numeric"` and `pattern="[0-9]*"` gives the numeric keypad without spinners, without accepting `e`/`-`, and with `maxLength` actually working.

`onComplete` fires once per fill rather than on every keystroke while full — otherwise a handler that submits a form would fire repeatedly. A ref tracks completion and resets when the code is no longer full.

**How to test**

1. Pull this branch and drop `otp-input-ad/` into any React app (React 18+ — uses `useId`).
2. Render `<OtpInput length={6} onComplete={console.log} invalid={failed} />`.
3. **Copy "123456" and paste into any box.** All six must fill, and focus should land on the last box.
4. Paste a partial code "12" — the first two fill and focus lands on box 3.
5. Paste text containing non-digits ("12-34-56") — only the digits are used.
6. Type into a filled box — the digit is **replaced**, not appended.
7. Press <kbd>Backspace</kbd> in a filled box — it clears. Press again — focus steps back and clears the previous box.
8. Use <kbd>←</kbd>/<kbd>→</kbd> to move between boxes.
9. **On an iPhone**, trigger an SMS code and confirm iOS offers it above the keyboard — this is the `one-time-code` attribute on box 1.
10. Confirm no spinner buttons appear and that typing `e` or `-` does nothing.
11. Fill the code and confirm `onComplete` fires exactly **once**, not on subsequent keystrokes.
12. Set `invalid` and confirm the error is announced politely.

**Edge cases covered**

- Paste distributes across all boxes and strips non-digits.
- Partial paste fills what it can and focuses the first empty box.
- Overwriting a filled box takes the last character typed rather than appending.
- Backspace on an empty box steps back and clears in one action.
- `onComplete` fires once per fill and resets when the code is emptied.
- Works controlled or uncontrolled — `value` is optional.
- `length` is validated with `Number.isFinite` and floored, so a bad prop cannot render zero boxes.
- All non-digit input is stripped at every entry point.
- `autocomplete` is on the first box only, where iOS actually honours it.
- `type="text"` + `inputMode="numeric"` avoids every `type="number"` pathology.
- Focus selects existing content, so typing always overwrites cleanly.
- Boxes shrink below 400px so a 6-digit code fits a narrow phone.
- `forced-colors` distinguishes the invalid state with a dashed border, since colour is discarded there.

**Verification**

- `OtpInput.jsx` parses cleanly through esbuild — exit code 0.
- `npx stylelint style.css` against the repo's own config — exit code 0.
- All component classes referenced in the JSX are defined in `style.css`.
- Paste distribution verified for full (`123456` → six boxes) and partial (`12` → two boxes, focus index 2) codes.
- Attribute checks confirmed: `autocomplete` conditional on index 0, `type="text"` + `inputMode="numeric"` on the real input (the only `type="number"` occurrence is inside the explanatory comment at line 21).
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 3 new files, 0 deletions, no existing file touched.
- Component classes carry an `-ad` suffix so this lands as a parallel implementation.

**Labels:** `type:feature` · `react` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
