### PR TITLE
add animated tooltip fade

### DIFF
--- a/submissions/examples/animated-tooltip-fade/README.md
+++ b/submissions/examples/animated-tooltip-fade/README.md
@@ -1,0 +1,18 @@
+# ease-tooltip-fade
+
+Small fade/scale-in tooltip utility that works on any element with a `data-tooltip` attribute — no extra markup needed.
+
+## Usage
+
+```html
+<button data-tooltip="This is a tooltip">Hover me</button>
+```
+
+## Notes
+
+- Zero extra DOM elements — tooltip is generated via `::after` and `content: attr(...)`.
+- Positioned above the element by default; flip to `top: 125%` for below.
+
+## Browser support
+
+All modern browsers.

--- a/submissions/examples/animated-tooltip-fade/demo.html
+++ b/submissions/examples/animated-tooltip-fade/demo.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-tooltip-fade demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <button data-tooltip="This is a tooltip">Hover me</button>
+</body>
+</html>

--- a/submissions/examples/animated-tooltip-fade/style.css
+++ b/submissions/examples/animated-tooltip-fade/style.css
@@ -1,0 +1,25 @@
+[data-tooltip] {
+  position: relative;
+}
+
+[data-tooltip]::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: 125%;
+  left: 50%;
+  transform: translateX(-50%) scale(0.9);
+  background: #333;
+  color: #fff;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+[data-tooltip]:hover::after {
+  opacity: 1;
+  transform: translateX(-50%) scale(1);
+}


### PR DESCRIPTION
## Summary
Adds `ease-tooltip-fade`, an attribute-driven tooltip utility.

## Changes
- New `[data-tooltip]` selector-based styles
- Demo with a single button example
- README

## Why
Zero-markup tooltips are convenient for quickly annotating any element without wrapper divs.

## Testing
Verified hover fade/scale on buttons, links, and icons.

## Checklist
- [x] No JS dependency
- [x] No extra markup required
- [x] Demo and README included