### PR TITLE
feat: add elastic-slide hero section glassmorphism layout for #64342

### DIFF
--- a/submissions/examples/elastic-slide-hero-glassmorphism-layouts/README.md
+++ b/submissions/examples/elastic-slide-hero-glassmorphism-layouts/README.md
@@ -1,0 +1,38 @@
+# Elastic-Slide Hero Section — Glassmorphism UI Layouts
+
+A CSS-only hero section that animates content in from opposite sides using an elastic easing curve, with glassmorphism frosted-glass panels.
+
+## Features
+
+- **Elastic slide-in animation** — content slides from the left, visual cards slide from the right, both using a bouncy `cubic-bezier(0.34, 1.56, 0.64, 1)` easing
+- **Glassmorphism styling** — semi-transparent panels with `backdrop-filter: blur()` and subtle borders
+- **Animated background orbs** — two floating blurred circles for depth
+- **Fully responsive** — stacks gracefully on mobile with full-width buttons
+- **Reduced-motion accessible** — all animations disabled when `prefers-reduced-motion: reduce` is active
+
+## CSS Custom Properties
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `--esh-bg` | `#080c18` | Page background |
+| `--esh-glass` | `rgba(255,255,255,0.07)` | Glass panel fill |
+| `--esh-glass-border` | `rgba(255,255,255,0.12)` | Glass border |
+| `--esh-glass-blur` | `20px` | Backdrop blur amount |
+| `--esh-shadow` | `rgba(0,0,0,0.4)` | Panel drop shadow |
+| `--esh-text` | `#e8ecf8` | Primary text |
+| `--esh-text-dim` | `rgba(232,236,248,0.55)` | Secondary text |
+| `--esh-teal` | `#5eead4` | Primary accent |
+| `--esh-violet` | `#a78bfa` | Secondary accent |
+| `--esh-pink` | `#f472b6` | Card icon colour |
+
+## How It Works
+
+1. The hero section is a glassmorphism panel using `backdrop-filter: blur(20px)`.
+2. Text content slides in from the left via `eshSlideLeft` keyframes.
+3. Visual cards slide in from the right via `eshSlideRight` keyframes.
+4. Both use `cubic-bezier(0.34, 1.56, 0.64, 1)` for a natural elastic overshoot.
+5. Staggered `animation-delay` values on cards create a cascading entrance.
+
+## Usage
+
+Copy `demo.html` and `style.css` into your project. No JavaScript or external dependencies needed. Override the CSS custom properties to match your theme.

--- a/submissions/examples/elastic-slide-hero-glassmorphism-layouts/demo.html
+++ b/submissions/examples/elastic-slide-hero-glassmorphism-layouts/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS Elastic-Slide Hero Section with glassmorphism layout. Pure CSS hero animation with no JavaScript.">
+  <title>Elastic-Slide Hero Section – Glassmorphism UI Layouts</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <header class="esh-hero" aria-label="Elastic-Slide Hero Section">
+    <div class="esh-hero__content">
+      <span class="esh-hero__badge">Glassmorphism UI</span>
+      <h1 class="esh-hero__title">Elastic-Slide Hero</h1>
+      <p class="esh-hero__desc">A hero section where content slides in from opposite sides with an elastic easing curve, wrapped in frosted-glass panels.</p>
+      <div class="esh-hero__actions">
+        <a href="#" class="esh-hero__btn esh-hero__btn--primary">Get Started</a>
+        <a href="#" class="esh-hero__btn esh-hero__btn--ghost">Learn More</a>
+      </div>
+    </div>
+
+    <div class="esh-hero__visual">
+      <div class="esh-hero__card esh-hero__card--left">
+        <span class="esh-hero__card-icon">&#9672;</span>
+        <span class="esh-hero__card-label">Design</span>
+      </div>
+      <div class="esh-hero__card esh-hero__card--right">
+        <span class="esh-hero__card-icon">&#9670;</span>
+        <span class="esh-hero__card-label">Develop</span>
+      </div>
+    </div>
+
+    <div class="esh-hero__bg" aria-hidden="true">
+      <div class="esh-hero__orb esh-hero__orb--a"></div>
+      <div class="esh-hero__orb esh-hero__orb--b"></div>
+    </div>
+  </header>
+
+</body>
+</html>

