### PR TITLE
feat: add ImageCompare React component with keyboard slider control (#63819)

### DIFF
--- a/submissions/react/image-compare-ad/ImageCompare.jsx
+++ b/submissions/react/image-compare-ad/ImageCompare.jsx
@@ -1,0 +1,188 @@
+/**
+ * EaseMotion CSS — ImageCompare
+ * ============================================================
+ * Before/after slider.
+ *
+ * Almost every implementation of this is drag-only, which makes it
+ * completely unusable without a pointer — and the content it hides is
+ * often the whole point of the page. Implementing the `slider` role with
+ * arrow-key control costs very little and makes the comparison operable
+ * by keyboard.
+ *
+ * The clipping approach matters too. Overlaying the "after" image and
+ * animating its `width` re-lays-out and re-scales the image on every
+ * frame, so the comparison visibly stutters and the image content shifts
+ * as it narrows. `clip-path: inset()` clips a fixed-size image instead —
+ * the pixels never move, only the visible region changes, and it stays
+ * on the compositor.
+ * ============================================================
+ */
+
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+/**
+ * @param {object} props
+ * @param {string}  props.beforeSrc
+ * @param {string}  props.afterSrc
+ * @param {string}  props.beforeAlt
+ * @param {string}  props.afterAlt
+ * @param {number}  [props.defaultValue=50]  Initial split, 0–100.
+ * @param {number}  [props.step=2]           Arrow-key increment.
+ * @param {string}  [props.beforeLabel='Before']
+ * @param {string}  [props.afterLabel='After']
+ * @param {string}  [props.className]
+ */
+export default function ImageCompare({
+  beforeSrc,
+  afterSrc,
+  beforeAlt = 'Before',
+  afterAlt = 'After',
+  defaultValue = 50,
+  step = 2,
+  beforeLabel = 'Before',
+  afterLabel = 'After',
+  className = '',
+  ...rest
+}) {
+  const baseId = useId();
+  const rootRef = useRef(null);
+  const handleRef = useRef(null);
+  const draggingRef = useRef(false);
+
+  const [split, setSplit] = useState(clamp(defaultValue, 0, 100));
+
+  const setFromClientX = useCallback((clientX) => {
+    const node = rootRef.current;
+    if (!node) return;
+
+    const rect = node.getBoundingClientRect();
+    if (rect.width === 0) return;
+
+    setSplit(clamp(((clientX - rect.left) / rect.width) * 100, 0, 100));
+  }, []);
+
+  const onPointerDown = useCallback(
+    (event) => {
+      if (event.button !== 0 && event.pointerType === 'mouse') return;
+
+      draggingRef.current = true;
+      // Capture routes later moves here even once the pointer leaves the
+      // element, so a fast drag does not lose the handle.
+      handleRef.current?.setPointerCapture?.(event.pointerId);
+      setFromClientX(event.clientX);
+      event.preventDefault();
+    },
+    [setFromClientX],
+  );
+
+  const onPointerMove = useCallback(
+    (event) => {
+      if (!draggingRef.current) return;
+      setFromClientX(event.clientX);
+    },
+    [setFromClientX],
+  );
+
+  const endDrag = useCallback((event) => {
+    if (!draggingRef.current) return;
+    draggingRef.current = false;
+
+    if (handleRef.current?.hasPointerCapture?.(event.pointerId)) {
+      handleRef.current.releasePointerCapture(event.pointerId);
+    }
+  }, []);
+
+  const onKeyDown = useCallback(
+    (event) => {
+      let next = null;
+
+      switch (event.key) {
+        case 'ArrowLeft':
+          next = split - step;
+          break;
+        case 'ArrowRight':
+          next = split + step;
+          break;
+        case 'PageDown':
+          next = split - step * 5;
+          break;
+        case 'PageUp':
+          next = split + step * 5;
+          break;
+        case 'Home':
+          next = 0;
+          break;
+        case 'End':
+          next = 100;
+          break;
+        default:
+          return;
+      }
+
+      event.preventDefault();
+      setSplit(clamp(next, 0, 100));
+    },
+    [split, step],
+  );
+
+  useEffect(
+    () => () => {
+      draggingRef.current = false;
+    },
+    [],
+  );
+
+  const classes = ['ease-icmp-ad', className].filter(Boolean).join(' ');
+
+  return (
+    <figure
+      className={classes}
+      ref={rootRef}
+      style={{ '--icmp-split-ad': `${split}%` }}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={endDrag}
+      onPointerCancel={endDrag}
+      {...rest}
+    >
+      <img className="ease-icmp-ad__img" src={beforeSrc} alt={beforeAlt} draggable="false" />
+
+      {/* Clipped rather than width-animated: the pixels never move, only
+          the visible region changes. */}
+      <img
+        className="ease-icmp-ad__img ease-icmp-ad__img--after"
+        id={`${baseId}-img`}
+        src={afterSrc}
+        alt={afterAlt}
+        draggable="false"
+      />
+
+      <span className="ease-icmp-ad__tag ease-icmp-ad__tag--before" aria-hidden="true">
+        {beforeLabel}
+      </span>
+      <span className="ease-icmp-ad__tag ease-icmp-ad__tag--after" aria-hidden="true">
+        {afterLabel}
+      </span>
+
+      <div
+        className="ease-icmp-ad__handle"
+        ref={handleRef}
+        role="slider"
+        tabIndex={0}
+        aria-label={`Compare ${beforeLabel} and ${afterLabel}`}
+        aria-valuenow={Math.round(split)}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuetext={`${Math.round(split)}% ${afterLabel}`}
+        aria-controls={`${baseId}-img`}
+        onKeyDown={onKeyDown}
+      >
+        <span className="ease-icmp-ad__grip" aria-hidden="true" />
+      </div>
+    </figure>
+  );
+}

--- a/submissions/react/image-compare-ad/README.md
+++ b/submissions/react/image-compare-ad/README.md
@@ -1,0 +1,50 @@
+# ImageCompare — before/after slider
+
+> Issue: [#63819](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/63819)
+
+A before/after comparison slider that works by drag **and** by keyboard.
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `beforeSrc` / `afterSrc` | `string` | — | Image sources. |
+| `beforeAlt` / `afterAlt` | `string` | `'Before'` / `'After'` | Alt text. |
+| `defaultValue` | `number` | `50` | Initial split, 0–100. |
+| `step` | `number` | `2` | Arrow-key increment. |
+| `beforeLabel` / `afterLabel` | `string` | `'Before'` / `'After'` | Corner captions. |
+| `className` | `string` | `''` | Merged onto the root. |
+
+## Keyboard
+
+| Key | Action |
+|---|---|
+| <kbd>←</kbd> / <kbd>→</kbd> | Move by `step` |
+| <kbd>PageUp</kbd> / <kbd>PageDown</kbd> | Move by `step × 5` |
+| <kbd>Home</kbd> / <kbd>End</kbd> | Jump to either extreme |
+
+## Usage
+
+```jsx
+import ImageCompare from './ImageCompare';
+import './style.css';
+
+<ImageCompare
+  beforeSrc="/shots/before.jpg"
+  afterSrc="/shots/after.jpg"
+  beforeAlt="Dashboard before the redesign"
+  afterAlt="Dashboard after the redesign"
+/>
+```
+
+## Why it fits EaseMotion
+
+**Almost every before/after slider is drag-only**, which makes it completely unusable without a pointer — and the hidden content is often the entire point of the page. Implementing the `slider` role with arrow-key control costs very little and makes the comparison genuinely operable.
+
+**The "after" image is clipped, not resized.** Overlaying it and animating `width` re-lays-out and re-scales the image on every frame: the comparison stutters, and the image *content* shifts as the panel narrows, so you are no longer comparing the same pixels. `clip-path: inset()` clips a fixed-size image — the pixels never move, only the visible region changes, and it stays on the compositor.
+
+`setPointerCapture` routes subsequent moves to the handle even once the pointer has left it, so a fast drag does not lose the slider partway. Pointer Events also cover mouse, touch and stylus with one code path.
+
+Three supporting details: `touch-action: none` stops a touch drag scrolling the page instead of comparing; `user-select: none` and `draggable="false"` stop the drag selecting text or starting a native image drag; and the handle is 40px wide with the visible line drawn by a pseudo-element, so the grab target meets the touch minimum without a 40px white bar across the image.
+
+`aria-valuetext` reports "62% After" rather than a bare number, which is meaningless out of context.

--- a/submissions/react/image-compare-ad/style.css
+++ b/submissions/react/image-compare-ad/style.css
@@ -13,6 +13,7 @@
     margin: 0;
     overflow: hidden;
     position: relative;
+
     /* Suppresses browser panning so a drag compares rather than scrolling
        the page underneath. */
     touch-action: none;
@@ -47,6 +48,7 @@
     left: var(--icmp-split-ad);
     position: absolute;
     top: 0;
+
     /* Wide enough to grab; the visible line is drawn by ::before. */
     transform: translateX(-50%);
     width: 40px;

--- a/submissions/react/image-compare-ad/style.css
+++ b/submissions/react/image-compare-ad/style.css
@@ -1,0 +1,136 @@
+/* ==========================================================================
+   EaseMotion CSS — ImageCompare component styles
+   Issue #63819
+   ========================================================================== */
+
+.ease-icmp-ad {
+    --icmp-split-ad: 50%;
+    --icmp-line-ad: #f8fafc;
+    --icmp-accent-ad: #38bdf8;
+    --icmp-tag-bg-ad: rgba(3, 7, 18, 0.72);
+
+    border-radius: 10px;
+    margin: 0;
+    overflow: hidden;
+    position: relative;
+    /* Suppresses browser panning so a drag compares rather than scrolling
+       the page underneath. */
+    touch-action: none;
+    user-select: none;
+}
+
+.ease-icmp-ad__img {
+    display: block;
+    height: auto;
+    pointer-events: none;
+    width: 100%;
+}
+
+/* The "after" image is clipped, not resized. Animating `width` would
+   re-scale the image on every frame, so its content visibly shifts as
+   the split moves; clipping leaves the pixels exactly where they are. */
+.ease-icmp-ad__img--after {
+    clip-path: inset(0 0 0 var(--icmp-split-ad));
+    inset: 0;
+    position: absolute;
+}
+
+/* ==========================================================================
+   Handle
+   ========================================================================== */
+.ease-icmp-ad__handle {
+    align-items: center;
+    bottom: 0;
+    cursor: col-resize;
+    display: flex;
+    justify-content: center;
+    left: var(--icmp-split-ad);
+    position: absolute;
+    top: 0;
+    /* Wide enough to grab; the visible line is drawn by ::before. */
+    transform: translateX(-50%);
+    width: 40px;
+}
+
+.ease-icmp-ad__handle::before {
+    background: var(--icmp-line-ad);
+    bottom: 0;
+    content: "";
+    left: 50%;
+    position: absolute;
+    top: 0;
+    transform: translateX(-50%);
+    width: 2px;
+}
+
+.ease-icmp-ad__handle:focus-visible {
+    outline: 2px solid var(--icmp-accent-ad);
+    outline-offset: -2px;
+}
+
+.ease-icmp-ad__grip {
+    align-items: center;
+    background: var(--icmp-line-ad);
+    border-radius: 50%;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
+    display: flex;
+    height: 34px;
+    justify-content: center;
+    position: relative;
+    width: 34px;
+}
+
+/* Two chevrons drawn with borders — no icon dependency. */
+.ease-icmp-ad__grip::before,
+.ease-icmp-ad__grip::after {
+    border: solid #0b1120;
+    border-width: 0 2px 2px 0;
+    content: "";
+    height: 7px;
+    position: absolute;
+    width: 7px;
+}
+
+.ease-icmp-ad__grip::before {
+    left: 9px;
+    transform: rotate(135deg);
+}
+
+.ease-icmp-ad__grip::after {
+    right: 9px;
+    transform: rotate(-45deg);
+}
+
+/* ==========================================================================
+   Labels
+   ========================================================================== */
+.ease-icmp-ad__tag {
+    background: var(--icmp-tag-bg-ad);
+    border-radius: 999px;
+    bottom: 0.75rem;
+    color: #f1f5f9;
+    font-size: 0.72rem;
+    letter-spacing: 0.05em;
+    padding: 0.25rem 0.6rem;
+    position: absolute;
+    text-transform: uppercase;
+}
+
+.ease-icmp-ad__tag--before {
+    left: 0.75rem;
+}
+
+.ease-icmp-ad__tag--after {
+    right: 0.75rem;
+}
+
+@media (forced-colors: active) {
+    .ease-icmp-ad__handle::before {
+        background: CanvasText;
+    }
+
+    .ease-icmp-ad__grip {
+        background: Canvas;
+        border: 1px solid CanvasText;
+    }
+}


### PR DESCRIPTION
Fixes #63819

**What was added**

A before/after comparison slider, under `submissions/react/image-compare-ad/`.

- `ImageCompare.jsx` — 167 non-empty lines: pointer-capture dragging, full keyboard slider control, clamping, and complete ARIA slider semantics.
- `style.css` — 120 non-empty lines: clip-based reveal, wide grab handle with a thin visible line, corner labels, forced-colors.
- `README.md` — props table, keyboard table, usage, and rationale.

**What is the problem**

**Almost every before/after slider is drag-only**, which makes it completely unusable without a pointer — and the hidden content is frequently the entire point of the page.

Second, **overlaying the "after" image and animating its `width`** re-lays-out and re-scales the image every frame. The comparison stutters, and the image *content* shifts as the panel narrows — so you are no longer comparing the same pixels at the same position, which defeats the purpose.

**Why this approach**

The handle implements the `slider` role with `tabIndex={0}`, arrow keys, PageUp/PageDown and Home/End. `aria-valuetext` reports "62% After" rather than a bare number.

The "after" image is **clipped** with `clip-path: inset()` rather than resized. The pixels never move; only the visible region changes, and it stays on the compositor.

`setPointerCapture` routes subsequent moves to the handle even once the pointer leaves it, so a fast drag does not lose the slider partway — and Pointer Events cover mouse, touch and stylus with one code path.

**How to test**

1. Pull this branch and drop `image-compare-ad/` into any React app (React 18+ — uses `useId`).
2. Render with two images of identical dimensions.
3. Drag the handle — the split follows. Drag fast past the edge and confirm it does not lose the handle.
4. **Watch the "after" image content while dragging.** It must stay fixed, with only the reveal boundary moving. Swap `clip-path` for an animated `width` locally and watch the image squash — that is the bug being avoided.
5. **Tab to the handle** and press <kbd>←</kbd>/<kbd>→</kbd> — the split moves by 2% per press.
6. Press <kbd>Home</kbd> / <kbd>End</kbd> and confirm it jumps to 0% and 100%.
7. Inspect with a screen reader — it should announce as a slider with a percentage and the "After" label.
8. On a touch device, drag the handle and confirm **the page does not scroll**.
9. Try to drag one of the images directly and confirm no native image drag starts.
10. Confirm `aria-controls` on the handle resolves to the after image's id.

**Edge cases covered**

- Clipping rather than resizing, so image content stays fixed while the boundary moves.
- Pointer capture prevents fast drags losing the handle.
- Values clamped to 0–100 on every path, verified for out-of-range input.
- A zero-width container short-circuits rather than dividing by zero.
- `touch-action: none` prevents page scroll during a touch drag.
- `user-select: none` plus `draggable="false"` stop text selection and native image dragging.
- Secondary mouse buttons are ignored.
- `pointercancel` is handled alongside `pointerup`, so an interrupted drag still releases.
- Capture is released only when actually held.
- The handle is 40px wide for grabbing, with the visible line drawn by a pseudo-element — meeting the touch target minimum without a 40px bar across the image.
- `aria-controls` resolves to a real element id (an initial draft referenced an id that did not exist).
- `aria-valuetext` gives context rather than a bare percentage.
- Images are `pointer-events: none`, so the drag never lands on them instead of the root.
- `forced-colors` restores a visible divider and grip.

**Verification**

- `ImageCompare.jsx` parses cleanly through esbuild — exit code 0.
- `npx stylelint style.css` against the repo's own config — exit code 0 (two comment-placement errors found and fixed).
- All component classes referenced in the JSX are defined in `style.css`.
- Verified programmatically: clip-path used with no width transition, `role="slider"` with `tabIndex`, full ARIA value set including `valuetext`, pointer capture present, `aria-controls` target resolves, and clamping correct at both bounds.
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 3 new files, 0 deletions, no existing file touched.
- Component classes carry an `-ad` suffix so this lands as a parallel implementation.

**Labels:** `type:feature` · `react` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
