### PR TITLE
feat: add analog speedometer gauge (#63161)

### DIFF
--- a/submissions/examples/speedometer-gauge-sk-v3/README.md
+++ b/submissions/examples/speedometer-gauge-sk-v3/README.md
@@ -1,0 +1,19 @@
+# Analog Speedometer Gauge
+
+## What does this do?
+
+An analog speedometer needle driven by a range input and CSS variable.
+
+## How is it used?
+
+```html
+<div class="gauge" style="--speed:35"><div class="gauge__needle"></div><input type="range"/></div>
+```
+
+Open `demo.html` in a browser to try it.
+
+## Why is it useful?
+
+Makes numeric magnitude obvious for analytics and vehicle-style UIs.
+
+Tracks issue #63161.

--- a/submissions/examples/speedometer-gauge-sk-v3/demo.html
+++ b/submissions/examples/speedometer-gauge-sk-v3/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Analog Speedometer Gauge</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0; min-height: 100vh; display: flex; flex-direction: column;
+      align-items: center; justify-content: center; gap: 1rem; padding: 24px;
+      background: linear-gradient(160deg, #f0fdfa, #ecfeff 55%, #f0fdfa);
+      color: #111827; font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+      
+    }
+    h1 { margin: 0; font-size: 1.25rem; text-align: center; }
+    .note { margin: 0; max-width: 420px; text-align: center; color: #4b5563; font-size: 0.92rem; line-height: 1.45; }
+  </style>
+</head>
+<body>
+  <h1>Analog Speedometer Gauge</h1>
+  <p class="note">Variant for #63161.</p>
+  
+  <div class="gauge" id="gauge" style="--speed: 35;">
+  <div class="gauge__face" aria-hidden="true"><div class="gauge__needle"></div></div>
+  <input type="range" min="0" max="100" value="35" aria-label="Speed" id="speed" />
+</div>
+  <script>
+var g=document.getElementById('gauge'),s=document.getElementById('speed');
+function sync(){g.style.setProperty('--speed',s.value)} s.addEventListener('input',sync);
+</script>
+</body>
+</html>

--- a/submissions/examples/speedometer-gauge-sk-v3/style.css
+++ b/submissions/examples/speedometer-gauge-sk-v3/style.css
@@ -1,0 +1,9 @@
+.gauge{--speed:35;width:220px;display:grid;justify-items:center;gap:12px}
+.gauge__face{width:200px;height:110px;border-radius:200px 200px 0 0;background:conic-gradient(from 180deg,#22c55e 0 40%,#f59e0b 40% 70%,#ef4444 70% 100%);position:relative;overflow:hidden}
+.gauge__face::after{content:"";position:absolute;inset:18px 18px 0;background:#f8fafc;border-radius:180px 180px 0 0}
+.gauge__needle{position:absolute;left:50%;bottom:0;width:4px;height:78px;margin-left:-2px;background:#111;transform-origin:bottom center;transform:rotate(calc(-90deg + var(--speed)*1.8deg));transition:transform 280ms cubic-bezier(.2,.8,.2,1);z-index:2}
+.gauge input{width:100%}
+@media (prefers-reduced-motion:reduce){.gauge__needle{transition:none}}
+
+/* issue #63161 variant */
+:root { --em-issue: 63161; }


### PR DESCRIPTION
## Pull Request Description

Adds `Analog Speedometer Gauge` under `submissions/examples/speedometer-gauge-sk-v3/` for #63161.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> PRs that fail this checklist will be closed without review.

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

An analog speedometer whose needle rotates from a CSS custom property driven by a range input. Include tick marks and color zones on the arc.

**How does a developer use it?**

```html
<div class="gauge" style="--speed: 35;">
  <div class="gauge__face" aria-hidden="true"></div>
  <div class="gauge__needle"></div>
  <input type="range" min="0" max="100" value="35" aria-label="Speed" />
</div>
```

**Why does it fit EaseMotion CSS?**

Human-readable motion demo that stays in submissions and is easy to standardize.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #63161.
