### PR TITLE
feat: add CSS Blur-Entrance Progress Bar for Minimalist Tech Layouts (#64659)

### DIFF
--- a/submissions/examples/minimalist-tech-blur-entrance-progress/README.md
+++ b/submissions/examples/minimalist-tech-blur-entrance-progress/README.md
@@ -1,0 +1,21 @@
+# CSS Blur-Entrance Progress Bar (Minimalist Tech)
+
+A pure CSS interactive progress bar component designed for Minimalist Tech Layouts. It features a cinematic "Blur-Entrance" animation, where the progress bar snaps into focus while filling up dynamically.
+
+## Features
+- Pure CSS and HTML (No JavaScript required for state management or animations).
+- **Minimalist Aesthetic**: Clean layout, sharp borders, and distinct blue/purple/pink accent colors over a sterile `f8fafc` background.
+- **State Management**: The triggering of the progress bars is handled entirely via the hidden checkbox hack (`<input type="checkbox">`). The "Run" buttons are `<label>` elements wired to these hidden inputs.
+- **The Blur-Entrance Effect**: 
+- Achieving this effect requires separating concerns to avoid keyframe property conflicts. We use two nested elements: `.blur-entrance-wrapper` and `.progress-fill`.
+- When triggered, the `.blur-entrance-wrapper` fires an `@keyframes` animation (`blur-entrance`) that transitions the element from `opacity: 0`, `filter: blur(10px)`, and `transform: scaleX(0.5)` to a sharp, fully visible state (`filter: blur(0px)`, `transform: scaleX(1)`).
+- Slightly delayed (0.2s), the inner `.progress-fill` fires its own `@keyframes` animation (`fill-width`) that expands its width from `0%` to a dynamically set CSS variable (`--target-width`).
+- This decoupling allows the blur/scale effect to act on the entire visual bar while the width expansion happens independently inside it, creating a cinematic, complex feel.
+- Fully accessible with `prefers-reduced-motion` support. For motion-sensitive users, the blur scaling and width expansion keyframes are completely disabled, immediately rendering the final state width without any visual stutter or motion.
+
+## Usage
+Open `demo.html` in your browser. You will see three mock System Diagnostics cards. Click the "Run Scan", "Rebuild", or "Ping Edge" buttons. Observe how the progress bars fade in rapidly from a blurred, shrunken state, before swiftly stretching out to their target widths using a bouncy easing curve.
+
+## Files
+- `demo.html`: The HTML structure for the layout, detailing the complex nested `.blur-entrance-wrapper` and `.progress-fill` setup, alongside the `--target-width` inline variable usage.
+- `style.css`: The styling, minimalist tech design tokens, and the complex decoupled `@keyframes` logic driving the entrance mechanics.

--- a/submissions/examples/minimalist-tech-blur-entrance-progress/demo.html
+++ b/submissions/examples/minimalist-tech-blur-entrance-progress/demo.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Blur-Entrance Progress Bar - Minimalist Tech</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        <header class="section-header">
+            <h1 class="title">System Diagnostics</h1>
+            <p class="subtitle">A minimalist tech progress bar featuring a cinematic blur-entrance animation.</p>
+        </header>
+
+        <div class="dashboard-area">
+            
+            <div class="card">
+                <div class="card-header">
+                    <h2>Memory Optimization</h2>
+                    <!-- Checkbox controls the animation state -->
+                    <input type="checkbox" id="trigger-anim-1" class="trigger-checkbox">
+                    <label for="trigger-anim-1" class="btn-trigger">Run Scan</label>
+                    
+                    <div class="progress-section">
+                        <div class="progress-info">
+                            <span class="progress-label">Reclaiming unallocated space</span>
+                            <span class="progress-value">64%</span>
+                        </div>
+                        
+                        <div class="progress-track">
+                            <!-- Wrapper needed to separate entrance animation from dynamic width filling -->
+                            <div class="blur-entrance-wrapper">
+                                <div class="progress-fill" style="--target-width: 64%;"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="card mt-4">
+                <div class="card-header">
+                    <h2>Database Indexing</h2>
+                    <input type="checkbox" id="trigger-anim-2" class="trigger-checkbox">
+                    <label for="trigger-anim-2" class="btn-trigger">Rebuild</label>
+                    
+                    <div class="progress-section">
+                        <div class="progress-info">
+                            <span class="progress-label">Compacting fragmentation</span>
+                            <span class="progress-value">82%</span>
+                        </div>
+                        
+                        <div class="progress-track">
+                            <div class="blur-entrance-wrapper color-purple">
+                                <div class="progress-fill" style="--target-width: 82%;"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="card mt-4">
+                <div class="card-header">
+                    <h2>Network Latency Test</h2>
+                    <input type="checkbox" id="trigger-anim-3" class="trigger-checkbox">
+                    <label for="trigger-anim-3" class="btn-trigger">Ping Edge</label>
+                    
+                    <div class="progress-section">
+                        <div class="progress-info">
+                            <span class="progress-label">Measuring jitter across CDN nodes</span>
+                            <span class="progress-value">45%</span>
+                        </div>
+                        
+                        <div class="progress-track">
+                            <div class="blur-entrance-wrapper color-pink">
+                                <div class="progress-fill" style="--target-width: 45%;"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/minimalist-tech-blur-entrance-progress/style.css
+++ b/submissions/examples/minimalist-tech-blur-entrance-progress/style.css
@@ -1,0 +1,246 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&display=swap');
+
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    --border-color: #e2e8f0;
+    
+    /* Tech Minimalist Accents */
+    --accent-blue: #0ea5e9;
+    --accent-purple: #8b5cf6;
+    --accent-pink: #ec4899;
+    --surface-white: #ffffff;
+    --surface-hover: #f1f5f9;
+    --track-bg: #f1f5f9;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 600px;
+    width: 100%;
+    padding: 40px 20px;
+}
+
+.section-header {
+    text-align: center;
+    margin-bottom: 50px;
+}
+
+.title {
+    font-size: 2rem;
+    font-weight: 600;
+    margin: 0 0 12px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    margin: 0;
+}
+
+
+/* =========================================
+   Card Styling
+   ========================================= */
+
+.card {
+    background: var(--surface-white);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 24px;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+}
+
+.mt-4 { margin-top: 24px; }
+
+.card-header {
+    position: relative;
+}
+
+.card-header h2 {
+    font-size: 1.15rem;
+    font-weight: 600;
+    margin: 0 0 24px 0;
+}
+
+
+/* =========================================
+   Trigger Mechanism
+   ========================================= */
+
+.trigger-checkbox {
+    display: none;
+}
+
+.btn-trigger {
+    position: absolute;
+    top: -4px;
+    right: 0;
+    padding: 6px 14px;
+    background: var(--bg-base);
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    font-size: 0.85rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.btn-trigger:hover {
+    background: var(--surface-hover);
+    border-color: #cbd5e1;
+}
+
+/* Change button style when active/running */
+.trigger-checkbox:checked + .btn-trigger {
+    background: var(--surface-hover);
+    color: var(--text-secondary);
+    pointer-events: none;
+    border-color: transparent;
+}
+.trigger-checkbox:checked + .btn-trigger::after {
+    content: "ning...";
+}
+
+
+/* =========================================
+   Progress Bar Structure
+   ========================================= */
+
+.progress-section {
+    opacity: 0.4;
+    transition: opacity 0.3s ease;
+}
+
+/* Light up the section when active */
+.trigger-checkbox:checked ~ .progress-section {
+    opacity: 1;
+}
+
+.progress-info {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 12px;
+    font-size: 0.9rem;
+}
+
+.progress-label {
+    color: var(--text-secondary);
+}
+
+.progress-value {
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.progress-track {
+    width: 100%;
+    height: 8px;
+    background: var(--track-bg);
+    border-radius: 4px;
+    /* Hide overflow so the blur doesn't bleed outside the rounded track */
+    overflow: hidden;
+    position: relative;
+}
+
+
+/* =========================================
+   The Blur-Entrance Effect
+   ========================================= */
+
+/* 
+  We must separate concerns:
+  1. The wrapper handles the entrance animation (blur + scale in).
+  2. The inner fill handles the width expansion.
+  If we combined them on one element, the width keyframe would conflict 
+  with the dynamic --target-width CSS variable.
+*/
+.blur-entrance-wrapper {
+    width: 100%;
+    height: 100%;
+    transform-origin: left center;
+    /* Start completely blurred out, transparent, and scaled down horizontally */
+    opacity: 0;
+    filter: blur(10px);
+    transform: scaleX(0.5);
+}
+
+.progress-fill {
+    height: 100%;
+    background: var(--accent-blue);
+    border-radius: 4px;
+    /* Start at 0 width */
+    width: 0%;
+}
+
+/* Color variations */
+.color-purple .progress-fill { background: var(--accent-purple); }
+.color-pink .progress-fill { background: var(--accent-pink); }
+
+/* 
+  Trigger the animations when the checkbox is checked.
+*/
+.trigger-checkbox:checked ~ .progress-section .blur-entrance-wrapper {
+    /* 
+      Cinematic entrance: fade in, remove blur, scale up to normal width.
+      Using a slow, elegant cubic-bezier curve.
+    */
+    animation: blur-entrance 0.8s cubic-bezier(0.25, 1, 0.5, 1) forwards;
+}
+
+.trigger-checkbox:checked ~ .progress-section .progress-fill {
+    /* 
+      Fill width up to the dynamically set --target-width.
+      We delay it slightly (0.2s) so the entrance blur resolves first.
+    */
+    animation: fill-width 1.5s cubic-bezier(0.34, 1.56, 0.64, 1) 0.2s forwards;
+}
+
+
+@keyframes blur-entrance {
+    0% {
+        opacity: 0;
+        filter: blur(10px);
+        transform: scaleX(0.5);
+    }
+    100% {
+        opacity: 1;
+        filter: blur(0px);
+        transform: scaleX(1);
+    }
+}
+
+@keyframes fill-width {
+    0% { width: 0%; }
+    100% { width: var(--target-width); }
+}
+
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    .trigger-checkbox:checked ~ .progress-section .blur-entrance-wrapper {
+        animation: none;
+        opacity: 1;
+        filter: blur(0px);
+        transform: scaleX(1);
+    }
+    
+    .trigger-checkbox:checked ~ .progress-section .progress-fill {
+        animation: none;
+        width: var(--target-width);
+    }
+}


### PR DESCRIPTION

### Description
This PR introduces the CSS Blur-Entrance Progress Bar designed for Minimalist Tech Layouts, resolving issue #64659 (and duplicate #65094). 

### Changes Made:
- Added `submissions/examples/minimalist-tech-blur-entrance-progress/` directory.
- Created `demo.html` showcasing three mock System Diagnostics cards. The layout utilizes the pure CSS checkbox hack (`<input type="checkbox">` paired with `<label>` elements) to manage the triggering of the progress bars without JavaScript.
- Created `style.css` featuring a clean, professional aesthetic utilizing the `Inter` font, sharp borders, and subtle box shadows.
  - Implemented the Blur-Entrance system. To prevent keyframe property conflicts, the structure separates concerns: an outer `.blur-entrance-wrapper` and an inner `.progress-fill`.
  - When triggered, the `.blur-entrance-wrapper` fires an `@keyframes` animation (`blur-entrance`) that transitions the element from a fully transparent, heavily blurred (`blur(10px)`), and shrunken state (`scaleX(0.5)`) to a sharp, fully visible state.
  - Slightly delayed, the inner `.progress-fill` fires its own `@keyframes` animation (`fill-width`) that expands its width from `0%` to a dynamically set inline CSS variable (`--target-width`).
- Added `README.md` documenting usage and technical features.
- Honors the `prefers-reduced-motion` accessibility standard. The blur scaling and width expansion keyframes are completely disabled, immediately rendering the final state width without any visual stutter or motion for motion-sensitive users.

Closes #64659
