### PR TITLE
feat: add avatar story ring states (#63157)

### DIFF
--- a/submissions/examples/avatar-story-ring-sk-v3/README.md
+++ b/submissions/examples/avatar-story-ring-sk-v3/README.md
@@ -1,0 +1,19 @@
+# Avatar Story Ring States
+
+## What does this do?
+
+Avatar rings for unseen, seen, and live story states.
+
+## How is it used?
+
+```html
+<button class="avatar-ring is-unseen" type="button"><img alt="" /></button>
+```
+
+Open `demo.html` in a browser to try it.
+
+## Why is it useful?
+
+Communicates media state at a glance for social UIs.
+
+Tracks issue #63157.

--- a/submissions/examples/avatar-story-ring-sk-v3/demo.html
+++ b/submissions/examples/avatar-story-ring-sk-v3/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Avatar Story Ring States</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0; min-height: 100vh; display: flex; flex-direction: column;
+      align-items: center; justify-content: center; gap: 1rem; padding: 24px;
+      background: linear-gradient(160deg, #f0fdfa, #ecfeff 55%, #f0fdfa);
+      color: #111827; font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+      
+    }
+    h1 { margin: 0; font-size: 1.25rem; text-align: center; }
+    .note { margin: 0; max-width: 420px; text-align: center; color: #4b5563; font-size: 0.92rem; line-height: 1.45; }
+  </style>
+</head>
+<body>
+  <h1>Avatar Story Ring States</h1>
+  <p class="note">Variant for #63157.</p>
+  
+  <div style="display:flex;gap:16px;align-items:center">
+  <button class="avatar-ring is-unseen" type="button" aria-label="Unread story"><span class="ph"></span></button>
+  <button class="avatar-ring is-seen" type="button" aria-label="Seen story"><span class="ph"></span></button>
+  <button class="avatar-ring is-live" type="button" aria-label="Live story"><span class="ph"></span></button>
+</div>
+  
+</body>
+</html>

--- a/submissions/examples/avatar-story-ring-sk-v3/style.css
+++ b/submissions/examples/avatar-story-ring-sk-v3/style.css
@@ -1,0 +1,9 @@
+.avatar-ring{border:0;padding:3px;border-radius:50%;background:conic-gradient(#f59e0b,#ef4444,#8b5cf6,#f59e0b);cursor:pointer}
+.avatar-ring.is-seen{background:#d1d5db}
+.avatar-ring.is-live{box-shadow:0 0 0 0 rgb(239 68 68/.5);animation:live-pulse 1.4.2s ease infinite}
+.avatar-ring img,.avatar-ring .ph{display:block;width:64px;height:64px;border-radius:50%;border:2px solid #fff;background:#cbd5e1}
+@keyframes live-pulse{70%{box-shadow:0 0 0 10px transparent}}
+@media (prefers-reduced-motion:reduce){.avatar-ring.is-live{animation:none}}
+
+/* issue #63157 variant */
+:root { --em-issue: 63157; }


### PR DESCRIPTION
## Pull Request Description

Adds `Avatar Story Ring States` under `submissions/examples/avatar-story-ring-sk-v3/` for #63157.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> PRs that fail this checklist will be closed without review.

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Avatar rings with unseen, seen, and live states. Unseen uses a conic gradient ring, seen uses a muted dashed ring, and live adds an outer pulse.

**How does a developer use it?**

```html
<button class="avatar-ring is-unseen" type="button" aria-label="Unread story">
  <img src="avatar.jpg" alt="" />
</button>
```

**Why does it fit EaseMotion CSS?**

Human-readable motion demo that stays in submissions and is easy to standardize.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #63157.
