### PR TITLE
feat: add CSS Elastic-Slide Tooltip for Minimalist Tech Layouts (#64526)

### DIFF
--- a/submissions/examples/minimalist-elastic-slide-tooltip/README.md
+++ b/submissions/examples/minimalist-elastic-slide-tooltip/README.md
@@ -1,0 +1,20 @@
+# CSS Elastic-Slide Tooltip (Minimalist Tech)
+
+A pure CSS tooltip component designed for Minimalist Tech Layouts. It features a playful, physics-based "Elastic-Slide" entrance animation triggered on hover, creating a satisfying and modern interaction model.
+
+## Features
+- Pure CSS and HTML (No JavaScript required).
+- The `.tooltip-content` is anchored absolute to the `.tooltip-trigger` parent (in this layout, the entire metric card).
+- The slide animation is achieved by transitioning the tooltip from a pushed-out state (`translateX(40px)`) and zero opacity, to its natural resting state (`translateX(0)`) upon hovering the trigger element. 
+- A heavily exaggerated `cubic-bezier(0.68, -0.55, 0.265, 1.55)` timing function gives the slide a snappy, elastic, "spring-like" feeling that overshoots its target before settling.
+- Clean, data-focused aesthetic designed for metric dashboards, utilizing a high-contrast dark tooltip against light cards.
+- Features a pure CSS side-pointing arrow built using border manipulation on the `::after` pseudo-element.
+- Includes a smart media query breakpoint (`max-width: 768px`) that automatically repositions the tooltips from the right side to the bottom on smaller screens to prevent horizontal viewport overflow.
+- Fully accessible with `prefers-reduced-motion` support ensuring degraded, safe static layouts for users sensitive to motion (the positional elastic slide is removed, relying only on a rapid opacity fade).
+
+## Usage
+Open `demo.html` in your browser. You will see a grid of system metrics. Hover your mouse anywhere over a metric card; a dark tooltip will snap elastically into view from the right side, revealing historical context.
+
+## Files
+- `demo.html`: The HTML structure for the metrics dashboard and the nested tooltip containers.
+- `style.css`: The styling, grid layouts, and CSS `transform` logic for the elastic-slide effect and responsive repositioning.

--- a/submissions/examples/minimalist-elastic-slide-tooltip/demo.html
+++ b/submissions/examples/minimalist-elastic-slide-tooltip/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Elastic-Slide Tooltip - Minimalist Tech</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">System Metrics</h1>
+            <p class="subtitle">Hover over the indicators for historical context.</p>
+        </header>
+
+        <div class="metrics-grid">
+            
+            <div class="metric-card tooltip-trigger">
+                <div class="metric-label">Memory Usage</div>
+                <div class="metric-value">
+                    84.2% <span class="trend up">↑</span>
+                </div>
+                <!-- The Elastic-Slide Tooltip -->
+                <div class="tooltip-content tooltip-right">
+                    <div class="tooltip-header">30-Day Trend</div>
+                    <div class="tooltip-body">Average usage has increased by 12% following the recent cluster expansion.</div>
+                </div>
+            </div>
+
+            <div class="metric-card tooltip-trigger">
+                <div class="metric-label">Cache Hit Ratio</div>
+                <div class="metric-value">
+                    99.1% <span class="trend up">↑</span>
+                </div>
+                <!-- The Elastic-Slide Tooltip -->
+                <div class="tooltip-content tooltip-right">
+                    <div class="tooltip-header">Optimization Target</div>
+                    <div class="tooltip-body">Currently exceeding the 95% SLA target for edge node requests.</div>
+                </div>
+            </div>
+
+            <div class="metric-card tooltip-trigger">
+                <div class="metric-label">Active Connections</div>
+                <div class="metric-value">
+                    12,408 <span class="trend down">↓</span>
+                </div>
+                <!-- The Elastic-Slide Tooltip -->
+                <div class="tooltip-content tooltip-right">
+                    <div class="tooltip-header">Load Balancing</div>
+                    <div class="tooltip-body">Connections are currently routing away from US-East due to maintenance.</div>
+                </div>
+            </div>
+
+        </div>
+        
+    </div>
+</body>
+</html>

--- a/submissions/examples/minimalist-elastic-slide-tooltip/style.css
+++ b/submissions/examples/minimalist-elastic-slide-tooltip/style.css
@@ -1,0 +1,213 @@
+@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600&display=swap');
+
+:root {
+    --bg-color: #f8fafc;
+    --card-bg: #ffffff;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    --border-color: #e2e8f0;
+    
+    --trend-up: #10b981;
+    --trend-down: #ef4444;
+    
+    /* Tooltip Theme */
+    --tooltip-bg: #0f172a; /* Slate 900 */
+    --tooltip-text: #f8fafc;
+    --tooltip-text-muted: #94a3b8;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    font-family: 'Space Grotesk', system-ui, -apple-system, sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 40px 20px;
+    box-sizing: border-box;
+}
+
+.layout-container {
+    max-width: 600px;
+    width: 100%;
+}
+
+.section-header {
+    margin-bottom: 32px;
+}
+
+.title {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin: 0 0 8px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+    margin: 0;
+    font-weight: 400;
+}
+
+
+/* Metrics Grid Layout */
+.metrics-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 16px;
+}
+
+.metric-card {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 24px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+    transition: box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.metric-card:hover {
+    box-shadow: 0 4px 12px rgba(0,0,0,0.05);
+    border-color: #cbd5e1;
+}
+
+.metric-label {
+    font-size: 0.9rem;
+    font-weight: 500;
+    color: var(--text-secondary);
+    margin-bottom: 8px;
+}
+
+.metric-value {
+    font-size: 1.75rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.trend {
+    font-size: 1.25rem;
+}
+
+.trend.up { color: var(--trend-up); }
+.trend.down { color: var(--trend-down); }
+
+
+/* =========================================
+   Tooltip Trigger & Container Logic
+   ========================================= */
+
+.tooltip-trigger {
+    position: relative; /* Anchor for the absolute tooltip */
+    cursor: help;
+}
+
+/* Tooltip Content Block */
+.tooltip-content {
+    position: absolute;
+    width: 240px;
+    background: var(--tooltip-bg);
+    border-radius: 8px;
+    padding: 12px 16px;
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+    pointer-events: none; /* Prevent tooltip from interfering with hover */
+    z-index: 100;
+    
+    /* Positioned to the right of the card */
+    top: 50%;
+    left: 100%;
+    margin-left: 15px; /* Spacing */
+    
+    /* Elastic-Slide Initial State */
+    opacity: 0;
+    /* Translate -50% on Y to center it relative to parent. 
+       Start further out on X (40px) for the slide effect */
+    transform: translateY(-50%) translateX(40px); 
+    
+    /* The elastic cubic-bezier */
+    transition: opacity 0.3s ease,
+                transform 0.5s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+}
+
+/* The little arrow pointing left */
+.tooltip-content::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    right: 100%; /* Position on the left edge pointing left */
+    margin-top: -6px;
+    border-width: 6px;
+    border-style: solid;
+    border-color: transparent var(--tooltip-bg) transparent transparent;
+}
+
+/* Tooltip Hover/Reveal State - The "Elastic Slide" */
+.tooltip-trigger:hover .tooltip-content {
+    opacity: 1;
+    /* Slide in to 0px on X, keeping Y centered */
+    transform: translateY(-50%) translateX(0); 
+}
+
+
+/* Tooltip Internal Styling */
+.tooltip-header {
+    font-weight: 600;
+    font-size: 0.85rem;
+    color: var(--tooltip-text);
+    margin-bottom: 4px;
+}
+
+.tooltip-body {
+    font-size: 0.8rem;
+    color: var(--tooltip-text-muted);
+    line-height: 1.5;
+    white-space: normal; /* Allow text to wrap */
+}
+
+
+@media (max-width: 768px) {
+    /* On smaller screens, sliding from the right might overflow the viewport.
+       Switch to a bottom-anchored tooltip */
+    .tooltip-content {
+        top: 100%;
+        left: 50%;
+        margin-left: 0;
+        margin-top: 15px;
+        transform: translateX(-50%) translateY(40px);
+    }
+    
+    .tooltip-content::after {
+        top: auto;
+        bottom: 100%;
+        left: 50%;
+        right: auto;
+        margin-top: 0;
+        margin-left: -6px;
+        border-color: transparent transparent var(--tooltip-bg) transparent;
+    }
+    
+    .tooltip-trigger:hover .tooltip-content {
+        transform: translateX(-50%) translateY(0);
+    }
+}
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    .tooltip-content {
+        transition: opacity 0.2s ease !important;
+        /* Lock transforms to their final hover state */
+        transform: translateY(-50%) translateX(0) !important; 
+    }
+    
+    @media (max-width: 768px) {
+        .tooltip-content {
+            transform: translateX(-50%) translateY(0) !important;
+        }
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces the CSS Elastic-Slide Tooltip designed for Minimalist Tech Layouts, resolving issue #64526. 

### Changes Made:
- Added `submissions/examples/minimalist-elastic-slide-tooltip/` directory.
- Created `demo.html` showcasing a grid of system metric cards where hovering over the entire card triggers the contextual tooltip. 
- Created `style.css` featuring a clean, data-focused aesthetic utilizing the `Space Grotesk` font family.
  - Implemented the elastic-slide hover effect. The `.tooltip-content` is anchored to the right side of the card and starts pushed out via `transform: translateX(40px)`. On hover, a heavily exaggerated `cubic-bezier(0.68, -0.55, 0.265, 1.55)` timing function snaps it elastically into place while fading in.
  - Built a smart CSS media query that dynamically repositions the tooltips from the right side to the bottom on screens `< 768px` to prevent horizontal viewport clipping.
- Added `README.md` documenting usage and features.
- Fully responsive layout.
- Honors the `prefers-reduced-motion` accessibility standard, stripping the positional elastic slide and restoring a static opacity fade for those sensitive to motion.

Closes #64526
