### PR TITLE
feat: add drag to dismiss sheet chrome (#63150)

### DIFF
--- a/submissions/examples/drag-dismiss-sheet-sk-v3/README.md
+++ b/submissions/examples/drag-dismiss-sheet-sk-v3/README.md
@@ -1,0 +1,19 @@
+# Drag-to-Dismiss Sheet Chrome
+
+## What does this do?
+
+A bottom sheet with handle chrome, backdrop, and open/dismiss motion.
+
+## How is it used?
+
+```html
+<label class="sheet"><input class="sheet__toggle" type="checkbox"/><div class="sheet__panel">...</div></label>
+```
+
+Open `demo.html` in a browser to try it.
+
+## Why is it useful?
+
+Core mobile pattern with readable travel-linked feedback.
+
+Tracks issue #63150.

--- a/submissions/examples/drag-dismiss-sheet-sk-v3/demo.html
+++ b/submissions/examples/drag-dismiss-sheet-sk-v3/demo.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Drag-to-Dismiss Sheet Chrome</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 1rem;
+      padding: 24px;
+      background: linear-gradient(160deg, #f0fdfa, #ecfeff 55%, #f0fdfa);
+      color: #111827;
+      font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+      
+    }
+    h1 { margin: 0; font-size: 1.25rem; text-align: center; }
+    .note { margin: 0; max-width: 420px; text-align: center; color: #4b5563; font-size: 0.92rem; line-height: 1.45; }
+  </style>
+</head>
+<body>
+  <h1>Drag-to-Dismiss Sheet Chrome</h1>
+  <p class="note">Variant for #63150.</p>
+  
+  <label class="sheet">
+  <input class="sheet__toggle" type="checkbox" />
+  <span class="sheet__open">Open sheet</span>
+  <div class="sheet__backdrop"></div>
+  <div class="sheet__panel" role="dialog" aria-modal="true">
+    <div class="sheet__handle" aria-hidden="true"></div>
+    <h2 style="margin:0 0 8px;font-size:1.05rem">Actions</h2>
+    <p class="note" style="text-align:left">Toggle the control to dismiss. Handle indicates drag affordance.</p>
+  </div>
+</label>
+  
+</body>
+</html>

--- a/submissions/examples/drag-dismiss-sheet-sk-v3/style.css
+++ b/submissions/examples/drag-dismiss-sheet-sk-v3/style.css
@@ -1,0 +1,12 @@
+.sheet{display:inline-block}
+.sheet__toggle{position:absolute;opacity:0;pointer-events:none}
+.sheet__open{padding:10px 16px;border:0;border-radius:10px;background:#134e4a;color:#fff;font-weight:700;cursor:pointer}
+.sheet__backdrop{position:fixed;inset:0;background:rgb(15 23 42/.45);opacity:0;pointer-events:none;transition:opacity 280ms ease}
+.sheet__panel{position:fixed;left:0;right:0;bottom:0;background:#fff;border-radius:18px 18px 0 0;padding:12px 16px 28px;transform:translateY(110%);transition:transform 320ms cubic-bezier(.2,.8,.2,1);box-shadow:0 -8px 30px rgb(0 0 0/.18)}
+.sheet__handle{width:42px;height:4px;margin:6px auto 14px;border-radius:999px;background:#d1d5db}
+.sheet:has(.sheet__toggle:checked) .sheet__panel{transform:translateY(0)}
+.sheet:has(.sheet__toggle:checked) .sheet__backdrop{opacity:1;pointer-events:auto}
+@media (prefers-reduced-motion:reduce){.sheet__panel,.sheet__backdrop{transition:none}}
+
+/* issue #63150 variant */
+:root { --em-issue: 63150; }


### PR DESCRIPTION
## Pull Request Description

Adds `Drag-to-Dismiss Sheet Chrome` under `submissions/examples/drag-dismiss-sheet-sk-v3/` for #63150.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> PRs that fail this checklist will be closed without review.

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A bottom sheet with a drag handle and staged positions (closed, half, full, dismissed). Backdrop opacity tracks sheet travel, with a light rubber-band settle.

**How does a developer use it?**

```html
<label class="sheet">
  <input class="sheet__toggle" type="checkbox" hidden />
  <div class="sheet__backdrop"></div>
  <div class="sheet__panel" role="dialog" aria-modal="true">
    <div class="sheet__handle" aria-hidden="true"></div>
    <p>Sheet content</p>
  </div>
</label>
```

**Why does it fit EaseMotion CSS?**

Human-readable motion demo that stays in submissions and is easy to standardize.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #63150.
