### PR TITLE
feat: add cyberpunk code terminal view component

### DIFF
--- a/submissions/examples/cyberpunk-code-terminal-view-bb/README.md
+++ b/submissions/examples/cyberpunk-code-terminal-view-bb/README.md
@@ -1,0 +1,14 @@
+# Cyberpunk Code Terminal Block (EaseMotion CSS)
+
+An interactive code snippet terminal container featuring CRT scanline overlays, glowing neon borders, syntax token highlighting, and a retro terminal typing cursor constructed with HTML5 and CSS3.
+
+## 1. What does this do?
+This component presents code snippets inside a futuristic hacker/cyberpunk terminal window. It incorporates CRT scanlines (`linear-gradient` overlays), custom syntax tokens (`.tok-keyword`, `.tok-string`), status bar readouts, and a blinking terminal block cursor (`animation: cursorBlink`).
+
+## 2. How is it used?
+Link `style.css` in your project and wrap code examples inside `.terminal-card` and `.code-viewport` as demonstrated in `demo.html`.
+
+## 3. Why is it useful?
+- **Developer Experience (DX) Boost**: Provides a stylish, high-tech presentation for technical documentation, API guides, code portfolios, and landing pages.
+- **Pure CSS Lightweight Styling**: Hardware-accelerated CSS animations with zero reliance on heavy JavaScript syntax highlighters.
+- **Fully Responsive**: Adapts code typography smoothly for small mobile viewports.

