### PR TITLE
add nav underline hover

### DIFF
--- a/submissions/examples/animated-nav-underline-hover/README.md
+++ b/submissions/examples/animated-nav-underline-hover/README.md
@@ -1,0 +1,21 @@
+# ease-nav-underline-hover
+
+Nav link underline that slides in from the left on hover.
+
+## Usage
+
+```html
+<nav class="ease-nav">
+  <a href="#">Home</a>
+  <a href="#">About</a>
+</nav>
+```
+
+## Notes
+
+- Underline color matches the link's `color` via `currentColor` — no separate color variable needed.
+- To slide in from the right instead, change `left: 0` to `right: 0` on the `::after`.
+
+## Browser support
+
+All modern browsers.

--- a/submissions/examples/animated-nav-underline-hover/demo.html
+++ b/submissions/examples/animated-nav-underline-hover/demo.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-nav-underline-hover demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav class="ease-nav">
+    <a href="#">Home</a>
+    <a href="#">About</a>
+    <a href="#">Contact</a>
+  </nav>
+</body>
+</html>

--- a/submissions/examples/animated-nav-underline-hover/style.css
+++ b/submissions/examples/animated-nav-underline-hover/style.css
@@ -1,0 +1,26 @@
+.ease-nav {
+  display: flex;
+  gap: 24px;
+}
+
+.ease-nav a {
+  position: relative;
+  text-decoration: none;
+  color: #333;
+  padding-bottom: 4px;
+}
+
+.ease-nav a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 0;
+  height: 2px;
+  background: currentColor;
+  transition: width 0.3s ease;
+}
+
+.ease-nav a:hover::after {
+  width: 100%;
+}


### PR DESCRIPTION
## Summary
Adds `ease-nav-underline-hover`, a sliding underline hover effect for nav links.

## Changes
- New `.ease-nav` class
- Demo with a 3-link nav
- README with left/right variant note

## Why
Very common nav micro-interaction; pure CSS, no extra markup per link.

## Testing
Verified hover-in and hover-out (width collapses back to 0) across links.

## Checklist
- [x] No JS dependency
- [x] Demo and README included