### PR TITLE
feat: add float-drift carousel for e-commerce checkout layouts closes…

### DIFF
--- a/submissions/examples/float-drift-checkout-carousel/README.md
+++ b/submissions/examples/float-drift-checkout-carousel/README.md
@@ -1,0 +1,75 @@
+Float-Drift Carousel
+
+A checkout upsell carousel: idle product cards drift gently in place (subtle vertical bob + tilt, staggered per card) until a shopper touches one, then that card holds still. Navigation is a real horizontal scroll-snap track with genuine per-slide prev/next arrows and dot indicators. Pure CSS/HTML — no JavaScript.
+
+demo.html shows it in context: a mock checkout order summary above, then a "you might also like" carousel of five add-on products below.
+
+Files
+File	Purpose
+demo.html	Order summary mock + 5-slide float-drift carousel
+style.css	Drift animation, scroll-snap track, arrows, dots
+README.md	This file
+The drift animation
+
+Each .product-card runs a continuous @keyframes loop combining a small vertical bob with a slight rotation:
+
+css
+.product-card {
+  animation: fd-drift var(--fd-drift-duration) ease-in-out infinite;
+}
+
+@keyframes fd-drift {
+  0%   { transform: translateY(0) rotate(0deg); }
+  25%  { transform: translateY(calc(var(--fd-drift-y) * -1)) rotate(calc(var(--fd-drift-rotate) * -1)); }
+  50%  { transform: translateY(calc(var(--fd-drift-y) * 0.4)) rotate(0deg); }
+  75%  { transform: translateY(calc(var(--fd-drift-y) * -0.6)) rotate(var(--fd-drift-rotate)); }
+  100% { transform: translateY(0) rotate(0deg); }
+}
+
+Each card gets a different negative animation-delay (0ms, -900ms, -1800ms...), which starts every card partway through the same cycle instead of all five bobbing in perfect unison — the drift reads as organic rather than mechanical.
+
+Touching a card — :hover or :focus-within — pauses its own animation via animation-play-state: paused, so the product a shopper is actually looking at holds still while its neighbors keep drifting.
+
+Navigation — genuinely relative prev/next, no JS
+
+This is the part that usually needs JavaScript in a carousel: a "next" arrow that knows what "next" means relative to whichever slide is currently in view. Here it's solved with position: sticky inside each slide, not on a single fixed control:
+
+html
+<li class="carousel-slide" id="slide-2">
+  <article class="product-card">…</article>
+  <a href="#slide-1" class="carousel-arrow carousel-arrow-prev">&larr;</a>
+  <a href="#slide-3" class="carousel-arrow carousel-arrow-next">&rarr;</a>
+</li>
+
+Because each <li> is exactly one viewport wide (flex: 0 0 100%) inside a horizontally scrolling track, only one slide's arrows are ever visible at a time — and position: sticky keeps them pinned to the left/right edge of that slide while it's in view. Since every slide's arrows point to its own actual neighbors, the arrows are correctly relative without a single line of script. First and last slides simply omit the arrow that would go out of bounds (rendered as a disabled <span> instead of an <a>).
+
+Dots + :target highlight
+
+Dots are plain anchor links to each slide's id:
+
+html
+<a href="#slide-3" class="carousel-dot" aria-label="Go to product 3"></a>
+
+Clicking one lets the browser's native :target + scroll-snap-align combination scroll the track to that slide. As a progressive enhancement, :has() lights up the matching dot:
+
+css
+.carousel-section:has(#slide-3:target) .carousel-dot:nth-child(3) {
+  background: var(--fd-accent);
+  transform: scale(1.25);
+}
+
+Browsers without :has() support simply show plain, unhighlighted dots — navigation itself doesn't depend on it at all.
+
+CSS custom properties
+Property	Default	Controls
+--fd-drift-duration	5200ms	Length of one full drift cycle
+--fd-drift-y	8px	How far a card bobs vertically
+--fd-drift-rotate	1.4deg	How far a card tilts during the cycle
+Accessibility
+Respects prefers-reduced-motion: reduce — the drift animation is removed entirely; cards sit still from the start.
+Drifting also pauses on :hover and :focus-within, so a keyboard user tabbing into a card's "Add" button gets a stable target, not a moving one.
+Arrows and dots are real <a> elements with descriptive aria-labels, not <div>s with click handlers — fully keyboard reachable, with a visible :focus-visible ring.
+Disabled edge arrows (before the first slide, after the last) are rendered as inert <span aria-hidden="true"> rather than a disabled link with an href pointing nowhere useful.
+Responsive behavior
+
+Card width is fluid (min(240px, 72vw)), so a single card never overflows a narrow phone screen. Slide padding and arrow size tighten slightly below 560px.

