### PR TITLE
Add ease-tag-cloud-word component

### DIFF
--- a/submissions/examples/tag-cloud-word-ij/README.md
+++ b/submissions/examples/tag-cloud-word-ij/README.md
@@ -1,0 +1,10 @@
+# ease-tag-cloud-word
+
+A word cloud where twelve text tags drift at different sizes while the term counter blinks beneath the layout.
+
+## Run
+Open `demo.html` directly in a browser to watch the tags drift.
+
+## Notes
+- Tags drift at their own pace.
+- The term counter blinks below.

--- a/submissions/examples/tag-cloud-word-ij/demo.html
+++ b/submissions/examples/tag-cloud-word-ij/demo.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-tag-cloud-word demo</title>
+</head>
+<body>
+<div class="tc-app">
+  <span class="tc-title">WORD CLOUD</span>
+  <div class="tc-cloud">
+    <span class="tc-tag tc-t1">CSS</span>
+    <span class="tc-tag tc-t2">ANIMATION</span>
+    <span class="tc-tag tc-t3">PIXELS</span>
+    <span class="tc-tag tc-t4">DESIGN</span>
+    <span class="tc-tag tc-t5">MOTION</span>
+    <span class="tc-tag tc-t6">LAYOUT</span>
+    <span class="tc-tag tc-t7">SPRITES</span>
+    <span class="tc-tag tc-t8">GRADIENT</span>
+    <span class="tc-tag tc-t9">TYPEFACE</span>
+    <span class="tc-tag tc-t10">VECTOR</span>
+    <span class="tc-tag tc-t11">SHADOW</span>
+    <span class="tc-tag tc-t12">STROKE</span>
+  </div>
+  <span class="tc-count">12 TERMS</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/tag-cloud-word-ij/style.css
+++ b/submissions/examples/tag-cloud-word-ij/style.css
@@ -1,0 +1,24 @@
+:root{--tc-cyan:#5fd0ff;--tc-dark:#06101a}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#0e2233,#06101a);font-family:'Segoe UI',sans-serif}
+.tc-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#0a1a28,#030810);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.tc-title{position:absolute;top:16px;left:0;right:0;text-align:center;font-size:12px;font-weight:800;letter-spacing:7px;color:#5fd0ff}
+.tc-cloud{position:absolute;top:52px;left:24px;right:24px;height:250px;border-radius:14px;background:#0b1e2e;box-shadow:inset 0 0 0 3px #16344a;display:flex;flex-wrap:wrap;align-content:center;align-items:center;justify-content:center;gap:14px;padding:16px}
+.tc-tag{display:inline-block;font-weight:900;color:#d6f2ff;border-radius:6px;box-shadow:inset 0 0 0 2px #1a4058;animation:drift-tag-cloud-word ease-in-out infinite}
+.tc-t1{font-size:26px;padding:6px 12px;animation-duration:3.4s}
+.tc-t2{font-size:14px;padding:4px 10px;animation-duration:4.2s}
+.tc-t3{font-size:20px;padding:5px 11px;animation-duration:3.8s}
+.tc-t4{font-size:12px;padding:3px 9px;animation-duration:4.6s}
+.tc-t5{font-size:22px;padding:5px 12px;animation-duration:3.2s}
+.tc-t6{font-size:15px;padding:4px 10px;animation-duration:4.4s}
+.tc-t7{font-size:18px;padding:5px 11px;animation-duration:3.6s}
+.tc-t8{font-size:13px;padding:3px 9px;animation-duration:4.8s}
+.tc-t9{font-size:17px;padding:5px 10px;animation-duration:4s}
+.tc-t10{font-size:11px;padding:3px 8px;animation-duration:5s}
+.tc-t11{font-size:16px;padding:4px 10px;animation-duration:4.1s}
+.tc-t12{font-size:12px;padding:3px 9px;animation-duration:4.7s}
+.tc-t1,.tc-t6,.tc-t11{color:#5fd0ff}
+.tc-t3,.tc-t8{color:#ffd23f}
+.tc-t5,.tc-t10{color:#7dffc8}
+.tc-count{position:absolute;bottom:16px;left:0;right:0;text-align:center;font-size:10px;font-weight:800;letter-spacing:4px;color:#3a7a99;animation:count-blink-tag-cloud-word 1.8s steps(1) infinite}
+@keyframes drift-tag-cloud-word{0%,100%{transform:translateY(0)}50%{transform:translateY(-6px)}}
+@keyframes count-blink-tag-cloud-word{0%,49%{opacity:1}50%,100%{opacity:0.35}}


### PR DESCRIPTION
## Component: ease-tag-cloud-word — tags drift, cloud holds, and count blinks

**Closes #65404**

### What this adds
A word cloud: twelve text tags drift at different sizes across the cloud, while the term counter blinks beneath the layout.

### Acceptance Criteria covered
- Tags drift at different sizes
- Cloud layout holds the terms
- Term counter blinks below

### Files
- `submissions/examples/tag-cloud-word-ij/demo.html`
- `submissions/examples/tag-cloud-word-ij/style.css`
- `submissions/examples/tag-cloud-word-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the tags drift.