### PR TITLE
feat: add scale-hover stepper glassmorphism layout for #64384

### DIFF
--- a/submissions/examples/scale-hover-stepper-glassmorphism-layouts/README.md
+++ b/submissions/examples/scale-hover-stepper-glassmorphism-layouts/README.md
@@ -1,0 +1,37 @@
+# Scale-Hover Stepper — Glassmorphism UI Layouts
+
+A CSS-only stepper where each step scales up on hover with a smooth cubic-bezier transition, wrapped in glassmorphism panels.
+
+## Features
+
+- **Scale hover effect** — both the step dot and card scale up on hover using `scale()` with a smooth ease-out curve
+- **Glassmorphism panels** — step cards use semi-transparent fill with `backdrop-filter: blur(18px)` and subtle borders
+- **Dot accent colour** — step dots use a tinted background that intensifies on hover
+- **Staggered entrance** — steps pop in one after another with increasing `animation-delay`
+- **Fully responsive** — adapts dot size and padding on smaller screens
+- **Reduced-motion accessible** — all animations, transitions, and hover transforms disabled when `prefers-reduced-motion: reduce`
+
+## CSS Custom Properties
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `--shs-bg` | `#070a17` | Page background |
+| `--shs-glass` | `rgba(255,255,255,0.05)` | Card fill |
+| `--shs-border` | `rgba(255,255,255,0.09)` | Card border |
+| `--shs-blur` | `18px` | Backdrop blur |
+| `--shs-shadow` | `rgba(0,0,0,0.42)` | Card shadow |
+| `--shs-text` | `#edf1ff` | Primary text |
+| `--shs-dim` | `rgba(237,241,255,0.46)` | Secondary text |
+| `--shs-violet` | `#a78bfa` | Accent colour |
+| `--shs-violet-soft` | `rgba(167,139,250,0.12)` | Dot background |
+
+## How It Works
+
+1. Each step dot and card has `transform: scale(1)` by default.
+2. On hover, the dot scales to `1.2` and the card scales to `1.03`.
+3. Transitions use `cubic-bezier(0.22, 1, 0.36, 1)` for a natural ease-out feel.
+4. The card also gains an accent border and enhanced shadow on hover.
+
+## Usage
+
+Copy `demo.html` and `style.css` into your project. No JavaScript or external dependencies needed. Override the CSS custom properties to match your theme.

