### PR TITLE
feat: add SortableList React component with keyboard reordering (#63825)

### DIFF
--- a/submissions/react/sortable-list-ad/README.md
+++ b/submissions/react/sortable-list-ad/README.md
@@ -1,0 +1,46 @@
+# SortableList — keyboard-accessible reorderable list
+
+> Issue: [#63825](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/63825)
+
+A reorderable list operable by keyboard as well as by drag.
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `items` | `Array<{ id, label }>` | `[]` | Items. Renders `null` if empty. |
+| `onReorder` | `(next: Array) => void` | — | Receives the reordered array. |
+| `renderItem` | `(item, index) => ReactNode` | `item.label` | Custom row content. |
+| `label` | `string` | `'Sortable list'` | Accessible list name. |
+| `disabled` | `boolean` | `false` | |
+| `className` | `string` | `''` | Merged onto the root. |
+
+## Keyboard
+
+| Key | Action |
+|---|---|
+| <kbd>Ctrl/Cmd</kbd> + <kbd>↑</kbd> / <kbd>↓</kbd> | Move the item one position |
+| <kbd>Ctrl/Cmd</kbd> + <kbd>Home</kbd> / <kbd>End</kbd> | Move to the top / bottom |
+
+## Usage
+
+```jsx
+import SortableList from './SortableList';
+import './style.css';
+
+<SortableList items={steps} onReorder={setSteps} label="Pipeline stages" />
+```
+
+## Why it fits EaseMotion
+
+**Drag-and-drop reordering is one of the least accessible patterns in common use.** Without a pointer there is no way to perform the action at all — there is no partial workaround, the feature is simply unavailable. Modifier+arrow makes it operable.
+
+**Every move is announced with its new position.** This matters as much as the keybinding: a silent reorder tells a screen reader user nothing about whether the action worked or where the item ended up. "Deploy moved to position 2 of 5" is the whole point.
+
+**Focus follows the item to its new index.** Without that, pressing Ctrl+↓ twice moves two *different* items — the first press moves your item down, and the second moves whatever slid into the position you are still focused on. Following the item is what makes repeated presses do the obvious thing.
+
+**The keybinding is in the accessible name.** "Press Control or Command with arrow keys to move" — because a keyboard-only affordance that is not announced is not discoverable, and the user has no reason to guess it exists.
+
+Movement is modifier-gated so plain arrow keys still scroll the page and navigate normally.
+
+Two drag-API details that are easy to miss: `preventDefault` on `dragover` is **required** or the drop event never fires at all, and Firefox refuses to start a drag unless `dataTransfer.setData` is called. The drop target is indicated by an offset *and* an accent edge, since a colour change alone is easy to miss mid-drag.

--- a/submissions/react/sortable-list-ad/SortableList.jsx
+++ b/submissions/react/sortable-list-ad/SortableList.jsx
@@ -1,0 +1,193 @@
+/**
+ * EaseMotion CSS — SortableList
+ * ============================================================
+ * Reorderable list operable by keyboard, not only by drag.
+ *
+ * Drag-and-drop reordering is one of the least accessible patterns in
+ * common use: without a pointer there is simply no way to perform the
+ * action at all. There is no partial workaround — the feature is either
+ * available or it is not.
+ *
+ * Modifier+arrow moves an item, and every move is announced with its new
+ * position. Announcing matters as much as the keybinding: a silent
+ * reorder tells a screen reader user nothing about whether the action
+ * worked or where the item landed.
+ *
+ * Drag is layered on top using the native HTML drag-and-drop API rather
+ * than pointer maths, so it inherits the platform's own drag affordances
+ * and does not need a custom drag image or scroll handling.
+ * ============================================================
+ */
+
+import { useCallback, useRef, useState } from 'react';
+
+/** Move an item within an array, returning a new array. */
+function reorder(list, from, to) {
+  const next = list.slice();
+  const [moved] = next.splice(from, 1);
+  next.splice(to, 0, moved);
+  return next;
+}
+
+/**
+ * @param {object} props
+ * @param {Array<{id: string, label: string}>} props.items
+ * @param {(next: Array) => void} props.onReorder
+ * @param {(item: object, index: number) => React.ReactNode} [props.renderItem]
+ * @param {string}  [props.label='Sortable list']
+ * @param {boolean} [props.disabled=false]
+ * @param {string}  [props.className]
+ */
+export default function SortableList({
+  items = [],
+  onReorder,
+  renderItem,
+  label = 'Sortable list',
+  disabled = false,
+  className = '',
+  ...rest
+}) {
+  const itemRefs = useRef([]);
+  const dragFrom = useRef(null);
+
+  const [dragOver, setDragOver] = useState(null);
+  const [announcement, setAnnouncement] = useState('');
+
+  const valid = items.filter((item) => item && item.id !== undefined);
+
+  const move = useCallback(
+    (from, to) => {
+      if (disabled) return;
+      if (to < 0 || to >= valid.length || from === to) return;
+
+      onReorder?.(reorder(valid, from, to));
+      setAnnouncement(
+        `${valid[from].label} moved to position ${to + 1} of ${valid.length}.`,
+      );
+
+      // Follow the item to its new index, so repeated presses keep
+      // moving the same item rather than whatever landed under the
+      // original position.
+      requestAnimationFrame(() => {
+        itemRefs.current[to]?.focus();
+      });
+    },
+    [disabled, valid, onReorder],
+  );
+
+  const onKeyDown = useCallback(
+    (event, index) => {
+      // Modifier-gated, so plain arrows still scroll and navigate.
+      const withModifier = event.metaKey || event.ctrlKey || event.altKey;
+      if (!withModifier) return;
+
+      if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        move(index, index - 1);
+      } else if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        move(index, index + 1);
+      } else if (event.key === 'Home') {
+        event.preventDefault();
+        move(index, 0);
+      } else if (event.key === 'End') {
+        event.preventDefault();
+        move(index, valid.length - 1);
+      }
+    },
+    [move, valid.length],
+  );
+
+  const onDragStart = useCallback(
+    (event, index) => {
+      if (disabled) return;
+      dragFrom.current = index;
+      event.dataTransfer.effectAllowed = 'move';
+      // Firefox refuses to start a drag unless data is set.
+      event.dataTransfer.setData('text/plain', String(index));
+    },
+    [disabled],
+  );
+
+  const onDragOver = useCallback((event, index) => {
+    // Required, or the drop event never fires.
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'move';
+    setDragOver(index);
+  }, []);
+
+  const onDrop = useCallback(
+    (event, index) => {
+      event.preventDefault();
+      const from = dragFrom.current;
+      dragFrom.current = null;
+      setDragOver(null);
+
+      if (from === null || from === index) return;
+      move(from, index);
+    },
+    [move],
+  );
+
+  const onDragEnd = useCallback(() => {
+    dragFrom.current = null;
+    setDragOver(null);
+  }, []);
+
+  if (valid.length === 0) return null;
+
+  const classes = [
+    'ease-sortl-ad',
+    disabled ? 'ease-sortl-ad--disabled' : '',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div className={classes} {...rest}>
+      <ul className="ease-sortl-ad__list" aria-label={label}>
+        {valid.map((item, index) => (
+          <li
+            className={`ease-sortl-ad__item${
+              dragOver === index ? ' ease-sortl-ad__item--over' : ''
+            }`}
+            key={item.id}
+            draggable={!disabled}
+            onDragStart={(event) => onDragStart(event, index)}
+            onDragOver={(event) => onDragOver(event, index)}
+            onDrop={(event) => onDrop(event, index)}
+            onDragEnd={onDragEnd}
+          >
+            <button
+              className="ease-sortl-ad__handle"
+              ref={(node) => {
+                itemRefs.current[index] = node;
+              }}
+              type="button"
+              disabled={disabled}
+              // The instruction is in the name because the keybinding is
+              // not discoverable any other way.
+              aria-label={`${item.label}, position ${index + 1} of ${valid.length}. Press Control or Command with arrow keys to move.`}
+              onKeyDown={(event) => onKeyDown(event, index)}
+            >
+              <span className="ease-sortl-ad__grip" aria-hidden="true" />
+            </button>
+
+            <span className="ease-sortl-ad__content">
+              {renderItem ? renderItem(item, index) : item.label}
+            </span>
+
+            <span className="ease-sortl-ad__pos" aria-hidden="true">
+              {index + 1}
+            </span>
+          </li>
+        ))}
+      </ul>
+
+      <span className="ease-sortl-ad__sr" role="status" aria-live="polite">
+        {announcement}
+      </span>
+    </div>
+  );
+}

