### PR TITLE
feat: Add CSS Skew-Active Tabs for Cyberpunk Neon Layouts (#64683)

### DIFF
--- a/submissions/examples/skew-active-tabs-cyberpunk-neon-64683/README.md
+++ b/submissions/examples/skew-active-tabs-cyberpunk-neon-64683/README.md
@@ -1,0 +1,24 @@
+# Skew-Active Tabs for Cyberpunk Neon Layouts
+
+A pure CSS implementation of cyberpunk-themed tabs featuring a skewed geometry, glowing neon borders, and dynamic fill animations on active states.
+
+## Usage
+
+```html
+<div class="ease-skew-tabs-cyberpunk" role="tablist">
+    <button class="ease-skew-tab active" role="tab" aria-selected="true">
+        <span>System</span>
+    </button>
+    <button class="ease-skew-tab" role="tab" aria-selected="false">
+        <span>Network</span>
+    </button>
+</div>
+```
+
+## Features
+
+- **Cyberpunk Aesthetic:** High-contrast neon colors on dark backgrounds with glowing shadows.
+- **Skewed Geometry:** Built using `transform: skewX()` for a sharp, angular futuristic look, while keeping the text un-skewed.
+- **Smooth Transitions:** Hover and active states feature cubic-bezier timing for the background fill and box-shadow enhancements.
+- **Accessibility:** Includes `prefers-reduced-motion` support to disable transitions.
+- **Responsiveness:** Automatically falls back to a stacked column layout on smaller viewports.

--- a/submissions/examples/skew-active-tabs-cyberpunk-neon-64683/demo.html
+++ b/submissions/examples/skew-active-tabs-cyberpunk-neon-64683/demo.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Skew-Active Tabs - Cyberpunk Neon Layouts</title>
+    <link rel="stylesheet" href="style.css">
+    <style>
+        body {
+            background-color: #050505;
+            color: #fff;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+            margin: 0;
+            font-family: sans-serif;
+        }
+        .container {
+            width: 100%;
+            max-width: 600px;
+            padding: 2rem;
+        }
+    </style>
+</head>
+<body>
+
+<div class="container">
+    <div class="ease-skew-tabs-cyberpunk" role="tablist" aria-label="Cyberpunk Neon Tabs">
+        <button class="ease-skew-tab active" role="tab" aria-selected="true">
+            <span>System</span>
+        </button>
+        <button class="ease-skew-tab" role="tab" aria-selected="false">
+            <span>Network</span>
+        </button>
+        <button class="ease-skew-tab" role="tab" aria-selected="false">
+            <span>Firewall</span>
+        </button>
+    </div>
+</div>
+
+<script>
+    const tabs = document.querySelectorAll('.ease-skew-tab');
+    tabs.forEach(tab => {
+        tab.addEventListener('click', () => {
+            tabs.forEach(t => {
+                t.classList.remove('active');
+                t.setAttribute('aria-selected', 'false');
+            });
+            tab.classList.add('active');
+            tab.setAttribute('aria-selected', 'true');
+        });
+    });
+</script>
+
+</body>
+</html>

--- a/submissions/examples/skew-active-tabs-cyberpunk-neon-64683/style.css
+++ b/submissions/examples/skew-active-tabs-cyberpunk-neon-64683/style.css
@@ -1,0 +1,82 @@
+/* Skew-Active Tabs for Cyberpunk Neon Layouts */
+
+.ease-skew-tabs-cyberpunk {
+  display: flex;
+  gap: 1rem;
+  padding: 1rem;
+  background: #0d0d12;
+  border-radius: 8px;
+}
+
+.ease-skew-tab {
+  position: relative;
+  padding: 0.75rem 2rem;
+  background: transparent;
+  color: #00ffcc;
+  border: 1px solid #00ffcc;
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 1rem;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  cursor: pointer;
+  outline: none;
+  transform: skewX(-15deg);
+  transition: all 0.3s ease;
+  overflow: hidden;
+  box-shadow: 0 0 5px rgba(0, 255, 204, 0.2);
+}
+
+.ease-skew-tab span {
+  display: inline-block;
+  transform: skewX(15deg); /* Counter skew for text */
+  position: relative;
+  z-index: 2;
+}
+
+.ease-skew-tab::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 100%;
+  height: 100%;
+  background: #00ffcc;
+  transition: left 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
+  z-index: 1;
+}
+
+.ease-skew-tab:hover {
+  box-shadow: 0 0 15px rgba(0, 255, 204, 0.6), inset 0 0 10px rgba(0, 255, 204, 0.4);
+  text-shadow: 0 0 8px rgba(0, 255, 204, 0.8);
+}
+
+.ease-skew-tab.active {
+  color: #0d0d12;
+  box-shadow: 0 0 20px rgba(0, 255, 204, 0.8), 0 0 40px rgba(0, 255, 204, 0.4);
+}
+
+.ease-skew-tab.active::before {
+  left: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-skew-tab,
+  .ease-skew-tab::before {
+    transition: none;
+  }
+}
+
+@media (max-width: 600px) {
+  .ease-skew-tabs-cyberpunk {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .ease-skew-tab {
+    text-align: center;
+    transform: skewX(0); /* Remove skew on mobile to save horizontal space */
+  }
+  .ease-skew-tab span {
+    transform: skewX(0);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR implements a pure CSS Skew-Active Tab layout designed for Cyberpunk and Neon themes. It solves the need for futuristic, angular tab navigation that relies entirely on CSS transformations (`skewX`), eliminating the need for complex SVGs or JavaScript. It addresses issue #64683.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A pure CSS set of cyberpunk-styled tabs featuring skewed geometry (`transform: skewX`), glowing neon borders, and smooth sliding background fills on active/hover states.

**How does a developer use it?**

```html
<div class="ease-skew-tabs-cyberpunk" role="tablist">
    <button class="ease-skew-tab active" role="tab" aria-selected="true">
        <span>System</span>
    </button>
    <button class="ease-skew-tab" role="tab" aria-selected="false">
        <span>Network</span>
    </button>
</div>
