### PR TITLE
Add ease-espresso-steam-shot component

### DIFF
--- a/submissions/examples/espresso-steam-shot-ij/README.md
+++ b/submissions/examples/espresso-steam-shot-ij/README.md
@@ -1,0 +1,10 @@
+# ease-espresso-steam-shot
+
+An espresso machine where steam wisps rise off the group head, the pressure needle sweeps the dial, and the bar note blinks beneath.
+
+## Run
+Open `demo.html` directly in a browser to watch the wisps rise.
+
+## Notes
+- The steam wisps rise off the group head.
+- The pressure needle sweeps the dial.

--- a/submissions/examples/espresso-steam-shot-ij/demo.html
+++ b/submissions/examples/espresso-steam-shot-ij/demo.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-espresso-steam-shot demo</title>
+</head>
+<body>
+<div class="ess-app">
+  <span class="ess-title">ESPRESSO</span>
+  <div class="ess-steam">
+    <span class="ess-wisp"></span>
+    <span class="ess-wisp"></span>
+    <span class="ess-wisp"></span>
+  </div>
+  <div class="ess-grouphead"><span class="ess-shot"></span></div>
+  <div class="ess-dial"><span class="ess-needle"></span></div>
+  <span class="ess-note">PRESSURE 9 BAR</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/espresso-steam-shot-ij/style.css
+++ b/submissions/examples/espresso-steam-shot-ij/style.css
@@ -1,0 +1,16 @@
+:root{--ess-cream:#f0d9b3;--ess-dark:#0a0703}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#1c1206,#0a0703);font-family:'Trebuchet MS',sans-serif}
+.ess-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#161004,#080502);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.ess-title{position:absolute;top:16px;left:0;right:0;text-align:center;font-size:12px;font-weight:800;letter-spacing:7px;color:#f0d9b3}
+.ess-steam{position:absolute;top:58px;left:50%;margin-left:-50px;width:100px;height:70px}
+.ess-wisp{position:absolute;bottom:0;width:8px;height:44px;border-radius:4px;background:linear-gradient(180deg,transparent,#f0d9b3);opacity:0.8;animation:wisp-rise-espresso-steam-shot 2s ease-in-out infinite}
+.ess-wisp:nth-child(2){left:38px;animation-delay:0.6s}
+.ess-wisp:nth-child(3){left:74px;animation-delay:1.2s}
+.ess-grouphead{position:absolute;top:134px;left:50%;margin-left:-34px;width:68px;height:44px;border-radius:8px 8px 4px 4px;background:#2a2010;box-shadow:inset 0 0 0 3px #4a3a1c}
+.ess-shot{position:absolute;top:46px;left:50%;margin-left:-6px;width:12px;height:16px;border-radius:0 0 6px 6px;background:#f0d9b3}
+.ess-dial{position:absolute;top:212px;left:50%;margin-left:-56px;width:112px;height:112px;border-radius:50%;background:#120c04;box-shadow:inset 0 0 0 3px #4a3a1c}
+.ess-needle{position:absolute;top:50%;left:50%;width:42px;height:3px;margin-top:-2px;margin-left:-42px;background:#f0d9b3;box-shadow:0 0 8px rgba(240,217,179,0.7);transform-origin:right center;animation:needle-sweep-espresso-steam-shot 3s ease-in-out infinite}
+.ess-note{position:absolute;bottom:16px;left:0;right:0;text-align:center;font-size:10px;font-weight:800;letter-spacing:4px;color:#8a6a3a;animation:note-blink-espresso-steam-shot 1.8s steps(1) infinite}
+@keyframes wisp-rise-espresso-steam-shot{0%{transform:translateY(0);opacity:0.8}100%{transform:translateY(-70px);opacity:0}}
+@keyframes needle-sweep-espresso-steam-shot{0%{transform:rotate(-40deg)}50%{transform:rotate(40deg)}100%{transform:rotate(-40deg)}}
+@keyframes note-blink-espresso-steam-shot{0%,49%{opacity:1}50%,100%{opacity:0.35}}


### PR DESCRIPTION
## Component: ease-espresso-steam-shot — wisps rise, needle sweeps, and note blinks

**Closes #65637**

### What this adds
An espresso machine: steam wisps rise off the group head, the pressure needle sweeps the dial, and the bar note blinks beneath.

### Acceptance Criteria covered
- Steam wisps rise off the group head
- Pressure needle sweeps the dial
- Bar note blinks beneath

### Files
- `submissions/examples/espresso-steam-shot-ij/demo.html`
- `submissions/examples/espresso-steam-shot-ij/style.css`
- `submissions/examples/espresso-steam-shot-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the wisps rise.