### PR TITLE
feat: add zoom-in feature grid glassmorphism layout for #64367

### DIFF
--- a/submissions/examples/zoom-in-feature-grid-glassmorphism-layouts/README.md
+++ b/submissions/examples/zoom-in-feature-grid-glassmorphism-layouts/README.md
@@ -1,0 +1,37 @@
+# Zoom-In Feature Grid — Glassmorphism UI Layouts
+
+A CSS-only feature grid where cards scale up on hover and reveal hidden detail text, wrapped in glassmorphism panels.
+
+## Features
+
+- **Zoom-in hover effect** — cards scale to `1.06` on hover with a smooth cubic-bezier transition
+- **Reveal detail text** — hidden description text expands via `max-height` and `opacity` transition on hover
+- **Glassmorphism panels** — semi-transparent cards with `backdrop-filter: blur(20px)` and subtle borders
+- **Staggered entrance** — cards fade in one after another with increasing `animation-delay`
+- **Fully responsive** — collapses from 3-column to 2-column to single column on smaller screens
+- **Reduced-motion accessible** — all animations and hover effects disabled when `prefers-reduced-motion: reduce`
+
+## CSS Custom Properties
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `--zifg-bg` | `#080c18` | Page background |
+| `--zifg-glass` | `rgba(255,255,255,0.05)` | Card fill |
+| `--zifg-border` | `rgba(255,255,255,0.09)` | Card border |
+| `--zifg-blur` | `20px` | Backdrop blur |
+| `--zifg-shadow` | `rgba(0,0,0,0.4)` | Card shadow |
+| `--zifg-text` | `#e8ecf8` | Primary text |
+| `--zifg-dim` | `rgba(232,236,248,0.48)` | Secondary text |
+| `--zifg-cyan` | `#22d3ee` | Primary accent |
+| `--zifg-purple` | `#c084fc` | Secondary accent |
+
+## How It Works
+
+1. Each card has an inner panel with `scale(1)` by default.
+2. On hover, `scale(1.06)` is applied with a smooth cubic-bezier transition.
+3. The detail text starts at `max-height: 0; opacity: 0` and expands to full height on hover.
+4. The `.zifg-tile` wrapper uses `overflow: hidden` and `border-radius` to clip the zoomed content cleanly.
+
+## Usage
+
+Copy `demo.html` and `style.css` into your project. No JavaScript or external dependencies needed. Override the CSS custom properties to match your theme.

