### PR TITLE
Add ease-snake-game-scoreboard component

### DIFF
--- a/submissions/examples/snake-game-scoreboard-ij/README.md
+++ b/submissions/examples/snake-game-scoreboard-ij/README.md
@@ -1,0 +1,10 @@
+# ease-snake-game-scoreboard
+
+An arcade scoreboard where the snake slithers across the grid, the apple food pulses, and the score panel rolls the running total.
+
+## Run
+Open `demo.html` directly in a browser to watch the snake move.
+
+## Notes
+- The snake loops its path.
+- The food pulses in place.

--- a/submissions/examples/snake-game-scoreboard-ij/demo.html
+++ b/submissions/examples/snake-game-scoreboard-ij/demo.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-snake-game-scoreboard demo</title>
+</head>
+<body>
+<div class="sg-app">
+  <span class="sg-title">SNAKE RUN</span>
+  <div class="sg-hud">
+    <span class="sg-score">SCORE 0240</span>
+    <span class="sg-best">BEST 1200</span>
+    <span class="sg-level">LVL 3</span>
+  </div>
+  <div class="sg-arena">
+    <span class="sg-snake sg-head"></span>
+    <span class="sg-snake sg-body-1"></span>
+    <span class="sg-snake sg-body-2"></span>
+    <span class="sg-snake sg-body-3"></span>
+    <span class="sg-food"></span>
+  </div>
+  <span class="sg-status">READY</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/snake-game-scoreboard-ij/style.css
+++ b/submissions/examples/snake-game-scoreboard-ij/style.css
@@ -1,0 +1,20 @@
+:root{--sg-lime:#b4ff3a;--sg-dark:#07120c}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#0f2419,#07120c);font-family:'Segoe UI',sans-serif}
+.sg-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#0c1e15,#051009);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.sg-title{position:absolute;top:16px;left:0;right:0;text-align:center;font-size:12px;font-weight:800;letter-spacing:7px;color:#b4ff3a}
+.sg-hud{position:absolute;top:48px;left:24px;right:24px;display:flex;justify-content:space-between;border-radius:8px;background:#0a1810;box-shadow:inset 0 0 0 2px #163324;padding:10px 12px}
+.sg-score{font-size:12px;font-weight:800;color:#d8ffb0;animation:score-roll-snake-game-scoreboard 1.6s steps(1) infinite}
+.sg-best{font-size:12px;font-weight:800;color:#5fae42}
+.sg-level{font-size:12px;font-weight:800;color:#b4ff3a}
+.sg-arena{position:absolute;top:104px;left:44px;width:284px;height:212px;border-radius:10px;background:#06140c;box-shadow:inset 0 0 0 3px #163324;overflow:hidden}
+.sg-snake{position:absolute;width:22px;height:22px;border-radius:4px;background:linear-gradient(180deg,#b4ff3a,#5fae42);animation:snake-slither-snake-game-scoreboard 3.2s steps(1) infinite}
+.sg-head{top:52px;left:52px;background:#e4ffb0;box-shadow:0 0 10px rgba(180,255,58,0.8)}
+.sg-body-1{top:82px;left:52px;animation-delay:0.4s}
+.sg-body-2{top:112px;left:52px;animation-delay:0.8s}
+.sg-body-3{top:142px;left:52px;animation-delay:1.2s}
+.sg-food{position:absolute;top:64px;left:196px;width:16px;height:16px;border-radius:50%;background:#ff5d5d;box-shadow:0 0 12px rgba(255,93,93,0.9);animation:food-pulse-snake-game-scoreboard 1.4s ease-in-out infinite}
+.sg-status{position:absolute;bottom:16px;left:0;right:0;text-align:center;font-size:10px;font-weight:800;letter-spacing:4px;color:#5fae42;animation:status-blink-snake-game-scoreboard 1.8s steps(1) infinite}
+@keyframes snake-slither-snake-game-scoreboard{0%,20%{transform:translate(0,0)}40%{transform:translate(0,30px)}60%{transform:translate(-30px,30px)}80%{transform:translate(-30px,0)}100%{transform:translate(0,0)}}
+@keyframes food-pulse-snake-game-scoreboard{0%,100%{transform:scale(1)}50%{transform:scale(1.3)}}
+@keyframes score-roll-snake-game-scoreboard{0%,100%{color:#d8ffb0}50%{color:#ffffff}}
+@keyframes status-blink-snake-game-scoreboard{0%,49%{opacity:1}50%,100%{opacity:0.3}}


### PR DESCRIPTION
## Component: ease-snake-game-scoreboard — snake slithers, food pulses, and score rolls

**Closes #63755**

### What this adds
An arcade scoreboard: the snake slithers across the grid, the apple food pulses, and the score panel rolls the running total beside the level.

### Acceptance Criteria covered
- Snake slithers across the grid
- Apple food pulses in the arena
- Score panel rolls the running total

### Files
- `submissions/examples/snake-game-scoreboard-ij/demo.html`
- `submissions/examples/snake-game-scoreboard-ij/style.css`
- `submissions/examples/snake-game-scoreboard-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the snake move.