### PR TITLE
feat: add macos dock magnification navigation bar component

### DIFF
--- a/submissions/examples/mac-os-dock-magnification-bar-bb/README.md
+++ b/submissions/examples/mac-os-dock-magnification-bar-bb/README.md
@@ -1,0 +1,14 @@
+# macOS Dock Magnification Navigation Bar (EaseMotion CSS)
+
+An interactive, desktop-inspired macOS magnification dock navigation bar built with pure HTML5 and CSS3 (`transform: scale()`, CSS sibling selectors `:has()`, and backdrop glassmorphism).
+
+## 1. What does this do?
+This component replicates the iconic macOS desktop dock menu magnification effect. When hovering over an icon, it smoothly scales up (`scale(1.45)`), while adjacent neighboring items dynamically scale up (`scale(1.2)`) using CSS `:has()` selector physics without needing JavaScript events.
+
+## 2. How is it used?
+Link `style.css` in your HTML page and implement the `.macos-dock` structure with `.dock-item` anchors as illustrated in `demo.html`.
+
+## 3. Why is it useful?
+- **Modern Desktop UX**: Elevates portfolio websites, WebOS dashboards, and creative web app interfaces.
+- **Pure CSS Physics**: Hardware-accelerated transitions via `transform` and modern `:has()` selector math deliver silky-smooth 60fps performance without JavaScript overhead.
+- **Fully Accessible & Responsive**: Includes tooltip labels, notification badge indicators, and fluid scaling across viewports.

