### PR TITLE
feat: add elastic-slide carousel cyberpunk neon layouts for #64677

### DIFF
--- a/submissions/examples/elastic-slide-carousel-cyberpunk-neon-layouts/README.md
+++ b/submissions/examples/elastic-slide-carousel-cyberpunk-neon-layouts/README.md
@@ -1,0 +1,42 @@
+# Elastic-Slide Carousel — Cyberpunk Neon Layouts
+
+A pure CSS horizontal scroll carousel with neon-bordered cards that slide in using elastic easing. Features cyberpunk dark grid background, glowing orb decorations, and color-coded cards.
+
+## Features
+
+- **Elastic slide-in animation** — cards enter with `cubic-bezier(0.34, 1.56, 0.64, 1)` for a bouncy overshoot
+- **Scroll-snap navigation** — native CSS `scroll-snap-type: x mandatory` for smooth card snapping
+- **Neon glow top bar** — each card reveals a colored glow line on hover
+- **Animated background orbs** — three floating blurred circles (cyan, pink, violet)
+- **Grid overlay** — subtle cyan grid lines on dark background
+- **Fully responsive** — cards shrink on mobile, scroll snap changes to proximity mode
+- **Reduced-motion accessible** — all animations and hover transforms disabled when `prefers-reduced-motion: reduce`
+
+## CSS Custom Properties
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `--esc-bg` | `#060a12` | Page background |
+| `--esc-surface` | `rgba(255,255,255,0.03)` | Card fill |
+| `--esc-border` | `rgba(255,255,255,0.07)` | Card border |
+| `--esc-text` | `#dfe6f0` | Primary text |
+| `--esc-text-dim` | `rgba(223,230,240,0.45)` | Secondary text |
+| `--esc-neon-cyan` | `#00e5ff` | Cyan neon accent |
+| `--esc-neon-pink` | `#ff1f71` | Pink neon accent |
+| `--esc-neon-violet` | `#9d4edd` | Violet neon accent |
+| `--esc-glow-cyan` | `rgba(0,229,255,0.3)` | Cyan glow shadow |
+| `--esc-glow-pink` | `rgba(255,31,113,0.3)` | Pink glow shadow |
+| `--esc-glow-violet` | `rgba(157,78,221,0.3)` | Violet glow shadow |
+| `--esc-elastic` | `cubic-bezier(0.34,1.56,0.64,1)` | Elastic easing curve |
+
+## How It Works
+
+1. The carousel uses native CSS `scroll-snap-type: x mandatory` for smooth card-by-card navigation.
+2. Each card slides in via `escCardSlide` keyframes — starting offset with horizontal scale.
+3. Cards are staggered with increasing `animation-delay` for a cascading entrance.
+4. Hovering a card lifts it with `translateY(-4px)` and reveals a neon glow bar at the top.
+5. Background orbs pulse with `escOrbFloat` keyframes on a subtle grid overlay.
+
+## Usage
+
+Copy `demo.html` and `style.css` into your project. No JavaScript or external dependencies needed. Override the CSS custom properties to adjust neon colors, glow intensity, or elastic bounce.

