### PR TITLE
feat: add CSS Zoom-In Tabs for Minimalist Tech Layouts (#64428)

### DIFF
--- a/submissions/examples/minimalist-zoom-in-tabs/README.md
+++ b/submissions/examples/minimalist-zoom-in-tabs/README.md
@@ -1,0 +1,21 @@
+# CSS Zoom-In Tabs (Minimalist Tech)
+
+A pure CSS interactive tabs component designed for Minimalist Tech Layouts. It features a bold "Zoom-In" transition on the content panels, expanding them outwards from the center into sharp focus.
+
+## Features
+- Pure CSS and HTML (No JavaScript required for state management or animations).
+- **State Management**: The active tab and corresponding panel are managed entirely via the hidden radio button hack (`input[type="radio"]:checked`).
+- **The Zoom-In Transition**: 
+- By default, `.tab-panel` elements are hidden: `opacity: 0` and scaled down aggressively (`transform: scale(0.85)`).
+- When a tab is activated (its associated radio button is `:checked`), the corresponding panel transitions to full opacity and scales up to its native size (`transform: scale(1)`).
+- We utilize a custom `cubic-bezier(0.25, 0.46, 0.45, 0.94)` transition curve. This creates a smooth, controlled expansion that feels fast but avoids unnatural bouncing.
+- **Tab Indicators**: Each tab label contains a `.tab-indicator` circle. When a tab becomes active, its indicator animates into the accent color, adds a subtle box-shadow glow, and scales up slightly (`scale(1.2)`) to draw the eye.
+- Clean, structured aesthetic utilizing the `Inter` font, subtle rounded borders, and heavily stylized mock data layouts (Kanban boards, task lists, and file grids) that demonstrate how the transition behaves with complex internal layouts.
+- Fully accessible with `prefers-reduced-motion` support. For motion-sensitive users, the aggressive zooming/scaling transitions (on both the panels and the tab indicators) are completely disabled. The interactions safely fall back to an immediate opacity cross-fade.
+
+## Usage
+Open `demo.html` in your browser. You will see a mock project dashboard. Click between the "Kanban Board", "Task List", and "Shared Files" tabs. Watch as the active tab indicator illuminates, and the new data panel rapidly scales up and fades into view from the center of the container.
+
+## Files
+- `demo.html`: The HTML structure for the layout, detailing the critical placement of the hidden `<input type="radio">` elements and the complex mock data components required for the showcase.
+- `style.css`: The styling, radio-state logic, and the `scale()` transitions driving the zoom-in mechanics.

--- a/submissions/examples/minimalist-zoom-in-tabs/demo.html
+++ b/submissions/examples/minimalist-zoom-in-tabs/demo.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Zoom-In Tabs - Minimalist Tech</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Project Dashboard</h1>
+            <p class="subtitle">Click a tab to trigger the pure CSS zoom-in panel transition.</p>
+        </header>
+
+        <div class="dashboard-area">
+            
+            <!-- Pure CSS Tabs Structure -->
+            <div class="tabs-container">
+                
+                <!-- Radio Inputs for State Management -->
+                <input type="radio" id="tab-kanban" name="project-tabs" class="tab-input" checked>
+                <input type="radio" id="tab-list" name="project-tabs" class="tab-input">
+                <input type="radio" id="tab-files" name="project-tabs" class="tab-input">
+                
+                <!-- Tab Headers (Navigation) -->
+                <div class="tab-headers">
+                    
+                    <label for="tab-kanban" class="tab-label">
+                        <span class="tab-indicator"></span>
+                        <span class="tab-text">Kanban Board</span>
+                    </label>
+                    
+                    <label for="tab-list" class="tab-label">
+                        <span class="tab-indicator"></span>
+                        <span class="tab-text">Task List</span>
+                    </label>
+                    
+                    <label for="tab-files" class="tab-label">
+                        <span class="tab-indicator"></span>
+                        <span class="tab-text">Shared Files</span>
+                    </label>
+                    
+                </div>
+                
+                <!-- Tab Content Panels (The Zoom-In Target) -->
+                <div class="tab-content-wrapper">
+                    
+                    <!-- Panel 1: Kanban -->
+                    <div class="tab-panel" id="panel-kanban">
+                        <div class="panel-header">
+                            <h2>Sprint Planning</h2>
+                            <button class="btn btn-primary btn-sm">+ New Task</button>
+                        </div>
+                        
+                        <div class="kanban-grid">
+                            <div class="kanban-col">
+                                <h3 class="col-title">To Do</h3>
+                                <div class="task-card">Design System Update</div>
+                                <div class="task-card">User Research Interviews</div>
+                            </div>
+                            <div class="kanban-col">
+                                <h3 class="col-title">In Progress</h3>
+                                <div class="task-card active">Implement Zoom-In Tabs</div>
+                            </div>
+                            <div class="kanban-col">
+                                <h3 class="col-title">Done</h3>
+                                <div class="task-card done">Database Migration</div>
+                                <div class="task-card done">API Rate Limiting</div>
+                                <div class="task-card done">OAuth Integration</div>
+                            </div>
+                        </div>
+                    </div>
+                    
+                    <!-- Panel 2: List -->
+                    <div class="tab-panel" id="panel-list">
+                        <div class="panel-header">
+                            <h2>All Tasks</h2>
+                            <div class="search-bar">Search tasks...</div>
+                        </div>
+                        
+                        <div class="task-list">
+                            <div class="list-row">
+                                <input type="checkbox" class="task-checkbox">
+                                <span class="task-name">Update documentation for v2.0 API</span>
+                                <span class="task-tag tag-low">Low</span>
+                            </div>
+                            <div class="list-row">
+                                <input type="checkbox" class="task-checkbox" checked>
+                                <span class="task-name done-text">Fix memory leak in background worker</span>
+                                <span class="task-tag tag-high">High</span>
+                            </div>
+                            <div class="list-row">
+                                <input type="checkbox" class="task-checkbox">
+                                <span class="task-name">Audit accessibility compliance</span>
+                                <span class="task-tag tag-med">Medium</span>
+                            </div>
+                            <div class="list-row">
+                                <input type="checkbox" class="task-checkbox">
+                                <span class="task-name">Prepare Q3 presentation deck</span>
+                                <span class="task-tag tag-med">Medium</span>
+                            </div>
+                        </div>
+                    </div>
+                    
+                    <!-- Panel 3: Files -->
+                    <div class="tab-panel" id="panel-files">
+                        <div class="panel-header">
+                            <h2>Design Assets</h2>
+                            <button class="btn btn-outline btn-sm">Upload File</button>
+                        </div>
+                        
+                        <div class="files-grid">
+                            <div class="file-card">
+                                <div class="file-icon bg-blue">PNG</div>
+                                <span class="file-name">logo-final-v3.png</span>
+                                <span class="file-size">1.2 MB</span>
+                            </div>
+                            <div class="file-card">
+                                <div class="file-icon bg-purple">FIG</div>
+                                <span class="file-name">app-mockups.fig</span>
+                                <span class="file-size">45 MB</span>
+                            </div>
+                            <div class="file-card">
+                                <div class="file-icon bg-green">CSV</div>
+                                <span class="file-name">user-feedback-q2.csv</span>
+                                <span class="file-size">84 KB</span>
+                            </div>
+                            <div class="file-card">
+                                <div class="file-icon bg-red">PDF</div>
+                                <span class="file-name">brand-guidelines.pdf</span>
+                                <span class="file-size">5.4 MB</span>
+                            </div>
+                        </div>
+                    </div>
+                    
+                </div>
+                
+            </div>
+
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/minimalist-zoom-in-tabs/style.css
+++ b/submissions/examples/minimalist-zoom-in-tabs/style.css
@@ -1,0 +1,361 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+:root {
+    --bg-color: #f8fafc; /* Slate 50 */
+    --card-bg: #ffffff;
+    --text-primary: #0f172a; /* Slate 900 */
+    --text-secondary: #64748b; /* Slate 500 */
+    --border-color: #e2e8f0; /* Slate 200 */
+    
+    --accent-color: #10b981; /* Emerald 500 */
+    --accent-light: #d1fae5; /* Emerald 100 */
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    font-family: 'Inter', system-ui, -apple-system, sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    padding: 60px 20px;
+    box-sizing: border-box;
+}
+
+.layout-container {
+    max-width: 950px;
+    width: 100%;
+}
+
+.section-header {
+    margin-bottom: 40px;
+}
+
+.title {
+    font-size: 2rem;
+    font-weight: 700;
+    margin: 0 0 8px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.05rem;
+    margin: 0;
+    font-weight: 400;
+}
+
+
+/* =========================================
+   Tabs Component Mechanics
+   ========================================= */
+
+.dashboard-area {
+    /* Container for the tabs */
+}
+
+/* Hide the radio inputs */
+.tab-input {
+    display: none;
+}
+
+.tab-headers {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 24px;
+    background: #f1f5f9;
+    padding: 8px;
+    border-radius: 16px;
+    border: 1px solid var(--border-color);
+}
+
+.tab-label {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 12px 16px;
+    border-radius: 10px;
+    font-size: 0.95rem;
+    font-weight: 500;
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: all 0.3s ease;
+    background: transparent;
+}
+
+.tab-indicator {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: transparent;
+    transition: all 0.3s ease;
+}
+
+.tab-label:hover {
+    color: var(--text-primary);
+    background: rgba(255,255,255,0.5);
+}
+
+/* Active Tab Styling */
+#tab-kanban:checked ~ .tab-headers label[for="tab-kanban"],
+#tab-list:checked ~ .tab-headers label[for="tab-list"],
+#tab-files:checked ~ .tab-headers label[for="tab-files"] {
+    background: var(--card-bg);
+    color: var(--text-primary);
+    box-shadow: 0 2px 8px rgba(0,0,0,0.05);
+}
+
+/* Active Indicator Animation */
+#tab-kanban:checked ~ .tab-headers label[for="tab-kanban"] .tab-indicator,
+#tab-list:checked ~ .tab-headers label[for="tab-list"] .tab-indicator,
+#tab-files:checked ~ .tab-headers label[for="tab-files"] .tab-indicator {
+    background: var(--accent-color);
+    box-shadow: 0 0 8px var(--accent-light);
+    transform: scale(1.2);
+}
+
+
+/* --- The Zoom-In Content Transition --- */
+
+.tab-content-wrapper {
+    position: relative;
+    min-height: 500px;
+}
+
+.tab-panel {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 16px;
+    padding: 32px;
+    box-sizing: border-box;
+    box-shadow: 0 10px 25px rgba(0,0,0,0.03);
+    
+    /* 
+      Default Hidden State:
+      We scale it down aggressively and completely fade it out.
+    */
+    opacity: 0;
+    visibility: hidden;
+    transform: scale(0.85);
+    
+    /* Smooth transition for the exit */
+    transition: transform 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94),
+                opacity 0.3s ease,
+                visibility 0.4s ease;
+}
+
+/* 
+  Show the active panel based on radio state.
+  We animate scale from 0.85 to 1.
+*/
+#tab-kanban:checked ~ .tab-content-wrapper #panel-kanban,
+#tab-list:checked ~ .tab-content-wrapper #panel-list,
+#tab-files:checked ~ .tab-content-wrapper #panel-files {
+    opacity: 1;
+    visibility: visible;
+    transform: scale(1);
+    z-index: 10;
+    /* A slight delay ensures it animates *after* the previous one begins exiting */
+    transition-delay: 0.1s;
+}
+
+
+/* =========================================
+   Mock Content Styling
+   ========================================= */
+
+.panel-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 32px;
+}
+
+.panel-header h2 {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 600;
+}
+
+.btn {
+    padding: 8px 16px;
+    border-radius: 8px;
+    font-size: 0.9rem;
+    font-weight: 500;
+    cursor: pointer;
+    font-family: inherit;
+    border: 1px solid transparent;
+    transition: all 0.2s ease;
+}
+.btn-sm { padding: 6px 12px; font-size: 0.85rem; }
+.btn-primary {
+    background: var(--accent-color);
+    color: #fff;
+}
+.btn-primary:hover { background: #059669; }
+.btn-outline {
+    background: transparent;
+    border-color: var(--border-color);
+    color: var(--text-primary);
+}
+.btn-outline:hover { background: #f1f5f9; }
+
+
+/* --- Kanban Grid (Panel 1) --- */
+.kanban-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 24px;
+}
+.kanban-col {
+    background: #f8fafc;
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 16px;
+}
+.col-title {
+    font-size: 0.95rem;
+    color: var(--text-secondary);
+    margin: 0 0 16px 0;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+.task-card {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    padding: 16px;
+    border-radius: 8px;
+    font-size: 0.9rem;
+    margin-bottom: 12px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.02);
+    border-left: 3px solid transparent;
+}
+.task-card:last-child { margin-bottom: 0; }
+.task-card.active { border-left-color: var(--accent-color); }
+.task-card.done { text-decoration: line-through; color: var(--text-secondary); }
+
+
+/* --- List View (Panel 2) --- */
+.search-bar {
+    padding: 8px 16px;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+    background: #f8fafc;
+    width: 200px;
+}
+.task-list {
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    overflow: hidden;
+}
+.list-row {
+    display: flex;
+    align-items: center;
+    padding: 16px 20px;
+    border-bottom: 1px solid var(--border-color);
+    background: #fff;
+}
+.list-row:last-child { border-bottom: none; }
+.task-checkbox {
+    width: 18px;
+    height: 18px;
+    accent-color: var(--accent-color);
+    margin-right: 16px;
+    cursor: pointer;
+}
+.task-name {
+    flex: 1;
+    font-size: 0.95rem;
+    font-weight: 500;
+}
+.done-text {
+    text-decoration: line-through;
+    color: var(--text-secondary);
+}
+.task-tag {
+    font-size: 0.75rem;
+    font-weight: 600;
+    padding: 4px 10px;
+    border-radius: 100px;
+}
+.tag-high { background: #fee2e2; color: #991b1b; }
+.tag-med { background: #fef3c7; color: #b45309; }
+.tag-low { background: #e0f2fe; color: #0369a1; }
+
+
+/* --- Files Grid (Panel 3) --- */
+.files-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 20px;
+}
+.file-card {
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    transition: all 0.2s ease;
+    cursor: pointer;
+}
+.file-card:hover {
+    border-color: #cbd5e1;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.03);
+    transform: translateY(-2px);
+}
+.file-icon {
+    width: 48px;
+    height: 48px;
+    border-radius: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    font-size: 0.9rem;
+    color: #fff;
+    margin-bottom: 16px;
+}
+.bg-blue { background: #3b82f6; }
+.bg-purple { background: #a855f7; }
+.bg-green { background: #10b981; }
+.bg-red { background: #ef4444; }
+
+.file-name {
+    font-size: 0.9rem;
+    font-weight: 500;
+    margin-bottom: 4px;
+    word-break: break-all;
+}
+.file-size {
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+}
+
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    /* Disable the aggressive zoom/scale transition */
+    .tab-panel {
+        transition: opacity 0.2s ease, visibility 0.2s ease !important;
+        transform: scale(1) !important;
+    }
+    
+    .tab-indicator {
+        transition: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces the CSS Zoom-In Tabs designed for Minimalist Tech Layouts, resolving issue #64428. 

### Changes Made:
- Added `submissions/examples/minimalist-zoom-in-tabs/` directory.
- Created `demo.html` showcasing a mock project management dashboard. It utilizes the pure CSS radio button hack (`<input type="radio">` paired with `<label>` elements) to natively manage the active tab state without JavaScript. It includes heavily stylized mock data components (Kanban boards, task lists, and file grids) to serve as realistic panel content.
- Created `style.css` featuring a clean, structured aesthetic utilizing the `Inter` font and subtle borders.
  - Implemented the Zoom-In effect. By default, `.tab-panel` elements are hidden, and scaled down aggressively (`transform: scale(0.85)`). 
  - When a tab is activated, the corresponding panel transitions to full opacity and scales up to its native size (`transform: scale(1)`). We utilize a custom `cubic-bezier(0.25, 0.46, 0.45, 0.94)` transition curve to create a smooth, controlled expansion.
  - Added subtle illuminating scale animations to the `.tab-indicator` dots within the tab labels upon activation.
- Added `README.md` documenting usage and technical features.
- Honors the `prefers-reduced-motion` accessibility standard. The aggressive zooming/scaling transitions (on both the panels and the tab indicators) are completely disabled. The interactions safely fall back to an immediate opacity cross-fade for users sensitive to motion.

Closes #64428