--- a/submissions/examples/zoom-in-feature-grid-glassmorphism-layouts/demo.html
+++ b/submissions/examples/zoom-in-feature-grid-glassmorphism-layouts/demo.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS Zoom-In Feature Grid with glassmorphism layout. Pure CSS feature cards with no JavaScript.">
+  <title>Zoom-In Feature Grid – Glassmorphism UI Layouts</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="zifg-wrap">
+    <header class="zifg-head">
+      <span class="zifg-head__badge">Glassmorphism UI</span>
+      <h1 class="zifg-head__title">What You Get</h1>
+      <p class="zifg-head__sub">Each card zooms in on hover revealing more detail.</p>
+    </header>
+
+    <div class="zifg-grid">
+
+      <article class="zifg-tile">
+        <div class="zifg-tile__inner">
+          <span class="zifg-tile__num">01</span>
+          <h2 class="zifg-tile__name">Speed</h2>
+          <p class="zifg-tile__detail">Sub-millisecond renders powered by a custom V8 pipeline.</p>
+        </div>
+      </article>
+
+      <article class="zifg-tile">
+        <div class="zifg-tile__inner">
+          <span class="zifg-tile__num">02</span>
+          <h2 class="zifg-tile__name">Scale</h2>
+          <p class="zifg-tile__detail">Handles millions of events per second without breaking a sweat.</p>
+        </div>
+      </article>
+
+      <article class="zifg-tile">
+        <div class="zifg-tile__inner">
+          <span class="zifg-tile__num">03</span>
+          <h2 class="zifg-tile__name">Security</h2>
+          <p class="zifg-tile__detail">End-to-end encryption with zero-knowledge architecture.</p>
+        </div>
+      </article>
+
+      <article class="zifg-tile">
+        <div class="zifg-tile__inner">
+          <span class="zifg-tile__num">04</span>
+          <h2 class="zifg-tile__name">Style</h2>
+          <p class="zifg-tile__detail">Customisable themes with dark mode baked in from day one.</p>
+        </div>
+      </article>
+
+      <article class="zifg-tile">
+        <div class="zifg-tile__inner">
+          <span class="zifg-tile__num">05</span>
+          <h2 class="zifg-tile__name">Support</h2>
+          <p class="zifg-tile__detail">24/7 human support with a median response time under 10 minutes.</p>
+        </div>
+      </article>
+
+      <article class="zifg-tile">
+        <div class="zifg-tile__inner">
+          <span class="zifg-tile__num">06</span>
+          <h2 class="zifg-tile__name">Deploy</h2>
+          <p class="zifg-tile__detail">One-click deploy to any major cloud with built-in rollback.</p>
+        </div>
+      </article>
+
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/zoom-in-feature-grid-glassmorphism-layouts/style.css
+++ b/submissions/examples/zoom-in-feature-grid-glassmorphism-layouts/style.css
@@ -1,0 +1,207 @@
+:root {
+  --zifg-bg: #080c18;
+  --zifg-glass: rgba(255, 255, 255, 0.05);
+  --zifg-border: rgba(255, 255, 255, 0.09);
+  --zifg-blur: 20px;
+  --zifg-shadow: rgba(0, 0, 0, 0.4);
+  --zifg-text: #e8ecf8;
+  --zifg-dim: rgba(232, 236, 248, 0.48);
+  --zifg-cyan: #22d3ee;
+  --zifg-purple: #c084fc;
+}
+
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: var(--zifg-bg);
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  color: var(--zifg-text);
+}
+
+/* ── layout ──────────────────────────────────────── */
+
+.zifg-wrap {
+  width: min(800px, 92vw);
+  padding: 40px 0;
+}
+
+.zifg-head {
+  text-align: center;
+  margin-bottom: 36px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  animation: zifgReveal 0.7s ease-out both;
+}
+
+.zifg-head__badge {
+  font-size: 0.66rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--zifg-cyan);
+  font-weight: 600;
+  background: rgba(34, 211, 238, 0.08);
+  border: 1px solid rgba(34, 211, 238, 0.22);
+  padding: 4px 12px;
+  border-radius: 999px;
+}
+
+.zifg-head__title {
+  font-size: clamp(1.8rem, 4vw, 2.5rem);
+  font-weight: 800;
+  background: linear-gradient(135deg, var(--zifg-text), var(--zifg-cyan));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.zifg-head__sub {
+  font-size: 0.92rem;
+  color: var(--zifg-dim);
+  max-width: 34ch;
+  line-height: 1.5;
+}
+
+/* ── grid ────────────────────────────────────────── */
+
+.zifg-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+
+/* ── tile ────────────────────────────────────────── */
+
+.zifg-tile {
+  position: relative;
+  border-radius: 16px;
+  overflow: hidden;
+  cursor: default;
+  opacity: 0;
+  animation: zifgReveal 0.6s ease-out both;
+}
+
+.zifg-tile:nth-child(1) { animation-delay: 0.06s; }
+.zifg-tile:nth-child(2) { animation-delay: 0.14s; }
+.zifg-tile:nth-child(3) { animation-delay: 0.22s; }
+.zifg-tile:nth-child(4) { animation-delay: 0.3s; }
+.zifg-tile:nth-child(5) { animation-delay: 0.38s; }
+.zifg-tile:nth-child(6) { animation-delay: 0.46s; }
+
+.zifg-tile__inner {
+  padding: 28px 20px;
+  background: var(--zifg-glass);
+  border: 1px solid var(--zifg-border);
+  border-radius: 16px;
+  backdrop-filter: blur(var(--zifg-blur));
+  -webkit-backdrop-filter: blur(var(--zifg-blur));
+  box-shadow: 0 6px 24px var(--zifg-shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  transform: scale(1);
+  transition: transform 0.4s cubic-bezier(0.22, 1, 0.36, 1), box-shadow 0.3s, border-color 0.3s;
+}
+
+.zifg-tile:hover .zifg-tile__inner {
+  transform: scale(1.06);
+  box-shadow: 0 12px 36px var(--zifg-shadow);
+  border-color: var(--zifg-cyan);
+}
+
+/* ── tile internals ──────────────────────────────── */
+
+.zifg-tile__num {
+  font-size: 0.65rem;
+  font-weight: 700;
+  color: var(--zifg-cyan);
+  opacity: 0.6;
+  letter-spacing: 0.08em;
+}
+
+.zifg-tile__name {
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.zifg-tile__detail {
+  font-size: 0.84rem;
+  color: var(--zifg-dim);
+  line-height: 1.5;
+  max-height: 0;
+  overflow: hidden;
+  opacity: 0;
+  transition: max-height 0.4s ease, opacity 0.3s ease;
+}
+
+.zifg-tile:hover .zifg-tile__detail {
+  max-height: 120px;
+  opacity: 1;
+}
+
+/* ── entrance ────────────────────────────────────── */
+
+@keyframes zifgReveal {
+  from {
+    opacity: 0;
+    transform: translateY(18px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* ── responsive ──────────────────────────────────── */
+
+@media (max-width: 600px) {
+  .zifg-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 400px) {
+  .zifg-grid {
+    grid-template-columns: 1fr;
+    max-width: 300px;
+    margin: 0 auto;
+  }
+
+  .zifg-wrap {
+    padding: 24px 10px;
+  }
+}
+
+/* ── accessibility ───────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .zifg-head,
+  .zifg-tile {
+    animation: none;
+    opacity: 1;
+  }
+
+  .zifg-tile__inner {
+    transition: none;
+  }
+
+  .zifg-tile:hover .zifg-tile__inner {
+    transform: none;
+  }
+
+  .zifg-tile__detail {
+    transition: none;
+    max-height: none;
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a CSS-only zoom-in feature grid with glassmorphism styling for Issue #64367.

## What's Included

- **demo.html** — Showcase page with 6 feature cards in a grid
- **style.css** — Pure CSS with glassmorphism panels, zoom-in hover effect, reveal detail text, staggered entrance
- **README.md** — Documentation with CSS custom properties table and usage guide

## Key Features

- Zoom-in hover effect — cards scale to 1.06 on hover with smooth cubic-bezier transition
- Reveal detail text — hidden description expands via max-height and opacity transition on hover
- Glassmorphism panels with `backdrop-filter: blur(20px)`
- Staggered fade-in entrance for cascading effect
- Responsive — 3-col → 2-col → 1-col
- `prefers-reduced-motion` support

## Checklist

- [x] All new files inside `submissions/examples/`
- [x] No existing files modified
- [x] Pure CSS/HTML — no JavaScript
- [x] `:root` with CSS custom properties (`--zifg-*` prefix)
- [x] Animations and transitions present
- [x] Responsive media queries
- [x] Reduced-motion accessibility