### PR TITLE
feat: add CSS Fade-In Progress Bar for Glassmorphism UI Layouts (#64396)

### DIFF
--- a/submissions/examples/glassmorphism-fade-in-progress/README.md
+++ b/submissions/examples/glassmorphism-fade-in-progress/README.md
@@ -1,0 +1,21 @@
+# CSS Fade-In Progress Bar (Glassmorphism UI)
+
+A pure CSS progress bar component designed for Glassmorphism UI Layouts. It features a polished, multi-stage "Fade-In" animation sequence, where the progress bar gently "swells" into existence before revealing a glowing leading edge and a shifting internal pattern.
+
+## Features
+- Pure CSS and HTML (No JavaScript required for animations).
+- **Glassmorphism Aesthetic**: The main container (`.glass-card`) utilizes `backdrop-filter: blur(16px)` layered over softly glowing, ambient background orbs (`.bg-orb`).
+- **The Staged Fade-In Effect**: 
+- When the bar loads, an `@keyframes` animation (`fade-in-progress`) is triggered on the main `.progress-fill` container. 
+- Rather than a simple opacity change, the keyframes utilize `transform: scaleX()` originating from the left (`transform-origin: left center`). The bar scales from 50% width up to 100% of its target inline width while fading in, creating a physical "swelling" entrance.
+- Nested inside the fill is a `.fill-head` glowing orb positioned at the leading edge. It has its own delayed keyframes (`fade-in-head`), meaning the bar finishes swelling *before* the bright leading-edge highlight pops into view.
+- Also nested inside is a `.fill-pattern` featuring a CSS diagonal stripe gradient. It runs a continuous, linear `pattern-shift` animation to simulate active data processing.
+- **Replay Button Hack**: Includes a hidden `<input type="checkbox">` and `<label>` acting as a replay button. Toggling the checkbox swaps all animations between two identical keyframe sets, tricking the browser into re-triggering the entire sequence purely via CSS.
+- Fully accessible with `prefers-reduced-motion` support. For motion-sensitive users, the scale swelling, delayed fading, and continuous pattern shifting are completely disabled. The interactions safely fall back to a simple, immediate opacity cross-fade.
+
+## Usage
+Open `demo.html` in your browser. You will see a mock system diagnostics dashboard. When the page loads, the purple progress bar will smoothly swell into existence from the left. A fraction of a second later, the bright leading edge highlight will fade in, and a subtle striped pattern will continuously scroll across the fill. Click the small replay icon located above the track to trigger the pure CSS sequence again.
+
+## Files
+- `demo.html`: The HTML structure for the layout, detailing the fixed inline width and the hidden checkbox hack for the replay button.
+- `style.css`: The styling, glassmorphism tokens, and the complex, delayed `@keyframes` driving the staged fade-in mechanics.

--- a/submissions/examples/glassmorphism-fade-in-progress/demo.html
+++ b/submissions/examples/glassmorphism-fade-in-progress/demo.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Fade-In Progress Bar - Glassmorphism UI</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    
+    <!-- Background Ambient Orbs for Glassmorphism Effect -->
+    <div class="bg-orb orb-1"></div>
+    <div class="bg-orb orb-2"></div>
+    <div class="bg-orb orb-3"></div>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">System Diagnostics</h1>
+            <p class="subtitle">A glassmorphic progress bar featuring a smooth, staged fade-in sequence.</p>
+        </header>
+
+        <div class="dashboard-area">
+            
+            <div class="glass-card">
+                <div class="card-header">
+                    <div class="header-icon">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 12h-4l-3 9L9 3l-3 9H2"></path></svg>
+                    </div>
+                    <div class="header-text">
+                        <h2>Running Health Check</h2>
+                        <span class="status-text">Analyzing cluster node performance...</span>
+                    </div>
+                    <div class="percentage-badge">55%</div>
+                </div>
+
+                <!-- Pure CSS Progress Bar Structure -->
+                <!-- We use a hidden checkbox hack to trigger the animation repeatedly for demo purposes -->
+                <input type="checkbox" id="trigger-anim" class="hidden-trigger">
+                
+                <div class="progress-wrapper">
+                    <label for="trigger-anim" class="replay-btn" title="Replay Animation">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21.5 2v6h-6M21.34 15.57a10 10 0 1 1-.59-9.28l5.67-5.67"></path></svg>
+                    </label>
+                    
+                    <div class="progress-track">
+                        <!-- 
+                          The Fill Element (Width controls progress).
+                          In a real app, the inline width would be updated via JS/Backend.
+                        -->
+                        <div class="progress-fill fade-target" style="width: 55%;">
+                            <!-- Glowing highlight at the leading edge -->
+                            <div class="fill-head"></div>
+                            
+                            <!-- Internal subtle grid pattern -->
+                            <div class="fill-pattern"></div>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="card-footer">
+                    <div class="stat">
+                        <span class="stat-label">Nodes Checked</span>
+                        <span class="stat-value">12 / 24</span>
+                    </div>
+                    <div class="stat">
+                        <span class="stat-label">Anomalies Found</span>
+                        <span class="stat-value highlight">0</span>
+                    </div>
+                    <div class="stat">
+                        <span class="stat-label">Elapsed Time</span>
+                        <span class="stat-value">45s</span>
+                    </div>
+                </div>
+
+            </div>
+
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/glassmorphism-fade-in-progress/style.css
+++ b/submissions/examples/glassmorphism-fade-in-progress/style.css
@@ -1,0 +1,367 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600&display=swap');
+
+:root {
+    --bg-base: #0f172a; /* Deep Slate */
+    --text-primary: #f8fafc;
+    --text-secondary: #94a3b8;
+    
+    /* Glass Tokens */
+    --glass-bg: rgba(30, 41, 59, 0.4);
+    --glass-border: rgba(255, 255, 255, 0.1);
+    
+    /* Progress Colors */
+    --accent-glow: rgba(168, 85, 247, 0.4); /* Purple Glow */
+    --accent-solid: #a855f7;
+    --accent-gradient: linear-gradient(90deg, #9333ea, #d946ef);
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Outfit', sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 60px 20px;
+    box-sizing: border-box;
+    overflow: hidden; /* Keep orbs constrained */
+    position: relative;
+}
+
+/* --- Ambient Background Orbs --- */
+.bg-orb {
+    position: absolute;
+    border-radius: 50%;
+    filter: blur(100px);
+    z-index: 0;
+    opacity: 0.5;
+}
+
+.orb-1 {
+    width: 450px;
+    height: 450px;
+    background: rgba(168, 85, 247, 0.15); /* Purple */
+    top: -150px;
+    right: -100px;
+}
+
+.orb-2 {
+    width: 350px;
+    height: 350px;
+    background: rgba(56, 189, 248, 0.15); /* Sky Blue */
+    bottom: -50px;
+    left: -100px;
+}
+
+.orb-3 {
+    width: 250px;
+    height: 250px;
+    background: rgba(16, 185, 129, 0.1); /* Emerald */
+    top: 40%;
+    right: 30%;
+}
+
+
+.layout-container {
+    position: relative;
+    z-index: 10;
+    max-width: 650px;
+    width: 100%;
+}
+
+.section-header {
+    margin-bottom: 50px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 600;
+    margin: 0 0 12px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    margin: 0;
+    font-weight: 300;
+}
+
+
+/* =========================================
+   Glass Card Styling
+   ========================================= */
+
+.glass-card {
+    background: var(--glass-bg);
+    border: 1px solid var(--glass-border);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border-radius: 24px;
+    padding: 32px 40px;
+    box-shadow: 0 20px 40px rgba(0,0,0,0.2), 
+                inset 0 1px 0 rgba(255,255,255,0.1);
+}
+
+.card-header {
+    display: flex;
+    align-items: center;
+    margin-bottom: 36px;
+}
+
+.header-icon {
+    width: 52px;
+    height: 52px;
+    background: rgba(168, 85, 247, 0.1);
+    border: 1px solid rgba(168, 85, 247, 0.2);
+    border-radius: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--accent-solid);
+    margin-right: 20px;
+    box-shadow: 0 0 15px rgba(168, 85, 247, 0.2);
+}
+
+.header-text {
+    flex: 1;
+}
+
+.header-text h2 {
+    margin: 0 0 6px 0;
+    font-size: 1.25rem;
+    font-weight: 500;
+}
+
+.status-text {
+    font-size: 0.95rem;
+    color: var(--text-secondary);
+}
+
+.percentage-badge {
+    background: rgba(255,255,255,0.05);
+    border: 1px solid var(--glass-border);
+    padding: 8px 16px;
+    border-radius: 100px;
+    font-weight: 600;
+    font-size: 1.1rem;
+    color: var(--accent-solid);
+    text-shadow: 0 0 10px rgba(168, 85, 247, 0.4);
+    letter-spacing: 0.5px;
+}
+
+
+/* =========================================
+   The Fade-In Progress Bar
+   ========================================= */
+
+.progress-wrapper {
+    position: relative;
+    margin-bottom: 40px;
+}
+
+.hidden-trigger {
+    display: none;
+}
+
+/* Replay button */
+.replay-btn {
+    position: absolute;
+    top: -24px;
+    right: 0;
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: color 0.2s;
+    z-index: 20;
+}
+.replay-btn:hover {
+    color: var(--text-primary);
+}
+
+
+.progress-track {
+    width: 100%;
+    height: 12px;
+    background: rgba(0, 0, 0, 0.3);
+    border-radius: 100px;
+    border: 1px solid rgba(255,255,255,0.05);
+    box-shadow: inset 0 2px 4px rgba(0,0,0,0.2);
+    position: relative;
+}
+
+/* 
+  The Fill Element. 
+  It has a fixed width defined in the HTML (55%).
+*/
+.progress-fill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    background: var(--accent-gradient);
+    border-radius: 100px;
+    box-shadow: 0 0 15px var(--accent-glow);
+    overflow: hidden; /* contain pattern */
+    
+    /* 
+      We set initial state to hidden for the animation.
+    */
+    opacity: 0;
+    
+    /* Ensure the animation plays once on load */
+    animation: fade-in-progress 1.2s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+}
+
+/* Replay animation when the hidden checkbox is toggled */
+.hidden-trigger:checked ~ .progress-wrapper .progress-fill {
+    animation: fade-in-progress-alt 1.2s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+}
+
+/* 
+  The Fade-In keyframes.
+  Rather than just changing opacity, we combine it with a subtle width expansion 
+  to make the fade feel more physical, like it's "swelling" into existence.
+  We use scaleX so it doesn't interfere with the inline width percentage.
+*/
+@keyframes fade-in-progress {
+    0% {
+        opacity: 0;
+        transform-origin: left center;
+        transform: scaleX(0.5); /* Start at 50% of its target width */
+    }
+    100% {
+        opacity: 1;
+        transform-origin: left center;
+        transform: scaleX(1);
+    }
+}
+
+@keyframes fade-in-progress-alt {
+    0% { opacity: 0; transform-origin: left center; transform: scaleX(0.5); }
+    100% { opacity: 1; transform-origin: left center; transform: scaleX(1); }
+}
+
+
+/* Internal Pattern Overlay */
+.fill-pattern {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-image: linear-gradient(45deg, rgba(255,255,255,0.1) 25%, transparent 25%, transparent 50%, rgba(255,255,255,0.1) 50%, rgba(255,255,255,0.1) 75%, transparent 75%, transparent);
+    background-size: 20px 20px;
+    z-index: 1;
+    /* Animate the pattern slowly shifting */
+    animation: pattern-shift 2s linear infinite;
+}
+
+@keyframes pattern-shift {
+    0% { background-position: 0 0; }
+    100% { background-position: 20px 0; }
+}
+
+
+/* A bright, intense glow positioned precisely at the leading edge of the progress bar */
+.fill-head {
+    position: absolute;
+    top: 50%;
+    right: 0;
+    width: 16px;
+    height: 16px;
+    background: #fff;
+    border-radius: 50%;
+    transform: translate(50%, -50%);
+    box-shadow: 0 0 15px 2px rgba(255,255,255,0.6), 
+                0 0 30px 5px var(--accent-solid);
+    z-index: 2;
+    /* Delayed fade in for the head */
+    opacity: 0;
+    animation: fade-in-head 1s ease 0.6s forwards;
+}
+
+.hidden-trigger:checked ~ .progress-wrapper .fill-head {
+    animation: fade-in-head-alt 1s ease 0.6s forwards;
+}
+
+@keyframes fade-in-head {
+    0% { opacity: 0; transform: translate(50%, -50%) scale(0); }
+    100% { opacity: 1; transform: translate(50%, -50%) scale(1); }
+}
+@keyframes fade-in-head-alt {
+    0% { opacity: 0; transform: translate(50%, -50%) scale(0); }
+    100% { opacity: 1; transform: translate(50%, -50%) scale(1); }
+}
+
+
+/* =========================================
+   Card Footer (Stats)
+   ========================================= */
+
+.card-footer {
+    display: flex;
+    justify-content: space-between;
+    border-top: 1px solid var(--glass-border);
+    padding-top: 28px;
+}
+
+.stat {
+    display: flex;
+    flex-direction: column;
+}
+
+.stat-label {
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 6px;
+    font-weight: 500;
+}
+
+.stat-value {
+    font-size: 1.1rem;
+    font-weight: 600;
+}
+
+.highlight {
+    color: var(--accent-solid);
+    text-shadow: 0 0 8px rgba(168, 85, 247, 0.3);
+}
+
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    /* Disable scale swelling, pattern shift, and delayed fade-ins */
+    .progress-fill {
+        animation: simple-fade 0.5s ease-out forwards !important;
+        transform: scaleX(1) !important;
+    }
+    .hidden-trigger:checked ~ .progress-wrapper .progress-fill {
+        animation: simple-fade-alt 0.5s ease-out forwards !important;
+    }
+    
+    .fill-head {
+        animation: simple-fade 0.5s ease-out forwards !important;
+    }
+    .hidden-trigger:checked ~ .progress-wrapper .fill-head {
+        animation: simple-fade-alt 0.5s ease-out forwards !important;
+    }
+    
+    .fill-pattern {
+        animation: none !important;
+    }
+    
+    @keyframes simple-fade {
+        0% { opacity: 0; }
+        100% { opacity: 1; }
+    }
+    @keyframes simple-fade-alt {
+        0% { opacity: 0; }
+        100% { opacity: 1; }
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces the CSS Fade-In Progress Bar designed for Glassmorphism UI Layouts, resolving issue #64396. 

### Changes Made:
- Added `submissions/examples/glassmorphism-fade-in-progress/` directory.
- Created `demo.html` showcasing a mock system diagnostics dashboard. The layout features ambient background orbs (`.bg-orb`) positioned behind the frosted glass card. It includes a pure CSS replay button powered by a hidden `<input type="checkbox">` hack.
- Created `style.css` featuring a premium glassmorphic aesthetic utilizing the `Outfit` font, heavy backdrop filters (`blur(16px)`), and a purple glowing color palette.
  - Implemented the Staged Fade-In sequence. When the bar loads (or the replay button is clicked), an `@keyframes` animation (`fade-in-progress`) is triggered on the main `.progress-fill`. 
  - Rather than a simple opacity change, the keyframes utilize `transform: scaleX()` originating from the left, scaling the bar from 50% width up to 100% of its target inline width while fading in, creating a physical "swelling" entrance.
  - Added a `.fill-head` glowing orb to the leading edge with a delayed `@keyframes` fade-in, ensuring the bar finishes swelling *before* the bright highlight pops into view.
  - Added a `.fill-pattern` (diagonal stripes) that runs a continuous `pattern-shift` linear animation.
- Added `README.md` documenting usage and technical features.
- Honors the `prefers-reduced-motion` accessibility standard. The scale swelling, delayed fading, and continuous pattern shifting are completely disabled. The interactions safely fall back to a simple, immediate opacity cross-fade for users sensitive to motion.

Closes #64396
