### PR TITLE
feat: add floating elevation (soft lift) hover class

### DIFF
--- a/submissions/examples/soft-lift-elevation/README.md
+++ b/submissions/examples/soft-lift-elevation/README.md
@@ -1,0 +1,11 @@
+Floating Elevation (Soft Lift)
+
+A single composable class: hover or focus an element and it translates upward slightly while its shadow grows larger, softer, and more diffused — reading as the element physically lifting toward the viewer. No layout or color opinions baked in, so .hover-lift-card stacks with anything.
+
+demo.html shows it on pricing cards (the exact use case from the issue), on plain unrelated elements (an icon tile, a banner) to prove it carries no layout assumptions, and across three intensity variants.
+
+Files
+File	Purpose
+demo.html	Pricing cards + stacking demo + intensity variants
+style.css	The lift mechanism, tokens, and demo chrome
+README.md	This file

--- a/submissions/examples/soft-lift-elevation/demo.html
+++ b/submissions/examples/soft-lift-elevation/demo.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Floating Elevation (Soft Lift) — EaseMotion CSS</title>
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@600;700&family=Inter:wght@400;500;600&family=IBM+Plex+Mono:wght@500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="noise" aria-hidden="true"></div>
+
+  <header class="hero">
+    <p class="eyebrow">EaseMotion CSS &middot; showcase</p>
+    <h1 class="hero-title">Floating elevation<br>(soft lift)</h1>
+    <p class="hero-sub">A single composable class: hover or focus an element and it lifts slightly while its shadow grows larger and softer &mdash; like it's rising off the page. One class, stackable with anything.</p>
+  </header>
+
+  <main class="showcase">
+
+    <!-- ================= Pricing cards — the exact use case from the issue ================= -->
+    <section class="demo-block" aria-labelledby="pricing-title">
+      <h2 id="pricing-title" class="demo-block-title">Pricing cards</h2>
+      <p class="demo-block-text">Hover or tab to any card &mdash; <code>.hover-lift-card</code> is the only class doing the work.</p>
+
+      <div class="pricing-grid">
+        <article class="hover-lift-card" tabindex="0">
+          <p class="plan-name">Starter</p>
+          <p class="plan-price">$0<span>/month</span></p>
+          <ul class="plan-features">
+            <li>3 projects</li>
+            <li>Community support</li>
+          </ul>
+        </article>
+
+        <article class="hover-lift-card hover-lift-card-featured" tabindex="0">
+          <span class="plan-badge">Most popular</span>
+          <p class="plan-name">Pro Plan</p>
+          <p class="plan-price">$19<span>/month</span></p>
+          <ul class="plan-features">
+            <li>Unlimited projects</li>
+            <li>Priority support</li>
+            <li>Team collaboration</li>
+          </ul>
+        </article>
+
+        <article class="hover-lift-card" tabindex="0">
+          <p class="plan-name">Enterprise</p>
+          <p class="plan-price">$49<span>/month</span></p>
+          <ul class="plan-features">
+            <li>Everything in Pro</li>
+            <li>SSO &amp; audit logs</li>
+          </ul>
+        </article>
+      </div>
+    </section>
+
+    <!-- ================= Stacked with other utilities ================= -->
+    <section class="demo-block" aria-labelledby="stack-title">
+      <h2 id="stack-title" class="demo-block-title">Stacks with anything</h2>
+      <p class="demo-block-text">The lift class carries no layout or color opinions &mdash; here it's combined with a plain icon tile and a full-width banner.</p>
+
+      <div class="stack-row">
+        <div class="icon-tile hover-lift-card" tabindex="0">
+          <span aria-hidden="true">&#9889;</span>
+        </div>
+        <div class="banner hover-lift-card" tabindex="0">
+          <p class="banner-title">New: Team workspaces</p>
+          <p class="banner-text">Invite collaborators and share components across projects.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- ================= Intensity variants ================= -->
+    <section class="demo-block" aria-labelledby="variants-title">
+      <h2 id="variants-title" class="demo-block-title">Intensity variants</h2>
+      <p class="demo-block-text">Same mechanism, tuned with custom properties &mdash; no extra keyframes needed.</p>
+
+      <div class="variant-row">
+        <div class="variant-card hover-lift-card hover-lift-subtle" tabindex="0">
+          <span class="variant-label">Subtle</span>
+        </div>
+        <div class="variant-card hover-lift-card" tabindex="0">
+          <span class="variant-label">Default</span>
+        </div>
+        <div class="variant-card hover-lift-card hover-lift-strong" tabindex="0">
+          <span class="variant-label">Strong</span>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <footer class="footer">
+    <p>EaseMotion CSS &middot; submissions/examples/soft-lift-elevation</p>
+  </footer>
+
+</body>
+</html>

