### PR TITLE
feat: add CSS 3D-Flip Drawer for Cyberpunk Neon Layouts (#64736)

### DIFF
--- a/submissions/examples/cyberpunk-3d-flip-drawer/README.md
+++ b/submissions/examples/cyberpunk-3d-flip-drawer/README.md
@@ -1,0 +1,19 @@
+# CSS 3D-Flip Drawer (Cyberpunk)
+
+A pure CSS drawer component designed for Cyberpunk Neon Layouts. It utilizes the checkbox hack for state management and features a dramatic 3D `rotateY` flip animation, giving the impression of a digital interface rapidly swinging open like a high-tech door.
+
+## Features
+- Pure CSS and HTML (No JavaScript required).
+- State management handled completely via a hidden `<input type="checkbox">` and the `~` general sibling selector.
+- True 3D spatial flip effect achieved using CSS `perspective` on a wrapper element and `transform-style: preserve-3d` combined with `rotateY` and a `transform-origin` on the left edge.
+- Includes pure CSS custom neon toggle switches (`<input type="checkbox">`) for the hardware configuration settings.
+- Immersive cyberpunk aesthetic featuring background grids, neon text-shadows, and aggressive orange/red box-shadow glows.
+- Fully responsive layout that adapts gracefully to screen sizes (taking up 90vw on small screens).
+- Fully accessible with `prefers-reduced-motion` support ensuring degraded, safe static layouts for users sensitive to motion.
+
+## Usage
+Open `demo.html` in your browser. Click the "ACCESS SETTINGS" button. The background overlay will fade in while the neon-orange hardware config drawer swings open from the left side of the screen along the Y-axis. Click the "X" in the header or the "ABORT" button to close the drawer.
+
+## Files
+- `demo.html`: The HTML structure for the layout, the hidden checkbox state manager, the 3D perspective wrapper, and the custom neon toggles.
+- `style.css`: The styling, neon effects, and CSS `perspective`/`rotateY` logic for the 3D flip animations and custom toggles.

--- a/submissions/examples/cyberpunk-3d-flip-drawer/demo.html
+++ b/submissions/examples/cyberpunk-3d-flip-drawer/demo.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS 3D-Flip Drawer - Cyberpunk</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="cyberpunk-layout">
+        
+        <h1 class="neon-text">SYS.CONFIG</h1>
+        
+        <!-- The Checkbox Hack for Pure CSS Drawer -->
+        <input type="checkbox" id="drawer-toggle" class="drawer-toggle">
+        
+        <label for="drawer-toggle" class="btn cyberpunk-btn">ACCESS SETTINGS</label>
+        
+        <!-- The Drawer Container -->
+        <div class="drawer-overlay">
+            
+            <!-- 3D Perspective Wrapper -->
+            <div class="drawer-perspective">
+                
+                <!-- The Drawer Panel (Flips in from the left) -->
+                <div class="drawer-panel">
+                    
+                    <div class="drawer-header">
+                        <h2><span class="blink">!</span> HARDWARE_CONFIG</h2>
+                        <label for="drawer-toggle" class="close-btn">&times;</label>
+                    </div>
+                    
+                    <div class="drawer-body">
+                        <p class="warning-text">Modifying these parameters may void your warranty.</p>
+                        
+                        <div class="settings-group">
+                            <label class="setting-item">
+                                <span class="setting-label">OVERCLOCK_GPU</span>
+                                <input type="checkbox" class="neon-toggle" checked>
+                            </label>
+                            
+                            <label class="setting-item">
+                                <span class="setting-label">BYPASS_THERMALS</span>
+                                <input type="checkbox" class="neon-toggle">
+                            </label>
+                            
+                            <label class="setting-item">
+                                <span class="setting-label">ENABLE_NEURAL_LINK</span>
+                                <input type="checkbox" class="neon-toggle" checked>
+                            </label>
+                        </div>
+                    </div>
+                    
+                    <div class="drawer-footer">
+                        <label for="drawer-toggle" class="btn outline-btn">ABORT</label>
+                        <button class="btn cyberpunk-btn-warning">COMMIT</button>
+                    </div>
+                    
+                </div>
+                
+            </div>
+            
+        </div>
+        
+    </div>
+</body>
+</html>

--- a/submissions/examples/cyberpunk-3d-flip-drawer/style.css
+++ b/submissions/examples/cyberpunk-3d-flip-drawer/style.css
@@ -1,0 +1,321 @@
+@import url('https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap');
+
+:root {
+    --bg-color: #050505;
+    --drawer-bg: rgba(15, 5, 5, 0.95);
+    --text-main: #e0e0e0;
+    --neon-orange: #ff7300;
+    --neon-orange-dim: rgba(255, 115, 0, 0.2);
+    --neon-red: #ff003c;
+    --neon-red-dim: rgba(255, 0, 60, 0.2);
+    --grid-color: rgba(255, 115, 0, 0.05);
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    background-image: 
+        linear-gradient(var(--grid-color) 1px, transparent 1px),
+        linear-gradient(90deg, var(--grid-color) 1px, transparent 1px);
+    background-size: 30px 30px;
+    font-family: 'Share Tech Mono', monospace;
+    color: var(--text-main);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    overflow: hidden; /* Prevents scroll when drawer opens */
+}
+
+.cyberpunk-layout {
+    text-align: center;
+}
+
+.neon-text {
+    font-size: 3rem;
+    color: var(--text-main);
+    text-shadow: 0 0 10px var(--neon-orange), 0 0 20px var(--neon-orange);
+    margin-bottom: 40px;
+    letter-spacing: 5px;
+}
+
+.btn {
+    display: inline-block;
+    padding: 12px 24px;
+    font-family: 'Share Tech Mono', monospace;
+    font-size: 1.1rem;
+    text-transform: uppercase;
+    cursor: pointer;
+    text-decoration: none;
+    transition: all 0.3s ease;
+    border: none;
+    outline: none;
+}
+
+.cyberpunk-btn {
+    background: transparent;
+    color: var(--neon-orange);
+    border: 1px solid var(--neon-orange);
+    box-shadow: inset 0 0 10px var(--neon-orange-dim), 0 0 15px var(--neon-orange-dim);
+    position: relative;
+    overflow: hidden;
+}
+
+.cyberpunk-btn::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: -100%;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(90deg, transparent, rgba(255, 115, 0, 0.4), transparent);
+    transition: all 0.4s ease;
+}
+
+.cyberpunk-btn:hover {
+    background: var(--neon-orange);
+    color: var(--bg-color);
+    box-shadow: 0 0 20px var(--neon-orange);
+}
+
+.cyberpunk-btn:hover::before {
+    left: 100%;
+}
+
+.cyberpunk-btn-warning {
+    background: var(--neon-red);
+    color: var(--bg-color);
+    border: 1px solid var(--neon-red);
+    box-shadow: 0 0 15px var(--neon-red-dim);
+}
+
+.cyberpunk-btn-warning:hover {
+    box-shadow: 0 0 25px var(--neon-red);
+}
+
+
+.outline-btn {
+    background: transparent;
+    color: var(--text-main);
+    border: 1px solid var(--text-main);
+}
+
+.outline-btn:hover {
+    background: rgba(255,255,255,0.1);
+}
+
+
+/* Drawer Checkbox Logic */
+.drawer-toggle {
+    display: none;
+}
+
+/* Drawer Overlay */
+.drawer-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.7);
+    backdrop-filter: blur(2px);
+    z-index: 1000;
+    
+    /* Fade In State */
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.4s ease, visibility 0.4s ease;
+}
+
+/* 3D Perspective Wrapper */
+.drawer-perspective {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 350px;
+    max-width: 90vw;
+    height: 100%;
+    perspective: 1200px;
+}
+
+/* The Drawer Panel (Flips in on the Y axis) */
+.drawer-panel {
+    width: 100%;
+    height: 100%;
+    background: var(--drawer-bg);
+    border-right: 2px solid var(--neon-orange);
+    box-shadow: 10px 0 30px var(--neon-orange-dim);
+    display: flex;
+    flex-direction: column;
+    
+    /* 3D Transform Logic */
+    transform-style: preserve-3d;
+    transform-origin: left center;
+    transform: rotateY(-90deg); /* Hidden state: swung out like a door */
+    
+    transition: transform 0.6s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+/* Activate Drawer via Checkbox */
+.drawer-toggle:checked ~ .drawer-overlay {
+    opacity: 1;
+    visibility: visible;
+}
+
+.drawer-toggle:checked ~ .drawer-overlay .drawer-panel {
+    transform: rotateY(0deg); /* Flipped open */
+}
+
+
+/* Drawer Inner Elements */
+.drawer-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background: rgba(255, 115, 0, 0.15);
+    color: var(--neon-orange);
+    padding: 20px;
+    border-bottom: 1px solid var(--neon-orange-dim);
+}
+
+.drawer-header h2 {
+    margin: 0;
+    font-size: 1.2rem;
+    letter-spacing: 2px;
+}
+
+.close-btn {
+    font-size: 2rem;
+    line-height: 1;
+    cursor: pointer;
+    font-weight: bold;
+    transition: text-shadow 0.2s ease;
+}
+
+.close-btn:hover {
+    text-shadow: 0 0 10px var(--neon-orange);
+}
+
+.drawer-body {
+    padding: 30px 20px;
+    text-align: left;
+    flex-grow: 1;
+    overflow-y: auto;
+}
+
+.warning-text {
+    font-size: 1rem;
+    margin: 0 0 30px 0;
+    color: var(--neon-red);
+    line-height: 1.5;
+    font-weight: bold;
+}
+
+/* Custom Neon Toggles */
+.settings-group {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.setting-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 15px;
+    background: rgba(255, 115, 0, 0.05);
+    border: 1px solid var(--neon-orange-dim);
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.setting-item:hover {
+    background: rgba(255, 115, 0, 0.1);
+    border-color: var(--neon-orange);
+}
+
+.setting-label {
+    font-size: 0.95rem;
+    color: var(--text-main);
+}
+
+/* Pure CSS Toggle Switch */
+.neon-toggle {
+    appearance: none;
+    width: 40px;
+    height: 20px;
+    background: rgba(0, 0, 0, 0.5);
+    border: 1px solid var(--neon-orange-dim);
+    border-radius: 10px;
+    position: relative;
+    outline: none;
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.neon-toggle::before {
+    content: '';
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 14px;
+    height: 14px;
+    background: var(--text-main);
+    border-radius: 50%;
+    transition: all 0.3s ease;
+}
+
+.neon-toggle:checked {
+    background: rgba(255, 115, 0, 0.2);
+    border-color: var(--neon-orange);
+    box-shadow: 0 0 10px var(--neon-orange-dim);
+}
+
+.neon-toggle:checked::before {
+    left: 22px;
+    background: var(--neon-orange);
+    box-shadow: 0 0 5px var(--neon-orange);
+}
+
+
+.drawer-footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 15px;
+    padding: 20px;
+    border-top: 1px solid var(--neon-orange-dim);
+}
+
+
+/* Blinking Cursor */
+.blink {
+    animation: blinker 1s linear infinite;
+    color: var(--neon-red);
+}
+
+@keyframes blinker {
+    50% { opacity: 0; }
+}
+
+
+@media (prefers-reduced-motion: reduce) {
+    .drawer-overlay, .drawer-panel {
+        transition: none !important;
+    }
+    .drawer-panel {
+        transform: rotateY(0deg) !important;
+        display: none; /* Hide via display instead of transform */
+    }
+    .drawer-toggle:checked ~ .drawer-overlay .drawer-panel {
+        display: flex;
+    }
+    
+    .blink {
+        animation: none !important;
+    }
+    
+    .cyberpunk-btn::before {
+        display: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces the CSS 3D-Flip Drawer designed for Cyberpunk Neon Layouts, resolving issue #64736. 

### Changes Made:
- Added `submissions/examples/cyberpunk-3d-flip-drawer/` directory.
- Created `demo.html` showcasing the drawer structure, activated entirely via the CSS checkbox hack for state management without JS. The layout acts as a hardware configuration panel and includes custom pure CSS toggle switches.
- Created `style.css` featuring an immersive cyberpunk aesthetic (grid backgrounds, orange/red neon glows, and monospace fonts). The drawer utilizes true 3D spatial geometry via a `perspective` wrapper and a `transform: rotateY()` transition anchored to the left edge to simulate a digital door swinging open.
- Added `README.md` documenting usage and features.
- Fully responsive layout that adapts gracefully from desktop to mobile.
- Honors the `prefers-reduced-motion` accessibility standard.

Closes #64736
