### PR TITLE
feat: add CSS Fade-In Tooltip for Minimalist Tech Layouts (#64518)

### DIFF
--- a/submissions/examples/minimalist-fade-in-tooltip/README.md
+++ b/submissions/examples/minimalist-fade-in-tooltip/README.md
@@ -1,0 +1,19 @@
+# CSS Fade-In Tooltip (Minimalist Tech)
+
+A pure CSS tooltip component designed for Minimalist Tech Layouts. It features a straightforward, hyper-clean "Fade-In" animation triggered on hover, favoring simplicity and immediate readability over complex motion.
+
+## Features
+- Pure CSS and HTML (No JavaScript required).
+- The `.tooltip-content` is anchored absolute to the `.tooltip-trigger` parent. 
+- The animation is achieved entirely through an `opacity` and `visibility` transition, ensuring the tooltip appears exactly where it needs to be without any spatial shifting or bouncing.
+- Clean, stark aesthetic designed for configuration panels and admin settings, utilizing the `Inter` font family and high-contrast toggle switches.
+- Features a pure CSS side-pointing arrow built using border manipulation on the `::after` pseudo-element.
+- Includes a smart media query breakpoint (`max-width: 768px`) that automatically repositions the tooltips from the right side to the bottom on smaller screens to prevent horizontal viewport overflow.
+- Naturally accessible, as the lack of spatial movement automatically complies with standard `prefers-reduced-motion` guidelines without requiring an explicit media query override.
+
+## Usage
+Open `demo.html` in your browser. You will see a list of security configuration settings. Hover your mouse over the dashed setting names; a dark tooltip will smoothly fade into view directly adjacent to the trigger, revealing detailed documentation.
+
+## Files
+- `demo.html`: The HTML structure for the settings list, toggle switches, and the nested tooltip containers.
+- `style.css`: The styling, flexbox layouts, and CSS `opacity` logic for the fade-in effect and responsive repositioning.

--- a/submissions/examples/minimalist-fade-in-tooltip/demo.html
+++ b/submissions/examples/minimalist-fade-in-tooltip/demo.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Fade-In Tooltip - Minimalist Tech</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Security Configuration</h1>
+            <p class="subtitle">Hover over settings for detailed documentation.</p>
+        </header>
+
+        <div class="settings-list">
+            
+            <div class="setting-item">
+                <div class="setting-info tooltip-trigger">
+                    <span class="setting-name">Enforce MFA</span>
+                    <!-- The Fade-In Tooltip -->
+                    <div class="tooltip-content tooltip-right">
+                        <div class="tooltip-body">Requires all users to configure Multi-Factor Authentication before accessing organization resources.</div>
+                    </div>
+                </div>
+                
+                <div class="setting-action">
+                    <label class="toggle-switch">
+                        <input type="checkbox" checked>
+                        <span class="slider"></span>
+                    </label>
+                </div>
+            </div>
+            
+            <div class="setting-item">
+                <div class="setting-info tooltip-trigger">
+                    <span class="setting-name">Session Timeout</span>
+                    <!-- The Fade-In Tooltip -->
+                    <div class="tooltip-content tooltip-right">
+                        <div class="tooltip-body">Automatically revokes access tokens after 15 minutes of inactivity. Forces re-authentication.</div>
+                    </div>
+                </div>
+                
+                <div class="setting-action">
+                    <label class="toggle-switch">
+                        <input type="checkbox" checked>
+                        <span class="slider"></span>
+                    </label>
+                </div>
+            </div>
+            
+            <div class="setting-item">
+                <div class="setting-info tooltip-trigger">
+                    <span class="setting-name">Allow External Sharing</span>
+                    <!-- The Fade-In Tooltip -->
+                    <div class="tooltip-content tooltip-right">
+                        <div class="tooltip-body">Permits generating public links for documents. Warning: This bypasses organizational access controls.</div>
+                    </div>
+                </div>
+                
+                <div class="setting-action">
+                    <label class="toggle-switch">
+                        <input type="checkbox">
+                        <span class="slider"></span>
+                    </label>
+                </div>
+            </div>
+
+        </div>
+        
+    </div>
+</body>
+</html>

--- a/submissions/examples/minimalist-fade-in-tooltip/style.css
+++ b/submissions/examples/minimalist-fade-in-tooltip/style.css
@@ -1,0 +1,213 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+:root {
+    --bg-color: #fafafa;
+    --card-bg: #ffffff;
+    --text-primary: #171717;
+    --text-secondary: #737373;
+    --border-color: #e5e5e5;
+    
+    --accent-color: #000000;
+    
+    /* Tooltip Theme */
+    --tooltip-bg: #171717;
+    --tooltip-text: #f5f5f5;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    font-family: 'Inter', system-ui, -apple-system, sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 40px 20px;
+    box-sizing: border-box;
+}
+
+.layout-container {
+    max-width: 500px;
+    width: 100%;
+}
+
+.section-header {
+    margin-bottom: 24px;
+}
+
+.title {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin: 0 0 4px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    margin: 0;
+    font-weight: 400;
+}
+
+
+/* Settings List Layout */
+.settings-list {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.02);
+}
+
+.setting-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 16px 20px;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.setting-item:last-child {
+    border-bottom: none;
+}
+
+.setting-name {
+    font-size: 0.95rem;
+    font-weight: 500;
+    color: var(--text-primary);
+    border-bottom: 1px dashed var(--text-secondary);
+}
+
+
+/* Toggle Switch */
+.toggle-switch {
+    position: relative;
+    display: inline-block;
+    width: 44px;
+    height: 24px;
+}
+
+.toggle-switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #d4d4d4;
+    transition: .3s;
+    border-radius: 24px;
+}
+
+.slider:before {
+    position: absolute;
+    content: "";
+    height: 18px;
+    width: 18px;
+    left: 3px;
+    bottom: 3px;
+    background-color: white;
+    transition: .3s;
+    border-radius: 50%;
+}
+
+input:checked + .slider {
+    background-color: var(--accent-color);
+}
+
+input:checked + .slider:before {
+    transform: translateX(20px);
+}
+
+
+/* =========================================
+   Tooltip Trigger & Fade-In Logic
+   ========================================= */
+
+.tooltip-trigger {
+    position: relative; /* Anchor for the absolute tooltip */
+    cursor: help;
+    display: flex;
+    align-items: center;
+}
+
+/* Tooltip Content Block */
+.tooltip-content {
+    position: absolute;
+    width: 220px;
+    background: var(--tooltip-bg);
+    border-radius: 6px;
+    padding: 10px 14px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    pointer-events: none; /* Prevent tooltip from interfering with hover */
+    z-index: 100;
+    
+    /* Positioned to the right */
+    top: 50%;
+    left: 100%;
+    margin-left: 12px; /* Static spacing */
+    transform: translateY(-50%); /* Centered vertically */
+    
+    /* Pure Fade-In Initial State */
+    opacity: 0;
+    visibility: hidden; /* Added visibility so it's not clickable when hidden */
+    
+    /* Smooth, simple fade transition */
+    transition: opacity 0.3s ease, visibility 0.3s ease;
+}
+
+/* The little arrow pointing left */
+.tooltip-content::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    right: 100%; /* Position on the left edge pointing left */
+    margin-top: -5px;
+    border-width: 5px;
+    border-style: solid;
+    border-color: transparent var(--tooltip-bg) transparent transparent;
+}
+
+/* Tooltip Hover/Reveal State - The "Fade-In" */
+.tooltip-trigger:hover .tooltip-content {
+    opacity: 1;
+    visibility: visible;
+}
+
+
+/* Tooltip Internal Styling */
+.tooltip-body {
+    font-size: 0.8rem;
+    color: var(--tooltip-text);
+    line-height: 1.5;
+    white-space: normal; /* Allow text to wrap */
+}
+
+
+@media (max-width: 768px) {
+    /* Responsive repositioning */
+    .tooltip-content {
+        top: 100%;
+        left: 0;
+        margin-left: 0;
+        margin-top: 10px;
+        transform: none;
+    }
+    
+    .tooltip-content::after {
+        top: auto;
+        bottom: 100%;
+        left: 20px;
+        right: auto;
+        margin-top: 0;
+        margin-left: -5px;
+        border-color: transparent transparent var(--tooltip-bg) transparent;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces the CSS Fade-In Tooltip designed for Minimalist Tech Layouts, resolving issue #64518. 

### Changes Made:
- Added `submissions/examples/minimalist-fade-in-tooltip/` directory.
- Created `demo.html` showcasing an administrative security configuration panel where hovering over the setting names triggers the tooltip. It includes pure CSS toggle switches for added layout realism.
- Created `style.css` featuring a clean, stark aesthetic utilizing the `Inter` font family.
  - Implemented the simple Fade-In hover effect. The `.tooltip-content` is anchored to the right side of the trigger element. On hover, it cleanly transitions `opacity` and `visibility`, appearing directly in place without any spatial shifting or bouncing.
  - Built a smart CSS media query that dynamically repositions the tooltips from the right side to the bottom on screens `< 768px` to prevent horizontal viewport clipping.
- Added `README.md` documenting usage and features.
- Fully responsive layout.
- Naturally accessible design. By avoiding spatial movement entirely, this tooltip inherently aligns with `prefers-reduced-motion` guidelines without requiring explicit overrides.

Closes #64518
