### PR TITLE
add accordian expand

### DIFF
--- a/submissions/examples/animated-accordian/README.md
+++ b/submissions/examples/animated-accordian/README.md
@@ -1,0 +1,25 @@
+# ease-accordion-expand
+
+Accordion panel with a smooth max-height expand/collapse transition.
+
+## Usage
+
+```html
+<div class="ease-accordion-header">Click to expand</div>
+<div class="ease-accordion-panel">
+  <div class="ease-accordion-content">
+    Panel content
+  </div>
+</div>
+```
+
+Toggle the `open` class on `.ease-accordion-panel` via JS.
+
+## Notes
+
+- The `max-height: 500px` cap is arbitrary — set it higher than your tallest expected content, or the transition will visibly "wait" for content shorter than the cap.
+- For fully dynamic height with no guessing, consider a `grid-template-rows: 0fr → 1fr` approach instead.
+
+## Browser support
+
+All modern browsers.

--- a/submissions/examples/animated-accordian/demo.html
+++ b/submissions/examples/animated-accordian/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-accordion-expand demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="ease-accordion-header" onclick="document.getElementById('panel1').classList.toggle('open')">
+    Click to expand
+  </div>
+  <div class="ease-accordion-panel" id="panel1">
+    <div class="ease-accordion-content">
+      <p>This is the accordion body content that expands and collapses smoothly.</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/animated-accordian/style.css
+++ b/submissions/examples/animated-accordian/style.css
@@ -1,0 +1,21 @@
+.ease-accordion-header {
+  cursor: pointer;
+  padding: 12px 16px;
+  background: #f5f5f5;
+  border-radius: 6px;
+  font-weight: 600;
+}
+
+.ease-accordion-panel {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.35s ease;
+}
+
+.ease-accordion-panel.open {
+  max-height: 500px;
+}
+
+.ease-accordion-content {
+  padding: 12px 16px;
+}


### PR DESCRIPTION
## Summary
Adds `ease-accordion-expand`, a max-height-based accordion expand/collapse animation.

## Changes
- New `.ease-accordion-header` / `.ease-accordion-panel` / `.ease-accordion-content` classes
- Demo with click-to-toggle header
- README noting the max-height cap tradeoff

## Why
Accordions are extremely common; this is the simplest reliable CSS approach, with a documented alternative for teams that want exact height matching.

## Testing
Verified expand/collapse with both short and long content within the 500px cap.

## Checklist
- [x] Demo file included
- [x] README documents the max-height tradeoff