### PR TITLE
Add animated ease tab underline

### DIFF
--- a/submissions/examples/animated-ease-tab-underline/README.md
+++ b/submissions/examples/animated-ease-tab-underline/README.md
@@ -1,0 +1,24 @@
+# ease-tab-underline
+
+Underline indicator that glides between tabs on selection.
+
+## Usage
+
+```html
+<div class="ease-tabs">
+  <div class="ease-tab active">Home</div>
+  <div class="ease-tab">Profile</div>
+  <div class="ease-tab-indicator"></div>
+</div>
+```
+
+Requires a small JS snippet (included in `demo.html`) to reposition `.ease-tab-indicator` on click, since tab widths are dynamic.
+
+## Notes
+
+- Call `moveIndicator()` on load to position the indicator under the initially active tab.
+- Works with any number of tabs; indicator width matches the clicked tab's width automatically.
+
+## Browser support
+
+All modern browsers.

--- a/submissions/examples/animated-ease-tab-underline/demo.html
+++ b/submissions/examples/animated-ease-tab-underline/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-tab-underline demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="ease-tabs" id="tabs">
+    <div class="ease-tab active" data-tab="1">Home</div>
+    <div class="ease-tab" data-tab="2">Profile</div>
+    <div class="ease-tab" data-tab="3">Settings</div>
+    <div class="ease-tab-indicator"></div>
+  </div>
+
+  <script>
+    const tabs = document.querySelectorAll('.ease-tab');
+    const indicator = document.querySelector('.ease-tab-indicator');
+
+    function moveIndicator(el) {
+      indicator.style.left = el.offsetLeft + 'px';
+      indicator.style.width = el.offsetWidth + 'px';
+    }
+
+    tabs.forEach(tab => {
+      tab.addEventListener('click', () => {
+        tabs.forEach(t => t.classList.remove('active'));
+        tab.classList.add('active');
+        moveIndicator(tab);
+      });
+    });
+
+    window.addEventListener('load', () => moveIndicator(document.querySelector('.ease-tab.active')));
+  </script>
+</body>
+</html>

--- a/submissions/examples/animated-ease-tab-underline/style.css
+++ b/submissions/examples/animated-ease-tab-underline/style.css
@@ -1,0 +1,25 @@
+.ease-tabs {
+  display: flex;
+  position: relative;
+  border-bottom: 2px solid #eee;
+}
+
+.ease-tab {
+  padding: 10px 16px;
+  cursor: pointer;
+  color: #666;
+  transition: color 0.3s ease;
+}
+
+.ease-tab.active {
+  color: #111;
+  font-weight: 600;
+}
+
+.ease-tab-indicator {
+  position: absolute;
+  bottom: -2px;
+  height: 2px;
+  background: #3b82f6;
+  transition: left 0.3s ease, width 0.3s ease;
+}


### PR DESCRIPTION
## Summary
Adds `ease-tab-underline`, a sliding underline indicator for tab navigation.

## Changes
- New `.ease-tabs`, `.ease-tab`, `.ease-tab-indicator` classes
- Demo includes minimal JS to reposition the indicator on click and on load
- README

## Why
Common pattern in dashboards/settings pages; CSS-only transition keeps it lightweight, JS is limited to positioning math.

## Testing
Tested with 2–5 tabs of varying label lengths; indicator aligns correctly on click and initial load.

## Checklist
- [x] Demo file included
- [x] README documents the required JS
- [x] Follows naming convention