### PR TITLE
feat: add float-drift hero section glassmorphism layout for #64346

### DIFF
--- a/submissions/examples/float-drift-hero-glassmorphism-layouts/README.md
+++ b/submissions/examples/float-drift-hero-glassmorphism-layouts/README.md
@@ -1,0 +1,39 @@
+# Float-Drift Hero Section — Glassmorphism UI Layouts
+
+A CSS-only hero section where background shapes gently drift across the viewport behind a frosted-glass content panel.
+
+## Features
+
+- **Floating shapes** — four blurred circles drift independently with `fdDrift1/2/3` keyframes at different speeds and directions
+- **Glassmorphism panel** — semi-transparent card with `backdrop-filter: blur(24px)` and subtle border
+- **Gradient text heading** — multi-stop gradient on the main title for visual depth
+- **Fade-up entrance** — content animates in from below on page load
+- **Fully responsive** — adapts to mobile viewports with reduced blur and opacity
+- **Reduced-motion accessible** — all animations and hover transforms disabled when `prefers-reduced-motion: reduce`
+
+## CSS Custom Properties
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `--fd-bg` | `#060a14` | Page background |
+| `--fd-glass` | `rgba(255,255,255,0.06)` | Glass panel fill |
+| `--fd-glass-edge` | `rgba(255,255,255,0.1)` | Glass border |
+| `--fd-blur` | `24px` | Backdrop blur |
+| `--fd-glow` | `rgba(0,0,0,0.45)` | Panel shadow |
+| `--fd-fg` | `#e2e8f8` | Primary text |
+| `--fd-fg-dim` | `rgba(226,232,248,0.5)` | Secondary text |
+| `--fd-mint` | `#67e8f9` | Cyan accent |
+| `--fd-amber` | `#fbbf24` | Gold accent |
+| `--fd-rose` | `#fb7185` | Pink accent |
+| `--fd-indigo` | `#818cf8` | Purple accent |
+
+## How It Works
+
+1. Four blurred circles are positioned absolutely behind the glass panel.
+2. Each shape runs a unique drift keyframe with alternating direction and staggered timing.
+3. The glass panel uses `backdrop-filter: blur()` to create the frosted-glass effect.
+4. Content fades up into view using a simple opacity + translateY transition.
+
+## Usage
+
+Copy `demo.html` and `style.css` into your project. No JavaScript or external dependencies needed. Customise the CSS custom properties to match your theme.

