### PR TITLE
feat: add CSS Blur-Entrance Tooltip for Product Catalog Layouts (#62290)

### DIFF
--- a/submissions/examples/product-blur-entrance-tooltip/README.md
+++ b/submissions/examples/product-blur-entrance-tooltip/README.md
@@ -1,0 +1,19 @@
+# CSS Blur-Entrance Tooltip
+
+A pure CSS tooltip component designed for Product Catalog Layouts. It features a soft, modern `filter: blur()` entrance animation triggered on hover, ideal for clarifying secondary action icons on product cards.
+
+## Features
+- Pure CSS and HTML (No JavaScript required).
+- State management handled purely through the CSS `:hover` pseudo-class.
+- Engaging `filter: blur()` and `opacity` transition for a soft, premium tooltip entrance.
+- Integrated CSS triangle arrow pointing down to the trigger element.
+- Clean, modern e-commerce product card styling.
+- Fully responsive grid layout across desktop, tablet, and mobile viewports.
+- Fully accessible with `prefers-reduced-motion` support ensuring degraded, safe animations.
+
+## Usage
+Open `demo.html` in your browser. Hover over the secondary action icons (like the heart or quick-view buttons) beneath the product details. The hidden tooltip will smoothly unblur and fade into view from above the icon.
+
+## Files
+- `demo.html`: The HTML structure for the product catalog layout, product cards, and the tooltip hover trigger.
+- `style.css`: The styling, grid layout, and CSS transformations for the blur-entrance hover transitions.

--- a/submissions/examples/product-blur-entrance-tooltip/demo.html
+++ b/submissions/examples/product-blur-entrance-tooltip/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Blur-Entrance Tooltip</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="catalog-layout">
+        <h1 class="catalog-title">Featured Products</h1>
+        
+        <div class="product-grid">
+            
+            <!-- Product Card 1 -->
+            <div class="product-card">
+                <div class="product-image placeholder-1"></div>
+                <div class="product-info">
+                    <h3 class="product-name">Ergonomic Chair</h3>
+                    <div class="product-price">$249.00</div>
+                </div>
+                
+                <div class="product-actions">
+                    <button class="add-to-cart">Add to Cart</button>
+                    
+                    <div class="tooltip-container">
+                        <button class="icon-btn">
+                            <span class="icon">♥</span>
+                        </button>
+                        <div class="blur-tooltip">Add to Wishlist</div>
+                    </div>
+                    
+                    <div class="tooltip-container">
+                        <button class="icon-btn">
+                            <span class="icon">◱</span>
+                        </button>
+                        <div class="blur-tooltip">Quick View</div>
+                    </div>
+                </div>
+            </div>
+            
+            <!-- Product Card 2 -->
+            <div class="product-card">
+                <div class="product-image placeholder-2"></div>
+                <div class="product-info">
+                    <h3 class="product-name">Mechanical Keyboard</h3>
+                    <div class="product-price">$129.50</div>
+                </div>
+                
+                <div class="product-actions">
+                    <button class="add-to-cart">Add to Cart</button>
+                    
+                    <div class="tooltip-container">
+                        <button class="icon-btn">
+                            <span class="icon">♥</span>
+                        </button>
+                        <div class="blur-tooltip">Add to Wishlist</div>
+                    </div>
+                    
+                    <div class="tooltip-container">
+                        <button class="icon-btn">
+                            <span class="icon">◱</span>
+                        </button>
+                        <div class="blur-tooltip">Quick View</div>
+                    </div>
+                </div>
+            </div>
+            
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/product-blur-entrance-tooltip/style.css
+++ b/submissions/examples/product-blur-entrance-tooltip/style.css
@@ -1,0 +1,194 @@
+:root {
+    --bg-color: #f1f5f9;
+    --card-bg: #ffffff;
+    --text-primary: #1e293b;
+    --text-secondary: #64748b;
+    --border-color: #e2e8f0;
+    --brand-color: #0ea5e9;
+    --brand-hover: #0284c7;
+    --tooltip-bg: #0f172a;
+    --tooltip-text: #f8fafc;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    font-family: 'Inter', system-ui, -apple-system, sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 40px 20px;
+    box-sizing: border-box;
+}
+
+.catalog-layout {
+    max-width: 900px;
+    width: 100%;
+}
+
+.catalog-title {
+    font-size: 2rem;
+    font-weight: 800;
+    margin: 0 0 32px 0;
+    text-align: center;
+}
+
+.product-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 32px;
+}
+
+.product-card {
+    background-color: var(--card-bg);
+    border-radius: 12px;
+    border: 1px solid var(--border-color);
+    overflow: hidden;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.product-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.1);
+}
+
+.product-image {
+    width: 100%;
+    height: 200px;
+    background-color: #e2e8f0;
+}
+
+.placeholder-1 {
+    background: linear-gradient(135deg, #fdf4ff 0%, #e879f9 100%);
+}
+
+.placeholder-2 {
+    background: linear-gradient(135deg, #f0fdf4 0%, #4ade80 100%);
+}
+
+.product-info {
+    padding: 20px;
+}
+
+.product-name {
+    font-size: 1.15rem;
+    font-weight: 600;
+    margin: 0 0 8px 0;
+}
+
+.product-price {
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: var(--brand-color);
+}
+
+.product-actions {
+    display: flex;
+    align-items: center;
+    padding: 0 20px 20px;
+    gap: 12px;
+}
+
+.add-to-cart {
+    flex-grow: 1;
+    padding: 10px 0;
+    background-color: var(--text-primary);
+    color: white;
+    border: none;
+    border-radius: 6px;
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+
+.add-to-cart:hover {
+    background-color: var(--text-secondary);
+}
+
+.icon-btn {
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: var(--bg-color);
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.icon-btn:hover {
+    background-color: var(--brand-color);
+    color: white;
+    border-color: var(--brand-color);
+}
+
+.icon {
+    font-size: 1.1rem;
+}
+
+/* Tooltip Logic - Blur Entrance */
+.tooltip-container {
+    position: relative;
+    display: inline-flex;
+}
+
+.blur-tooltip {
+    position: absolute;
+    bottom: calc(100% + 10px);
+    left: 50%;
+    transform: translateX(-50%) translateY(10px);
+    background-color: var(--tooltip-bg);
+    color: var(--tooltip-text);
+    padding: 6px 12px;
+    border-radius: 6px;
+    font-size: 0.75rem;
+    font-weight: 500;
+    white-space: nowrap;
+    pointer-events: none;
+    
+    /* Blur Entrance Specifics */
+    opacity: 0;
+    filter: blur(8px);
+    transition: opacity 0.3s ease, filter 0.3s ease, transform 0.3s ease;
+}
+
+.blur-tooltip::after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border-width: 5px;
+    border-style: solid;
+    border-color: var(--tooltip-bg) transparent transparent transparent;
+}
+
+/* Active Hover State */
+.tooltip-container:hover .blur-tooltip {
+    opacity: 1;
+    filter: blur(0);
+    transform: translateX(-50%) translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .product-card {
+        transition: none;
+        transform: none !important;
+    }
+    .blur-tooltip {
+        transition: opacity 0.2s ease;
+        filter: none !important;
+        transform: translateX(-50%) translateY(-5px) !important;
+    }
+    .tooltip-container:hover .blur-tooltip {
+        transform: translateX(-50%) translateY(0) !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces the CSS Blur-Entrance Tooltip designed for Product Catalog Layouts, resolving issue #62290. 

### Changes Made:
- Added `submissions/examples/product-blur-entrance-tooltip/` directory.
- Created `demo.html` using a `:hover` state management system for pure HTML/CSS tooltips on product action icons without JavaScript.
- Created `style.css` featuring an elegant `filter: blur()` and `opacity` transition triggered on hover to give the tooltip a soft, premium entrance.
- Added `README.md` documenting usage and features.
- Fully responsive product grid across desktop, tablet, and mobile viewports.
- Honors the `prefers-reduced-motion` accessibility standard.

Closes #62290
