### PR TITLE
feat: add css slide up popover submission

### DIFF
--- a/submissions/examples/css-slide-up-popover-cyberpunk-neon-ag/README.md
+++ b/submissions/examples/css-slide-up-popover-cyberpunk-neon-ag/README.md
@@ -1,0 +1,33 @@
+# CSS Slide-Up Popover (Cyberpunk Neon Layouts)
+
+A pure CSS showcase for a sleek slide-up popover animation, styled with a modern Cyberpunk Neon aesthetic. 
+
+## Features
+- **Pure CSS / HTML**: No JavaScript required. Uses `:hover` and `:focus-within` for interactions.
+- **Smooth Animations**: Utilizes `cubic-bezier` for a dynamic and smooth slide-up effect.
+- **Cyberpunk Theme**: Styled with neon glows, sharp borders, and monospaced typography.
+- **Accessible**: Fully supports `prefers-reduced-motion` by gracefully degrading to a simple opacity fade, respecting user settings.
+
+## Usage
+
+Simply wrap your trigger element and your popover content in a relative container.
+
+```html
+<div class="popover-container">
+  <button class="cyber-button">Hover Me</button>
+  <div class="popover-content">
+    <h3 class="popover-title">Neon Popover</h3>
+    <p class="popover-text">This is pure CSS!</p>
+  </div>
+</div>
+```
+
+## CSS Custom Properties
+You can easily customize the theme by changing the root variables in `style.css`:
+- `--neon-pink`: Button glow and border color (default: `#ff007f`)
+- `--neon-blue`: Popover glow and highlight color (default: `#00f3ff`)
+- `--bg-dark`: Background color for the page (default: `#09090b`)
+- `--text-light`: Default text color (default: `#e0e0e0`)
+
+## Browser Support
+Works in all modern browsers (Chrome, Firefox, Safari, Edge).

--- a/submissions/examples/css-slide-up-popover-cyberpunk-neon-ag/demo.html
+++ b/submissions/examples/css-slide-up-popover-cyberpunk-neon-ag/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Slide-Up Popover - Cyberpunk Neon Layouts</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+
+  <div class="popover-container">
+    <button class="cyber-button" aria-haspopup="true" aria-expanded="false">
+      Connect Uplink
+    </button>
+    <div class="popover-content" role="tooltip">
+      <h3 class="popover-title">Uplink Status</h3>
+      <p class="popover-text">Secure connection established. Ready for data transfer.</p>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/css-slide-up-popover-cyberpunk-neon-ag/style.css
+++ b/submissions/examples/css-slide-up-popover-cyberpunk-neon-ag/style.css
@@ -1,0 +1,121 @@
+:root {
+  --neon-pink: #ff007f;
+  --neon-blue: #00f3ff;
+  --bg-dark: #09090b;
+  --text-light: #e0e0e0;
+}
+
+body {
+  background-color: var(--bg-dark);
+  color: var(--text-light);
+  font-family: 'Courier New', Courier, monospace;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  margin: 0;
+}
+
+/* Container for positioning */
+.popover-container {
+  position: relative;
+  display: inline-block;
+}
+
+/* Trigger Button */
+.cyber-button {
+  background: transparent;
+  color: var(--neon-pink);
+  border: 2px solid var(--neon-pink);
+  padding: 12px 24px;
+  font-size: 1rem;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  cursor: pointer;
+  box-shadow: 0 0 10px var(--neon-pink), inset 0 0 10px var(--neon-pink);
+  transition: all 0.3s ease;
+  outline: none;
+}
+
+.cyber-button:hover,
+.cyber-button:focus-visible {
+  background: var(--neon-pink);
+  color: var(--bg-dark);
+  box-shadow: 0 0 20px var(--neon-pink), inset 0 0 20px var(--neon-pink);
+}
+
+/* Popover Content */
+.popover-content {
+  position: absolute;
+  bottom: calc(100% + 15px);
+  left: 50%;
+  /* Initial state: offset downwards, transparent, hidden */
+  transform: translateX(-50%) translateY(20px);
+  opacity: 0;
+  visibility: hidden;
+  
+  background: rgba(9, 9, 11, 0.95);
+  border: 1px solid var(--neon-blue);
+  box-shadow: 0 0 15px var(--neon-blue);
+  padding: 15px 20px;
+  width: max-content;
+  max-width: 250px;
+  text-align: center;
+  z-index: 10;
+  border-radius: 2px;
+  
+  /* The Slide-Up animation */
+  transition: opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+              transform 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+              visibility 0.3s;
+}
+
+/* The neon glowing pointer */
+.popover-content::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 10px;
+  border-style: solid;
+  border-color: var(--neon-blue) transparent transparent transparent;
+  filter: drop-shadow(0 2px 4px var(--neon-blue));
+}
+
+/* Show the popover on hover or focus-within */
+.popover-container:hover .popover-content,
+.popover-container:focus-within .popover-content {
+  opacity: 1;
+  visibility: visible;
+  /* Final state: original position */
+  transform: translateX(-50%) translateY(0);
+}
+
+.popover-title {
+  color: var(--neon-blue);
+  margin-top: 0;
+  margin-bottom: 8px;
+  font-size: 1.1rem;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.popover-text {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+/* Accessibility: prefers-reduced-motion */
+@media (prefers-reduced-motion: reduce) {
+  .popover-content {
+    transition: opacity 0.2s ease, visibility 0.2s ease;
+    transform: translateX(-50%); /* Remove slide animation */
+  }
+  .popover-container:hover .popover-content,
+  .popover-container:focus-within .popover-content {
+    transform: translateX(-50%);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #64702.

This PR adds the "CSS Slide-Up Popover for Cyberpunk Neon Layouts" submission. It introduces a pure CSS showcase for a sleek slide-up popover animation, styled with a modern Cyberpunk Neon aesthetic. 

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

It adds a fully responsive, JavaScript-free tooltip/popover component that uses a smooth `cubic-bezier` slide-up (`translateY`) animation, styled with sharp neon borders and drop shadows.

**How does a developer use it?**

```html
<div class="popover-container">
  <button class="cyber-button">Connect Uplink</button>
  <div class="popover-content">
    <h3 class="popover-title">Uplink Status</h3>
    <p class="popover-text">Secure connection established.</p>
  </div>
</div>
