### PR TITLE
add burst confetti

### DIFF
--- a/submissions/examples/animated-burst-confetti/README.md
+++ b/submissions/examples/animated-burst-confetti/README.md
@@ -1,0 +1,22 @@
+# ease-confetti-burst
+
+A button that bursts small colored confetti pieces outward on click, each flying a randomized distance/angle/rotation.
+
+## Usage
+1. Include `style.css`.
+2. Add markup:
+```html
+   <button class="confetti-btn">Click Me 🎉</button>
+```
+3. Attach the click listener from `demo.html` to spawn and animate confetti pieces.
+
+## Customization
+- `count` (JS): number of confetti pieces per burst.
+- `colors` array: palette used for pieces.
+- `distance` range: how far pieces travel from the button center.
+- Swap `border-radius: 50%` vs `2px` per-piece for circle/square confetti mix.
+
+## Notes
+- Each piece's trajectory (`--tx`, `--ty`, `--rot` CSS custom properties) is randomized in JS per click, then handed to a single shared CSS `@keyframes` animation — JS only computes numbers, CSS does all the rendering/animating.
+- Pieces self-remove via the `animationend` event, so repeated clicks don't leave stale DOM nodes behind.
+- Positioned absolutely relative to the button (`overflow: visible` on `.confetti-btn`) so the burst radiates from the button's own center.

--- a/submissions/examples/animated-burst-confetti/demo.html
+++ b/submissions/examples/animated-burst-confetti/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-confetti-burst demo</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body {
+    height: 100vh;
+    margin: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #f4f4f5;
+  }
+</style>
+</head>
+<body>
+
+<button class="confetti-btn" id="confettiBtn">Click Me 🎉</button>
+
+<script>
+  const btn = document.getElementById('confettiBtn');
+  const colors = ['#f43f5e', '#3b82f6', '#22c55e', '#eab308', '#a855f7', '#ec4899'];
+
+  btn.addEventListener('click', () => {
+    const count = 24;
+    for (let i = 0; i < count; i++) {
+      const piece = document.createElement('span');
+      piece.className = 'confetti-piece';
+
+      const angle = Math.random() * Math.PI * 2;
+      const distance = 60 + Math.random() * 60;
+      const tx = Math.cos(angle) * distance;
+      const ty = Math.sin(angle) * distance;
+      const rot = (Math.random() - 0.5) * 720;
+
+      piece.style.setProperty('--tx', `${tx}px`);
+      piece.style.setProperty('--ty', `${ty}px`);
+      piece.style.setProperty('--rot', `${rot}deg`);
+      piece.style.background = colors[Math.floor(Math.random() * colors.length)];
+      piece.style.borderRadius = Math.random() > 0.5 ? '50%' : '2px';
+
+      btn.appendChild(piece);
+      piece.addEventListener('animationend', () => piece.remove());
+    }
+  });
+</script>
+
+</body>
+</html>

--- a/submissions/examples/animated-burst-confetti/style.css
+++ b/submissions/examples/animated-burst-confetti/style.css
@@ -1,0 +1,34 @@
+.confetti-btn {
+  position: relative;
+  padding: 16px 36px;
+  border: none;
+  border-radius: 10px;
+  background: #111;
+  color: #fff;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  overflow: visible;
+}
+
+.confetti-piece {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 8px;
+  height: 8px;
+  pointer-events: none;
+  opacity: 1;
+  animation: confetti-fly 0.9s ease-out forwards;
+}
+
+@keyframes confetti-fly {
+  0% {
+    transform: translate(-50%, -50%) rotate(0deg) scale(1);
+    opacity: 1;
+  }
+  100% {
+    transform: translate(var(--tx), var(--ty)) rotate(var(--rot)) scale(0.4);
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Summary
Adds `ease-confetti-burst`, a click-triggered confetti particle burst radiating from a button.

## What's included
- `submissions/ease-confetti-burst/style.css`
- `submissions/ease-confetti-burst/demo.html`
- `submissions/ease-confetti-burst/readme.md`

## Implementation notes
- JS only computes per-piece randomized trajectory values (`--tx`, `--ty`, `--rot` as CSS custom properties) — the actual fly-out animation is a single shared `@keyframes` in CSS, keeping JS lightweight.
- Each piece removes itself on `animationend` rather than via a `setTimeout`, so cleanup timing can't drift out of sync with the actual animation duration.
- Mixed circle/square piece shapes (randomized `border-radius`) avoid a uniform, mechanical-looking burst.

## Testing checklist
- [x] Verified rapid repeated clicks don't leave orphaned confetti elements in the DOM
- [x] Verified burst radiates outward in random directions each click, not a fixed pattern
- [x] Placed only inside `submissions/`