### PR TITLE
feat: add ToastStack React component with pausable auto-dismiss (#63813)

### DIFF
--- a/submissions/react/toast-stack-ad/README.md
+++ b/submissions/react/toast-stack-ad/README.md
@@ -1,0 +1,50 @@
+# ToastStack — stacked notifications
+
+> Issue: [#63813](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/63813)
+
+A toast stack with pausable auto-dismiss, a real exit animation, and a bounded visible count.
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `toasts` | `Array<{ id, tone?, title?, message?, action?, duration? }>` | `[]` | Entries without an `id` are skipped. Renders `null` if none remain. |
+| `onDismiss` | `(id) => void` | — | Called **after** the exit animation completes. |
+| `max` | `number` | `3` | Visible toasts before collapsing to a count. Clamped to ≥ 1. |
+| `position` | `'top-right' \| 'top-left' \| 'bottom-right' \| 'bottom-left'` | `'bottom-right'` | |
+| `label` | `string` | `'Notifications'` | Accessible list name. |
+| `className` | `string` | `''` | Merged onto the root. |
+
+Tones: `info` · `success` · `warning` · `danger`. Per-toast `duration` defaults to 5000ms; pass `0` or `Infinity` for a sticky toast.
+
+## Usage
+
+```jsx
+import ToastStack from './ToastStack';
+import './style.css';
+
+<ToastStack
+  toasts={toasts}
+  onDismiss={(id) => setToasts((t) => t.filter((x) => x.id !== id))}
+  max={3}
+  position="bottom-right"
+/>
+```
+
+## Why it fits EaseMotion
+
+Four things toast implementations routinely get wrong:
+
+**Auto-dismiss keeps running while the user is reading.** A toast that vanishes mid-sentence is worse than no toast — the information is gone with no way to retrieve it. Timers pause on hover **and** on focus, so a keyboard user tabbing to the action button gets the same protection a mouse user does.
+
+The pause tracks *remaining* time rather than restarting the timer. Restarting means hovering repeatedly resets the countdown to full each time, so a toast can effectively become permanent.
+
+**The exit never plays.** Removing the item from state unmounts it immediately, so the slide-out is written, styled, and never seen once. Each toast stays mounted through an `exiting` phase and removes itself on `transitionend`, with a timeout fallback for when that event does not fire (off-screen, background tab, interrupted transition).
+
+The `transitionend` handler checks `event.target === node` — without it, a transition on the close button or an action inside the toast bubbles up and removes the toast early, mid-interaction.
+
+**Every toast is an alert.** `warning` and `danger` use `role="alert"`; `info` and `success` use `role="status"`. Marking routine confirmations assertive trains users to ignore the interruptions that matter.
+
+**Unbounded stacking.** Twenty toasts cover the viewport and the app underneath becomes unusable. `max` bounds the visible count and the remainder collapses to "+N more".
+
+Bottom-positioned stacks use `column-reverse` so new toasts appear nearest the screen edge, where the eye already is. Under `prefers-reduced-motion` the exit transition is **shortened, not removed** — unmount waits on `transitionend`, which does not fire at zero duration.

--- a/submissions/react/toast-stack-ad/ToastStack.jsx
+++ b/submissions/react/toast-stack-ad/ToastStack.jsx
@@ -1,0 +1,203 @@
+/**
+ * EaseMotion CSS — ToastStack
+ * ============================================================
+ * Stacked notifications with a real exit animation.
+ *
+ * Four things toast implementations routinely get wrong:
+ *
+ *  1. Auto-dismiss keeps running while the user is reading. A toast that
+ *     vanishes mid-sentence is worse than no toast — the information is
+ *     gone and there is no way to get it back. Timers pause on hover and
+ *     on focus.
+ *
+ *  2. The exit never plays. Removing the item from state unmounts it
+ *     immediately, so the slide-out is written, styled, and never seen.
+ *
+ *  3. Every toast is an alert. Marking routine confirmations assertive
+ *     trains users to ignore the interruptions that matter.
+ *
+ *  4. Unbounded stacking. Twenty toasts cover the viewport and the app
+ *     underneath becomes unusable. A visible limit plus an overflow count
+ *     keeps the stack bounded.
+ * ============================================================
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+const TONES = {
+  info: { glyph: 'i', role: 'status', live: 'polite' },
+  success: { glyph: '✓', role: 'status', live: 'polite' },
+  warning: { glyph: '!', role: 'alert', live: 'assertive' },
+  danger: { glyph: '⚠', role: 'alert', live: 'assertive' },
+};
+
+/** Must exceed the CSS exit duration; guards a missed transitionend. */
+const EXIT_FALLBACK_MS = 420;
+
+function Toast({ toast, onDismiss, paused }) {
+  const config = TONES[toast.tone] ?? TONES.info;
+  const [exiting, setExiting] = useState(false);
+  const nodeRef = useRef(null);
+  const exitTimer = useRef(null);
+  const dismissTimer = useRef(null);
+  const remainingRef = useRef(toast.duration ?? 5000);
+  const startedRef = useRef(null);
+
+  const finish = useCallback(() => {
+    if (exitTimer.current) clearTimeout(exitTimer.current);
+    exitTimer.current = null;
+    onDismiss(toast.id);
+  }, [onDismiss, toast.id]);
+
+  const beginExit = useCallback(() => {
+    setExiting(true);
+  }, []);
+
+  // Auto-dismiss, pausable. Remaining time is tracked rather than the
+  // timer being restarted, so hovering repeatedly does not reset the
+  // countdown to full each time.
+  useEffect(() => {
+    if (exiting) return undefined;
+    if (!Number.isFinite(remainingRef.current) || remainingRef.current <= 0) {
+      return undefined;
+    }
+
+    if (paused) {
+      if (startedRef.current !== null) {
+        remainingRef.current -= Date.now() - startedRef.current;
+        startedRef.current = null;
+      }
+      if (dismissTimer.current) clearTimeout(dismissTimer.current);
+      return undefined;
+    }
+
+    startedRef.current = Date.now();
+    dismissTimer.current = setTimeout(beginExit, Math.max(remainingRef.current, 0));
+
+    return () => {
+      if (dismissTimer.current) clearTimeout(dismissTimer.current);
+    };
+  }, [paused, exiting, beginExit]);
+
+  // Wait for the exit transition before unmounting.
+  useEffect(() => {
+    if (!exiting) return undefined;
+
+    const node = nodeRef.current;
+
+    // Only this element's own transition — a descendant's would bubble
+    // and remove the toast early.
+    const onEnd = (event) => {
+      if (event.target === node) finish();
+    };
+
+    node?.addEventListener('transitionend', onEnd);
+    exitTimer.current = setTimeout(finish, EXIT_FALLBACK_MS);
+
+    return () => {
+      node?.removeEventListener('transitionend', onEnd);
+      if (exitTimer.current) clearTimeout(exitTimer.current);
+    };
+  }, [exiting, finish]);
+
+  return (
+    <li
+      className={`ease-toast-ad ease-toast-ad--${toast.tone in TONES ? toast.tone : 'info'}${
+        exiting ? ' ease-toast-ad--exiting' : ''
+      }`}
+      ref={nodeRef}
+      role={config.role}
+      aria-live={config.live}
+      aria-atomic="true"
+    >
+      <span className="ease-toast-ad__icon" aria-hidden="true">
+        {config.glyph}
+      </span>
+
+      <div className="ease-toast-ad__body">
+        {toast.title && <p className="ease-toast-ad__title">{toast.title}</p>}
+        {toast.message && <p className="ease-toast-ad__msg">{toast.message}</p>}
+        {toast.action && <div className="ease-toast-ad__action">{toast.action}</div>}
+      </div>
+
+      <button
+        className="ease-toast-ad__close"
+        type="button"
+        onClick={beginExit}
+        aria-label="Dismiss notification"
+      >
+        &times;
+      </button>
+    </li>
+  );
+}
+
+/**
+ * @param {object} props
+ * @param {Array<{id, tone?, title?, message?, action?, duration?}>} props.toasts
+ * @param {(id: string|number) => void} props.onDismiss
+ * @param {number}  [props.max=3]   Visible toasts before collapsing.
+ * @param {'top-right'|'top-left'|'bottom-right'|'bottom-left'} [props.position='bottom-right']
+ * @param {string}  [props.label='Notifications']
+ * @param {string}  [props.className]
+ */
+export default function ToastStack({
+  toasts = [],
+  onDismiss,
+  max = 3,
+  position = 'bottom-right',
+  label = 'Notifications',
+  className = '',
+  ...rest
+}) {
+  const [paused, setPaused] = useState(false);
+
+  const safeMax = Number.isFinite(max) && max >= 1 ? Math.floor(max) : 1;
+
+  const { visible, overflow } = useMemo(() => {
+    const valid = toasts.filter((t) => t && t.id !== undefined);
+    return {
+      visible: valid.slice(0, safeMax),
+      overflow: Math.max(0, valid.length - safeMax),
+    };
+  }, [toasts, safeMax]);
+
+  if (visible.length === 0) return null;
+
+  const classes = [
+    'ease-toaststack-ad',
+    `ease-toaststack-ad--${position}`,
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <ol
+      className={classes}
+      aria-label={label}
+      // Pause on hover AND focus — a keyboard user tabbing to the action
+      // button needs the same protection a mouse user gets.
+      onMouseEnter={() => setPaused(true)}
+      onMouseLeave={() => setPaused(false)}
+      onFocusCapture={() => setPaused(true)}
+      onBlurCapture={() => setPaused(false)}
+      {...rest}
+    >
+      {visible.map((toast) => (
+        <Toast
+          key={toast.id}
+          toast={toast}
+          onDismiss={onDismiss}
+          paused={paused}
+        />
+      ))}
+
+      {overflow > 0 && (
+        <li className="ease-toaststack-ad__overflow">
+          +{overflow} more notification{overflow === 1 ? '' : 's'}
+        </li>
+      )}
+    </ol>
+  );
+}

--- a/submissions/react/toast-stack-ad/style.css
+++ b/submissions/react/toast-stack-ad/style.css
@@ -1,0 +1,213 @@
+/* ==========================================================================
+   EaseMotion CSS — ToastStack component styles
+   Issue #63813
+   ========================================================================== */
+
+.ease-toaststack-ad {
+    --ts-gap-ad: 0.6rem;
+    --ts-width-ad: 340px;
+    --ts-edge-ad: 1.25rem;
+    --ts-exit-ad: 280ms;
+    --ts-ease-ad: cubic-bezier(0.16, 1, 0.3, 1);
+
+    display: flex;
+    flex-direction: column;
+    gap: var(--ts-gap-ad);
+    list-style: none;
+    margin: 0;
+    max-width: calc(100vw - var(--ts-edge-ad) * 2);
+    padding: 0;
+    position: fixed;
+    width: var(--ts-width-ad);
+    z-index: 90;
+}
+
+/* -- Positions. Bottom stacks reverse so new toasts appear nearest the
+      edge, which is where the eye already is. -- */
+.ease-toaststack-ad--top-right {
+    right: var(--ts-edge-ad);
+    top: var(--ts-edge-ad);
+}
+
+.ease-toaststack-ad--top-left {
+    left: var(--ts-edge-ad);
+    top: var(--ts-edge-ad);
+}
+
+.ease-toaststack-ad--bottom-right {
+    bottom: var(--ts-edge-ad);
+    flex-direction: column-reverse;
+    right: var(--ts-edge-ad);
+}
+
+.ease-toaststack-ad--bottom-left {
+    bottom: var(--ts-edge-ad);
+    flex-direction: column-reverse;
+    left: var(--ts-edge-ad);
+}
+
+.ease-toaststack-ad__overflow {
+    color: #64748b;
+    font-size: 0.78rem;
+    padding: 0.25rem 0.5rem;
+    text-align: center;
+}
+
+/* ==========================================================================
+   Toast
+   ========================================================================== */
+.ease-toast-ad {
+    --to-accent-ad: #60a5fa;
+    --to-bg-ad: rgba(17, 25, 42, 0.97);
+    --to-title-ad: #f1f5f9;
+    --to-text-ad: #94a3b8;
+
+    background: var(--to-bg-ad);
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    border-left: 3px solid var(--to-accent-ad);
+    border-radius: 11px;
+    box-shadow: 0 16px 34px -18px rgba(0, 0, 0, 0.9);
+    display: flex;
+    gap: 0.7rem;
+    /* Bounded so the collapse has a real value to animate from — `auto`
+       is not interpolatable and the exit would not collapse. */
+    max-height: 20rem;
+    opacity: 1;
+    overflow: hidden;
+    padding: 0.85rem 0.9rem;
+    transform: translateX(0);
+    transition:
+        max-height var(--ts-exit-ad) var(--ts-ease-ad),
+        margin var(--ts-exit-ad) var(--ts-ease-ad),
+        opacity var(--ts-exit-ad) var(--ts-ease-ad),
+        padding var(--ts-exit-ad) var(--ts-ease-ad),
+        transform var(--ts-exit-ad) var(--ts-ease-ad);
+}
+
+.ease-toast-ad--exiting {
+    margin-bottom: 0;
+    margin-top: 0;
+    max-height: 0;
+    opacity: 0;
+    padding-bottom: 0;
+    padding-top: 0;
+    transform: translateX(14px);
+}
+
+/* -- Tones -- */
+.ease-toast-ad--info {
+    --to-accent-ad: #60a5fa;
+}
+
+.ease-toast-ad--success {
+    --to-accent-ad: #34d399;
+}
+
+.ease-toast-ad--warning {
+    --to-accent-ad: #fbbf24;
+}
+
+.ease-toast-ad--danger {
+    --to-accent-ad: #f87171;
+}
+
+/* -- Parts -- */
+.ease-toast-ad__icon {
+    align-items: center;
+    background: var(--to-accent-ad);
+    border-radius: 50%;
+    color: #06101f;
+    display: flex;
+    flex: 0 0 auto;
+    font-size: 0.7rem;
+    font-weight: 700;
+    height: 19px;
+    justify-content: center;
+    line-height: 1;
+    margin-top: 0.15rem;
+    width: 19px;
+}
+
+.ease-toast-ad__body {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.ease-toast-ad__title {
+    color: var(--to-title-ad);
+    font-size: 0.88rem;
+    font-weight: 600;
+    margin: 0 0 0.15rem;
+}
+
+.ease-toast-ad__msg {
+    color: var(--to-text-ad);
+    font-size: 0.82rem;
+    margin: 0;
+}
+
+.ease-toast-ad__action {
+    margin-top: 0.55rem;
+}
+
+.ease-toast-ad__close {
+    align-items: center;
+    background: none;
+    border: 0;
+    border-radius: 50%;
+    color: var(--to-text-ad);
+    cursor: pointer;
+    display: flex;
+    flex: 0 0 auto;
+    font-size: 1.05rem;
+    height: 22px;
+    justify-content: center;
+    line-height: 1;
+    padding: 0;
+    width: 22px;
+}
+
+.ease-toast-ad__close:hover {
+    background: rgba(148, 163, 184, 0.16);
+    color: var(--to-title-ad);
+}
+
+.ease-toast-ad__close:focus-visible {
+    outline: 2px solid var(--to-accent-ad);
+    outline-offset: 2px;
+}
+
+/* The exit transition is shortened, never removed — unmount waits on
+   transitionend, which does not fire at zero duration. */
+@media (prefers-reduced-motion: reduce) {
+    .ease-toast-ad {
+        transition-duration: 1ms;
+    }
+
+    .ease-toast-ad--exiting {
+        transform: none;
+    }
+}
+
+@media (max-width: 420px) {
+    .ease-toaststack-ad {
+        --ts-edge-ad: 0.75rem;
+        --ts-width-ad: auto;
+
+        left: var(--ts-edge-ad);
+        right: var(--ts-edge-ad);
+    }
+}
+
+@media (forced-colors: active) {
+    .ease-toast-ad {
+        border: 1px solid CanvasText;
+        border-left-width: 3px;
+    }
+
+    .ease-toast-ad__icon {
+        background: Canvas;
+        border: 1px solid CanvasText;
+        color: CanvasText;
+    }
+}

--- a/submissions/react/toast-stack-ad/style.css
+++ b/submissions/react/toast-stack-ad/style.css
@@ -69,6 +69,7 @@
     box-shadow: 0 16px 34px -18px rgba(0, 0, 0, 0.9);
     display: flex;
     gap: 0.7rem;
+
     /* Bounded so the collapse has a real value to animate from — `auto`
        is not interpolatable and the exit would not collapse. */
     max-height: 20rem;


### PR DESCRIPTION
Fixes #63813

**What was added**

A toast stack, under `submissions/react/toast-stack-ad/`.

- `ToastStack.jsx` — 178 non-empty lines: pausable per-toast timers with remaining-time tracking, transitionend-driven exit with fallback, tone-scoped ARIA, and a bounded visible count.
- `style.css` — 185 non-empty lines: four positions, four tones, collapse-and-slide exit, narrow-viewport handling, reduced-motion and forced-colors.
- `README.md` — props table, usage, and rationale.

**What is the problem**

Four things toast implementations routinely get wrong:

1. **Auto-dismiss keeps running while the user is reading.** A toast that vanishes mid-sentence is worse than no toast — the information is gone with no way to retrieve it.
2. **The exit never plays.** Removing the item from state unmounts it immediately, so the slide-out is written, styled, and never seen once.
3. **Every toast is an alert.** Marking routine confirmations assertive trains users to ignore the interruptions that matter.
4. **Unbounded stacking.** Twenty toasts cover the viewport and the app underneath becomes unusable.

**Why this approach**

Timers pause on hover **and** on focus — a keyboard user tabbing to the toast's action button needs the same protection a mouse user gets, and focus-only or hover-only implementations leave one group out.

The pause tracks **remaining** time rather than restarting the timer. Restarting means hovering repeatedly resets the countdown to full, so a toast can effectively become permanent — a subtle bug that only shows up with real mouse movement.

Each toast stays mounted through an `exiting` phase and removes itself on `transitionend`, with a timeout fallback (420ms, above the 280ms CSS exit) for when that event does not fire — off-screen, background tab, or interrupted transition.

The `transitionend` handler checks `event.target === node`. Without it, a transition on the close button or an action inside the toast bubbles up and removes the toast early, mid-interaction.

Tones map to `role="alert"` only for `warning` and `danger`.

**How to test**

1. Pull this branch and drop `toast-stack-ad/` into any React app (React 16.8+).
2. Render with 5 toasts and `max={3}` — confirm 3 render plus a "+2 more" row.
3. **Hover a toast and hold.** It must not dismiss. Move away and confirm it dismisses shortly after — **not** after a full fresh 5 seconds. That difference is the remaining-time tracking.
4. Hover on and off several times quickly, then leave — the toast must still dismiss promptly rather than restarting each time.
5. **Tab into a toast's action button** and wait — auto-dismiss must pause for focus too.
6. Let a toast auto-dismiss and confirm it **collapses and slides out** before unmounting, and that `onDismiss` fires after the animation, not at the start.
7. Start a dismissal, then hover the close button mid-exit — the toast must not disappear early. That is the `event.target` guard.
8. Confirm `warning`/`danger` carry `role="alert"` and `info`/`success` carry `role="status"`.
9. Pass `duration: 0` and confirm the toast is sticky.
10. Resize below 420px and confirm the stack spans the viewport with reduced edge padding.
11. Enable reduced motion and confirm toasts still dismiss promptly.

**Edge cases covered**

- Pause on hover and focus, so pointer and keyboard users both get reading time.
- Remaining-time tracking prevents repeated hovers resetting the countdown.
- `transitionend` filtered to the element itself, so descendant transitions cannot unmount it early.
- Timeout fallback guarantees removal if `transitionend` never fires; verified to exceed the CSS duration.
- Reduced motion shortens rather than removes the transition, since unmount depends on `transitionend` firing.
- Entries without an `id` are filtered out; empty input returns `null`.
- `max` is validated and floored, so a bad prop cannot hide every toast.
- Unknown tones degrade to `info` in both the config lookup and the class name.
- `duration: 0` / `Infinity` produces a sticky toast rather than an immediate dismiss.
- Bottom stacks use `column-reverse` so new toasts appear nearest the screen edge.
- `max-height` is bounded rather than `auto`, so the collapse is interpolatable.
- `margin` and `padding` animate too, so remaining toasts slide up smoothly.
- `min-width: 0` on the body lets long unbroken text shrink instead of overflowing.

**Verification**

- `ToastStack.jsx` parses cleanly through esbuild — exit code 0.
- `npx stylelint style.css` against the repo's own config — exit code 0 (one comment-placement error found and fixed).
- All component classes referenced in the JSX are defined in `style.css`; all four tones have matching modifiers.
- Verified programmatically: `event.target` guard present, hover+focus pause present, remaining-time tracking present, and `EXIT_FALLBACK_MS` (420) > CSS exit (280).
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 3 new files, 0 deletions, no existing file touched.
- Component classes carry an `-ad` suffix so this lands as a parallel implementation.

**Labels:** `type:feature` · `react` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
