### PR TITLE
feat: add css blur entrance tabs submission

### DIFF
--- a/submissions/examples/css-blur-entrance-tabs-cyberpunk-neon-ag/README.md
+++ b/submissions/examples/css-blur-entrance-tabs-cyberpunk-neon-ag/README.md
@@ -1,0 +1,42 @@
+# CSS Blur-Entrance Tabs (Cyberpunk Neon Layouts)
+
+A pure CSS implementation of a tabbed interface featuring a smooth "focus-in" blur entrance animation for tab panels and cyberpunk-inspired neon styling.
+
+## Features
+- **Pure CSS / HTML**: Built using the radio button hack, completely avoiding JavaScript.
+- **Blur-Entrance Animation**: Panels transition smoothly into view by animating `filter: blur()` and opacity, simulating a camera focusing on the content.
+- **Cyberpunk Theme**: Styled with neon glows, dark panels, and futuristic monospaced typography.
+- **Accessible & Responsive**: Adapts to smaller viewports and fully supports `prefers-reduced-motion` by gracefully disabling the blur animations.
+
+## Usage
+
+Use hidden radio buttons paired with labels to control the active state. 
+
+```html
+<div class="cyber-tabs">
+  <input type="radio" id="tab1" name="my-tabs" checked>
+  <input type="radio" id="tab2" name="my-tabs">
+
+  <div class="tabs-header">
+    <label for="tab1" class="tab-label">Tab 1</label>
+    <label for="tab2" class="tab-label">Tab 2</label>
+    <div class="tab-slider"></div>
+  </div>
+
+  <div class="tabs-content-container">
+    <div class="tab-panel" id="panel1">Content 1</div>
+    <div class="tab-panel" id="panel2">Content 2</div>
+  </div>
+</div>
+```
+
+## CSS Custom Properties
+Easily customize the color scheme using the root variables in `style.css`:
+- `--neon-pink`: Highlight color for the active tab text and slider (default: `#ff007f`)
+- `--neon-blue`: Primary border and header color (default: `#00f3ff`)
+- `--neon-purple`: Secondary border color (default: `#b026ff`)
+- `--bg-dark`: Page background (default: `#070709`)
+- `--bg-panel`: Tabs container background (default: `#14141a`)
+
+## Browser Support
+Works in all modern browsers (Chrome, Firefox, Safari, Edge).

