### PR TITLE
feat: add CSS glitch text hover effect for cyberpunk UI closes#63739

### DIFF
--- a/submissions/examples/ag26-v3-glitch-text/README.md
+++ b/submissions/examples/ag26-v3-glitch-text/README.md
@@ -1,0 +1,66 @@
+Glitch Text Hover
+
+A CSS-only "digital glitch" effect for cyberpunk / tech UI: two duplicate text layers, colored cyan and magenta, sliced with animated clip-path and offset with transform, flash on top of the real text on hover or keyboard focus. No JavaScript, no images, no extra markup beyond a data-text attribute.
+
+demo.html shows a hero heading, a nav-style link list, a button label, and three intensity variants side by side.
+
+Files
+File	Purpose
+demo.html	Hero + nav links + button + intensity variant showcase
+style.css	The glitch mechanism, tokens, and cyberpunk backdrop
+README.md	This file
+Markup
+html
+<h1 class="glitch" data-text="SIGNAL LOST">SIGNAL LOST</h1>
+
+data-text must match the element's visible text exactly — it's read by content: attr(data-text) on the two pseudo-elements that form the glitch layers, so there's a single source of truth for the copy instead of duplicating it in the markup.
+
+How it works
+
+Each .glitch element gets two pseudo-elements, each a full duplicate of the text, pre-clipped to invisible (clip-path: inset(0 0 100% 0) / inset(100% 0 0 0)) and transparent:
+
+css
+.glitch::before { color: var(--gx-cyan);    clip-path: inset(0 0 100% 0); }
+.glitch::after  { color: var(--gx-magenta); clip-path: inset(100% 0 0 0); }
+
+On :hover / :focus-visible, three animations run at once, all on a steps(2, end) timing function so the motion reads as sharp digital jumps rather than a smooth ease:
+
+The real text (ag-glitch-jitter) nudges a few pixels on a transform, scaled by --gx-amp.
+The cyan layer (ag-glitch-slice-cyan) reveals shifting horizontal bands via clip-path: inset(...) and shifts left.
+The magenta layer (ag-glitch-slice-magenta) does the same with different band positions, offset timing, and shifts right.
+
+The two layers never reveal the same band at the same time, so the result reads as the text tearing into color-fringed slices rather than just producing a blurry double image.
+
+CSS custom properties
+Property	Default	Controls
+--gx-amp	4px	How far the jitter/slice layers travel — the "how broken does it look" dial
+--gx-duration	420ms	Length of one full glitch cycle
+--gx-cyan / --gx-magenta	neon cyan / magenta	The two split-channel colors
+
+Both are set per-instance in the demo (.glitch-hero, .glitch-nav-link, .glitch-btn-label, and the three .glitch-subtle / .glitch-default / .glitch-heavy variants), so the same two keyframe sets produce a whole range of intensities without being rewritten.
+
+css
+.glitch-heavy {
+  --gx-amp: 9px;
+  --gx-duration: 260ms;
+}
+Preview toggle
+
+Because the effect is hover/focus-only by default, the demo includes a "Preview without hovering" switch (checkbox hack, top of the page) that applies the same glitch state globally, so reviewers can see it without needing to move a cursor around. This is a demo convenience, not part of the shipped component's required markup.
+
+Button variant
+
+The button glitches its label rather than itself, keeping the button's shape and hit target stable while only the text tears. It repeats the same three animations directly on .cyber-btn:hover .glitch-btn-label rather than relying on .glitch:hover, since the trigger is the parent button, not the label itself.
+
+Accessibility
+The glitch is purely visual/decorative; the real, readable text is the element's own text content, not something only present in a pseudo-element.
+Triggers on :focus-visible as well as :hover, so keyboard users see the same feedback mouse users do.
+Respects prefers-reduced-motion: reduce — the jitter and slicing animations are removed entirely and replaced with a static two-pixel RGB-split offset, so the "glitched" identity survives without motion.
+Known limitation: because the glitch layers duplicate the text via content: attr(data-text), some screen reader / browser combinations may announce that duplicated content in addition to the real text. This is a common trade-off for this specific effect industry-wide; if a project needs to rule it out entirely, wrapping the pseudo-generating container in aria-hidden="true" alongside a separate visually-hidden copy of the real text is the more bulletproof (if more verbose) alternative.
+Responsive behavior
+
+The intensity-variant grid drops from three columns to one at 640px; the hero heading's clamp() font size keeps it legible without overflowing on narrow viewports.
+
+Browser support
+
+Uses clip-path, CSS custom properties inside @keyframes (widely supported), and standard animations — works in all current evergreen browsers. Where clip-path is unsupported the pseudo-layers simply don't reveal, so hovering falls back to a plain (non-glitching) text color change with no layout break.

