### PR TITLE
feat: add CSS Elastic-Slide Progress Bar for Glassmorphism UI Layouts (#64404)

### DIFF
--- a/submissions/examples/glassmorphism-elastic-slide-progress/README.md
+++ b/submissions/examples/glassmorphism-elastic-slide-progress/README.md
@@ -1,0 +1,21 @@
+# CSS Elastic-Slide Progress Bar (Glassmorphism UI)
+
+A pure CSS interactive progress bar component designed for Glassmorphism UI Layouts. It features a highly dynamic "Elastic-Slide" entrance animation, causing the progress bar fill to aggressively overshoot its target before snapping back into place like a rubber band.
+
+## Features
+- Pure CSS and HTML (No JavaScript required for animations).
+- **Glassmorphism Aesthetic**: The main container (`.glass-card`) utilizes `backdrop-filter: blur(16px)` layered over glowing, ambient background orbs (`.bg-orb`).
+- **Dynamic CSS Variables**: The target width of the progress bar is controlled via an inline CSS variable (`style="--target-width: 84%;"`). The `@keyframes` animation reads this variable directly to calculate the overshoot math via `calc()`. This allows the exact same CSS class to be used for any percentage value dynamically.
+- **The Elastic-Slide Effect**: 
+- When the bar loads, an `@keyframes` animation (`elastic-slide`) is triggered on the `.progress-fill`.
+- Using a custom `cubic-bezier(0.5, -0.5, 0.3, 1.5)` alongside the `calc(var(--target-width) + 15%)` keyframe, the bar rapidly shoots past its intended width, snaps backwards, and finally settles on its precise target.
+- The `.fill-head` acts as a bright, glowing orb positioned exactly at the leading edge of the progress bar (`transform: translate(50%, -50%)`), enhancing the kinetic energy of the rubber-band effect.
+- **Replay Button Hack**: Includes a hidden `<input type="checkbox">` and `<label>` acting as a replay button. Toggling the checkbox swaps the animation between two identical keyframes (`elastic-slide` and `elastic-slide-alt`), tricking the browser into re-triggering the entrance animation purely via CSS.
+- Fully accessible with `prefers-reduced-motion` support. For motion-sensitive users, the aggressive elastic overshooting and bouncing bezier curves are completely stripped. The interaction safely falls back to a clean, linear fill transition.
+
+## Usage
+Open `demo.html` in your browser. You will see a mock data migration dashboard. When the page loads, the green progress bar rapidly shoots across the track, overshoots its 84% target, and snaps back elastically. You can click the small replay icon located above the track to trigger the pure CSS animation again.
+
+## Files
+- `demo.html`: The HTML structure for the layout, detailing the CSS variable injection for `--target-width` and the hidden checkbox hack for the replay button.
+- `style.css`: The styling, glassmorphism tokens, and the dynamic `calc()` based `@keyframes` driving the elastic rubber-band mechanics.

--- a/submissions/examples/glassmorphism-elastic-slide-progress/demo.html
+++ b/submissions/examples/glassmorphism-elastic-slide-progress/demo.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Elastic-Slide Progress Bar - Glassmorphism UI</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    
+    <!-- Background Ambient Orbs for Glassmorphism Effect -->
+    <div class="bg-orb orb-1"></div>
+    <div class="bg-orb orb-2"></div>
+    <div class="bg-orb orb-3"></div>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Data Migration</h1>
+            <p class="subtitle">A glassmorphic progress bar featuring a highly elastic slide entrance animation.</p>
+        </header>
+
+        <div class="dashboard-area">
+            
+            <div class="glass-card">
+                <div class="card-header">
+                    <div class="header-icon">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="17 8 12 3 7 8"></polyline><line x1="12" y1="3" x2="12" y2="15"></line></svg>
+                    </div>
+                    <div class="header-text">
+                        <h2>Syncing Database Clusters</h2>
+                        <span class="status-text">Transferring records to US-East-1...</span>
+                    </div>
+                    <div class="percentage-badge">84%</div>
+                </div>
+
+                <!-- Pure CSS Progress Bar Structure -->
+                <!-- We use a hidden checkbox hack to trigger the animation repeatedly for demo purposes -->
+                <input type="checkbox" id="trigger-anim" class="hidden-trigger">
+                
+                <div class="progress-wrapper">
+                    <label for="trigger-anim" class="replay-btn" title="Replay Animation">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21.5 2v6h-6M21.34 15.57a10 10 0 1 1-.59-9.28l5.67-5.67"></path></svg>
+                    </label>
+                    
+                    <div class="progress-track">
+                        <!-- 
+                          The Fill Element (Width controls progress).
+                          In a real app, the inline width would be updated via JS/Backend. 
+                          Here we set a CSS variable that the keyframe animation reads.
+                        -->
+                        <div class="progress-fill elastic-target" style="--target-width: 84%;">
+                            <!-- Glowing highlight at the leading edge -->
+                            <div class="fill-head"></div>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="card-footer">
+                    <div class="stat">
+                        <span class="stat-label">Processed</span>
+                        <span class="stat-value">1.4M / 1.7M</span>
+                    </div>
+                    <div class="stat">
+                        <span class="stat-label">Transfer Rate</span>
+                        <span class="stat-value highlight">450 MB/s</span>
+                    </div>
+                    <div class="stat">
+                        <span class="stat-label">Time Remaining</span>
+                        <span class="stat-value">00:02:45</span>
+                    </div>
+                </div>
+
+            </div>
+
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/glassmorphism-elastic-slide-progress/style.css
+++ b/submissions/examples/glassmorphism-elastic-slide-progress/style.css
@@ -1,0 +1,321 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600&display=swap');
+
+:root {
+    --bg-base: #0f172a; /* Deep Slate */
+    --text-primary: #f8fafc;
+    --text-secondary: #94a3b8;
+    
+    /* Glass Tokens */
+    --glass-bg: rgba(30, 41, 59, 0.4);
+    --glass-border: rgba(255, 255, 255, 0.1);
+    
+    /* Progress Colors */
+    --accent-glow: rgba(16, 185, 129, 0.4); /* Emerald Glow */
+    --accent-solid: #10b981;
+    --accent-gradient: linear-gradient(90deg, #059669, #34d399);
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Outfit', sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 60px 20px;
+    box-sizing: border-box;
+    overflow: hidden; /* Keep orbs constrained */
+    position: relative;
+}
+
+/* --- Ambient Background Orbs --- */
+.bg-orb {
+    position: absolute;
+    border-radius: 50%;
+    filter: blur(100px);
+    z-index: 0;
+    opacity: 0.5;
+}
+
+.orb-1 {
+    width: 450px;
+    height: 450px;
+    background: rgba(16, 185, 129, 0.15); /* Emerald */
+    top: -150px;
+    right: -100px;
+}
+
+.orb-2 {
+    width: 350px;
+    height: 350px;
+    background: rgba(14, 165, 233, 0.15); /* Sky Blue */
+    bottom: -50px;
+    left: -100px;
+}
+
+.orb-3 {
+    width: 250px;
+    height: 250px;
+    background: rgba(236, 72, 153, 0.1); /* Pink */
+    top: 40%;
+    right: 30%;
+}
+
+
+.layout-container {
+    position: relative;
+    z-index: 10;
+    max-width: 650px;
+    width: 100%;
+}
+
+.section-header {
+    margin-bottom: 50px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 600;
+    margin: 0 0 12px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    margin: 0;
+    font-weight: 300;
+}
+
+
+/* =========================================
+   Glass Card Styling
+   ========================================= */
+
+.glass-card {
+    background: var(--glass-bg);
+    border: 1px solid var(--glass-border);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border-radius: 24px;
+    padding: 32px 40px;
+    box-shadow: 0 20px 40px rgba(0,0,0,0.2), 
+                inset 0 1px 0 rgba(255,255,255,0.1);
+}
+
+.card-header {
+    display: flex;
+    align-items: center;
+    margin-bottom: 36px;
+}
+
+.header-icon {
+    width: 52px;
+    height: 52px;
+    background: rgba(16, 185, 129, 0.1);
+    border: 1px solid rgba(16, 185, 129, 0.2);
+    border-radius: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--accent-solid);
+    margin-right: 20px;
+    box-shadow: 0 0 15px rgba(16, 185, 129, 0.2);
+}
+
+.header-text {
+    flex: 1;
+}
+
+.header-text h2 {
+    margin: 0 0 6px 0;
+    font-size: 1.25rem;
+    font-weight: 500;
+}
+
+.status-text {
+    font-size: 0.95rem;
+    color: var(--text-secondary);
+}
+
+.percentage-badge {
+    background: rgba(255,255,255,0.05);
+    border: 1px solid var(--glass-border);
+    padding: 8px 16px;
+    border-radius: 100px;
+    font-weight: 600;
+    font-size: 1.1rem;
+    color: var(--accent-solid);
+    text-shadow: 0 0 10px rgba(16, 185, 129, 0.4);
+    letter-spacing: 0.5px;
+}
+
+
+/* =========================================
+   The Elastic-Slide Progress Bar
+   ========================================= */
+
+.progress-wrapper {
+    position: relative;
+    margin-bottom: 40px;
+}
+
+.hidden-trigger {
+    display: none;
+}
+
+/* 
+  A small icon button to replay the animation 
+  purely via CSS radio/checkbox state 
+*/
+.replay-btn {
+    position: absolute;
+    top: -24px;
+    right: 0;
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: color 0.2s;
+    z-index: 20;
+}
+.replay-btn:hover {
+    color: var(--text-primary);
+}
+
+
+.progress-track {
+    width: 100%;
+    height: 14px;
+    background: rgba(0, 0, 0, 0.3);
+    border-radius: 100px;
+    border: 1px solid rgba(255,255,255,0.05);
+    box-shadow: inset 0 2px 4px rgba(0,0,0,0.2);
+    position: relative;
+    /* overflow: hidden is OMITTED here so the glowing head can bleed outside if needed */
+}
+
+/* 
+  The Fill Element. 
+  It reads --target-width from the HTML inline style.
+*/
+.progress-fill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    background: var(--accent-gradient);
+    border-radius: 100px;
+    box-shadow: 0 0 15px var(--accent-glow);
+    
+    /* Default state is at target width */
+    width: var(--target-width);
+    
+    /* Ensure the animation plays once on load */
+    animation: elastic-slide 1.5s cubic-bezier(0.5, -0.5, 0.3, 1.5) forwards;
+}
+
+/* Replay animation when the hidden checkbox is toggled */
+.hidden-trigger:checked ~ .progress-wrapper .progress-fill {
+    animation: elastic-slide-alt 1.5s cubic-bezier(0.5, -0.5, 0.3, 1.5) forwards;
+}
+
+/* 
+  The highly elastic keyframes.
+  It overshoots its target width significantly before snapping back.
+  We use the --target-width CSS variable so the keyframe is dynamic.
+*/
+@keyframes elastic-slide {
+    0% { width: 0%; }
+    40% { width: calc(var(--target-width) + 15%); } /* Massive overshoot */
+    60% { width: calc(var(--target-width) - 5%); }  /* Snap back */
+    80% { width: calc(var(--target-width) + 2%); }  /* Minor overshoot */
+    100% { width: var(--target-width); }
+}
+
+/* Exact same keyframe for the replay toggle hack */
+@keyframes elastic-slide-alt {
+    0% { width: 0%; }
+    40% { width: calc(var(--target-width) + 15%); }
+    60% { width: calc(var(--target-width) - 5%); }
+    80% { width: calc(var(--target-width) + 2%); }
+    100% { width: var(--target-width); }
+}
+
+
+/* A bright, intense glow positioned precisely at the leading edge of the progress bar */
+.fill-head {
+    position: absolute;
+    top: 50%;
+    right: 0;
+    width: 20px;
+    height: 20px;
+    background: #fff;
+    border-radius: 50%;
+    transform: translate(50%, -50%);
+    box-shadow: 0 0 20px 5px rgba(255,255,255,0.5), 
+                0 0 40px 10px var(--accent-solid);
+    z-index: 2;
+}
+
+
+/* =========================================
+   Card Footer (Stats)
+   ========================================= */
+
+.card-footer {
+    display: flex;
+    justify-content: space-between;
+    border-top: 1px solid var(--glass-border);
+    padding-top: 28px;
+}
+
+.stat {
+    display: flex;
+    flex-direction: column;
+}
+
+.stat-label {
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 6px;
+    font-weight: 500;
+}
+
+.stat-value {
+    font-size: 1.1rem;
+    font-weight: 600;
+}
+
+.highlight {
+    color: var(--accent-solid);
+    text-shadow: 0 0 8px rgba(16, 185, 129, 0.3);
+}
+
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    /* 
+      Disable the severe elastic bouncing.
+      Replace with a clean, linear fill transition.
+    */
+    .progress-fill {
+        animation: simple-fill 1s ease-out forwards !important;
+    }
+    .hidden-trigger:checked ~ .progress-wrapper .progress-fill {
+        animation: simple-fill-alt 1s ease-out forwards !important;
+    }
+    
+    @keyframes simple-fill {
+        0% { width: 0%; }
+        100% { width: var(--target-width); }
+    }
+    @keyframes simple-fill-alt {
+        0% { width: 0%; }
+        100% { width: var(--target-width); }
+    }
+}


