### PR TITLE
feat: add 3D-flip hero section glassmorphism layout for #64338

### DIFF
--- a/submissions/examples/3d-flip-hero-glassmorphism-layouts/README.md
+++ b/submissions/examples/3d-flip-hero-glassmorphism-layouts/README.md
@@ -1,0 +1,44 @@
+# 3D-Flip Hero Section — Glassmorphism UI Layouts
+
+A CSS-only hero section that performs a 3D card flip on hover, combining glassmorphism backdrop-blur with perspective-based transforms.
+
+## Features
+
+- **Pure CSS 3D flip** — uses `transform-style: preserve-3d`, `rotateY(180deg)`, and `backface-visibility: hidden` for a clean card flip effect
+- **Glassmorphism styling** — semi-transparent background with `backdrop-filter: blur()` and subtle border for a frosted-glass look
+- **Animated background orbs** — floating blurred circles add depth without JavaScript
+- **Entrance animation** — the hero scene fades in and scales up on page load
+- **Fully responsive** — scales gracefully from 400px mobile screens up to full desktop width
+- **Reduced-motion accessible** — all animations and transitions respect the `prefers-reduced-motion` media query
+
+## CSS Custom Properties
+
+All theme values are defined as CSS custom properties on `:root` for easy customization:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `--3fh-bg-deep` | `#0a0e1a` | Page background colour |
+| `--3fh-glass-bg` | `rgba(255,255,255,0.08)` | Glass panel background tint |
+| `--3fh-glass-border` | `rgba(255,255,255,0.15)` | Glass panel border colour |
+| `--3fh-glass-shadow` | `rgba(0,0,0,0.35)` | Glass panel drop-shadow |
+| `--3fh-text-primary` | `#f0f4ff` | Main text colour |
+| `--3fh-text-secondary` | `rgba(240,244,255,0.6)` | Secondary text colour |
+| `--3fh-accent` | `#6ee7b7` | Primary accent (green) |
+| `--3fh-accent-alt` | `#818cf8` | Secondary accent (indigo) |
+| `--3fh-flip-duration` | `0.7s` | Flip animation speed |
+| `--3fh-card-w` | `min(520px, 88vw)` | Card width |
+| `--3fh-card-h` | `340px` | Card height |
+
+## How It Works
+
+1. The hero scene sets `perspective: 900px` to establish a 3D rendering context.
+2. The card uses `transform-style: preserve-3d` so its children exist in 3D space.
+3. On hover, the card rotates 180 degrees along the Y axis (`rotateY(180deg)`).
+4. Each face has `backface-visibility: hidden` so only the front-facing side is visible.
+5. The back face is pre-rotated 180 degrees so it appears correctly after the flip.
+
+## Usage
+
+Copy the `demo.html` and `style.css` files into your project. The hero section works standalone — no JavaScript or external dependencies required.
+
+To customise colours or timing, override the CSS custom properties in your own stylesheet.

