### PR TITLE
feat: add neon glow audio equalizer visualizer component

### DIFF
--- a/submissions/examples/neon-equalizer-audio-visualizer-bb/README.md
+++ b/submissions/examples/neon-equalizer-audio-visualizer-bb/README.md
@@ -1,0 +1,14 @@
+# Neon Glow Audio Equalizer Visualizer (EaseMotion CSS)
+
+A dynamic audio equalizer frequency visualizer component with glowing neon spectrum bars and organic fluid keyframe animations built with HTML5 and CSS3.
+
+## 1. What does this do?
+This component simulates a real-time audio spectrum analyzer card. 12 vertical neon equalizer bars oscillate fluidly using independent keyframe durations and delay offsets to mimic live frequency playback across sub-bass to treble bands.
+
+## 2. How is it used?
+Link `style.css` in your HTML file and render the `.visualizer-card` structure as demonstrated in `demo.html`.
+
+## 3. Why is it useful?
+- **Cyberpunk / Synthwave Visual Appeal**: Enhances music web apps, podcast platforms, portfolio audio players, and streaming dashboards.
+- **Hardware-Accelerated Performance**: Uses CSS `height`, `opacity`, and `filter` transforms for smooth 60fps animations without requiring Canvas or JavaScript rendering loops.
+- **Responsive Layout**: Resizes fluidly across mobile and desktop viewports.

