### PR TITLE
Add avatar group component with overflow indicator (closes #10876)

### DIFF
--- a/submissions/examples/avatar-group/README.md
+++ b/submissions/examples/avatar-group/README.md
@@ -1,0 +1,31 @@
+# Avatar Group (Avatar Stack)
+
+Overlapping avatar circles with a "+N" overflow indicator - for team pages,
+chat headers, and collaboration tools.
+
+Resolves #10876.
+
+## Features
+- Overlapping circular avatars with consistent border/ring styling
+- "+N" overflow badge for counts beyond what's shown
+- Hover lifts an avatar above its neighbours (z-index handled per-item)
+- Staggered pop-in entrance animation
+- `avatar-group-sm` size variant
+- Respects `prefers-reduced-motion`
+
+## Usage
+```html
+<div class="avatar-group">
+  <img class="avatar-item" src="user1.jpg" alt="Name">
+  <img class="avatar-item" src="user2.jpg" alt="Name">
+  <div class="avatar-item avatar-overflow">+5</div>
+</div>
+```
+
+## Notes for maintainer
+- Naming is illustrative (`avatar-group`, `avatar-item`) - happy to have it
+  converted to `ease-*`.
+- z-index is hardcoded per nth-child up to 5 avatars; for arbitrarily large
+  groups this could move to CSS `:nth-child` counter logic or be documented
+  as a known limit.
+- Tested in Chrome, Firefox, Safari.

--- a/submissions/examples/avatar-group/demo.html
+++ b/submissions/examples/avatar-group/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Avatar Group Submission Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <h2>Team members</h2>
+  <div class="avatar-group">
+    <img class="avatar-item" src="https://i.pravatar.cc/100?img=1" alt="Aisha">
+    <img class="avatar-item" src="https://i.pravatar.cc/100?img=2" alt="Ravi">
+    <img class="avatar-item" src="https://i.pravatar.cc/100?img=3" alt="Meera">
+    <img class="avatar-item" src="https://i.pravatar.cc/100?img=4" alt="Devon">
+    <div class="avatar-item avatar-overflow">+5</div>
+  </div>
+
+  <h2 style="margin-top:3rem;">Small size</h2>
+  <div class="avatar-group avatar-group-sm">
+    <img class="avatar-item" src="https://i.pravatar.cc/100?img=5" alt="Sam">
+    <img class="avatar-item" src="https://i.pravatar.cc/100?img=6" alt="Lena">
+    <div class="avatar-item avatar-overflow">+12</div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/avatar-group/style.css
+++ b/submissions/examples/avatar-group/style.css
@@ -1,0 +1,75 @@
+.avatar-group {
+  display: flex;
+  align-items: center;
+  font-family: system-ui, sans-serif;
+}
+
+.avatar-item {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 2px solid #fff;
+  box-shadow: 0 0 0 1px #e2e2e2;
+  margin-left: -12px;
+  transition: transform 0.2s ease, z-index 0.2s ease;
+  background: #f0f0f0;
+}
+
+.avatar-group .avatar-item:first-child {
+  margin-left: 0;
+}
+
+/* stack order — later avatars sit on top */
+.avatar-group .avatar-item:nth-child(1) { z-index: 1; }
+.avatar-group .avatar-item:nth-child(2) { z-index: 2; }
+.avatar-group .avatar-item:nth-child(3) { z-index: 3; }
+.avatar-group .avatar-item:nth-child(4) { z-index: 4; }
+.avatar-group .avatar-item:nth-child(5) { z-index: 5; }
+
+/* hover: lift the hovered avatar above its neighbours */
+.avatar-group .avatar-item:hover {
+  transform: translateY(-6px) scale(1.08);
+  z-index: 10;
+}
+
+.avatar-overflow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #6c63ff;
+  color: #fff;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+/* entrance animation — avatars pop in with a slight stagger */
+.avatar-group .avatar-item {
+  animation: avatar-pop-in 0.3s ease backwards;
+}
+.avatar-group .avatar-item:nth-child(1) { animation-delay: 0s; }
+.avatar-group .avatar-item:nth-child(2) { animation-delay: 0.05s; }
+.avatar-group .avatar-item:nth-child(3) { animation-delay: 0.1s; }
+.avatar-group .avatar-item:nth-child(4) { animation-delay: 0.15s; }
+.avatar-group .avatar-item:nth-child(5) { animation-delay: 0.2s; }
+
+@keyframes avatar-pop-in {
+  from { opacity: 0; transform: scale(0.5); }
+  to   { opacity: 1; transform: scale(1); }
+}
+
+/* size variant */
+.avatar-group-sm .avatar-item {
+  width: 32px;
+  height: 32px;
+  margin-left: -10px;
+  font-size: 0.65rem;
+}
+
+/* respect reduced motion (framework already supports this globally) */
+@media (prefers-reduced-motion: reduce) {
+  .avatar-group .avatar-item {
+    animation: none;
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a CSS-only avatar group (avatar stack) component - overlapping circular
avatars with a "+N" overflow indicator, commonly used on team pages, chat
headers, and collaboration tool UIs. Closes #10876.

---

## Type of Change
- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/avatar-group/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
An avatar group component that overlaps circular user avatars with a
consistent border/ring, and shows a "+N" badge for any overflow beyond
what's displayed.

**How does a developer use it?**
```html
<div class="avatar-group">
  <img class="avatar-item" src="user1.jpg" alt="Name">
  <img class="avatar-item" src="user2.jpg" alt="Name">
  <div class="avatar-item avatar-overflow">+5</div>