### PR TITLE
Add ease-radio-antenna-signal component

### DIFF
--- a/submissions/examples/radio-antenna-signal-ij/README.md
+++ b/submissions/examples/radio-antenna-signal-ij/README.md
@@ -1,0 +1,10 @@
+# ease-radio-antenna-signal
+
+A radio mast where the signal arcs pulse outward, the warning lamp blinks on the tower, and the frequency tag ticks beneath.
+
+## Run
+Open `demo.html` directly in a browser to watch the arcs wave.
+
+## Notes
+- The signal arcs pulse outward.
+- The warning lamp blinks on the tower.

--- a/submissions/examples/radio-antenna-signal-ij/demo.html
+++ b/submissions/examples/radio-antenna-signal-ij/demo.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-radio-antenna-signal demo</title>
+</head>
+<body>
+<div class="ras-app">
+  <span class="ras-title">RADIO MAST</span>
+  <div class="ras-tower">
+    <span class="ras-arc"></span>
+    <span class="ras-arc"></span>
+    <span class="ras-arc"></span>
+    <span class="ras-lamp"></span>
+  </div>
+  <span class="ras-freq">FM 98.6</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/radio-antenna-signal-ij/style.css
+++ b/submissions/examples/radio-antenna-signal-ij/style.css
@@ -1,0 +1,13 @@
+:root{--ras-green:#35e06a;--ras-dark:#060a06}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#0e1c10,#060a06);font-family:'Trebuchet MS',sans-serif}
+.ras-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#0a160c,#040804);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.ras-title{position:absolute;top:16px;left:0;right:0;text-align:center;font-size:12px;font-weight:800;letter-spacing:7px;color:#35e06a}
+.ras-tower{position:absolute;top:84px;left:50%;margin-left:-42px;width:84px;height:200px;border-radius:10px;background:repeating-linear-gradient(180deg,#1c3a24 0 18px,#0a160c 18px 36px);box-shadow:inset 0 0 0 3px #1c3a24}
+.ras-arc{position:absolute;top:-24px;left:50%;width:76px;height:40px;margin-left:-38px;border:3px solid transparent;border-bottom-color:#35e06a;border-radius:50% 50% 0 0;opacity:0;transform-origin:bottom center;animation:arc-wave-radio-antenna-signal 2.4s ease-out infinite}
+.ras-arc:nth-child(2){animation-delay:0.8s}
+.ras-arc:nth-child(3){animation-delay:1.6s}
+.ras-lamp{position:absolute;top:-8px;left:50%;margin-left:-8px;width:16px;height:16px;border-radius:50%;background:#ff5b5b;box-shadow:0 0 12px rgba(255,91,91,0.8);animation:lamp-blink-radio-antenna-signal 1.4s steps(1) infinite}
+.ras-freq{position:absolute;bottom:16px;left:0;right:0;text-align:center;font-size:13px;font-weight:900;letter-spacing:5px;color:#35e06a;animation:freq-blink-radio-antenna-signal 1.6s steps(1) infinite}
+@keyframes arc-wave-radio-antenna-signal{0%{transform:scaleY(0.2);opacity:0}40%{opacity:0.9}100%{transform:scaleY(1.6);opacity:0}}
+@keyframes lamp-blink-radio-antenna-signal{0%,49%{opacity:1}50%,100%{opacity:0.25}}
+@keyframes freq-blink-radio-antenna-signal{0%,49%{opacity:1}50%,100%{opacity:0.4}}


### PR DESCRIPTION
## Component: ease-radio-antenna-signal — arcs wave, lamp blinks, and freq ticks

**Closes #65695**

### What this adds
A radio mast: the signal arcs pulse outward, the warning lamp blinks on the tower, and the frequency tag ticks beneath.

### Acceptance Criteria covered
- Signal arcs pulse outward
- Warning lamp blinks on the tower
- Frequency tag ticks beneath

### Files
- `submissions/examples/radio-antenna-signal-ij/demo.html`
- `submissions/examples/radio-antenna-signal-ij/style.css`
- `submissions/examples/radio-antenna-signal-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the arcs wave.