### PR TITLE
add svg draw

### DIFF
--- a/submissions/examples/animated-svg-draw/README.md
+++ b/submissions/examples/animated-svg-draw/README.md
@@ -1,0 +1,22 @@
+# ease-svg-draw
+
+An SVG path that appears to "draw itself" on load, using the stroke-dasharray/dashoffset trick — no JS.
+
+## Usage
+1. Include `style.css`.
+2. Add any SVG with a `<path>` (or apply the same rule to `line`, `circle`, `polyline`):
+```html
+   <svg class="svg-draw" viewBox="0 0 200 200">
+     <path d="M20,100 Q60,20 100,100 T180,100" />
+   </svg>
+```
+
+## Customization
+- `stroke-dasharray` value **must be ≥ the total path length** — set it generously high (1000 works for most simple paths; use `path.getTotalLength()` in JS for pixel-perfect matching on complex paths).
+- `stroke-width`/`stroke` color for line styling.
+- Animation duration for draw speed.
+
+## Notes
+- The technique: `stroke-dasharray` creates one dash equal to the whole path length, then `stroke-dashoffset` shifts it fully off-screen at start and animates to 0, revealing the stroke progressively.
+- Works with any path shape/complexity, but very long/complex paths may need a JS-measured `stroke-dasharray` (via `getTotalLength()`) instead of a fixed guess, so the draw speed feels even along the whole path.
+- Purely presentational — no JS dependency for the animation itself.

--- a/submissions/examples/animated-svg-draw/demo.html
+++ b/submissions/examples/animated-svg-draw/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-svg-draw demo</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body {
+    height: 100vh;
+    margin: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #fafafa;
+  }
+</style>
+</head>
+<body>
+
+<svg class="svg-draw" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+  <path d="M20,100 Q60,20 100,100 T180,100" />
+</svg>
+
+</body>
+</html>

--- a/submissions/examples/animated-svg-draw/style.css
+++ b/submissions/examples/animated-svg-draw/style.css
@@ -1,0 +1,19 @@
+.svg-draw {
+  width: 200px;
+  height: 200px;
+}
+
+.svg-draw path {
+  fill: none;
+  stroke: #2563eb;
+  stroke-width: 4;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-dasharray: 1000;
+  stroke-dashoffset: 1000;
+  animation: draw-line 2.5s ease forwards;
+}
+
+@keyframes draw-line {
+  to { stroke-dashoffset: 0; }
+}


### PR DESCRIPTION
## Summary
Adds `ease-svg-draw`, a self-drawing SVG path animation using pure CSS (stroke-dasharray/dashoffset).

## What's included
- `submissions/ease-svg-draw/style.css`
- `submissions/ease-svg-draw/demo.html`
- `submissions/ease-svg-draw/readme.md`

## Implementation notes
- Uses the standard dasharray = path-length / dashoffset animate-to-zero technique — no JS, no `getTotalLength()` dependency, since the demo path is simple enough for a generous fixed dasharray value to work cleanly.
- `stroke-linecap: round` on the path keeps the leading edge of the draw looking like a pen stroke rather than a hard-cut line end.
- Noted in the readme that longer/complex real-world paths should measure exact length via JS for a perfectly even draw speed — flagged as a known extension point, not shipped as a requirement for this simple demo.

## Testing checklist
- [x] Verified path draws fully from start to end with no visible jump/skip
- [x] Verified no residual dash pattern remains after animation completes
- [x] Placed only inside `submissions/`