### PR TITLE
feat: add morph-glow stepper glassmorphism layout for #64392

### DIFF
--- a/submissions/examples/morph-glow-stepper-glassmorphism-layouts/README.md
+++ b/submissions/examples/morph-glow-stepper-glassmorphism-layouts/README.md
@@ -1,0 +1,39 @@
+# Morph-Glow Stepper — Glassmorphism UI Layouts
+
+A CSS-only stepper where each step dot morphs from a circle to a rounded square and gains a glowing shadow on hover.
+
+## Features
+
+- **Morph effect** — step dots transition from `border-radius: 50%` (circle) to `border-radius: 30%` (squircle) on hover
+- **Glow shadow** — the morphed dot emits a soft ambient glow using layered `box-shadow`
+- **Scale pop** — the dot scales up slightly on hover for extra emphasis
+- **Glassmorphism panels** — step content uses semi-transparent fill with `backdrop-filter: blur(18px)` and subtle borders
+- **Vertical connector** — a thin line links all steps via a pseudo-element on the track
+- **Staggered entrance** — steps fade in one after another with increasing `animation-delay`
+- **Fully responsive** — adapts dot size, connector position, and padding on smaller screens
+- **Reduced-motion accessible** — all morph, glow, and hover effects disabled when `prefers-reduced-motion: reduce`
+
+## CSS Custom Properties
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `--mgs-bg` | `#060a16` | Page background |
+| `--mgs-glass` | `rgba(255,255,255,0.05)` | Panel fill |
+| `--mgs-border` | `rgba(255,255,255,0.09)` | Panel border |
+| `--mgs-blur` | `18px` | Backdrop blur |
+| `--mgs-shadow` | `rgba(0,0,0,0.42)` | Panel shadow |
+| `--mgs-text` | `#edf1ff` | Primary text |
+| `--mgs-dim` | `rgba(237,241,255,0.46)` | Secondary text |
+| `--mgs-amber` | `#fbbf24` | Accent colour |
+| `--mgs-glow` | `rgba(251,191,36,0.25)` | Glow colour |
+
+## How It Works
+
+1. Each step dot starts as a circle with `border-radius: 50%`.
+2. On hover, `border-radius` transitions to `30%` creating a squircle shape.
+3. A layered `box-shadow` creates the ambient glow effect.
+4. The `transform: scale(1.1)` adds a subtle pop.
+
+## Usage
+
+Copy `demo.html` and `style.css` into your project. No JavaScript or external dependencies needed. Override the CSS custom properties to match your theme.

