### PR TITLE
add modal pop

### DIFF
--- a/submissions/examples/animated-modal-pop/README.md
+++ b/submissions/examples/animated-modal-pop/README.md
@@ -1,0 +1,24 @@
+# ease-modal-pop
+
+Modal dialog that pops in with a synced backdrop fade.
+
+## Usage
+
+```html
+<div class="ease-modal-backdrop">
+  <div class="ease-modal">
+    <!-- modal content -->
+  </div>
+</div>
+```
+
+Toggle the backdrop's `display` via JS to open/close.
+
+## Notes
+
+- Backdrop fade and modal pop run simultaneously (0.3s each) for a cohesive open.
+- No exit animation is included by default — add a `.closing` variant if you need one.
+
+## Browser support
+
+All modern browsers.

--- a/submissions/examples/animated-modal-pop/demo.html
+++ b/submissions/examples/animated-modal-pop/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-modal-pop demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <button onclick="document.getElementById('modalRoot').style.display='flex'">Open Modal</button>
+
+  <div class="ease-modal-backdrop" id="modalRoot" style="display:none;">
+    <div class="ease-modal">
+      <h3>Modal Title</h3>
+      <p>This is a modal that pops in.</p>
+      <button onclick="document.getElementById('modalRoot').style.display='none'">Close</button>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/animated-modal-pop/style.css
+++ b/submissions/examples/animated-modal-pop/style.css
@@ -1,0 +1,32 @@
+.ease-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0);
+  animation: ease-backdrop-fade 0.3s ease forwards;
+}
+
+@keyframes ease-backdrop-fade {
+  to {
+    background: rgba(0, 0, 0, 0.5);
+  }
+}
+
+.ease-modal {
+  background: #fff;
+  border-radius: 10px;
+  padding: 24px;
+  min-width: 280px;
+  transform: scale(0.8);
+  opacity: 0;
+  animation: ease-modal-pop 0.3s ease forwards;
+}
+
+@keyframes ease-modal-pop {
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Summary
Adds `ease-modal-pop`, a modal with a scale-in pop animation synced to a backdrop fade.

## Changes
- New `.ease-modal-backdrop` / `.ease-modal` classes
- Demo with open/close buttons
- README

## Why
Modals are one of the most requested animation patterns; this keeps backdrop and content transitions visually synced.

## Testing
Verified open animation timing and layout centering across viewport sizes.

## Checklist
- [x] Demo file included
- [x] README included
- [x] Notes exit-animation limitation