### PR TITLE
feat: add type to confirm destructive dialog (#63153)

### DIFF
--- a/submissions/examples/type-to-confirm-dialog-sk-v2/README.md
+++ b/submissions/examples/type-to-confirm-dialog-sk-v2/README.md
@@ -1,0 +1,19 @@
+# Type-to-Confirm Destructive Dialog
+
+## What does this do?
+
+A destructive dialog that enables the danger button only after typing DELETE.
+
+## How is it used?
+
+```html
+<dialog open><input pattern="DELETE" required/><button class="danger">Delete</button></dialog>
+```
+
+Open `demo.html` in a browser to try it.
+
+## Why is it useful?
+
+Reduces accidental deletes with a clear disabled/ready state machine.
+
+Tracks issue #63153.

--- a/submissions/examples/type-to-confirm-dialog-sk-v2/demo.html
+++ b/submissions/examples/type-to-confirm-dialog-sk-v2/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Type-to-Confirm Destructive Dialog</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 1rem;
+      padding: 24px;
+      background: linear-gradient(160deg, #f8fafc, #eef2ff 55%, #f8fafc);
+      color: #111827;
+      font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+      
+    }
+    h1 { margin: 0; font-size: 1.25rem; text-align: center; }
+    .note { margin: 0; max-width: 420px; text-align: center; color: #4b5563; font-size: 0.92rem; line-height: 1.45; }
+  </style>
+</head>
+<body>
+  <h1>Type-to-Confirm Destructive Dialog</h1>
+  <p class="note">Variant for #63153.</p>
+  
+  <dialog class="confirm-dialog" open>
+  <form method="dialog">
+    <p style="margin:0">Type <strong>DELETE</strong> to confirm.</p>
+    <input name="confirm" required pattern="DELETE" placeholder="DELETE" aria-label="Type DELETE to confirm" />
+    <button type="submit" class="danger">Delete project</button>
+  </form>
+</dialog>
+  
+</body>
+</html>

--- a/submissions/examples/type-to-confirm-dialog-sk-v2/style.css
+++ b/submissions/examples/type-to-confirm-dialog-sk-v2/style.css
@@ -1,0 +1,13 @@
+.confirm-dialog{border:0;border-radius:14px;padding:20px;width:min(100%,360px);box-shadow:0 20px 50px rgb(0 0 0/.18);font-family:inherit}
+.confirm-dialog form{display:grid;gap:12px}
+.confirm-dialog input{height:40px;border:1px solid #d1d5db;border-radius:8px;padding:0 10px;font:inherit}
+.confirm-dialog input:focus-visible{outline:2px solid #dc2626;outline-offset:2px}
+.danger{height:40px;border:0;border-radius:8px;background:#dc2626;color:#fff;font-weight:700;opacity:.4;pointer-events:none;transition:opacity 160ms ease,transform 120ms ease}
+.confirm-dialog input:valid ~ .danger{opacity:1;pointer-events:auto}
+.danger:active{transform:translateY(1px)}
+.confirm-dialog input:invalid:not(:placeholder-shown){animation:field-shake .3s ease;border-color:#dc2626}
+@keyframes field-shake{25%{transform:translateX(-3px)}75%{transform:translateX(3px)}}
+@media (prefers-reduced-motion:reduce){.danger,.confirm-dialog input{transition:none;animation:none}}
+
+/* issue #63153 variant */
+:root { --em-issue: 63153; }


### PR DESCRIPTION
## Pull Request Description

Adds `Type-to-Confirm Destructive Dialog` under `submissions/examples/type-to-confirm-dialog-sk-v2/` for #63153.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> PRs that fail this checklist will be closed without review.

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A destructive confirmation dialog that keeps the primary action disabled until the user types a required confirmation word. Invalid attempts can shake the field; valid input enable

**How does a developer use it?**

```html
<dialog class="confirm-dialog" open>
  <form method="dialog">
    <p>Type <strong>DELETE</strong> to confirm.</p>
    <input name="confirm" required pattern="DELETE" placeholder="DELETE" />
    <button type="submit" class="danger">Delete project</button>
  </form>
</dialog>
```

**Why does it fit EaseMotion CSS?**

Human-readable motion demo that stays in submissions and is easy to standardize.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #63153.
