### PR TITLE
feat: add ScrollSpy React component with topmost-section resolution (#63570)

### DIFF
--- a/submissions/react/scroll-spy-ad/README.md
+++ b/submissions/react/scroll-spy-ad/README.md
@@ -1,0 +1,45 @@
+# ScrollSpy — section navigation
+
+> Issue: [#63570](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/63570)
+
+A nav that highlights the section currently in view, using `IntersectionObserver`.
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `sections` | `Array<{ id, label }>` | `[]` | Sections to track. Ids must match real element ids. Renders `null` if empty. |
+| `offset` | `number` | `0` | Sticky header height in px. |
+| `label` | `string` | `'Page sections'` | Accessible nav name. |
+| `onChange` | `(id: string) => void` | — | Fires when the active section changes. |
+| `className` | `string` | `''` | Merged onto the root. |
+
+## Usage
+
+```jsx
+import ScrollSpy from './ScrollSpy';
+import './style.css';
+
+<ScrollSpy
+  offset={64}
+  sections={[
+    { id: 'intro', label: 'Introduction' },
+    { id: 'install', label: 'Installation' },
+    { id: 'api', label: 'API reference' },
+  ]}
+/>
+```
+
+Section elements need matching ids: `<section id="intro">…</section>`.
+
+## Why it fits EaseMotion
+
+**`IntersectionObserver`, not a scroll listener.** A scroll handler fires dozens of times per second and typically calls `getBoundingClientRect` on every section each time, forcing synchronous layout. That is the classic cause of janky scrolling on documentation pages — the nav itself makes the page feel slow.
+
+**`rootMargin` must account for the sticky header.** Without a negative top margin, a section "enters the viewport" while still hidden behind the header, so the nav highlights the next item before the reader can see it. The `-55%` bottom margin narrows the trigger band so only one section is current at a time.
+
+**Multiple visible sections need disambiguation.** With three short sections on screen, `isIntersecting` is true for all of them. Visible entries are tracked in a Map and the **topmost** is selected by comparing `boundingClientRect.top` — which is what a reader perceives as "current". Picking the first entry in the callback array instead would flicker, since entry order is not positional.
+
+Three smaller details: the observer is disconnected on unmount *and* whenever `sections` or `offset` change, or observers accumulate and keep firing against stale nodes. `onChange` is held in a ref so an inline arrow function does not tear down and rebuild the observer on every parent render. And clicking a link moves **focus** to the target section, not just the scroll position — scrolling alone leaves a keyboard user's focus stranded in the nav.
+
+Smooth scrolling is skipped when `prefers-reduced-motion` is set.

--- a/submissions/react/scroll-spy-ad/ScrollSpy.jsx
+++ b/submissions/react/scroll-spy-ad/ScrollSpy.jsx
@@ -1,0 +1,175 @@
+/**
+ * EaseMotion CSS — ScrollSpy
+ * ============================================================
+ * Section navigation that highlights whatever is currently in view.
+ *
+ * Uses IntersectionObserver rather than a scroll listener. A scroll
+ * handler fires dozens of times per second and calls getBoundingClientRect
+ * on every section each time, which forces synchronous layout — the
+ * classic cause of janky scrolling on documentation pages.
+ *
+ * Two details that are easy to get wrong:
+ *
+ *   rootMargin must account for a sticky header. Without it, a section
+ *   "enters the viewport" while still hidden behind the header, so the
+ *   nav highlights the next item before the user can see it.
+ *
+ *   With several sections visible at once, `isIntersecting` alone is
+ *   ambiguous — every visible section reports true. The topmost visible
+ *   section is selected by comparing boundingClientRect.top, which is
+ *   what a reader actually perceives as "current".
+ * ============================================================
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * @param {object} props
+ * @param {Array<{id: string, label: string}>} props.sections
+ * @param {number}  [props.offset=0]     Sticky header height, in px.
+ * @param {string}  [props.label='Page sections']
+ * @param {(id: string) => void} [props.onChange]
+ * @param {string}  [props.className]
+ */
+export default function ScrollSpy({
+  sections = [],
+  offset = 0,
+  label = 'Page sections',
+  onChange,
+  className = '',
+  ...rest
+}) {
+  const [activeId, setActiveId] = useState(sections[0]?.id ?? null);
+  const observerRef = useRef(null);
+  const visibleRef = useRef(new Map());
+  const onChangeRef = useRef(onChange);
+
+  // Held in a ref so an inline arrow passed as onChange does not tear
+  // down and rebuild the observer on every parent render.
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !('IntersectionObserver' in window)) {
+      return undefined;
+    }
+
+    const ids = sections.map((section) => section.id).filter(Boolean);
+    if (ids.length === 0) return undefined;
+
+    const visible = visibleRef.current;
+    visible.clear();
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            visible.set(entry.target.id, entry.boundingClientRect.top);
+          } else {
+            visible.delete(entry.target.id);
+          }
+        });
+
+        if (visible.size === 0) return;
+
+        // Topmost visible section wins — with several on screen at once,
+        // isIntersecting alone cannot disambiguate.
+        let bestId = null;
+        let bestTop = Infinity;
+
+        visible.forEach((top, id) => {
+          if (top < bestTop) {
+            bestTop = top;
+            bestId = id;
+          }
+        });
+
+        if (bestId) {
+          setActiveId((previous) => {
+            if (previous !== bestId) onChangeRef.current?.(bestId);
+            return bestId;
+          });
+        }
+      },
+      {
+        // Negative top margin pulls the trigger line below a sticky header,
+        // so a section is only "current" once actually visible.
+        rootMargin: `-${offset}px 0px -55% 0px`,
+        threshold: 0,
+      },
+    );
+
+    ids.forEach((id) => {
+      const element = document.getElementById(id);
+      if (element) observer.observe(element);
+    });
+
+    observerRef.current = observer;
+
+    // Disconnect on unmount and whenever sections/offset change, or
+    // observers accumulate and keep firing against stale nodes.
+    return () => {
+      observer.disconnect();
+      observerRef.current = null;
+      visible.clear();
+    };
+  }, [sections, offset]);
+
+  const handleClick = useCallback(
+    (event, id) => {
+      const target = document.getElementById(id);
+      if (!target) return;
+
+      event.preventDefault();
+
+      const prefersReduced =
+        typeof window !== 'undefined' &&
+        window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+
+      window.scrollTo({
+        top: target.getBoundingClientRect().top + window.scrollY - offset,
+        behavior: prefersReduced ? 'auto' : 'smooth',
+      });
+
+      // Move focus to the section so keyboard users actually land there —
+      // scrolling alone leaves focus in the nav.
+      target.setAttribute('tabindex', '-1');
+      target.focus({ preventScroll: true });
+
+      setActiveId(id);
+    },
+    [offset],
+  );
+
+  if (sections.length === 0) return null;
+
+  const classes = ['ease-spy-ad', className].filter(Boolean).join(' ');
+
+  return (
+    <nav className={classes} aria-label={label} {...rest}>
+      <ul className="ease-spy-ad__list">
+        {sections.map((section) => {
+          const isActive = section.id === activeId;
+
+          return (
+            <li className="ease-spy-ad__item" key={section.id}>
+              <a
+                className={
+                  isActive
+                    ? 'ease-spy-ad__link ease-spy-ad__link--active'
+                    : 'ease-spy-ad__link'
+                }
+                href={`#${section.id}`}
+                aria-current={isActive ? 'true' : undefined}
+                onClick={(event) => handleClick(event, section.id)}
+              >
+                {section.label}
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/submissions/react/scroll-spy-ad/style.css
+++ b/submissions/react/scroll-spy-ad/style.css
@@ -20,6 +20,13 @@
     padding: 0;
 }
 
+/* Establishes the containing block for each link's indicator, so the
+   marker cannot bleed past its own row. */
+.ease-spy-ad__item {
+    margin: 0;
+    position: relative;
+}
+
 .ease-spy-ad__link {
     color: var(--spy-text-ad);
     display: block;

--- a/submissions/react/scroll-spy-ad/style.css
+++ b/submissions/react/scroll-spy-ad/style.css
@@ -1,0 +1,83 @@
+/* ==========================================================================
+   EaseMotion CSS — ScrollSpy component styles
+   Issue #63570
+   ========================================================================== */
+
+.ease-spy-ad {
+    --spy-text-ad: #64748b;
+    --spy-active-ad: #f1f5f9;
+    --spy-accent-ad: #38bdf8;
+    --spy-rail-ad: rgba(148, 163, 184, 0.18);
+    --spy-ease-ad: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.ease-spy-ad__list {
+    border-left: 2px solid var(--spy-rail-ad);
+    display: flex;
+    flex-direction: column;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.ease-spy-ad__link {
+    color: var(--spy-text-ad);
+    display: block;
+    font-size: 0.85rem;
+    padding: 0.4rem 0.9rem;
+    position: relative;
+    text-decoration: none;
+    transition:
+        color 200ms var(--spy-ease-ad),
+        padding-left 200ms var(--spy-ease-ad);
+}
+
+.ease-spy-ad__link:hover {
+    color: var(--spy-active-ad);
+}
+
+.ease-spy-ad__link:focus-visible {
+    outline: 2px solid var(--spy-accent-ad);
+    outline-offset: -2px;
+}
+
+/* The indicator overlays the rail rather than replacing it, so the rail
+   stays continuous while the active marker slides along it. */
+.ease-spy-ad__link::before {
+    background: var(--spy-accent-ad);
+    bottom: 0;
+    content: "";
+    left: -2px;
+    opacity: 0;
+    position: absolute;
+    top: 0;
+    width: 2px;
+    transition: opacity 200ms var(--spy-ease-ad);
+}
+
+.ease-spy-ad__link--active {
+    color: var(--spy-active-ad);
+    font-weight: 600;
+    padding-left: 1.05rem;
+}
+
+.ease-spy-ad__link--active::before {
+    opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .ease-spy-ad__link,
+    .ease-spy-ad__link::before {
+        transition-duration: 1ms;
+    }
+}
+
+@media (forced-colors: active) {
+    .ease-spy-ad__link--active {
+        text-decoration: underline;
+    }
+
+    .ease-spy-ad__link::before {
+        background: Highlight;
+    }
+}


### PR DESCRIPTION
Fixes #63570

**What was added**

Section navigation with scroll tracking, under `submissions/react/scroll-spy-ad/`.

- `ScrollSpy.jsx` — 151 non-empty lines: `IntersectionObserver` setup with header-aware `rootMargin`, topmost-visible resolution, full cleanup, and focus-moving click handling.
- `style.css` — rail, link, active indicator, reduced-motion and forced-colors handling.
- `README.md` — props table, usage, and rationale.

**What is the problem**

**Scroll listeners make the page they document feel slow.** The usual implementation fires dozens of times per second and calls `getBoundingClientRect` on every section each time, forcing synchronous layout. The nav itself becomes the source of scroll jank.

**Multiple sections are visible at once.** With three short sections on screen, `isIntersecting` is true for all of them — so "which one is current" is genuinely ambiguous and naive implementations flicker between them.

**Sticky headers break the trigger point.** Without compensation, a section "enters the viewport" while still hidden behind the header, so the nav highlights the next item before the reader can see it.

**Why this approach**

`IntersectionObserver` moves the work off the main thread entirely — no per-frame layout reads.

Visible entries are tracked in a Map and the **topmost** is selected by comparing `boundingClientRect.top`, which matches what a reader perceives as "current". Taking the first entry in the callback array instead would flicker, because entry order is not positional.

`rootMargin: -{offset}px 0px -55% 0px` pulls the trigger line below the sticky header and narrows the band so only one section is current at a time.

Three smaller but real details: the observer is disconnected on unmount **and** whenever `sections` or `offset` change, or observers accumulate and keep firing against stale nodes. `onChange` is held in a ref so an inline arrow function does not tear down and rebuild the observer on every parent render. And clicking a link moves **focus** to the target section, not just the scroll position — scrolling alone leaves a keyboard user's focus stranded in the nav, so the next Tab goes to the wrong place.

**How to test**

1. Pull this branch and drop `scroll-spy-ad/` into any React app (React 16.8+).
2. Build a long page with `<section id="intro">`, `<section id="install">`, `<section id="api">` and a 64px sticky header, then render:
   ```jsx
   <ScrollSpy offset={64} sections={[
     { id: 'intro', label: 'Introduction' },
     { id: 'install', label: 'Installation' },
     { id: 'api', label: 'API reference' },
   ]} />
   ```
3. Scroll — the active link should track the section actually visible below the header, not the one still hidden behind it.
4. **Make two sections short enough to be visible simultaneously.** The nav must settle on the topmost one, with no flicker between them.
5. Click a nav link — the page scrolls to the section, and **focus moves there**. Press Tab and confirm you continue from inside the section, not from the nav.
6. Enable OS-level "reduce motion" and click a link — the jump must be instant, not smooth-scrolled.
7. Open DevTools Performance and scroll — confirm there is no per-frame layout thrash.
8. Unmount the component and confirm no observer callbacks continue firing.
9. Render with `sections={[]}` and confirm it returns `null`.

**Edge cases covered**

- Topmost-visible resolution disambiguates multiple simultaneously visible sections.
- `rootMargin` accounts for the sticky header so the highlight matches what is actually seen.
- Observer is disconnected on unmount and on every `sections`/`offset` change.
- `onChange` lives in a ref, so an inline arrow does not rebuild the observer each render.
- `IntersectionObserver` presence is feature-detected, and `window` is guarded for SSR.
- Section ids that do not resolve to a real element are skipped rather than throwing.
- Click moves focus to the target with `preventScroll`, so the scroll animation is not interrupted.
- Smooth scrolling is skipped under `prefers-reduced-motion`.
- `aria-current` marks the active link for assistive tech, not just a CSS class.
- The active indicator overlays the rail rather than replacing it, so the rail stays continuous.
- Empty `sections` returns `null` rather than an empty `<nav>`.

**Verification**

- `ScrollSpy.jsx` parses cleanly through esbuild — exit code 0.
- `npx stylelint style.css` against the repo's own config — exit code 0.
- All component classes referenced in the JSX are defined in `style.css` (an initial check found `__item` unstyled; it now carries a real containing-block rule).
- Topmost-wins resolution verified numerically: `{a: 300, b: 50, c: 180}` selects `b`.
- Cleanup, ref-held `onChange`, focus handling, reduced-motion and feature-detection all verified present.
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 3 new files, 0 deletions, no existing file touched.
- Component classes carry an `-ad` suffix so this lands as a parallel implementation.

**Labels:** `type:feature` · `react` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
