### PR TITLE
feat: add text-balance SCSS mixin with supports-scoped fallback (#63799)

### DIFF
--- a/submissions/scss/text-balance-ad/README.md
+++ b/submissions/scss/text-balance-ad/README.md
@@ -1,0 +1,42 @@
+# Text Balance mixin
+
+> Issue: [#63799](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/63799)
+
+Headline wrapping that avoids orphaned words, with a real fallback and the right tool per text type.
+
+## Mixins
+
+### `text-balance($measure, $center)` — for headings
+
+```scss
+.hero__title { @include text-balance(34ch, $center: true); }
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `$measure` | `Number` | `34ch` | Fallback max-width where `balance` is unsupported. |
+| `$center` | `Bool` | `false` | Centre the block within its parent. |
+
+### `text-pretty($measure)` — for body copy
+
+### `text-clamp-lines($lines)` — hard line cap for card titles
+
+### `text-no-orphan` — last-resort, markup-dependent
+
+### `text-balance-headings($levels)` — apply across a heading scale
+
+## Configuration
+
+```scss
+@use "text-balance" with ($text-balance-measure: 30ch);
+```
+
+## Why it fits EaseMotion
+
+**`text-wrap: balance` is a headings-only tool, and that is not a style preference.** Browsers cap it at a small line count — four in Chromium at time of writing — because the algorithm is expensive. Applied to body copy it is silently ignored past that cap, which looks like a browser bug rather than a documented limit. `text-balance-headings` therefore deliberately does **not** touch `p`.
+
+`text-wrap: pretty` is the correct choice for long text: it targets orphans and ragged edges without the line-count cap, at far lower cost. Offering both, clearly separated, is the point of the module.
+
+**The fallback is ordered deliberately.** `max-width` is declared first and then released to `none` inside `@supports (text-wrap: balance)`. Where balance works, the measure would fight it — an artificially narrow column forces breaks the algorithm was trying to avoid. Where it does not, a bounded `ch` measure at least prevents a full-width headline dropping one word onto its own line, which is the exact ugliness balance exists to fix.
+
+`text-no-orphan` is included because it is the only technique that works everywhere, but its markup dependency is documented rather than hidden — it needs a span around the final two words, so it is a fallback rather than a default.

--- a/submissions/scss/text-balance-ad/_text-balance.scss
+++ b/submissions/scss/text-balance-ad/_text-balance.scss
@@ -1,0 +1,109 @@
+// ==========================================================================
+// EaseMotion CSS — Text Balance mixin
+// Issue #63799
+// --------------------------------------------------------------------------
+// Headline wrapping that avoids orphans, with a real fallback.
+//
+// `text-wrap: balance` is the right tool and carries a hard constraint:
+// browsers cap it at a small line count (four in Chromium at time of
+// writing) because the algorithm is expensive. Applying it to body copy
+// is silently ignored past that cap — so it is a HEADING tool, and using
+// it on a paragraph is a no-op that looks like a browser bug.
+//
+// The fallback matters too. Where `balance` is unsupported, a `max-width`
+// in `ch` at least prevents a full-width headline dropping one word onto
+// its own line — the specific ugliness `balance` exists to fix.
+//
+// `text-wrap: pretty` is the correct choice for body copy: it targets
+// orphans and rags without the line-count cap, at much lower cost.
+// ==========================================================================
+
+@use "sass:meta";
+
+$text-balance-measure: 34ch !default;
+$text-balance-body-measure: 68ch !default;
+
+// --------------------------------------------------------------------------
+// text-balance
+//
+// For headings. Falls back to a `ch` measure where `balance` is absent.
+//
+// @param {Number} $measure  Fallback max-width, in ch.
+// @param {Bool}   $center   Centre the block within its parent.
+// --------------------------------------------------------------------------
+@mixin text-balance($measure: $text-balance-measure, $center: false) {
+    // Fallback first — a bounded measure is better than nothing and is
+    // harmless where `balance` is supported.
+    max-width: $measure;
+
+    @if $center {
+        margin-inline: auto;
+    }
+
+    @supports (text-wrap: balance) {
+        max-width: none;
+        text-wrap: balance;
+    }
+}
+
+// --------------------------------------------------------------------------
+// text-pretty
+//
+// For body copy. `pretty` has no line-count cap and specifically targets
+// orphans and ragged edges, which is what long text actually needs.
+// --------------------------------------------------------------------------
+@mixin text-pretty($measure: $text-balance-body-measure) {
+    max-width: $measure;
+
+    @supports (text-wrap: pretty) {
+        text-wrap: pretty;
+    }
+}
+
+// --------------------------------------------------------------------------
+// text-no-orphan
+//
+// Last-resort orphan prevention where neither `balance` nor `pretty` is
+// available. Works by making the last two words unbreakable.
+//
+// Note: this requires the markup to wrap those words, e.g.
+//   <h2>A headline that <span class="no-orphan">ends here</span></h2>
+// It is included because it is the only approach that works everywhere,
+// but it is markup-dependent and should be a fallback, not a default.
+// --------------------------------------------------------------------------
+@mixin text-no-orphan {
+    white-space: nowrap;
+}
+
+// --------------------------------------------------------------------------
+// text-clamp-lines
+//
+// Bounded headings that must not exceed N lines regardless of content —
+// for card titles in a fixed grid where a third line would break
+// alignment across the row.
+// --------------------------------------------------------------------------
+@mixin text-clamp-lines($lines: 2) {
+    @if meta.type-of($lines) != "number" or $lines < 1 {
+        @error "text-clamp-lines(): $lines must be a positive number, got `#{$lines}`.";
+    }
+
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: $lines;
+    overflow: hidden;
+}
+
+// --------------------------------------------------------------------------
+// text-balance-headings
+//
+// Apply balance across a heading scale in one call. Deliberately does not
+// touch `p` — `balance` is capped at a few lines and would be ignored
+// there, giving the false impression it had been applied.
+// --------------------------------------------------------------------------
+@mixin text-balance-headings($levels: (h1, h2, h3, h4)) {
+    @each $level in $levels {
+        #{$level} {
+            @include text-balance;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #63799

**What was added**

Headline wrapping helpers, under `submissions/scss/text-balance-ad/`.

- `_text-balance.scss` — `text-balance()`, `text-pretty()`, `text-clamp-lines()`, `text-no-orphan()` and `text-balance-headings()`.
- `README.md` — parameter tables, usage, and rationale.

**What is the problem**

A full-width headline that drops one word onto its own line looks broken. `text-wrap: balance` fixes it — but it carries a constraint that is easy to trip over.

**`balance` is capped at a small line count** (four in Chromium at time of writing) because the algorithm is expensive. Applied to body copy it is silently ignored past that cap. Nothing errors, nothing warns; it simply does not work, which reads as a browser bug rather than a documented limit.

**Why this approach**

The module separates the two tools explicitly. `text-balance` is for headings; `text-pretty` is for body copy, where it targets orphans and ragged edges without the line-count cap and at far lower cost. `text-balance-headings` deliberately does **not** touch `p`, so it cannot give the false impression balance was applied to paragraphs.

**The fallback ordering is deliberate.** `max-width` is declared first, then released to `none` inside `@supports (text-wrap: balance)`. Where balance works, keeping the measure would actively fight it — an artificially narrow column forces the very breaks the algorithm is trying to avoid. Where balance is absent, a bounded `ch` measure at least prevents the single-orphan case.

`text-no-orphan` is included because it is the only technique that works everywhere, but its markup dependency is documented rather than buried — it needs a span around the final two words, so it is a fallback and not a default.

**How to test**

1. Pull this branch and compile:
   ```scss
   @use "submissions/scss/text-balance-ad/text-balance" as tb;
   .title { @include tb.text-balance(34ch, $center: true); }
   .body  { @include tb.text-pretty; }
   .card  { @include tb.text-clamp-lines(2); }
   @include tb.text-balance-headings((h1, h2));
   ```
2. Confirm `.title` emits `max-width: 34ch` outside the `@supports` block and `max-width: none` **inside** it — the release is what stops the measure fighting balance.
3. Confirm `.body` keeps its measure and only adds `text-wrap: pretty` inside `@supports`.
4. **Confirm no `p` selector is emitted** by `text-balance-headings` — grep the output; it should be zero.
5. In Chrome, put a headline that would orphan its last word in `.title` and confirm the break moves.
6. In a browser without `text-wrap: balance`, confirm the `34ch` measure still prevents the orphan.
7. Pass `text-clamp-lines(0)` and confirm a build error.

**Edge cases covered**

- `max-width` is released inside `@supports`, so the fallback cannot fight the real algorithm.
- The fallback is declared first, so unsupporting engines still get a bounded measure.
- `balance` and `pretty` are separated by intended use, matching the line-count cap.
- `text-balance-headings` never targets `p`, where balance would be silently ignored.
- `$center` is opt-in, so the mixin does not impose `margin-inline: auto` on left-aligned headings.
- `text-clamp-lines` validates `$lines` as a positive number.
- `text-no-orphan`'s markup dependency is documented rather than implied.
- Both measures are `!default`, so a project can set its own typographic measure globally.

**Verification**

- Compiled with the repo's own `sass` dependency; the `@supports` release verified, and the absence of any `p` selector confirmed by grep.
- Zero deprecation warnings.
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 2 new files, 0 deletions, no existing file touched.
- Folder carries an `-ad` suffix so this lands as a parallel implementation.

**Labels:** `type:feature` · `scss` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
