### PR TITLE
Add ease-weather-forecast-carousel component

### DIFF
--- a/submissions/examples/weather-forecast-carousel-ij/README.md
+++ b/submissions/examples/weather-forecast-carousel-ij/README.md
@@ -1,0 +1,10 @@
+# ease-weather-forecast-carousel
+
+A forecast strip where the highlight slides across five day cards while the sun and rain icons bob above each temperature.
+
+## Run
+Open `demo.html` directly in a browser to watch the highlight travel.
+
+## Notes
+- The highlight travels card to card.
+- Forecast icons bob in place.

--- a/submissions/examples/weather-forecast-carousel-ij/demo.html
+++ b/submissions/examples/weather-forecast-carousel-ij/demo.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-weather-forecast-carousel demo</title>
+</head>
+<body>
+<div class="wf-app">
+  <span class="wf-title">5 DAY FORECAST</span>
+  <div class="wf-strip">
+    <div class="wf-card wf-card-1">
+      <span class="wf-day">MON</span>
+      <span class="wf-icon">&#9728;</span>
+      <span class="wf-hi">31&#176;</span>
+      <span class="wf-lo">22&#176;</span>
+    </div>
+    <div class="wf-card wf-card-2">
+      <span class="wf-day">TUE</span>
+      <span class="wf-icon">&#9729;</span>
+      <span class="wf-hi">27&#176;</span>
+      <span class="wf-lo">19&#176;</span>
+    </div>
+    <div class="wf-card wf-card-3">
+      <span class="wf-day">WED</span>
+      <span class="wf-icon">&#9730;</span>
+      <span class="wf-hi">24&#176;</span>
+      <span class="wf-lo">17&#176;</span>
+    </div>
+    <div class="wf-card wf-card-4">
+      <span class="wf-day">THU</span>
+      <span class="wf-icon">&#9728;</span>
+      <span class="wf-hi">29&#176;</span>
+      <span class="wf-lo">21&#176;</span>
+    </div>
+    <div class="wf-card wf-card-5">
+      <span class="wf-day">FRI</span>
+      <span class="wf-icon">&#9748;</span>
+      <span class="wf-hi">22&#176;</span>
+      <span class="wf-lo">15&#176;</span>
+    </div>
+    <span class="wf-glide"></span>
+  </div>
+  <div class="wf-dots">
+    <span class="wf-dot wf-dot-1"></span>
+    <span class="wf-dot wf-dot-2"></span>
+    <span class="wf-dot wf-dot-3"></span>
+    <span class="wf-dot wf-dot-4"></span>
+    <span class="wf-dot wf-dot-5"></span>
+  </div>
+  <span class="wf-updated">UPDATED 06:00</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/weather-forecast-carousel-ij/style.css
+++ b/submissions/examples/weather-forecast-carousel-ij/style.css
@@ -1,0 +1,18 @@
+:root{--wf-sky:#7cc7ff;--wf-dark:#071830}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#0e2a4a,#071830);font-family:'Segoe UI',sans-serif}
+.wf-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#0b2440,#051226);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.wf-title{position:absolute;top:16px;left:0;right:0;text-align:center;font-size:12px;font-weight:800;letter-spacing:6px;color:#7cc7ff}
+.wf-strip{position:absolute;top:58px;left:22px;right:22px;height:196px;display:flex;gap:10px;overflow:hidden}
+.wf-card{position:relative;flex:1;border-radius:12px;background:#0a2140;box-shadow:inset 0 0 0 2px #12365e;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:6px}
+.wf-glide{position:absolute;top:8px;bottom:8px;left:6px;width:62px;border-radius:10px;background:rgba(124,199,255,0.14);box-shadow:inset 0 0 0 2px #7cc7ff;animation:glide-slide-weather-forecast-carousel 6s ease-in-out infinite}
+.wf-day{font-size:11px;font-weight:800;color:#a8d2f2;letter-spacing:1px}
+.wf-icon{font-size:26px;animation:icon-bob-weather-forecast-carousel 2.2s ease-in-out infinite}
+.wf-hi{font-size:20px;font-weight:900;color:#ffffff}
+.wf-lo{font-size:12px;font-weight:700;color:#6b96bd}
+.wf-dots{position:absolute;top:278px;left:0;right:0;display:flex;justify-content:center;gap:8px}
+.wf-dot{width:8px;height:8px;border-radius:50%;background:#1a3d63}
+.wf-dot-1{animation:dot-pulse-weather-forecast-carousel 6s ease-in-out infinite}
+.wf-updated{position:absolute;bottom:16px;left:0;right:0;text-align:center;font-size:10px;font-weight:700;letter-spacing:3px;color:#4f7ea6}
+@keyframes glide-slide-weather-forecast-carousel{0%{transform:translateX(0)}18%{transform:translateX(72px)}38%{transform:translateX(144px)}56%{transform:translateX(216px)}74%{transform:translateX(288px)}100%{transform:translateX(0)}}
+@keyframes icon-bob-weather-forecast-carousel{0%,100%{transform:translateY(0)}50%{transform:translateY(-6px)}}
+@keyframes dot-pulse-weather-forecast-carousel{0%,18%{background:#7cc7ff;transform:scale(1.3)}100%{background:#1a3d63;transform:scale(1)}}


### PR DESCRIPTION
## Component: ease-weather-forecast-carousel — cards slide, highlight travels, and icons bob

**Closes #63744**

### What this adds
A forecast strip: five day cards sit in a row, a highlight slides across the active card, and the sun and rain icons bob above each temperature.

### Acceptance Criteria covered
- Highlight slides across day cards
- Weather icons bob over each card
- High and low temps alternate rows

### Files
- `submissions/examples/weather-forecast-carousel-ij/demo.html`
- `submissions/examples/weather-forecast-carousel-ij/style.css`
- `submissions/examples/weather-forecast-carousel-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the highlight travel.