### PR TITLE
feat: add MeterBar React component with pattern-coded thresholds (#63823)

### DIFF
--- a/submissions/react/meter-bar-ad/MeterBar.jsx
+++ b/submissions/react/meter-bar-ad/MeterBar.jsx
@@ -1,0 +1,120 @@
+/**
+ * EaseMotion CSS — MeterBar
+ * ============================================================
+ * Bounded value meter with semantic thresholds.
+ *
+ * `role="meter"` rather than `progressbar` — these are different things
+ * and the distinction is not pedantic. A progressbar represents a task
+ * advancing toward completion; a meter represents a measurement within a
+ * known range. Disk usage, quota consumption and temperature are meters.
+ * Announcing "75% complete" for a disk that is 75% full is wrong in a way
+ * that matters.
+ *
+ * Threshold bands change PATTERN as well as colour. A meter's whole
+ * purpose is signalling "this is fine" versus "this needs attention", so
+ * encoding that in hue alone puts the one bit of information the
+ * component exists to convey out of reach for a colour-blind user.
+ * ============================================================
+ */
+
+import { useMemo } from 'react';
+
+const TONES = {
+  ok: { label: 'Normal', pattern: 'solid' },
+  warn: { label: 'Approaching limit', pattern: 'hatch' },
+  over: { label: 'Over limit', pattern: 'dense' },
+};
+
+/**
+ * @param {object} props
+ * @param {number}  props.value
+ * @param {number}  [props.min=0]
+ * @param {number}  [props.max=100]
+ * @param {number}  [props.warnAt=0.75]   Fraction of range entering warn.
+ * @param {number}  [props.overAt=1]      Fraction entering over.
+ * @param {string}  props.label
+ * @param {string}  [props.valueText]     Overrides the announced value.
+ * @param {boolean} [props.showValue=true]
+ * @param {'sm'|'md'} [props.size='md']
+ * @param {string}  [props.className]
+ */
+export default function MeterBar({
+  value = 0,
+  min = 0,
+  max = 100,
+  warnAt = 0.75,
+  overAt = 1,
+  label,
+  valueText,
+  showValue = true,
+  size = 'md',
+  className = '',
+  ...rest
+}) {
+  const safe = useMemo(() => {
+    const lo = Number.isFinite(min) ? min : 0;
+    // An inverted or zero range would divide by zero, so max is forced
+    // above min rather than trusted.
+    const hi = Number.isFinite(max) && max > lo ? max : lo + 1;
+    const v = Number.isFinite(value) ? Math.min(Math.max(value, lo), hi) : lo;
+
+    return { lo, hi, v };
+  }, [value, min, max]);
+
+  const fraction = (safe.v - safe.lo) / (safe.hi - safe.lo);
+
+  const tone = fraction >= overAt ? 'over' : fraction >= warnAt ? 'warn' : 'ok';
+
+  const percent = Math.round(fraction * 100);
+
+  const classes = [
+    'ease-meter-ad',
+    `ease-meter-ad--${size}`,
+    `ease-meter-ad--${tone}`,
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  // "42 of 50 seats, approaching limit" beats a bare percentage — the
+  // band name is the actionable part.
+  const announced =
+    valueText ?? `${safe.v} of ${safe.hi}, ${TONES[tone].label.toLowerCase()}`;
+
+  return (
+    <div className={classes} {...rest}>
+      {(label || showValue) && (
+        <div className="ease-meter-ad__head">
+          {label && <span className="ease-meter-ad__label">{label}</span>}
+          {showValue && (
+            <span className="ease-meter-ad__value" aria-hidden="true">
+              {safe.v} / {safe.hi}
+            </span>
+          )}
+        </div>
+      )}
+
+      <div
+        className="ease-meter-ad__track"
+        role="meter"
+        aria-label={label}
+        aria-valuenow={safe.v}
+        aria-valuemin={safe.lo}
+        aria-valuemax={safe.hi}
+        aria-valuetext={announced}
+      >
+        <span
+          className="ease-meter-ad__fill"
+          style={{ '--meter-pct-ad': `${percent}%` }}
+          aria-hidden="true"
+        />
+      </div>
+
+      {tone !== 'ok' && (
+        <p className="ease-meter-ad__note" aria-hidden="true">
+          {TONES[tone].label}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/submissions/react/meter-bar-ad/README.md
+++ b/submissions/react/meter-bar-ad/README.md
@@ -1,0 +1,41 @@
+# MeterBar — bounded value meter
+
+> Issue: [#63823](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/63823)
+
+A meter with semantic threshold bands that change pattern as well as colour.
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `value` | `number` | `0` | Clamped to `[min, max]`. |
+| `min` / `max` | `number` | `0` / `100` | Range. `max` is forced above `min`. |
+| `warnAt` | `number` | `0.75` | Fraction of range entering the warn band. |
+| `overAt` | `number` | `1` | Fraction entering the over band. |
+| `label` | `string` | — | Accessible name and visible heading. |
+| `valueText` | `string` | derived | Overrides the announced value. |
+| `showValue` | `boolean` | `true` | Render the numeric readout. |
+| `size` | `'sm' \| 'md'` | `'md'` | Track height. |
+| `className` | `string` | `''` | Merged onto the root. |
+
+## Usage
+
+```jsx
+import MeterBar from './MeterBar';
+import './style.css';
+
+<MeterBar label="Seats used" value={42} max={50} warnAt={0.8} />
+<MeterBar label="Storage" value={318} max={500} size="sm" />
+```
+
+## Why it fits EaseMotion
+
+**`role="meter"`, not `progressbar`** — and the distinction is not pedantic. A progressbar represents a task advancing toward completion; a meter represents a measurement within a known range. Disk usage, quota consumption and temperature are meters. Announcing "75% complete" for a disk that is 75% *full* is wrong in a way that misleads.
+
+**Threshold bands change pattern as well as colour.** A meter's entire purpose is signalling "this is fine" versus "this needs attention" — so encoding that in hue alone puts the one bit of information the component exists to convey out of reach for a colour-blind user. The warn band gets a diagonal hatch, the over band a denser one, so the three states are distinguishable in greyscale and in print.
+
+**`aria-valuetext` carries the band name**, not just a number: "42 of 50, approaching limit" rather than "42". The band is the actionable part, and a bare value forces the listener to do the threshold arithmetic themselves.
+
+The range is validated rather than trusted — an inverted or zero-width range would divide by zero, so `max` is forced above `min` and `value` is clamped into the result.
+
+Under `forced-colors: active` the fill is given a system colour explicitly. Backgrounds are discarded there, so without this the meter would render as an empty track with no fill at all.

--- a/submissions/react/meter-bar-ad/style.css
+++ b/submissions/react/meter-bar-ad/style.css
@@ -1,0 +1,123 @@
+/* ==========================================================================
+   EaseMotion CSS — MeterBar component styles
+   Issue #63823
+   ========================================================================== */
+
+.ease-meter-ad {
+    --mt-track-ad: rgba(148, 163, 184, 0.18);
+    --mt-fill-ad: #34d399;
+    --mt-text-ad: #f1f5f9;
+    --mt-muted-ad: #94a3b8;
+    --mt-height-ad: 8px;
+    --mt-ease-ad: cubic-bezier(0.16, 1, 0.3, 1);
+
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.ease-meter-ad--sm {
+    --mt-height-ad: 5px;
+}
+
+.ease-meter-ad__head {
+    align-items: baseline;
+    display: flex;
+    gap: 1rem;
+    justify-content: space-between;
+}
+
+.ease-meter-ad__label {
+    color: var(--mt-text-ad);
+    font-size: 0.82rem;
+    font-weight: 550;
+}
+
+.ease-meter-ad__value {
+    color: var(--mt-muted-ad);
+    font-family: "JetBrains Mono", ui-monospace, monospace;
+    font-size: 0.76rem;
+    font-variant-numeric: tabular-nums;
+}
+
+.ease-meter-ad__track {
+    background: var(--mt-track-ad);
+    border-radius: 999px;
+    height: var(--mt-height-ad);
+    overflow: hidden;
+    width: 100%;
+}
+
+.ease-meter-ad__fill {
+    background: var(--mt-fill-ad);
+    border-radius: inherit;
+    display: block;
+    height: 100%;
+    width: var(--meter-pct-ad, 0%);
+    transition: width 320ms var(--mt-ease-ad);
+}
+
+.ease-meter-ad__note {
+    color: var(--mt-fill-ad);
+    font-size: 0.76rem;
+    margin: 0;
+}
+
+/* ==========================================================================
+   Threshold bands
+   --------------------------------------------------------------------------
+   Each band changes PATTERN as well as colour. A meter exists to signal
+   "fine" versus "needs attention" — encoding that in hue alone puts the
+   component's only real payload out of reach for a colour-blind user.
+   ========================================================================== */
+.ease-meter-ad--ok {
+    --mt-fill-ad: #34d399;
+}
+
+.ease-meter-ad--warn {
+    --mt-fill-ad: #fbbf24;
+}
+
+/* Diagonal hatch — visible in greyscale and in print. */
+.ease-meter-ad--warn .ease-meter-ad__fill {
+    background-image: repeating-linear-gradient(
+        45deg,
+        rgba(0, 0, 0, 0.22) 0,
+        rgba(0, 0, 0, 0.22) 3px,
+        transparent 3px,
+        transparent 7px
+    );
+}
+
+.ease-meter-ad--over {
+    --mt-fill-ad: #f87171;
+}
+
+/* Denser hatch, so `over` is distinguishable from `warn` without colour. */
+.ease-meter-ad--over .ease-meter-ad__fill {
+    background-image: repeating-linear-gradient(
+        45deg,
+        rgba(0, 0, 0, 0.32) 0,
+        rgba(0, 0, 0, 0.32) 2px,
+        transparent 2px,
+        transparent 4px
+    );
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .ease-meter-ad__fill {
+        transition-duration: 1ms;
+    }
+}
+
+@media (forced-colors: active) {
+    .ease-meter-ad__track {
+        border: 1px solid CanvasText;
+    }
+
+    /* Backgrounds are discarded, so the hatch is the only differentiator
+       left — forced to a system colour rather than dropped. */
+    .ease-meter-ad__fill {
+        background: Highlight;
+    }
+}


### PR DESCRIPTION
Fixes #63823

**What was added**

A bounded value meter, under `submissions/react/meter-bar-ad/`.

- `MeterBar.jsx` — 108 non-empty lines: range validation and clamping, threshold banding, and full meter ARIA with band-aware `aria-valuetext`.
- `style.css` — 106 non-empty lines: track and fill, two hatch patterns, two sizes, reduced-motion, forced-colors.
- `README.md` — props table, usage, and rationale.

**What is the problem**

**`progressbar` is the wrong role**, and the distinction is not pedantic. A progressbar represents a task advancing toward completion; a meter represents a measurement within a known range. Disk usage, quota consumption and temperature are meters — announcing "75% complete" for a disk that is 75% *full* actively misleads.

**Threshold colour alone hides the payload.** A meter exists to signal "this is fine" versus "this needs attention". Encoding that in hue puts the one bit of information the component is for out of reach for a colour-blind user — the bar is visible, its meaning is not.

**Why this approach**

`role="meter"` with the full value set, and `aria-valuetext` carrying the **band name**: "42 of 50, approaching limit" rather than "42". The band is the actionable part; a bare number forces the listener to do the threshold arithmetic themselves.

The warn band gets a diagonal hatch and the over band a denser one, so all three states are distinguishable in greyscale and in print.

The range is validated rather than trusted — an inverted or zero-width range would divide by zero, so `max` is forced above `min` and `value` is clamped into the result.

**How to test**

1. Pull this branch and drop `meter-bar-ad/` into any React app (React 16.8+).
2. Render several meters spanning the bands:
   ```jsx
   <MeterBar label="Seats" value={10} max={50} />
   <MeterBar label="Seats" value={40} max={50} />
   <MeterBar label="Seats" value={50} max={50} />
   ```
3. Confirm the bands: 20% → ok, 80% → warn, 100% → over.
4. **Apply a greyscale filter.** The three meters must remain distinguishable — the warn hatch and the denser over hatch are what carry the state once colour is gone.
5. Inspect with a screen reader — it must announce as a **meter** (not a progress bar), with "42 of 50, approaching limit" rather than a bare number.
6. Pass `value={60}` with `max={50}` and confirm it clamps to 100% rather than overflowing the track.
7. Pass `min={100} max={0}` and confirm no `NaN` appears anywhere.
8. Pass `value={NaN}` and confirm it renders at the minimum rather than breaking.
9. View in forced-colors mode and confirm the fill is still visible — backgrounds are discarded there, so an unhandled meter renders as an empty track.
10. Enable reduced motion and confirm the fill still updates, just without the transition.

**Edge cases covered**

- `role="meter"` rather than `progressbar`, matching what the value actually represents.
- Pattern plus colour, so band state survives greyscale and print.
- The warn and over hatches differ in density, so they are distinguishable from each other and not just from `ok`.
- `aria-valuetext` carries the band name, not a bare number.
- Inverted or zero-width ranges are corrected rather than dividing by zero — verified to produce no `NaN`.
- Non-finite `value` falls back to the minimum.
- Values outside the range clamp to the bounds.
- `warnAt` / `overAt` are fractions of the range, so they follow a changed `max` automatically.
- The numeric readout is `aria-hidden`, since `aria-valuetext` already carries it — otherwise it is announced twice.
- The band note only renders outside the `ok` state, so a healthy meter is not cluttered.
- `tabular-nums` stops the readout jittering as digits change.
- `forced-colors: active` gives the fill a system colour, since backgrounds are discarded there.

**Verification**

- `MeterBar.jsx` parses cleanly through esbuild — exit code 0.
- `npx stylelint style.css` against the repo's own config — exit code 0.
- All component classes referenced in the JSX are defined in `style.css`.
- Band derivation verified across four values; both range guards (inverted range, `NaN` value) verified to produce finite results.
- Two distinct hatch patterns confirmed present.
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 3 new files, 0 deletions, no existing file touched.
- Component classes carry an `-ad` suffix so this lands as a parallel implementation.

**Labels:** `type:feature` · `react` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