--- a/submissions/react/sortable-list-ad/style.css
+++ b/submissions/react/sortable-list-ad/style.css
@@ -1,0 +1,125 @@
+/* ==========================================================================
+   EaseMotion CSS — SortableList component styles
+   Issue #63825
+   ========================================================================== */
+
+.ease-sortl-ad {
+    --sl-bg-ad: rgba(15, 23, 40, 0.85);
+    --sl-border-ad: rgba(148, 163, 184, 0.2);
+    --sl-text-ad: #f1f5f9;
+    --sl-muted-ad: #64748b;
+    --sl-accent-ad: #38bdf8;
+    --sl-ease-ad: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.ease-sortl-ad__sr {
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+}
+
+.ease-sortl-ad__list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.ease-sortl-ad__item {
+    align-items: center;
+    background: var(--sl-bg-ad);
+    border: 1px solid var(--sl-border-ad);
+    border-radius: 9px;
+    display: flex;
+    gap: 0.6rem;
+    padding: 0.55rem 0.75rem;
+    transition:
+        border-color 180ms var(--sl-ease-ad),
+        transform 180ms var(--sl-ease-ad);
+}
+
+/* Drop target indicated by an offset and an accent edge — a colour
+   change alone is easy to miss mid-drag. */
+.ease-sortl-ad__item--over {
+    border-color: var(--sl-accent-ad);
+    transform: translateX(4px);
+}
+
+.ease-sortl-ad--disabled .ease-sortl-ad__item {
+    opacity: 0.55;
+}
+
+.ease-sortl-ad__handle {
+    background: none;
+    border: 0;
+    border-radius: 6px;
+    color: var(--sl-muted-ad);
+    cursor: grab;
+    display: flex;
+    flex: 0 0 auto;
+    padding: 0.25rem;
+}
+
+.ease-sortl-ad__handle:focus-visible {
+    outline: 2px solid var(--sl-accent-ad);
+    outline-offset: 2px;
+}
+
+.ease-sortl-ad__handle:disabled {
+    cursor: not-allowed;
+}
+
+/* Six-dot grip drawn with a repeating gradient — no icon dependency. */
+.ease-sortl-ad__grip {
+    background-image: radial-gradient(currentcolor 1.2px, transparent 1.3px);
+    background-position: 0 0;
+    background-size: 5px 5px;
+    display: block;
+    height: 15px;
+    width: 10px;
+}
+
+.ease-sortl-ad__content {
+    color: var(--sl-text-ad);
+    flex: 1 1 auto;
+    font-size: 0.85rem;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.ease-sortl-ad__pos {
+    color: var(--sl-muted-ad);
+    flex: 0 0 auto;
+    font-family: "JetBrains Mono", ui-monospace, monospace;
+    font-size: 0.74rem;
+    font-variant-numeric: tabular-nums;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .ease-sortl-ad__item {
+        transition-duration: 1ms;
+    }
+
+    .ease-sortl-ad__item--over {
+        transform: none;
+    }
+}
+
+@media (forced-colors: active) {
+    .ease-sortl-ad__item {
+        border: 1px solid CanvasText;
+    }
+
+    .ease-sortl-ad__item--over {
+        border-color: Highlight;
+        border-width: 2px;
+    }
+}


### PR DESCRIPTION
Fixes #63825

**What was added**

A keyboard-accessible reorderable list, under `submissions/react/sortable-list-ad/`.

- `SortableList.jsx` — 172 non-empty lines: modifier+arrow reordering with position announcements, focus-follows-item, and native HTML drag layered on top.
- `style.css` — 109 non-empty lines: rows, grip, drop-target indication, reduced-motion, forced-colors.
- `README.md` — props table, keyboard table, usage, and rationale.

**What is the problem**

**Drag-and-drop reordering is one of the least accessible patterns in common use.** Without a pointer there is no way to perform the action at all — no partial workaround exists, the feature is simply unavailable to keyboard and switch users.

**Why this approach**

Modifier+arrow makes reordering operable, with Home/End for the extremes.

**Every move is announced with its new position** — "Deploy moved to position 2 of 5". This matters as much as the keybinding: a silent reorder tells a screen reader user nothing about whether the action worked or where the item landed.

**Focus follows the item to its new index.** Without that, pressing Ctrl+↓ twice moves two *different* items — the first press moves your item down, and the second moves whatever slid into the position you are still focused on. Following the item is what makes repeated presses do the obvious thing, and it is the bug that makes hand-rolled keyboard reordering feel broken.

**The keybinding is in the accessible name.** A keyboard-only affordance that is not announced is not discoverable — the user has no reason to guess it exists.

Movement is modifier-gated so plain arrows still scroll and navigate.

**How to test**

1. Pull this branch and drop `sortable-list-ad/` into any React app (React 16.8+).
2. Render 5 items with `onReorder`.
3. **Tab to the second item's grip and press <kbd>Ctrl/Cmd</kbd>+<kbd>↓</kbd> twice.** The **same** item must move down twice, ending at position 4 — not two different items moving once each.
4. Confirm each move is announced with the new position and total.
5. Press <kbd>Ctrl/Cmd</kbd>+<kbd>Home</kbd> and confirm the item jumps to the top.
6. Press plain <kbd>↓</kbd> without a modifier and confirm the page scrolls normally — reordering must not hijack bare arrows.
7. Drag an item with the mouse and confirm the drop target shows an offset **and** an accent edge.
8. **Test the drag in Firefox specifically** — remove the `setData` call locally and confirm the drag stops working there; that is what the line is for.
9. Try dropping an item on itself and confirm nothing changes.
10. Set `disabled` and confirm neither drag nor keyboard moves anything.
11. Inspect a grip with a screen reader — it should announce the label, position, total, **and** the keybinding.

**Edge cases covered**

- Focus follows the moved item, so repeated presses move the same item.
- Moves are announced with the resulting position and total.
- The keybinding is announced, making a keyboard-only affordance discoverable.
- Modifier-gating leaves plain arrow keys free for scrolling and navigation.
- `preventDefault` on `dragover` — without it the drop event never fires at all.
- `dataTransfer.setData` is called, which Firefox requires before a drag will start.
- Out-of-range and same-position moves are rejected before touching state.
- `dragFrom` is reset on both drop and `dragend`, so an abandoned drag leaves no stale state.
- Items without an `id` are filtered out; empty input returns `null`.
- `disabled` blocks drag (`draggable={false}`) as well as keyboard.
- Focus restoration is deferred a frame so the target exists after re-render.
- Drop target uses offset plus colour, since colour alone is easy to miss mid-drag.
- Long labels truncate rather than stretching the row.
- Reorder is pure — a new array is returned rather than mutating the prop.

**Verification**

- `SortableList.jsx` parses cleanly through esbuild — exit code 0.
- `npx stylelint style.css` against the repo's own config — exit code 0, and braces verified balanced.
- All component classes referenced in the JSX are defined in `style.css`.
- Reorder arithmetic verified against three cases: `0→2` gives `bcad`, `3→0` gives `dabc`, `1→2` gives `acbd`.
- Modifier gating, focus-follows-item, `dragover` preventDefault, and the Firefox `setData` call all confirmed present.
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 3 new files, 0 deletions, no existing file touched.
- Component classes carry an `-ad` suffix so this lands as a parallel implementation.

**Labels:** `type:feature` · `react` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
