### PR TITLE
feat: add CSS Blur-Entrance Drawer for Minimalist Tech Layouts (#64477)

### DIFF
--- a/submissions/examples/minimalist-blur-entrance-drawer/README.md
+++ b/submissions/examples/minimalist-blur-entrance-drawer/README.md
@@ -1,0 +1,19 @@
+# CSS Blur-Entrance Drawer (Minimalist Tech)
+
+A pure CSS interactive drawer component designed for Minimalist Tech Layouts. It features a sophisticated "Blur-Entrance" animation, providing a cinematic, soft-focus feel as the drawer enters the viewport, combined with staggered interior content animations.
+
+## Features
+- Pure CSS and HTML (No JavaScript required for state management or animations).
+- State management is natively handled via the hidden checkbox hack (`input[type="checkbox"]` paired with `<label>`), allowing the drawer to be toggled open and closed without JS event listeners.
+- **The Blur-Entrance Effect**: The `.drawer` element is initially positioned slightly off-screen (`transform: translateX(10%)`) and heavily blurred (`filter: blur(10px)`). When triggered, it simultaneously translates into place and resolves the blur to `0px`. This mimics the feeling of a camera rapidly pulling focus on a fast-moving object.
+- **Staggered Content Entrance**: The interior `.schema-block` elements leverage the `:checked` sibling selector combined with CSS `transition-delay` to slide up sequentially after the drawer has opened.
+- Includes a premium frosted-glass background on the drawer itself using `backdrop-filter: blur(20px)`.
+- Clean, structured aesthetic utilizing the `Inter` font for UI and `JetBrains Mono` for the technical API documentation layout.
+- Fully accessible with `prefers-reduced-motion` support. For motion-sensitive users, the spatial translation, the blur filter, and the staggered interior sliding are entirely stripped. The complex interaction gracefully falls back to a safe, immediate opacity fade.
+
+## Usage
+Open `demo.html` in your browser. You will see a mock API dashboard. Click the "View Details" button to trigger the pure CSS drawer. Observe how the drawer seems to snap into focus as it enters the screen, followed by the content blocks cascading upwards sequentially. Click the overlay background or the "X" button to close the drawer.
+
+## Files
+- `demo.html`: The HTML structure for the layout, detailing the critical `<input type="checkbox">` and `<label>` pairing required for the CSS-only drawer trigger.
+- `style.css`: The styling, frosted glass effects, and the combined `filter: blur()` and `transform` CSS transitions driving the entrance mechanics.

--- a/submissions/examples/minimalist-blur-entrance-drawer/demo.html
+++ b/submissions/examples/minimalist-blur-entrance-drawer/demo.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Blur-Entrance Drawer - Minimalist Tech</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    
+    <!-- State Management Checkbox -->
+    <input type="checkbox" id="drawer-toggle" class="drawer-toggle">
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">API Documentation</h1>
+            <p class="subtitle">Select an endpoint to view detailed schema and parameters.</p>
+        </header>
+
+        <div class="api-list">
+            <div class="api-item">
+                <div class="api-method GET">GET</div>
+                <div class="api-path">/v1/users</div>
+                <!-- Drawer Trigger -->
+                <label for="drawer-toggle" class="btn btn-outline">
+                    View Details
+                </label>
+            </div>
+            
+            <div class="api-item">
+                <div class="api-method POST">POST</div>
+                <div class="api-path">/v1/users</div>
+                <button class="btn btn-outline" disabled>View Details</button>
+            </div>
+            
+            <div class="api-item">
+                <div class="api-method DELETE">DEL</div>
+                <div class="api-path">/v1/users/{id}</div>
+                <button class="btn btn-outline" disabled>View Details</button>
+            </div>
+        </div>
+        
+    </div>
+
+    <!-- The Drawer Overlay Background -->
+    <label for="drawer-toggle" class="drawer-overlay"></label>
+
+    <!-- The Blur-Entrance Drawer -->
+    <aside class="drawer">
+        <div class="drawer-header">
+            <h2 class="drawer-title">GET /v1/users</h2>
+            <label for="drawer-toggle" class="drawer-close">&times;</label>
+        </div>
+        
+        <div class="drawer-body">
+            
+            <div class="schema-block staggered-1">
+                <h3>Description</h3>
+                <p>Retrieves a paginated list of user objects associated with the authenticated workspace.</p>
+            </div>
+            
+            <div class="schema-block staggered-2">
+                <h3>Query Parameters</h3>
+                <div class="param-row">
+                    <span class="param-name">limit</span>
+                    <span class="param-type">integer</span>
+                    <span class="param-desc">Maximum number of results (default: 20)</span>
+                </div>
+                <div class="param-row">
+                    <span class="param-name">page</span>
+                    <span class="param-type">integer</span>
+                    <span class="param-desc">Page number for pagination</span>
+                </div>
+            </div>
+            
+            <div class="schema-block staggered-3">
+                <h3>Response (200 OK)</h3>
+                <pre class="code-block">
+{
+  "data": [
+    {
+      "id": "usr_9k2m",
+      "email": "jane@example.com",
+      "role": "admin"
+    }
+  ],
+  "has_more": false
+}</pre>
+            </div>
+
+        </div>
+    </aside>
+
+</body>
+</html>

--- a/submissions/examples/minimalist-blur-entrance-drawer/style.css
+++ b/submissions/examples/minimalist-blur-entrance-drawer/style.css
@@ -1,0 +1,334 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap');
+
+:root {
+    --bg-color: #fafafa;
+    --card-bg: #ffffff;
+    --text-primary: #171717;
+    --text-secondary: #737373;
+    --border-color: #e5e5e5;
+    
+    /* Drawer Theme */
+    --drawer-bg: rgba(255, 255, 255, 0.95); /* Slightly transparent for blur */
+    --overlay-color: rgba(0, 0, 0, 0.2);
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    font-family: 'Inter', system-ui, -apple-system, sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 20px;
+    box-sizing: border-box;
+    overflow-x: hidden; 
+}
+
+.layout-container {
+    max-width: 800px;
+    width: 100%;
+}
+
+.section-header {
+    margin-bottom: 32px;
+}
+
+.title {
+    font-size: 1.75rem;
+    font-weight: 600;
+    margin: 0 0 8px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1rem;
+    margin: 0;
+    font-weight: 400;
+}
+
+
+/* --- Dashboard Fake UI --- */
+.api-list {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.02);
+}
+
+.api-item {
+    display: flex;
+    align-items: center;
+    padding: 16px 24px;
+    border-bottom: 1px solid var(--border-color);
+}
+.api-item:last-child {
+    border-bottom: none;
+}
+
+.api-method {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.8rem;
+    font-weight: 500;
+    padding: 4px 8px;
+    border-radius: 4px;
+    margin-right: 16px;
+    width: 40px;
+    text-align: center;
+}
+.api-method.GET { background: #dbeafe; color: #2563eb; }
+.api-method.POST { background: #dcfce7; color: #16a34a; }
+.api-method.DELETE { background: #fee2e2; color: #dc2626; }
+
+.api-path {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.95rem;
+    color: var(--text-primary);
+    flex: 1;
+}
+
+.btn {
+    display: inline-block;
+    cursor: pointer;
+    text-decoration: none;
+    font-weight: 500;
+    font-size: 0.85rem;
+    padding: 8px 16px;
+    border-radius: 6px;
+    transition: all 0.2s ease;
+    text-align: center;
+    border: none;
+}
+
+.btn-outline {
+    background: transparent;
+    color: var(--text-primary);
+    border: 1px solid var(--border-color);
+}
+
+.btn-outline:hover:not(:disabled) {
+    background: var(--bg-color);
+}
+
+.btn-outline:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+
+/* =========================================
+   Drawer Layout & Blur-Entrance Logic
+   ========================================= */
+
+/* State Management Checkbox */
+.drawer-toggle {
+    display: none;
+}
+
+/* Background Overlay */
+.drawer-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background: var(--overlay-color);
+    z-index: 100;
+    
+    /* Hidden state */
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.3s ease, visibility 0.3s ease;
+}
+
+/* The Drawer Container */
+.drawer {
+    position: fixed;
+    top: 0;
+    right: 0;
+    width: 450px;
+    max-width: 100vw;
+    height: 100vh;
+    background: var(--drawer-bg);
+    border-left: 1px solid var(--border-color);
+    
+    /* Add a frosted glass effect to the drawer itself */
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    
+    box-shadow: -10px 0 30px rgba(0, 0, 0, 0.05);
+    z-index: 101;
+    display: flex;
+    flex-direction: column;
+    
+    /* 
+      Hidden state: 
+      We slide it slightly off-screen and apply a heavy blur filter.
+      The blur filter gives the illusion of motion blur or a soft focus entrance.
+    */
+    transform: translateX(10%);
+    filter: blur(10px);
+    opacity: 0;
+    visibility: hidden;
+    
+    /* Transition the filter and transform together */
+    transition: transform 0.5s cubic-bezier(0.16, 1, 0.3, 1),
+                filter 0.5s cubic-bezier(0.16, 1, 0.3, 1),
+                opacity 0.4s ease,
+                visibility 0.5s ease;
+}
+
+/* --- Active State Triggers --- */
+.drawer-toggle:checked ~ .drawer-overlay {
+    opacity: 1;
+    visibility: visible;
+}
+
+.drawer-toggle:checked ~ .drawer {
+    /* Slide into place, remove the blur, fully visible */
+    transform: translateX(0);
+    filter: blur(0);
+    opacity: 1;
+    visibility: visible;
+}
+
+
+/* --- Drawer Internal Styling --- */
+.drawer-header {
+    padding: 24px;
+    border-bottom: 1px solid var(--border-color);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.drawer-title {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 1.1rem;
+    font-weight: 500;
+    margin: 0;
+}
+
+.drawer-close {
+    font-size: 1.5rem;
+    line-height: 1;
+    cursor: pointer;
+    color: var(--text-secondary);
+    transition: color 0.2s ease;
+}
+
+.drawer-close:hover {
+    color: var(--text-primary);
+}
+
+.drawer-body {
+    padding: 24px;
+    flex: 1;
+    overflow-y: auto;
+}
+
+/* --- Staggered Content Entrance --- */
+.schema-block {
+    margin-bottom: 32px;
+    
+    /* Initial state for staggered entrance */
+    opacity: 0;
+    transform: translateY(15px);
+    transition: opacity 0.4s ease, transform 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* 
+  When the drawer is checked, animate the inner blocks.
+  We use nth-child logic (via class names) to delay the transitions.
+*/
+.drawer-toggle:checked ~ .drawer .staggered-1 {
+    opacity: 1;
+    transform: translateY(0);
+    transition-delay: 0.1s;
+}
+.drawer-toggle:checked ~ .drawer .staggered-2 {
+    opacity: 1;
+    transform: translateY(0);
+    transition-delay: 0.2s;
+}
+.drawer-toggle:checked ~ .drawer .staggered-3 {
+    opacity: 1;
+    transform: translateY(0);
+    transition-delay: 0.3s;
+}
+
+.schema-block h3 {
+    font-size: 0.95rem;
+    font-weight: 600;
+    margin: 0 0 12px 0;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-secondary);
+}
+
+.schema-block p {
+    font-size: 0.95rem;
+    line-height: 1.6;
+    margin: 0;
+}
+
+.param-row {
+    display: flex;
+    align-items: center;
+    padding: 12px 0;
+    border-bottom: 1px solid var(--border-color);
+}
+.param-row:last-child {
+    border-bottom: none;
+}
+
+.param-name {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.85rem;
+    font-weight: 500;
+    width: 80px;
+}
+.param-type {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    width: 80px;
+}
+.param-desc {
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+    flex: 1;
+}
+
+.code-block {
+    background: #f8fafc;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 16px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.85rem;
+    line-height: 1.5;
+    margin: 0;
+    overflow-x: auto;
+}
+
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    /* Strip the blur and transform from the drawer entrance */
+    .drawer {
+        transition: opacity 0.3s ease, visibility 0.3s ease;
+        transform: translateX(0) !important;
+        filter: blur(0) !important;
+    }
+    
+    /* Strip the staggered sliding from the inner content */
+    .schema-block {
+        transition: none !important;
+        transform: translateY(0) !important;
+        opacity: 1 !important; /* Make immediately visible */
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces the CSS Blur-Entrance Drawer designed for Minimalist Tech Layouts, resolving issue #64477. 

### Changes Made:
- Added `submissions/examples/minimalist-blur-entrance-drawer/` directory.
- Created `demo.html` showcasing an API documentation layout. It utilizes the pure CSS checkbox hack (`<input type="checkbox">` paired with `<label>`) to trigger the drawer state without any JavaScript.
- Created `style.css` featuring a clean, structured aesthetic utilizing the `Inter` and `JetBrains Mono` fonts for a technical feel.
  - Implemented the Blur-Entrance effect. The drawer starts slightly off-screen (`transform: translateX(10%)`) and heavily blurred (`filter: blur(10px)`). Upon opening, it simultaneously translates into place and resolves the blur to `0px`, creating a soft-focus, cinematic entrance.
  - Added staggered CSS entrance animations for the interior `.schema-block` elements using `transition-delay`.
  - Added a premium `backdrop-filter: blur(20px)` to the drawer background.
- Added `README.md` documenting usage and technical features.
- Fully responsive layout ensuring the drawer does not overflow small mobile screens.
- Honors the `prefers-reduced-motion` accessibility standard. The spatial slide-in, the blur filter, and the staggered interior sliding are entirely stripped. The complex interaction gracefully falls back to a safe, immediate opacity fade for users sensitive to motion.

Closes #64477
