### PR TITLE
feat: add fade-in-popover-checkout

### DIFF
--- a/submissions/examples/fade-in-popover-checkout-aaniya/README.md
+++ b/submissions/examples/fade-in-popover-checkout-aaniya/README.md
@@ -1,0 +1,33 @@
+# fade-in-popover-checkout-aaniya
+
+## What does this do?
+A fade-in popover for e-commerce checkout layouts, built with the native HTML `popover` attribute and CSS Anchor Positioning — no JavaScript required. Clicking a trigger button (e.g. "Delivery info") reveals a small panel anchored to it, with a smooth fade + rise transition powered by `@starting-style`.
+
+## How is it used?
+```html
+<button
+  class="ease-fade-popover-trigger"
+  popovertarget="ease-delivery-popover"
+>
+  Delivery info
+</button>
+
+<div id="ease-delivery-popover" class="ease-fade-popover" popover>
+  <h4>Estimated delivery</h4>
+  <p>Arrives in 3&ndash;5 business days.</p>
+</div>
+```
+The trigger button needs `popovertarget` matching the panel's `id`. The panel needs the `popover` attribute and the `.ease-fade-popover` class.
+
+### CSS custom properties
+| Property | Purpose |
+|---|---|
+| `--ease-popover-bg` | Panel background color |
+| `--ease-popover-border` | Panel border color |
+| `--ease-popover-shadow` | Panel drop shadow |
+| `--ease-popover-radius` | Corner radius (panel + trigger context) |
+| `--ease-accent` | Accent color (badge text) |
+| `--ease-transition-duration` | Fade/rise transition speed |
+
+## Why is it useful?
+Checkout flows are cluttered with details (delivery windows, return policy, stock status) that don't deserve permanent screen space but need to be one click away. Historically this meant a JS popover library to manage positioning and open/close state. Using the native `popover` attribute plus CSS Anchor Positioning (`anchor-name` / `position-anchor` / `anchor()`), the browser handles both the top-layer stacking and the anchor positioning natively. `@starting-style` provides the fade-in transition on open, which normally requires JS since `display: none` elements can't transition. A `@supports` fallback keeps the popover functional (just statically positioned) in browsers without Anchor Positioning support, and `prefers-reduced-motion` disables the transition for users who request it.

