### PR TITLE
add animated drawer slide

### DIFF
--- a/submissions/examples/animated-drawer-slide/README.md
+++ b/submissions/examples/animated-drawer-slide/README.md
@@ -1,0 +1,23 @@
+# ease-drawer-slide
+
+Off-canvas side drawer / mobile menu with a slide-in transition and dimming overlay.
+
+## Usage
+
+```html
+<div class="ease-drawer-overlay"></div>
+<div class="ease-drawer">
+  <!-- menu content -->
+</div>
+```
+
+Toggle the `open` class on both elements via JS.
+
+## Notes
+
+- Overlay uses `pointer-events: none` when closed so it doesn't block clicks underneath.
+- For a right-side drawer, change `left: 0` to `right: 0` and flip the `translateX` direction.
+
+## Browser support
+
+All modern browsers.

--- a/submissions/examples/animated-drawer-slide/demo.html
+++ b/submissions/examples/animated-drawer-slide/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-drawer-slide demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <button onclick="document.getElementById('drawer').classList.add('open'); document.getElementById('overlay').classList.add('open')">
+    Open Menu
+  </button>
+
+  <div class="ease-drawer-overlay" id="overlay" onclick="this.classList.remove('open'); document.getElementById('drawer').classList.remove('open')"></div>
+  <div class="ease-drawer" id="drawer">
+    <p>Menu Item 1</p>
+    <p>Menu Item 2</p>
+    <p>Menu Item 3</p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/animated-drawer-slide/style.css
+++ b/submissions/examples/animated-drawer-slide/style.css
@@ -1,0 +1,31 @@
+.ease-drawer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 280px;
+  background: #fff;
+  padding: 24px;
+  box-shadow: 2px 0 12px rgba(0, 0, 0, 0.15);
+  transform: translateX(-100%);
+  transition: transform 0.35s ease;
+  z-index: 20;
+}
+
+.ease-drawer.open {
+  transform: translateX(0);
+}
+
+.ease-drawer-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0);
+  pointer-events: none;
+  transition: background 0.35s ease;
+  z-index: 10;
+}
+
+.ease-drawer-overlay.open {
+  background: rgba(0, 0, 0, 0.4);
+  pointer-events: auto;
+}


### PR DESCRIPTION
## Summary
Adds `ease-drawer-slide`, an off-canvas drawer with slide-in and overlay dimming.

## Changes
- New `.ease-drawer` / `.ease-drawer-overlay` classes
- Demo with open/close via overlay click
- README with right-side variant note

## Why
Mobile nav drawers are a near-universal pattern; overlay + drawer sync keeps the interaction feeling cohesive.

## Testing
Verified open/close transitions and overlay click-to-close behavior.

## Checklist
- [x] Demo file included
- [x] README included
- [x] Overlay doesn't block clicks when closed