### PR TITLE
feat: add CSS Ripple-Wave Tabs for Minimalist Tech Layouts (#64436)

### DIFF
--- a/submissions/examples/minimalist-ripple-wave-tabs/README.md
+++ b/submissions/examples/minimalist-ripple-wave-tabs/README.md
@@ -1,0 +1,20 @@
+# CSS Ripple-Wave Tabs (Minimalist Tech)
+
+A pure CSS interactive tabs component designed for Minimalist Tech Layouts. It features a tactile "Ripple-Wave" click effect on the tab headers, alongside smooth sliding indicators and panel transitions.
+
+## Features
+- Pure CSS and HTML (No JavaScript required for state management or animations).
+- **State Management**: The active tab and corresponding panel are managed entirely via the hidden radio button hack (`input[type="radio"]:checked`).
+- **The Ripple-Wave Effect**: When a user clicks a `<label>` linked to a radio input, the radio becomes `:checked`. This state change natively triggers an `@keyframes` animation (`ripple-wave`) on a hidden `.ripple-element` nested inside the label.
+- The ripple starts perfectly centered (`top: 50%; left: 50%; transform: translate(-50%, -50%)`) with `0` width/height and full opacity. Over `0.6s`, it expands massively while fading out, simulating a classic material ripple without needing JS to calculate the exact click coordinates.
+- **Sliding Indicator**: The `.active-indicator` underline utilizes the sibling combinator (`~`) and `transform: translateX()` to smoothly slide between the active tabs based on which radio input is currently checked.
+- **Panel Transitions**: The content panels smoothly slide up (`translateY(10px)` to `0`) and fade in when their corresponding tab is activated.
+- Clean, structured aesthetic utilizing the `Inter` font, subtle borders, and properly styled mock settings form elements.
+- Fully accessible with `prefers-reduced-motion` support. For motion-sensitive users, the expanding ripple animation and the sliding indicator transitions are completely disabled. The interactions safely fall back to immediate visual state changes without motion.
+
+## Usage
+Open `demo.html` in your browser. You will see a mock account settings dashboard. Click on the "Notifications" or "Security" tabs. Watch as the blue active indicator smoothly slides over, the new panel fades into view, and a soft blue ripple expands outwards from the center of the clicked tab header.
+
+## Files
+- `demo.html`: The HTML structure for the layout, detailing the critical placement of the hidden `<input type="radio">` elements as siblings to both the `.tab-headers` and `.tab-content-wrapper`.
+- `style.css`: The styling, radio-state logic, and the `@keyframes` driving the expanding ripple effect.

--- a/submissions/examples/minimalist-ripple-wave-tabs/demo.html
+++ b/submissions/examples/minimalist-ripple-wave-tabs/demo.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Ripple-Wave Tabs - Minimalist Tech</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Account Settings</h1>
+            <p class="subtitle">Click a tab to trigger the pure CSS ripple-wave effect.</p>
+        </header>
+
+        <div class="dashboard-area">
+            
+            <!-- Pure CSS Tabs Structure -->
+            <div class="tabs-container">
+                
+                <!-- Radio Inputs for State Management -->
+                <input type="radio" id="tab-1" name="settings-tabs" class="tab-input" checked>
+                <input type="radio" id="tab-2" name="settings-tabs" class="tab-input">
+                <input type="radio" id="tab-3" name="settings-tabs" class="tab-input">
+                
+                <!-- Tab Headers (Navigation) -->
+                <div class="tab-headers">
+                    
+                    <label for="tab-1" class="tab-label">
+                        <span class="label-text">Profile</span>
+                        <!-- The Ripple Element -->
+                        <div class="ripple-element"></div>
+                    </label>
+                    
+                    <label for="tab-2" class="tab-label">
+                        <span class="label-text">Notifications</span>
+                        <!-- The Ripple Element -->
+                        <div class="ripple-element"></div>
+                    </label>
+                    
+                    <label for="tab-3" class="tab-label">
+                        <span class="label-text">Security</span>
+                        <!-- The Ripple Element -->
+                        <div class="ripple-element"></div>
+                    </label>
+                    
+                    <!-- The Active Indicator Line -->
+                    <div class="active-indicator"></div>
+                </div>
+                
+                <!-- Tab Content Panels -->
+                <div class="tab-content-wrapper">
+                    
+                    <!-- Panel 1: Profile -->
+                    <div class="tab-panel" id="panel-1">
+                        <h2>Public Profile</h2>
+                        <p class="panel-desc">Manage how your profile appears to other users on the platform.</p>
+                        
+                        <div class="form-group">
+                            <label>Display Name</label>
+                            <input type="text" value="Jane Doe" class="form-input">
+                        </div>
+                        
+                        <div class="form-group">
+                            <label>Bio</label>
+                            <textarea class="form-input" rows="3">Senior Software Engineer passionate about pure CSS solutions.</textarea>
+                        </div>
+                        
+                        <button class="btn btn-primary mt-2">Update Profile</button>
+                    </div>
+                    
+                    <!-- Panel 2: Notifications -->
+                    <div class="tab-panel" id="panel-2">
+                        <h2>Notification Preferences</h2>
+                        <p class="panel-desc">Choose which alerts you want to receive and how you receive them.</p>
+                        
+                        <div class="toggle-row">
+                            <div class="toggle-info">
+                                <strong>Email Summaries</strong>
+                                <span>Receive a weekly digest of activity.</span>
+                            </div>
+                            <div class="mock-toggle active"></div>
+                        </div>
+                        
+                        <div class="toggle-row">
+                            <div class="toggle-info">
+                                <strong>Push Notifications</strong>
+                                <span>Get instant alerts on your desktop.</span>
+                            </div>
+                            <div class="mock-toggle"></div>
+                        </div>
+                    </div>
+                    
+                    <!-- Panel 3: Security -->
+                    <div class="tab-panel" id="panel-3">
+                        <h2>Security Settings</h2>
+                        <p class="panel-desc">Protect your account and manage active sessions.</p>
+                        
+                        <div class="security-card">
+                            <div class="sec-icon">
+                                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect><path d="M7 11V7a5 5 0 0 1 10 0v4"></path></svg>
+                            </div>
+                            <div class="sec-info">
+                                <strong>Two-Factor Authentication</strong>
+                                <span>Add an extra layer of security to your account.</span>
+                            </div>
+                            <button class="btn btn-outline">Enable 2FA</button>
+                        </div>
+                        
+                        <div class="form-group mt-6">
+                            <label>Change Password</label>
+                            <input type="password" placeholder="Current Password" class="form-input mb-3">
+                            <input type="password" placeholder="New Password" class="form-input mb-3">
+                            <button class="btn btn-primary">Update Password</button>
+                        </div>
+                    </div>
+                    
+                </div>
+                
+            </div>
+
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/minimalist-ripple-wave-tabs/style.css
+++ b/submissions/examples/minimalist-ripple-wave-tabs/style.css
@@ -1,0 +1,356 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+:root {
+    --bg-color: #fafafa;
+    --card-bg: #ffffff;
+    --text-primary: #171717;
+    --text-secondary: #737373;
+    --border-color: #e5e5e5;
+    
+    --accent-color: #0ea5e9; /* Sky Blue */
+    --accent-light: rgba(14, 165, 233, 0.15);
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    font-family: 'Inter', system-ui, -apple-system, sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    padding: 60px 20px;
+    box-sizing: border-box;
+}
+
+.layout-container {
+    max-width: 800px;
+    width: 100%;
+}
+
+.section-header {
+    margin-bottom: 40px;
+}
+
+.title {
+    font-size: 2rem;
+    font-weight: 600;
+    margin: 0 0 8px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.05rem;
+    margin: 0;
+    font-weight: 400;
+}
+
+
+/* =========================================
+   Tabs Component Mechanics
+   ========================================= */
+
+.dashboard-area {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.03);
+    overflow: hidden;
+}
+
+/* Hide the radio inputs */
+.tab-input {
+    display: none;
+}
+
+.tab-headers {
+    display: flex;
+    position: relative;
+    border-bottom: 1px solid var(--border-color);
+    background: #f8fafc;
+}
+
+.tab-label {
+    flex: 1;
+    text-align: center;
+    padding: 18px 0;
+    font-size: 0.95rem;
+    font-weight: 500;
+    color: var(--text-secondary);
+    cursor: pointer;
+    position: relative;
+    overflow: hidden; /* Required to contain the ripple */
+    transition: color 0.3s ease;
+    /* Ensure ripple sits behind text */
+    z-index: 1;
+}
+
+.label-text {
+    position: relative;
+    z-index: 2; /* Sit above the ripple */
+}
+
+.tab-label:hover {
+    color: var(--text-primary);
+    background: rgba(0,0,0,0.02);
+}
+
+
+/* --- The Ripple-Wave Effect --- */
+
+.ripple-element {
+    position: absolute;
+    /* Center it inside the tab */
+    top: 50%;
+    left: 50%;
+    width: 0;
+    height: 0;
+    background: var(--accent-light);
+    border-radius: 50%;
+    transform: translate(-50%, -50%);
+    opacity: 0;
+    z-index: 1;
+    pointer-events: none;
+}
+
+/* 
+  When a tab becomes checked, trigger the ripple animation.
+  By placing the ripple inside the label, we can trigger it natively via the :checked state.
+*/
+#tab-1:checked ~ .tab-headers label[for="tab-1"] .ripple-element,
+#tab-2:checked ~ .tab-headers label[for="tab-2"] .ripple-element,
+#tab-3:checked ~ .tab-headers label[for="tab-3"] .ripple-element {
+    animation: ripple-wave 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
+}
+
+@keyframes ripple-wave {
+    0% {
+        width: 0;
+        height: 0;
+        opacity: 1;
+    }
+    100% {
+        /* Expand large enough to cover the whole tab */
+        width: 300px;
+        height: 300px;
+        opacity: 0;
+    }
+}
+
+
+/* --- The Active Indicator Line --- */
+
+.active-indicator {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 33.333%;
+    height: 3px;
+    background-color: var(--accent-color);
+    border-radius: 3px 3px 0 0;
+    transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+    z-index: 3;
+}
+
+/* Move the indicator based on which radio is checked */
+#tab-1:checked ~ .tab-headers .active-indicator { transform: translateX(0); }
+#tab-2:checked ~ .tab-headers .active-indicator { transform: translateX(100%); }
+#tab-3:checked ~ .tab-headers .active-indicator { transform: translateX(200%); }
+
+/* Color the active text */
+#tab-1:checked ~ .tab-headers label[for="tab-1"],
+#tab-2:checked ~ .tab-headers label[for="tab-2"],
+#tab-3:checked ~ .tab-headers label[for="tab-3"] {
+    color: var(--accent-color);
+}
+
+
+/* --- Tab Content Panels --- */
+
+.tab-content-wrapper {
+    position: relative;
+    padding: 32px;
+    min-height: 350px;
+}
+
+.tab-panel {
+    position: absolute;
+    top: 32px;
+    left: 32px;
+    right: 32px;
+    /* Default hidden state */
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(10px);
+    transition: all 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+
+/* Show the active panel based on radio state */
+#tab-1:checked ~ .tab-content-wrapper #panel-1,
+#tab-2:checked ~ .tab-content-wrapper #panel-2,
+#tab-3:checked ~ .tab-content-wrapper #panel-3 {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+    /* A slight delay ensures it fades in *after* the previous one fades out */
+    transition-delay: 0.1s;
+}
+
+
+/* =========================================
+   Mock Content Styling
+   ========================================= */
+
+.tab-panel h2 {
+    margin: 0 0 8px 0;
+    font-size: 1.25rem;
+    font-weight: 600;
+}
+
+.panel-desc {
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+    margin: 0 0 24px 0;
+}
+
+/* Forms */
+.form-group {
+    margin-bottom: 20px;
+}
+.form-group label {
+    display: block;
+    font-size: 0.9rem;
+    font-weight: 500;
+    margin-bottom: 8px;
+}
+.form-input {
+    width: 100%;
+    padding: 10px 12px;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    font-family: inherit;
+    font-size: 0.95rem;
+    box-sizing: border-box;
+    transition: border-color 0.2s ease;
+}
+.form-input:focus {
+    outline: none;
+    border-color: var(--accent-color);
+}
+.mb-3 { margin-bottom: 12px; }
+.mt-6 { margin-top: 24px; }
+.mt-2 { margin-top: 8px; }
+
+/* Buttons */
+.btn {
+    display: inline-block;
+    padding: 10px 20px;
+    border-radius: 6px;
+    font-size: 0.9rem;
+    font-weight: 500;
+    cursor: pointer;
+    text-align: center;
+    transition: all 0.2s ease;
+    border: 1px solid transparent;
+    font-family: inherit;
+}
+.btn-primary {
+    background: var(--accent-color);
+    color: #fff;
+}
+.btn-primary:hover { background: #0284c7; }
+.btn-outline {
+    background: transparent;
+    border-color: var(--border-color);
+    color: var(--text-primary);
+}
+.btn-outline:hover { background: #f8fafc; }
+
+/* Toggles & Cards */
+.toggle-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 16px 0;
+    border-bottom: 1px solid var(--border-color);
+}
+.toggle-row:last-child { border-bottom: none; }
+.toggle-info {
+    display: flex;
+    flex-direction: column;
+}
+.toggle-info strong { font-size: 0.95rem; margin-bottom: 4px; font-weight: 500; }
+.toggle-info span { font-size: 0.85rem; color: var(--text-secondary); }
+
+.mock-toggle {
+    width: 44px;
+    height: 24px;
+    background: #e2e8f0;
+    border-radius: 12px;
+    position: relative;
+    cursor: pointer;
+}
+.mock-toggle::after {
+    content: '';
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 20px;
+    height: 20px;
+    background: #fff;
+    border-radius: 50%;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+.mock-toggle.active { background: var(--accent-color); }
+.mock-toggle.active::after { left: 22px; }
+
+.security-card {
+    display: flex;
+    align-items: center;
+    padding: 16px;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    background: #f8fafc;
+}
+.sec-icon {
+    width: 40px;
+    height: 40px;
+    background: #e0f2fe;
+    color: var(--accent-color);
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-right: 16px;
+}
+.sec-info {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+.sec-info strong { font-size: 0.95rem; font-weight: 500; margin-bottom: 2px; }
+.sec-info span { font-size: 0.85rem; color: var(--text-secondary); }
+
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    /* Disable the ripple wave animation */
+    .ripple-element {
+        display: none !important;
+        animation: none !important;
+    }
+    
+    /* Disable the sliding indicator animation */
+    .active-indicator {
+        transition: none !important;
+    }
+    
+    /* Disable panel sliding */
+    .tab-panel {
+        transition: opacity 0.2s ease !important;
+        transform: translateY(0) !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces the CSS Ripple-Wave Tabs designed for Minimalist Tech Layouts, resolving issue #64436. 

### Changes Made:
- Added `submissions/examples/minimalist-ripple-wave-tabs/` directory.
- Created `demo.html` showcasing a mock account settings dashboard. It utilizes the pure CSS radio button hack (`<input type="radio">` paired with `<label>` elements) to natively manage the active tab state without any JavaScript.
- Created `style.css` featuring a clean, structured aesthetic utilizing the `Inter` font, subtle borders, and properly styled mock settings form elements.
  - Implemented the Ripple-Wave effect. A hidden `.ripple-element` is nested inside each tab label. When the associated radio button becomes `:checked`, it triggers an `@keyframes` animation (`ripple-wave`) that expands the ripple from the center of the tab while fading it out, simulating a classic material ripple click effect entirely in CSS.
  - Added an `.active-indicator` that smoothly slides between tabs using `transform: translateX()`.
  - Content panels smoothly slide up and fade into view when activated.
- Added `README.md` documenting usage and technical features.
- Honors the `prefers-reduced-motion` accessibility standard. The expanding ripple animation and the sliding indicator transitions are completely disabled. The interactions safely fall back to immediate visual state changes without motion.

Closes #64436
