### PR TITLE
Add ease-phone-signal-indicator component

### DIFF
--- a/submissions/examples/phone-signal-indicator-ij/README.md
+++ b/submissions/examples/phone-signal-indicator-ij/README.md
@@ -1,0 +1,10 @@
+# ease-phone-signal-indicator
+
+A phone status row where the signal bars pulse, the wifi arcs blink beside them, and the carrier tag ticks at the end.
+
+## Run
+Open `demo.html` directly in a browser to watch the bars pulse.
+
+## Notes
+- The signal bars pulse in the row.
+- The wifi arcs blink beside.

--- a/submissions/examples/phone-signal-indicator-ij/demo.html
+++ b/submissions/examples/phone-signal-indicator-ij/demo.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-phone-signal-indicator demo</title>
+</head>
+<body>
+<div class="psi-app">
+  <span class="psi-title">STATUS</span>
+  <div class="psi-sig">
+    <span class="psi-bar"></span>
+    <span class="psi-bar"></span>
+    <span class="psi-bar"></span>
+    <span class="psi-bar"></span>
+  </div>
+  <div class="psi-wifi"><span class="psi-arc"></span><span class="psi-arc"></span></div>
+  <div class="psi-batt"><span class="psi-fill"></span></div>
+  <span class="psi-carrier">5G</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/phone-signal-indicator-ij/style.css
+++ b/submissions/examples/phone-signal-indicator-ij/style.css
@@ -1,0 +1,18 @@
+:root{--psi-teal:#3adfe0;--psi-dark:#061012}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#0a1a1e,#061012);font-family:'Lucida Console',monospace}
+.psi-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#081418,#040a0c);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.psi-title{position:absolute;top:16px;left:0;right:0;text-align:center;font-size:12px;font-weight:800;letter-spacing:7px;color:#3adfe0}
+.psi-sig{position:absolute;top:96px;left:50%;margin-left:-86px;width:172px;height:60px;display:flex;align-items:flex-end;justify-content:center;gap:8px}
+.psi-bar{width:14px;border-radius:4px 4px 0 0;background:#3adfe0;animation:bar-pulse-phone-signal-indicator 1.2s ease-in-out infinite}
+.psi-bar:nth-child(1){height:22px}
+.psi-bar:nth-child(2){height:34px;animation-delay:0.2s}
+.psi-bar:nth-child(3){height:46px;animation-delay:0.4s}
+.psi-bar:nth-child(4){height:58px;animation-delay:0.6s}
+.psi-wifi{position:absolute;top:210px;left:50%;margin-left:-42px;width:84px;height:44px;display:flex;align-items:flex-end;justify-content:center;gap:6px}
+.psi-arc{width:30px;height:30px;border-radius:50%;border:3px solid transparent;border-top-color:#3adfe0;opacity:0.8;animation:wifi-blink-phone-signal-indicator 1.4s steps(1) infinite}
+.psi-batt{position:absolute;top:300px;left:50%;margin-left:-34px;width:68px;height:26px;border-radius:6px;background:#040a0c;box-shadow:inset 0 0 0 2px #3adfe0;display:flex;align-items:center;padding:3px}
+.psi-fill{display:block;width:58%;height:16px;border-radius:3px;background:#3adfe0}
+.psi-carrier{position:absolute;bottom:16px;left:0;right:0;text-align:center;font-size:12px;font-weight:900;letter-spacing:5px;color:#3adfe0;animation:carrier-blink-phone-signal-indicator 1.6s steps(1) infinite}
+@keyframes bar-pulse-phone-signal-indicator{0%,100%{opacity:1}50%{opacity:0.25}}
+@keyframes wifi-blink-phone-signal-indicator{0%,49%{opacity:0.8}50%,100%{opacity:0.2}}
+@keyframes carrier-blink-phone-signal-indicator{0%,49%{opacity:1}50%,100%{opacity:0.4}}


### PR DESCRIPTION
## Component: ease-phone-signal-indicator — bars pulse, wifi blinks, and carrier ticks

**Closes #65673**

### What this adds
A phone status row: the signal bars pulse, the wifi arcs blink beside them, and the carrier tag ticks at the end.

### Acceptance Criteria covered
- Signal bars pulse in the row
- Wifi arcs blink beside
- Carrier tag ticks at the end

### Files
- `submissions/examples/phone-signal-indicator-ij/demo.html`
- `submissions/examples/phone-signal-indicator-ij/style.css`
- `submissions/examples/phone-signal-indicator-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the bars pulse.