### PR TITLE
Add ease-pomodoro-break-timer component

### DIFF
--- a/submissions/examples/pomodoro-break-timer-ij/README.md
+++ b/submissions/examples/pomodoro-break-timer-ij/README.md
@@ -1,0 +1,10 @@
+# ease-pomodoro-break-timer
+
+A focus timer whose outer ring depletes as the session counts down, the digits tick toward zero, and the WORK and BREAK tabs pulse in turn.
+
+## Run
+Open `demo.html` directly in a browser to watch the ring deplete.
+
+## Notes
+- The ring arc rotates full circle.
+- The START button breathes in rhythm.

--- a/submissions/examples/pomodoro-break-timer-ij/demo.html
+++ b/submissions/examples/pomodoro-break-timer-ij/demo.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-pomodoro-break-timer demo</title>
+</head>
+<body>
+<div class="pd-app">
+  <span class="pd-brand">FOCUS CLOCK</span>
+  <div class="pd-tabs">
+    <span class="pd-tab pd-tab-work pd-tab-active">WORK</span>
+    <span class="pd-tab pd-tab-break">BREAK</span>
+  </div>
+  <div class="pd-ring">
+    <span class="pd-arc"></span>
+  </div>
+  <span class="pd-time">24:59</span>
+  <div class="pd-controls">
+    <span class="pd-btn pd-btn-start">START</span>
+    <span class="pd-btn pd-btn-reset">RESET</span>
+  </div>
+  <span class="pd-session">SESSION 3 OF 4</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/pomodoro-break-timer-ij/style.css
+++ b/submissions/examples/pomodoro-break-timer-ij/style.css
@@ -1,0 +1,19 @@
+:root{--pd-red:#ff5d5d;--pd-dark:#1a0c12}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#2a1626,#150b12);font-family:'Segoe UI',sans-serif}
+.pd-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#25121f,#12090e);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.pd-brand{position:absolute;top:16px;left:0;right:0;text-align:center;font-size:12px;font-weight:800;letter-spacing:7px;color:#ff8a8a}
+.pd-tabs{position:absolute;top:52px;left:64px;right:64px;display:flex;border-radius:8px;overflow:hidden;box-shadow:inset 0 0 0 2px #3a1a28}
+.pd-tab{flex:1;text-align:center;font-size:11px;font-weight:800;letter-spacing:3px;color:#a86a7a;padding:8px 0}
+.pd-tab-active{color:#1a0c12;background:#ff5d5d;animation:tab-pulse-pomodoro-break-timer 2s ease-in-out infinite}
+.pd-ring{position:absolute;top:102px;left:50%;margin-left:-74px;width:148px;height:148px;border-radius:50%;box-shadow:inset 0 0 0 6px #331424}
+.pd-arc{position:absolute;top:0;left:0;width:148px;height:148px;border-radius:50%;border:6px solid transparent;border-top-color:#ff5d5d;border-right-color:#ff5d5d;animation:ring-deplete-pomodoro-break-timer 2.4s ease-in-out infinite}
+.pd-time{position:absolute;top:158px;left:0;right:0;text-align:center;font-size:34px;font-weight:900;color:#ffe3e3;font-variant-numeric:tabular-nums;animation:digit-tick-pomodoro-break-timer 1s steps(1) infinite}
+.pd-controls{position:absolute;top:230px;left:0;right:0;display:flex;justify-content:center;gap:14px}
+.pd-btn{width:96px;padding:10px 0;text-align:center;border-radius:8px;font-size:11px;font-weight:800;letter-spacing:2px}
+.pd-btn-start{background:#ff5d5d;color:#1a0c12;animation:btn-breathe-pomodoro-break-timer 2.4s ease-in-out infinite}
+.pd-btn-reset{background:#24101c;color:#d9a6b2;box-shadow:inset 0 0 0 2px #4a2234}
+.pd-session{position:absolute;bottom:16px;left:0;right:0;text-align:center;font-size:10px;font-weight:700;letter-spacing:4px;color:#a86a7a}
+@keyframes ring-deplete-pomodoro-break-timer{0%{transform:rotate(0deg)}100%{transform:rotate(360deg)}}
+@keyframes digit-tick-pomodoro-break-timer{0%,49%{opacity:1}50%,100%{opacity:0.35}}
+@keyframes tab-pulse-pomodoro-break-timer{0%,100%{filter:brightness(1)}50%{filter:brightness(1.25)}}
+@keyframes btn-breathe-pomodoro-break-timer{0%,100%{box-shadow:0 0 0 0 rgba(255,93,93,0.4)}50%{box-shadow:0 0 18px 4px rgba(255,93,93,0.5)}}


### PR DESCRIPTION
## Component: ease-pomodoro-break-timer — ring depletes, digits tick, and tabs pulse

**Closes #63742**

### What this adds
A focus timer: the outer ring depletes as the session counts down, the digits tick toward zero, and the WORK and BREAK tabs pulse in sequence.

### Acceptance Criteria covered
- Outer ring depletes with the session
- Countdown digits tick downward
- WORK and BREAK tabs pulse

### Files
- `submissions/examples/pomodoro-break-timer-ij/demo.html`
- `submissions/examples/pomodoro-break-timer-ij/style.css`
- `submissions/examples/pomodoro-break-timer-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the ring deplete.