--- a/submissions/examples/ag26-v3-glitch-text/demo.html
+++ b/submissions/examples/ag26-v3-glitch-text/demo.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Glitch Text Hover — EaseMotion CSS</title>
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="grid-overlay" aria-hidden="true"></div>
+  <div class="scanlines" aria-hidden="true"></div>
+
+  <!-- Lets anyone previewing the demo see the effect without hovering -->
+  <input type="checkbox" id="always-glitch" class="always-glitch-toggle">
+
+  <header class="hero">
+    <p class="eyebrow">EaseMotion CSS &middot; showcase</p>
+
+    <h1 class="glitch glitch-hero" data-text="SIGNAL LOST">SIGNAL LOST</h1>
+
+    <p class="hero-sub">A CSS-only glitch effect for cyberpunk / tech UI: two duplicate text layers sliced with animated <code>clip-path</code> and offset with colored <code>text-shadow</code>, triggered on hover or focus. No JavaScript, no images.</p>
+
+    <label for="always-glitch" class="preview-toggle">
+      <span class="preview-toggle-dot" aria-hidden="true"></span>
+      Preview without hovering
+    </label>
+  </header>
+
+  <main class="showcase">
+
+    <!-- ================= Nav-style link list ================= -->
+    <section class="demo-block" aria-labelledby="nav-title">
+      <h2 id="nav-title" class="demo-block-title">Navigation links</h2>
+      <p class="demo-block-text">Hover or tab to any link &mdash; each one glitches independently.</p>
+
+      <nav class="glitch-nav" aria-label="Example navigation">
+        <a href="#" class="glitch glitch-nav-link" data-text="ARCHIVE">ARCHIVE</a>
+        <a href="#" class="glitch glitch-nav-link" data-text="TERMINAL">TERMINAL</a>
+        <a href="#" class="glitch glitch-nav-link" data-text="NETWORK">NETWORK</a>
+        <a href="#" class="glitch glitch-nav-link" data-text="OVERRIDE">OVERRIDE</a>
+      </nav>
+    </section>
+
+    <!-- ================= Button ================= -->
+    <section class="demo-block" aria-labelledby="btn-title">
+      <h2 id="btn-title" class="demo-block-title">Button label</h2>
+      <p class="demo-block-text">The glitch layers sit on the label only, so the button shape stays stable.</p>
+
+      <button type="button" class="cyber-btn">
+        <span class="glitch glitch-btn-label" data-text="INITIALIZE">INITIALIZE</span>
+      </button>
+    </section>
+
+    <!-- ================= Intensity variants ================= -->
+    <section class="demo-block" aria-labelledby="variants-title">
+      <h2 id="variants-title" class="demo-block-title">Intensity variants</h2>
+      <p class="demo-block-text">Same mechanism, different amplitude &mdash; tune with one custom property.</p>
+
+      <div class="variant-row">
+        <div class="variant-card">
+          <span class="variant-label">Subtle</span>
+          <p class="glitch glitch-subtle" data-text="STABLE">STABLE</p>
+        </div>
+        <div class="variant-card">
+          <span class="variant-label">Default</span>
+          <p class="glitch glitch-default" data-text="UNSTABLE">UNSTABLE</p>
+        </div>
+        <div class="variant-card">
+          <span class="variant-label">Heavy</span>
+          <p class="glitch glitch-heavy" data-text="CORRUPTED">CORRUPTED</p>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <footer class="footer">
+    <p>EaseMotion CSS &middot; submissions/examples/ag26-v3-glitch-text</p>
+  </footer>
+
+</body>
+</html>

