### PR TITLE
feat: add concentric fitness activity rings (#63140)

### DIFF
--- a/submissions/examples/fitness-activity-rings-sk-v2/README.md
+++ b/submissions/examples/fitness-activity-rings-sk-v2/README.md
@@ -1,0 +1,19 @@
+# Concentric Fitness Activity Rings
+
+## What does this do?
+
+Three concentric progress rings driven by CSS variables for goal completion.
+
+## How is it used?
+
+```html
+<div class="activity-rings" style="--move:.72;--exercise:.45;--stand:.9;"><svg viewBox="0 0 120 120" aria-label="Activity rings"><circle class="ring ring--move" cx="60" cy="60" r="54" pathLength="1"/><circle class="ring ring--exercise" cx="60" cy="60" r="42" pathLength="1"/><circle class="ring ring--stand" cx="60" cy="60" r="30" pathLength="1"/></svg></div>
+```
+
+Open `demo.html` in a browser to try it.
+
+## Why is it useful?
+
+Readable goal metaphor for habit and fitness UIs with staggered motion.
+
+Tracks issue #63140.

--- a/submissions/examples/fitness-activity-rings-sk-v2/demo.html
+++ b/submissions/examples/fitness-activity-rings-sk-v2/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Concentric Fitness Activity Rings</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 1rem;
+      padding: 24px;
+      background: linear-gradient(160deg, #f8fafc, #eef2ff 55%, #f8fafc);
+      color: #111827;
+      font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+      
+    }
+    h1 { margin: 0; font-size: 1.25rem; text-align: center; }
+    .note { margin: 0; max-width: 420px; text-align: center; color: #4b5563; font-size: 0.92rem; line-height: 1.45; }
+  </style>
+</head>
+<body>
+  <h1>Concentric Fitness Activity Rings</h1>
+  <p class="note">Concentric Fitness Activity Rings demo for #63140.</p>
+  <div class="activity-rings" style="--move:.72; --exercise:.45; --stand:.9;">
+  <svg viewBox="0 0 120 120" aria-label="Activity rings">
+    <circle class="ring ring--move" cx="60" cy="60" r="54" pathLength="1"/>
+    <circle class="ring ring--exercise" cx="60" cy="60" r="42" pathLength="1"/>
+    <circle class="ring ring--stand" cx="60" cy="60" r="30" pathLength="1"/>
+  </svg>
+</div>
+  
+</body>
+</html>

--- a/submissions/examples/fitness-activity-rings-sk-v2/style.css
+++ b/submissions/examples/fitness-activity-rings-sk-v2/style.css
@@ -1,0 +1,8 @@
+.activity-rings{width:180px}.activity-rings svg{width:100%;display:block;transform:rotate(-90deg)}
+.ring{fill:none;stroke-width:10;stroke-linecap:round;stroke-dasharray:1;stroke-dashoffset:1;animation:ring-fill 1.1s ease forwards}
+.ring--move{stroke:#ff2d55;--t:var(--move)}.ring--exercise{stroke:#7aff3a;animation-delay:.12s;--t:var(--exercise)}.ring--stand{stroke:#32ade6;animation-delay:.24.2s;--t:var(--stand)}
+@keyframes ring-fill{to{stroke-dashoffset:calc(1 - var(--t))}}
+@media (prefers-reduced-motion:reduce){.ring{animation:none;stroke-dashoffset:calc(1 - var(--t))}}
+
+/* issue #63140 variant */
+:root { --em-issue: 63140; }


### PR DESCRIPTION
## Pull Request Description

Adds `Concentric Fitness Activity Rings` under `submissions/examples/fitness-activity-rings-sk-v2/` for #63140.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> PRs that fail this checklist will be closed without review.

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Three concentric progress rings driven by CSS custom properties (for example move, exercise, and stand). Rings animate stroke progress on entrance and can glow softly when complete

**How does a developer use it?**

```html
<div class="activity-rings" style="--move:0.72; --exercise:0.45; --stand:0.9;">
  <svg viewBox="0 0 120 120" aria-label="Activity rings">
    <circle class="ring ring--move" cx="60" cy="60" r="54" pathLength="1" />
    <circle class="ring ring--exercise" cx="60" cy="60" r="42" pathLength="1" />
    <circle class="ring ring--stand" cx="60" cy="60" r="30" pathLength="1" />
  </svg>
</div>
```

**Why does it fit EaseMotion CSS?**

Human-readable motion demo that stays in submissions and is easy to standardize.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #63140.
