### PR TITLE
feat: add holographic glassmorphism 3d card deck showcase

### DIFF
--- a/submissions/examples/holographic-glass-3d-deck-bb/README.md
+++ b/submissions/examples/holographic-glass-3d-deck-bb/README.md
@@ -1,0 +1,14 @@
+# Holographic Glassmorphism 3D Card Deck (EaseMotion CSS)
+
+An interactive 3D perspective card deck component featuring glassmorphism, prismatic holographic sheen, and dynamic hover fan-out depth transitions created purely with HTML5 and CSS3.
+
+## 1. What does this do?
+This component renders three stacked glassmorphic cards angled in 3D space (`perspective: 1200px` and `transform-style: preserve-3d`). On hover, the deck fans out into a staggered layout while a prismatic rainbow sheen sweeps across the holographic layer via CSS linear gradients and `color-dodge` blend modes.
+
+## 2. How is it used?
+Link `style.css` in your HTML document and structure your cards using the `.card-deck` and `.glass-card` classes as shown in `demo.html`.
+
+## 3. Why is it useful?
+- **High Visual Impact**: Elevates landing pages, feature showcases, pricing tables, or portfolio cards with modern Web3/SaaS aesthetics.
+- **Pure CSS Performance**: Hardware-accelerated transitions via `transform` and `opacity` ensure smooth 60fps rendering without reliance on JavaScript libraries.
+- **Fully Responsive**: Scalable for desktop and mobile viewports alike.