--- a/submissions/examples/cyberpunk-code-terminal-view-bb/demo.html
+++ b/submissions/examples/cyberpunk-code-terminal-view-bb/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cyberpunk Code Terminal Block - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;600;700&family=Orbitron:wght@600;800&display=swap" rel="stylesheet">
+</head>
+<body>
+  <div class="terminal-wrapper">
+    <header class="terminal-header">
+      <span class="badge">GSSoC 2026 Developer Experience</span>
+      <h1 class="title">CYBER TERMINAL BLOCK</h1>
+      <p class="subtitle">Interactive code snippet container featuring typewriter text stream & glowing neon borders</p>
+    </header>
+
+    <div class="terminal-card">
+      <!-- Window Controls Header -->
+      <div class="window-header">
+        <div class="window-buttons">
+          <span class="btn btn-close"></span>
+          <span class="btn btn-minimize"></span>
+          <span class="btn btn-expand"></span>
+        </div>
+        <div class="window-title">bash -- root@easemotion-core:~/matrix</div>
+        <div class="window-status">
+          <span class="pulse-dot"></span>
+          ACTIVE
+        </div>
+      </div>
+
+      <!-- Code Viewport Body -->
+      <div class="code-viewport">
+        <div class="scanline"></div>
+        
+        <div class="code-lines">
+          <div class="line"><span class="ln">01</span><span class="tok-comment">// Initialize Neural Motion Pipeline</span></div>
+          <div class="line"><span class="ln">02</span><span class="tok-keyword">import</span> { <span class="tok-func">createCyberEngine</span> } <span class="tok-keyword">from</span> <span class="tok-string">'@easemotion/core'</span>;</div>
+          <div class="line"><span class="ln">03</span></div>
+          <div class="line"><span class="ln">04</span><span class="tok-keyword">const</span> <span class="tok-var">matrix</span> = <span class="tok-keyword">new</span> <span class="tok-func">createCyberEngine</span>({</div>
+          <div class="line"><span class="ln">05</span>  <span class="tok-attr">fps</span>: <span class="tok-num">120</span>,</div>
+          <div class="line"><span class="ln">06</span>  <span class="tok-attr">hardwareAcceleration</span>: <span class="tok-bool">true</span>,</div>
+          <div class="line"><span class="ln">07</span>  <span class="tok-attr">glowColor</span>: <span class="tok-string">'#00f3ff'</span></div>
+          <div class="line"><span class="ln">08</span>});</div>
+          <div class="line"><span class="ln">09</span></div>
+          <div class="line"><span class="ln">10</span><span class="tok-var">matrix</span>.<span class="tok-func">startExecutionStream</span>(); <span class="cursor-blink">█</span></div>
+        </div>
+      </div>
+
+      <!-- Terminal Footer Bar -->
+      <div class="terminal-footer">
+        <div class="stat-group">
+          <span class="stat-label">RAM:</span>
+          <span class="stat-val text-cyan">42.8 MB</span>
+        </div>
+        <div class="stat-group">
+          <span class="stat-label">ENCODING:</span>
+          <span class="stat-val text-green">UTF-8</span>
+        </div>
+        <button class="copy-btn">
+          <span class="copy-icon">📋</span> COPY SNIPPET
+        </button>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/cyberpunk-code-terminal-view-bb/style.css
+++ b/submissions/examples/cyberpunk-code-terminal-view-bb/style.css
@@ -1,0 +1,261 @@
+:root {
+  --bg-dark: #080c14;
+  --panel-bg: rgba(10, 16, 28, 0.85);
+  --neon-cyan: #00f3ff;
+  --neon-pink: #ff007f;
+  --neon-green: #10b981;
+  --border-cyan: rgba(0, 243, 255, 0.3);
+  --text-main: #e2e8f0;
+  --text-muted: #64748b;
+  --font-code: 'Fira Code', monospace;
+  --font-title: 'Orbitron', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  background: var(--bg-dark);
+  background-image: 
+    radial-gradient(circle at 50% 50%, rgba(0, 243, 255, 0.05) 0%, transparent 60%),
+    linear-gradient(to right, rgba(255, 255, 255, 0.02) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(255, 255, 255, 0.02) 1px, transparent 1px);
+  background-size: 100% 100%, 32px 32px, 32px 32px;
+  font-family: var(--font-code);
+  color: var(--text-main);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 24px;
+  overflow-x: hidden;
+}
+
+.terminal-wrapper {
+  max-width: 680px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+
+.terminal-header {
+  text-align: center;
+}
+
+.badge {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-family: var(--font-title);
+  letter-spacing: 1.5px;
+  color: var(--neon-cyan);
+  background: rgba(0, 243, 255, 0.1);
+  border: 1px solid rgba(0, 243, 255, 0.2);
+  padding: 6px 14px;
+  border-radius: 20px;
+  margin-bottom: 12px;
+}
+
+.title {
+  font-family: var(--font-title);
+  font-size: 2rem;
+  font-weight: 800;
+  letter-spacing: 2px;
+  background: linear-gradient(135deg, #fff 0%, var(--neon-cyan) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  margin-bottom: 8px;
+}
+
+.subtitle {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+/* Main Code Terminal Card Surface */
+.terminal-card {
+  width: 100%;
+  background: var(--panel-bg);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border: 1px solid var(--border-cyan);
+  border-radius: 18px;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.7), inset 0 0 30px rgba(0, 243, 255, 0.05);
+  overflow: hidden;
+}
+
+/* Window Header Bar */
+.window-header {
+  background: rgba(0, 15, 30, 0.7);
+  border-bottom: 1px solid var(--border-cyan);
+  padding: 12px 18px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.window-buttons {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.btn {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+
+.btn-close { background: #ef4444; }
+.btn-minimize { background: #eab308; }
+.btn-expand { background: #22c55e; }
+
+.window-title {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  letter-spacing: 1px;
+}
+
+.window-status {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.65rem;
+  font-family: var(--font-title);
+  color: var(--neon-cyan);
+}
+
+.pulse-dot {
+  width: 6px;
+  height: 6px;
+  background: var(--neon-cyan);
+  border-radius: 50%;
+  box-shadow: 0 0 8px var(--neon-cyan);
+  animation: dotPulse 1.5s infinite ease-in-out;
+}
+
+/* Code Viewport Area */
+.code-viewport {
+  position: relative;
+  padding: 24px;
+  background: rgba(4, 8, 16, 0.95);
+  overflow-x: auto;
+}
+
+/* CRT Overlay Scanline Effect */
+.scanline {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(to bottom, transparent 50%, rgba(0, 243, 255, 0.04) 51%);
+  background-size: 100% 4px;
+  pointer-events: none;
+}
+
+.code-lines {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.88rem;
+  line-height: 1.6;
+}
+
+.line {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.ln {
+  color: #475569;
+  user-select: none;
+  font-size: 0.75rem;
+}
+
+/* Syntax Highlighting Token Styles */
+.tok-comment { color: #64748b; font-style: italic; }
+.tok-keyword { color: var(--neon-pink); font-weight: 600; }
+.tok-func { color: var(--neon-cyan); }
+.tok-string { color: #a7f3d0; }
+.tok-var { color: #f1f5f9; }
+.tok-attr { color: #93c5fd; }
+.tok-num { color: #fde047; }
+.tok-bool { color: #f472b6; }
+
+/* Typing Cursor Pulse */
+.cursor-blink {
+  color: var(--neon-cyan);
+  animation: cursorBlink 1s infinite steps(1);
+}
+
+/* Terminal Footer Panel */
+.terminal-footer {
+  background: rgba(0, 15, 30, 0.7);
+  border-top: 1px solid var(--border-cyan);
+  padding: 10px 18px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.75rem;
+}
+
+.stat-group {
+  display: flex;
+  gap: 6px;
+}
+
+.stat-label { color: var(--text-muted); }
+.text-cyan { color: var(--neon-cyan); }
+.text-green { color: var(--neon-green); }
+
+.copy-btn {
+  background: rgba(0, 243, 255, 0.1);
+  border: 1px solid var(--border-cyan);
+  color: var(--neon-cyan);
+  font-family: var(--font-code);
+  font-size: 0.7rem;
+  padding: 4px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  transition: all 0.3s ease;
+}
+
+.copy-btn:hover {
+  background: var(--neon-cyan);
+  color: #000;
+  box-shadow: 0 0 12px var(--neon-cyan);
+}
+
+/* Keyframe Animations */
+@keyframes dotPulse {
+  0%, 100% { opacity: 0.4; }
+  50% { opacity: 1; }
+}
+
+@keyframes cursorBlink {
+  0%, 50% { opacity: 1; }
+  51%, 100% { opacity: 0; }
+}
+
+/* Responsive */
+@media (max-width: 520px) {
+  .code-viewport {
+    padding: 16px;
+  }
+  .code-lines {
+    font-size: 0.78rem;
+  }
+  .terminal-footer {
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+}


### PR DESCRIPTION
# Related Issue
Closes #65365 

# Summary
Adds a retro cyberpunk code terminal container with CRT scanlines and syntax token styling.

# Changes Made
- Created `submissions/examples/cyberpunk-code-terminal-view-bb/demo.html`
- Created `submissions/examples/cyberpunk-code-terminal-view-bb/style.css`
- Created `submissions/examples/cyberpunk-code-terminal-view-bb/README.md`

# Testing
- Verified syntax highlighting contrast and responsive overflow behavior.
