### PR TITLE
Add ease-flight-board-flip component

### DIFF
--- a/submissions/examples/flight-board-flip-ij/README.md
+++ b/submissions/examples/flight-board-flip-ij/README.md
@@ -1,0 +1,10 @@
+# ease-flight-board-flip
+
+A departures board where flight codes and times flip over, boarding statuses blink, and the last call flashes beneath.
+
+## Run
+Open `demo.html` directly in a browser to watch the codes flip.
+
+## Notes
+- Codes and times flip in place.
+- Status labels blink per row.

--- a/submissions/examples/flight-board-flip-ij/demo.html
+++ b/submissions/examples/flight-board-flip-ij/demo.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-flight-board-flip demo</title>
+</head>
+<body>
+<div class="fb-app">
+  <span class="fb-title">DEPARTURES</span>
+  <div class="fb-board">
+    <div class="fb-row">
+      <span class="fb-code">AC101</span>
+      <span class="fb-city">TORONTO</span>
+      <span class="fb-time">14:05</span>
+      <span class="fb-status fb-on">ON TIME</span>
+    </div>
+    <div class="fb-row">
+      <span class="fb-code">BA284</span>
+      <span class="fb-city">LONDON</span>
+      <span class="fb-time">14:20</span>
+      <span class="fb-status fb-boarding">BOARDING</span>
+    </div>
+    <div class="fb-row">
+      <span class="fb-code">QF456</span>
+      <span class="fb-city">SYDNEY</span>
+      <span class="fb-time">14:35</span>
+      <span class="fb-status fb-delay">DELAYED</span>
+    </div>
+  </div>
+  <span class="fb-flash">LAST CALL</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/flight-board-flip-ij/style.css
+++ b/submissions/examples/flight-board-flip-ij/style.css
@@ -1,0 +1,19 @@
+:root{--fb-yellow:#ffd23f;--fb-dark:#0a0a05}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#1a1a0c,#0a0a05);font-family:'Courier New',monospace}
+.fb-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#131309,#070704);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.fb-title{position:absolute;top:16px;left:0;right:0;text-align:center;font-size:12px;font-weight:800;letter-spacing:7px;color:#ffd23f}
+.fb-board{position:absolute;top:58px;left:28px;right:28px;border-radius:12px;background:#0a0a05;box-shadow:inset 0 0 0 3px #2a2a12;display:flex;flex-direction:column;padding:10px}
+.fb-row{display:grid;grid-template-columns:64px 1fr 56px 76px;gap:8px;align-items:center;padding:10px 6px;border-bottom:1px solid #1c1c0c}
+.fb-row:last-child{border-bottom:none}
+.fb-code{font-size:13px;font-weight:900;color:#ffd23f;animation:flip-code-flight-board-flip 3s steps(1) infinite}
+.fb-city{font-size:12px;font-weight:800;color:#e8e6c8;letter-spacing:1px}
+.fb-time{font-size:13px;font-weight:900;color:#c8c89c;font-variant-numeric:tabular-nums;animation:flip-time-flight-board-flip 3s steps(1) infinite}
+.fb-status{font-size:9px;font-weight:800;letter-spacing:1px;text-align:right}
+.fb-on{color:#35d968}
+.fb-boarding{color:#ffd23f;animation:status-blink-flight-board-flip 1s steps(1) infinite}
+.fb-delay{color:#ff5b5b;animation:status-blink-flight-board-flip 1.2s steps(1) infinite}
+.fb-flash{position:absolute;bottom:16px;left:0;right:0;text-align:center;font-size:11px;font-weight:800;letter-spacing:5px;color:#ffd23f;animation:flash-blink-flight-board-flip 1.4s steps(1) infinite}
+@keyframes flip-code-flight-board-flip{0%,14%{transform:rotateX(0deg)}20%{transform:rotateX(90deg)}26%,100%{transform:rotateX(0deg)}}
+@keyframes flip-time-flight-board-flip{0%,44%{transform:rotateX(0deg)}50%{transform:rotateX(90deg)}56%,100%{transform:rotateX(0deg)}}
+@keyframes status-blink-flight-board-flip{0%,49%{opacity:1}50%,100%{opacity:0.2}}
+@keyframes flash-blink-flight-board-flip{0%,49%{opacity:1}50%,100%{opacity:0.3}}


### PR DESCRIPTION
## Component: ease-flight-board-flip — codes flip, times flip, and statuses blink

**Closes #65326**

### What this adds
A departures board: flight codes and times flip over in place, boarding and delay statuses blink per row, and the last call flashes below.

### Acceptance Criteria covered
- Flight codes flip in place
- Times flip over in sync
- Status labels blink per row

### Files
- `submissions/examples/flight-board-flip-ij/demo.html`
- `submissions/examples/flight-board-flip-ij/style.css`
- `submissions/examples/flight-board-flip-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the codes flip.