### PR TITLE
feat: add CSS Fade-In Modal for Cyberpunk Neon Layouts (#64716)

### DIFF
--- a/submissions/examples/cyberpunk-fade-in-modal/README.md
+++ b/submissions/examples/cyberpunk-fade-in-modal/README.md
@@ -1,0 +1,19 @@
+# CSS Fade-In Modal (Cyberpunk)
+
+A pure CSS modal component designed for Cyberpunk Neon Layouts. It utilizes the checkbox hack for state management and features a sleek fade-in overlay with a subtle scale-up animation for the modal content, heavily stylized with neon glows, grids, and monospace typography.
+
+## Features
+- Pure CSS and HTML (No JavaScript required).
+- State management handled completely via a hidden `<input type="checkbox">` and the `~` general sibling selector.
+- Smooth `opacity`, `visibility`, and `transform` CSS transitions paired with a `cubic-bezier` timing function for a polished entrance.
+- Immersive cyberpunk aesthetic featuring background grids, neon text-shadows, and box-shadow glows (using Cyan, Pink, and Yellow).
+- Animated button hover states simulating light sweeps.
+- Fully responsive across desktop, tablet, and mobile viewports.
+- Fully accessible with `prefers-reduced-motion` support ensuring degraded, safe static layouts for users sensitive to motion.
+
+## Usage
+Open `demo.html` in your browser. Click the "INITIALIZE MODAL" button. The background overlay will fade in, blurring the background, while the neon-bordered modal content slides up slightly and scales into view. Click the "X" in the header or the "DISCONNECT" button to close the modal.
+
+## Files
+- `demo.html`: The HTML structure for the layout, the hidden checkbox state manager, and the modal overlay container.
+- `style.css`: The styling, neon effects, and CSS `transition` logic for the fade-in modal animations.

--- a/submissions/examples/cyberpunk-fade-in-modal/demo.html
+++ b/submissions/examples/cyberpunk-fade-in-modal/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Fade-In Modal - Cyberpunk</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="cyberpunk-layout">
+        
+        <h1 class="neon-text">SYSTEM.ACCESS</h1>
+        
+        <!-- The Checkbox Hack for Pure CSS Modal -->
+        <input type="checkbox" id="modal-toggle" class="modal-toggle">
+        
+        <label for="modal-toggle" class="btn cyberpunk-btn">INITIALIZE MODAL</label>
+        
+        <!-- The Modal Container -->
+        <div class="modal-overlay">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h2><span class="blink">_</span>CONNECTION ESTABLISHED</h2>
+                    <label for="modal-toggle" class="close-btn">&times;</label>
+                </div>
+                
+                <div class="modal-body">
+                    <p>Welcome to the main frame. Your neural link is stable.</p>
+                    <div class="data-stream">
+                        <div>> Loading resources... 100%</div>
+                        <div>> Decrypting payload... OK</div>
+                        <div>> Bypassing firewall... SUCCESS</div>
+                    </div>
+                </div>
+                
+                <div class="modal-footer">
+                    <label for="modal-toggle" class="btn outline-btn">DISCONNECT</label>
+                    <button class="btn cyberpunk-btn">PROCEED</button>
+                </div>
+            </div>
+        </div>
+        
+    </div>
+</body>
+</html>

--- a/submissions/examples/cyberpunk-fade-in-modal/style.css
+++ b/submissions/examples/cyberpunk-fade-in-modal/style.css
@@ -1,0 +1,225 @@
+@import url('https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap');
+
+:root {
+    --bg-color: #050505;
+    --modal-bg: rgba(10, 10, 15, 0.95);
+    --text-main: #e0e0e0;
+    --neon-cyan: #0ff;
+    --neon-cyan-dim: rgba(0, 255, 255, 0.2);
+    --neon-pink: #f0f;
+    --neon-yellow: #ff0;
+    --grid-color: rgba(0, 255, 255, 0.1);
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    background-image: 
+        linear-gradient(var(--grid-color) 1px, transparent 1px),
+        linear-gradient(90deg, var(--grid-color) 1px, transparent 1px);
+    background-size: 30px 30px;
+    font-family: 'Share Tech Mono', monospace;
+    color: var(--text-main);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.cyberpunk-layout {
+    text-align: center;
+}
+
+.neon-text {
+    font-size: 3rem;
+    color: var(--text-main);
+    text-shadow: 0 0 10px var(--neon-cyan), 0 0 20px var(--neon-cyan);
+    margin-bottom: 40px;
+    letter-spacing: 5px;
+}
+
+.btn {
+    display: inline-block;
+    padding: 12px 24px;
+    font-family: 'Share Tech Mono', monospace;
+    font-size: 1.1rem;
+    text-transform: uppercase;
+    cursor: pointer;
+    text-decoration: none;
+    transition: all 0.3s ease;
+    border: none;
+    outline: none;
+}
+
+.cyberpunk-btn {
+    background: transparent;
+    color: var(--neon-cyan);
+    border: 1px solid var(--neon-cyan);
+    box-shadow: inset 0 0 10px var(--neon-cyan-dim), 0 0 15px var(--neon-cyan-dim);
+    position: relative;
+    overflow: hidden;
+}
+
+.cyberpunk-btn::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: -100%;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(90deg, transparent, rgba(0, 255, 255, 0.4), transparent);
+    transition: all 0.4s ease;
+}
+
+.cyberpunk-btn:hover {
+    background: var(--neon-cyan);
+    color: var(--bg-color);
+    box-shadow: 0 0 20px var(--neon-cyan);
+}
+
+.cyberpunk-btn:hover::before {
+    left: 100%;
+}
+
+.outline-btn {
+    background: transparent;
+    color: var(--text-main);
+    border: 1px solid var(--text-main);
+}
+
+.outline-btn:hover {
+    background: rgba(255,255,255,0.1);
+}
+
+/* Modal Checkbox Logic */
+.modal-toggle {
+    display: none;
+}
+
+/* Modal Overlay & Animation */
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.8);
+    backdrop-filter: blur(4px);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+    
+    /* Fade In State */
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.4s cubic-bezier(0.16, 1, 0.3, 1),
+                visibility 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.modal-content {
+    background: var(--modal-bg);
+    border: 2px solid var(--neon-pink);
+    box-shadow: 0 0 20px rgba(255, 0, 255, 0.3), inset 0 0 15px rgba(255, 0, 255, 0.1);
+    width: 90%;
+    max-width: 500px;
+    padding: 2px; /* For the inner border effect */
+    position: relative;
+    
+    /* Slide Up State */
+    transform: translateY(30px) scale(0.95);
+    transition: transform 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* Activate Modal via Checkbox */
+.modal-toggle:checked ~ .modal-overlay {
+    opacity: 1;
+    visibility: visible;
+}
+
+.modal-toggle:checked ~ .modal-overlay .modal-content {
+    transform: translateY(0) scale(1);
+}
+
+/* Modal Inner Elements */
+.modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background: var(--neon-pink);
+    color: var(--bg-color);
+    padding: 10px 20px;
+}
+
+.modal-header h2 {
+    margin: 0;
+    font-size: 1.2rem;
+    letter-spacing: 2px;
+}
+
+.close-btn {
+    font-size: 2rem;
+    line-height: 1;
+    cursor: pointer;
+    font-weight: bold;
+    transition: transform 0.2s ease;
+}
+
+.close-btn:hover {
+    transform: scale(1.2);
+}
+
+.modal-body {
+    padding: 30px 20px;
+    text-align: left;
+}
+
+.modal-body p {
+    font-size: 1.1rem;
+    margin: 0 0 20px 0;
+}
+
+.data-stream {
+    background: rgba(0, 255, 255, 0.05);
+    border-left: 3px solid var(--neon-cyan);
+    padding: 15px;
+    font-size: 0.9rem;
+    color: var(--neon-yellow);
+}
+
+.data-stream div {
+    margin-bottom: 5px;
+}
+
+.modal-footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 15px;
+    padding: 20px;
+    border-top: 1px solid rgba(255, 0, 255, 0.3);
+}
+
+/* Blinking Cursor */
+.blink {
+    animation: blinker 1s linear infinite;
+}
+
+@keyframes blinker {
+    50% { opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .modal-overlay, .modal-content {
+        transition: none !important;
+    }
+    .modal-content {
+        transform: translateY(0) scale(1) !important;
+    }
+    .blink {
+        animation: none !important;
+    }
+    .cyberpunk-btn::before {
+        display: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces the CSS Fade-In Modal designed for Cyberpunk Neon Layouts, resolving issue #64716. 

### Changes Made:
- Added `submissions/examples/cyberpunk-fade-in-modal/` directory.
- Created `demo.html` showcasing the modal structure, activated entirely via the CSS checkbox hack for state management without JS.
- Created `style.css` featuring an immersive cyberpunk aesthetic (grid backgrounds, cyan/pink neon glows, and monospace fonts). The modal utilizes a smooth `opacity`, `visibility`, and `transform` transition to gently scale and fade into view when activated.
- Added `README.md` documenting usage and features.
- Fully responsive layout that adapts gracefully from desktop to mobile.
- Honors the `prefers-reduced-motion` accessibility standard.

Closes #64716
