### PR TITLE
feat: add caret-style SCSS mixin for visible carets and selection (#63811)

### DIFF
--- a/submissions/scss/caret-style-ad/README.md
+++ b/submissions/scss/caret-style-ad/README.md
@@ -1,0 +1,45 @@
+# Caret Style mixin
+
+> Issue: [#63811](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/63811)
+
+Keeps the text caret visible on custom-styled inputs, and fixes the `::selection` half-configuration bug.
+
+## Mixins
+
+### `caret-style($color, $select-bg, $select-fg)`
+
+```scss
+.input { @include caret-style; }
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `$color` | `Color \| auto` | `#38bdf8` | Caret colour. |
+| `$select-bg` | `Color` | `rgba(56,189,248,0.3)` | Selection background. |
+| `$select-fg` | `Color` | `#f1f5f9` | Selection foreground. |
+
+### `caret-contrast($background, $light, $dark)`
+
+Picks a caret that contrasts with the field's own surface.
+
+### `caret-editable($color, $min-height, $placeholder)`
+
+For contenteditable surfaces.
+
+### `caret-hidden`
+
+Suppresses the caret on focusable non-text controls.
+
+## Why it fits EaseMotion
+
+**The caret defaults to the element's `color`,** which is fine until the input is styled. A dark-themed field with light text on a light focus background, a search box that inverts on focus, or a contenteditable with a coloured backdrop can all end up with a caret matching its own background. The user cannot tell where they are typing, or whether the field is focused at all — a total failure of the control, easy to miss because the caret only exists while focused.
+
+**`::selection` is set on both halves, always.** Setting only the background is the common bug: the inherited text colour lands on the new background with no contrast, so selected text *disappears* exactly when the user is trying to read it. Setting both is not optional polish.
+
+The `-moz-selection` prefix is emitted as its own rule rather than grouped with the standard selector — an unrecognised selector inside a list invalidates the **entire** rule, so grouping them would silently break selection styling in every non-Firefox browser.
+
+**`caret-editable` handles a specific contenteditable failure:** an empty contenteditable collapses to zero height, so the caret has nowhere to render and the field looks unfocused even when it is. `min-height` plus an optional `:empty::before` placeholder keeps it visible.
+
+`caret-contrast` uses perceptual luminance rather than lightness, for the same reason a foreground picker must — saturated blue and saturated yellow can share a lightness value while needing opposite carets.
+
+`caret-hidden` exists because a blinking caret in a listbox or segmented control implies typing will do something, which it will not.

--- a/submissions/scss/caret-style-ad/_caret-style.scss
+++ b/submissions/scss/caret-style-ad/_caret-style.scss
@@ -1,0 +1,126 @@
+// ==========================================================================
+// EaseMotion CSS — Caret Style mixin
+// Issue #63811
+// --------------------------------------------------------------------------
+// Keeps the text caret visible on custom-styled inputs.
+//
+// The caret defaults to the element's `color`. That is fine until the
+// input is styled — a dark-themed field with light text on a light-focus
+// background, a search box that inverts on focus, or a contenteditable
+// surface with a coloured backdrop can all end up with a caret that
+// matches its own background and is effectively invisible.
+//
+// The user then cannot tell where they are typing, or whether the field
+// is focused at all. It is a small property and a total failure of the
+// control when it goes wrong, and it is easy to miss because the caret
+// only exists while focused.
+//
+// `caret-color` decouples it from `color`, so the caret can be pinned to
+// something that always contrasts.
+// ==========================================================================
+
+@use "sass:color";
+@use "sass:math";
+@use "sass:meta";
+
+$caret-color: #38bdf8 !default;
+$caret-selection-bg: rgba(56, 189, 248, 0.3) !default;
+$caret-selection-fg: #f1f5f9 !default;
+
+// --------------------------------------------------------------------------
+// caret-style
+//
+// @param {Color} $color      Caret colour.
+// @param {Color} $select-bg  Selection background.
+// @param {Color} $select-fg  Selection foreground.
+// --------------------------------------------------------------------------
+@mixin caret-style(
+    $color: $caret-color,
+    $select-bg: $caret-selection-bg,
+    $select-fg: $caret-selection-fg
+) {
+    @if meta.type-of($color) != "color" and $color != auto {
+        @error "caret-style(): $color must be a color or `auto`, got `#{$color}`.";
+    }
+
+    caret-color: $color;
+
+    // Both halves of ::selection, always. Setting only the background is
+    // the common bug: the inherited text colour can land on top of the
+    // new background with no contrast, so the selected text disappears
+    // exactly when the user is trying to read it.
+    &::selection {
+        background: $select-bg;
+        color: $select-fg;
+    }
+
+    // Firefox needs the prefixed pseudo-element separately — it cannot be
+    // grouped with the standard one, because an unrecognised selector in
+    // a list invalidates the whole rule.
+    &::-moz-selection {
+        background: $select-bg;
+        color: $select-fg;
+    }
+}
+
+// --------------------------------------------------------------------------
+// caret-contrast
+//
+// Picks a caret colour that contrasts with the field's own background,
+// for themes where the input surface is not known at author time.
+// --------------------------------------------------------------------------
+@mixin caret-contrast($background, $light: #ffffff, $dark: #0b1120) {
+    @if meta.type-of($background) != "color" {
+        @error "caret-contrast(): $background must be a color.";
+    }
+
+    caret-color: pick-caret($background, $light, $dark);
+}
+
+@function pick-caret($background, $light, $dark) {
+    // Perceptual luminance rather than lightness — a saturated blue and a
+    // saturated yellow can share a lightness value while needing opposite
+    // carets.
+    $r: color.channel($background, "red", $space: rgb);
+    $g: color.channel($background, "green", $space: rgb);
+    $b: color.channel($background, "blue", $space: rgb);
+    $luminance: math.div(0.2126 * $r + 0.7152 * $g + 0.0722 * $b, 255);
+
+    @if $luminance > 0.55 {
+        @return $dark;
+    }
+
+    @return $light;
+}
+
+// --------------------------------------------------------------------------
+// caret-editable
+//
+// For contenteditable surfaces. An empty contenteditable collapses to
+// zero height, so the caret has nowhere to render and the user cannot
+// tell the field is focused. `min-height` plus an empty-state placeholder
+// keeps it visible.
+// --------------------------------------------------------------------------
+@mixin caret-editable($color: $caret-color, $min-height: 1.5em, $placeholder: "") {
+    caret-color: $color;
+    min-height: $min-height;
+
+    @if $placeholder != "" {
+        &:empty::before {
+            content: $placeholder;
+            opacity: 0.5;
+            pointer-events: none;
+        }
+    }
+}
+
+// --------------------------------------------------------------------------
+// caret-hidden
+//
+// Suppresses the caret on elements that accept focus but not text input —
+// a custom listbox or a segmented control rendered as a focusable div.
+// A blinking caret in a non-text control implies typing will do something.
+// --------------------------------------------------------------------------
+@mixin caret-hidden {
+    caret-color: transparent;
+}


### PR DESCRIPTION
Fixes #63811

**What was added**

Caret and selection styling, under `submissions/scss/caret-style-ad/`.

- `_caret-style.scss` — `caret-style()`, `caret-contrast()`, `caret-editable()` and `caret-hidden()`.
- `README.md` — mixin reference and rationale.

**What is the problem**

**The caret defaults to the element's `color`**, which is fine until the input is styled. A dark-themed field with light text on a light focus background, a search box that inverts on focus, or a contenteditable with a coloured backdrop can all end up with a caret that matches its own background. The user then cannot tell where they are typing, or whether the field is focused at all — a total failure of the control, and easy to miss in review because the caret only exists while focused.

**`::selection` set half-way is a second, separate bug.** Setting only the background leaves the inherited text colour on top of the new background with no contrast — so selected text *disappears* at exactly the moment the user is trying to read it.

**Why this approach**

`caret-color` decouples the caret from `color`, so it can be pinned to something that always contrasts.

`::selection` is always set on both halves.

**The `-moz-selection` prefix is emitted as its own rule, not grouped.** An unrecognised selector inside a selector list invalidates the **entire** rule — so `&::selection, &::-moz-selection { … }` silently breaks selection styling in every non-Firefox browser. Splitting them is required, not stylistic.

**`caret-editable` handles a specific contenteditable failure:** an empty contenteditable collapses to zero height, so the caret has nowhere to render and the field looks unfocused even when focused. `min-height` plus an optional `:empty::before` placeholder keeps it visible.

`caret-hidden` exists because a blinking caret in a listbox or segmented control implies typing will do something, which it will not.

**How to test**

1. Pull this branch and compile:
   ```scss
   @use "submissions/scss/caret-style-ad/caret-style" as ca;
   .input { @include ca.caret-style; }
   .dark  { @include ca.caret-contrast(#0b1120); }
   .light { @include ca.caret-contrast(#ffff00); }
   .edit  { @include ca.caret-editable(#38bdf8, 1.5em, "Type here"); }
   ```
2. **Confirm `::selection` and `::-moz-selection` are emitted as two separate rules**, never as a grouped selector list.
3. Confirm both rules set `background` **and** `color`.
4. Confirm `.dark` resolves to `#ffffff` and `.light` to `#0b1120` — perceptual luminance, not lightness.
5. In a browser, style an input with light text on a light focus background and confirm the caret remains visible.
6. Select text in the input and confirm the selected text is readable, not background-on-background.
7. Focus an **empty** `contenteditable` with `.edit` and confirm the caret is visible and the placeholder shows.
8. Apply `caret-hidden` to a focusable listbox div and confirm no caret blinks.
9. Pass a non-colour `$color` and confirm a build error.

**Edge cases covered**

- `caret-color` decoupled from `color`, so styled fields keep a visible caret.
- `::selection` always sets both foreground and background.
- `-moz-selection` is a separate rule, avoiding whole-rule invalidation in non-Firefox engines.
- `caret-editable` prevents an empty contenteditable collapsing to zero height with nowhere to draw the caret.
- The placeholder is `pointer-events: none`, so it cannot block clicks into the field.
- `caret-contrast` uses perceptual luminance, correct for saturated hues where lightness is not.
- `caret-hidden` removes a misleading affordance on non-text controls.
- `$color` accepts `auto` as well as a colour, so the UA default can be restored explicitly.
- Uses `color.channel(..., $space:)` and `math.div` rather than deprecated `red()`/`green()`/`blue()` and slash division.

**Verification**

- Compiled with the repo's own `sass` dependency; both selection rules confirmed separate, and both contrast cases verified.
- Zero deprecation warnings. An initial draft used `red()`/`green()`/`blue()` and slash division; both replaced.
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 2 new files, 0 deletions, no existing file touched.
- Folder carries an `-ad` suffix so this lands as a parallel implementation.

**Labels:** `type:feature` · `scss` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
