### PR TITLE
feat: add MultiSelect React component with combobox semantics (#63816)

### DIFF
--- a/submissions/react/multi-select-ad/MultiSelect.jsx
+++ b/submissions/react/multi-select-ad/MultiSelect.jsx
@@ -1,0 +1,252 @@
+/**
+ * EaseMotion CSS — MultiSelect
+ * ============================================================
+ * Multi-select implementing the ARIA combobox pattern.
+ *
+ * The critical detail is `aria-activedescendant`, not roving tabindex.
+ * In a combobox, DOM focus must STAY on the input while the highlighted
+ * option changes — otherwise arrow-key navigation moves focus out of the
+ * text field and the user can no longer type to filter. Most hand-rolled
+ * multi-selects move focus to the option, which breaks the one
+ * interaction the component exists for.
+ *
+ * Other things handled that are commonly missed:
+ *
+ *  - Backspace on an empty input removes the last chip, which is the
+ *    interaction people expect from every tag field they have used.
+ *  - Chip removal returns focus to the input rather than to <body>.
+ *  - Selection changes are announced, since a chip appearing silently is
+ *    invisible to a screen reader user.
+ * ============================================================
+ */
+
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+
+/**
+ * @param {object} props
+ * @param {Array<{value: string, label: string, disabled?: boolean}>} props.options
+ * @param {string[]} props.value           Selected values.
+ * @param {(next: string[]) => void} props.onChange
+ * @param {string}   [props.placeholder='Select…']
+ * @param {string}   [props.label='Selection']
+ * @param {number}   [props.max]           Maximum selections.
+ * @param {boolean}  [props.disabled=false]
+ * @param {string}   [props.className]
+ */
+export default function MultiSelect({
+  options = [],
+  value = [],
+  onChange,
+  placeholder = 'Select…',
+  label = 'Selection',
+  max,
+  disabled = false,
+  className = '',
+  ...rest
+}) {
+  const baseId = useId();
+  const inputRef = useRef(null);
+  const listRef = useRef(null);
+
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [announcement, setAnnouncement] = useState('');
+
+  const selected = useMemo(() => new Set(value), [value]);
+
+  const filtered = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    return options.filter((option) => {
+      if (!option || selected.has(option.value)) return false;
+      if (!needle) return true;
+      return option.label.toLowerCase().includes(needle);
+    });
+  }, [options, query, selected]);
+
+  const atMax = Number.isFinite(max) && value.length >= max;
+
+  // Clamp the highlight when filtering shrinks the list, or it can point
+  // past the end and Enter selects nothing.
+  useEffect(() => {
+    setActiveIndex((current) => Math.min(current, Math.max(filtered.length - 1, 0)));
+  }, [filtered.length]);
+
+  const labelFor = useCallback(
+    (val) => options.find((o) => o?.value === val)?.label ?? val,
+    [options],
+  );
+
+  const select = useCallback(
+    (option) => {
+      if (!option || option.disabled || atMax) return;
+
+      onChange?.([...value, option.value]);
+      setAnnouncement(`${option.label} added.`);
+      setQuery('');
+      inputRef.current?.focus();
+    },
+    [onChange, value, atMax],
+  );
+
+  const remove = useCallback(
+    (val) => {
+      onChange?.(value.filter((v) => v !== val));
+      setAnnouncement(`${labelFor(val)} removed.`);
+      // Focus must land somewhere deliberate — removing the focused chip
+      // would otherwise drop focus to <body>.
+      inputRef.current?.focus();
+    },
+    [onChange, value, labelFor],
+  );
+
+  const onKeyDown = useCallback(
+    (event) => {
+      switch (event.key) {
+        case 'ArrowDown':
+          event.preventDefault();
+          setOpen(true);
+          setActiveIndex((i) => (filtered.length ? (i + 1) % filtered.length : 0));
+          break;
+        case 'ArrowUp':
+          event.preventDefault();
+          setOpen(true);
+          setActiveIndex((i) =>
+            filtered.length ? (i - 1 + filtered.length) % filtered.length : 0,
+          );
+          break;
+        case 'Enter':
+          if (open && filtered[activeIndex]) {
+            event.preventDefault();
+            select(filtered[activeIndex]);
+          }
+          break;
+        case 'Escape':
+          if (open) {
+            event.preventDefault();
+            setOpen(false);
+          }
+          break;
+        case 'Backspace':
+          // Only when the input is empty, or this would eat characters.
+          if (query === '' && value.length > 0) {
+            event.preventDefault();
+            remove(value[value.length - 1]);
+          }
+          break;
+        default:
+          break;
+      }
+    },
+    [filtered, activeIndex, open, query, value, select, remove],
+  );
+
+  // Keep the highlighted option scrolled into view without moving focus.
+  useEffect(() => {
+    if (!open) return;
+    const node = listRef.current?.querySelector('[data-active="true"]');
+    node?.scrollIntoView({ block: 'nearest' });
+  }, [activeIndex, open]);
+
+  const classes = [
+    'ease-msel-ad',
+    open ? 'ease-msel-ad--open' : '',
+    disabled ? 'ease-msel-ad--disabled' : '',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const listId = `${baseId}-list`;
+  const activeId = filtered[activeIndex] ? `${baseId}-opt-${activeIndex}` : undefined;
+
+  return (
+    <div className={classes} {...rest}>
+      <div
+        className="ease-msel-ad__control"
+        onClick={() => !disabled && inputRef.current?.focus()}
+        role="presentation"
+      >
+        {value.map((val) => (
+          <span className="ease-msel-ad__chip" key={val}>
+            {labelFor(val)}
+            <button
+              className="ease-msel-ad__chip-x"
+              type="button"
+              disabled={disabled}
+              onClick={(event) => {
+                event.stopPropagation();
+                remove(val);
+              }}
+              aria-label={`Remove ${labelFor(val)}`}
+            >
+              &times;
+            </button>
+          </span>
+        ))}
+
+        <input
+          className="ease-msel-ad__input"
+          ref={inputRef}
+          type="text"
+          role="combobox"
+          aria-expanded={open}
+          aria-controls={listId}
+          aria-autocomplete="list"
+          aria-label={label}
+          // Focus stays on the input; only this pointer moves.
+          aria-activedescendant={open ? activeId : undefined}
+          value={query}
+          disabled={disabled}
+          placeholder={value.length === 0 ? placeholder : ''}
+          onChange={(event) => {
+            setQuery(event.target.value);
+            setOpen(true);
+          }}
+          onFocus={() => setOpen(true)}
+          onBlur={() => setOpen(false)}
+          onKeyDown={onKeyDown}
+        />
+      </div>
+
+      {open && (
+        <ul className="ease-msel-ad__list" ref={listRef} id={listId} role="listbox">
+          {atMax && (
+            <li className="ease-msel-ad__empty">Maximum of {max} selected</li>
+          )}
+
+          {!atMax && filtered.length === 0 && (
+            <li className="ease-msel-ad__empty">No matches</li>
+          )}
+
+          {!atMax &&
+            filtered.map((option, index) => (
+              <li
+                className={`ease-msel-ad__option${
+                  index === activeIndex ? ' ease-msel-ad__option--active' : ''
+                }`}
+                key={option.value}
+                id={`${baseId}-opt-${index}`}
+                role="option"
+                aria-selected={index === activeIndex}
+                data-active={index === activeIndex ? 'true' : undefined}
+                // mousedown, not click: click fires after blur, which
+                // would close the list before the selection registers.
+                onMouseDown={(event) => {
+                  event.preventDefault();
+                  select(option);
+                }}
+                onMouseEnter={() => setActiveIndex(index)}
+              >
+                {option.label}
+              </li>
+            ))}
+        </ul>
+      )}
+
+      <span className="ease-msel-ad__sr" role="status" aria-live="polite">
+        {announcement}
+      </span>
+    </div>
+  );
+}

