### PR TITLE
Add Analog Speedometer Gauge Component

### DIFF
--- a/submissions/examples/speedometer-gauge/README.md
+++ b/submissions/examples/speedometer-gauge/README.md
@@ -1,0 +1,162 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 40px 20px;
+    font-family: Arial, Helvetica, sans-serif;
+    background: linear-gradient(135deg, #081b34, #124c79);
+    color: #fff;
+}
+
+.container {
+    width: min(900px, 100%);
+    text-align: center;
+}
+
+h1 {
+    margin-bottom: 30px;
+}
+
+.gauge {
+    --angle: calc((var(--speed) / 100) * 180deg - 90deg);
+
+    width: 320px;
+    margin: auto;
+}
+
+.gauge-face {
+    position: relative;
+    width: 320px;
+    height: 160px;
+    overflow: hidden;
+    border-radius: 320px 320px 0 0;
+    background: #1d2c42;
+    border: 10px solid #ffffff15;
+}
+
+/* Colored speed zones */
+
+.zone {
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+}
+
+.zone-green {
+    background:
+        conic-gradient(
+            from 180deg,
+            #2ecc71 0deg 60deg,
+            transparent 60deg
+        );
+}
+
+.zone-yellow {
+    background:
+        conic-gradient(
+            from 180deg,
+            transparent 60deg,
+            #f1c40f 60deg 120deg,
+            transparent 120deg
+        );
+}
+
+.zone-red {
+    background:
+        conic-gradient(
+            from 180deg,
+            transparent 120deg,
+            #e74c3c 120deg 180deg,
+            transparent 180deg
+        );
+}
+
+/* Tick marks */
+
+.ticks {
+    position: absolute;
+    inset: 15px;
+    border-radius: 50%;
+    background:
+        repeating-conic-gradient(
+            #ffffffaa 0deg 2deg,
+            transparent 2deg 12deg
+        );
+    mask: radial-gradient(circle, transparent 62%, black 63%);
+}
+
+/* Needle */
+
+.gauge-needle {
+    position: absolute;
+    left: 50%;
+    bottom: 0;
+
+    width: 4px;
+    height: 46%;
+
+    background: #ffffff;
+
+    transform-origin: bottom center;
+    transform: translateX(-50%) rotate(var(--angle));
+
+    transition: transform .4s ease;
+
+    border-radius: 4px;
+}
+
+/* Center hub */
+
+.gauge-center {
+    position: absolute;
+    left: 50%;
+    bottom: -10px;
+
+    width: 22px;
+    height: 22px;
+
+    background: #ffffff;
+    border-radius: 50%;
+
+    transform: translateX(-50%);
+}
+
+.speed-text {
+    margin-top: 20px;
+    font-size: 1.5rem;
+    font-weight: bold;
+}
+
+input[type="range"] {
+    width: 320px;
+    margin-top: 30px;
+}
+
+@media (max-width: 500px) {
+
+    .gauge,
+    .gauge-face,
+    input[type="range"] {
+        width: 260px;
+    }
+
+    .gauge-face {
+        height: 130px;
+    }
+
+}
+
+@media (prefers-reduced-motion: reduce) {
+
+    .gauge-needle {
+        transition: none;
+    }
+
+}

--- a/submissions/examples/speedometer-gauge/demo.html
+++ b/submissions/examples/speedometer-gauge/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Analog Speedometer Gauge</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="container">
+
+    <h1>Analog Speedometer Gauge</h1>
+
+    <div class="gauge" style="--speed:35;">
+
+        <div class="gauge-face" aria-hidden="true">
+
+            <div class="ticks"></div>
+
+            <div class="zone zone-green"></div>
+            <div class="zone zone-yellow"></div>
+            <div class="zone zone-red"></div>
+
+            <div class="gauge-needle"></div>
+
+            <div class="gauge-center"></div>
+
+        </div>
+
+        <div class="speed-text">
+            35 km/h
+        </div>
+
+    </div>
+
+    <input
+        type="range"
+        min="0"
+        max="100"
+        value="35"
+        aria-label="Speed">
+
+</div>
+
+</body>
+</html>

