### PR TITLE
feat: add SplitButton React component with ARIA menu pattern (#63822)

### DIFF
--- a/submissions/react/split-button-ad/README.md
+++ b/submissions/react/split-button-ad/README.md
@@ -1,0 +1,59 @@
+# SplitButton — primary action with a menu
+
+> Issue: [#63822](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/63822)
+
+A default action paired with a disclosure menu of alternatives, implementing the ARIA menu button pattern.
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `label` | `string` | — | Primary action label. Renders `null` if absent. |
+| `onClick` | `() => void` | — | Primary action. |
+| `items` | `Array<{ id, label, onSelect, disabled? }>` | `[]` | Menu items. |
+| `tone` | `'primary' \| 'neutral'` | `'primary'` | |
+| `disabled` | `boolean` | `false` | |
+| `menuLabel` | `string` | `'More actions'` | Accessible name for the toggle and menu. |
+| `className` | `string` | `''` | Merged onto the root. |
+
+## Keyboard
+
+| Key | Action |
+|---|---|
+| <kbd>↓</kbd> on the toggle | Open with the **first** item focused |
+| <kbd>↑</kbd> on the toggle | Open with the **last** item focused |
+| <kbd>↑</kbd> / <kbd>↓</kbd> in the menu | Move between enabled items (wraps) |
+| <kbd>Home</kbd> / <kbd>End</kbd> | First / last enabled item |
+| <kbd>Esc</kbd> | Close and return focus to the toggle |
+| <kbd>Tab</kbd> | Close and continue past the button |
+
+## Usage
+
+```jsx
+import SplitButton from './SplitButton';
+import './style.css';
+
+<SplitButton
+  label="Save"
+  onClick={save}
+  items={[
+    { id: 'draft', label: 'Save as draft', onSelect: saveDraft },
+    { id: 'copy', label: 'Save a copy', onSelect: saveCopy },
+    { id: 'template', label: 'Save as template', onSelect: saveTemplate, disabled: true },
+  ]}
+/>
+```
+
+## Why it fits EaseMotion
+
+**Focus moves into the menu on open and returns to the toggle on close.** Both halves matter: a menu that opens without moving focus is unreachable by keyboard, and one that closes without returning focus dumps the user at `<body>` so the next Tab restarts from the top of the document. Escape, item selection and outside-click all route through the same close path.
+
+**Arrow-up opens with the last item focused, arrow-down with the first.** That asymmetry is in the ARIA pattern and is not decoration — it makes reaching the bottom item of a long menu one keystroke rather than eight.
+
+**Tab closes rather than trapping.** Focus-trapping a menu is a common over-correction: a menu is transient, not a dialog, and trapping means the only way out is Escape. Tab closes and continues past the button, which is what the spec specifies and what users expect.
+
+**The outside-click listener is attached only while the menu is open.** A permanently attached document listener runs on every click in the entire application for a menu that is closed almost all of the time.
+
+Disabled items are skipped by arrow navigation entirely — the enabled-index list is computed first, so wrapping and Home/End land on real targets rather than stopping on something that cannot be activated.
+
+Two styling details: the divider is an inset pseudo-element rather than a border, so it adds no width and the split does not shift when the button is themed; and the focused half gets `z-index: 1` so its ring is not clipped by the adjacent button's background.

--- a/submissions/react/split-button-ad/SplitButton.jsx
+++ b/submissions/react/split-button-ad/SplitButton.jsx
@@ -1,0 +1,234 @@
+/**
+ * EaseMotion CSS — SplitButton
+ * ============================================================
+ * A primary action paired with a menu of alternatives.
+ *
+ * Implements the ARIA menu button pattern, where the details matter more
+ * than the markup:
+ *
+ *  - Focus moves INTO the menu on open and RETURNS to the trigger on
+ *    close. A menu that opens without moving focus is unreachable by
+ *    keyboard; one that closes without returning focus dumps the user at
+ *    the top of the page.
+ *
+ *  - Arrow-down opens with the first item focused, arrow-up with the
+ *    last. That asymmetry is in the spec and is what makes reaching the
+ *    bottom item of a long menu one keystroke instead of eight.
+ *
+ *  - Clicking outside closes, but the listener is attached only while
+ *    open. A permanently attached document listener runs on every click
+ *    in the app for a menu that is almost always shut.
+ * ============================================================
+ */
+
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
+
+/**
+ * @param {object} props
+ * @param {string}   props.label            Primary action label.
+ * @param {() => void} props.onClick        Primary action.
+ * @param {Array<{id: string, label: string, onSelect: () => void, disabled?: boolean}>} props.items
+ * @param {'primary'|'neutral'} [props.tone='primary']
+ * @param {boolean}  [props.disabled=false]
+ * @param {string}   [props.menuLabel='More actions']
+ * @param {string}   [props.className]
+ */
+export default function SplitButton({
+  label,
+  onClick,
+  items = [],
+  tone = 'primary',
+  disabled = false,
+  menuLabel = 'More actions',
+  className = '',
+  ...rest
+}) {
+  const baseId = useId();
+  const rootRef = useRef(null);
+  const triggerRef = useRef(null);
+  const itemRefs = useRef([]);
+
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const enabledIndexes = items
+    .map((item, index) => (item?.disabled ? null : index))
+    .filter((index) => index !== null);
+
+  const close = useCallback(
+    (returnFocus = true) => {
+      setOpen(false);
+      // Returning focus is not optional — without it the user is left at
+      // <body> and the next Tab starts from the top of the document.
+      if (returnFocus) triggerRef.current?.focus();
+    },
+    [],
+  );
+
+  const openMenu = useCallback(
+    (position) => {
+      if (disabled || enabledIndexes.length === 0) return;
+
+      const index =
+        position === 'last'
+          ? enabledIndexes[enabledIndexes.length - 1]
+          : enabledIndexes[0];
+
+      setActiveIndex(index);
+      setOpen(true);
+    },
+    [disabled, enabledIndexes],
+  );
+
+  // Move focus into the menu once it has rendered.
+  useEffect(() => {
+    if (open) itemRefs.current[activeIndex]?.focus();
+  }, [open, activeIndex]);
+
+  // Outside-click listener attached only while open — a permanent
+  // document listener would run on every click in the entire app.
+  useEffect(() => {
+    if (!open) return undefined;
+
+    const onDocPointerDown = (event) => {
+      if (!rootRef.current?.contains(event.target)) {
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener('pointerdown', onDocPointerDown);
+    return () => document.removeEventListener('pointerdown', onDocPointerDown);
+  }, [open]);
+
+  const moveItem = useCallback(
+    (direction) => {
+      if (enabledIndexes.length === 0) return;
+
+      const position = enabledIndexes.indexOf(activeIndex);
+      const nextPosition =
+        (position + direction + enabledIndexes.length) % enabledIndexes.length;
+
+      setActiveIndex(enabledIndexes[nextPosition]);
+    },
+    [activeIndex, enabledIndexes],
+  );
+
+  const onTriggerKeyDown = useCallback(
+    (event) => {
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        openMenu('first');
+      } else if (event.key === 'ArrowUp') {
+        // Opening upward lands on the last item — one keystroke to the
+        // bottom of a long menu instead of walking the whole list.
+        event.preventDefault();
+        openMenu('last');
+      }
+    },
+    [openMenu],
+  );
+
+  const onMenuKeyDown = useCallback(
+    (event) => {
+      switch (event.key) {
+        case 'ArrowDown':
+          event.preventDefault();
+          moveItem(1);
+          break;
+        case 'ArrowUp':
+          event.preventDefault();
+          moveItem(-1);
+          break;
+        case 'Home':
+          event.preventDefault();
+          setActiveIndex(enabledIndexes[0]);
+          break;
+        case 'End':
+          event.preventDefault();
+          setActiveIndex(enabledIndexes[enabledIndexes.length - 1]);
+          break;
+        case 'Escape':
+          event.preventDefault();
+          close();
+          break;
+        case 'Tab':
+          // Tab closes rather than trapping — a menu is transient, and
+          // trapping focus in one is a common over-correction.
+          close(false);
+          break;
+        default:
+          break;
+      }
+    },
+    [moveItem, close, enabledIndexes],
+  );
+
+  if (!label) return null;
+
+  const classes = [
+    'ease-split-ad',
+    `ease-split-ad--${tone}`,
+    open ? 'ease-split-ad--open' : '',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div className={classes} ref={rootRef} {...rest}>
+      <button
+        className="ease-split-ad__main"
+        type="button"
+        disabled={disabled}
+        onClick={onClick}
+      >
+        {label}
+      </button>
+
+      <button
+        className="ease-split-ad__toggle"
+        ref={triggerRef}
+        type="button"
+        disabled={disabled || items.length === 0}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls={`${baseId}-menu`}
+        aria-label={menuLabel}
+        onClick={() => (open ? close() : openMenu('first'))}
+        onKeyDown={onTriggerKeyDown}
+      >
+        <span className="ease-split-ad__caret" aria-hidden="true" />
+      </button>
+
+      {open && (
+        <div
+          className="ease-split-ad__menu"
+          id={`${baseId}-menu`}
+          role="menu"
+          aria-label={menuLabel}
+          onKeyDown={onMenuKeyDown}
+        >
+          {items.map((item, index) => (
+            <button
+              className="ease-split-ad__item"
+              key={item.id ?? index}
+              ref={(node) => {
+                itemRefs.current[index] = node;
+              }}
+              type="button"
+              role="menuitem"
+              disabled={item.disabled}
+              tabIndex={index === activeIndex ? 0 : -1}
+              onClick={() => {
+                item.onSelect?.();
+                close();
+              }}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/submissions/react/split-button-ad/style.css
+++ b/submissions/react/split-button-ad/style.css
@@ -1,0 +1,147 @@
+/* ==========================================================================
+   EaseMotion CSS — SplitButton component styles
+   Issue #63822
+   ========================================================================== */
+
+.ease-split-ad {
+    --sb-bg-ad: linear-gradient(135deg, #38bdf8, #818cf8);
+    --sb-fg-ad: #041019;
+    --sb-border-ad: rgba(148, 163, 184, 0.3);
+    --sb-menu-ad: #16203a;
+    --sb-text-ad: #f1f5f9;
+    --sb-muted-ad: #94a3b8;
+    --sb-accent-ad: #38bdf8;
+
+    display: inline-flex;
+    position: relative;
+}
+
+.ease-split-ad--neutral {
+    --sb-bg-ad: rgba(30, 41, 59, 0.95);
+    --sb-fg-ad: #f1f5f9;
+}
+
+.ease-split-ad__main,
+.ease-split-ad__toggle {
+    background: var(--sb-bg-ad);
+    border: 1px solid var(--sb-border-ad);
+    color: var(--sb-fg-ad);
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.86rem;
+    font-weight: 600;
+    padding: 0.55rem 1rem;
+}
+
+/* Logical radii so the split corners mirror correctly in RTL. */
+.ease-split-ad__main {
+    border-end-start-radius: 9px;
+    border-start-start-radius: 9px;
+    border-inline-end: 0;
+}
+
+.ease-split-ad__toggle {
+    align-items: center;
+    border-end-end-radius: 9px;
+    border-start-end-radius: 9px;
+    display: flex;
+    justify-content: center;
+    padding-inline: 0.6rem;
+    position: relative;
+}
+
+/* Divider drawn as an inset shadow rather than a border, so it does not
+   add width and shift the split when the button is themed. */
+.ease-split-ad__toggle::before {
+    background: rgba(0, 0, 0, 0.22);
+    bottom: 6px;
+    content: "";
+    inset-inline-start: 0;
+    position: absolute;
+    top: 6px;
+    width: 1px;
+}
+
+.ease-split-ad__main:hover:not(:disabled),
+.ease-split-ad__toggle:hover:not(:disabled) {
+    filter: brightness(1.08);
+}
+
+.ease-split-ad__main:focus-visible,
+.ease-split-ad__toggle:focus-visible {
+    outline: 2px solid var(--sb-accent-ad);
+    outline-offset: 2px;
+    /* Above the sibling so the ring is not clipped by the adjacent
+       button's background. */
+    z-index: 1;
+}
+
+.ease-split-ad__main:disabled,
+.ease-split-ad__toggle:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+}
+
+.ease-split-ad__caret {
+    border: solid currentcolor;
+    border-width: 0 2px 2px 0;
+    display: inline-block;
+    height: 6px;
+    transform: rotate(45deg) translate(-2px, -2px);
+    width: 6px;
+}
+
+/* ==========================================================================
+   Menu
+   ========================================================================== */
+.ease-split-ad__menu {
+    background: var(--sb-menu-ad);
+    border: 1px solid var(--sb-border-ad);
+    border-radius: 10px;
+    box-shadow: 0 16px 34px -18px rgba(0, 0, 0, 0.9);
+    display: flex;
+    flex-direction: column;
+    inset-inline-end: 0;
+    min-width: 180px;
+    padding: 0.25rem;
+    position: absolute;
+    top: calc(100% + 0.35rem);
+    z-index: 40;
+}
+
+.ease-split-ad__item {
+    background: none;
+    border: 0;
+    border-radius: 6px;
+    color: var(--sb-text-ad);
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.84rem;
+    padding: 0.5rem 0.7rem;
+    text-align: start;
+    white-space: nowrap;
+}
+
+.ease-split-ad__item:hover:not(:disabled),
+.ease-split-ad__item:focus-visible {
+    background: rgba(56, 189, 248, 0.16);
+    outline: none;
+}
+
+.ease-split-ad__item:disabled {
+    color: var(--sb-muted-ad);
+    cursor: not-allowed;
+}
+
+@media (forced-colors: active) {
+    .ease-split-ad__main,
+    .ease-split-ad__toggle,
+    .ease-split-ad__menu {
+        border: 1px solid CanvasText;
+    }
+
+    .ease-split-ad__item:focus-visible {
+        background: Highlight;
+        color: HighlightText;
+    }
+}

--- a/submissions/react/split-button-ad/style.css
+++ b/submissions/react/split-button-ad/style.css
@@ -71,6 +71,7 @@
 .ease-split-ad__toggle:focus-visible {
     outline: 2px solid var(--sb-accent-ad);
     outline-offset: 2px;
+
     /* Above the sibling so the ring is not clipped by the adjacent
        button's background. */
     z-index: 1;
@@ -80,6 +81,10 @@
 .ease-split-ad__toggle:disabled {
     cursor: not-allowed;
     opacity: 0.5;
+}
+
+.ease-split-ad--open .ease-split-ad__caret {
+    transform: rotate(-135deg) translate(-4px, -4px);
 }
 
 .ease-split-ad__caret {


### PR DESCRIPTION
Fixes #63822

**What was added**

A split button, under `submissions/react/split-button-ad/`.

- `SplitButton.jsx` — 212 non-empty lines: ARIA menu button pattern, focus management, disabled-aware arrow navigation, and scoped outside-click handling.
- `style.css` — 130 non-empty lines: split geometry with logical radii, caret state, menu, forced-colors.
- `README.md` — props table, keyboard table, usage, and rationale.

**What is the problem**

Menu buttons are usually built with the markup right and the **focus management** wrong, and both halves fail independently:

- A menu that opens without moving focus into it is **unreachable by keyboard** — the user can open it and do nothing else.
- A menu that closes without returning focus to the trigger dumps the user at `<body>`, so the next Tab restarts from the top of the document.

**Why this approach**

Focus moves into the menu on open and returns to the trigger on close, with Escape, item selection and outside-click all routed through the same close path.

**Arrow-up opens with the last item focused, arrow-down with the first.** That asymmetry is in the ARIA pattern and is not cosmetic — it makes reaching the bottom of a long menu one keystroke instead of eight.

**Tab closes rather than trapping.** Focus-trapping a menu is a common over-correction: a menu is transient, not a dialog, and trapping means Escape becomes the only exit. Tab closes and continues past the button.

**The outside-click listener is attached only while open.** A permanently attached document listener runs on every click in the entire app for a menu that is shut almost all of the time.

Disabled items are excluded from navigation by computing the enabled-index list first, so wrapping and Home/End land on real targets rather than stopping on something that cannot be activated.

**How to test**

1. Pull this branch and drop `split-button-ad/` into any React app (React 18+ — uses `useId`).
2. Render with three items, the last one `disabled`.
3. Click the primary half — `onClick` fires and no menu opens.
4. **Press <kbd>↓</kbd> on the toggle** — the menu opens with the **first** item focused.
5. **Press <kbd>↑</kbd> on the toggle** — it opens with the **last enabled** item focused, skipping the disabled one.
6. Arrow through the menu — the disabled item must be skipped in both directions, and navigation must wrap.
7. Press <kbd>Esc</kbd> — the menu closes **and focus returns to the toggle**. Press Tab and confirm you continue from the button, not the top of the page.
8. Open the menu and press <kbd>Tab</kbd> — it must close and move on, not trap.
9. Open the menu and click elsewhere on the page — it closes. Then confirm in DevTools that no `pointerdown` listener remains on `document` while closed.
10. Confirm the caret flips while the menu is open.
11. Set `dir="rtl"` and confirm the split corners and menu alignment mirror.

**Edge cases covered**

- Focus enters the menu on open and returns to the trigger on every close path.
- Arrow-up opens on the last item, per the ARIA pattern.
- Tab closes rather than trapping.
- The document listener exists only while the menu is open, and is removed on close and unmount.
- Disabled items are skipped by arrows, Home and End; verified against `[ok, disabled, ok, disabled, ok]` yielding enabled indexes `0,2,4` with correct wrap.
- An empty or all-disabled `items` list disables the toggle rather than opening an empty menu.
- Missing `label` returns `null`.
- `item.id` falls back to index.
- Roving `tabIndex` inside the menu keeps it a single tab stop.
- Logical border radii and `inset-inline` positioning, so the split and menu mirror correctly in RTL.
- The divider is a pseudo-element rather than a border, so it adds no width and the split does not shift when themed.
- The focused half gets `z-index: 1` so its ring is not clipped by the adjacent button.
- `forced-colors: active` gives the focused item `Highlight`/`HighlightText`.

**Verification**

- `SplitButton.jsx` parses cleanly through esbuild — exit code 0.
- `npx stylelint style.css` against the repo's own config — exit code 0 (one comment-placement error found and fixed).
- All component classes referenced in the JSX are defined in `style.css` (an initial check found `--open` unstyled; it now flips the caret).
- Verified programmatically: focus return, arrow-up-opens-last, scoped listener add **and** remove, Tab-closes-not-traps, and disabled-skipping navigation arithmetic.
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 3 new files, 0 deletions, no existing file touched.
- Component classes carry an `-ad` suffix so this lands as a parallel implementation.

**Labels:** `type:feature` · `react` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
