### PR TITLE
Add ease-supermarket-checkout-screen component

### DIFF
--- a/submissions/examples/supermarket-checkout-screen-ij/README.md
+++ b/submissions/examples/supermarket-checkout-screen-ij/README.md
@@ -1,0 +1,10 @@
+# ease-supermarket-checkout-screen
+
+A checkout register where the item lines roll up the screen, the running total ticks higher, and the item count tag blinks beneath.
+
+## Run
+Open `demo.html` directly in a browser to watch the items roll.
+
+## Notes
+- The item lines roll up the screen.
+- The item count tag blinks beneath.

--- a/submissions/examples/supermarket-checkout-screen-ij/demo.html
+++ b/submissions/examples/supermarket-checkout-screen-ij/demo.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-supermarket-checkout-screen demo</title>
+</head>
+<body>
+<div class="scs-app">
+  <span class="scs-brand">CHECKOUT 4</span>
+  <div class="scs-screen">
+    <span class="scs-item">MILK 2.49</span>
+    <span class="scs-item">BREAD 1.19</span>
+    <span class="scs-item">EGGS 3.45</span>
+    <span class="scs-item">JAM 2.80</span>
+    <span class="scs-total">TOTAL 9.93</span>
+  </div>
+  <span class="scs-count">3 ITEMS</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/supermarket-checkout-screen-ij/style.css
+++ b/submissions/examples/supermarket-checkout-screen-ij/style.css
@@ -1,0 +1,14 @@
+:root{--scs-green:#39d05a;--scs-dark:#1c2a1a}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#1c2a1a,#0a0f09);font-family:'Courier New',monospace}
+.scs-app{position:relative;width:340px;height:376px;border-radius:16px;overflow:hidden;background:linear-gradient(180deg,#263a22,#111b0f);box-shadow:0 14px 32px rgba(0,0,0,0.5)}
+.scs-brand{position:absolute;top:14px;left:0;right:0;text-align:center;font-size:11px;font-weight:700;letter-spacing:6px;color:#39d05a}
+.scs-screen{position:absolute;top:52px;left:34px;right:34px;height:220px;border-radius:10px;background:#050d08;box-shadow:inset 0 0 0 3px #1c3a1c;padding:12px;display:flex;flex-direction:column;gap:10px}
+.scs-item{font-size:10px;color:#a7c9a9;animation:item-roll-supermarket-checkout-screen 2.4s ease-out infinite}
+.scs-item:nth-of-type(2){animation-delay:0.4s}
+.scs-item:nth-of-type(3){animation-delay:0.8s}
+.scs-item:nth-of-type(4){animation-delay:1.2s}
+.scs-total{margin-top:6px;font-size:11px;font-weight:700;color:#39d05a;border-top:2px dashed #1c3a1c;padding-top:8px;animation:total-tick-supermarket-checkout-screen 1s steps(1) infinite}
+.scs-count{position:absolute;bottom:14px;left:0;right:0;text-align:center;font-size:10px;letter-spacing:4px;color:#39d05a;animation:tag-blink-supermarket-checkout-screen 1.8s steps(1) infinite}
+@keyframes item-roll-supermarket-checkout-screen{0%{transform:translateX(26px);opacity:0}30%,100%{transform:translateX(0);opacity:1}}
+@keyframes total-tick-supermarket-checkout-screen{0%,49%{opacity:1}50%,100%{opacity:0.35}}
+@keyframes tag-blink-supermarket-checkout-screen{0%,49%{opacity:1}50%,100%{opacity:0.3}}


### PR DESCRIPTION
## Component: ease-supermarket-checkout-screen — items roll, total ticks, and tag blinks

**Closes #65714**

### What this adds
A checkout register: the item lines roll up the screen, the running total ticks higher, and the item count tag blinks beneath.

### Acceptance Criteria covered
- Item lines roll up the screen
- Running total ticks higher
- Item count tag blinks beneath

### Files
- `submissions/examples/supermarket-checkout-screen-ij/demo.html`
- `submissions/examples/supermarket-checkout-screen-ij/style.css`
- `submissions/examples/supermarket-checkout-screen-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the items roll.