--- a/submissions/examples/mac-os-dock-magnification-bar-bb/demo.html
+++ b/submissions/examples/mac-os-dock-magnification-bar-bb/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>macOS Dock Magnification Navigation Bar - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;600;800&display=swap" rel="stylesheet">
+</head>
+<body>
+  <div class="dock-demo-wrapper">
+    <header class="dock-header">
+      <span class="badge">GSSoC 2026 Interactive Navigation</span>
+      <h1 class="title">macOS Dock Magnification</h1>
+      <p class="subtitle">Hover across the dock items to trigger smooth physics-based proximity scaling & active indicators</p>
+    </header>
+
+    <div class="desktop-viewport">
+      <!-- Glassmorphic macOS Dock Navigation -->
+      <nav class="macos-dock">
+        <div class="dock-container">
+          <a href="#finder" class="dock-item" data-tooltip="Finder">
+            <span class="icon">📁</span>
+            <span class="active-dot"></span>
+          </a>
+          <a href="#safari" class="dock-item" data-tooltip="Safari">
+            <span class="icon">🌐</span>
+            <span class="active-dot"></span>
+          </a>
+          <a href="#messages" class="dock-item" data-tooltip="Messages">
+            <span class="icon">💬</span>
+            <span class="badge-count">3</span>
+          </a>
+          <a href="#mail" class="dock-item" data-tooltip="Mail">
+            <span class="icon">✉️</span>
+          </a>
+          
+          <div class="dock-divider"></div>
+
+          <a href="#code" class="dock-item" data-tooltip="VS Code">
+            <span class="icon">⚡</span>
+            <span class="active-dot"></span>
+          </a>
+          <a href="#terminal" class="dock-item" data-tooltip="Terminal">
+            <span class="icon">💻</span>
+          </a>
+          <a href="#settings" class="dock-item" data-tooltip="Settings">
+            <span class="icon">⚙️</span>
+          </a>
+        </div>
+      </nav>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/mac-os-dock-magnification-bar-bb/style.css
+++ b/submissions/examples/mac-os-dock-magnification-bar-bb/style.css
@@ -1,0 +1,199 @@
+:root {
+  --bg-gradient: linear-gradient(135deg, #0f172a 0%, #1e1b4b 50%, #090d16 100%);
+  --dock-bg: rgba(255, 255, 255, 0.12);
+  --dock-border: rgba(255, 255, 255, 0.2);
+  --text-main: #f8fafc;
+  --text-muted: #94a3b8;
+  --font-family: 'Plus Jakarta Sans', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  background: var(--bg-gradient);
+  font-family: var(--font-family);
+  color: var(--text-main);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 24px;
+  overflow-x: hidden;
+}
+
+.dock-demo-wrapper {
+  max-width: 800px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 50px;
+}
+
+.dock-header {
+  text-align: center;
+}
+
+.badge {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  color: #a855f7;
+  background: rgba(168, 85, 247, 0.1);
+  border: 1px solid rgba(168, 85, 247, 0.2);
+  padding: 6px 14px;
+  border-radius: 20px;
+  margin-bottom: 12px;
+}
+
+.title {
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #ffffff 0%, #cbd5e1 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  margin-bottom: 8px;
+}
+
+.subtitle {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+/* Desktop Viewport Framing */
+.desktop-viewport {
+  width: 100%;
+  height: 240px;
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  padding-bottom: 20px;
+}
+
+/* macOS Glassmorphic Dock Container */
+.macos-dock {
+  background: var(--dock-bg);
+  backdrop-filter: blur(24px);
+  -webkit-backdrop-filter: blur(24px);
+  border: 1px solid var(--dock-border);
+  border-radius: 24px;
+  padding: 10px 16px;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4), inset 0 0 20px rgba(255, 255, 255, 0.1);
+}
+
+.dock-container {
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
+}
+
+/* Dock Item Button */
+.dock-item {
+  position: relative;
+  width: 52px;
+  height: 52px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 16px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-decoration: none;
+  font-size: 1.6rem;
+  transform-origin: bottom center;
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1), background-color 0.3s ease;
+}
+
+/* Neighbor Proximity & Active Magnification Effects */
+.dock-item:hover {
+  transform: scale(1.45) translateY(-10px);
+  background: rgba(255, 255, 255, 0.2);
+  z-index: 10;
+}
+
+.dock-item:hover + .dock-item,
+.dock-item:has(+ .dock-item:hover) {
+  transform: scale(1.2) translateY(-4px);
+  z-index: 5;
+}
+
+/* Tooltip Popup */
+.dock-item::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  top: -42px;
+  left: 50%;
+  transform: translateX(-50%) scale(0.8);
+  background: rgba(15, 23, 42, 0.9);
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 4px 10px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: all 0.25s ease;
+}
+
+.dock-item:hover::after {
+  opacity: 1;
+  transform: translateX(-50%) scale(1);
+}
+
+/* Active Running App Dot Indicator */
+.active-dot {
+  position: absolute;
+  bottom: -6px;
+  width: 4px;
+  height: 4px;
+  background: #38bdf8;
+  border-radius: 50%;
+  box-shadow: 0 0 6px #38bdf8;
+}
+
+/* Notification Badge Count */
+.badge-count {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  background: #ef4444;
+  color: #fff;
+  font-size: 0.65rem;
+  font-weight: 800;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  box-shadow: 0 2px 8px rgba(239, 68, 68, 0.5);
+}
+
+/* Dock Vertical Divider Line */
+.dock-divider {
+  width: 1px;
+  height: 36px;
+  background: rgba(255, 255, 255, 0.15);
+  margin: 0 4px;
+  align-self: center;
+}
+
+/* Responsive */
+@media (max-width: 540px) {
+  .dock-container {
+    gap: 8px;
+  }
+  .dock-item {
+    width: 42px;
+    height: 42px;
+    font-size: 1.3rem;
+  }
+}


### PR DESCRIPTION
# Related Issue
Closes #65362 

# Summary
Adds a macOS glassmorphic dock menu featuring pure CSS proximity magnification and neighbor scaling.

# Changes Made
- Created `submissions/examples/mac-os-dock-magnification-bar-bb/demo.html`
- Created `submissions/examples/mac-os-dock-magnification-bar-bb/style.css`
- Created `submissions/examples/mac-os-dock-magnification-bar-bb/README.md`

# Testing
- Local testing of CSS `:has()` selector proximity scaling and tooltip popups.