--- a/submissions/examples/float-drift-hero-glassmorphism-layouts/demo.html
+++ b/submissions/examples/float-drift-hero-glassmorphism-layouts/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS Float-Drift Hero Section with glassmorphism layout. Pure CSS hero animation with no JavaScript.">
+  <title>Float-Drift Hero Section – Glassmorphism UI Layouts</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <section class="fd-hero" aria-label="Float-Drift Hero Section">
+    <div class="fd-hero__inner">
+      <span class="fd-hero__tag">Glassmorphism UI</span>
+      <h1 class="fd-hero__heading">Float-Drift Hero</h1>
+      <p class="fd-hero__body">Elements drift gently across the viewport with a soft floating motion, layered over frosted-glass panels and blurred background shapes.</p>
+      <a href="#" class="fd-hero__link">Explore Layouts</a>
+    </div>
+
+    <div class="fd-hero__shapes" aria-hidden="true">
+      <div class="fd-hero__shape fd-hero__shape--1"></div>
+      <div class="fd-hero__shape fd-hero__shape--2"></div>
+      <div class="fd-hero__shape fd-hero__shape--3"></div>
+      <div class="fd-hero__shape fd-hero__shape--4"></div>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/float-drift-hero-glassmorphism-layouts/style.css
+++ b/submissions/examples/float-drift-hero-glassmorphism-layouts/style.css
@@ -1,0 +1,222 @@
+:root {
+  --fd-bg: #060a14;
+  --fd-glass: rgba(255, 255, 255, 0.06);
+  --fd-glass-edge: rgba(255, 255, 255, 0.1);
+  --fd-blur: 24px;
+  --fd-glow: rgba(0, 0, 0, 0.45);
+  --fd-fg: #e2e8f8;
+  --fd-fg-dim: rgba(226, 232, 248, 0.5);
+  --fd-mint: #67e8f9;
+  --fd-amber: #fbbf24;
+  --fd-rose: #fb7185;
+  --fd-indigo: #818cf8;
+}
+
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: var(--fd-bg);
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  color: var(--fd-fg);
+  overflow: hidden;
+}
+
+/* ── hero card ───────────────────────────────────── */
+
+.fd-hero {
+  position: relative;
+  width: min(700px, 90vw);
+  padding: 52px 44px 60px;
+  border-radius: 20px;
+  background: var(--fd-glass);
+  border: 1px solid var(--fd-glass-edge);
+  box-shadow: 0 16px 48px var(--fd-glow);
+  backdrop-filter: blur(var(--fd-blur));
+  -webkit-backdrop-filter: blur(var(--fd-blur));
+  z-index: 1;
+  text-align: center;
+  overflow: hidden;
+}
+
+.fd-hero__inner {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  animation: fdFadeUp 1s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.fd-hero__tag {
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--fd-mint);
+  font-weight: 600;
+  border: 1px solid rgba(103, 232, 249, 0.25);
+  padding: 4px 14px;
+  border-radius: 999px;
+  background: rgba(103, 232, 249, 0.08);
+}
+
+.fd-hero__heading {
+  font-size: clamp(2rem, 5vw, 3rem);
+  font-weight: 800;
+  line-height: 1.12;
+  background: linear-gradient(160deg, var(--fd-fg) 30%, var(--fd-amber));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.fd-hero__body {
+  font-size: 0.95rem;
+  color: var(--fd-fg-dim);
+  line-height: 1.65;
+  max-width: 42ch;
+}
+
+.fd-hero__link {
+  display: inline-block;
+  margin-top: 6px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  text-decoration: none;
+  color: var(--fd-bg);
+  background: var(--fd-mint);
+  padding: 10px 28px;
+  border-radius: 10px;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.fd-hero__link:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(103, 232, 249, 0.3);
+}
+
+/* ── floating shapes ─────────────────────────────── */
+
+.fd-hero__shapes {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  overflow: hidden;
+}
+
+.fd-hero__shape {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(60px);
+  opacity: 0.35;
+}
+
+.fd-hero__shape--1 {
+  width: 180px;
+  height: 180px;
+  background: var(--fd-mint);
+  top: -40px;
+  left: -30px;
+  animation: fdDrift1 7s ease-in-out infinite alternate;
+}
+
+.fd-hero__shape--2 {
+  width: 140px;
+  height: 140px;
+  background: var(--fd-indigo);
+  bottom: -30px;
+  right: -20px;
+  animation: fdDrift2 9s ease-in-out infinite alternate;
+}
+
+.fd-hero__shape--3 {
+  width: 100px;
+  height: 100px;
+  background: var(--fd-rose);
+  top: 30%;
+  right: 10%;
+  animation: fdDrift3 8s ease-in-out infinite alternate;
+}
+
+.fd-hero__shape--4 {
+  width: 80px;
+  height: 80px;
+  background: var(--fd-amber);
+  bottom: 20%;
+  left: 15%;
+  animation: fdDrift1 6s ease-in-out infinite alternate-reverse;
+}
+
+@keyframes fdDrift1 {
+  0%   { transform: translate(0, 0); }
+  100% { transform: translate(25px, 18px); }
+}
+
+@keyframes fdDrift2 {
+  0%   { transform: translate(0, 0) scale(1); }
+  100% { transform: translate(-20px, -15px) scale(1.08); }
+}
+
+@keyframes fdDrift3 {
+  0%   { transform: translate(0, 0); }
+  100% { transform: translate(15px, 25px); }
+}
+
+/* ── entrance ────────────────────────────────────── */
+
+@keyframes fdFadeUp {
+  from {
+    opacity: 0;
+    transform: translateY(24px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* ── responsive ──────────────────────────────────── */
+
+@media (max-width: 560px) {
+  .fd-hero {
+    padding: 36px 22px 44px;
+  }
+
+  .fd-hero__body {
+    font-size: 0.88rem;
+  }
+
+  .fd-hero__shape {
+    filter: blur(45px);
+    opacity: 0.22;
+  }
+}
+
+/* ── accessibility ───────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .fd-hero__inner {
+    animation: none;
+  }
+
+  .fd-hero__shape--1,
+  .fd-hero__shape--2,
+  .fd-hero__shape--3,
+  .fd-hero__shape--4 {
+    animation: none;
+  }
+
+  .fd-hero__link:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a CSS-only float-drift hero section with glassmorphism styling for Issue #64346.

## What's Included

- **demo.html** — Showcase page with the float-drift hero
- **style.css** — Pure CSS with glassmorphism backdrop-blur, floating drift animations, gradient text heading
- **README.md** — Documentation with CSS custom properties table and usage guide

## Key Features

- Four blurred shapes drift independently across the viewport at different speeds and directions
- Glassmorphism panel with `backdrop-filter: blur(24px)`
- Gradient text heading for visual depth
- Fade-up entrance animation on content
- Fully responsive with reduced blur on mobile
- `prefers-reduced-motion` support

## Checklist

- [x] All new files inside `submissions/examples/`
- [x] No existing files modified
- [x] Pure CSS/HTML — no JavaScript
- [x] `:root` with CSS custom properties (`--fd-*` prefix)
- [x] Animations and transitions present
- [x] Responsive media queries
- [x] Reduced-motion accessibility