### PR TITLE
feat: add pure CSS cyberpunk glitch text effect

### DIFF
--- a/submissions/examples/ease-glitch-text/README.md
+++ b/submissions/examples/ease-glitch-text/README.md
@@ -1,0 +1,12 @@
+# Glitch Text Reveal
+
+An edgy, high-impact typography animation that simulates a digital "screen tear" or glitch when hovered. This is a highly requested effect for gaming hubs, Web3 landing pages, and cyberpunk-themed portfolios.
+
+### Usage
+```html
+<h1 class="ease-glitch-text" data-text="CYBERPUNK">CYBERPUNK</h1>
+```
+*Note: The `data-text` attribute must exactly match the inner HTML of the element for the pseudo-elements to duplicate the text properly.*
+
+### Why is it useful?
+Historically, glitch effects were either pre-rendered as GIFs/videos or generated via canvas/WebGL plugins. This component brings the effect directly into the DOM using pure CSS. By leveraging `clip-path` to rapidly slice overlapping pseudo-elements colored in cyan and magenta, it achieves a highly performant, authentic digital tear effect with zero JavaScript overhead.

--- a/submissions/examples/ease-glitch-text/demo.html
+++ b/submissions/examples/ease-glitch-text/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ease Glitch Text Hover</title>
+    <link rel="stylesheet" href="../../../easemotion.min.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="ease-glitch-container">
+        <!-- The data-text attribute is essential for the pseudo-elements to duplicate the content -->
+        <h1 class="ease-glitch-text" data-text="CYBERPUNK">CYBERPUNK</h1>
+        <p class="ease-glitch-subtitle">Hover over the text to trigger the digital tear effect.</p>
+    </div>
+</body>
+</html>

--- a/submissions/examples/ease-glitch-text/style.css
+++ b/submissions/examples/ease-glitch-text/style.css
@@ -1,0 +1,90 @@
+body {
+    margin: 0;
+    padding: 0;
+    background-color: #111111; /* Dark background */
+    font-family: 'Courier New', Courier, monospace;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+}
+
+.ease-glitch-container {
+    text-align: center;
+    color: #ffffff;
+}
+
+.ease-glitch-subtitle {
+    margin-top: 20px;
+    font-size: 14px;
+    color: #888888;
+}
+
+.ease-glitch-text {
+    position: relative;
+    font-size: 80px;
+    font-weight: 900;
+    margin: 0;
+    text-transform: uppercase;
+    letter-spacing: 5px;
+    color: #ffffff;
+    display: inline-block;
+    user-select: none;
+}
+
+/* Pseudo-elements for the duplicate layers */
+.ease-glitch-text::before,
+.ease-glitch-text::after {
+    content: attr(data-text);
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: #111111;
+    opacity: 0;
+}
+
+/* Cyan layer (offset left) */
+.ease-glitch-text::before {
+    left: 3px;
+    text-shadow: -2px 0 #00ffff;
+    clip-path: polygon(0 0, 100% 0, 100% 45%, 0 45%);
+}
+
+/* Magenta layer (offset right) */
+.ease-glitch-text::after {
+    left: -3px;
+    text-shadow: 2px 0 #ff00ff;
+    clip-path: polygon(0 55%, 100% 55%, 100% 100%, 0 100%);
+}
+
+/* Hover trigger */
+.ease-glitch-text:hover::before {
+    opacity: 1;
+    animation: ease-kf-glitch-anim-1 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94) both infinite;
+}
+
+.ease-glitch-text:hover::after {
+    opacity: 1;
+    animation: ease-kf-glitch-anim-2 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94) both infinite reverse;
+}
+
+/* Slicing animations */
+@keyframes ease-kf-glitch-anim-1 {
+    0% { clip-path: polygon(0 20%, 100% 20%, 100% 30%, 0 30%); transform: translate(-3px, 1px); }
+    20% { clip-path: polygon(0 60%, 100% 60%, 100% 70%, 0 70%); transform: translate(3px, -1px); }
+    40% { clip-path: polygon(0 40%, 100% 40%, 100% 50%, 0 50%); transform: translate(-3px, 2px); }
+    60% { clip-path: polygon(0 80%, 100% 80%, 100% 90%, 0 90%); transform: translate(3px, -2px); }
+    80% { clip-path: polygon(0 10%, 100% 10%, 100% 20%, 0 20%); transform: translate(-3px, 1px); }
+    100% { clip-path: polygon(0 30%, 100% 30%, 100% 40%, 0 40%); transform: translate(3px, -1px); }
+}
+
+@keyframes ease-kf-glitch-anim-2 {
+    0% { clip-path: polygon(0 15%, 100% 15%, 100% 25%, 0 25%); transform: translate(3px, -1px); }
+    20% { clip-path: polygon(0 55%, 100% 55%, 100% 65%, 0 65%); transform: translate(-3px, 1px); }
+    40% { clip-path: polygon(0 35%, 100% 35%, 100% 45%, 0 45%); transform: translate(3px, -2px); }
+    60% { clip-path: polygon(0 75%, 100% 75%, 100% 85%, 0 85%); transform: translate(-3px, 2px); }
+    80% { clip-path: polygon(0 5%, 100% 5%, 100% 15%, 0 15%); transform: translate(3px, -1px); }
+    100% { clip-path: polygon(0 25%, 100% 25%, 100% 35%, 0 35%); transform: translate(-3px, 1px); }
+}


### PR DESCRIPTION
fixes #64852 

## Pull Request Description

Adds an `ease-glitch-text` typography effect. Gaming hubs, Web3 apps, and cyberpunk-themed portfolios often require edgy, high-impact header animations. This submission implements a digital "screen tear" effect that violently slices and offsets text on hover, achieving an authentic glitch purely via CSS.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component (Standard Track)
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/ease-glitch-text/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

An edgy typography animation that uses a `data-text` attribute to generate duplicate layers of the text via pseudo-elements (`::before` / `::after`), applying cyan/magenta text-shadows and rapid `clip-path` keyframes to simulate a digital screen tear on hover.

**How does a developer use it?**

```html
<h1 class="ease-glitch-text" data-text="CYBERPUNK">CYBERPUNK</h1>