--- a/submissions/examples/speedometer-gauge/style.css
+++ b/submissions/examples/speedometer-gauge/style.css
@@ -1,0 +1,162 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 40px 20px;
+    font-family: Arial, Helvetica, sans-serif;
+    background: linear-gradient(135deg, #081b34, #124c79);
+    color: #fff;
+}
+
+.container {
+    width: min(900px, 100%);
+    text-align: center;
+}
+
+h1 {
+    margin-bottom: 30px;
+}
+
+.gauge {
+    --angle: calc((var(--speed) / 100) * 180deg - 90deg);
+
+    width: 320px;
+    margin: auto;
+}
+
+.gauge-face {
+    position: relative;
+    width: 320px;
+    height: 160px;
+    overflow: hidden;
+    border-radius: 320px 320px 0 0;
+    background: #1d2c42;
+    border: 10px solid #ffffff15;
+}
+
+/* Colored speed zones */
+
+.zone {
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+}
+
+.zone-green {
+    background:
+        conic-gradient(
+            from 180deg,
+            #2ecc71 0deg 60deg,
+            transparent 60deg
+        );
+}
+
+.zone-yellow {
+    background:
+        conic-gradient(
+            from 180deg,
+            transparent 60deg,
+            #f1c40f 60deg 120deg,
+            transparent 120deg
+        );
+}
+
+.zone-red {
+    background:
+        conic-gradient(
+            from 180deg,
+            transparent 120deg,
+            #e74c3c 120deg 180deg,
+            transparent 180deg
+        );
+}
+
+/* Tick marks */
+
+.ticks {
+    position: absolute;
+    inset: 15px;
+    border-radius: 50%;
+    background:
+        repeating-conic-gradient(
+            #ffffffaa 0deg 2deg,
+            transparent 2deg 12deg
+        );
+    mask: radial-gradient(circle, transparent 62%, black 63%);
+}
+
+/* Needle */
+
+.gauge-needle {
+    position: absolute;
+    left: 50%;
+    bottom: 0;
+
+    width: 4px;
+    height: 46%;
+
+    background: #ffffff;
+
+    transform-origin: bottom center;
+    transform: translateX(-50%) rotate(var(--angle));
+
+    transition: transform .4s ease;
+
+    border-radius: 4px;
+}
+
+/* Center hub */
+
+.gauge-center {
+    position: absolute;
+    left: 50%;
+    bottom: -10px;
+
+    width: 22px;
+    height: 22px;
+
+    background: #ffffff;
+    border-radius: 50%;
+
+    transform: translateX(-50%);
+}
+
+.speed-text {
+    margin-top: 20px;
+    font-size: 1.5rem;
+    font-weight: bold;
+}
+
+input[type="range"] {
+    width: 320px;
+    margin-top: 30px;
+}
+
+@media (max-width: 500px) {
+
+    .gauge,
+    .gauge-face,
+    input[type="range"] {
+        width: 260px;
+    }
+
+    .gauge-face {
+        height: 130px;
+    }
+
+}
+
+@media (prefers-reduced-motion: reduce) {
+
+    .gauge-needle {
+        transition: none;
+    }
+
+}


### PR DESCRIPTION
## Summary

This PR adds an **Analog Speedometer Gauge** component built with pure HTML and CSS.

### Features

- Analog gauge interface
- Needle controlled by a CSS custom property
- Green, yellow, and red speed zones
- Tick marks around the gauge
- Responsive layout
- Supports `prefers-reduced-motion`

## Files Added

```
submissions/examples/speedometer-gauge/
├── demo.html
├── style.css
└── README.md
```

## Testing

- [x] Gauge renders correctly
- [x] Needle rotates using CSS custom property
- [x] Tick marks display correctly
- [x] Speed zones display correctly
- [x] Responsive layout tested
- [x] Reduced motion support included
- [x] Pure HTML & CSS implementation