### PR TITLE
feat: add ease-anchor-tooltip

### DIFF
--- a/submissions/examples/ease-anchor-tooltip-aaniya/README.md
+++ b/submissions/examples/ease-anchor-tooltip-aaniya/README.md
@@ -1,0 +1,14 @@
+# ease-anchor-tooltip-aaniya
+
+## What does this do?
+A tooltip that natively "sticks" to its trigger button using the CSS Anchor Positioning API — no JavaScript positioning library required.
+
+## How is it used?
+```html
+<button class="ease-anchor-btn">Hover me</button>
+<div class="ease-anchor-tooltip">I'm natively anchored, no JS!</div>
+```
+The tooltip must be a sibling immediately after the trigger button in the DOM.
+
+## Why is it useful?
+Traditionally, tooltips/dropdowns that need to track a trigger element on scroll or resize require JS libraries like Floating UI or Popper.js to recalculate coordinates. The CSS Anchor Positioning API lets the browser engine handle this natively via `anchor-name` and `anchor()`, removing a runtime JS dependency entirely. This fits EaseMotion's philosophy of lightweight, CSS-first interactivity. A `@supports` fallback hides the tooltip gracefully in browsers that don't yet support the API.

--- a/submissions/examples/ease-anchor-tooltip-aaniya/demo.html
+++ b/submissions/examples/ease-anchor-tooltip-aaniya/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>ease-anchor-tooltip-aaniya demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #f3f4f6;
+      margin: 0;
+    }
+  </style>
+</head>
+<body>
+  <button class="ease-anchor-btn">Hover me</button>
+  <div class="ease-anchor-tooltip">I'm natively anchored, no JS!</div>
+</body>
+</html>

--- a/submissions/examples/ease-anchor-tooltip-aaniya/style.css
+++ b/submissions/examples/ease-anchor-tooltip-aaniya/style.css
@@ -1,0 +1,46 @@
+/* ease-anchor-tooltip-aaniya — CSS Anchor Positioning API demo
+   Issue #62015: tooltip that "sticks" to its trigger button
+   using native browser anchor positioning, zero JS required. */
+
+.ease-anchor-btn {
+  anchor-name: --ease-btn;
+  padding: 10px 20px;
+  border-radius: 8px;
+  border: none;
+  background: #6366f1;
+  color: white;
+  font-family: sans-serif;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.ease-anchor-tooltip {
+  position: absolute;
+  position-anchor: --ease-btn;
+  left: anchor(center);
+  top: calc(anchor(bottom) + 8px);
+  translate: -50% 0;
+
+  padding: 6px 12px;
+  border-radius: 6px;
+  background: #1e1b2e;
+  color: white;
+  font-family: sans-serif;
+  font-size: 13px;
+  white-space: nowrap;
+
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 150ms ease;
+}
+
+.ease-anchor-btn:hover + .ease-anchor-tooltip,
+.ease-anchor-btn:focus-visible + .ease-anchor-tooltip {
+  opacity: 1;
+}
+
+@supports not (anchor-name: --ease-btn) {
+  .ease-anchor-tooltip {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-anchor-tooltip`, a tooltip component that uses the native CSS Anchor Positioning API to stay pinned to its trigger button without any JavaScript positioning library.

---

## Type of Change

- [x] 🧩 New component

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/ease-anchor-tooltip/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A tooltip that natively "sticks" to its trigger button using the CSS Anchor Positioning API — no JS required.

**How does a developer use it?**

```html
<button class="ease-anchor-btn">Hover me</button>
<div class="ease-anchor-tooltip">I'm natively anchored, no JS!</div>
```

**Why does it fit EaseMotion CSS?**

It removes a runtime JS dependency (Floating UI / Popper.js) for a common interaction pattern, keeping things CSS-first and lightweight, in line with EaseMotion's philosophy. Includes a `@supports` fallback for browsers without anchor positioning support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainer

Closes #62015. Note: I found an existing `ease-anchor-tooltip` submission already merged via #61017 — this is a fresh implementation per the issue's own spec (`anchor-name`, `position-anchor`, `anchor()`), happy to have it closed as duplicate if the existing one already covers this.