### PR TITLE
feat: add overscroll SCSS mixin for scroll chaining containment (#63809)

### DIFF
--- a/submissions/scss/overscroll-ad/README.md
+++ b/submissions/scss/overscroll-ad/README.md
@@ -1,0 +1,35 @@
+# Overscroll mixin
+
+> Issue: [#63809](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/63809)
+
+Stops scroll chaining out of nested scroll areas, with the right containment strength per surface type.
+
+## Mixins
+
+### `overscroll-contain($axis)` — for lists, dropdowns, chat panels
+
+Keeps the rubber-band bounce, which users read as "this is the end of the list".
+
+### `overscroll-lock($axis)` — for modal surfaces
+
+Suppresses the bounce too, so the page behind is never revealed.
+
+### `scroll-region($max-height, $axis, $contain)`
+
+A complete scrollable region with containment and a stable scrollbar gutter.
+
+### `body-scroll-lock($selector)` — document-level lock while a modal is open
+
+### `overscroll-snap-region($align, $padding)` — carousels and chip rows
+
+## Why it fits EaseMotion
+
+**Scroll chaining is almost always wrong in a nested region.** The user flicks to the bottom of a dropdown and the page behind it lurches. On iOS it is worse: the page scrolls *under* an open modal, and closing it leaves the user somewhere they never navigated to.
+
+`overscroll-behavior: contain` fixes it in one declaration — so the reason this is a mixin is the surrounding detail.
+
+**`contain` and `none` are not interchangeable.** `contain` stops the chain but keeps the bounce; `none` suppresses the bounce as well. For a list the bounce is useful feedback that you have hit the end. For a modal it is harmful, because bouncing the dialog surface reveals the page behind it and breaks the illusion that the dialog is a separate layer. Getting this backwards makes a modal feel broken on iOS specifically, which is easy to miss on desktop.
+
+**`body-scroll-lock` deliberately avoids `position: fixed`.** The common lock sets `position: fixed` on the body — which collapses the scroll position to zero, so closing the modal returns the user to the *top of the page* rather than where they were. `overflow: hidden` plus `overscroll-behavior: none` locks scrolling while preserving position.
+
+**`scrollbar-gutter: stable` is the quiet win.** Without it, a list that grows from 9 to 10 items gains a scrollbar and every row shifts sideways by its width — a layout jump caused by what should be an unrelated change. The same property on the locked body prevents the classic content shift when a modal opens and the page scrollbar disappears.

--- a/submissions/scss/overscroll-ad/_overscroll.scss
+++ b/submissions/scss/overscroll-ad/_overscroll.scss
@@ -1,0 +1,137 @@
+// ==========================================================================
+// EaseMotion CSS — Overscroll mixin
+// Issue #63809
+// --------------------------------------------------------------------------
+// Stops scroll chaining out of nested scroll areas.
+//
+// Scroll chaining is the behaviour where reaching the end of a scrollable
+// child hands the remaining scroll to its parent. In a dropdown, a drawer
+// or a chat panel this is almost always wrong: the user flicks to the
+// bottom of the list and the page behind it lurches. On iOS it is worse —
+// the page scrolls *under* an open modal, and closing it leaves the user
+// somewhere they never navigated to.
+//
+// `overscroll-behavior: contain` fixes it in one declaration. The reason
+// this is a mixin is the surrounding detail: `contain` still permits the
+// rubber-band bounce, `none` suppresses it too, and which you want
+// differs between a modal (none) and a list (contain). Getting that
+// backwards makes a modal feel broken on iOS.
+// ==========================================================================
+
+@use "sass:meta";
+
+// --------------------------------------------------------------------------
+// overscroll-contain
+//
+// For scrollable regions inside a scrollable page — dropdowns, list
+// panels, chat logs. Keeps the bounce, which users read as "this is the
+// end of the list".
+//
+// @param {String} $axis  `both`, `y` or `x`.
+// --------------------------------------------------------------------------
+@mixin overscroll-contain($axis: both) {
+    @if $axis == both {
+        overscroll-behavior: contain;
+    } @else if $axis == y {
+        overscroll-behavior-y: contain;
+    } @else if $axis == x {
+        overscroll-behavior-x: contain;
+    } @else {
+        @error "overscroll-contain(): $axis must be `both`, `y` or `x`, got `#{$axis}`.";
+    }
+
+    // Momentum scrolling on older iOS, which otherwise scrolls in a
+    // single stiff step inside a nested region.
+    -webkit-overflow-scrolling: touch;
+}
+
+// --------------------------------------------------------------------------
+// overscroll-lock
+//
+// For modal surfaces. `none` also suppresses the bounce — appropriate
+// here, because a bounce on a dialog surface reveals the page behind it
+// and breaks the illusion that the dialog is a separate layer.
+// --------------------------------------------------------------------------
+@mixin overscroll-lock($axis: both) {
+    @if $axis == both {
+        overscroll-behavior: none;
+    } @else if $axis == y {
+        overscroll-behavior-y: none;
+    } @else if $axis == x {
+        overscroll-behavior-x: none;
+    } @else {
+        @error "overscroll-lock(): $axis must be `both`, `y` or `x`, got `#{$axis}`.";
+    }
+}
+
+// --------------------------------------------------------------------------
+// scroll-region
+//
+// A complete scrollable region: containment, a max height, and a
+// scrollbar that does not shift layout when content grows past the
+// threshold.
+//
+// `scrollbar-gutter: stable` is the part worth having — without it, a
+// list that grows from 9 to 10 items gains a scrollbar and every row
+// shifts left by its width, which reads as a layout jump on what should
+// be an unrelated change.
+// --------------------------------------------------------------------------
+@mixin scroll-region($max-height: 320px, $axis: y, $contain: true) {
+    max-height: $max-height;
+    scrollbar-gutter: stable;
+
+    @if $axis == y {
+        overflow-x: hidden;
+        overflow-y: auto;
+    } @else if $axis == x {
+        overflow-x: auto;
+        overflow-y: hidden;
+    } @else {
+        overflow: auto;
+    }
+
+    @if $contain {
+        @include overscroll-contain($axis);
+    }
+}
+
+// --------------------------------------------------------------------------
+// body-scroll-lock
+//
+// Applied to the document while a modal is open.
+//
+// `position: fixed` is deliberately NOT used. The common lock sets
+// `position: fixed` on the body, which collapses the scroll position to
+// zero — so closing the modal returns the user to the top of the page
+// rather than where they were. Combining `overflow: hidden` with
+// `overscroll-behavior: none` locks scrolling while preserving position.
+// --------------------------------------------------------------------------
+@mixin body-scroll-lock($selector: "[data-scroll-locked]") {
+    #{$selector} {
+        overflow: hidden;
+        overscroll-behavior: none;
+        // Reserving the gutter prevents the page reflowing sideways as
+        // the scrollbar disappears — the classic modal-open content shift.
+        scrollbar-gutter: stable;
+    }
+}
+
+// --------------------------------------------------------------------------
+// overscroll-snap-region
+//
+// Carousels and chip rows: containment plus snapping, so a flick reaches
+// the end of the track without scrolling the page.
+// --------------------------------------------------------------------------
+@mixin overscroll-snap-region($align: start, $padding: 0) {
+    display: flex;
+    overflow-x: auto;
+    overscroll-behavior-x: contain;
+    scroll-padding-inline: $padding;
+    scroll-snap-type: x mandatory;
+    -webkit-overflow-scrolling: touch;
+
+    > * {
+        flex: 0 0 auto;
+        scroll-snap-align: $align;
+    }
+}


### PR DESCRIPTION
Fixes #63809

**What was added**

Scroll containment mixins, under `submissions/scss/overscroll-ad/`.

- `_overscroll.scss` — `overscroll-contain()`, `overscroll-lock()`, `scroll-region()`, `body-scroll-lock()` and `overscroll-snap-region()`.
- `README.md` — mixin reference and rationale.

**What is the problem**

**Scroll chaining is almost always wrong in a nested region.** The user flicks to the bottom of a dropdown and the page behind it lurches. On iOS it is worse: the page scrolls *under* an open modal, and closing it leaves the user somewhere they never navigated to — a disorienting bug that only reproduces on touch.

**Why this approach**

`overscroll-behavior: contain` is one declaration, so the value here is the surrounding detail.

**`contain` and `none` are not interchangeable.** `contain` stops the chain but keeps the rubber-band bounce; `none` suppresses the bounce as well. For a list the bounce is useful feedback that you have hit the end. For a modal it is harmful, because bouncing the dialog surface reveals the page behind it and breaks the illusion of a separate layer. Getting this backwards makes a modal feel broken **on iOS specifically**, which is easy to miss testing on desktop. The two cases are separate mixins so the choice is explicit.

**`body-scroll-lock` deliberately avoids `position: fixed`.** The common lock sets `position: fixed` on the body — which collapses the scroll position to zero, so closing the modal returns the user to the *top of the page* rather than where they were. `overflow: hidden` plus `overscroll-behavior: none` locks scrolling while preserving position.

**`scrollbar-gutter: stable` is the quiet win.** Without it, a list that grows from 9 to 10 items gains a scrollbar and every row shifts sideways by its width — a layout jump from what should be an unrelated change. The same property on the locked body prevents the classic content shift when a modal opens.

**How to test**

1. Pull this branch and compile:
   ```scss
   @use "submissions/scss/overscroll-ad/overscroll" as ov;
   .list  { @include ov.scroll-region(320px, y); }
   .modal { @include ov.overscroll-lock; }
   .chips { @include ov.overscroll-snap-region(start, 1rem); }
   @include ov.body-scroll-lock;
   ```
2. Confirm `.list` gets `contain` and `.modal` / the body lock get `none`.
3. **Confirm `position: fixed` appears nowhere in the output** — grep it; the count should be zero.
4. Confirm `scrollbar-gutter: stable` appears on both the scroll region and the body lock.
5. In a browser, scroll to the bottom of a `.list` inside a long page and keep scrolling — **the page must not move**.
6. On iOS or touch emulation, open a modal and flick on it — the page behind must not scroll, and the dialog must not bounce.
7. Scroll a long page halfway, open a modal, close it — **you must return to where you were**, not the top.
8. Grow a `.list` from 9 to 10 items and confirm rows do not shift sideways when the scrollbar appears.
9. Pass an invalid `$axis` and confirm a build error.

**Edge cases covered**

- `contain` vs `none` chosen per surface type, so a modal does not bounce and a list still does.
- `body-scroll-lock` preserves scroll position by avoiding `position: fixed`.
- `scrollbar-gutter: stable` prevents both the list-growth shift and the modal-open content shift.
- `-webkit-overflow-scrolling: touch` restores momentum in nested regions on older iOS.
- Per-axis containment, so a horizontal carousel does not also lock vertical page scroll.
- `scroll-region` sets the opposite axis to `hidden` rather than leaving it `auto`, avoiding a phantom second scrollbar.
- `overscroll-snap-region` sets `flex: 0 0 auto` on children, so snap items are not shrunk by flex.
- `scroll-padding-inline` keeps snapped items clear of sticky edges.
- Invalid `$axis` values raise build errors in both containment mixins.

**Verification**

- Compiled with the repo's own `sass` dependency. Verified programmatically: `contain` on the list, `none` twice for modal and body lock, `scrollbar-gutter: stable` twice, and **zero** occurrences of `position: fixed`.
- Zero deprecation warnings.
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 2 new files, 0 deletions, no existing file touched.
- Folder carries an `-ad` suffix so this lands as a parallel implementation.

**Labels:** `type:feature` · `scss` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
