### PR TITLE
feat: add morph-glow-tabs-checkout

### DIFF
--- a/submissions/examples/morph-glow-tabs-checkout-aaniya/README.md
+++ b/submissions/examples/morph-glow-tabs-checkout-aaniya/README.md
@@ -1,0 +1,38 @@
+# morph-glow-tabs-checkout-aaniya
+
+## What does this do?
+A pure CSS tab component for e-commerce checkout flows (Cart / Delivery / Payment / Confirm), with a glowing pill indicator that smoothly slides and morphs between tabs as they're selected. No JavaScript — driven entirely by hidden radio inputs and sibling combinators.
+
+## How is it used?
+```html
+<div class="ease-morph-tabs">
+  <div class="ease-morph-tabs__inputs">
+    <input type="radio" name="ease-checkout-tabs" id="ease-tab-1" checked />
+    <input type="radio" name="ease-checkout-tabs" id="ease-tab-2" />
+  </div>
+
+  <div class="ease-morph-tabs__list">
+    <div class="ease-morph-tabs__indicator"></div>
+    <label class="ease-morph-tabs__label" for="ease-tab-1">Cart</label>
+    <label class="ease-morph-tabs__label" for="ease-tab-2">Delivery</label>
+  </div>
+
+  <div class="ease-morph-tabs__panels">
+    <div class="ease-morph-tabs__panel" id="ease-panel-1">Cart contents…</div>
+    <div class="ease-morph-tabs__panel" id="ease-panel-2">Delivery options…</div>
+  </div>
+</div>
+```
+Radio `id`s and their matching `#ease-panel-N` / `label[for]` targets must stay in sync — the CSS selectors are keyed to `#ease-tab-1` through `#ease-tab-4`. Radios share one `name` so only one can be checked at a time.
+
+### CSS custom properties
+| Property | Purpose |
+|---|---|
+| `--ease-tabs-bg` | Track background behind the tabs |
+| `--ease-tabs-indicator` | Indicator pill color |
+| `--ease-tabs-glow` | Indicator glow color (box-shadow) |
+| `--ease-tabs-text` / `--ease-tabs-text-active` | Inactive / active label text color |
+| `--ease-tabs-transition` | Slide/morph transition timing |
+
+## Why is it useful?
+Tab indicators that slide between tabs are usually built with JS to measure each tab's offset/width and animate a floating element. This version keeps the indicator as an absolutely-positioned sibling inside a CSS grid track, and uses `:checked` on hidden radios to translate it by fixed percentage steps (`0%`, `100%`, `200%`, `300%`) — matching the grid's equal-width columns, so no JS measurement is needed. The glow intensifies via `box-shadow` on the same transition, giving a "morph" feel without extra markup. Includes a `prefers-reduced-motion` override and a responsive 2×2 grid fallback with adjusted transform steps for narrow viewports.

