### PR TITLE
feat: add CSS Zoom-In Accordion for Minimalist Tech Layouts (#64551)

### DIFF
--- a/submissions/examples/minimalist-zoom-in-accordion/README.md
+++ b/submissions/examples/minimalist-zoom-in-accordion/README.md
@@ -1,0 +1,20 @@
+# CSS Zoom-In Accordion (Minimalist Tech)
+
+A pure CSS accordion component designed for Minimalist Tech Layouts. It utilizes the radio button hack for state management (allowing only one section to be open at a time). When activated, the inner content performs a distinct "Zoom-In" entrance animation, scaling up smoothly from 90% to 100%.
+
+## Features
+- Pure CSS and HTML (No JavaScript required).
+- State management handled completely via hidden `<input type="radio">` buttons and the `~` general sibling selector, enabling standard accordion behavior.
+- Clean, data-focused aesthetic designed for dashboards and metric displays.
+- The accordion header features a custom pure CSS `+` to `-` morphing indicator (built using `::before` and `::after` pseudo-elements).
+- Content expands via a `max-height` transition on the wrapper, followed by a slightly delayed `transform: scale()` and `opacity` transition on the `.zoom-in-element` content block, creating a satisfying pop-in effect.
+- Active panels gain a subtle indigo border highlight and shadow.
+- Fully responsive layout.
+- Fully accessible with `prefers-reduced-motion` support ensuring degraded, safe static layouts for users sensitive to motion.
+
+## Usage
+Open `demo.html` in your browser. Click any of the accordion headers. The `+` indicator will morph into a `-`, the accordion will open, and the inner content will rapidly scale up (zoom-in) into place. Selecting another item will automatically close the currently active one.
+
+## Files
+- `demo.html`: The HTML structure for the accordion, utilizing hidden radio buttons for mutually exclusive state management, and nested content blocks for the zoom effect.
+- `style.css`: The styling, flexbox layouts, and CSS `transition` logic for the zoom-in content effects and the morphing indicator.

--- a/submissions/examples/minimalist-zoom-in-accordion/demo.html
+++ b/submissions/examples/minimalist-zoom-in-accordion/demo.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Zoom-In Accordion - Minimalist Tech</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">System Metrics</h1>
+            <p class="subtitle">Expand panels to view detailed analytics.</p>
+        </header>
+
+        <div class="accordion-container">
+            
+            <!-- Accordion Item 1 -->
+            <div class="accordion-item">
+                <input type="radio" name="accordion-group" id="acc-1" class="accordion-toggle">
+                <label for="acc-1" class="accordion-header">
+                    <div class="header-left">
+                        <span class="header-icon">
+                            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20v-6M6 20V10M18 20V4"></path></svg>
+                        </span>
+                        <span class="header-text">Compute Resources</span>
+                    </div>
+                    <span class="header-indicator"></span>
+                </label>
+                <div class="accordion-content">
+                    <div class="content-inner zoom-in-element">
+                        <p>Current CPU utilization is averaging 42% across all clusters. Peak loads identified in the EU-West region during batch processing cycles.</p>
+                        <div class="metric-grid">
+                            <div class="metric-box">
+                                <span class="metric-value">42%</span>
+                                <span class="metric-label">Avg Load</span>
+                            </div>
+                            <div class="metric-box">
+                                <span class="metric-value">128</span>
+                                <span class="metric-label">Active Nodes</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Accordion Item 2 -->
+            <div class="accordion-item">
+                <input type="radio" name="accordion-group" id="acc-2" class="accordion-toggle" checked>
+                <label for="acc-2" class="accordion-header">
+                    <div class="header-left">
+                        <span class="header-icon">
+                            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="5" rx="9" ry="3"></ellipse><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"></path><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"></path></svg>
+                        </span>
+                        <span class="header-text">Storage Capacity</span>
+                    </div>
+                    <span class="header-indicator"></span>
+                </label>
+                <div class="accordion-content">
+                    <div class="content-inner zoom-in-element">
+                        <p>Primary SSD arrays are at 78% capacity. Automated archival to cold storage is scheduled to begin within 48 hours to free up immediate IOPS headroom.</p>
+                        <div class="progress-bar">
+                            <div class="progress-fill" style="width: 78%;"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Accordion Item 3 -->
+            <div class="accordion-item">
+                <input type="radio" name="accordion-group" id="acc-3" class="accordion-toggle">
+                <label for="acc-3" class="accordion-header">
+                    <div class="header-left">
+                        <span class="header-icon">
+                            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4"></path></svg>
+                        </span>
+                        <span class="header-text">Network Latency</span>
+                    </div>
+                    <span class="header-indicator"></span>
+                </label>
+                <div class="accordion-content">
+                    <div class="content-inner zoom-in-element">
+                        <p>Global packet routing remains stable. Minor latency spikes detected originating from the APAC edge nodes, currently under investigation by infrastructure teams.</p>
+                        <button class="btn-outline">View Trace Logs</button>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+        
+    </div>
+</body>
+</html>

--- a/submissions/examples/minimalist-zoom-in-accordion/style.css
+++ b/submissions/examples/minimalist-zoom-in-accordion/style.css
@@ -1,0 +1,287 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+:root {
+    --bg-color: #f3f4f6;
+    --card-bg: #ffffff;
+    --text-primary: #111827;
+    --text-secondary: #6b7280;
+    --accent-color: #4f46e5;
+    --accent-light: #e0e7ff;
+    --border-color: #e5e7eb;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    font-family: 'Inter', system-ui, -apple-system, sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 40px 20px;
+    box-sizing: border-box;
+}
+
+.layout-container {
+    max-width: 600px;
+    width: 100%;
+}
+
+.section-header {
+    margin-bottom: 32px;
+}
+
+.title {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin: 0 0 8px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+    margin: 0;
+    font-weight: 400;
+}
+
+/* Accordion Container */
+.accordion-container {
+    display: flex;
+    flex-direction: column;
+    gap: 16px; /* Space between cards */
+}
+
+.accordion-item {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+    transition: box-shadow 0.3s ease, border-color 0.3s ease;
+}
+
+.accordion-item:hover {
+    box-shadow: 0 4px 15px rgba(0,0,0,0.05);
+}
+
+/* Checkbox Logic */
+.accordion-toggle {
+    display: none;
+}
+
+/* Accordion Header */
+.accordion-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 20px 24px;
+    cursor: pointer;
+    background-color: transparent;
+    user-select: none;
+    border-radius: 12px;
+}
+
+.header-left {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+}
+
+.header-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-secondary);
+    background: #f3f4f6;
+    width: 36px;
+    height: 36px;
+    border-radius: 8px;
+    transition: all 0.3s ease;
+}
+
+.header-text {
+    font-weight: 500;
+    font-size: 1rem;
+    color: var(--text-primary);
+}
+
+/* Custom +/- Indicator */
+.header-indicator {
+    position: relative;
+    width: 20px;
+    height: 20px;
+}
+
+.header-indicator::before,
+.header-indicator::after {
+    content: '';
+    position: absolute;
+    background-color: var(--text-secondary);
+    transition: transform 0.4s cubic-bezier(0.16, 1, 0.3, 1), background-color 0.3s ease;
+}
+
+/* Horizontal line (-) */
+.header-indicator::before {
+    top: 50%;
+    left: 0;
+    width: 100%;
+    height: 2px;
+    margin-top: -1px;
+}
+
+/* Vertical line (|) to make it a (+) */
+.header-indicator::after {
+    top: 0;
+    left: 50%;
+    width: 2px;
+    height: 100%;
+    margin-left: -1px;
+}
+
+
+/* Active State Styles */
+.accordion-toggle:checked ~ .accordion-item {
+    border-color: var(--accent-light);
+    box-shadow: 0 4px 20px rgba(79, 70, 229, 0.1);
+}
+
+.accordion-toggle:checked ~ .accordion-header .header-icon {
+    background: var(--accent-light);
+    color: var(--accent-color);
+}
+
+/* Morph the (+) into a (-) by scaling the vertical line to 0 */
+.accordion-toggle:checked ~ .accordion-header .header-indicator::after {
+    transform: scaleY(0);
+}
+
+.accordion-toggle:checked ~ .accordion-header .header-indicator::before,
+.accordion-toggle:checked ~ .accordion-header .header-indicator::after {
+    background-color: var(--accent-color);
+}
+
+
+/* Accordion Content Container */
+.accordion-content {
+    max-height: 0;
+    overflow: hidden;
+    /* We don't transition opacity here, we do it on the inner element */
+    transition: max-height 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* Reveal Content Wrapper */
+.accordion-toggle:checked ~ .accordion-content {
+    max-height: 500px; 
+}
+
+/* The Zoom-In Element (Inner Content) */
+.zoom-in-element {
+    padding: 0 24px 24px 24px;
+    color: var(--text-secondary);
+    line-height: 1.6;
+    font-size: 0.95rem;
+    
+    /* Zoom-In Initial State */
+    opacity: 0;
+    transform: scale(0.9);
+    transition: transform 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275),
+                opacity 0.4s ease;
+}
+
+/* Trigger the Zoom-In when active */
+.accordion-toggle:checked ~ .accordion-content .zoom-in-element {
+    opacity: 1;
+    transform: scale(1);
+    /* Slight delay so the max-height has time to open space first */
+    transition-delay: 0.1s; 
+}
+
+
+/* UI Details inside content */
+.metric-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+    margin-top: 20px;
+}
+
+.metric-box {
+    background: #f9fafb;
+    border: 1px solid var(--border-color);
+    padding: 16px;
+    border-radius: 8px;
+    display: flex;
+    flex-direction: column;
+}
+
+.metric-value {
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.metric-label {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-top: 4px;
+}
+
+.progress-bar {
+    width: 100%;
+    height: 8px;
+    background: #f3f4f6;
+    border-radius: 4px;
+    margin-top: 20px;
+    overflow: hidden;
+}
+
+.progress-fill {
+    height: 100%;
+    background: var(--accent-color);
+    border-radius: 4px;
+}
+
+.btn-outline {
+    margin-top: 20px;
+    background: transparent;
+    border: 1px solid var(--border-color);
+    padding: 8px 16px;
+    border-radius: 6px;
+    font-family: inherit;
+    font-size: 0.9rem;
+    font-weight: 500;
+    color: var(--text-primary);
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.btn-outline:hover {
+    border-color: var(--accent-color);
+    color: var(--accent-color);
+}
+
+
+@media (max-width: 480px) {
+    .accordion-header {
+        padding: 16px;
+    }
+    .header-text {
+        font-size: 0.95rem;
+    }
+    .zoom-in-element {
+        padding: 0 16px 20px 16px;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .accordion-content, .zoom-in-element, .header-indicator::before, .header-indicator::after {
+        transition: none !important;
+        transition-delay: 0s !important;
+    }
+    .zoom-in-element {
+        transform: scale(1) !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces the CSS Zoom-In Accordion designed for Minimalist Tech Layouts, resolving issue #64551. 

### Changes Made:
- Added `submissions/examples/minimalist-zoom-in-accordion/` directory.
- Created `demo.html` showcasing a system metrics dashboard layout, activated entirely via the CSS radio-button hack for mutually exclusive state management without JS. 
- Created `style.css` featuring a clean, data-focused aesthetic. The accordion features a pure CSS `+` to `-` morphing icon built using pseudo-elements. When activated, the inner content block undergoes a snappy `transform: scale()` zoom-in animation paired with an opacity fade.
- Added `README.md` documenting usage and features.
- Fully responsive layout that adapts gracefully from desktop to mobile.
- Honors the `prefers-reduced-motion` accessibility standard.

Closes #64551
