### PR TITLE
docs(submissions): propose Stylelint CI workflow (submissions/docs/stylelint-ci) - fixes #63629

### DIFF
--- a/submissions/docs/stylelint-ci/.stylelintignore
+++ b/submissions/docs/stylelint-ci/.stylelintignore
@@ -1,0 +1,5 @@
+# Ignore build artifacts and node deps
+node_modules/
+dist/
+build/
+easemotion.min.css

--- a/submissions/docs/stylelint-ci/README.md
+++ b/submissions/docs/stylelint-ci/README.md
@@ -12,6 +12,11 @@ How to adopt (maintainer instructions)
 2. Merge `.stylelintignore` content into the repo root if desired.
 3. CI will run `npx stylelint "**/*.css" --max-warnings=0` (fail on warnings).
 
+Copy instruction:
+1.Copy stylelint-workflow.yml to .github/workflows/stylelint.yml.
+2.Copy .stylelintignore to the repository root (or merge its contents into the existing .stylelintignore).
+3.Run npm ci once in CI (the workflow already uses that).
+
 Local testing
 1. From repo root:
    - npm ci
@@ -20,3 +25,4 @@ Local testing
 
 Notes
 - This submission intentionally re-uses the existing top-level `.stylelintrc.json` and does not add another `.stylelintrc.json`.
+- "The workflow uses --ignore-path .stylelintignore and --allow-empty-input to avoid linting build artifacts and to avoid failing when no CSS files are present."

--- a/submissions/docs/stylelint-ci/README.md
+++ b/submissions/docs/stylelint-ci/README.md
@@ -1,28 +1,29 @@
 # Stylelint CI — Submission
 
-What this submission does
-- Proposes a GitHub Actions workflow to run Stylelint on CSS files in CI.
-- Provides a `.stylelintignore` and a ready-to-copy workflow YAML (`stylelint-workflow.yml`) that maintainers can place in `.github/workflows/`.
+## Summary
+This submission proposes a ready-to-use GitHub Actions workflow to run Stylelint on the repository's CSS files in CI. It includes:
+- a candidate workflow YAML (`stylelint-workflow.yml`),
+- a `.stylelintignore` to exclude build artifacts,
+- a small demo page, and
+- this README with adoption instructions.
 
-Why this is in `submissions/`
-- EaseMotion CSS enforces a submission-first model: contributors add proposals under `submissions/` and the maintainer reviews and integrates accepted items into the repository root. This submission follows that model and avoids editing root config files directly.
+Issue: Fixes / relates to #63629
 
-How to adopt (maintainer instructions)
-1. If accepted, copy `stylelint-workflow.yml` to `.github/workflows/stylelint.yml`.
-2. Merge `.stylelintignore` content into the repo root if desired.
-3. CI will run `npx stylelint "**/*.css" --max-warnings=0` (fail on warnings).
+---
 
-Copy instruction:
-1.Copy stylelint-workflow.yml to .github/workflows/stylelint.yml.
-2.Copy .stylelintignore to the repository root (or merge its contents into the existing .stylelintignore).
-3.Run npm ci once in CI (the workflow already uses that).
+## Files included
+- `stylelint-workflow.yml` — Candidate GitHub Actions workflow (copy to `.github/workflows/stylelint.yml` to enable).
+- `.stylelintignore` — Files & directories to exclude from linting (copy to repo root or merge into existing ignore).
+- `demo.html` + `style.css` — Minimal demo files required by the `submissions/docs/` track.
+- `README.md` — This file (instructions and rationale).
 
-Local testing
-1. From repo root:
-   - npm ci
-   - npm run lint:css
-   (The repo already has stylelint in devDependencies and a `lint:css` script.)
+All files live under `submissions/docs/stylelint-ci/` per the project’s submission model.
 
