### PR TITLE
Add ease-camera-shutter-app component

### DIFF
--- a/submissions/examples/camera-shutter-app-ij/README.md
+++ b/submissions/examples/camera-shutter-app-ij/README.md
@@ -1,0 +1,10 @@
+# ease-camera-shutter-app
+
+A camera app where the focus box pulses over the viewfinder grid, the shutter ring blinks, and the READY status glows above the settings row.
+
+## Run
+Open `demo.html` directly in a browser to watch the focus pulse.
+
+## Notes
+- The focus box pulses on the grid.
+- The shutter ring blinks in place.

--- a/submissions/examples/camera-shutter-app-ij/demo.html
+++ b/submissions/examples/camera-shutter-app-ij/demo.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-camera-shutter-app demo</title>
+</head>
+<body>
+<div class="ca-app">
+  <span class="ca-title">VIEWFINDER</span>
+  <div class="ca-lens">
+    <span class="ca-grid"></span>
+    <span class="ca-focus"></span>
+  </div>
+  <div class="ca-controls">
+    <span class="ca-btn ca-mode">AUTO</span>
+    <span class="ca-btn ca-shutter"></span>
+    <span class="ca-btn ca-flash">FLASH</span>
+  </div>
+  <div class="ca-settings">
+    <span class="ca-set">ISO 400</span>
+    <span class="ca-set">F 2.8</span>
+    <span class="ca-set">1/125</span>
+  </div>
+  <span class="ca-ready">READY</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/camera-shutter-app-ij/style.css
+++ b/submissions/examples/camera-shutter-app-ij/style.css
@@ -1,0 +1,20 @@
+:root{--ca-red:#ff5540;--ca-dark:#0d0706}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#1e120d,#0d0706);font-family:'Segoe UI',sans-serif}
+.ca-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#170d09,#0a0503);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.ca-title{position:absolute;top:16px;left:0;right:0;text-align:center;font-size:12px;font-weight:800;letter-spacing:7px;color:#ff5540}
+.ca-lens{position:absolute;top:56px;left:34px;right:34px;height:170px;border-radius:14px;background:#20120d;box-shadow:inset 0 0 0 3px #3a1f16;overflow:hidden}
+.ca-grid{position:absolute;top:0;left:0;right:0;bottom:0;background:repeating-linear-gradient(0deg,transparent 0 44px,rgba(255,255,255,0.08) 44px 45px),repeating-linear-gradient(90deg,transparent 0 44px,rgba(255,255,255,0.08) 44px 45px)}
+.ca-focus{position:absolute;top:50%;left:50%;width:66px;height:66px;margin:-33px 0 0 -33px;border-radius:50%;border:3px solid #ffd23f;box-shadow:0 0 14px rgba(255,210,63,0.4);animation:focus-pulse-camera-shutter-app 1.6s ease-in-out infinite}
+.ca-focus::before{content:'';position:absolute;top:-3px;left:50%;margin-left:-3px;width:6px;height:6px;border-radius:50%;background:#ffd23f}
+.ca-controls{position:absolute;top:246px;left:0;right:0;display:flex;justify-content:center;align-items:center;gap:24px}
+.ca-btn{border-radius:50%;display:flex;align-items:center;justify-content:center}
+.ca-mode{width:44px;height:44px;font-size:9px;font-weight:900;letter-spacing:1px;color:#ffd23f;background:#241009;box-shadow:inset 0 0 0 3px #4a2a18}
+.ca-shutter{width:62px;height:62px;background:radial-gradient(circle at 35% 35%,#ff8a70,#b92f1c);box-shadow:0 0 0 5px #3a1f16,0 0 18px rgba(255,85,64,0.5);animation:shutter-blink-camera-shutter-app 2s ease-in-out infinite}
+.ca-flash{width:44px;height:44px;font-size:9px;font-weight:900;letter-spacing:1px;color:#ffd23f;background:#241009;box-shadow:inset 0 0 0 3px #4a2a18;animation:flash-blink-camera-shutter-app 2s steps(1) infinite}
+.ca-settings{position:absolute;top:326px;left:0;right:0;display:flex;justify-content:center;gap:16px}
+.ca-set{font-size:10px;font-weight:800;color:#c9a08d;letter-spacing:1px}
+.ca-ready{position:absolute;bottom:14px;left:0;right:0;text-align:center;font-size:9px;font-weight:800;letter-spacing:4px;color:#ff5540;animation:ready-blink-camera-shutter-app 1.6s steps(1) infinite}
+@keyframes focus-pulse-camera-shutter-app{0%,100%{transform:scale(1);opacity:0.9}50%{transform:scale(1.08);opacity:1}}
+@keyframes shutter-blink-camera-shutter-app{0%,100%{box-shadow:0 0 0 5px #3a1f16,0 0 14px rgba(255,85,64,0.4)}50%{box-shadow:0 0 0 5px #3a1f16,0 0 26px rgba(255,85,64,0.8)}}
+@keyframes flash-blink-camera-shutter-app{0%,49%{opacity:1}50%,100%{opacity:0.3}}
+@keyframes ready-blink-camera-shutter-app{0%,49%{opacity:1}50%,100%{opacity:0.35}}


### PR DESCRIPTION
## Component: ease-camera-shutter-app — focus pulses, shutter blinks, and ready glows

**Closes #65408**

### What this adds
A camera app: the focus box pulses over the viewfinder grid, the shutter ring blinks, and the READY status glows above the settings row.

### Acceptance Criteria covered
- Focus box pulses on the grid
- Shutter ring blinks in place
- READY status glows above

### Files
- `submissions/examples/camera-shutter-app-ij/demo.html`
- `submissions/examples/camera-shutter-app-ij/style.css`
- `submissions/examples/camera-shutter-app-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the focus pulse.