--- a/submissions/examples/elastic-slide-hero-glassmorphism-layouts/style.css
+++ b/submissions/examples/elastic-slide-hero-glassmorphism-layouts/style.css
@@ -1,0 +1,283 @@
+:root {
+  --esh-bg: #080c18;
+  --esh-glass: rgba(255, 255, 255, 0.07);
+  --esh-glass-border: rgba(255, 255, 255, 0.12);
+  --esh-glass-blur: 20px;
+  --esh-shadow: rgba(0, 0, 0, 0.4);
+  --esh-text: #e8ecf8;
+  --esh-text-dim: rgba(232, 236, 248, 0.55);
+  --esh-teal: #5eead4;
+  --esh-violet: #a78bfa;
+  --esh-pink: #f472b6;
+}
+
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: var(--esh-bg);
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  color: var(--esh-text);
+  overflow-x: hidden;
+}
+
+/* ── background ──────────────────────────────────── */
+
+.esh-hero__bg {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+}
+
+.esh-hero__orb {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(110px);
+  opacity: 0.4;
+  animation: eshOrbDrift 10s ease-in-out infinite alternate;
+}
+
+.esh-hero__orb--a {
+  width: 400px;
+  height: 400px;
+  background: var(--esh-teal);
+  top: -15%;
+  right: 10%;
+}
+
+.esh-hero__orb--b {
+  width: 300px;
+  height: 300px;
+  background: var(--esh-violet);
+  bottom: -10%;
+  left: 5%;
+  animation-delay: -4s;
+}
+
+@keyframes eshOrbDrift {
+  0%   { transform: translate(0, 0) scale(1); }
+  100% { transform: translate(-30px, 25px) scale(1.1); }
+}
+
+/* ── hero section ────────────────────────────────── */
+
+.esh-hero {
+  position: relative;
+  z-index: 1;
+  width: min(820px, 92vw);
+  padding: 48px 40px 56px;
+  border-radius: 24px;
+  background: var(--esh-glass);
+  border: 1px solid var(--esh-glass-border);
+  box-shadow: 0 12px 40px var(--esh-shadow);
+  backdrop-filter: blur(var(--esh-glass-blur));
+  -webkit-backdrop-filter: blur(var(--esh-glass-blur));
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 40px;
+  text-align: center;
+  overflow: hidden;
+}
+
+/* ── content (slides from left) ──────────────────── */
+
+.esh-hero__content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  animation: eshSlideLeft 0.9s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+.esh-hero__badge {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--esh-teal);
+  font-weight: 600;
+  background: rgba(94, 234, 212, 0.1);
+  padding: 4px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(94, 234, 212, 0.2);
+}
+
+.esh-hero__title {
+  font-size: clamp(2rem, 5vw, 3.2rem);
+  font-weight: 800;
+  line-height: 1.1;
+  background: linear-gradient(135deg, var(--esh-text), var(--esh-teal));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.esh-hero__desc {
+  font-size: 1rem;
+  color: var(--esh-text-dim);
+  line-height: 1.65;
+  max-width: 44ch;
+}
+
+/* ── buttons ─────────────────────────────────────── */
+
+.esh-hero__actions {
+  display: flex;
+  gap: 12px;
+  margin-top: 4px;
+  animation: eshSlideLeft 0.9s cubic-bezier(0.34, 1.56, 0.64, 1) 0.15s both;
+}
+
+.esh-hero__btn {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-decoration: none;
+  padding: 10px 24px;
+  border-radius: 12px;
+  transition: background 0.25s, color 0.25s, transform 0.2s;
+}
+
+.esh-hero__btn:hover {
+  transform: translateY(-1px);
+}
+
+.esh-hero__btn--primary {
+  background: var(--esh-teal);
+  color: var(--esh-bg);
+}
+
+.esh-hero__btn--primary:hover {
+  background: #2dd4bf;
+}
+
+.esh-hero__btn--ghost {
+  background: transparent;
+  color: var(--esh-text);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.esh-hero__btn--ghost:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+/* ── visual cards (slide from right) ─────────────── */
+
+.esh-hero__visual {
+  display: flex;
+  gap: 20px;
+}
+
+.esh-hero__card {
+  width: 140px;
+  height: 100px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  animation: eshSlideRight 0.9s cubic-bezier(0.34, 1.56, 0.64, 1) 0.25s both;
+}
+
+.esh-hero__card--right {
+  animation-delay: 0.35s;
+}
+
+.esh-hero__card-icon {
+  font-size: 1.6rem;
+  color: var(--esh-pink);
+}
+
+.esh-hero__card-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--esh-text-dim);
+}
+
+/* ── slide keyframes ─────────────────────────────── */
+
+@keyframes eshSlideLeft {
+  0% {
+    opacity: 0;
+    transform: translateX(-50px) scale(0.95);
+  }
+  100% {
+    opacity: 1;
+    transform: translateX(0) scale(1);
+  }
+}
+
+@keyframes eshSlideRight {
+  0% {
+    opacity: 0;
+    transform: translateX(50px) scale(0.95);
+  }
+  100% {
+    opacity: 1;
+    transform: translateX(0) scale(1);
+  }
+}
+
+/* ── responsive ──────────────────────────────────── */
+
+@media (max-width: 600px) {
+  .esh-hero {
+    padding: 32px 20px 40px;
+    gap: 28px;
+  }
+
+  .esh-hero__visual {
+    flex-direction: column;
+  }
+
+  .esh-hero__card {
+    width: 180px;
+    height: 80px;
+  }
+
+  .esh-hero__actions {
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .esh-hero__btn {
+    width: 100%;
+    text-align: center;
+  }
+
+  .esh-hero__orb {
+    filter: blur(80px);
+    opacity: 0.25;
+  }
+}
+
+/* ── accessibility ───────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .esh-hero__content,
+  .esh-hero__actions,
+  .esh-hero__card,
+  .esh-hero__card--right {
+    animation: none;
+  }
+
+  .esh-hero__orb {
+    animation: none;
+  }
+
+  .esh-hero__btn:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a CSS-only elastic-slide hero section with glassmorphism styling for Issue #64342.

## What's Included

- **demo.html** — Showcase page with the elastic-slide hero
- **style.css** — Pure CSS with glassmorphism backdrop-blur, elastic slide-in animations, animated background orbs
- **README.md** — Documentation with CSS custom properties table and usage guide

## Key Features

- Elastic slide-in from left (text) and right (cards) using `cubic-bezier(0.34, 1.56, 0.64, 1)` for bouncy overshoot
- Glassmorphism panels with `backdrop-filter: blur(20px)`
- Staggered card entrance via `animation-delay`
- Fully responsive (stacks on mobile)
- `prefers-reduced-motion` support

## Checklist

- [x] All new files inside `submissions/examples/`
- [x] No existing files modified
- [x] Pure CSS/HTML — no JavaScript
- [x] `:root` with CSS custom properties (`--esh-*` prefix)
- [x] Animations and transitions present
- [x] Responsive media queries
- [x] Reduced-motion accessibility