-Notes
-- This submission intentionally re-uses the existing top-level `.stylelintrc.json` and does not add another `.stylelintrc.json`.
-- "The workflow uses --ignore-path .stylelintignore and --allow-empty-input to avoid linting build artifacts and to avoid failing when no CSS files are present."
+---
+
+## Adoption — step-by-step (for maintainers)
+If you accept this proposal, perform the following to enable the workflow:
+
+1. Copy the workflow YAML into the workflows folder:
+```bash
+cp submissions/docs/stylelint-ci/stylelint-workflow.yml .github/workflows/stylelint.yml

--- a/submissions/docs/stylelint-ci/README.md
+++ b/submissions/docs/stylelint-ci/README.md
@@ -1,0 +1,22 @@
+# Stylelint CI — Submission
+
+What this submission does
+- Proposes a GitHub Actions workflow to run Stylelint on CSS files in CI.
+- Provides a `.stylelintignore` and a ready-to-copy workflow YAML (`stylelint-workflow.yml`) that maintainers can place in `.github/workflows/`.
+
+Why this is in `submissions/`
+- EaseMotion CSS enforces a submission-first model: contributors add proposals under `submissions/` and the maintainer reviews and integrates accepted items into the repository root. This submission follows that model and avoids editing root config files directly.
+
+How to adopt (maintainer instructions)
+1. If accepted, copy `stylelint-workflow.yml` to `.github/workflows/stylelint.yml`.
+2. Merge `.stylelintignore` content into the repo root if desired.
+3. CI will run `npx stylelint "**/*.css" --max-warnings=0` (fail on warnings).
+
+Local testing
+1. From repo root:
+   - npm ci
+   - npm run lint:css
+   (The repo already has stylelint in devDependencies and a `lint:css` script.)
+
+Notes
+- This submission intentionally re-uses the existing top-level `.stylelintrc.json` and does not add another `.stylelintrc.json`.

--- a/submissions/docs/stylelint-ci/demo.html
+++ b/submissions/docs/stylelint-ci/demo.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <title>Proposal: Stylelint CI for EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main style="font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif; max-width:900px;margin:48px auto">
+    <h1>Stylelint CI — Submission</h1>
+    <p>This submission proposes a Stylelint GitHub Actions workflow to run CSS linting in CI. It contains a candidate workflow file, a .stylelintignore, and documentation for maintainers to adopt.</p>
+
+    <section>
+      <h2>What I am proposing</h2>
+      <ul>
+        <li>Provide a candidate workflow YAML (stylelint-workflow.yml) that maintainers can copy to <code>.github/workflows/stylelint.yml</code>.</li>
+        <li>Provide a <code>.stylelintignore</code> to exclude generated artifacts.</li>
+        <li>Do NOT duplicate or replace the repo's top-level <code>.stylelintrc.json</code>. This uses the existing config.</li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/docs/stylelint-ci/style.css
+++ b/submissions/docs/stylelint-ci/style.css
@@ -1,0 +1,3 @@
+body { background: #fbfbff; color: #111827; margin: 0; padding: 0; }
+main { padding: 48px; }
+h1 { color: #6c63ff; margin-top: 0; }

--- a/submissions/docs/stylelint-ci/stylelint-workflow.yml
+++ b/submissions/docs/stylelint-ci/stylelint-workflow.yml
@@ -19,10 +19,16 @@ jobs:
         with:
           node-version: "18"
 
+      - name: Cache node modules
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
       - name: Install dependencies
-        run: |
-          npm ci
+        run: npm ci
 
       - name: Run Stylelint (fail on warnings)
-        run: |
-          npx stylelint "**/*.css" --max-warnings=0
+        run: npx stylelint "**/*.css" --ignore-path .stylelintignore --allow-empty-input --max-warnings=0

--- a/submissions/docs/stylelint-ci/stylelint-workflow.yml
+++ b/submissions/docs/stylelint-ci/stylelint-workflow.yml
@@ -1,0 +1,28 @@
+name: Stylelint
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  stylelint:
+    name: Stylelint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+
+      - name: Install dependencies
+        run: |
+          npm ci
+
+      - name: Run Stylelint (fail on warnings)
+        run: |
+          npx stylelint "**/*.css" --max-warnings=0


### PR DESCRIPTION
## Pull Request Description

Proposes a candidate GitHub Actions workflow to run Stylelint on the repository's CSS files, plus a `.stylelintignore`, demo files, and adoption instructions. All files are placed under `submissions/docs/stylelint-ci/` so the maintainer can review and integrate the workflow into the repository root if accepted.

Fixes: #63629
---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [X] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [X] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [X] Includes `demo.html` — self-contained, opens in browser with no server
- [X] Includes `style.css` — raw CSS for the proposed feature
- [X] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [X] **No changes to `core/`**
- [X] **No changes to `components/`**
- [X] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A candidate Stylelint CI workflow (`stylelint-workflow.yml`) plus `.stylelintignore`, `demo.html`, `style.css`, and `README.md` under `submissions/docs/stylelint-ci/`. The workflow runs Stylelint in CI (fails on warnings and errors) once the maintainer copies the YAML to `.github/workflows/` and the ignore file to the repo root.

**How does a developer use it?**

- For contributors: add or update CSS under the repo (or in a submission). This workflow is a maintainer-adopted CI check — contributors only need to ensure their CSS passes stylelint before opening a PR.
- To enable CI (maintainer action): copy submissions/docs/stylelint-ci/stylelint-workflow.yml → .github/workflows/stylelint.yml and submissions/docs/stylelint-ci/.stylelintignore → .stylelintignore.
- To run locally:
- npm ci
- npm run lint:css
- or: npx stylelint "**/*.css" --ignore-path .stylelintignore --allow-empty-input --max-warnings=0
- Demo: open submissions/docs/stylelint-ci/demo.html in a browser to view the demo styles that the workflow will lint.

```html
<!-- Show the class usage in HTML -->
<!doctype html>
<html lang="en">
<head>
  <meta charset="utf-8" />
  <meta name="viewport" content="width=device-width,initial-scale=1" />
  <title>Stylelint CI Demo</title>
  <link rel="stylesheet" href="style.css" />