--- a/submissions/examples/morph-glow-stepper-glassmorphism-layouts/demo.html
+++ b/submissions/examples/morph-glow-stepper-glassmorphism-layouts/demo.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS Morph-Glow Stepper with glassmorphism layout. Pure CSS step progress with no JavaScript.">
+  <title>Morph-Glow Stepper – Glassmorphism UI Layouts</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="mgs-wrap">
+    <header class="mgs-head">
+      <span class="mgs-head__badge">Glassmorphism UI</span>
+      <h1 class="mgs-head__title">Onboarding</h1>
+      <p class="mgs-head__sub">Hover a step to see its dot morph and glow.</p>
+    </header>
+
+    <ol class="mgs-track">
+
+      <li class="mgs-step">
+        <div class="mgs-step__orb">
+          <span class="mgs-step__num">A</span>
+        </div>
+        <div class="mgs-step__panel">
+          <h2 class="mgs-step__title">Verify Email</h2>
+          <p class="mgs-step__desc">Check your inbox and click the confirmation link.</p>
+        </div>
+      </li>
+
+      <li class="mgs-step">
+        <div class="mgs-step__orb">
+          <span class="mgs-step__num">B</span>
+        </div>
+        <div class="mgs-step__panel">
+          <h2 class="mgs-step__title">Set Profile</h2>
+          <p class="mgs-step__desc">Add your name, avatar, and a short bio.</p>
+        </div>
+      </li>
+
+      <li class="mgs-step">
+        <div class="mgs-step__orb">
+          <span class="mgs-step__num">C</span>
+        </div>
+        <div class="mgs-step__panel">
+          <h2 class="mgs-step__title">Link Workspace</h2>
+          <p class="mgs-step__desc">Connect your GitHub, GitLab, or Bitbucket account.</p>
+        </div>
+      </li>
+
+      <li class="mgs-step">
+        <div class="mgs-step__orb">
+          <span class="mgs-step__num">D</span>
+        </div>
+        <div class="mgs-step__panel">
+          <h2 class="mgs-step__title">Go Live</h2>
+          <p class="mgs-step__desc">Deploy your first project and share it with your team.</p>
+        </div>
+      </li>
+
+    </ol>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/morph-glow-stepper-glassmorphism-layouts/style.css
+++ b/submissions/examples/morph-glow-stepper-glassmorphism-layouts/style.css
@@ -1,0 +1,247 @@
+:root {
+  --mgs-bg: #060a16;
+  --mgs-glass: rgba(255, 255, 255, 0.05);
+  --mgs-border: rgba(255, 255, 255, 0.09);
+  --mgs-blur: 18px;
+  --mgs-shadow: rgba(0, 0, 0, 0.42);
+  --mgs-text: #edf1ff;
+  --mgs-dim: rgba(237, 241, 255, 0.46);
+  --mgs-amber: #fbbf24;
+  --mgs-glow: rgba(251, 191, 36, 0.25);
+}
+
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: var(--mgs-bg);
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  color: var(--mgs-text);
+}
+
+/* ── layout ──────────────────────────────────────── */
+
+.mgs-wrap {
+  width: min(500px, 92vw);
+  padding: 40px 0;
+}
+
+.mgs-head {
+  text-align: center;
+  margin-bottom: 32px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  animation: mgsFadeUp 0.65s ease-out both;
+}
+
+.mgs-head__badge {
+  font-size: 0.66rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--mgs-amber);
+  font-weight: 600;
+  background: rgba(251, 191, 36, 0.08);
+  border: 1px solid rgba(251, 191, 36, 0.22);
+  padding: 4px 12px;
+  border-radius: 999px;
+}
+
+.mgs-head__title {
+  font-size: clamp(1.8rem, 4vw, 2.4rem);
+  font-weight: 800;
+  background: linear-gradient(135deg, var(--mgs-text), var(--mgs-amber));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.mgs-head__sub {
+  font-size: 0.92rem;
+  color: var(--mgs-dim);
+  max-width: 30ch;
+  line-height: 1.5;
+}
+
+/* ── track ───────────────────────────────────────── */
+
+.mgs-track {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  position: relative;
+}
+
+/* connector */
+.mgs-track::before {
+  content: "";
+  position: absolute;
+  left: 19px;
+  top: 28px;
+  bottom: 28px;
+  width: 2px;
+  background: rgba(255, 255, 255, 0.07);
+}
+
+/* ── step ────────────────────────────────────────── */
+
+.mgs-step {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  position: relative;
+  opacity: 0;
+  animation: mgsFadeUp 0.5s ease-out both;
+}
+
+.mgs-step:nth-child(1) { animation-delay: 0.06s; }
+.mgs-step:nth-child(2) { animation-delay: 0.16s; }
+.mgs-step:nth-child(3) { animation-delay: 0.26s; }
+.mgs-step:nth-child(4) { animation-delay: 0.36s; }
+
+.mgs-step + .mgs-step {
+  margin-top: 12px;
+}
+
+/* ── orb ─────────────────────────────────────────── */
+
+.mgs-step__orb {
+  position: relative;
+  flex-shrink: 0;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: rgba(251, 191, 36, 0.08);
+  border: 1.5px solid rgba(251, 191, 36, 0.2);
+  display: grid;
+  place-items: center;
+  z-index: 2;
+  transition:
+    border-radius 0.4s cubic-bezier(0.22, 1, 0.36, 1),
+    box-shadow 0.4s,
+    background 0.3s,
+    transform 0.35s;
+}
+
+.mgs-step:hover .mgs-step__orb {
+  border-radius: 30%;
+  box-shadow: 0 0 20px var(--mgs-glow), 0 0 40px var(--mgs-glow);
+  background: rgba(251, 191, 36, 0.15);
+  transform: scale(1.1);
+}
+
+.mgs-step__num {
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: var(--mgs-amber);
+}
+
+/* ── panel ───────────────────────────────────────── */
+
+.mgs-step__panel {
+  flex: 1;
+  background: var(--mgs-glass);
+  border: 1px solid var(--mgs-border);
+  border-radius: 14px;
+  padding: 18px 20px;
+  backdrop-filter: blur(var(--mgs-blur));
+  -webkit-backdrop-filter: blur(var(--mgs-blur));
+  box-shadow: 0 4px 16px var(--mgs-shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  transition: border-color 0.3s, box-shadow 0.3s;
+}
+
+.mgs-step:hover .mgs-step__panel {
+  border-color: var(--mgs-amber);
+  box-shadow: 0 6px 24px var(--mgs-shadow);
+}
+
+.mgs-step__title {
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.mgs-step__desc {
+  font-size: 0.84rem;
+  color: var(--mgs-dim);
+  line-height: 1.5;
+}
+
+/* ── entrance ────────────────────────────────────── */
+
+@keyframes mgsFadeUp {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* ── responsive ──────────────────────────────────── */
+
+@media (max-width: 440px) {
+  .mgs-wrap {
+    padding: 24px 10px;
+  }
+
+  .mgs-step__orb {
+    width: 34px;
+    height: 34px;
+  }
+
+  .mgs-step__num {
+    font-size: 0.7rem;
+  }
+
+  .mgs-track::before {
+    left: 16px;
+  }
+
+  .mgs-step__panel {
+    padding: 14px 16px;
+  }
+}
+
+/* ── accessibility ───────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .mgs-head,
+  .mgs-step {
+    animation: none;
+    opacity: 1;
+  }
+
+  .mgs-step__orb {
+    transition: none;
+  }
+
+  .mgs-step:hover .mgs-step__orb {
+    border-radius: 50%;
+    transform: none;
+    box-shadow: none;
+  }
+
+  .mgs-step__panel {
+    transition: none;
+  }
+
+  .mgs-step:hover .mgs-step__panel {
+    border-color: var(--mgs-border);
+    box-shadow: 0 4px 16px var(--mgs-shadow);
+  }
+}


### PR DESCRIPTION
## Summary

Adds a CSS-only morph-glow stepper with glassmorphism styling for Issue #64392.

## What's Included

- **demo.html** — Showcase page with 4-step vertical stepper (Verify Email, Set Profile, Link Workspace, Go Live)
- **style.css** — Pure CSS with glassmorphism panels, morph-glow effect on step dots, vertical connector, staggered entrance, hover highlight
- **README.md** — Documentation with CSS custom properties table and usage guide

## Key Features

- Morph effect — dots transition from circle to squircle using border-radius on hover
- Glow shadow — layered box-shadow creates ambient glow around morphed dot
- Scale pop — dot scales up slightly on hover
- Glassmorphism panels with `backdrop-filter: blur(18px)`
- Vertical connector line linking all steps
- Responsive — adapts dot size and padding on mobile
- `prefers-reduced-motion` support

## Checklist

- [x] All new files inside `submissions/examples/`
- [x] No existing files modified
- [x] Pure CSS/HTML — no JavaScript
- [x] `:root` with CSS custom properties (`--mgs-*` prefix)
- [x] Animations and transitions present
- [x] Responsive media queries
- [x] Reduced-motion accessibility