### PR TITLE
feat: add CSS Slide-Up Drawer for Minimalist Tech Layouts (#64473)

### DIFF
--- a/submissions/examples/minimalist-slide-up-drawer/README.md
+++ b/submissions/examples/minimalist-slide-up-drawer/README.md
@@ -1,0 +1,19 @@
+# CSS Slide-Up Drawer (Minimalist Tech)
+
+A pure CSS interactive drawer component designed for Minimalist Tech Layouts. It features a bottom-anchored modal sheet that elegantly slides up into view, complete with a blurred background overlay, all without requiring any JavaScript.
+
+## Features
+- Pure CSS and HTML (No JavaScript required for state management or animations).
+- State management is handled via the hidden checkbox hack (`input[type="checkbox"]` paired with `<label>`), allowing the drawer to be toggled open and closed natively.
+- **The Slide-Up Effect**: The `.drawer-bottom` element is initially hidden by applying `transform: translate(-50%, 100%)`, pushing it exactly its own height down below the viewport edge. When triggered, the transform smoothly animates to `translate(-50%, 0)`, sliding it up into view while maintaining its horizontal center alignment.
+- A fixed `max-width` constraint ensures the drawer behaves like a mobile "sheet" on small screens, but doesn't stretch awkwardly across ultra-wide desktop monitors.
+- Includes a premium frosted-glass background overlay (`backdrop-filter: blur(4px)`) that fades in behind the drawer.
+- Clean, structured aesthetic utilizing the `Inter` font, subtle borders, and a polished form layout.
+- Fully accessible with `prefers-reduced-motion` support. For motion-sensitive users, the spatial slide-up translation is entirely stripped. The complex interaction gracefully falls back to a safe, simple opacity fade.
+
+## Usage
+Open `demo.html` in your browser. You will see a mock settings dashboard. Click the "Update Billing" button to trigger the pure CSS drawer. The background will blur, and the payment form sheet will slide up from the bottom of the screen. Click the overlay background, the "X" button, or the "Save Payment Method" button to close the drawer.
+
+## Files
+- `demo.html`: The HTML structure for the layout, detailing the critical `<input type="checkbox">` and `<label>` pairing required for the CSS-only drawer trigger.
+- `style.css`: The styling, form layouts, drawer positioning, and the `translateY` CSS transitions driving the slide-up mechanics.

--- a/submissions/examples/minimalist-slide-up-drawer/demo.html
+++ b/submissions/examples/minimalist-slide-up-drawer/demo.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Slide-Up Drawer - Minimalist Tech</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    
+    <!-- State Management Checkbox -->
+    <input type="checkbox" id="drawer-toggle" class="drawer-toggle">
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Workspace Settings</h1>
+            <p class="subtitle">Manage your organization preferences.</p>
+        </header>
+
+        <div class="dashboard">
+            <div class="settings-panel">
+                <div class="setting-item">
+                    <div>
+                        <h3>API Configuration</h3>
+                        <p>Manage Webhooks and API Keys.</p>
+                    </div>
+                    <button class="btn btn-outline" disabled>Configured</button>
+                </div>
+                
+                <div class="setting-item">
+                    <div>
+                        <h3>Billing Details</h3>
+                        <p>Update payment methods and view invoices.</p>
+                    </div>
+                    <!-- Drawer Trigger -->
+                    <label for="drawer-toggle" class="btn btn-primary">
+                        Update Billing
+                    </label>
+                </div>
+            </div>
+        </div>
+        
+    </div>
+
+    <!-- The Drawer Overlay Background -->
+    <label for="drawer-toggle" class="drawer-overlay"></label>
+
+    <!-- The Slide-Up Drawer -->
+    <aside class="drawer-bottom">
+        <div class="drawer-header">
+            <h2 class="drawer-title">Update Billing Method</h2>
+            <label for="drawer-toggle" class="drawer-close">&times;</label>
+        </div>
+        
+        <div class="drawer-body">
+            <p class="drawer-desc">Your current plan is billed annually at $299/yr. Please provide a new payment method below.</p>
+            
+            <div class="form-group">
+                <label class="form-label">Cardholder Name</label>
+                <input type="text" class="form-input" placeholder="Jane Doe">
+            </div>
+            
+            <div class="form-group">
+                <label class="form-label">Card Number</label>
+                <input type="text" class="form-input" placeholder="**** **** **** 4242">
+            </div>
+            
+            <div class="form-row">
+                <div class="form-group">
+                    <label class="form-label">Expiry (MM/YY)</label>
+                    <input type="text" class="form-input" placeholder="12/26">
+                </div>
+                <div class="form-group">
+                    <label class="form-label">CVC</label>
+                    <input type="text" class="form-input" placeholder="***">
+                </div>
+            </div>
+            
+            <!-- Close the drawer on submit via label -->
+            <label for="drawer-toggle" class="btn btn-submit">Save Payment Method</label>
+        </div>
+    </aside>
+
+</body>
+</html>

--- a/submissions/examples/minimalist-slide-up-drawer/style.css
+++ b/submissions/examples/minimalist-slide-up-drawer/style.css
@@ -1,0 +1,278 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+:root {
+    --bg-color: #f8fafc;
+    --card-bg: #ffffff;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    --border-color: #e2e8f0;
+    
+    --accent-color: #2563eb; /* Blue */
+    --accent-hover: #1d4ed8;
+    
+    --overlay-color: rgba(15, 23, 42, 0.4);
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    font-family: 'Inter', system-ui, -apple-system, sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 20px;
+    box-sizing: border-box;
+    overflow-x: hidden; 
+}
+
+.layout-container {
+    max-width: 800px;
+    width: 100%;
+}
+
+.section-header {
+    margin-bottom: 32px;
+}
+
+.title {
+    font-size: 1.75rem;
+    font-weight: 600;
+    margin: 0 0 8px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1rem;
+    margin: 0;
+    font-weight: 400;
+}
+
+
+/* --- Dashboard Fake UI --- */
+.settings-panel {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    box-shadow: 0 4px 6px rgba(0,0,0,0.02);
+}
+
+.setting-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 24px;
+    border-bottom: 1px solid var(--border-color);
+}
+.setting-item:last-child {
+    border-bottom: none;
+}
+
+.setting-item h3 {
+    margin: 0 0 8px 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+}
+
+.setting-item p {
+    color: var(--text-secondary);
+    margin: 0;
+    font-size: 0.95rem;
+}
+
+.btn {
+    display: inline-block;
+    cursor: pointer;
+    text-decoration: none;
+    font-weight: 500;
+    font-size: 0.9rem;
+    padding: 10px 20px;
+    border-radius: 6px;
+    transition: all 0.2s ease;
+    text-align: center;
+    border: none;
+}
+
+.btn-primary {
+    background: var(--text-primary);
+    color: #fff;
+    border: 1px solid var(--text-primary);
+}
+
+.btn-primary:hover {
+    background: #000;
+}
+
+.btn-outline {
+    background: transparent;
+    color: var(--text-secondary);
+    border: 1px solid var(--border-color);
+}
+.btn-outline:disabled {
+    cursor: not-allowed;
+    opacity: 0.7;
+}
+
+.btn-submit {
+    width: 100%;
+    background: var(--accent-color);
+    color: #fff;
+    margin-top: 12px;
+}
+.btn-submit:hover {
+    background: var(--accent-hover);
+}
+
+
+/* =========================================
+   Drawer Layout & Slide-Up Logic
+   ========================================= */
+
+/* State Management Checkbox */
+.drawer-toggle {
+    display: none;
+}
+
+/* Background Overlay */
+.drawer-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background: var(--overlay-color);
+    backdrop-filter: blur(4px); /* Premium feel */
+    -webkit-backdrop-filter: blur(4px);
+    z-index: 100;
+    
+    /* Hidden state */
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.3s ease, visibility 0.3s ease;
+}
+
+/* The Bottom Drawer Container */
+.drawer-bottom {
+    position: fixed;
+    bottom: 0;
+    left: 50%;
+    width: 100%;
+    max-width: 600px; /* Keep it centered and bounded on large screens */
+    background: var(--card-bg);
+    border-radius: 20px 20px 0 0;
+    box-shadow: 0 -10px 40px rgba(0, 0, 0, 0.1);
+    z-index: 101;
+    display: flex;
+    flex-direction: column;
+    
+    /* Hidden state: shifted down below the screen */
+    transform: translate(-50%, 100%);
+    /* The snappy slide-up transition */
+    transition: transform 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* --- Active State Triggers --- */
+.drawer-toggle:checked ~ .drawer-overlay {
+    opacity: 1;
+    visibility: visible;
+}
+
+.drawer-toggle:checked ~ .drawer-bottom {
+    /* Slide up into place (keeping the -50% X centering) */
+    transform: translate(-50%, 0);
+}
+
+
+/* --- Drawer Internal Styling --- */
+.drawer-header {
+    padding: 24px;
+    border-bottom: 1px solid var(--border-color);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.drawer-title {
+    font-size: 1.2rem;
+    font-weight: 600;
+    margin: 0;
+}
+
+.drawer-close {
+    font-size: 1.75rem;
+    line-height: 1;
+    cursor: pointer;
+    color: var(--text-secondary);
+    transition: color 0.2s ease;
+}
+
+.drawer-close:hover {
+    color: var(--text-primary);
+}
+
+.drawer-body {
+    padding: 24px;
+}
+
+.drawer-desc {
+    color: var(--text-secondary);
+    margin: 0 0 24px 0;
+    font-size: 0.95rem;
+    line-height: 1.5;
+}
+
+/* Form Styles */
+.form-group {
+    margin-bottom: 16px;
+    flex: 1;
+}
+
+.form-row {
+    display: flex;
+    gap: 16px;
+}
+
+.form-label {
+    display: block;
+    font-size: 0.85rem;
+    font-weight: 500;
+    margin-bottom: 8px;
+    color: var(--text-primary);
+}
+
+.form-input {
+    width: 100%;
+    padding: 10px 12px;
+    box-sizing: border-box;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    font-family: inherit;
+    font-size: 0.95rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-input:focus {
+    outline: none;
+    border-color: var(--accent-color);
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+}
+
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    /* Slide -> fade */
+    .drawer-bottom {
+        transition: opacity 0.3s ease;
+        transform: translate(-50%, 0) !important;
+        opacity: 0;
+        visibility: hidden;
+    }
+    
+    .drawer-toggle:checked ~ .drawer-bottom {
+        opacity: 1;
+        visibility: visible;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces the CSS Slide-Up Drawer designed for Minimalist Tech Layouts, resolving issue #64473. 

### Changes Made:
- Added `submissions/examples/minimalist-slide-up-drawer/` directory.
- Created `demo.html` showcasing a mock billing settings layout. It utilizes the pure CSS checkbox hack (`<input type="checkbox">` paired with `<label>`) to trigger the drawer without any JavaScript.
- Created `style.css` featuring a clean, structured aesthetic utilizing the `Inter` font, mimicking a modern bottom-sheet modal.
  - Implemented the Slide-Up effect. The `.drawer-bottom` element is initially positioned off-screen using `transform: translate(-50%, 100%)`. Upon the checkbox receiving the `:checked` state, it smoothly transitions to `translate(-50%, 0)`, sliding up into view while maintaining its horizontal center alignment.
  - Included a premium frosted-glass background overlay utilizing `backdrop-filter: blur()`.
- Added `README.md` documenting usage and technical features.
- Fully responsive layout. The drawer acts as a full-width bottom sheet on mobile, but respects a `max-width` constraint on desktop so it doesn't stretch awkwardly.
- Honors the `prefers-reduced-motion` accessibility standard. The spatial slide-up translation is completely stripped. The complex interaction gracefully falls back to a safe, simple opacity cross-fade for users sensitive to motion.

Closes #64473