--- a/submissions/examples/css-blur-entrance-tabs-cyberpunk-neon-ag/demo.html
+++ b/submissions/examples/css-blur-entrance-tabs-cyberpunk-neon-ag/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Blur-Entrance Tabs - Cyberpunk Neon Layouts</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+
+  <div class="cyber-tabs">
+    <input type="radio" id="tab1" name="cyber-tabs" checked>
+    <input type="radio" id="tab2" name="cyber-tabs">
+    <input type="radio" id="tab3" name="cyber-tabs">
+
+    <div class="tabs-header">
+      <label for="tab1" class="tab-label">Core</label>
+      <label for="tab2" class="tab-label">Network</label>
+      <label for="tab3" class="tab-label">Security</label>
+      <div class="tab-slider"></div>
+    </div>
+
+    <div class="tabs-content-container">
+      <div class="tab-panel" id="panel1">
+        <h2>Core Systems</h2>
+        <p>Mainframe CPU running at optimal capacity. Coolant systems engaged. Energy matrix stable.</p>
+      </div>
+      <div class="tab-panel" id="panel2">
+        <h2>Network Uplink</h2>
+        <p>Establishing encrypted connection to sector 7G. Packet loss minimal. Latency within acceptable bounds.</p>
+      </div>
+      <div class="tab-panel" id="panel3">
+        <h2>Security Protocols</h2>
+        <p>Firewall active. Intrusion detection system scanning for anomalies. No breaches detected.</p>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/css-blur-entrance-tabs-cyberpunk-neon-ag/style.css
+++ b/submissions/examples/css-blur-entrance-tabs-cyberpunk-neon-ag/style.css
@@ -1,0 +1,154 @@
+:root {
+  --neon-pink: #ff007f;
+  --neon-blue: #00f3ff;
+  --neon-purple: #b026ff;
+  --bg-dark: #070709;
+  --bg-panel: #14141a;
+  --text-light: #e0e0e0;
+}
+
+body {
+  background-color: var(--bg-dark);
+  color: var(--text-light);
+  font-family: 'Courier New', Courier, monospace;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  margin: 0;
+  padding: 20px;
+}
+
+.cyber-tabs {
+  position: relative;
+  width: 100%;
+  max-width: 600px;
+  background: var(--bg-panel);
+  border: 1px solid var(--neon-blue);
+  box-shadow: 0 0 15px rgba(0, 243, 255, 0.2);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+/* Hide the radio inputs */
+.cyber-tabs input[type="radio"] {
+  display: none;
+}
+
+/* Tab Headers */
+.tabs-header {
+  display: flex;
+  position: relative;
+  border-bottom: 1px solid var(--neon-purple);
+  background: rgba(7, 7, 9, 0.8);
+}
+
+.tab-label {
+  flex: 1;
+  padding: 15px;
+  text-align: center;
+  cursor: pointer;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  color: #666;
+  transition: color 0.3s ease;
+  z-index: 2;
+}
+
+.tab-label:hover {
+  color: var(--neon-blue);
+}
+
+/* The active indicator slider */
+.tab-slider {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  height: 3px;
+  width: 33.333%;
+  background: var(--neon-pink);
+  box-shadow: 0 0 10px var(--neon-pink), 0 -2px 10px var(--neon-pink);
+  z-index: 1;
+  transition: transform 0.4s ease;
+}
+
+/* Tab Content */
+.tabs-content-container {
+  position: relative;
+  min-height: 200px;
+}
+
+.tab-panel {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  padding: 25px;
+  
+  /* Initial state: blurred and invisible */
+  opacity: 0;
+  filter: blur(8px);
+  visibility: hidden;
+  
+  transition: opacity 0.5s ease, filter 0.5s ease, visibility 0.5s;
+  box-sizing: border-box;
+}
+
+.tab-panel h2 {
+  color: var(--neon-blue);
+  margin-top: 0;
+  text-shadow: 0 0 5px var(--neon-blue);
+}
+
+.tab-panel p {
+  line-height: 1.6;
+}
+
+/* Handle state changes based on checked radios */
+#tab1:checked ~ .tabs-header .tab-label[for="tab1"],
+#tab2:checked ~ .tabs-header .tab-label[for="tab2"],
+#tab3:checked ~ .tabs-header .tab-label[for="tab3"] {
+  color: var(--neon-pink);
+  text-shadow: 0 0 8px var(--neon-pink);
+}
+
+/* Move the slider */
+#tab1:checked ~ .tabs-header .tab-slider {
+  transform: translateX(0%);
+}
+#tab2:checked ~ .tabs-header .tab-slider {
+  transform: translateX(100%);
+}
+#tab3:checked ~ .tabs-header .tab-slider {
+  transform: translateX(200%);
+}
+
+/* Show the active panel with a blur-entrance */
+#tab1:checked ~ .tabs-content-container #panel1,
+#tab2:checked ~ .tabs-content-container #panel2,
+#tab3:checked ~ .tabs-content-container #panel3 {
+  opacity: 1;
+  visibility: visible;
+  /* Final state: sharp focus */
+  filter: blur(0);
+}
+
+/* Responsive adjustments */
+@media (max-width: 600px) {
+  .tab-label {
+    font-size: 0.8rem;
+    padding: 12px 5px;
+  }
+}
+
+/* Accessibility: prefers-reduced-motion */
+@media (prefers-reduced-motion: reduce) {
+  .tab-slider {
+    transition: transform 0.2s ease;
+  }
+  .tab-panel {
+    transition: opacity 0.2s ease, visibility 0.2s ease;
+    filter: blur(0) !important; /* Disable blur animation */
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #64690.

This PR adds the "CSS Blur-Entrance Tabs for Cyberpunk Neon Layouts" submission. It introduces a pure CSS implementation of a tabbed interface featuring a smooth "focus-in" blur entrance animation for tab panels, styled with a modern Cyberpunk Neon aesthetic.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

It adds a fully responsive, JavaScript-free tabbed navigation component using the radio-button hack. The tab panels transition smoothly into view by animating `filter: blur()` and `opacity`, simulating a cinematic camera focus effect. 

**How does a developer use it?**

```html
<div class="cyber-tabs">
  <input type="radio" id="tab1" name="my-tabs" checked>
  <input type="radio" id="tab2" name="my-tabs">

  <div class="tabs-header">
    <label for="tab1" class="tab-label">Tab 1</label>
    <label for="tab2" class="tab-label">Tab 2</label>
    <div class="tab-slider"></div>
  </div>

  <div class="tabs-content-container">
    <div class="tab-panel" id="panel1">Content 1</div>
    <div class="tab-panel" id="panel2">Content 2</div>
  </div>
</div>
