### PR TITLE
feat: add ripple-wave feature grid glassmorphism layout for #64375

### DIFF
--- a/submissions/examples/ripple-wave-feature-grid-glassmorphism-layouts/README.md
+++ b/submissions/examples/ripple-wave-feature-grid-glassmorphism-layouts/README.md
@@ -1,0 +1,38 @@
+# Ripple-Wave Feature Grid — Glassmorphism UI Layouts
+
+A CSS-only feature grid where a circular ripple wave expands from the centre of each card on hover, wrapped in glassmorphism panels.
+
+## Features
+
+- **Ripple wave hover effect** — a circular pseudo-element expands from the card's centre on hover using `width` and `height` transitions with a cubic-bezier curve
+- **Icon scale** — the icon scales up slightly on hover for extra feedback
+- **Glassmorphism panels** — semi-transparent cards with `backdrop-filter: blur(18px)` and subtle borders
+- **Staggered entrance** — cards fade in one after another with increasing `animation-delay`
+- **Fully responsive** — collapses from 3-column to 2-column to single column on smaller screens
+- **Reduced-motion accessible** — all animations, transitions, and hover effects disabled when `prefers-reduced-motion: reduce`
+
+## CSS Custom Properties
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `--rwfg-bg` | `#070a18` | Page background |
+| `--rwfg-glass` | `rgba(255,255,255,0.05)` | Card fill |
+| `--rwfg-border` | `rgba(255,255,255,0.09)` | Card border |
+| `--rwfg-blur` | `18px` | Backdrop blur |
+| `--rwfg-shadow` | `rgba(0,0,0,0.42)` | Card shadow |
+| `--rwfg-text` | `#eef2ff` | Primary text |
+| `--rwfg-dim` | `rgba(238,242,255,0.46)` | Secondary text |
+| `--rwfg-blue` | `#60a5fa` | Icon accent |
+| `--rwfg-blue-soft` | `rgba(96,165,250,0.15)` | Ripple colour |
+| `--rwfg-violet` | `#a78bfa` | Title gradient |
+
+## How It Works
+
+1. Each card has a `::before` pseudo-element positioned at its centre with `width: 0; height: 0`.
+2. On hover, the pseudo-element expands to `320px × 320px`, creating a circular ripple.
+3. The transition uses `cubic-bezier(0.22, 1, 0.36, 1)` for a natural ease-out feel.
+4. Content sits above the ripple using `z-index: 1` on child elements.
+
+## Usage
+
+Copy `demo.html` and `style.css` into your project. No JavaScript or external dependencies needed. Override the CSS custom properties to match your theme.

