### PR TITLE
feat: add cyberpunk fade card grid example

### DIFF
--- a/submissions/examples/cyberpunk-fade-card-grid/README.md
+++ b/submissions/examples/cyberpunk-fade-card-grid/README.md
@@ -1,0 +1,90 @@
+# Cyberpunk Fade-In Card Grid
+
+A modern **CSS Fade-In Card Grid** designed for cyberpunk-inspired interfaces with glowing neon accents, staggered entrance animations, and responsive layouts.
+
+Built entirely with **HTML5** and **CSS3**—no JavaScript required.
+
+---
+
+## Features
+
+- Responsive CSS Grid layout
+- Staggered fade-in entrance animation
+- Neon cyan & magenta glow
+- Glassmorphism-inspired cards
+- Hover glow effects
+- Pure HTML & CSS
+- CSS Custom Properties
+- `prefers-reduced-motion` support
+- Mobile friendly
+
+---
+
+## Folder Structure
+
+```
+cyberpunk-fade-card-grid/
+├── demo.html
+├── style.css
+└── README.md
+```
+
+---
+
+## Usage
+
+1. Open `demo.html` in any modern browser.
+2. The cards fade in sequentially when the page loads.
+3. Hover over a card to view the neon glow effect.
+4. Customize colors and timings using the CSS variables in `:root`.
+
+---
+
+## Customization
+
+You can easily change:
+
+- Neon colors
+- Background theme
+- Card spacing
+- Border radius
+- Animation duration
+- Glow intensity
+
+---
+
+## Accessibility
+
+- Responsive layout
+- Keyboard-friendly HTML
+- Supports `prefers-reduced-motion`
+- No JavaScript required
+
+---
+
+## Technologies Used
+
+- HTML5
+- CSS3
+- CSS Grid
+- CSS Variables
+- CSS Animations
+- CSS Transitions
+- CSS Transforms
+- Pseudo Elements
+
+---
+
+## Browser Support
+
+- Google Chrome
+- Mozilla Firefox
+- Microsoft Edge
+- Safari
+- Opera
+
+---
+
+## Author
+
+Submitted as an EaseMotion CSS example under `submissions/examples/`.

--- a/submissions/examples/cyberpunk-fade-card-grid/demo.html
+++ b/submissions/examples/cyberpunk-fade-card-grid/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cyberpunk Fade-In Card Grid</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<section class="card-grid">
+
+    <article class="card">
+        <span class="badge">AI</span>
+        <h2>Neural Core</h2>
+        <p>Power futuristic interfaces with glowing cyberpunk components.</p>
+        <a href="#">Explore</a>
+    </article>
+
+    <article class="card">
+        <span class="badge">UI</span>
+        <h2>Neon Dashboard</h2>
+        <p>Modern responsive layouts built with lightweight CSS animations.</p>
+        <a href="#">Preview</a>
+    </article>
+
+    <article class="card">
+        <span class="badge">CSS</span>
+        <h2>Motion Library</h2>
+        <p>Elegant fade-in entrance animations for modern web experiences.</p>
+        <a href="#">Learn More</a>
+    </article>
+
+</section>
+
+</body>
+</html>

--- a/submissions/examples/cyberpunk-fade-card-grid/style.css
+++ b/submissions/examples/cyberpunk-fade-card-grid/style.css
@@ -1,0 +1,212 @@
+:root{
+    --bg:#070b14;
+    --card:#111827;
+    --cyan:#00f5ff;
+    --pink:#ff00d4;
+    --text:#f8fafc;
+    --border:rgba(255,255,255,.08);
+    --duration:.6s;
+}
+
+*{
+    margin:0;
+    padding:0;
+    box-sizing:border-box;
+    font-family:Arial,Helvetica,sans-serif;
+}
+
+body{
+    min-height:100vh;
+    display:flex;
+    justify-content:center;
+    align-items:center;
+    padding:40px;
+    background:
+        radial-gradient(circle at top,#14213d,#070b14 75%);
+}
+
+.card-grid{
+    width:100%;
+    max-width:1200px;
+    display:grid;
+    grid-template-columns:repeat(auto-fit,minmax(260px,1fr));
+    gap:30px;
+}
+
+.card{
+
+    position:relative;
+
+    background:rgba(17,24,39,.75);
+
+    backdrop-filter:blur(10px);
+
+    border:1px solid var(--border);
+
+    border-radius:18px;
+
+    padding:30px;
+
+    overflow:hidden;
+
+    opacity:0;
+
+    transform:translateY(40px);
+
+    animation:fadeInUp .8s ease forwards;
+
+    transition:
+        box-shadow .35s ease,
+        border-color .35s ease;
+
+}
+
+.card:nth-child(2){
+
+    animation-delay:.2s;
+
+}
+
+.card:nth-child(3){
+
+    animation-delay:.4s;
+
+}
+
+.card::before{
+
+    content:"";
+
+    position:absolute;
+
+    inset:0;
+
+    background:linear-gradient(
+        135deg,
+        rgba(0,245,255,.15),
+        transparent,
+        rgba(255,0,212,.15)
+    );
+
+    opacity:0;
+
+    transition:opacity .35s ease;
+
+}
+
+.card:hover{
+
+    border-color:var(--cyan);
+
+    box-shadow:
+        0 0 18px rgba(0,245,255,.4),
+        0 0 35px rgba(255,0,212,.25);
+
+}
+
+.card:hover::before{
+
+    opacity:1;
+
+}
+
+.card>*{
+
+    position:relative;
+
+    z-index:2;
+
+}
+
+.badge{
+
+    display:inline-block;
+
+    padding:6px 14px;
+
+    border-radius:999px;
+
+    background:rgba(0,245,255,.15);
+
+    color:var(--cyan);
+
+    font-size:13px;
+
+    margin-bottom:18px;
+
+}
+
+.card h2{
+
+    color:var(--text);
+
+    margin-bottom:14px;
+
+}
+
+.card p{
+
+    color:#cbd5e1;
+
+    line-height:1.7;
+
+    margin-bottom:22px;
+
+}
+
+.card a{
+
+    color:var(--pink);
+
+    text-decoration:none;
+
+    font-weight:bold;
+
+}
+
+@keyframes fadeInUp{
+
+    from{
+
+        opacity:0;
+        transform:translateY(40px);
+
+    }
+
+    to{
+
+        opacity:1;
+        transform:translateY(0);
+
+    }
+
+}
+
+@media(max-width:768px){
+
+    body{
+
+        padding:20px;
+
+    }
+
+}
+
+@media(prefers-reduced-motion:reduce){
+
+    *{
+
+        animation:none !important;
+        transition:none !important;
+        scroll-behavior:auto !important;
+
+    }
+
+    .card{
+
+        opacity:1;
+        transform:none;
+
+    }
+
+}


### PR DESCRIPTION
## Description

This PR adds a new **CSS Fade-In Card Grid for Cyberpunk Neon Layouts** example under the `submissions/examples/` directory.

### Features

- Responsive CSS Grid layout
- Staggered fade-in animation
- Neon cyan & magenta glow
- Glassmorphism-inspired styling
- CSS Custom Properties
- `prefers-reduced-motion` support
- Pure HTML & CSS

### Files Included

- demo.html
- style.css
- README.md

Closes #64748