### PR TITLE
feat: add rising bubble ambient field (#63183)

### DIFF
--- a/submissions/examples/rising-bubble-field-sk-v2/README.md
+++ b/submissions/examples/rising-bubble-field-sk-v2/README.md
@@ -1,0 +1,19 @@
+# Rising Bubble Ambient Field
+
+## What does this do?
+
+An ambient rising-bubbles background with staggered sizes, blur depth layers, and reduced-motion pause.
+
+## How is it used?
+
+```html
+<div class="bubbles" aria-hidden="true">
+  <span></span><span></span><span></span>
+</div>
+```
+
+Open `demo.html` in a browser to try it.
+
+## Why is it useful?
+
+Ambient bubble fields add atmosphere behind glass cards without asset weight and stay composable as a utility overlay.

--- a/submissions/examples/rising-bubble-field-sk-v2/demo.html
+++ b/submissions/examples/rising-bubble-field-sk-v2/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Rising Bubble Ambient Field</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0; min-height: 100vh; display: flex; flex-direction: column;
+      align-items: center; justify-content: center; gap: 1rem; padding: 24px;
+      background: linear-gradient(160deg, #f8fafc, #eef2ff 55%, #f8fafc);
+      color: #111827; font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+    }
+    h1 { margin: 0; font-size: 1.25rem; text-align: center; }
+    .note { margin: 0; max-width: 420px; text-align: center; color: #4b5563; font-size: 0.92rem; line-height: 1.45; }
+  </style>
+</head>
+<body>
+  <h1>Rising Bubble Ambient Field</h1>
+  <p class="note">Staggered bubble sizes and blur layers behind a glass card.</p>
+  <div class="scene">
+    <div class="bubbles" aria-hidden="true">
+      <span></span><span></span><span></span><span></span><span></span><span></span>
+    </div>
+    <div class="card">Floating UI</div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/rising-bubble-field-sk-v2/style.css
+++ b/submissions/examples/rising-bubble-field-sk-v2/style.css
@@ -1,0 +1,57 @@
+.scene {
+  position: relative;
+  width: min(100%, 380px);
+  height: 240px;
+  border-radius: 16px;
+  overflow: hidden;
+  background: linear-gradient(180deg, #38bdf8, #0369a1);
+  display: grid;
+  place-items: center;
+}
+
+.card {
+  position: relative;
+  z-index: 1;
+  padding: 16px 18px;
+  border-radius: 12px;
+  background: rgb(255 255 255 / 0.22);
+  backdrop-filter: blur(8px);
+  color: #fff;
+  font-weight: 700;
+}
+
+.bubbles {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+}
+
+.bubbles span {
+  position: absolute;
+  bottom: -24px;
+  border-radius: 50%;
+  background: rgb(255 255 255 / 0.35);
+  animation: rise 8s linear infinite;
+}
+
+.bubbles span:nth-child(1) { left: 8%; width: 8px; height: 8px; animation-duration: 6.5s; }
+.bubbles span:nth-child(2) { left: 22%; width: 16px; height: 16px; animation-delay: 1.1s; filter: blur(1px); }
+.bubbles span:nth-child(3) { left: 40%; width: 11px; height: 11px; animation-delay: 2.2s; animation-duration: 7.2s; }
+.bubbles span:nth-child(4) { left: 58%; width: 20px; height: 20px; animation-delay: 0.6s; filter: blur(2px); animation-duration: 9s; }
+.bubbles span:nth-child(5) { left: 74%; width: 10px; height: 10px; animation-delay: 3.4s; }
+.bubbles span:nth-child(6) { left: 88%; width: 14px; height: 14px; animation-delay: 1.8s; filter: blur(1px); animation-duration: 7.8s; }
+
+@keyframes rise {
+  to {
+    transform: translateY(-280px);
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bubbles span {
+    animation: none;
+    opacity: 0.35;
+    bottom: 42%;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `Rising Bubble Ambient Field` under `submissions/examples/rising-bubble-field-sk-v2/` for #63183.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> PRs that fail this checklist will be closed without review.

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Ambient rising bubbles with staggered sizes and blur depth behind a glass card.

**How does a developer use it?**

```html
<div class="bubbles" aria-hidden="true">
  <span></span><span></span><span></span>
</div>
```

**Why does it fit EaseMotion CSS?**

Lightweight atmosphere overlay for glass UIs without image assets.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #63183.

Made with [Cursor](https://cursor.com)