### PR TITLE
add animated scroll reveal

### DIFF
--- a/submissions/examples/animated-scroll-reveal/README.md
+++ b/submissions/examples/animated-scroll-reveal/README.md
@@ -1,0 +1,28 @@
+# ease-scroll-reveal
+
+Utility class + a tiny `IntersectionObserver` snippet that reveals any element as it enters the viewport.
+
+## Usage
+
+```html
+<div class="ease-reveal">Content to reveal on scroll</div>
+```
+
+```js
+const observer = new IntersectionObserver(entries => {
+  entries.forEach(entry => {
+    if (entry.isIntersecting) entry.target.classList.add('visible');
+  });
+}, { threshold: 0.2 });
+
+document.querySelectorAll('.ease-reveal').forEach(el => observer.observe(el));
+```
+
+## Notes
+
+- Apply `.ease-reveal` to as many elements as you like — one observer handles them all.
+- Threshold of `0.2` means 20% of the element must be visible to trigger.
+
+## Browser support
+
+All modern browsers with `IntersectionObserver` support.

--- a/submissions/examples/animated-scroll-reveal/demo.html
+++ b/submissions/examples/animated-scroll-reveal/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-scroll-reveal demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div style="height: 100vh;"></div>
+  <div class="ease-reveal">This fades and slides up on scroll.</div>
+  <div style="height: 50px;"></div>
+  <div class="ease-reveal">So does this.</div>
+
+  <script>
+    const targets = document.querySelectorAll('.ease-reveal');
+    const observer = new IntersectionObserver(entries => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) entry.target.classList.add('visible');
+      });
+    }, { threshold: 0.2 });
+    targets.forEach(el => observer.observe(el));
+  </script>
+</body>
+</html>

--- a/submissions/examples/animated-scroll-reveal/style.css
+++ b/submissions/examples/animated-scroll-reveal/style.css
@@ -1,0 +1,10 @@
+.ease-reveal {
+  opacity: 0;
+  transform: translateY(30px);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.ease-reveal.visible {
+  opacity: 1;
+  transform: translateY(0);
+}


### PR DESCRIPTION
## Summary
Adds `ease-scroll-reveal`, a reusable scroll-triggered fade/slide-up utility.

## Changes
- New `.ease-reveal` / `.ease-reveal.visible` classes
- Demo with a shared IntersectionObserver across multiple elements
- README with copy-paste JS snippet

## Why
This is one of the most requested landing-page effects; providing it as a reusable utility (not a one-off component) covers many use cases at once.

## Testing
Verified multiple `.ease-reveal` elements trigger independently as scrolled into view.

## Checklist
- [x] Demo file included
- [x] README includes full JS snippet
- [x] Works with multiple elements via one observer