### PR TITLE
Add ease-parking-lot-finder component

### DIFF
--- a/submissions/examples/parking-lot-finder-ij/README.md
+++ b/submissions/examples/parking-lot-finder-ij/README.md
@@ -1,0 +1,10 @@
+# ease-parking-lot-finder
+
+A parking map where available spots glow, the open counter blinks, and reserved slots stay amber on the grid.
+
+## Run
+Open `demo.html` directly in a browser to watch the hot spots pulse.
+
+## Notes
+- Hot open spots pulse in the grid.
+- The open count blinks beneath.

--- a/submissions/examples/parking-lot-finder-ij/demo.html
+++ b/submissions/examples/parking-lot-finder-ij/demo.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-parking-lot-finder demo</title>
+</head>
+<body>
+<div class="pl-app">
+  <span class="pl-title">PARK FINDER</span>
+  <div class="pl-lot">
+    <span class="pl-spot pl-free">A1</span>
+    <span class="pl-spot pl-used">A2</span>
+    <span class="pl-spot pl-free">A3</span>
+    <span class="pl-spot pl-hot">A4</span>
+    <span class="pl-spot pl-used">B1</span>
+    <span class="pl-spot pl-res">B2</span>
+    <span class="pl-spot pl-free">B3</span>
+    <span class="pl-spot pl-used">B4</span>
+    <span class="pl-spot pl-hot">C1</span>
+    <span class="pl-spot pl-used">C2</span>
+    <span class="pl-spot pl-free">C3</span>
+    <span class="pl-spot pl-free">C4</span>
+  </div>
+  <span class="pl-open">12 SPOTS OPEN</span>
+  <span class="pl-legend">FREE RESERVED OCCUPIED</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/parking-lot-finder-ij/style.css
+++ b/submissions/examples/parking-lot-finder-ij/style.css
@@ -1,0 +1,14 @@
+:root{--pl-green:#5ef07a;--pl-dark:#08120a}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#0f2414,#08120a);font-family:'Segoe UI',sans-serif}
+.pl-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#0b1c10,#050c07);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.pl-title{position:absolute;top:16px;left:0;right:0;text-align:center;font-size:12px;font-weight:800;letter-spacing:7px;color:#5ef07a}
+.pl-lot{position:absolute;top:58px;left:32px;right:32px;height:216px;border-radius:14px;background:#0a1810;box-shadow:inset 0 0 0 3px #16301e;display:grid;grid-template-columns:repeat(3,1fr);gap:10px;padding:14px}
+.pl-spot{display:flex;align-items:center;justify-content:center;border-radius:8px;font-size:11px;font-weight:800}
+.pl-free{background:#0e2416;color:#5ef07a;box-shadow:inset 0 0 0 2px #1c4426}
+.pl-used{background:#12241a;color:#3a5842;box-shadow:inset 0 0 0 2px #1a3422;text-decoration:line-through}
+.pl-res{background:#231d08;color:#c8a64a;box-shadow:inset 0 0 0 2px #3a3a14}
+.pl-hot{background:#5ef07a;color:#08120a;box-shadow:0 0 16px rgba(94,240,122,0.6);animation:hot-pulse-parking-lot-finder 1.3s ease-in-out infinite}
+.pl-open{position:absolute;top:292px;left:0;right:0;text-align:center;font-size:15px;font-weight:900;color:#e8ffe9;letter-spacing:2px;animation:open-blink-parking-lot-finder 1.6s steps(1) infinite}
+.pl-legend{position:absolute;bottom:16px;left:0;right:0;text-align:center;font-size:9px;font-weight:800;letter-spacing:2px;color:#3a5842}
+@keyframes hot-pulse-parking-lot-finder{0%,100%{transform:scale(1)}50%{transform:scale(1.12)}}
+@keyframes open-blink-parking-lot-finder{0%,49%{opacity:1}50%,100%{opacity:0.35}}


### PR DESCRIPTION
## Component: ease-parking-lot-finder — spots glow, counter blinks, and grid stays

**Closes #65292**

### What this adds
A parking map: hot available spots glow on the grid, the open counter blinks above, and the legend stays readable below.

### Acceptance Criteria covered
- Hot open spots glow on the grid
- Open counter blinks above
- Legend stays readable below

### Files
- `submissions/examples/parking-lot-finder-ij/demo.html`
- `submissions/examples/parking-lot-finder-ij/style.css`
- `submissions/examples/parking-lot-finder-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the hot spots pulse.