### PR TITLE
feat: add rtl-logical SCSS mixin with direction-neutral escape hatch (#63805)

### DIFF
--- a/submissions/scss/rtl-logical-ad/README.md
+++ b/submissions/scss/rtl-logical-ad/README.md
@@ -1,0 +1,42 @@
+# RTL Logical mixin
+
+> Issue: [#63805](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/63805)
+
+Logical properties with physical fallbacks — and, more importantly, an explicit way to mark what must *not* mirror.
+
+## Mixins
+
+### `logical($property, $value)`
+
+```scss
+.card { @include logical("margin-left", 1rem); }
+// → margin-left: 1rem;
+//   @supports (margin-inline-start: 0) { margin-left: revert; margin-inline-start: 1rem; }
+```
+
+Supported: `margin-left/right` · `padding-left/right` · `border-left/right` · `left` · `right`. Anything else raises a build error.
+
+### `logical-inset($side, $value)` — `start` or `end`
+### `logical-text-align($side)` — `start` or `end`
+### `rtl-preserve` — mark an element direction-neutral
+### `rtl-flip-icon` — mirror a directional icon
+### `rtl-only` / `ltr-only` — direction-scoped `@content` blocks
+
+## Why it fits EaseMotion
+
+**The usual RTL failure is not "nothing flipped" — it is "everything flipped".** A blanket `transform: scaleX(-1)` or a mirrored stylesheet breaks four categories that must stay put:
+
+| Must not mirror | Why |
+|---|---|
+| Media controls | Play still points right in RTL; a mirrored play button reads as rewind. |
+| Progress bars, timelines | Time runs left-to-right regardless of script direction. |
+| Numbers, code, Latin text | Embedded LTR runs have their own direction. |
+| Logos and brand marks | They are images of a fixed thing. |
+
+So the module deliberately splits the two cases: logical properties handle what *should* mirror, `rtl-flip-icon` handles directional icons that should, and `rtl-preserve` explicitly marks what should not.
+
+**`rtl-preserve` sets `unicode-bidi: isolate`, not just `direction: ltr`.** Without isolation, an LTR run inside RTL text reorders the punctuation around it — a code snippet or a number in an Arabic sentence can drag the neighbouring comma or bracket to the wrong side. `direction` alone fixes the element and breaks its surroundings.
+
+**The physical property comes first, then `revert` inside `@supports`.** Emitting only the logical property would leave older engines with no layout at all for that side. Emitting both unconditionally would leave the physical value winning on specificity ties. `revert` inside the feature query cleanly hands over once logical support is confirmed.
+
+`ltr-only` matches `:root:not([dir="rtl"])` as well as an explicit `[dir="ltr"]`, since most LTR documents never set the attribute at all.

--- a/submissions/scss/rtl-logical-ad/_rtl-logical.scss
+++ b/submissions/scss/rtl-logical-ad/_rtl-logical.scss
@@ -1,0 +1,167 @@
+// ==========================================================================
+// EaseMotion CSS — RTL Logical mixin
+// Issue #63805
+// --------------------------------------------------------------------------
+// Logical properties with physical fallbacks, so layouts mirror in RTL
+// without a second stylesheet.
+//
+// The important part is knowing what should NOT be mirrored. The usual
+// RTL failure is not "nothing flipped" — it is "everything flipped",
+// including things that must not:
+//
+//   - Media controls. Play still points right in RTL; a mirrored play
+//     button reads as rewind.
+//   - Progress and timelines that represent time, which runs left-to-
+//     right regardless of script direction.
+//   - Numbers, code, and Latin-script content embedded in RTL text.
+//   - Logos and brand marks.
+//
+// Blanket `transform: scaleX(-1)` RTL hacks break all four. This module
+// provides logical properties for what should mirror and an explicit
+// `rtl-preserve` for what should not.
+// ==========================================================================
+
+@use "sass:map";
+
+// Physical → logical property equivalents.
+$rtl-logical-map: (
+    "margin-left": margin-inline-start,
+    "margin-right": margin-inline-end,
+    "padding-left": padding-inline-start,
+    "padding-right": padding-inline-end,
+    "border-left": border-inline-start,
+    "border-right": border-inline-end,
+    "left": inset-inline-start,
+    "right": inset-inline-end,
+);
+
+// --------------------------------------------------------------------------
+// logical
+//
+// Emit a logical property with a physical fallback for older engines.
+//
+// @param {String} $property  Physical property name.
+// @param {*}      $value
+// --------------------------------------------------------------------------
+@mixin logical($property, $value) {
+    @if not map.has-key($rtl-logical-map, $property) {
+        @error "logical(): no logical equivalent for `#{$property}`. "
+             + "Supported: margin-left/right, padding-left/right, "
+             + "border-left/right, left, right.";
+    }
+
+    $logical-name: map.get($rtl-logical-map, $property);
+
+    // Physical first, so engines without logical support still lay out —
+    // they simply do not mirror, which beats no layout at all.
+    #{$property}: $value;
+
+    @supports (#{$logical-name}: 0) {
+        #{$property}: revert;
+        #{$logical-name}: $value;
+    }
+}
+
+// --------------------------------------------------------------------------
+// rtl-preserve
+//
+// Marks an element as direction-neutral. Applied to media controls,
+// timelines, logos and code — anything whose meaning is tied to physical
+// direction rather than reading order.
+//
+// `direction: ltr` on the element keeps its internal layout unflipped
+// even inside an RTL document.
+// --------------------------------------------------------------------------
+@mixin rtl-preserve {
+    direction: ltr;
+
+    // `unicode-bidi: isolate` stops the element's LTR content from
+    // reordering the RTL text around it — without it, a code snippet or
+    // number in an Arabic sentence can drag neighbouring punctuation to
+    // the wrong side.
+    unicode-bidi: isolate;
+}
+
+// --------------------------------------------------------------------------
+// rtl-only / ltr-only
+//
+// Direction-scoped blocks, matched on the `dir` attribute rather than a
+// class, so they work with the document's real direction.
+// --------------------------------------------------------------------------
+@mixin rtl-only {
+    [dir="rtl"] & {
+        @content;
+    }
+}
+
+@mixin ltr-only {
+    [dir="ltr"] &,
+    :root:not([dir="rtl"]) & {
+        @content;
+    }
+}
+
+// --------------------------------------------------------------------------
+// rtl-flip-icon
+//
+// Mirrors a directional icon — an arrow, a chevron, a back button —
+// which SHOULD flip, unlike the cases `rtl-preserve` covers.
+// --------------------------------------------------------------------------
+@mixin rtl-flip-icon {
+    [dir="rtl"] & {
+        transform: scaleX(-1);
+    }
+}
+
+// --------------------------------------------------------------------------
+// logical-inset
+//
+// Shorthand for positioning an absolutely placed element on the inline
+// start or end edge.
+// --------------------------------------------------------------------------
+@mixin logical-inset($side, $value) {
+    @if $side != start and $side != end {
+        @error "logical-inset(): $side must be `start` or `end`, got `#{$side}`.";
+    }
+
+    @if $side == start {
+        left: $value;
+
+        @supports (inset-inline-start: 0) {
+            left: revert;
+            inset-inline-start: $value;
+        }
+    } @else {
+        right: $value;
+
+        @supports (inset-inline-end: 0) {
+            right: revert;
+            inset-inline-end: $value;
+        }
+    }
+}
+
+// --------------------------------------------------------------------------
+// logical-text-align
+//
+// `start` / `end` rather than `left` / `right`.
+// --------------------------------------------------------------------------
+@mixin logical-text-align($side: start) {
+    @if $side != start and $side != end {
+        @error "logical-text-align(): $side must be `start` or `end`.";
+    }
+
+    text-align: if-ltr-physical($side);
+
+    @supports (text-align: start) {
+        text-align: $side;
+    }
+}
+
+@function if-ltr-physical($side) {
+    @if $side == start {
+        @return left;
+    }
+
+    @return right;
+}


### PR DESCRIPTION
Fixes #63805

**What was added**

Logical-property helpers with RTL escape hatches, under `submissions/scss/rtl-logical-ad/`.

- `_rtl-logical.scss` — `logical()`, `logical-inset()`, `logical-text-align()`, `rtl-preserve()`, `rtl-flip-icon()`, `rtl-only()` and `ltr-only()`.
- `README.md` — mixin reference, a must-not-mirror table, and rationale.

**What is the problem**

**The usual RTL failure is not "nothing flipped" — it is "everything flipped".** A blanket `transform: scaleX(-1)` or a mirrored stylesheet breaks four categories that must stay put:

| Must not mirror | Why |
|---|---|
| Media controls | Play still points right in RTL; a mirrored play button reads as rewind. |
| Progress bars, timelines | Time runs left-to-right regardless of script direction. |
| Numbers, code, embedded Latin text | Those runs have their own direction. |
| Logos and brand marks | They are images of a fixed thing. |

None of these are caught by "does the page mirror?" testing, because the page *does* mirror — that is the bug.

**Why this approach**

The module splits the two cases explicitly rather than treating mirroring as global. Logical properties handle what should flow with reading direction, `rtl-flip-icon` handles directional icons that genuinely should mirror, and `rtl-preserve` marks what must not.

**`rtl-preserve` sets `unicode-bidi: isolate`, not just `direction: ltr`.** Without isolation an LTR run inside RTL text reorders the punctuation *around* it — a code snippet or number in an Arabic sentence drags the neighbouring bracket or comma to the wrong side. `direction` alone fixes the element and breaks its surroundings, which is a subtler bug than the one it solves.

**Physical first, then `revert` inside `@supports`.** Emitting only the logical property leaves older engines with no layout for that side at all. Emitting both unconditionally leaves the physical value winning on specificity ties. `revert` inside the feature query hands over cleanly once logical support is confirmed.

**How to test**

1. Pull this branch and compile:
   ```scss
   @use "submissions/scss/rtl-logical-ad/rtl-logical" as rl;
   .a { @include rl.logical("margin-left", 1rem); }
   .b { @include rl.logical-inset(start, 0.5rem); }
   .c { @include rl.rtl-preserve; }
   .d { @include rl.rtl-flip-icon; }
   ```
2. Confirm `.a` emits `margin-left: 1rem` first, then `margin-left: revert; margin-inline-start: 1rem` inside `@supports`.
3. Confirm `.c` emits **both** `direction: ltr` and `unicode-bidi: isolate`.
4. Set `<html dir="rtl">` in a browser and confirm padding, margins and insets mirror.
5. **Put a `.c` element (a code span or a number) inside an Arabic sentence.** The surrounding punctuation must stay in place — remove `unicode-bidi: isolate` locally and watch a bracket jump to the wrong side.
6. Confirm a `.d` chevron mirrors in RTL while a `.c` play button does not.
7. Pass an unsupported property to `logical()` and confirm a build error listing supported ones.
8. Pass an invalid `$side` to `logical-inset` and confirm a build error.

**Edge cases covered**

- Physical fallback precedes the logical property, so older engines still lay out.
- `revert` inside `@supports` prevents the physical value winning once logical is available.
- `rtl-preserve` isolates bidi, so an LTR run does not reorder surrounding RTL punctuation.
- Directional icons and direction-neutral elements are separate mixins, not one global flip.
- `ltr-only` matches `:root:not([dir="rtl"])` as well as explicit `[dir="ltr"]`, since most LTR documents never set the attribute.
- Unsupported properties and invalid `$side` values raise build errors.
- Direction blocks match the real `dir` attribute rather than a convention-based class.
- Uses `sass:map` module functions; zero deprecation warnings.

**Verification**

- Compiled with the repo's own `sass` dependency; the physical→`revert`→logical ordering verified in output.
- Zero deprecation warnings. An initial draft hand-rolled map lookups with three helper functions; replaced with `map.get` / `map.has-key`.
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 2 new files, 0 deletions, no existing file touched.
- Folder carries an `-ad` suffix so this lands as a parallel implementation.

**Labels:** `type:feature` · `scss` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