--- a/submissions/examples/fade-in-popover-checkout-aaniya/demo.html
+++ b/submissions/examples/fade-in-popover-checkout-aaniya/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>fade-in-popover-checkout-aaniya demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #f3f4f6;
+      margin: 0;
+      padding: 2rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="ease-checkout-item">
+    <div class="ease-checkout-item__info">
+      <h3>Wireless Headphones</h3>
+      <p>Qty: 1 &middot; $79.00</p>
+    </div>
+
+    <button
+      class="ease-fade-popover-trigger"
+      popovertarget="ease-delivery-popover"
+      aria-describedby="ease-delivery-popover"
+    >
+      Delivery info
+    </button>
+
+    <div id="ease-delivery-popover" class="ease-fade-popover" popover>
+      <h4>Estimated delivery</h4>
+      <p>Arrives in 3&ndash;5 business days. Free returns within 30 days of delivery.</p>
+      <span class="ease-fade-popover__badge">✓ In stock</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/fade-in-popover-checkout-aaniya/style.css
+++ b/submissions/examples/fade-in-popover-checkout-aaniya/style.css
@@ -1,0 +1,175 @@
+/* ==========================================================================
+   Fade-In Popover for E-Commerce Checkout Layouts
+   Pure CSS using the native Popover API + @starting-style for fade-in
+   ========================================================================== */
+
+:root {
+  --ease-popover-bg: #ffffff;
+  --ease-popover-border: #e2e8f0;
+  --ease-popover-shadow: 0 10px 30px rgba(15, 23, 42, 0.15);
+  --ease-popover-radius: 12px;
+  --ease-popover-text: #1e293b;
+  --ease-popover-muted: #64748b;
+  --ease-accent: #16a34a;
+  --ease-trigger-bg: #0f172a;
+  --ease-trigger-bg-hover: #1e293b;
+  --ease-transition-duration: 220ms;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--ease-popover-text);
+}
+
+/* -------------------------------------------------------------------- */
+/* Checkout line item row (demo context)                                */
+/* -------------------------------------------------------------------- */
+.ease-checkout-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  border: 1px solid var(--ease-popover-border);
+  border-radius: var(--ease-popover-radius);
+  background: #fff;
+  max-width: 420px;
+}
+
+.ease-checkout-item__info h3 {
+  margin: 0 0 0.25rem;
+  font-size: 1rem;
+}
+
+.ease-checkout-item__info p {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--ease-popover-muted);
+}
+
+/* -------------------------------------------------------------------- */
+/* Trigger button                                                       */
+/* -------------------------------------------------------------------- */
+.ease-fade-popover-trigger {
+  appearance: none;
+  border: none;
+  cursor: pointer;
+  background: var(--ease-trigger-bg);
+  color: #fff;
+  font-size: 0.875rem;
+  font-weight: 600;
+  padding: 0.5rem 0.9rem;
+  border-radius: 999px;
+  anchor-name: --ease-fade-popover-anchor;
+  transition: background var(--ease-transition-duration) ease;
+}
+
+.ease-fade-popover-trigger:hover,
+.ease-fade-popover-trigger:focus-visible {
+  background: var(--ease-trigger-bg-hover);
+}
+
+.ease-fade-popover-trigger:focus-visible {
+  outline: 2px solid var(--ease-accent);
+  outline-offset: 2px;
+}
+
+/* -------------------------------------------------------------------- */
+/* Popover panel                                                        */
+/* -------------------------------------------------------------------- */
+.ease-fade-popover {
+  position: absolute;
+  position-anchor: --ease-fade-popover-anchor;
+  top: anchor(bottom);
+  left: anchor(left);
+  margin: 0.5rem 0 0;
+
+  width: 260px;
+  padding: 1rem 1.1rem;
+  border: 1px solid var(--ease-popover-border);
+  border-radius: var(--ease-popover-radius);
+  background: var(--ease-popover-bg);
+  box-shadow: var(--ease-popover-shadow);
+  color: var(--ease-popover-text);
+
+  /* Fade + subtle rise transition */
+  opacity: 0;
+  transform: translateY(-6px);
+  transition:
+    opacity var(--ease-transition-duration) ease,
+    transform var(--ease-transition-duration) ease,
+    display var(--ease-transition-duration) allow-discrete,
+    overlay var(--ease-transition-duration) allow-discrete;
+}
+
+.ease-fade-popover:popover-open {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* Entry state for the fade-in (requires browser support for @starting-style) */
+@starting-style {
+  .ease-fade-popover:popover-open {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+}
+
+.ease-fade-popover h4 {
+  margin: 0 0 0.35rem;
+  font-size: 0.95rem;
+}
+
+.ease-fade-popover p {
+  margin: 0;
+  font-size: 0.825rem;
+  line-height: 1.4;
+  color: var(--ease-popover-muted);
+}
+
+.ease-fade-popover__badge {
+  display: inline-block;
+  margin-top: 0.6rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--ease-accent);
+}
+
+/* -------------------------------------------------------------------- */
+/* Fallback for browsers without Popover API / @starting-style support  */
+/* -------------------------------------------------------------------- */
+@supports not (position-anchor: --ease-fade-popover-anchor) {
+  .ease-fade-popover {
+    position: absolute;
+    top: 100%;
+    left: 0;
+  }
+}
+
+/* -------------------------------------------------------------------- */
+/* Reduced motion                                                       */
+/* -------------------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  .ease-fade-popover-trigger,
+  .ease-fade-popover {
+    transition: none !important;
+  }
+}
+
+/* -------------------------------------------------------------------- */
+/* Responsive                                                           */
+/* -------------------------------------------------------------------- */
+@media (max-width: 480px) {
+  .ease-checkout-item {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .ease-fade-popover {
+    width: min(260px, calc(100vw - 2.5rem));
+  }
+}


### PR DESCRIPTION
Closes #62468
## Pull Request Description
Adds a fade-in popover component for e-commerce checkout layouts, built with the native HTML `popover` attribute and CSS Anchor Positioning — no JavaScript required.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/fade-in-popover-checkout-aaniya/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A click-triggered, natively-anchored popover with a smooth fade + rise entrance, for showing checkout details like delivery estimates.

**How does a developer use it?**
```html
<button class="ease-fade-popover-trigger" popovertarget="ease-delivery-popover">
  Delivery info
</button>

<div id="ease-delivery-popover" class="ease-fade-popover" popover>
  <h4>Estimated delivery</h4>
  <p>Arrives in 3–5 business days.</p>
</div>
```

**Why does it fit EaseMotion CSS?**
It replaces what's traditionally a JS-dependent pattern (positioning + open/close state) with browser-native primitives — the `popover` attribute for toggle/top-layer behavior, CSS Anchor Positioning for placement, and `@starting-style` for the fade transition. Fully declarative, matches the human-readable, animation-first philosophy.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Uses `@starting-style` and CSS Anchor Positioning, both fairly recent CSS features — included a `@supports` fallback for browsers without Anchor Positioning support, so the popover still opens/closes correctly there (just statically positioned rather than anchored).