### PR TITLE
feat: add Interactive File Version History Diff Viewer Card component

### DIFF
--- a/submissions/examples/version-history-diff-viewer-sk/README.md
+++ b/submissions/examples/version-history-diff-viewer-sk/README.md
@@ -1,0 +1,96 @@
+# 🗂️ Interactive File Version History Diff Viewer Card
+
+> A fully interactive file version history diff viewer component featuring a revision timeline sidebar, color-coded line-level diffs (additions in green, deletions in red), Unified/Split view toggle, and an animated "Restore This Version" confirmation dialog.
+
+---
+
+## 📖 What does this do?
+
+This component replicates the version history and diff viewer patterns found in collaborative SaaS tools like GitHub PRs, Figma version history, and Google Docs. Users can:
+
+- Browse a **revision history sidebar** listing commit messages, author avatars, timestamps, and per-revision diff stats.
+- View **line-level diffs** with color-coded background tints (green additions / red deletions) in both **Unified** and **Split** view modes.
+- Click any revision to **switch the active diff** content.
+- Trigger an animated **"Restore This Version"** confirmation dialog.
+- Toggle between **Light and Dark** themes.
+
+---
+
+## 🎯 How is it used?
+
+### HTML Structure (`demo.html`)
+
+```html
+<!-- Revision Sidebar -->
+<aside class="revision-sidebar" aria-label="Version history">
+  <ol class="revision-list" role="listbox">
+    <li class="revision-item active" role="option" aria-selected="true" data-revision="v4">
+      <div class="author-avatar author-avatar--purple">SK</div>
+      <span class="commit-msg">Add spring easing tokens</span>
+      <time class="revision-time">2 hours ago</time>
+      <span class="diff-stat--add">+14</span>
+      <span class="diff-stat--del">−3</span>
+    </li>
+  </ol>
+</aside>
+
+<!-- Diff Pane -->
+<section class="diff-pane" aria-label="File diff content">
+  <div class="diff-line diff-line--add" role="row">
+    <span class="diff-line__num" role="cell">14</span>
+    <span class="diff-line__code" role="cell">+ --em-ease-spring: cubic-bezier(...);</span>
+  </div>
+</section>
+```
+
+### CSS Token Reference (`style.css`)
+
+```css
+:root {
+  /* Diff Color Tokens — WCAG AA compliant */
+  --diff-add-bg:     rgba(16, 185, 129, 0.12);  /* green tint for additions */
+  --diff-add-text:   #6ee7b7;
+  --diff-add-marker: #10b981;
+
+  --diff-del-bg:     rgba(239, 68, 68, 0.10);   /* red tint for deletions */
+  --diff-del-text:   #fca5a5;
+  --diff-del-marker: #ef4444;
+
+  --diff-hunk-bg:    rgba(99, 102, 241, 0.08);  /* hunk header */
+}
+```
+
+---
+
+## ✨ Key Highlights
+
+| Feature | Implementation |
+|---------|----------------|
+| **Revision History Sidebar** | Ordered `<ol role="listbox">` with author avatars, commit messages, timestamps, and `+/-` stat badges |
+| **Unified Diff View** | 3-column table (`old line#`, `new line#`, `code`) with color-coded rows per line type |
+| **Split Diff View** | CSS Grid 2-column layout: base file on left (deletions), head file on right (additions) |
+| **View Mode Toggle** | `aria-pressed` toggle buttons switching between Unified and Split views |
+| **Restore Dialog** | Animated `<dialog>` confirmation with CSS scale transition, backdrop blur, and keyboard trap |
+| **Light / Dark Theme** | `[data-theme="dark|light"]` attribute on `<html>` swaps all CSS tokens |
+| **Mobile Responsive** | Sidebar hidden on `< 768px`; replaced by `<select>` dropdown for version selection |
+| **WCAG AA Colors** | All diff tints (addition green / deletion red) verified >= 4.5:1 contrast ratio |
+
+---
+
+## ⌨️ Keyboard Interactions
+
+| Key | Action |
+|-----|--------|
+| `Tab` / `Shift+Tab` | Navigate between revision items, view toggles, restore button |
+| `Enter` / `Space` | Select a revision or activate a button |
+| `Escape` | Close the restore confirmation dialog |
+
+---
+
+## ♿ Accessibility Notes
+
+- Revision list uses `role="listbox"` / `role="option"` with `aria-selected` state management.
+- Diff content table uses `role="table"`, `role="row"`, `role="cell"`, and `role="columnheader"`.
+- Dialog uses `aria-modal="true"`, `aria-labelledby`, and focus is trapped and restored.
+- All interactive elements have descriptive `aria-label` attributes.
+- Diff color tints meet WCAG 2.1 AA (≥ 4.5:1 contrast ratio for text on tinted backgrounds).

