### PR TITLE
add hamburger morph

### DIFF
--- a/submissions/examples/animated-hamburger-morph/README.md
+++ b/submissions/examples/animated-hamburger-morph/README.md
@@ -1,0 +1,23 @@
+# ease-hamburger-morph
+
+A hamburger icon that morphs smoothly into an X on toggle — three bars, pure CSS transitions.
+
+## Usage
+1. Include `style.css`.
+2. Add markup:
+   \`\`\`html
+   <button class="hamburger" aria-label="Toggle menu" aria-expanded="false">
+     <span></span><span></span><span></span>
+   </button>
+   \`\`\`
+3. Toggle the `.active` class on click (see `demo.html`) and keep `aria-expanded` in sync for accessibility.
+
+## Customization
+- `--size`: icon dimensions.
+- `--bar-color`: bar color.
+- Transition timing/easing on `span` for a snappier or slower morph.
+
+## Notes
+- The middle bar fades out and slides slightly rather than just disappearing, avoiding an abrupt pop.
+- Top and bottom bars both animate `top` (to converge on center) and `transform: rotate()` simultaneously, which is what makes the X read as one continuous morph instead of two separate steps.
+- `aria-expanded` toggling is included since this is a real interactive control, not just a visual — screen readers need the state.

--- a/submissions/examples/animated-hamburger-morph/demo.html
+++ b/submissions/examples/animated-hamburger-morph/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-hamburger-morph demo</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body {
+    height: 100vh;
+    margin: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #f4f4f5;
+  }
+</style>
+</head>
+<body>
+
+<button class="hamburger" id="hamburgerBtn" aria-label="Toggle menu" aria-expanded="false">
+  <span></span>
+  <span></span>
+  <span></span>
+</button>
+
+<script>
+  const btn = document.getElementById('hamburgerBtn');
+  btn.addEventListener('click', () => {
+    const isActive = btn.classList.toggle('active');
+    btn.setAttribute('aria-expanded', isActive);
+  });
+</script>
+
+</body>
+</html>

--- a/submissions/examples/animated-hamburger-morph/style.css
+++ b/submissions/examples/animated-hamburger-morph/style.css
@@ -1,0 +1,42 @@
+.hamburger {
+  --bar-color: #111;
+  --size: 32px;
+  position: relative;
+  width: var(--size);
+  height: var(--size);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+
+.hamburger span {
+  position: absolute;
+  left: 0;
+  width: 100%;
+  height: 3px;
+  border-radius: 2px;
+  background: var(--bar-color);
+  transition: transform 0.35s cubic-bezier(0.4, 0, 0.2, 1),
+              opacity 0.25s ease,
+              top 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.hamburger span:nth-child(1) { top: 6px; }
+.hamburger span:nth-child(2) { top: 15px; }
+.hamburger span:nth-child(3) { top: 24px; }
+
+.hamburger.active span:nth-child(1) {
+  top: 15px;
+  transform: rotate(45deg);
+}
+
+.hamburger.active span:nth-child(2) {
+  opacity: 0;
+  transform: translateX(-10px);
+}
+
+.hamburger.active span:nth-child(3) {
+  top: 15px;
+  transform: rotate(-45deg);
+}


### PR DESCRIPTION
## Summary
Adds `ease-hamburger-morph`, a hamburger-to-X icon morph toggle, pure CSS transitions.

## What's included
- `submissions/ease-hamburger-morph/style.css`
- `submissions/ease-hamburger-morph/demo.html`
- `submissions/ease-hamburger-morph/readme.md`

## Implementation notes
- Top/bottom bars animate `top` and `transform: rotate()` in parallel on the same transition, so they converge and rotate as one continuous motion rather than two visible phases.
- Middle bar fades and slides out slightly instead of just `opacity: 0`, avoiding an abrupt pop at the midpoint of the morph.
- `aria-expanded` is toggled in JS alongside the `.active` class, since this is a functional menu control and needs to expose its state to assistive tech.

## Testing checklist
- [x] Verified morph reads as one fluid motion, not three independent bar animations
- [x] Verified `aria-expanded` toggles correctly with click state
- [x] Placed only inside `submissions/`