### PR TITLE
feat: add skew-active feature grid glassmorphism layout for #64363

### DIFF
--- a/submissions/examples/skew-active-feature-grid-glassmorphism-layouts/README.md
+++ b/submissions/examples/skew-active-feature-grid-glassmorphism-layouts/README.md
@@ -1,0 +1,37 @@
+# Skew-Active Feature Grid — Glassmorphism UI Layouts
+
+A CSS-only feature grid where cards skew on hover with alternating directions, wrapped in glassmorphism panels.
+
+## Features
+
+- **Skew hover effect** — cards tilt with `skewY(-2deg)` on hover; even-numbered cards tilt the opposite way for visual variety
+- **Counter-skew icon** — each card's icon counter-rotates to stay upright while the card tilts
+- **Glassmorphism panels** — semi-transparent cards with `backdrop-filter: blur(18px)` and subtle borders
+- **Staggered entrance** — cards fade in one after another with increasing `animation-delay`
+- **Fully responsive** — collapses from 3-column to 2-column to single column on smaller screens
+- **Reduced-motion accessible** — all animations and hover transforms disabled when `prefers-reduced-motion: reduce`
+
+## CSS Custom Properties
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `--saf-bg` | `#090d1b` | Page background |
+| `--saf-glass` | `rgba(255,255,255,0.05)` | Card fill |
+| `--saf-glass-border` | `rgba(255,255,255,0.09)` | Card border |
+| `--saf-blur` | `18px` | Backdrop blur |
+| `--saf-shadow` | `rgba(0,0,0,0.4)` | Card shadow |
+| `--saf-text` | `#e8ecf8` | Primary text |
+| `--saf-text-dim` | `rgba(232,236,248,0.48)` | Secondary text |
+| `--saf-orange` | `#fb923c` | Accent colour |
+| `--saf-blue` | `#60a5fa` | Secondary accent |
+
+## How It Works
+
+1. Each card has `transform: skewY(0deg)` by default.
+2. On hover, `skewY(-2deg)` is applied with a smooth cubic-bezier transition.
+3. Even-numbered cards use `skewY(2deg)` for alternating tilt direction.
+4. The icon inside each card counter-rotates with `skewY(2deg)` or `skewY(-2deg)` to remain visually upright.
+
+## Usage
+
+Copy `demo.html` and `style.css` into your project. No JavaScript or external dependencies needed. Override the CSS custom properties to match your theme.

