### PR TITLE
feat: add moon phase cycle indicator (#63178)

### DIFF
--- a/submissions/examples/moon-phase-cycle-sk-v2/README.md
+++ b/submissions/examples/moon-phase-cycle-sk-v2/README.md
@@ -1,0 +1,20 @@
+# Moon Phase Cycle Indicator
+
+## What does this do?
+
+A lunar phase control where a shadow disc translates across a moon sphere based on a `--phase` CSS variable.
+
+## How is it used?
+
+```html
+<div class="moon" style="--phase: 0.35;">
+  <div class="moon__sphere"></div>
+  <input type="range" min="0" max="100" value="35" aria-label="Moon phase" />
+</div>
+```
+
+Open `demo.html` in a browser to try it.
+
+## Why is it useful?
+
+Readable phase visualization for calendars and night-mode UI without image assets.

--- a/submissions/examples/moon-phase-cycle-sk-v2/demo.html
+++ b/submissions/examples/moon-phase-cycle-sk-v2/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Moon Phase Cycle Indicator</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0; min-height: 100vh; display: flex; flex-direction: column;
+      align-items: center; justify-content: center; gap: 1rem; padding: 24px;
+      background: linear-gradient(180deg, #0b1220, #1e293b 55%, #0b1220);
+      color: #e2e8f0; font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+    }
+    h1 { margin: 0; font-size: 1.25rem; text-align: center; }
+    .note { margin: 0; max-width: 420px; text-align: center; color: #94a3b8; font-size: 0.92rem; line-height: 1.45; }
+  </style>
+</head>
+<body>
+  <h1>Moon Phase Cycle Indicator</h1>
+  <p class="note">Scrub the range to move the shadow disc across the moon sphere.</p>
+  <div class="moon" id="moon" style="--phase: 0.35;">
+    <div class="moon__sphere" aria-hidden="true"></div>
+    <input type="range" min="0" max="100" value="35" aria-label="Moon phase" id="phase" />
+  </div>
+  <script>
+    var m = document.getElementById("moon");
+    var p = document.getElementById("phase");
+    p.addEventListener("input", function () {
+      m.style.setProperty("--phase", (p.value / 100).toFixed(3));
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/moon-phase-cycle-sk-v2/style.css
+++ b/submissions/examples/moon-phase-cycle-sk-v2/style.css
@@ -1,0 +1,38 @@
+.moon {
+  display: grid;
+  gap: 14px;
+  justify-items: center;
+}
+
+.moon__sphere {
+  width: 104px;
+  height: 104px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 32% 28%, #fff8dc, #e7d7a5 55%, #c4b07a);
+  position: relative;
+  overflow: hidden;
+  box-shadow:
+    inset -10px -8px 18px rgb(0 0 0 / 0.28),
+    0 0 24px rgb(250 250 210 / 0.25);
+}
+
+.moon__sphere::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: #0b1220;
+  transform: translateX(calc((var(--phase) - 0.5) * 200%));
+  transition: transform 120ms linear;
+}
+
+.moon input {
+  width: 220px;
+  accent-color: #f5f0d8;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .moon__sphere::after {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `Moon Phase Cycle Indicator` under `submissions/examples/moon-phase-cycle-sk-v2/` for #63178.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> PRs that fail this checklist will be closed without review.

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Scrubbable moon phase via `--phase`, with a shadow disc sliding across the sphere.

**How does a developer use it?**

```html
<div class="moon" style="--phase: 0.35;">
  <div class="moon__sphere"></div>
  <input type="range" min="0" max="100" value="35" aria-label="Moon phase" />
</div>
```

**Why does it fit EaseMotion CSS?**

Pure CSS phase control for calendars and night UI without image assets.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #63178.

Made with [Cursor](https://cursor.com)