### PR TITLE
feat: add CSS Zoom-In Feature Grid for Glassmorphism UI Layouts (#64367)

### DIFF
--- a/submissions/examples/glassmorphism-zoom-in-feature-grid/README.md
+++ b/submissions/examples/glassmorphism-zoom-in-feature-grid/README.md
@@ -1,0 +1,22 @@
+# CSS Zoom-In Feature Grid (Glassmorphism UI)
+
+A pure CSS interactive feature grid component designed for Glassmorphism UI Layouts. It focuses on a cinematic, slow "Zoom-In" background interaction that creates a premium sense of depth without overwhelming the user interface.
+
+## Features
+- Pure CSS and HTML (No JavaScript required for interactions or animations).
+- **Glassmorphism Aesthetic**: The feature cards (`.glass-card`) utilize `backdrop-filter: blur(16px)` layered over glowing, ambient background orbs (`.bg-orb`).
+- **The Zoom-In Effect**: 
+- We use a dedicated, absolutely positioned `.zoom-layer` inside each card, placed strictly behind the content layer (`z-index: 1`).
+- The `.feature-card` acts as the container and uses `overflow: hidden` so the zoomed background never spills out of the rounded card edges.
+- Each `.zoom-layer` is styled with a distinct subtle radial gradient (e.g., `.bg-image-1`, `.bg-image-2`).
+- Upon hovering the card, the `.zoom-layer` smoothly and slowly scales up (`transform: scale(1.2)`) using a deliberate `0.8s` duration and a custom cubic-bezier curve. Simultaneously, it slightly increases its opacity and blur radius (`filter: blur(4px)`).
+- This creates an elegant, cinematic parallax feeling where the card's background physically pushes forward, adding dynamic depth to the glassmorphism.
+- **Card Hover Interactions**: Hovering over the card also elevates it (`transform: translateY(-8px)`), brightens the border, and sharply scales/colors the icon wrapper (`transform: scale(1.1)`), drawing the user's eye to the primary content while the background slowly expands.
+- Fully accessible with `prefers-reduced-motion` support. For motion-sensitive users, the card elevation, icon scaling, and the background zoom scaling are completely disabled. The interactions safely fall back to subtle, immediate CSS opacity and border color changes.
+
+## Usage
+Open `demo.html` in your browser. You will see a mock "Explore Capabilities" feature grid. Hover your mouse over any of the six feature cards. You will observe the card lift, the icon snap to attention, and the blurred background layer smoothly and slowly zoom inward, creating a premium sense of depth behind the glass surface.
+
+## Files
+- `demo.html`: The HTML structure for the layout, detailing the grid implementation and the hidden `.zoom-layer` required inside each card to achieve the depth effect.
+- `style.css`: The styling, glassmorphism tokens, radial gradient backgrounds, and the slow `0.8s` cubic-bezier transition logic driving the zoom mechanics.

--- a/submissions/examples/glassmorphism-zoom-in-feature-grid/demo.html
+++ b/submissions/examples/glassmorphism-zoom-in-feature-grid/demo.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Zoom-In Feature Grid - Glassmorphism UI</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    
+    <!-- Background Ambient Orbs for Glassmorphism Effect -->
+    <div class="bg-orb orb-1"></div>
+    <div class="bg-orb orb-2"></div>
+    <div class="bg-orb orb-3"></div>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Explore Capabilities</h1>
+            <p class="subtitle">A glassmorphic feature grid utilizing subtle zoom-in hover interactions for depth.</p>
+        </header>
+
+        <!-- Feature Grid Container -->
+        <div class="feature-grid">
+            
+            <!-- Feature Card 1 -->
+            <div class="glass-card feature-card">
+                <div class="zoom-layer bg-image-1"></div>
+                <div class="card-content">
+                    <div class="icon-wrapper">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path></svg>
+                    </div>
+                    <h3>Security First</h3>
+                    <p>Enterprise-grade encryption protecting your data at rest and in transit.</p>
+                </div>
+            </div>
+
+            <!-- Feature Card 2 -->
+            <div class="glass-card feature-card">
+                <div class="zoom-layer bg-image-2"></div>
+                <div class="card-content">
+                    <div class="icon-wrapper">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><polyline points="12 6 12 12 16 14"></polyline></svg>
+                    </div>
+                    <h3>Real-time Sync</h3>
+                    <p>Changes propagate across all connected devices instantly.</p>
+                </div>
+            </div>
+
+            <!-- Feature Card 3 -->
+            <div class="glass-card feature-card">
+                <div class="zoom-layer bg-image-3"></div>
+                <div class="card-content">
+                    <div class="icon-wrapper">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path></svg>
+                    </div>
+                    <h3>Modular Architecture</h3>
+                    <p>Build custom workflows using our extensible microservices.</p>
+                </div>
+            </div>
+
+            <!-- Feature Card 4 -->
+            <div class="glass-card feature-card">
+                <div class="zoom-layer bg-image-4"></div>
+                <div class="card-content">
+                    <div class="icon-wrapper">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><line x1="3" y1="9" x2="21" y2="9"></line><line x1="9" y1="21" x2="9" y2="9"></line></svg>
+                    </div>
+                    <h3>Intuitive Dashboard</h3>
+                    <p>Manage everything from a single, clean glassmorphic interface.</p>
+                </div>
+            </div>
+
+            <!-- Feature Card 5 -->
+            <div class="glass-card feature-card">
+                <div class="zoom-layer bg-image-5"></div>
+                <div class="card-content">
+                    <div class="icon-wrapper">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"></polyline></svg>
+                    </div>
+                    <h3>Analytics Engine</h3>
+                    <p>Gain deep insights with our high-performance metrics processing.</p>
+                </div>
+            </div>
+
+            <!-- Feature Card 6 -->
+            <div class="glass-card feature-card">
+                <div class="zoom-layer bg-image-6"></div>
+                <div class="card-content">
+                    <div class="icon-wrapper">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"></polygon></svg>
+                    </div>
+                    <h3>Premium Support</h3>
+                    <p>24/7 access to our dedicated engineering team for enterprise users.</p>
+                </div>
+            </div>
+
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/glassmorphism-zoom-in-feature-grid/style.css
+++ b/submissions/examples/glassmorphism-zoom-in-feature-grid/style.css
@@ -1,0 +1,253 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600&display=swap');
+
+:root {
+    --bg-base: #0f172a; /* Deep Slate */
+    --text-primary: #f8fafc;
+    --text-secondary: #94a3b8;
+    
+    /* Glass Tokens */
+    --glass-bg: rgba(30, 41, 59, 0.4);
+    --glass-border: rgba(255, 255, 255, 0.1);
+    
+    /* Accent Color */
+    --accent: #38bdf8; /* Sky Blue */
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Outfit', sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 80px 20px;
+    box-sizing: border-box;
+    overflow-x: hidden;
+    position: relative;
+}
+
+/* --- Ambient Background Orbs --- */
+.bg-orb {
+    position: absolute;
+    border-radius: 50%;
+    filter: blur(120px);
+    z-index: 0;
+    opacity: 0.4;
+}
+
+.orb-1 {
+    width: 600px;
+    height: 600px;
+    background: rgba(56, 189, 248, 0.15); /* Sky Blue */
+    top: -200px;
+    left: -100px;
+}
+
+.orb-2 {
+    width: 500px;
+    height: 500px;
+    background: rgba(139, 92, 246, 0.15); /* Violet */
+    bottom: -100px;
+    right: -100px;
+}
+
+.orb-3 {
+    width: 400px;
+    height: 400px;
+    background: rgba(16, 185, 129, 0.1); /* Emerald */
+    top: 40%;
+    left: 30%;
+}
+
+
+.layout-container {
+    position: relative;
+    z-index: 10;
+    max-width: 1100px;
+    width: 100%;
+}
+
+.section-header {
+    margin-bottom: 60px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.8rem;
+    font-weight: 600;
+    margin: 0 0 16px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.15rem;
+    margin: 0;
+    font-weight: 300;
+}
+
+
+/* =========================================
+   Glass Card & Grid Styling
+   ========================================= */
+
+.feature-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 24px;
+}
+
+.glass-card {
+    background: var(--glass-bg);
+    border: 1px solid var(--glass-border);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border-radius: 24px;
+    box-shadow: 0 15px 35px rgba(0,0,0,0.2), 
+                inset 0 1px 0 rgba(255,255,255,0.1);
+}
+
+.feature-card {
+    position: relative;
+    padding: 40px 32px;
+    cursor: pointer;
+    overflow: hidden; /* Important: keeps zoomed background contained */
+    transition: transform 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94),
+                border-color 0.4s ease,
+                box-shadow 0.4s ease;
+}
+
+.feature-card:hover {
+    transform: translateY(-8px);
+    border-color: rgba(56, 189, 248, 0.4);
+    box-shadow: 0 20px 40px rgba(0,0,0,0.4), 
+                0 0 20px rgba(56, 189, 248, 0.15),
+                inset 0 1px 0 rgba(255,255,255,0.1);
+}
+
+/* Make content z-index higher than the background layer */
+.card-content {
+    position: relative;
+    z-index: 5;
+}
+
+
+/* =========================================
+   The Zoom-In Effect Background Layer
+   ========================================= */
+
+.zoom-layer {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 1;
+    opacity: 0.15;
+    /* CSS gradients act as subtle thematic backgrounds */
+    background-size: cover;
+    background-position: center;
+    /* Initialize at scale 1 */
+    transform: scale(1);
+    /* Very smooth, slightly slow transition for a premium feel */
+    transition: transform 0.8s cubic-bezier(0.25, 0.46, 0.45, 0.94),
+                opacity 0.4s ease;
+    /* Apply a slight blur by default to blend it into the glass */
+    filter: blur(2px);
+}
+
+/* Background Variations */
+.bg-image-1 { background-image: radial-gradient(circle at top right, rgba(56, 189, 248, 0.8), transparent 70%); }
+.bg-image-2 { background-image: radial-gradient(circle at bottom left, rgba(168, 85, 247, 0.8), transparent 70%); }
+.bg-image-3 { background-image: radial-gradient(circle at top left, rgba(236, 72, 153, 0.8), transparent 70%); }
+.bg-image-4 { background-image: radial-gradient(circle at bottom right, rgba(16, 185, 129, 0.8), transparent 70%); }
+.bg-image-5 { background-image: radial-gradient(circle at center, rgba(245, 158, 11, 0.8), transparent 70%); }
+.bg-image-6 { background-image: radial-gradient(circle at top right, rgba(99, 102, 241, 0.8), transparent 70%); }
+
+/* 
+  Hover Interaction
+  When card is hovered, scale up the background layer smoothly
+  and slightly increase opacity and sharpen the blur.
+*/
+.feature-card:hover .zoom-layer {
+    transform: scale(1.2);
+    opacity: 0.3;
+    filter: blur(4px);
+}
+
+
+/* =========================================
+   Icon & Text Content
+   ========================================= */
+
+.icon-wrapper {
+    width: 56px;
+    height: 56px;
+    border-radius: 16px;
+    margin-bottom: 24px;
+    background: rgba(255,255,255,0.05);
+    border: 1px solid rgba(255,255,255,0.1);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-primary);
+    transition: all 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+
+.feature-card:hover .icon-wrapper {
+    background: rgba(56, 189, 248, 0.15);
+    border-color: rgba(56, 189, 248, 0.4);
+    color: var(--accent);
+    transform: scale(1.1);
+    box-shadow: 0 0 15px rgba(56, 189, 248, 0.2);
+}
+
+
+/* Text */
+.feature-card h3 {
+    font-size: 1.3rem;
+    font-weight: 500;
+    margin: 0 0 12px 0;
+    transition: color 0.3s ease;
+}
+
+.feature-card p {
+    font-size: 0.95rem;
+    color: var(--text-secondary);
+    line-height: 1.6;
+    margin: 0;
+    transition: color 0.3s ease;
+}
+
+.feature-card:hover p {
+    color: var(--text-primary);
+}
+
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    .feature-card {
+        transition: border-color 0.2s ease, box-shadow 0.2s ease !important;
+    }
+    .feature-card:hover {
+        transform: none !important;
+    }
+    
+    .zoom-layer {
+        transition: opacity 0.2s ease !important;
+    }
+    .feature-card:hover .zoom-layer {
+        transform: scale(1) !important;
+        filter: blur(2px) !important;
+    }
+    
+    .icon-wrapper {
+        transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease !important;
+    }
+    .feature-card:hover .icon-wrapper {
+        transform: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces the CSS Zoom-In Feature Grid designed for Glassmorphism UI Layouts, resolving issue #64367. 

### Changes Made:
- Added `submissions/examples/glassmorphism-zoom-in-feature-grid/` directory.
- Created `demo.html` showcasing a mock "Explore Capabilities" grid. The layout features ambient background orbs (`.bg-orb`) positioned behind the frosted glass cards.
- Created `style.css` featuring a premium glassmorphic aesthetic utilizing the `Outfit` font, heavy backdrop filters (`blur(16px)`), and sky-blue glowing accents.
  - Implemented the Zoom-In system. Inside each card, hidden securely behind the text content but above the glass blur, is an absolutely positioned `.zoom-layer`. 
  - Each `.zoom-layer` uses a distinct, subtle radial CSS gradient (`.bg-image-1`, `.bg-image-2`, etc.).
  - When a user hovers over the card, the `.zoom-layer` smoothly and slowly scales up (`transform: scale(1.2)`) using a deliberate `0.8s` duration and a custom cubic-bezier curve. Simultaneously, it slightly increases its opacity and blur radius.
  - By combining this with `overflow: hidden` on the parent card, this creates an elegant cinematic parallax feeling where the card's background physically pushes forward.
  - Card hover states also elevate the card (`transform: translateY(-8px)`) and sharply scale the icon wrapper (`transform: scale(1.1)`), drawing the user's eye to the primary content while the background expands.
- Added `README.md` documenting usage and technical features.
- Honors the `prefers-reduced-motion` accessibility standard. The card elevation, icon scaling, and the slow background zoom scaling transitions are completely disabled. The interactions safely fall back to subtle, immediate CSS opacity and border color changes for motion-sensitive users.

Closes #64367
