### PR TITLE
feat(scss): add reusable glassmorphism mixin

### DIFF
--- a/submissions/scss/ease-glassmorphism/README.md
+++ b/submissions/scss/ease-glassmorphism/README.md
@@ -1,0 +1,50 @@
+# SCSS Glassmorphism Mixin
+
+A highly customizable and reusable SCSS mixin for generating cross-browser glassmorphism effects. It encapsulates the complex syntax of `backdrop-filter`, `rgba` calculations, and vendor prefixes into a single, clean include.
+
+## Features
+- Generates cross-browser `backdrop-filter` rules.
+- Automatically calculates `rgba` color with alpha transparency.
+- Adds subtle 1px translucent border highlights.
+- Accepts configurable parameters for blur intensity and color.
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `$blur` | `String` | `10px` | The blur intensity for the backdrop filter. |
+| `$opacity` | `Number` | `0.15` | The alpha opacity of the background color. |
+| `$base-color` | `Color` | `#ffffff` | The base color of the glass. |
+| `$with-border` | `Boolean` | `true` | Whether to include the subtle border highlight. |
+| `$border-opacity` | `Number` | `0.2` | The alpha opacity of the border highlight. |
+
+## Usage
+
+Import the mixin and use it in your components:
+
+```scss
+@import 'ease-glass';
+
+.my-glass-card {
+  // Uses default values (10px blur, white base, 0.15 opacity)
+  @include ease-glass();
+  
+  border-radius: 20px;
+  padding: 30px;
+}
+
+.my-dark-glass-modal {
+  // Custom dark mode glassmorphism
+  @include ease-glass(
+    $blur: 20px,
+    $opacity: 0.25,
+    $base-color: #000000,
+    $border-opacity: 0.1
+  );
+  
+  border-radius: 12px;
+}
+```
+
+## Why it fits EaseMotion CSS
+Glassmorphism is a prominent trend across our community submissions. This mixin reduces repetitive boilerplate, helping developers build complex layered UI designs faster while remaining perfectly aligned with the EaseMotion standard architecture.

--- a/submissions/scss/ease-glassmorphism/_ease-glass.scss
+++ b/submissions/scss/ease-glassmorphism/_ease-glass.scss
@@ -1,0 +1,31 @@
+/// EaseMotion Glassmorphism Mixin
+/// Generates cross-browser glassmorphism styles with customizable blur, opacity, and borders.
+/// 
+/// @param {String} $blur [10px] - The blur intensity for the backdrop filter.
+/// @param {Number} $opacity [0.15] - The alpha opacity of the background color.
+/// @param {Color} $base-color [#ffffff] - The base color of the glass.
+/// @param {Boolean} $with-border [true] - Whether to include the subtle border highlight.
+/// @param {Number} $border-opacity [0.2] - The alpha opacity of the border highlight.
+
+@mixin ease-glass(
+  $blur: 10px,
+  $opacity: 0.15,
+  $base-color: #ffffff,
+  $with-border: true,
+  $border-opacity: 0.2
+) {
+  // Convert base color to rgba with given opacity
+  background: rgba($base-color, $opacity);
+  
+  // Cross-browser backdrop-filter
+  -webkit-backdrop-filter: blur($blur);
+  backdrop-filter: blur($blur);
+  
+  // Subtle border highlight
+  @if $with-border {
+    border: 1px solid rgba($base-color, $border-opacity);
+  }
+  
+  // Base structural properties typical for glass cards
+  box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.1);
+}


### PR DESCRIPTION
fixes #64309 

## Pull Request Description

Adds a highly customizable and reusable `ease-glass` SCSS mixin to generate cross-browser glassmorphism styles. It abstracts away the complex boilerplate of `backdrop-filter`, `rgba` calculations, and subtle borders into a single, clean mixin block.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component (SCSS Mixin)
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/scss/ease-glassmorphism/`)
- [x] Includes `_ease-glass.scss` — raw SCSS mixin code for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A reusable SCSS mixin (`_ease-glass.scss`) that accepts parameters for blur intensity, background opacity, and border highlights, automatically outputting correct cross-browser glass properties.

**How does a developer use it?**

```scss
@import 'ease-glass';

.my-glass-card {
  @include ease-glass(
    $blur: 15px,
    $opacity: 0.2,
    $base-color: #ffffff,
    $with-border: true
  );
  border-radius: 12px;
}
