### PR TITLE
feat: add LogStream React component with reader-controlled auto-scroll (#63827)

### DIFF
--- a/submissions/react/log-stream-ad/LogStream.jsx
+++ b/submissions/react/log-stream-ad/LogStream.jsx
@@ -1,0 +1,171 @@
+/**
+ * EaseMotion CSS — LogStream
+ * ============================================================
+ * Auto-scrolling log viewer.
+ *
+ * The failure this exists to fix: auto-scroll that fights the reader.
+ * The user scrolls up to read a stack trace, a new line arrives, and
+ * they are yanked back to the bottom. On a busy stream this makes the
+ * log genuinely unreadable — the one moment you need to look at it is
+ * the one moment it will not hold still.
+ *
+ * Following stops the instant the user scrolls away from the bottom, and
+ * resumes only when they return there or press the jump control. That is
+ * the whole design: the reader decides, not the stream.
+ *
+ * Announcement is deliberately NOT wired to a live region. A log emitting
+ * several lines a second would make a screen reader unusable. The region
+ * is a focusable, scrollable log the user can read on demand, and only
+ * error-level lines are announced.
+ * ============================================================
+ */
+
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+
+const LEVELS = {
+  debug: { label: 'Debug', mark: '·' },
+  info: { label: 'Info', mark: 'i' },
+  warn: { label: 'Warning', mark: '!' },
+  error: { label: 'Error', mark: '×' },
+};
+
+/** Distance from the bottom still treated as "at the bottom", in px. */
+const BOTTOM_THRESHOLD = 24;
+
+/**
+ * @param {object} props
+ * @param {Array<{id, level?, time?, text}>} props.lines
+ * @param {number}  [props.height=320]
+ * @param {number}  [props.maxLines=1000]  Older lines are dropped.
+ * @param {boolean} [props.showTime=true]
+ * @param {string}  [props.label='Log output']
+ * @param {string}  [props.className]
+ */
+export default function LogStream({
+  lines = [],
+  height = 320,
+  maxLines = 1000,
+  showTime = true,
+  label = 'Log output',
+  className = '',
+  ...rest
+}) {
+  const viewportRef = useRef(null);
+  const [following, setFollowing] = useState(true);
+  const [missed, setMissed] = useState(0);
+  const lastCount = useRef(lines.length);
+
+  const safeMax = Number.isFinite(maxLines) && maxLines > 0 ? Math.floor(maxLines) : 1000;
+
+  // Dropping from the front bounds memory and DOM size — an unbounded
+  // log viewer is a slow memory leak on any long-running stream.
+  const visible = lines.length > safeMax ? lines.slice(-safeMax) : lines;
+
+  const atBottom = useCallback(() => {
+    const node = viewportRef.current;
+    if (!node) return true;
+
+    return node.scrollHeight - node.scrollTop - node.clientHeight <= BOTTOM_THRESHOLD;
+  }, []);
+
+  const onScroll = useCallback(() => {
+    const bottom = atBottom();
+    setFollowing(bottom);
+    if (bottom) setMissed(0);
+  }, [atBottom]);
+
+  const jumpToLatest = useCallback(() => {
+    const node = viewportRef.current;
+    if (!node) return;
+
+    node.scrollTop = node.scrollHeight;
+    setFollowing(true);
+    setMissed(0);
+  }, []);
+
+  // useLayoutEffect, not useEffect: scrolling must happen in the same
+  // frame the new lines paint, or the viewport visibly jumps.
+  useLayoutEffect(() => {
+    const grew = lines.length - lastCount.current;
+    lastCount.current = lines.length;
+
+    if (grew <= 0) return;
+
+    if (following) {
+      const node = viewportRef.current;
+      if (node) node.scrollTop = node.scrollHeight;
+    } else {
+      // Counting what arrived while paused is what makes the jump
+      // control informative rather than just a scroll button.
+      setMissed((n) => n + grew);
+    }
+  }, [lines.length, following]);
+
+  // Only errors are announced. A live region on the whole stream would
+  // make a screen reader unusable at any real log rate.
+  const lastError = visible.filter((l) => l?.level === 'error').slice(-1)[0];
+
+  const classes = [
+    'ease-log-ad',
+    following ? 'ease-log-ad--following' : '',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div className={classes} {...rest}>
+      <div
+        className="ease-log-ad__viewport"
+        ref={viewportRef}
+        style={{ height: `${height}px` }}
+        onScroll={onScroll}
+        tabIndex={0}
+        role="log"
+        aria-label={label}
+        // `off` deliberately: the region is readable on demand rather
+        // than announced continuously.
+        aria-live="off"
+      >
+        {visible.length === 0 ? (
+          <p className="ease-log-ad__empty">No output yet</p>
+        ) : (
+          <ol className="ease-log-ad__list">
+            {visible.map((line, index) => {
+              const level = line?.level in LEVELS ? line.level : 'info';
+
+              return (
+                <li
+                  className={`ease-log-ad__line ease-log-ad__line--${level}`}
+                  key={line?.id ?? index}
+                >
+                  {/* Glyph as well as colour, so level survives greyscale. */}
+                  <span className="ease-log-ad__mark" aria-hidden="true">
+                    {LEVELS[level].mark}
+                  </span>
+                  <span className="ease-log-ad__sr">{LEVELS[level].label}:</span>
+
+                  {showTime && line?.time && (
+                    <span className="ease-log-ad__time">{line.time}</span>
+                  )}
+
+                  <span className="ease-log-ad__text">{line?.text}</span>
+                </li>
+              );
+            })}
+          </ol>
+        )}
+      </div>
+
+      {!following && (
+        <button className="ease-log-ad__jump" type="button" onClick={jumpToLatest}>
+          {missed > 0 ? `${missed} new line${missed === 1 ? '' : 's'}` : 'Jump to latest'}
+        </button>
+      )}
+
+      <span className="ease-log-ad__sr" role="status" aria-live="polite">
+        {lastError ? `Error: ${lastError.text}` : ''}
+      </span>
+    </div>
+  );
+}

--- a/submissions/react/log-stream-ad/README.md
+++ b/submissions/react/log-stream-ad/README.md
@@ -1,0 +1,41 @@
+# LogStream — auto-scrolling log viewer
+
+> Issue: [#63827](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/63827)
+
+An auto-scrolling log that stops following the moment the reader scrolls up.
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `lines` | `Array<{ id, level?, time?, text }>` | `[]` | Log lines. |
+| `height` | `number` | `320` | Viewport height in px. |
+| `maxLines` | `number` | `1000` | Older lines are dropped beyond this. |
+| `showTime` | `boolean` | `true` | Render timestamps. |
+| `label` | `string` | `'Log output'` | Accessible name. |
+| `className` | `string` | `''` | Merged onto the root. |
+
+Levels: `debug` · `info` · `warn` · `error`.
+
+## Usage
+
+```jsx
+import LogStream from './LogStream';
+import './style.css';
+
+<LogStream lines={logLines} height={360} maxLines={2000} label="Build output" />
+```
+
+## Why it fits EaseMotion
+
+**Auto-scroll that fights the reader is the failure this exists to fix.** You scroll up to read a stack trace, a new line arrives, and you are yanked back to the bottom. On a busy stream the log becomes genuinely unreadable — the one moment you need it to hold still is the one moment it will not.
+
+Following stops the instant the user scrolls away from the bottom, and resumes only when they return there or press the jump control. The reader decides, not the stream. Lines that arrive while paused are **counted**, so the control reads "23 new lines" rather than a bare scroll button — which is the difference between an affordance and a nag.
+
+**The scroll happens in `useLayoutEffect`, not `useEffect`.** With `useEffect` the new lines paint first and the scroll lands a frame later, so the viewport visibly jumps on every update. `useLayoutEffect` runs before paint, so the growth is invisible.
+
+**Announcement is deliberately not wired to a live region.** A log emitting several lines a second would make a screen reader completely unusable — every line interrupting the last. The viewport is a focusable `role="log"` with `aria-live="off"`, readable on demand, and only **error-level** lines are announced politely.
+
+Severity uses a glyph as well as colour, so level survives greyscale and print.
+
+`maxLines` bounds memory and DOM size by dropping from the front — an unbounded log viewer is a slow memory leak on any long-running stream. Long lines wrap rather than forcing horizontal scrolling, because a stack trace that needs sideways scrolling per line is unreadable.

--- a/submissions/react/log-stream-ad/style.css
+++ b/submissions/react/log-stream-ad/style.css
@@ -35,6 +35,12 @@
     padding: 0.5rem 0;
 }
 
+/* A live border while following, so the reader can tell at a glance
+   whether the view is tracking new output or held in place. */
+.ease-log-ad--following .ease-log-ad__viewport {
+    border-color: rgba(56, 189, 248, 0.35);
+}
+
 .ease-log-ad__viewport:focus-visible {
     outline: 2px solid var(--lg-accent-ad);
     outline-offset: 2px;

--- a/submissions/react/log-stream-ad/style.css
+++ b/submissions/react/log-stream-ad/style.css
@@ -1,0 +1,143 @@
+/* ==========================================================================
+   EaseMotion CSS — LogStream component styles
+   Issue #63827
+   ========================================================================== */
+
+.ease-log-ad {
+    --lg-bg-ad: #0a0f1a;
+    --lg-border-ad: rgba(148, 163, 184, 0.16);
+    --lg-text-ad: #cbd5e1;
+    --lg-muted-ad: #64748b;
+    --lg-accent-ad: #38bdf8;
+
+    position: relative;
+}
+
+.ease-log-ad__sr {
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+}
+
+.ease-log-ad__viewport {
+    background: var(--lg-bg-ad);
+    border: 1px solid var(--lg-border-ad);
+    border-radius: 10px;
+    font-family: "JetBrains Mono", ui-monospace, monospace;
+    font-size: 0.76rem;
+    line-height: 1.6;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    padding: 0.5rem 0;
+}
+
+.ease-log-ad__viewport:focus-visible {
+    outline: 2px solid var(--lg-accent-ad);
+    outline-offset: 2px;
+}
+
+.ease-log-ad__empty {
+    color: var(--lg-muted-ad);
+    margin: 0;
+    padding: 0.5rem 0.75rem;
+}
+
+.ease-log-ad__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.ease-log-ad__line {
+    display: flex;
+    gap: 0.5rem;
+    padding: 0.05rem 0.75rem;
+}
+
+/* Long lines wrap rather than forcing a horizontal scrollbar — a stack
+   trace is unreadable if every line needs sideways scrolling. */
+.ease-log-ad__text {
+    color: var(--lg-text-ad);
+    min-width: 0;
+    overflow-wrap: anywhere;
+    white-space: pre-wrap;
+}
+
+.ease-log-ad__time {
+    color: var(--lg-muted-ad);
+    flex: 0 0 auto;
+    font-variant-numeric: tabular-nums;
+}
+
+.ease-log-ad__mark {
+    flex: 0 0 auto;
+    font-weight: 700;
+    text-align: center;
+    width: 0.9rem;
+}
+
+/* ==========================================================================
+   Levels — glyph plus colour, so severity survives greyscale
+   ========================================================================== */
+.ease-log-ad__line--debug .ease-log-ad__mark {
+    color: var(--lg-muted-ad);
+}
+
+.ease-log-ad__line--info .ease-log-ad__mark {
+    color: #60a5fa;
+}
+
+.ease-log-ad__line--warn .ease-log-ad__mark {
+    color: #fbbf24;
+}
+
+.ease-log-ad__line--error .ease-log-ad__mark {
+    color: #f87171;
+}
+
+.ease-log-ad__line--error {
+    background: rgba(248, 113, 113, 0.08);
+}
+
+.ease-log-ad__line--warn {
+    background: rgba(251, 191, 36, 0.06);
+}
+
+/* ==========================================================================
+   Jump control — only rendered while paused
+   ========================================================================== */
+.ease-log-ad__jump {
+    background: var(--lg-accent-ad);
+    border: 0;
+    border-radius: 999px;
+    bottom: 0.75rem;
+    box-shadow: 0 6px 18px -6px rgba(0, 0, 0, 0.8);
+    color: #041019;
+    cursor: pointer;
+    font-size: 0.74rem;
+    font-weight: 650;
+    left: 50%;
+    padding: 0.3rem 0.8rem;
+    position: absolute;
+    transform: translateX(-50%);
+}
+
+.ease-log-ad__jump:focus-visible {
+    outline: 2px solid var(--lg-accent-ad);
+    outline-offset: 3px;
+}
+
+@media (forced-colors: active) {
+    .ease-log-ad__viewport,
+    .ease-log-ad__jump {
+        border: 1px solid CanvasText;
+    }
+
+    .ease-log-ad__mark {
+        color: CanvasText;
+    }
+}


### PR DESCRIPTION
Fixes #63827

**What was added**

An auto-scrolling log viewer, under `submissions/react/log-stream-ad/`.

- `LogStream.jsx` — 149 non-empty lines: reader-controlled following, missed-line counting, layout-effect scrolling, bounded buffer, and error-only announcement.
- `style.css` — 122 non-empty lines: viewport, level glyphs and tints, jump control, following-state border, forced-colors.
- `README.md` — props table, usage, and rationale.

**What is the problem**

**Auto-scroll that fights the reader.** You scroll up to read a stack trace, a new line arrives, and you are yanked back to the bottom. On a busy stream the log becomes genuinely unreadable — the one moment you need it to hold still is the one moment it will not.

Second, **a log wired to a live region destroys screen reader usability.** At any real log rate every line interrupts the last, and the user can hear nothing else on the page.

**Why this approach**

Following stops the instant the user scrolls away from the bottom, and resumes only when they return there or press the jump control. Lines arriving while paused are **counted**, so the control reads "23 new lines" rather than being a bare scroll button — the difference between an affordance and a nag.

**The scroll happens in `useLayoutEffect`, not `useEffect`.** With `useEffect` the new lines paint first and the scroll lands a frame later, so the viewport visibly jumps on every update. `useLayoutEffect` runs before paint, so growth is invisible.

The viewport is a focusable `role="log"` with `aria-live="off"` — readable on demand — and only **error-level** lines are announced politely.

`maxLines` bounds memory and DOM size by dropping from the front; an unbounded log viewer is a slow memory leak on any long-running stream.

**How to test**

1. Pull this branch and drop `log-stream-ad/` into any React app (React 16.8+).
2. Drive it with a timer appending a line every 200ms.
3. Confirm the view follows the bottom while untouched.
4. **Scroll up mid-stream.** Following must stop immediately and the view must **stay put** as new lines arrive — this is the core requirement.
5. Confirm the jump control appears and counts up: "5 new lines", "6 new lines"…
6. Press it — the view jumps to the bottom, following resumes, and the counter clears.
7. Scroll manually back to the bottom instead — following must resume without pressing anything.
8. Watch the viewport border while following versus paused; the state should be visible at a glance.
9. **Turn on a screen reader** with the stream running — it must stay quiet. Emit an `error` line and confirm only that is announced.
10. Emit 1,500 lines with `maxLines={1000}` and confirm the DOM holds 1,000, oldest dropped.
11. Emit a long single-line stack trace and confirm it wraps rather than adding a horizontal scrollbar.
12. Apply a greyscale filter and confirm severity is still readable via the glyphs.

**Edge cases covered**

- Following stops on any scroll away from the bottom and resumes on return.
- A 24px threshold treats "almost at the bottom" as at the bottom, so sub-pixel scroll positions do not spuriously pause following.
- Missed lines are counted while paused, making the jump control informative.
- `useLayoutEffect` prevents the visible jump a post-paint scroll would cause.
- Only errors are announced; the log region itself is `aria-live="off"`.
- `maxLines` drops from the front, bounding memory and DOM size; verified for both over- and under-limit cases.
- Non-finite or non-positive `maxLines` falls back to 1000.
- Unknown or missing `level` falls back to `info` rather than producing an undefined class.
- Lines missing `id` fall back to index keys.
- An empty stream renders a placeholder rather than a blank box.
- Level is carried by a glyph plus a screen-reader label, not colour alone.
- Long lines wrap with `overflow-wrap: anywhere`, so a stack trace does not require horizontal scrolling.
- `overscroll-behavior: contain` stops scroll chaining to the page.
- The viewport is `tabIndex={0}`, so keyboard users can scroll it.

**Verification**

- `LogStream.jsx` parses cleanly through esbuild — exit code 0.
- `npx stylelint style.css` against the repo's own config — exit code 0, braces verified balanced.
- All component classes referenced in the JSX are defined in `style.css` (an initial check found `--following` unstyled; it now drives the viewport border).
- Bottom detection verified at two scroll positions; buffer trimming verified above and below the limit; all four levels confirmed styled.
- `useLayoutEffect`, `aria-live="off"` and error-only announcement all confirmed present.
- `npm test` — 61/61 pass, unchanged.
- Branch synced with `upstream/main` before coding started.
- Only additions: 3 new files, 0 deletions, no existing file touched.
- Component classes carry an `-ad` suffix so this lands as a parallel implementation.

**Labels:** `type:feature` · `react` · `gssoc:approved`

Please review and merge this under GSSoC 2026.