--- a/submissions/react/multi-select-ad/README.md
+++ b/submissions/react/multi-select-ad/README.md
@@ -1,0 +1,55 @@
+# MultiSelect — accessible multi-select
+
+> Issue: [#63816](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/63816)
+
+A multi-select implementing the ARIA combobox pattern, with removable chips and type-to-filter.
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `options` | `Array<{ value, label, disabled? }>` | `[]` | Available options. |
+| `value` | `string[]` | `[]` | Selected values. |
+| `onChange` | `(next: string[]) => void` | — | Receives the new selection. |
+| `placeholder` | `string` | `'Select…'` | Shown when nothing is selected. |
+| `label` | `string` | `'Selection'` | Accessible name for the input. |
+| `max` | `number` | — | Maximum selections. |
+| `disabled` | `boolean` | `false` | |
+| `className` | `string` | `''` | Merged onto the root. |
+
+## Keyboard
+
+| Key | Action |
+|---|---|
+| type | Filter options |
+| <kbd>↓</kbd> / <kbd>↑</kbd> | Move the highlight (wraps) |
+| <kbd>Enter</kbd> | Select the highlighted option |
+| <kbd>Esc</kbd> | Close the list |
+| <kbd>Backspace</kbd> | Remove the last chip (only when the input is empty) |
+
+## Usage
+
+```jsx
+import MultiSelect from './MultiSelect';
+import './style.css';
+
+<MultiSelect
+  label="Tags"
+  options={tags}
+  value={selected}
+  onChange={setSelected}
+  max={5}
+/>
+```
+
+## Why it fits EaseMotion
+
+**`aria-activedescendant`, not roving tabindex.** This is the load-bearing decision. In a combobox, DOM focus must *stay on the input* while the highlighted option changes — otherwise arrow keys move focus out of the text field and the user can no longer type to filter. Most hand-rolled multi-selects move focus onto the option and break the one interaction the component exists for. Here focus never leaves the input; only the `aria-activedescendant` pointer moves, and the visual highlight follows it.
+
+**Options select on `mousedown`, not `click`.** A `click` fires *after* `blur`, which closes the list — so the option unmounts before the click lands and the selection silently never happens. This is the classic dropdown bug, and it looks like a random intermittent failure.
+
+**Backspace only removes a chip when the input is empty.** Otherwise it would eat typed characters, which makes filtering impossible.
+
+**Chip removal returns focus to the input.** Removing the chip that currently has focus would otherwise drop focus to `<body>`, dumping a keyboard user at the top of the page.
+
+The highlight index is clamped when filtering shrinks the list — without that it can point past the end and Enter selects nothing. Selection changes are announced politely, since a chip appearing is invisible to a screen reader user otherwise. And the focus ring lives on the *control* rather than the bare input, which has no visible border of its own.

--- a/submissions/react/multi-select-ad/style.css
+++ b/submissions/react/multi-select-ad/style.css
@@ -1,0 +1,158 @@
+/* ==========================================================================
+   EaseMotion CSS — MultiSelect component styles
+   Issue #63816
+   ========================================================================== */
+
+.ease-msel-ad {
+    --ms-bg-ad: rgba(15, 23, 40, 0.85);
+    --ms-border-ad: rgba(148, 163, 184, 0.28);
+    --ms-accent-ad: #38bdf8;
+    --ms-text-ad: #f1f5f9;
+    --ms-muted-ad: #64748b;
+    --ms-chip-ad: rgba(56, 189, 248, 0.16);
+
+    position: relative;
+}
+
+.ease-msel-ad__sr {
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+}
+
+/* ==========================================================================
+   Control
+   ========================================================================== */
+.ease-msel-ad__control {
+    align-items: center;
+    background: var(--ms-bg-ad);
+    border: 1px solid var(--ms-border-ad);
+    border-radius: 10px;
+    cursor: text;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.3rem;
+    min-height: 42px;
+    padding: 0.3rem 0.45rem;
+}
+
+/* Focus ring lives on the control, driven by the input inside it — the
+   input itself has no visible border, so its own ring would float. */
+.ease-msel-ad:focus-within .ease-msel-ad__control {
+    border-color: var(--ms-accent-ad);
+    box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.2);
+}
+
+.ease-msel-ad--disabled .ease-msel-ad__control {
+    cursor: not-allowed;
+    opacity: 0.55;
+}
+
+.ease-msel-ad__input {
+    background: none;
+    border: 0;
+    color: var(--ms-text-ad);
+    flex: 1 1 6ch;
+    font: inherit;
+    min-width: 6ch;
+    outline: none;
+    padding: 0.25rem;
+}
+
+.ease-msel-ad__input::placeholder {
+    color: var(--ms-muted-ad);
+}
+
+/* ==========================================================================
+   Chips
+   ========================================================================== */
+.ease-msel-ad__chip {
+    align-items: center;
+    background: var(--ms-chip-ad);
+    border-radius: 6px;
+    color: var(--ms-text-ad);
+    display: inline-flex;
+    font-size: 0.8rem;
+    gap: 0.3rem;
+    max-width: 100%;
+    padding: 0.2rem 0.25rem 0.2rem 0.5rem;
+}
+
+.ease-msel-ad__chip-x {
+    background: none;
+    border: 0;
+    border-radius: 4px;
+    color: var(--ms-muted-ad);
+    cursor: pointer;
+    font-size: 0.95rem;
+    line-height: 1;
+    padding: 0 0.2rem;
+}
+
+.ease-msel-ad__chip-x:hover {
+    background: rgba(148, 163, 184, 0.2);
+    color: var(--ms-text-ad);
+}
+
+.ease-msel-ad__chip-x:focus-visible {
+    outline: 2px solid var(--ms-accent-ad);
+    outline-offset: 1px;
+}
+
+/* ==========================================================================
+   Listbox
+   ========================================================================== */
+.ease-msel-ad__list {
+    background: #16203a;
+    border: 1px solid var(--ms-border-ad);
+    border-radius: 10px;
+    box-shadow: 0 16px 34px -18px rgba(0, 0, 0, 0.9);
+    left: 0;
+    list-style: none;
+    margin: 0.3rem 0 0;
+    max-height: 240px;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    padding: 0.25rem;
+    position: absolute;
+    right: 0;
+    top: 100%;
+    z-index: 40;
+}
+
+.ease-msel-ad__option {
+    border-radius: 6px;
+    color: var(--ms-text-ad);
+    cursor: pointer;
+    font-size: 0.85rem;
+    padding: 0.45rem 0.6rem;
+}
+
+/* Highlight only — DOM focus never leaves the input, so this is the
+   user's only indication of position in the list. */
+.ease-msel-ad__option--active {
+    background: rgba(56, 189, 248, 0.18);
+}
+
+.ease-msel-ad__empty {
+    color: var(--ms-muted-ad);
+    font-size: 0.82rem;
+    padding: 0.5rem 0.6rem;
+}
+
+@media (forced-colors: active) {
+    .ease-msel-ad__control,
+    .ease-msel-ad__list,
+    .ease-msel-ad__chip {
+        border: 1px solid CanvasText;
+    }
+
+    .ease-msel-ad__option--active {
+        background: Highlight;
+        color: HighlightText;
+    }
+}