</head>
<body>
  <main style="max-width:800px;margin:48px auto;font-family:system-ui,Segoe UI,Roboto,sans-serif">
    <section class="ease-stylelint-demo" aria-label="Stylelint CI demo">
      <h1 class="ease-stylelint-title">Stylelint CI Demo</h1>
      <p class="ease-stylelint-desc">This demo page uses <code>style.css</code>. The proposed CI workflow will automatically lint this CSS when enabled.</p>
      <!-- Example element showing class usage -->
      <div class="ease-card ease-stylelint-example" style="padding:1rem;border-radius:8px;border:1px solid #e6e9ef;background:#fff;">
        <h2 class="ease-stylelint-example__title">Example Card</h2>
        <p class="ease-stylelint-example__body">This element uses demo classes that are checked by Stylelint in CI.</p>
      </div>
    </section>
  </main>
</body>
</html>
```

**Why does it fit EaseMotion CSS?**

- Improves CSS quality and consistency by enforcing linting in CI.
- Matches the repository’s submission-first model (contribution placed under submissions/ for maintainer review).
- Does not modify or duplicate the existing top-level .stylelintrc.json — it re-uses the repo’s config and provides a safe, adoptable workflow.

---

## Demo

- [X] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

- To enable strict Stylelint CI, please copy/merge the following files into the repository root:
- submissions/docs/stylelint-ci/stylelint-workflow.yml → .github/workflows/stylelint.yml
- submissions/docs/stylelint-ci/.stylelintignore → .stylelintignore (or merge its contents)
- The recommended workflow runs:
- npm ci
- npx stylelint "**/*.css" --ignore-path .stylelintignore --allow-empty-input --max-warnings=0
- It includes an optional npm cache step to speed CI.
- This submission intentionally does not change the existing .stylelintrc.json held at the repo root; leave rule edits to maintainers.
- Optional follow-ups I can provide:
- Add reviewdog annotations to make lint failures appear inline on PRs.
- Propose curated .stylelintrc.json rule changes if you want stricter rules.
- Provide a lint-staged / Husky suggestion for local pre-commit checks.

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
