### PR TITLE
add stack card wipe

### DIFF
--- a/submissions/examples/animated-card-stack-wipe/README.md
+++ b/submissions/examples/animated-card-stack-wipe/README.md
@@ -1,0 +1,25 @@
+# ease-card-stack-swipe
+
+A Tinder-style stacked card deck — drag the top card left/right to swipe it away, revealing the next card underneath.
+
+## Usage
+1. Include `style.css`.
+2. Stack cards in DOM order (first child = top card):
+```html
+   <div class="card-stack">
+     <div class="stack-card">Card 1</div>
+     <div class="stack-card">Card 2</div>
+     <div class="stack-card">Card 3</div>
+   </div>
+```
+3. Attach the drag handling from `demo.html` to each card.
+
+## Customization
+- `:nth-child(2)`/`:nth-child(3)` scale/translateY/opacity: how much the stacked-behind cards peek out.
+- Swipe threshold (`100` in JS): how far a drag must travel to count as a swipe vs. snap back.
+- `swipe-out-left`/`-right` transform distance and rotation for exit style.
+
+## Notes
+- Only the top card (`:nth-child(1)`) is draggable in this demo; cards behind it automatically become "top" once the card above is removed, since CSS `:nth-child` recalculates on DOM changes.
+- During active drag, `transition: none` is applied so the card tracks the cursor/finger 1:1; on release, the transition returns for the snap-back or swipe-out animation.
+- Supports both mouse and touch input via parallel event listeners.

--- a/submissions/examples/animated-card-stack-wipe/demo.html
+++ b/submissions/examples/animated-card-stack-wipe/demo.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-card-stack-swipe demo</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  body {
+    height: 100vh;
+    margin: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #f4f4f5;
+  }
+</style>
+</head>
+<body>
+
+<div class="card-stack" id="cardStack">
+  <div class="stack-card">Card 1</div>
+  <div class="stack-card">Card 2</div>
+  <div class="stack-card">Card 3</div>
+  <div class="stack-card">Card 4</div>
+</div>
+
+<script>
+  const stack = document.getElementById('cardStack');
+
+  function attachDrag(card) {
+    let startX = 0, currentX = 0, dragging = false;
+
+    const onDown = (clientX) => {
+      dragging = true;
+      startX = clientX;
+      card.classList.add('dragging');
+    };
+
+    const onMove = (clientX) => {
+      if (!dragging) return;
+      currentX = clientX - startX;
+      const rotate = currentX * 0.06;
+      card.style.transform = `translateX(${currentX}px) rotate(${rotate}deg)`;
+    };
+
+    const onUp = () => {
+      if (!dragging) return;
+      dragging = false;
+      card.classList.remove('dragging');
+
+      if (currentX > 100) {
+        card.classList.add('swipe-out-right');
+        setTimeout(() => { card.remove(); }, 400);
+      } else if (currentX < -100) {
+        card.classList.add('swipe-out-left');
+        setTimeout(() => { card.remove(); }, 400);
+      } else {
+        card.style.transform = '';
+      }
+      currentX = 0;
+    };
+
+    card.addEventListener('mousedown', (e) => onDown(e.clientX));
+    window.addEventListener('mousemove', (e) => onMove(e.clientX));
+    window.addEventListener('mouseup', onUp);
+
+    card.addEventListener('touchstart', (e) => onDown(e.touches[0].clientX), { passive: true });
+    card.addEventListener('touchmove', (e) => onMove(e.touches[0].clientX), { passive: true });
+    card.addEventListener('touchend', onUp);
+  }
+
+  document.querySelectorAll('.stack-card').forEach(attachDrag);
+</script>
+
+</body>
+</html>

--- a/submissions/examples/animated-card-stack-wipe/style.css
+++ b/submissions/examples/animated-card-stack-wipe/style.css
@@ -1,0 +1,51 @@
+.card-stack {
+  position: relative;
+  width: 280px;
+  height: 360px;
+}
+
+.card-stack .stack-card {
+  position: absolute;
+  inset: 0;
+  border-radius: 20px;
+  background: linear-gradient(135deg, #2563eb, #7c3aed);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: system-ui, sans-serif;
+  font-size: 22px;
+  font-weight: 700;
+  box-shadow: 0 10px 30px rgba(0,0,0,0.15);
+  cursor: grab;
+  user-select: none;
+  transition: transform 0.4s cubic-bezier(0.2, 0.8, 0.3, 1), opacity 0.4s ease;
+  will-change: transform;
+}
+
+.card-stack .stack-card:nth-child(1) { z-index: 3; }
+.card-stack .stack-card:nth-child(2) {
+  z-index: 2;
+  transform: scale(0.94) translateY(14px);
+  opacity: 0.85;
+}
+.card-stack .stack-card:nth-child(3) {
+  z-index: 1;
+  transform: scale(0.88) translateY(28px);
+  opacity: 0.7;
+}
+
+.card-stack .stack-card.dragging {
+  transition: none;
+  cursor: grabbing;
+}
+
+.card-stack .stack-card.swipe-out-left {
+  transform: translate(-160%, 20px) rotate(-20deg) !important;
+  opacity: 0;
+}
+
+.card-stack .stack-card.swipe-out-right {
+  transform: translate(160%, 20px) rotate(20deg) !important;
+  opacity: 0;
+}


### PR DESCRIPTION
## Summary
Adds `ease-card-stack-swipe`, a draggable stacked-card deck with swipe-to-dismiss support for both mouse and touch interactions.

## What's Included
- `submissions/ease-card-stack-swipe/style.css`
- `submissions/ease-card-stack-swipe/demo.html`
- `submissions/ease-card-stack-swipe/readme.md`

## Implementation Notes
- Uses `:nth-child` selectors for stack depth styling, allowing the next card to automatically become the top card when the current top card is removed—no JavaScript state management required.
- Applies `transition: none` only while dragging to ensure smooth 1:1 pointer tracking. On release, transitions are restored for swipe-out or snap-back animations.
- Mouse and touch interactions share the same `onDown`, `onMove`, and `onUp` handlers to avoid duplicate drag logic and keep the implementation clean.

## Testing Checklist
- [x] Verified swipe threshold correctly distinguishes between dismiss and snap-back.
- [x] Verified the next card becomes interactive immediately after the top card is removed.
- [x] Confirmed all files are placed only inside the `submissions/` directory.