### PR TITLE
Add ease-tram-arrival-board component

### DIFF
--- a/submissions/examples/tram-arrival-board-ij/README.md
+++ b/submissions/examples/tram-arrival-board-ij/README.md
@@ -1,0 +1,10 @@
+# ease-tram-arrival-board
+
+A tram stop board where the arrival digits flip down, the tram icon glides across the strip, and the route label blinks beneath.
+
+## Run
+Open `demo.html` directly in a browser to watch the digits flip.
+
+## Notes
+- The arrival digits flip down.
+- The tram icon glides across.

--- a/submissions/examples/tram-arrival-board-ij/demo.html
+++ b/submissions/examples/tram-arrival-board-ij/demo.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-tram-arrival-board demo</title>
+</head>
+<body>
+<div class="tab-app">
+  <span class="tab-title">TRAM STOP 4</span>
+  <div class="tab-board">
+    <div class="tab-row"><span class="tab-line">M4</span><span class="tab-eta">3</span><span class="tab-unit">MIN</span></div>
+    <div class="tab-row"><span class="tab-line">M6</span><span class="tab-eta">7</span><span class="tab-unit">MIN</span></div>
+  </div>
+  <div class="tab-strip"><span class="tab-tram"></span></div>
+  <span class="tab-route">TO CITY CENTER</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/tram-arrival-board-ij/style.css
+++ b/submissions/examples/tram-arrival-board-ij/style.css
@@ -1,0 +1,16 @@
+:root{--tab-yellow:#ffd23f;--tab-dark:#0a0804}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#1c1708,#0a0804);font-family:'Consolas',monospace}
+.tab-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#151105,#070503);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.tab-title{position:absolute;top:16px;left:0;right:0;text-align:center;font-size:12px;font-weight:800;letter-spacing:7px;color:#ffd23f}
+.tab-board{position:absolute;top:58px;left:26px;right:26px;display:flex;flex-direction:column;gap:10px}
+.tab-row{height:52px;border-radius:8px;background:#120f06;box-shadow:inset 0 0 0 2px #3a2f10;display:flex;align-items:center;gap:10px;padding:0 12px}
+.tab-line{width:34px;height:26px;border-radius:6px;background:#ffd23f;color:#0a0804;font-size:13px;font-weight:900;display:flex;align-items:center;justify-content:center}
+.tab-eta{font-size:30px;font-weight:900;color:#ffd23f;font-variant-numeric:tabular-nums;animation:eta-flip-tram-arrival-board 1s steps(1) infinite}
+.tab-eta:nth-child(3){animation-delay:0.5s}
+.tab-unit{font-size:11px;font-weight:800;color:#a89a5a;letter-spacing:2px}
+.tab-strip{position:absolute;top:166px;left:26px;right:26px;height:46px;border-radius:8px;background:#120f06;box-shadow:inset 0 0 0 2px #3a2f10;overflow:hidden}
+.tab-tram{position:absolute;top:9px;left:-90px;width:64px;height:28px;border-radius:6px;background:#ffd23f;animation:tram-glide-tram-arrival-board 5s linear infinite}
+.tab-route{position:absolute;bottom:16px;left:0;right:0;text-align:center;font-size:10px;font-weight:800;letter-spacing:4px;color:#8a7a3a;animation:route-blink-tram-arrival-board 1.8s steps(1) infinite}
+@keyframes eta-flip-tram-arrival-board{0%,100%{transform:translateY(0)}50%{transform:translateY(-12px)}}
+@keyframes tram-glide-tram-arrival-board{0%{left:-90px}100%{left:330px}}
+@keyframes route-blink-tram-arrival-board{0%,49%{opacity:1}50%,100%{opacity:0.35}}


### PR DESCRIPTION
## Component: ease-tram-arrival-board — digits flip, tram glides, and route blinks

**Closes #65639**

### What this adds
A tram stop board: the arrival digits flip down, the tram icon glides across the strip, and the route label blinks beneath.

### Acceptance Criteria covered
- Arrival digits flip down
- Tram icon glides across
- Route label blinks below

### Files
- `submissions/examples/tram-arrival-board-ij/demo.html`
- `submissions/examples/tram-arrival-board-ij/style.css`
- `submissions/examples/tram-arrival-board-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the digits flip.