### PR TITLE
Add ease-camera-roll-gallery component

### DIFF
--- a/submissions/examples/camera-roll-gallery-ij/README.md
+++ b/submissions/examples/camera-roll-gallery-ij/README.md
@@ -1,0 +1,10 @@
+# ease-camera-roll-gallery
+
+A gallery grid where the photo tiles shimmer in sequence, the picked tile pulses with a border, and the item count blinks beneath.
+
+## Run
+Open `demo.html` directly in a browser to watch the photos shimmer.
+
+## Notes
+- The photo tiles shimmer in sequence.
+- The picked tile pulses with a border.

--- a/submissions/examples/camera-roll-gallery-ij/demo.html
+++ b/submissions/examples/camera-roll-gallery-ij/demo.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-camera-roll-gallery demo</title>
+</head>
+<body>
+<div class="crg-app">
+  <span class="crg-title">CAMERA ROLL</span>
+  <div class="crg-grid">
+    <span class="crg-photo"></span>
+    <span class="crg-photo"></span>
+    <span class="crg-photo"></span>
+    <span class="crg-photo"></span>
+    <span class="crg-photo crg-pick"></span>
+    <span class="crg-photo"></span>
+  </div>
+  <span class="crg-count">24 ITEMS</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/camera-roll-gallery-ij/style.css
+++ b/submissions/examples/camera-roll-gallery-ij/style.css
@@ -1,0 +1,15 @@
+:root{--crg-pink:#ff5b9a;--crg-dark:#12060c}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#24101a,#12060c);font-family:'Franklin Gothic Medium',sans-serif}
+.crg-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#1a0c14,#0c0509);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.crg-title{position:absolute;top:16px;left:0;right:0;text-align:center;font-size:12px;font-weight:800;letter-spacing:7px;color:#ff5b9a}
+.crg-grid{position:absolute;top:70px;left:30px;right:30px;display:grid;grid-template-columns:repeat(3,1fr);gap:12px}
+.crg-photo{height:86px;border-radius:10px;background:linear-gradient(135deg,#3a1626,#1c0c16);box-shadow:inset 0 0 0 2px #5a2436;animation:photo-shimmer-camera-roll-gallery 2s ease-in-out infinite}
+.crg-photo:nth-child(2){animation-delay:0.3s}
+.crg-photo:nth-child(3){animation-delay:0.6s}
+.crg-photo:nth-child(4){animation-delay:0.9s}
+.crg-photo:nth-child(6){animation-delay:1.2s}
+.crg-pick{box-shadow:inset 0 0 0 3px #ff5b9a,0 0 14px rgba(255,91,154,0.6);animation:select-pulse-camera-roll-gallery 1.2s ease-in-out infinite}
+.crg-count{position:absolute;bottom:16px;left:0;right:0;text-align:center;font-size:11px;font-weight:800;letter-spacing:4px;color:#8a3a5a;animation:count-blink-camera-roll-gallery 1.8s steps(1) infinite}
+@keyframes photo-shimmer-camera-roll-gallery{0%,100%{opacity:0.6}50%{opacity:1}}
+@keyframes select-pulse-camera-roll-gallery{0%,100%{transform:scale(1)}50%{transform:scale(1.06)}}
+@keyframes count-blink-camera-roll-gallery{0%,49%{opacity:1}50%,100%{opacity:0.35}}


### PR DESCRIPTION
## Component: ease-camera-roll-gallery — photos shimmer, pick pulses, and count blinks

**Closes #65693**

### What this adds
A gallery grid: the photo tiles shimmer in sequence, the picked tile pulses with a border, and the item count blinks beneath.

### Acceptance Criteria covered
- Photo tiles shimmer in sequence
- Picked tile pulses with a border
- Item count blinks beneath

### Files
- `submissions/examples/camera-roll-gallery-ij/demo.html`
- `submissions/examples/camera-roll-gallery-ij/style.css`
- `submissions/examples/camera-roll-gallery-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the photos shimmer.