--- a/submissions/examples/elastic-slide-carousel-cyberpunk-neon-layouts/demo.html
+++ b/submissions/examples/elastic-slide-carousel-cyberpunk-neon-layouts/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS Elastic-Slide Carousel with cyberpunk neon styling. Pure CSS carousel with elastic easing, neon glow cards, and dark cyberpunk UI.">
+  <title>Elastic-Slide Carousel – Cyberpunk Neon Layouts</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="esc-page">
+    <header class="esc-header">
+      <span class="esc-header__tag">Cyberpunk Neon UI</span>
+      <h1 class="esc-header__title">Elastic-Slide Carousel</h1>
+      <p class="esc-header__sub">Neon-bordered cards that slide in with elastic bounce on a dark grid.</p>
+    </header>
+
+    <section class="esc-carousel" aria-label="Elastic-Slide Carousel">
+      <div class="esc-carousel__track">
+        <article class="esc-card esc-card--a">
+          <div class="esc-card__glow" aria-hidden="true"></div>
+          <span class="esc-card__num">01</span>
+          <h2 class="esc-card__title">Grid Breach</h2>
+          <p class="esc-card__text">Infiltration vector detected across sector 7. Neon firewalls bypassed.</p>
+          <div class="esc-card__bar"></div>
+        </article>
+
+        <article class="esc-card esc-card--b">
+          <div class="esc-card__glow" aria-hidden="true"></div>
+          <span class="esc-card__num">02</span>
+          <h2 class="esc-card__title">Data Heist</h2>
+          <p class="esc-card__text">Encrypted payload extracted from mainframe node. Zero traces left.</p>
+          <div class="esc-card__bar"></div>
+        </article>
+
+        <article class="esc-card esc-card--c">
+          <div class="esc-card__glow" aria-hidden="true"></div>
+          <span class="esc-card__num">03</span>
+          <h2 class="esc-card__title">Neon Chase</h2>
+          <p class="esc-card__text">High-speed pursuit through rain-soaked megacity corridors at dusk.</p>
+          <div class="esc-card__bar"></div>
+        </article>
+
+        <article class="esc-card esc-card--d">
+          <div class="esc-card__glow" aria-hidden="true"></div>
+          <span class="esc-card__num">04</span>
+          <h2 class="esc-card__title">Synth Wave</h2>
+          <p class="esc-card__text">Audio synthesis module booting. Retro-futuristic frequencies engaged.</p>
+          <div class="esc-card__bar"></div>
+        </article>
+
+        <article class="esc-card esc-card--e">
+          <div class="esc-card__glow" aria-hidden="true"></div>
+          <span class="esc-card__num">05</span>
+          <h2 class="esc-card__title">Ghost Protocol</h2>
+          <p class="esc-card__text">Identity scrubbed from all databases. Operative status: phantom.</p>
+          <div class="esc-card__bar"></div>
+        </article>
+      </div>
+    </section>
+
+    <div class="esc-bg" aria-hidden="true">
+      <div class="esc-bg__orb esc-bg__orb--1"></div>
+      <div class="esc-bg__orb esc-bg__orb--2"></div>
+      <div class="esc-bg__orb esc-bg__orb--3"></div>
+      <div class="esc-bg__grid"></div>
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/elastic-slide-carousel-cyberpunk-neon-layouts/style.css
+++ b/submissions/examples/elastic-slide-carousel-cyberpunk-neon-layouts/style.css
@@ -1,0 +1,321 @@
+:root {
+  --esc-bg: #060a12;
+  --esc-surface: rgba(255, 255, 255, 0.03);
+  --esc-border: rgba(255, 255, 255, 0.07);
+  --esc-text: #dfe6f0;
+  --esc-text-dim: rgba(223, 230, 240, 0.45);
+  --esc-neon-cyan: #00e5ff;
+  --esc-neon-pink: #ff1f71;
+  --esc-neon-violet: #9d4edd;
+  --esc-glow-cyan: rgba(0, 229, 255, 0.3);
+  --esc-glow-pink: rgba(255, 31, 113, 0.3);
+  --esc-glow-violet: rgba(157, 78, 221, 0.3);
+  --esc-elastic: cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: var(--esc-bg);
+  font-family: "Share Tech Mono", "Courier New", monospace;
+  color: var(--esc-text);
+  overflow-x: hidden;
+}
+
+/* ── background ──────────────────────────────────── */
+
+.esc-bg {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  overflow: hidden;
+}
+
+.esc-bg__grid {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(0, 229, 255, 0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0, 229, 255, 0.04) 1px, transparent 1px);
+  background-size: 60px 60px;
+}
+
+.esc-bg__orb {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(120px);
+  opacity: 0.25;
+}
+
+.esc-bg__orb--1 {
+  width: 350px;
+  height: 350px;
+  background: var(--esc-neon-cyan);
+  top: -10%;
+  left: 8%;
+  animation: escOrbFloat 9s ease-in-out infinite alternate;
+}
+
+.esc-bg__orb--2 {
+  width: 280px;
+  height: 280px;
+  background: var(--esc-neon-pink);
+  bottom: -8%;
+  right: 12%;
+  animation: escOrbFloat 9s ease-in-out infinite alternate 3s;
+}
+
+.esc-bg__orb--3 {
+  width: 200px;
+  height: 200px;
+  background: var(--esc-neon-violet);
+  top: 40%;
+  left: 50%;
+  transform: translateX(-50%);
+  animation: escOrbFloat 9s ease-in-out infinite alternate 6s;
+}
+
+@keyframes escOrbFloat {
+  0%   { opacity: 0.2; transform: translate(0, 0) scale(1); }
+  100% { opacity: 0.35; transform: translate(-20px, 15px) scale(1.1); }
+}
+
+/* ── page ────────────────────────────────────────── */
+
+.esc-page {
+  position: relative;
+  z-index: 1;
+  width: min(900px, 94vw);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 36px;
+}
+
+/* ── header ──────────────────────────────────────── */
+
+.esc-header {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+
+.esc-header__tag {
+  font-size: 0.62rem;
+  text-transform: uppercase;
+  letter-spacing: 0.28em;
+  color: var(--esc-neon-pink);
+  background: rgba(255, 31, 113, 0.08);
+  padding: 4px 14px;
+  border: 1px solid rgba(255, 31, 113, 0.2);
+}
+
+.esc-header__title {
+  font-size: clamp(1.6rem, 4vw, 2.6rem);
+  font-weight: 700;
+  background: linear-gradient(135deg, var(--esc-neon-cyan), var(--esc-neon-pink));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.esc-header__sub {
+  font-size: 0.82rem;
+  color: var(--esc-text-dim);
+  max-width: 42ch;
+  line-height: 1.6;
+}
+
+/* ── carousel track ──────────────────────────────── */
+
+.esc-carousel {
+  width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scroll-snap-type: x mandatory;
+  scrollbar-width: thin;
+  scrollbar-color: var(--esc-neon-cyan) transparent;
+  padding: 12px 0 20px;
+}
+
+.esc-carousel::-webkit-scrollbar {
+  height: 4px;
+}
+
+.esc-carousel::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.esc-carousel::-webkit-scrollbar-thumb {
+  background: var(--esc-neon-cyan);
+  border-radius: 2px;
+}
+
+.esc-carousel__track {
+  display: flex;
+  gap: 20px;
+  width: max-content;
+  padding: 0 8px;
+}
+
+/* ── cards ───────────────────────────────────────── */
+
+.esc-card {
+  scroll-snap-align: center;
+  position: relative;
+  width: 240px;
+  min-height: 280px;
+  flex-shrink: 0;
+  background: var(--esc-surface);
+  border: 1px solid var(--esc-border);
+  border-radius: 6px;
+  padding: 28px 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  overflow: hidden;
+  animation: escCardSlide 0.7s var(--esc-elastic) both;
+}
+
+.esc-card--a { animation-delay: 0.05s; border-left: 3px solid var(--esc-neon-cyan); }
+.esc-card--b { animation-delay: 0.12s; border-left: 3px solid var(--esc-neon-pink); }
+.esc-card--c { animation-delay: 0.19s; border-left: 3px solid var(--esc-neon-violet); }
+.esc-card--d { animation-delay: 0.26s; border-left: 3px solid var(--esc-neon-cyan); }
+.esc-card--e { animation-delay: 0.33s; border-left: 3px solid var(--esc-neon-pink); }
+
+.esc-card__glow {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 3px;
+  opacity: 0;
+  transition: opacity 0.35s ease;
+}
+
+.esc-card--a .esc-card__glow { background: var(--esc-neon-cyan); }
+.esc-card--b .esc-card__glow { background: var(--esc-neon-pink); }
+.esc-card--c .esc-card__glow { background: var(--esc-neon-violet); }
+.esc-card--d .esc-card__glow { background: var(--esc-neon-cyan); }
+.esc-card--e .esc-card__glow { background: var(--esc-neon-pink); }
+
+.esc-card:hover .esc-card__glow {
+  opacity: 1;
+}
+
+.esc-card:hover {
+  border-color: rgba(255, 255, 255, 0.15);
+  transform: translateY(-4px);
+  transition: transform 0.3s var(--esc-elastic), border-color 0.3s ease;
+}
+
+.esc-card__num {
+  font-size: 2rem;
+  font-weight: 800;
+  line-height: 1;
+  opacity: 0.12;
+}
+
+.esc-card--a .esc-card__num { color: var(--esc-neon-cyan); opacity: 0.25; }
+.esc-card--b .esc-card__num { color: var(--esc-neon-pink); opacity: 0.25; }
+.esc-card--c .esc-card__num { color: var(--esc-neon-violet); opacity: 0.25; }
+.esc-card--d .esc-card__num { color: var(--esc-neon-cyan); opacity: 0.25; }
+.esc-card--e .esc-card__num { color: var(--esc-neon-pink); opacity: 0.25; }
+
+.esc-card__title {
+  font-size: 1.05rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.esc-card--a .esc-card__title { color: var(--esc-neon-cyan); }
+.esc-card--b .esc-card__title { color: var(--esc-neon-pink); }
+.esc-card--c .esc-card__title { color: var(--esc-neon-violet); }
+.esc-card--d .esc-card__title { color: var(--esc-neon-cyan); }
+.esc-card--e .esc-card__title { color: var(--esc-neon-pink); }
+
+.esc-card__text {
+  font-size: 0.78rem;
+  color: var(--esc-text-dim);
+  line-height: 1.7;
+  flex: 1;
+}
+
+.esc-card__bar {
+  width: 100%;
+  height: 2px;
+  border-radius: 1px;
+  opacity: 0.3;
+}
+
+.esc-card--a .esc-card__bar { background: var(--esc-neon-cyan); }
+.esc-card--b .esc-card__bar { background: var(--esc-neon-pink); }
+.esc-card--c .esc-card__bar { background: var(--esc-neon-violet); }
+.esc-card--d .esc-card__bar { background: var(--esc-neon-cyan); }
+.esc-card--e .esc-card__bar { background: var(--esc-neon-pink); }
+
+/* ── elastic slide keyframes ─────────────────────── */
+
+@keyframes escCardSlide {
+  0% {
+    opacity: 0;
+    transform: translateX(60px) scaleX(0.92);
+  }
+  100% {
+    opacity: 1;
+    transform: translateX(0) scaleX(1);
+  }
+}
+
+/* ── responsive ──────────────────────────────────── */
+
+@media (max-width: 600px) {
+  .esc-page {
+    gap: 24px;
+  }
+
+  .esc-carousel {
+    scroll-snap-type: x proximity;
+  }
+
+  .esc-card {
+    width: 200px;
+    min-height: 240px;
+    padding: 22px 18px;
+  }
+
+  .esc-bg__orb {
+    filter: blur(90px);
+    opacity: 0.15;
+  }
+}
+
+/* ── accessibility ───────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .esc-card {
+    animation: none;
+  }
+
+  .esc-card:hover {
+    transform: none;
+    transition: none;
+  }
+
+  .esc-bg__orb {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary
Adds a pure CSS Elastic-Slide Carousel with cyberpunk neon styling for Issue #64677.

## What's Included
- **demo.html** — Showcase with 5 neon-bordered cards in a horizontal scroll carousel
- **style.css** — Pure CSS with elastic easing, scroll-snap navigation, neon glow effects, and animated background
- **README.md** — Documentation with custom properties table and usage guide

## CSS Features
- Elastic slide-in animation (`cubic-bezier(0.34, 1.56, 0.64, 1)`) with staggered delays
- Native CSS `scroll-snap-type: x mandatory` for card-by-card navigation
- Neon glow top bar revealed on card hover
- Three animated background orbs (cyan, pink, violet) with subtle grid overlay
- `prefers-reduced-motion` media query support (disables all animations)
- Fully responsive (cards shrink, snap mode changes on mobile)

## Validator Compliance
- Only adds files inside `submissions/examples/` — no existing files modified
- `demo.html`: has DOCTYPE, html, head, body, `<meta name="description">`, `<meta name="viewport">`, `<title>`, `<link rel="stylesheet">`
- `style.css`: has `:root` with CSS custom properties, `*` box-sizing reset, keyframe animations, media queries, `prefers-reduced-motion`
- `README.md`: 5+ non-empty non-header lines
- No `.js` files, no files outside `submissions/`

## Files Changed
- `submissions/examples/elastic-slide-carousel-cyberpunk-neon-layouts/demo.html` (new)
- `submissions/examples/elastic-slide-carousel-cyberpunk-neon-layouts/style.css` (new)
- `submissions/examples/elastic-slide-carousel-cyberpunk-neon-layouts/README.md` (new)

Closes #64677
