### PR TITLE
feat: add CSS Ripple-Wave Modal for Cyberpunk Neon Layouts (#64726)

### DIFF
--- a/submissions/examples/cyberpunk-ripple-wave-modal/README.md
+++ b/submissions/examples/cyberpunk-ripple-wave-modal/README.md
@@ -1,0 +1,19 @@
+# CSS Ripple-Wave Modal (Cyberpunk)
+
+A pure CSS modal component designed for Cyberpunk Neon Layouts. It utilizes the checkbox hack for state management and features a fluid ripple-wave background animation that expands outward when the modal is opened, simulating a digital network sync.
+
+## Features
+- Pure CSS and HTML (No JavaScript required).
+- State management handled completely via a hidden `<input type="checkbox">` and the `~` general sibling selector.
+- The background utilizes an absolute positioned `.ripple-wave` element with a `radial-gradient` that scales up from 0 to 1 on activation.
+- Includes a subtle, infinite `@keyframes pulse-wave` animation that keeps the background feeling "alive" while the modal is open.
+- Immersive cyberpunk aesthetic featuring background grids, neon text-shadows, and glowing accents (using Blue and Purple).
+- Fully responsive across desktop, tablet, and mobile viewports.
+- Fully accessible with `prefers-reduced-motion` support ensuring degraded, safe static layouts for users sensitive to motion.
+
+## Usage
+Open `demo.html` in your browser. Click the "SYNC DATA" button. The background overlay will fade in, and a large blue ripple wave will expand from the center of the modal behind the content. Click the "X" in the header or the "CANCEL" button to close the modal.
+
+## Files
+- `demo.html`: The HTML structure for the layout, the hidden checkbox state manager, and the layered modal content (background ripple + foreground content).
+- `style.css`: The styling, neon effects, and CSS `transform: scale()` logic for the ripple-wave animations.

--- a/submissions/examples/cyberpunk-ripple-wave-modal/demo.html
+++ b/submissions/examples/cyberpunk-ripple-wave-modal/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Ripple-Wave Modal - Cyberpunk</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="cyberpunk-layout">
+        
+        <h1 class="neon-text">NEURAL.INTERFACE</h1>
+        
+        <!-- The Checkbox Hack for Pure CSS Modal -->
+        <input type="checkbox" id="modal-toggle" class="modal-toggle">
+        
+        <label for="modal-toggle" class="btn cyberpunk-btn">SYNC DATA</label>
+        
+        <!-- The Modal Container -->
+        <div class="modal-overlay">
+            
+            <div class="modal-content">
+                <!-- The Ripple Background -->
+                <div class="ripple-wave"></div>
+                
+                <div class="modal-inner">
+                    <div class="modal-header">
+                        <h2>DATA SYNCHRONIZATION</h2>
+                        <label for="modal-toggle" class="close-btn">&times;</label>
+                    </div>
+                    
+                    <div class="modal-body">
+                        <p>Establishing link with local sub-nodes. Prepare for data ingestion.</p>
+                        <div class="sync-grid">
+                            <div class="sync-node active">NODE ALPHA</div>
+                            <div class="sync-node active">NODE BETA</div>
+                            <div class="sync-node pending">NODE GAMMA</div>
+                        </div>
+                    </div>
+                    
+                    <div class="modal-footer">
+                        <label for="modal-toggle" class="btn outline-btn">CANCEL</label>
+                        <button class="btn cyberpunk-btn-sync">CONFIRM</button>
+                    </div>
+                </div>
+            </div>
+            
+        </div>
+        
+    </div>
+</body>
+</html>

--- a/submissions/examples/cyberpunk-ripple-wave-modal/style.css
+++ b/submissions/examples/cyberpunk-ripple-wave-modal/style.css
@@ -1,0 +1,290 @@
+@import url('https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap');
+
+:root {
+    --bg-color: #050505;
+    --modal-bg: rgba(5, 10, 15, 0.95);
+    --text-main: #e0e0e0;
+    --neon-blue: #007bff;
+    --neon-blue-dim: rgba(0, 123, 255, 0.2);
+    --neon-purple: #8a2be2;
+    --neon-purple-dim: rgba(138, 43, 226, 0.2);
+    --grid-color: rgba(0, 123, 255, 0.05);
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    background-image: 
+        linear-gradient(var(--grid-color) 1px, transparent 1px),
+        linear-gradient(90deg, var(--grid-color) 1px, transparent 1px);
+    background-size: 40px 40px;
+    font-family: 'Share Tech Mono', monospace;
+    color: var(--text-main);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.cyberpunk-layout {
+    text-align: center;
+}
+
+.neon-text {
+    font-size: 3rem;
+    color: var(--neon-blue);
+    text-shadow: 0 0 10px var(--neon-blue-dim), 0 0 20px var(--neon-blue-dim);
+    margin-bottom: 40px;
+    letter-spacing: 5px;
+}
+
+.btn {
+    display: inline-block;
+    padding: 12px 24px;
+    font-family: 'Share Tech Mono', monospace;
+    font-size: 1.1rem;
+    text-transform: uppercase;
+    cursor: pointer;
+    text-decoration: none;
+    transition: all 0.3s ease;
+    border: none;
+    outline: none;
+    position: relative;
+    z-index: 10;
+}
+
+.cyberpunk-btn {
+    background: transparent;
+    color: var(--neon-blue);
+    border: 1px solid var(--neon-blue);
+    box-shadow: inset 0 0 10px var(--neon-blue-dim), 0 0 15px var(--neon-blue-dim);
+    position: relative;
+    overflow: hidden;
+}
+
+.cyberpunk-btn::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: -100%;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(90deg, transparent, rgba(0, 123, 255, 0.4), transparent);
+    transition: all 0.4s ease;
+}
+
+.cyberpunk-btn:hover {
+    background: var(--neon-blue);
+    color: var(--bg-color);
+    box-shadow: 0 0 20px var(--neon-blue);
+}
+
+.cyberpunk-btn:hover::before {
+    left: 100%;
+}
+
+.cyberpunk-btn-sync {
+    background: var(--neon-purple);
+    color: var(--bg-color);
+    border: 1px solid var(--neon-purple);
+    box-shadow: 0 0 15px var(--neon-purple-dim);
+}
+
+.cyberpunk-btn-sync:hover {
+    box-shadow: 0 0 25px var(--neon-purple);
+}
+
+.outline-btn {
+    background: transparent;
+    color: var(--text-main);
+    border: 1px solid var(--text-main);
+}
+
+.outline-btn:hover {
+    background: rgba(255,255,255,0.1);
+}
+
+/* Modal Checkbox Logic */
+.modal-toggle {
+    display: none;
+}
+
+/* Modal Overlay */
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.85);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+    
+    /* Fade In State */
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.4s ease, visibility 0.4s ease;
+}
+
+.modal-content {
+    background: var(--modal-bg);
+    border: 1px solid var(--neon-blue);
+    box-shadow: 0 0 30px var(--neon-blue-dim);
+    width: 90%;
+    max-width: 500px;
+    position: relative;
+    overflow: hidden; /* Contains the ripple */
+    
+    /* Slight Scale for entrance */
+    transform: scale(0.95);
+    transition: transform 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* The Ripple Wave Background */
+.ripple-wave {
+    position: absolute;
+    bottom: -50%;
+    left: -50%;
+    width: 200%;
+    height: 200%;
+    background: radial-gradient(circle, rgba(0, 123, 255, 0.15) 0%, transparent 60%);
+    opacity: 0;
+    transform: scale(0);
+    z-index: 1;
+    transition: transform 0.8s cubic-bezier(0.2, 0.8, 0.2, 1), 
+                opacity 0.8s ease;
+}
+
+/* The Content Layer */
+.modal-inner {
+    position: relative;
+    z-index: 2;
+}
+
+
+/* Activate Modal via Checkbox */
+.modal-toggle:checked ~ .modal-overlay {
+    opacity: 1;
+    visibility: visible;
+}
+
+.modal-toggle:checked ~ .modal-overlay .modal-content {
+    transform: scale(1);
+}
+
+/* Trigger the Ripple when opened */
+.modal-toggle:checked ~ .modal-overlay .ripple-wave {
+    transform: scale(1);
+    opacity: 1;
+    /* Optional: infinite gentle pulsing once open */
+    animation: pulse-wave 4s infinite alternate ease-in-out 0.8s;
+}
+
+@keyframes pulse-wave {
+    0% { transform: scale(1); opacity: 1; }
+    100% { transform: scale(1.1); opacity: 0.7; }
+}
+
+
+/* Modal Inner Elements */
+.modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 15px 20px;
+    border-bottom: 1px solid var(--neon-blue-dim);
+    background: rgba(0, 123, 255, 0.1);
+}
+
+.modal-header h2 {
+    margin: 0;
+    font-size: 1.2rem;
+    color: var(--neon-blue);
+    letter-spacing: 2px;
+}
+
+.close-btn {
+    font-size: 2rem;
+    line-height: 1;
+    color: var(--neon-blue);
+    cursor: pointer;
+    font-weight: bold;
+    transition: text-shadow 0.2s ease;
+}
+
+.close-btn:hover {
+    text-shadow: 0 0 10px var(--neon-blue);
+}
+
+.modal-body {
+    padding: 30px 20px;
+    text-align: left;
+}
+
+.modal-body p {
+    font-size: 1.1rem;
+    margin: 0 0 20px 0;
+    color: var(--text-main);
+}
+
+.sync-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 10px;
+}
+
+.sync-node {
+    padding: 10px 15px;
+    border-left: 3px solid var(--neon-blue);
+    background: rgba(0, 123, 255, 0.05);
+    font-size: 0.9rem;
+    color: var(--neon-blue);
+}
+
+.sync-node.pending {
+    border-left-color: var(--neon-purple);
+    color: var(--neon-purple);
+    background: rgba(138, 43, 226, 0.05);
+    position: relative;
+}
+.sync-node.pending::after {
+    content: '...';
+    position: absolute;
+    right: 15px;
+    animation: blinker 1.5s linear infinite;
+}
+
+.modal-footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 15px;
+    padding: 20px;
+    border-top: 1px solid rgba(0, 123, 255, 0.3);
+}
+
+@keyframes blinker {
+    50% { opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .modal-overlay, .modal-content, .ripple-wave {
+        transition: none !important;
+        animation: none !important;
+    }
+    .modal-content {
+        transform: scale(1) !important;
+    }
+    .ripple-wave {
+        transform: scale(1) !important;
+        opacity: 1 !important;
+    }
+    .sync-node.pending::after {
+        animation: none !important;
+    }
+    .cyberpunk-btn::before {
+        display: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces the CSS Ripple-Wave Modal designed for Cyberpunk Neon Layouts, resolving issue #64726. 

### Changes Made:
- Added `submissions/examples/cyberpunk-ripple-wave-modal/` directory.
- Created `demo.html` showcasing the modal structure, activated entirely via the CSS checkbox hack for state management without JS. The layout features a layered structure with a dedicated ripple background element beneath the content.
- Created `style.css` featuring an immersive cyberpunk aesthetic (grid backgrounds, blue/purple neon glows, and monospace fonts). The modal utilizes an absolute positioned `.ripple-wave` element with a `radial-gradient` that scales up from 0 to 1 on activation. It also includes an infinite `@keyframes pulse-wave` to keep the background active while open.
- Added `README.md` documenting usage and features.
- Fully responsive layout that adapts gracefully from desktop to mobile.
- Honors the `prefers-reduced-motion` accessibility standard.

Closes #64726
