### PR TITLE
feat: add blur-entrance pricing table minimalist tech layouts for #64614

### DIFF
--- a/submissions/examples/blur-entrance-pricing-table-minimalist-tech/README.md
+++ b/submissions/examples/blur-entrance-pricing-table-minimalist-tech/README.md
@@ -1,0 +1,40 @@
+# Blur-Entrance Pricing Table — Minimalist Tech Layouts
+
+A pure CSS pricing table with blur-to-sharp entrance animation. Three tiered cards (Starter, Pro, Enterprise) fade in with a deblur effect on a clean light background with monospace typography.
+
+## Features
+
+- **Blur entrance animation** — cards start blurred and fade in with `filter: blur(12px)` transitioning to sharp
+- **Staggered entrance** — each card has a different `animation-delay` for cascading reveal
+- **Minimalist tech aesthetic** — light background, monospace font, clean borders, subtle dot decorations
+- **Featured card highlight** — Pro card has blue border, shadow, and badge
+- **Fully responsive** — stacks to single column on screens under 700px
+- **Reduced-motion accessible** — all animations disabled, cards shown immediately when `prefers-reduced-motion: reduce`
+
+## CSS Custom Properties
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `--bpt-bg` | `#fafafa` | Page background |
+| `--bpt-surface` | `#ffffff` | Card fill |
+| `--bpt-border` | `#e5e7eb` | Border color |
+| `--bpt-text` | `#1a1a2e` | Primary text |
+| `--bpt-text-dim` | `#6b7280` | Secondary text |
+| `--bpt-accent` | `#2563eb` | Primary accent (blue) |
+| `--bpt-accent-light` | `rgba(37,99,235,0.08)` | Accent background tint |
+| `--bpt-success` | `#10b981` | Feature check color |
+| `--bpt-radius` | `10px` | Card border radius |
+| `--bpt-blur` | `12px` | Entrance blur amount |
+| `--bpt-duration` | `0.6s` | Animation duration |
+
+## How It Works
+
+1. Cards are initially set to `filter: blur(12px)` and `opacity: 0`.
+2. The `bptBlurIn` keyframe animates both blur and opacity simultaneously, plus a subtle upward slide.
+3. Each card has a staggered `animation-delay` (0.1s, 0.25s, 0.4s) for a cascading entrance.
+4. Background decorative dots pulse with `bptDotPulse` keyframes.
+5. On `prefers-reduced-motion: reduce`, all animations are removed and cards display instantly.
+
+## Usage
+
+Copy `demo.html` and `style.css` into your project. No JavaScript or external dependencies needed. Override the CSS custom properties to adjust blur amount, accent colors, or animation timing.

