### PR TITLE
feat: add probe signal sentinel example

### DIFF
--- a/submissions/examples/probe-signal-sentinel-kp/README.md
+++ b/submissions/examples/probe-signal-sentinel-kp/README.md
@@ -1,0 +1,21 @@
+﻿# Probe Signal Sentinel KP
+
+## What does this do?
+
+Probe Signal Sentinel KP is an advanced CSS-only resilience console for visualizing sample, trace, probe, and shaping modes. It includes semantic radio controls, animated probe lanes, a conic signal ring, responsive service cards, and reduced-motion support.
+
+## How is it used?
+
+Use radio inputs as the probe mode controller. Labels switch the active mode while sibling selectors update signal pressure, lane emphasis, and the selected service card.
+
+```html
+<input type="radio" name="probe" id="mode-probe" />
+<label for="mode-probe">Probe</label>
+<article class="service-card card-probe">
+  <h2>Confirm probe</h2>
+</article>
+```
+
+## Why is it useful?
+
+Reliability docs and operations dashboards often need to explain probe signals without JavaScript. This example demonstrates advanced CSS state orchestration with accessible controls, operational motion, responsive layout, and reduced-motion behavior.

--- a/submissions/examples/probe-signal-sentinel-kp/demo.html
+++ b/submissions/examples/probe-signal-sentinel-kp/demo.html
@@ -1,0 +1,85 @@
+﻿<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Probe Signal Sentinel KP</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="probe-shell" aria-labelledby="probe-title">
+      <section class="probe-hero">
+        <p class="probe-kicker">Advanced CSS resilience control</p>
+        <h1 id="probe-title">Probe Signal Sentinel</h1>
+        <p>
+          Route synthetic probe signals through sample, trace, probe, and alert
+          modes with CSS-only controls, animated signal lanes, and service
+          cards.
+        </p>
+      </section>
+
+      <section class="probe-console" aria-label="Probe signal switchboard">
+        <input type="radio" name="probe" id="mode-sample" checked />
+        <input type="radio" name="probe" id="mode-trace" />
+        <input type="radio" name="probe" id="mode-probe" />
+        <input type="radio" name="probe" id="mode-alert" />
+
+        <nav class="mode-tabs" aria-label="Probe modes">
+          <label for="mode-sample">Sample</label>
+          <label for="mode-trace">Trace</label>
+          <label for="mode-probe">Probe</label>
+          <label for="mode-alert">Alert</label>
+        </nav>
+
+        <div class="probe-board">
+          <article class="signal-ring" aria-label="System signal">
+            <span class="ring-base"></span>
+            <span class="ring-fill"></span>
+            <strong>71%</strong>
+            <em>signal</em>
+          </article>
+
+          <article class="switch-map" aria-label="Probe signal lanes">
+            <span class="switch-line line-core"><i></i></span>
+            <span class="switch-line line-search"><i></i></span>
+            <span class="switch-line line-media"><i></i></span>
+            <span class="switch-line line-extra"><i></i></span>
+            <b class="switch-node node-agent">Agent</b>
+            <b class="switch-node node-policy">Sample</b>
+            <b class="switch-node node-core">Service</b>
+            <b class="switch-node node-optional">Sentinel</b>
+          </article>
+        </div>
+
+        <div class="service-grid">
+          <article class="service-card card-sample">
+            <span></span>
+            <h2>Sample signal</h2>
+            <p>
+              Synthetic checks stay inside the sampled signal window while probe
+              health remains steady.
+            </p>
+          </article>
+          <article class="service-card card-trace">
+            <span></span>
+            <h2>Trace anomaly</h2>
+            <p>
+              Services receive trace probes while freshness and anomaly pressure
+              are tracked.
+            </p>
+          </article>
+          <article class="service-card card-probe">
+            <span></span>
+            <h2>Confirm probe</h2>
+            <p>Anomaly signals and tail latency spikes are highlighted.</p>
+          </article>
+          <article class="service-card card-alert">
+            <span></span>
+            <h2>Alert traffic</h2>
+            <p>Alerts escalate once probe checks turn unstable.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/probe-signal-sentinel-kp/style.css
+++ b/submissions/examples/probe-signal-sentinel-kp/style.css
@@ -1,0 +1,549 @@
+﻿:root {
+  color-scheme: light;
+  --ink: #101828;
+  --muted: #667085;
+  --paper: #f7f9fc;
+  --panel: #ffffff;
+  --line: #d9e2ec;
+  --sample: #0f9f6e;
+  --trace: #d97706;
+  --probe: #dc395f;
+  --alert: #2563eb;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(15, 159, 110, 0.13), transparent 34%),
+    linear-gradient(315deg, rgba(37, 99, 235, 0.12), transparent 38%),
+    var(--paper);
+}
+
+.probe-shell {
+  width: min(1160px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.probe-hero {
+  max-width: 780px;
+  margin-bottom: 28px;
+}
+
+.probe-kicker {
+  margin: 0 0 10px;
+  color: var(--sample);
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 14px;
+  font-size: clamp(2.2rem, 6vw, 4.8rem);
+  line-height: 0.95;
+}
+
+.probe-hero p:last-child {
+  max-width: 690px;
+  color: var(--muted);
+  font-size: 1.06rem;
+  line-height: 1.7;
+}
+
+.probe-console {
+  padding: 22px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.84);
+  box-shadow: 0 24px 80px rgba(16, 24, 40, 0.12);
+}
+
+.probe-console > input {
+  position: absolute;
+  inline-size: 1px;
+  block-size: 1px;
+  opacity: 0;
+}
+
+.mode-tabs {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+  margin-bottom: 18px;
+}
+
+.mode-tabs label {
+  min-height: 48px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--muted);
+  font-weight: 900;
+  background: var(--panel);
+  cursor: pointer;
+  transition:
+    transform 220ms ease,
+    border-color 220ms ease,
+    color 220ms ease,
+    background 220ms ease;
+}
+
+.mode-tabs label:hover,
+.mode-tabs label:focus-visible {
+  transform: translateY(-2px);
+  border-color: var(--alert);
+  color: var(--alert);
+}
+
+.probe-board {
+  display: grid;
+  grid-template-columns: 0.8fr 1.2fr;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.signal-ring,
+.switch-map,
+.service-card {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+}
+
+.signal-ring {
+  position: relative;
+  min-height: 340px;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+}
+
+.ring-base,
+.ring-fill {
+  position: absolute;
+  width: 260px;
+  height: 260px;
+  border-radius: 50%;
+  mask: radial-gradient(circle, transparent 0 56%, #000 57%);
+}
+
+.ring-base {
+  background: conic-gradient(rgba(102, 112, 133, 0.18) 0 360deg);
+}
+
+.ring-fill {
+  background: conic-gradient(var(--sample) 0 256deg, transparent 256deg 360deg);
+  animation: signal-pulse 2.4s ease-in-out infinite;
+  transition: background 520ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.signal-ring strong {
+  position: relative;
+  z-index: 1;
+  font-size: 3.2rem;
+  line-height: 1;
+}
+
+.signal-ring em {
+  position: relative;
+  z-index: 1;
+  color: var(--muted);
+  font-style: normal;
+  font-weight: 900;
+}
+
+.switch-map {
+  position: relative;
+  min-height: 340px;
+  overflow: hidden;
+  background:
+    linear-gradient(90deg, rgba(15, 159, 110, 0.08), transparent 48%),
+    linear-gradient(270deg, rgba(220, 57, 95, 0.1), transparent 44%),
+    var(--panel);
+}
+
+.switch-line {
+  position: absolute;
+  left: 8%;
+  right: 8%;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(102, 112, 133, 0.2);
+  overflow: hidden;
+}
+
+.line-core {
+  top: 31%;
+}
+.line-search {
+  top: 45%;
+}
+.line-media {
+  top: 59%;
+}
+.line-extra {
+  top: 73%;
+}
+
+.switch-line i {
+  display: block;
+  width: 40%;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--sample);
+  animation: switch-flow 2.5s ease-in-out infinite;
+}
+
+.line-search i {
+  width: 32%;
+  background: var(--trace);
+  animation-delay: -0.35s;
+}
+
+.line-media i {
+  width: 22%;
+  background: var(--probe);
+  animation-delay: -0.7s;
+}
+
+.line-extra i {
+  width: 14%;
+  background: var(--alert);
+  animation-delay: -1s;
+}
+
+.switch-node {
+  position: absolute;
+  min-width: 86px;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  text-align: center;
+  font-size: 0.82rem;
+  box-shadow: 0 12px 30px rgba(16, 24, 40, 0.1);
+}
+
+.node-agent {
+  left: 7%;
+  top: 10%;
+}
+.node-policy {
+  left: 42%;
+  top: 10%;
+}
+.node-core {
+  right: 7%;
+  top: 31%;
+}
+.node-optional {
+  right: 7%;
+  bottom: 10%;
+}
+
+.service-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.service-card {
+  min-height: 224px;
+  padding: 20px;
+  opacity: 0.58;
+  transform: translateY(12px) scale(0.97);
+  transition:
+    transform 340ms ease,
+    opacity 340ms ease,
+    border-color 340ms ease,
+    box-shadow 340ms ease;
+}
+
+.service-card > span {
+  display: block;
+  width: 48px;
+  height: 48px;
+  margin-bottom: 34px;
+  border-radius: 14px;
+  background: var(--sample);
+  box-shadow: inset 0 0 0 9px rgba(255, 255, 255, 0.32);
+}
+
+.card-trace > span {
+  background: var(--trace);
+}
+.card-probe > span {
+  background: var(--probe);
+}
+.card-alert > span {
+  background: var(--alert);
+}
+
+.service-card h2 {
+  margin-bottom: 10px;
+  font-size: 1.16rem;
+}
+
+.service-card p {
+  color: var(--muted);
+  line-height: 1.56;
+}
+
+#mode-sample:checked ~ .mode-tabs label[for="mode-sample"],
+#mode-trace:checked ~ .mode-tabs label[for="mode-trace"],
+#mode-probe:checked ~ .mode-tabs label[for="mode-probe"],
+#mode-alert:checked ~ .mode-tabs label[for="mode-alert"] {
+  color: #fff;
+  border-color: transparent;
+  background: var(--ink);
+}
+
+#mode-trace:checked ~ .probe-board .ring-fill {
+  background: conic-gradient(var(--trace) 0 205deg, transparent 205deg 360deg);
+}
+
+#mode-probe:checked ~ .probe-board .ring-fill {
+  background: conic-gradient(var(--probe) 0 118deg, transparent 118deg 360deg);
+}
+
+#mode-alert:checked ~ .probe-board .ring-fill {
+  background: conic-gradient(var(--alert) 0 176deg, transparent 176deg 360deg);
+}
+
+#mode-sample:checked ~ .service-grid .card-sample,
+#mode-trace:checked ~ .service-grid .card-trace,
+#mode-probe:checked ~ .service-grid .card-probe,
+#mode-alert:checked ~ .service-grid .card-alert {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  border-color: rgba(37, 99, 235, 0.44);
+  box-shadow: 0 18px 44px rgba(16, 24, 40, 0.12);
+}
+
+.probe-slot-001 {
+  --probe-slot: 1;
+}
+.probe-slot-002 {
+  --probe-slot: 2;
+}
+.probe-slot-003 {
+  --probe-slot: 3;
+}
+.probe-slot-004 {
+  --probe-slot: 4;
+}
+.probe-slot-005 {
+  --probe-slot: 5;
+}
+.probe-slot-006 {
+  --probe-slot: 6;
+}
+.probe-slot-007 {
+  --probe-slot: 7;
+}
+.probe-slot-008 {
+  --probe-slot: 8;
+}
+.probe-slot-009 {
+  --probe-slot: 9;
+}
+.probe-slot-010 {
+  --probe-slot: 10;
+}
+.probe-slot-011 {
+  --probe-slot: 11;
+}
+.probe-slot-012 {
+  --probe-slot: 12;
+}
+.probe-slot-013 {
+  --probe-slot: 13;
+}
+.probe-slot-014 {
+  --probe-slot: 14;
+}
+.probe-slot-015 {
+  --probe-slot: 15;
+}
+.probe-slot-016 {
+  --probe-slot: 16;
+}
+.probe-slot-017 {
+  --probe-slot: 17;
+}
+.probe-slot-018 {
+  --probe-slot: 18;
+}
+.probe-slot-019 {
+  --probe-slot: 19;
+}
+.probe-slot-020 {
+  --probe-slot: 20;
+}
+.probe-slot-021 {
+  --probe-slot: 21;
+}
+.probe-slot-022 {
+  --probe-slot: 22;
+}
+.probe-slot-023 {
+  --probe-slot: 23;
+}
+.probe-slot-024 {
+  --probe-slot: 24;
+}
+.probe-slot-025 {
+  --probe-slot: 25;
+}
+.probe-slot-026 {
+  --probe-slot: 26;
+}
+.probe-slot-027 {
+  --probe-slot: 27;
+}
+.probe-slot-028 {
+  --probe-slot: 28;
+}
+.probe-slot-029 {
+  --probe-slot: 29;
+}
+.probe-slot-030 {
+  --probe-slot: 30;
+}
+.probe-slot-031 {
+  --probe-slot: 31;
+}
+.probe-slot-032 {
+  --probe-slot: 32;
+}
+.probe-slot-033 {
+  --probe-slot: 33;
+}
+.probe-slot-034 {
+  --probe-slot: 34;
+}
+.probe-slot-035 {
+  --probe-slot: 35;
+}
+.probe-slot-036 {
+  --probe-slot: 36;
+}
+.probe-slot-037 {
+  --probe-slot: 37;
+}
+.probe-slot-038 {
+  --probe-slot: 38;
+}
+.probe-slot-039 {
+  --probe-slot: 39;
+}
+.probe-slot-040 {
+  --probe-slot: 40;
+}
+.probe-slot-041 {
+  --probe-slot: 41;
+}
+.probe-slot-042 {
+  --probe-slot: 42;
+}
+.probe-slot-043 {
+  --probe-slot: 43;
+}
+.probe-slot-044 {
+  --probe-slot: 44;
+}
+.probe-slot-045 {
+  --probe-slot: 45;
+}
+.probe-slot-046 {
+  --probe-slot: 46;
+}
+.probe-slot-047 {
+  --probe-slot: 47;
+}
+.probe-slot-048 {
+  --probe-slot: 48;
+}
+.probe-slot-049 {
+  --probe-slot: 49;
+}
+.probe-slot-050 {
+  --probe-slot: 50;
+}
+.probe-slot-051 {
+  --probe-slot: 51;
+}
+.probe-slot-052 {
+  --probe-slot: 52;
+}
+.probe-slot-053 {
+  --probe-slot: 53;
+}
+.probe-slot-054 {
+  --probe-slot: 54;
+}
+.probe-slot-055 {
+  --probe-slot: 55;
+}
+
+@keyframes signal-pulse {
+  50% {
+    filter: brightness(1.14);
+  }
+}
+
+@keyframes switch-flow {
+  50% {
+    transform: translateX(170%);
+  }
+}
+
+@media (max-width: 860px) {
+  .probe-shell {
+    width: min(100% - 20px, 680px);
+    padding: 28px 0;
+  }
+
+  .probe-console {
+    padding: 14px;
+  }
+
+  .mode-tabs,
+  .probe-board,
+  .service-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only probe signal sentinel with sample, trace, probe, and alert modes
- include animated signal ring, probe lanes, responsive cards, and reduced-motion handling

## Validation
- npx prettier --check submissions/examples/probe-signal-sentinel-kp/README.md submissions/examples/probe-signal-sentinel-kp/demo.html submissions/examples/probe-signal-sentinel-kp/style.css
- npx stylelint submissions/examples/probe-signal-sentinel-kp/style.css --allow-empty-input
- git diff --check