### PR TITLE
feat: add state-layer SCSS mixin for variant-agnostic interaction overlays (#63808)

### DIFF
--- a/submissions/scss/state-layer-ad/README.md
+++ b/submissions/scss/state-layer-ad/README.md
@@ -1,0 +1,43 @@
+# State Layer mixin
+
+> Issue: [#63808](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/63808)
+
+Interaction overlays that work on any button variant without a per-variant colour.
+
+## Mixins
+
+### `state-layer($hover, $focus, $press, $radius, $color)`
+
+```scss
+.btn { @include state-layer; }
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `$hover` | `Number` | `0.08` | Hover overlay opacity. |
+| `$focus` | `Number` | `0.12` | Focus-visible opacity. |
+| `$press` | `Number` | `0.16` | Active opacity. |
+| `$radius` | `Number` | `inherit` | Overlay radius. |
+| `$color` | `Color` | `currentcolor` | Overlay colour. |
+
+### `state-layer-tinted($tint, …)` — explicit tint for white-on-brand buttons
+### `state-layer-inset(…)` — square overlay for list rows and table cells
+### `state-layer-selected($opacity, $selector)` — persistent selected state
+
+## Why it fits EaseMotion
+
+**The problem with hand-written hover states is combinatorial.** A button with 5 variants across 2 themes needs 10 hover colours, 10 active colours and 10 focus colours — 30 values that must all stay in step when the palette changes. They drift, and a "subtle" hover on one variant ends up twice as strong as on another.
+
+Overlaying `currentcolor` at a fixed opacity replaces all of it with one rule. Because `currentcolor` resolves to the button's own text colour, the overlay is automatically in-family for every variant and theme, and the *perceived* strength stays constant.
+
+Three details do real work:
+
+**`:focus-visible`, not `:focus`.** A mouse press leaves the focus state applied afterwards, so a plain `:focus` overlay stays lit after every click and reads as a stuck hover.
+
+**`:active` is declared last.** An active button is also hovered, and the two rules have equal specificity — source order is what makes the press state actually win.
+
+**`pointer-events: none` on the overlay.** Without it the pseudo-element sits above the button and swallows every click. This is the classic way this pattern is broken, and it fails silently: the button looks right and simply does nothing.
+
+`state-layer-tinted` exists for the one case the pattern does not cover on its own — a white-on-brand button would overlay white, which lightens rather than deepens. Supplying an explicit tint fixes that case without abandoning the approach everywhere else.
+
+`forced-colors: active` discards the overlay entirely, so a border substitutes — otherwise the only remaining feedback would be the focus ring, and hover would have none at all.

--- a/submissions/scss/state-layer-ad/_state-layer.scss
+++ b/submissions/scss/state-layer-ad/_state-layer.scss
@@ -1,0 +1,132 @@
+// ==========================================================================
+// EaseMotion CSS — State Layer mixin
+// Issue #63808
+// --------------------------------------------------------------------------
+// Interaction overlays (hover, focus, press) that work on any button
+// variant without picking a colour per variant.
+//
+// The problem with hand-written hover states is combinatorial. A button
+// with 5 variants × 2 themes needs 10 hover colours, 10 active colours
+// and 10 focus colours — 30 values that all have to stay in step when the
+// palette changes. In practice they drift, and a "subtle" hover on one
+// variant ends up twice as strong as on another.
+//
+// A state layer replaces all of it with one rule: overlay `currentcolor`
+// at a fixed opacity. Because `currentcolor` resolves to the button's own
+// text colour, the overlay is automatically in-family for every variant
+// and every theme, and the *perceived* strength stays constant.
+// ==========================================================================
+
+@use "sass:meta";
+
+$state-layer-hover: 0.08 !default;
+$state-layer-focus: 0.12 !default;
+$state-layer-press: 0.16 !default;
+$state-layer-duration: 160ms !default;
+
+// --------------------------------------------------------------------------
+// state-layer
+//
+// @param {Number} $hover
+// @param {Number} $focus
+// @param {Number} $press
+// @param {Number} $radius    Overlay radius. `inherit` follows the host.
+// @param {String} $color     Overlay colour. `currentcolor` by default.
+// --------------------------------------------------------------------------
+@mixin state-layer(
+    $hover: $state-layer-hover,
+    $focus: $state-layer-focus,
+    $press: $state-layer-press,
+    $radius: inherit,
+    $color: currentcolor
+) {
+    @if meta.type-of($hover) != "number" {
+        @error "state-layer(): $hover must be a number, got `#{$hover}`.";
+    }
+
+    isolation: isolate;
+    position: relative;
+
+    &::before {
+        background: $color;
+        border-radius: $radius;
+        content: "";
+        inset: 0;
+        opacity: 0;
+        // Without this the overlay swallows every click on the button.
+        pointer-events: none;
+        position: absolute;
+        transition: opacity $state-layer-duration ease-out;
+    }
+
+    &:hover:not(:disabled)::before {
+        opacity: $hover;
+    }
+
+    // `:focus-visible`, not `:focus` — a press on a mouse leaves the
+    // focus state applied afterwards, so a plain `:focus` overlay stays
+    // lit after every click and looks like a stuck hover.
+    &:focus-visible::before {
+        opacity: $focus;
+    }
+
+    // Listed last so a press beats hover — an active button is hovered
+    // too, and source order decides between equal-specificity rules.
+    &:active:not(:disabled)::before {
+        opacity: $press;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        &::before {
+            transition-duration: 1ms;
+        }
+    }
+
+    // Forced colors discards the overlay entirely, so the only remaining
+    // feedback would be the focus ring. A border change substitutes.
+    @media (forced-colors: active) {
+        &:hover:not(:disabled),
+        &:focus-visible {
+            outline: 1px solid Highlight;
+        }
+    }
+}
+
+// --------------------------------------------------------------------------
+// state-layer-tinted
+//
+// For surfaces whose text colour is a poor overlay — a white-on-brand
+// button would get a white wash, which lightens rather than deepens.
+// Supplying an explicit tint fixes that one case without abandoning the
+// pattern everywhere else.
+// --------------------------------------------------------------------------
+@mixin state-layer-tinted($tint, $hover: $state-layer-hover, $focus: $state-layer-focus, $press: $state-layer-press) {
+    @include state-layer($hover, $focus, $press, $color: $tint);
+}
+
+// --------------------------------------------------------------------------
+// state-layer-inset
+//
+// For list rows and table cells, where an overlay at the element's own
+// radius would round corners that are visually square.
+// --------------------------------------------------------------------------
+@mixin state-layer-inset($hover: $state-layer-hover, $focus: $state-layer-focus) {
+    @include state-layer($hover, $focus, $radius: 0);
+}
+
+// --------------------------------------------------------------------------
+// state-layer-selected
+//
+// A persistent selected state that composes with the transient ones —
+// a selected row that is also hovered should read as slightly stronger,
+// not identical to an unselected hovered row.
+// --------------------------------------------------------------------------
+@mixin state-layer-selected($opacity: 0.14, $selector: "[aria-selected='true']") {
+    &#{$selector}::before {
+        opacity: $opacity;
+    }
+
+    &#{$selector}:hover::before {
+        opacity: $opacity + $state-layer-hover;
+    }
+}


