### PR TITLE
Add ease-loading-bar-indeterminate component

### DIFF
--- a/submissions/examples/loading-bar-indeterminate-ij/README.md
+++ b/submissions/examples/loading-bar-indeterminate-ij/README.md
@@ -1,0 +1,10 @@
+# ease-loading-bar-indeterminate
+
+A sync bar where the indeterminate stripe glides along the track while the percent readout blinks at an unknown value and the status holds below.
+
+## Run
+Open `demo.html` directly in a browser to watch the stripe glide.
+
+## Notes
+- The stripe glides both ways.
+- The percent stays unknown.

--- a/submissions/examples/loading-bar-indeterminate-ij/demo.html
+++ b/submissions/examples/loading-bar-indeterminate-ij/demo.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-loading-bar-indeterminate demo</title>
+</head>
+<body>
+<div class="lb-app">
+  <span class="lb-title">SYNCING ASSETS</span>
+  <div class="lb-track">
+    <span class="lb-fill"></span>
+  </div>
+  <span class="lb-percent">--%</span>
+  <span class="lb-status">TRANSFER IN PROGRESS</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/loading-bar-indeterminate-ij/style.css
+++ b/submissions/examples/loading-bar-indeterminate-ij/style.css
@@ -1,0 +1,10 @@
+:root{--lb-azure:#5cd8ff;--lb-dark:#081520}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#0f2336,#081520);font-family:'Segoe UI',sans-serif}
+.lb-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#0c1e30,#06111c);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.lb-title{position:absolute;top:16px;left:0;right:0;text-align:center;font-size:12px;font-weight:800;letter-spacing:6px;color:#5cd8ff}
+.lb-track{position:absolute;top:118px;left:36px;right:36px;height:18px;border-radius:9px;background:#123149;box-shadow:inset 0 0 0 2px #1c4c6e;overflow:hidden}
+.lb-fill{position:absolute;top:0;left:0;height:18px;width:44px;border-radius:9px;background:linear-gradient(90deg,#5cd8ff,#2a8fc7);animation:fill-glide-loading-bar-indeterminate 1.6s ease-in-out infinite}
+.lb-percent{position:absolute;top:158px;left:0;right:0;text-align:center;font-size:30px;font-weight:900;color:#d8f4ff;font-family:'Courier New',monospace;animation:percent-blink-loading-bar-indeterminate 1.2s steps(1) infinite}
+.lb-status{position:absolute;bottom:16px;left:0;right:0;text-align:center;font-size:10px;font-weight:800;letter-spacing:3px;color:#4f8fb3}
+@keyframes fill-glide-loading-bar-indeterminate{0%{transform:translateX(-44px)}60%{transform:translateX(320px)}100%{transform:translateX(320px)}}
+@keyframes percent-blink-loading-bar-indeterminate{0%,49%{opacity:1}50%,100%{opacity:0.3}}


### PR DESCRIPTION
## Component: ease-loading-bar-indeterminate — stripe glides, percent blinks, and title holds

**Closes #64128**

### What this adds
A sync bar: the indeterminate stripe glides along the track, the percent readout blinks at an unknown value, and the transfer status sits below.

### Acceptance Criteria covered
- Stripe glides along the track
- Percent readout blinks
- Transfer status holds steady

### Files
- `submissions/examples/loading-bar-indeterminate-ij/demo.html`
- `submissions/examples/loading-bar-indeterminate-ij/style.css`
- `submissions/examples/loading-bar-indeterminate-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the stripe glide.