### PR TITLE
feat(scss): add fluid typography clamp mixin

### DIFF
--- a/submissions/scss/ease-fluid-type/README.md
+++ b/submissions/scss/ease-fluid-type/README.md
@@ -1,0 +1,41 @@
+# SCSS Fluid Typography (`clamp()`) Mixin
+
+Writing responsive typography typically involves a messy stack of media queries. Modern CSS allows us to use the `clamp()` function to scale text smoothly across all screen sizes based on the viewport width (`vw`). However, calculating the exact mathematical slope and intersection required for a perfectly smooth scale is extremely tedious. 
+
+This SCSS mixin handles the complex math for you.
+
+## Features
+- Generates a mathematically perfect CSS `clamp()` function.
+- Converts all output to `rem` for accessibility (assumes 16px base font).
+- Fully customizable viewport bounds (where the scaling starts and stops).
+- Dependency-free.
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `$min-size` | `Number` | Required | Minimum font size in pixels (e.g., `16` or `16px`). |
+| `$max-size` | `Number` | Required | Maximum font size in pixels (e.g., `32` or `32px`). |
+| `$min-viewport` | `Number` | `320` | Viewport width (px) where the font *stops* shrinking. |
+| `$max-viewport` | `Number` | `1200` | Viewport width (px) where the font *stops* growing. |
+
+## Usage
+
+Import the mixin and use it in your typographical elements.
+
+```scss
+@import 'ease-fluid-type';
+
+// A heading that is 32px on mobile, scaling up to 64px on desktop (1200px screens)
+h1 {
+  @include ease-fluid-type(32, 64);
+}
+
+// A paragraph that scales from 14px to 18px, but only between 768px and 1440px viewports
+p {
+  @include ease-fluid-type(14, 18, 768, 1440);
+}
+```
+
+## Why it fits EaseMotion CSS
+Fluid, responsive interfaces are core to good animation and motion design. When elements snap violently between sizes at media query breakpoints, it breaks immersion. Using `clamp()` ensures layout changes happen smoothly as the user resizes their window, complementing EaseMotion's fluid animation utilities.

--- a/submissions/scss/ease-fluid-type/_ease-fluid-type.scss
+++ b/submissions/scss/ease-fluid-type/_ease-fluid-type.scss
@@ -1,0 +1,42 @@
+/// EaseMotion Fluid Typography Mixin
+/// Calculates and outputs a CSS clamp() function for perfectly fluid responsive typography.
+/// 
+/// @param {Number} $min-size - Minimum font size in pixels (unitless or px).
+/// @param {Number} $max-size - Maximum font size in pixels (unitless or px).
+/// @param {Number} $min-viewport [320] - The viewport width (px) where font stops shrinking.
+/// @param {Number} $max-viewport [1200] - The viewport width (px) where font stops growing.
+
+@function strip-unit($value) {
+  @if type-of($value) == 'number' and not unitless($value) {
+    @return $value / ($value * 0 + 1);
+  }
+  @return $value;
+}
+
+@mixin ease-fluid-type(
+  $min-size,
+  $max-size,
+  $min-viewport: 320,
+  $max-viewport: 1200
+) {
+  // Strip units to ensure calculation math works perfectly
+  $u-min-size: strip-unit($min-size);
+  $u-max-size: strip-unit($max-size);
+  $u-min-vw: strip-unit($min-viewport);
+  $u-max-vw: strip-unit($max-viewport);
+
+  // Calculate the slope and intersection for the clamp function
+  $slope: ($u-max-size - $u-min-size) / ($u-max-vw - $u-min-vw);
+  $intersection: -1 * $u-min-vw * $slope + $u-min-size;
+  
+  // Convert calculations into the final CSS viewport/rem units
+  // Intersection is converted to rems assuming a 16px base
+  $preferred-vw: ($slope * 100) * 1vw;
+  $preferred-rem: ($intersection / 16) * 1rem;
+  
+  $min-rem: ($u-min-size / 16) * 1rem;
+  $max-rem: ($u-max-size / 16) * 1rem;
+
+  // Output the clamp function
+  font-size: clamp(#{$min-rem}, #{$preferred-rem} + #{$preferred-vw}, #{$max-rem});
+}


### PR DESCRIPTION
fixes #65283 

## Pull Request Description

Adds an `ease-fluid-type` SCSS mixin. Writing responsive typography typically involves a messy stack of media queries. Modern CSS allows us to use the `clamp()` function to scale text smoothly across all screen sizes, but calculating the exact `vw` math (slope and intersection) for a perfectly smooth scale is extremely tedious. This mixin abstracts the math away entirely.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component (SCSS Track)
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/scss/ease-fluid-type/`)
- [x] Includes `_ease-fluid-type.scss` — raw SCSS mixin code for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

An advanced SCSS mixin (`_ease-fluid-type.scss`) that accepts minimum font size, maximum font size, and optional viewport boundary parameters. It calculates the correct mathematical slope and intersection, and outputs a perfectly formed CSS `clamp()` rule. It also automatically converts pixel values to accessible `rem` units based on a standard `16px` root size.

**How does a developer use it?**

```scss
@import 'ease-fluid-type';

// A heading that is 32px on mobile, scaling fluidly up to 64px on desktop (1200px screens)
h1 {
  @include ease-fluid-type(32, 64);
}
