### PR TITLE
feat: add CSS Blur-Entrance Carousel for Minimalist Tech Layouts (#64416)

### DIFF
--- a/submissions/examples/minimalist-blur-entrance-carousel/README.md
+++ b/submissions/examples/minimalist-blur-entrance-carousel/README.md
@@ -1,0 +1,23 @@
+# CSS Blur-Entrance Carousel (Minimalist Tech)
+
+A pure CSS interactive carousel component designed for Minimalist Tech Layouts. It features a highly cinematic, sequential "Blur-Entrance" animation that executes on individual slide elements every time a new slide is navigated to.
+
+## Features
+- Pure CSS and HTML (No JavaScript required for state management, navigation, or animations).
+- **State Management**: The active slide is managed entirely via the hidden radio button hack (`input[type="radio"]:checked`).
+- **Dynamic Navigation**: Both the bottom indicator dots and the side arrows use `<label>` elements linked to the radio inputs. The side arrows utilize a complex CSS architecture (using the `~` sibling selector) to conditionally display the correct "Next" or "Previous" arrows depending on which slide is currently active, allowing infinite looping without JS.
+- **The Blur-Entrance Effect**: 
+- Individual elements within each slide (the image, the quote, the text, the buttons) are tagged with the `.anim-target` class.
+- By default, these targets are set to `opacity: 0`, heavily blurred (`filter: blur(10px)`), and scaled up/translated downwards.
+- When a slide becomes active (its radio is checked), the parent triggers an `@keyframes` animation (`cinematic-blur-in`) on all its child `.anim-target` elements. 
+- We utilize utility classes (`.stagger-1`, `.stagger-2`, etc.) applying sequential `animation-delay`s to cascade the elements into view one by one. 
+- The custom `cubic-bezier(0.19, 1, 0.22, 1)` transition timing function creates a highly cinematic, dramatic easing that starts fast and settles slowly into sharp focus.
+- Clean, structured aesthetic utilizing the `Inter` font, subtle borders, and distinct content areas (images vs typography).
+- Fully accessible with `prefers-reduced-motion` support. For motion-sensitive users, the aggressive spatial scaling, translation, and blurring are completely stripped from the entrance animation. The interaction safely falls back to a simple, staggered opacity cross-fade.
+
+## Usage
+Open `demo.html` in your browser. You will see a customer stories carousel. Click the navigation arrows on the sides or the indicator dots at the bottom. Watch as the newly activated slide triggers a cinematic, cascading blur-entrance animation, bringing each element of the slide into sharp focus sequentially.
+
+## Files
+- `demo.html`: The HTML structure for the layout, detailing the complex `<input type="radio">` setup required to handle both direct dot navigation and relative arrow navigation without JavaScript, as well as the `.stagger-*` utility classes.
+- `style.css`: The styling, radio-state logic, and the complex `@keyframes` driving the cinematic blur mechanics.

--- a/submissions/examples/minimalist-blur-entrance-carousel/demo.html
+++ b/submissions/examples/minimalist-blur-entrance-carousel/demo.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Blur-Entrance Carousel - Minimalist Tech</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Customer Stories</h1>
+            <p class="subtitle">Navigate the carousel to see the cinematic blur-entrance transition.</p>
+        </header>
+
+        <div class="dashboard-area">
+            
+            <!-- Pure CSS Carousel Structure -->
+            <div class="carousel-container">
+                
+                <!-- Radio Inputs for State Management -->
+                <input type="radio" id="slide-1" name="carousel-nav" class="slide-input" checked>
+                <input type="radio" id="slide-2" name="carousel-nav" class="slide-input">
+                <input type="radio" id="slide-3" name="carousel-nav" class="slide-input">
+                
+                <!-- The Slides Wrapper -->
+                <div class="slides-wrapper">
+                    
+                    <!-- Slide 1 -->
+                    <div class="carousel-slide" id="content-1">
+                        <div class="slide-content">
+                            <!-- Image gets the blur animation via CSS class targeting -->
+                            <div class="slide-image bg-blue anim-target"></div>
+                            
+                            <div class="slide-text">
+                                <div class="quote-mark anim-target stagger-1">"</div>
+                                <h2 class="anim-target stagger-2">We reduced our deployment times by over 400% using this platform.</h2>
+                                <div class="author-info anim-target stagger-3">
+                                    <strong>Sarah Jenkins</strong>
+                                    <span>CTO, TechCorp Industries</span>
+                                </div>
+                                <button class="btn btn-outline anim-target stagger-4 mt-4">Read Full Story</button>
+                            </div>
+                        </div>
+                    </div>
+                    
+                    <!-- Slide 2 -->
+                    <div class="carousel-slide" id="content-2">
+                        <div class="slide-content">
+                            <div class="slide-image bg-emerald anim-target"></div>
+                            
+                            <div class="slide-text">
+                                <div class="quote-mark anim-target stagger-1">"</div>
+                                <h2 class="anim-target stagger-2">The analytics dashboard provided insights we didn't even know we were missing.</h2>
+                                <div class="author-info anim-target stagger-3">
+                                    <strong>David Chen</strong>
+                                    <span>Head of Product, DataFlow</span>
+                                </div>
+                                <button class="btn btn-outline anim-target stagger-4 mt-4">Read Full Story</button>
+                            </div>
+                        </div>
+                    </div>
+                    
+                    <!-- Slide 3 -->
+                    <div class="carousel-slide" id="content-3">
+                        <div class="slide-content">
+                            <div class="slide-image bg-violet anim-target"></div>
+                            
+                            <div class="slide-text">
+                                <div class="quote-mark anim-target stagger-1">"</div>
+                                <h2 class="anim-target stagger-2">Customer retention skyrocketed after we integrated the new notification system.</h2>
+                                <div class="author-info anim-target stagger-3">
+                                    <strong>Aisha Patel</strong>
+                                    <span>VP of Marketing, GrowthStack</span>
+                                </div>
+                                <button class="btn btn-outline anim-target stagger-4 mt-4">Read Full Story</button>
+                            </div>
+                        </div>
+                    </div>
+                    
+                </div>
+                
+                <!-- Navigation Controls (Arrows) -->
+                <div class="nav-arrows">
+                    <!-- Left Arrow controls -->
+                    <label for="slide-3" class="arrow left-arrow slide-1-active">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"></polyline></svg>
+                    </label>
+                    <label for="slide-1" class="arrow left-arrow slide-2-active">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"></polyline></svg>
+                    </label>
+                    <label for="slide-2" class="arrow left-arrow slide-3-active">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"></polyline></svg>
+                    </label>
+                    
+                    <!-- Right Arrow controls -->
+                    <label for="slide-2" class="arrow right-arrow slide-1-active">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"></polyline></svg>
+                    </label>
+                    <label for="slide-3" class="arrow right-arrow slide-2-active">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"></polyline></svg>
+                    </label>
+                    <label for="slide-1" class="arrow right-arrow slide-3-active">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"></polyline></svg>
+                    </label>
+                </div>
+                
+                <!-- Navigation Dots -->
+                <div class="nav-dots">
+                    <label for="slide-1" class="dot" id="dot-1"></label>
+                    <label for="slide-2" class="dot" id="dot-2"></label>
+                    <label for="slide-3" class="dot" id="dot-3"></label>
+                </div>
+                
+            </div>
+
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/minimalist-blur-entrance-carousel/style.css
+++ b/submissions/examples/minimalist-blur-entrance-carousel/style.css
@@ -1,0 +1,341 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+:root {
+    --bg-color: #fafafa;
+    --card-bg: #ffffff;
+    --text-primary: #171717;
+    --text-secondary: #737373;
+    --border-color: #e5e5e5;
+    
+    --accent-color: #3b82f6;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    font-family: 'Inter', system-ui, -apple-system, sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 60px 20px;
+    box-sizing: border-box;
+}
+
+.layout-container {
+    max-width: 900px;
+    width: 100%;
+}
+
+.section-header {
+    margin-bottom: 40px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2rem;
+    font-weight: 700;
+    margin: 0 0 8px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.05rem;
+    margin: 0;
+    font-weight: 400;
+}
+
+
+/* =========================================
+   Carousel Mechanics & State
+   ========================================= */
+
+.dashboard-area {
+    /* Main wrapper */
+}
+
+.carousel-container {
+    position: relative;
+    width: 100%;
+    margin: 0 auto;
+}
+
+/* Hide the radio inputs */
+.slide-input {
+    display: none;
+}
+
+.slides-wrapper {
+    position: relative;
+    width: 100%;
+    height: 400px; /* Fixed height for the carousel */
+    border-radius: 16px;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    box-shadow: 0 10px 30px rgba(0,0,0,0.05);
+    overflow: hidden; 
+}
+
+
+/* --- The Blur-Entrance Transition --- */
+
+.carousel-slide {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    
+    /* Default Hidden State for the Slide Container */
+    opacity: 0;
+    visibility: hidden;
+    z-index: 1;
+    
+    /* Fade the container in normally */
+    transition: opacity 0.3s ease, visibility 0.3s ease;
+}
+
+/* Show the active slide container */
+#slide-1:checked ~ .slides-wrapper #content-1,
+#slide-2:checked ~ .slides-wrapper #content-2,
+#slide-3:checked ~ .slides-wrapper #content-3 {
+    opacity: 1;
+    visibility: visible;
+    z-index: 10;
+}
+
+
+/* 
+  The Cinematic Blur Animation on Target Elements.
+  We set up the initial state for the children when they are NOT active.
+*/
+.anim-target {
+    opacity: 0;
+    filter: blur(10px);
+    transform: scale(1.05) translateY(10px);
+    /* No transition here, we use keyframes when activated to ensure it replays */
+}
+
+/* Stagger Delays for children to create a cascade */
+.stagger-1 { animation-delay: 0.1s; }
+.stagger-2 { animation-delay: 0.2s; }
+.stagger-3 { animation-delay: 0.3s; }
+.stagger-4 { animation-delay: 0.4s; }
+
+/* 
+  When the parent slide becomes active, trigger the keyframes on the children.
+*/
+#slide-1:checked ~ .slides-wrapper #content-1 .anim-target,
+#slide-2:checked ~ .slides-wrapper #content-2 .anim-target,
+#slide-3:checked ~ .slides-wrapper #content-3 .anim-target {
+    animation: cinematic-blur-in 0.8s cubic-bezier(0.19, 1, 0.22, 1) forwards;
+}
+
+/* Override the delay for the image so it comes in first/fastest */
+#slide-1:checked ~ .slides-wrapper #content-1 .slide-image,
+#slide-2:checked ~ .slides-wrapper #content-2 .slide-image,
+#slide-3:checked ~ .slides-wrapper #content-3 .slide-image {
+    animation-delay: 0s;
+    animation-duration: 1.2s;
+}
+
+/* The Keyframes */
+@keyframes cinematic-blur-in {
+    0% {
+        opacity: 0;
+        filter: blur(15px);
+        transform: scale(1.05) translateY(20px);
+    }
+    100% {
+        opacity: 1;
+        filter: blur(0px);
+        transform: scale(1) translateY(0);
+    }
+}
+
+
+/* =========================================
+   Slide Content Styling
+   ========================================= */
+
+.slide-content {
+    display: flex;
+    height: 100%;
+}
+
+.slide-image {
+    width: 45%;
+    height: 100%;
+}
+.bg-blue { background: linear-gradient(135deg, #3b82f6, #1d4ed8); }
+.bg-emerald { background: linear-gradient(135deg, #10b981, #047857); }
+.bg-violet { background: linear-gradient(135deg, #8b5cf6, #5b21b6); }
+
+.slide-text {
+    width: 55%;
+    padding: 50px 40px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    position: relative;
+}
+
+.quote-mark {
+    font-family: serif;
+    font-size: 6rem;
+    color: var(--border-color);
+    position: absolute;
+    top: 20px;
+    left: 20px;
+    line-height: 1;
+    z-index: -1;
+}
+
+.slide-text h2 {
+    font-size: 1.6rem;
+    font-weight: 500;
+    margin: 0 0 32px 0;
+    line-height: 1.4;
+    color: var(--text-primary);
+}
+
+.author-info {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 24px;
+}
+.author-info strong {
+    font-size: 1.05rem;
+    font-weight: 600;
+}
+.author-info span {
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+}
+
+.btn {
+    padding: 10px 24px;
+    border-radius: 6px;
+    font-size: 0.95rem;
+    font-weight: 500;
+    cursor: pointer;
+    font-family: inherit;
+    border: 1px solid transparent;
+    transition: all 0.2s ease;
+    width: max-content;
+}
+.mt-4 { margin-top: 16px; }
+.btn-outline {
+    background: transparent;
+    border-color: var(--border-color);
+    color: var(--text-primary);
+}
+.btn-outline:hover { background: #f1f5f9; }
+
+
+/* =========================================
+   Navigation Controls (Arrows & Dots)
+   ========================================= */
+
+/* --- Arrows --- */
+.nav-arrows {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    pointer-events: none; /* Let clicks pass through the container */
+    z-index: 20;
+}
+
+.arrow {
+    width: 48px;
+    height: 48px;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.05);
+    color: var(--text-secondary);
+    transition: all 0.2s ease;
+    pointer-events: auto; /* Re-enable clicks on the arrows */
+    /* Hide all arrows by default */
+    display: none;
+}
+.arrow:hover {
+    color: var(--text-primary);
+    background: #f8fafc;
+    transform: scale(1.05);
+}
+.left-arrow { margin-left: -24px; }
+.right-arrow { margin-right: -24px; }
+
+/* Show the correct arrows based on which slide is active */
+#slide-1:checked ~ .nav-arrows .slide-1-active { display: flex; }
+#slide-2:checked ~ .nav-arrows .slide-2-active { display: flex; }
+#slide-3:checked ~ .nav-arrows .slide-3-active { display: flex; }
+
+
+/* --- Dots --- */
+.nav-dots {
+    display: flex;
+    justify-content: center;
+    gap: 12px;
+    margin-top: 24px;
+}
+
+.dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: #cbd5e1;
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+/* Color the active dot */
+#slide-1:checked ~ .nav-dots #dot-1,
+#slide-2:checked ~ .nav-dots #dot-2,
+#slide-3:checked ~ .nav-dots #dot-3 {
+    background: var(--text-primary);
+    transform: scale(1.2);
+}
+
+
+/* Responsive */
+@media (max-width: 768px) {
+    .slides-wrapper { height: 550px; }
+    .slide-content { flex-direction: column; }
+    .slide-image { width: 100%; height: 35%; }
+    .slide-text { width: 100%; height: 65%; padding: 32px 24px; }
+    .slide-text h2 { font-size: 1.3rem; margin-bottom: 24px; }
+    .quote-mark { top: 10px; left: 10px; font-size: 4rem; }
+    .left-arrow { margin-left: 12px; }
+    .right-arrow { margin-right: 12px; }
+}
+
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    /* 
+      Disable the blur, scaling, and spatial translation.
+      Fallback to a simple immediate opacity cross-fade.
+    */
+    .anim-target {
+        animation: simple-fade 0.4s ease-out forwards !important;
+        filter: blur(0) !important;
+        transform: none !important;
+    }
+    
+    @keyframes simple-fade {
+        from { opacity: 0; }
+        to { opacity: 1; }
+    }
+}


### PR DESCRIPTION

### Description
This PR introduces the CSS Blur-Entrance Carousel designed for Minimalist Tech Layouts, resolving issue #64416. 

### Changes Made:
- Added `submissions/examples/minimalist-blur-entrance-carousel/` directory.
- Created `demo.html` showcasing a customer stories carousel. It utilizes the pure CSS radio button hack (`<input type="radio">` paired with `<label>` elements) to natively manage the active slide without JavaScript. It includes complex sibling selector logic (`~`) to conditionally render the correct "Next" and "Previous" arrows depending on which slide is currently active.
- Created `style.css` featuring a clean, structured aesthetic utilizing the `Inter` font, subtle borders, and distinct content areas.
  - Implemented the Blur-Entrance transition. Individual elements within each slide (the image, the quote, the text, the buttons) are targeted via `.anim-target` and `.stagger-*` utility classes. 
  - By default, these targets are set to `opacity: 0`, heavily blurred, and scaled up. When a slide becomes active, the parent triggers an `@keyframes` animation (`cinematic-blur-in`) on all its children. 
  - The sequential `animation-delay`s cascade the elements into view one by one. The custom `cubic-bezier(0.19, 1, 0.22, 1)` transition timing function creates a highly cinematic, dramatic easing that starts fast and settles slowly into sharp focus.
- Added `README.md` documenting usage and technical features.
- Honors the `prefers-reduced-motion` accessibility standard. The aggressive spatial scaling, translation, and blurring are completely stripped from the entrance animation. The interaction safely falls back to a staggered opacity cross-fade for users sensitive to motion.

Closes #64416