--- a/submissions/examples/morph-glow-tabs-checkout-aaniya/demo.html
+++ b/submissions/examples/morph-glow-tabs-checkout-aaniya/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>morph-glow-tabs-checkout-aaniya demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #f8fafc;
+      margin: 0;
+      padding: 2rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="ease-morph-tabs">
+    <div class="ease-morph-tabs__inputs">
+      <input type="radio" name="ease-checkout-tabs" id="ease-tab-1" checked />
+      <input type="radio" name="ease-checkout-tabs" id="ease-tab-2" />
+      <input type="radio" name="ease-checkout-tabs" id="ease-tab-3" />
+      <input type="radio" name="ease-checkout-tabs" id="ease-tab-4" />
+    </div>
+
+    <div class="ease-morph-tabs__list">
+      <div class="ease-morph-tabs__indicator"></div>
+      <label class="ease-morph-tabs__label" for="ease-tab-1">Cart</label>
+      <label class="ease-morph-tabs__label" for="ease-tab-2">Delivery</label>
+      <label class="ease-morph-tabs__label" for="ease-tab-3">Payment</label>
+      <label class="ease-morph-tabs__label" for="ease-tab-4">Confirm</label>
+    </div>
+
+    <div class="ease-morph-tabs__panels">
+      <div class="ease-morph-tabs__panel" id="ease-panel-1">
+        <strong>Cart</strong> — 2 items, $158.00 subtotal.
+      </div>
+      <div class="ease-morph-tabs__panel" id="ease-panel-2">
+        <strong>Delivery</strong> — Standard shipping, 3&ndash;5 business days.
+      </div>
+      <div class="ease-morph-tabs__panel" id="ease-panel-3">
+        <strong>Payment</strong> — Card ending in 4242.
+      </div>
+      <div class="ease-morph-tabs__panel" id="ease-panel-4">
+        <strong>Confirm</strong> — Review your order and place it.
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/morph-glow-tabs-checkout-aaniya/style.css
+++ b/submissions/examples/morph-glow-tabs-checkout-aaniya/style.css
@@ -1,0 +1,186 @@
+/* ==========================================================================
+   Morph-Glow Tabs for E-Commerce Checkout Layouts
+   Pure CSS radio-driven tabs with a sliding, glowing active indicator
+   ========================================================================== */
+
+:root {
+  --ease-tabs-bg: #f1f5f9;
+  --ease-tabs-text: #475569;
+  --ease-tabs-text-active: #ffffff;
+  --ease-tabs-indicator: #6366f1;
+  --ease-tabs-glow: rgba(99, 102, 241, 0.55);
+  --ease-tabs-radius: 999px;
+  --ease-tabs-transition: 350ms cubic-bezier(0.65, 0, 0.35, 1);
+  --ease-tabs-panel-bg: #ffffff;
+  --ease-tabs-panel-border: #e2e8f0;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #1e293b;
+}
+
+/* -------------------------------------------------------------------- */
+/* Tab structure                                                        */
+/* -------------------------------------------------------------------- */
+.ease-morph-tabs {
+  position: relative;
+  width: 100%;
+  max-width: 480px;
+}
+
+.ease-morph-tabs__inputs {
+  /* radio inputs are visually hidden but remain keyboard accessible */
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.ease-morph-tabs__list {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  background: var(--ease-tabs-bg);
+  border-radius: var(--ease-tabs-radius);
+  padding: 0.35rem;
+  gap: 0.25rem;
+}
+
+.ease-morph-tabs__label {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.6rem 0.5rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--ease-tabs-text);
+  border-radius: var(--ease-tabs-radius);
+  cursor: pointer;
+  text-align: center;
+  transition: color var(--ease-tabs-transition);
+}
+
+/* -------------------------------------------------------------------- */
+/* Morph-glow sliding indicator                                         */
+/* -------------------------------------------------------------------- */
+.ease-morph-tabs__indicator {
+  position: absolute;
+  top: 0.35rem;
+  bottom: 0.35rem;
+  left: 0.35rem;
+  width: calc(25% - 0.35rem);
+  background: var(--ease-tabs-indicator);
+  border-radius: var(--ease-tabs-radius);
+  box-shadow: 0 0 0 0 var(--ease-tabs-glow);
+  transition:
+    transform var(--ease-tabs-transition),
+    box-shadow var(--ease-tabs-transition),
+    border-radius var(--ease-tabs-transition);
+}
+
+/* Each radio, when checked, moves the indicator via a sibling combinator
+   and morphs its glow + shape slightly for a "liquid" feel */
+#ease-tab-1:checked ~ .ease-morph-tabs__list .ease-morph-tabs__indicator {
+  transform: translateX(0%);
+}
+
+#ease-tab-2:checked ~ .ease-morph-tabs__list .ease-morph-tabs__indicator {
+  transform: translateX(100%);
+}
+
+#ease-tab-3:checked ~ .ease-morph-tabs__list .ease-morph-tabs__indicator {
+  transform: translateX(200%);
+}
+
+#ease-tab-4:checked ~ .ease-morph-tabs__list .ease-morph-tabs__indicator {
+  transform: translateX(300%);
+}
+
+.ease-morph-tabs__inputs:focus-visible ~ .ease-morph-tabs__list .ease-morph-tabs__indicator,
+#ease-tab-1:checked ~ .ease-morph-tabs__list .ease-morph-tabs__indicator,
+#ease-tab-2:checked ~ .ease-morph-tabs__list .ease-morph-tabs__indicator,
+#ease-tab-3:checked ~ .ease-morph-tabs__list .ease-morph-tabs__indicator,
+#ease-tab-4:checked ~ .ease-morph-tabs__list .ease-morph-tabs__indicator {
+  box-shadow: 0 4px 18px 2px var(--ease-tabs-glow);
+}
+
+/* Active label text color */
+#ease-tab-1:checked ~ .ease-morph-tabs__list label[for="ease-tab-1"],
+#ease-tab-2:checked ~ .ease-morph-tabs__list label[for="ease-tab-2"],
+#ease-tab-3:checked ~ .ease-morph-tabs__list label[for="ease-tab-3"],
+#ease-tab-4:checked ~ .ease-morph-tabs__list label[for="ease-tab-4"] {
+  color: var(--ease-tabs-text-active);
+}
+
+/* Keyboard focus ring on the label when its radio has focus */
+.ease-morph-tabs__inputs:focus-visible + label {
+  outline: 2px solid var(--ease-tabs-indicator);
+  outline-offset: 2px;
+}
+
+/* -------------------------------------------------------------------- */
+/* Panels                                                                */
+/* -------------------------------------------------------------------- */
+.ease-morph-tabs__panel {
+  display: none;
+  margin-top: 1rem;
+  padding: 1.25rem;
+  background: var(--ease-tabs-panel-bg);
+  border: 1px solid var(--ease-tabs-panel-border);
+  border-radius: 12px;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+#ease-tab-1:checked ~ .ease-morph-tabs__panels #ease-panel-1,
+#ease-tab-2:checked ~ .ease-morph-tabs__panels #ease-panel-2,
+#ease-tab-3:checked ~ .ease-morph-tabs__panels #ease-panel-3,
+#ease-tab-4:checked ~ .ease-morph-tabs__panels #ease-panel-4 {
+  display: block;
+}
+
+/* -------------------------------------------------------------------- */
+/* Reduced motion                                                       */
+/* -------------------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  .ease-morph-tabs__indicator,
+  .ease-morph-tabs__label {
+    transition: none !important;
+  }
+}
+
+/* -------------------------------------------------------------------- */
+/* Responsive                                                           */
+/* -------------------------------------------------------------------- */
+@media (max-width: 420px) {
+  .ease-morph-tabs__list {
+    grid-template-columns: repeat(2, 1fr);
+    grid-template-rows: repeat(2, auto);
+  }
+
+  .ease-morph-tabs__indicator {
+    width: calc(50% - 0.35rem);
+  }
+
+  #ease-tab-1:checked ~ .ease-morph-tabs__list .ease-morph-tabs__indicator {
+    transform: translate(0%, 0%);
+  }
+
+  #ease-tab-2:checked ~ .ease-morph-tabs__list .ease-morph-tabs__indicator {
+    transform: translate(100%, 0%);
+  }
+
+  #ease-tab-3:checked ~ .ease-morph-tabs__list .ease-morph-tabs__indicator {
+    transform: translate(0%, 100%);
+  }
+
+  #ease-tab-4:checked ~ .ease-morph-tabs__list .ease-morph-tabs__indicator {
+    transform: translate(100%, 100%);
+  }
+}


