### PR TITLE
Add ease-radio-tuner-dial component

### DIFF
--- a/submissions/examples/radio-tuner-dial-ij/README.md
+++ b/submissions/examples/radio-tuner-dial-ij/README.md
@@ -1,0 +1,10 @@
+# ease-radio-tuner-dial
+
+A table radio where the tuner needle glides across the frequency scale, the dial lights blink in turn, and the band tag ticks.
+
+## Run
+Open `demo.html` directly in a browser to watch the needle glide.
+
+## Notes
+- The tuner needle glides across the scale.
+- The band tag ticks beneath.

--- a/submissions/examples/radio-tuner-dial-ij/demo.html
+++ b/submissions/examples/radio-tuner-dial-ij/demo.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-radio-tuner-dial demo</title>
+</head>
+<body>
+<div class="rtd-app">
+  <span class="rtd-title">TABLE RADIO</span>
+  <div class="rtd-speaker"></div>
+  <div class="rtd-dial"><div class="rtd-needle"></div><span class="rtd-band">FM</span></div>
+  <div class="rtd-knob"></div>
+  <div class="rtd-lights"><span class="rtd-lite"></span><span class="rtd-lite"></span><span class="rtd-lite"></span></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/radio-tuner-dial-ij/style.css
+++ b/submissions/examples/radio-tuner-dial-ij/style.css
@@ -1,0 +1,16 @@
+:root{--rtd-orange:#ff8a3c;--rtd-dark:#241a10}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#241a10,#0f0a05);font-family:'Mistral',cursive}
+.rtd-app{position:relative;width:376px;height:376px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#3a2a16,#1a1208);box-shadow:0 16px 36px rgba(0,0,0,0.6)}
+.rtd-title{position:absolute;top:14px;left:0;right:0;text-align:center;font-size:11px;font-weight:700;letter-spacing:7px;color:#ff8a3c}
+.rtd-speaker{position:absolute;top:60px;left:30px;width:120px;height:90px;border-radius:14px;background:repeating-radial-gradient(circle at 30% 40%,#4a341c 0 4px,#241a10 4px 9px);box-shadow:inset 0 0 0 4px #4a341c}
+.rtd-dial{position:absolute;top:60px;right:30px;width:170px;height:64px;border-radius:10px;background:#1a1208;box-shadow:inset 0 0 0 3px #4a341c;overflow:hidden}
+.rtd-needle{position:absolute;top:14px;left:16px;width:2px;height:36px;background:#ff8a3c;box-shadow:0 0 8px rgba(255,138,60,0.8);animation:needle-glide-radio-tuner-dial 3s ease-in-out infinite}
+.rtd-band{position:absolute;top:6px;left:0;right:0;text-align:center;font-size:9px;letter-spacing:3px;color:#ff8a3c;animation:band-tick-radio-tuner-dial 1.6s steps(1) infinite}
+.rtd-knob{position:absolute;top:176px;left:50%;margin-left:-16px;width:32px;height:32px;border-radius:50%;background:#3a2a16;box-shadow:inset 0 0 0 3px #ff8a3c}
+.rtd-lights{position:absolute;bottom:20px;left:0;right:0;display:flex;justify-content:center;gap:12px}
+.rtd-lite{width:10px;height:10px;border-radius:50%;background:#ff8a3c;box-shadow:0 0 10px rgba(255,138,60,0.7);animation:dial-blink-radio-tuner-dial 1.4s steps(1) infinite}
+.rtd-lite:nth-of-type(2){animation-delay:0.4s}
+.rtd-lite:nth-of-type(3){animation-delay:0.8s}
+@keyframes needle-glide-radio-tuner-dial{0%{left:16px}50%{left:140px}100%{left:16px}}
+@keyframes dial-blink-radio-tuner-dial{0%,49%{opacity:1}50%,100%{opacity:0.2}}
+@keyframes band-tick-radio-tuner-dial{0%,49%{opacity:1}50%,100%{opacity:0.3}}


### PR DESCRIPTION
## Component: ease-radio-tuner-dial — needle glides, lights blink, and band ticks

**Closes #65781**

### What this adds
A table radio: the tuner needle glides across the frequency scale, the dial lights blink in turn, and the band tag ticks.

### Acceptance Criteria covered
- Tuner needle glides across the scale
- Dial lights blink in turn
- Band tag ticks beneath

### Files
- `submissions/examples/radio-tuner-dial-ij/demo.html`
- `submissions/examples/radio-tuner-dial-ij/style.css`
- `submissions/examples/radio-tuner-dial-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the needle glide.