### PR TITLE
feat: add PasswordMeter React component with actionable criteria (#63815)

### DIFF
--- a/submissions/react/password-meter-ad/PasswordMeter.jsx
+++ b/submissions/react/password-meter-ad/PasswordMeter.jsx
@@ -1,0 +1,197 @@
+/**
+ * EaseMotion CSS — PasswordMeter
+ * ============================================================
+ * Password strength with actionable feedback.
+ *
+ * The usual meter shows a coloured bar and the word "Weak". That tells
+ * the user they have a problem and nothing about how to fix it, so they
+ * add an exclamation mark and try again. Listing the specific unmet
+ * criteria is the difference between a meter that helps and one that
+ * just judges.
+ *
+ * Announcement is threshold-based, not per-keystroke. A meter wired to a
+ * live region that updates on every character makes the field unusable
+ * with a screen reader — the user cannot hear their own typing.
+ *
+ * Scoring note: length dominates deliberately. Character-class rules are
+ * weak predictors of real strength (they push people toward `P@ssw0rd!`,
+ * which is trivially guessable), whereas length is the single strongest
+ * factor. NIST 800-63B makes the same recommendation. The class checks
+ * are kept because most registration forms still require them, but they
+ * are worth less than length here.
+ * ============================================================
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+const LEVELS = ['Very weak', 'Weak', 'Fair', 'Strong', 'Very strong'];
+
+/** Sequences that make a password trivially guessable regardless of form. */
+const COMMON_PATTERNS = [
+  /^(.)\1+$/, // all one character
+  /12345|23456|34567|45678|56789/,
+  /qwerty|asdfgh|zxcvbn/i,
+  /password|letmein|welcome|admin/i,
+];
+
+/**
+ * Evaluate a password. Returns a score 0–4 and the unmet criteria.
+ */
+function evaluate(password, minLength) {
+  const value = typeof password === 'string' ? password : '';
+
+  const checks = [
+    { id: 'length', label: `At least ${minLength} characters`, met: value.length >= minLength },
+    { id: 'lower', label: 'A lowercase letter', met: /[a-z]/.test(value) },
+    { id: 'upper', label: 'An uppercase letter', met: /[A-Z]/.test(value) },
+    { id: 'number', label: 'A number', met: /\d/.test(value) },
+    { id: 'symbol', label: 'A symbol', met: /[^\w\s]/.test(value) },
+  ];
+
+  if (value === '') {
+    return { score: 0, checks, unmet: checks.filter((c) => !c.met), common: false };
+  }
+
+  const common = COMMON_PATTERNS.some((pattern) => pattern.test(value));
+
+  // A recognisable pattern caps the score regardless of composition —
+  // "Password123!" satisfies every class check and is still guessable.
+  if (common) {
+    return { score: 0, checks, unmet: checks.filter((c) => !c.met), common: true };
+  }
+
+  let score = 0;
+
+  // Length carries the most weight.
+  if (value.length >= minLength) score += 1;
+  if (value.length >= minLength + 4) score += 1;
+  if (value.length >= minLength + 10) score += 1;
+
+  const classes = checks.slice(1).filter((c) => c.met).length;
+  if (classes >= 3) score += 1;
+
+  return {
+    score: Math.min(score, LEVELS.length - 1),
+    checks,
+    unmet: checks.filter((c) => !c.met),
+    common: false,
+  };
+}
+
+/**
+ * @param {object} props
+ * @param {string}  props.value
+ * @param {number}  [props.minLength=12]
+ * @param {boolean} [props.showChecklist=true]
+ * @param {(result: object) => void} [props.onEvaluate]
+ * @param {string}  [props.className]
+ */
+export default function PasswordMeter({
+  value = '',
+  minLength = 12,
+  showChecklist = true,
+  onEvaluate,
+  className = '',
+  ...rest
+}) {
+  const result = useMemo(() => evaluate(value, minLength), [value, minLength]);
+
+  const onEvaluateRef = useRef(onEvaluate);
+  useEffect(() => {
+    onEvaluateRef.current = onEvaluate;
+  }, [onEvaluate]);
+
+  useEffect(() => {
+    onEvaluateRef.current?.(result);
+  }, [result]);
+
+  // Announce on score CHANGE only — never per keystroke.
+  const [announcement, setAnnouncement] = useState('');
+  const lastScore = useRef(null);
+
+  useEffect(() => {
+    if (value === '') {
+      lastScore.current = null;
+      setAnnouncement('');
+      return;
+    }
+
+    if (result.score === lastScore.current) return;
+    lastScore.current = result.score;
+
+    if (result.common) {
+      setAnnouncement('This is a commonly used password. Choose something less predictable.');
+    } else if (result.unmet.length > 0) {
+      setAnnouncement(
+        `${LEVELS[result.score]}. Still needed: ${result.unmet.map((c) => c.label).join(', ')}.`,
+      );
+    } else {
+      setAnnouncement(`${LEVELS[result.score]}. All requirements met.`);
+    }
+  }, [result, value]);
+
+  const classes = [
+    'ease-pwmeter-ad',
+    `ease-pwmeter-ad--score-${result.score}`,
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div className={classes} {...rest}>
+      <div
+        className="ease-pwmeter-ad__track"
+        role="meter"
+        aria-valuenow={result.score}
+        aria-valuemin={0}
+        aria-valuemax={LEVELS.length - 1}
+        aria-valuetext={value === '' ? 'No password entered' : LEVELS[result.score]}
+        aria-label="Password strength"
+      >
+        {LEVELS.map((_, index) => (
+          <span
+            className={`ease-pwmeter-ad__seg${
+              value !== '' && index <= result.score ? ' ease-pwmeter-ad__seg--on' : ''
+            }`}
+            key={index}
+            aria-hidden="true"
+          />
+        ))}
+      </div>
+
+      <p className="ease-pwmeter-ad__label" aria-hidden="true">
+        {value === '' ? 'Enter a password' : LEVELS[result.score]}
+      </p>
+
+      {result.common && value !== '' && (
+        <p className="ease-pwmeter-ad__warn">
+          This is a commonly used password.
+        </p>
+      )}
+
+      {showChecklist && (
+        <ul className="ease-pwmeter-ad__checks">
+          {result.checks.map((check) => (
+            <li
+              className={`ease-pwmeter-ad__check${
+                check.met ? ' ease-pwmeter-ad__check--met' : ''
+              }`}
+              key={check.id}
+            >
+              {/* Glyph carries the state alongside colour. */}
+              <span className="ease-pwmeter-ad__mark" aria-hidden="true">
+                {check.met ? '✓' : '○'}
+              </span>
+              {check.label}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <span className="ease-pwmeter-ad__sr" role="status" aria-live="polite">
+        {announcement}
+      </span>
+    </div>
+  );
+}

--- a/submissions/react/password-meter-ad/README.md
+++ b/submissions/react/password-meter-ad/README.md
@@ -1,0 +1,37 @@
+# PasswordMeter — strength meter with actionable feedback
+
+> Issue: [#63815](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/63815)
+
+A password strength meter that says what is missing, not just how bad it is.
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `value` | `string` | `''` | The password. |
+| `minLength` | `number` | `12` | Length requirement. |
+| `showChecklist` | `boolean` | `true` | Render the per-criterion checklist. |
+| `onEvaluate` | `(result) => void` | — | Receives `{ score, checks, unmet, common }`. |
+| `className` | `string` | `''` | Merged onto the root. |
+
+## Usage
+
+```jsx
+import PasswordMeter from './PasswordMeter';
+import './style.css';
+
+<input type="password" value={pw} onChange={(e) => setPw(e.target.value)} />
+<PasswordMeter value={pw} minLength={12} onEvaluate={(r) => setValid(r.score >= 3)} />
+```
+
+## Why it fits EaseMotion
+
+**A bar and the word "Weak" tells the user they have a problem and nothing about how to fix it** — so they add an exclamation mark and try again. Listing the specific unmet criteria is the difference between a meter that helps and one that just judges.
+
+**Announcement is threshold-based.** A meter wired to a live region that updates on every character makes the field unusable with a screen reader — the user cannot hear their own typing. Announcements fire only when the score band changes, and they carry the unmet criteria so the announcement is as actionable as the visual.
+
+**Length dominates the score, deliberately.** Character-class rules are weak predictors of real strength — they push people toward `P@ssw0rd!`, which satisfies every class check and is trivially guessable. Length is the single strongest factor, and NIST 800-63B makes the same recommendation. The class checks are kept because most registration forms still require them, but they are weighted below length.
+
+That is also why a recognised common pattern **caps the score at zero** regardless of composition. Without that, `Password123!` scores full marks.
+
+Two presentation details: the track is **segmented rather than continuous**, because a smooth fill implies a precision the scoring does not have and invites the user to chase the last few percent of what is really five buckets. And each checklist item carries a glyph (`✓` / `○`) as well as a colour, so met and unmet states survive without colour vision.

--- a/submissions/react/password-meter-ad/style.css
+++ b/submissions/react/password-meter-ad/style.css
@@ -1,0 +1,135 @@
+/* ==========================================================================
+   EaseMotion CSS — PasswordMeter component styles
+   Issue #63815
+   ========================================================================== */
+
+.ease-pwmeter-ad {
+    --pw-track-ad: rgba(148, 163, 184, 0.18);
+    --pw-fill-ad: #64748b;
+    --pw-text-ad: #94a3b8;
+    --pw-strong-ad: #f1f5f9;
+    --pw-ease-ad: cubic-bezier(0.16, 1, 0.3, 1);
+
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+}
+
+.ease-pwmeter-ad__sr {
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+}
+
+/* ==========================================================================
+   Segmented track
+   --------------------------------------------------------------------------
+   Discrete segments rather than a continuous bar: a continuous fill
+   implies a precision the scoring does not have, and invites the user to
+   chase the last few percent of a number that is really five buckets.
+   ========================================================================== */
+.ease-pwmeter-ad__track {
+    display: flex;
+    gap: 3px;
+}
+
+.ease-pwmeter-ad__seg {
+    background: var(--pw-track-ad);
+    border-radius: 999px;
+    flex: 1 1 0;
+    height: 4px;
+    transition: background-color 260ms var(--pw-ease-ad);
+}
+
+.ease-pwmeter-ad__seg--on {
+    background: var(--pw-fill-ad);
+}
+
+/* -- Score ramp -- */
+.ease-pwmeter-ad--score-0 {
+    --pw-fill-ad: #f87171;
+}
+
+.ease-pwmeter-ad--score-1 {
+    --pw-fill-ad: #fb923c;
+}
+
+.ease-pwmeter-ad--score-2 {
+    --pw-fill-ad: #fbbf24;
+}
+
+.ease-pwmeter-ad--score-3 {
+    --pw-fill-ad: #a3e635;
+}
+
+.ease-pwmeter-ad--score-4 {
+    --pw-fill-ad: #34d399;
+}
+
+/* ==========================================================================
+   Labels and checklist
+   ========================================================================== */
+.ease-pwmeter-ad__label {
+    color: var(--pw-text-ad);
+    font-size: 0.78rem;
+    margin: 0;
+}
+
+.ease-pwmeter-ad__warn {
+    color: #f87171;
+    font-size: 0.78rem;
+    margin: 0;
+}
+
+.ease-pwmeter-ad__checks {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.ease-pwmeter-ad__check {
+    align-items: center;
+    color: var(--pw-text-ad);
+    display: flex;
+    font-size: 0.78rem;
+    gap: 0.4rem;
+}
+
+.ease-pwmeter-ad__check--met {
+    color: var(--pw-strong-ad);
+}
+
+.ease-pwmeter-ad__mark {
+    color: var(--pw-text-ad);
+    flex: 0 0 auto;
+    font-size: 0.72rem;
+    line-height: 1;
+    width: 0.9rem;
+}
+
+.ease-pwmeter-ad__check--met .ease-pwmeter-ad__mark {
+    color: #34d399;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .ease-pwmeter-ad__seg {
+        transition-duration: 1ms;
+    }
+}
+
+@media (forced-colors: active) {
+    .ease-pwmeter-ad__seg {
+        border: 1px solid CanvasText;
+    }
+
+    .ease-pwmeter-ad__seg--on {
+        background: Highlight;
+    }
+}


### PR DESCRIPTION
Fixes #63815

**What was added**

A password strength meter, under `submissions/react/password-meter-ad/`.

- `PasswordMeter.jsx` — 172 non-empty lines: length-dominant scoring, common-pattern detection, per-criterion checklist, and threshold-based announcement.
- `style.css` — segmented track, five-step colour ramp, checklist glyphs, reduced-motion and forced-colors.
- `README.md` — props table, usage, and rationale.

**What is the problem**

**A bar and the word "Weak" tells the user they have a problem and nothing about how to fix it** — so they append an exclamation mark and try again. The meter judges without helping.

Second, **a meter wired to a live region announces on every keystroke**, which makes the field unusable with a screen reader: the user cannot hear their own typing.

Third, **class-based scoring rewards the wrong thing.** Requiring upper/lower/digit/symbol pushes people toward `P@ssw0rd!` — which satisfies every rule and is trivially guessable.

**Why this approach**

The component lists the **specific unmet criteria**, both visually and in the announcement, so the feedback is actionable rather than a verdict.

Announcements fire only when the score *band* changes, not per character.

Scoring weights length above character classes, following NIST 800-63B. The class checks are retained because most registration forms still require them, but they are worth less than length. A recognised common pattern **caps the score at zero** regardless of composition.

The verified results demonstrate this works:

| Password | Score |
|---|---|
| `Password123!` — satisfies **every** class check | **0** (common-pattern cap) |
| `Tr0ub4dor&3xyz` — 14 chars, all classes | 2 |
| `correct horse battery staple` — lowercase only | **3** |
| `aaaa` | 0 |

The passphrase beating the symbol-laden password is the intended outcome, and it is the clearest evidence the weighting is right.

**How to test**

1. Pull this branch and drop `password-meter-ad/` into any React app (React 16.8+).
2. Render alongside a password input:
   ```jsx
   <PasswordMeter value={pw} minLength={12} onEvaluate={(r) => setValid(r.score >= 3)} />
   ```
3. **Type `Password123!`** — it satisfies every class check and must still score **0**, with the "commonly used password" warning shown.
4. **Type `correct horse battery staple`** — it must score **higher** than `Tr0ub4dor&3xyz`.
5. Confirm the checklist shows exactly which criteria are unmet, updating as you type.
6. **Turn on a screen reader and type continuously.** Announcements must fire only when the strength band changes — not per keystroke — and must include what is still needed.
7. Clear the field and confirm the announcement clears rather than leaving a stale one.
8. Confirm the track is segmented, and that met/unmet checklist items differ by glyph as well as colour.
9. Apply a greyscale filter and confirm the checklist is still readable.
10. Confirm `role="meter"` carries `aria-valuenow` / `min` / `max` / `valuetext`.

**Edge cases covered**

- Common patterns cap the score regardless of character classes.
- Length weighted above class rules, per NIST 800-63B.
- Announcements fire on band change only, and clear when the field empties.
- The checklist carries glyphs as well as colour, so state survives without colour vision.
- Empty input renders a neutral state rather than "Very weak", which would read as a criticism of nothing.
- Non-string `value` is coerced rather than throwing.
- `onEvaluate` is held in a ref, so an inline arrow does not retrigger the effect each render.
- The segmented track avoids implying precision the five-bucket score does not have.
- `role="meter"` exposes the full value range, with `aria-valuetext` giving the band name rather than a bare number.
- Segments are `aria-hidden`, since the meter role already carries the value.
- `forced-colors: active` gives filled segments the system `Highlight` colour.

**Verification**

- `PasswordMeter.jsx` parses cleanly through esbuild — exit code 0.
- `npx stylelint style.css` against the repo's own config — exit code 0.
- All component classes referenced in the JSX are defined in `style.css`; all five score modifiers present.
- Scoring logic verified against five inputs, including the two decisive cases above.
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 3 new files, 0 deletions, no existing file touched.
- Component classes carry an `-ad` suffix so this lands as a parallel implementation.

**Labels:** `type:feature` · `react` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
