### PR TITLE
add tilit 3d

### DIFF
--- a/submissions/examples/animated-tilt-3d/README.md
+++ b/submissions/examples/animated-tilt-3d/README.md
@@ -1,0 +1,26 @@
+# ease-3d-tilt
+
+A card that tilts in 3D space to follow cursor position, with inner content lifted on the Z-axis for parallax depth.
+
+## Usage
+1. Include `style.css`.
+2. Add markup:
+```html
+   <div class="tilt-card">
+     <div class="tilt-content">
+       <h3>Title</h3>
+       <p>Description</p>
+     </div>
+   </div>
+```
+3. Attach the mousemove/mouseleave listener from `demo.html`.
+
+## Customization
+- `maxTilt` (JS): maximum rotation in degrees — lower for a subtler effect.
+- `translateZ(40px)` on `.tilt-content`: how far inner content "pops" forward for parallax.
+- `perspective(800px)`: lower values = more dramatic/exaggerated tilt.
+
+## Notes
+- Rotation is computed from cursor position relative to the card's own bounding box (0–1 normalized), not viewport position.
+- `.tilt-content` is pushed forward on Z so it visually separates from the card surface as it tilts, reinforcing the 3D read.
+- JS is required since CSS alone can't read live cursor coordinates; CSS handles all the actual transform/transition rendering.

--- a/submissions/examples/animated-tilt-3d/demo.html
+++ b/submissions/examples/animated-tilt-3d/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-3d-tilt demo</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body {
+    height: 100vh;
+    margin: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #f4f4f5;
+  }
+</style>
+</head>
+<body>
+
+<div class="tilt-card" id="tiltCard">
+  <div class="tilt-content">
+    <h3>Tilt Me</h3>
+    <p>Move your cursor across this card</p>
+  </div>
+</div>
+
+<script>
+  const card = document.getElementById('tiltCard');
+  const maxTilt = 14; // degrees
+
+  card.addEventListener('mousemove', (e) => {
+    const rect = card.getBoundingClientRect();
+    const x = (e.clientX - rect.left) / rect.width;  // 0 to 1
+    const y = (e.clientY - rect.top) / rect.height;  // 0 to 1
+    const rotateY = (x - 0.5) * maxTilt * 2;
+    const rotateX = (0.5 - y) * maxTilt * 2;
+    card.style.transform = `perspective(800px) rotateX(${rotateX}deg) rotateY(${rotateY}deg)`;
+  });
+
+  card.addEventListener('mouseleave', () => {
+    card.style.transform = 'perspective(800px) rotateX(0deg) rotateY(0deg)';
+  });
+</script>
+
+</body>
+</html>

--- a/submissions/examples/animated-tilt-3d/style.css
+++ b/submissions/examples/animated-tilt-3d/style.css
@@ -1,0 +1,38 @@
+.tilt-card {
+  width: 280px;
+  height: 180px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, #1e1e2e, #2a2a3e);
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  font-family: system-ui, sans-serif;
+  transform-style: preserve-3d;
+  transform: perspective(800px) rotateX(0deg) rotateY(0deg);
+  transition: transform 0.15s ease-out, box-shadow 0.15s ease-out;
+  box-shadow: 0 10px 30px rgba(0,0,0,0.2);
+  will-change: transform;
+}
+
+.tilt-card:hover {
+  box-shadow: 0 25px 50px rgba(0,0,0,0.35);
+}
+
+.tilt-card .tilt-content {
+  transform: translateZ(40px);
+  text-align: center;
+  pointer-events: none;
+}
+
+.tilt-card h3 {
+  margin: 0 0 8px;
+  font-size: 18px;
+}
+
+.tilt-card p {
+  margin: 0;
+  font-size: 13px;
+  opacity: 0.7;
+}


### PR DESCRIPTION
## Summary
Adds `ease-3d-tilt`, a cursor-tracking 3D tilt card with parallaxed inner content.

## What's included
- `submissions/ease-3d-tilt/style.css`
- `submissions/ease-3d-tilt/demo.html`
- `submissions/ease-3d-tilt/readme.md`

## Implementation notes
- Rotation angles are derived from cursor position normalized against the card's own bounding box, so the tilt direction stays correct regardless of where the card sits on the page.
- Inner content is separated onto its own `translateZ(40px)` layer, giving a parallax "lift" as the card rotates rather than a flat tilting plane.
- `transition: transform 0.15s ease-out` only applies smoothing on mousemove/leave; JS never animates the value directly, keeping the motion GPU-friendly.

## Testing checklist
- [x] Verified tilt direction matches cursor position correctly on all four corners
- [x] Verified reset to flat on mouse leave is smooth, no snapping
- [x] Placed only inside `submissions/`