### PR TITLE
feat: add sticky stacking cards scroll example

### DIFF
--- a/submissions/examples/ease-stacking-cards/README.md
+++ b/submissions/examples/ease-stacking-cards/README.md
@@ -1,0 +1,18 @@
+# Sticky Stacking Cards
+
+A highly requested scrolling interaction popular on modern marketing sites (like Stripe or Apple). As the user scrolls down the page, cards stick to the top of the viewport and visually stack on top of one another like a deck of cards.
+
+### Usage
+```html
+<div class="ease-stack-container">
+    <div class="ease-stack-card card-1">
+        <div class="card-inner">Card 1 Content</div>
+    </div>
+    <div class="ease-stack-card card-2">
+        <div class="card-inner">Card 2 Content</div>
+    </div>
+</div>
+```
+
+### Why is it useful?
+Historically, creating this "deck of cards" scroll effect required heavy scroll-jacking JavaScript libraries (like GSAP's ScrollTrigger). This component implements the effect natively and responsively using pure CSS `position: sticky` and calculated incremental `top` offsets. It is perfectly smooth, hardware-accelerated, and completely accessible as it doesn't hijack the native browser scrollbar.

--- a/submissions/examples/ease-stacking-cards/demo.html
+++ b/submissions/examples/ease-stacking-cards/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ease Stacking Cards</title>
+    <link rel="stylesheet" href="../../../easemotion.min.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header class="page-header">
+        <h1>Scroll Down to See the Stacking Effect</h1>
+        <p>Keep scrolling...</p>
+    </header>
+
+    <div class="ease-stack-container">
+        
+        <div class="ease-stack-card card-1" id="card1">
+            <div class="card-inner">
+                <h2>Card One</h2>
+                <p>This is the first card in the stack. It will stop near the top of the viewport.</p>
+            </div>
+        </div>
+
+        <div class="ease-stack-card card-2" id="card2">
+            <div class="card-inner">
+                <h2>Card Two</h2>
+                <p>This is the second card. Notice how it overlaps the first card seamlessly using sticky positioning.</p>
+            </div>
+        </div>
+
+        <div class="ease-stack-card card-3" id="card3">
+            <div class="card-inner">
+                <h2>Card Three</h2>
+                <p>The third card in the sequence. You can add as many as you need, just increment the top offset.</p>
+            </div>
+        </div>
+        
+        <div class="ease-stack-card card-4" id="card4">
+            <div class="card-inner">
+                <h2>Card Four</h2>
+                <p>The final card in this stack demonstration.</p>
+            </div>
+        </div>
+
+    </div>
+
+    <footer class="page-footer">
+        <h2>End of Stack</h2>
+    </footer>
+</body>
+</html>

--- a/submissions/examples/ease-stacking-cards/style.css
+++ b/submissions/examples/ease-stacking-cards/style.css
@@ -1,0 +1,86 @@
+body {
+    margin: 0;
+    padding: 0;
+    font-family: sans-serif;
+    background-color: #f1f5f9;
+    color: #334155;
+}
+
+.page-header, .page-footer {
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    background-color: #0f172a;
+    color: white;
+}
+
+.ease-stack-container {
+    padding: 40px 20px;
+    max-width: 800px;
+    margin: 0 auto;
+    
+    /* Important for calculating sticky bounds correctly */
+    position: relative; 
+}
+
+.ease-stack-card {
+    /* The magic that makes it stick */
+    position: sticky;
+    
+    /* Visual separation */
+    margin-bottom: 20px;
+    
+    /* Smooth transition for any hover effects if added later */
+    transition: transform 0.3s ease;
+}
+
+/* 
+  Calculated top offsets. 
+  Each card needs a slightly higher top value so they stack 
+  like a deck of cards rather than completely covering one another.
+  Base offset is 40px, adding 20px for each subsequent card.
+*/
+.card-1 { top: 40px; }
+.card-2 { top: 60px; }
+.card-3 { top: 80px; }
+.card-4 { top: 100px; }
+
+/* 
+  Optional dynamic scaling trick: 
+  As subsequent cards stack on top, we slightly scale down the lower ones 
+  to enhance the 3D stacking effect. This works best when utilizing 
+  CSS scroll-driven animations (not used here for maximum browser compatibility), 
+  but can also be approximated visually with shadows.
+*/
+
+.card-inner {
+    background-color: #ffffff;
+    border-radius: 24px;
+    padding: 40px;
+    height: 300px;
+    box-shadow: 0 -10px 20px rgba(0,0,0,0.05), 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    border: 1px solid #e2e8f0;
+}
+
+/* Coloring the cards differently to make the stack obvious */
+.card-1 .card-inner { background: linear-gradient(135deg, #e0f2fe, #bae6fd); }
+.card-2 .card-inner { background: linear-gradient(135deg, #fce7f3, #fbcfe8); }
+.card-3 .card-inner { background: linear-gradient(135deg, #fef3c7, #fde68a); }
+.card-4 .card-inner { background: linear-gradient(135deg, #dcfce3, #bbf7d0); }
+
+h2 {
+    margin-top: 0;
+    font-size: 32px;
+    color: #0f172a;
+}
+
+p {
+    font-size: 18px;
+    line-height: 1.6;
+    color: #475569;
+}


### PR DESCRIPTION
fixes #65290 

## Pull Request Description

Adds an `ease-stacking-cards` scrolling layout. A highly requested interaction on modern marketing sites (like Stripe or Apple) is the "Stacking Cards" effect, where scrolling causes sections to stick to the top of the viewport and visually overlap like a deck of cards. This submission implements this effect entirely in CSS, bypassing the need for heavy scroll-jacking JavaScript.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component (Standard Track)
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/ease-stacking-cards/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A fully responsive, scrolling "deck of cards" layout that leverages native CSS `position: sticky;` combined with meticulously calculated incremental `top` offsets for each subsequent card. 

**How does a developer use it?**

```html
<div class="ease-stack-container">
    <div class="ease-stack-card card-1">
        <div class="card-inner">Card 1</div>
    </div>
    <div class="ease-stack-card card-2">
        <!-- Will stick exactly 20px below the first card -->
        <div class="card-inner">Card 2</div>
    </div>
</div>
