### PR TITLE
feat: add CSS 3D-flip dropdown for product catalog layouts

### DIFF
--- a/submissions/examples/3d-flip-product-dropdown-hg/README.md
+++ b/submissions/examples/3d-flip-product-dropdown-hg/README.md
@@ -1,0 +1,69 @@
+3D-Flip Dropdown
+
+A dropdown panel for product catalog toolbars that opens by rotating down from its trigger on a 3D hinge — transform-origin at the top edge, rotateX() from a steep angle down to flat, under a perspective — rather than a plain fade or slide. Pure CSS, driven by the checkbox hack. No JavaScript.
+
+demo.html shows it in a real catalog toolbar: a Category dropdown, a Sort dropdown, and a Filters dropdown with checkboxes inside, sitting above a small product grid for context.
+
+Files
+File	Purpose
+demo.html	Catalog toolbar (3 dropdown variants) + product grid
+style.css	The flip mechanism, tokens, and demo styling
+README.md	This file
+Markup
+html
+<div class="flip-dropdown">
+  <input type="checkbox" id="dd-category" class="flip-dropdown__toggle">
+  <label for="dd-category" class="flip-dropdown__close-overlay" aria-hidden="true"></label>
+  <label for="dd-category" class="flip-dropdown__trigger">
+    Category: <strong>All</strong>
+    <span class="flip-dropdown__chevron" aria-hidden="true"></span>
+  </label>
+  <div class="flip-dropdown__panel" role="menu">
+    <a href="#" class="flip-dropdown__item" role="menuitem">All categories</a>
+    …
+  </div>
+</div>
+
+Four pieces, in this order (order matters — the CSS relies on the general sibling combinator, which only looks forward):
+
+The hidden checkbox — the actual state.
+A full-viewport <label for="..."> overlay — invisible and inert while closed, becomes a click target the instant the dropdown opens, so clicking anywhere outside closes it.
+The visible trigger <label for="...">.
+The panel.
+How the flip works
+css
+.flip-dropdown {
+  perspective: var(--fd-perspective);
+}
+
+.flip-dropdown__panel {
+  transform-origin: top center;
+  transform: rotateX(var(--fd-flip-angle)); /* -100deg by default */
+  opacity: 0;
+}
+
+.flip-dropdown__toggle:checked ~ .flip-dropdown__panel {
+  transform: rotateX(0deg);
+  opacity: 1;
+}
+
+The parent's perspective gives the rotation actual depth instead of looking like a squashed scale animation — without it, rotateX() still technically works but reads as flat and wrong. Starting the angle past -90deg (rather than exactly -90deg) means the panel is very slightly past "invisible edge-on" at rest, which avoids a one-frame flash of a perfectly knife-edge shape right as the transition begins.
+
+visibility toggles alongside opacity — instant on the way in, delayed by the full transition duration on the way out — so the closed panel never intercepts clicks or keyboard focus while it's still animating out.
+
+CSS custom properties
+Property	Default	Controls
+--fd-duration	420ms	Length of the flip transition
+--fd-ease	cubic-bezier(0.2, 0.9, 0.25, 1)	Easing curve
+--fd-perspective	1000px	3D depth — lower values exaggerate the flip, higher values flatten it
+--fd-flip-angle	-100deg	Starting rotation before the panel opens
+Anchor variant
+
+.flip-dropdown-right (used on the Filters dropdown) right-aligns the panel instead of left-aligning it, so a trigger near the right edge of a toolbar doesn't force its panel off-screen. The flip mechanics are identical — only left/right on the panel changes.
+
+Accessibility
+The checkbox is real and stays in the tab order (hidden with a clip-based technique, not display: none), so <kbd>Tab</kbd> + <kbd>Space</kbd> opens/closes it exactly like a native checkbox.
+.flip-dropdown__toggle:focus-visible ~ .flip-dropdown__trigger draws a visible ring on the trigger when the hidden checkbox has keyboard focus.
+Closes on outside click via the overlay label, described above.
+Panels carry role="menu" with role="menuitem" links, or plain checkboxes for the multi-select Filters panel.
+Respects prefers-reduced-motion: reduce — the panel appears/disappears at its resting rotation immediately, with transitions collapsed to 1ms, so nothing spins for someone who's asked not to see it.

