### PR TITLE
feat: add CSS 3D-Flip Tooltip for Minimalist Tech Layouts (#64522)

### DIFF
--- a/submissions/examples/minimalist-3d-flip-tooltip/README.md
+++ b/submissions/examples/minimalist-3d-flip-tooltip/README.md
@@ -1,0 +1,19 @@
+# CSS 3D-Flip Tooltip (Minimalist Tech)
+
+A pure CSS tooltip component designed for Minimalist Tech Layouts. It features a sophisticated 3D "flip-down" animation triggered on hover, creating the illusion of a physical card swinging out from a hinge on its top edge.
+
+## Features
+- Pure CSS and HTML (No JavaScript required).
+- The 3D effect is achieved by placing a `.tooltip-content` block inside a `.tooltip-perspective` wrapper wrapper. The wrapper establishes a 3D spatial field via `perspective: 1000px`.
+- The animation is driven by a `transform: rotateX(-90deg)` to `rotateX(0deg)` transition, anchoring the movement to the top edge using `transform-origin: top center`. 
+- A `cubic-bezier` timing function gives the swing a physical, snappy feeling that bounces slightly upon fully opening.
+- Clean, data-focused aesthetic designed for user lists and admin tables, utilizing a stark black-and-white color palette to focus on the content.
+- Features a pure CSS upward-pointing arrow built using border manipulation on the `::after` and `::before` pseudo-elements (creating a masked stroke effect).
+- Fully accessible with `prefers-reduced-motion` support ensuring degraded, safe static layouts for users sensitive to motion (the 3D spatial flip is removed, relying only on a rapid opacity fade).
+
+## Usage
+Open `demo.html` in your browser. You will see a list of users with corresponding role badges. Hover your mouse over any of the role badges; a detailed tooltip card will swing down dynamically from the top edge on a 3D axis.
+
+## Files
+- `demo.html`: The HTML structure for the layout, utilizing the required nested `tooltip-perspective` and `tooltip-content` blocks.
+- `style.css`: The styling, flexbox layouts, and CSS `transform-style: preserve-3d` logic for the 3D flip effect.

--- a/submissions/examples/minimalist-3d-flip-tooltip/demo.html
+++ b/submissions/examples/minimalist-3d-flip-tooltip/demo.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS 3D-Flip Tooltip - Minimalist Tech</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">User Access Roles</h1>
+            <p class="subtitle">Hover over the permission badges to view specifics.</p>
+        </header>
+
+        <div class="user-list">
+            
+            <div class="user-item">
+                <div class="user-info">
+                    <span class="user-name">Eleanor Vance</span>
+                    <span class="user-email">evance@organization.com</span>
+                </div>
+                
+                <div class="role-badge tooltip-trigger">
+                    Admin
+                    <!-- The 3D-Flip Tooltip -->
+                    <div class="tooltip-perspective">
+                        <div class="tooltip-content tooltip-bottom">
+                            <div class="tooltip-header">Full Access</div>
+                            <div class="tooltip-body">Can modify billing, manage all users, and delete workspaces.</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="user-item">
+                <div class="user-info">
+                    <span class="user-name">Arthur Dent</span>
+                    <span class="user-email">adent@organization.com</span>
+                </div>
+                
+                <div class="role-badge tooltip-trigger">
+                    Editor
+                    <!-- The 3D-Flip Tooltip -->
+                    <div class="tooltip-perspective">
+                        <div class="tooltip-content tooltip-bottom">
+                            <div class="tooltip-header">Write Access</div>
+                            <div class="tooltip-body">Can create and edit projects. Cannot invite new members.</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="user-item">
+                <div class="user-info">
+                    <span class="user-name">Marvin Android</span>
+                    <span class="user-email">mandroid@organization.com</span>
+                </div>
+                
+                <div class="role-badge tooltip-trigger">
+                    Viewer
+                    <!-- The 3D-Flip Tooltip -->
+                    <div class="tooltip-perspective">
+                        <div class="tooltip-content tooltip-bottom">
+                            <div class="tooltip-header">Read-Only</div>
+                            <div class="tooltip-body">Can view all public projects. Cannot make any modifications.</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+        
+    </div>
+</body>
+</html>

--- a/submissions/examples/minimalist-3d-flip-tooltip/style.css
+++ b/submissions/examples/minimalist-3d-flip-tooltip/style.css
@@ -1,0 +1,225 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+:root {
+    --bg-color: #fafafa;
+    --card-bg: #ffffff;
+    --text-primary: #171717;
+    --text-secondary: #737373;
+    --border-color: #e5e5e5;
+    
+    /* Tooltip Theme */
+    --tooltip-bg: #ffffff;
+    --tooltip-border: #d4d4d4;
+    --tooltip-text: #171717;
+    --tooltip-text-muted: #525252;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    font-family: 'Inter', system-ui, -apple-system, sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 40px 20px;
+    box-sizing: border-box;
+}
+
+.layout-container {
+    max-width: 500px;
+    width: 100%;
+}
+
+.section-header {
+    margin-bottom: 24px;
+}
+
+.title {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin: 0 0 4px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    margin: 0;
+    font-weight: 400;
+}
+
+
+/* User List Layout */
+.user-list {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.02);
+}
+
+.user-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 16px 20px;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.user-item:last-child {
+    border-bottom: none;
+}
+
+.user-info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.user-name {
+    font-size: 0.95rem;
+    font-weight: 600;
+}
+
+.user-email {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+}
+
+.role-badge {
+    font-size: 0.8rem;
+    font-weight: 500;
+    background: #f5f5f5;
+    padding: 4px 10px;
+    border-radius: 4px;
+    border: 1px solid var(--border-color);
+}
+
+
+/* =========================================
+   Tooltip Trigger & 3D Perspective Logic
+   ========================================= */
+
+.tooltip-trigger {
+    position: relative; /* Anchor for the absolute tooltip */
+    cursor: help;
+}
+
+/* 
+  The perspective wrapper establishes the 3D space. 
+  It must be a separate wrapper so it doesn't get transformed itself.
+*/
+.tooltip-perspective {
+    position: absolute;
+    top: 100%; /* Anchor below the trigger */
+    left: 50%;
+    transform: translateX(-50%);
+    perspective: 1000px; /* Crucial for 3D depth */
+    
+    /* Initially hide the wrapper so it doesn't block hover events */
+    visibility: hidden; 
+    z-index: 100;
+    
+    /* Ensure there's a small hit area gap */
+    padding-top: 10px; 
+}
+
+/* Tooltip Content Block (The card that actually flips) */
+.tooltip-content {
+    width: 220px;
+    background: var(--tooltip-bg);
+    border: 1px solid var(--tooltip-border);
+    border-radius: 8px;
+    padding: 12px 16px;
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
+    
+    /* 3D Transform Logic */
+    transform-style: preserve-3d;
+    transform-origin: top center; /* Hinge from the top edge */
+    
+    /* Initial Hidden State: Flipped up 90 degrees away from viewer */
+    transform: rotateX(-90deg); 
+    opacity: 0;
+    
+    /* The snappy transition */
+    transition: transform 0.5s cubic-bezier(0.175, 0.885, 0.32, 1.275),
+                opacity 0.4s ease;
+}
+
+/* The little arrow pointing up */
+.tooltip-content::after {
+    content: '';
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    margin-left: -6px;
+    border-width: 6px;
+    border-style: solid;
+    border-color: transparent transparent var(--tooltip-border) transparent;
+}
+/* Mask the arrow border slightly for a clean look */
+.tooltip-content::before {
+    content: '';
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    margin-left: -5px;
+    border-width: 5px;
+    border-style: solid;
+    border-color: transparent transparent var(--tooltip-bg) transparent;
+    z-index: 2;
+}
+
+/* Tooltip Hover/Reveal State - The "3D Flip" */
+.tooltip-trigger:hover .tooltip-perspective {
+    visibility: visible;
+}
+
+.tooltip-trigger:hover .tooltip-content {
+    opacity: 1;
+    /* Swing down into flat view */
+    transform: rotateX(0deg); 
+}
+
+
+/* Tooltip Internal Styling */
+.tooltip-header {
+    font-weight: 600;
+    font-size: 0.85rem;
+    color: var(--tooltip-text);
+    margin-bottom: 4px;
+}
+
+.tooltip-body {
+    font-size: 0.8rem;
+    color: var(--tooltip-text-muted);
+    line-height: 1.5;
+    white-space: normal; /* Allow text to wrap inside the fixed width */
+}
+
+
+@media (max-width: 480px) {
+    .tooltip-perspective {
+        /* On very small screens, nudge it over so it doesn't overflow the right edge */
+        left: auto;
+        right: -20px;
+        transform: none;
+    }
+    .tooltip-content::after, .tooltip-content::before {
+        left: auto;
+        right: 30px;
+    }
+}
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    .tooltip-content {
+        transition: opacity 0.2s ease !important;
+        transform: rotateX(0) !important; 
+    }
+    .tooltip-trigger:hover .tooltip-content {
+        transform: rotateX(0) !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces the CSS 3D-Flip Tooltip designed for Minimalist Tech Layouts, resolving issue #64522. 

### Changes Made:
- Added `submissions/examples/minimalist-3d-flip-tooltip/` directory.
- Created `demo.html` showcasing an administrative user list where hovering over role badges triggers the 3D-tooltip. 
- Created `style.css` featuring a clean, high-contrast aesthetic utilizing the `Inter` font family.
  - Implemented the 3D-Flip hover effect. This requires two nested elements: a `.tooltip-perspective` wrapper that anchors the 3D space (`perspective: 1000px`), and the `.tooltip-content` which performs the actual `rotateX(-90deg)` to `rotateX(0)` transition. 
  - The hinge is anchored to the top via `transform-origin: top center`, giving the feeling of a physical card swinging open on a hinge.
  - Built a custom bordered arrow utilizing both `::before` and `::after` pseudo-elements.
- Added `README.md` documenting usage and features.
- Fully responsive layout, featuring edge-detection CSS to prevent horizontal clipping on mobile screens.
- Honors the `prefers-reduced-motion` accessibility standard, stripping the spatial 3D rotation and restoring a safe static opacity fade for those sensitive to motion.

Closes #64522
