### PR TITLE
Add ease-radio-frequency-dial component

### DIFF
--- a/submissions/examples/radio-frequency-dial-ij/README.md
+++ b/submissions/examples/radio-frequency-dial-ij/README.md
@@ -1,0 +1,10 @@
+# ease-radio-frequency-dial
+
+An FM tuner whose needle sweeps across the band, the tuning knob turns with it, and the station readout blinks below.
+
+## Run
+Open `demo.html` directly in a browser to watch the needle sweep.
+
+## Notes
+- The needle swings across the dial.
+- The knob turns in the same rhythm.

--- a/submissions/examples/radio-frequency-dial-ij/demo.html
+++ b/submissions/examples/radio-frequency-dial-ij/demo.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-radio-frequency-dial demo</title>
+</head>
+<body>
+<div class="rf-app">
+  <span class="rf-title">FM TUNER</span>
+  <div class="rf-radio">
+    <div class="rf-scale">
+      <span class="rf-freq">88</span>
+      <span class="rf-freq">92</span>
+      <span class="rf-freq">96</span>
+      <span class="rf-freq">100</span>
+      <span class="rf-freq">104</span>
+      <span class="rf-freq">108</span>
+    </div>
+    <div class="rf-ticks">
+      <span class="rf-tick"></span>
+      <span class="rf-tick-2"></span>
+      <span class="rf-tick"></span>
+      <span class="rf-tick-2"></span>
+      <span class="rf-tick"></span>
+      <span class="rf-tick-2"></span>
+      <span class="rf-tick"></span>
+      <span class="rf-tick-2"></span>
+      <span class="rf-tick"></span>
+    </div>
+    <span class="rf-needle"></span>
+  </div>
+  <span class="rf-station">103.7</span>
+  <span class="rf-band">STEREO</span>
+  <div class="rf-dial">
+    <span class="rf-knob"></span>
+  </div>
+  <span class="rf-knob-label">TUNING</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/radio-frequency-dial-ij/style.css
+++ b/submissions/examples/radio-frequency-dial-ij/style.css
@@ -1,0 +1,19 @@
+:root{--rf-amber:#ffb347;--rf-dark:#140c04}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#241a0a,#140c04);font-family:'Courier New',monospace}
+.rf-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#1e160a,#100a03);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.rf-title{position:absolute;top:16px;left:0;right:0;text-align:center;font-size:12px;font-weight:800;letter-spacing:7px;color:#ffb347}
+.rf-radio{position:absolute;top:60px;left:34px;right:34px;height:170px;border-radius:14px;background:#1a1308;box-shadow:inset 0 0 0 3px #33260e;overflow:hidden}
+.rf-scale{position:absolute;top:26px;left:0;right:0;display:flex;justify-content:space-between;padding:0 16px;font-size:12px;font-weight:800;color:#c99b54}
+.rf-ticks{position:absolute;top:50px;left:0;right:0;display:flex;justify-content:space-between;padding:0 30px}
+.rf-tick{width:2px;height:12px;background:#4a3a1a}
+.rf-tick-2{width:2px;height:8px;background:#3a2e14}
+.rf-needle{position:absolute;top:34px;left:50%;margin-left:-2px;width:4px;height:120px;background:linear-gradient(180deg,#ff6a2e,#c93a10);box-shadow:0 0 10px rgba(255,106,46,0.7);transform-origin:bottom center;animation:needle-sweep-radio-frequency-dial 5s ease-in-out infinite}
+.rf-station{position:absolute;top:248px;left:0;right:0;text-align:center;font-size:26px;font-weight:900;color:#ffe3b3;font-variant-numeric:tabular-nums;animation:station-blink-radio-frequency-dial 2s steps(1) infinite}
+.rf-band{position:absolute;top:282px;left:0;right:0;text-align:center;font-size:10px;font-weight:800;letter-spacing:4px;color:#c99b54}
+.rf-dial{position:absolute;bottom:34px;left:0;right:0;display:flex;justify-content:center}
+.rf-knob{width:46px;height:46px;border-radius:50%;background:radial-gradient(circle at 35% 35%,#5a4518,#241a08);box-shadow:inset 0 0 0 4px #3a2e14;position:relative;animation:knob-turn-radio-frequency-dial 5s ease-in-out infinite}
+.rf-knob::after{content:'';position:absolute;top:5px;left:50%;margin-left:-2px;width:4px;height:14px;border-radius:2px;background:#ffb347}
+.rf-knob-label{position:absolute;bottom:10px;left:0;right:0;text-align:center;font-size:9px;font-weight:800;letter-spacing:3px;color:#8a6a34}
+@keyframes needle-sweep-radio-frequency-dial{0%{transform:rotate(-34deg)}50%{transform:rotate(34deg)}100%{transform:rotate(-34deg)}}
+@keyframes knob-turn-radio-frequency-dial{0%{transform:rotate(0deg)}50%{transform:rotate(60deg)}100%{transform:rotate(0deg)}}
+@keyframes station-blink-radio-frequency-dial{0%,49%{opacity:1}50%,100%{opacity:0.4}}


### PR DESCRIPTION
## Component: ease-radio-frequency-dial — needle sweeps, knob turns, and station blinks

**Closes #65300**

### What this adds
An FM tuner: the needle sweeps across the band, the tuning knob turns with it, and the station readout blinks below the dial.

### Acceptance Criteria covered
- Needle sweeps across the band
- Tuning knob turns in rhythm
- Station readout blinks below

### Files
- `submissions/examples/radio-frequency-dial-ij/demo.html`
- `submissions/examples/radio-frequency-dial-ij/style.css`
- `submissions/examples/radio-frequency-dial-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the needle sweep.