### PR TITLE
add image zoom

### DIFF
--- a/submissions/examples/animated-image-zoom/README.md
+++ b/submissions/examples/animated-image-zoom/README.md
@@ -1,0 +1,20 @@
+# ease-image-zoom
+
+Image container that zooms the photo on hover, clipped so it never overflows its box.
+
+## Usage
+
+```html
+<div class="ease-zoom-container" style="width: 300px; height: 200px;">
+  <img src="photo.jpg" alt="...">
+</div>
+```
+
+## Notes
+
+- `overflow: hidden` on the container is what clips the zoom — don't remove it.
+- `object-fit: cover` keeps the image filling the box at any aspect ratio.
+
+## Browser support
+
+All modern browsers.

--- a/submissions/examples/animated-image-zoom/demo.html
+++ b/submissions/examples/animated-image-zoom/demo.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-image-zoom demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="ease-zoom-container" style="width: 300px; height: 200px;">
+    <img src="https://picsum.photos/600/400" alt="Sample">
+  </div>
+</body>
+</html>

--- a/submissions/examples/animated-image-zoom/style.css
+++ b/submissions/examples/animated-image-zoom/style.css
@@ -1,0 +1,16 @@
+.ease-zoom-container {
+  overflow: hidden;
+  border-radius: 8px;
+}
+
+.ease-zoom-container img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.4s ease;
+}
+
+.ease-zoom-container:hover img {
+  transform: scale(1.15);
+}


### PR DESCRIPTION
## Summary
Adds `ease-image-zoom`, a clipped hover-zoom effect for image containers.

## Changes
- New `.ease-zoom-container` class
- Demo using a placeholder image
- README

## Why
Common gallery/card hover effect; clipping via the wrapper avoids layout shift on hover.

## Testing
Verified zoom stays within container bounds at multiple aspect ratios.

## Checklist
- [x] No JS dependency
- [x] Demo file included
- [x] README included