### PR TITLE
Add ease-solar-panel-monitor component

### DIFF
--- a/submissions/examples/solar-panel-monitor-ij/README.md
+++ b/submissions/examples/solar-panel-monitor-ij/README.md
@@ -1,0 +1,10 @@
+# ease-solar-panel-monitor
+
+A solar monitor where the panel row tilts toward the sun icon, the kilowatt output bars rise and fall, and the battery charge level pulses beneath.
+
+## Run
+Open `demo.html` directly in a browser to watch the panels tilt.
+
+## Notes
+- The panels tilt toward the sun.
+- The output bars rise and fall.

--- a/submissions/examples/solar-panel-monitor-ij/demo.html
+++ b/submissions/examples/solar-panel-monitor-ij/demo.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-solar-panel-monitor demo</title>
+</head>
+<body>
+<div class="spm-app">
+  <span class="spm-title">SOLAR ARRAY</span>
+  <span class="spm-sun"></span>
+  <div class="spm-panels">
+    <div class="spm-panel"><span class="spm-cell"></span></div>
+    <div class="spm-panel"><span class="spm-cell"></span></div>
+    <div class="spm-panel"><span class="spm-cell"></span></div>
+  </div>
+  <div class="spm-bars">
+    <span class="spm-bar"></span>
+    <span class="spm-bar"></span>
+    <span class="spm-bar"></span>
+    <span class="spm-bar"></span>
+  </div>
+  <div class="spm-battery">
+    <span class="spm-fill"></span>
+    <span class="spm-cap"></span>
+  </div>
+  <span class="spm-read">CHARGE 72%</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/solar-panel-monitor-ij/style.css
+++ b/submissions/examples/solar-panel-monitor-ij/style.css
@@ -1,0 +1,24 @@
+:root{--spm-yellow:#ffd23f;--spm-green:#35e06a;--spm-dark:#0a1406}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#101c08,#0a1406);font-family:'Trebuchet MS',sans-serif}
+.spm-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#0c1608,#060c04);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.spm-title{position:absolute;top:16px;left:0;right:0;text-align:center;font-size:12px;font-weight:800;letter-spacing:7px;color:#ffd23f}
+.spm-sun{position:absolute;top:52px;left:50%;margin-left:-30px;width:60px;height:60px;border-radius:50%;background:radial-gradient(circle at 35% 35%,#ffe98a,#ffd23f);box-shadow:22px 0 0 -6px #ffe98a,-22px 0 0 -6px #ffe98a,0 22px 0 -6px #ffe98a,0 -22px 0 -6px #ffe98a,15px 15px 0 -6px #ffe98a,-15px -15px 0 -6px #ffe98a,-15px 15px 0 -6px #ffe98a,15px -15px 0 -6px #ffe98a;animation:sun-pulse-solar-panel-monitor 2s ease-in-out infinite}
+.spm-panels{position:absolute;top:134px;left:50%;margin-left:-114px;width:228px;height:64px;display:flex;gap:10px}
+.spm-panel{flex:1;border-radius:8px;background:#1c2c14;box-shadow:inset 0 0 0 3px #2a4a1c;display:flex;align-items:center;justify-content:center;transform-origin:bottom center;animation:panel-tilt-solar-panel-monitor 3s ease-in-out infinite}
+.spm-panel:nth-child(2){animation-delay:0.6s}
+.spm-panel:nth-child(3){animation-delay:1.2s}
+.spm-cell{width:22px;height:22px;border-radius:4px;background:linear-gradient(135deg,#3adf6a,#1c6a36)}
+.spm-bars{position:absolute;top:218px;left:66px;right:66px;height:54px;display:flex;align-items:flex-end;justify-content:space-evenly}
+.spm-bar{width:16px;height:22%;border-radius:4px 4px 0 0;background:linear-gradient(180deg,#ffd23f,#8a6a1a);transform-origin:bottom center;animation:bar-rise-solar-panel-monitor 1.6s ease-in-out infinite}
+.spm-bar:nth-child(2){animation-delay:0.3s}
+.spm-bar:nth-child(3){animation-delay:0.6s}
+.spm-bar:nth-child(4){animation-delay:0.9s}
+.spm-battery{position:absolute;top:296px;left:50%;margin-left:-48px;width:96px;height:34px;border-radius:6px;background:#0c1608;box-shadow:inset 0 0 0 3px #2a4a1c;display:flex;align-items:center;padding:4px}
+.spm-fill{display:block;height:18px;width:62%;border-radius:3px;background:linear-gradient(90deg,#35e06a,#8a6a1a);animation:charge-pulse-solar-panel-monitor 2.2s steps(1) infinite}
+.spm-cap{position:absolute;right:-10px;top:8px;width:8px;height:14px;border-radius:0 4px 4px 0;background:#2a4a1c}
+.spm-read{position:absolute;bottom:14px;left:0;right:0;text-align:center;font-size:10px;font-weight:800;letter-spacing:4px;color:#5a8a3a;animation:read-blink-solar-panel-monitor 1.8s steps(1) infinite}
+@keyframes sun-pulse-solar-panel-monitor{0%,100%{transform:scale(1);opacity:0.9}50%{transform:scale(1.1);opacity:1}}
+@keyframes panel-tilt-solar-panel-monitor{0%,100%{transform:rotate(-8deg)}50%{transform:rotate(8deg)}}
+@keyframes bar-rise-solar-panel-monitor{0%,100%{height:22%}50%{height:100%}}
+@keyframes charge-pulse-solar-panel-monitor{0%,49%{opacity:1}50%,100%{opacity:0.5}}
+@keyframes read-blink-solar-panel-monitor{0%,49%{opacity:1}50%,100%{opacity:0.35}}


### PR DESCRIPTION
## Component: ease-solar-panel-monitor — panels tilt, bars rise, and charge pulses

**Closes #65511**

### What this adds
A solar monitor: the panel row tilts toward the sun icon, the kilowatt output bars rise and fall, and the battery charge level pulses beneath.

### Acceptance Criteria covered
- Panels tilt toward the sun
- Kilowatt bars rise and fall
- Battery charge pulses below

### Files
- `submissions/examples/solar-panel-monitor-ij/demo.html`
- `submissions/examples/solar-panel-monitor-ij/style.css`
- `submissions/examples/solar-panel-monitor-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the panels tilt.