### PR TITLE
CSS Zoom-In Drawer for Cyberpunk Neon Layouts

### DIFF
--- a/submissions/examples/zoom-in-cyberpunk-drawer/README.md
+++ b/submissions/examples/zoom-in-cyberpunk-drawer/README.md
@@ -1,0 +1,30 @@
+# Sandbox Showcase: CSS Zoom-In Drawer for Cyberpunk Neon Layouts
+
+## Overview
+A lightweight, pure CSS/HTML slide-out panel component designed for futuristic dashboards, cyberpunk UI themes, and gaming control panels. It combines `transform: scale()` zoom animations with backdrop blur effects and checkbox state bindings to deliver smooth hardware-accelerated drawer transitions without JavaScript.
+
+## 📁 Sandbox Configuration Files
+* `demo.html` — Self-contained user cockpit hosting an interactive cyberpunk dashboard and zoom-in drawer.
+* `style.css` — Scoped layout modifier specifying `scale()` and `translate3d()` transforms alongside neon color themes.
+
+## ⚙️ CSS Custom Properties
+
+Customize the component's visual theme easily by altering these root CSS variables in `style.css`:
+
+| Variable | Default Value | Description |
+| :--- | :--- | :--- |
+| `--neon-cyan` | `#00f3ff` | Primary cyan accent color |
+| `--neon-magenta` | `#ff0055` | Secondary magenta glow color |
+| `--neon-cyan-glow` | `rgba(0, 243, 255, 0.35)` | Ambient glowing shadow for buttons |
+| `--neon-magenta-glow` | `rgba(255, 0, 85, 0.35)` | Ambient glowing shadow for drawer panel |
+| `--cyber-bg` | `#030712` | Stage container background color |
+| `--cyber-card-bg` | `rgba(15, 23, 42, 0.85)` | Glassmorphic surface color for drawer |
+| `--drawer-speed` | `400ms` | Transition duration for drawer slide/zoom |
+| `--drawer-ease` | `cubic-bezier(0.16, 1, 0.3, 1)` | Smooth decelerating easing curve |
+
+## 🛠️ How It Works
+
+1. **Pure CSS State Machine:** A hidden `<input type="checkbox">` element retains open/closed panel state.
+2. **Sibling Selector Bindings:** `.alm-drawer-checkbox:checked ~ .alm-sandbox-stage .alm-zoom-drawer` triggers visual state changes.
+3. **GPU-Accelerated Scale/Slide:** Uses `transform: scale(0.85) translate3d(100%, 0, 0)` animating to `scale(1) translate3d(0, 0, 0)` for silky-smooth $60\text{fps}$ performance.
+4. **Accessibility Built-In:** Includes explicit `:focus-visible` rings for keyboard controls and gracefully disables scaling/sliding when `@media (prefers-reduced-motion: reduce)` is enabled.

