### PR TITLE
Add ease-thermostat-schedule component

### DIFF
--- a/submissions/examples/thermostat-schedule-ij/README.md
+++ b/submissions/examples/thermostat-schedule-ij/README.md
@@ -1,0 +1,10 @@
+# ease-thermostat-schedule
+
+A weekly schedule where the temperature bars rise and fall per day, the active day chip pulses, and the next-event label blinks beneath.
+
+## Run
+Open `demo.html` directly in a browser to watch the bars move.
+
+## Notes
+- The temperature bars rise and fall per day.
+- The next-event label blinks beneath.

--- a/submissions/examples/thermostat-schedule-ij/demo.html
+++ b/submissions/examples/thermostat-schedule-ij/demo.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-thermostat-schedule demo</title>
+</head>
+<body>
+<div class="tsc-app">
+  <span class="tsc-title">SCHEDULE</span>
+  <div class="tsc-days">
+    <span class="tsc-day">MON</span>
+    <span class="tsc-day tsc-act">TUE</span>
+    <span class="tsc-day">WED</span>
+    <span class="tsc-day">THU</span>
+    <span class="tsc-day">FRI</span>
+  </div>
+  <div class="tsc-bars">
+    <span class="tsc-bar"></span>
+    <span class="tsc-bar"></span>
+    <span class="tsc-bar"></span>
+    <span class="tsc-bar"></span>
+    <span class="tsc-bar"></span>
+    <span class="tsc-bar"></span>
+  </div>
+  <span class="tsc-next">NEXT: 18:00</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/thermostat-schedule-ij/style.css
+++ b/submissions/examples/thermostat-schedule-ij/style.css
@@ -1,0 +1,18 @@
+:root{--tsc-orange:#ff9a4d;--tsc-dark:#0d0704}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#241206,#0d0704);font-family:'Gill Sans',sans-serif}
+.tsc-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#1d0f05,#0a0502);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
+.tsc-title{position:absolute;top:16px;left:0;right:0;text-align:center;font-size:12px;font-weight:800;letter-spacing:7px;color:#ff9a4d}
+.tsc-days{position:absolute;top:76px;left:30px;right:30px;display:flex;gap:8px;justify-content:center}
+.tsc-day{flex:1;padding:10px 0;text-align:center;border-radius:8px;background:#1a0f05;color:#b38a5a;font-size:10px;font-weight:800;letter-spacing:1px;box-shadow:inset 0 0 0 2px #4a2a10}
+.tsc-act{background:#4a2a10;color:#ffd9b3;box-shadow:inset 0 0 0 2px #ff9a4d;animation:day-pulse-thermostat-schedule 1.4s ease-in-out infinite}
+.tsc-bars{position:absolute;top:184px;left:40px;right:40px;height:110px;display:flex;gap:12px;align-items:flex-end}
+.tsc-bar{flex:1;border-radius:6px 6px 0 0;background:linear-gradient(180deg,#ff9a4d,#5a2c10);transform-origin:bottom center;animation:bar-move-thermostat-schedule 2s ease-in-out infinite}
+.tsc-bar:nth-child(2){animation-delay:0.3s}
+.tsc-bar:nth-child(3){animation-delay:0.6s}
+.tsc-bar:nth-child(4){animation-delay:0.9s}
+.tsc-bar:nth-child(5){animation-delay:1.2s}
+.tsc-bar:nth-child(6){animation-delay:1.5s}
+.tsc-next{position:absolute;bottom:16px;left:0;right:0;text-align:center;font-size:10px;font-weight:800;letter-spacing:4px;color:#8a5a3a;animation:next-blink-thermostat-schedule 1.8s steps(1) infinite}
+@keyframes bar-move-thermostat-schedule{0%,100%{height:22%}50%{height:92%}}
+@keyframes day-pulse-thermostat-schedule{0%,100%{box-shadow:inset 0 0 0 2px #ff9a4d,0 0 12px rgba(255,154,77,0.5)}50%{box-shadow:inset 0 0 0 2px #ff9a4d,0 0 4px rgba(255,154,77,0.2)}}
+@keyframes next-blink-thermostat-schedule{0%,49%{opacity:1}50%,100%{opacity:0.35}}


### PR DESCRIPTION
## Component: ease-thermostat-schedule — bars move, day pulses, and next blinks

**Closes #65699**

### What this adds
A weekly schedule: the temperature bars rise and fall per day, the active day chip pulses, and the next-event label blinks beneath.

### Acceptance Criteria covered
- Temperature bars rise and fall per day
- Active day chip pulses in turn
- Next-event label blinks beneath

### Files
- `submissions/examples/thermostat-schedule-ij/demo.html`
- `submissions/examples/thermostat-schedule-ij/style.css`
- `submissions/examples/thermostat-schedule-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the bars move.