### PR TITLE
add animated badge pop

### DIFF
--- a/submissions/examples/animated-badge-pop/README.md
+++ b/submissions/examples/animated-badge-pop/README.md
@@ -1,0 +1,18 @@
+# ease-badge-pop
+
+Badge/tag that pops in with a slight overshoot, spring-like scale animation.
+
+## Usage
+
+```html
+<span class="ease-badge">New</span>
+```
+
+## Notes
+
+- The overshoot comes from the `cubic-bezier(0.34, 1.56, 0.64, 1)` easing curve, which briefly exceeds `scale(1)` before settling.
+- Runs automatically on mount/render — no trigger needed.
+
+## Browser support
+
+All modern browsers.

--- a/submissions/examples/animated-badge-pop/demo.html
+++ b/submissions/examples/animated-badge-pop/demo.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-badge-pop demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <span class="ease-badge">New</span>
+  <span class="ease-badge">3</span>
+</body>
+</html>

--- a/submissions/examples/animated-badge-pop/style.css
+++ b/submissions/examples/animated-badge-pop/style.css
@@ -1,0 +1,17 @@
+.ease-badge {
+  display: inline-block;
+  background: #ef4444;
+  color: #fff;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 4px 10px;
+  border-radius: 999px;
+  transform: scale(0);
+  animation: ease-badge-pop 0.45s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+
+@keyframes ease-badge-pop {
+  to {
+    transform: scale(1);
+  }
+}


### PR DESCRIPTION
## Summary
Adds `ease-badge-pop`, a spring-like scale-in animation for badges/tags.

## Changes
- New `.ease-badge` class with overshoot cubic-bezier animation
- Demo with two badge examples
- README

## Why
Notification badges/count tags benefit from a small pop to draw attention without being disruptive.

## Testing
Verified overshoot animation renders correctly on mount.

## Checklist
- [x] No JS dependency
- [x] Demo and README included