--- a/submissions/examples/scale-hover-stepper-glassmorphism-layouts/demo.html
+++ b/submissions/examples/scale-hover-stepper-glassmorphism-layouts/demo.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS Scale-Hover Stepper with glassmorphism layout. Pure CSS step progress with no JavaScript.">
+  <title>Scale-Hover Stepper – Glassmorphism UI Layouts</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="shs-wrap">
+    <header class="shs-head">
+      <span class="shs-head__badge">Glassmorphism UI</span>
+      <h1 class="shs-head__title">Get Started</h1>
+      <p class="shs-head__sub">Hover each step to see it scale up.</p>
+    </header>
+
+    <ol class="shs-steps">
+
+      <li class="shs-steps__item">
+        <div class="shs-steps__dot">1</div>
+        <div class="shs-steps__card">
+          <h2 class="shs-steps__name">Create Account</h2>
+          <p class="shs-steps__info">Sign up with your email and set a password. Takes about 30 seconds.</p>
+        </div>
+      </li>
+
+      <li class="shs-steps__item">
+        <div class="shs-steps__dot">2</div>
+        <div class="shs-steps__card">
+          <h2 class="shs-steps__name">Pick a Plan</h2>
+          <p class="shs-steps__info">Choose the tier that matches your team size and usage needs.</p>
+        </div>
+      </li>
+
+      <li class="shs-steps__item">
+        <div class="shs-steps__dot">3</div>
+        <div class="shs-steps__card">
+          <h2 class="shs-steps__name">Connect Tools</h2>
+          <p class="shs-steps__info">Link your existing CI/CD, monitoring, and version control services.</p>
+        </div>
+      </li>
+
+      <li class="shs-steps__item">
+        <div class="shs-steps__dot">4</div>
+        <div class="shs-steps__card">
+          <h2 class="shs-steps__name">Ship It</h2>
+          <p class="shs-steps__info">Push your first deploy with a single command from the terminal.</p>
+        </div>
+      </li>
+
+    </ol>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/scale-hover-stepper-glassmorphism-layouts/style.css
+++ b/submissions/examples/scale-hover-stepper-glassmorphism-layouts/style.css
@@ -1,0 +1,208 @@
+:root {
+  --shs-bg: #070a17;
+  --shs-glass: rgba(255, 255, 255, 0.05);
+  --shs-border: rgba(255, 255, 255, 0.09);
+  --shs-blur: 18px;
+  --shs-shadow: rgba(0, 0, 0, 0.42);
+  --shs-text: #edf1ff;
+  --shs-dim: rgba(237, 241, 255, 0.46);
+  --shs-violet: #a78bfa;
+  --shs-violet-soft: rgba(167, 139, 250, 0.12);
+}
+
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: var(--shs-bg);
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  color: var(--shs-text);
+}
+
+/* ── layout ──────────────────────────────────────── */
+
+.shs-wrap {
+  width: min(520px, 92vw);
+  padding: 40px 0;
+}
+
+.shs-head {
+  text-align: center;
+  margin-bottom: 36px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  animation: shsPopIn 0.65s ease-out both;
+}
+
+.shs-head__badge {
+  font-size: 0.66rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--shs-violet);
+  font-weight: 600;
+  background: rgba(167, 139, 250, 0.08);
+  border: 1px solid rgba(167, 139, 250, 0.22);
+  padding: 4px 12px;
+  border-radius: 999px;
+}
+
+.shs-head__title {
+  font-size: clamp(1.8rem, 4vw, 2.4rem);
+  font-weight: 800;
+  background: linear-gradient(135deg, var(--shs-text), var(--shs-violet));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.shs-head__sub {
+  font-size: 0.92rem;
+  color: var(--shs-dim);
+  max-width: 30ch;
+  line-height: 1.5;
+}
+
+/* ── steps list ──────────────────────────────────── */
+
+.shs-steps {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.shs-steps__item {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  opacity: 0;
+  animation: shsPopIn 0.5s ease-out both;
+}
+
+.shs-steps__item:nth-child(1) { animation-delay: 0.06s; }
+.shs-steps__item:nth-child(2) { animation-delay: 0.16s; }
+.shs-steps__item:nth-child(3) { animation-delay: 0.26s; }
+.shs-steps__item:nth-child(4) { animation-delay: 0.36s; }
+
+/* ── dot ─────────────────────────────────────────── */
+
+.shs-steps__dot {
+  flex-shrink: 0;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  background: var(--shs-violet-soft);
+  border: 1.5px solid rgba(167, 139, 250, 0.25);
+  display: grid;
+  place-items: center;
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: var(--shs-violet);
+  transition: transform 0.35s cubic-bezier(0.22, 1, 0.36, 1), background 0.3s;
+}
+
+.shs-steps__item:hover .shs-steps__dot {
+  transform: scale(1.2);
+  background: rgba(167, 139, 250, 0.22);
+}
+
+/* ── card ────────────────────────────────────────── */
+
+.shs-steps__card {
+  flex: 1;
+  background: var(--shs-glass);
+  border: 1px solid var(--shs-border);
+  border-radius: 14px;
+  padding: 18px 20px;
+  backdrop-filter: blur(var(--shs-blur));
+  -webkit-backdrop-filter: blur(var(--shs-blur));
+  box-shadow: 0 4px 16px var(--shs-shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  transition: transform 0.35s cubic-bezier(0.22, 1, 0.36, 1), border-color 0.3s, box-shadow 0.3s;
+}
+
+.shs-steps__item:hover .shs-steps__card {
+  transform: scale(1.03);
+  border-color: var(--shs-violet);
+  box-shadow: 0 8px 28px var(--shs-shadow);
+}
+
+.shs-steps__name {
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.shs-steps__info {
+  font-size: 0.84rem;
+  color: var(--shs-dim);
+  line-height: 1.5;
+}
+
+/* ── entrance ────────────────────────────────────── */
+
+@keyframes shsPopIn {
+  from {
+    opacity: 0;
+    transform: translateY(12px) scale(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+/* ── responsive ──────────────────────────────────── */
+
+@media (max-width: 440px) {
+  .shs-wrap {
+    padding: 24px 10px;
+  }
+
+  .shs-steps__dot {
+    width: 28px;
+    height: 28px;
+    font-size: 0.7rem;
+  }
+
+  .shs-steps__card {
+    padding: 14px 16px;
+  }
+}
+
+/* ── accessibility ───────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .shs-head,
+  .shs-steps__item {
+    animation: none;
+    opacity: 1;
+  }
+
+  .shs-steps__dot {
+    transition: none;
+  }
+
+  .shs-steps__card {
+    transition: none;
+  }
+
+  .shs-steps__item:hover .shs-steps__dot {
+    transform: none;
+  }
+
+  .shs-steps__item:hover .shs-steps__card {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a CSS-only scale-hover stepper with glassmorphism styling for Issue #64384.

## What's Included

- **demo.html** — Showcase page with 4-step vertical stepper (Create Account, Pick a Plan, Connect Tools, Ship It)
- **style.css** — Pure CSS with glassmorphism panels, scale hover on dot and card, staggered entrance, accent border on hover
- **README.md** — Documentation with CSS custom properties table and usage guide

## Key Features

- Scale hover effect — both dot and card scale up on hover using `scale()` with smooth cubic-bezier
- Glassmorphism panels with `backdrop-filter: blur(18px)`
- Dot accent colour intensifies on hover
- Staggered pop-in entrance
- Responsive — adapts dot size and padding on mobile
- `prefers-reduced-motion` support

## Checklist

- [x] All new files inside `submissions/examples/`
- [x] No existing files modified
- [x] Pure CSS/HTML — no JavaScript
- [x] `:root` with CSS custom properties (`--shs-*` prefix)
- [x] Animations and transitions present
- [x] Responsive media queries
- [x] Reduced-motion accessibility