### PR TITLE
Add ease-airport-departure-screen component

### DIFF
--- a/submissions/examples/airport-departure-screen-ij/README.md
+++ b/submissions/examples/airport-departure-screen-ij/README.md
@@ -1,0 +1,10 @@
+# ease-airport-departure-screen
+
+A flight board where the departure rows slide into place, the flight status tags blink in turn, and the board clock ticks at the corner.
+
+## Run
+Open `demo.html` directly in a browser to watch the rows slide.
+
+## Notes
+- The rows slide into place.
+- The status tags blink in turn.

--- a/submissions/examples/airport-departure-screen-ij/demo.html
+++ b/submissions/examples/airport-departure-screen-ij/demo.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-airport-departure-screen demo</title>
+</head>
+<body>
+<div class="adp-app">
+  <span class="adp-title">FLIGHT DEPARTURES</span>
+  <div class="adp-board">
+    <div class="adp-row"><span class="adp-code">BA214</span><span class="adp-dest">BERLIN</span><span class="adp-time">08:40</span><span class="adp-status">ON TIME</span></div>
+    <div class="adp-row"><span class="adp-code">AF143</span><span class="adp-dest">PARIS</span><span class="adp-time">09:05</span><span class="adp-status">BOARDING</span></div>
+    <div class="adp-row"><span class="adp-code">LH412</span><span class="adp-dest">FRANKFURT</span><span class="adp-time">09:30</span><span class="adp-status">GATE OPEN</span></div>
+    <div class="adp-row"><span class="adp-code">KL601</span><span class="adp-dest">AMSTERDAM</span><span class="adp-time">10:10</span><span class="adp-status">DELAYED</span></div>
+  </div>
+  <span class="adp-clock">12:00:00</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/airport-departure-screen-ij/style.css
+++ b/submissions/examples/airport-departure-screen-ij/style.css
@@ -1,0 +1,17 @@
+:root{--adp-blue:#4da6ff;--adp-dark:#060a12}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#0c1424,#060a12);font-family:'Arial',sans-serif}
+.adp-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#080e1c,#04060c);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.adp-title{position:absolute;top:16px;left:0;right:0;text-align:center;font-size:12px;font-weight:800;letter-spacing:7px;color:#4da6ff}
+.adp-board{position:absolute;top:60px;left:26px;right:26px;display:flex;flex-direction:column;gap:10px}
+.adp-row{height:44px;border-radius:8px;background:#0a1424;box-shadow:inset 0 0 0 2px #1c3a5a;display:flex;align-items:center;gap:8px;padding:0 10px;animation:row-slide-airport-departure-screen 0.8s ease-out infinite alternate}
+.adp-row:nth-child(2){animation-delay:0.2s}
+.adp-row:nth-child(3){animation-delay:0.4s}
+.adp-row:nth-child(4){animation-delay:0.6s}
+.adp-code{font-size:13px;font-weight:900;color:#d8e6ff}
+.adp-dest{flex:1;font-size:12px;font-weight:800;letter-spacing:1px;color:#b3c9e8}
+.adp-time{font-size:13px;font-weight:900;color:#b3d4ff;font-variant-numeric:tabular-nums}
+.adp-status{font-size:9px;font-weight:900;letter-spacing:1px;color:#35e06a;animation:status-blink-airport-departure-screen 1.4s steps(1) infinite}
+.adp-clock{position:absolute;bottom:16px;left:0;right:0;text-align:center;font-size:10px;font-weight:800;letter-spacing:4px;color:#3a6a9a;font-variant-numeric:tabular-nums;animation:clock-tick-airport-departure-screen 1s steps(1) infinite}
+@keyframes row-slide-airport-departure-screen{0%,100%{transform:translateX(0)}50%{transform:translateX(8px)}}
+@keyframes status-blink-airport-departure-screen{0%,49%{opacity:1}50%,100%{opacity:0.3}}
+@keyframes clock-tick-airport-departure-screen{0%,49%{opacity:1}50%,100%{opacity:0.4}}


### PR DESCRIPTION
## Component: ease-airport-departure-screen — rows slide, status blinks, and clock ticks

**Closes #65625**

### What this adds
A flight board: the departure rows slide into place, the flight status tags blink in turn, and the board clock ticks at the corner.

### Acceptance Criteria covered
- Departure rows slide into place
- Flight status tags blink in turn
- Board clock ticks at the corner

### Files
- `submissions/examples/airport-departure-screen-ij/demo.html`
- `submissions/examples/airport-departure-screen-ij/style.css`
- `submissions/examples/airport-departure-screen-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the rows slide.