### PR TITLE
feat: add film grain overlay utility (#63148)

### DIFF
--- a/submissions/examples/film-grain-overlay-sk-v3/README.md
+++ b/submissions/examples/film-grain-overlay-sk-v3/README.md
@@ -1,0 +1,19 @@
+# Film Grain Overlay Utility
+
+## What does this do?
+
+An animated film-grain overlay utility with intensity controlled by a CSS variable.
+
+## How is it used?
+
+```html
+<section class="grain" style="--grain-opacity:.2">...</section>
+```
+
+Open `demo.html` in a browser to try it.
+
+## Why is it useful?
+
+Adds atmosphere without heavy assets; composable overlay for heroes and cards.
+
+Tracks issue #63148.

--- a/submissions/examples/film-grain-overlay-sk-v3/demo.html
+++ b/submissions/examples/film-grain-overlay-sk-v3/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Film Grain Overlay Utility</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 1rem;
+      padding: 24px;
+      background: linear-gradient(160deg, #f0fdfa, #ecfeff 55%, #f0fdfa);
+      color: #111827;
+      font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+      
+    }
+    h1 { margin: 0; font-size: 1.25rem; text-align: center; }
+    .note { margin: 0; max-width: 420px; text-align: center; color: #4b5563; font-size: 0.92rem; line-height: 1.45; }
+  </style>
+</head>
+<body>
+  <h1>Film Grain Overlay Utility</h1>
+  <p class="note">Variant for #63148.</p>
+  
+  <section class="grain" style="--grain-opacity: 0.22;">
+  <h2 style="margin:0 0 8px;font-size:1.1rem">Grain overlay</h2>
+  <p style="margin:0;opacity:.85">Intensity via --grain-opacity</p>
+</section>
+  
+</body>
+</html>

--- a/submissions/examples/film-grain-overlay-sk-v3/style.css
+++ b/submissions/examples/film-grain-overlay-sk-v3/style.css
@@ -1,0 +1,11 @@
+.grain{position:relative;isolation:isolate;width:min(100%,380px);padding:28px;border-radius:16px;background:linear-gradient(135deg,#1e293b,#0f172a);color:#f8fafc;overflow:hidden}
+.grain::after{content:"";position:absolute;inset:0;pointer-events:none;opacity:var(--grain-opacity,.15);background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.55'/%3E%3C/svg%3E");animation:grain-shift .45s steps(2) infinite;mix-blend-mode:soft-light}
+@keyframes grain-shift{to{transform:translate(-1.5%,1.5%)}}
+@media (prefers-reduced-motion:reduce){.grain::after{animation:none}}
+
+/* state tokens */
+:root{--demo-gap:1rem}
+.demo-safe{min-width:0}
+
+/* issue #63148 variant */
+:root { --em-issue: 63148; }


### PR DESCRIPTION
## Pull Request Description

Adds `Film Grain Overlay Utility` under `submissions/examples/film-grain-overlay-sk-v3/` for #63148.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> PRs that fail this checklist will be closed without review.

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

An animated film-grain/noise overlay utility using an SVG turbulence texture. Intensity is controlled with a CSS variable, and motion pauses under prefers-reduced-motion.

**How does a developer use it?**

```html
<section class="hero grain" style="--grain-opacity: 0.18;"><h1>Featured</h1></section>
```

**Why does it fit EaseMotion CSS?**

Human-readable motion demo that stays in submissions and is easy to standardize.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #63148.
