### PR TITLE
feat: add blur-entrance pricing table glassmorphism layout for #64355

### DIFF
--- a/submissions/examples/blur-entrance-pricing-glassmorphism-layouts/README.md
+++ b/submissions/examples/blur-entrance-pricing-glassmorphism-layouts/README.md
@@ -1,0 +1,37 @@
+# Blur-Entrance Pricing Table — Glassmorphism UI Layouts
+
+A CSS-only pricing table where cards blur into focus on page load, with glassmorphism panels and a highlighted "Popular" tier.
+
+## Features
+
+- **Blur entrance animation** — cards start blurred and out of focus, then snap into clarity using `filter: blur()` and `scale()`
+- **Glassmorphism cards** — semi-transparent panels with `backdrop-filter: blur(20px)` and subtle borders
+- **Popular tier highlight** — middle card gets an accent border, glow shadow, and floating badge
+- **Hover lift** — cards rise up on hover with enhanced shadow
+- **Fully responsive** — collapses to single column on mobile
+- **Reduced-motion accessible** — all animations and hover effects disabled when `prefers-reduced-motion: reduce`
+
+## CSS Custom Properties
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `--bep-bg` | `#0b0f1e` | Page background |
+| `--bep-card` | `rgba(255,255,255,0.05)` | Card fill |
+| `--bep-card-border` | `rgba(255,255,255,0.09)` | Card border |
+| `--bep-blur` | `20px` | Backdrop blur |
+| `--bep-shadow` | `rgba(0,0,0,0.45)` | Card shadow |
+| `--bep-white` | `#edf0ff` | Primary text |
+| `--bep-muted` | `rgba(237,240,255,0.48)` | Secondary text |
+| `--bep-lime` | `#a3e635` | Badge accent |
+| `--bep-cyan` | `#22d3ee` | Popular tier accent |
+
+## How It Works
+
+1. Each card starts with `opacity: 0`, `filter: blur(14px)`, and `scale(0.96)`.
+2. The `bepBlurIn` keyframe animates it to full opacity, zero blur, and natural scale.
+3. Staggered `animation-delay` values create a cascading entrance effect.
+4. The popular card uses `::before` positioning for the "Popular" badge.
+
+## Usage
+
+Copy `demo.html` and `style.css` into your project. No JavaScript or external dependencies required. Customise the CSS custom properties to match your theme.