--- a/submissions/examples/ripple-wave-feature-grid-glassmorphism-layouts/demo.html
+++ b/submissions/examples/ripple-wave-feature-grid-glassmorphism-layouts/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS Ripple-Wave Feature Grid with glassmorphism layout. Pure CSS feature cards with no JavaScript.">
+  <title>Ripple-Wave Feature Grid – Glassmorphism UI Layouts</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="rwfg-wrap">
+    <header class="rwfg-head">
+      <span class="rwfg-head__badge">Glassmorphism UI</span>
+      <h1 class="rwfg-head__title">Building Blocks</h1>
+      <p class="rwfg-head__sub">Hover over a card to trigger the ripple wave from its centre.</p>
+    </header>
+
+    <div class="rwfg-grid">
+
+      <article class="rwfg-cell">
+        <span class="rwfg-cell__icon">&#9729;</span>
+        <h2 class="rwfg-cell__label">Cloud Native</h2>
+        <p class="rwfg-cell__desc">Built to run anywhere with zero config deployment.</p>
+      </article>
+
+      <article class="rwfg-cell">
+        <span class="rwfg-cell__icon">&#9881;</span>
+        <h2 class="rwfg-cell__label">Extensible</h2>
+        <p class="rwfg-cell__desc">Hook into any lifecycle event with a single function.</p>
+      </article>
+
+      <article class="rwfg-cell">
+        <span class="rwfg-cell__icon">&#9733;</span>
+        <h2 class="rwfg-cell__label">Observable</h2>
+        <p class="rwfg-cell__desc">Built-in tracing and structured logging out of the box.</p>
+      </article>
+
+      <article class="rwfg-cell">
+        <span class="rwfg-cell__icon">&#9878;</span>
+        <h2 class="rwfg-cell__label">Resilient</h2>
+        <p class="rwfg-cell__desc">Automatic retries and circuit breakers for every call.</p>
+      </article>
+
+      <article class="rwfg-cell">
+        <span class="rwfg-cell__icon">&#9883;</span>
+        <h2 class="rwfg-cell__label">Concurrent</h2>
+        <p class="rwfg-cell__desc">Lock-free data structures for high throughput workloads.</p>
+      </article>
+
+      <article class="rwfg-cell">
+        <span class="rwfg-cell__icon">&#9775;</span>
+        <h2 class="rwfg-cell__label">Composable</h2>
+        <p class="rwfg-cell__desc">Mix and match primitives to build complex pipelines.</p>
+      </article>
+
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/ripple-wave-feature-grid-glassmorphism-layouts/style.css
+++ b/submissions/examples/ripple-wave-feature-grid-glassmorphism-layouts/style.css
@@ -1,0 +1,220 @@
+:root {
+  --rwfg-bg: #070a18;
+  --rwfg-glass: rgba(255, 255, 255, 0.05);
+  --rwfg-border: rgba(255, 255, 255, 0.09);
+  --rwfg-blur: 18px;
+  --rwfg-shadow: rgba(0, 0, 0, 0.42);
+  --rwfg-text: #eef2ff;
+  --rwfg-dim: rgba(238, 242, 255, 0.46);
+  --rwfg-blue: #60a5fa;
+  --rwfg-blue-soft: rgba(96, 165, 250, 0.15);
+  --rwfg-violet: #a78bfa;
+}
+
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: var(--rwfg-bg);
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  color: var(--rwfg-text);
+}
+
+/* ── layout ──────────────────────────────────────── */
+
+.rwfg-wrap {
+  width: min(800px, 92vw);
+  padding: 40px 0;
+}
+
+.rwfg-head {
+  text-align: center;
+  margin-bottom: 36px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  animation: rwfgFadeUp 0.65s ease-out both;
+}
+
+.rwfg-head__badge {
+  font-size: 0.66rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--rwfg-blue);
+  font-weight: 600;
+  background: rgba(96, 165, 250, 0.08);
+  border: 1px solid rgba(96, 165, 250, 0.22);
+  padding: 4px 12px;
+  border-radius: 999px;
+}
+
+.rwfg-head__title {
+  font-size: clamp(1.8rem, 4vw, 2.5rem);
+  font-weight: 800;
+  background: linear-gradient(135deg, var(--rwfg-text), var(--rwfg-violet));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.rwfg-head__sub {
+  font-size: 0.92rem;
+  color: var(--rwfg-dim);
+  max-width: 36ch;
+  line-height: 1.5;
+}
+
+/* ── grid ────────────────────────────────────────── */
+
+.rwfg-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+
+/* ── cell ────────────────────────────────────────── */
+
+.rwfg-cell {
+  position: relative;
+  overflow: hidden;
+  background: var(--rwfg-glass);
+  border: 1px solid var(--rwfg-border);
+  border-radius: 16px;
+  padding: 28px 20px;
+  backdrop-filter: blur(var(--rwfg-blur));
+  -webkit-backdrop-filter: blur(var(--rwfg-blur));
+  box-shadow: 0 6px 24px var(--rwfg-shadow);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  text-align: center;
+  cursor: default;
+  opacity: 0;
+  animation: rwfgFadeUp 0.55s ease-out both;
+}
+
+.rwfg-cell:nth-child(1) { animation-delay: 0.06s; }
+.rwfg-cell:nth-child(2) { animation-delay: 0.14s; }
+.rwfg-cell:nth-child(3) { animation-delay: 0.22s; }
+.rwfg-cell:nth-child(4) { animation-delay: 0.3s; }
+.rwfg-cell:nth-child(5) { animation-delay: 0.38s; }
+.rwfg-cell:nth-child(6) { animation-delay: 0.46s; }
+
+/* ── ripple pseudo ───────────────────────────────── */
+
+.rwfg-cell::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 0;
+  height: 0;
+  border-radius: 50%;
+  background: var(--rwfg-blue-soft);
+  transform: translate(-50%, -50%);
+  transition: width 0.55s cubic-bezier(0.22, 1, 0.36, 1), height 0.55s cubic-bezier(0.22, 1, 0.36, 1);
+  z-index: 0;
+}
+
+.rwfg-cell:hover::before {
+  width: 320px;
+  height: 320px;
+}
+
+/* ── cell internals (above ripple) ───────────────── */
+
+.rwfg-cell > * {
+  position: relative;
+  z-index: 1;
+}
+
+.rwfg-cell__icon {
+  font-size: 1.6rem;
+  color: var(--rwfg-blue);
+  transition: transform 0.3s ease;
+}
+
+.rwfg-cell:hover .rwfg-cell__icon {
+  transform: scale(1.15);
+}
+
+.rwfg-cell__label {
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.rwfg-cell__desc {
+  font-size: 0.84rem;
+  color: var(--rwfg-dim);
+  line-height: 1.5;
+}
+
+/* ── entrance ────────────────────────────────────── */
+
+@keyframes rwfgFadeUp {
+  from {
+    opacity: 0;
+    transform: translateY(18px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* ── responsive ──────────────────────────────────── */
+
+@media (max-width: 600px) {
+  .rwfg-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 400px) {
+  .rwfg-grid {
+    grid-template-columns: 1fr;
+    max-width: 300px;
+    margin: 0 auto;
+  }
+
+  .rwfg-wrap {
+    padding: 24px 10px;
+  }
+}
+
+/* ── accessibility ───────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .rwfg-head,
+  .rwfg-cell {
+    animation: none;
+    opacity: 1;
+  }
+
+  .rwfg-cell::before {
+    transition: none;
+  }
+
+  .rwfg-cell:hover::before {
+    width: 0;
+    height: 0;
+  }
+
+  .rwfg-cell__icon {
+    transition: none;
+  }
+
+  .rwfg-cell:hover .rwfg-cell__icon {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a CSS-only ripple-wave feature grid with glassmorphism styling for Issue #64375.

## What's Included

- **demo.html** — Showcase page with 6 feature cards in a grid
- **style.css** — Pure CSS with glassmorphism panels, circular ripple wave on hover, icon scale effect, staggered entrance
- **README.md** — Documentation with CSS custom properties table and usage guide

## Key Features

- Ripple wave hover effect — circular pseudo-element expands from card centre using width/height transitions
- Icon scales up on hover for extra feedback
- Glassmorphism panels with `backdrop-filter: blur(18px)`
- Staggered fade-in entrance for cascading effect
- Responsive — 3-col → 2-col → 1-col
- `prefers-reduced-motion` support

## Checklist

- [x] All new files inside `submissions/examples/`
- [x] No existing files modified
- [x] Pure CSS/HTML — no JavaScript
- [x] `:root` with CSS custom properties (`--rwfg-*` prefix)
- [x] Animations and transitions present
- [x] Responsive media queries
- [x] Reduced-motion accessibility