### PR TITLE
feat: add CSS Ripple-Wave Card Grid for Minimalist Tech Layouts (#64498)

### DIFF
--- a/submissions/examples/minimalist-ripple-wave-card-grid/README.md
+++ b/submissions/examples/minimalist-ripple-wave-card-grid/README.md
@@ -1,0 +1,20 @@
+# CSS Ripple-Wave Card Grid (Minimalist Tech)
+
+A pure CSS interactive grid component designed for Minimalist Tech Layouts. It features a tactile "Ripple-Wave" click effect on the cards, simulating a material ink ripple without requiring any JavaScript event listeners or coordinate calculations.
+
+## Features
+- Pure CSS and HTML (No JavaScript required).
+- The `.ripple-card` elements utilize a cleverly configured `::after` pseudo-element combined with the `:active` CSS state.
+- When the user clicks (and holds) the card, the `:active` state instantly expands (`scale(2)`) and reveals (`opacity: 1`) a circular background shape anchored to the center of the card, with `transition: 0s`.
+- When the user releases the click, the `:active` state is removed. The element then falls back to its default state, which defines a slow `transform` and `opacity` transition, creating the smooth fade-out ripple effect.
+- The cards feature an `overflow: hidden` constraint to ensure the ripple respects the border-radius of the card container.
+- Clean, structured aesthetic utilizing the `Inter` font, subtle borders, and gentle hover-lift physics.
+- Fully responsive CSS Grid layout that automatically adapts columns based on the viewport width using `auto-fill`.
+- Fully accessible with `prefers-reduced-motion` support ensuring degraded, safe static layouts for users sensitive to motion (the ripple effect and hover translation are stripped).
+
+## Usage
+Open `demo.html` in your browser. You will see a grid of integration cards. Hover over them to see the icon highlight and the card lift slightly. Click anywhere on a card to witness the blue ripple instantly expand from the center, and slowly fade away when you release the mouse button.
+
+## Files
+- `demo.html`: The HTML structure for the grid layout and the anchor tags acting as the interactive cards.
+- `style.css`: The styling, CSS Grid configurations, and the pure CSS `:active` logic driving the ripple-wave mechanics.

--- a/submissions/examples/minimalist-ripple-wave-card-grid/demo.html
+++ b/submissions/examples/minimalist-ripple-wave-card-grid/demo.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Ripple-Wave Card Grid - Minimalist Tech</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Integrations</h1>
+            <p class="subtitle">Connect your data across the ecosystem. Click a card to activate the ripple effect.</p>
+        </header>
+
+        <div class="card-grid">
+            
+            <a href="#" class="ripple-card">
+                <div class="card-icon">
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>
+                </div>
+                <h3 class="card-title">Data Warehouse</h3>
+                <p class="card-desc">Sync metrics to Snowflake, BigQuery, or Redshift automatically.</p>
+                <!-- Pure CSS Ripple via pseudo-element active state -->
+            </a>
+
+            <a href="#" class="ripple-card">
+                <div class="card-icon">
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect><line x1="8" y1="21" x2="16" y2="21"></line><line x1="12" y1="17" x2="12" y2="21"></line></svg>
+                </div>
+                <h3 class="card-title">Monitoring</h3>
+                <p class="card-desc">Export logs to Datadog, New Relic, or custom endpoints.</p>
+            </a>
+
+            <a href="#" class="ripple-card">
+                <div class="card-icon">
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path></svg>
+                </div>
+                <h3 class="card-title">Alerting</h3>
+                <p class="card-desc">Route incident notifications directly to Slack or PagerDuty.</p>
+            </a>
+            
+            <a href="#" class="ripple-card">
+                <div class="card-icon">
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path></svg>
+                </div>
+                <h3 class="card-title">Authentication</h3>
+                <p class="card-desc">Setup SSO with Okta, Google Workspace, or Azure AD.</p>
+            </a>
+
+        </div>
+        
+    </div>
+</body>
+</html>

--- a/submissions/examples/minimalist-ripple-wave-card-grid/style.css
+++ b/submissions/examples/minimalist-ripple-wave-card-grid/style.css
@@ -1,0 +1,175 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+:root {
+    --bg-color: #f8fafc;
+    --card-bg: #ffffff;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    --border-color: #e2e8f0;
+    
+    --accent-color: #3b82f6; /* Blue */
+    --ripple-color: rgba(59, 130, 246, 0.4);
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    font-family: 'Inter', system-ui, -apple-system, sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 40px 20px;
+    box-sizing: border-box;
+}
+
+.layout-container {
+    max-width: 800px;
+    width: 100%;
+}
+
+.section-header {
+    margin-bottom: 32px;
+}
+
+.title {
+    font-size: 1.75rem;
+    font-weight: 600;
+    margin: 0 0 8px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1rem;
+    margin: 0;
+    font-weight: 400;
+}
+
+
+/* =========================================
+   Grid Layout
+   ========================================= */
+.card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 20px;
+}
+
+
+/* =========================================
+   Card Styles & Ripple Logic
+   ========================================= */
+.ripple-card {
+    position: relative;
+    display: block;
+    text-decoration: none;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 24px;
+    color: inherit;
+    /* Crucial for containing the absolute positioned ripple */
+    overflow: hidden; 
+    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+    transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ripple-card:hover {
+    border-color: #cbd5e1;
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(0,0,0,0.05);
+}
+
+/* Card Content */
+.card-icon {
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #f1f5f9;
+    color: var(--text-primary);
+    border-radius: 8px;
+    margin-bottom: 16px;
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.ripple-card:hover .card-icon {
+    background: rgba(59, 130, 246, 0.1);
+    color: var(--accent-color);
+}
+
+.card-title {
+    font-size: 1.1rem;
+    font-weight: 600;
+    margin: 0 0 8px 0;
+}
+
+.card-desc {
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+    margin: 0;
+    line-height: 1.5;
+}
+
+
+/* The Ripple Effect (Pure CSS using :active) */
+.ripple-card::after {
+    content: '';
+    position: absolute;
+    /* Position the center of the ripple in the middle of the card */
+    top: 50%;
+    left: 50%;
+    width: 100%;
+    /* Make height match width to create a perfect circle */
+    padding-top: 100%;
+    background: var(--ripple-color);
+    border-radius: 50%;
+    
+    /* Center it perfectly using negative margins */
+    transform: translate(-50%, -50%) scale(0);
+    opacity: 0;
+    pointer-events: none;
+    
+    /* 
+      We define the transition for the *release* of the click here.
+      It rapidly scales back down and fades out.
+    */
+    transition: transform 0.5s ease-out, opacity 0.5s ease-out;
+}
+
+/* When the user clicks/holds down on the card */
+.ripple-card:active::after {
+    /* Instantly expand to fill the card */
+    transform: translate(-50%, -50%) scale(2);
+    /* Make it visible */
+    opacity: 1;
+    /* 
+      Remove the transition duration so it happens instantly on click.
+      The transition defined above handles the smooth fade out upon release.
+    */
+    transition: 0s;
+}
+
+
+/* Responsive */
+@media (max-width: 480px) {
+    .card-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    .ripple-card {
+        transition: border-color 0.2s ease, box-shadow 0.2s ease;
+        transform: none !important;
+    }
+    
+    .ripple-card::after {
+        display: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces the CSS Ripple-Wave Card Grid designed for Minimalist Tech Layouts, resolving issue #64498. 

### Changes Made:
- Added `submissions/examples/minimalist-ripple-wave-card-grid/` directory.
- Created `demo.html` showcasing an integrations page layout featuring an auto-filling CSS Grid of interactive cards.
- Created `style.css` featuring a clean, structured aesthetic utilizing the `Inter` font family and subtle hover physics.
  - Implemented a pure CSS Ripple effect. By utilizing the `:active` pseudo-class and a `::after` element, the ripple instantly scales up to cover the card when the user clicks down, by overriding the transition time to `0s`. When the click is released, the `:active` state ends, and the element gracefully fades out using a slow transition to return to its default state. 
  - `overflow: hidden` is applied to the cards to ensure the circular ripple clips cleanly to the card's rounded borders.
- Added `README.md` documenting usage and features.
- Fully responsive layout relying on `grid-template-columns: repeat(auto-fill, ...)` for fluid adaptation without aggressive media queries.
- Honors the `prefers-reduced-motion` accessibility standard. The spatial hover translation and the click-ripple effect are entirely stripped for users sensitive to motion.

Closes #64498
