### PR TITLE
feat: add CSS Scale-Hover Popover for Minimalist Tech Layouts (#64445)

### DIFF
--- a/submissions/examples/minimalist-scale-hover-popover/README.md
+++ b/submissions/examples/minimalist-scale-hover-popover/README.md
@@ -1,0 +1,19 @@
+# CSS Scale-Hover Popover (Minimalist Tech)
+
+A pure CSS interactive popover component designed for Minimalist Tech Layouts. It features a highly responsive, snappy "Scale-Hover" animation that mimics natural, physical expansion from a trigger point.
+
+## Features
+- Pure CSS and HTML (No JavaScript required for interactions).
+- **The Scale Effect**: The `.popover-content` card is initially scaled down aggressively (`transform: scale(0.6)`). Crucially, the `transform-origin: bottom center;` property is set. This ensures that when the element scales up to `1` on hover, it expands outward from the trigger button below it, rather than expanding from its own center. This creates a much more grounded and physically logical animation.
+- A custom `cubic-bezier(0.34, 1.56, 0.64, 1)` transition timing function is used to create an elastic, bouncy "pop" as the element reaches full size.
+- **Micro-interactions**: The trigger button itself features subtle hover states, including a slight upward nudge (`translateY(-2px)`) and an icon rotation (`transform: rotate(90deg)`), adding polish to the interaction.
+- The internal `.action-item` links utilize an `:active` state transform (`scale(0.98)`) to provide tactile feedback when clicked.
+- Clean, structured aesthetic utilizing the `Inter` font and minimalist SVG iconography.
+- Fully accessible with `prefers-reduced-motion` support. For motion-sensitive users, the trigger animations are disabled, and the popover's spatial scaling is entirely stripped. The transforms are locked to their final state, gracefully falling back to a safe, immediate opacity cross-fade.
+
+## Usage
+Open `demo.html` in your browser. You will see a "Quick Actions" dashboard area featuring a plus icon button. Hover over the button. Watch as the icon rotates slightly, and the context menu rapidly pops up, scaling outward from the button itself with an elastic bounce.
+
+## Files
+- `demo.html`: The HTML structure for the layout, detailing the nested positioning of the trigger button and the popover content within the relative `.popover-container`.
+- `style.css`: The styling, micro-interactions, `transform-origin` logic, and the custom `cubic-bezier` transition driving the scale mechanics.

--- a/submissions/examples/minimalist-scale-hover-popover/demo.html
+++ b/submissions/examples/minimalist-scale-hover-popover/demo.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Scale-Hover Popover - Minimalist Tech</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Quick Actions</h1>
+            <p class="subtitle">Hover over the plus icon to reveal the context menu.</p>
+        </header>
+
+        <div class="dashboard-area">
+            
+            <div class="popover-container">
+                <!-- Trigger Element -->
+                <button class="trigger-btn">
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>
+                </button>
+                
+                <!-- The Popover Content -->
+                <div class="popover-content">
+                    
+                    <a href="#" class="action-item">
+                        <div class="action-icon">
+                            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+                        </div>
+                        <div class="action-text">
+                            <strong>New Document</strong>
+                            <span>Create a blank file</span>
+                        </div>
+                    </a>
+                    
+                    <a href="#" class="action-item">
+                        <div class="action-icon">
+                            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path></svg>
+                        </div>
+                        <div class="action-text">
+                            <strong>New Folder</strong>
+                            <span>Organize your files</span>
+                        </div>
+                    </a>
+                    
+                    <a href="#" class="action-item">
+                        <div class="action-icon">
+                            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="17 8 12 3 7 8"></polyline><line x1="12" y1="3" x2="12" y2="15"></line></svg>
+                        </div>
+                        <div class="action-text">
+                            <strong>Upload</strong>
+                            <span>Import from computer</span>
+                        </div>
+                    </a>
+                    
+                </div>
+            </div>
+
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/minimalist-scale-hover-popover/style.css
+++ b/submissions/examples/minimalist-scale-hover-popover/style.css
@@ -1,0 +1,234 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+:root {
+    --bg-color: #fafafa;
+    --card-bg: #ffffff;
+    --text-primary: #171717;
+    --text-secondary: #737373;
+    --border-color: #e5e5e5;
+    
+    --accent-color: #0ea5e9; /* Sky Blue */
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    font-family: 'Inter', system-ui, -apple-system, sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 40px 20px;
+    box-sizing: border-box;
+}
+
+.layout-container {
+    max-width: 800px;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.section-header {
+    margin-bottom: 60px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2rem;
+    font-weight: 600;
+    margin: 0 0 8px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.05rem;
+    margin: 0;
+    font-weight: 400;
+}
+
+.dashboard-area {
+    padding: 40px;
+}
+
+
+/* =========================================
+   Popover Layout & Mechanics
+   ========================================= */
+
+.popover-container {
+    position: relative;
+    display: inline-block; 
+}
+
+
+/* --- The Trigger (Plus Icon) --- */
+.trigger-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 56px;
+    height: 56px;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 50%;
+    color: var(--text-primary);
+    cursor: pointer;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.05);
+    transition: transform 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275),
+                box-shadow 0.3s ease,
+                background 0.3s ease;
+    z-index: 2;
+    position: relative;
+}
+
+/* 
+  Animate the button itself slightly on hover, 
+  including rotating the plus icon.
+*/
+.popover-container:hover .trigger-btn {
+    box-shadow: 0 8px 24px rgba(0,0,0,0.1);
+    transform: translateY(-2px);
+    background: #f8fafc;
+}
+.popover-container:hover .trigger-btn svg {
+    transition: transform 0.3s ease;
+    transform: rotate(90deg);
+}
+
+
+/* --- The Popover Content & Scale-Hover Effect --- */
+.popover-content {
+    position: absolute;
+    /* Position above the trigger */
+    bottom: calc(100% + 16px);
+    /* Center it */
+    left: 50%;
+    
+    width: 240px;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    box-shadow: 0 10px 25px rgba(0,0,0,0.08);
+    z-index: 10;
+    padding: 8px;
+    
+    /* 
+      Initial state: hidden, scaled down significantly, 
+      and transformed slightly downwards.
+      Crucially, we set the transform-origin to the bottom center 
+      so it scales UP out of the trigger button.
+    */
+    transform-origin: bottom center;
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transform: translateX(-50%) translateY(10px) scale(0.6);
+    
+    /* 
+      The Scale transition uses an elastic cubic-bezier 
+      for a very snappy pop-in feel.
+    */
+    transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1),
+                opacity 0.3s ease,
+                visibility 0.4s ease;
+}
+
+/* Arrow pointing down to the trigger */
+.popover-content::after {
+    content: '';
+    position: absolute;
+    bottom: -6px;
+    left: 50%;
+    transform: translateX(-50%) rotate(45deg);
+    width: 12px;
+    height: 12px;
+    background: var(--card-bg);
+    border-right: 1px solid var(--border-color);
+    border-bottom: 1px solid var(--border-color);
+}
+
+/* Trigger the Popover on Hover */
+.popover-container:hover .popover-content {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+    /* 
+      Scale up to full size.
+      The transform-origin ensures it expands upward naturally.
+    */
+    transform: translateX(-50%) translateY(0) scale(1);
+}
+
+
+/* --- Popover Internal Styling --- */
+.action-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px;
+    text-decoration: none;
+    color: inherit;
+    border-radius: 8px;
+    transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.action-item:hover {
+    background: #f1f5f9;
+}
+
+.action-item:active {
+    transform: scale(0.98);
+}
+
+.action-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    background: #f8fafc;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    color: var(--text-secondary);
+    transition: color 0.2s ease, border-color 0.2s ease;
+}
+
+.action-item:hover .action-icon {
+    color: var(--accent-color);
+    border-color: #bae6fd;
+}
+
+.action-text {
+    display: flex;
+    flex-direction: column;
+}
+
+.action-text strong {
+    font-size: 0.9rem;
+    font-weight: 500;
+}
+
+.action-text span {
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+}
+
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    /* Strip button transform */
+    .trigger-btn { transition: none; }
+    .popover-container:hover .trigger-btn { transform: none !important; }
+    .popover-container:hover .trigger-btn svg { transform: none !important; }
+    
+    /* Strip popover scaling */
+    .popover-content {
+        transition: opacity 0.2s ease, visibility 0.2s ease;
+        transform: translateX(-50%) translateY(0) scale(1) !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces the CSS Scale-Hover Popover designed for Minimalist Tech Layouts, resolving issue #64445. 

### Changes Made:
- Added `submissions/examples/minimalist-scale-hover-popover/` directory.
- Created `demo.html` showcasing a "Quick Actions" context menu layout. Hovering over the plus icon triggers the detailed actions popover, structured entirely with nested CSS positioning.
- Created `style.css` featuring a clean, structured aesthetic utilizing the `Inter` font, subtle drop shadows, and minimalist SVG iconography.
  - Implemented the Scale effect. The `.popover-content` card is initially scaled down (`transform: scale(0.6)`). Crucially, the `transform-origin: bottom center` property is set. When hovered, the card scales to full size, naturally expanding *outward* from the trigger button rather than its own center.
  - Implemented an elastic, snappy entrance using a custom `cubic-bezier(0.34, 1.56, 0.64, 1)` transition timing function.
  - Added micro-interactions to the trigger button itself (a slight upward nudge and rotation of the plus icon) for a polished feel.
- Added `README.md` documenting usage and technical features.
- Honors the `prefers-reduced-motion` accessibility standard. The micro-interactions on the button are removed, and the spatial scaling of the popover is stripped. The complex transforms are locked to their final state, and the interaction gracefully falls back to a safe, immediate opacity cross-fade for users sensitive to motion.

Closes #64445
