### PR TITLE
feat: add CSS Blur-Entrance Drawer for Cyberpunk Neon Layouts (#64737)

### DIFF
--- a/submissions/examples/cyberpunk-blur-entrance-drawer/README.md
+++ b/submissions/examples/cyberpunk-blur-entrance-drawer/README.md
@@ -1,0 +1,19 @@
+# CSS Blur-Entrance Drawer (Cyberpunk)
+
+A pure CSS drawer component designed for Cyberpunk Neon Layouts. It utilizes the checkbox hack for state management and features a cinematic, high-tech entrance sequence where the panel and its contents pull into focus from a heavily blurred state.
+
+## Features
+- Pure CSS and HTML (No JavaScript required).
+- State management handled completely via a hidden `<input type="checkbox">` and the `~` general sibling selector.
+- The `.drawer-panel` enters the screen with a combined `filter: blur()`, `opacity`, and `transform: translateX()` CSS transition, simulating a camera pulling focus.
+- Inner list elements (`.blur-enter`) utilize a sequential stagger effect, leveraging a custom CSS property (`--delay`) mathematically calculated within the `transition-delay`.
+- Immersive cyberpunk aesthetic featuring background grids, neon text-shadows, and glowing status indicators (Pink/Cyan/Red).
+- Fully responsive layout that adapts gracefully to screen sizes (taking up 90vw on small screens).
+- Fully accessible with `prefers-reduced-motion` support ensuring degraded, safe static layouts for users sensitive to motion.
+
+## Usage
+Open `demo.html` in your browser. Click the "VIEW NODES" button. The background overlay will fade in, and a side panel will slide in from the left while pulling sharply into focus from a blurred state. The list of active connections inside the panel will then sequentially pop into focus one by one. Click the "X" in the header or the "CLOSE" button to close the drawer.
+
+## Files
+- `demo.html`: The HTML structure for the layout, the hidden checkbox state manager, the drawer panel, and the inner list items utilizing inline `--delay` variables.
+- `style.css`: The styling, neon effects, and CSS `filter: blur()` logic for both the parent drawer and the staggered child elements.

--- a/submissions/examples/cyberpunk-blur-entrance-drawer/demo.html
+++ b/submissions/examples/cyberpunk-blur-entrance-drawer/demo.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Blur-Entrance Drawer - Cyberpunk</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="cyberpunk-layout">
+        
+        <h1 class="neon-text">SYS.NETWORK</h1>
+        
+        <!-- The Checkbox Hack for Pure CSS Drawer -->
+        <input type="checkbox" id="drawer-toggle" class="drawer-toggle">
+        
+        <label for="drawer-toggle" class="btn cyberpunk-btn">VIEW NODES</label>
+        
+        <!-- The Drawer Container -->
+        <div class="drawer-overlay">
+            
+            <!-- The Drawer Panel -->
+            <div class="drawer-panel">
+                
+                <div class="drawer-header">
+                    <h2><span class="blink">_</span> ACTIVE_CONNECTIONS</h2>
+                    <label for="drawer-toggle" class="close-btn">&times;</label>
+                </div>
+                
+                <div class="drawer-body">
+                    <p class="status-text">Scanning for local area network signatures...</p>
+                    
+                    <div class="node-list">
+                        <!-- Items that will blur-in sequentially -->
+                        <div class="node-item blur-enter" style="--delay: 1;">
+                            <span class="node-status status-up"></span>
+                            <span class="node-name">PROXY_01 [192.168.1.10]</span>
+                        </div>
+                        <div class="node-item blur-enter" style="--delay: 2;">
+                            <span class="node-status status-up"></span>
+                            <span class="node-name">PROXY_02 [192.168.1.11]</span>
+                        </div>
+                        <div class="node-item blur-enter" style="--delay: 3;">
+                            <span class="node-status status-down"></span>
+                            <span class="node-name">GATEWAY [OFFLINE]</span>
+                        </div>
+                        <div class="node-item blur-enter" style="--delay: 4;">
+                            <span class="node-status status-up"></span>
+                            <span class="node-name">DATA_VAULT [10.0.0.5]</span>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="drawer-footer">
+                    <label for="drawer-toggle" class="btn outline-btn">CLOSE</label>
+                    <button class="btn cyberpunk-btn-scan">RESCAN</button>
+                </div>
+                
+            </div>
+            
+        </div>
+        
+    </div>
+</body>
+</html>

--- a/submissions/examples/cyberpunk-blur-entrance-drawer/style.css
+++ b/submissions/examples/cyberpunk-blur-entrance-drawer/style.css
@@ -1,0 +1,313 @@
+@import url('https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap');
+
+:root {
+    --bg-color: #050505;
+    --drawer-bg: rgba(5, 5, 10, 0.95);
+    --text-main: #e0e0e0;
+    --neon-cyan: #0ff;
+    --neon-cyan-dim: rgba(0, 255, 255, 0.2);
+    --neon-pink: #f0f;
+    --neon-pink-dim: rgba(255, 0, 255, 0.2);
+    --neon-red: #ff003c;
+    --grid-color: rgba(255, 0, 255, 0.05);
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    background-image: 
+        linear-gradient(var(--grid-color) 1px, transparent 1px),
+        linear-gradient(90deg, var(--grid-color) 1px, transparent 1px);
+    background-size: 30px 30px;
+    font-family: 'Share Tech Mono', monospace;
+    color: var(--text-main);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    overflow: hidden; /* Prevents scroll when drawer opens */
+}
+
+.cyberpunk-layout {
+    text-align: center;
+}
+
+.neon-text {
+    font-size: 3rem;
+    color: var(--text-main);
+    text-shadow: 0 0 10px var(--neon-pink), 0 0 20px var(--neon-pink);
+    margin-bottom: 40px;
+    letter-spacing: 5px;
+}
+
+.btn {
+    display: inline-block;
+    padding: 12px 24px;
+    font-family: 'Share Tech Mono', monospace;
+    font-size: 1.1rem;
+    text-transform: uppercase;
+    cursor: pointer;
+    text-decoration: none;
+    transition: all 0.3s ease;
+    border: none;
+    outline: none;
+}
+
+.cyberpunk-btn {
+    background: transparent;
+    color: var(--neon-pink);
+    border: 1px solid var(--neon-pink);
+    box-shadow: inset 0 0 10px var(--neon-pink-dim), 0 0 15px var(--neon-pink-dim);
+    position: relative;
+    overflow: hidden;
+}
+
+.cyberpunk-btn::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: -100%;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(90deg, transparent, rgba(255, 0, 255, 0.4), transparent);
+    transition: all 0.4s ease;
+}
+
+.cyberpunk-btn:hover {
+    background: var(--neon-pink);
+    color: var(--bg-color);
+    box-shadow: 0 0 20px var(--neon-pink);
+}
+
+.cyberpunk-btn:hover::before {
+    left: 100%;
+}
+
+.cyberpunk-btn-scan {
+    background: var(--neon-cyan);
+    color: var(--bg-color);
+    border: 1px solid var(--neon-cyan);
+    box-shadow: 0 0 15px var(--neon-cyan-dim);
+}
+
+.cyberpunk-btn-scan:hover {
+    box-shadow: 0 0 25px var(--neon-cyan);
+}
+
+.outline-btn {
+    background: transparent;
+    color: var(--text-main);
+    border: 1px solid var(--text-main);
+}
+
+.outline-btn:hover {
+    background: rgba(255,255,255,0.1);
+}
+
+
+/* Drawer Checkbox Logic */
+.drawer-toggle {
+    display: none;
+}
+
+/* Drawer Overlay */
+.drawer-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.7);
+    z-index: 1000;
+    
+    /* Overlay Fade In */
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.4s ease, visibility 0.4s ease;
+}
+
+/* The Drawer Panel (Fixed on the left) */
+.drawer-panel {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 350px;
+    max-width: 90vw;
+    height: 100%;
+    background: var(--drawer-bg);
+    border-right: 2px solid var(--neon-pink);
+    box-shadow: 10px 0 30px var(--neon-pink-dim);
+    display: flex;
+    flex-direction: column;
+    
+    /* Blur Entrance State - Drawer */
+    opacity: 0;
+    filter: blur(20px);
+    transform: translateX(-50px);
+    transition: opacity 0.5s ease,
+                filter 0.5s ease,
+                transform 0.5s ease;
+}
+
+/* Activate Drawer via Checkbox */
+.drawer-toggle:checked ~ .drawer-overlay {
+    opacity: 1;
+    visibility: visible;
+}
+
+.drawer-toggle:checked ~ .drawer-overlay .drawer-panel {
+    /* Focus State */
+    opacity: 1;
+    filter: blur(0px);
+    transform: translateX(0);
+}
+
+
+/* Drawer Inner Elements */
+.drawer-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background: rgba(255, 0, 255, 0.1);
+    color: var(--neon-pink);
+    padding: 20px;
+    border-bottom: 1px solid var(--neon-pink-dim);
+}
+
+.drawer-header h2 {
+    margin: 0;
+    font-size: 1.2rem;
+    letter-spacing: 2px;
+}
+
+.close-btn {
+    font-size: 2rem;
+    line-height: 1;
+    cursor: pointer;
+    font-weight: bold;
+    transition: text-shadow 0.2s ease;
+}
+
+.close-btn:hover {
+    text-shadow: 0 0 10px var(--neon-pink);
+}
+
+.drawer-body {
+    padding: 30px 20px;
+    text-align: left;
+    flex-grow: 1;
+    overflow-y: auto;
+}
+
+.status-text {
+    font-size: 1rem;
+    margin: 0 0 30px 0;
+    color: var(--text-main);
+    line-height: 1.5;
+}
+
+
+/* Inner Sequential Blur Logic */
+.node-list {
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+}
+
+.node-item {
+    display: flex;
+    align-items: center;
+    padding: 15px;
+    background: rgba(255, 0, 255, 0.05);
+    border: 1px solid var(--neon-pink-dim);
+}
+
+.node-name {
+    font-size: 0.9rem;
+    color: var(--text-main);
+}
+
+.node-status {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    margin-right: 15px;
+}
+
+.status-up {
+    background-color: var(--neon-cyan);
+    box-shadow: 0 0 8px var(--neon-cyan);
+}
+
+.status-down {
+    background-color: var(--neon-red);
+    box-shadow: 0 0 8px var(--neon-red);
+}
+
+/* Inner Blur Transition */
+.blur-enter {
+    opacity: 0;
+    filter: blur(10px);
+    transform: translateY(10px);
+    transition: opacity 0.4s ease, filter 0.4s ease, transform 0.4s ease;
+    /* Use the inline --delay CSS variable, calc against a base time */
+    transition-delay: calc(var(--delay) * 0.1s);
+}
+
+/* Trigger Inner Blur when drawer opens */
+.drawer-toggle:checked ~ .drawer-overlay .blur-enter {
+    opacity: 1;
+    filter: blur(0px);
+    transform: translateY(0);
+}
+
+
+.drawer-footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 15px;
+    padding: 20px;
+    border-top: 1px solid var(--neon-pink-dim);
+}
+
+
+/* Blinking Cursor */
+.blink {
+    animation: blinker 1s linear infinite;
+}
+
+@keyframes blinker {
+    50% { opacity: 0; }
+}
+
+
+@media (prefers-reduced-motion: reduce) {
+    .drawer-overlay, .drawer-panel, .blur-enter {
+        transition: none !important;
+        transition-delay: 0s !important;
+    }
+    .drawer-panel {
+        transform: translateX(0) !important;
+        filter: blur(0px) !important;
+        display: none; /* Hide via display instead of transform/opacity/blur */
+    }
+    .drawer-toggle:checked ~ .drawer-overlay .drawer-panel {
+        display: flex;
+        opacity: 1;
+    }
+    
+    .blur-enter {
+        opacity: 1 !important;
+        filter: blur(0px) !important;
+        transform: translateY(0) !important;
+    }
+    
+    .blink {
+        animation: none !important;
+    }
+    
+    .cyberpunk-btn::before {
+        display: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces the CSS Blur-Entrance Drawer designed for Cyberpunk Neon Layouts, resolving issue #64737. 

### Changes Made:
- Added `submissions/examples/cyberpunk-blur-entrance-drawer/` directory.
- Created `demo.html` showcasing a side-drawer structure, activated entirely via the CSS checkbox hack for state management without JS. The layout acts as a network node scanner interface.
- Created `style.css` featuring an immersive cyberpunk aesthetic (grid backgrounds, pink/cyan neon glows, and monospace fonts). The primary animation utilizes a cinematic `filter: blur()` paired with `opacity` and `transform` to simulate pulling the drawer into focus.
- Implemented a custom inline CSS variable (`--delay`) strategy on the child node list items to stagger their own individual blur-in entrances sequentially after the drawer opens.
- Added `README.md` documenting usage and features.
- Fully responsive layout that adapts gracefully from desktop to mobile.
- Honors the `prefers-reduced-motion` accessibility standard.

Closes #64737
