### PR TITLE
feat: add css blur entrance carousel submission

### DIFF
--- a/submissions/examples/css-blur-entrance-carousel-cyberpunk-neon-ag/README.md
+++ b/submissions/examples/css-blur-entrance-carousel-cyberpunk-neon-ag/README.md
@@ -1,0 +1,41 @@
+# CSS Blur-Entrance Carousel (Cyberpunk Neon Layouts)
+
+A pure CSS carousel component featuring a cinematic "focus-in" blur entrance animation for its slides, styled with a striking Cyberpunk Neon aesthetic.
+
+## Features
+- **Pure CSS / HTML**: Built using the hidden radio button hack, managing the active slide state entirely without JavaScript.
+- **Blur-Entrance Animation**: Slides transition smoothly into view by animating `filter: blur()` and opacity, simulating a cinematic camera focus effect when navigating between items.
+- **Cyberpunk Theme**: Styled with neon glows, glowing radial backgrounds, and futuristic monospaced typography. Active pagination dots adapt their neon color to match the current slide.
+- **Accessible & Responsive**: Adapts to smaller viewports and fully supports `prefers-reduced-motion` by gracefully disabling the blur animations in favor of simple opacity fades.
+
+## Usage
+
+Use hidden radio buttons paired with `<label>` dots to control the active state of the carousel slides.
+
+```html
+<div class="cyber-carousel">
+  <input type="radio" id="slide1" name="carousel" checked>
+  <input type="radio" id="slide2" name="carousel">
+
+  <div class="carousel-slides">
+    <div class="carousel-slide" id="content1">...</div>
+    <div class="carousel-slide" id="content2">...</div>
+  </div>
+
+  <div class="carousel-controls">
+    <label for="slide1" class="carousel-dot"></label>
+    <label for="slide2" class="carousel-dot"></label>
+  </div>
+</div>
+```
+
+## CSS Custom Properties
+Easily customize the color scheme using the root variables in `style.css`:
+- `--neon-pink`: Color theme for Slide 1 (default: `#ff007f`)
+- `--neon-blue`: Color theme for Slide 2 (default: `#00f3ff`)
+- `--neon-purple`: Color theme for Slide 3 and primary borders (default: `#b026ff`)
+- `--neon-yellow`: Color theme for Slide 4 (default: `#fcee0a`)
+- `--bg-dark`: Page background (default: `#070709`)
+
+## Browser Support
+Works in all modern browsers (Chrome, Firefox, Safari, Edge).

