### PR TITLE
feat: add StickyTable React component with three-tier sticky layering (#63818)

### DIFF
--- a/submissions/react/sticky-table-ad/README.md
+++ b/submissions/react/sticky-table-ad/README.md
@@ -1,0 +1,53 @@
+# StickyTable — sticky headers and pinned columns
+
+> Issue: [#63818](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/63818)
+
+A data table with a sticky header row and optionally pinned leading columns.
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `columns` | `Array<{ key, label, align?, width? }>` | `[]` | Column definitions. |
+| `rows` | `Array<object>` | `[]` | Row data, keyed by column `key`. |
+| `pinnedColumns` | `number` | `0` | Leading columns to pin. Clamped to the column count. |
+| `getKey` | `(row, index) => key` | index | Stable React key. |
+| `caption` | `string` | — | Table caption, also used as the region label. |
+| `maxHeight` | `number` | `420` | Scroll viewport height in px. |
+| `className` | `string` | `''` | Merged onto the root. |
+
+**Pinned columns need an explicit `width`.** Offsets are computed from declared widths; an unmeasurable column cannot be positioned correctly and falls back to 160px.
+
+## Usage
+
+```jsx
+import StickyTable from './StickyTable';
+import './style.css';
+
+<StickyTable
+  caption="Quarterly revenue"
+  pinnedColumns={1}
+  columns={[
+    { key: 'account', label: 'Account', width: '180px' },
+    { key: 'q1', label: 'Q1', align: 'end' },
+    { key: 'q2', label: 'Q2', align: 'end' },
+  ]}
+  rows={data}
+  getKey={(r) => r.id}
+/>
+```
+
+## Why it fits EaseMotion
+
+**The layering is the hard part.** Three overlapping sticky regions exist: the header row (sticky top), the pinned columns (sticky left), and the corner cells (both). A single z-index cannot resolve them:
+
+- If the header wins, pinned cells scroll under it correctly — but the corner disappears behind the header the moment you scroll right.
+- If the pinned column wins, the corner survives — but body rows slide *over* the header.
+
+The corner needs a **higher** z-index than either, which is only obvious once you have watched it fail. Three explicit tiers (pinned = 2, header = 3, corner = 4) resolve it.
+
+**`border-collapse: collapse` is incompatible with sticky cells.** Collapsed borders belong to the *table*, not the cell — so they scroll away and leave sticky headers with no bottom edge, floating over the content. `separate` plus `box-shadow` borders keeps the edge attached to the cell.
+
+**Pinned leading cells are `<th scope="row">`, not `<td>`.** That is what lets a screen reader announce "Revenue, Northwind" instead of reading a bare number with no context — the same reason the column is pinned visually.
+
+Two smaller details: the edge shadow is drawn only on the **last** pinned column, so a two-column pin gets one divider rather than two; and `forced-colors` restores an opaque `Canvas` background on sticky cells, because high-contrast mode discards backgrounds and rows would otherwise show through the header.

--- a/submissions/react/sticky-table-ad/StickyTable.jsx
+++ b/submissions/react/sticky-table-ad/StickyTable.jsx
@@ -1,0 +1,160 @@
+/**
+ * EaseMotion CSS — StickyTable
+ * ============================================================
+ * Data table with a sticky header and optionally pinned columns.
+ *
+ * The layering is the hard part, and it is where most implementations
+ * break. Three overlapping sticky regions exist:
+ *
+ *   the header row      (sticky top)
+ *   the pinned columns  (sticky left)
+ *   the corner cells    (both at once)
+ *
+ * A single z-index cannot resolve this. If the header wins, pinned cells
+ * scroll underneath it correctly but the corner cell disappears behind
+ * the header as soon as you scroll right. If the pinned column wins, the
+ * corner survives but body rows slide over the header. The corner needs a
+ * HIGHER z-index than either, which is only obvious once you have seen it
+ * fail.
+ *
+ * `border-collapse: collapse` is also incompatible with sticky cells —
+ * collapsed borders belong to the table, not the cell, so they scroll
+ * away and leave sticky headers with no bottom edge. `separate` plus
+ * box-shadow borders is the fix.
+ * ============================================================
+ */
+
+import { useMemo } from 'react';
+
+/**
+ * @param {object} props
+ * @param {Array<{key: string, label: string, align?: 'start'|'end', width?: string}>} props.columns
+ * @param {Array<object>} props.rows
+ * @param {number}  [props.pinnedColumns=0]  Leading columns to pin.
+ * @param {(row: object, index: number) => string|number} [props.getKey]
+ * @param {string}  [props.caption]
+ * @param {number}  [props.maxHeight=420]
+ * @param {string}  [props.className]
+ */
+export default function StickyTable({
+  columns = [],
+  rows = [],
+  pinnedColumns = 0,
+  getKey,
+  caption,
+  maxHeight = 420,
+  className = '',
+  ...rest
+}) {
+  const pinned = Number.isFinite(pinnedColumns)
+    ? Math.max(0, Math.min(Math.floor(pinnedColumns), columns.length))
+    : 0;
+
+  // Cumulative left offsets for pinned columns. Each pinned column must
+  // sit at the sum of the widths before it, or they stack on top of
+  // each other at left: 0.
+  const offsets = useMemo(() => {
+    const out = [];
+    let running = 0;
+
+    for (let i = 0; i < pinned; i += 1) {
+      out.push(running);
+      // Falls back to a sane default when no width is given — an
+      // unmeasurable column cannot be offset correctly, so a fixed
+      // width is required for pinning to work.
+      const width = parseFloat(columns[i]?.width ?? '160');
+      running += Number.isFinite(width) ? width : 160;
+    }
+
+    return out;
+  }, [columns, pinned]);
+
+  if (columns.length === 0 || rows.length === 0) return null;
+
+  const classes = ['ease-stable-ad', className].filter(Boolean).join(' ');
+
+  const cellClass = (index, isHeader) => {
+    const parts = ['ease-stable-ad__cell'];
+
+    if (isHeader) parts.push('ease-stable-ad__cell--head');
+    if (index < pinned) parts.push('ease-stable-ad__cell--pinned');
+    // The corner needs its own class: it is both sticky-top and
+    // sticky-left, and needs to outrank both.
+    if (isHeader && index < pinned) parts.push('ease-stable-ad__cell--corner');
+    if (index === pinned - 1) parts.push('ease-stable-ad__cell--pinned-last');
+
+    return parts.join(' ');
+  };
+
+  const cellStyle = (index, column) => {
+    const style = {};
+
+    if (column?.width) style.width = column.width;
+    if (index < pinned) style.left = `${offsets[index]}px`;
+    if (column?.align === 'end') style.textAlign = 'right';
+
+    return style;
+  };
+
+  return (
+    <div
+      className={classes}
+      style={{ maxHeight: `${maxHeight}px` }}
+      // Focusable so keyboard users can scroll the region without a
+      // pointer — a scrollable div with no tabindex is unreachable.
+      tabIndex={0}
+      role="region"
+      aria-label={caption ?? 'Data table'}
+      {...rest}
+    >
+      <table className="ease-stable-ad__table">
+        {caption && <caption className="ease-stable-ad__caption">{caption}</caption>}
+
+        <thead>
+          <tr>
+            {columns.map((column, index) => (
+              <th
+                className={cellClass(index, true)}
+                key={column.key}
+                style={cellStyle(index, column)}
+                scope="col"
+              >
+                {column.label}
+              </th>
+            ))}
+          </tr>
+        </thead>
+
+        <tbody>
+          {rows.map((row, rowIndex) => (
+            <tr key={getKey ? getKey(row, rowIndex) : rowIndex}>
+              {columns.map((column, index) =>
+                index < pinned ? (
+                  // Pinned leading cells are row headers, not data —
+                  // this is what lets a screen reader announce "Revenue,
+                  // Northwind" instead of a bare number.
+                  <th
+                    className={cellClass(index, false)}
+                    key={column.key}
+                    style={cellStyle(index, column)}
+                    scope="row"
+                  >
+                    {row[column.key]}
+                  </th>
+                ) : (
+                  <td
+                    className={cellClass(index, false)}
+                    key={column.key}
+                    style={cellStyle(index, column)}
+                  >
+                    {row[column.key]}
+                  </td>
+                ),
+              )}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/submissions/react/sticky-table-ad/style.css
+++ b/submissions/react/sticky-table-ad/style.css
@@ -1,0 +1,114 @@
+/* ==========================================================================
+   EaseMotion CSS — StickyTable component styles
+   Issue #63818
+   ========================================================================== */
+
+.ease-stable-ad {
+    --st-bg-ad: #0f1628;
+    --st-head-ad: #16203a;
+    --st-border-ad: rgba(148, 163, 184, 0.16);
+    --st-text-ad: #cbd5e1;
+    --st-head-text-ad: #94a3b8;
+    --st-accent-ad: #38bdf8;
+
+    background: var(--st-bg-ad);
+    border: 1px solid var(--st-border-ad);
+    border-radius: 10px;
+    overflow: auto;
+    overscroll-behavior: contain;
+    position: relative;
+}
+
+.ease-stable-ad:focus-visible {
+    outline: 2px solid var(--st-accent-ad);
+    outline-offset: 2px;
+}
+
+/* `separate`, not `collapse`. Collapsed borders belong to the table
+   rather than the cell, so they scroll away and leave sticky headers with
+   no bottom edge. Borders are drawn with box-shadow instead. */
+.ease-stable-ad__table {
+    border-collapse: separate;
+    border-spacing: 0;
+    width: 100%;
+}
+
+.ease-stable-ad__caption {
+    caption-side: top;
+    color: var(--st-head-text-ad);
+    font-size: 0.78rem;
+    letter-spacing: 0.06em;
+    padding: 0.7rem 0.9rem;
+    text-align: left;
+    text-transform: uppercase;
+}
+
+.ease-stable-ad__cell {
+    background: var(--st-bg-ad);
+    box-shadow: inset 0 -1px 0 var(--st-border-ad);
+    color: var(--st-text-ad);
+    font-size: 0.84rem;
+    font-weight: 400;
+    padding: 0.6rem 0.9rem;
+    text-align: left;
+    white-space: nowrap;
+}
+
+/* ==========================================================================
+   Sticky layering
+   --------------------------------------------------------------------------
+   Three overlapping sticky regions need three z-index tiers. A single
+   value cannot resolve them: whichever of header or pinned column wins,
+   the corner ends up hidden behind the other.
+   ========================================================================== */
+
+/* Tier 1 — pinned body cells. Above normal cells, below the header. */
+.ease-stable-ad__cell--pinned {
+    background: var(--st-bg-ad);
+    left: 0;
+    position: sticky;
+    z-index: 2;
+}
+
+/* Tier 2 — header row. Above pinned body cells. */
+.ease-stable-ad__cell--head {
+    background: var(--st-head-ad);
+    color: var(--st-head-text-ad);
+    font-size: 0.74rem;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    position: sticky;
+    text-transform: uppercase;
+    top: 0;
+    z-index: 3;
+}
+
+/* Tier 3 — the corner. Sticky on both axes, so it must outrank both. */
+.ease-stable-ad__cell--corner {
+    background: var(--st-head-ad);
+    z-index: 4;
+}
+
+/* Edge shadow marking where the pinned region ends. Only rendered on the
+   last pinned column, so a two-column pin gets one divider, not two. */
+.ease-stable-ad__cell--pinned-last {
+    box-shadow:
+        inset 0 -1px 0 var(--st-border-ad),
+        6px 0 8px -8px rgba(0, 0, 0, 0.8);
+}
+
+@media (forced-colors: active) {
+    .ease-stable-ad,
+    .ease-stable-ad__cell {
+        border: 1px solid CanvasText;
+    }
+
+    /* Sticky cells rely on an opaque background to hide scrolled content.
+       Forced colors discards it, so Canvas is restored explicitly or rows
+       show through the header. */
+    .ease-stable-ad__cell--pinned,
+    .ease-stable-ad__cell--head,
+    .ease-stable-ad__cell--corner {
+        background: Canvas;
+    }
+}


### PR DESCRIPTION
Fixes #63818

**What was added**

A sticky data table, under `submissions/react/sticky-table-ad/`.

- `StickyTable.jsx` — 144 non-empty lines: cumulative pin offsets, three-tier sticky class assignment, and row-header semantics for pinned cells.
- `style.css` — 101 non-empty lines: three z-index tiers, shadow-based borders, pin edge shadow, and forced-colors handling.
- `README.md` — props table, usage, and rationale.

**What is the problem**

**The layering cannot be solved with one z-index**, and this is where implementations break. Three overlapping sticky regions exist: the header row (sticky top), the pinned columns (sticky left), and the corner cells (both at once).

- If the header wins, pinned cells scroll under it correctly — but **the corner disappears behind the header** the moment you scroll right.
- If the pinned column wins, the corner survives — but **body rows slide over the header**.

Either way it looks correct until you scroll on the *other* axis.

Separately, **`border-collapse: collapse` is incompatible with sticky cells.** Collapsed borders belong to the table rather than the cell, so they scroll away and leave sticky headers with no bottom edge, floating over the content.

**Why this approach**

Three explicit z-index tiers — pinned body cells (2), header (3), corner (4). The corner must outrank *both*, which is only obvious once you have watched it fail on the second axis.

`border-collapse: separate` with `box-shadow` borders keeps the edge attached to the cell, so sticky headers retain their divider.

**Pinned leading cells are `<th scope="row">`, not `<td>`.** That is what lets a screen reader announce "Revenue, Northwind" instead of a bare number with no context — the same reason the column is pinned visually in the first place.

**How to test**

1. Pull this branch and drop `sticky-table-ad/` into any React app (React 16.8+).
2. Render a wide, tall table with `pinnedColumns={1}` and an explicit `width` on the pinned column.
3. Scroll **down** — the header stays; body rows pass underneath it.
4. Scroll **right** — the pinned column stays; other columns pass underneath it.
5. **Scroll down and right together.** The corner cell must remain visible above both. This is the case that fails with a single z-index — try setting all three tiers equal and watch the corner vanish.
6. Confirm the sticky header keeps a visible bottom border while scrolling — set `border-collapse: collapse` locally and watch it disappear.
7. Set `pinnedColumns={2}` with widths `180px` and `120px`; confirm the second pinned column sits at `left: 180px`, not `0`.
8. Confirm only **one** divider shadow appears at the right edge of the pinned region, not one per pinned column.
9. Inspect a pinned cell with a screen reader — it should be announced as a row header.
10. Tab to the table and confirm it can be scrolled by keyboard.
11. View in forced-colors mode and confirm rows do not show through the header.

**Edge cases covered**

- Three z-index tiers resolve the header / pinned / corner overlap; verified strictly increasing (2 < 3 < 4).
- `border-collapse: separate` keeps cell borders attached to sticky cells.
- Cumulative left offsets so multiple pinned columns stack correctly rather than piling at `left: 0`; verified as `0, 180, 300` for widths 180/120/100.
- Missing widths fall back to 160px, with the requirement documented rather than failing silently.
- `pinnedColumns` is clamped to the column count and floored, so a bad prop cannot pin more columns than exist.
- The edge shadow renders only on the last pinned column.
- Pinned cells use `<th scope="row">`, giving screen readers row context.
- Header cells use `scope="col"`.
- The scroll region is `tabIndex={0}` with `role="region"`, so keyboard users can reach and scroll it.
- `overscroll-behavior: contain` stops scroll chaining to the page.
- `forced-colors` restores opaque backgrounds on sticky cells, which would otherwise be transparent and let rows show through.
- Empty `columns` or `rows` returns `null`.

**Verification**

- `StickyTable.jsx` parses cleanly through esbuild — exit code 0.
- `npx stylelint style.css` against the repo's own config — exit code 0.
- All component classes referenced in the JSX are defined in `style.css`.
- Z-index tiers verified programmatically as strictly increasing; `border-collapse: collapse` confirmed absent; cumulative offset arithmetic verified.
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 3 new files, 0 deletions, no existing file touched.
- Component classes carry an `-ad` suffix so this lands as a parallel implementation.

**Labels:** `type:feature` · `react` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
