### PR TITLE
Add ease-airplane-seat-map component

### DIFF
--- a/submissions/examples/airplane-seat-map-ij/README.md
+++ b/submissions/examples/airplane-seat-map-ij/README.md
@@ -1,0 +1,10 @@
+# ease-airplane-seat-map
+
+A seat picker where occupied seats stay dim, the selected seat glows in its row, and the note and legend blink beneath the cabin map.
+
+## Run
+Open `demo.html` directly in a browser to watch the seat glow.
+
+## Notes
+- Occupied seats stay dim.
+- The selected seat pulses in place.

--- a/submissions/examples/airplane-seat-map-ij/demo.html
+++ b/submissions/examples/airplane-seat-map-ij/demo.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-airplane-seat-map demo</title>
+</head>
+<body>
+<div class="as-app">
+  <span class="as-title">SEAT SELECTION</span>
+  <div class="as-fuselage">
+    <div class="as-row as-row-1">
+      <span class="as-seat as-occupied">A</span>
+      <span class="as-seat as-free">B</span>
+      <span class="as-aisle"></span>
+      <span class="as-seat as-pick">C</span>
+      <span class="as-seat as-free">D</span>
+    </div>
+    <div class="as-row as-row-2">
+      <span class="as-seat as-free">E</span>
+      <span class="as-seat as-free">F</span>
+      <span class="as-aisle"></span>
+      <span class="as-seat as-free">G</span>
+      <span class="as-seat as-occupied">H</span>
+    </div>
+    <div class="as-row as-row-3">
+      <span class="as-seat as-occupied">J</span>
+      <span class="as-seat as-occupied">K</span>
+      <span class="as-aisle"></span>
+      <span class="as-seat as-free">L</span>
+      <span class="as-seat as-pick">M</span>
+    </div>
+    <div class="as-row as-row-4">
+      <span class="as-seat as-free">N</span>
+      <span class="as-seat as-pick">P</span>
+      <span class="as-aisle"></span>
+      <span class="as-seat as-occupied">Q</span>
+      <span class="as-seat as-free">R</span>
+    </div>
+  </div>
+  <div class="as-legend">
+    <span class="as-key as-key-free">FREE</span>
+    <span class="as-key as-key-pick">SELECTED</span>
+    <span class="as-key as-key-used">OCCUPIED</span>
+  </div>
+  <span class="as-note">SELECTED SEAT C</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/airplane-seat-map-ij/style.css
+++ b/submissions/examples/airplane-seat-map-ij/style.css
@@ -1,0 +1,20 @@
+:root{--as-cyan:#52e0f4;--as-dark:#07131a}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#0e2230,#07131a);font-family:'Segoe UI',sans-serif}
+.as-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#0a1b26,#050d13);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.as-title{position:absolute;top:16px;left:0;right:0;text-align:center;font-size:12px;font-weight:800;letter-spacing:6px;color:#52e0f4}
+.as-fuselage{position:absolute;top:58px;left:50%;margin-left:-143px;width:286px;height:210px;border-radius:70px;background:#0c2030;box-shadow:inset 0 0 0 3px #1c4157;display:flex;flex-direction:column;justify-content:space-evenly;padding:16px 22px}
+.as-row{display:flex;gap:8px;align-items:center}
+.as-seat{width:36px;height:26px;border-radius:6px;display:flex;align-items:center;justify-content:center;font-size:10px;font-weight:800}
+.as-free{background:#0e2a3a;color:#52e0f4;box-shadow:inset 0 0 0 2px #1c4157}
+.as-occupied{background:#20303a;color:#4a6a78;box-shadow:inset 0 0 0 2px #2c4656}
+.as-pick{background:#52e0f4;color:#07131a;box-shadow:0 0 14px rgba(82,224,244,0.6);animation:seat-pulse-airplane-seat-map 1.4s ease-in-out infinite}
+.as-aisle{width:22px}
+.as-legend{position:absolute;top:296px;left:0;right:0;display:flex;justify-content:center;gap:18px}
+.as-key{font-size:9px;font-weight:800;letter-spacing:1px}
+.as-key-free{color:#52e0f4}
+.as-key-pick{color:#52e0f4;animation:key-blink-airplane-seat-map 1.4s steps(1) infinite}
+.as-key-used{color:#4a6a78}
+.as-note{position:absolute;bottom:16px;left:0;right:0;text-align:center;font-size:11px;font-weight:800;letter-spacing:3px;color:#a8ecf5;animation:note-blink-airplane-seat-map 1.8s steps(1) infinite}
+@keyframes seat-pulse-airplane-seat-map{0%,100%{transform:scale(1)}50%{transform:scale(1.12)}}
+@keyframes key-blink-airplane-seat-map{0%,49%{opacity:1}50%,100%{opacity:0.3}}
+@keyframes note-blink-airplane-seat-map{0%,49%{opacity:1}50%,100%{opacity:0.45}}


### PR DESCRIPTION
## Component: ease-airplane-seat-map — seats stay, pick glows, and notes blink

**Closes #65059**

### What this adds
A seat picker: occupied seats stay dim, the selected seat glows in the aisle, and the note and legend blink beneath the cabin map.

### Acceptance Criteria covered
- Occupied seats stay dim
- Selected seat glows in the row
- Seat note blinks below

### Files
- `submissions/examples/airplane-seat-map-ij/demo.html`
- `submissions/examples/airplane-seat-map-ij/style.css`
- `submissions/examples/airplane-seat-map-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the seat glow.