--- a/submissions/examples/zoom-in-cyberpunk-drawer/demo.html
+++ b/submissions/examples/zoom-in-cyberpunk-drawer/demo.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion CSS Sandbox — Zoom-In Cyberpunk Drawer</title>
+  
+  <!-- Relative path loading your sandbox style context cleanly -->
+  <link rel="stylesheet" href="./style.css">
+  
+  <style>
+    body {
+      background-color: #0b1121;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      margin: 0;
+      padding: 1.5rem;
+    }
+  </style>
+</head>
+<body>
+
+  <header style="margin-bottom: 2rem; text-align: center; max-width: 520px;">
+    <h1 style="color: white; margin: 0; font-size: 1.5rem; font-weight: 700;">Zoom-In Cyberpunk Drawer Canvas</h1>
+    <p style="color: #64748b; margin: 4px 0 0 0; font-size: 0.875rem; line-height: 1.5;">Click "Open Cybernetic Drawer". Driven entirely by checkbox state bindings and GPU-accelerated scale/translate transforms with 0 scripts.</p>
+  </header>
+
+  <!-- PURE CSS HIDDEN CHECKBOX STATE CONTROLLER -->
+  <input type="checkbox" id="cyberDrawerToggle" class="alm-drawer-checkbox">
+
+  <!-- Sandbox Active Stage Envelope -->
+  <div class="alm-sandbox-stage">
+    
+    <!-- GRID BACKGROUND PATTERN -->
+    <div class="alm-cyber-grid-bg"></div>
+
+    <!-- MAIN CANVAS CONTENT -->
+    <div class="alm-cyber-content-wrapper">
+      <span class="alm-card-tag">[Cyber_Terminal_V8]</span>
+      <h2 class="alm-cyber-title">Neural Matrix Control Plane</h2>
+      <p class="alm-cyber-body">
+        Select the action below to open the slide-out telemetry drawer. The zoom-in transition scales the panel from 85% to 100% while sliding horizontally into place.
+      </p>
+
+      <label for="cyberDrawerToggle" class="alm-cyber-btn-trigger">
+        <span>⚡ Open Cybernetic Drawer</span>
+      </label>
+    </div>
+
+    <!-- BACKDROP DIMMER LAYER -->
+    <label for="cyberDrawerToggle" class="alm-drawer-backdrop" aria-label="Close Drawer Backdrop"></label>
+
+    <!-- ZOOM-IN CYBERPUNK DRAWER PANEL -->
+    <aside class="alm-zoom-drawer" aria-label="Cybernetic Telemetry Panel">
+      <div>
+        <div class="alm-drawer-header">
+          <span class="alm-card-tag">[DRAWER_OVERLAY]</span>
+          <label for="cyberDrawerToggle" class="alm-btn-close" aria-label="Close Drawer">✕</label>
+        </div>
+
+        <h3 style="margin: 0.75rem 0 0 0; font-size: 1rem; color: #ffffff; text-transform: uppercase;">
+          System Telemetry
+        </h3>
+
+        <div class="alm-cyber-metric-group">
+          <div class="alm-metric-item">
+            <div class="alm-metric-label">Neural Core Load</div>
+            <div class="alm-metric-val">98.4% [OVERCLOCKED]</div>
+          </div>
+
+          <div class="alm-metric-item">
+            <div class="alm-metric-label">Memory Allocation</div>
+            <div class="alm-metric-val">128.4 TB / 256 TB</div>
+          </div>
+
+          <div class="alm-metric-item">
+            <div class="alm-metric-label">Encryption Cipher</div>
+            <div class="alm-metric-val" style="color: var(--neon-magenta);">AES-512-QUANTUM</div>
+          </div>
+        </div>
+      </div>
+
+      <div style="border-top: 1px solid rgba(255,255,255,0.08); padding-top: 0.75rem;">
+        <label for="cyberDrawerToggle" class="alm-cyber-btn-trigger" style="width: 100%; justify-content: center; box-sizing: border-box;">
+          <span>Close Panel</span>
+        </label>
+      </div>
+    </aside>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/zoom-in-cyberpunk-drawer/style.css
+++ b/submissions/examples/zoom-in-cyberpunk-drawer/style.css
@@ -1,0 +1,277 @@
+/* ============================================================
+   EaseMotion CSS Sandbox — zoom-in-cyberpunk-drawer/style.css
+   ============================================================ */
+
+/* Step back 3 levels out of submissions/examples/zoom-in-cyberpunk-drawer to pull root tokens */
+@import "../../../core/variables.css";
+@import "../../../core/utilities.css";
+
+@layer easemotion-components {
+
+/* ── Custom Component Properties ───────────────────────── */
+:root {
+  --neon-cyan: #00f3ff;
+  --neon-magenta: #ff0055;
+  --neon-cyan-glow: rgba(0, 243, 255, 0.35);
+  --neon-magenta-glow: rgba(255, 0, 85, 0.35);
+  --cyber-bg: #030712;
+  --cyber-card-bg: rgba(15, 23, 42, 0.85);
+  --cyber-border: rgba(0, 243, 255, 0.2);
+  --cyber-text: #f8fafc;
+  --cyber-muted: #94a3b8;
+  --drawer-speed: 400ms;
+  --drawer-ease: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* ── Hidden State Controller Checkbox ──────────────────── */
+.alm-drawer-checkbox {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+}
+
+/* ── Outer Stage Frame ─────────────────────────────────── */
+.alm-sandbox-stage {
+  position: relative;
+  width: 100%;
+  max-width: 680px;
+  height: 480px;
+  background: var(--cyber-bg);
+  border: 1px solid var(--cyber-border);
+  border-radius: var(--ease-radius-xl, 1.5rem);
+  box-sizing: border-box;
+  font-family: var(--ease-font-sans, system-ui, -apple-system, sans-serif);
+  color: var(--cyber-text);
+  overflow: hidden;
+  box-shadow: 0 0 30px rgba(0, 0, 0, 0.8);
+}
+
+/* High-Contrast Cyberpunk Background Grid */
+.alm-cyber-grid-bg {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-image: 
+    linear-gradient(rgba(0, 243, 255, 0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0, 243, 255, 0.05) 1px, transparent 1px);
+  background-size: 24px 24px;
+  z-index: 0;
+}
+
+/* ── Main Canvas Viewport Content ──────────────────────── */
+.alm-cyber-content-wrapper {
+  position: relative;
+  z-index: 1;
+  padding: var(--ease-space-6, 2rem);
+  display: flex;
+  flex-direction: column;
+  gap: var(--ease-space-4, 1rem);
+  height: 100%;
+  box-sizing: border-box;
+}
+
+.alm-card-tag {
+  font-family: monospace;
+  font-size: 0.65rem;
+  font-weight: 700;
+  color: var(--neon-cyan);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.alm-cyber-title {
+  margin: 0;
+  font-size: var(--ease-text-lg, 1.25rem);
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background: linear-gradient(90deg, var(--neon-cyan), var(--neon-magenta));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.alm-cyber-body {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--cyber-muted);
+  line-height: 1.6;
+}
+
+/* Trigger Button */
+.alm-cyber-btn-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ease-space-2, 0.5rem);
+  align-self: flex-start;
+  padding: var(--ease-space-3, 0.75rem) var(--ease-space-5, 1.25rem);
+  background: rgba(0, 243, 255, 0.1);
+  border: 1px solid var(--neon-cyan);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  color: var(--neon-cyan);
+  font-size: 0.75rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+  user-select: none;
+  box-shadow: 0 0 15px var(--neon-cyan-glow);
+  transition: background-color var(--ease-speed-fast, 150ms) ease,
+              box-shadow var(--ease-speed-fast, 150ms) ease,
+              transform var(--ease-speed-fast, 150ms) ease;
+}
+
+.alm-cyber-btn-trigger:hover {
+  background: var(--neon-cyan);
+  color: #000000;
+  box-shadow: 0 0 25px var(--neon-cyan);
+}
+
+/* ── OVERLAY BACKDROP SHADOW ───────────────────────────── */
+.alm-drawer-backdrop {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(3, 7, 18, 0.7);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  z-index: 10;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--drawer-speed) ease;
+}
+
+/* Backdrop Checked State */
+.alm-drawer-checkbox:checked ~ .alm-sandbox-stage .alm-drawer-backdrop {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* ── ZOOM-IN DRAWER PANEL ──────────────────────────────── */
+.alm-zoom-drawer {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 320px;
+  height: 100%;
+  background: var(--cyber-card-bg);
+  border-left: 2px solid var(--neon-magenta);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  box-shadow: -10px 0 35px var(--neon-magenta-glow);
+  padding: var(--ease-space-5, 1.5rem);
+  box-sizing: border-box;
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  /* SUCCESS: Hardware-accelerated scale-zoom & offscreen translate */
+  transform: scale(0.85) translate3d(100%, 0, 0);
+  transform-origin: 100% 50%;
+  opacity: 0;
+  pointer-events: none;
+  will-change: transform, opacity;
+  transition: transform var(--drawer-speed) var(--drawer-ease),
+              opacity var(--drawer-speed) ease;
+}
+
+/* Drawer Checked Visible State */
+.alm-drawer-checkbox:checked ~ .alm-sandbox-stage .alm-zoom-drawer {
+  transform: scale(1) translate3d(0, 0, 0);
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Drawer Interior Header */
+.alm-drawer-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid rgba(255, 0, 85, 0.2);
+  padding-bottom: var(--ease-space-3, 0.75rem);
+}
+
+.alm-btn-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  background: transparent;
+  border: 1px solid var(--neon-magenta);
+  border-radius: 50%;
+  color: var(--neon-magenta);
+  font-size: 0.9rem;
+  font-weight: 900;
+  cursor: pointer;
+  user-select: none;
+  transition: background-color var(--ease-speed-fast, 150ms) ease,
+              color var(--ease-speed-fast, 150ms) ease;
+}
+
+.alm-btn-close:hover {
+  background: var(--neon-magenta);
+  color: #ffffff;
+  box-shadow: 0 0 15px var(--neon-magenta-glow);
+}
+
+/* Cyberpunk Metric List */
+.alm-cyber-metric-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ease-space-3, 0.75rem);
+  margin-top: var(--ease-space-4, 1rem);
+}
+
+.alm-metric-item {
+  background: rgba(0, 0, 0, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  padding: var(--ease-space-3, 0.75rem);
+}
+
+.alm-metric-label {
+  font-size: 0.65rem;
+  color: var(--cyber-muted);
+  text-transform: uppercase;
+  font-family: monospace;
+}
+
+.alm-metric-val {
+  font-size: 0.9rem;
+  font-weight: 800;
+  color: var(--neon-cyan);
+  margin-top: 2px;
+}
+
+/* ── Keyboard Focus Ring Rules ─────────────────────────── */
+.alm-drawer-checkbox:focus-visible ~ .alm-sandbox-stage .alm-cyber-btn-trigger {
+  outline: 2px solid var(--neon-cyan);
+  outline-offset: 4px;
+}
+
+/* ── Responsive Viewport Adjustments ───────────────────── */
+@media (max-width: 520px) {
+  .alm-zoom-drawer {
+    width: 100%;
+    border-left: none;
+    border-top: 2px solid var(--neon-magenta);
+  }
+}
+
+/* ── Accessibility: Reduced Motion Override ────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .alm-zoom-drawer,
+  .alm-drawer-backdrop {
+    transition: opacity var(--ease-speed-fast, 150ms) linear !important;
+    transform: none !important;
+  }
+}
+
+}


### PR DESCRIPTION
## Pull Request Description
This PR introduces an isolated showcase submission for a CSS Zoom-In Drawer for Cyberpunk Neon Layouts placed strictly inside submissions/examples/zoom-in-cyberpunk-drawer/. It provides a futuristic slide-out panel tailored for gaming control planes, cyberpunk HUDs, and dark-mode dashboards.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

<!-- A pure CSS zoom-in drawer component with neon cyan/magenta glows, backdrop blur filters, glassmorphic panel surfacing, and dark-mode cyberpunk styling. -->

**How does a developer use it?**

```html
<!-- <!-- State Controller -->
<input type="checkbox" id="cyberDrawerToggle" class="alm-drawer-checkbox">

<div class="alm-sandbox-stage">
  <label for="cyberDrawerToggle" class="alm-cyber-btn-trigger">Open Drawer</label>
  <aside class="alm-zoom-drawer">Drawer Content</aside>
</div> -->
```

**Why does it fit EaseMotion CSS?**

<!-- It aligns with the repository's goal of delivering modern, lightweight UI patterns powered by pure CSS. GPU-accelerated transforms ensure smooth rendering across modern desktop and mobile browsers. -->

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---
close #64733