--- a/submissions/examples/3d-flip-product-dropdown-hg/demo.html
+++ b/submissions/examples/3d-flip-product-dropdown-hg/demo.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>3D-Flip Dropdown — EaseMotion CSS</title>
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@600;700&family=Inter:wght@400;500;600&family=IBM+Plex+Mono:wght@500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="noise" aria-hidden="true"></div>
+
+  <header class="hero">
+    <p class="eyebrow">EaseMotion CSS &middot; showcase</p>
+    <h1 class="hero-title">3D-flip dropdown</h1>
+    <p class="hero-sub">A dropdown panel that opens by flipping down from its trigger on a 3D hinge, instead of a plain fade or slide. Pure CSS, driven by the checkbox hack. No JavaScript.</p>
+  </header>
+
+  <main class="catalog-page">
+
+    <!-- ================= Toolbar with two flip dropdowns ================= -->
+    <div class="catalog-toolbar">
+
+      <div class="flip-dropdown">
+        <input type="checkbox" id="dd-category" class="flip-dropdown__toggle">
+        <label for="dd-category" class="flip-dropdown__close-overlay" aria-hidden="true"></label>
+        <label for="dd-category" class="flip-dropdown__trigger">
+          Category: <strong>All</strong>
+          <span class="flip-dropdown__chevron" aria-hidden="true"></span>
+        </label>
+        <div class="flip-dropdown__panel" role="menu" aria-label="Filter by category">
+          <a href="#" class="flip-dropdown__item" role="menuitem">All categories</a>
+          <a href="#" class="flip-dropdown__item" role="menuitem">Headphones</a>
+          <a href="#" class="flip-dropdown__item" role="menuitem">Keyboards</a>
+          <a href="#" class="flip-dropdown__item" role="menuitem">Desk accessories</a>
+          <a href="#" class="flip-dropdown__item" role="menuitem">Lighting</a>
+        </div>
+      </div>
+
+      <div class="flip-dropdown">
+        <input type="checkbox" id="dd-sort" class="flip-dropdown__toggle">
+        <label for="dd-sort" class="flip-dropdown__close-overlay" aria-hidden="true"></label>
+        <label for="dd-sort" class="flip-dropdown__trigger">
+          Sort by: <strong>Featured</strong>
+          <span class="flip-dropdown__chevron" aria-hidden="true"></span>
+        </label>
+        <div class="flip-dropdown__panel" role="menu" aria-label="Sort products">
+          <a href="#" class="flip-dropdown__item" role="menuitem">Featured</a>
+          <a href="#" class="flip-dropdown__item" role="menuitem">Price: low to high</a>
+          <a href="#" class="flip-dropdown__item" role="menuitem">Price: high to low</a>
+          <a href="#" class="flip-dropdown__item" role="menuitem">Newest</a>
+          <a href="#" class="flip-dropdown__item" role="menuitem">Best rating</a>
+        </div>
+      </div>
+
+      <div class="flip-dropdown flip-dropdown-right">
+        <input type="checkbox" id="dd-filters" class="flip-dropdown__toggle">
+        <label for="dd-filters" class="flip-dropdown__close-overlay" aria-hidden="true"></label>
+        <label for="dd-filters" class="flip-dropdown__trigger flip-dropdown__trigger-ghost">
+          Filters
+          <span class="flip-dropdown__badge">2</span>
+          <span class="flip-dropdown__chevron" aria-hidden="true"></span>
+        </label>
+        <div class="flip-dropdown__panel flip-dropdown__panel-wide" role="menu" aria-label="Additional filters">
+          <label class="flip-dropdown__check">
+            <input type="checkbox" checked> In stock only
+          </label>
+          <label class="flip-dropdown__check">
+            <input type="checkbox" checked> Free shipping
+          </label>
+          <label class="flip-dropdown__check">
+            <input type="checkbox"> On sale
+          </label>
+          <label class="flip-dropdown__check">
+            <input type="checkbox"> 4 stars &amp; up
+          </label>
+        </div>
+      </div>
+
+    </div>
+
+    <!-- ================= Product grid for context ================= -->
+    <div class="product-grid">
+      <article class="product-card">
+        <div class="product-thumb product-thumb-1" aria-hidden="true"></div>
+        <p class="product-name">Mechanical Keyboard, 65%</p>
+        <p class="product-price">$89.00</p>
+      </article>
+      <article class="product-card">
+        <div class="product-thumb product-thumb-2" aria-hidden="true"></div>
+        <p class="product-name">Studio Headphones</p>
+        <p class="product-price">$129.00</p>
+      </article>
+      <article class="product-card">
+        <div class="product-thumb product-thumb-3" aria-hidden="true"></div>
+        <p class="product-name">Desk Lamp, Warm LED</p>
+        <p class="product-price">$42.00</p>
+      </article>
+      <article class="product-card">
+        <div class="product-thumb product-thumb-4" aria-hidden="true"></div>
+        <p class="product-name">Cable Organizer Tray</p>
+        <p class="product-price">$18.00</p>
+      </article>
+    </div>
+
+  </main>
+
+  <footer class="footer">
+    <p>EaseMotion CSS &middot; submissions/examples/3d-flip-product-dropdown</p>
+  </footer>
+
+</body>
+</html>