### PR DESCRIPTION

### Description
This PR introduces the CSS Elastic-Slide Progress Bar designed for Glassmorphism UI Layouts, resolving issue #64404. 

### Changes Made:
- Added `submissions/examples/glassmorphism-elastic-slide-progress/` directory.
- Created `demo.html` showcasing a mock data migration dashboard. The layout features ambient background orbs (`.bg-orb`) positioned behind the frosted glass card. It includes a pure CSS replay button powered by a hidden `<input type="checkbox">` hack.
- Created `style.css` featuring a premium glassmorphic aesthetic utilizing the `Outfit` font, heavy backdrop filters (`blur(16px)`), and glowing accents.
  - Implemented the Elastic-Slide effect. The `.progress-fill` utilizes an inline CSS variable (`--target-width`) so the keyframes can be fully dynamic.
  - When the bar loads (or the replay button is clicked), an `@keyframes` animation (`elastic-slide`) rapidly shoots the fill bar across the track. 
  - Using a custom `cubic-bezier(0.5, -0.5, 0.3, 1.5)` alongside the `calc(var(--target-width) + 15%)` keyframe, the bar aggressively overshoots its intended width before snapping back into place like a rubber band.
  - Added a `.fill-head` glowing orb to the leading edge to emphasize the kinetic energy of the snapping effect.
- Added `README.md` documenting usage and technical features.
- Honors the `prefers-reduced-motion` accessibility standard. The aggressive elastic overshooting and bouncing bezier curves are completely stripped. The interaction safely falls back to a clean, linear fill transition for users sensitive to motion.

Closes #64404
