### PR TITLE
[Feature] Dark Mode Toggle — Sun/Moon Icon Morph

### DIFF
--- a/submissions/examples/sun-moon-toggle/README.md
+++ b/submissions/examples/sun-moon-toggle/README.md
@@ -1,0 +1,16 @@
+# Theme Toggle — Sun/Moon Icon Morph
+
+## 1. What does this do?
+A single-element toggle switch that morphs a sun icon into a crescent moon (and back) using only `box-shadow` rays that fade out and a masking circle that slides in — no SVGs, no icon fonts.
+
+## 2. How is it used?
+```html
+<label class="theme-toggle">
+  <input type="checkbox" onchange="document.documentElement.classList.toggle('dark', this.checked)">
+  <span class="theme-toggle-icon"></span>
+</label>
+```
+Checking the box adds a `dark` class to `<html>` (for the consumer's own dark-mode styles) and, purely through CSS, swaps the icon from sun to moon.
+
+## 3. Why is this useful?
+Dark mode toggles are on nearly every modern site, and the sun-to-moon morph is one of the most-copied micro-interactions in UI design. Doing it with zero dependencies — just shapes, `box-shadow`, and `transition` — is a strong, on-brand showcase for EaseMotion CSS's animation-first, zero-dependency philosophy.

--- a/submissions/examples/sun-moon-toggle/demo.html
+++ b/submissions/examples/sun-moon-toggle/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Theme Toggle — Sun/Moon Icon Morph</title>
+<link rel="stylesheet" href="style.css" />
+<style>
+  body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 24px;
+    font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+    background-color: #f8fafc;
+    color: #0f172a;
+    transition: background-color 0.5s ease, color 0.5s ease;
+  }
+  html.dark body {
+    background-color: #0f172a;
+    color: #f8fafc;
+  }
+  h1 { font-size: 1.25rem; font-weight: 600; }
+  p.hint { opacity: 0.7; font-size: 0.9rem; }
+</style>
+</head>
+<body>
+  <h1>Sun/Moon Theme Toggle Demo</h1>
+
+  <label class="theme-toggle" id="themeToggle">
+    <input
+      type="checkbox"
+      onchange="
+        document.documentElement.classList.toggle('dark', this.checked);
+        document.getElementById('themeToggle').classList.toggle('is-dark', this.checked);
+      "
+    />
+    <span class="theme-toggle-icon"></span>
+  </label>
+
+  <p class="hint">Click the toggle — box-shadow rays fade out and a masking circle slides in to carve the crescent.</p>
+</body>
+</html>

--- a/submissions/examples/sun-moon-toggle/style.css
+++ b/submissions/examples/sun-moon-toggle/style.css
@@ -1,0 +1,1 @@
+/* real CSS goes here — paste the full style.css content */

--- a/submissions/examples/sun-moon-toggle/style.css
+++ b/submissions/examples/sun-moon-toggle/style.css
@@ -1,1 +1,88 @@
-/* real CSS goes here — paste the full style.css content */
+/* Theme Toggle — Sun/Moon Icon Morph
+   Pure CSS, single element, no icon library.
+   - Rays are drawn with box-shadow "dots" around the disc; they fade out on check.
+   - The crescent is carved by a masking circle (::after) that slides over the disc,
+     painted the same colour as the toggle track so it visually "cuts" the moon shape.
+*/
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 64px;
+  height: 34px;
+  padding: 4px;
+  border-radius: 999px;
+  background-color: #cbd5e1;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  transition: background-color 0.5s ease;
+}
+
+.theme-toggle input {
+  position: absolute;
+  width: 0;
+  height: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.theme-toggle-icon {
+  position: relative;
+  width: 26px;
+  height: 26px;
+  margin-left: 0;
+  border-radius: 50%;
+  background-color: #fbbf24;
+  transition: transform 0.5s ease, background-color 0.5s ease, box-shadow 0.5s ease;
+  transform: translateX(0);
+
+  box-shadow:
+    0 -15px 0 -9px #fbbf24,
+    11px -11px 0 -9px #fbbf24,
+    15px 0 0 -9px #fbbf24,
+    11px 11px 0 -9px #fbbf24,
+    0 15px 0 -9px #fbbf24,
+    -11px 11px 0 -9px #fbbf24,
+    -15px 0 0 -9px #fbbf24,
+    -11px -11px 0 -9px #fbbf24;
+}
+
+.theme-toggle-icon::after {
+  content: "";
+  position: absolute;
+  top: -4px;
+  right: -12px;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background-color: #cbd5e1;
+  transform: scale(0);
+  transition: transform 0.5s ease, background-color 0.5s ease;
+}
+
+.theme-toggle input:checked ~ .theme-toggle-icon {
+  background-color: #e2e8f0;
+  transform: translateX(30px);
+  box-shadow:
+    0 -15px 0 -9px rgba(226, 232, 240, 0),
+    11px -11px 0 -9px rgba(226, 232, 240, 0),
+    15px 0 0 -9px rgba(226, 232, 240, 0),
+    11px 11px 0 -9px rgba(226, 232, 240, 0),
+    0 15px 0 -9px rgba(226, 232, 240, 0),
+    -11px 11px 0 -9px rgba(226, 232, 240, 0),
+    -15px 0 0 -9px rgba(226, 232, 240, 0),
+    -11px -11px 0 -9px rgba(226, 232, 240, 0);
+}
+
+.theme-toggle input:checked ~ .theme-toggle-icon::after {
+  transform: scale(1) translate(-6px, 3px);
+}
+
+.theme-toggle:has(input:checked) {
+  background-color: #334155;
+}
+
+.theme-toggle.is-dark {
+  background-color: #334155;
+}


### PR DESCRIPTION
Closes #63455.

Adds a pure-CSS sun/moon theme toggle to `submissions/examples/sun-moon-toggle/`.

- Single element, no SVG, no icon library
- box-shadow "rays" fade out on toggle
- a masking circle slides in to carve the crescent moon shape
- self-contained demo.html, no build step / server needed

Note: submissions/examples/theme-toggle/ already exists with a different implementation by another contributor, so this one lives in a separate sun-moon-toggle/ folder to avoid collision.