### PR TITLE
add progress scroll

### DIFF
--- a/submissions/examples/animated-progress-scroll/README.md
+++ b/submissions/examples/animated-progress-scroll/README.md
@@ -1,0 +1,23 @@
+# ease-scroll-progress
+
+A thin fixed bar at the top of the page that fills left-to-right based on scroll position.
+
+## Usage
+1. Include `style.css`.
+2. Add markup as the first element in `<body>`:
+```html
+   <div class="scroll-progress-bar">
+     <div class="fill" id="progressFill"></div>
+   </div>
+```
+3. Attach the scroll listener from `demo.html` to compute and set `.fill`'s width.
+
+## Customization
+- `height` on `.scroll-progress-bar`: bar thickness.
+- Gradient colors on `.fill`.
+- `transition: width 0.1s linear` on `.fill`: smooths rapid scroll jumps slightly; remove for instant 1:1 tracking.
+
+## Notes
+- Progress percentage is `scrollY / (scrollHeight - innerHeight) * 100`, i.e. how far through the *scrollable* range the user is, not raw pixel position.
+- `{ passive: true }` on the scroll listener avoids blocking scroll performance.
+- CSS handles the visual fill and smoothing transition; JS only computes and sets the percentage.

--- a/submissions/examples/animated-progress-scroll/demo.html
+++ b/submissions/examples/animated-progress-scroll/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-scroll-progress demo</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body {
+    margin: 0;
+    font-family: system-ui, sans-serif;
+    line-height: 1.7;
+  }
+  .content {
+    max-width: 640px;
+    margin: 60px auto;
+    padding: 0 24px 200px;
+  }
+  .content h2 { margin-top: 48px; }
+</style>
+</head>
+<body>
+
+<div class="scroll-progress-bar">
+  <div class="fill" id="progressFill"></div>
+</div>
+
+<div class="content">
+  <h1>Scroll Down</h1>
+  <p>The bar at the top fills as you scroll through this page.</p>
+  <h2>Section One</h2>
+  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+  <h2>Section Two</h2>
+  <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+  <h2>Section Three</h2>
+  <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
+  <h2>Section Four</h2>
+  <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+</div>
+
+<script>
+  const fill = document.getElementById('progressFill');
+
+  function updateProgress() {
+    const scrollTop = window.scrollY;
+    const docHeight = document.documentElement.scrollHeight - window.innerHeight;
+    const percent = docHeight > 0 ? (scrollTop / docHeight) * 100 : 0;
+    fill.style.width = percent + '%';
+  }
+
+  window.addEventListener('scroll', updateProgress, { passive: true });
+  updateProgress();
+</script>
+
+</body>
+</html>

--- a/submissions/examples/animated-progress-scroll/style.css
+++ b/submissions/examples/animated-progress-scroll/style.css
@@ -1,0 +1,17 @@
+.scroll-progress-bar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 4px;
+  width: 100%;
+  background: rgba(0,0,0,0.08);
+  z-index: 1000;
+}
+
+.scroll-progress-bar .fill {
+  height: 100%;
+  width: 0%;
+  background: linear-gradient(90deg, #2563eb, #7c3aed);
+  transform-origin: left;
+  transition: width 0.1s linear;
+}


### PR DESCRIPTION
## Summary
Adds `ease-scroll-progress`, a fixed top-of-page bar that fills based on scroll progress.

## What's included
- `submissions/ease-scroll-progress/style.css`
- `submissions/ease-scroll-progress/demo.html`
- `submissions/ease-scroll-progress/readme.md`

## Implementation notes
- Percentage is computed against `scrollHeight - innerHeight` (the actual scrollable range), not raw `scrollY`, so the bar reaches exactly 100% at the true bottom of any page regardless of viewport height.
- Scroll listener is registered `{ passive: true }` to avoid blocking scroll performance on longer pages.
- A short `transition: width 0.1s linear` on the fill smooths out fast/jumpy scroll input without introducing noticeable lag.

## Testing checklist
- [x] Verified bar reaches exactly 0% at top and 100% at bottom on pages of varying length
- [x] Verified no scroll jank introduced by the listener
- [x] Placed only inside `submissions/`