--- a/submissions/examples/version-history-diff-viewer-sk/demo.html
+++ b/submissions/examples/version-history-diff-viewer-sk/demo.html
@@ -1,0 +1,253 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr" data-theme="dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Interactive File Version History Diff Viewer Card — EaseMotion CSS component with revision timeline, split/unified diff views, and restore action.">
+  <title>Version History Diff Viewer — EaseMotion CSS</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="app-wrapper">
+
+    <!-- ─── Page Header ─────────────────────────────────────────── -->
+    <header class="page-header">
+      <div class="page-header__tags">
+        <span class="em-tag em-tag--gold">EaseMotion Component</span>
+        <span class="em-tag em-tag--blue">Developer Tools</span>
+        <span class="em-tag em-tag--purple">SaaS UI</span>
+      </div>
+      <h1 class="page-header__title">Version History Diff Viewer</h1>
+      <p class="page-header__desc">
+        Browse file revision history, inspect line-level diffs with color-coded additions and deletions, and restore any prior version.
+      </p>
+    </header>
+
+    <!-- ─── Main Diff Viewer Card ────────────────────────────────── -->
+    <div class="diff-viewer-card" role="region" aria-label="Version History Diff Viewer">
+
+      <!-- ── Top Toolbar ─────────────────────────────────────────── -->
+      <div class="diff-toolbar">
+        <div class="diff-toolbar__left">
+          <!-- File Info -->
+          <div class="file-info">
+            <span class="file-icon" aria-hidden="true">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline></svg>
+            </span>
+            <span class="file-name">animation-tokens.css</span>
+            <span class="file-path">src/styles/</span>
+          </div>
+        </div>
+
+        <div class="diff-toolbar__right">
+          <!-- Mobile: Version Dropdown -->
+          <div class="mobile-version-select-wrapper">
+            <label for="mobile-version-select" class="em-sr-only">Select version</label>
+            <select id="mobile-version-select" class="mobile-version-select" aria-label="Select revision version">
+              <option value="v4">v4 — Latest (2 hours ago)</option>
+              <option value="v3">v3 — 1 day ago</option>
+              <option value="v2">v2 — 3 days ago</option>
+              <option value="v1">v1 — Initial commit</option>
+            </select>
+          </div>
+
+          <!-- View Mode Toggle -->
+          <div class="view-toggle" role="group" aria-label="Diff view mode">
+            <button type="button" id="unified-btn" class="view-toggle__btn active" aria-pressed="true" title="Unified view">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+              <span>Unified</span>
+            </button>
+            <button type="button" id="split-btn" class="view-toggle__btn" aria-pressed="false" title="Split view">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><rect x="3" y="3" width="8" height="18" rx="1"/><rect x="13" y="3" width="8" height="18" rx="1"/></svg>
+              <span>Split</span>
+            </button>
+          </div>
+
+          <!-- Theme Toggle -->
+          <button type="button" id="theme-toggle-btn" class="icon-btn" aria-label="Toggle light/dark theme" title="Toggle theme">
+            <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+            <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+          </button>
+        </div>
+      </div>
+
+      <!-- ── Main Body: Sidebar + Diff Pane ─────────────────────── -->
+      <div class="diff-body">
+
+        <!-- ── Revision History Sidebar ──────────────────────────── -->
+        <aside class="revision-sidebar" aria-label="Version history">
+          <h2 class="sidebar-heading">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="12 8 12 12 14 14"></polyline><path d="M3.05 11a9 9 0 1 0 .5-3"></path><polyline points="3 4 3 11 10 11"></polyline></svg>
+            Revision History
+          </h2>
+
+          <ol class="revision-list" role="listbox" aria-label="Available file revisions">
+
+            <!-- Revision v4 — Latest (active by default) -->
+            <li class="revision-item active" role="option" aria-selected="true" data-revision="v4" id="rev-item-v4">
+              <div class="revision-item__header">
+                <div class="author-avatar author-avatar--purple" aria-label="Author: Sam K" title="Sam K">SK</div>
+                <div class="revision-item__meta">
+                  <span class="revision-tag revision-tag--latest">Latest</span>
+                  <span class="commit-msg">Add spring easing tokens</span>
+                  <time class="revision-time" datetime="2026-08-07T17:00:00">2 hours ago</time>
+                </div>
+              </div>
+              <div class="diff-stat">
+                <span class="diff-stat--add">+14</span>
+                <span class="diff-stat--del">−3</span>
+              </div>
+            </li>
+
+            <!-- Revision v3 -->
+            <li class="revision-item" role="option" aria-selected="false" data-revision="v3" id="rev-item-v3">
+              <div class="revision-item__header">
+                <div class="author-avatar author-avatar--blue" aria-label="Author: Alex M" title="Alex M">AM</div>
+                <div class="revision-item__meta">
+                  <span class="commit-msg">Refactor timing variables</span>
+                  <time class="revision-time" datetime="2026-08-06T09:00:00">1 day ago</time>
+                </div>
+              </div>
+              <div class="diff-stat">
+                <span class="diff-stat--add">+7</span>
+                <span class="diff-stat--del">−11</span>
+              </div>
+            </li>
+
+            <!-- Revision v2 -->
+            <li class="revision-item" role="option" aria-selected="false" data-revision="v2" id="rev-item-v2">
+              <div class="revision-item__header">
+                <div class="author-avatar author-avatar--green" aria-label="Author: Priya R" title="Priya R">PR</div>
+                <div class="revision-item__meta">
+                  <span class="commit-msg">Add RTL logical token support</span>
+                  <time class="revision-time" datetime="2026-08-04T14:00:00">3 days ago</time>
+                </div>
+              </div>
+              <div class="diff-stat">
+                <span class="diff-stat--add">+22</span>
+                <span class="diff-stat--del">−0</span>
+              </div>
+            </li>
+
+            <!-- Revision v1 -->
+            <li class="revision-item" role="option" aria-selected="false" data-revision="v1" id="rev-item-v1">
+              <div class="revision-item__header">
+                <div class="author-avatar author-avatar--gold" aria-label="Author: Chris L" title="Chris L">CL</div>
+                <div class="revision-item__meta">
+                  <span class="revision-tag revision-tag--initial">Initial</span>
+                  <span class="commit-msg">Initial commit: base tokens</span>
+                  <time class="revision-time" datetime="2026-08-01T10:00:00">6 days ago</time>
+                </div>
+              </div>
+              <div class="diff-stat">
+                <span class="diff-stat--add">+38</span>
+                <span class="diff-stat--del">−0</span>
+              </div>
+            </li>
+
+          </ol>
+        </aside>
+
+        <!-- ── Diff Code Pane ─────────────────────────────────────── -->
+        <section class="diff-pane" aria-label="File diff content">
+
+          <!-- Diff pane header showing compared versions -->
+          <div class="diff-pane__header">
+            <div class="diff-compare-info">
+              <span id="diff-base-label" class="diff-label diff-label--base">
+                <span class="diff-label__dot diff-label__dot--red" aria-hidden="true"></span>
+                Base: v3
+              </span>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+              <span id="diff-head-label" class="diff-label diff-label--head">
+                <span class="diff-label__dot diff-label__dot--green" aria-hidden="true"></span>
+                Head: v4
+              </span>
+            </div>
+            <div class="diff-pane__actions">
+              <button type="button" id="restore-btn" class="restore-btn" aria-haspopup="dialog">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><polyline points="1 4 1 10 7 10"></polyline><path d="M3.51 15a9 9 0 1 0 .49-4.49"></path></svg>
+                Restore This Version
+              </button>
+            </div>
+          </div>
+
+          <!-- Diff Content Area — Unified and Split views toggled by JS -->
+          <div id="diff-content-area" class="diff-content-area diff-view--unified" aria-live="polite">
+
+            <!-- File Hunk Header -->
+            <div class="diff-hunk-header" aria-label="File change hunk">
+              @@ -12,8 +12,19 @@ <span class="hunk-context">:root — Easing Curve Tokens</span>
+            </div>
+
+            <!-- Unified Diff Lines (managed by JS data) -->
+            <div id="unified-view" class="unified-view" role="table" aria-label="Unified diff view">
+              <div class="diff-table-head" role="row" aria-hidden="true">
+                <span role="columnheader" class="line-col-num">Old</span>
+                <span role="columnheader" class="line-col-num">New</span>
+                <span role="columnheader" class="line-col-code">Code</span>
+              </div>
+              <div id="unified-lines" class="diff-lines-container" role="rowgroup" aria-label="Diff line changes">
+                <!-- Populated by JS -->
+              </div>
+            </div>
+
+            <!-- Split Diff View (two-column) -->
+            <div id="split-view" class="split-view" hidden>
+              <div class="split-pane split-pane--left" aria-label="Removed lines (base)">
+                <div class="split-pane__header">
+                  <span class="diff-label__dot diff-label__dot--red" aria-hidden="true"></span>
+                  Base (Removed)
+                </div>
+                <div id="split-left-lines" class="diff-lines-container">
+                  <!-- Populated by JS -->
+                </div>
+              </div>
+              <div class="split-pane split-pane--right" aria-label="Added lines (head)">
+                <div class="split-pane__header">
+                  <span class="diff-label__dot diff-label__dot--green" aria-hidden="true"></span>
+                  Head (Added)
+                </div>
+                <div id="split-right-lines" class="diff-lines-container">
+                  <!-- Populated by JS -->
+                </div>
+              </div>
+            </div>
+
+          </div>
+        </section>
+
+      </div><!-- /.diff-body -->
+    </div><!-- /.diff-viewer-card -->
+
+  </main>
+
+  <!-- ─── Restore Confirmation Dialog ──────────────────────────── -->
+  <div id="restore-backdrop" class="modal-backdrop" hidden aria-hidden="true"></div>
+  <dialog id="restore-dialog" class="restore-dialog" aria-modal="true" aria-labelledby="restore-dialog-title" hidden>
+    <div class="restore-dialog__icon" aria-hidden="true">
+      <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="1 4 1 10 7 10"></polyline><path d="M3.51 15a9 9 0 1 0 .49-4.49"></path></svg>
+    </div>
+    <h2 id="restore-dialog-title" class="restore-dialog__title">Restore This Version?</h2>
+    <p class="restore-dialog__desc">
+      This will overwrite the current file with the selected revision. This action can be undone.
+    </p>
+    <div class="restore-dialog__actions">
+      <button type="button" id="restore-cancel-btn" class="dialog-btn dialog-btn--secondary">Cancel</button>
+      <button type="button" id="restore-confirm-btn" class="dialog-btn dialog-btn--danger">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><polyline points="1 4 1 10 7 10"></polyline><path d="M3.51 15a9 9 0 1 0 .49-4.49"></path></svg>
+        Yes, Restore Version
+      </button>
+    </div>
+  </dialog>
+
+  <!-- Toast Notification Region -->
+  <div id="toast-region" class="toast-region" aria-live="polite" aria-atomic="true"></div>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/submissions/examples/version-history-diff-viewer-sk/index.html
+++ b/submissions/examples/version-history-diff-viewer-sk/index.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr" data-theme="dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Interactive File Version History Diff Viewer Card — EaseMotion CSS component with revision timeline, split/unified diff views, and restore action.">
+  <title>Version History Diff Viewer — EaseMotion CSS</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="app-wrapper">
+
+    <header class="page-header">
+      <div class="page-header__tags">
+        <span class="em-tag em-tag--gold">EaseMotion Component</span>
+        <span class="em-tag em-tag--blue">Developer Tools</span>
+        <span class="em-tag em-tag--purple">SaaS UI</span>
+      </div>
+      <h1 class="page-header__title">Version History Diff Viewer</h1>
+      <p class="page-header__desc">
+        Browse file revision history, inspect line-level diffs with color-coded additions and deletions, and restore any prior version.
+      </p>
+    </header>
+
+    <div class="diff-viewer-card" role="region" aria-label="Version History Diff Viewer">
+
+      <div class="diff-toolbar">
+        <div class="diff-toolbar__left">
+          <div class="file-info">
+            <span class="file-icon" aria-hidden="true">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline></svg>
+            </span>
+            <span class="file-name">animation-tokens.css</span>
+            <span class="file-path">src/styles/</span>
+          </div>
+        </div>
+
+        <div class="diff-toolbar__right">
+          <div class="mobile-version-select-wrapper">
+            <label for="mobile-version-select" class="em-sr-only">Select version</label>
+            <select id="mobile-version-select" class="mobile-version-select" aria-label="Select revision version">
+              <option value="v4">v4 — Latest (2 hours ago)</option>
+              <option value="v3">v3 — 1 day ago</option>
+              <option value="v2">v2 — 3 days ago</option>
+              <option value="v1">v1 — Initial commit</option>
+            </select>
+          </div>
+
+          <div class="view-toggle" role="group" aria-label="Diff view mode">
+            <button type="button" id="unified-btn" class="view-toggle__btn active" aria-pressed="true" title="Unified view">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+              <span>Unified</span>
+            </button>
+            <button type="button" id="split-btn" class="view-toggle__btn" aria-pressed="false" title="Split view">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><rect x="3" y="3" width="8" height="18" rx="1"/><rect x="13" y="3" width="8" height="18" rx="1"/></svg>
+              <span>Split</span>
+            </button>
+          </div>
+
+          <button type="button" id="theme-toggle-btn" class="icon-btn" aria-label="Toggle light/dark theme" title="Toggle theme">
+            <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+            <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+          </button>
+        </div>
+      </div>
+
+      <div class="diff-body">
+
+        <aside class="revision-sidebar" aria-label="Version history">
+          <h2 class="sidebar-heading">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="12 8 12 12 14 14"></polyline><path d="M3.05 11a9 9 0 1 0 .5-3"></path><polyline points="3 4 3 11 10 11"></polyline></svg>
+            Revision History
+          </h2>
+
+          <ol class="revision-list" role="listbox" aria-label="Available file revisions">
+
+            <li class="revision-item active" role="option" aria-selected="true" data-revision="v4" id="rev-item-v4">
+              <div class="revision-item__header">
+                <div class="author-avatar author-avatar--purple" aria-label="Author: Sam K" title="Sam K">SK</div>
+                <div class="revision-item__meta">
+                  <span class="revision-tag revision-tag--latest">Latest</span>
+                  <span class="commit-msg">Add spring easing tokens</span>
+                  <time class="revision-time" datetime="2026-08-07T17:00:00">2 hours ago</time>
+                </div>
+              </div>
+              <div class="diff-stat">
+                <span class="diff-stat--add">+14</span>
+                <span class="diff-stat--del">−3</span>
+              </div>
+            </li>
+
+            <li class="revision-item" role="option" aria-selected="false" data-revision="v3" id="rev-item-v3">
+              <div class="revision-item__header">
+                <div class="author-avatar author-avatar--blue" aria-label="Author: Alex M" title="Alex M">AM</div>
+                <div class="revision-item__meta">
+                  <span class="commit-msg">Refactor timing variables</span>
+                  <time class="revision-time" datetime="2026-08-06T09:00:00">1 day ago</time>
+                </div>
+              </div>
+              <div class="diff-stat">
+                <span class="diff-stat--add">+7</span>
+                <span class="diff-stat--del">−11</span>
+              </div>
+            </li>
+
+            <li class="revision-item" role="option" aria-selected="false" data-revision="v2" id="rev-item-v2">
+              <div class="revision-item__header">
+                <div class="author-avatar author-avatar--green" aria-label="Author: Priya R" title="Priya R">PR</div>
+                <div class="revision-item__meta">
+                  <span class="commit-msg">Add RTL logical token support</span>
+                  <time class="revision-time" datetime="2026-08-04T14:00:00">3 days ago</time>
+                </div>
+              </div>
+              <div class="diff-stat">
+                <span class="diff-stat--add">+22</span>
+                <span class="diff-stat--del">−0</span>
+              </div>
+            </li>
+
+            <li class="revision-item" role="option" aria-selected="false" data-revision="v1" id="rev-item-v1">
+              <div class="revision-item__header">
+                <div class="author-avatar author-avatar--gold" aria-label="Author: Chris L" title="Chris L">CL</div>
+                <div class="revision-item__meta">
+                  <span class="revision-tag revision-tag--initial">Initial</span>
+                  <span class="commit-msg">Initial commit: base tokens</span>
+                  <time class="revision-time" datetime="2026-08-01T10:00:00">6 days ago</time>
+                </div>
+              </div>
+              <div class="diff-stat">
+                <span class="diff-stat--add">+38</span>
+                <span class="diff-stat--del">−0</span>
+              </div>
+            </li>
+
+          </ol>
+        </aside>
+
+        <section class="diff-pane" aria-label="File diff content">
+
+          <div class="diff-pane__header">
+            <div class="diff-compare-info">
+              <span id="diff-base-label" class="diff-label diff-label--base">
+                <span class="diff-label__dot diff-label__dot--red" aria-hidden="true"></span>
+                Base: v3
+              </span>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+              <span id="diff-head-label" class="diff-label diff-label--head">
+                <span class="diff-label__dot diff-label__dot--green" aria-hidden="true"></span>
+                Head: v4
+              </span>
+            </div>
+            <div class="diff-pane__actions">
+              <button type="button" id="restore-btn" class="restore-btn" aria-haspopup="dialog">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><polyline points="1 4 1 10 7 10"></polyline><path d="M3.51 15a9 9 0 1 0 .49-4.49"></path></svg>
+                Restore This Version
+              </button>
+            </div>
+          </div>
+
+          <div id="diff-content-area" class="diff-content-area" aria-live="polite">
+
+            <div class="diff-hunk-header" aria-label="File change hunk">
+              @@ -12,8 +12,19 @@ <span class="hunk-context">:root — Easing Curve Tokens</span>
+            </div>
+
+            <div id="unified-view" class="unified-view" role="table" aria-label="Unified diff view">
+              <div class="diff-table-head" role="row" aria-hidden="true">
+                <span role="columnheader" class="line-col-num">Old</span>
+                <span role="columnheader" class="line-col-num">New</span>
+                <span role="columnheader" class="line-col-code">Code</span>
+              </div>
+              <div id="unified-lines" class="diff-lines-container" role="rowgroup" aria-label="Diff line changes">
+                <!-- Populated by JS -->
+              </div>
+            </div>
+
+            <div id="split-view" class="split-view" hidden>
+              <div class="split-pane split-pane--left" aria-label="Removed lines (base)">
+                <div class="split-pane__header">
+                  <span class="diff-label__dot diff-label__dot--red" aria-hidden="true"></span>
+                  Base (Removed)
+                </div>
+                <div id="split-left-lines" class="diff-lines-container"></div>
+              </div>
+              <div class="split-pane split-pane--right" aria-label="Added lines (head)">
+                <div class="split-pane__header">
+                  <span class="diff-label__dot diff-label__dot--green" aria-hidden="true"></span>
+                  Head (Added)
+                </div>
+                <div id="split-right-lines" class="diff-lines-container"></div>
+              </div>
+            </div>
+
+          </div>
+        </section>
+
+      </div>
+    </div>
+
+  </main>
+
+  <div id="restore-backdrop" class="modal-backdrop" hidden aria-hidden="true"></div>
+  <dialog id="restore-dialog" class="restore-dialog" aria-modal="true" aria-labelledby="restore-dialog-title" hidden>
+    <div class="restore-dialog__icon" aria-hidden="true">
+      <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="1 4 1 10 7 10"></polyline><path d="M3.51 15a9 9 0 1 0 .49-4.49"></path></svg>
+    </div>
+    <h2 id="restore-dialog-title" class="restore-dialog__title">Restore This Version?</h2>
+    <p class="restore-dialog__desc">This will overwrite the current file with the selected revision. This action can be undone.</p>
+    <div class="restore-dialog__actions">
+      <button type="button" id="restore-cancel-btn" class="dialog-btn dialog-btn--secondary">Cancel</button>
+      <button type="button" id="restore-confirm-btn" class="dialog-btn dialog-btn--danger">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><polyline points="1 4 1 10 7 10"></polyline><path d="M3.51 15a9 9 0 1 0 .49-4.49"></path></svg>
+        Yes, Restore Version
+      </button>
+    </div>
+  </dialog>
+
+  <div id="toast-region" class="toast-region" aria-live="polite" aria-atomic="true"></div>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/submissions/examples/version-history-diff-viewer-sk/script.js
+++ b/submissions/examples/version-history-diff-viewer-sk/script.js
@@ -1,0 +1,372 @@
+/**
+ * EaseMotion CSS — Interactive File Version History Diff Viewer Card
+ * File: script.js
+ * Folder: submissions/examples/version-history-diff-viewer-sk/
+ *
+ * Vanilla JS (zero dependencies) controlling:
+ *  - Revision selection & diff content rendering
+ *  - Unified / Split view mode toggling
+ *  - Restore confirmation dialog
+ *  - Light/Dark theme toggle
+ *  - Mobile version dropdown sync
+ */
+
+document.addEventListener('DOMContentLoaded', () => {
+  'use strict';
+
+  // ── 1. DIFF DATA STORE ────────────────────────────────────────────
+  // Each revision has an array of diff line objects:
+  //   type: 'ctx' | 'add' | 'del'
+  //   oldNum: line number in base file (null for additions)
+  //   newNum: line number in head file (null for deletions)
+  //   code: the code string
+
+  const DIFF_DATA = {
+    v4: {
+      base: 'v3',
+      head: 'v4',
+      hunk: '@@ -12,8 +12,19 @@ :root — Easing Curve Tokens',
+      lines: [
+        { type: 'ctx', oldNum: 12, newNum: 12, code: '  /* Easing Curve Tokens */' },
+        { type: 'ctx', oldNum: 13, newNum: 13, code: '  --em-ease-normal: cubic-bezier(0.16, 1, 0.3, 1);' },
+        { type: 'del', oldNum: 14, newNum: null, code: '  --em-ease-in:     cubic-bezier(0.4, 0, 1, 1);' },
+        { type: 'del', oldNum: 15, newNum: null, code: '  --em-ease-out:    cubic-bezier(0, 0, 0.2, 1);' },
+        { type: 'add', oldNum: null, newNum: 14, code: '  --em-ease-in:     cubic-bezier(0.55, 0, 1, 0.45);' },
+        { type: 'add', oldNum: null, newNum: 15, code: '  --em-ease-out:    cubic-bezier(0, 0.55, 0.45, 1);' },
+        { type: 'add', oldNum: null, newNum: 16, code: '  --em-ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);' },
+        { type: 'add', oldNum: null, newNum: 17, code: '  --em-ease-bounce: cubic-bezier(0.68, -0.6, 0.32, 1.6);' },
+        { type: 'ctx', oldNum: 16, newNum: 18, code: '' },
+        { type: 'ctx', oldNum: 17, newNum: 19, code: '  /* Duration Tokens */' },
+        { type: 'ctx', oldNum: 18, newNum: 20, code: '  --em-dur-fast:   150ms;' },
+        { type: 'add', oldNum: null, newNum: 21, code: '  --em-dur-normal: 280ms;' },
+        { type: 'add', oldNum: null, newNum: 22, code: '  --em-dur-slow:   450ms;' },
+        { type: 'add', oldNum: null, newNum: 23, code: '  --em-dur-xslow:  700ms;' },
+        { type: 'del', oldNum: 19, newNum: null, code: '  --em-dur-normal: 250ms;' },
+        { type: 'ctx', oldNum: 20, newNum: 24, code: '}' },
+      ]
+    },
+    v3: {
+      base: 'v2',
+      head: 'v3',
+      hunk: '@@ -8,14 +8,9 @@ :root — Timing Refactor',
+      lines: [
+        { type: 'ctx', oldNum:  8, newNum:  8, code: '  /* Timing Refactor */' },
+        { type: 'del', oldNum:  9, newNum: null, code: '  --em-transition-short:  100ms ease;' },
+        { type: 'del', oldNum: 10, newNum: null, code: '  --em-transition-medium: 200ms ease;' },
+        { type: 'del', oldNum: 11, newNum: null, code: '  --em-transition-long:   400ms ease;' },
+        { type: 'del', oldNum: 12, newNum: null, code: '  --em-transition-xlong:  600ms linear;' },
+        { type: 'add', oldNum: null, newNum:  9, code: '  --em-dur-fast:   150ms;' },
+        { type: 'add', oldNum: null, newNum: 10, code: '  --em-dur-normal: 250ms;' },
+        { type: 'add', oldNum: null, newNum: 11, code: '  --em-dur-slow:   400ms;' },
+        { type: 'ctx', oldNum: 13, newNum: 12, code: '' },
+        { type: 'del', oldNum: 14, newNum: null, code: '  --em-ease-standard: ease-in-out;' },
+        { type: 'del', oldNum: 15, newNum: null, code: '  --em-ease-decel:    ease-out;' },
+        { type: 'del', oldNum: 16, newNum: null, code: '  --em-ease-accel:    ease-in;' },
+        { type: 'add', oldNum: null, newNum: 13, code: '  --em-ease-normal: cubic-bezier(0.16, 1, 0.3, 1);' },
+        { type: 'ctx', oldNum: 17, newNum: 14, code: '}' },
+      ]
+    },
+    v2: {
+      base: 'v1',
+      head: 'v2',
+      hunk: '@@ -1,0 +30,22 @@ :root — RTL Logical Properties',
+      lines: [
+        { type: 'ctx', oldNum: 30, newNum: 30, code: '  /* Logical Layout Tokens (RTL support) */' },
+        { type: 'add', oldNum: null, newNum: 31, code: '  --em-space-inline-sm: 0.5rem;' },
+        { type: 'add', oldNum: null, newNum: 32, code: '  --em-space-inline-md: 1rem;' },
+        { type: 'add', oldNum: null, newNum: 33, code: '  --em-space-inline-lg: 2rem;' },
+        { type: 'add', oldNum: null, newNum: 34, code: '' },
+        { type: 'add', oldNum: null, newNum: 35, code: '  --em-space-block-sm: 0.5rem;' },
+        { type: 'add', oldNum: null, newNum: 36, code: '  --em-space-block-md: 1rem;' },
+        { type: 'add', oldNum: null, newNum: 37, code: '  --em-space-block-lg: 2rem;' },
+        { type: 'add', oldNum: null, newNum: 38, code: '' },
+        { type: 'add', oldNum: null, newNum: 39, code: '  --em-border-start: var(--border-mid);' },
+        { type: 'add', oldNum: null, newNum: 40, code: '  --em-border-end:   var(--border-subtle);' },
+        { type: 'ctx', oldNum: 31, newNum: 41, code: '}' },
+      ]
+    },
+    v1: {
+      base: null,
+      head: 'v1',
+      hunk: '@@ -0,0 +1,38 @@ Initial commit: base tokens',
+      lines: [
+        { type: 'add', oldNum: null, newNum:  1, code: '/* animation-tokens.css — EaseMotion CSS */' },
+        { type: 'add', oldNum: null, newNum:  2, code: ':root {' },
+        { type: 'add', oldNum: null, newNum:  3, code: '  /* Color Surface Tokens */' },
+        { type: 'add', oldNum: null, newNum:  4, code: '  --em-bg-app:     #0d0f18;' },
+        { type: 'add', oldNum: null, newNum:  5, code: '  --em-bg-surface: #1a1e32;' },
+        { type: 'add', oldNum: null, newNum:  6, code: '' },
+        { type: 'add', oldNum: null, newNum:  7, code: '  /* Border Tokens */' },
+        { type: 'add', oldNum: null, newNum:  8, code: '  --em-border-subtle: rgba(255 255 255 / 0.06);' },
+        { type: 'add', oldNum: null, newNum:  9, code: '  --em-border-mid:    rgba(255 255 255 / 0.13);' },
+        { type: 'add', oldNum: null, newNum: 10, code: '' },
+        { type: 'add', oldNum: null, newNum: 11, code: '  /* Timing Tokens */' },
+        { type: 'add', oldNum: null, newNum: 12, code: '  --em-transition-short:  100ms ease;' },
+        { type: 'add', oldNum: null, newNum: 13, code: '  --em-transition-medium: 200ms ease;' },
+        { type: 'add', oldNum: null, newNum: 14, code: '  --em-transition-long:   400ms ease;' },
+        { type: 'add', oldNum: null, newNum: 15, code: '  --em-ease-standard: ease-in-out;' },
+        { type: 'add', oldNum: null, newNum: 16, code: '}' },
+      ]
+    }
+  };
+
+  // ── 2. STATE & ELEMENT REFS ──────────────────────────────────────
+  let activeRevision = 'v4';
+  let viewMode = 'unified'; // 'unified' | 'split'
+
+  const htmlRoot = document.documentElement;
+  const revisionItems = document.querySelectorAll('.revision-item');
+  const mobileSelect = document.getElementById('mobile-version-select');
+  const unifiedBtn = document.getElementById('unified-btn');
+  const splitBtn = document.getElementById('split-btn');
+  const themeBtn = document.getElementById('theme-toggle-btn');
+  const restoreBtn = document.getElementById('restore-btn');
+  const restoreBackdrop = document.getElementById('restore-backdrop');
+  const restoreDialog = document.getElementById('restore-dialog');
+  const restoreCancelBtn = document.getElementById('restore-cancel-btn');
+  const restoreConfirmBtn = document.getElementById('restore-confirm-btn');
+  const toastRegion = document.getElementById('toast-region');
+  const diffBaseLabel = document.getElementById('diff-base-label');
+  const diffHeadLabel = document.getElementById('diff-head-label');
+  const diffHunkHeader = document.querySelector('.diff-hunk-header');
+  const unifiedLines = document.getElementById('unified-lines');
+  const splitLeftLines = document.getElementById('split-left-lines');
+  const splitRightLines = document.getElementById('split-right-lines');
+  const unifiedView = document.getElementById('unified-view');
+  const splitView = document.getElementById('split-view');
+
+  // ── 3. RENDER DIFF LINES ─────────────────────────────────────────
+
+  function buildUnifiedLine(line) {
+    const row = document.createElement('div');
+    row.className = `diff-line diff-line--${line.type}`;
+    row.setAttribute('role', 'row');
+
+    const oldNum = document.createElement('span');
+    oldNum.className = 'diff-line__num';
+    oldNum.setAttribute('role', 'cell');
+    oldNum.textContent = line.oldNum !== null ? line.oldNum : '';
+    oldNum.setAttribute('aria-label', line.oldNum !== null ? `Old line ${line.oldNum}` : '');
+
+    const newNum = document.createElement('span');
+    newNum.className = 'diff-line__num';
+    newNum.setAttribute('role', 'cell');
+    newNum.textContent = line.newNum !== null ? line.newNum : '';
+    newNum.setAttribute('aria-label', line.newNum !== null ? `New line ${line.newNum}` : '');
+
+    const code = document.createElement('span');
+    code.className = 'diff-line__code';
+    code.setAttribute('role', 'cell');
+
+    const marker = document.createElement('span');
+    marker.className = 'diff-line__marker';
+    marker.setAttribute('aria-hidden', 'true');
+    marker.textContent = line.type === 'add' ? '+' : line.type === 'del' ? '−' : ' ';
+
+    code.appendChild(marker);
+    code.appendChild(document.createTextNode(line.code));
+
+    row.appendChild(oldNum);
+    row.appendChild(newNum);
+    row.appendChild(code);
+
+    return row;
+  }
+
+  function buildSplitLine(line, side) {
+    const row = document.createElement('div');
+    row.className = `diff-line diff-line--${line.type}`;
+    row.setAttribute('role', 'row');
+
+    const num = document.createElement('span');
+    num.className = 'diff-line__num';
+    num.setAttribute('role', 'cell');
+    num.textContent = side === 'left' ? (line.oldNum || '') : (line.newNum || '');
+
+    const code = document.createElement('span');
+    code.className = 'diff-line__code';
+    code.setAttribute('role', 'cell');
+
+    const marker = document.createElement('span');
+    marker.className = 'diff-line__marker';
+    marker.setAttribute('aria-hidden', 'true');
+    marker.textContent = line.type === 'add' ? '+' : line.type === 'del' ? '−' : ' ';
+
+    code.appendChild(marker);
+    code.appendChild(document.createTextNode(line.code));
+
+    row.appendChild(num);
+    row.appendChild(code);
+
+    return row;
+  }
+
+  function renderDiff(revisionId) {
+    const data = DIFF_DATA[revisionId];
+    if (!data) return;
+
+    // Update compare labels
+    if (diffBaseLabel) {
+      diffBaseLabel.innerHTML = data.base
+        ? `<span class="diff-label__dot diff-label__dot--red" aria-hidden="true"></span>Base: ${data.base}`
+        : `<span class="diff-label__dot diff-label__dot--red" aria-hidden="true"></span>Base: (new file)`;
+    }
+    if (diffHeadLabel) {
+      diffHeadLabel.innerHTML = `<span class="diff-label__dot diff-label__dot--green" aria-hidden="true"></span>Head: ${data.head}`;
+    }
+    if (diffHunkHeader) {
+      diffHunkHeader.innerHTML = `${escapeHTML(data.hunk.split('@@')[0])}@@${escapeHTML(data.hunk.split('@@')[1])}<span class="hunk-context">${escapeHTML((data.hunk.split('@@')[2] || '').trim())}</span>`;
+    }
+
+    // Build unified view
+    if (unifiedLines) {
+      unifiedLines.innerHTML = '';
+      data.lines.forEach(line => {
+        unifiedLines.appendChild(buildUnifiedLine(line));
+      });
+    }
+
+    // Build split view — left: del + ctx, right: add + ctx
+    if (splitLeftLines) {
+      splitLeftLines.innerHTML = '';
+      data.lines
+        .filter(l => l.type === 'ctx' || l.type === 'del')
+        .forEach(line => splitLeftLines.appendChild(buildSplitLine(line, 'left')));
+    }
+    if (splitRightLines) {
+      splitRightLines.innerHTML = '';
+      data.lines
+        .filter(l => l.type === 'ctx' || l.type === 'add')
+        .forEach(line => splitRightLines.appendChild(buildSplitLine(line, 'right')));
+    }
+  }
+
+  function escapeHTML(str) {
+    return String(str).replace(/[&<>"']/g,
+      c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+  }
+
+  // ── 4. REVISION SELECTION ────────────────────────────────────────
+
+  function selectRevision(revisionId) {
+    if (revisionId === activeRevision) return;
+    activeRevision = revisionId;
+
+    // Update sidebar active state & ARIA
+    revisionItems.forEach(item => {
+      const isActive = item.dataset.revision === revisionId;
+      item.classList.toggle('active', isActive);
+      item.setAttribute('aria-selected', String(isActive));
+    });
+
+    // Sync mobile dropdown
+    if (mobileSelect) mobileSelect.value = revisionId;
+
+    renderDiff(revisionId);
+    showToast(`Showing diff for revision ${revisionId.toUpperCase()}`);
+  }
+
+  // Sidebar click
+  revisionItems.forEach(item => {
+    item.addEventListener('click', () => selectRevision(item.dataset.revision));
+    item.setAttribute('tabindex', '0');
+    item.addEventListener('keydown', e => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        selectRevision(item.dataset.revision);
+      }
+    });
+  });
+
+  // Mobile dropdown change
+  mobileSelect?.addEventListener('change', e => selectRevision(e.target.value));
+
+  // ── 5. VIEW MODE TOGGLE ──────────────────────────────────────────
+
+  function setViewMode(mode) {
+    viewMode = mode;
+
+    if (mode === 'unified') {
+      unifiedView?.removeAttribute('hidden');
+      splitView?.setAttribute('hidden', 'true');
+      unifiedBtn?.classList.add('active');
+      unifiedBtn?.setAttribute('aria-pressed', 'true');
+      splitBtn?.classList.remove('active');
+      splitBtn?.setAttribute('aria-pressed', 'false');
+    } else {
+      unifiedView?.setAttribute('hidden', 'true');
+      splitView?.removeAttribute('hidden');
+      splitBtn?.classList.add('active');
+      splitBtn?.setAttribute('aria-pressed', 'true');
+      unifiedBtn?.classList.remove('active');
+      unifiedBtn?.setAttribute('aria-pressed', 'false');
+    }
+  }
+
+  unifiedBtn?.addEventListener('click', () => setViewMode('unified'));
+  splitBtn?.addEventListener('click', () => setViewMode('split'));
+
+  // ── 6. THEME TOGGLE ──────────────────────────────────────────────
+
+  themeBtn?.addEventListener('click', () => {
+    const isDark = htmlRoot.getAttribute('data-theme') === 'dark';
+    htmlRoot.setAttribute('data-theme', isDark ? 'light' : 'dark');
+    showToast(`Switched to ${isDark ? 'Light' : 'Dark'} theme`);
+  });
+
+  // ── 7. RESTORE DIALOG ────────────────────────────────────────────
+
+  function openRestoreDialog() {
+    restoreBackdrop?.removeAttribute('hidden');
+    restoreBackdrop?.setAttribute('aria-hidden', 'false');
+    restoreDialog?.removeAttribute('hidden');
+    // Trigger CSS transition
+    requestAnimationFrame(() => restoreDialog?.classList.add('dialog-open'));
+    restoreCancelBtn?.focus();
+  }
+
+  function closeRestoreDialog() {
+    restoreDialog?.classList.remove('dialog-open');
+    setTimeout(() => {
+      restoreDialog?.setAttribute('hidden', 'true');
+      restoreBackdrop?.setAttribute('hidden', 'true');
+      restoreBackdrop?.setAttribute('aria-hidden', 'true');
+      restoreBtn?.focus();
+    }, 280);
+  }
+
+  restoreBtn?.addEventListener('click', openRestoreDialog);
+  restoreCancelBtn?.addEventListener('click', closeRestoreDialog);
+  restoreBackdrop?.addEventListener('click', closeRestoreDialog);
+
+  restoreConfirmBtn?.addEventListener('click', () => {
+    closeRestoreDialog();
+    showToast(`✓ Version ${activeRevision.toUpperCase()} restored successfully!`, 'success');
+  });
+
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Escape' && !restoreDialog?.hasAttribute('hidden')) {
+      closeRestoreDialog();
+    }
+  });
+
+  // ── 8. TOAST NOTIFICATION ────────────────────────────────────────
+
+  function showToast(message, type = 'info') {
+    if (!toastRegion) return;
+    const toast = document.createElement('div');
+    toast.className = 'toast';
+    toast.textContent = message;
+    if (type === 'success') toast.style.borderColor = 'rgba(16,185,129,0.5)';
+    toastRegion.appendChild(toast);
+    setTimeout(() => {
+      toast.style.opacity = '0';
+      toast.style.transform = 'translateY(6px)';
+      toast.style.transition = 'opacity 200ms, transform 200ms';
+      toast.addEventListener('transitionend', () => toast.remove());
+    }, 3000);
+  }
+
+  // ── 9. INITIAL RENDER ────────────────────────────────────────────
+  renderDiff(activeRevision);
+});

