### PR TITLE
add animated btn ripple

### DIFF
--- a/submissions/examples/animated-btn-ripple/README.md
+++ b/submissions/examples/animated-btn-ripple/README.md
@@ -1,0 +1,33 @@
+# ease-btn-ripple
+
+Material-style ripple effect on button click. The ripple animation is pure CSS; a small JS snippet positions it at the click coordinates.
+
+## Usage
+
+```html
+<button class="ease-ripple-btn" onclick="createRipple(event)">Click me</button>
+```
+
+```js
+function createRipple(e) {
+  const btn = e.currentTarget;
+  const ripple = document.createElement('span');
+  const rect = btn.getBoundingClientRect();
+  const size = Math.max(rect.width, rect.height);
+  ripple.className = 'ease-ripple';
+  ripple.style.width = ripple.style.height = size + 'px';
+  ripple.style.left = (e.clientX - rect.left - size / 2) + 'px';
+  ripple.style.top = (e.clientY - rect.top - size / 2) + 'px';
+  btn.appendChild(ripple);
+  ripple.addEventListener('animationend', () => ripple.remove());
+}
+```
+
+## Notes
+
+- Ripple auto-removes itself after the animation ends, so repeated clicks don't accumulate DOM nodes.
+- Requires `position: relative` and `overflow: hidden` on the button (already included in `.ease-ripple-btn`).
+
+## Browser support
+
+All modern browsers.

--- a/submissions/examples/animated-btn-ripple/demo.html
+++ b/submissions/examples/animated-btn-ripple/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-btn-ripple demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <button class="ease-ripple-btn" onclick="createRipple(event)">Click me</button>
+
+  <script>
+    function createRipple(e) {
+      const btn = e.currentTarget;
+      const ripple = document.createElement('span');
+      const rect = btn.getBoundingClientRect();
+      const size = Math.max(rect.width, rect.height);
+      ripple.className = 'ease-ripple';
+      ripple.style.width = ripple.style.height = size + 'px';
+      ripple.style.left = (e.clientX - rect.left - size / 2) + 'px';
+      ripple.style.top = (e.clientY - rect.top - size / 2) + 'px';
+      btn.appendChild(ripple);
+      ripple.addEventListener('animationend', () => ripple.remove());
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/animated-btn-ripple/style.css
+++ b/submissions/examples/animated-btn-ripple/style.css
@@ -1,0 +1,27 @@
+.ease-ripple-btn {
+  position: relative;
+  overflow: hidden;
+  padding: 12px 24px;
+  border: none;
+  border-radius: 6px;
+  background: #3b82f6;
+  color: #fff;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.ease-ripple {
+  position: absolute;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.6);
+  transform: scale(0);
+  animation: ease-ripple-anim 0.6s linear;
+  pointer-events: none;
+}
+
+@keyframes ease-ripple-anim {
+  to {
+    transform: scale(4);
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Summary
Adds `ease-btn-ripple`, a Material-style click ripple for buttons.

## Changes
- New `.ease-ripple-btn` / `.ease-ripple` classes
- Demo with click-coordinate positioning JS
- README with full JS snippet and cleanup note

## Why
Ripple feedback is a widely recognized interaction pattern; CSS drives the animation, JS only handles positioning and cleanup.

## Testing
Verified ripple originates from exact click point and self-removes after animation, tested with rapid repeated clicks.

## Checklist
- [x] Ripple cleans up after itself (no DOM leak)
- [x] Demo and README included