### PR TITLE
feat: add dual thumb range slider (#63139)

### DIFF
--- a/submissions/examples/dual-thumb-range-sk-v2/README.md
+++ b/submissions/examples/dual-thumb-range-sk-v2/README.md
@@ -1,0 +1,22 @@
+# Dual-Thumb Range Slider
+
+## What does this do?
+
+A dual-handle range slider for selecting a min/max span on one track.
+
+## How is it used?
+
+```html
+<div class="dual-range" style="--min:20;--max:80;">
+  <input class="dual-range__input" type="range" min="0" max="100" value="20" />
+  <input class="dual-range__input" type="range" min="0" max="100" value="80" />
+</div>
+```
+
+Open `demo.html` in a browser to try it.
+
+## Why is it useful?
+
+Common filter control with clear selected-span feedback for animation-first form UIs.
+
+Tracks issue #63139.

--- a/submissions/examples/dual-thumb-range-sk-v2/demo.html
+++ b/submissions/examples/dual-thumb-range-sk-v2/demo.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Dual-Thumb Range Slider</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 1rem;
+      padding: 24px;
+      background: linear-gradient(160deg, #f8fafc, #eef2ff 55%, #f8fafc);
+      color: #111827;
+      font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+      
+    }
+    h1 { margin: 0; font-size: 1.25rem; text-align: center; }
+    .note { margin: 0; max-width: 420px; text-align: center; color: #4b5563; font-size: 0.92rem; line-height: 1.45; }
+  </style>
+</head>
+<body>
+  <h1>Dual-Thumb Range Slider</h1>
+  <p class="note">Variant for #63139.</p>
+  
+  <div class="dual-range" id="dualRange" style="--min:20; --max:80;">
+  <div class="dual-range__track" aria-hidden="true"></div>
+  <input class="dual-range__input" id="minRange" type="range" min="0" max="100" value="20" aria-label="Minimum" />
+  <input class="dual-range__input" id="maxRange" type="range" min="0" max="100" value="80" aria-label="Maximum" />
+</div>
+<p class="dual-range__values"><span id="minOut">20</span> – <span id="maxOut">80</span></p>
+  <script>
+var root=document.getElementById('dualRange'),a=document.getElementById('minRange'),b=document.getElementById('maxRange'),ao=document.getElementById('minOut'),bo=document.getElementById('maxOut');
+function sync(){if(+a.value>+b.value){if(document.activeElement===a)b.value=a.value;else a.value=b.value;}var min=+a.value,max=+b.value;root.style.setProperty('--min',min);root.style.setProperty('--max',max);ao.textContent=min;bo.textContent=max;}
+a.addEventListener('input',sync);b.addEventListener('input',sync);sync();
+</script>
+</body>
+</html>

--- a/submissions/examples/dual-thumb-range-sk-v2/style.css
+++ b/submissions/examples/dual-thumb-range-sk-v2/style.css
@@ -1,0 +1,10 @@
+.dual-range{--min:20;--max:80;position:relative;width:min(100%,340px);height:48px}
+.dual-range__track{position:absolute;left:0;right:0;top:50%;height:6px;transform:translateY(-50%);border-radius:999px;background:linear-gradient(#2563eb,#2563eb) calc(var(--min)*1%)/calc((var(--max) - var(--min))*1%) 100% no-repeat,#e5e7eb}
+.dual-range__input{position:absolute;inset:0;margin:0;appearance:none;background:transparent;pointer-events:none}
+.dual-range__input::-webkit-slider-thumb{pointer-events:auto;appearance:none;width:22px;height:22px;border-radius:50%;background:#111827;box-shadow:0 1px 4px rgb(0 0 0/.25);transition:transform 120ms ease}
+.dual-range__input:focus-visible::-webkit-slider-thumb{outline:2px solid #2563eb;outline-offset:2px}
+.dual-range__input::-moz-range-thumb{pointer-events:auto;width:22px;height:22px;border:0;border-radius:50%;background:#111827}
+.dual-range__values{font-weight:600;font-variant-numeric:tabular-nums}
+
+/* issue #63139 variant */
+:root { --em-issue: 63139; }


### PR DESCRIPTION
## Pull Request Description

Adds `Dual-Thumb Range Slider` under `submissions/examples/dual-thumb-range-sk-v2/` for #63139.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> PRs that fail this checklist will be closed without review.

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A dual-handle range slider for spans such as price or date filters. Two overlapping range inputs share one track; the selected span between thumbs is highlighted, and focus raises 

**How does a developer use it?**

```html
<div class="dual-range" style="--min:20; --max:80;">
  <div class="dual-range__track"></div>
  <input class="dual-range__thumb" type="range" min="0" max="100" value="20" />
  <input class="dual-range__thumb" type="range" min="0" max="100" value="80" />
</div>
```

**Why does it fit EaseMotion CSS?**

Human-readable motion demo that stays in submissions and is easy to standardize.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #63139.
