### PR TITLE
feat: add CSS 3D-Flip Progress Bar for Glassmorphism UI Layouts (#64400)

### DIFF
--- a/submissions/examples/glassmorphism-3d-flip-progress/README.md
+++ b/submissions/examples/glassmorphism-3d-flip-progress/README.md
@@ -1,0 +1,22 @@
+# CSS 3D-Flip Progress Bar (Glassmorphism UI)
+
+A pure CSS progress bar component designed for Glassmorphism UI Layouts. It features a mesmerizing, continuous "3D-Flip" animation, where segmented blocks of the progress fill continuously rotate along the X-axis, creating a mechanical, server-rack style loading indicator.
+
+## Features
+- Pure CSS and HTML (No JavaScript required for animations).
+- **Glassmorphism Aesthetic**: The main container (`.glass-card`) utilizes `backdrop-filter: blur(16px)` layered over glowing, ambient background orbs (`.bg-orb`).
+- **The 3D-Flip Effect**: 
+- We establish a 3D context globally on the `body` using `perspective: 1200px`.
+- Crucially, both the `.progress-track` and the `.progress-fill` elements must include `transform-style: preserve-3d` to pass this perspective down to the children.
+- Inside the `.progress-fill` element, we use flexbox (`flex: 1`) to evenly distribute several `.flip-segment` divs across whatever the current width of the progress bar happens to be.
+- Each segment runs an `@keyframes` animation (`flip-3d`) that rotates it from `rotateX(0deg)` to `rotateX(180deg)`. The `transform-origin: center` ensures they spin tightly on their own axis.
+- We apply `animation-delay` utility classes (`.s1` through `.s7`) to stagger the flips, causing a cascading "wave" of spinning blocks to travel across the bar continuously.
+- **Pause/Resume Control**: Includes a hidden `<input type="checkbox">` and `<label>` acting as a toggle button. Checking the box targets the segments using the sibling combinator (`~`) and sets `animation-play-state: paused`, halting the 3D flips instantly.
+- Fully accessible with `prefers-reduced-motion` support. For motion-sensitive users, the 3D flipping blocks and the sweeping highlight are completely disabled. The segments become static, leaving a clean, segmented gradient fill.
+
+## Usage
+Open `demo.html` in your browser. You will see a mock system backup dashboard. The progress bar fill is divided into segmented blocks that continuously flip in 3D space, cascading from left to right. Click the "Pause / Resume" text button above the progress bar to instantly freeze or unfreeze the 3D animation using pure CSS state management.
+
+## Files
+- `demo.html`: The HTML structure for the layout, detailing the segmented divs required for the flip effect and the hidden checkbox hack for the pause toggle.
+- `style.css`: The styling, glassmorphism tokens, `preserve-3d` requirements, and the staggered `@keyframes` driving the continuous 3D rotation mechanics.

--- a/submissions/examples/glassmorphism-3d-flip-progress/demo.html
+++ b/submissions/examples/glassmorphism-3d-flip-progress/demo.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS 3D-Flip Progress Bar - Glassmorphism UI</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    
+    <!-- Background Ambient Orbs for Glassmorphism Effect -->
+    <div class="bg-orb orb-1"></div>
+    <div class="bg-orb orb-2"></div>
+    <div class="bg-orb orb-3"></div>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">System Backup</h1>
+            <p class="subtitle">A glassmorphic progress bar featuring a continuous 3D-Flip loading animation.</p>
+        </header>
+
+        <div class="dashboard-area">
+            
+            <div class="glass-card">
+                <div class="card-header">
+                    <div class="header-icon">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
+                    </div>
+                    <div class="header-text">
+                        <h2>Creating Snapshot</h2>
+                        <span class="status-text">Compressing and encrypting volume data...</span>
+                    </div>
+                    <div class="percentage-badge">42%</div>
+                </div>
+
+                <!-- Pure CSS 3D Progress Bar Structure -->
+                <!-- We use a hidden checkbox hack to toggle between states for demo purposes -->
+                <input type="checkbox" id="toggle-state" class="hidden-trigger">
+                
+                <div class="progress-wrapper">
+                    <label for="toggle-state" class="toggle-btn" title="Toggle Progress State">
+                        Pause / Resume
+                    </label>
+                    
+                    <div class="progress-track">
+                        <!-- 
+                          The Fill Element (Width controls progress).
+                          In a real app, the inline width would be updated via JS/Backend.
+                        -->
+                        <div class="progress-fill" style="width: 42%;">
+                            
+                            <!-- The 3D Flip Segments -->
+                            <div class="flip-segment s1"></div>
+                            <div class="flip-segment s2"></div>
+                            <div class="flip-segment s3"></div>
+                            <div class="flip-segment s4"></div>
+                            <div class="flip-segment s5"></div>
+                            <div class="flip-segment s6"></div>
+                            <div class="flip-segment s7"></div>
+                            
+                            <!-- A glowing overlay to unify the segments -->
+                            <div class="fill-glow"></div>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="card-footer">
+                    <div class="stat">
+                        <span class="stat-label">File Size</span>
+                        <span class="stat-value">18.4 GB</span>
+                    </div>
+                    <div class="stat">
+                        <span class="stat-label">Est. Time</span>
+                        <span class="stat-value highlight">12 mins</span>
+                    </div>
+                    <div class="stat">
+                        <span class="stat-label">Destination</span>
+                        <span class="stat-value">S3 Standard-IA</span>
+                    </div>
+                </div>
+
+            </div>
+
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/glassmorphism-3d-flip-progress/style.css
+++ b/submissions/examples/glassmorphism-3d-flip-progress/style.css
@@ -1,0 +1,353 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600&display=swap');
+
+:root {
+    --bg-base: #0f172a; /* Deep Slate */
+    --text-primary: #f8fafc;
+    --text-secondary: #94a3b8;
+    
+    /* Glass Tokens */
+    --glass-bg: rgba(30, 41, 59, 0.4);
+    --glass-border: rgba(255, 255, 255, 0.1);
+    
+    /* Progress Colors */
+    --accent-glow: rgba(244, 63, 94, 0.4); /* Rose Glow */
+    --accent-solid: #f43f5e;
+    --accent-gradient: linear-gradient(90deg, #e11d48, #fb7185);
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Outfit', sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 60px 20px;
+    box-sizing: border-box;
+    overflow: hidden; /* Keep orbs constrained */
+    position: relative;
+    /* Important: Establish a 3D perspective context for the whole layout */
+    perspective: 1200px;
+}
+
+/* --- Ambient Background Orbs --- */
+.bg-orb {
+    position: absolute;
+    border-radius: 50%;
+    filter: blur(100px);
+    z-index: 0;
+    opacity: 0.5;
+}
+
+.orb-1 {
+    width: 450px;
+    height: 450px;
+    background: rgba(244, 63, 94, 0.15); /* Rose */
+    top: -150px;
+    right: -100px;
+}
+
+.orb-2 {
+    width: 350px;
+    height: 350px;
+    background: rgba(139, 92, 246, 0.15); /* Violet */
+    bottom: -50px;
+    left: -100px;
+}
+
+.orb-3 {
+    width: 250px;
+    height: 250px;
+    background: rgba(236, 72, 153, 0.1); /* Pink */
+    top: 40%;
+    right: 30%;
+}
+
+
+.layout-container {
+    position: relative;
+    z-index: 10;
+    max-width: 650px;
+    width: 100%;
+}
+
+.section-header {
+    margin-bottom: 50px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 600;
+    margin: 0 0 12px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    margin: 0;
+    font-weight: 300;
+}
+
+
+/* =========================================
+   Glass Card Styling
+   ========================================= */
+
+.glass-card {
+    background: var(--glass-bg);
+    border: 1px solid var(--glass-border);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border-radius: 24px;
+    padding: 32px 40px;
+    box-shadow: 0 20px 40px rgba(0,0,0,0.2), 
+                inset 0 1px 0 rgba(255,255,255,0.1);
+}
+
+.card-header {
+    display: flex;
+    align-items: center;
+    margin-bottom: 36px;
+}
+
+.header-icon {
+    width: 52px;
+    height: 52px;
+    background: rgba(244, 63, 94, 0.1);
+    border: 1px solid rgba(244, 63, 94, 0.2);
+    border-radius: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--accent-solid);
+    margin-right: 20px;
+    box-shadow: 0 0 15px rgba(244, 63, 94, 0.2);
+}
+
+.header-text {
+    flex: 1;
+}
+
+.header-text h2 {
+    margin: 0 0 6px 0;
+    font-size: 1.25rem;
+    font-weight: 500;
+}
+
+.status-text {
+    font-size: 0.95rem;
+    color: var(--text-secondary);
+}
+
+.percentage-badge {
+    background: rgba(255,255,255,0.05);
+    border: 1px solid var(--glass-border);
+    padding: 8px 16px;
+    border-radius: 100px;
+    font-weight: 600;
+    font-size: 1.1rem;
+    color: var(--accent-solid);
+    text-shadow: 0 0 10px rgba(244, 63, 94, 0.4);
+    letter-spacing: 0.5px;
+}
+
+
+/* =========================================
+   The 3D-Flip Progress Bar
+   ========================================= */
+
+.progress-wrapper {
+    position: relative;
+    margin-bottom: 40px;
+}
+
+.hidden-trigger {
+    display: none;
+}
+
+.toggle-btn {
+    position: absolute;
+    top: -24px;
+    right: 0;
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    cursor: pointer;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    font-weight: 500;
+    transition: color 0.2s;
+    z-index: 20;
+}
+.toggle-btn:hover {
+    color: var(--text-primary);
+}
+
+
+.progress-track {
+    width: 100%;
+    height: 18px; /* Slightly thicker to show 3D volume */
+    background: rgba(0, 0, 0, 0.3);
+    border-radius: 4px;
+    border: 1px solid rgba(255,255,255,0.05);
+    box-shadow: inset 0 2px 4px rgba(0,0,0,0.3);
+    position: relative;
+    /* Must preserve 3D for children to flip correctly */
+    transform-style: preserve-3d; 
+}
+
+/* 
+  The Fill Element acts as a container for the flipping segments.
+*/
+.progress-fill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    border-radius: 4px;
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+    /* Must preserve 3D */
+    transform-style: preserve-3d; 
+    /* Smooth width changes if updated via JS */
+    transition: width 0.6s ease;
+    overflow: hidden;
+}
+
+/* 
+  The individual segments that flip.
+  We use flexbox to divide the fill container into blocks.
+*/
+.flip-segment {
+    height: 100%;
+    flex: 1; /* Automatically fill the available width */
+    background: var(--accent-gradient);
+    border-right: 1px solid rgba(255,255,255,0.2); /* Creates the segmented look */
+    /* Set the transform origin to the center of each block */
+    transform-origin: center;
+    /* The 3D animation */
+    animation: flip-3d 2s infinite ease-in-out;
+}
+.flip-segment:last-child {
+    border-right: none;
+}
+
+/* Stagger the flips so it cascades across the bar */
+.s1 { animation-delay: 0.0s; }
+.s2 { animation-delay: 0.2s; }
+.s3 { animation-delay: 0.4s; }
+.s4 { animation-delay: 0.6s; }
+.s5 { animation-delay: 0.8s; }
+.s6 { animation-delay: 1.0s; }
+.s7 { animation-delay: 1.2s; }
+
+
+@keyframes flip-3d {
+    0% {
+        transform: rotateX(0deg);
+        opacity: 1;
+    }
+    50% {
+        /* Flip vertically by 90 degrees (edge-on to viewer) */
+        transform: rotateX(90deg);
+        /* Dim slightly as it turns away from the light */
+        opacity: 0.5;
+    }
+    100% {
+        /* Complete the 180 degree flip */
+        transform: rotateX(180deg);
+        opacity: 1;
+    }
+}
+
+/* 
+  A subtle glowing overlay on the fill itself.
+  This sits ABOVE the flipping segments, softening the hard edges
+  and providing the glassmorphic ambient glow.
+*/
+.fill-glow {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(90deg, transparent, rgba(255,255,255,0.2), transparent);
+    animation: fill-sweep 3s infinite linear;
+    z-index: 2;
+    pointer-events: none;
+}
+
+@keyframes fill-sweep {
+    0% { transform: translateX(-100%); }
+    100% { transform: translateX(100%); }
+}
+
+/* Pause animations when the toggle checkbox is checked */
+.hidden-trigger:checked ~ .progress-wrapper .flip-segment,
+.hidden-trigger:checked ~ .progress-wrapper .fill-glow {
+    animation-play-state: paused;
+}
+/* Change label color when paused */
+.hidden-trigger:checked ~ .progress-wrapper .toggle-btn {
+    color: var(--accent-solid);
+}
+
+
+/* =========================================
+   Card Footer (Stats)
+   ========================================= */
+
+.card-footer {
+    display: flex;
+    justify-content: space-between;
+    border-top: 1px solid var(--glass-border);
+    padding-top: 28px;
+}
+
+.stat {
+    display: flex;
+    flex-direction: column;
+}
+
+.stat-label {
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 6px;
+    font-weight: 500;
+}
+
+.stat-value {
+    font-size: 1.1rem;
+    font-weight: 600;
+}
+
+.highlight {
+    color: var(--accent-solid);
+    text-shadow: 0 0 8px rgba(244, 63, 94, 0.3);
+}
+
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    /* 
+      Disable the 3D flipping and the sweeping highlight.
+      The bar becomes a static fill gradient.
+    */
+    .flip-segment {
+        animation: none !important;
+        transform: rotateX(0deg) !important;
+        opacity: 1 !important;
+    }
+    
+    .fill-glow {
+        animation: none !important;
+        display: none;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces the CSS 3D-Flip Progress Bar designed for Glassmorphism UI Layouts, resolving issue #64400. 

### Changes Made:
- Added `submissions/examples/glassmorphism-3d-flip-progress/` directory.
- Created `demo.html` showcasing a mock system backup dashboard. The layout features ambient background orbs (`.bg-orb`) positioned behind the frosted glass card. It includes a pure CSS pause/resume toggle button powered by a hidden `<input type="checkbox">` hack.
- Created `style.css` featuring a premium glassmorphic aesthetic utilizing the `Outfit` font, heavy backdrop filters (`blur(16px)`), and glowing accents.
  - Implemented the continuous 3D-Flip effect. We establish a 3D context globally using `perspective: 1200px` and enforce `transform-style: preserve-3d` on the progress track containers.
  - Inside the `.progress-fill` element, we use flexbox to evenly distribute several `.flip-segment` divs across the current width of the progress bar.
  - Each segment runs an `@keyframes` animation (`flip-3d`) that rotates it from `rotateX(0deg)` to `rotateX(180deg)`.
  - We applied staggered `animation-delay` values, causing a continuous cascading "wave" of spinning blocks to travel across the bar.
  - Toggling the hidden checkbox utilizes the sibling combinator to set `animation-play-state: paused` on the segments, halting the 3D flips instantly.
- Added `README.md` documenting usage and technical features.
- Honors the `prefers-reduced-motion` accessibility standard. The 3D flipping blocks and sweeping highlights are completely disabled. The segments become static, leaving a clean, segmented gradient fill for users sensitive to motion.

Closes #64400