--- a/submissions/examples/holographic-glass-3d-deck-bb/demo.html
+++ b/submissions/examples/holographic-glass-3d-deck-bb/demo.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Holographic Glassmorphism 3D Card Deck - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;600;800&display=swap" rel="stylesheet">
+</head>
+<body>
+  <div class="deck-wrapper">
+    <header class="deck-header">
+      <span class="badge">GSSoC 2026 Interactive Showcase</span>
+      <h1 class="title">Holographic 3D Glass Deck</h1>
+      <p class="subtitle">Hover over the stacked glass cards to trigger perspective tilt and prismatic spectral sheen</p>
+    </header>
+
+    <div class="card-deck">
+      <!-- Card 1 -->
+      <div class="glass-card card-top">
+        <div class="holographic-overlay"></div>
+        <div class="card-content">
+          <div class="card-chip">CYBER-SECURITY</div>
+          <h2 class="card-title">Quantum Shield</h2>
+          <p class="card-desc">Next-generation cryptographic key management with hardware-isolated security modules.</p>
+          <div class="card-footer">
+            <span class="metric-val">99.999%</span>
+            <span class="metric-lbl">Uptime SLA</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Card 2 -->
+      <div class="glass-card card-mid">
+        <div class="holographic-overlay"></div>
+        <div class="card-content">
+          <div class="card-chip">NEURAL-AI</div>
+          <h2 class="card-title">Synapse Core</h2>
+          <p class="card-desc">Real-time dynamic LLM inference streaming with distributed GPU acceleration.</p>
+          <div class="card-footer">
+            <span class="metric-val">1.2 TFLOPS</span>
+            <span class="metric-lbl">Compute Power</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Card 3 -->
+      <div class="glass-card card-bot">
+        <div class="holographic-overlay"></div>
+        <div class="card-content">
+          <div class="card-chip">FINTECH</div>
+          <h2 class="card-title">Vortex Vault</h2>
+          <p class="card-desc">Decentralized asset ledger featuring instant settlement and automated compliance.</p>
+          <div class="card-footer">
+            <span class="metric-val">&lt; 15ms</span>
+            <span class="metric-lbl">Latency</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/holographic-glass-3d-deck-bb/style.css
+++ b/submissions/examples/holographic-glass-3d-deck-bb/style.css
@@ -1,0 +1,236 @@
+:root {
+  --bg-gradient: linear-gradient(135deg, #090d16 0%, #111827 50%, #030712 100%);
+  --glass-bg: rgba(255, 255, 255, 0.05);
+  --glass-border: rgba(255, 255, 255, 0.15);
+  --holo-cyan: rgba(0, 240, 255, 0.4);
+  --holo-pink: rgba(255, 0, 200, 0.4);
+  --holo-purple: rgba(140, 0, 255, 0.4);
+  --text-main: #f8fafc;
+  --text-muted: #94a3b8;
+  --font-family: 'Plus Jakarta Sans', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  background: var(--bg-gradient);
+  font-family: var(--font-family);
+  color: var(--text-main);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 24px;
+  overflow-x: hidden;
+}
+
+.deck-wrapper {
+  max-width: 900px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 40px;
+}
+
+.deck-header {
+  text-align: center;
+  max-width: 540px;
+}
+
+.badge {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  color: #38bdf8;
+  background: rgba(56, 189, 248, 0.1);
+  padding: 6px 14px;
+  border-radius: 20px;
+  border: 1px solid rgba(56, 189, 248, 0.2);
+  margin-bottom: 12px;
+}
+
+.title {
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #ffffff 0%, #cbd5e1 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  margin-bottom: 8px;
+}
+
+.subtitle {
+  font-size: 0.95rem;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+/* 3D Card Deck Perspective Container */
+.card-deck {
+  position: relative;
+  width: 340px;
+  height: 420px;
+  perspective: 1200px;
+}
+
+/* Base Glass Card */
+.glass-card {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: var(--glass-bg);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border: 1px solid var(--glass-border);
+  border-radius: 24px;
+  padding: 32px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+  transform-style: preserve-3d;
+  transition: transform 0.6s cubic-bezier(0.23, 1, 0.32, 1), box-shadow 0.6s ease, border-color 0.6s ease;
+  overflow: hidden;
+  cursor: pointer;
+}
+
+/* Stacked Card Orientations */
+.card-top {
+  transform: translateZ(0px) translateY(0px) rotateX(10deg) rotateY(-5deg);
+  z-index: 3;
+}
+
+.card-mid {
+  transform: translateZ(-40px) translateY(24px) rotateX(10deg) rotateY(-5deg) scale(0.94);
+  opacity: 0.85;
+  z-index: 2;
+}
+
+.card-bot {
+  transform: translateZ(-80px) translateY(48px) rotateX(10deg) rotateY(-5deg) scale(0.88);
+  opacity: 0.6;
+  z-index: 1;
+}
+
+/* Deck Hover State - Fan Out */
+.card-deck:hover .card-top {
+  transform: translateZ(30px) translateY(-20px) rotateX(5deg) rotateY(-12deg);
+  box-shadow: 0 35px 60px -15px rgba(0, 240, 255, 0.25);
+  border-color: rgba(0, 240, 255, 0.4);
+}
+
+.card-deck:hover .card-mid {
+  transform: translateZ(10px) translateY(40px) rotateX(5deg) rotateY(0deg) scale(0.96);
+  opacity: 0.95;
+  box-shadow: 0 30px 50px -15px rgba(255, 0, 200, 0.2);
+  border-color: rgba(255, 0, 200, 0.4);
+}
+
+.card-deck:hover .card-bot {
+  transform: translateZ(-10px) translateY(100px) rotateX(5deg) rotateY(12deg) scale(0.92);
+  opacity: 0.9;
+  box-shadow: 0 30px 50px -15px rgba(140, 0, 255, 0.2);
+  border-color: rgba(140, 0, 255, 0.4);
+}
+
+/* Holographic Prismatic Overlay */
+.holographic-overlay {
+  position: absolute;
+  top: -50%;
+  left: -50%;
+  width: 200%;
+  height: 200%;
+  background: linear-gradient(
+    115deg,
+    transparent 20%,
+    var(--holo-cyan) 40%,
+    var(--holo-pink) 60%,
+    var(--holo-purple) 80%,
+    transparent 100%
+  );
+  opacity: 0.3;
+  mix-blend-mode: color-dodge;
+  transform: rotate(-30deg) translateY(-100%);
+  transition: transform 0.8s ease, opacity 0.8s ease;
+  pointer-events: none;
+}
+
+.glass-card:hover .holographic-overlay {
+  transform: rotate(-30deg) translateY(50%);
+  opacity: 0.7;
+}
+
+/* Card Content Typography & Elements */
+.card-content {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.card-chip {
+  align-self: flex-start;
+  font-size: 0.65rem;
+  font-weight: 800;
+  letter-spacing: 2px;
+  color: var(--text-main);
+  background: rgba(255, 255, 255, 0.1);
+  padding: 4px 10px;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.card-title {
+  font-size: 1.5rem;
+  font-weight: 800;
+  color: #fff;
+  line-height: 1.2;
+}
+
+.card-desc {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.card-footer {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  padding-top: 16px;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.metric-val {
+  font-size: 1.25rem;
+  font-weight: 800;
+  color: #38bdf8;
+}
+
+.metric-lbl {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+/* Responsive Adjustments */
+@media (max-width: 480px) {
+  .card-deck {
+    width: 290px;
+    height: 380px;
+  }
+  .title {
+    font-size: 1.75rem;
+  }
+}


### PR DESCRIPTION
# Related Issue
Closes #65352 

# Summary
Adds a 3D glassmorphic perspective card deck featuring holographic prismatic light sheen and hover fan-out depth.

# Changes Made
- Created `submissions/examples/holographic-glass-3d-deck-bb/demo.html`
- Created `submissions/examples/holographic-glass-3d-deck-bb/style.css`
- Created `submissions/examples/holographic-glass-3d-deck-bb/README.md`

# Testing
- Tested 3D hover transform performance across browsers.
