### PR TITLE
feat: add oscilloscope crt retrace (oscilloscope-crt-retrace-ns)

### DIFF
--- a/submissions/examples/oscilloscope-crt-retrace-ns/README.md
+++ b/submissions/examples/oscilloscope-crt-retrace-ns/README.md
@@ -1,0 +1,16 @@
+# Oscilloscope CRT Retrace
+
+## What does this do?
+Renders a self-contained CSS-only `ease-oscilloscope-crt-retrace` demo: CRT oscilloscope beam drawing a sine then retracing.
+
+## How is it used?
+Open `demo.html` in a browser. The animated face uses classes like `ease-oscilloscope-crt-retrace`, `ease-oscilloscope-crt-retrace__arm`, and `ease-oscilloscope-crt-retrace__core`. No build step or JavaScript is required for the motion.
+
+```html
+<section class="ease-oscilloscope-crt-retrace">
+  <div class="ease-oscilloscope-crt-retrace__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/oscilloscope-crt-retrace-ns/demo.html
+++ b/submissions/examples/oscilloscope-crt-retrace-ns/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Oscilloscope CRT Retrace — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Oscilloscope CRT Retrace demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Oscilloscope CRT Retrace</h1>
+      <p class="lede">CRT oscilloscope beam drawing a sine then retracing</p>
+    </header>
+
+    <section class="ease-oscilloscope-crt-retrace" data-demo="oscilloscope-crt-retrace" aria-live="polite">
+      <div class="ease-oscilloscope-crt-retrace__housing">
+        <div class="ease-oscilloscope-crt-retrace__bezel">
+          <div class="ease-oscilloscope-crt-retrace__face">
+            <div class="ease-oscilloscope-crt-retrace__readout">
+              <span class="ease-oscilloscope-crt-retrace__label">Oscilloscope CRT Retrace</span>
+              <span class="ease-oscilloscope-crt-retrace__value" id="val-oscilloscope-crt-retrace">READY</span>
+            </div>
+            <div class="ease-oscilloscope-crt-retrace__motion" aria-hidden="true">
+              <span class="ease-oscilloscope-crt-retrace__arm"></span>
+              <span class="ease-oscilloscope-crt-retrace__core"></span>
+              <span class="ease-oscilloscope-crt-retrace__trail"></span>
+              <span class="ease-oscilloscope-crt-retrace__mark m1"></span>
+              <span class="ease-oscilloscope-crt-retrace__mark m2"></span>
+              <span class="ease-oscilloscope-crt-retrace__mark m3"></span>
+            </div>
+            <div class="ease-oscilloscope-crt-retrace__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-oscilloscope-crt-retrace__controls">
+          <button type="button" class="ease-oscilloscope-crt-retrace__btn primary">Engage</button>
+          <button type="button" class="ease-oscilloscope-crt-retrace__btn">Reset</button>
+          <label class="ease-oscilloscope-crt-retrace__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-oscilloscope-crt-retrace__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/oscilloscope-crt-retrace-ns/style.css
+++ b/submissions/examples/oscilloscope-crt-retrace-ns/style.css
@@ -1,0 +1,295 @@
+/* Oscilloscope CRT Retrace — original submission styles (idx 16) */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body{margin:0;min-height:100vh;background:linear-gradient(160deg,#1e140f,#0f766e33 50%,#1e140f);color:#fff7ed;font-family:Georgia,'Times New Roman',serif;display:grid;place-content:center;padding:1.5rem}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 42ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-oscilloscope-crt-retrace {
+  --accent: #ea580c;
+  --accent-2: #0f766e;
+  --panel: color-mix(in srgb, #fff7ed 8%, #1e140f);
+  --line: color-mix(in srgb, #fff7ed 18%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 16px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #1e140f 70%, #000);
+}
+
+.ease-oscilloscope-crt-retrace__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-oscilloscope-crt-retrace__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #fff7ed 6%, transparent), transparent 40%),
+    color-mix(in srgb, #1e140f 88%, #ea580c);
+}
+
+.ease-oscilloscope-crt-retrace__face {
+  position: relative;
+  min-height: 220px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 30% 20%, color-mix(in srgb, var(--accent) 28%, transparent), transparent 45%),
+    linear-gradient(145deg, color-mix(in srgb, #1e140f 80%, #000), color-mix(in srgb, #1e140f 60%, var(--accent-2)));
+  border: 1px solid color-mix(in srgb, #fff7ed 12%, transparent);
+}
+
+.ease-oscilloscope-crt-retrace__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 2;
+}
+
+.ease-oscilloscope-crt-retrace__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-oscilloscope-crt-retrace__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-oscilloscope-crt-retrace__motion {
+  position: absolute;
+  inset: 18% 8% 22%;
+  z-index: 1;
+}
+
+.ease-oscilloscope-crt-retrace__arm,
+.ease-oscilloscope-crt-retrace__core,
+.ease-oscilloscope-crt-retrace__trail,
+.ease-oscilloscope-crt-retrace__mark {
+  position: absolute;
+  display: block;
+}
+
+.ease-oscilloscope-crt-retrace__arm {
+  left: 12%;
+  top: 42%;
+  width: 46%;
+  height: 6px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, transparent, var(--accent));
+  transform-origin: left center;
+  animation: oscilloscope_crt_retrace_arm 2.9000000000000004s cubic-bezier(0.45, 0.05, 0.2, 1) infinite;
+  animation-delay: 0.08s;
+}
+
+.ease-oscilloscope-crt-retrace__core {
+  left: 44%;
+  top: 28%;
+  width: 54px;
+  height: 54px;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 35% 30%, #fff8, transparent 40%),
+    radial-gradient(circle at 50% 50%, var(--accent), color-mix(in srgb, var(--accent-2) 70%, #000));
+  box-shadow: 0 0 0 2px color-mix(in srgb, #fff7ed 20%, transparent), 0 0 28px color-mix(in srgb, var(--accent) 45%, transparent);
+  animation: oscilloscope_crt_retrace_core 3.33s ease-in-out infinite;
+  animation-delay: 0.18s;
+}
+
+.ease-oscilloscope-crt-retrace__trail {
+  left: 18%;
+  right: 14%;
+  bottom: 18%;
+  height: 38%;
+  border-radius: 40% 40% 30% 30%;
+  background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 35%, transparent), transparent);
+  filter: blur(2px);
+  opacity: 0.55;
+  animation: oscilloscope_crt_retrace_trail 2.61s ease-in-out infinite alternate;
+}
+
+.ease-oscilloscope-crt-retrace__mark {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  background: color-mix(in srgb, #fff7ed 70%, var(--accent));
+  animation: oscilloscope_crt_retrace_mark 2.9000000000000004s ease-in-out infinite;
+}
+
+.ease-oscilloscope-crt-retrace__mark.m1 { left: 22%; top: 22%; animation-delay: 0s; }
+.ease-oscilloscope-crt-retrace__mark.m2 { left: 70%; top: 30%; animation-delay: 0.25s; }
+.ease-oscilloscope-crt-retrace__mark.m3 { left: 58%; top: 62%; animation-delay: 0.45s; }
+
+.ease-oscilloscope-crt-retrace__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-oscilloscope-crt-retrace__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #fff7ed 14%, transparent);
+  overflow: hidden;
+}
+
+.ease-oscilloscope-crt-retrace__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 35%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: oscilloscope_crt_retrace_meter 1.40s ease-in-out infinite alternate;
+}
+
+.ease-oscilloscope-crt-retrace__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 55%; }
+.ease-oscilloscope-crt-retrace__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 70%; }
+.ease-oscilloscope-crt-retrace__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 48%; }
+.ease-oscilloscope-crt-retrace__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 82%; }
+.ease-oscilloscope-crt-retrace__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 60%; }
+
+.ease-oscilloscope-crt-retrace__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-oscilloscope-crt-retrace__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #fff7ed 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-oscilloscope-crt-retrace__btn.primary {
+  background: color-mix(in srgb, var(--accent) 28%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 55%, transparent);
+}
+
+.ease-oscilloscope-crt-retrace__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+}
+
+.ease-oscilloscope-crt-retrace__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-oscilloscope-crt-retrace__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-oscilloscope-crt-retrace__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 50%, transparent);
+  animation: oscilloscope_crt_retrace_pulse 1.8s ease-out infinite;
+}
+
+@keyframes oscilloscope_crt_retrace_arm {
+  0% { transform: rotate(-18deg) scaleX(0.85); opacity: 0.55; }
+  40% { transform: rotate(12deg) scaleX(1); opacity: 1; }
+  70% { transform: rotate(28deg) scaleX(1.05); opacity: 0.9; }
+  100% { transform: rotate(-18deg) scaleX(0.85); opacity: 0.55; }
+}
+
+@keyframes oscilloscope_crt_retrace_core {
+  0%, 100% { transform: translateY(0) scale(1); filter: saturate(1); }
+  50% { transform: translateY(-8px) scale(1.06); filter: saturate(1.25); }
+}
+
+@keyframes oscilloscope_crt_retrace_trail {
+  0% { transform: translateY(8px) scaleX(0.92); opacity: 0.25; }
+  100% { transform: translateY(-4px) scaleX(1.05); opacity: 0.7; }
+}
+
+@keyframes oscilloscope_crt_retrace_mark {
+  0%, 100% { transform: translateY(0); opacity: 0.35; }
+  50% { transform: translateY(-10px); opacity: 1; }
+}
+
+@keyframes oscilloscope_crt_retrace_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes oscilloscope_crt_retrace_pulse {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-oscilloscope-crt-retrace__arm,
+  .ease-oscilloscope-crt-retrace__core,
+  .ease-oscilloscope-crt-retrace__trail,
+  .ease-oscilloscope-crt-retrace__mark,
+  .ease-oscilloscope-crt-retrace__meters i::after,
+  .ease-oscilloscope-crt-retrace__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a CSS-only `oscilloscope-crt-retrace` submission under `submissions/examples/oscilloscope-crt-retrace-ns/` for #65572.

---

## Type of Change

- [x] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

CRT oscilloscope beam drawing a sine then retracing

**How does a developer use it?**

```html
<section class="ease-oscilloscope-crt-retrace">
  <div class="ease-oscilloscope-crt-retrace__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Pure CSS motion, self-contained demo, ready for maintainer `ease-*` standardization.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #65572.
