### PR TITLE
Add ease-music-equalizer-bars component

### DIFF
--- a/submissions/examples/music-equalizer-bars-ij/README.md
+++ b/submissions/examples/music-equalizer-bars-ij/README.md
@@ -1,0 +1,10 @@
+# ease-music-equalizer-bars
+
+A studio equalizer whose eight bars dance at different rates while the level meter peaks and the frequency labels glow.
+
+## Run
+Open `demo.html` directly in a browser to watch the bars dance.
+
+## Notes
+- Each bar has its own beat.
+- The level readout blinks.

--- a/submissions/examples/music-equalizer-bars-ij/demo.html
+++ b/submissions/examples/music-equalizer-bars-ij/demo.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-music-equalizer-bars demo</title>
+</head>
+<body>
+<div class="mq-app">
+  <span class="mq-brand">EQ STUDIO</span>
+  <div class="mq-bars">
+    <span class="mq-bar mq-bar-1"></span>
+    <span class="mq-bar mq-bar-2"></span>
+    <span class="mq-bar mq-bar-3"></span>
+    <span class="mq-bar mq-bar-4"></span>
+    <span class="mq-bar mq-bar-5"></span>
+    <span class="mq-bar mq-bar-6"></span>
+    <span class="mq-bar mq-bar-7"></span>
+    <span class="mq-bar mq-bar-8"></span>
+  </div>
+  <div class="mq-freq">
+    <span class="mq-f">60</span>
+    <span class="mq-f">250</span>
+    <span class="mq-f">1K</span>
+    <span class="mq-f">4K</span>
+    <span class="mq-f">16K</span>
+  </div>
+  <span class="mq-level">LEVEL -12 dB</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/music-equalizer-bars-ij/style.css
+++ b/submissions/examples/music-equalizer-bars-ij/style.css
@@ -1,0 +1,20 @@
+:root{--mq-cyan:#4dd0ff;--mq-dark:#0a0e1c}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#131a35,#080b18);font-family:'Segoe UI',sans-serif}
+.mq-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#0f1630,#060915);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.mq-brand{position:absolute;top:16px;left:0;right:0;text-align:center;font-size:12px;font-weight:800;letter-spacing:7px;color:#4dd0ff}
+.mq-bars{position:absolute;top:70px;left:52px;right:52px;height:190px;display:flex;align-items:flex-end;justify-content:space-between}
+.mq-bar{width:22px;border-radius:4px;background:linear-gradient(180deg,#4dd0ff,#7a5cff);transform-origin:bottom;animation-name:bar-bounce-music-equalizer-bars;animation-duration:1.1s;animation-timing-function:ease-in-out;animation-iteration-count:infinite}
+.mq-bar-1{height:62px;animation-delay:0s}
+.mq-bar-2{height:104px;animation-delay:0.14s}
+.mq-bar-3{height:76px;animation-delay:0.28s}
+.mq-bar-4{height:132px;animation-delay:0.42s}
+.mq-bar-5{height:54px;animation-delay:0.56s}
+.mq-bar-6{height:120px;animation-delay:0.7s}
+.mq-bar-7{height:88px;animation-delay:0.84s}
+.mq-bar-8{height:68px;animation-delay:0.98s}
+.mq-freq{position:absolute;top:282px;left:0;right:0;display:flex;justify-content:space-between;padding:0 44px;font-size:10px;font-weight:700;color:#4f6f9c}
+.mq-f{animation:label-glow-music-equalizer-bars 2.2s ease-in-out infinite}
+.mq-level{position:absolute;bottom:16px;left:0;right:0;text-align:center;font-size:11px;font-weight:800;letter-spacing:3px;color:#4dd0ff;animation:level-blink-music-equalizer-bars 1.4s steps(1) infinite}
+@keyframes bar-bounce-music-equalizer-bars{0%,100%{transform:scaleY(0.35)}50%{transform:scaleY(1)}}
+@keyframes label-glow-music-equalizer-bars{0%,100%{opacity:0.45}50%{opacity:1}}
+@keyframes level-blink-music-equalizer-bars{0%,49%{opacity:1}50%,100%{opacity:0.3}}


### PR DESCRIPTION
## Component: ease-music-equalizer-bars — bars dance, levels peak, and freq labels glow

**Closes #63746**

### What this adds
A studio equalizer: eight vertical bars dance at different rates, the level meter peaks, and the frequency labels glow as the music plays.

### Acceptance Criteria covered
- Eight bars dance at different rates
- Level meter peaks on the beat
- Frequency labels glow in turn

### Files
- `submissions/examples/music-equalizer-bars-ij/demo.html`
- `submissions/examples/music-equalizer-bars-ij/style.css`
- `submissions/examples/music-equalizer-bars-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the bars dance.