--- a/submissions/react/multi-select-ad/style.css
+++ b/submissions/react/multi-select-ad/style.css
@@ -47,6 +47,13 @@
     box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.2);
 }
 
+/* While the list is open the control keeps its accent border even if
+   focus is momentarily elsewhere, so the two read as one connected
+   surface rather than a floating panel. */
+.ease-msel-ad--open .ease-msel-ad__control {
+    border-color: var(--ms-accent-ad);
+}
+
 .ease-msel-ad--disabled .ease-msel-ad__control {
     cursor: not-allowed;
     opacity: 0.55;


### PR DESCRIPTION
Fixes #63816

**What was added**

An accessible multi-select, under `submissions/react/multi-select-ad/`.

- `MultiSelect.jsx` — 231 non-empty lines: combobox semantics with `aria-activedescendant`, type-to-filter, removable chips, wrap-around arrow navigation, and announced selection changes.
- `style.css` — control, chips, listbox, open/disabled states, and forced-colors.
- `README.md` — props table, keyboard table, usage, and rationale.

**What is the problem**

**Most hand-rolled multi-selects move DOM focus onto the highlighted option.** That breaks the one interaction the component exists for: once focus leaves the text field, the user can no longer type to filter. It looks correct in a click-only test and fails immediately for anyone using the keyboard.

Second, **options wired to `click` silently fail to select.** `click` fires *after* `blur`, which closes the list — so the option unmounts before the click lands. It presents as a random intermittent bug.

**Why this approach**

`aria-activedescendant` keeps DOM focus on the input permanently. Only the pointer moves, and the visual highlight follows it — so arrow keys navigate while typing still filters.

Options select on `mousedown`, which fires before `blur`.

Three supporting details:

**Backspace only removes a chip when the input is empty** — otherwise it would eat typed characters and make filtering impossible.

**Chip removal returns focus to the input.** Removing the chip that currently holds focus would otherwise drop focus to `<body>`, dumping a keyboard user at the top of the page.

**The highlight index is clamped when filtering shrinks the list** — without it the index can point past the end and Enter selects nothing.

**How to test**

1. Pull this branch and drop `multi-select-ad/` into any React app (React 18+ — uses `useId`).
2. Render with ~10 options and `max={5}`.
3. **Type to filter, then press <kbd>↓</kbd> a few times, then keep typing.** Filtering must continue working — this is what `aria-activedescendant` buys, and it is the case roving-tabindex implementations fail.
4. Inspect the DOM mid-navigation: focus must remain on the `<input>`, with `aria-activedescendant` pointing at the highlighted `<li>`.
5. **Click an option with the mouse** — it must select. Change `onMouseDown` to `onClick` locally and watch selections stop registering.
6. Press <kbd>Enter</kbd> on a highlight, then <kbd>Backspace</kbd> with an empty input — the last chip is removed.
7. Type a character, then press Backspace — it must delete the character, **not** a chip.
8. Remove a chip via its × button and confirm focus returns to the input.
9. Arrow past the last option and confirm it wraps to the first.
10. Filter to a shorter list while a late option is highlighted, then press Enter — it must select a real option, not nothing.
11. Select up to `max` and confirm the list shows the limit message.
12. Confirm additions and removals are announced.

**Edge cases covered**

- `aria-activedescendant` keeps focus on the input, so typing and arrow navigation coexist.
- `mousedown` selection avoids the blur-before-click failure.
- Backspace is guarded on an empty query.
- Focus returns to the input after chip removal.
- The highlight index is clamped when the filtered list shrinks.
- Arrow navigation wraps in both directions, verified numerically.
- Already-selected options are filtered out of the list rather than shown as duplicates.
- `max` shows an explicit limit message instead of silently ignoring clicks.
- `scrollIntoView({ block: 'nearest' })` keeps the highlight visible without moving focus or over-scrolling.
- The chip's × button stops propagation, so removing does not also refocus-and-open via the control's click handler.
- `overscroll-behavior: contain` on the list stops scroll chaining to the page.
- The focus ring sits on the control, since the bare input has no visible border.
- `forced-colors: active` gives the active option `Highlight`/`HighlightText`.

**Verification**

- `MultiSelect.jsx` parses cleanly through esbuild — exit code 0.
- `npx stylelint style.css` against the repo's own config — exit code 0.
- All component classes referenced in the JSX are defined in `style.css` (an initial check found `--open` unstyled; it now carries a real border rule).
- Verified programmatically: `aria-activedescendant` present with no roving tabindex, `mousedown` selection, Backspace guard, focus restoration, highlight clamping, and wrap arithmetic.
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 3 new files, 0 deletions, no existing file touched.
- Component classes carry an `-ad` suffix so this lands as a parallel implementation.

**Labels:** `type:feature` · `react` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