--- a/submissions/examples/blur-entrance-pricing-glassmorphism-layouts/demo.html
+++ b/submissions/examples/blur-entrance-pricing-glassmorphism-layouts/demo.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS Blur-Entrance Pricing Table with glassmorphism layout. Pure CSS pricing cards with no JavaScript.">
+  <title>Blur-Entrance Pricing Table – Glassmorphism UI Layouts</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="bep-wrap">
+    <header class="bep-head">
+      <span class="bep-head__label">Glassmorphism UI</span>
+      <h1 class="bep-head__title">Simple Pricing</h1>
+      <p class="bep-head__text">No hidden fees. Cancel anytime. All plans include a 14-day free trial.</p>
+    </header>
+
+    <div class="bep-row">
+
+      <article class="bep-card">
+        <h2 class="bep-card__name">Basic</h2>
+        <span class="bep-card__price">$12<span>/mo</span></span>
+        <p class="bep-card__desc">For individuals getting started.</p>
+        <ul class="bep-card__features">
+          <li>3 projects</li>
+          <li>5 GB storage</li>
+          <li>Community support</li>
+        </ul>
+        <a href="#" class="bep-card__cta">Get Basic</a>
+      </article>
+
+      <article class="bep-card bep-card--popular">
+        <span class="bep-card__badge">Popular</span>
+        <h2 class="bep-card__name">Team</h2>
+        <span class="bep-card__price">$39<span>/mo</span></span>
+        <p class="bep-card__desc">For small teams who ship fast.</p>
+        <ul class="bep-card__features">
+          <li>Unlimited projects</li>
+          <li>50 GB storage</li>
+          <li>Priority email support</li>
+        </ul>
+        <a href="#" class="bep-card__cta bep-card__cta--pop">Get Team</a>
+      </article>
+
+      <article class="bep-card">
+        <h2 class="bep-card__name">Business</h2>
+        <span class="bep-card__price">$89<span>/mo</span></span>
+        <p class="bep-card__desc">For companies that need control.</p>
+        <ul class="bep-card__features">
+          <li>Everything in Team</li>
+          <li>Unlimited storage</li>
+          <li>Dedicated account rep</li>
+        </ul>
+        <a href="#" class="bep-card__cta">Get Business</a>
+      </article>
+
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/blur-entrance-pricing-glassmorphism-layouts/style.css
+++ b/submissions/examples/blur-entrance-pricing-glassmorphism-layouts/style.css
@@ -1,0 +1,267 @@
+:root {
+  --bep-bg: #0b0f1e;
+  --bep-card: rgba(255, 255, 255, 0.05);
+  --bep-card-border: rgba(255, 255, 255, 0.09);
+  --bep-blur: 20px;
+  --bep-shadow: rgba(0, 0, 0, 0.45);
+  --bep-white: #edf0ff;
+  --bep-muted: rgba(237, 240, 255, 0.48);
+  --bep-lime: #a3e635;
+  --bep-cyan: #22d3ee;
+}
+
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: var(--bep-bg);
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  color: var(--bep-white);
+}
+
+/* ── wrapper ─────────────────────────────────────── */
+
+.bep-wrap {
+  width: min(880px, 92vw);
+}
+
+.bep-head {
+  text-align: center;
+  margin-bottom: 44px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  animation: bepBlurIn 0.8s ease-out both;
+}
+
+.bep-head__label {
+  font-size: 0.66rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--bep-lime);
+  font-weight: 600;
+  background: rgba(163, 230, 53, 0.08);
+  border: 1px solid rgba(163, 230, 53, 0.22);
+  padding: 4px 12px;
+  border-radius: 999px;
+}
+
+.bep-head__title {
+  font-size: clamp(1.8rem, 4vw, 2.5rem);
+  font-weight: 800;
+  background: linear-gradient(135deg, var(--bep-white), var(--bep-cyan));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.bep-head__text {
+  font-size: 0.92rem;
+  color: var(--bep-muted);
+  max-width: 36ch;
+  line-height: 1.55;
+}
+
+/* ── row ─────────────────────────────────────────── */
+
+.bep-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  align-items: stretch;
+}
+
+/* ── card ────────────────────────────────────────── */
+
+.bep-card {
+  position: relative;
+  background: var(--bep-card);
+  border: 1px solid var(--bep-card-border);
+  border-radius: 18px;
+  padding: 34px 24px;
+  backdrop-filter: blur(var(--bep-blur));
+  -webkit-backdrop-filter: blur(var(--bep-blur));
+  box-shadow: 0 8px 28px var(--bep-shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  opacity: 0;
+  filter: blur(14px);
+  animation: bepBlurIn 0.7s ease-out both;
+}
+
+.bep-card:nth-child(1) { animation-delay: 0.08s; }
+.bep-card:nth-child(2) { animation-delay: 0.2s; }
+.bep-card:nth-child(3) { animation-delay: 0.32s; }
+
+.bep-card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 14px 36px var(--bep-shadow);
+  transition: transform 0.3s, box-shadow 0.3s;
+}
+
+/* ── popular card ────────────────────────────────── */
+
+.bep-card--popular {
+  border-color: var(--bep-cyan);
+  box-shadow: 0 8px 28px rgba(34, 211, 238, 0.15);
+}
+
+.bep-card__badge {
+  position: absolute;
+  top: -11px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 0.62rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--bep-bg);
+  background: var(--bep-cyan);
+  padding: 3px 12px;
+  border-radius: 999px;
+  white-space: nowrap;
+}
+
+/* ── card internals ──────────────────────────────── */
+
+.bep-card__name {
+  font-size: 0.82rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--bep-muted);
+}
+
+.bep-card__price {
+  font-size: 2.5rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.bep-card__price span {
+  font-size: 0.82rem;
+  font-weight: 400;
+  color: var(--bep-muted);
+}
+
+.bep-card__desc {
+  font-size: 0.88rem;
+  color: var(--bep-muted);
+  line-height: 1.45;
+}
+
+.bep-card__features {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  margin-top: 4px;
+}
+
+.bep-card__features li {
+  font-size: 0.86rem;
+  color: var(--bep-muted);
+  padding: 9px 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.bep-card__features li:last-child {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+/* ── cta ─────────────────────────────────────────── */
+
+.bep-card__cta {
+  display: block;
+  text-align: center;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-decoration: none;
+  padding: 10px 18px;
+  border-radius: 10px;
+  margin-top: 6px;
+  background: transparent;
+  color: var(--bep-white);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  transition: background 0.2s, color 0.2s;
+}
+
+.bep-card__cta:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.bep-card__cta--pop {
+  background: var(--bep-cyan);
+  color: var(--bep-bg);
+  border-color: var(--bep-cyan);
+}
+
+.bep-card__cta--pop:hover {
+  background: #06b6d4;
+}
+
+/* ── blur entrance ───────────────────────────────── */
+
+@keyframes bepBlurIn {
+  0% {
+    opacity: 0;
+    filter: blur(14px);
+    transform: scale(0.96);
+  }
+  100% {
+    opacity: 1;
+    filter: blur(0);
+    transform: scale(1);
+  }
+}
+
+/* ── responsive ──────────────────────────────────── */
+
+@media (max-width: 680px) {
+  .bep-row {
+    grid-template-columns: 1fr;
+    max-width: 320px;
+    margin: 0 auto;
+  }
+
+  .bep-card--popular .bep-card__badge {
+    top: auto;
+    bottom: -11px;
+  }
+}
+
+@media (max-width: 440px) {
+  .bep-wrap {
+    padding: 0 10px;
+  }
+
+  .bep-card {
+    padding: 28px 18px;
+  }
+}
+
+/* ── accessibility ───────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .bep-head,
+  .bep-card {
+    animation: none;
+    opacity: 1;
+    filter: none;
+    transform: none;
+  }
+
+  .bep-card:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a CSS-only blur-entrance pricing table with glassmorphism styling for Issue #64355.

## What's Included

- **demo.html** — Showcase page with 3-tier pricing cards (Basic, Team, Business)
- **style.css** — Pure CSS with glassmorphism panels, blur-to-focus entrance animation, popular tier highlight, hover lift effect
- **README.md** — Documentation with CSS custom properties table and usage guide

## Key Features

- Blur entrance animation — cards start blurred and scale into focus using `filter: blur()` and `scale()`
- Staggered card delays for cascading entrance effect
- Glassmorphism panels with `backdrop-filter: blur(20px)`
- Popular tier with accent border, glow shadow, and floating badge
- Fully responsive — collapses to single column on mobile
- `prefers-reduced-motion` support

## Checklist

- [x] All new files inside `submissions/examples/`
- [x] No existing files modified
- [x] Pure CSS/HTML — no JavaScript
- [x] `:root` with CSS custom properties (`--bep-*` prefix)
- [x] Animations and transitions present
- [x] Responsive media queries
- [x] Reduced-motion accessibility
