### PR TITLE
feat: add macos dock magnification navigation bar component

### DIFF
--- a/submissions/examples/gssoc-2026-mac-os-dock-magnification-v2-bb/README.md
+++ b/submissions/examples/gssoc-2026-mac-os-dock-magnification-v2-bb/README.md
@@ -1,0 +1,23 @@
+# macOS Dock Magnification Navigation Bar
+
+A modern macOS desktop dock navigation component built with pure CSS `:hover` scaling and `:has()` sibling proximity selection rules.
+
+## 1. What does this do?
+This component replicates the famous Apple macOS desktop dock icon magnification effect when hovering over icons, smooth spring curve transforms, active application indicator dots, and contextual tooltips.
+
+## 2. How is it used?
+Wrap menu items in `.dock-bar` container and assign icon graphics with tooltip attributes:
+
+```html
+<div class="dock-bar">
+  <div class="dock-item" data-tooltip="Terminal">
+    <div class="dock-icon">...</div>
+    <div class="dock-dot active-dot"></div>
+  </div>
+</div>
+```
+
+## 3. Why is it useful?
+- **Zero JavaScript Overhead**: Uses modern CSS `:has()` relational selector logic for smooth sibling icon enlargement.
+- **Mac Desktop Styling**: Frosted glassmorphism background panel with subtle backdrop blur filter.
+- **Accessible Design**: Reduces hover magnification scale when `prefers-reduced-motion: reduce` is detected.

--- a/submissions/examples/gssoc-2026-mac-os-dock-magnification-v2-bb/demo.html
+++ b/submissions/examples/gssoc-2026-mac-os-dock-magnification-v2-bb/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>macOS Dock Magnification Navigation | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <div class="dock-wrapper">
+    <div class="dock-bar">
+      <!-- Item 1 -->
+      <div class="dock-item" data-tooltip="Finder">
+        <div class="dock-icon icon-finder">
+          <svg width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"/></svg>
+        </div>
+        <div class="dock-dot"></div>
+      </div>
+
+      <!-- Item 2 -->
+      <div class="dock-item" data-tooltip="Terminal">
+        <div class="dock-icon icon-term">
+          <svg width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M4 17l6-5-6-5M12 19h8"/></svg>
+        </div>
+        <div class="dock-dot active-dot"></div>
+      </div>
+
+      <!-- Item 3 -->
+      <div class="dock-item" data-tooltip="Code Editor">
+        <div class="dock-icon icon-code">
+          <svg width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/></svg>
+        </div>
+        <div class="dock-dot active-dot"></div>
+      </div>
+
+      <!-- Item 4 -->
+      <div class="dock-item" data-tooltip="Settings">
+        <div class="dock-icon icon-settings">
+          <svg width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M12 15a3 3 0 100-6 3 3 0 000 6z"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-2 2 2 2 0 01-2-2v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83 0 2 2 0 010-2.83l.06-.06a1.65 1.65 0 00.33-1.82 1.65 1.65 0 00-1.51-1H3a2 2 0 01-2-2 2 2 0 012-2h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 010-2.83 2 2 0 012.83 0l.06.06a1.65 1.65 0 001.82.33H9a1.65 1.65 0 001-1.51V3a2 2 0 012-2 2 2 0 012 2v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 0 2 2 0 010 2.83l-.06.06a1.65 1.65 0 00-.33 1.82V9a1.65 1.65 0 001.51 1H21a2 2 0 012 2 2 2 0 01-2 2h-.09a1.65 1.65 0 00-1.51 1z"/></svg>
+        </div>
+        <div class="dock-dot"></div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/gssoc-2026-mac-os-dock-magnification-v2-bb/style.css
+++ b/submissions/examples/gssoc-2026-mac-os-dock-magnification-v2-bb/style.css
@@ -1,0 +1,116 @@
+:root {
+  --dock-bg: rgba(255, 255, 255, 0.12);
+  --dock-border: rgba(255, 255, 255, 0.2);
+  --icon-bg: rgba(255, 255, 255, 0.25);
+  --accent-blue: #38bdf8;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  background: radial-gradient(circle at center, #1e1b4b, #0f172a);
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  padding-bottom: 3rem;
+}
+
+.dock-wrapper {
+  display: flex;
+  justify-content: center;
+}
+
+.dock-bar {
+  background: var(--dock-bg);
+  border: 1px solid var(--dock-border);
+  padding: 0.75rem 1.25rem;
+  border-radius: 28px;
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  display: flex;
+  align-items: flex-end;
+  gap: 1rem;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+}
+
+.dock-item {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  cursor: pointer;
+  transition: transform 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+.dock-icon {
+  width: 52px;
+  height: 52px;
+  border-radius: 16px;
+  background: var(--icon-bg);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: #ffffff;
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
+  transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+.dock-item:hover .dock-icon {
+  transform: translateY(-16px) scale(1.35);
+  background: rgba(255, 255, 255, 0.35);
+  box-shadow: 0 15px 30px rgba(0, 0, 0, 0.3);
+}
+
+.dock-item:hover + .dock-item .dock-icon,
+.dock-item:has(+ .dock-item:hover) .dock-icon {
+  transform: translateY(-8px) scale(1.15);
+}
+
+.dock-dot {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: transparent;
+  margin-top: 6px;
+}
+
+.active-dot {
+  background: #ffffff;
+  box-shadow: 0 0 6px #ffffff;
+}
+
+.dock-item::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  top: -45px;
+  background: rgba(15, 23, 42, 0.9);
+  color: #ffffff;
+  padding: 0.35rem 0.75rem;
+  border-radius: 8px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  transform: translateY(6px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.dock-item:hover::after {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dock-item:hover .dock-icon {
+    transform: translateY(-4px);
+  }
+}


### PR DESCRIPTION
# Related Issue
Closes #65402 

# Summary
Adds a macOS desktop floating dock navigation component to `submissions/examples/`.

# Changes Made
- Created `submissions/examples/gssoc-2026-mac-os-dock-magnification-v2-bb/demo.html` with dock menu icons.
- Created `submissions/examples/gssoc-2026-mac-os-dock-magnification-v2-bb/style.css` featuring pure CSS `:has()` sibling magnification, frosted glass panels, and tooltips.
- Created `submissions/examples/gssoc-2026-mac-os-dock-magnification-v2-bb/README.md` with integration notes.

# Testing
- Tested icon scale transforms across Chrome, Edge, and Firefox.
- Verified tooltip positioning and hover transition smoothness.
- Checked reduced motion overrides to limit hover scale offsets.

# Screenshots
macOS desktop floating dock bar with icon magnification and active indicator dots.

# Impact
Showcases cutting-edge CSS `:has()` capabilities within the EaseMotion CSS component ecosystem.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered
