### PR TITLE
feat: add WizardSteps React component with shape-coded states (#63820)

### DIFF
--- a/submissions/react/wizard-steps-ad/README.md
+++ b/submissions/react/wizard-steps-ad/README.md
@@ -1,0 +1,54 @@
+# WizardSteps — multi-step progress indicator
+
+> Issue: [#63820](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/63820)
+
+A step indicator where state is carried by shape as well as colour, and exposed structurally rather than only visually.
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `steps` | `Array<{ id, label, description? }>` | `[]` | Steps. Renders `null` if empty. |
+| `current` | `number` | `0` | Zero-based active index. Clamped to range. |
+| `onStepClick` | `(index, step) => void` | — | Enables navigation back to completed steps. |
+| `allowBackNav` | `boolean` | `true` | Whether completed steps are clickable. |
+| `orientation` | `'horizontal' \| 'vertical'` | `'horizontal'` | |
+| `label` | `string` | `'Progress'` | Accessible nav name. |
+| `className` | `string` | `''` | Merged onto the root. |
+
+## State markers
+
+| State | Marker | Colour |
+|---|---|---|
+| Complete | `✓` | green |
+| Current | `●` | accent |
+| Upcoming | step number | muted |
+
+## Usage
+
+```jsx
+import WizardSteps from './WizardSteps';
+import './style.css';
+
+<WizardSteps
+  current={step}
+  onStepClick={(i) => setStep(i)}
+  steps={[
+    { id: 'details', label: 'Details' },
+    { id: 'payment', label: 'Payment', description: 'Card or transfer' },
+    { id: 'review', label: 'Review' },
+  ]}
+/>
+```
+
+## Why it fits EaseMotion
+
+**State is carried by shape, not only colour.** A green circle and a grey circle are the same circle to a user with deuteranopia. Completed steps show a check, the current step a filled dot, upcoming steps their number — so the progression is legible in greyscale and in print.
+
+**Progress is exposed structurally.** `aria-current="step"` marks the active step, and each step's accessible name includes its position and state: "Step 2 of 4, Payment, current" rather than just "Payment". Styling alone tells assistive tech nothing at all.
+
+**Only navigable steps are buttons.** Rendering every step as a button and ignoring clicks on future ones is the usual shortcut, and it means a keyboard user tabs through controls that do nothing when activated — which is worse than not being able to reach them. Non-navigable steps are plain elements and are not tab stops.
+
+For those non-navigable steps the accessible name is a **visually-hidden text node**, not an `aria-label` on a span. `aria-label` is only reliably honoured on elements with a widget or landmark role; on a generic span, support varies. An initial draft used `role="text"` for this, which is a Safari-only quirk rather than a real ARIA role.
+
+The connector line is drawn per step and skipped on the last one, so it does not trail off the end of the track — and a completed step's outgoing connector is filled, which makes the line read as a progress track rather than a static divider.

--- a/submissions/react/wizard-steps-ad/WizardSteps.jsx
+++ b/submissions/react/wizard-steps-ad/WizardSteps.jsx
@@ -1,0 +1,142 @@
+/**
+ * EaseMotion CSS — WizardSteps
+ * ============================================================
+ * Multi-step progress indicator.
+ *
+ * Two things this gets right:
+ *
+ *  1. State is carried by SHAPE as well as colour. A green circle and a
+ *     grey circle are the same circle to a user with deuteranopia, so
+ *     completed steps show a check, the current step shows a filled dot,
+ *     and upcoming steps show their number. The progression is legible
+ *     in greyscale.
+ *
+ *  2. Progress is exposed structurally, not just visually. `aria-current`
+ *     marks the active step and each step's state is in its accessible
+ *     name — "Step 2 of 4, Payment, current" rather than "Payment".
+ *     Styling alone tells assistive tech nothing.
+ *
+ * Navigable steps are real buttons; non-navigable ones are not. Rendering
+ * everything as a button and ignoring clicks on future steps is the usual
+ * shortcut, and it means a keyboard user tabs through controls that do
+ * nothing.
+ * ============================================================
+ */
+
+import { useCallback, useMemo } from 'react';
+
+/**
+ * @param {object} props
+ * @param {Array<{id: string, label: string, description?: string}>} props.steps
+ * @param {number}   props.current            Zero-based active index.
+ * @param {(index: number, step: object) => void} [props.onStepClick]
+ * @param {boolean}  [props.allowBackNav=true] Completed steps are clickable.
+ * @param {'horizontal'|'vertical'} [props.orientation='horizontal']
+ * @param {string}   [props.label='Progress']
+ * @param {string}   [props.className]
+ */
+export default function WizardSteps({
+  steps = [],
+  current = 0,
+  onStepClick,
+  allowBackNav = true,
+  orientation = 'horizontal',
+  label = 'Progress',
+  className = '',
+  ...rest
+}) {
+  const total = steps.length;
+  const active = Math.max(0, Math.min(current, Math.max(total - 1, 0)));
+
+  const stateOf = useCallback(
+    (index) => {
+      if (index < active) return 'complete';
+      if (index === active) return 'current';
+      return 'upcoming';
+    },
+    [active],
+  );
+
+  const items = useMemo(
+    () =>
+      steps.map((step, index) => {
+        const state = stateOf(index);
+        // Only completed steps are navigable, and only when allowed —
+        // a future step has no meaningful destination.
+        const navigable = Boolean(onStepClick) && allowBackNav && state === 'complete';
+
+        return { step, index, state, navigable };
+      }),
+    [steps, stateOf, onStepClick, allowBackNav],
+  );
+
+  if (total === 0) return null;
+
+  const classes = [
+    'ease-wizard-ad',
+    `ease-wizard-ad--${orientation}`,
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const stateWord = { complete: 'completed', current: 'current', upcoming: 'not started' };
+
+  return (
+    <nav className={classes} aria-label={label} {...rest}>
+      <ol className="ease-wizard-ad__list">
+        {items.map(({ step, index, state, navigable }) => {
+          const marker =
+            state === 'complete' ? '✓' : state === 'current' ? '●' : index + 1;
+
+          const accessibleName =
+            `Step ${index + 1} of ${total}, ${step.label}, ${stateWord[state]}`;
+
+          const inner = (
+            <>
+              <span className="ease-wizard-ad__marker" aria-hidden="true">
+                {marker}
+              </span>
+              <span className="ease-wizard-ad__text">
+                <span className="ease-wizard-ad__label">{step.label}</span>
+                {step.description && (
+                  <span className="ease-wizard-ad__desc">{step.description}</span>
+                )}
+              </span>
+            </>
+          );
+
+          return (
+            <li
+              className={`ease-wizard-ad__step ease-wizard-ad__step--${state}`}
+              key={step.id ?? index}
+              aria-current={state === 'current' ? 'step' : undefined}
+            >
+              {navigable ? (
+                <button
+                  className="ease-wizard-ad__btn"
+                  type="button"
+                  onClick={() => onStepClick(index, step)}
+                  aria-label={`${accessibleName}. Go back to this step`}
+                >
+                  {inner}
+                </button>
+              ) : (
+                // Not a button: a non-navigable step should not be a tab
+                // stop that does nothing when activated. `aria-label` is
+                // unreliable on a plain span, so the accessible name is a
+                // visually-hidden text node instead.
+                <span className="ease-wizard-ad__static">
+                  <span className="ease-wizard-ad__sr">{accessibleName}</span>
+                  <span aria-hidden="true" className="ease-wizard-ad__visual">
+                    {inner}
+                  </span>
+                </span>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/submissions/react/wizard-steps-ad/style.css
+++ b/submissions/react/wizard-steps-ad/style.css
@@ -1,0 +1,189 @@
+/* ==========================================================================
+   EaseMotion CSS — WizardSteps component styles
+   Issue #63820
+   ========================================================================== */
+
+.ease-wizard-ad {
+    --wz-line-ad: rgba(148, 163, 184, 0.28);
+    --wz-muted-ad: #64748b;
+    --wz-text-ad: #f1f5f9;
+    --wz-accent-ad: #38bdf8;
+    --wz-done-ad: #34d399;
+    --wz-size-ad: 28px;
+}
+
+.ease-wizard-ad__sr {
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+}
+
+.ease-wizard-ad__list {
+    display: flex;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.ease-wizard-ad--vertical .ease-wizard-ad__list {
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.ease-wizard-ad__step {
+    flex: 1 1 0;
+    position: relative;
+}
+
+.ease-wizard-ad--vertical .ease-wizard-ad__step {
+    flex: 0 0 auto;
+}
+
+/* Connector line drawn between markers. Skipped on the last step so the
+   line does not trail off the end of the track. */
+.ease-wizard-ad__step:not(:last-child)::after {
+    background: var(--wz-line-ad);
+    content: "";
+    position: absolute;
+}
+
+.ease-wizard-ad--horizontal .ease-wizard-ad__step:not(:last-child)::after {
+    height: 2px;
+    left: calc(50% + var(--wz-size-ad));
+    right: calc(-50% + var(--wz-size-ad));
+    top: calc(var(--wz-size-ad) / 2);
+}
+
+.ease-wizard-ad--vertical .ease-wizard-ad__step:not(:last-child)::after {
+    bottom: -0.25rem;
+    left: calc(var(--wz-size-ad) / 2 - 1px);
+    top: calc(var(--wz-size-ad) + 0.25rem);
+    width: 2px;
+}
+
+/* A completed step's outgoing connector is filled, so the line reads as
+   a progress track rather than a static divider. */
+.ease-wizard-ad__step--complete:not(:last-child)::after {
+    background: var(--wz-done-ad);
+}
+
+/* ==========================================================================
+   Step content
+   ========================================================================== */
+.ease-wizard-ad__btn,
+.ease-wizard-ad__static {
+    align-items: center;
+    background: none;
+    border: 0;
+    color: inherit;
+    display: flex;
+    font: inherit;
+    gap: 0.6rem;
+    padding: 0;
+    text-align: left;
+    width: 100%;
+}
+
+.ease-wizard-ad__visual {
+    align-items: center;
+    display: flex;
+    gap: 0.6rem;
+    width: 100%;
+}
+
+.ease-wizard-ad__btn {
+    border-radius: 8px;
+    cursor: pointer;
+}
+
+.ease-wizard-ad__btn:focus-visible {
+    outline: 2px solid var(--wz-accent-ad);
+    outline-offset: 3px;
+}
+
+.ease-wizard-ad--horizontal .ease-wizard-ad__btn,
+.ease-wizard-ad--horizontal .ease-wizard-ad__static,
+.ease-wizard-ad--horizontal .ease-wizard-ad__visual {
+    flex-direction: column;
+    gap: 0.4rem;
+    text-align: center;
+}
+
+.ease-wizard-ad__marker {
+    align-items: center;
+    background: transparent;
+    border: 2px solid var(--wz-line-ad);
+    border-radius: 50%;
+    color: var(--wz-muted-ad);
+    display: flex;
+    flex: 0 0 auto;
+    font-size: 0.78rem;
+    font-weight: 600;
+    height: var(--wz-size-ad);
+    justify-content: center;
+    line-height: 1;
+    position: relative;
+    width: var(--wz-size-ad);
+    z-index: 1;
+}
+
+.ease-wizard-ad__text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+    min-width: 0;
+}
+
+.ease-wizard-ad__label {
+    color: var(--wz-muted-ad);
+    font-size: 0.82rem;
+    font-weight: 550;
+}
+
+.ease-wizard-ad__desc {
+    color: var(--wz-muted-ad);
+    font-size: 0.74rem;
+}
+
+/* ==========================================================================
+   States — shape carries meaning alongside colour
+   ========================================================================== */
+.ease-wizard-ad__step--complete .ease-wizard-ad__marker {
+    background: var(--wz-done-ad);
+    border-color: var(--wz-done-ad);
+    color: #052e1c;
+}
+
+.ease-wizard-ad__step--complete .ease-wizard-ad__label {
+    color: var(--wz-text-ad);
+}
+
+.ease-wizard-ad__step--current .ease-wizard-ad__marker {
+    border-color: var(--wz-accent-ad);
+    color: var(--wz-accent-ad);
+    font-size: 0.6rem;
+}
+
+.ease-wizard-ad__step--current .ease-wizard-ad__label {
+    color: var(--wz-text-ad);
+    font-weight: 650;
+}
+
+@media (forced-colors: active) {
+    .ease-wizard-ad__marker {
+        border: 2px solid CanvasText;
+    }
+
+    .ease-wizard-ad__step--current .ease-wizard-ad__marker {
+        border-color: Highlight;
+        color: Highlight;
+    }
+
+    .ease-wizard-ad__step:not(:last-child)::after {
+        background: CanvasText;
+    }
+}


### PR DESCRIPTION
Fixes #63820

**What was added**

A multi-step progress indicator, under `submissions/react/wizard-steps-ad/`.

- `WizardSteps.jsx` — 130 non-empty lines: state derivation, conditional navigability, position-and-state accessible names, and clamping.
- `style.css` — 163 non-empty lines: shape-coded markers, filled progress connectors, both orientations, forced-colors.
- `README.md` — props table, marker table, usage, and rationale.

**What is the problem**

**A green circle and a grey circle are the same circle** to a user with deuteranopia. Encoding completed/current/upcoming purely in colour makes the single most important thing on the screen — where am I in this flow — unreadable for a meaningful fraction of users.

Second, **progress styled but not exposed** tells assistive tech nothing. A screen reader announces "Payment" with no indication that it is step 2 of 4, or that steps 1 is done and 3 has not started.

**Why this approach**

Each state has a distinct **shape**: `✓` for complete, `●` for current, the step number for upcoming. The progression stays legible in greyscale and in print.

`aria-current="step"` marks the active step, and each accessible name carries position and state — "Step 2 of 4, Payment, current".

**Only navigable steps are buttons.** Rendering every step as a button and ignoring clicks on future ones is the usual shortcut, and it means a keyboard user tabs through controls that do nothing when activated — worse than not reaching them at all.

For non-navigable steps the accessible name is a **visually-hidden text node**, not an `aria-label` on a span. `aria-label` is only reliably honoured on elements with a widget or landmark role; on a generic span support varies. An initial draft used `role="text"` here, which is a Safari-only quirk rather than a real ARIA role — caught and replaced.

**How to test**

1. Pull this branch and drop `wizard-steps-ad/` into any React app (React 16.8+).
2. Render 4 steps with `current={1}` and an `onStepClick`.
3. **Apply a greyscale filter** (DevTools → Rendering → Emulate vision deficiencies → Achromatopsia). Completed, current and upcoming steps must remain distinguishable by their markers alone.
4. Confirm the connector into step 2 is filled while later connectors are not, and that no connector trails past the last step.
5. **Tab through the component.** Only completed steps should be tab stops — step 3 and 4 must not receive focus.
6. Inspect step 2 with a screen reader — it should announce "Step 2 of 4, Payment, current", not just "Payment".
7. Confirm `aria-current="step"` appears on exactly one step.
8. Click a completed step and confirm `onStepClick` fires with the right index.
9. Set `allowBackNav={false}` and confirm nothing is a tab stop.
10. Pass `current={9}` with 3 steps and confirm it clamps to the last rather than rendering all as complete.
11. Switch to `orientation="vertical"` and confirm the connector runs vertically.

**Edge cases covered**

- Shape carries state, so meaning survives without colour vision.
- Position and state are in each accessible name, not implied by styling.
- Only completed steps are focusable, so no dead tab stops exist.
- The accessible name for non-navigable steps uses a hidden text node rather than `aria-label` on a span, which is unreliably supported.
- No invalid `role="text"`.
- `current` is clamped to `[0, total-1]`, verified for both out-of-range directions.
- The connector is skipped on the last step so it does not trail off the track.
- A completed step's outgoing connector is filled, making the line read as progress rather than decoration.
- `onStepClick` being absent disables navigation entirely rather than rendering dead buttons.
- `step.id` falls back to index when absent.
- Marker has `z-index: 1` so the connector passes behind it rather than through it.
- `forced-colors: active` distinguishes the current step with `Highlight`.

**Verification**

- `WizardSteps.jsx` parses cleanly through esbuild — exit code 0.
- `npx stylelint style.css` against the repo's own config — exit code 0.
- All component classes referenced in the JSX are defined in `style.css`.
- Verified programmatically: state derivation (`complete,current,upcoming,upcoming` for current=1 of 4), clamping at both bounds, `aria-current` wiring, distinct shape markers, and absence of `role="text"`.
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 3 new files, 0 deletions, no existing file touched.
- Component classes carry an `-ad` suffix so this lands as a parallel implementation.

**Labels:** `type:feature` · `react` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