--- a/submissions/examples/float-drift-checkout-carousel/demo.html
+++ b/submissions/examples/float-drift-checkout-carousel/demo.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Float-Drift Carousel — EaseMotion CSS</title>
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@600;700&family=Inter:wght@400;500;600&family=IBM+Plex+Mono:wght@500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="noise" aria-hidden="true"></div>
+
+  <header class="hero">
+    <p class="eyebrow">EaseMotion CSS &middot; showcase</p>
+    <h1 class="hero-title">Float-drift carousel</h1>
+    <p class="hero-sub">A checkout upsell carousel where idle cards drift gently in place, and navigation is real prev/next + dots &mdash; all pure CSS, no JavaScript.</p>
+  </header>
+
+  <main class="checkout-page">
+
+    <!-- ================= Mock checkout summary ================= -->
+    <section class="order-summary" aria-labelledby="summary-title">
+      <h2 id="summary-title" class="summary-title">Order summary</h2>
+
+      <ul class="summary-list">
+        <li class="summary-row">
+          <span class="summary-item">Wireless keyboard &times; 1</span>
+          <span class="summary-price">$89.00</span>
+        </li>
+        <li class="summary-row">
+          <span class="summary-item">USB-C hub &times; 1</span>
+          <span class="summary-price">$34.00</span>
+        </li>
+      </ul>
+
+      <div class="summary-total">
+        <span>Total</span>
+        <span>$123.00</span>
+      </div>
+
+      <button type="button" class="checkout-btn">Complete order</button>
+    </section>
+
+    <!-- ================= Float-drift carousel ================= -->
+    <section class="carousel-section" aria-labelledby="carousel-title">
+      <div class="carousel-head">
+        <h2 id="carousel-title" class="carousel-title">Add these before you checkout</h2>
+        <p class="carousel-sub">Swipe, scroll, or use the arrows &mdash; drifting pauses the moment you touch a card.</p>
+      </div>
+
+      <div class="carousel-viewport">
+        <ul class="carousel-track" role="list">
+
+          <li class="carousel-slide" id="slide-1">
+            <article class="product-card">
+              <div class="product-thumb product-thumb-1" aria-hidden="true"></div>
+              <h3 class="product-name">Mechanical wrist rest</h3>
+              <p class="product-price">$18.00</p>
+              <button type="button" class="add-btn">Add</button>
+            </article>
+            <span class="carousel-arrow carousel-arrow-prev is-disabled" aria-hidden="true">&larr;</span>
+            <a href="#slide-2" class="carousel-arrow carousel-arrow-next" aria-label="Next product">&rarr;</a>
+          </li>
+
+          <li class="carousel-slide" id="slide-2">
+            <article class="product-card">
+              <div class="product-thumb product-thumb-2" aria-hidden="true"></div>
+              <h3 class="product-name">Cable management kit</h3>
+              <p class="product-price">$12.50</p>
+              <button type="button" class="add-btn">Add</button>
+            </article>
+            <a href="#slide-1" class="carousel-arrow carousel-arrow-prev" aria-label="Previous product">&larr;</a>
+            <a href="#slide-3" class="carousel-arrow carousel-arrow-next" aria-label="Next product">&rarr;</a>
+          </li>
+
+          <li class="carousel-slide" id="slide-3">
+            <article class="product-card">
+              <div class="product-thumb product-thumb-3" aria-hidden="true"></div>
+              <h3 class="product-name">Laptop stand, aluminum</h3>
+              <p class="product-price">$42.00</p>
+              <button type="button" class="add-btn">Add</button>
+            </article>
+            <a href="#slide-2" class="carousel-arrow carousel-arrow-prev" aria-label="Previous product">&larr;</a>
+            <a href="#slide-4" class="carousel-arrow carousel-arrow-next" aria-label="Next product">&rarr;</a>
+          </li>
+
+          <li class="carousel-slide" id="slide-4">
+            <article class="product-card">
+              <div class="product-thumb product-thumb-4" aria-hidden="true"></div>
+              <h3 class="product-name">2-year extended warranty</h3>
+              <p class="product-price">$9.99</p>
+              <button type="button" class="add-btn">Add</button>
+            </article>
+            <a href="#slide-3" class="carousel-arrow carousel-arrow-prev" aria-label="Previous product">&larr;</a>
+            <a href="#slide-5" class="carousel-arrow carousel-arrow-next" aria-label="Next product">&rarr;</a>
+          </li>
+
+          <li class="carousel-slide" id="slide-5">
+            <article class="product-card">
+              <div class="product-thumb product-thumb-5" aria-hidden="true"></div>
+              <h3 class="product-name">Gift wrap &amp; card</h3>
+              <p class="product-price">$4.00</p>
+              <button type="button" class="add-btn">Add</button>
+            </article>
+            <a href="#slide-4" class="carousel-arrow carousel-arrow-prev" aria-label="Previous product">&larr;</a>
+            <span class="carousel-arrow carousel-arrow-next is-disabled" aria-hidden="true">&rarr;</span>
+          </li>
+
+        </ul>
+      </div>
+
+      <nav class="carousel-dots" aria-label="Choose a product to view">
+        <a href="#slide-1" class="carousel-dot" aria-label="Go to product 1"></a>
+        <a href="#slide-2" class="carousel-dot" aria-label="Go to product 2"></a>
+        <a href="#slide-3" class="carousel-dot" aria-label="Go to product 3"></a>
+        <a href="#slide-4" class="carousel-dot" aria-label="Go to product 4"></a>
+        <a href="#slide-5" class="carousel-dot" aria-label="Go to product 5"></a>
+      </nav>
+    </section>
+
+  </main>
+
+  <footer class="footer">
+    <p>EaseMotion CSS &middot; submissions/examples/float-drift-checkout-carousel</p>
+  </footer>
+
+</body>
+</html>

