### PR TITLE
Add ease-ferris-wheel-cabin component

### DIFF
--- a/submissions/examples/ferris-wheel-cabin-ij/README.md
+++ b/submissions/examples/ferris-wheel-cabin-ij/README.md
@@ -1,0 +1,10 @@
+# ease-ferris-wheel-cabin
+
+A fairground wheel where the rim turns on the hub, the hanging cabins bob at the ends, and the ride sign blinks.
+
+## Run
+Open `demo.html` directly in a browser to watch the wheel turn.
+
+## Notes
+- The rim turns on the hub.
+- The ride sign blinks beneath.

--- a/submissions/examples/ferris-wheel-cabin-ij/demo.html
+++ b/submissions/examples/ferris-wheel-cabin-ij/demo.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-ferris-wheel-cabin demo</title>
+</head>
+<body>
+<div class="fwc-app">
+  <span class="fwc-title">SKY VIEW</span>
+  <div class="fwc-rim">
+    <span class="fwc-cabin"></span>
+    <span class="fwc-cabin"></span>
+    <span class="fwc-cabin"></span>
+    <span class="fwc-cabin"></span>
+  </div>
+  <div class="fwc-spoke"></div>
+  <div class="fwc-hub"></div>
+  <div class="fwc-stand"></div>
+  <span class="fwc-sign">RIDE</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/ferris-wheel-cabin-ij/style.css
+++ b/submissions/examples/ferris-wheel-cabin-ij/style.css
@@ -1,0 +1,17 @@
+:root{--fwc-pink:#ff8ac0;--fwc-dark:#1a1428}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#1a1428,#0a0712);font-family:'Rockwell',serif}
+.fwc-app{position:relative;width:376px;height:420px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#241c38,#120b1e);box-shadow:0 16px 36px rgba(0,0,0,0.6)}
+.fwc-title{position:absolute;top:14px;left:0;right:0;text-align:center;font-size:11px;font-weight:700;letter-spacing:7px;color:#ff8ac0}
+.fwc-rim{position:absolute;top:40px;left:50%;margin-left:-130px;width:260px;height:260px;border-radius:50%;border:10px solid #3a3050;animation:wheel-turn-ferris-wheel-cabin 12s linear infinite}
+.fwc-cabin{position:absolute;width:40px;height:44px;border-radius:10px;background:#ff8ac0;box-shadow:inset 0 0 0 3px #a84a76;animation:cabin-bob-ferris-wheel-cabin 2s ease-in-out infinite}
+.fwc-cabin:nth-of-type(1){top:-27px;left:50%;margin-left:-20px}
+.fwc-cabin:nth-of-type(2){top:50%;right:-34px;margin-top:-22px}
+.fwc-cabin:nth-of-type(3){bottom:-27px;left:50%;margin-left:-20px}
+.fwc-cabin:nth-of-type(4){top:50%;left:-34px;margin-top:-22px}
+.fwc-spoke{position:absolute;top:184px;left:50%;margin-left:-1px;width:2px;height:140px;background:#3a3050;transform-origin:50% 0;animation:wheel-turn-ferris-wheel-cabin 12s linear infinite}
+.fwc-hub{position:absolute;top:172px;left:50%;margin-left:-16px;width:32px;height:32px;border-radius:50%;background:#3a3050;box-shadow:inset 0 0 0 4px #ff8ac0}
+.fwc-stand{position:absolute;top:300px;left:50%;margin-left:-8px;width:16px;height:70px;background:#3a3050}
+.fwc-sign{position:absolute;bottom:14px;left:0;right:0;text-align:center;font-size:10px;letter-spacing:7px;color:#ff8ac0;animation:sign-blink-ferris-wheel-cabin 1.8s steps(1) infinite}
+@keyframes wheel-turn-ferris-wheel-cabin{0%{transform:rotate(0)}100%{transform:rotate(360deg)}}
+@keyframes cabin-bob-ferris-wheel-cabin{0%,100%{transform:rotate(0)}50%{transform:rotate(-4deg)}}
+@keyframes sign-blink-ferris-wheel-cabin{0%,49%{opacity:1}50%,100%{opacity:0.3}}


### PR DESCRIPTION
## Component: ease-ferris-wheel-cabin — wheel turns, cabins bob, and sign blinks

**Closes #65750**

### What this adds
A fairground wheel: the rim turns on the hub, the hanging cabins bob at the ends, and the ride sign blinks.

### Acceptance Criteria covered
- Rim turns on the hub
- Hanging cabins bob at the ends
- Ride sign blinks beneath

### Files
- `submissions/examples/ferris-wheel-cabin-ij/demo.html`
- `submissions/examples/ferris-wheel-cabin-ij/style.css`
- `submissions/examples/ferris-wheel-cabin-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the wheel turn.