--- a/submissions/examples/skew-active-feature-grid-glassmorphism-layouts/demo.html
+++ b/submissions/examples/skew-active-feature-grid-glassmorphism-layouts/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS Skew-Active Feature Grid with glassmorphism layout. Pure CSS feature cards with no JavaScript.">
+  <title>Skew-Active Feature Grid – Glassmorphism UI Layouts</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="saf-wrap">
+    <header class="saf-head">
+      <span class="saf-head__pill">Glassmorphism UI</span>
+      <h1 class="saf-head__title">Features</h1>
+      <p class="saf-head__sub">Hover over each card to see the skew transform kick in.</p>
+    </header>
+
+    <div class="saf-grid">
+
+      <article class="saf-cell">
+        <span class="saf-cell__icon">&#9733;</span>
+        <h2 class="saf-cell__name">Fast Builds</h2>
+        <p class="saf-cell__desc">Optimised pipeline that cuts compile times in half.</p>
+      </article>
+
+      <article class="saf-cell">
+        <span class="saf-cell__icon">&#9881;</span>
+        <h2 class="saf-cell__name">Modular Core</h2>
+        <p class="saf-cell__desc">Plug-and-play modules that snap together cleanly.</p>
+      </article>
+
+      <article class="saf-cell">
+        <span class="saf-cell__icon">&#9878;</span>
+        <h2 class="saf-cell__name">Type Safe</h2>
+        <p class="saf-cell__desc">Full type coverage with zero runtime overhead.</p>
+      </article>
+
+      <article class="saf-cell">
+        <span class="saf-cell__icon">&#9883;</span>
+        <h2 class="saf-cell__name">Live Reload</h2>
+        <p class="saf-cell__desc">Instant feedback loop as you edit and save.</p>
+      </article>
+
+      <article class="saf-cell">
+        <span class="saf-cell__icon">&#9775;</span>
+        <h2 class="saf-cell__name">Dark Mode</h2>
+        <p class="saf-cell__desc">System-aware theme with manual override toggle.</p>
+      </article>
+
+      <article class="saf-cell">
+        <span class="saf-cell__icon">&#9879;</span>
+        <h2 class="saf-cell__name">Deploy Ready</h2>
+        <p class="saf-cell__desc">One command to ship to any cloud provider.</p>
+      </article>
+
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/skew-active-feature-grid-glassmorphism-layouts/style.css
+++ b/submissions/examples/skew-active-feature-grid-glassmorphism-layouts/style.css
@@ -1,0 +1,202 @@
+:root {
+  --saf-bg: #090d1b;
+  --saf-glass: rgba(255, 255, 255, 0.05);
+  --saf-glass-border: rgba(255, 255, 255, 0.09);
+  --saf-blur: 18px;
+  --saf-shadow: rgba(0, 0, 0, 0.4);
+  --saf-text: #e8ecf8;
+  --saf-text-dim: rgba(232, 236, 248, 0.48);
+  --saf-orange: #fb923c;
+  --saf-blue: #60a5fa;
+}
+
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: var(--saf-bg);
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  color: var(--saf-text);
+}
+
+/* ── layout ──────────────────────────────────────── */
+
+.saf-wrap {
+  width: min(780px, 92vw);
+  padding: 40px 0;
+}
+
+.saf-head {
+  text-align: center;
+  margin-bottom: 36px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  animation: safFadeIn 0.65s ease-out both;
+}
+
+.saf-head__pill {
+  font-size: 0.66rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--saf-orange);
+  font-weight: 600;
+  background: rgba(251, 146, 60, 0.08);
+  border: 1px solid rgba(251, 146, 60, 0.22);
+  padding: 4px 12px;
+  border-radius: 999px;
+}
+
+.saf-head__title {
+  font-size: clamp(1.8rem, 4vw, 2.5rem);
+  font-weight: 800;
+  background: linear-gradient(135deg, var(--saf-text), var(--saf-orange));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.saf-head__sub {
+  font-size: 0.92rem;
+  color: var(--saf-text-dim);
+  max-width: 34ch;
+  line-height: 1.5;
+}
+
+/* ── grid ────────────────────────────────────────── */
+
+.saf-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+
+/* ── cell ────────────────────────────────────────── */
+
+.saf-cell {
+  background: var(--saf-glass);
+  border: 1px solid var(--saf-glass-border);
+  border-radius: 16px;
+  padding: 28px 20px;
+  backdrop-filter: blur(var(--saf-blur));
+  -webkit-backdrop-filter: blur(var(--saf-blur));
+  box-shadow: 0 6px 24px var(--saf-shadow);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  text-align: center;
+  transform: skewY(0deg);
+  transition: transform 0.35s cubic-bezier(0.22, 1, 0.36, 1), box-shadow 0.3s;
+  cursor: default;
+  opacity: 0;
+  animation: safFadeIn 0.55s ease-out both;
+}
+
+.saf-cell:nth-child(1) { animation-delay: 0.06s; }
+.saf-cell:nth-child(2) { animation-delay: 0.14s; }
+.saf-cell:nth-child(3) { animation-delay: 0.22s; }
+.saf-cell:nth-child(4) { animation-delay: 0.3s; }
+.saf-cell:nth-child(5) { animation-delay: 0.38s; }
+.saf-cell:nth-child(6) { animation-delay: 0.46s; }
+
+.saf-cell:hover {
+  transform: skewY(-2deg);
+  box-shadow: 0 10px 32px var(--saf-shadow);
+  border-color: var(--saf-orange);
+}
+
+.saf-cell:nth-child(even):hover {
+  transform: skewY(2deg);
+}
+
+/* ── cell internals ──────────────────────────────── */
+
+.saf-cell__icon {
+  font-size: 1.8rem;
+  color: var(--saf-orange);
+  transition: transform 0.3s;
+}
+
+.saf-cell:hover .saf-cell__icon {
+  transform: skewY(2deg);
+}
+
+.saf-cell:nth-child(even):hover .saf-cell__icon {
+  transform: skewY(-2deg);
+}
+
+.saf-cell__name {
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.saf-cell__desc {
+  font-size: 0.85rem;
+  color: var(--saf-text-dim);
+  line-height: 1.5;
+}
+
+/* ── entrance ────────────────────────────────────── */
+
+@keyframes safFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* ── responsive ──────────────────────────────────── */
+
+@media (max-width: 600px) {
+  .saf-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 400px) {
+  .saf-grid {
+    grid-template-columns: 1fr;
+    max-width: 300px;
+    margin: 0 auto;
+  }
+
+  .saf-wrap {
+    padding: 24px 10px;
+  }
+}
+
+/* ── accessibility ───────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .saf-head,
+  .saf-cell {
+    animation: none;
+    opacity: 1;
+  }
+
+  .saf-cell {
+    transition: none;
+  }
+
+  .saf-cell:hover {
+    transform: none;
+  }
+
+  .saf-cell:hover .saf-cell__icon {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a CSS-only skew-active feature grid with glassmorphism styling for Issue #64363.

## What's Included

- **demo.html** — Showcase page with 6 feature cards in a grid
- **style.css** — Pure CSS with glassmorphism panels, alternating skew hover effect, counter-rotating icons, staggered entrance
- **README.md** — Documentation with CSS custom properties table and usage guide

## Key Features

- Skew hover effect with alternating directions (odd cards skew -2deg, even cards skew +2deg)
- Counter-rotating icons stay upright while card tilts
- Glassmorphism panels with `backdrop-filter: blur(18px)`
- Staggered fade-in entrance for cascading effect
- Responsive — 3-col → 2-col → 1-col
- `prefers-reduced-motion` support

## Checklist

- [x] All new files inside `submissions/examples/`
- [x] No existing files modified
- [x] Pure CSS/HTML — no JavaScript
- [x] `:root` with CSS custom properties (`--saf-*` prefix)
- [x] Animations and transitions present
- [x] Responsive media queries
- [x] Reduced-motion accessibility