--- a/submissions/examples/neon-equalizer-audio-visualizer-bb/demo.html
+++ b/submissions/examples/neon-equalizer-audio-visualizer-bb/demo.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Neon Glow Audio Equalizer Visualizer - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@500;700;900&family=Inter:wght@400;600&display=swap" rel="stylesheet">
+</head>
+<body>
+  <div class="player-wrapper">
+    <header class="player-header">
+      <span class="badge">GSSoC 2026 Pure CSS Motion</span>
+      <h1 class="title">CYBER SOUNDWAVE</h1>
+      <p class="subtitle">Real-time dynamic fluid equalizer frequency spectrum visualizer</p>
+    </header>
+
+    <div class="visualizer-card">
+      <div class="now-playing-info">
+        <div class="track-art">
+          <div class="art-glow"></div>
+          <span class="art-icon">🎵</span>
+        </div>
+        <div class="track-details">
+          <span class="track-name">NEON HORIZON 2077</span>
+          <span class="artist-name">SYNTHWAVE ARCHITECTS</span>
+        </div>
+        <div class="live-indicator">
+          <span class="live-dot"></span>
+          LIVE BASS
+        </div>
+      </div>
+
+      <!-- Equalizer Bars Container -->
+      <div class="equalizer-bars">
+        <div class="bar bar-1"></div>
+        <div class="bar bar-2"></div>
+        <div class="bar bar-3"></div>
+        <div class="bar bar-4"></div>
+        <div class="bar bar-5"></div>
+        <div class="bar bar-6"></div>
+        <div class="bar bar-7"></div>
+        <div class="bar bar-8"></div>
+        <div class="bar bar-9"></div>
+        <div class="bar bar-10"></div>
+        <div class="bar bar-11"></div>
+        <div class="bar bar-12"></div>
+      </div>
+
+      <div class="frequency-labels">
+        <span>60Hz</span>
+        <span>250Hz</span>
+        <span>1kHz</span>
+        <span>4kHz</span>
+        <span>16kHz</span>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/neon-equalizer-audio-visualizer-bb/style.css
+++ b/submissions/examples/neon-equalizer-audio-visualizer-bb/style.css
@@ -1,0 +1,221 @@
+:root {
+  --bg-dark: #070913;
+  --panel-bg: rgba(13, 17, 33, 0.8);
+  --border-neon: rgba(255, 0, 128, 0.3);
+  --neon-pink: #ff007f;
+  --neon-cyan: #00f3ff;
+  --neon-purple: #9d4edd;
+  --text-main: #f8fafc;
+  --text-muted: #64748b;
+  --font-orbitron: 'Orbitron', sans-serif;
+  --font-inter: 'Inter', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  background: var(--bg-dark);
+  background-image: 
+    radial-gradient(circle at 50% 30%, rgba(255, 0, 128, 0.08) 0%, transparent 60%),
+    radial-gradient(circle at 50% 80%, rgba(0, 243, 255, 0.08) 0%, transparent 60%);
+  font-family: var(--font-inter);
+  color: var(--text-main);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 24px;
+  overflow-x: hidden;
+}
+
+.player-wrapper {
+  max-width: 580px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+
+.player-header {
+  text-align: center;
+}
+
+.badge {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-family: var(--font-orbitron);
+  letter-spacing: 2px;
+  color: var(--neon-cyan);
+  background: rgba(0, 243, 255, 0.1);
+  border: 1px solid rgba(0, 243, 255, 0.2);
+  padding: 6px 14px;
+  border-radius: 20px;
+  margin-bottom: 10px;
+}
+
+.title {
+  font-family: var(--font-orbitron);
+  font-size: 2rem;
+  font-weight: 900;
+  letter-spacing: 3px;
+  background: linear-gradient(135deg, #fff 0%, var(--neon-pink) 50%, var(--neon-cyan) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  margin-bottom: 6px;
+}
+
+.subtitle {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+/* Visualizer Card */
+.visualizer-card {
+  width: 100%;
+  background: var(--panel-bg);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border: 1px solid var(--border-neon);
+  border-radius: 24px;
+  padding: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.6), inset 0 0 30px rgba(255, 0, 128, 0.05);
+}
+
+/* Now Playing Info */
+.now-playing-info {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.track-art {
+  position: relative;
+  width: 50px;
+  height: 50px;
+  background: linear-gradient(135deg, var(--neon-pink), var(--neon-purple));
+  border-radius: 12px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 1.5rem;
+  box-shadow: 0 0 15px rgba(255, 0, 128, 0.4);
+}
+
+.track-details {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+}
+
+.track-name {
+  font-family: var(--font-orbitron);
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #fff;
+  letter-spacing: 1px;
+}
+
+.artist-name {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  letter-spacing: 1px;
+}
+
+.live-indicator {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-orbitron);
+  font-size: 0.65rem;
+  color: var(--neon-pink);
+  background: rgba(255, 0, 128, 0.1);
+  padding: 4px 10px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 0, 128, 0.3);
+}
+
+.live-dot {
+  width: 6px;
+  height: 6px;
+  background: var(--neon-pink);
+  border-radius: 50%;
+  box-shadow: 0 0 8px var(--neon-pink);
+  animation: liveBlink 1.2s infinite ease-in-out;
+}
+
+/* Equalizer Spectrum Bars */
+.equalizer-bars {
+  height: 160px;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.bar {
+  flex: 1;
+  background: linear-gradient(to top, var(--neon-cyan) 0%, var(--neon-purple) 50%, var(--neon-pink) 100%);
+  border-radius: 4px 4px 0 0;
+  box-shadow: 0 0 12px rgba(0, 243, 255, 0.4);
+  animation: equalizerJump 1.4s ease-in-out infinite alternate;
+}
+
+/* Staggered Keyframe Durations & Delays for Organic Fluid Movement */
+.bar-1 { animation-duration: 0.8s; animation-delay: 0.1s; }
+.bar-2 { animation-duration: 1.2s; animation-delay: 0.4s; }
+.bar-3 { animation-duration: 0.9s; animation-delay: 0.2s; }
+.bar-4 { animation-duration: 1.5s; animation-delay: 0.6s; }
+.bar-5 { animation-duration: 0.7s; animation-delay: 0.3s; }
+.bar-6 { animation-duration: 1.1s; animation-delay: 0.5s; }
+.bar-7 { animation-duration: 1.3s; animation-delay: 0.15s; }
+.bar-8 { animation-duration: 0.85s; animation-delay: 0.35s; }
+.bar-9 { animation-duration: 1.4s; animation-delay: 0.25s; }
+.bar-10 { animation-duration: 0.95s; animation-delay: 0.45s; }
+.bar-11 { animation-duration: 1.15s; animation-delay: 0.05s; }
+.bar-12 { animation-duration: 0.75s; animation-delay: 0.55s; }
+
+/* Frequency Labels */
+.frequency-labels {
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--font-orbitron);
+  font-size: 0.65rem;
+  color: var(--text-muted);
+}
+
+/* Keyframes */
+@keyframes equalizerJump {
+  0% { height: 15%; opacity: 0.4; }
+  50% { height: 85%; opacity: 0.95; filter: drop-shadow(0 0 10px var(--neon-pink)); }
+  100% { height: 35%; opacity: 0.6; }
+}
+
+@keyframes liveBlink {
+  0%, 100% { opacity: 0.3; }
+  50% { opacity: 1; }
+}
+
+/* Responsive */
+@media (max-width: 480px) {
+  .visualizer-card {
+    padding: 20px;
+  }
+  .equalizer-bars {
+    gap: 4px;
+    height: 120px;
+  }
+  .now-playing-info {
+    flex-wrap: wrap;
+  }
+}


### PR DESCRIPTION
# Related Issue
Closes #65354

# Summary
Adds a neon audio spectrum visualizer with staggered frequency bar animations.

# Changes Made
- Created `submissions/examples/neon-equalizer-audio-visualizer-bb/demo.html`
- Created `submissions/examples/neon-equalizer-audio-visualizer-bb/style.css`
- Created `submissions/examples/neon-equalizer-audio-visualizer-bb/README.md`

# Testing
- Local browser verification of keyframe stagger logic and layout responsiveness.