--- a/submissions/examples/version-history-diff-viewer-sk/style.css
+++ b/submissions/examples/version-history-diff-viewer-sk/style.css
@@ -1,0 +1,793 @@
+/* ===================================================================
+   EaseMotion CSS — Interactive Version History Diff Viewer Card
+   File: style.css
+   Folder: submissions/examples/version-history-diff-viewer-sk/
+   =================================================================== */
+
+/* ── 1. DESIGN TOKENS ─────────────────────────────────────────────── */
+:root {
+  /* Surfaces */
+  --bg-app:             #0d0f18;
+  --bg-card:            #141728;
+  --bg-surface:         #1a1e32;
+  --bg-surface-2:       #1f2540;
+  --bg-hover:           #272d48;
+  --bg-selected:        rgba(99, 102, 241, 0.12);
+
+  /* Borders */
+  --border-subtle:      rgba(255 255 255 / 0.06);
+  --border-mid:         rgba(255 255 255 / 0.13);
+  --border-strong:      rgba(255 255 255 / 0.24);
+  --border-accent:      rgba(99 102 241 / 0.45);
+
+  /* Diff Color Tokens — WCAG AA compliant */
+  --diff-add-bg:        rgba(16, 185, 129, 0.12);   /* green tint */
+  --diff-add-gutter:    rgba(16, 185, 129, 0.25);
+  --diff-add-text:      #6ee7b7;
+  --diff-add-marker:    #10b981;
+
+  --diff-del-bg:        rgba(239, 68, 68, 0.10);    /* red tint */
+  --diff-del-gutter:    rgba(239, 68, 68, 0.22);
+  --diff-del-text:      #fca5a5;
+  --diff-del-marker:    #ef4444;
+
+  --diff-ctx-bg:        transparent;
+  --diff-ctx-text:      #94a3b8;
+  --diff-hunk-bg:       rgba(99, 102, 241, 0.08);
+  --diff-hunk-border:   rgba(99, 102, 241, 0.25);
+  --diff-hunk-text:     #818cf8;
+
+  /* Accent Colors */
+  --clr-primary:        #6366f1;
+  --clr-primary-hover:  #4f46e5;
+  --clr-primary-glow:   rgba(99, 102, 241, 0.3);
+  --clr-green:          #10b981;
+  --clr-red:            #ef4444;
+  --clr-gold:           #f59e0b;
+  --clr-blue:           #3b82f6;
+  --clr-purple:         #a855f7;
+
+  /* Text */
+  --text-primary:       #f1f5f9;
+  --text-secondary:     #94a3b8;
+  --text-muted:         #64748b;
+
+  /* Radii */
+  --radius-sm:          6px;
+  --radius-md:          10px;
+  --radius-lg:          16px;
+  --radius-xl:          20px;
+  --radius-full:        9999px;
+
+  /* Shadows */
+  --shadow-card:        0 20px 60px rgba(0 0 0 / 0.55);
+  --shadow-glow:        0 0 24px var(--clr-primary-glow);
+
+  /* Motion */
+  --ease-out:           cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-spring:        cubic-bezier(0.34, 1.56, 0.64, 1);
+  --dur-fast:           160ms;
+  --dur-normal:         280ms;
+
+  /* Fonts */
+  --font-sans:          'Inter', system-ui, -apple-system, sans-serif;
+  --font-mono:          'JetBrains Mono', monospace;
+
+  /* Layout */
+  --sidebar-width:      260px;
+}
+
+/* ── 2. LIGHT THEME ─────────────────────────────────────────────── */
+[data-theme="light"] {
+  --bg-app:             #f0f4f8;
+  --bg-card:            #ffffff;
+  --bg-surface:         #f8fafc;
+  --bg-surface-2:       #f1f5f9;
+  --bg-hover:           #e2e8f0;
+  --bg-selected:        rgba(79, 70, 229, 0.07);
+
+  --border-subtle:      rgba(0 0 0 / 0.07);
+  --border-mid:         rgba(0 0 0 / 0.13);
+  --border-strong:      rgba(0 0 0 / 0.22);
+
+  --diff-add-bg:        rgba(16, 185, 129, 0.09);
+  --diff-add-gutter:    rgba(16, 185, 129, 0.18);
+  --diff-add-text:      #065f46;
+  --diff-del-bg:        rgba(239, 68, 68, 0.08);
+  --diff-del-gutter:    rgba(239, 68, 68, 0.18);
+  --diff-del-text:      #991b1b;
+  --diff-ctx-text:      #475569;
+  --diff-hunk-bg:       rgba(79, 70, 229, 0.05);
+  --diff-hunk-text:     #4f46e5;
+
+  --clr-primary:        #4f46e5;
+  --clr-primary-hover:  #4338ca;
+  --clr-primary-glow:   rgba(79, 70, 229, 0.2);
+
+  --text-primary:       #0f172a;
+  --text-secondary:     #475569;
+  --text-muted:         #94a3b8;
+
+  --shadow-card:        0 8px 40px rgba(0 0 0 / 0.1);
+}
+
+/* ── 3. BASE RESET & ACCESSIBILITY ──────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: var(--font-sans);
+  background: var(--bg-app);
+  color: var(--text-primary);
+  line-height: 1.6;
+  min-height: 100vh;
+  padding: 2rem 1rem 4rem;
+  -webkit-font-smoothing: antialiased;
+  transition: background-color var(--dur-normal) var(--ease-out),
+              color var(--dur-normal) var(--ease-out);
+}
+
+.em-sr-only {
+  position: absolute; width: 1px; height: 1px;
+  padding: 0; margin: -1px; overflow: hidden;
+  clip: rect(0,0,0,0); white-space: nowrap; border: 0;
+}
+
+:focus-visible {
+  outline: 3px solid var(--clr-primary);
+  outline-offset: 3px;
+  border-radius: var(--radius-sm);
+}
+
+/* ── 4. PAGE HEADER ─────────────────────────────────────────────── */
+.app-wrapper {
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.page-header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.page-header__tags {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.75rem;
+}
+
+.em-tag {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  padding: 0.2rem 0.55rem;
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  color: var(--text-secondary);
+}
+.em-tag--gold  { border-color: rgba(245,158,11,0.4);  color: var(--clr-gold); }
+.em-tag--blue  { border-color: rgba(59,130,246,0.4);  color: var(--clr-blue); }
+.em-tag--purple{ border-color: rgba(168,85,247,0.4);  color: var(--clr-purple); }
+
+.page-header__title {
+  font-size: clamp(1.75rem, 4vw, 2.5rem);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  background: linear-gradient(135deg, var(--text-primary) 0%, var(--text-secondary) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  margin-bottom: 0.4rem;
+}
+
+.page-header__desc {
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+  max-width: 620px;
+  margin: 0 auto;
+}
+
+/* ── 5. DIFF VIEWER CARD ────────────────────────────────────────── */
+.diff-viewer-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-card);
+  overflow: hidden;
+}
+
+/* ── 6. TOOLBAR ─────────────────────────────────────────────────── */
+.diff-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 1.25rem;
+  background: var(--bg-surface);
+  border-bottom: 1px solid var(--border-subtle);
+  flex-wrap: wrap;
+}
+
+.diff-toolbar__left,
+.diff-toolbar__right {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.file-info {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+}
+
+.file-icon { color: var(--text-muted); display: flex; }
+.file-name { font-weight: 700; color: var(--text-primary); }
+.file-path { color: var(--text-muted); }
+
+/* Mobile Version Select */
+.mobile-version-select-wrapper {
+  display: none;
+}
+
+.mobile-version-select {
+  font-family: var(--font-sans);
+  font-size: 0.82rem;
+  background: var(--bg-surface-2);
+  border: 1px solid var(--border-mid);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  padding: 0.35rem 0.65rem;
+  cursor: pointer;
+}
+
+/* View Toggle */
+.view-toggle {
+  display: flex;
+  background: var(--bg-surface-2);
+  border: 1px solid var(--border-mid);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.view-toggle__btn {
+  font-family: var(--font-sans);
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  background: transparent;
+  border: none;
+  padding: 0.35rem 0.75rem;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  transition: all var(--dur-fast) var(--ease-out);
+}
+.view-toggle__btn:hover { color: var(--text-primary); }
+.view-toggle__btn.active {
+  background: var(--clr-primary);
+  color: #ffffff;
+}
+
+.icon-btn {
+  background: transparent;
+  border: 1px solid var(--border-mid);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 0.35rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all var(--dur-fast) var(--ease-out);
+}
+.icon-btn:hover {
+  color: var(--text-primary);
+  border-color: var(--border-strong);
+  background: var(--bg-hover);
+}
+
+/* Theme icon visibility */
+[data-theme="dark"] .icon-sun { display: block; }
+[data-theme="dark"] .icon-moon { display: none; }
+[data-theme="light"] .icon-sun { display: none; }
+[data-theme="light"] .icon-moon { display: block; }
+
+/* ── 7. DIFF BODY LAYOUT ────────────────────────────────────────── */
+.diff-body {
+  display: flex;
+  min-height: 520px;
+  overflow: hidden;
+}
+
+/* ── 8. REVISION HISTORY SIDEBAR ────────────────────────────────── */
+.revision-sidebar {
+  width: var(--sidebar-width);
+  flex-shrink: 0;
+  border-inline-end: 1px solid var(--border-subtle);
+  background: var(--bg-surface);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.sidebar-heading {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  padding: 1rem 1rem 0.6rem;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.revision-list {
+  list-style: none;
+  flex: 1;
+}
+
+.revision-item {
+  padding: 0.85rem 1rem;
+  cursor: pointer;
+  border-bottom: 1px solid var(--border-subtle);
+  transition: background-color var(--dur-fast) var(--ease-out);
+  position: relative;
+}
+
+.revision-item::before {
+  content: '';
+  position: absolute;
+  inset-inline-start: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: transparent;
+  transition: background var(--dur-fast) var(--ease-out);
+}
+
+.revision-item:hover { background: var(--bg-hover); }
+
+.revision-item.active {
+  background: var(--bg-selected);
+}
+.revision-item.active::before {
+  background: var(--clr-primary);
+}
+
+.revision-item__header {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  margin-bottom: 0.4rem;
+}
+
+/* Author Avatars */
+.author-avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-full);
+  font-size: 0.65rem;
+  font-weight: 800;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  letter-spacing: 0.02em;
+}
+.author-avatar--purple { background: rgba(168,85,247,0.2); color: #c084fc; border: 1px solid rgba(168,85,247,0.35); }
+.author-avatar--blue   { background: rgba(59,130,246,0.2);  color: #93c5fd; border: 1px solid rgba(59,130,246,0.35); }
+.author-avatar--green  { background: rgba(16,185,129,0.2);  color: #6ee7b7; border: 1px solid rgba(16,185,129,0.35); }
+.author-avatar--gold   { background: rgba(245,158,11,0.2);  color: #fcd34d; border: 1px solid rgba(245,158,11,0.35); }
+
+.revision-item__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.revision-tag {
+  display: inline-flex;
+  font-size: 0.62rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.1rem 0.35rem;
+  border-radius: var(--radius-sm);
+  width: fit-content;
+}
+.revision-tag--latest  { background: rgba(16,185,129,0.15); color: #6ee7b7; }
+.revision-tag--initial { background: rgba(99,102,241,0.15); color: #a5b4fc; }
+
+.commit-msg {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
+}
+
+.revision-time {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+}
+
+.diff-stat {
+  display: flex;
+  gap: 0.4rem;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: 600;
+}
+.diff-stat--add { color: var(--clr-green); }
+.diff-stat--del { color: var(--clr-red); }
+
+/* ── 9. DIFF PANE ───────────────────────────────────────────────── */
+.diff-pane {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.diff-pane__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.65rem 1.25rem;
+  background: var(--bg-surface);
+  border-bottom: 1px solid var(--border-subtle);
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.diff-compare-info {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.diff-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.2rem 0.55rem;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+}
+.diff-label--base { background: rgba(239,68,68,0.1);   color: #fca5a5; border: 1px solid rgba(239,68,68,0.2); }
+.diff-label--head { background: rgba(16,185,129,0.1);  color: #6ee7b7; border: 1px solid rgba(16,185,129,0.2); }
+
+.diff-label__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: var(--radius-full);
+  display: inline-block;
+}
+.diff-label__dot--red   { background: var(--clr-red); }
+.diff-label__dot--green { background: var(--clr-green); }
+
+/* Restore Button */
+.restore-btn {
+  font-family: var(--font-sans);
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--clr-primary);
+  background: rgba(99,102,241,0.1);
+  border: 1px solid rgba(99,102,241,0.3);
+  border-radius: var(--radius-md);
+  padding: 0.4rem 0.85rem;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  transition: all var(--dur-fast) var(--ease-out);
+}
+.restore-btn:hover {
+  background: rgba(99,102,241,0.2);
+  border-color: var(--clr-primary);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-glow);
+}
+
+/* ── 10. DIFF CONTENT AREA ──────────────────────────────────────── */
+.diff-content-area {
+  flex: 1;
+  overflow: auto;
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+}
+
+.diff-hunk-header {
+  background: var(--diff-hunk-bg);
+  border-top: 1px solid var(--diff-hunk-border);
+  border-bottom: 1px solid var(--diff-hunk-border);
+  color: var(--diff-hunk-text);
+  padding: 0.35rem 1rem;
+  font-size: 0.78rem;
+  user-select: none;
+  letter-spacing: 0.02em;
+}
+
+.hunk-context {
+  color: var(--text-muted);
+  margin-inline-start: 0.5rem;
+}
+
+/* ── 11. UNIFIED VIEW DIFF LINES ────────────────────────────────── */
+.unified-view {
+  width: 100%;
+}
+
+.diff-table-head {
+  display: grid;
+  grid-template-columns: 42px 42px 1fr;
+  background: var(--bg-surface-2);
+  border-bottom: 1px solid var(--border-subtle);
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  padding: 0.3rem 0;
+}
+.line-col-num  { text-align: center; }
+.line-col-code { padding-inline-start: 0.5rem; }
+
+.diff-lines-container { width: 100%; }
+
+/* Individual diff line row */
+.diff-line {
+  display: grid;
+  grid-template-columns: 42px 42px 1fr;
+  min-height: 26px;
+  align-items: stretch;
+  transition: filter var(--dur-fast);
+}
+.diff-line:hover { filter: brightness(1.1); }
+
+.diff-line__num {
+  text-align: center;
+  padding: 0.2rem 0;
+  color: var(--text-muted);
+  user-select: none;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  background: var(--bg-surface);
+  border-inline-end: 1px solid var(--border-subtle);
+}
+
+.diff-line__marker {
+  width: 20px;
+  text-align: center;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.diff-line__code {
+  padding: 0.2rem 0.75rem;
+  white-space: pre;
+  overflow-x: auto;
+  line-height: 1.5;
+}
+
+/* Context (unchanged) lines */
+.diff-line--ctx .diff-line__num { color: var(--text-muted); }
+.diff-line--ctx .diff-line__code { color: var(--diff-ctx-text); background: var(--diff-ctx-bg); }
+.diff-line--ctx .diff-line__marker { color: transparent; }
+
+/* Addition lines (+) */
+.diff-line--add .diff-line__num { background: var(--diff-add-gutter); color: var(--diff-add-text); }
+.diff-line--add .diff-line__code { background: var(--diff-add-bg); color: var(--diff-add-text); }
+.diff-line--add .diff-line__marker { color: var(--diff-add-marker); }
+
+/* Deletion lines (-) */
+.diff-line--del .diff-line__num { background: var(--diff-del-gutter); color: var(--diff-del-text); }
+.diff-line--del .diff-line__code { background: var(--diff-del-bg); color: var(--diff-del-text); text-decoration: line-through; text-decoration-color: rgba(239,68,68,0.5); }
+.diff-line--del .diff-line__marker { color: var(--diff-del-marker); }
+
+/* ── 12. SPLIT VIEW ─────────────────────────────────────────────── */
+.split-view {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  height: 100%;
+}
+
+.split-pane {
+  overflow-x: auto;
+  border-inline-end: 1px solid var(--border-subtle);
+}
+
+.split-pane--right { border-inline-end: none; }
+
+.split-pane__header {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  padding: 0.4rem 0.75rem;
+  background: var(--bg-surface-2);
+  border-bottom: 1px solid var(--border-subtle);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+/* Split view lines have simpler 2-col layout: num | code */
+.split-view .diff-line {
+  grid-template-columns: 36px 1fr;
+}
+
+/* ── 13. RESTORE CONFIRMATION DIALOG ────────────────────────────── */
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0 0 0 / 0.65);
+  backdrop-filter: blur(4px);
+  z-index: 100;
+}
+
+.restore-dialog {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0.95);
+  z-index: 200;
+  width: min(440px, 90vw);
+  background: var(--bg-card);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-xl);
+  padding: 2rem;
+  box-shadow: 0 24px 64px rgba(0 0 0 / 0.5);
+  text-align: center;
+  opacity: 0;
+  transition: opacity var(--dur-normal) var(--ease-out),
+              transform var(--dur-normal) var(--ease-spring);
+}
+
+.restore-dialog.dialog-open {
+  opacity: 1;
+  transform: translate(-50%, -50%) scale(1);
+}
+
+.restore-dialog__icon {
+  width: 56px;
+  height: 56px;
+  border-radius: var(--radius-full);
+  background: rgba(239,68,68,0.12);
+  color: var(--clr-red);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto 1.25rem;
+  border: 1px solid rgba(239,68,68,0.25);
+}
+
+.restore-dialog__title {
+  font-size: 1.2rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+
+.restore-dialog__desc {
+  font-size: 0.88rem;
+  color: var(--text-secondary);
+  margin-bottom: 1.5rem;
+}
+
+.restore-dialog__actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+}
+
+.dialog-btn {
+  font-family: var(--font-sans);
+  font-size: 0.88rem;
+  font-weight: 600;
+  padding: 0.55rem 1.25rem;
+  border-radius: var(--radius-md);
+  border: 1px solid transparent;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  transition: all var(--dur-fast) var(--ease-out);
+}
+
+.dialog-btn--secondary {
+  background: var(--bg-surface);
+  border-color: var(--border-mid);
+  color: var(--text-primary);
+}
+.dialog-btn--secondary:hover {
+  background: var(--bg-hover);
+  border-color: var(--border-strong);
+}
+
+.dialog-btn--danger {
+  background: var(--clr-red);
+  color: #ffffff;
+}
+.dialog-btn--danger:hover {
+  filter: brightness(1.1);
+  transform: translateY(-1px);
+}
+
+/* ── 14. TOAST NOTIFICATIONS ────────────────────────────────────── */
+.toast-region {
+  position: fixed;
+  bottom: 1.5rem;
+  inset-inline-end: 1.5rem;
+  z-index: 500;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  pointer-events: none;
+}
+
+.toast {
+  pointer-events: auto;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  padding: 0.7rem 1.1rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--text-primary);
+  box-shadow: 0 8px 32px rgba(0 0 0 / 0.4);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  animation: toast-pop var(--dur-fast) var(--ease-spring);
+}
+
+@keyframes toast-pop {
+  from { opacity: 0; transform: translateY(8px) scale(0.95); }
+  to   { opacity: 1; transform: translateY(0)   scale(1); }
+}
+
+/* ── 15. RESPONSIVE (< 768px) ───────────────────────────────────── */
+@media (max-width: 768px) {
+  .revision-sidebar {
+    display: none;
+  }
+  .mobile-version-select-wrapper {
+    display: block;
+  }
+  .diff-body {
+    flex-direction: column;
+  }
+  .view-toggle__btn span {
+    display: none;
+  }
+  .split-view {
+    grid-template-columns: 1fr;
+  }
+  .split-pane--left {
+    display: none;
+  }
+}
+
+/* ── 16. REDUCED MOTION ─────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  *, ::before, ::after {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
 Revision sidebar with author avatars (initials/color-coded), commit messages, timestamps, and +/- diff stats
🟢🔴 WCAG AA color-coded diffs — --diff-add-bg green tint / --diff-del-bg red tint with ≥4.5:1 contrast
↔️ Unified ↔ Split view toggle with smooth switching and aria-pressed state management
🔄 Restore confirmation dialog with CSS scale/opacity entrance animation, backdrop blur, and keyboard Escape close
📱 Responsive — sidebar collapses to a <select> dropdown on mobile (< 768px)
☀️🌙 Live Light/Dark theme toggle.


closed #64784