### PR TITLE
feat: add slide to confirm action rail (#63136)

### DIFF
--- a/submissions/examples/slide-to-confirm-rail-sk-v3/README.md
+++ b/submissions/examples/slide-to-confirm-rail-sk-v3/README.md
@@ -1,0 +1,28 @@
+# Slide-to-Confirm Action Rail
+
+## What does this do?
+
+A slide-to-confirm control that fills a rail as the handle moves and locks into a confirmed state at the end of the track, with a keyboard fallback button.
+
+## How is it used?
+
+```html
+<div class="slide-confirm" data-threshold="98">
+  <label class="slide-confirm__rail">
+    <span class="slide-confirm__fill" aria-hidden="true"></span>
+    <span class="slide-confirm__hint">Slide to confirm payment</span>
+    <input class="slide-confirm__input" type="range" min="0" max="100" value="0" />
+    <span class="slide-confirm__chevron" aria-hidden="true">›</span>
+    <span class="slide-confirm__check" aria-hidden="true">Confirmed</span>
+  </label>
+  <button type="button" class="slide-confirm__fallback">Confirm with keyboard</button>
+</div>
+```
+
+Open `demo.html` in a browser. Drag the handle to the end, or use the keyboard button. Use Reset to try again.
+
+## Why is it useful?
+
+It is an animation-first confirmation microinteraction for payments and destructive actions. The states (idle, dragging, confirmed) are readable, composable, and fit EaseMotion CSS without changing core framework files.
+
+Tracks issue #63136.

--- a/submissions/examples/slide-to-confirm-rail-sk-v3/demo.html
+++ b/submissions/examples/slide-to-confirm-rail-sk-v3/demo.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Slide-to-Confirm Action Rail</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 1.25rem;
+      padding: 24px;
+      background:
+        radial-gradient(circle at top left, #f0fdf4 0, transparent 42%),
+        linear-gradient(180deg, #f0fdfa, #ecfeff);
+      color: #111827;
+    }
+
+    h1 {
+      margin: 0;
+      font: 700 1.35rem/1.3 "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+    }
+
+    p {
+      margin: 0;
+      max-width: 360px;
+      text-align: center;
+      color: #4b5563;
+      font: 400 0.95rem/1.45 "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+    }
+
+    .demo-actions {
+      display: flex;
+      gap: 8px;
+    }
+
+    .demo-actions button {
+      border: 1px solid #d1d5db;
+      background: #fff;
+      border-radius: 8px;
+      padding: 8px 12px;
+      font: 600 0.85rem/1 "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+      cursor: pointer;
+    }
+  </style>
+</head>
+<body>
+  <h1>Slide to confirm</h1>
+  <p>Drag the handle to the end to confirm. A keyboard button is available as a fallback.</p>
+
+  <div class="slide-confirm" id="slideConfirm" data-threshold="98">
+    <label class="slide-confirm__rail">
+      <span class="slide-confirm__fill" aria-hidden="true"></span>
+      <span class="slide-confirm__hint">Slide to confirm payment</span>
+      <input
+        class="slide-confirm__input"
+        id="slideInput"
+        type="range"
+        min="0"
+        max="100"
+        value="0"
+        step="1"
+        aria-valuemin="0"
+        aria-valuemax="100"
+        aria-valuenow="0"
+        aria-label="Slide to confirm payment"
+      />
+      <span class="slide-confirm__chevron" aria-hidden="true">›</span>
+      <span class="slide-confirm__check" aria-hidden="true">Confirmed</span>
+    </label>
+    <button type="button" class="slide-confirm__fallback" id="confirmFallback">
+      Confirm with keyboard
+    </button>
+  </div>
+
+  <div class="demo-actions">
+    <button type="button" id="resetDemo">Reset</button>
+  </div>
+
+  <script>
+    (function () {
+      var root = document.getElementById("slideConfirm");
+      var input = document.getElementById("slideInput");
+      var fallback = document.getElementById("confirmFallback");
+      var reset = document.getElementById("resetDemo");
+      var threshold = Number(root.getAttribute("data-threshold") || 98);
+
+      function setFill(value) {
+        var pct = Math.max(0, Math.min(100, Number(value) || 0));
+        root.style.setProperty("--fill-pct", pct + "%");
+        root.style.setProperty("--fill-ratio", String(pct / 100));
+        input.setAttribute("aria-valuenow", String(pct));
+      }
+
+      function confirm() {
+        root.classList.add("is-confirmed");
+        root.classList.remove("is-dragging");
+        input.value = "100";
+        setFill(100);
+        input.disabled = true;
+        fallback.textContent = "Confirmed";
+        fallback.disabled = true;
+      }
+
+      function clearConfirm() {
+        root.classList.remove("is-confirmed", "is-dragging");
+        input.disabled = false;
+        input.value = "0";
+        setFill(0);
+        fallback.textContent = "Confirm with keyboard";
+        fallback.disabled = false;
+      }
+
+      function onInput() {
+        var value = Number(input.value);
+        setFill(value);
+        if (value >= threshold) {
+          confirm();
+        }
+      }
+
+      input.addEventListener("pointerdown", function () {
+        if (!root.classList.contains("is-confirmed")) {
+          root.classList.add("is-dragging");
+        }
+      });
+
+      input.addEventListener("pointerup", function () {
+        root.classList.remove("is-dragging");
+        if (!root.classList.contains("is-confirmed") && Number(input.value) < threshold) {
+          input.value = "0";
+          setFill(0);
+        }
+      });
+
+      input.addEventListener("input", onInput);
+      input.addEventListener("change", onInput);
+
+      fallback.addEventListener("click", function () {
+        if (!root.classList.contains("is-confirmed")) {
+          confirm();
+        }
+      });
+
+      reset.addEventListener("click", clearConfirm);
+      setFill(0);
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/examples/slide-to-confirm-rail-sk-v3/style.css
+++ b/submissions/examples/slide-to-confirm-rail-sk-v3/style.css
@@ -1,0 +1,231 @@
+.slide-confirm {
+  --rail-height: 56px;
+  --thumb-size: 48px;
+  --track: #e6e8ec;
+  --fill: #16a34a;
+  --thumb: #134e4a;
+  --label: #6b7280;
+  --success: #15803d;
+
+  width: min(100%, 360px);
+  font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+}
+
+.slide-confirm__rail {
+  position: relative;
+  display: block;
+  height: var(--rail-height);
+  border-radius: 999px;
+  background: var(--track);
+  overflow: hidden;
+  user-select: none;
+  -webkit-user-select: none;
+  box-shadow: inset 0 1px 2px rgb(0 0 0 / 0.08);
+}
+
+.slide-confirm__fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: var(--fill-pct, 0%);
+  background: var(--fill);
+  border-radius: inherit;
+  pointer-events: none;
+  transition: width 40ms linear;
+}
+
+.slide-confirm__hint {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding-left: calc(var(--thumb-size) * 0.35);
+  color: var(--label);
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  pointer-events: none;
+  opacity: 1;
+  transition: opacity 180ms ease;
+}
+
+.slide-confirm__input {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  appearance: none;
+  background: transparent;
+  cursor: grab;
+}
+
+.slide-confirm__input:active {
+  cursor: grabbing;
+}
+
+.slide-confirm__input:focus-visible {
+  outline: none;
+}
+
+.slide-confirm__rail:has(.slide-confirm__input:focus-visible) {
+  box-shadow:
+    inset 0 1px 2px rgb(0 0 0 / 0.08),
+    0 0 0 3px rgb(22 163 74 / 0.35);
+}
+
+.slide-confirm__input::-webkit-slider-runnable-track {
+  height: var(--rail-height);
+  background: transparent;
+}
+
+.slide-confirm__input::-webkit-slider-thumb {
+  appearance: none;
+  width: var(--thumb-size);
+  height: var(--thumb-size);
+  margin-top: calc((var(--rail-height) - var(--thumb-size)) / 2);
+  border: 0;
+  border-radius: 50%;
+  background:
+    linear-gradient(135deg, #1f2937, var(--thumb))
+      center / 100% 100% no-repeat;
+  box-shadow:
+    0 2px 8px rgb(0 0 0 / 0.28),
+    inset 0 1px 0 rgb(255 255 255 / 0.18);
+  transition: transform 160ms ease, background-color 160ms ease;
+}
+
+.slide-confirm__input::-moz-range-track {
+  height: var(--rail-height);
+  background: transparent;
+  border: none;
+}
+
+.slide-confirm__input::-moz-range-thumb {
+  width: var(--thumb-size);
+  height: var(--thumb-size);
+  border: 0;
+  border-radius: 50%;
+  background: var(--thumb);
+  box-shadow: 0 2px 8px rgb(0 0 0 / 0.28);
+  transition: transform 160ms ease;
+}
+
+.slide-confirm__chevron {
+  position: absolute;
+  top: 50%;
+  left: calc(
+    (var(--thumb-size) / 2) +
+      ((100% - var(--thumb-size)) * var(--fill-ratio, 0))
+  );
+  z-index: 3;
+  width: var(--thumb-size);
+  height: var(--thumb-size);
+  transform: translate(-50%, -50%);
+  display: grid;
+  place-items: center;
+  color: #fff;
+  font-size: 1.15rem;
+  font-weight: 700;
+  pointer-events: none;
+  transition: left 40ms linear, opacity 160ms ease;
+}
+
+.slide-confirm__check {
+  position: absolute;
+  inset: 0;
+  z-index: 4;
+  display: grid;
+  place-items: center;
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  opacity: 0;
+  transform: scale(0.92);
+  pointer-events: none;
+  transition: opacity 200ms ease, transform 200ms ease;
+}
+
+.slide-confirm__fallback {
+  margin-top: 14px;
+  width: 100%;
+  height: 44px;
+  border: 1px solid #d1d5db;
+  border-radius: 10px;
+  background: #fff;
+  color: #134e4a;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease,
+    transform 120ms ease;
+}
+
+.slide-confirm__fallback:hover {
+  background: #f9fafb;
+  border-color: #9ca3af;
+}
+
+.slide-confirm__fallback:active {
+  transform: translateY(1px);
+}
+
+.slide-confirm__fallback:focus-visible {
+  outline: 3px solid rgb(22 163 74 / 0.4);
+  outline-offset: 2px;
+}
+
+.slide-confirm.is-dragging .slide-confirm__hint {
+  opacity: 0.35;
+}
+
+.slide-confirm.is-confirmed {
+  --fill: var(--success);
+}
+
+.slide-confirm.is-confirmed .slide-confirm__fill {
+  width: 100%;
+  transition: width 180ms ease;
+}
+
+.slide-confirm.is-confirmed .slide-confirm__hint,
+.slide-confirm.is-confirmed .slide-confirm__chevron,
+.slide-confirm.is-confirmed .slide-confirm__input {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.slide-confirm.is-confirmed .slide-confirm__check {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.slide-confirm.is-confirmed .slide-confirm__fallback {
+  background: #ecfdf5;
+  border-color: #86efac;
+  color: var(--success);
+  cursor: default;
+}
+
+.slide-confirm.is-confirmed .slide-confirm__fallback:hover {
+  background: #ecfdf5;
+  border-color: #86efac;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .slide-confirm__fill,
+  .slide-confirm__chevron,
+  .slide-confirm__hint,
+  .slide-confirm__check,
+  .slide-confirm__input::-webkit-slider-thumb,
+  .slide-confirm__input::-moz-range-thumb,
+  .slide-confirm__fallback {
+    transition: none;
+  }
+}
+
+/* issue #63136 variant */
+:root { --em-issue: 63136; }


### PR DESCRIPTION
## Pull Request Description

Adds `Slide-to-Confirm Action Rail` under `submissions/examples/slide-to-confirm-rail-sk-v3/` for #63136.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> PRs that fail this checklist will be closed without review.

- [x] All changes are inside `submissions/examples/your-feature-name/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A confirmation control where the user slides a grip along a track to confirm an action. The track fills as the thumb moves; at full travel the control enters a confirmed success st

**How does a developer use it?**

```html
<div class="slide-confirm">
  <label class="slide-confirm__rail">
    <span class="slide-confirm__label">Slide to confirm</span>
    <input class="slide-confirm__input" type="range" min="0" max="100" value="0" />
  </label>
  <button type="button" class="slide-confirm__fallback">Confirm</button>
</div>
```

**Why does it fit EaseMotion CSS?**

Human-readable motion demo that stays in submissions and is easy to standardize.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #63136.
