### PR TITLE
feat: add CSS Slide-Up Badge for Minimalist Tech Layouts (#64535)

### DIFF
--- a/submissions/examples/minimalist-slide-up-badge/README.md
+++ b/submissions/examples/minimalist-slide-up-badge/README.md
@@ -1,0 +1,18 @@
+# CSS Slide-Up Badge (Minimalist Tech)
+
+A pure CSS interactive badge component designed for Minimalist Tech Layouts. It features a hover-driven animation where the badge smoothly slides up from a hidden overflow state into full view.
+
+## Features
+- Pure CSS and HTML (No JavaScript required).
+- The `.slide-up-badge` is nested inside an `overflow: hidden` container. Initially, it sits at `transform: translateY(100%)`.
+- When the parent `.commit-item` row is hovered, the badge triggers a `transform: translateY(0)` transition using a bouncy `cubic-bezier` timing function.
+- Clean, data-focused aesthetic designed for git history layouts and activity feeds, utilizing monospace typography for commit data (`JetBrains Mono`).
+- Fully responsive layout. On mobile devices where hover is not viable, the badges are statically visible by default.
+- Fully accessible with `prefers-reduced-motion` support ensuring degraded, safe static layouts for users sensitive to motion (badges are permanently visible).
+
+## Usage
+Open `demo.html` in your browser. You will see a list of recent git commits. Hover your mouse over any of the rows; the corresponding status badge will slide up into view from the bottom edge of its container.
+
+## Files
+- `demo.html`: The HTML structure for the layout and the nested badge containers.
+- `style.css`: The styling, flexbox layouts, and CSS `transform` logic for the hover-driven slide-up effect.

--- a/submissions/examples/minimalist-slide-up-badge/demo.html
+++ b/submissions/examples/minimalist-slide-up-badge/demo.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Slide-Up Badge - Minimalist Tech</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Latest Commits</h1>
+            <p class="subtitle">Recent activity on branch 'main'. Hover items to view details.</p>
+        </header>
+
+        <div class="commit-list">
+            
+            <!-- Item 1 -->
+            <div class="commit-item">
+                <div class="commit-info">
+                    <span class="commit-author">Sarah Jenkins</span>
+                    <span class="commit-message">Merge pull request #142 from feature/auth</span>
+                </div>
+                <!-- The Slide-Up Badge Container -->
+                <div class="badge-container">
+                    <div class="badge badge-primary slide-up-badge">
+                        MERGED
+                    </div>
+                </div>
+            </div>
+
+            <!-- Item 2 -->
+            <div class="commit-item">
+                <div class="commit-info">
+                    <span class="commit-author">David Chen</span>
+                    <span class="commit-message">Fix OAuth token refresh loop condition</span>
+                </div>
+                <!-- The Slide-Up Badge Container -->
+                <div class="badge-container">
+                    <div class="badge badge-success slide-up-badge">
+                        VERIFIED
+                    </div>
+                </div>
+            </div>
+
+            <!-- Item 3 -->
+            <div class="commit-item">
+                <div class="commit-info">
+                    <span class="commit-author">Automated CI/CD</span>
+                    <span class="commit-message">Bump dependencies: @babel/core to 7.22</span>
+                </div>
+                <!-- The Slide-Up Badge Container -->
+                <div class="badge-container">
+                    <div class="badge badge-neutral slide-up-badge">
+                        CHORE
+                    </div>
+                </div>
+            </div>
+
+        </div>
+        
+    </div>
+</body>
+</html>

--- a/submissions/examples/minimalist-slide-up-badge/style.css
+++ b/submissions/examples/minimalist-slide-up-badge/style.css
@@ -1,0 +1,175 @@
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@500;600&family=Inter:wght@400;500;600&display=swap');
+
+:root {
+    --bg-color: #fafafa;
+    --card-bg: #ffffff;
+    --text-primary: #171717;
+    --text-secondary: #737373;
+    --border-color: #e5e5e5;
+    
+    /* Badge Colors */
+    --badge-primary-bg: #e0e7ff; /* Indigo */
+    --badge-primary-text: #4338ca;
+    
+    --badge-success-bg: #dcfce7; /* Green */
+    --badge-success-text: #166534;
+    
+    --badge-neutral-bg: #f3f4f6; /* Gray */
+    --badge-neutral-text: #4b5563;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    font-family: 'Inter', system-ui, -apple-system, sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 40px 20px;
+    box-sizing: border-box;
+}
+
+.layout-container {
+    max-width: 600px;
+    width: 100%;
+}
+
+.section-header {
+    margin-bottom: 24px;
+}
+
+.title {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin: 0 0 4px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    margin: 0;
+    font-weight: 400;
+}
+
+
+/* List Layout */
+.commit-list {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+}
+
+.commit-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 16px 20px;
+    border-bottom: 1px solid var(--border-color);
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+
+.commit-item:hover {
+    background-color: #f9fafb;
+}
+
+.commit-item:last-child {
+    border-bottom: none;
+}
+
+.commit-info {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.commit-author {
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: var(--text-secondary);
+}
+
+.commit-message {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.9rem;
+    font-weight: 500;
+    color: var(--text-primary);
+}
+
+
+/* =========================================
+   Badge Container & Slide-Up Animation
+   ========================================= */
+
+/* The container establishes the bounds for overflow hiding */
+.badge-container {
+    overflow: hidden; /* Key for the slide-up reveal */
+    display: flex;
+    align-items: center;
+    height: 30px; /* Fixed height to match badge */
+}
+
+/* Base Badge Styles */
+.badge {
+    font-family: 'JetBrains Mono', monospace;
+    font-weight: 600;
+    font-size: 0.75rem;
+    letter-spacing: 0.5px;
+    padding: 6px 12px;
+    border-radius: 4px;
+    text-transform: uppercase;
+}
+
+/* Slide-Up Animation Logic */
+.slide-up-badge {
+    /* Initial state: pushed down out of the container bounds */
+    transform: translateY(100%);
+    opacity: 0;
+    transition: transform 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275),
+                opacity 0.3s ease;
+}
+
+/* Trigger animation when the parent row is hovered */
+.commit-item:hover .slide-up-badge {
+    transform: translateY(0);
+    opacity: 1;
+}
+
+/* Status variants */
+.badge-primary {
+    background: var(--badge-primary-bg);
+    color: var(--badge-primary-text);
+}
+
+.badge-success {
+    background: var(--badge-success-bg);
+    color: var(--badge-success-text);
+}
+
+.badge-neutral {
+    background: var(--badge-neutral-bg);
+    color: var(--badge-neutral-text);
+}
+
+
+@media (max-width: 480px) {
+    /* On mobile, we don't rely on hover, just show them */
+    .slide-up-badge {
+        transform: translateY(0);
+        opacity: 1;
+    }
+}
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    .slide-up-badge {
+        transition: none !important;
+        transform: translateY(0) !important;
+        opacity: 1 !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces the CSS Slide-Up Badge designed for Minimalist Tech Layouts, resolving issue #64535. 

### Changes Made:
- Added `submissions/examples/minimalist-slide-up-badge/` directory.
- Created `demo.html` showcasing an interactive git commit history feed. 
- Created `style.css` featuring a clean, professional aesthetic built on the `Inter` and `JetBrains Mono` fonts.
  - Implemented an interactive hover effect. The badges are nested inside an `overflow: hidden` container and start shifted out of view via `transform: translateY(100%)`. Hovering the parent row triggers the badge to snap up into view.
- Added `README.md` documenting usage and features.
- Fully responsive layout. On narrow mobile viewports, the hover effect is bypassed and badges are permanently visible.
- Honors the `prefers-reduced-motion` accessibility standard, locking the badges to a visible static state for those sensitive to motion.

Closes #64535