--- a/submissions/examples/soft-lift-elevation/style.css
+++ b/submissions/examples/soft-lift-elevation/style.css
@@ -1,0 +1,415 @@
+* =========================================================================
+   Floating Elevation (Soft Lift) — EaseMotion CSS
+   A single composable class: on hover or keyboard focus, the element
+   translates upward slightly while its drop shadow grows larger, softer,
+   and more diffused — reading as the element physically lifting toward
+   the viewer. No layout or color opinions baked in, so it stacks cleanly
+   with any other class. Pure CSS.
+   ========================================================================= */
+ 
+ 
+/* -------------------------------------------------------------------------
+   1. Design tokens
+   ------------------------------------------------------------------------- */
+ 
+:root {
+  --em-bg: #0e1116;
+  --em-surface: #151a21;
+  --em-surface-2: #1c222b;
+  --em-border: #262e39;
+  --em-text: #edeff2;
+  --em-text-muted: #98a2b3;
+ 
+  --em-accent: #7de0c0;
+  --em-accent-strong: #9beed4;
+  --em-accent-soft: rgba(125, 224, 192, 0.14);
+ 
+  --em-font-display: "Space Grotesk", "Segoe UI", sans-serif;
+  --em-font-body: "Inter", "Segoe UI", sans-serif;
+  --em-font-mono: "IBM Plex Mono", "Courier New", monospace;
+}
+ 
+* {
+  box-sizing: border-box;
+}
+ 
+body {
+  margin: 0;
+  background: var(--em-bg);
+  color: var(--em-text);
+  font-family: var(--em-font-body);
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+ 
+.noise {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.035;
+  z-index: 0;
+  background-image: radial-gradient(circle at 1px 1px, #ffffff 1px, transparent 0);
+  background-size: 3px 3px;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   2. Hero
+   ------------------------------------------------------------------------- */
+ 
+.hero {
+  position: relative;
+  z-index: 1;
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 92px 24px 56px;
+  text-align: center;
+}
+ 
+.eyebrow {
+  font-family: var(--em-font-mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--em-accent);
+  margin: 0 0 20px;
+}
+ 
+.hero-title {
+  font-family: var(--em-font-display);
+  font-weight: 600;
+  font-size: clamp(32px, 5.5vw, 50px);
+  line-height: 1.12;
+  letter-spacing: -0.01em;
+  margin: 0 0 16px;
+}
+ 
+.hero-sub {
+  font-size: 15px;
+  color: var(--em-text-muted);
+  max-width: 500px;
+  margin: 0 auto;
+}
+ 
+.hero-sub code {
+  font-family: var(--em-font-mono);
+  font-size: 13px;
+  color: var(--em-text);
+  background: var(--em-surface-2);
+  padding: 1px 6px;
+  border-radius: 5px;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   3. THE COMPONENT — .hover-lift-card
+   Everything a consumer needs is this one block plus its variants below.
+   ------------------------------------------------------------------------- */
+ 
+.hover-lift-card {
+  /* Public API: override these on an instance to retune the lift without
+     touching the transition/keyframe logic at all. */
+  --lift-distance: 10px;
+  --lift-duration: 320ms;
+  --lift-ease: cubic-bezier(0.16, 1, 0.3, 1);
+  --lift-shadow-rest: 0 6px 16px -8px rgba(0, 0, 0, 0.45);
+  --lift-shadow-active: 0 28px 48px -16px rgba(0, 0, 0, 0.55);
+ 
+  transform: translateY(0);
+  box-shadow: var(--lift-shadow-rest);
+  transition:
+    transform var(--lift-duration) var(--lift-ease),
+    box-shadow var(--lift-duration) var(--lift-ease);
+  will-change: transform;
+}
+ 
+.hover-lift-card:hover,
+.hover-lift-card:focus-visible {
+  transform: translateY(calc(var(--lift-distance) * -1));
+  box-shadow: var(--lift-shadow-active);
+}
+ 
+/* Keyboard focus needs its own visible indicator independent of the lift
+   itself — the shadow growing isn't enough signal on its own. */
+.hover-lift-card:focus-visible {
+  outline: 2px solid var(--em-accent);
+  outline-offset: 4px;
+}
+ 
+/* Settling back down uses the same transition, just reversed, so there's
+   no separate "un-lift" animation to maintain. */
+ 
+ 
+/* -------------------------------------------------------------------------
+   4. Intensity variants — same mechanism, different tokens
+   ------------------------------------------------------------------------- */
+ 
+.hover-lift-subtle {
+  --lift-distance: 4px;
+  --lift-duration: 260ms;
+  --lift-shadow-active: 0 16px 28px -14px rgba(0, 0, 0, 0.5);
+}
+ 
+.hover-lift-strong {
+  --lift-distance: 16px;
+  --lift-duration: 380ms;
+  --lift-shadow-active: 0 40px 64px -18px rgba(0, 0, 0, 0.6);
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   5. Showcase layout (demo chrome — not part of the component itself)
+   ------------------------------------------------------------------------- */
+ 
+.showcase {
+  position: relative;
+  z-index: 1;
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 0 24px 90px;
+  display: flex;
+  flex-direction: column;
+  gap: 56px;
+}
+ 
+.demo-block-title {
+  font-family: var(--em-font-display);
+  font-size: 17px;
+  font-weight: 600;
+  margin: 0 0 8px;
+  text-align: center;
+}
+ 
+.demo-block-text {
+  font-size: 13.5px;
+  color: var(--em-text-muted);
+  text-align: center;
+  margin: 0 0 28px;
+}
+ 
+.demo-block-text code {
+  font-family: var(--em-font-mono);
+  font-size: 12.5px;
+  color: var(--em-text);
+  background: var(--em-surface-2);
+  padding: 1px 6px;
+  border-radius: 5px;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   6. Pricing cards
+   ------------------------------------------------------------------------- */
+ 
+.pricing-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+}
+ 
+.hover-lift-card {
+  position: relative;
+  background: var(--em-surface);
+  border: 1px solid var(--em-border);
+  border-radius: 18px;
+  padding: 26px 22px;
+  cursor: default;
+}
+ 
+.hover-lift-card-featured {
+  border-color: rgba(125, 224, 192, 0.4);
+  background: linear-gradient(180deg, var(--em-accent-soft), var(--em-surface) 60%);
+}
+ 
+.plan-badge {
+  position: absolute;
+  top: -11px;
+  left: 22px;
+  font-family: var(--em-font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--em-bg);
+  background: var(--em-accent);
+  padding: 3px 9px;
+  border-radius: 999px;
+}
+ 
+.plan-name {
+  font-family: var(--em-font-display);
+  font-size: 14.5px;
+  font-weight: 600;
+  color: var(--em-text-muted);
+  margin: 4px 0 10px;
+}
+ 
+.plan-price {
+  font-family: var(--em-font-display);
+  font-size: 30px;
+  font-weight: 700;
+  margin: 0 0 18px;
+}
+ 
+.plan-price span {
+  font-family: var(--em-font-body);
+  font-size: 13px;
+  font-weight: 400;
+  color: var(--em-text-muted);
+}
+ 
+.plan-features {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid var(--em-border);
+  padding-top: 14px;
+}
+ 
+.plan-features li {
+  font-size: 13px;
+  color: var(--em-text-muted);
+  padding: 5px 0;
+}
+ 
+.plan-features li::before {
+  content: "✓";
+  color: var(--em-accent);
+  margin-right: 8px;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   7. "Stacks with anything" row
+   ------------------------------------------------------------------------- */
+ 
+.stack-row {
+  display: flex;
+  gap: 18px;
+  align-items: stretch;
+}
+ 
+.icon-tile {
+  flex: 0 0 auto;
+  width: 84px;
+  height: 84px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 28px;
+  background: var(--em-surface-2);
+  border: 1px solid var(--em-border);
+  border-radius: 16px;
+}
+ 
+.banner {
+  flex: 1 1 auto;
+  background: var(--em-surface);
+  border: 1px solid var(--em-border);
+  border-radius: 16px;
+  padding: 20px 22px;
+}
+ 
+.banner-title {
+  font-family: var(--em-font-display);
+  font-size: 14.5px;
+  font-weight: 600;
+  margin: 0 0 4px;
+}
+ 
+.banner-text {
+  font-size: 13px;
+  color: var(--em-text-muted);
+  margin: 0;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   8. Intensity variant cards
+   ------------------------------------------------------------------------- */
+ 
+.variant-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+ 
+.variant-card {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 84px;
+  background: var(--em-surface-2);
+  border: 1px solid var(--em-border);
+  border-radius: 14px;
+}
+ 
+.variant-label {
+  font-family: var(--em-font-mono);
+  font-size: 12px;
+  letter-spacing: 0.03em;
+  color: var(--em-text-muted);
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   9. Footer
+   ------------------------------------------------------------------------- */
+ 
+.footer {
+  position: relative;
+  z-index: 1;
+  text-align: center;
+  padding: 8px 24px 48px;
+  font-size: 12.5px;
+  color: var(--em-text-muted);
+  font-family: var(--em-font-mono);
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   10. Responsive
+   ------------------------------------------------------------------------- */
+ 
+@media (max-width: 720px) {
+  .pricing-grid,
+  .variant-row {
+    grid-template-columns: 1fr;
+  }
+ 
+  .stack-row {
+    flex-direction: column;
+  }
+ 
+  .icon-tile {
+    width: 100%;
+    height: 64px;
+  }
+}
+ 
+@media (max-width: 480px) {
+  .hero {
+    padding: 68px 20px 44px;
+  }
+ 
+  .showcase {
+    gap: 44px;
+  }
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   11. Reduced motion
+   ------------------------------------------------------------------------- */
+ 
+@media (prefers-reduced-motion: reduce) {
+  .hover-lift-card {
+    transition-duration: 1ms;
+  }
+ 
+  .hover-lift-card:hover,
+  .hover-lift-card:focus-visible {
+    /* Keep the shadow feedback (not motion), drop the translate so
+       nothing moves for someone who's asked not to see it. */
+    transform: translateY(0);
+  }
+}


### PR DESCRIPTION
Closes #63002

## Pull Request Description
Adds `.hover-lift-card` — a single composable class where hover or focus lifts an element slightly while its shadow grows larger and softer, reading as the element rising off the surface. No layout or color opinions, stacks with any other class.

## Type of Change
- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/soft-lift-elevation/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A single class, `.hover-lift-card`, that lifts an element and grows/softens its shadow on hover or keyboard focus.

**How does a developer use it?**
```html
<div class="hover-lift-card">
  <h3>Pro Plan</h3>
  <p>$19/month</p>
</div>
```
Add `.hover-lift-subtle` or `.hover-lift-strong` alongside it to retune intensity — both are just custom-property overrides on the same mechanism.

**Why does it fit EaseMotion CSS?**
Matches the issue's own framing exactly: it's composable (no layout/color assumptions, demonstrated in the demo by applying it to a pricing card, a plain icon tile, and a banner with no adjustment needed) and handles the bezier/timing nuance internally so a developer never has to think about it.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

## Notes for Maintainer
Respects `prefers-reduced-motion` by dropping the `translateY` but keeping the shadow change, so interaction is still visibly acknowledged without motion. The demo's non-card tiles use `tabindex="0"` purely to make `:focus-visible` demonstrable on non-interactive elements — called out in the README as a demo-only choice, not a real-usage recommendation.