--- a/submissions/examples/blur-entrance-pricing-table-minimalist-tech/demo.html
+++ b/submissions/examples/blur-entrance-pricing-table-minimalist-tech/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS Blur-Entrance Pricing Table with minimalist tech styling. Pure CSS pricing cards with blur fade-in animations and clean monospace UI.">
+  <title>Blur-Entrance Pricing Table – Minimalist Tech Layouts</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="bpt-page">
+    <header class="bpt-header">
+      <span class="bpt-header__label">Minimalist Tech</span>
+      <h1 class="bpt-header__title">Pricing Table</h1>
+      <p class="bpt-header__sub">Clean plans that blur into view. No clutter, just code.</p>
+    </header>
+
+    <section class="bpt-pricing" aria-label="Pricing Plans">
+      <article class="bpt-card bpt-card--starter">
+        <div class="bpt-card__head">
+          <span class="bpt-card__tier">Starter</span>
+          <span class="bpt-card__price">$0<span class="bpt-card__period">/mo</span></span>
+        </div>
+        <ul class="bpt-card__list">
+          <li>5 Projects</li>
+          <li>1 GB Storage</li>
+          <li>Community Support</li>
+          <li>Basic Analytics</li>
+        </ul>
+        <a href="#" class="bpt-card__cta">Get Started</a>
+      </article>
+
+      <article class="bpt-card bpt-card--pro">
+        <div class="bpt-card__badge">Popular</div>
+        <div class="bpt-card__head">
+          <span class="bpt-card__tier">Pro</span>
+          <span class="bpt-card__price">$19<span class="bpt-card__period">/mo</span></span>
+        </div>
+        <ul class="bpt-card__list">
+          <li>Unlimited Projects</li>
+          <li>50 GB Storage</li>
+          <li>Priority Support</li>
+          <li>Advanced Analytics</li>
+        </ul>
+        <a href="#" class="bpt-card__cta bpt-card__cta--primary">Get Pro</a>
+      </article>
+
+      <article class="bpt-card bpt-card--enterprise">
+        <div class="bpt-card__head">
+          <span class="bpt-card__tier">Enterprise</span>
+          <span class="bpt-card__price">$49<span class="bpt-card__period">/mo</span></span>
+        </div>
+        <ul class="bpt-card__list">
+          <li>Unlimited Everything</li>
+          <li>500 GB Storage</li>
+          <li>24/7 Dedicated Support</li>
+          <li>Custom Integrations</li>
+        </ul>
+        <a href="#" class="bpt-card__cta">Contact Sales</a>
+      </article>
+    </section>
+
+    <div class="bpt-bg" aria-hidden="true">
+      <div class="bpt-bg__dot bpt-bg__dot--1"></div>
+      <div class="bpt-bg__dot bpt-bg__dot--2"></div>
+      <div class="bpt-bg__line"></div>
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/blur-entrance-pricing-table-minimalist-tech/style.css
+++ b/submissions/examples/blur-entrance-pricing-table-minimalist-tech/style.css
@@ -1,0 +1,309 @@
+:root {
+  --bpt-bg: #fafafa;
+  --bpt-surface: #ffffff;
+  --bpt-border: #e5e7eb;
+  --bpt-text: #1a1a2e;
+  --bpt-text-dim: #6b7280;
+  --bpt-accent: #2563eb;
+  --bpt-accent-light: rgba(37, 99, 235, 0.08);
+  --bpt-success: #10b981;
+  --bpt-radius: 10px;
+  --bpt-blur: 12px;
+  --bpt-duration: 0.6s;
+}
+
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: var(--bpt-bg);
+  font-family: "SF Mono", "Fira Code", "Courier New", monospace;
+  color: var(--bpt-text);
+  overflow-x: hidden;
+}
+
+/* ── background ──────────────────────────────────── */
+
+.bpt-bg {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+}
+
+.bpt-bg__dot {
+  position: absolute;
+  width: 220px;
+  height: 220px;
+  border-radius: 50%;
+  background: var(--bpt-accent);
+  opacity: 0.04;
+}
+
+.bpt-bg__dot--1 {
+  top: 10%;
+  right: 15%;
+  animation: bptDotPulse 7s ease-in-out infinite alternate;
+}
+
+.bpt-bg__dot--2 {
+  bottom: 15%;
+  left: 10%;
+  width: 180px;
+  height: 180px;
+  background: var(--bpt-success);
+  animation: bptDotPulse 7s ease-in-out infinite alternate 3.5s;
+}
+
+@keyframes bptDotPulse {
+  0%   { opacity: 0.03; transform: scale(1); }
+  100% { opacity: 0.07; transform: scale(1.15); }
+}
+
+.bpt-bg__line {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--bpt-border), transparent);
+}
+
+/* ── page ────────────────────────────────────────── */
+
+.bpt-page {
+  position: relative;
+  z-index: 1;
+  width: min(820px, 92vw);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 36px;
+}
+
+/* ── header ──────────────────────────────────────── */
+
+.bpt-header {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+
+.bpt-header__label {
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.3em;
+  color: var(--bpt-accent);
+  background: var(--bpt-accent-light);
+  padding: 3px 12px;
+}
+
+.bpt-header__title {
+  font-size: clamp(1.6rem, 4vw, 2.4rem);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+}
+
+.bpt-header__sub {
+  font-size: 0.78rem;
+  color: var(--bpt-text-dim);
+  max-width: 36ch;
+  line-height: 1.6;
+}
+
+/* ── pricing grid ────────────────────────────────── */
+
+.bpt-pricing {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+  width: 100%;
+}
+
+/* ── card ────────────────────────────────────────── */
+
+.bpt-card {
+  position: relative;
+  background: var(--bpt-surface);
+  border: 1px solid var(--bpt-border);
+  border-radius: var(--bpt-radius);
+  padding: 28px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  filter: blur(var(--bpt-blur));
+  opacity: 0;
+  animation: bptBlurIn var(--bpt-duration) ease-out forwards;
+}
+
+.bpt-card--starter  { animation-delay: 0.1s; }
+.bpt-card--pro      { animation-delay: 0.25s; }
+.bpt-card--enterprise { animation-delay: 0.4s; }
+
+.bpt-card--pro {
+  border-color: var(--bpt-accent);
+  box-shadow: 0 4px 20px rgba(37, 99, 235, 0.08);
+}
+
+.bpt-card__badge {
+  position: absolute;
+  top: -10px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--bpt-accent);
+  color: #fff;
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  padding: 3px 12px;
+  border-radius: 20px;
+}
+
+/* ── card head ───────────────────────────────────── */
+
+.bpt-card__head {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.bpt-card__tier {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--bpt-text-dim);
+}
+
+.bpt-card__price {
+  font-size: 2.2rem;
+  font-weight: 800;
+  letter-spacing: -0.04em;
+}
+
+.bpt-card--pro .bpt-card__price {
+  color: var(--bpt-accent);
+}
+
+.bpt-card__period {
+  font-size: 0.75rem;
+  font-weight: 400;
+  color: var(--bpt-text-dim);
+}
+
+/* ── feature list ────────────────────────────────── */
+
+.bpt-card__list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  flex: 1;
+}
+
+.bpt-card__list li {
+  font-size: 0.75rem;
+  color: var(--bpt-text-dim);
+  padding-left: 18px;
+  position: relative;
+  line-height: 1.5;
+}
+
+.bpt-card__list li::before {
+  content: "+";
+  position: absolute;
+  left: 0;
+  color: var(--bpt-success);
+  font-weight: 700;
+}
+
+.bpt-card--pro .bpt-card__list li::before {
+  color: var(--bpt-accent);
+}
+
+/* ── cta ─────────────────────────────────────────── */
+
+.bpt-card__cta {
+  display: block;
+  text-align: center;
+  font-family: inherit;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  text-decoration: none;
+  padding: 10px 0;
+  border: 1px solid var(--bpt-border);
+  border-radius: 6px;
+  color: var(--bpt-text);
+  background: transparent;
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s, border-color 0.2s;
+}
+
+.bpt-card__cta:hover {
+  background: var(--bpt-text);
+  color: var(--bpt-surface);
+  border-color: var(--bpt-text);
+}
+
+.bpt-card__cta--primary {
+  background: var(--bpt-accent);
+  color: #fff;
+  border-color: var(--bpt-accent);
+}
+
+.bpt-card__cta--primary:hover {
+  background: #1d4ed8;
+  border-color: #1d4ed8;
+}
+
+/* ── blur entrance keyframes ─────────────────────── */
+
+@keyframes bptBlurIn {
+  0% {
+    filter: blur(var(--bpt-blur));
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  100% {
+    filter: blur(0);
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* ── responsive ──────────────────────────────────── */
+
+@media (max-width: 700px) {
+  .bpt-pricing {
+    grid-template-columns: 1fr;
+    max-width: 340px;
+  }
+
+  .bpt-card {
+    padding: 24px 20px;
+  }
+}
+
+/* ── accessibility ───────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .bpt-card {
+    animation: none;
+    filter: none;
+    opacity: 1;
+  }
+
+  .bpt-bg__dot {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary
Adds a pure CSS Blur-Entrance Pricing Table with minimalist tech styling for Issue #64614.

## What's Included
- **demo.html** — Three-tier pricing table (Starter, Pro, Enterprise) with blur-to-sharp entrance
- **style.css** — Pure CSS with blur filter animation, staggered delays, minimalist light theme, monospace font
- **README.md** — Documentation with custom properties table and usage guide

## CSS Features
- Blur entrance animation (`filter: blur(12px)` → `blur(0)`) with opacity and translateY transition
- Staggered card delays (0.1s, 0.25s, 0.4s) for cascading reveal
- Minimalist light theme with monospace typography and clean borders
- Featured Pro card with blue accent border, shadow, and badge
- Pulsing background dot decorations
- `prefers-reduced-motion` media query support (disables all animations, shows cards immediately)
- Fully responsive (single column stack under 700px)

## Validator Compliance
- Only adds files inside `submissions/examples/` — no existing files modified
- `demo.html`: has DOCTYPE, html, head, body, `<meta name="description">`, `<meta name="viewport">`, `<title>`, `<link rel="stylesheet">`
- `style.css`: has `:root` with CSS custom properties (`--bpt-*`), `*` box-sizing reset, `@keyframes`, `@media (prefers-reduced-motion)`
- `README.md`: 5+ non-empty non-header lines
- No `.js` files, no files outside `submissions/`

## Files Changed
- `submissions/examples/blur-entrance-pricing-table-minimalist-tech/demo.html` (new)
- `submissions/examples/blur-entrance-pricing-table-minimalist-tech/style.css` (new)
- `submissions/examples/blur-entrance-pricing-table-minimalist-tech/README.md` (new)

Closes #64614