### PR TITLE
Add ease-server-load-monitor component

### DIFF
--- a/submissions/examples/server-load-monitor-ij/README.md
+++ b/submissions/examples/server-load-monitor-ij/README.md
@@ -1,0 +1,10 @@
+# ease-server-load-monitor
+
+A server rack whose load meters pulse across four units, the status LEDs blink at staggered rates, and the rack temp readout blinks below.
+
+## Run
+Open `demo.html` directly in a browser to watch the meters pulse.
+
+## Notes
+- Each unit carries its own load level.
+- The LEDs blink on separate delays.

--- a/submissions/examples/server-load-monitor-ij/demo.html
+++ b/submissions/examples/server-load-monitor-ij/demo.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-server-load-monitor demo</title>
+</head>
+<body>
+<div class="sl-app">
+  <span class="sl-title">SERVER FARM</span>
+  <div class="sl-rack">
+    <div class="sl-unit sl-unit-1">
+      <span class="sl-led sl-led-1"></span>
+      <span class="sl-meter"><span class="sl-fill"></span></span>
+      <span class="sl-tag">WEB-01</span>
+    </div>
+    <div class="sl-unit sl-unit-2">
+      <span class="sl-led sl-led-2"></span>
+      <span class="sl-meter"><span class="sl-fill"></span></span>
+      <span class="sl-tag">DB-01</span>
+    </div>
+    <div class="sl-unit sl-unit-3">
+      <span class="sl-led sl-led-3"></span>
+      <span class="sl-meter"><span class="sl-fill"></span></span>
+      <span class="sl-tag">CACHE-01</span>
+    </div>
+    <div class="sl-unit sl-unit-4">
+      <span class="sl-led sl-led-4"></span>
+      <span class="sl-meter"><span class="sl-fill"></span></span>
+      <span class="sl-tag">QUEUE-01</span>
+    </div>
+  </div>
+  <span class="sl-temp">RACK TEMP 31C</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/server-load-monitor-ij/style.css
+++ b/submissions/examples/server-load-monitor-ij/style.css
@@ -1,0 +1,22 @@
+:root{--sl-cyan:#58e0ff;--sl-dark:#070c10}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#0e1a22,#070c10);font-family:'Courier New',monospace}
+.sl-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#0a131a,#05080c);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.sl-title{position:absolute;top:16px;left:0;right:0;text-align:center;font-size:12px;font-weight:800;letter-spacing:7px;color:#58e0ff}
+.sl-rack{position:absolute;top:56px;left:44px;right:44px;height:250px;border-radius:14px;background:#0a1118;box-shadow:inset 0 0 0 3px #1c2c38;display:flex;flex-direction:column;justify-content:space-evenly;padding:0 16px}
+.sl-unit{height:44px;border-radius:8px;background:#0e1a24;box-shadow:inset 0 0 0 2px #1c2c38;display:flex;align-items:center;gap:12px;padding:0 12px}
+.sl-led{width:10px;height:10px;border-radius:50%;background:#1c3a2a}
+.sl-led-1{animation:led-blink-server-load-monitor 1.2s steps(1) infinite}
+.sl-led-2{animation:led-blink-server-load-monitor 1.6s steps(1) infinite;animation-delay:0.3s}
+.sl-led-3{animation:led-blink-server-load-monitor 2s steps(1) infinite;animation-delay:0.6s}
+.sl-led-4{animation:led-blink-server-load-monitor 1.4s steps(1) infinite;animation-delay:0.9s}
+.sl-meter{flex:1;height:10px;border-radius:5px;background:#0c1a24;box-shadow:inset 0 0 0 2px #1c2c38;overflow:hidden}
+.sl-fill{display:block;height:10px;border-radius:5px;background:linear-gradient(90deg,#58e0ff,#2f7ea0);animation:load-fill-server-load-monitor 3s ease-in-out infinite}
+.sl-unit-1 .sl-fill{width:38%}
+.sl-unit-2 .sl-fill{width:64%}
+.sl-unit-3 .sl-fill{width:52%}
+.sl-unit-4 .sl-fill{width:78%}
+.sl-tag{font-size:10px;font-weight:800;letter-spacing:1px;color:#7fc8df}
+.sl-temp{position:absolute;bottom:16px;left:0;right:0;text-align:center;font-size:11px;font-weight:800;letter-spacing:4px;color:#58e0ff;animation:temp-blink-server-load-monitor 1.8s steps(1) infinite}
+@keyframes load-fill-server-load-monitor{0%,100%{opacity:0.5}50%{opacity:1}}
+@keyframes led-blink-server-load-monitor{0%,49%{background:#35d968;box-shadow:0 0 8px rgba(53,217,104,0.9)}50%,100%{background:#1c3a2a;box-shadow:none}}
+@keyframes temp-blink-server-load-monitor{0%,49%{opacity:1}50%,100%{opacity:0.35}}


### PR DESCRIPTION
## Component: ease-server-load-monitor — loads pulse, LEDs blink, and temp blinks

**Closes #65098**

### What this adds
A server rack: the load meters pulse across four units, the status LEDs blink at staggered rates, and the rack temp readout blinks below.

### Acceptance Criteria covered
- Load meters pulse per unit
- Status LEDs blink in turn
- Rack temp readout blinks

### Files
- `submissions/examples/server-load-monitor-ij/demo.html`
- `submissions/examples/server-load-monitor-ij/style.css`
- `submissions/examples/server-load-monitor-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the meters pulse.