### PR TITLE
add animated divider draw

### DIFF
--- a/submissions/examples/animated-divider-draw/README.md
+++ b/submissions/examples/animated-divider-draw/README.md
@@ -1,0 +1,20 @@
+# ease-divider-draw
+
+Horizontal divider line that "draws" itself left-to-right when scrolled into view.
+
+## Usage
+
+```html
+<div class="ease-divider"></div>
+```
+
+Requires an `IntersectionObserver` (included in `demo.html`) to add the `draw` class when the element enters the viewport.
+
+## Notes
+
+- Threshold is set to `0.5` (50% visible) before triggering — adjust to taste.
+- Animation only runs once per page load since the class isn't removed on scroll-out; unobserve after triggering if you don't need repeats.
+
+## Browser support
+
+All modern browsers with `IntersectionObserver` support.

--- a/submissions/examples/animated-divider-draw/demo.html
+++ b/submissions/examples/animated-divider-draw/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-divider-draw demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <p>Scroll down to see the divider draw in.</p>
+  <div style="height: 100vh;"></div>
+  <div class="ease-divider"></div>
+  <p>Content after the divider.</p>
+
+  <script>
+    const divider = document.querySelector('.ease-divider');
+    const observer = new IntersectionObserver(entries => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) entry.target.classList.add('draw');
+      });
+    }, { threshold: 0.5 });
+    observer.observe(divider);
+  </script>
+</body>
+</html>

--- a/submissions/examples/animated-divider-draw/style.css
+++ b/submissions/examples/animated-divider-draw/style.css
@@ -1,0 +1,15 @@
+.ease-divider {
+  height: 2px;
+  width: 0;
+  background: #3b82f6;
+}
+
+.ease-divider.draw {
+  animation: ease-divider-draw 1s ease forwards;
+}
+
+@keyframes ease-divider-draw {
+  to {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
Adds `ease-divider-draw`, a scroll-triggered left-to-right divider draw animation.

## Changes
- New `.ease-divider` / `.ease-divider.draw` classes
- Demo with IntersectionObserver trigger
- README

## Why
Scroll-reveal dividers are a nice section-break effect for landing pages; IntersectionObserver keeps it performant (no scroll event listeners).

## Testing
Verified draw animation fires once divider is 50% visible in viewport.

## Checklist
- [x] Demo file included
- [x] README documents the IntersectionObserver requirement