--- a/submissions/examples/ag26-v3-glitch-text/style.css
+++ b/submissions/examples/ag26-v3-glitch-text/style.css
@@ -1,0 +1,508 @@
+/* =========================================================================
+   Glitch Text Hover — EaseMotion CSS
+   A cyberpunk-style text glitch: two duplicate layers (via ::before/::after
+   reading content from a data-text attribute) are colored cyan/magenta,
+   offset with text-shadow, and sliced with animated clip-path so thin
+   horizontal bands appear to misalign and snap back. Triggered on hover
+   or keyboard focus. Pure CSS/HTML — no JavaScript, no images.
+   ========================================================================= */
+ 
+ 
+/* -------------------------------------------------------------------------
+   1. Design tokens
+   ------------------------------------------------------------------------- */
+ 
+:root {
+  --gx-bg: #06070a;
+  --gx-surface: #0e1016;
+  --gx-border: #1e222c;
+  --gx-text: #e8ecf5;
+  --gx-text-muted: #7d8494;
+ 
+  --gx-cyan: #37f2f2;
+  --gx-magenta: #ff3ec8;
+  --gx-accent: #37f2f2;
+ 
+  --gx-font-display: "Space Grotesk", "Segoe UI", sans-serif;
+  --gx-font-body: "Inter", "Segoe UI", sans-serif;
+  --gx-font-mono: "JetBrains Mono", "Courier New", monospace;
+ 
+  /* Glitch tuning — override per-instance for intensity variants */
+  --gx-amp: 4px;
+  --gx-duration: 420ms;
+}
+ 
+* {
+  box-sizing: border-box;
+}
+ 
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--gx-bg);
+  color: var(--gx-text);
+  font-family: var(--gx-font-body);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  position: relative;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   2. Cyberpunk backdrop — decorative grid + scanlines
+   ------------------------------------------------------------------------- */
+ 
+.grid-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(rgba(55, 242, 242, 0.06) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(55, 242, 242, 0.06) 1px, transparent 1px);
+  background-size: 42px 42px;
+  -webkit-mask-image: radial-gradient(circle at 50% 0%, black 0%, transparent 70%);
+  mask-image: radial-gradient(circle at 50% 0%, black 0%, transparent 70%);
+}
+ 
+.scanlines {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  opacity: 0.5;
+  background-image: repeating-linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.025) 0px,
+    rgba(255, 255, 255, 0.025) 1px,
+    transparent 1px,
+    transparent 3px
+  );
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   3. Preview toggle (checkbox hack) — see the effect without hovering
+   ------------------------------------------------------------------------- */
+ 
+.always-glitch-toggle {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+ 
+.preview-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 28px;
+  font-family: var(--gx-font-mono);
+  font-size: 12px;
+  letter-spacing: 0.02em;
+  color: var(--gx-text-muted);
+  cursor: pointer;
+  user-select: none;
+}
+ 
+.preview-toggle-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--gx-border);
+  box-shadow: 0 0 0 1px var(--gx-border);
+  transition: background 160ms ease, box-shadow 160ms ease;
+}
+ 
+.always-glitch-toggle:checked ~ * .preview-toggle-dot {
+  background: var(--gx-cyan);
+  box-shadow: 0 0 8px 1px var(--gx-cyan);
+}
+ 
+.always-glitch-toggle:focus-visible ~ * .preview-toggle {
+  outline: 2px solid var(--gx-cyan);
+  outline-offset: 3px;
+  border-radius: 4px;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   4. Hero
+   ------------------------------------------------------------------------- */
+ 
+.hero {
+  position: relative;
+  z-index: 1;
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 100px 24px 56px;
+  text-align: center;
+}
+ 
+.eyebrow {
+  font-family: var(--gx-font-mono);
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--gx-cyan);
+  margin: 0 0 22px;
+}
+ 
+.hero-sub {
+  font-size: 15.5px;
+  color: var(--gx-text-muted);
+  max-width: 480px;
+  margin: 22px auto 0;
+}
+ 
+.hero-sub code {
+  font-family: var(--gx-font-mono);
+  font-size: 13px;
+  color: var(--gx-text);
+  background: var(--gx-surface);
+  border: 1px solid var(--gx-border);
+  padding: 1px 6px;
+  border-radius: 5px;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   5. Glitch mechanism — the core, reusable on any element
+   ------------------------------------------------------------------------- */
+ 
+.glitch {
+  position: relative;
+  display: inline-block;
+  color: var(--gx-text);
+  font-family: var(--gx-font-display);
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  isolation: isolate;
+}
+ 
+.glitch::before,
+.glitch::after {
+  content: attr(data-text);
+  position: absolute;
+  inset: 0;
+  color: var(--gx-text);
+  background: var(--gx-bg);
+  opacity: 0;
+  pointer-events: none;
+}
+ 
+.glitch::before {
+  color: var(--gx-cyan);
+  clip-path: inset(0 0 100% 0);
+}
+ 
+.glitch::after {
+  color: var(--gx-magenta);
+  clip-path: inset(100% 0 0 0);
+}
+ 
+/* Trigger on hover, keyboard focus, or the global preview toggle */
+.glitch:hover,
+.glitch:focus-visible,
+.always-glitch-toggle:checked ~ * .glitch {
+  animation: ag-glitch-jitter var(--gx-duration) steps(2, end) infinite;
+}
+ 
+.glitch:hover::before,
+.glitch:focus-visible::before,
+.always-glitch-toggle:checked ~ * .glitch::before {
+  opacity: 0.85;
+  animation: ag-glitch-slice-cyan var(--gx-duration) steps(2, end) infinite;
+}
+ 
+.glitch:hover::after,
+.glitch:focus-visible::after,
+.always-glitch-toggle:checked ~ * .glitch::after {
+  opacity: 0.85;
+  animation: ag-glitch-slice-magenta var(--gx-duration) steps(2, end) infinite;
+}
+ 
+/* Base text jitters a few pixels, scaled by --gx-amp */
+@keyframes ag-glitch-jitter {
+  0%   { transform: translate(0, 0); }
+  20%  { transform: translate(calc(var(--gx-amp) * -0.4), calc(var(--gx-amp) * 0.25)); }
+  40%  { transform: translate(calc(var(--gx-amp) * 0.3), calc(var(--gx-amp) * -0.3)); }
+  60%  { transform: translate(0, 0); }
+  80%  { transform: translate(calc(var(--gx-amp) * -0.25), calc(var(--gx-amp) * 0.2)); }
+  100% { transform: translate(0, 0); }
+}
+ 
+/* Cyan layer: thin horizontal bands reveal + shift left */
+@keyframes ag-glitch-slice-cyan {
+  0%   { clip-path: inset(15% 0 68% 0); transform: translate(calc(var(--gx-amp) * -1), 0); }
+  20%  { clip-path: inset(62% 0 5% 0);  transform: translate(calc(var(--gx-amp) * -1.4), 0); }
+  40%  { clip-path: inset(4% 0 82% 0);  transform: translate(calc(var(--gx-amp) * -0.6), 0); }
+  60%  { clip-path: inset(78% 0 2% 0);  transform: translate(calc(var(--gx-amp) * -1), 0); }
+  80%  { clip-path: inset(32% 0 48% 0); transform: translate(calc(var(--gx-amp) * -0.8), 0); }
+  100% { clip-path: inset(8% 0 88% 0);  transform: translate(calc(var(--gx-amp) * -1.2), 0); }
+}
+ 
+/* Magenta layer: different bands, shifts right, slightly offset timing */
+@keyframes ag-glitch-slice-magenta {
+  0%   { clip-path: inset(70% 0 10% 0); transform: translate(calc(var(--gx-amp) * 1), 0); }
+  20%  { clip-path: inset(8% 0 74% 0);  transform: translate(calc(var(--gx-amp) * 1.3), 0); }
+  40%  { clip-path: inset(84% 0 4% 0);  transform: translate(calc(var(--gx-amp) * 0.7), 0); }
+  60%  { clip-path: inset(20% 0 60% 0); transform: translate(calc(var(--gx-amp) * 1.1), 0); }
+  80%  { clip-path: inset(90% 0 3% 0);  transform: translate(calc(var(--gx-amp) * 0.9), 0); }
+  100% { clip-path: inset(45% 0 40% 0); transform: translate(calc(var(--gx-amp) * 1.2), 0); }
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   6. Hero heading instance
+   ------------------------------------------------------------------------- */
+ 
+.glitch-hero {
+  font-size: clamp(40px, 8vw, 76px);
+  line-height: 1;
+  letter-spacing: 0.02em;
+  margin: 0 auto;
+  --gx-amp: 6px;
+  --gx-duration: 380ms;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   7. Showcase layout
+   ------------------------------------------------------------------------- */
+ 
+.showcase {
+  position: relative;
+  z-index: 1;
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 0 24px 90px;
+  display: flex;
+  flex-direction: column;
+  gap: 56px;
+}
+ 
+.demo-block {
+  text-align: center;
+}
+ 
+.demo-block-title {
+  font-family: var(--gx-font-display);
+  font-size: 17px;
+  font-weight: 600;
+  margin: 0 0 8px;
+}
+ 
+.demo-block-text {
+  font-size: 13.5px;
+  color: var(--gx-text-muted);
+  margin: 0 0 28px;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   8. Nav links
+   ------------------------------------------------------------------------- */
+ 
+.glitch-nav {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 12px;
+}
+ 
+.glitch-nav-link {
+  font-family: var(--gx-font-mono);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-decoration: none;
+  color: var(--gx-text);
+  background: var(--gx-surface);
+  border: 1px solid var(--gx-border);
+  border-radius: 8px;
+  padding: 10px 16px;
+  --gx-amp: 3px;
+  --gx-duration: 340ms;
+}
+ 
+.glitch-nav-link:hover,
+.glitch-nav-link:focus-visible {
+  border-color: rgba(55, 242, 242, 0.4);
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   9. Button
+   ------------------------------------------------------------------------- */
+ 
+.cyber-btn {
+  font-family: var(--gx-font-mono);
+  font-size: 13px;
+  letter-spacing: 0.06em;
+  color: var(--gx-text);
+  background: var(--gx-surface);
+  border: 1px solid var(--gx-cyan);
+  border-radius: 6px;
+  padding: 14px 28px;
+  cursor: pointer;
+  transition: box-shadow 200ms ease, background 200ms ease;
+}
+ 
+.cyber-btn:hover,
+.cyber-btn:focus-visible {
+  background: rgba(55, 242, 242, 0.08);
+  box-shadow: 0 0 0 1px var(--gx-cyan), 0 0 18px rgba(55, 242, 242, 0.25);
+}
+ 
+.cyber-btn:focus-visible {
+  outline: none;
+}
+ 
+.glitch-btn-label {
+  font-size: 13px;
+  --gx-amp: 3px;
+  --gx-duration: 340ms;
+}
+ 
+/* The button, not just the label, should trigger the label's glitch */
+.cyber-btn:hover .glitch-btn-label,
+.cyber-btn:focus-visible .glitch-btn-label {
+  animation: ag-glitch-jitter var(--gx-duration) steps(2, end) infinite;
+}
+ 
+.cyber-btn:hover .glitch-btn-label::before,
+.cyber-btn:focus-visible .glitch-btn-label::before {
+  opacity: 0.85;
+  animation: ag-glitch-slice-cyan var(--gx-duration) steps(2, end) infinite;
+}
+ 
+.cyber-btn:hover .glitch-btn-label::after,
+.cyber-btn:focus-visible .glitch-btn-label::after {
+  opacity: 0.85;
+  animation: ag-glitch-slice-magenta var(--gx-duration) steps(2, end) infinite;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   10. Intensity variants
+   ------------------------------------------------------------------------- */
+ 
+.variant-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 14px;
+}
+ 
+.variant-card {
+  background: var(--gx-surface);
+  border: 1px solid var(--gx-border);
+  border-radius: 14px;
+  padding: 26px 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+}
+ 
+.variant-label {
+  font-family: var(--gx-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--gx-text-muted);
+}
+ 
+.glitch-subtle {
+  --gx-amp: 1.5px;
+  --gx-duration: 500ms;
+  font-size: 15px;
+  margin: 0;
+}
+ 
+.glitch-default {
+  --gx-amp: 4px;
+  --gx-duration: 420ms;
+  font-size: 15px;
+  margin: 0;
+}
+ 
+.glitch-heavy {
+  --gx-amp: 9px;
+  --gx-duration: 260ms;
+  font-size: 15px;
+  margin: 0;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   11. Footer
+   ------------------------------------------------------------------------- */
+ 
+.footer {
+  position: relative;
+  z-index: 1;
+  text-align: center;
+  padding: 8px 24px 48px;
+  font-family: var(--gx-font-mono);
+  font-size: 12px;
+  color: var(--gx-text-muted);
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   12. Responsive
+   ------------------------------------------------------------------------- */
+ 
+@media (max-width: 640px) {
+  .hero {
+    padding: 80px 20px 44px;
+  }
+ 
+  .showcase {
+    gap: 44px;
+  }
+ 
+  .variant-row {
+    grid-template-columns: 1fr;
+  }
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   13. Reduced motion
+   ------------------------------------------------------------------------- */
+ 
+@media (prefers-reduced-motion: reduce) {
+  .glitch,
+  .glitch::before,
+  .glitch::after,
+  .glitch-btn-label,
+  .glitch-btn-label::before,
+  .glitch-btn-label::after {
+    animation: none !important;
+  }
+ 
+  /* Still communicate the "glitched" state without motion: a static
+     RGB-split offset instead of an animated one. */
+  .glitch:hover::before,
+  .glitch:focus-visible::before,
+  .always-glitch-toggle:checked ~ * .glitch::before {
+    opacity: 0.7;
+    clip-path: none;
+    transform: translate(-2px, 0);
+  }
+ 
+  .glitch:hover::after,
+  .glitch:focus-visible::after,
+  .always-glitch-toggle:checked ~ * .glitch::after {
+    opacity: 0.7;
+    clip-path: none;
+    transform: translate(2px, 0);
+  }
+}


### PR DESCRIPTION
Closes #63739

## Pull Request Description
Adds a pure CSS/HTML glitch-text hover effect for cyberpunk/tech UI — two duplicate text layers colored cyan/magenta, sliced with animated `clip-path` and offset with `transform`, triggered on hover or keyboard focus. No JavaScript.

## Type of Change
- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/ag26-v3-glitch-text/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

## Feature Description

**What does this add?**
A glitch/RGB-split text hover effect driven entirely by `::before`/`::after` pseudo-elements and animated `clip-path`.

**How does a developer use it?**
```html
<h1 class="glitch" data-text="SIGNAL LOST">SIGNAL LOST</h1>
```
`data-text` must match the visible text — it feeds the two pseudo-element layers. Override `--gx-amp` and `--gx-duration` per instance to tune intensity (see the "Subtle / Default / Heavy" variants in the demo).

**Why does it fit EaseMotion CSS?**
It's a single reusable mechanism (`.glitch` + two custom properties) that works on headings, links, and button labels alike without rewriting any CSS, and it's fully declarative — no JS timers or classList toggling.

