### PR TITLE
add animated copy confirm

### DIFF
--- a/submissions/examples/animated-copy-confirm/README.md
+++ b/submissions/examples/animated-copy-confirm/README.md
@@ -1,0 +1,29 @@
+# ease-copy-confirm
+
+Button that morphs its label into a checkmark + "Copied!" confirmation on click.
+
+## Usage
+
+```html
+<button class="ease-copy-btn" onclick="copyIt(this)">
+  <span class="icon-copy">📋 Copy</span>
+  <span class="icon-check">✅ Copied!</span>
+</button>
+```
+
+```js
+function copyIt(btn) {
+  navigator.clipboard.writeText('text to copy');
+  btn.classList.add('copied');
+  setTimeout(() => btn.classList.remove('copied'), 2000);
+}
+```
+
+## Notes
+
+- Confirmation reverts to the copy icon after 2s (adjust the `setTimeout` delay as needed).
+- Uses `navigator.clipboard.writeText`, which requires a secure context (HTTPS or localhost).
+
+## Browser support
+
+All modern browsers; clipboard API requires HTTPS.

--- a/submissions/examples/animated-copy-confirm/demo.html
+++ b/submissions/examples/animated-copy-confirm/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-copy-confirm demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <button class="ease-copy-btn" onclick="copyIt(this)">
+    <span class="icon-copy">📋 Copy</span>
+    <span class="icon-check">✅ Copied!</span>
+  </button>
+
+  <script>
+    function copyIt(btn) {
+      navigator.clipboard.writeText('Sample copied text');
+      btn.classList.add('copied');
+      setTimeout(() => btn.classList.remove('copied'), 2000);
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/animated-copy-confirm/style.css
+++ b/submissions/examples/animated-copy-confirm/style.css
@@ -1,0 +1,32 @@
+.ease-copy-btn {
+  position: relative;
+  padding: 10px 20px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  background: #fff;
+  cursor: pointer;
+  overflow: hidden;
+}
+
+.ease-copy-btn .icon-copy,
+.ease-copy-btn .icon-check {
+  display: inline-block;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.ease-copy-btn .icon-check {
+  position: absolute;
+  left: 20px;
+  opacity: 0;
+  transform: scale(0.5);
+}
+
+.ease-copy-btn.copied .icon-copy {
+  opacity: 0;
+  transform: scale(0.5);
+}
+
+.ease-copy-btn.copied .icon-check {
+  opacity: 1;
+  transform: scale(1);
+}


### PR DESCRIPTION
## Summary
Adds `ease-copy-confirm`, a copy-button with a morphing checkmark confirmation state.

## Changes
- New `.ease-copy-btn` class with `.icon-copy` / `.icon-check` cross-fade
- Demo using the Clipboard API
- README noting the HTTPS requirement

## Why
Copy-to-clipboard buttons are everywhere (code blocks, share links); a clear success state improves UX confidence.

## Testing
Verified copy action, icon morph, and auto-revert after 2s on HTTPS/localhost.

## Checklist
- [x] Demo file included
- [x] README notes secure-context requirement for Clipboard API
- [x] Auto-reverts to default state