### PR TITLE
Add ease-profile-card-hover component

### DIFF
--- a/submissions/examples/profile-card-hover-ij/README.md
+++ b/submissions/examples/profile-card-hover-ij/README.md
@@ -1,0 +1,10 @@
+# ease-profile-card-hover
+
+A contributor card whose avatar glow pulses while the stats sit across the middle and the social links rise up before settling back down.
+
+## Run
+Open `demo.html` directly in a browser to watch the links rise.
+
+## Notes
+- The avatar glow breathes slowly.
+- Links rise and settle on a loop.

--- a/submissions/examples/profile-card-hover-ij/demo.html
+++ b/submissions/examples/profile-card-hover-ij/demo.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-profile-card-hover demo</title>
+</head>
+<body>
+<div class="pf-app">
+  <span class="pf-label">CONTRIBUTOR PROFILE</span>
+  <div class="pf-card">
+    <span class="pf-avatar">MK</span>
+    <span class="pf-name">MARCO KANE</span>
+    <span class="pf-role">FRONTEND ENGINEER</span>
+    <div class="pf-stats">
+      <span class="pf-stat"><b>128</b>PULLS</span>
+      <span class="pf-stat"><b>96</b>ISSUES</span>
+      <span class="pf-stat"><b>42</b>STARS</span>
+    </div>
+    <div class="pf-links">
+      <span class="pf-link">GITHUB</span>
+      <span class="pf-link">LINKEDIN</span>
+      <span class="pf-link">SITE</span>
+    </div>
+  </div>
+  <span class="pf-hint">HOVER TO REVEAL LINKS</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/profile-card-hover-ij/style.css
+++ b/submissions/examples/profile-card-hover-ij/style.css
@@ -1,0 +1,18 @@
+:root{--pf-rose:#ff7ab0;--pf-dark:#1c0712}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#2a0f20,#1c0712);font-family:'Segoe UI',sans-serif}
+.pf-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#240c1c,#160710);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.pf-label{position:absolute;top:16px;left:0;right:0;text-align:center;font-size:12px;font-weight:800;letter-spacing:6px;color:#ff7ab0}
+.pf-card{position:absolute;top:52px;left:46px;right:46px;height:252px;border-radius:16px;background:#2a1122;box-shadow:inset 0 0 0 2px #4a1c38;padding:20px;box-sizing:border-box}
+.pf-avatar{display:flex;align-items:center;justify-content:center;width:72px;height:72px;margin:0 auto;border-radius:50%;background:#4a1c38;box-shadow:inset 0 0 0 3px #ff7ab0,0 0 20px rgba(255,122,176,0.3);font-size:24px;font-weight:900;color:#ffe3ee;animation:avatar-glow-profile-card-hover 2.4s ease-in-out infinite}
+.pf-name{display:block;margin-top:14px;text-align:center;font-size:18px;font-weight:900;color:#ffffff;letter-spacing:2px}
+.pf-role{display:block;margin-top:6px;text-align:center;font-size:11px;font-weight:700;letter-spacing:3px;color:#c77ba2}
+.pf-stats{display:flex;justify-content:space-around;margin-top:18px;padding:12px 0;border-top:1px solid #3a1730;border-bottom:1px solid #3a1730}
+.pf-stat{text-align:center;font-size:10px;font-weight:800;letter-spacing:1px;color:#c77ba2}
+.pf-stat b{display:block;font-size:18px;color:#ff7ab0}
+.pf-links{display:flex;justify-content:space-around;margin-top:14px;transform:translateY(22px);opacity:0;animation:links-rise-profile-card-hover 4s ease-in-out infinite}
+.pf-card:hover .pf-links{transform:translateY(0);opacity:1;animation:none}
+.pf-link{font-size:10px;font-weight:800;letter-spacing:2px;color:#ffb0cf}
+.pf-hint{position:absolute;bottom:16px;left:0;right:0;text-align:center;font-size:10px;font-weight:800;letter-spacing:4px;color:#b35586;animation:hint-blink-profile-card-hover 1.8s steps(1) infinite}
+@keyframes links-rise-profile-card-hover{0%,30%{transform:translateY(22px);opacity:0}50%,90%{transform:translateY(0);opacity:1}100%{transform:translateY(22px);opacity:0}}
+@keyframes avatar-glow-profile-card-hover{0%,100%{box-shadow:inset 0 0 0 3px #ff7ab0,0 0 14px rgba(255,122,176,0.2)}50%{box-shadow:inset 0 0 0 3px #ff7ab0,0 0 26px rgba(255,122,176,0.55)}}
+@keyframes hint-blink-profile-card-hover{0%,49%{opacity:1}50%,100%{opacity:0.35}}


### PR DESCRIPTION
## Component: ease-profile-card-hover — avatar glows, links rise, and stats set

**Closes #64142**

### What this adds
A contributor card: the avatar glow pulses, the three stats line the middle, and the social links rise up before settling back down.

### Acceptance Criteria covered
- Avatar glow pulses in place
- Stats sit across the card
- Social links rise and settle

### Files
- `submissions/examples/profile-card-hover-ij/demo.html`
- `submissions/examples/profile-card-hover-ij/style.css`
- `submissions/examples/profile-card-hover-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the links rise.