### PR TITLE
docs: submit bundle size CI check proposal

### DIFF
--- a/submissions/docs/bundle-size-workflow-63442/README.md
+++ b/submissions/docs/bundle-size-workflow-63442/README.md
@@ -1,0 +1,50 @@
+# Bundle Size Badge + size-limit CI Check (#63442)
+
+**What does this do?**
+This submission proposes an infrastructure update: adding an automated CI workflow using the `size-limit` tool to measure the gzipped size of the published CSS bundle on every PR, failing the check if it exceeds a 40KB budget, and adding a size badge to the root `README.md`.
+
+**How is it used?**
+Since contributors cannot modify root files directly, the maintainer can integrate this proposal by applying the following changes to the core repository:
+
+1. **Add Badge to `README.md`:**
+```html
+<img src="https://img.shields.io/badge/bundle%20size-18.4kb%20gzip-brightgreen" alt="Bundle Size">
+```
+
+2. **Add to `package.json`:**
+```json
+"devDependencies": {
+  "size-limit": "^13.0.3",
+  "@size-limit/file": "^13.0.3"
+},
+"size-limit": [
+  {
+    "path": "easemotion.min.css",
+    "limit": "40 KB"
+  }
+]
+```
+
+3. **Create `.github/workflows/size-limit.yml`:**
+```yaml
+name: size-limit
+
+on: [pull_request]
+
+jobs:
+  size-limit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: npm ci
+      - uses: andresz1/size-limit-action@v1.9.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          skip_step: install
+```
+
+**Why is it useful?**
+One of the project's core promises is being lightweight. As more components are merged, there's currently no automated guardrail stopping the bundle from silently bloating. This proposal makes "stay lightweight" an enforced CI rule instead of just a stated philosophy.

--- a/submissions/docs/bundle-size-workflow-63442/demo.html
+++ b/submissions/docs/bundle-size-workflow-63442/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Bundle Size Workflow Showcase</title>
+    <link rel="stylesheet" href="../../../easemotion.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body class="ease-flex ease-justify-center ease-items-center ease-h-screen ease-bg-gray-100">
+    <div class="ease-text-center ease-p-8 ease-bg-white ease-rounded-lg ease-shadow-md">
+        <h1 class="ease-text-2xl ease-font-bold ease-mb-4">Bundle Size CI Check (#63442)</h1>
+        <p class="ease-mb-6 ease-text-gray-600">This submission proposes an automated CI workflow using size-limit.</p>
+        <div class="ci-badge-container">
+            <img src="https://img.shields.io/badge/bundle%20size-18.4kb%20gzip-brightgreen" alt="Bundle Size" class="ease-hover-scale-105 ease-transition">
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/docs/bundle-size-workflow-63442/style.css
+++ b/submissions/docs/bundle-size-workflow-63442/style.css
@@ -1,0 +1,16 @@
+/* Custom styling for the CI badge container */
+.ci-badge-container {
+    display: inline-block;
+    padding: 10px 20px;
+    background-color: #f8fafc;
+    border: 2px solid #e2e8f0;
+    border-radius: 8px;
+    transition: all 0.3s ease;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+}
+
+.ci-badge-container:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+    border-color: #cbd5e1;
+}


### PR DESCRIPTION
## Pull Request Description

This PR submits a proposal for issue #63442. It provides an automated CI workflow using the `size-limit` tool to measure the gzipped size of the published CSS bundle (`easemotion.min.css`) on every PR, failing the check if it exceeds a 40KB budget. Because contributors cannot modify root files directly, I have created a showcase containing the proposed GitHub Actions workflow, `package.json` updates, and a size badge snippet for the `README.md`.

The maintainer can review this submission and apply the changes to the core repository to enforce the lightweight bundle size.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement (Infrastructure / CI Proposal)
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A proposal for an automated GitHub Actions workflow (`size-limit.yml`) that measures the gzipped bundle size of `easemotion.min.css` on every PR, failing the check if it exceeds 40KB, along with a README badge snippet.

**How does a developer use it?**

```html
<!-- Not a runtime HTML feature — this is a CI/tooling workflow proposal.
     Example badge usage in the project README: -->
<img src="https://img.shields.io/badge/bundle%20size-18.4kb%20gzip-brightgreen" alt="Bundle Size">