--- a/submissions/examples/float-drift-checkout-carousel/style.css
+++ b/submissions/examples/float-drift-checkout-carousel/style.css
@@ -1,0 +1,483 @@
+/* =========================================================================
+   Float-Drift Carousel — EaseMotion CSS
+   A checkout upsell carousel. Idle cards drift gently in place (subtle
+   vertical bob + tilt, staggered per card) until a shopper touches one,
+   at which point drifting pauses. Navigation is a real horizontal
+   scroll-snap track with genuine prev/next arrows (position: sticky
+   inside each slide, so the href differs per slide with zero JS) and
+   dot indicators. Pure CSS/HTML throughout.
+   ========================================================================= */
+ 
+ 
+/* -------------------------------------------------------------------------
+   1. Design tokens
+   ------------------------------------------------------------------------- */
+ 
+:root {
+  --fd-bg: #0e1116;
+  --fd-surface: #151a21;
+  --fd-surface-2: #1c222b;
+  --fd-border: #262e39;
+  --fd-text: #edeff2;
+  --fd-text-muted: #98a2b3;
+ 
+  --fd-accent: #7de0c0;
+  --fd-accent-strong: #9beed4;
+  --fd-accent-soft: rgba(125, 224, 192, 0.14);
+ 
+  --fd-font-display: "Space Grotesk", "Segoe UI", sans-serif;
+  --fd-font-body: "Inter", "Segoe UI", sans-serif;
+  --fd-font-mono: "IBM Plex Mono", "Courier New", monospace;
+ 
+  /* Drift tuning */
+  --fd-drift-duration: 5200ms;
+  --fd-drift-y: 8px;
+  --fd-drift-rotate: 1.4deg;
+}
+ 
+* {
+  box-sizing: border-box;
+}
+ 
+body {
+  margin: 0;
+  background: var(--fd-bg);
+  color: var(--fd-text);
+  font-family: var(--fd-font-body);
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+ 
+.noise {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.035;
+  z-index: 0;
+  background-image: radial-gradient(circle at 1px 1px, #ffffff 1px, transparent 0);
+  background-size: 3px 3px;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   2. Hero
+   ------------------------------------------------------------------------- */
+ 
+.hero {
+  position: relative;
+  z-index: 1;
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 88px 24px 52px;
+  text-align: center;
+}
+ 
+.eyebrow {
+  font-family: var(--fd-font-mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--fd-accent);
+  margin: 0 0 20px;
+}
+ 
+.hero-title {
+  font-family: var(--fd-font-display);
+  font-weight: 600;
+  font-size: clamp(32px, 5.5vw, 50px);
+  line-height: 1.1;
+  letter-spacing: -0.01em;
+  margin: 0 0 16px;
+}
+ 
+.hero-sub {
+  font-size: 15.5px;
+  color: var(--fd-text-muted);
+  max-width: 460px;
+  margin: 0 auto;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   3. Checkout page mock
+   ------------------------------------------------------------------------- */
+ 
+.checkout-page {
+  position: relative;
+  z-index: 1;
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 0 24px 90px;
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   4. Order summary card
+   ------------------------------------------------------------------------- */
+ 
+.order-summary {
+  background: var(--fd-surface);
+  border: 1px solid var(--fd-border);
+  border-radius: 16px;
+  padding: 24px 26px 26px;
+}
+ 
+.summary-title {
+  font-family: var(--fd-font-display);
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0 0 16px;
+}
+ 
+.summary-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+ 
+.summary-row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 13.5px;
+  color: var(--fd-text-muted);
+  padding: 9px 0;
+  border-bottom: 1px solid var(--fd-border);
+}
+ 
+.summary-row:last-child {
+  border-bottom: none;
+}
+ 
+.summary-total {
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--fd-font-display);
+  font-size: 16px;
+  font-weight: 600;
+  padding-top: 16px;
+  margin-top: 8px;
+  border-top: 1px solid var(--fd-border);
+}
+ 
+.checkout-btn {
+  width: 100%;
+  margin-top: 20px;
+  padding: 13px;
+  border: none;
+  border-radius: 10px;
+  background: var(--fd-accent);
+  color: var(--fd-bg);
+  font-family: var(--fd-font-body);
+  font-size: 14.5px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 160ms ease;
+}
+ 
+.checkout-btn:hover {
+  background: var(--fd-accent-strong);
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   5. Carousel section head
+   ------------------------------------------------------------------------- */
+ 
+.carousel-head {
+  text-align: center;
+  margin-bottom: 22px;
+}
+ 
+.carousel-title {
+  font-family: var(--fd-font-display);
+  font-size: 17px;
+  font-weight: 600;
+  margin: 0 0 6px;
+}
+ 
+.carousel-sub {
+  font-size: 13px;
+  color: var(--fd-text-muted);
+  margin: 0;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   6. Carousel track — horizontal scroll-snap
+   ------------------------------------------------------------------------- */
+ 
+.carousel-viewport {
+  position: relative;
+  border-radius: 20px;
+}
+ 
+.carousel-track {
+  display: flex;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scroll-behavior: smooth;
+  border-radius: 20px;
+ 
+  /* Hide the native scrollbar but keep the element scrollable/swipeable */
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+ 
+.carousel-track::-webkit-scrollbar {
+  display: none;
+}
+ 
+.carousel-slide {
+  position: relative;
+  flex: 0 0 100%;
+  scroll-snap-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 34px 20px;
+}
+ 
+/* A soft highlight ring on whichever slide is currently the browser's
+   URL target — i.e. the one just navigated to via a dot or arrow link. */
+.carousel-slide:target .product-card {
+  box-shadow:
+    0 0 0 2px var(--fd-accent),
+    0 20px 40px -18px rgba(0, 0, 0, 0.55);
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   7. Product card + float-drift animation
+   ------------------------------------------------------------------------- */
+ 
+.product-card {
+  width: min(240px, 72vw);
+  background: var(--fd-surface);
+  border: 1px solid var(--fd-border);
+  border-radius: 18px;
+  padding: 22px 20px 24px;
+  text-align: center;
+  box-shadow: 0 20px 40px -18px rgba(0, 0, 0, 0.5);
+ 
+  animation: fd-drift var(--fd-drift-duration) ease-in-out infinite;
+  transition: box-shadow 200ms ease;
+}
+ 
+/* Stagger so cards don't bob in lockstep */
+.carousel-slide:nth-child(1) .product-card { animation-delay: 0ms; }
+.carousel-slide:nth-child(2) .product-card { animation-delay: -900ms; }
+.carousel-slide:nth-child(3) .product-card { animation-delay: -1800ms; }
+.carousel-slide:nth-child(4) .product-card { animation-delay: -2700ms; }
+.carousel-slide:nth-child(5) .product-card { animation-delay: -3600ms; }
+ 
+@keyframes fd-drift {
+  0%   { transform: translateY(0) rotate(0deg); }
+  25%  { transform: translateY(calc(var(--fd-drift-y) * -1)) rotate(calc(var(--fd-drift-rotate) * -1)); }
+  50%  { transform: translateY(calc(var(--fd-drift-y) * 0.4)) rotate(0deg); }
+  75%  { transform: translateY(calc(var(--fd-drift-y) * -0.6)) rotate(var(--fd-drift-rotate)); }
+  100% { transform: translateY(0) rotate(0deg); }
+}
+ 
+/* Drifting pauses the instant a shopper interacts with a card */
+.product-card:hover,
+.product-card:focus-within {
+  animation-play-state: paused;
+}
+ 
+.product-thumb {
+  width: 100%;
+  height: 96px;
+  border-radius: 12px;
+  margin-bottom: 16px;
+  background: linear-gradient(135deg, var(--fd-surface-2), var(--fd-border));
+}
+ 
+.product-thumb-1 { background: linear-gradient(135deg, #2a3a3a, #1c222b); }
+.product-thumb-2 { background: linear-gradient(135deg, #33313f, #1c222b); }
+.product-thumb-3 { background: linear-gradient(135deg, #2b3340, #1c222b); }
+.product-thumb-4 { background: linear-gradient(135deg, #3a2f2b, #1c222b); }
+.product-thumb-5 { background: linear-gradient(135deg, #2f3a2c, #1c222b); }
+ 
+.product-name {
+  font-family: var(--fd-font-display);
+  font-size: 14.5px;
+  font-weight: 600;
+  margin: 0 0 6px;
+}
+ 
+.product-price {
+  font-family: var(--fd-font-mono);
+  font-size: 13px;
+  color: var(--fd-accent);
+  margin: 0 0 16px;
+}
+ 
+.add-btn {
+  width: 100%;
+  padding: 9px;
+  border-radius: 8px;
+  border: 1px solid var(--fd-border);
+  background: var(--fd-surface-2);
+  color: var(--fd-text);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 160ms ease, border-color 160ms ease;
+}
+ 
+.add-btn:hover {
+  background: #232a34;
+  border-color: var(--fd-accent);
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   8. Prev / next arrows — sticky per slide, so hrefs are genuinely
+      relative to whichever slide is currently in view
+   ------------------------------------------------------------------------- */
+ 
+.carousel-arrow {
+  position: sticky;
+  top: 50%;
+  z-index: 2;
+  width: 38px;
+  height: 38px;
+  margin-top: -19px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--fd-surface-2);
+  border: 1px solid var(--fd-border);
+  color: var(--fd-text);
+  text-decoration: none;
+  font-size: 16px;
+  transition: background 160ms ease, border-color 160ms ease, transform 160ms ease;
+}
+ 
+.carousel-arrow-prev {
+  left: 12px;
+  margin-right: auto;
+}
+ 
+.carousel-arrow-next {
+  right: 12px;
+  margin-left: auto;
+}
+ 
+.carousel-arrow:hover {
+  background: var(--fd-accent-soft);
+  border-color: var(--fd-accent);
+  transform: translateY(-1px);
+}
+ 
+.carousel-arrow:focus-visible {
+  outline: 2px solid var(--fd-accent);
+  outline-offset: 2px;
+}
+ 
+.carousel-arrow.is-disabled {
+  opacity: 0.3;
+  pointer-events: none;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   9. Dot indicators
+   ------------------------------------------------------------------------- */
+ 
+.carousel-dots {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 18px;
+}
+ 
+.carousel-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--fd-border);
+  transition: background 160ms ease, transform 160ms ease;
+}
+ 
+.carousel-dot:hover {
+  background: var(--fd-text-muted);
+}
+ 
+.carousel-dot:focus-visible {
+  outline: 2px solid var(--fd-accent);
+  outline-offset: 3px;
+}
+ 
+/* Highlight the dot matching whichever slide is currently targeted.
+   Progressive enhancement: browsers without :has() just show plain dots,
+   navigation itself is unaffected either way. */
+.carousel-section:has(#slide-1:target) .carousel-dot:nth-child(1),
+.carousel-section:has(#slide-2:target) .carousel-dot:nth-child(2),
+.carousel-section:has(#slide-3:target) .carousel-dot:nth-child(3),
+.carousel-section:has(#slide-4:target) .carousel-dot:nth-child(4),
+.carousel-section:has(#slide-5:target) .carousel-dot:nth-child(5) {
+  background: var(--fd-accent);
+  transform: scale(1.25);
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   10. Footer
+   ------------------------------------------------------------------------- */
+ 
+.footer {
+  position: relative;
+  z-index: 1;
+  text-align: center;
+  padding: 8px 24px 48px;
+  font-size: 12.5px;
+  color: var(--fd-text-muted);
+  font-family: var(--fd-font-mono);
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   11. Responsive
+   ------------------------------------------------------------------------- */
+ 
+@media (max-width: 560px) {
+  .hero {
+    padding: 68px 20px 40px;
+  }
+ 
+  .checkout-page {
+    gap: 36px;
+  }
+ 
+  .carousel-slide {
+    padding: 26px 12px;
+  }
+ 
+  .carousel-arrow {
+    width: 34px;
+    height: 34px;
+  }
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   12. Reduced motion
+   ------------------------------------------------------------------------- */
+ 
+@media (prefers-reduced-motion: reduce) {
+  .product-card {
+    animation: none;
+  }
+ 
+  .carousel-track {
+    scroll-behavior: auto;
+  }
+}


### PR DESCRIPTION
Closes #62449

## Pull Request Description
Adds a pure CSS/HTML "float-drift" carousel for e-commerce checkout upsells — product cards drift gently in place when idle and pause on touch, with a real scroll-snap track, per-slide sticky prev/next arrows, and dot navigation. No JavaScript.

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/float-drift-checkout-carousel/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

## Feature Description

**What does this add?**
A checkout-context product carousel where cards idle-drift (bob + tilt) until touched, navigated by a real horizontal scroll-snap track with genuinely relative prev/next arrows and dot indicators.

**How does a developer use it?**
```html
<ul class="carousel-track">
  <li class="carousel-slide" id="slide-1">
    <article class="product-card">…</article>
    <a href="#slide-2" class="carousel-arrow carousel-arrow-next">→</a>
  </li>
</ul>
```
Each slide's arrows live inside that slide and use `position: sticky`, so their `href`s point to the correct actual neighbor with zero JavaScript. Add/remove slides freely; just update the neighboring `href`s.

**Why does it fit EaseMotion CSS?**
It solves a problem people usually reach for JavaScript to solve — a "next" button that's relative to current position — using only `position: sticky` and native anchor navigation, which fits the library's animation-first, script-free philosophy. The drift itself is one `@keyframes` rule with staggered negative `animation-delay`s, tunable via three custom properties.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

## Notes for Maintainer
The active-dot highlight uses `:has()`, which is purely cosmetic progressive enhancement — navigation, scrolling, and arrows all work identically without it. Everything else (`scroll-snap-type`, `position: sticky`, `:target`) has long-standing broad support.