### PR TITLE
Add ease-football-scorecard component

### DIFF
--- a/submissions/examples/football-scorecard-ij/README.md
+++ b/submissions/examples/football-scorecard-ij/README.md
@@ -1,0 +1,10 @@
+# ease-football-scorecard
+
+A match board where the home and away score digits pulse with the action, the LIVE tag glows in the status bar, and the match minute ticks beside it.
+
+## Run
+Open `demo.html` directly in a browser to watch the scores pulse.
+
+## Notes
+- Both score digits pulse on the board.
+- The LIVE tag glows in rhythm.

--- a/submissions/examples/football-scorecard-ij/demo.html
+++ b/submissions/examples/football-scorecard-ij/demo.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-football-scorecard demo</title>
+</head>
+<body>
+<div class="fs-app">
+  <span class="fs-title">MATCH DAY</span>
+  <div class="fs-board">
+    <div class="fs-team">
+      <span class="fs-crest fs-crest-home">FC</span>
+      <span class="fs-name">RIVER SIDE</span>
+    </div>
+    <div class="fs-score">
+      <span class="fs-digit">2</span>
+      <span class="fs-colon">-</span>
+      <span class="fs-digit">1</span>
+    </div>
+    <div class="fs-team">
+      <span class="fs-crest fs-crest-away">UN</span>
+      <span class="fs-name">NORTH END</span>
+    </div>
+  </div>
+  <div class="fs-status">
+    <span class="fs-min">67</span>
+    <span class="fs-pulse">LIVE</span>
+  </div>
+  <span class="fs-venue">STADIUM BAY</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/football-scorecard-ij/style.css
+++ b/submissions/examples/football-scorecard-ij/style.css
@@ -1,0 +1,20 @@
+:root{--fs-green:#37e06a;--fs-dark:#07100a}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#0e2316,#07100a);font-family:'Segoe UI',sans-serif}
+.fs-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#0a1a10,#040a06);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.fs-title{position:absolute;top:16px;left:0;right:0;text-align:center;font-size:12px;font-weight:800;letter-spacing:7px;color:#37e06a}
+.fs-board{position:absolute;top:58px;left:30px;right:30px;height:150px;border-radius:14px;background:#0c2014;box-shadow:inset 0 0 0 3px #1c4a2c;display:flex;align-items:center;justify-content:space-between;padding:0 18px}
+.fs-team{display:flex;flex-direction:column;align-items:center;gap:8px;width:88px}
+.fs-crest{width:42px;height:42px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:10px;font-weight:900;color:#07100a}
+.fs-crest-home{background:linear-gradient(180deg,#ff5b5b,#b91f1f)}
+.fs-crest-away{background:linear-gradient(180deg,#4d9bff,#1f4bb9)}
+.fs-name{font-size:11px;font-weight:800;color:#cfe8d5;letter-spacing:1px;text-align:center}
+.fs-score{display:flex;align-items:center;gap:10px}
+.fs-digit{font-size:46px;font-weight:900;color:#eafff0;font-variant-numeric:tabular-nums;animation:score-pulse-football-scorecard 1.6s ease-in-out infinite}
+.fs-colon{font-size:26px;font-weight:900;color:#4a7a5a}
+.fs-status{position:absolute;top:226px;left:0;right:0;display:flex;justify-content:center;align-items:center;gap:14px}
+.fs-min{font-size:14px;font-weight:900;color:#8fd8a5;font-variant-numeric:tabular-nums;animation:min-tick-football-scorecard 1s steps(1) infinite}
+.fs-pulse{font-size:11px;font-weight:900;letter-spacing:3px;color:#37e06a;animation:live-glow-football-scorecard 1.4s ease-in-out infinite}
+.fs-venue{position:absolute;bottom:16px;left:0;right:0;text-align:center;font-size:10px;font-weight:800;letter-spacing:4px;color:#3a7a4c}
+@keyframes score-pulse-football-scorecard{0%,100%{transform:scale(1)}50%{transform:scale(1.1)}}
+@keyframes live-glow-football-scorecard{0%,100%{opacity:0.6}50%{opacity:1}}
+@keyframes min-tick-football-scorecard{0%,49%{opacity:1}50%,100%{opacity:0.4}}


### PR DESCRIPTION
## Component: ease-football-scorecard — scores pulse, live glows, and minutes tick

**Closes #65391**

### What this adds
A match board: the home and away score digits pulse with the action, the LIVE tag glows in the status bar, and the match minute ticks beside it.

### Acceptance Criteria covered
- Home and away score digits pulse
- LIVE tag glows in the status bar
- Match minute ticks beside it

### Files
- `submissions/examples/football-scorecard-ij/demo.html`
- `submissions/examples/football-scorecard-ij/style.css`
- `submissions/examples/football-scorecard-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the scores pulse.