### PR TITLE
Add ease-piano-keys-demo component

### DIFF
--- a/submissions/examples/piano-keys-demo-ij/README.md
+++ b/submissions/examples/piano-keys-demo-ij/README.md
@@ -1,0 +1,10 @@
+# ease-piano-keys-demo
+
+A synth keyboard where the white keys glow softly, the waveform strip scrolls below the keys, and the prompt label blinks at the bottom.
+
+## Run
+Open `demo.html` directly in a browser to watch the keys glow.
+
+## Notes
+- The white keys brighten in a loop.
+- The waveform strip scrolls sideways.

--- a/submissions/examples/piano-keys-demo-ij/demo.html
+++ b/submissions/examples/piano-keys-demo-ij/demo.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-piano-keys-demo demo</title>
+</head>
+<body>
+<div class="pk-app">
+  <span class="pk-title">SYNTH PIANO</span>
+  <div class="pk-keys">
+    <span class="pk-key pk-white">C</span>
+    <span class="pk-key pk-black pk-b1"></span>
+    <span class="pk-key pk-white">D</span>
+    <span class="pk-key pk-black pk-b2"></span>
+    <span class="pk-key pk-white">E</span>
+    <span class="pk-key pk-white">F</span>
+    <span class="pk-key pk-black pk-b3"></span>
+    <span class="pk-key pk-white">G</span>
+    <span class="pk-key pk-black pk-b4"></span>
+    <span class="pk-key pk-white">A</span>
+    <span class="pk-key pk-black pk-b5"></span>
+    <span class="pk-key pk-white">B</span>
+  </div>
+  <span class="pk-wave"></span>
+  <span class="pk-label">PRESS A KEY</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/piano-keys-demo-ij/style.css
+++ b/submissions/examples/piano-keys-demo-ij/style.css
@@ -1,0 +1,17 @@
+:root{--pk-mint:#7dffc8;--pk-dark:#0a100d}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#12221a,#0a100d);font-family:'Segoe UI',sans-serif}
+.pk-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#0e1a14,#060c09);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.pk-title{position:absolute;top:16px;left:0;right:0;text-align:center;font-size:12px;font-weight:800;letter-spacing:7px;color:#7dffc8}
+.pk-keys{position:absolute;top:64px;left:34px;right:34px;height:190px;display:flex;gap:3px}
+.pk-white{flex:1;position:relative;border-radius:0 0 8px 8px;background:linear-gradient(180deg,#f2fff8,#bfe6d2);color:#0a100d;display:flex;align-items:flex-end;justify-content:center;padding-bottom:8px;font-size:11px;font-weight:800;animation:key-glow-piano-keys-demo 3.6s ease-in-out infinite}
+.pk-black{position:absolute;top:0;width:22px;height:112px;border-radius:0 0 5px 5px;background:linear-gradient(180deg,#16241c,#050806);z-index:2}
+.pk-b1{left:38px}
+.pk-b2{left:86px}
+.pk-b3{left:198px}
+.pk-b4{left:244px}
+.pk-b5{left:290px}
+.pk-wave{position:absolute;top:276px;left:40px;right:40px;height:40px;border-bottom:3px solid #7dffc8;background:repeating-linear-gradient(90deg,transparent 0 9px,#7dffc8 9px 11px);background-size:44px 40px;animation:wave-scroll-piano-keys-demo 1.2s linear infinite}
+.pk-label{position:absolute;bottom:16px;left:0;right:0;text-align:center;font-size:11px;font-weight:800;letter-spacing:4px;color:#7dffc8;animation:label-blink-piano-keys-demo 1.6s steps(1) infinite}
+@keyframes key-glow-piano-keys-demo{0%,100%{filter:brightness(1)}50%{filter:brightness(1.2)}}
+@keyframes wave-scroll-piano-keys-demo{0%{background-position:0 0}100%{background-position:44px 0}}
+@keyframes label-blink-piano-keys-demo{0%,49%{opacity:1}50%,100%{opacity:0.35}}


### PR DESCRIPTION
## Component: ease-piano-keys-demo — keys glow, wave scrolls, and labels blink

**Closes #65069**

### What this adds
A synth keyboard: the white keys glow softly in turn, the waveform strip scrolls below the keys, and the label blinks at the bottom.

### Acceptance Criteria covered
- White keys glow in turn
- Waveform strip scrolls below
- Prompt label blinks beneath

### Files
- `submissions/examples/piano-keys-demo-ij/demo.html`
- `submissions/examples/piano-keys-demo-ij/style.css`
- `submissions/examples/piano-keys-demo-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the keys glow.