### PR TITLE
Add ease-heart-rate-monitor component

### DIFF
--- a/submissions/examples/heart-rate-monitor-ij/README.md
+++ b/submissions/examples/heart-rate-monitor-ij/README.md
@@ -1,0 +1,10 @@
+# ease-heart-rate-monitor
+
+A vital monitor where the heartbeat trace draws across the screen, a scan sweep trails the trace, and the BPM readout blinks beneath.
+
+## Run
+Open `demo.html` directly in a browser to watch the ECG draw.
+
+## Notes
+- The trace redraws in a loop.
+- The scan line follows the beat.

--- a/submissions/examples/heart-rate-monitor-ij/demo.html
+++ b/submissions/examples/heart-rate-monitor-ij/demo.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-heart-rate-monitor demo</title>
+</head>
+<body>
+<div class="hr-app">
+  <span class="hr-title">VITAL MONITOR</span>
+  <div class="hr-screen">
+    <svg class="hr-ecg" viewBox="0 0 300 140" preserveAspectRatio="none">
+      <polyline class="hr-path" points="0,70 40,70 55,70 62,30 70,110 78,70 120,70 140,70 150,20 160,120 170,70 220,70 240,70 250,45 258,95 266,70 300,70"/>
+    </svg>
+    <span class="hr-sweep"></span>
+  </div>
+  <span class="hr-bpm">72</span>
+  <span class="hr-unit">BPM</span>
+  <span class="hr-label">HEART RATE</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/heart-rate-monitor-ij/style.css
+++ b/submissions/examples/heart-rate-monitor-ij/style.css
@@ -1,0 +1,15 @@
+:root{--hr-red:#ff5b5b;--hr-dark:#140808}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#260d0d,#140808);font-family:'Courier New',monospace}
+.hr-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#200a0a,#100505);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.hr-title{position:absolute;top:16px;left:0;right:0;text-align:center;font-size:12px;font-weight:800;letter-spacing:7px;color:#ff5b5b}
+.hr-screen{position:absolute;top:56px;left:34px;right:34px;height:170px;border-radius:12px;background:#0f0505;box-shadow:inset 0 0 0 2px #2c1414;overflow:hidden}
+.hr-ecg{position:absolute;top:0;left:0;width:100%;height:100%}
+.hr-path{fill:none;stroke:#ff5b5b;stroke-width:3;stroke-linejoin:round;stroke-linecap:round;stroke-dasharray:620;stroke-dashoffset:620;animation:draw-ecg-heart-rate-monitor 2.4s linear infinite;filter:drop-shadow(0 0 6px rgba(255,91,91,0.8))}
+.hr-sweep{position:absolute;top:0;bottom:0;left:0;width:3px;background:linear-gradient(180deg,transparent,#ff5b5b,transparent);animation:sweep-scan-heart-rate-monitor 2.4s linear infinite}
+.hr-bpm{position:absolute;top:240px;left:0;right:0;text-align:center;font-size:40px;font-weight:900;color:#ffe0e0;font-variant-numeric:tabular-nums;animation:digit-blink-heart-rate-monitor 1s steps(1) infinite}
+.hr-unit{position:absolute;top:286px;left:0;right:0;text-align:center;font-size:11px;font-weight:800;letter-spacing:4px;color:#b35b5b}
+.hr-label{position:absolute;bottom:16px;left:0;right:0;text-align:center;font-size:10px;font-weight:800;letter-spacing:5px;color:#ff5b5b;animation:label-pulse-heart-rate-monitor 1.6s ease-in-out infinite}
+@keyframes draw-ecg-heart-rate-monitor{0%{stroke-dashoffset:620}100%{stroke-dashoffset:0}}
+@keyframes sweep-scan-heart-rate-monitor{0%{transform:translateX(0)}100%{transform:translateX(300px)}}
+@keyframes digit-blink-heart-rate-monitor{0%,49%{opacity:1}50%,100%{opacity:0.45}}
+@keyframes label-pulse-heart-rate-monitor{0%,100%{opacity:0.6}50%{opacity:1}}


### PR DESCRIPTION
## Component: ease-heart-rate-monitor — ECG draws, sweep scans, and BPM blinks

**Closes #65130**

### What this adds
A vital monitor: the heartbeat trace draws across the screen, a scan line sweeps after it, and the BPM readout blinks beneath.

### Acceptance Criteria covered
- Heartbeat trace draws across
- Scan sweep trails the trace
- BPM readout blinks below

### Files
- `submissions/examples/heart-rate-monitor-ij/demo.html`
- `submissions/examples/heart-rate-monitor-ij/style.css`
- `submissions/examples/heart-rate-monitor-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the ECG draw.