### PR TITLE
feat: add clip-reveal SCSS mixin with non-clipping fill mode (#63807)

### DIFF
--- a/submissions/scss/clip-reveal-ad/README.md
+++ b/submissions/scss/clip-reveal-ad/README.md
@@ -1,0 +1,43 @@
+# Clip Reveal mixin
+
+> Issue: [#63807](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/63807)
+
+Directional wipe entrances that reveal content without moving it.
+
+## Setup
+
+Call the keyframes mixin **once**, at top level:
+
+```scss
+@include clip-reveal-keyframes;
+```
+
+## Mixins
+
+### `clip-reveal($direction, $duration, $delay, $easing, $prefix)`
+
+```scss
+.hero { @include clip-reveal("up"); }
+```
+
+Directions: `up` · `down` · `left` · `right` · `center-x` · `center-y`
+
+### `clip-reveal-stagger($count, $step, $direction, $duration)`
+
+Per-child wipe cascade.
+
+### `clip-reveal-hover($direction, $duration, $easing)`
+
+Wipe on hover/focus rather than on load — for image overlays and caption bars.
+
+## Why it fits EaseMotion
+
+**A translate entrance moves the element, which means it overlaps its neighbours mid-animation.** In a dense grid or a tight list that overlap reads as a glitch, and the usual fix — adding margin so there is room to move through — changes the resting layout permanently. A `clip-path` wipe animates only the visible region: the element never leaves its box, so nothing can overlap and the layout is untouched.
+
+**The fill mode is `backwards`, deliberately not `both`** — and this is the detail that makes the mixin safe to use. `clip-path` clips descendants absolutely, including anything intentionally overflowing. With `both` fill, the final `inset(0 0 0 0)` frame stays applied forever, so a tooltip or dropdown opened *inside* a revealed card would be cut off at the card's edge long after the animation finished. `backwards` holds the opening frame through any delay but does not retain the ending frame, so `clip-path` reverts to its unclipped default once the animation completes.
+
+That also makes the `@supports not (clip-path: inset(0))` fallback correct: where the property is unsupported the animation never runs, and because nothing is retained, the element is simply visible — which is the right degradation.
+
+`clip-reveal-hover` uses a transition rather than an animation so it reverses cleanly on hover-out, and carries a `@media (hover: none)` guard — on touch there is no hover-out, so an overlay would latch open with no way to dismiss it. There it is shown unconditionally instead.
+
+Reduced motion shortens rather than removes, since removal plus `backwards` fill would strand the element at its opening frame.

--- a/submissions/scss/clip-reveal-ad/_clip-reveal.scss
+++ b/submissions/scss/clip-reveal-ad/_clip-reveal.scss
@@ -1,0 +1,158 @@
+// ==========================================================================
+// EaseMotion CSS — Clip Reveal mixin
+// Issue #63807
+// --------------------------------------------------------------------------
+// Directional wipe entrances that reveal content without moving it.
+//
+// Why this exists alongside translate-based entrances: a `translateY`
+// entrance moves the element, which means it visually overlaps whatever
+// is above or below it during the animation. In a dense grid or a list
+// with tight gaps that overlap reads as a glitch, and adding margin to
+// avoid it changes the resting layout.
+//
+// A `clip-path` wipe animates only the visible region. The element never
+// leaves its box, so nothing can overlap and the resting layout is
+// untouched. It is also compositor-friendly on modern engines.
+//
+// The one real constraint: `clip-path` clips descendants absolutely,
+// including anything intentionally overflowing — a tooltip or dropdown
+// inside a clipped element will be cut off even after the animation
+// finishes, because the property remains applied. `both` fill is
+// therefore deliberately NOT used here; the animation ends on a
+// full-inset frame and the property is left at its unclipped default.
+// ==========================================================================
+
+@use "sass:map";
+@use "sass:list";
+@use "sass:meta";
+
+// Inset origins: which edge the wipe starts from.
+$clip-reveal-directions: (
+    "up": (100% 0 0 0),
+    "down": (0 0 100% 0),
+    "left": (0 100% 0 0),
+    "right": (0 0 0 100%),
+    "center-x": (0 50% 0 50%),
+    "center-y": (50% 0 50% 0),
+) !default;
+
+$clip-reveal-duration: 620ms !default;
+$clip-reveal-easing: cubic-bezier(0.16, 1, 0.3, 1) !default;
+
+// --------------------------------------------------------------------------
+// clip-reveal-keyframes
+//
+// Emit keyframes for the requested directions. Call once at top level.
+// --------------------------------------------------------------------------
+@mixin clip-reveal-keyframes($directions: ("up", "down", "left", "right"), $prefix: "clip-reveal-ad") {
+    @each $direction in $directions {
+        @if not map.has-key($clip-reveal-directions, $direction) {
+            @error "clip-reveal-keyframes(): unknown direction `#{$direction}`. "
+                 + "Known: #{list.join((), map.keys($clip-reveal-directions), $separator: comma)}.";
+        }
+
+        $from: map.get($clip-reveal-directions, $direction);
+
+        @keyframes #{$prefix}-#{$direction} {
+            from {
+                clip-path: inset(#{$from});
+            }
+
+            to {
+                clip-path: inset(0 0 0 0);
+            }
+        }
+    }
+}
+
+// --------------------------------------------------------------------------
+// clip-reveal
+//
+// @param {String} $direction
+// @param {Number} $duration
+// @param {Number} $delay
+// @param {String} $easing
+// --------------------------------------------------------------------------
+@mixin clip-reveal(
+    $direction: "up",
+    $duration: $clip-reveal-duration,
+    $delay: 0s,
+    $easing: $clip-reveal-easing,
+    $prefix: "clip-reveal-ad"
+) {
+    @if not map.has-key($clip-reveal-directions, $direction) {
+        @error "clip-reveal(): unknown direction `#{$direction}`.";
+    }
+
+    // `backwards` rather than `both`: the opening frame is held through
+    // the delay, but the ENDING frame is not retained — so `clip-path`
+    // reverts to its default afterwards and cannot clip a tooltip or
+    // dropdown that later overflows this element.
+    animation: #{$prefix}-#{$direction} $duration $easing $delay backwards;
+
+    @supports not (clip-path: inset(0)) {
+        // Without clip-path the animation never runs, and `backwards`
+        // fill would leave nothing applied — so the element is simply
+        // visible, which is the correct degradation.
+        animation: none;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        animation-delay: 0s;
+        animation-duration: 1ms;
+    }
+}
+
+// --------------------------------------------------------------------------
+// clip-reveal-stagger
+//
+// Per-child delays for a wipe cascade.
+// --------------------------------------------------------------------------
+@mixin clip-reveal-stagger($count, $step: 80ms, $direction: "up", $duration: $clip-reveal-duration) {
+    @if meta.type-of($count) != "number" or $count < 1 {
+        @error "clip-reveal-stagger(): $count must be a positive number.";
+    }
+
+    @for $i from 1 through $count {
+        > *:nth-child(#{$i}) {
+            @include clip-reveal($direction, $duration, $step * $i);
+        }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        > * {
+            animation-delay: 0s;
+            animation-duration: 1ms;
+        }
+    }
+}
+
+// --------------------------------------------------------------------------
+// clip-reveal-hover
+//
+// A wipe on hover/focus rather than on load — for image overlays and
+// caption bars. Transitioned rather than animated, so it reverses
+// cleanly on hover-out.
+// --------------------------------------------------------------------------
+@mixin clip-reveal-hover($direction: "up", $duration: 320ms, $easing: $clip-reveal-easing) {
+    $from: map.get($clip-reveal-directions, $direction);
+
+    clip-path: inset(#{$from});
+    transition: clip-path $duration $easing;
+
+    &:hover,
+    &:focus-visible,
+    &:focus-within {
+        clip-path: inset(0 0 0 0);
+    }
+
+    @media (hover: none) {
+        // No hover-out on touch, so the overlay would latch open. Show it
+        // unconditionally instead.
+        clip-path: inset(0 0 0 0);
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        transition-duration: 1ms;
+    }
+}


### PR DESCRIPTION
Fixes #63807

**What was added**

Directional wipe entrances, under `submissions/scss/clip-reveal-ad/`.

- `_clip-reveal.scss` — a six-direction inset map, `clip-reveal-keyframes()`, `clip-reveal()`, `clip-reveal-stagger()` and `clip-reveal-hover()`.
- `README.md` — setup, mixin reference, and rationale.

**What is the problem**

A `translateY` entrance **moves the element**, so it visually overlaps whatever sits above or below it mid-animation. In a dense grid or a tight list that overlap reads as a rendering glitch, and the usual workaround — adding margin so there is room to move through — permanently changes the resting layout to accommodate a 600ms animation.

**Why this approach**

A `clip-path` wipe animates only the visible region. The element never leaves its box, so nothing can overlap and the resting layout is untouched.

**The fill mode is `backwards`, deliberately not `both`, and this is the detail that makes the mixin safe.** `clip-path` clips descendants absolutely, including anything intentionally overflowing. With `both` fill the final `inset(0 0 0 0)` frame stays applied indefinitely — so a tooltip or dropdown opened *inside* a revealed card would be cut off at the card's edge long after the animation finished, and the cause would be very hard to find. `backwards` holds the opening frame through any delay but does not retain the ending frame, so `clip-path` reverts to its unclipped default on completion.

That choice also makes the `@supports not (clip-path: inset(0))` fallback correct: where the property is unsupported the animation never runs, and since nothing is retained, the element is simply visible.

`clip-reveal-hover` uses a transition rather than an animation so it reverses cleanly on hover-out, and carries a `@media (hover: none)` guard — on touch there is no hover-out, so the overlay would latch open with no way to dismiss it.

**How to test**

1. Pull this branch and compile:
   ```scss
   @use "submissions/scss/clip-reveal-ad/clip-reveal" as cl;
   @include cl.clip-reveal-keyframes;
   .a    { @include cl.clip-reveal("up"); }
   .grid { @include cl.clip-reveal-stagger(3, 80ms, "left"); }
   .img  { @include cl.clip-reveal-hover("up"); }
   ```
2. Confirm four `@keyframes` blocks are emitted, each going from a single-edge inset to `inset(0 0 0 0)`.
3. **Confirm `backwards` is used and `both` appears nowhere** — grep the output; `backwards` should appear on every `clip-reveal` call and `both` zero times.
4. **The decisive test:** put a dropdown or tooltip inside a `.a` element that overflows its bounds. After the entrance completes, the dropdown must render **outside** the card. Change `backwards` to `both` locally and watch it get clipped — that is the bug this avoids.
5. Put `.a` items in a tight grid and confirm no element overlaps its neighbour during the wipe.
6. Confirm `.img` reveals on hover and reverses on hover-out.
7. Emulate a touch device and confirm `.img`'s overlay is shown unconditionally rather than latching.
8. Enable reduced motion and confirm elements are visible, not stranded at their opening frame.
9. Pass an unknown direction and confirm a build error listing valid ones.

**Edge cases covered**

- `backwards` fill prevents `clip-path` persisting and clipping later overflowing descendants.
- The `@supports not` fallback degrades to a plain visible element, which is correct given nothing is retained.
- Reduced motion shortens rather than removes, since removal plus `backwards` would strand the opening frame.
- `clip-reveal-hover` uses a transition so it reverses on hover-out, unlike an animation.
- `@media (hover: none)` prevents the hover overlay latching open on touch.
- Unknown directions raise build errors in both the keyframes and the apply mixin.
- Non-positive `$count` in the stagger raises a build error.
- Keyframes live in a separate top-level mixin so they are emitted once regardless of call-site count.
- Keyframe names carry the `-ad` prefix so they cannot collide in the global keyframe namespace.

**Verification**

- Compiled with the repo's own `sass` dependency. Verified programmatically: 4 keyframe blocks, `backwards` present 4 times, `both` present **0** times.
- The `hover: none` guard confirmed in output.
- Zero deprecation warnings.
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 2 new files, 0 deletions, no existing file touched.
- Folder carries an `-ad` suffix so this lands as a parallel implementation.

**Labels:** `type:feature` · `scss` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