--- a/submissions/examples/css-blur-entrance-carousel-cyberpunk-neon-ag/demo.html
+++ b/submissions/examples/css-blur-entrance-carousel-cyberpunk-neon-ag/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Blur-Entrance Carousel - Cyberpunk Neon Layouts</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+
+  <div class="cyber-carousel">
+    <!-- Radio inputs for state -->
+    <input type="radio" id="carousel-radio1" name="cyber-carousel" checked>
+    <input type="radio" id="carousel-radio2" name="cyber-carousel">
+    <input type="radio" id="carousel-radio3" name="cyber-carousel">
+    <input type="radio" id="carousel-radio4" name="cyber-carousel">
+
+    <!-- Carousel Slides -->
+    <div class="carousel-slides">
+      <div class="carousel-slide" id="slide1-content">
+        <h2>Neon Nights</h2>
+        <p>Explore the glowing streets of the metropolis. Shadows and light dance in the eternal rain.</p>
+      </div>
+      <div class="carousel-slide" id="slide2-content">
+        <h2>Grid Hack</h2>
+        <p>Infiltrate the mainframe. Bypass the firewalls and secure the encrypted data packets before the trace completes.</p>
+      </div>
+      <div class="carousel-slide" id="slide3-content">
+        <h2>Synthwave</h2>
+        <p>Ride into the digital sunset. Fast cars, retro beats, and endless vector highways.</p>
+      </div>
+      <div class="carousel-slide" id="slide4-content">
+        <h2>Cyber Augment</h2>
+        <p>Upgrade your hardware. Enhance your reflexes and jack into the neural net for the ultimate experience.</p>
+      </div>
+    </div>
+
+    <!-- Navigation Controls -->
+    <div class="carousel-controls">
+      <label for="carousel-radio1" class="carousel-dot dot1" aria-label="Slide 1"></label>
+      <label for="carousel-radio2" class="carousel-dot dot2" aria-label="Slide 2"></label>
+      <label for="carousel-radio3" class="carousel-dot dot3" aria-label="Slide 3"></label>
+      <label for="carousel-radio4" class="carousel-dot dot4" aria-label="Slide 4"></label>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/css-blur-entrance-carousel-cyberpunk-neon-ag/style.css
+++ b/submissions/examples/css-blur-entrance-carousel-cyberpunk-neon-ag/style.css
@@ -1,0 +1,179 @@
+:root {
+  --neon-pink: #ff007f;
+  --neon-blue: #00f3ff;
+  --neon-purple: #b026ff;
+  --neon-yellow: #fcee0a;
+  --bg-dark: #070709;
+  --text-light: #e0e0e0;
+}
+
+body {
+  background-color: var(--bg-dark);
+  color: var(--text-light);
+  font-family: 'Courier New', Courier, monospace;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  margin: 0;
+  padding: 20px;
+}
+
+.cyber-carousel {
+  position: relative;
+  width: 100%;
+  max-width: 800px;
+  height: 400px;
+  background: #000;
+  border: 1px solid var(--neon-purple);
+  box-shadow: 0 0 20px rgba(176, 38, 255, 0.2);
+  border-radius: 4px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Hide the radio inputs */
+.cyber-carousel input[type="radio"] {
+  display: none;
+}
+
+/* Carousel Slides Container */
+.carousel-slides {
+  position: relative;
+  flex-grow: 1;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+.carousel-slide {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  padding: 40px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  
+  /* Initial Blur-Entrance State: Invisible, Blurred */
+  opacity: 0;
+  filter: blur(15px);
+  visibility: hidden;
+  
+  transition: opacity 0.6s ease, filter 0.6s ease, visibility 0.6s;
+  z-index: 1;
+}
+
+.carousel-slide h2 {
+  font-size: 2.5rem;
+  margin-bottom: 10px;
+  text-transform: uppercase;
+  letter-spacing: 4px;
+}
+
+.carousel-slide p {
+  font-size: 1.1rem;
+  max-width: 80%;
+  line-height: 1.5;
+}
+
+/* Specific styling for slides to look Cyberpunk */
+#slide1-content h2 { color: var(--neon-pink); text-shadow: 0 0 10px var(--neon-pink); }
+#slide2-content h2 { color: var(--neon-blue); text-shadow: 0 0 10px var(--neon-blue); }
+#slide3-content h2 { color: var(--neon-purple); text-shadow: 0 0 10px var(--neon-purple); }
+#slide4-content h2 { color: var(--neon-yellow); text-shadow: 0 0 10px var(--neon-yellow); }
+
+/* When a radio is checked, blur-entrance its corresponding slide in */
+#carousel-radio1:checked ~ .carousel-slides #slide1-content,
+#carousel-radio2:checked ~ .carousel-slides #slide2-content,
+#carousel-radio3:checked ~ .carousel-slides #slide3-content,
+#carousel-radio4:checked ~ .carousel-slides #slide4-content {
+  opacity: 1;
+  visibility: visible;
+  /* Final State: Sharp focus */
+  filter: blur(0);
+  z-index: 10;
+}
+
+/* Carousel Controls (Dots) */
+.carousel-controls {
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 15px;
+  z-index: 20;
+}
+
+.carousel-dot {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: transparent;
+  border: 2px solid #555;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.carousel-dot:hover {
+  border-color: var(--neon-purple);
+  box-shadow: 0 0 8px var(--neon-purple);
+}
+
+/* Active Dot Styling */
+#carousel-radio1:checked ~ .carousel-controls .dot1 {
+  background: var(--neon-pink);
+  border-color: var(--neon-pink);
+  box-shadow: 0 0 12px var(--neon-pink);
+}
+#carousel-radio2:checked ~ .carousel-controls .dot2 {
+  background: var(--neon-blue);
+  border-color: var(--neon-blue);
+  box-shadow: 0 0 12px var(--neon-blue);
+}
+#carousel-radio3:checked ~ .carousel-controls .dot3 {
+  background: var(--neon-purple);
+  border-color: var(--neon-purple);
+  box-shadow: 0 0 12px var(--neon-purple);
+}
+#carousel-radio4:checked ~ .carousel-controls .dot4 {
+  background: var(--neon-yellow);
+  border-color: var(--neon-yellow);
+  box-shadow: 0 0 12px var(--neon-yellow);
+}
+
+/* Background Gradients for Slides */
+.carousel-slide::before {
+  content: '';
+  position: absolute;
+  top: 0; left: 0; right: 0; bottom: 0;
+  z-index: -1;
+  opacity: 0.15;
+}
+
+#slide1-content::before { background: radial-gradient(circle at center, var(--neon-pink) 0%, transparent 70%); }
+#slide2-content::before { background: radial-gradient(circle at center, var(--neon-blue) 0%, transparent 70%); }
+#slide3-content::before { background: radial-gradient(circle at center, var(--neon-purple) 0%, transparent 70%); }
+#slide4-content::before { background: radial-gradient(circle at center, var(--neon-yellow) 0%, transparent 70%); }
+
+/* Responsive adjustments */
+@media (max-width: 600px) {
+  .cyber-carousel { height: 300px; }
+  .carousel-slide h2 { font-size: 1.8rem; }
+  .carousel-slide p { font-size: 0.9rem; }
+}
+
+/* Accessibility: prefers-reduced-motion */
+@media (prefers-reduced-motion: reduce) {
+  .carousel-slide {
+    transition: opacity 0.3s ease, visibility 0.3s ease;
+    filter: blur(0) !important; /* Disable blur animation */
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #64674.

This PR adds the "CSS Blur-Entrance Carousel for Cyberpunk Neon Layouts" submission. It introduces a pure CSS carousel component featuring a smooth "focus-in" blur entrance animation for its slides, styled with a striking Cyberpunk Neon aesthetic.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

It adds a fully responsive, JavaScript-free carousel navigation component using the hidden radio-button hack. The individual slides transition smoothly into view by animating `filter: blur()` and `opacity`, simulating a cinematic camera focus effect when navigating between items.

**How does a developer use it?**

```html
<div class="cyber-carousel">
  <input type="radio" id="slide1" name="carousel" checked>
  <input type="radio" id="slide2" name="carousel">

  <div class="carousel-slides">
    <div class="carousel-slide" id="content1">...</div>
    <div class="carousel-slide" id="content2">...</div>
  </div>

  <div class="carousel-controls">
    <label for="slide1" class="carousel-dot"></label>
    <label for="slide2" class="carousel-dot"></label>
  </div>
</div>
