### PR TITLE
feat: add CSS Slide-Up Drawer for Cyberpunk Neon Layouts (#64732)

### DIFF
--- a/submissions/examples/cyberpunk-slide-up-drawer/README.md
+++ b/submissions/examples/cyberpunk-slide-up-drawer/README.md
@@ -1,0 +1,18 @@
+# CSS Slide-Up Drawer (Cyberpunk)
+
+A pure CSS drawer component designed for Cyberpunk Neon Layouts. It utilizes the checkbox hack for state management and features a bottom-aligned panel that smoothly slides up into view, stylized as a retro-futuristic terminal console.
+
+## Features
+- Pure CSS and HTML (No JavaScript required).
+- State management handled completely via a hidden `<input type="checkbox">` and the `~` general sibling selector.
+- The `.drawer-panel` is anchored to the bottom of the viewport using Flexbox on the overlay, and slides up smoothly using a `transform: translateY()` transition.
+- Immersive cyberpunk terminal aesthetic featuring green neon glows, monospace typography, and a blinking cursor animation.
+- Fully responsive layout that takes up a fixed percentage of the viewport height (`60vh`), ensuring it looks great on both desktop and mobile screens.
+- Fully accessible with `prefers-reduced-motion` support ensuring degraded, safe static layouts (toggling display states) for users sensitive to motion.
+
+## Usage
+Open `demo.html` in your browser. Click the "OPEN TERMINAL" button. The background overlay will fade in, and a terminal console panel will smoothly slide up from the bottom edge of the screen. Click the "X" in the header or the "TERMINATE" button to close the drawer.
+
+## Files
+- `demo.html`: The HTML structure for the layout, the hidden checkbox state manager, and the bottom-aligned drawer panel containing the terminal UI.
+- `style.css`: The styling, neon effects, and CSS `@keyframes` logic for the slide-up animation and blinking cursor.

--- a/submissions/examples/cyberpunk-slide-up-drawer/demo.html
+++ b/submissions/examples/cyberpunk-slide-up-drawer/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Slide-Up Drawer - Cyberpunk</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="cyberpunk-layout">
+        
+        <h1 class="neon-text">SYS.DIAGNOSTICS</h1>
+        
+        <!-- The Checkbox Hack for Pure CSS Drawer -->
+        <input type="checkbox" id="drawer-toggle" class="drawer-toggle">
+        
+        <label for="drawer-toggle" class="btn cyberpunk-btn">OPEN TERMINAL</label>
+        
+        <!-- The Drawer Container -->
+        <div class="drawer-overlay">
+            <!-- The Drawer Panel (Slides up from the bottom) -->
+            <div class="drawer-panel">
+                
+                <div class="drawer-header">
+                    <h2><span class="blink">_</span> TERMINAL_ACCESS</h2>
+                    <label for="drawer-toggle" class="close-btn">&times;</label>
+                </div>
+                
+                <div class="drawer-body">
+                    <div class="terminal-output">
+                        <p>> Initializing core systems...</p>
+                        <p>> Bypassing firewall protocols [OK]</p>
+                        <p>> Establishing secure tunnel... <span class="highlight">CONNECTED</span></p>
+                        <p>> Awaiting user input...</p>
+                        <div class="input-line">
+                            <span class="prompt">root@sys:~#</span> <span class="cursor blink">█</span>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="drawer-footer">
+                    <label for="drawer-toggle" class="btn outline-btn">TERMINATE</label>
+                </div>
+                
+            </div>
+        </div>
+        
+    </div>
+</body>
+</html>

--- a/submissions/examples/cyberpunk-slide-up-drawer/style.css
+++ b/submissions/examples/cyberpunk-slide-up-drawer/style.css
@@ -1,0 +1,249 @@
+@import url('https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap');
+
+:root {
+    --bg-color: #050505;
+    --drawer-bg: rgba(10, 15, 10, 0.95);
+    --text-main: #e0e0e0;
+    --neon-green: #39ff14;
+    --neon-green-dim: rgba(57, 255, 20, 0.2);
+    --grid-color: rgba(57, 255, 20, 0.05);
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    background-image: 
+        linear-gradient(var(--grid-color) 1px, transparent 1px),
+        linear-gradient(90deg, var(--grid-color) 1px, transparent 1px);
+    background-size: 30px 30px;
+    font-family: 'Share Tech Mono', monospace;
+    color: var(--text-main);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    overflow: hidden; /* Prevents scroll when drawer opens */
+}
+
+.cyberpunk-layout {
+    text-align: center;
+}
+
+.neon-text {
+    font-size: 3rem;
+    color: var(--text-main);
+    text-shadow: 0 0 10px var(--neon-green), 0 0 20px var(--neon-green);
+    margin-bottom: 40px;
+    letter-spacing: 5px;
+}
+
+.btn {
+    display: inline-block;
+    padding: 12px 24px;
+    font-family: 'Share Tech Mono', monospace;
+    font-size: 1.1rem;
+    text-transform: uppercase;
+    cursor: pointer;
+    text-decoration: none;
+    transition: all 0.3s ease;
+    border: none;
+    outline: none;
+}
+
+.cyberpunk-btn {
+    background: transparent;
+    color: var(--neon-green);
+    border: 1px solid var(--neon-green);
+    box-shadow: inset 0 0 10px var(--neon-green-dim), 0 0 15px var(--neon-green-dim);
+    position: relative;
+    overflow: hidden;
+}
+
+.cyberpunk-btn::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: -100%;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(90deg, transparent, rgba(57, 255, 20, 0.4), transparent);
+    transition: all 0.4s ease;
+}
+
+.cyberpunk-btn:hover {
+    background: var(--neon-green);
+    color: var(--bg-color);
+    box-shadow: 0 0 20px var(--neon-green);
+}
+
+.cyberpunk-btn:hover::before {
+    left: 100%;
+}
+
+.outline-btn {
+    background: transparent;
+    color: var(--text-main);
+    border: 1px solid var(--text-main);
+}
+
+.outline-btn:hover {
+    background: rgba(255,255,255,0.1);
+}
+
+
+/* Drawer Checkbox Logic */
+.drawer-toggle {
+    display: none;
+}
+
+/* Drawer Overlay */
+.drawer-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.6);
+    backdrop-filter: blur(3px);
+    z-index: 1000;
+    
+    /* Fade In State */
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.4s ease, visibility 0.4s ease;
+    
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end; /* Align drawer to bottom */
+}
+
+/* The Drawer Panel (Slides up from the bottom) */
+.drawer-panel {
+    width: 100%;
+    height: 60vh; /* Takes up 60% of viewport height */
+    max-height: 500px;
+    background: var(--drawer-bg);
+    border-top: 2px solid var(--neon-green);
+    box-shadow: 0 -10px 30px var(--neon-green-dim);
+    display: flex;
+    flex-direction: column;
+    
+    /* Slide Down (Hidden) State */
+    transform: translateY(100%);
+    transition: transform 0.5s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* Activate Drawer via Checkbox */
+.drawer-toggle:checked ~ .drawer-overlay {
+    opacity: 1;
+    visibility: visible;
+}
+
+.drawer-toggle:checked ~ .drawer-overlay .drawer-panel {
+    transform: translateY(0);
+}
+
+
+/* Drawer Inner Elements */
+.drawer-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background: rgba(57, 255, 20, 0.1);
+    color: var(--neon-green);
+    padding: 15px 30px;
+    border-bottom: 1px solid var(--neon-green-dim);
+}
+
+.drawer-header h2 {
+    margin: 0;
+    font-size: 1.2rem;
+    letter-spacing: 2px;
+}
+
+.close-btn {
+    font-size: 2rem;
+    line-height: 1;
+    cursor: pointer;
+    font-weight: bold;
+    transition: text-shadow 0.2s ease;
+}
+
+.close-btn:hover {
+    text-shadow: 0 0 10px var(--neon-green);
+}
+
+.drawer-body {
+    padding: 30px;
+    text-align: left;
+    flex-grow: 1;
+    overflow-y: auto;
+}
+
+/* Terminal Aesthetic */
+.terminal-output {
+    background: rgba(0, 0, 0, 0.5);
+    border: 1px solid var(--neon-green-dim);
+    padding: 20px;
+    height: 100%;
+    box-sizing: border-box;
+    font-size: 1rem;
+    line-height: 1.6;
+    color: var(--neon-green);
+}
+
+.terminal-output p {
+    margin: 0 0 10px 0;
+}
+
+.highlight {
+    color: #fff;
+    background: var(--neon-green);
+    padding: 0 5px;
+}
+
+.input-line {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-top: 20px;
+}
+
+.drawer-footer {
+    display: flex;
+    justify-content: flex-end;
+    padding: 15px 30px;
+    border-top: 1px solid var(--neon-green-dim);
+    background: rgba(0, 0, 0, 0.3);
+}
+
+/* Blinking Cursor */
+.blink {
+    animation: blinker 1s linear infinite;
+}
+
+@keyframes blinker {
+    50% { opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .drawer-overlay, .drawer-panel {
+        transition: none !important;
+    }
+    .drawer-panel {
+        transform: translateY(0) !important;
+        display: none; /* Hide via display instead of transform */
+    }
+    .drawer-toggle:checked ~ .drawer-overlay .drawer-panel {
+        display: flex;
+    }
+    
+    .blink {
+        animation: none !important;
+    }
+    
+    .cyberpunk-btn::before {
+        display: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces the CSS Slide-Up Drawer designed for Cyberpunk Neon Layouts, resolving issue #64732. 

### Changes Made:
- Added `submissions/examples/cyberpunk-slide-up-drawer/` directory.
- Created `demo.html` showcasing the drawer structure, activated entirely via the CSS checkbox hack for state management without JS. The layout acts as a bottom-aligned slide-up terminal console.
- Created `style.css` featuring an immersive cyberpunk aesthetic (grid backgrounds, green neon glows, and monospace fonts). The drawer is anchored to the bottom using flexbox on the overlay and slides up smoothly using a `transform: translateY()` transition. Includes terminal-themed inner content with a blinking cursor.
- Added `README.md` documenting usage and features.
- Fully responsive layout that adapts gracefully to screen sizes using viewport height (`vh`) units.
- Honors the `prefers-reduced-motion` accessibility standard.

Closes #64732
