### PR TITLE
feat: add optical-align SCSS mixin for icon and text optical centring (#63798)

### DIFF
--- a/submissions/scss/optical-align-ad/README.md
+++ b/submissions/scss/optical-align-ad/README.md
@@ -1,0 +1,46 @@
+# Optical Align mixin
+
+> Issue: [#63798](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/63798)
+
+Compensates for the gap between geometric and optical centring in icons and text.
+
+## Mixins
+
+### `optical-align($shape, $size)`
+
+```scss
+.play-icon { @include optical-align("triangle-right", 1em); }
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `$shape` | `String` | — | Key from `$optical-shapes`. Unknown keys raise a build error listing valid ones. |
+| `$size` | `Number` | `1em` | Size the offset is scaled against. |
+
+Shapes: `triangle-right/left/up/down` · `chevron-right/left` · `circle` · `square` · `diamond` · `plus`
+
+### `optical-text-align($ratio)`
+
+Lifts uppercase or small-caps text that sits low in its line box.
+
+### `optical-icon-button($shape, $size, $icon-size)`
+
+A complete centred icon button — the icon is offset, the button is not.
+
+### `optical-inset($inline, $trim, $side)`
+
+Trims padding on the icon side of a trailing-icon button.
+
+### `optical-align-reset` / `register-optical-shape($name, $x, $y)`
+
+## Why it fits EaseMotion
+
+**These corrections are not subjective.** A play triangle centred by bounding box looks shifted left because its visual mass sits toward the point. Uppercase text sits low because the line box reserves descender space that uppercase glyphs never occupy. Both are consequences of how a bounding box relates to perceived centre of mass — which is why every design system ends up hand-nudging them, usually inconsistently.
+
+Naming the offsets means they are applied the same way everywhere rather than re-derived per component, and a shape change is one keyword rather than a fresh round of eyeballing.
+
+**The offset goes on the icon, not the button.** `optical-icon-button` translates the child while leaving the button geometrically placed. Offsetting the button itself would shift it relative to its neighbours — fixing the icon by breaking the row.
+
+`optical-align-reset` exists for runtime shape swaps: a triangle replaced by a circle would otherwise keep the triangle's shift and look wrong in the opposite direction.
+
+Offsets are fractions of `$size` rather than fixed pixels, so an icon that scales keeps its correction proportional — a 4% shift stays a 4% shift at any size.

--- a/submissions/scss/optical-align-ad/_optical-align.scss
+++ b/submissions/scss/optical-align-ad/_optical-align.scss
@@ -1,0 +1,149 @@
+// ==========================================================================
+// EaseMotion CSS — Optical Align mixin
+// Issue #63798
+// --------------------------------------------------------------------------
+// Geometric centring is not optical centring.
+//
+// A play triangle centred by its bounding box looks shifted left, because
+// its visual mass sits toward the point. Uppercase text in a button sits
+// low, because the line box reserves descender space that uppercase never
+// uses. A circle inside a square looks correct; almost nothing else does.
+//
+// These are not subjective preferences — they are consequences of how the
+// bounding box relates to the perceived centre of mass, and every design
+// system ends up hand-nudging them. This mixin names the offsets so they
+// are applied consistently instead of being re-derived per component.
+// ==========================================================================
+
+@use "sass:map";
+@use "sass:math";
+@use "sass:meta";
+@use "sass:list";
+
+// Offsets as a fraction of the element's size. Positive X shifts right.
+// Values are the conventional corrections used across design systems.
+$optical-shapes: (
+    "triangle-right": (x: 0.08, y: 0),
+    "triangle-left": (x: -0.08, y: 0),
+    "triangle-up": (x: 0, y: -0.06),
+    "triangle-down": (x: 0, y: 0.06),
+    "circle": (x: 0, y: 0),
+    "square": (x: 0, y: 0),
+    "diamond": (x: 0, y: 0),
+    "plus": (x: 0, y: 0),
+    "chevron-right": (x: 0.04, y: 0),
+    "chevron-left": (x: -0.04, y: 0),
+) !default;
+
+// --------------------------------------------------------------------------
+// optical-align
+//
+// @param {String} $shape  Key from $optical-shapes.
+// @param {Number} $size   Element size the offset is scaled against.
+// --------------------------------------------------------------------------
+@mixin optical-align($shape, $size: 1em) {
+    @if not map.has-key($optical-shapes, $shape) {
+        @error "optical-align(): unknown shape `#{$shape}`. Known: "
+             + "#{list.join((), map.keys($optical-shapes), $separator: comma)}.";
+    }
+
+    $offset: map.get($optical-shapes, $shape);
+    $x: map.get($offset, x);
+    $y: map.get($offset, y);
+
+    @if $x != 0 or $y != 0 {
+        transform: translate(#{$x * $size}, #{$y * $size});
+    }
+}
+
+// --------------------------------------------------------------------------
+// optical-text-align
+//
+// Uppercase and small-caps text sits low in its line box, because the box
+// reserves descender space that uppercase glyphs never occupy. Nudging up
+// by a fraction of the cap-height difference restores optical centring.
+//
+// @param {Number} $ratio  Fraction of font-size to lift. 0.05 suits most
+//                         humanist sans faces; raise it for tall x-height.
+// --------------------------------------------------------------------------
+@mixin optical-text-align($ratio: 0.05) {
+    @if meta.type-of($ratio) != "number" {
+        @error "optical-text-align(): $ratio must be a number, got `#{$ratio}`.";
+    }
+
+    // `em` keeps the lift proportional if the button's font-size changes.
+    transform: translateY(-#{$ratio}em);
+}
+
+// --------------------------------------------------------------------------
+// optical-icon-button
+//
+// A complete centred icon button. The icon is offset optically while the
+// button itself stays geometrically placed, so surrounding layout is
+// unaffected — applying the offset to the button would misalign it
+// against its neighbours.
+// --------------------------------------------------------------------------
+@mixin optical-icon-button($shape: "circle", $size: 40px, $icon-size: 1em) {
+    align-items: center;
+    display: inline-flex;
+    height: $size;
+    justify-content: center;
+    width: $size;
+
+    > * {
+        @include optical-align($shape, $icon-size);
+
+        flex: 0 0 auto;
+    }
+}
+
+// --------------------------------------------------------------------------
+// optical-inset
+//
+// Trailing-icon buttons need less padding on the icon side: an arrow
+// glyph carries built-in side bearing, so equal padding reads as too much
+// space after the icon.
+//
+// @param {Number} $inline  Base inline padding.
+// @param {Number} $trim    Fraction of it to remove on the icon side.
+// @param {String} $side    `end` (default) or `start`.
+// --------------------------------------------------------------------------
+@mixin optical-inset($inline: 1rem, $trim: 0.25, $side: end) {
+    @if $side != end and $side != start {
+        @error "optical-inset(): $side must be `end` or `start`, got `#{$side}`.";
+    }
+
+    padding-inline: $inline;
+
+    @if $side == end {
+        padding-inline-end: $inline * (1 - $trim);
+    } @else {
+        padding-inline-start: $inline * (1 - $trim);
+    }
+}
+
+// --------------------------------------------------------------------------
+// optical-align-reset
+//
+// Removes an inherited optical offset. Needed when a shape is swapped at
+// runtime — a triangle replaced by a circle would otherwise keep the
+// triangle's shift.
+// --------------------------------------------------------------------------
+@mixin optical-align-reset {
+    transform: none;
+}
+
+// --------------------------------------------------------------------------
+// register-optical-shape
+//
+// Add a project-specific shape offset. Refuses to overwrite an existing
+// key rather than silently changing every existing call site.
+// --------------------------------------------------------------------------
+@mixin register-optical-shape($name, $x: 0, $y: 0) {
+    @if map.has-key($optical-shapes, $name) {
+        @error "register-optical-shape(): `#{$name}` already exists. "
+             + "Pick a different name.";
+    }
+
+    $optical-shapes: map.set($optical-shapes, $name, (x: $x, y: $y)) !global;
+}


### PR DESCRIPTION
Fixes #63798

**What was added**

Optical centring helpers, under `submissions/scss/optical-align-ad/`.

- `_optical-align.scss` — a 10-shape offset map, `optical-align()`, `optical-text-align()`, `optical-icon-button()`, `optical-inset()`, `optical-align-reset()` and `register-optical-shape()`.
- `README.md` — parameter tables, shape list, and rationale.

**What is the problem**

Geometric centring is not optical centring, and the difference is not subjective. A play triangle centred by bounding box looks shifted left, because its visual mass sits toward the point. Uppercase text in a button sits low, because the line box reserves descender space that uppercase glyphs never occupy.

Every design system ends up hand-nudging these — usually inconsistently, with a different magic value per component, and no record of why the number is what it is.

**Why this approach**

Naming the offsets means they are applied identically everywhere rather than re-derived per component, and swapping a shape becomes one keyword instead of a fresh round of eyeballing.

**The offset is applied to the icon, not the button.** `optical-icon-button` translates the child while leaving the button geometrically placed. Offsetting the button itself would shift it relative to its neighbours — fixing the icon by breaking the row.

Offsets are fractions of `$size` rather than fixed pixels, so a scaled icon keeps its correction proportional.

`optical-align-reset` exists for runtime shape swaps: a triangle replaced by a circle would otherwise retain the triangle's shift and look wrong in the opposite direction.

**How to test**

1. Pull this branch and compile:
   ```scss
   @use "submissions/scss/optical-align-ad/optical-align" as oa;
   .play  { @include oa.optical-align("triangle-right", 1em); }
   .circ  { @include oa.optical-align("circle"); }
   .caps  { @include oa.optical-text-align; }
   .btn   { @include oa.optical-icon-button("triangle-right", 40px); }
   .trail { @include oa.optical-inset(1rem, 0.25, end); }
   ```
2. Confirm `.play` emits `transform: translate(0.08em, 0em)`.
3. **Confirm `.circ` emits nothing at all** — a circle needs no correction, and the zero-offset guard should skip the declaration rather than emitting a no-op `translate(0, 0)`.
4. Confirm `.caps` emits `translateY(-0.05em)`.
5. Confirm `.btn` applies the offset to `> *`, not to `.btn` itself.
6. Confirm `.trail` emits `padding-inline: 1rem` followed by `padding-inline-end: 0.75rem`.
7. In a browser, put a play triangle in a circular button and toggle the mixin — the icon should look centred with it, and left-heavy without.
8. Pass an unknown shape and confirm a build error listing valid shapes.

**Edge cases covered**

- Zero-offset shapes emit no `transform` at all, so a circle does not get a pointless declaration that would override an existing transform.
- Unknown shapes raise a build error listing every valid key.
- Non-numeric `$ratio` raises a build error.
- Offsets scale with `$size`, staying proportional at any icon size.
- The offset targets the icon child, so button placement in a row is unaffected.
- `optical-inset` validates `$side` rather than silently emitting neither branch.
- `optical-inset` uses logical `padding-inline`, so it mirrors correctly in RTL.
- `register-optical-shape` refuses to overwrite an existing key, which would silently change every existing call site.
- `optical-align-reset` allows a runtime shape swap to clear a stale offset.

**Verification**

- Compiled with the repo's own `sass` dependency; every emitted value verified, including the zero-offset skip.
- Zero deprecation warnings.
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 2 new files, 0 deletions, no existing file touched.
- Folder carries an `-ad` suffix so this lands as a parallel implementation.

**Labels:** `type:feature` · `scss` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
