### PR TITLE
feat: add film negative develop (film-negative-develop-ns)

### DIFF
--- a/submissions/examples/film-negative-develop-ns/README.md
+++ b/submissions/examples/film-negative-develop-ns/README.md
@@ -1,0 +1,16 @@
+# Film Negative Develop
+
+## What does this do?
+Renders a self-contained CSS-only `ease-film-negative-develop` demo: Film strip developing from blank to visible frames in a tray.
+
+## How is it used?
+Open `demo.html` in a browser. The animated face uses classes like `ease-film-negative-develop`, `ease-film-negative-develop__arm`, and `ease-film-negative-develop__core`. No build step or JavaScript is required for the motion.
+
+```html
+<section class="ease-film-negative-develop">
+  <div class="ease-film-negative-develop__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/film-negative-develop-ns/demo.html
+++ b/submissions/examples/film-negative-develop-ns/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Film Negative Develop — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Film Negative Develop demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Film Negative Develop</h1>
+      <p class="lede">Film strip developing from blank to visible frames in a tray</p>
+    </header>
+
+    <section class="ease-film-negative-develop" data-demo="film-negative-develop" aria-live="polite">
+      <div class="ease-film-negative-develop__housing">
+        <div class="ease-film-negative-develop__bezel">
+          <div class="ease-film-negative-develop__face">
+            <div class="ease-film-negative-develop__readout">
+              <span class="ease-film-negative-develop__label">Film Negative Develop</span>
+              <span class="ease-film-negative-develop__value" id="val-film-negative-develop">READY</span>
+            </div>
+            <div class="ease-film-negative-develop__motion" aria-hidden="true">
+              <span class="ease-film-negative-develop__arm"></span>
+              <span class="ease-film-negative-develop__core"></span>
+              <span class="ease-film-negative-develop__trail"></span>
+              <span class="ease-film-negative-develop__mark m1"></span>
+              <span class="ease-film-negative-develop__mark m2"></span>
+              <span class="ease-film-negative-develop__mark m3"></span>
+            </div>
+            <div class="ease-film-negative-develop__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-film-negative-develop__controls">
+          <button type="button" class="ease-film-negative-develop__btn primary">Engage</button>
+          <button type="button" class="ease-film-negative-develop__btn">Reset</button>
+          <label class="ease-film-negative-develop__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-film-negative-develop__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/film-negative-develop-ns/style.css
+++ b/submissions/examples/film-negative-develop-ns/style.css
@@ -1,0 +1,295 @@
+/* Film Negative Develop — original submission styles (idx 10) */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body{margin:0;min-height:100vh;background:radial-gradient(1200px 600px at 20% 0%,#d9770622,#0f1c2e);color:#f4e8d0;font-family:'Segoe UI',Candara,Calibri,sans-serif;display:flex;align-items:center;justify-content:center;padding:2rem}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 42ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-film-negative-develop {
+  --accent: #d97706;
+  --accent-2: #1d4e89;
+  --panel: color-mix(in srgb, #f4e8d0 8%, #0f1c2e);
+  --line: color-mix(in srgb, #f4e8d0 18%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 16px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #0f1c2e 70%, #000);
+}
+
+.ease-film-negative-develop__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-film-negative-develop__bezel {
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #f4e8d0 6%, transparent), transparent 40%),
+    color-mix(in srgb, #0f1c2e 88%, #d97706);
+}
+
+.ease-film-negative-develop__face {
+  position: relative;
+  min-height: 220px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 30% 20%, color-mix(in srgb, var(--accent) 28%, transparent), transparent 45%),
+    linear-gradient(145deg, color-mix(in srgb, #0f1c2e 80%, #000), color-mix(in srgb, #0f1c2e 60%, var(--accent-2)));
+  border: 1px solid color-mix(in srgb, #f4e8d0 12%, transparent);
+}
+
+.ease-film-negative-develop__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 2;
+}
+
+.ease-film-negative-develop__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-film-negative-develop__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-film-negative-develop__motion {
+  position: absolute;
+  inset: 18% 8% 22%;
+  z-index: 1;
+}
+
+.ease-film-negative-develop__arm,
+.ease-film-negative-develop__core,
+.ease-film-negative-develop__trail,
+.ease-film-negative-develop__mark {
+  position: absolute;
+  display: block;
+}
+
+.ease-film-negative-develop__arm {
+  left: 12%;
+  top: 42%;
+  width: 46%;
+  height: 6px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, transparent, var(--accent));
+  transform-origin: left center;
+  animation: film_negative_develop_arm 3.25s cubic-bezier(0.45, 0.05, 0.2, 1) infinite;
+  animation-delay: 0.0s;
+}
+
+.ease-film-negative-develop__core {
+  left: 44%;
+  top: 28%;
+  width: 54px;
+  height: 54px;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 35% 30%, #fff8, transparent 40%),
+    radial-gradient(circle at 50% 50%, var(--accent), color-mix(in srgb, var(--accent-2) 70%, #000));
+  box-shadow: 0 0 0 2px color-mix(in srgb, #f4e8d0 20%, transparent), 0 0 28px color-mix(in srgb, var(--accent) 45%, transparent);
+  animation: film_negative_develop_core 3.74s ease-in-out infinite;
+  animation-delay: 0.1s;
+}
+
+.ease-film-negative-develop__trail {
+  left: 18%;
+  right: 14%;
+  bottom: 18%;
+  height: 38%;
+  border-radius: 40% 40% 30% 30%;
+  background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 35%, transparent), transparent);
+  filter: blur(4px);
+  opacity: 0.55;
+  animation: film_negative_develop_trail 2.93s ease-in-out infinite alternate;
+}
+
+.ease-film-negative-develop__mark {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  background: color-mix(in srgb, #f4e8d0 70%, var(--accent));
+  animation: film_negative_develop_mark 3.25s ease-in-out infinite;
+}
+
+.ease-film-negative-develop__mark.m1 { left: 22%; top: 22%; animation-delay: 0s; }
+.ease-film-negative-develop__mark.m2 { left: 70%; top: 30%; animation-delay: 0.25s; }
+.ease-film-negative-develop__mark.m3 { left: 58%; top: 62%; animation-delay: 0.45s; }
+
+.ease-film-negative-develop__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-film-negative-develop__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #f4e8d0 14%, transparent);
+  overflow: hidden;
+}
+
+.ease-film-negative-develop__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 35%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: film_negative_develop_meter 1.80s ease-in-out infinite alternate;
+}
+
+.ease-film-negative-develop__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 55%; }
+.ease-film-negative-develop__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 70%; }
+.ease-film-negative-develop__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 48%; }
+.ease-film-negative-develop__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 82%; }
+.ease-film-negative-develop__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 60%; }
+
+.ease-film-negative-develop__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-film-negative-develop__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #f4e8d0 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-film-negative-develop__btn.primary {
+  background: color-mix(in srgb, var(--accent) 28%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 55%, transparent);
+}
+
+.ease-film-negative-develop__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+}
+
+.ease-film-negative-develop__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-film-negative-develop__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-film-negative-develop__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 50%, transparent);
+  animation: film_negative_develop_pulse 1.8s ease-out infinite;
+}
+
+@keyframes film_negative_develop_arm {
+  0% { transform: rotate(-18deg) scaleX(0.85); opacity: 0.55; }
+  40% { transform: rotate(12deg) scaleX(1); opacity: 1; }
+  70% { transform: rotate(28deg) scaleX(1.05); opacity: 0.9; }
+  100% { transform: rotate(-18deg) scaleX(0.85); opacity: 0.55; }
+}
+
+@keyframes film_negative_develop_core {
+  0%, 100% { transform: translateY(0) scale(1); filter: saturate(1); }
+  50% { transform: translateY(-8px) scale(1.06); filter: saturate(1.25); }
+}
+
+@keyframes film_negative_develop_trail {
+  0% { transform: translateY(8px) scaleX(0.92); opacity: 0.25; }
+  100% { transform: translateY(-4px) scaleX(1.05); opacity: 0.7; }
+}
+
+@keyframes film_negative_develop_mark {
+  0%, 100% { transform: translateY(0); opacity: 0.35; }
+  50% { transform: translateY(-10px); opacity: 1; }
+}
+
+@keyframes film_negative_develop_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes film_negative_develop_pulse {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-film-negative-develop__arm,
+  .ease-film-negative-develop__core,
+  .ease-film-negative-develop__trail,
+  .ease-film-negative-develop__mark,
+  .ease-film-negative-develop__meters i::after,
+  .ease-film-negative-develop__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a CSS-only `film-negative-develop` submission under `submissions/examples/film-negative-develop-ns/` for #65566.

---

## Type of Change

- [x] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Film strip developing from blank to visible frames in a tray

**How does a developer use it?**

```html
<section class="ease-film-negative-develop">
  <div class="ease-film-negative-develop__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Pure CSS motion, self-contained demo, ready for maintainer `ease-*` standardization.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #65566.
