### PR TITLE
Add ease-traffic-jam-lights component

### DIFF
--- a/submissions/examples/traffic-jam-lights-ij/README.md
+++ b/submissions/examples/traffic-jam-lights-ij/README.md
@@ -1,0 +1,10 @@
+# ease-traffic-jam-lights
+
+A junction board where the traffic signals cycle red to green, the cars creep forward in the lane, and the queue tag blinks.
+
+## Run
+Open `demo.html` directly in a browser to watch the signals cycle.
+
+## Notes
+- The traffic signals cycle red to green.
+- The queue tag blinks beneath.

--- a/submissions/examples/traffic-jam-lights-ij/demo.html
+++ b/submissions/examples/traffic-jam-lights-ij/demo.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-traffic-jam-lights demo</title>
+</head>
+<body>
+<div class="tjl-app">
+  <span class="tjl-title">JUNCTION 5</span>
+  <div class="tjl-lights">
+    <div class="tjl-head">
+      <span class="tjl-lamp tjl-red"></span>
+      <span class="tjl-lamp tjl-amber"></span>
+      <span class="tjl-lamp tjl-green"></span>
+    </div>
+    <div class="tjl-head">
+      <span class="tjl-lamp tjl-red"></span>
+      <span class="tjl-lamp tjl-amber"></span>
+      <span class="tjl-lamp tjl-green"></span>
+    </div>
+    <div class="tjl-head">
+      <span class="tjl-lamp tjl-red"></span>
+      <span class="tjl-lamp tjl-amber"></span>
+      <span class="tjl-lamp tjl-green"></span>
+    </div>
+  </div>
+  <div class="tjl-lane">
+    <div class="tjl-car tjl-car-a"></div>
+    <div class="tjl-car tjl-car-b"></div>
+    <div class="tjl-car tjl-car-c"></div>
+  </div>
+  <span class="tjl-queue">QUEUE 3</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/traffic-jam-lights-ij/style.css
+++ b/submissions/examples/traffic-jam-lights-ij/style.css
@@ -1,0 +1,21 @@
+:root{--tjl-red:#ff5a4d;--tjl-amber:#ffc24d;--tjl-green:#39d05a;--tjl-dark:#1a1c22}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#1a1c22,#0a0b0e);font-family:'Times New Roman',serif}
+.tjl-app{position:relative;width:376px;height:420px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#262a33,#14161b);box-shadow:0 16px 36px rgba(0,0,0,0.6)}
+.tjl-title{position:absolute;top:14px;left:0;right:0;text-align:center;font-size:12px;font-weight:700;letter-spacing:8px;color:#9aa6b8}
+.tjl-lights{position:absolute;top:50px;left:30px;right:30px;display:flex;justify-content:space-between}
+.tjl-head{width:44px;border-radius:10px;background:#14161b;box-shadow:inset 0 0 0 3px #343a45;padding:6px;display:flex;flex-direction:column;gap:6px}
+.tjl-lamp{height:10px;border-radius:5px;background:#2a2e38}
+.tjl-red{animation:signal-red-traffic-jam-lights 3s steps(1) infinite}
+.tjl-amber{animation:signal-amber-traffic-jam-lights 3s steps(1) infinite}
+.tjl-green{animation:signal-green-traffic-jam-lights 3s steps(1) infinite}
+.tjl-lane{position:absolute;top:190px;left:24px;right:24px;height:140px;border-radius:12px;background:repeating-linear-gradient(90deg,#2a2e38 0 20px,#22262e 20px 40px);box-shadow:inset 0 0 0 3px #3a404c;overflow:hidden}
+.tjl-car{position:absolute;width:26px;height:14px;border-radius:5px;background:#3c6ae8;box-shadow:inset 0 0 0 2px #1c3a8a;animation:car-creep-traffic-jam-lights 3.4s ease-in-out infinite}
+.tjl-car-a{top:24px;left:0;animation-delay:0s}
+.tjl-car-b{top:64px;left:0;animation-delay:0.8s}
+.tjl-car-c{top:104px;left:0;animation-delay:1.6s}
+.tjl-queue{position:absolute;bottom:12px;left:0;right:0;text-align:center;font-size:10px;letter-spacing:6px;color:#9aa6b8;animation:queue-blink-traffic-jam-lights 1.8s steps(1) infinite}
+@keyframes signal-red-traffic-jam-lights{0%,30%{background:#ff5a4d}31%,100%{background:#2a2e38}}
+@keyframes signal-amber-traffic-jam-lights{0%,32%{background:#2a2e38}33%,60%{background:#ffc24d}61%,100%{background:#2a2e38}}
+@keyframes signal-green-traffic-jam-lights{0%,65%{background:#2a2e38}66%,95%{background:#39d05a}96%,100%{background:#2a2e38}}
+@keyframes car-creep-traffic-jam-lights{0%{left:0}50%,100%{left:320px}}
+@keyframes queue-blink-traffic-jam-lights{0%,49%{opacity:1}50%,100%{opacity:0.3}}


### PR DESCRIPTION
## Component: ease-traffic-jam-lights — signals cycle, cars creep, and queue blinks

**Closes #65732**

### What this adds
A junction board: the traffic signals cycle red to green, the cars creep forward in the lane, and the queue tag blinks.

### Acceptance Criteria covered
- Traffic signals cycle red to green
- Cars creep forward in the lane
- Queue tag blinks beneath

### Files
- `submissions/examples/traffic-jam-lights-ij/demo.html`
- `submissions/examples/traffic-jam-lights-ij/style.css`
- `submissions/examples/traffic-jam-lights-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the signals cycle.