### PR TITLE
feat: add CSS Float-Drift Tooltip for Minimalist Tech Layouts (#64531)

### DIFF
--- a/submissions/examples/minimalist-float-drift-tooltip/README.md
+++ b/submissions/examples/minimalist-float-drift-tooltip/README.md
@@ -1,0 +1,19 @@
+# CSS Float-Drift Tooltip (Minimalist Tech)
+
+A pure CSS tooltip component designed for Minimalist Tech Layouts. It features a smooth, physics-based "Float-Drift" entrance animation triggered on hover, creating an elegant and professional interaction model.
+
+## Features
+- Pure CSS and HTML (No JavaScript required).
+- The `.tooltip-content` is anchored absolute to the `.tooltip-trigger` parent. 
+- The drift animation is achieved by transitioning the tooltip from a pushed down state (`translateY(15px)`) and zero opacity, to its natural resting state (`translateY(0)`) and full opacity upon hovering the trigger element. 
+- A bouncy `cubic-bezier` timing function gives the drift a natural, floating feeling.
+- Clean, data-focused aesthetic designed for API documentation layouts, utilizing monospace typography for code paths (`JetBrains Mono`).
+- Features a pure CSS downward-pointing arrow built using border manipulation on the `::after` pseudo-element.
+- Fully accessible with `prefers-reduced-motion` support ensuring degraded, safe static layouts for users sensitive to motion (the positional drift is removed, relying only on a rapid opacity fade).
+
+## Usage
+Open `demo.html` in your browser. You will see a list of API endpoints. Hover your mouse over the dashed endpoint paths; a dark tooltip will smoothly drift upwards into view, revealing additional details.
+
+## Files
+- `demo.html`: The HTML structure for the layout and the nested tooltip containers.
+- `style.css`: The styling, flexbox layouts, and CSS `transform` logic for the hover-driven float-drift effect.

--- a/submissions/examples/minimalist-float-drift-tooltip/demo.html
+++ b/submissions/examples/minimalist-float-drift-tooltip/demo.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Float-Drift Tooltip - Minimalist Tech</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">API Endpoints</h1>
+            <p class="subtitle">Hover over the endpoint paths for usage details.</p>
+        </header>
+
+        <div class="endpoint-list">
+            
+            <div class="endpoint-item">
+                <span class="method get">GET</span>
+                <span class="path tooltip-trigger">
+                    /v1/users/{id}
+                    
+                    <!-- The Float-Drift Tooltip -->
+                    <div class="tooltip-content">
+                        <div class="tooltip-header">Fetch User Details</div>
+                        <div class="tooltip-body">Returns the complete user profile including active session metadata.</div>
+                    </div>
+                </span>
+            </div>
+            
+            <div class="endpoint-item">
+                <span class="method post">POST</span>
+                <span class="path tooltip-trigger">
+                    /v1/workspaces
+                    
+                    <!-- The Float-Drift Tooltip -->
+                    <div class="tooltip-content">
+                        <div class="tooltip-header">Create Workspace</div>
+                        <div class="tooltip-body">Requires billing_tier and organization_id in the request payload.</div>
+                    </div>
+                </span>
+            </div>
+            
+            <div class="endpoint-item">
+                <span class="method del">DEL</span>
+                <span class="path tooltip-trigger">
+                    /v1/auth/tokens
+                    
+                    <!-- The Float-Drift Tooltip -->
+                    <div class="tooltip-content">
+                        <div class="tooltip-header">Revoke Access</div>
+                        <div class="tooltip-body">Invalidates all active refresh tokens for the authenticated user.</div>
+                    </div>
+                </span>
+            </div>
+
+        </div>
+        
+    </div>
+</body>
+</html>

--- a/submissions/examples/minimalist-float-drift-tooltip/style.css
+++ b/submissions/examples/minimalist-float-drift-tooltip/style.css
@@ -1,0 +1,196 @@
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Inter:wght@400;500;600&display=swap');
+
+:root {
+    --bg-color: #fafafa;
+    --card-bg: #ffffff;
+    --text-primary: #171717;
+    --text-secondary: #737373;
+    --border-color: #e5e5e5;
+    
+    /* Method Colors */
+    --method-get: #10b981;  /* Emerald */
+    --method-post: #3b82f6; /* Blue */
+    --method-del: #ef4444;  /* Red */
+    
+    /* Tooltip Theme */
+    --tooltip-bg: #171717;
+    --tooltip-text: #f5f5f5;
+    --tooltip-text-muted: #a3a3a3;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    font-family: 'Inter', system-ui, -apple-system, sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 40px 20px;
+    box-sizing: border-box;
+}
+
+.layout-container {
+    max-width: 600px;
+    width: 100%;
+}
+
+.section-header {
+    margin-bottom: 32px;
+}
+
+.title {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin: 0 0 8px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+    margin: 0;
+    font-weight: 400;
+}
+
+
+/* Endpoint List Layout */
+.endpoint-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.endpoint-item {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    padding: 12px 16px;
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.02);
+}
+
+.method {
+    font-family: 'JetBrains Mono', monospace;
+    font-weight: 600;
+    font-size: 0.8rem;
+    padding: 4px 8px;
+    border-radius: 4px;
+    min-width: 45px;
+    text-align: center;
+}
+
+.get { color: var(--method-get); background: rgba(16, 185, 129, 0.1); }
+.post { color: var(--method-post); background: rgba(59, 130, 246, 0.1); }
+.del { color: var(--method-del); background: rgba(239, 68, 68, 0.1); }
+
+
+/* =========================================
+   Tooltip Trigger & Container Logic
+   ========================================= */
+
+.tooltip-trigger {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.95rem;
+    font-weight: 500;
+    color: var(--text-primary);
+    position: relative; /* Anchor for the absolute tooltip */
+    cursor: help;
+    display: inline-block;
+    padding: 4px 0;
+    border-bottom: 1px dashed var(--text-secondary);
+    transition: color 0.2s ease;
+}
+
+.tooltip-trigger:hover {
+    color: var(--method-post);
+}
+
+/* Tooltip Content Block */
+.tooltip-content {
+    position: absolute;
+    bottom: 100%; /* Position above */
+    left: 50%; /* Center horizontally */
+    margin-bottom: 12px; /* Space between text and tooltip */
+    
+    width: 260px;
+    background: var(--tooltip-bg);
+    border-radius: 8px;
+    padding: 12px 16px;
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+    pointer-events: none; /* Prevent tooltip from interfering with hover */
+    z-index: 100;
+    
+    /* Float-Drift Initial State */
+    opacity: 0;
+    transform: translateX(-50%) translateY(15px); /* Centered, pushed down slightly */
+    transition: opacity 0.3s ease,
+                transform 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* The little arrow pointing down */
+.tooltip-content::after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    margin-left: -6px;
+    border-width: 6px;
+    border-style: solid;
+    border-color: var(--tooltip-bg) transparent transparent transparent;
+}
+
+/* Tooltip Hover/Reveal State - The "Drift" */
+.tooltip-trigger:hover .tooltip-content {
+    opacity: 1;
+    /* Move it up into place */
+    transform: translateX(-50%) translateY(0); 
+}
+
+
+/* Tooltip Internal Styling */
+.tooltip-header {
+    font-family: 'Inter', sans-serif;
+    font-weight: 600;
+    font-size: 0.85rem;
+    color: var(--tooltip-text);
+    margin-bottom: 4px;
+}
+
+.tooltip-body {
+    font-family: 'Inter', sans-serif;
+    font-size: 0.8rem;
+    color: var(--tooltip-text-muted);
+    line-height: 1.5;
+    white-space: normal; /* Allow text to wrap inside the fixed width */
+}
+
+
+@media (max-width: 480px) {
+    /* Mobile adjustments - Tooltips on mobile generally suck, but we'll try to center it better */
+    .tooltip-content {
+        left: 0;
+        transform: translateX(-20%) translateY(15px);
+    }
+    .tooltip-content::after {
+        left: 30%;
+    }
+    .tooltip-trigger:hover .tooltip-content {
+        transform: translateX(-20%) translateY(0);
+    }
+}
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    .tooltip-content {
+        transition: opacity 0.2s ease !important;
+        transform: translateX(-50%) translateY(0) !important; 
+    }
+    .tooltip-trigger:hover .tooltip-content {
+        transform: translateX(-50%) translateY(0) !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces the CSS Float-Drift Tooltip designed for Minimalist Tech Layouts, resolving issue #64531. 

### Changes Made:
- Added `submissions/examples/minimalist-float-drift-tooltip/` directory.
- Created `demo.html` showcasing an API endpoints list where hovering over the URL paths triggers the tooltip. 
- Created `style.css` featuring a clean, professional aesthetic built on the `Inter` and `JetBrains Mono` fonts.
  - Implemented the float-drift hover effect. The `.tooltip-content` is absolutely positioned and starts slightly pushed down via `transform: translateY(15px)`. On hover, a bouncy `cubic-bezier` timing function drifts it up into its natural resting place while simultaneously fading in. 
  - The tooltip includes a pure CSS triangle pointer using border hacks on the `::after` pseudo-element.
- Added `README.md` documenting usage and features.
- Fully responsive layout.
- Honors the `prefers-reduced-motion` accessibility standard, stripping the positional drift animation and restoring a simple, static opacity fade for those sensitive to motion.

Closes #64531