--- a/submissions/examples/3d-flip-hero-glassmorphism-layouts/demo.html
+++ b/submissions/examples/3d-flip-hero-glassmorphism-layouts/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS 3D-Flip Hero Section with glassmorphism layout. Pure CSS hero animation with no JavaScript.">
+  <title>3D-Flip Hero Section – Glassmorphism UI Layouts</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <section class="hero-scene" aria-label="3D Flip Hero Section">
+    <div class="hero-card">
+
+      <div class="hero-card__face hero-card__face--front">
+        <span class="hero-card__eyebrow">Glassmorphism UI</span>
+        <h1 class="hero-card__title">3D Flip Hero</h1>
+        <p class="hero-card__tagline">A card that flips on hover to reveal additional content, built entirely with CSS 3D transforms and glassmorphism.</p>
+        <span class="hero-card__cta">Hover or tap to flip</span>
+      </div>
+
+      <div class="hero-card__face hero-card__face--back">
+        <span class="hero-card__eyebrow">Back Side</span>
+        <h2 class="hero-card__title">More Details</h2>
+        <p class="hero-card__tagline">Pure CSS 3D flip with perspective, backface-visibility, and glassmorphism backdrop-blur. No JavaScript required.</p>
+        <span class="hero-card__cta">Hover or tap again</span>
+      </div>
+
+    </div>
+
+    <div class="hero-bg" aria-hidden="true">
+      <div class="hero-bg__orb hero-bg__orb--1"></div>
+      <div class="hero-bg__orb hero-bg__orb--2"></div>
+      <div class="hero-bg__orb hero-bg__orb--3"></div>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/3d-flip-hero-glassmorphism-layouts/style.css
+++ b/submissions/examples/3d-flip-hero-glassmorphism-layouts/style.css
@@ -1,0 +1,242 @@
+:root {
+  --3fh-bg-deep: #0a0e1a;
+  --3fh-glass-bg: rgba(255, 255, 255, 0.08);
+  --3fh-glass-border: rgba(255, 255, 255, 0.15);
+  --3fh-glass-shadow: rgba(0, 0, 0, 0.35);
+  --3fh-text-primary: #f0f4ff;
+  --3fh-text-secondary: rgba(240, 244, 255, 0.6);
+  --3fh-accent: #6ee7b7;
+  --3fh-accent-alt: #818cf8;
+  --3fh-flip-duration: 0.7s;
+  --3fh-card-w: min(520px, 88vw);
+  --3fh-card-h: 340px;
+}
+
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: var(--3fh-bg-deep);
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  color: var(--3fh-text-primary);
+  overflow: hidden;
+}
+
+/* ── animated background orbs ────────────────────── */
+
+.hero-bg {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+}
+
+.hero-bg__orb {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(100px);
+  opacity: 0.45;
+  animation: orbFloat 8s ease-in-out infinite alternate;
+}
+
+.hero-bg__orb--1 {
+  width: 380px;
+  height: 380px;
+  background: var(--3fh-accent);
+  top: -10%;
+  left: -6%;
+}
+
+.hero-bg__orb--2 {
+  width: 320px;
+  height: 320px;
+  background: var(--3fh-accent-alt);
+  bottom: -12%;
+  right: -8%;
+  animation-delay: -3s;
+}
+
+.hero-bg__orb--3 {
+  width: 220px;
+  height: 220px;
+  background: #f472b6;
+  top: 55%;
+  left: 50%;
+  animation-delay: -5s;
+}
+
+@keyframes orbFloat {
+  0%   { transform: translate(0, 0) scale(1); }
+  100% { transform: translate(40px, 30px) scale(1.15); }
+}
+
+/* ── scene (perspective container) ───────────────── */
+
+.hero-scene {
+  position: relative;
+  z-index: 1;
+  perspective: 900px;
+  width: var(--3fh-card-w);
+  height: var(--3fh-card-h);
+}
+
+/* ── card ────────────────────────────────────────── */
+
+.hero-card {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  transform-style: preserve-3d;
+  transition: transform var(--3fh-flip-duration) cubic-bezier(0.4, 0, 0.2, 1);
+  cursor: pointer;
+}
+
+.hero-card:hover,
+.hero-card:focus-within {
+  transform: rotateY(180deg);
+}
+
+/* ── face (shared) ──────────────────────────────── */
+
+.hero-card__face {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 14px;
+  padding: 40px 36px;
+  border-radius: 22px;
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+
+  background: var(--3fh-glass-bg);
+  border: 1px solid var(--3fh-glass-border);
+  box-shadow:
+    0 8px 32px var(--3fh-glass-shadow),
+    inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+}
+
+.hero-card__face--back {
+  transform: rotateY(180deg);
+}
+
+/* ── face typography ─────────────────────────────── */
+
+.hero-card__eyebrow {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--3fh-accent);
+  font-weight: 600;
+}
+
+.hero-card__title {
+  font-size: clamp(1.8rem, 4vw, 2.8rem);
+  font-weight: 800;
+  line-height: 1.15;
+  background: linear-gradient(135deg, var(--3fh-text-primary), var(--3fh-accent-alt));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.hero-card__tagline {
+  font-size: 0.95rem;
+  color: var(--3fh-text-secondary);
+  line-height: 1.6;
+  max-width: 38ch;
+  text-align: center;
+}
+
+.hero-card__cta {
+  margin-top: 6px;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--3fh-accent);
+  border: 1px solid rgba(110, 231, 183, 0.35);
+  padding: 6px 18px;
+  border-radius: 999px;
+  transition: background 0.25s, color 0.25s;
+}
+
+.hero-card:hover .hero-card__cta {
+  background: var(--3fh-accent);
+  color: var(--3fh-bg-deep);
+}
+
+/* ── entrance animation ──────────────────────────── */
+
+.hero-scene {
+  animation: heroEntrance 0.8s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+@keyframes heroEntrance {
+  from {
+    opacity: 0;
+    transform: translateY(30px) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+/* ── responsive ──────────────────────────────────── */
+
+@media (max-width: 640px) {
+  :root {
+    --3fh-card-h: 290px;
+  }
+
+  .hero-card__face {
+    padding: 28px 22px;
+  }
+
+  .hero-card__tagline {
+    font-size: 0.85rem;
+  }
+
+  .hero-bg__orb {
+    filter: blur(70px);
+    opacity: 0.3;
+  }
+}
+
+@media (max-width: 400px) {
+  :root {
+    --3fh-card-h: 260px;
+  }
+
+  .hero-card__title {
+    font-size: 1.5rem;
+  }
+}
+
+/* ── accessibility: reduced-motion ───────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-card {
+    transition-duration: 0.01ms;
+  }
+
+  .hero-bg__orb {
+    animation: none;
+  }
+
+  .hero-scene {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a CSS-only 3D-flip hero section with glassmorphism styling for Issue #64338.

## What's Included

- **demo.html** — Showcase page with the 3D-flip hero section
- **style.css** — Pure CSS with glassmorphism backdrop-blur, 3D card flip, animated background orbs, entrance animation
- **README.md** — Documentation with CSS custom properties table, usage guide

## Key Features

- 3D card flip on hover using `preserve-3d` + `rotateY(180deg)` + `backface-visibility: hidden`
- Glassmorphism: semi-transparent backgrounds with `backdrop-filter: blur()`
- Animated floating background orbs
- Fully responsive (400px mobile → desktop)
- `prefers-reduced-motion` support

## Checklist

- [x] All new files inside `submissions/examples/`
- [x] No existing files modified
- [x] Pure CSS/HTML — no JavaScript
- [x] `:root` with CSS custom properties (`--3fh-*` prefix)
- [x] Animations and transitions present
- [x] Responsive media queries
- [x] Reduced-motion accessibility