### PR TITLE
feat: add CSS fade-in hero section for glassmorphism UI layouts (#64333)

### DIFF
--- a/submissions/examples/fade-in-hero-glassmorphism-layouts/README.md
+++ b/submissions/examples/fade-in-hero-glassmorphism-layouts/README.md
@@ -1,0 +1,57 @@
+# CSS Fade-In Hero Section — Glassmorphism Layouts
+
+A pure CSS hero section featuring frosted-glass panels, ambient gradient orbs, and a staggered fade-in entrance animation. Built for SaaS landing pages, product showcases, and modern web apps.
+
+## Demo
+
+Open `demo.html` in any modern browser. No build step required.
+
+## Features
+
+- **Glassmorphism panels** — `backdrop-filter: blur` with semi-transparent backgrounds
+- **Staggered fade-in** — panels enter sequentially using `animation-delay`
+- **Ambient orbs** — three animated gradient blobs drift behind the glass
+- **Responsive** — three-column stats grid collapses to two-column, then single-column
+- **Accessible** — `prefers-reduced-motion` disables all animations instantly
+- **Zero JavaScript** — pure HTML + CSS, no frameworks
+
+## CSS Custom Properties
+
+Override these on `:root` to re-theme the component:
+
+```css
+:root {
+  --fhg-bg: #0c0f1a;
+  --fhg-text: #e8ecf4;
+  --fhg-muted: #8892a8;
+  --fhg-accent: #7c6aef;
+  --fhg-accent-light: #a49bff;
+  --fhg-glass-bg: rgba(255, 255, 255, 0.06);
+  --fhg-glass-border: rgba(255, 255, 255, 0.12);
+  --fhg-glass-blur: 18px;
+  --fhg-radius: 24px;
+  --fhg-enter: 0.8s cubic-bezier(0.22, 1, 0.36, 1);
+  --fhg-stagger: 0.12s;
+}
+```
+
+## How It Works
+
+1. Each `.glass-panel` starts with `opacity: 0` and `translateY(24px)`
+2. The `fhg-fade-in` keyframe animates both properties to their final state
+3. `animation-delay` is set via CSS `calc()` using the `--fhg-stagger` variable
+4. The `@media (prefers-reduced-motion: reduce)` block sets `animation: none` and resets opacity/transform
+
+## Responsive Breakpoints
+
+- **Desktop** (> 768px): 4-column stats grid, 2-column feature grid
+- **Tablet** (≤ 768px): 2-column stats, single-column features
+- **Mobile** (≤ 480px): full-width stack, stacked buttons
+
+## Browser Support
+
+Chrome 76+, Firefox 103+, Safari 14+, Edge 79+
+
+## License
+
+Free to use in any EaseMotion CSS project.

--- a/submissions/examples/fade-in-hero-glassmorphism-layouts/demo.html
+++ b/submissions/examples/fade-in-hero-glassmorphism-layouts/demo.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="CSS Fade-In Hero Section with glassmorphism effect for modern UI layouts">
+    <title>Fade-In Hero Section — Glassmorphism Layouts</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="hero-bg" aria-hidden="true">
+        <div class="hero-bg__orb hero-bg__orb--1"></div>
+        <div class="hero-bg__orb hero-bg__orb--2"></div>
+        <div class="hero-bg__orb hero-bg__orb--3"></div>
+    </div>
+
+    <main class="hero">
+
+        <section class="glass-panel glass-panel--hero">
+            <span class="badge">EaseMotion CSS</span>
+            <h1 class="hero__title">Build interfaces that feel alive</h1>
+            <p class="hero__subtitle">
+                A lightweight, pure-CSS hero section with frosted glass panels,
+                smooth fade-in entrance, and ambient colour orbs that drift
+                across the viewport.
+            </p>
+            <div class="hero__actions">
+                <a href="#demo" class="btn btn--primary">Get Started</a>
+                <a href="#docs" class="btn btn--ghost">View Docs</a>
+            </div>
+        </section>
+
+        <section class="glass-panel glass-panel--stats" id="demo">
+            <div class="stat">
+                <span class="stat__value">0 KB</span>
+                <span class="stat__label">JavaScript</span>
+            </div>
+            <div class="stat">
+                <span class="stat__value">&lt;4 KB</span>
+                <span class="stat__label">CSS gzipped</span>
+            </div>
+            <div class="stat">
+                <span class="stat__value">60 fps</span>
+                <span class="stat__label">Animations</span>
+            </div>
+            <div class="stat">
+                <span class="stat__value">AAA</span>
+                <span class="stat__label">Accessibility</span>
+            </div>
+        </section>
+
+        <section class="glass-panel glass-panel--features" id="docs">
+            <h2 class="section-title">What you get</h2>
+            <div class="feature-grid">
+                <article class="feature-card">
+                    <div class="feature-card__icon" aria-hidden="true">&#9672;</div>
+                    <h3>Frosted Panels</h3>
+                    <p>Backdrop-filter blur with subtle borders creates depth without heavy shadows.</p>
+                </article>
+                <article class="feature-card">
+                    <div class="feature-card__icon" aria-hidden="true">&#9678;</div>
+                    <h3>Staggered Fade-In</h3>
+                    <p>Each element enters sequentially with a soft translateY and opacity transition.</p>
+                </article>
+                <article class="feature-card">
+                    <div class="feature-card__icon" aria-hidden="true">&#9674;</div>
+                    <h3>Ambient Orbs</h3>
+                    <p>Animated gradient blobs float behind the glass for visual interest.</p>
+                </article>
+                <article class="feature-card">
+                    <div class="feature-card__icon" aria-hidden="true">&#9676;</div>
+                    <h3>Responsive Stack</h3>
+                    <p>Three-column layout collapses to a single column on narrow viewports.</p>
+                </article>
+            </div>
+        </section>
+
+    </main>
+
+</body>
+</html>

--- a/submissions/examples/fade-in-hero-glassmorphism-layouts/style.css
+++ b/submissions/examples/fade-in-hero-glassmorphism-layouts/style.css
@@ -1,0 +1,356 @@
+:root {
+  --fhg-bg: #0c0f1a;
+  --fhg-text: #e8ecf4;
+  --fhg-muted: #8892a8;
+  --fhg-accent: #7c6aef;
+  --fhg-accent-light: #a49bff;
+  --fhg-glass-bg: rgba(255, 255, 255, 0.06);
+  --fhg-glass-border: rgba(255, 255, 255, 0.12);
+  --fhg-glass-blur: 18px;
+  --fhg-radius: 24px;
+  --fhg-enter: 0.8s cubic-bezier(0.22, 1, 0.36, 1);
+  --fhg-stagger: 0.12s;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  scroll-behavior: smooth;
+  -webkit-text-size-adjust: 100%;
+}
+
+body {
+  min-height: 100dvh;
+  background: var(--fhg-bg);
+  color: var(--fhg-text);
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  line-height: 1.6;
+  overflow-x: hidden;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* ── Background orbs ─────────────────────────────────── */
+
+.hero-bg {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.hero-bg__orb {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(90px);
+  opacity: 0.35;
+}
+
+.hero-bg__orb--1 {
+  width: 500px;
+  height: 500px;
+  top: -10%;
+  left: -5%;
+  background: radial-gradient(circle, #7c6aef, transparent 70%);
+  animation: fhg-drift-1 18s ease-in-out infinite alternate;
+}
+
+.hero-bg__orb--2 {
+  width: 400px;
+  height: 400px;
+  bottom: -8%;
+  right: -4%;
+  background: radial-gradient(circle, #38bdf8, transparent 70%);
+  animation: fhg-drift-2 22s ease-in-out infinite alternate;
+}
+
+.hero-bg__orb--3 {
+  width: 300px;
+  height: 300px;
+  top: 40%;
+  left: 55%;
+  background: radial-gradient(circle, #f472b6, transparent 70%);
+  animation: fhg-drift-3 20s ease-in-out infinite alternate;
+}
+
+@keyframes fhg-drift-1 {
+  0%   { transform: translate(0, 0) scale(1); }
+  100% { transform: translate(80px, 60px) scale(1.15); }
+}
+
+@keyframes fhg-drift-2 {
+  0%   { transform: translate(0, 0) scale(1); }
+  100% { transform: translate(-70px, -50px) scale(1.1); }
+}
+
+@keyframes fhg-drift-3 {
+  0%   { transform: translate(0, 0) scale(1); }
+  100% { transform: translate(-40px, 70px) scale(0.9); }
+}
+
+/* ── Main layout ─────────────────────────────────────── */
+
+.hero {
+  position: relative;
+  z-index: 1;
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem 5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+/* ── Glass panels ────────────────────────────────────── */
+
+.glass-panel {
+  background: var(--fhg-glass-bg);
+  border: 1px solid var(--fhg-glass-border);
+  border-radius: var(--fhg-radius);
+  backdrop-filter: blur(var(--fhg-glass-blur));
+  -webkit-backdrop-filter: blur(var(--fhg-glass-blur));
+  padding: 2.5rem;
+  opacity: 0;
+  transform: translateY(24px);
+  animation: fhg-fade-in var(--fhg-enter) forwards;
+}
+
+.glass-panel--hero {
+  text-align: center;
+  padding: 4rem 2rem;
+  animation-delay: calc(var(--fhg-stagger) * 0);
+}
+
+.glass-panel--stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1.5rem;
+  text-align: center;
+  animation-delay: calc(var(--fhg-stagger) * 1);
+}
+
+.glass-panel--features {
+  animation-delay: calc(var(--fhg-stagger) * 2);
+}
+
+@keyframes fhg-fade-in {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* ── Badge ───────────────────────────────────────────── */
+
+.badge {
+  display: inline-block;
+  padding: 0.3rem 0.9rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--fhg-accent-light);
+  border: 1px solid rgba(124, 106, 239, 0.3);
+  border-radius: 999px;
+  background: rgba(124, 106, 239, 0.1);
+  margin-bottom: 1.2rem;
+}
+
+/* ── Hero text ───────────────────────────────────────── */
+
+.hero__title {
+  font-size: clamp(2rem, 5vw, 3.4rem);
+  font-weight: 800;
+  line-height: 1.1;
+  letter-spacing: -0.03em;
+  margin-bottom: 1rem;
+}
+
+.hero__subtitle {
+  max-width: 560px;
+  margin: 0 auto 1.8rem;
+  color: var(--fhg-muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+/* ── Buttons ─────────────────────────────────────────── */
+
+.hero__actions {
+  display: flex;
+  gap: 0.8rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.65rem 1.6rem;
+  font-size: 0.88rem;
+  font-weight: 700;
+  border-radius: 12px;
+  text-decoration: none;
+  transition: background 0.25s ease, color 0.25s ease, transform 0.25s ease;
+}
+
+.btn--primary {
+  background: var(--fhg-accent);
+  color: #fff;
+}
+
+.btn--primary:hover {
+  background: var(--fhg-accent-light);
+  transform: translateY(-2px);
+}
+
+.btn--ghost {
+  background: transparent;
+  color: var(--fhg-text);
+  border: 1px solid var(--fhg-glass-border);
+}
+
+.btn--ghost:hover {
+  background: rgba(255, 255, 255, 0.08);
+  transform: translateY(-2px);
+}
+
+.btn:focus-visible {
+  outline: 2px solid var(--fhg-accent);
+  outline-offset: 3px;
+}
+
+/* ── Stats row ───────────────────────────────────────── */
+
+.stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.stat__value {
+  font-size: 1.4rem;
+  font-weight: 800;
+  color: var(--fhg-accent-light);
+}
+
+.stat__label {
+  font-size: 0.75rem;
+  color: var(--fhg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+/* ── Feature grid ────────────────────────────────────── */
+
+.section-title {
+  font-size: 1.3rem;
+  font-weight: 700;
+  margin-bottom: 1.4rem;
+  letter-spacing: -0.01em;
+}
+
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.2rem;
+}
+
+.feature-card {
+  padding: 1.4rem;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  transition: background 0.3s ease, border-color 0.3s ease;
+}
+
+.feature-card:hover {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.12);
+}
+
+.feature-card__icon {
+  font-size: 1.5rem;
+  margin-bottom: 0.6rem;
+  color: var(--fhg-accent-light);
+}
+
+.feature-card h3 {
+  font-size: 0.95rem;
+  font-weight: 700;
+  margin-bottom: 0.35rem;
+}
+
+.feature-card p {
+  font-size: 0.85rem;
+  color: var(--fhg-muted);
+  line-height: 1.55;
+}
+
+/* ── Responsive ──────────────────────────────────────── */
+
+@media (max-width: 768px) {
+  .glass-panel--hero {
+    padding: 2.5rem 1.25rem;
+  }
+
+  .glass-panel--stats {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .feature-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 480px) {
+  .hero {
+    padding: 2rem 1rem 3rem;
+  }
+
+  .glass-panel {
+    padding: 1.5rem;
+    border-radius: 18px;
+  }
+
+  .hero__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .btn {
+    justify-content: center;
+  }
+}
+
+/* ── Reduced motion ──────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  .glass-panel {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+
+  .hero-bg__orb {
+    animation: none;
+  }
+
+  .btn {
+    transition: none;
+  }
+
+  .feature-card {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## What this PR does

Adds a pure CSS hero section with frosted-glass panels, ambient gradient orbs, and staggered fade-in entrance animation. Resolves #64333.

## What's included

- `demo.html` — Semantic HTML5 showcase page with glass panels, stats row, and feature grid
- `style.css` — Pure CSS with glassmorphism effect, drift animations, and responsive breakpoints
- `README.md` — Full documentation with CSS custom properties and usage guide

## Features

- **Glassmorphism panels** — `backdrop-filter: blur` with semi-transparent backgrounds and subtle borders
- **Staggered fade-in** — panels enter sequentially using `animation-delay` calculated from a CSS variable
- **Ambient orbs** — three animated gradient blobs float behind the glass using `@keyframes`
- **Fully responsive** — 4-col → 2-col → 1-col stats grid, 2-col → 1-col feature grid
- **`prefers-reduced-motion`** — all animations disabled, elements shown immediately
- **CSS custom properties** — every colour, spacing, and timing value is overridable via `:root`
- **Zero JavaScript** — pure HTML + CSS, no external dependencies

## Checklist

- [x] Files placed only inside `submissions/examples/fade-in-hero-glassmorphism-layouts/`
- [x] Pure CSS/HTML, no JavaScript frameworks
- [x] Smooth CSS transitions and keyframe animations
- [x] Fully responsive across desktop, tablet, and mobile
- [x] Accessible with `prefers-reduced-motion` and `focus-visible` support
- [x] CSS custom properties for easy theming
- [x] Semantic HTML structure

Closes #64333