### PR TITLE
Add ease-stadium-fan-flags component

### DIFF
--- a/submissions/examples/stadium-fan-flags-ij/README.md
+++ b/submissions/examples/stadium-fan-flags-ij/README.md
@@ -1,0 +1,10 @@
+# ease-stadium-fan-flags
+
+A stadium stand where the fan flags wave across the rows, the foam hands sway in front, and the section label blinks beneath.
+
+## Run
+Open `demo.html` directly in a browser to watch the flags wave.
+
+## Notes
+- The flags wave across the rows.
+- The foam hands sway in front.

--- a/submissions/examples/stadium-fan-flags-ij/demo.html
+++ b/submissions/examples/stadium-fan-flags-ij/demo.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-stadium-fan-flags demo</title>
+</head>
+<body>
+<div class="sff-app">
+  <span class="sff-title">THE STAND</span>
+  <div class="sff-row">
+    <span class="sff-flag">TEAM</span>
+    <span class="sff-flag">BLUE</span>
+    <span class="sff-flag">ARMS</span>
+    <span class="sff-flag">GOAL</span>
+  </div>
+  <div class="sff-stand">
+    <span class="sff-hand"></span>
+    <span class="sff-hand"></span>
+    <span class="sff-hand"></span>
+  </div>
+  <span class="sff-section">SECTION 12</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/stadium-fan-flags-ij/style.css
+++ b/submissions/examples/stadium-fan-flags-ij/style.css
@@ -1,0 +1,17 @@
+:root{--sff-red:#ff5b5b;--sff-dark:#120608}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#24101a,#120608);font-family:'Georgia',serif}
+.sff-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#1a0c14,#0c0509);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.sff-title{position:absolute;top:16px;left:0;right:0;text-align:center;font-size:12px;font-weight:800;letter-spacing:7px;color:#ff5b5b}
+.sff-row{position:absolute;top:58px;left:30px;right:30px;height:96px;display:flex;gap:12px;align-items:flex-start}
+.sff-flag{flex:1;height:84px;border-radius:8px;background:linear-gradient(180deg,#3a1a24,#1c0c12);box-shadow:inset 0 0 0 3px #5a2430;display:flex;align-items:center;justify-content:center;font-size:9px;font-weight:900;letter-spacing:2px;color:#ffb3b3;transform-origin:top center;animation:flag-wave-stadium-fan-flags ease-in-out infinite}
+.sff-flag:nth-child(2){animation-duration:2.2s}
+.sff-flag:nth-child(3){animation-duration:2s}
+.sff-flag:nth-child(4){animation-duration:2.4s}
+.sff-stand{position:absolute;top:190px;left:36px;right:36px;height:100px;border-radius:14px;background:#1c0c12;box-shadow:inset 0 0 0 4px #5a2430;display:flex;justify-content:space-evenly;align-items:center}
+.sff-hand{width:18px;height:56px;border-radius:9px;background:#ff5b5b;box-shadow:0 4px 8px rgba(0,0,0,0.5);transform-origin:bottom center;animation:hand-sway-stadium-fan-flags 1.6s ease-in-out infinite}
+.sff-hand:nth-child(2){animation-delay:0.4s}
+.sff-hand:nth-child(3){animation-delay:0.8s}
+.sff-section{position:absolute;bottom:16px;left:0;right:0;text-align:center;font-size:10px;font-weight:800;letter-spacing:4px;color:#8a3a4a;animation:section-blink-stadium-fan-flags 1.8s steps(1) infinite}
+@keyframes flag-wave-stadium-fan-flags{0%,100%{transform:rotate(-6deg)}50%{transform:rotate(6deg)}}
+@keyframes hand-sway-stadium-fan-flags{0%,100%{transform:rotate(-10deg)}50%{transform:rotate(10deg)}}
+@keyframes section-blink-stadium-fan-flags{0%,49%{opacity:1}50%,100%{opacity:0.35}}


### PR DESCRIPTION
## Component: ease-stadium-fan-flags — flags wave, hands sway, and section blinks

**Closes #65524**

### What this adds
A stadium stand: the fan flags wave across the rows, the foam hands sway in front, and the section label blinks beneath.

### Acceptance Criteria covered
- Fan flags wave across the rows
- Foam hands sway in front
- Section label blinks below

### Files
- `submissions/examples/stadium-fan-flags-ij/demo.html`
- `submissions/examples/stadium-fan-flags-ij/style.css`
- `submissions/examples/stadium-fan-flags-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the flags wave.