### PR TITLE
feat: add backdrop-layer SCSS mixin with legible fallback (#63804)

### DIFF
--- a/submissions/scss/backdrop-layer-ad/README.md
+++ b/submissions/scss/backdrop-layer-ad/README.md
@@ -1,0 +1,47 @@
+# Backdrop Layer mixin
+
+> Issue: [#63804](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/63804)
+
+Frosted surfaces and scrims with a fallback that stays legible when `backdrop-filter` is unavailable.
+
+## Mixins
+
+### `backdrop-layer($surface, $blur, $solid, $blurred, $saturate)`
+
+```scss
+.panel { @include backdrop-layer; }
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `$surface` | `Color` | `#0b1120` | Base colour. |
+| `$blur` | `Number` | `12px` | Blur radius. |
+| `$solid` | `Number` | `0.92` | Fallback alpha. Must be ≥ `$blurred`. |
+| `$blurred` | `Number` | `0.62` | Alpha once blur is confirmed. |
+| `$saturate` | `Number` | `160%` | Saturation boost. |
+
+### `backdrop-scrim($surface, $blur, $solid, $blurred)`
+
+Full-viewport scrim behind a dialog, with a `forced-colors` fallback.
+
+### `backdrop-edge($surface, $blur, $side)`
+
+Sticky header/footer with the blur masked out at its inner edge.
+
+### `backdrop-perf-hint`
+
+Containment and compositing hints for frosted surfaces that move.
+
+## Why it fits EaseMotion
+
+**This is a legibility bug, not a cosmetic one.** The common pattern is a 40%-opaque background plus a blur. Where `backdrop-filter` is unsupported you are left with just the 40% scrim over whatever was behind it — and on a busy photo or a dense table, modal text becomes genuinely unreadable. The blur was doing the work, and the alpha alone cannot.
+
+So the ordering is inverted from the usual: the **fallback is the opaque one** (`0.92`), legible with no blur at all, and the alpha is *reduced* to `0.62` only inside `@supports`, once the blur is confirmed to be carrying part of the load. A build error fires if `$solid` is set below `$blurred`, since that inverts the safety property the whole mixin depends on.
+
+`saturate(160%)` accompanies the blur because heavy blurring desaturates — without it, colourful content behind a frosted panel goes flat and grey.
+
+**`backdrop-edge` masks the blur at its inner edge.** A sticky header with a hard blur boundary reads as a pasted-on rectangle; fading it out removes the seam. The mask is gated on `@supports` for both `backdrop-filter` and `mask-image`, since a mask without a blur would just fade the header itself away.
+
+`backdrop-perf-hint` exists because `backdrop-filter` is one of the most expensive things in CSS — it promotes the element to its own compositing layer and re-samples everything behind it every frame. The hint is documented as being for surfaces that *move*; on a static panel the extra layer is pure overhead, and `will-change` is dropped under `prefers-reduced-motion` where the animation will not run anyway.
+
+`backdrop-scrim` restores an opaque `Canvas` background under `forced-colors: active`, where both the alpha and the filter are discarded and the scrim would otherwise vanish, leaving the dialog floating over live content.

--- a/submissions/scss/backdrop-layer-ad/_backdrop-layer.scss
+++ b/submissions/scss/backdrop-layer-ad/_backdrop-layer.scss
@@ -1,0 +1,151 @@
+// ==========================================================================
+// EaseMotion CSS — Backdrop Layer mixin
+// Issue #63804
+// --------------------------------------------------------------------------
+// Scrims and frosted surfaces with a fallback that actually works.
+//
+// The failure this prevents is a legibility one, not a cosmetic one. The
+// common pattern is:
+//
+//   background: rgba(15, 23, 42, 0.4);
+//   backdrop-filter: blur(12px);
+//
+// Where `backdrop-filter` is unsupported you are left with a 40%-opaque
+// scrim over whatever was behind it. On a busy photo or a dense table,
+// modal text becomes genuinely unreadable — the blur was doing the work,
+// and the alpha alone cannot.
+//
+// The fix is to make the FALLBACK opaque enough to stand alone, then
+// reduce the alpha only inside `@supports`, once the blur is confirmed to
+// be carrying part of the load.
+// ==========================================================================
+
+@use "sass:color";
+@use "sass:meta";
+
+$backdrop-surface: #0b1120 !default;
+$backdrop-blur: 12px !default;
+
+// Alpha used when blur is unavailable — high enough to be readable alone.
+$backdrop-alpha-solid: 0.92 !default;
+
+// Alpha used once blur is confirmed — the blur carries the rest.
+$backdrop-alpha-blurred: 0.62 !default;
+
+// --------------------------------------------------------------------------
+// backdrop-layer
+//
+// @param {Color}  $surface  Base colour.
+// @param {Number} $blur     Blur radius.
+// @param {Number} $solid    Fallback alpha.
+// @param {Number} $blurred  Alpha applied once blur is supported.
+// @param {Number} $saturate Saturation boost, which keeps colour behind a
+//                           heavy blur from going flat and grey.
+// --------------------------------------------------------------------------
+@mixin backdrop-layer(
+    $surface: $backdrop-surface,
+    $blur: $backdrop-blur,
+    $solid: $backdrop-alpha-solid,
+    $blurred: $backdrop-alpha-blurred,
+    $saturate: 160%
+) {
+    @if meta.type-of($surface) != "color" {
+        @error "backdrop-layer(): $surface must be a color, got `#{$surface}`.";
+    }
+
+    @if $solid < $blurred {
+        @error "backdrop-layer(): $solid (#{$solid}) must be >= $blurred "
+             + "(#{$blurred}) — the fallback has to be MORE opaque, since "
+             + "it carries legibility on its own without the blur.";
+    }
+
+    // Opaque fallback first. Legible with no blur at all.
+    background-color: color.change($surface, $alpha: $solid);
+
+    @supports (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px)) {
+        -webkit-backdrop-filter: blur($blur) saturate($saturate);
+        backdrop-filter: blur($blur) saturate($saturate);
+        background-color: color.change($surface, $alpha: $blurred);
+    }
+}
+
+// --------------------------------------------------------------------------
+// backdrop-scrim
+//
+// Full-viewport scrim behind a dialog. Kept separate because a scrim is
+// about obscuring content, not about being a surface itself.
+// --------------------------------------------------------------------------
+@mixin backdrop-scrim(
+    $surface: #030712,
+    $blur: 6px,
+    $solid: 0.78,
+    $blurred: 0.6
+) {
+    background-color: color.change($surface, $alpha: $solid);
+    inset: 0;
+    position: fixed;
+
+    @supports (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px)) {
+        -webkit-backdrop-filter: blur($blur);
+        backdrop-filter: blur($blur);
+        background-color: color.change($surface, $alpha: $blurred);
+    }
+
+    // Forced colors discards both the alpha and the filter, so the scrim
+    // would vanish and leave the dialog floating over live content.
+    @media (forced-colors: active) {
+        background-color: Canvas;
+    }
+}
+
+// --------------------------------------------------------------------------
+// backdrop-edge
+//
+// A sticky header or footer over scrolling content. The mask fades the
+// blur out at the inner edge, so there is no hard line where the frosted
+// region stops — that hard line is what makes naive sticky headers look
+// like a pasted-on rectangle.
+// --------------------------------------------------------------------------
+@mixin backdrop-edge($surface: $backdrop-surface, $blur: 10px, $side: top) {
+    @if $side != top and $side != bottom {
+        @error "backdrop-edge(): $side must be `top` or `bottom`, got `#{$side}`.";
+    }
+
+    background-color: color.change($surface, $alpha: 0.9);
+
+    @supports (backdrop-filter: blur(1px)) and (mask-image: linear-gradient(#000, #000)) {
+        $direction: to bottom;
+
+        @if $side == bottom {
+            $direction: to top;
+        }
+
+        -webkit-backdrop-filter: blur($blur);
+        backdrop-filter: blur($blur);
+        background-color: color.change($surface, $alpha: 0.55);
+        -webkit-mask-image: linear-gradient($direction, #000 65%, transparent);
+        mask-image: linear-gradient($direction, #000 65%, transparent);
+    }
+}
+
+// --------------------------------------------------------------------------
+// backdrop-perf-hint
+//
+// `backdrop-filter` promotes an element to its own compositing layer and
+// re-samples everything behind it every frame. Applied to a scrolling or
+// animating element it is one of the most expensive things in CSS.
+//
+// This limits the cost by confining what the browser must re-evaluate.
+// Use it on frosted surfaces that move; skip it on static ones, where the
+// extra layer is pure overhead.
+// --------------------------------------------------------------------------
+@mixin backdrop-perf-hint {
+    contain: paint;
+    will-change: backdrop-filter;
+
+    // will-change on a permanently-hinted element wastes memory, so it is
+    // dropped for users who will not see the animation anyway.
+    @media (prefers-reduced-motion: reduce) {
+        will-change: auto;
+    }
+}


### PR DESCRIPTION
Fixes #63804

**What was added**

Frosted-surface and scrim mixins, under `submissions/scss/backdrop-layer-ad/`.

- `_backdrop-layer.scss` — `backdrop-layer()`, `backdrop-scrim()`, `backdrop-edge()` and `backdrop-perf-hint()`, with argument validation.
- `README.md` — parameter tables, usage, and rationale.

**What is the problem**

This is a **legibility** bug, not a cosmetic one. The common pattern is:

```css
background: rgba(15, 23, 42, 0.4);
backdrop-filter: blur(12px);
```

Where `backdrop-filter` is unsupported, you are left with a 40%-opaque scrim over whatever was behind it. On a busy photo or a dense table, modal text becomes **genuinely unreadable** — the blur was doing the work, and the alpha alone cannot carry it. Nothing errors; the modal just becomes illegible for a subset of users.

**Why this approach**

The ordering is inverted from the usual fallback pattern. The **fallback is the opaque one** (`0.92`), legible with no blur at all, and the alpha is *reduced* to `0.62` only inside `@supports` — once the blur is confirmed to be carrying part of the load.

A build error fires if `$solid` is set below `$blurred`, because that inverts the exact safety property the mixin exists to guarantee. Getting those two backwards produces something that looks fine in a modern browser and is unreadable elsewhere, so it fails loudly instead.

`saturate(160%)` accompanies the blur because heavy blurring desaturates — without it, colourful content behind a frosted panel goes flat and grey.

`backdrop-edge` masks the blur at its inner edge: a sticky header with a hard blur boundary reads as a pasted-on rectangle. The mask is gated on `@supports` for **both** `backdrop-filter` and `mask-image`, since a mask applied without a blur would simply fade the header itself away.

`backdrop-perf-hint` is documented as being for surfaces that *move*. `backdrop-filter` promotes the element to its own compositing layer and re-samples everything behind it every frame — on a static panel the extra layer is pure overhead, so the hint is opt-in rather than baked in.

**How to test**

1. Pull this branch and compile:
   ```scss
   @use "submissions/scss/backdrop-layer-ad/backdrop-layer" as bl;
   .panel { @include bl.backdrop-layer; }
   .scrim { @include bl.backdrop-scrim; }
   .hdr   { @include bl.backdrop-edge(#0b1120, 10px, top); }
   ```
2. Confirm `.panel` emits `rgba(11, 17, 32, 0.92)` **outside** the `@supports` block and `0.62` **inside** it — the fallback must be the more opaque of the two.
3. **The decisive test:** put `.panel` over a busy photograph, then disable `backdrop-filter` in DevTools. The panel's text must remain readable. With the conventional pattern it will not be.
4. Confirm `.hdr`'s mask sits inside a `@supports` requiring both `backdrop-filter` and `mask-image`.
5. Confirm `.scrim` restores an opaque `Canvas` background under `forced-colors: active`.
6. Invert the alphas and confirm the build fails:
   ```scss
   @include bl.backdrop-layer($solid: 0.3, $blurred: 0.8);
   ```
7. Pass a non-colour `$surface` and confirm a build error.

**Edge cases covered**

- The fallback is the opaque variant, so legibility never depends on blur support.
- Inverted alphas raise a build error explaining why the ordering matters.
- Non-colour `$surface` raises a build error.
- `saturate()` prevents heavy blur washing colour out to grey.
- `backdrop-edge` gates its mask on both required features, so a mask cannot apply without its blur.
- `backdrop-edge` validates `$side` rather than emitting neither branch.
- `backdrop-scrim` survives `forced-colors: active`, where alpha and filter are both discarded.
- `-webkit-` prefixes are emitted alongside standard properties for Safari.
- `backdrop-perf-hint` drops `will-change` under reduced motion, where the memory cost buys nothing.
- Every alpha token is `!default`, so a project can tune the pair globally while keeping the ordering guarantee.

**Verification**

- Compiled with the repo's own `sass` dependency; the alpha inversion across the `@supports` boundary verified in output.
- Guard verified to fail the build with the intended message.
- Zero deprecation warnings.
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 2 new files, 0 deletions, no existing file touched.
- Folder carries an `-ad` suffix so this lands as a parallel implementation.

**Labels:** `type:feature` · `scss` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
