### PR TITLE
add carousel fade

### DIFF
--- a/submissions/examples/animated-carousel-fade/README.md
+++ b/submissions/examples/animated-carousel-fade/README.md
@@ -1,0 +1,23 @@
+# ease-carousel-fade
+
+Crossfade transition between carousel/testimonial slides.
+
+## Usage
+
+```html
+<div class="ease-carousel">
+  <div class="ease-carousel-slide active">Slide 1</div>
+  <div class="ease-carousel-slide">Slide 2</div>
+</div>
+```
+
+Cycle the `active` class between slides via JS (see `demo.html` for a simple `setInterval` example).
+
+## Notes
+
+- The active slide uses `position: relative` to establish the container's height; inactive slides stack via `position: absolute`.
+- Fixed-height containers avoid layout jump if slide content lengths differ — set an explicit `height` on `.ease-carousel`.
+
+## Browser support
+
+All modern browsers.

--- a/submissions/examples/animated-carousel-fade/demo.html
+++ b/submissions/examples/animated-carousel-fade/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-carousel-fade demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="ease-carousel" style="height: 150px;">
+    <div class="ease-carousel-slide active">Slide 1: "Great product!"</div>
+    <div class="ease-carousel-slide">Slide 2: "Loved the experience."</div>
+    <div class="ease-carousel-slide">Slide 3: "Highly recommend."</div>
+  </div>
+
+  <script>
+    const slides = document.querySelectorAll('.ease-carousel-slide');
+    let i = 0;
+    setInterval(() => {
+      slides[i].classList.remove('active');
+      i = (i + 1) % slides.length;
+      slides[i].classList.add('active');
+    }, 3000);
+  </script>
+</body>
+</html>

--- a/submissions/examples/animated-carousel-fade/style.css
+++ b/submissions/examples/animated-carousel-fade/style.css
@@ -1,0 +1,19 @@
+.ease-carousel {
+  position: relative;
+  width: 100%;
+}
+
+.ease-carousel-slide {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  transition: opacity 0.6s ease;
+  padding: 20px;
+  background: #f5f5f5;
+  border-radius: 8px;
+}
+
+.ease-carousel-slide.active {
+  opacity: 1;
+  position: relative;
+}


### PR DESCRIPTION
## Summary
Adds `ease-carousel-fade`, a crossfade transition for carousel/testimonial rotation.

## Changes
- New `.ease-carousel` / `.ease-carousel-slide` classes
- Demo with auto-rotating slides via `setInterval`
- README noting the fixed-height recommendation

## Why
Testimonial/quote carousels are common; fade is a simpler, less jarring alternative to slide transitions.

## Testing
Verified crossfade smoothness with slides of different content lengths.

## Checklist
- [x] Demo file included
- [x] README included
- [x] Notes fixed-height recommendation to avoid layout jump