### PR TITLE
feat: add CSS Glitch-Flicker Carousel for Minimalist Tech Layouts (#64420)

### DIFF
--- a/submissions/examples/minimalist-glitch-flicker-carousel/README.md
+++ b/submissions/examples/minimalist-glitch-flicker-carousel/README.md
@@ -1,0 +1,22 @@
+# CSS Glitch-Flicker Carousel (Minimalist Tech)
+
+A pure CSS interactive carousel component designed for Minimalist Tech Layouts. It features a bold, cyberpunk-inspired "Glitch-Flicker" transition effect that triggers whenever a new slide is navigated to.
+
+## Features
+- Pure CSS and HTML (No JavaScript required for state management or animations).
+- **State Management**: The active slide is managed entirely via the hidden radio button hack (`input[type="radio"]:checked`).
+- **Dynamic Navigation**: Both the bottom indicator dots and the side arrows use `<label>` elements linked to the radio inputs. The side arrows utilize a complex CSS architecture (using the `~` sibling selector) to conditionally display the correct "Next" or "Previous" arrows depending on which slide is currently active.
+- **The Glitch-Flicker Transition**: 
+- We bypass standard smooth fading. Instead, `.carousel-slide` elements use `transition: opacity 0s step-end` to appear instantly.
+- When a slide becomes active, it triggers animations on two hidden `.glitch-layer` elements (Cyan and Magenta) that sit behind the main text but over the background.
+- These layers utilize intense `@keyframes` (`glitch-anim-cyan`, `glitch-anim-magenta`) with rapid, aggressive `clip-path: polygon()` slicing and translations to simulate digital tearing.
+- Simultaneously, the main `.slide-content` executes a `content-flicker` animation that slightly shifts the container left and right while applying rapid `filter: hue-rotate()` changes, completing the glitch illusion.
+- Clean, structured aesthetic utilizing the `Inter` font, subtle borders, and geometric CSS background patterns for the slide images.
+- Fully accessible with `prefers-reduced-motion` support. For motion-sensitive users, the aggressive clipping, tearing, and hue-shifting animations are completely disabled. The interactions safely fall back to a standard, immediate opacity cross-fade.
+
+## Usage
+Open `demo.html` in your browser. You will see a featured projects carousel. Click the navigation arrows on the sides or the indicator dots at the bottom. Watch as the newly activated slide violently flickers and tears into view using the pure CSS glitch effect before settling into sharp focus.
+
+## Files
+- `demo.html`: The HTML structure for the layout, detailing the complex `<input type="radio">` setup required to handle both direct dot navigation and relative arrow navigation without JavaScript.
+- `style.css`: The styling, radio-state logic, and the complex `clip-path` `@keyframes` driving the cyberpunk glitch mechanics.

--- a/submissions/examples/minimalist-glitch-flicker-carousel/demo.html
+++ b/submissions/examples/minimalist-glitch-flicker-carousel/demo.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Glitch-Flicker Carousel - Minimalist Tech</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Featured Projects</h1>
+            <p class="subtitle">Navigate the carousel to experience the cyberpunk glitch-flicker transition effect.</p>
+        </header>
+
+        <div class="dashboard-area">
+            
+            <!-- Pure CSS Carousel Structure -->
+            <div class="carousel-container">
+                
+                <!-- Radio Inputs for State Management -->
+                <input type="radio" id="slide-1" name="carousel-nav" class="slide-input" checked>
+                <input type="radio" id="slide-2" name="carousel-nav" class="slide-input">
+                <input type="radio" id="slide-3" name="carousel-nav" class="slide-input">
+                
+                <!-- The Slides Wrapper -->
+                <div class="slides-wrapper">
+                    
+                    <!-- Slide 1 -->
+                    <div class="carousel-slide" id="content-1">
+                        <!-- Glitch Layers -->
+                        <div class="glitch-layer layer-cyan"></div>
+                        <div class="glitch-layer layer-magenta"></div>
+                        
+                        <!-- Slide Content -->
+                        <div class="slide-content">
+                            <div class="slide-image pattern-1"></div>
+                            <div class="slide-text">
+                                <span class="tag tag-blue">Infrastructure</span>
+                                <h2>Distributed Key-Value Store</h2>
+                                <p>A high-performance, in-memory datastore designed for sub-millisecond latency across multi-region deployments.</p>
+                                <button class="btn btn-outline mt-4">View Case Study</button>
+                            </div>
+                        </div>
+                    </div>
+                    
+                    <!-- Slide 2 -->
+                    <div class="carousel-slide" id="content-2">
+                        <!-- Glitch Layers -->
+                        <div class="glitch-layer layer-cyan"></div>
+                        <div class="glitch-layer layer-magenta"></div>
+                        
+                        <!-- Slide Content -->
+                        <div class="slide-content">
+                            <div class="slide-image pattern-2"></div>
+                            <div class="slide-text">
+                                <span class="tag tag-green">Machine Learning</span>
+                                <h2>Predictive Analysis Engine</h2>
+                                <p>Real-time anomaly detection utilizing deep neural networks to automatically identify and isolate network intrusions.</p>
+                                <button class="btn btn-outline mt-4">View Case Study</button>
+                            </div>
+                        </div>
+                    </div>
+                    
+                    <!-- Slide 3 -->
+                    <div class="carousel-slide" id="content-3">
+                        <!-- Glitch Layers -->
+                        <div class="glitch-layer layer-cyan"></div>
+                        <div class="glitch-layer layer-magenta"></div>
+                        
+                        <!-- Slide Content -->
+                        <div class="slide-content">
+                            <div class="slide-image pattern-3"></div>
+                            <div class="slide-text">
+                                <span class="tag tag-purple">Design System</span>
+                                <h2>Neo-Brutalism UI Kit</h2>
+                                <p>A highly opinionated, raw CSS framework prioritizing stark contrasts, heavy borders, and aggressive typography.</p>
+                                <button class="btn btn-outline mt-4">View Case Study</button>
+                            </div>
+                        </div>
+                    </div>
+                    
+                </div>
+                
+                <!-- Navigation Controls (Arrows) -->
+                <div class="nav-arrows">
+                    <!-- Left Arrow controls -->
+                    <label for="slide-3" class="arrow left-arrow slide-1-active">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"></polyline></svg>
+                    </label>
+                    <label for="slide-1" class="arrow left-arrow slide-2-active">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"></polyline></svg>
+                    </label>
+                    <label for="slide-2" class="arrow left-arrow slide-3-active">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"></polyline></svg>
+                    </label>
+                    
+                    <!-- Right Arrow controls -->
+                    <label for="slide-2" class="arrow right-arrow slide-1-active">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"></polyline></svg>
+                    </label>
+                    <label for="slide-3" class="arrow right-arrow slide-2-active">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"></polyline></svg>
+                    </label>
+                    <label for="slide-1" class="arrow right-arrow slide-3-active">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"></polyline></svg>
+                    </label>
+                </div>
+                
+                <!-- Navigation Dots -->
+                <div class="nav-dots">
+                    <label for="slide-1" class="dot" id="dot-1"></label>
+                    <label for="slide-2" class="dot" id="dot-2"></label>
+                    <label for="slide-3" class="dot" id="dot-3"></label>
+                </div>
+                
+            </div>
+
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/minimalist-glitch-flicker-carousel/style.css
+++ b/submissions/examples/minimalist-glitch-flicker-carousel/style.css
@@ -1,0 +1,374 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+:root {
+    --bg-color: #fafafa;
+    --card-bg: #ffffff;
+    --text-primary: #171717;
+    --text-secondary: #737373;
+    --border-color: #e5e5e5;
+    
+    /* Glitch Colors */
+    --glitch-cyan: rgba(34, 211, 238, 0.9);
+    --glitch-magenta: rgba(236, 72, 153, 0.9);
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    font-family: 'Inter', system-ui, -apple-system, sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 60px 20px;
+    box-sizing: border-box;
+}
+
+.layout-container {
+    max-width: 800px;
+    width: 100%;
+}
+
+.section-header {
+    margin-bottom: 40px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2rem;
+    font-weight: 700;
+    margin: 0 0 8px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.05rem;
+    margin: 0;
+    font-weight: 400;
+}
+
+
+/* =========================================
+   Carousel Mechanics & State
+   ========================================= */
+
+.dashboard-area {
+    /* Main wrapper */
+}
+
+.carousel-container {
+    position: relative;
+    width: 100%;
+    margin: 0 auto;
+}
+
+/* Hide the radio inputs */
+.slide-input {
+    display: none;
+}
+
+.slides-wrapper {
+    position: relative;
+    width: 100%;
+    height: 380px; /* Fixed height for the carousel */
+    border-radius: 16px;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    box-shadow: 0 10px 30px rgba(0,0,0,0.05);
+    /* Contain the glitch layers */
+    overflow: hidden; 
+}
+
+
+/* --- The Glitch-Flicker Transition --- */
+
+.carousel-slide {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    
+    /* Default Hidden State */
+    opacity: 0;
+    visibility: hidden;
+    z-index: 1;
+    
+    /* 
+      We use a step-end transition so the opacity changes instantly
+      once the delay is over, rather than fading softly. 
+      This is key for the raw, glitchy feel.
+    */
+    transition: opacity 0s step-end 0.4s, visibility 0s step-end 0.4s;
+}
+
+/* Show the active slide */
+#slide-1:checked ~ .slides-wrapper #content-1,
+#slide-2:checked ~ .slides-wrapper #content-2,
+#slide-3:checked ~ .slides-wrapper #content-3 {
+    opacity: 1;
+    visibility: visible;
+    z-index: 10;
+    /* Instant visible on check */
+    transition: opacity 0s step-end 0s, visibility 0s step-end 0s;
+}
+
+/* 
+  Trigger the Glitch Animation.
+  When a slide BECOMES active, we animate its glitch layers.
+*/
+#slide-1:checked ~ .slides-wrapper #content-1 .layer-cyan,
+#slide-2:checked ~ .slides-wrapper #content-2 .layer-cyan,
+#slide-3:checked ~ .slides-wrapper #content-3 .layer-cyan {
+    animation: glitch-anim-cyan 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
+}
+
+#slide-1:checked ~ .slides-wrapper #content-1 .layer-magenta,
+#slide-2:checked ~ .slides-wrapper #content-2 .layer-magenta,
+#slide-3:checked ~ .slides-wrapper #content-3 .layer-magenta {
+    animation: glitch-anim-magenta 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards reverse;
+}
+
+/* Flicker the main content slightly during the transition */
+#slide-1:checked ~ .slides-wrapper #content-1 .slide-content,
+#slide-2:checked ~ .slides-wrapper #content-2 .slide-content,
+#slide-3:checked ~ .slides-wrapper #content-3 .slide-content {
+    animation: content-flicker 0.4s forwards;
+}
+
+
+/* --- The Glitch Layers --- */
+.glitch-layer {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: var(--card-bg);
+    opacity: 0; /* Hidden by default */
+    z-index: 2; /* Sits above the background, below the content text */
+    pointer-events: none;
+}
+
+.layer-cyan { box-shadow: inset 0 0 0 4px var(--glitch-cyan); }
+.layer-magenta { box-shadow: inset 0 0 0 4px var(--glitch-magenta); }
+
+/* Glitch Keyframes utilizing severe clip-path tearing */
+@keyframes glitch-anim-cyan {
+    0% { opacity: 1; clip-path: polygon(0 5%, 100% 5%, 100% 10%, 0 10%); transform: translate(-10px, 5px); }
+    15% { clip-path: polygon(0 20%, 100% 20%, 100% 25%, 0 25%); transform: translate(10px, -5px); }
+    30% { clip-path: polygon(0 50%, 100% 50%, 100% 60%, 0 60%); transform: translate(-15px, 10px); }
+    45% { clip-path: polygon(0 15%, 100% 15%, 100% 20%, 0 20%); transform: translate(15px, -10px); }
+    60% { clip-path: polygon(0 80%, 100% 80%, 100% 90%, 0 90%); transform: translate(-5px, 5px); }
+    75% { clip-path: polygon(0 30%, 100% 30%, 100% 40%, 0 40%); transform: translate(10px, -5px); }
+    100% { opacity: 0; clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%); transform: translate(0); }
+}
+
+@keyframes glitch-anim-magenta {
+    0% { opacity: 1; clip-path: polygon(0 10%, 100% 10%, 100% 15%, 0 15%); transform: translate(10px, -5px); }
+    15% { clip-path: polygon(0 40%, 100% 40%, 100% 50%, 0 50%); transform: translate(-10px, 5px); }
+    30% { clip-path: polygon(0 25%, 100% 25%, 100% 30%, 0 30%); transform: translate(15px, -10px); }
+    45% { clip-path: polygon(0 70%, 100% 70%, 100% 80%, 0 80%); transform: translate(-15px, 10px); }
+    60% { clip-path: polygon(0 5%, 100% 5%, 100% 15%, 0 15%); transform: translate(5px, -5px); }
+    75% { clip-path: polygon(0 60%, 100% 60%, 100% 70%, 0 70%); transform: translate(-10px, 5px); }
+    100% { opacity: 0; clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%); transform: translate(0); }
+}
+
+@keyframes content-flicker {
+    0% { opacity: 0; transform: translateX(-5px); }
+    20% { opacity: 0.5; transform: translateX(5px); filter: hue-rotate(90deg); }
+    40% { opacity: 0; transform: translateX(-2px); }
+    60% { opacity: 0.8; transform: translateX(2px); filter: hue-rotate(-90deg); }
+    80% { opacity: 0.2; transform: translateX(-1px); }
+    100% { opacity: 1; transform: translateX(0); filter: hue-rotate(0deg); }
+}
+
+
+/* =========================================
+   Slide Content Styling
+   ========================================= */
+
+.slide-content {
+    display: flex;
+    height: 100%;
+    position: relative;
+    z-index: 3; /* Sit above the glitch layers */
+    background: var(--card-bg); /* Prevents layers bleeding through the text */
+}
+
+.slide-image {
+    width: 40%;
+    height: 100%;
+    background-color: #f1f5f9;
+    border-right: 1px solid var(--border-color);
+}
+.pattern-1 { background-image: radial-gradient(#cbd5e1 1.5px, transparent 1.5px); background-size: 20px 20px; }
+.pattern-2 { background-image: linear-gradient(45deg, #e2e8f0 25%, transparent 25%, transparent 75%, #e2e8f0 75%, #e2e8f0), linear-gradient(45deg, #e2e8f0 25%, transparent 25%, transparent 75%, #e2e8f0 75%, #e2e8f0); background-size: 20px 20px; background-position: 0 0, 10px 10px; }
+.pattern-3 { background-image: repeating-linear-gradient(45deg, #e2e8f0 25%, transparent 25%, transparent 75%, #e2e8f0 75%, #e2e8f0), repeating-linear-gradient(45deg, #e2e8f0 25%, #f1f5f9 25%, #f1f5f9 75%, #e2e8f0 75%, #e2e8f0); background-position: 0 0, 10px 10px; background-size: 20px 20px; }
+
+.slide-text {
+    width: 60%;
+    padding: 40px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+
+.slide-text h2 {
+    font-size: 1.8rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+    line-height: 1.2;
+}
+
+.slide-text p {
+    font-size: 1rem;
+    color: var(--text-secondary);
+    line-height: 1.6;
+    margin: 0;
+}
+
+.tag {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    padding: 4px 10px;
+    border-radius: 100px;
+    width: max-content;
+    margin-bottom: 16px;
+}
+.tag-blue { background: #eff6ff; color: #2563eb; }
+.tag-green { background: #f0fdf4; color: #16a34a; }
+.tag-purple { background: #faf5ff; color: #9333ea; }
+
+.btn {
+    padding: 10px 20px;
+    border-radius: 6px;
+    font-size: 0.95rem;
+    font-weight: 500;
+    cursor: pointer;
+    font-family: inherit;
+    border: 1px solid transparent;
+    transition: all 0.2s ease;
+    width: max-content;
+}
+.mt-4 { margin-top: 24px; }
+.btn-outline {
+    background: transparent;
+    border-color: var(--border-color);
+    color: var(--text-primary);
+}
+.btn-outline:hover { background: #f8fafc; }
+
+
+/* =========================================
+   Navigation Controls (Arrows & Dots)
+   ========================================= */
+
+/* --- Arrows --- */
+.nav-arrows {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    pointer-events: none; /* Let clicks pass through the container */
+    z-index: 20;
+}
+
+.arrow {
+    width: 48px;
+    height: 48px;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.05);
+    color: var(--text-secondary);
+    transition: all 0.2s ease;
+    pointer-events: auto; /* Re-enable clicks on the arrows */
+    /* Hide all arrows by default */
+    display: none;
+}
+.arrow:hover {
+    color: var(--text-primary);
+    background: #f8fafc;
+    transform: scale(1.05);
+}
+.left-arrow { margin-left: -24px; }
+.right-arrow { margin-right: -24px; }
+
+/* Show the correct arrows based on which slide is active */
+#slide-1:checked ~ .nav-arrows .slide-1-active { display: flex; }
+#slide-2:checked ~ .nav-arrows .slide-2-active { display: flex; }
+#slide-3:checked ~ .nav-arrows .slide-3-active { display: flex; }
+
+
+/* --- Dots --- */
+.nav-dots {
+    display: flex;
+    justify-content: center;
+    gap: 12px;
+    margin-top: 24px;
+}
+
+.dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: #cbd5e1;
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+/* Color the active dot */
+#slide-1:checked ~ .nav-dots #dot-1,
+#slide-2:checked ~ .nav-dots #dot-2,
+#slide-3:checked ~ .nav-dots #dot-3 {
+    background: var(--text-primary);
+    transform: scale(1.2);
+}
+
+
+/* Responsive */
+@media (max-width: 768px) {
+    .slides-wrapper { height: 500px; }
+    .slide-content { flex-direction: column; }
+    .slide-image { width: 100%; height: 40%; border-right: none; border-bottom: 1px solid var(--border-color); }
+    .slide-text { width: 100%; height: 60%; padding: 24px; }
+    .left-arrow { margin-left: 12px; }
+    .right-arrow { margin-right: 12px; }
+}
+
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    /* Completely disable the aggressive glitch flickering */
+    #slide-1:checked ~ .slides-wrapper #content-1 .layer-cyan,
+    #slide-2:checked ~ .slides-wrapper #content-2 .layer-cyan,
+    #slide-3:checked ~ .slides-wrapper #content-3 .layer-cyan,
+    #slide-1:checked ~ .slides-wrapper #content-1 .layer-magenta,
+    #slide-2:checked ~ .slides-wrapper #content-2 .layer-magenta,
+    #slide-3:checked ~ .slides-wrapper #content-3 .layer-magenta {
+        animation: none !important;
+    }
+    
+    #slide-1:checked ~ .slides-wrapper #content-1 .slide-content,
+    #slide-2:checked ~ .slides-wrapper #content-2 .slide-content,
+    #slide-3:checked ~ .slides-wrapper #content-3 .slide-content {
+        animation: none !important;
+    }
+    
+    /* Fall back to a standard, immediate opacity cross-fade */
+    .carousel-slide {
+        transition: opacity 0.3s ease, visibility 0.3s ease !important;
+    }
+}


### PR DESCRIPTION

### Description
This PR introduces the CSS Glitch-Flicker Carousel designed for Minimalist Tech Layouts, resolving issue #64420. 

### Changes Made:
- Added `submissions/examples/minimalist-glitch-flicker-carousel/` directory.
- Created `demo.html` showcasing a featured projects carousel. It utilizes the pure CSS radio button hack (`<input type="radio">` paired with `<label>` elements) to natively manage the active slide without JavaScript. It includes complex sibling selector logic (`~`) to conditionally render the correct "Next" and "Previous" arrows depending on which slide is currently active.
- Created `style.css` featuring a clean, structured aesthetic utilizing the `Inter` font, subtle borders, and geometric CSS background patterns.
  - Implemented the Glitch-Flicker transition. We bypass standard smooth fading and use `transition: opacity 0s step-end` to make slides appear instantly.
  - When a slide becomes active, it triggers animations on two hidden `.glitch-layer` elements (Cyan and Magenta). These layers utilize intense `@keyframes` with rapid `clip-path: polygon()` slicing to simulate digital tearing.
  - Simultaneously, a `content-flicker` animation applies rapid `filter: hue-rotate()` changes and spatial translations to the main content container, completing the raw cyberpunk feel.
- Added `README.md` documenting usage and technical features.
- Honors the `prefers-reduced-motion` accessibility standard. The aggressive clipping, tearing, and hue-shifting animations are completely disabled. The interactions safely fall back to a standard, immediate opacity cross-fade for users sensitive to motion.

Closes #64420
