### PR TITLE
Add ease-bus-route-stops component

### DIFF
--- a/submissions/examples/bus-route-stops-ij/README.md
+++ b/submissions/examples/bus-route-stops-ij/README.md
@@ -1,0 +1,10 @@
+# ease-bus-route-stops
+
+A route map where the bus icon moves along the stop line, the stop dots pulse in turn, and the next-stop label blinks beneath.
+
+## Run
+Open `demo.html` directly in a browser to watch the bus move.
+
+## Notes
+- The bus icon moves along the stop line.
+- The stop dots pulse in turn.

--- a/submissions/examples/bus-route-stops-ij/demo.html
+++ b/submissions/examples/bus-route-stops-ij/demo.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-bus-route-stops demo</title>
+</head>
+<body>
+<div class="brs-app">
+  <span class="brs-title">ROUTE 21</span>
+  <div class="brs-map">
+    <span class="brs-stop"></span>
+    <span class="brs-stop"></span>
+    <span class="brs-stop"></span>
+    <span class="brs-stop"></span>
+    <span class="brs-bus"></span>
+  </div>
+  <span class="brs-next">NEXT: MARKET ST</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/bus-route-stops-ij/style.css
+++ b/submissions/examples/bus-route-stops-ij/style.css
@@ -1,0 +1,15 @@
+:root{--brs-green:#3adf5f;--brs-dark:#06100a}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#0f2214,#06100a);font-family:'Cambria',serif}
+.brs-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#0a1a10,#040a06);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.brs-title{position:absolute;top:16px;left:0;right:0;text-align:center;font-size:12px;font-weight:800;letter-spacing:7px;color:#3adf5f}
+.brs-map{position:absolute;top:90px;left:40px;right:40px;height:200px;border-radius:16px;background:#0e1c14;box-shadow:inset 0 0 0 3px #1c4a2c;position:relative}
+.brs-stop{position:absolute;top:50%;width:12px;height:12px;margin:-6px 0 0 -6px;border-radius:50%;background:#3adf5f;box-shadow:0 0 8px rgba(58,223,95,0.8);animation:stop-pulse-bus-route-stops 1.6s ease-in-out infinite}
+.brs-stop:nth-child(1){left:12%}
+.brs-stop:nth-child(2){left:38%;animation-delay:0.4s}
+.brs-stop:nth-child(3){left:62%;animation-delay:0.8s}
+.brs-stop:nth-child(4){left:88%;animation-delay:1.2s}
+.brs-bus{position:absolute;top:50%;left:-18px;width:36px;height:18px;margin-top:-9px;border-radius:6px;background:#ffd23f;animation:bus-move-bus-route-stops 6s linear infinite}
+.brs-next{position:absolute;bottom:16px;left:0;right:0;text-align:center;font-size:10px;font-weight:800;letter-spacing:4px;color:#3a7a4c;animation:next-blink-bus-route-stops 1.8s steps(1) infinite}
+@keyframes bus-move-bus-route-stops{0%{left:-18px}100%{left:330px}}
+@keyframes stop-pulse-bus-route-stops{0%,100%{transform:scale(1)}50%{transform:scale(1.6)}}
+@keyframes next-blink-bus-route-stops{0%,49%{opacity:1}50%,100%{opacity:0.35}}


### PR DESCRIPTION
## Component: ease-bus-route-stops — bus moves, stops pulse, and next blinks

**Closes #65643**

### What this adds
A route map: the bus icon moves along the stop line, the stop dots pulse in turn, and the next-stop label blinks beneath.

### Acceptance Criteria covered
- Bus icon moves along the stop line
- Stop dots pulse in turn
- Next-stop label blinks below

### Files
- `submissions/examples/bus-route-stops-ij/demo.html`
- `submissions/examples/bus-route-stops-ij/style.css`
- `submissions/examples/bus-route-stops-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the bus move.