### PR DESCRIPTION
Closes #62464
## Pull Request Description
Adds a pure CSS morph-glow tabs component for e-commerce checkout layouts, using hidden radio inputs and sibling combinators to drive a sliding, glowing active-tab indicator — no JavaScript required.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/morph-glow-tabs-checkout-aaniya/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A 4-tab checkout navigation (Cart / Delivery / Payment / Confirm) with a glowing pill indicator that smoothly slides and morphs between tabs on selection.

**How does a developer use it?**
```html
<div class="ease-morph-tabs">
  <div class="ease-morph-tabs__inputs">
    <input type="radio" name="ease-checkout-tabs" id="ease-tab-1" checked />
    <input type="radio" name="ease-checkout-tabs" id="ease-tab-2" />
  </div>

  <div class="ease-morph-tabs__list">
    <div class="ease-morph-tabs__indicator"></div>
    <label class="ease-morph-tabs__label" for="ease-tab-1">Cart</label>
    <label class="ease-morph-tabs__label" for="ease-tab-2">Delivery</label>
  </div>

  <div class="ease-morph-tabs__panels">
    <div class="ease-morph-tabs__panel" id="ease-panel-1">Cart contents…</div>
    <div class="ease-morph-tabs__panel" id="ease-panel-2">Delivery options…</div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
Sliding tab indicators are normally JS-dependent — measuring each tab's offset/width and animating a floating element to match. This version places the indicator inside a CSS grid track and moves it with fixed percentage `transform` steps triggered by `:checked` on hidden radios, so no JS measurement is needed. Fully declarative and keyboard accessible.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Pure CSS, no experimental features here (unlike the popover PR) — should work consistently across all evergreen browsers. Includes a `prefers-reduced-motion` override and a responsive 2×2 grid fallback for narrow viewports.