### PR TITLE
add blob button

### DIFF
--- a/submissions/examples/animated-blob-btn/README.md
+++ b/submissions/examples/animated-blob-btn/README.md
@@ -1,0 +1,20 @@
+# ease-blob-btn
+
+A button whose border-radius continuously morphs into organic "blob" shapes on hover — pure CSS, no SVG.
+
+## Usage
+1. Include `style.css`.
+2. Add markup:
+```html
+   <button class="blob-btn">Hover Me</button>
+```
+
+## Customization
+- Edit the `border-radius` values (each keyframe uses 8 values: 4 for horizontal, 4 for vertical corner radii) to change the blob shapes.
+- Animation duration (`3s`) controls morph speed.
+- Base `background`/`color` for theming.
+
+## Notes
+- The organic look comes entirely from asymmetric elliptical `border-radius` shorthand (`X% Y% Z% W% / X% Y% Z% W%`), animated between three keyframe states.
+- Animation only runs on `:hover`, so the button is static (fixed rounded-pill shape) at rest.
+- No SVG, clip-path, or JS required — this is achievable because `border-radius` supports independent horizontal/vertical radii per corner.

--- a/submissions/examples/animated-blob-btn/demo.html
+++ b/submissions/examples/animated-blob-btn/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-blob-btn demo</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body {
+    height: 100vh;
+    margin: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #f4f4f5;
+  }
+</style>
+</head>
+<body>
+
+<button class="blob-btn">Hover Me</button>
+
+</body>
+</html>

--- a/submissions/examples/animated-blob-btn/style.css
+++ b/submissions/examples/animated-blob-btn/style.css
@@ -1,0 +1,30 @@
+.blob-btn {
+  position: relative;
+  padding: 18px 44px;
+  border: none;
+  border-radius: 50px;
+  background: #7c3aed;
+  color: #fff;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  overflow: visible;
+  transition: border-radius 0.4s ease, transform 0.3s ease;
+  z-index: 1;
+}
+
+.blob-btn:hover {
+  border-radius: 42% 58% 65% 35% / 45% 40% 60% 55%;
+  transform: scale(1.05);
+  animation: blob-morph 3s ease-in-out infinite;
+}
+
+@keyframes blob-morph {
+  0%, 100% { border-radius: 42% 58% 65% 35% / 45% 40% 60% 55%; }
+  33%      { border-radius: 60% 40% 30% 70% / 55% 65% 35% 45%; }
+  66%      { border-radius: 35% 65% 55% 45% / 40% 50% 50% 60%; }
+}
+
+.blob-btn:active {
+  transform: scale(0.96);
+}


### PR DESCRIPTION
## Summary
Adds `ease-blob-btn`, a hover-triggered organic blob-morph button using animated `border-radius` only.

## What's included
- `submissions/ease-blob-btn/style.css`
- `submissions/ease-blob-btn/demo.html`
- `submissions/ease-blob-btn/readme.md`

## Implementation notes
- Blob shapes come purely from the 8-value elliptical `border-radius` shorthand animated across three keyframes — no SVG path, clip-path, or JS needed.
- Animation is scoped to `:hover` only, so the button stays a clean static pill shape at rest and doesn't distract when not interacted with.
- `transform: scale(1.05)` on hover is layered on top of the morph for a bit of added emphasis without competing with the shape animation.

## Testing checklist
- [x] Verified blob morph loops seamlessly with no visual jump between cycles
- [x] Verified button returns to clean pill shape when hover ends
- [x] Placed only inside `submissions/`