### PR TITLE
feat(scss): add reusable neumorphism mixin

### DIFF
--- a/submissions/scss/ease-neumorphism/README.md
+++ b/submissions/scss/ease-neumorphism/README.md
@@ -1,0 +1,47 @@
+# SCSS Neumorphism (Soft UI) Mixin
+
+A reusable, dynamic SCSS mixin for instantly generating Neumorphic (Soft UI) styles. It automatically calculates the correct highlight and shadow hex colors based on a single base color, rendering precise dual box-shadows.
+
+## Features
+- Generates precise dual box-shadows (`lighten` and `darken` calculations).
+- Supports both `outset` (extruded) and `inset` (recessed) modes.
+- Configurable elevation depth and contrast ratios.
+- Automatically handles the base background color.
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `$base-color` | `Color` | `#e0e5ec` | The base background color of the element and the surrounding area. |
+| `$depth` | `Number` | `8px` | The intensity of the elevation (controls shadow offset and blur). |
+| `$inset` | `Boolean` | `false` | If true, generates an inset shadow simulating a recessed (pressed) effect. |
+| `$contrast` | `Number` | `0.15` | The contrast ratio applied to the light and dark shadow calculation. |
+
+## Usage
+
+Import the mixin and use it in your components. Note: Neumorphism requires the element's background color to precisely match the surrounding container's background color.
+
+```scss
+@import 'ease-neumorphism';
+
+// Parent container
+.dashboard-panel {
+  background-color: #e0e5ec;
+  padding: 40px;
+}
+
+// Outset Card (Extruded)
+.neuo-card {
+  @include ease-neumorphism($base-color: #e0e5ec, $depth: 10px);
+  border-radius: 24px;
+}
+
+// Inset Button (Pressed state)
+.neuo-btn:active {
+  @include ease-neumorphism($base-color: #e0e5ec, $depth: 4px, $inset: true);
+  border-radius: 12px;
+}
+```
+
+## Why it fits EaseMotion CSS
+Neumorphism is heavily reliant on complex, multi-layered box shadows. Calculating the precise light/dark hex codes manually across different UI themes is extremely tedious. This mixin abstracts the math, allowing developers to generate highly polished, consistent soft UI components instantly.

--- a/submissions/scss/ease-neumorphism/_ease-neumorphism.scss
+++ b/submissions/scss/ease-neumorphism/_ease-neumorphism.scss
@@ -1,0 +1,34 @@
+/// EaseMotion Neumorphism (Soft UI) Mixin
+/// Generates precise dual box-shadows to simulate an extruded or recessed surface.
+/// 
+/// @param {Color} $base-color [#e0e5ec] - The base background color of the element.
+/// @param {Number} $depth [8px] - The intensity of the elevation (controls shadow blur and spread).
+/// @param {Boolean} $inset [false] - If true, generates an inset shadow (recessed effect).
+/// @param {Number} $contrast [0.15] - The contrast ratio for the dark/light shadow calculation.
+
+@mixin ease-neumorphism(
+  $base-color: #e0e5ec,
+  $depth: 8px,
+  $inset: false,
+  $contrast: 0.15
+) {
+  // Calculate highlight (light shadow) and shadow (dark shadow) based on the base color
+  $light-color: lighten($base-color, $contrast * 100%);
+  $dark-color: darken($base-color, $contrast * 100%);
+
+  // Apply the base background
+  background-color: $base-color;
+  
+  // Calculate coordinates based on depth
+  $offset: $depth;
+  $blur: $depth * 2;
+  
+  // Generate the dual shadow
+  @if $inset {
+    box-shadow: inset $offset $offset $blur $dark-color,
+                inset ($offset * -1) ($offset * -1) $blur $light-color;
+  } @else {
+    box-shadow: $offset $offset $blur $dark-color,
+                ($offset * -1) ($offset * -1) $blur $light-color;
+  }
+}


### PR DESCRIPTION
fixes #64771 

## Pull Request Description

Adds a dynamic, reusable `ease-neumorphism` SCSS mixin. Neumorphism (Soft UI) relies on precise dual box-shadows (one light, one dark) to simulate an extruded or recessed surface. This mixin completely abstracts the tedious hex-color math, instantly generating flawless inset or outset shadows based on a single `$base-color`.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component (SCSS Track)
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/scss/ease-neumorphism/`)
- [x] Includes `_ease-neumorphism.scss` — raw SCSS mixin code for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

An advanced SCSS mixin (`_ease-neumorphism.scss`) that utilizes built-in SCSS color functions (`lighten()` / `darken()`) to automatically calculate and apply the correct contrast box-shadows required for Soft UI, supporting both extruded and pressed (inset) visual states.

**How does a developer use it?**

```scss
@import 'ease-neumorphism';

// Outset Card (Extruded)
.neuo-card {
  @include ease-neumorphism($base-color: #e0e5ec, $depth: 10px);
  border-radius: 24px;
}

// Inset Button (Pressed state)
.neuo-btn:active {
  @include ease-neumorphism($base-color: #e0e5ec, $depth: 4px, $inset: true);
}
