### PR TITLE
add flipcard 3d

### DIFF
--- a/submissions/examples/animated-flipcard-3d/README.md
+++ b/submissions/examples/animated-flipcard-3d/README.md
@@ -1,0 +1,26 @@
+# ease-3d-flip-card
+
+A card that flips 180° on the Y-axis on hover (or tap), revealing a back face — pure CSS 3D transforms.
+
+## Usage
+1. Include `style.css`.
+2. Add markup:
+   \`\`\`html
+   <div class="flip-card">
+     <div class="flip-card-inner">
+       <div class="flip-card-face flip-card-front">Front</div>
+       <div class="flip-card-face flip-card-back">Back</div>
+     </div>
+   </div>
+   \`\`\`
+3. (Optional) Include the click-toggle script from `demo.html` for touch devices where `:hover` isn't reliable.
+
+## Customization
+- `perspective` on `.flip-card`: controls how pronounced the 3D depth looks — lower values = more dramatic flip.
+- Transition duration/easing on `.flip-card-inner`.
+- Swap `.flip-card.flipped` class toggle (JS) as an alternative trigger to hover.
+
+## Notes
+- `backface-visibility: hidden` is what prevents the back face from showing through mirrored during the first half of the flip.
+- `.flip-card-back` is pre-rotated 180° so it lands right-side-up once the parent flips.
+- Fully CSS-driven for hover; the small JS snippet is only needed if you want click/tap-triggered flipping instead of/in addition to hover.

--- a/submissions/examples/animated-flipcard-3d/demo.html
+++ b/submissions/examples/animated-flipcard-3d/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-3d-flip-card demo</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body {
+    height: 100vh;
+    margin: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #f4f4f5;
+  }
+</style>
+</head>
+<body>
+
+<div class="flip-card">
+  <div class="flip-card-inner">
+    <div class="flip-card-face flip-card-front">
+      <h3>Front Side</h3>
+      <p>Hover or tap to flip</p>
+    </div>
+    <div class="flip-card-face flip-card-back">
+      <h3>Back Side</h3>
+      <p>Revealed content goes here — details, stats, or a call to action.</p>
+    </div>
+  </div>
+</div>
+
+<script>
+  // Optional: click/tap support for touch devices (no hover state)
+  document.querySelector('.flip-card').addEventListener('click', function () {
+    this.classList.toggle('flipped');
+  });
+</script>
+
+</body>
+</html>

--- a/submissions/examples/animated-flipcard-3d/style.css
+++ b/submissions/examples/animated-flipcard-3d/style.css
@@ -1,0 +1,58 @@
+.flip-card {
+  width: 260px;
+  height: 340px;
+  perspective: 1200px;
+  cursor: pointer;
+}
+
+.flip-card-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transition: transform 0.7s cubic-bezier(0.4, 0.2, 0.2, 1);
+  transform-style: preserve-3d;
+}
+
+.flip-card:hover .flip-card-inner,
+.flip-card.flipped .flip-card-inner {
+  transform: rotateY(180deg);
+}
+
+.flip-card-face {
+  position: absolute;
+  inset: 0;
+  backface-visibility: hidden;
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  box-sizing: border-box;
+  text-align: center;
+  font-family: system-ui, sans-serif;
+}
+
+.flip-card-front {
+  background: linear-gradient(135deg, #2563eb, #7c3aed);
+  color: #fff;
+}
+
+.flip-card-back {
+  background: #fff;
+  color: #111;
+  border: 1px solid #e5e5e5;
+  transform: rotateY(180deg);
+}
+
+.flip-card-face h3 {
+  margin: 0 0 12px;
+  font-size: 20px;
+}
+
+.flip-card-face p {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.5;
+  opacity: 0.85;
+}


### PR DESCRIPTION
## Summary
Adds `ease-3d-flip-card`, a hover/tap-triggered 3D card flip revealing a back face.

## What's included
- `submissions/ease-3d-flip-card/style.css`
- `submissions/ease-3d-flip-card/demo.html`
- `submissions/ease-3d-flip-card/readme.md`

## Implementation notes
- `transform-style: preserve-3d` on the inner wrapper plus `backface-visibility: hidden` on both faces is what makes this a true 3D flip rather than a cross-fade — the back face is physically rotated behind the front, not just hidden via opacity.
- `.flip-card-back` is pre-rotated `rotateY(180deg)` in its resting state so it reads right-side-up once the whole card flips, rather than mirrored.
- Included an optional click-toggle (`.flipped` class) alongside hover, since hover isn't a reliable trigger on touch devices.

## Testing checklist
- [x] Verified flip looks fully 3D (no visible mirroring/flicker at 90°)
- [x] Verified back face text is right-reading, not mirrored, after flip
- [x] Placed only inside `submissions/`