### PR DESCRIPTION
Fixes #63808

**What was added**

Interaction overlay mixins, under `submissions/scss/state-layer-ad/`.

- `_state-layer.scss` — `state-layer()`, `state-layer-tinted()`, `state-layer-inset()` and `state-layer-selected()`.
- `README.md` — parameter table, usage, and rationale.

**What is the problem**

**Hand-written hover states are combinatorial.** A button with 5 variants across 2 themes needs 10 hover colours, 10 active colours and 10 focus colours — 30 values that all have to stay in step when the palette changes. In practice they drift, and a "subtle" hover on one variant ends up twice as strong as on another. Nothing catches this; it just slowly stops looking like one system.

**Why this approach**

Overlaying `currentcolor` at a fixed opacity replaces all 30 values with one rule. Because `currentcolor` resolves to the button's own text colour, the overlay is automatically in-family for every variant and theme, and the *perceived* strength stays constant.

Three details do real work:

**`:focus-visible`, not `:focus`.** A mouse press leaves the focus state applied afterwards, so a plain `:focus` overlay stays lit after every click and reads as a stuck hover.

**`:active` is declared last.** An active button is also hovered, and the two rules have equal specificity — source order is the only thing that makes the press state win.

**`pointer-events: none` on the overlay.** Without it the pseudo-element sits above the button and swallows every click. This is the classic way this pattern breaks, and it fails silently — the button looks correct and simply does nothing.

`state-layer-tinted` covers the one case the pattern cannot handle alone: a white-on-brand button would overlay white, which lightens rather than deepens.

**How to test**

1. Pull this branch and compile:
   ```scss
   @use "submissions/scss/state-layer-ad/state-layer" as sl;
   .btn { @include sl.state-layer; }
   .row { @include sl.state-layer-inset; @include sl.state-layer-selected; }
   ```
2. **Confirm the rule order** in the output: `:hover` (line ~15), then `:focus-visible` (~18), then `:active` (~21). Active must come last.
3. Confirm `pointer-events: none` is present on the overlay.
4. **Click the button and confirm the click registers.** Remove `pointer-events: none` locally and watch the button stop responding entirely while still looking normal — that is the failure being prevented.
5. Apply `.btn` to a dark-text-on-light and a light-text-on-dark variant with **no other changes**. Both hover states must look correctly in-family.
6. Click with a mouse, then move away — the focus overlay must **not** remain lit.
7. Press and hold — the press overlay must be visibly stronger than hover.
8. Apply to a `[aria-selected="true"]` row and confirm a hovered selected row is stronger than an unselected hovered one.
9. View in forced-colors mode and confirm hover still produces a visible border.
10. Pass a non-numeric `$hover` and confirm a build error.

**Edge cases covered**

- `pointer-events: none` keeps the overlay from swallowing clicks.
- `:active` declared after `:hover` so the press state wins on source order.
- `:focus-visible` avoids the stuck-overlay-after-click artefact.
- `:not(:disabled)` on hover and active so disabled controls give no feedback.
- `isolation: isolate` creates a stacking context, so the overlay cannot escape above sibling content.
- `border-radius: inherit` follows the host, with `state-layer-inset` for square rows where inheriting would round visually-square corners.
- `state-layer-tinted` handles white-on-brand surfaces where `currentcolor` would lighten rather than deepen.
- `state-layer-selected` composes with the transient states rather than replacing them.
- `forced-colors: active` substitutes a border, since the overlay is discarded there.
- Reduced motion shortens the transition rather than removing the state change.
- All four opacity tokens are `!default`.

**Verification**

- Compiled with the repo's own `sass` dependency. Rule ordering verified by line number in the output; `pointer-events: none` confirmed present on both emitted overlays.
- Zero deprecation warnings.
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 2 new files, 0 deletions, no existing file touched.
- Folder carries an `-ad` suffix so this lands as a parallel implementation.

**Labels:** `type:feature` · `scss` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
