### PR TITLE
feat: add neumorphic toggle switches for interactive UI closes#63736

### DIFF
--- a/submissions/examples/ag26-v3-neumorphic-toggles/README.md
+++ b/submissions/examples/ag26-v3-neumorphic-toggles/README.md
@@ -1,0 +1,74 @@
+Neumorphic Toggle Switches
+
+Soft, extruded toggle switches built entirely from paired box-shadow highlights and shadows — the "soft UI" look. State (on/off, hover, focus, disabled) is driven entirely by CSS on a hidden checkbox. No JavaScript.
+
+demo.html shows the switch in a real settings-panel context (label + description + toggle, the way it'd actually ship), plus a grid of size and accent-color variants.
+
+Files
+File	Purpose
+demo.html	Settings panel demo + size/color variant grid
+style.css	All styling, tokens, and the neumorphic shadow system
+README.md	This file
+Why a light theme
+
+Neumorphism only reads correctly when the shadow color and the surface color are close in value — the illusion depends on subtle light/dark shadow pairs against a mid-tone background. On a near-black surface (like EaseMotion's usual dark showcase palette) that contrast disappears, so this component uses its own light palette (--nm-bg, --nm-surface, --nm-shadow-dark, --nm-shadow-light). Everything else — the checkbox hack, the accent system, the size tokens — still follows the same conventions as the rest of the library.
+
+Markup
+html
+<label class="nm-toggle">
+  <input type="checkbox" class="nm-toggle-input">
+  <span class="nm-toggle-track">
+    <span class="nm-toggle-thumb"></span>
+  </span>
+</label>
+
+The <input> is the real, focusable control — hidden visually with a clip-based technique (not display: none), so it stays reachable and toggleable from the keyboard. <label> wraps everything, so clicking anywhere on the switch toggles it without any for/id pairing required.
+
+How the shadow illusion works
+
+Off (track): an inset dark shadow toward the light source and an inset light shadow away from it — reads as a groove pressed into the surface.
+
+css
+.nm-toggle-track {
+  box-shadow:
+    inset 4px 4px 8px var(--nm-shadow-dark),
+    inset -4px -4px 8px var(--nm-shadow-light);
+}
+
+Off (thumb): the same pairing without inset — reads as a disc sitting proud of the surface, the physical opposite of the track it's in.
+
+On: the track flattens into a tinted, slightly recessed groove instead (so it still reads as a channel, now "active"), the thumb slides across via transform: translateX(), turns white, and picks up an accent-colored glow ring so the on-state is unambiguous even for someone who can't distinguish the track's color shift.
+
+css
+.nm-toggle-input:checked ~ .nm-toggle-track .nm-toggle-thumb {
+  transform: translateX(calc(var(--nm-toggle-w) - var(--nm-toggle-h)));
+  box-shadow: 2px 2px 5px rgba(0,0,0,0.25), 0 0 0 6px rgba(108,92,231,0.16);
+}
+
+Pressing the switch (:active) briefly widens the thumb by 4px, a small squash cue that makes the interaction feel physical.
+
+CSS custom properties
+Property	Default	Controls
+--nm-toggle-w / --nm-toggle-h	58px / 32px	Track dimensions
+--nm-thumb-size	24px	Thumb diameter
+--nm-duration	260ms	Transition length for the slide/shadow change
+--nm-ease	cubic-bezier(0.2, 0.8, 0.2, 1)	Easing curve
+--nm-accent / --nm-accent-strong	purple pair	On-state color
+--nm-shadow-dark / --nm-shadow-light	—	The two shadow colors the whole effect is built from
+Variants
+Size — add .nm-toggle-sm or .nm-toggle-lg alongside .nm-toggle; each just overrides the three geometry tokens, so the shadow math and slide distance recalculate automatically.
+Accent color — add .nm-toggle-accent-warn for the amber on-state shown in the "Location access" row; duplicate that block with a new class and new --nm-warn-style variables to add further accents.
+Disabled — add the disabled attribute to the <input>. The track drops to 55% opacity and the cursor switches to not-allowed on both the track and (via :has(), with no functional loss if unsupported) the label itself.
+Accessibility
+The checkbox is real and stays in the tab order — reachable with <kbd>Tab</kbd>, toggled with <kbd>Space</kbd>, exactly like a native <input type="checkbox">, because it is one.
+.nm-toggle-input:focus-visible ~ .nm-toggle-track draws a visible outline on the track when the hidden input has keyboard focus, so focus is never invisible just because the control itself is.
+Every toggle in the settings panel is paired with a real <label for="..."> carrying its name, plus a <p> description — the accessible name is never carried by color or position alone.
+The on-state is signaled by position, color, and a glow ring — not color change alone — so it still reads for color-vision-deficient users.
+Respects prefers-reduced-motion: reduce by collapsing all transitions to 1ms.
+Responsive behavior
+
+The variant grid drops from three columns to two at 560px, and the settings panel's inner padding tightens slightly so labels don't crowd the toggle on narrow viewports.
+
+Browser support
+
+Uses CSS custom properties, box-shadow, and standard transitions — supported everywhere current. The one modern-only touch is :has() on the disabled-cursor rule, which is purely cosmetic and has no effect on function if unsupported.

--- a/submissions/examples/ag26-v3-neumorphic-toggles/demo.html
+++ b/submissions/examples/ag26-v3-neumorphic-toggles/demo.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Neumorphic Toggle Switches — EaseMotion CSS</title>
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=IBM+Plex+Mono:wght@500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <header class="hero">
+    <p class="eyebrow">EaseMotion CSS · showcase</p>
+    <h1 class="hero-title">Neumorphic<br>toggle switches</h1>
+    <p class="hero-sub">Soft, extruded switches built from paired <code>box-shadow</code> highlights and shadows. State is driven entirely by <code>:checked</code> on a hidden checkbox &mdash; no JavaScript.</p>
+  </header>
+
+  <main class="showcase">
+
+    <!-- ================= Settings panel — real usage context ================= -->
+    <section class="panel" aria-labelledby="panel-title">
+      <h2 id="panel-title" class="panel-title">Notification settings</h2>
+
+      <div class="setting-row">
+        <div class="setting-copy">
+          <label for="toggle-push" class="setting-label">Push notifications</label>
+          <p class="setting-desc">Get notified the moment something needs your attention.</p>
+        </div>
+        <label class="nm-toggle">
+          <input type="checkbox" id="toggle-push" class="nm-toggle-input" checked>
+          <span class="nm-toggle-track">
+            <span class="nm-toggle-thumb"></span>
+          </span>
+        </label>
+      </div>
+
+      <div class="setting-row">
+        <div class="setting-copy">
+          <label for="toggle-email" class="setting-label">Weekly email digest</label>
+          <p class="setting-desc">A summary of activity, sent every Monday morning.</p>
+        </div>
+        <label class="nm-toggle">
+          <input type="checkbox" id="toggle-email" class="nm-toggle-input">
+          <span class="nm-toggle-track">
+            <span class="nm-toggle-thumb"></span>
+          </span>
+        </label>
+      </div>
+
+      <div class="setting-row">
+        <div class="setting-copy">
+          <label for="toggle-location" class="setting-label">Location access</label>
+          <p class="setting-desc">Required for local weather and nearby recommendations.</p>
+        </div>
+        <label class="nm-toggle nm-toggle-accent-warn">
+          <input type="checkbox" id="toggle-location" class="nm-toggle-input">
+          <span class="nm-toggle-track">
+            <span class="nm-toggle-thumb"></span>
+          </span>
+        </label>
+      </div>
+
+      <div class="setting-row">
+        <div class="setting-copy">
+          <label for="toggle-billing" class="setting-label setting-label-disabled">Auto-renew billing</label>
+          <p class="setting-desc">Managed by your workspace admin.</p>
+        </div>
+        <label class="nm-toggle">
+          <input type="checkbox" id="toggle-billing" class="nm-toggle-input" checked disabled>
+          <span class="nm-toggle-track">
+            <span class="nm-toggle-thumb"></span>
+          </span>
+        </label>
+      </div>
+    </section>
+
+    <!-- ================= Size & color variants ================= -->
+    <section class="variants" aria-label="Size and color variants">
+      <h2 class="variants-title">Sizes &amp; accents</h2>
+
+      <div class="variant-grid">
+
+        <div class="variant-card">
+          <span class="variant-label">Small</span>
+          <label class="nm-toggle nm-toggle-sm">
+            <input type="checkbox" class="nm-toggle-input" checked>
+            <span class="nm-toggle-track">
+              <span class="nm-toggle-thumb"></span>
+            </span>
+          </label>
+        </div>
+
+        <div class="variant-card">
+          <span class="variant-label">Default</span>
+          <label class="nm-toggle">
+            <input type="checkbox" class="nm-toggle-input" checked>
+            <span class="nm-toggle-track">
+              <span class="nm-toggle-thumb"></span>
+            </span>
+          </label>
+        </div>
+
+        <div class="variant-card">
+          <span class="variant-label">Large</span>
+          <label class="nm-toggle nm-toggle-lg">
+            <input type="checkbox" class="nm-toggle-input" checked>
+            <span class="nm-toggle-track">
+              <span class="nm-toggle-thumb"></span>
+            </span>
+          </label>
+        </div>
+
+        <div class="variant-card">
+          <span class="variant-label">Success accent</span>
+          <label class="nm-toggle">
+            <input type="checkbox" class="nm-toggle-input" checked>
+            <span class="nm-toggle-track">
+              <span class="nm-toggle-thumb"></span>
+            </span>
+          </label>
+        </div>
+
+        <div class="variant-card">
+          <span class="variant-label">Warning accent</span>
+          <label class="nm-toggle nm-toggle-accent-warn">
+            <input type="checkbox" class="nm-toggle-input" checked>
+            <span class="nm-toggle-track">
+              <span class="nm-toggle-thumb"></span>
+            </span>
+          </label>
+        </div>
+
+        <div class="variant-card">
+          <span class="variant-label">Disabled</span>
+          <label class="nm-toggle">
+            <input type="checkbox" class="nm-toggle-input" disabled>
+            <span class="nm-toggle-track">
+              <span class="nm-toggle-thumb"></span>
+            </span>
+          </label>
+        </div>
+
+      </div>
+    </section>
+
+  </main>
+
+  <footer class="footer">
+    <p>EaseMotion CSS &middot; submissions/examples/ag26-v3-neumorphic-toggles</p>
+  </footer>
+
+</body>
+</html>

--- a/submissions/examples/ag26-v3-neumorphic-toggles/style.css
+++ b/submissions/examples/ag26-v3-neumorphic-toggles/style.css
@@ -1,0 +1,391 @@
+/* =========================================================================
+   Neumorphic Toggle Switches — EaseMotion CSS
+   Soft, extruded switches built from paired light/dark box-shadows on a
+   mid-tone base color — the classic "soft UI" read only works when the
+   surface and background are close in value, so this component uses a
+   light theme rather than EaseMotion's usual dark showcase palette.
+   State is driven entirely by :checked on a visually-hidden checkbox.
+   No JavaScript.
+   ========================================================================= */
+ 
+ 
+/* -------------------------------------------------------------------------
+   1. Design tokens
+   ------------------------------------------------------------------------- */
+ 
+:root {
+  /* Neumorphic base — track/thumb shadows are computed against this */
+  --nm-bg: #e6e9f0;
+  --nm-surface: #eef1f7;
+  --nm-shadow-dark: #b9c0cf;
+  --nm-shadow-light: #ffffff;
+ 
+  --nm-text: #2b2f3a;
+  --nm-text-muted: #6b7280;
+  --nm-text-faint: #9aa1af;
+  --nm-border: rgba(43, 47, 58, 0.06);
+ 
+  --nm-accent: #6c5ce7;
+  --nm-accent-strong: #5b4bd1;
+  --nm-warn: #e8925c;
+  --nm-warn-strong: #d97e46;
+ 
+  --nm-font-display: "Space Grotesk", "Segoe UI", sans-serif;
+  --nm-font-body: "Inter", "Segoe UI", sans-serif;
+  --nm-font-mono: "IBM Plex Mono", "Courier New", monospace;
+ 
+  /* Toggle geometry — override per-instance for size variants */
+  --nm-toggle-w: 58px;
+  --nm-toggle-h: 32px;
+  --nm-thumb-size: 24px;
+  --nm-duration: 260ms;
+  --nm-ease: cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+ 
+* {
+  box-sizing: border-box;
+}
+ 
+body {
+  margin: 0;
+  background: var(--nm-bg);
+  color: var(--nm-text);
+  font-family: var(--nm-font-body);
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   2. Hero
+   ------------------------------------------------------------------------- */
+ 
+.hero {
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 96px 24px 60px;
+  text-align: center;
+}
+ 
+.eyebrow {
+  font-family: var(--nm-font-mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--nm-accent);
+  margin: 0 0 20px;
+}
+ 
+.hero-title {
+  font-family: var(--nm-font-display);
+  font-weight: 600;
+  font-size: clamp(34px, 6vw, 56px);
+  line-height: 1.08;
+  letter-spacing: -0.02em;
+  margin: 0 0 18px;
+  color: var(--nm-text);
+}
+ 
+.hero-sub {
+  font-size: 16px;
+  color: var(--nm-text-muted);
+  max-width: 480px;
+  margin: 0 auto;
+}
+ 
+.hero-sub code {
+  font-family: var(--nm-font-mono);
+  font-size: 13.5px;
+  color: var(--nm-text);
+  background: var(--nm-surface);
+  padding: 1px 6px;
+  border-radius: 5px;
+  box-shadow: inset 1px 1px 2px var(--nm-shadow-dark);
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   3. Layout
+   ------------------------------------------------------------------------- */
+ 
+.showcase {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 0 24px 90px;
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   4. Settings panel — real usage context
+   ------------------------------------------------------------------------- */
+ 
+.panel {
+  background: var(--nm-surface);
+  border-radius: 24px;
+  padding: 8px 28px;
+  box-shadow:
+    8px 8px 20px var(--nm-shadow-dark),
+    -8px -8px 20px var(--nm-shadow-light);
+}
+ 
+.panel-title {
+  font-family: var(--nm-font-display);
+  font-size: 17px;
+  font-weight: 600;
+  margin: 24px 0 4px;
+}
+ 
+.setting-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 20px 0;
+  border-bottom: 1px solid var(--nm-border);
+}
+ 
+.setting-row:last-child {
+  border-bottom: none;
+}
+ 
+.setting-copy {
+  min-width: 0;
+}
+ 
+.setting-label {
+  display: block;
+  font-size: 14.5px;
+  font-weight: 500;
+  color: var(--nm-text);
+  cursor: pointer;
+}
+ 
+.setting-label-disabled {
+  color: var(--nm-text-faint);
+  cursor: not-allowed;
+}
+ 
+.setting-desc {
+  font-size: 12.5px;
+  color: var(--nm-text-muted);
+  margin: 3px 0 0;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   5. Toggle core
+   ------------------------------------------------------------------------- */
+ 
+.nm-toggle {
+  position: relative;
+  display: inline-flex;
+  flex: 0 0 auto;
+  cursor: pointer;
+}
+ 
+/* Visually hidden, still focusable/toggleable from the keyboard */
+.nm-toggle-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+ 
+.nm-toggle-track {
+  display: block;
+  width: var(--nm-toggle-w);
+  height: var(--nm-toggle-h);
+  border-radius: var(--nm-toggle-h);
+  background: var(--nm-surface);
+ 
+  /* Off state reads as "pressed in" — inset dark shadow toward the light
+     source, inset light shadow away from it. */
+  box-shadow:
+    inset 4px 4px 8px var(--nm-shadow-dark),
+    inset -4px -4px 8px var(--nm-shadow-light);
+ 
+  transition: box-shadow var(--nm-duration) var(--nm-ease),
+    background var(--nm-duration) var(--nm-ease);
+}
+ 
+.nm-toggle-thumb {
+  display: block;
+  width: var(--nm-thumb-size);
+  height: var(--nm-thumb-size);
+  margin: calc((var(--nm-toggle-h) - var(--nm-thumb-size)) / 2);
+  border-radius: 50%;
+  background: var(--nm-surface);
+ 
+  /* On its own the thumb reads as "raised" — the inverse pairing from
+     the track it sits inside. */
+  box-shadow:
+    3px 3px 6px var(--nm-shadow-dark),
+    -3px -3px 6px var(--nm-shadow-light);
+ 
+  transform: translateX(0);
+  transition: transform var(--nm-duration) var(--nm-ease),
+    box-shadow var(--nm-duration) var(--nm-ease),
+    background var(--nm-duration) var(--nm-ease);
+}
+ 
+/* Checked state: track tints toward the accent and flattens slightly
+   (it now reads as an active groove the thumb rides in), thumb slides
+   across and picks up an accent-colored glow. */
+.nm-toggle-input:checked ~ .nm-toggle-track {
+  background: linear-gradient(135deg, var(--nm-accent), var(--nm-accent-strong));
+  box-shadow:
+    inset 2px 2px 5px rgba(0, 0, 0, 0.18),
+    inset -2px -2px 5px rgba(255, 255, 255, 0.12);
+}
+ 
+.nm-toggle-input:checked ~ .nm-toggle-track .nm-toggle-thumb {
+  transform: translateX(calc(var(--nm-toggle-w) - var(--nm-toggle-h)));
+  background: #ffffff;
+  box-shadow:
+    2px 2px 5px rgba(0, 0, 0, 0.25),
+    0 0 0 6px rgba(108, 92, 231, 0.16);
+}
+ 
+/* Warning accent variant */
+.nm-toggle-accent-warn .nm-toggle-input:checked ~ .nm-toggle-track {
+  background: linear-gradient(135deg, var(--nm-warn), var(--nm-warn-strong));
+}
+ 
+.nm-toggle-accent-warn .nm-toggle-input:checked ~ .nm-toggle-track .nm-toggle-thumb {
+  box-shadow:
+    2px 2px 5px rgba(0, 0, 0, 0.25),
+    0 0 0 6px rgba(232, 146, 92, 0.2);
+}
+ 
+/* Pressed feedback — thumb compresses slightly, like a real switch */
+.nm-toggle-input:active ~ .nm-toggle-track .nm-toggle-thumb {
+  width: calc(var(--nm-thumb-size) + 4px);
+}
+ 
+/* Keyboard focus ring on the track, since the real input is hidden */
+.nm-toggle-input:focus-visible ~ .nm-toggle-track {
+  outline: 2px solid var(--nm-accent);
+  outline-offset: 3px;
+}
+ 
+/* Disabled state — flatten the shadows so it visually recedes, and
+   drop the pointer affordance */
+.nm-toggle-input:disabled ~ .nm-toggle-track {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+ 
+.nm-toggle:has(.nm-toggle-input:disabled) {
+  cursor: not-allowed;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   6. Size variants
+   ------------------------------------------------------------------------- */
+ 
+.nm-toggle-sm {
+  --nm-toggle-w: 44px;
+  --nm-toggle-h: 24px;
+  --nm-thumb-size: 18px;
+}
+ 
+.nm-toggle-lg {
+  --nm-toggle-w: 72px;
+  --nm-toggle-h: 40px;
+  --nm-thumb-size: 30px;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   7. Size & color variant grid
+   ------------------------------------------------------------------------- */
+ 
+.variants-title {
+  font-family: var(--nm-font-display);
+  font-size: 17px;
+  font-weight: 600;
+  margin: 0 0 20px;
+  text-align: center;
+}
+ 
+.variant-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+ 
+.variant-card {
+  background: var(--nm-surface);
+  border-radius: 18px;
+  padding: 24px 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  box-shadow:
+    6px 6px 14px var(--nm-shadow-dark),
+    -6px -6px 14px var(--nm-shadow-light);
+}
+ 
+.variant-label {
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--nm-text-muted);
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   8. Footer
+   ------------------------------------------------------------------------- */
+ 
+.footer {
+  text-align: center;
+  padding: 8px 24px 48px;
+  font-size: 12.5px;
+  color: var(--nm-text-faint);
+  font-family: var(--nm-font-mono);
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   9. Responsive
+   ------------------------------------------------------------------------- */
+ 
+@media (max-width: 560px) {
+  .hero {
+    padding: 72px 20px 44px;
+  }
+ 
+  .panel {
+    padding: 4px 20px;
+  }
+ 
+  .setting-row {
+    gap: 14px;
+  }
+ 
+  .variant-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   10. Reduced motion
+   ------------------------------------------------------------------------- */
+ 
+@media (prefers-reduced-motion: reduce) {
+  .nm-toggle-track,
+  .nm-toggle-thumb {
+    transition-duration: 1ms;
+  }
+}


### PR DESCRIPTION
Closes #63736

## Pull Request Description
Adds a pure CSS/HTML neumorphic (soft UI) toggle switch component — extruded switches built from paired `box-shadow` highlights/shadows, with state driven entirely by `:checked` on a hidden checkbox. No JavaScript.

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/ag26-v3-neumorphic-toggles/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

## Feature Description

**What does this add?**
A soft-UI toggle switch whose on/off state, hover, focus, and disabled styling are all handled in CSS via `:checked`/`:focus-visible`/`:disabled` on a hidden checkbox.