--- a/submissions/examples/3d-flip-product-dropdown-hg/style.css
+++ b/submissions/examples/3d-flip-product-dropdown-hg/style.css
@@ -1,0 +1,425 @@
+/* =========================================================================
+   3D-Flip Dropdown — EaseMotion CSS
+   A dropdown panel that opens by rotating down from its trigger on a 3D
+   hinge (transform-origin at the top edge, rotateX from -100deg to 0deg
+   under a perspective), rather than a plain fade or slide. Driven by the
+   checkbox hack — a hidden <input type="checkbox"> toggled by its
+   <label>. Pure CSS/HTML, no JavaScript.
+   ========================================================================= */
+ 
+ 
+/* -------------------------------------------------------------------------
+   1. Design tokens
+   ------------------------------------------------------------------------- */
+ 
+:root {
+  --fd-bg: #0e1116;
+  --fd-surface: #151a21;
+  --fd-surface-2: #1c222b;
+  --fd-border: #262e39;
+  --fd-text: #edeff2;
+  --fd-text-muted: #98a2b3;
+ 
+  --fd-accent: #7de0c0;
+  --fd-accent-strong: #9beed4;
+  --fd-accent-soft: rgba(125, 224, 192, 0.14);
+ 
+  --fd-font-display: "Space Grotesk", "Segoe UI", sans-serif;
+  --fd-font-body: "Inter", "Segoe UI", sans-serif;
+  --fd-font-mono: "IBM Plex Mono", "Courier New", monospace;
+ 
+  /* Flip mechanics — override per-instance to retune */
+  --fd-duration: 420ms;
+  --fd-ease: cubic-bezier(0.2, 0.9, 0.25, 1);
+  --fd-perspective: 1000px;
+  --fd-flip-angle: -100deg;
+}
+ 
+* {
+  box-sizing: border-box;
+}
+ 
+body {
+  margin: 0;
+  background: var(--fd-bg);
+  color: var(--fd-text);
+  font-family: var(--fd-font-body);
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+ 
+.noise {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.035;
+  z-index: 0;
+  background-image: radial-gradient(circle at 1px 1px, #ffffff 1px, transparent 0);
+  background-size: 3px 3px;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   2. Hero
+   ------------------------------------------------------------------------- */
+ 
+.hero {
+  position: relative;
+  z-index: 1;
+  max-width: 660px;
+  margin: 0 auto;
+  padding: 88px 24px 52px;
+  text-align: center;
+}
+ 
+.eyebrow {
+  font-family: var(--fd-font-mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--fd-accent);
+  margin: 0 0 20px;
+}
+ 
+.hero-title {
+  font-family: var(--fd-font-display);
+  font-weight: 600;
+  font-size: clamp(30px, 5.5vw, 48px);
+  line-height: 1.1;
+  letter-spacing: -0.01em;
+  margin: 0 0 16px;
+}
+ 
+.hero-sub {
+  font-size: 15px;
+  color: var(--fd-text-muted);
+  max-width: 500px;
+  margin: 0 auto;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   3. Catalog page shell
+   ------------------------------------------------------------------------- */
+ 
+.catalog-page {
+  position: relative;
+  z-index: 1;
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 0 24px 90px;
+}
+ 
+.catalog-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 28px;
+}
+ 
+.flip-dropdown-right {
+  margin-left: auto;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   4. Flip dropdown core
+   ------------------------------------------------------------------------- */
+ 
+.flip-dropdown {
+  position: relative;
+  perspective: var(--fd-perspective);
+}
+ 
+/* Real, focusable checkbox — hidden visually, not with display:none */
+.flip-dropdown__toggle {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+ 
+.flip-dropdown__trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 11px 16px;
+  border-radius: 10px;
+  background: var(--fd-surface);
+  border: 1px solid var(--fd-border);
+  color: var(--fd-text-muted);
+  font-size: 13.5px;
+  cursor: pointer;
+  user-select: none;
+  transition: border-color 160ms ease, background 160ms ease;
+}
+ 
+.flip-dropdown__trigger strong {
+  color: var(--fd-text);
+  font-weight: 600;
+}
+ 
+.flip-dropdown__trigger:hover {
+  border-color: rgba(125, 224, 192, 0.35);
+}
+ 
+.flip-dropdown__trigger-ghost {
+  background: var(--fd-surface-2);
+}
+ 
+.flip-dropdown__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 17px;
+  height: 17px;
+  padding: 0 5px;
+  border-radius: 999px;
+  background: var(--fd-accent);
+  color: var(--fd-bg);
+  font-family: var(--fd-font-mono);
+  font-size: 10.5px;
+  font-weight: 600;
+}
+ 
+.flip-dropdown__chevron {
+  width: 8px;
+  height: 8px;
+  border-right: 1.5px solid var(--fd-text-muted);
+  border-bottom: 1.5px solid var(--fd-text-muted);
+  transform: rotate(45deg) translateY(-2px);
+  transition: transform var(--fd-duration) var(--fd-ease);
+}
+ 
+.flip-dropdown__toggle:checked ~ .flip-dropdown__trigger .flip-dropdown__chevron {
+  transform: rotate(225deg) translateY(-1px);
+}
+ 
+.flip-dropdown__toggle:focus-visible ~ .flip-dropdown__trigger {
+  outline: 2px solid var(--fd-accent);
+  outline-offset: 2px;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   5. The flip panel itself
+   ------------------------------------------------------------------------- */
+ 
+.flip-dropdown__panel {
+  position: absolute;
+  z-index: 20;
+  top: calc(100% + 10px);
+  left: 0;
+  min-width: 220px;
+  padding: 8px;
+  border-radius: 12px;
+  background: var(--fd-surface);
+  border: 1px solid var(--fd-border);
+  box-shadow: 0 24px 48px -16px rgba(0, 0, 0, 0.55);
+ 
+  transform-origin: top center;
+  transform: rotateX(var(--fd-flip-angle));
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  backface-visibility: hidden;
+ 
+  transition:
+    transform var(--fd-duration) var(--fd-ease),
+    opacity calc(var(--fd-duration) * 0.7) linear,
+    visibility 0s linear var(--fd-duration);
+}
+ 
+.flip-dropdown-right .flip-dropdown__panel {
+  left: auto;
+  right: 0;
+}
+ 
+.flip-dropdown__toggle:checked ~ .flip-dropdown__panel {
+  transform: rotateX(0deg);
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition:
+    transform var(--fd-duration) var(--fd-ease),
+    opacity calc(var(--fd-duration) * 0.5) linear,
+    visibility 0s linear 0s;
+}
+ 
+.flip-dropdown__panel-wide {
+  min-width: 200px;
+}
+ 
+/* -------------------------------------------------------------------------
+   6. Panel contents
+   ------------------------------------------------------------------------- */
+ 
+.flip-dropdown__item {
+  display: block;
+  padding: 9px 11px;
+  border-radius: 8px;
+  font-size: 13.5px;
+  color: var(--fd-text);
+  text-decoration: none;
+  transition: background 120ms ease;
+}
+ 
+.flip-dropdown__item:hover {
+  background: var(--fd-surface-2);
+}
+ 
+.flip-dropdown__check {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 9px 11px;
+  border-radius: 8px;
+  font-size: 13.5px;
+  color: var(--fd-text);
+  cursor: pointer;
+}
+ 
+.flip-dropdown__check:hover {
+  background: var(--fd-surface-2);
+}
+ 
+.flip-dropdown__check input {
+  accent-color: var(--fd-accent);
+  width: 15px;
+  height: 15px;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   7. Outside-click close overlay
+   ------------------------------------------------------------------------- */
+ 
+.flip-dropdown__close-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 15;
+  opacity: 0;
+  pointer-events: none;
+}
+ 
+.flip-dropdown__toggle:checked ~ .flip-dropdown__close-overlay {
+  pointer-events: auto;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   8. Product grid (demo context, not part of the component)
+   ------------------------------------------------------------------------- */
+ 
+.product-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 14px;
+}
+ 
+.product-card {
+  background: var(--fd-surface);
+  border: 1px solid var(--fd-border);
+  border-radius: 14px;
+  padding: 14px;
+}
+ 
+.product-thumb {
+  height: 84px;
+  border-radius: 10px;
+  margin-bottom: 12px;
+  background: linear-gradient(135deg, var(--fd-surface-2), var(--fd-border));
+}
+ 
+.product-thumb-1 { background: linear-gradient(135deg, #2b3340, #1c222b); }
+.product-thumb-2 { background: linear-gradient(135deg, #33313f, #1c222b); }
+.product-thumb-3 { background: linear-gradient(135deg, #3a2f2b, #1c222b); }
+.product-thumb-4 { background: linear-gradient(135deg, #2a3a3a, #1c222b); }
+ 
+.product-name {
+  font-size: 12.5px;
+  color: var(--fd-text);
+  margin: 0 0 4px;
+}
+ 
+.product-price {
+  font-family: var(--fd-font-mono);
+  font-size: 12px;
+  color: var(--fd-accent);
+  margin: 0;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   9. Footer
+   ------------------------------------------------------------------------- */
+ 
+.footer {
+  position: relative;
+  z-index: 1;
+  text-align: center;
+  padding: 8px 24px 48px;
+  font-size: 12.5px;
+  color: var(--fd-text-muted);
+  font-family: var(--fd-font-mono);
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   10. Responsive
+   ------------------------------------------------------------------------- */
+ 
+@media (max-width: 640px) {
+  .hero {
+    padding: 68px 20px 44px;
+  }
+ 
+  .catalog-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+ 
+  .flip-dropdown-right {
+    margin-left: 0;
+  }
+ 
+  .flip-dropdown__panel {
+    left: 0;
+    right: 0;
+    min-width: 0;
+  }
+ 
+  .flip-dropdown-right .flip-dropdown__panel {
+    left: 0;
+    right: 0;
+  }
+ 
+  .product-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   11. Reduced motion
+   ------------------------------------------------------------------------- */
+ 
+@media (prefers-reduced-motion: reduce) {
+  .flip-dropdown__panel {
+    transform: none;
+    transition-duration: 1ms;
+  }
+ 
+  .flip-dropdown__toggle:checked ~ .flip-dropdown__panel {
+    transform: none;
+  }
+ 
+  .flip-dropdown__chevron {
+    transition-duration: 1ms;
+  }
+}


### PR DESCRIPTION
Closes #62351

## Pull Request Description
Adds a pure CSS/HTML dropdown that opens with a 3D hinge-flip (rotateX under perspective) instead of a plain fade/slide, shown in a product catalog toolbar context (Category, Sort, and multi-select Filters dropdowns above a product grid). No JavaScript.

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/3d-flip-product-dropdown/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A `.flip-dropdown` component whose panel opens via a 3D rotateX hinge-flip rather than a fade/slide, driven entirely by the checkbox hack.

**How does a developer use it?**
```html
<div class="flip-dropdown">
  <input type="checkbox" id="dd-1" class="flip-dropdown__toggle">
  <label for="dd-1" class="flip-dropdown__close-overlay" aria-hidden="true"></label>
  <label for="dd-1" class="flip-dropdown__trigger">Category</label>
  <div class="flip-dropdown__panel">…</div>
</div>
```
Add `.flip-dropdown-right` to right-align the panel. Retune `--fd-duration`, `--fd-perspective`, or `--fd-flip-angle` per instance to change the feel of the flip.

**Why does it fit EaseMotion CSS?**
It's a distinct, named motion signature (a literal 3D hinge, not a generic transition) with the mechanics fully exposed as CSS custom properties, and it demonstrates a full real-world usage context (catalog toolbar + product grid) rather than an isolated animated box.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

## Notes for Maintainer
Uses `perspective`/`rotateX()`/`backface-visibility` — all long-supported, no fallback needed. Closing behavior (outside click, `Esc` via native checkbox blur is not included since that specifically needs JS) relies on a full-viewport overlay label per dropdown; flagged here in case the maintainer wants that documented more prominently in the main README.