### PR TITLE
feat: add pure css hover-intent buttons example

### DIFF
--- a/submissions/examples/hover-intent-buttons/README.md
+++ b/submissions/examples/hover-intent-buttons/README.md
@@ -1,0 +1,17 @@
+# Hover-Intent Navigation Buttons
+
+A pure CSS solution to a common UX problem: accidental hover flashes. When a user drags their mouse across the screen, they often trigger a cascade of aggressive hover animations on navigational elements. This component uses asymmetric `transition-delay` to ensure the user actually intends to hover over the button before animating it.
+
+## Features
+- **Zero JavaScript**: Entirely powered by asymmetric CSS transitions.
+- **Accidental Swipe Protection**: Adds a `100ms` `transition-delay` when the user's cursor enters the element. If the cursor leaves before the 100ms mark, the animation never fires.
+- **Instant Retreat**: When the cursor leaves the element, the `transition-delay` is set to `0ms`, allowing the button to snap back to its rest state instantly, keeping the UI feeling highly responsive.
+
+## Usage
+Open `demo.html` in your browser. You will see two columns.
+1. Drag your mouse quickly up and down over the **Standard** column. You will notice every button flashes and jumps chaotically.
+2. Drag your mouse quickly up and down over the **Hover-Intent** column. You will notice they remain completely still. They will only animate if you intentionally pause your mouse over them for a fraction of a second.
+
+## Files
+- `demo.html`: The HTML structure demonstrating the side-by-side comparison.
+- `style.css`: The styling rules showcasing the difference between symmetric transitions and the asymmetric `btn-intent` transition rules.

--- a/submissions/examples/hover-intent-buttons/demo.html
+++ b/submissions/examples/hover-intent-buttons/demo.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hover-Intent Buttons - EaseMotion</title>
+    <!-- Include EaseMotion CSS -->
+    <link rel="stylesheet" href="../../../easemotion.min.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="layout-container">
+        <header class="header">
+            <h1 class="title">Hover-Intent Navigation</h1>
+            <p class="subtitle">Swipe your mouse quickly across these buttons. Notice how the chaotic flashing is prevented by a subtle delay on entry, but they snap back instantly on exit.</p>
+        </header>
+
+        <main class="showcase">
+            <div class="column">
+                <h3>Standard (Flashing issue)</h3>
+                <p class="desc">These buttons animate the millisecond your cursor touches them. Dragging your mouse across them creates chaos.</p>
+                <nav class="nav-stack">
+                    <button class="btn btn-standard">Dashboard</button>
+                    <button class="btn btn-standard">Projects</button>
+                    <button class="btn btn-standard">Analytics</button>
+                    <button class="btn btn-standard">Settings</button>
+                </nav>
+            </div>
+
+            <div class="column">
+                <h3>Hover-Intent (Protected)</h3>
+                <p class="desc">These buttons require a 100ms hover duration before animating, proving the user intended to interact.</p>
+                <nav class="nav-stack">
+                    <button class="btn btn-intent">Dashboard</button>
+                    <button class="btn btn-intent">Projects</button>
+                    <button class="btn btn-intent">Analytics</button>
+                    <button class="btn btn-intent">Settings</button>
+                </nav>
+            </div>
+        </main>
+    </div>
+</body>
+</html>

--- a/submissions/examples/hover-intent-buttons/style.css
+++ b/submissions/examples/hover-intent-buttons/style.css
@@ -1,0 +1,148 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+:root {
+    --bg-color: #fafafa;
+    --text-primary: #171717;
+    --text-secondary: #737373;
+    
+    --btn-bg: #ffffff;
+    --btn-border: #e5e5e5;
+    
+    --btn-hover-bg: #3b82f6;
+    --btn-hover-text: #ffffff;
+    --btn-hover-border: #3b82f6;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    font-family: 'Inter', system-ui, sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 40px 20px;
+    box-sizing: border-box;
+}
+
+.layout-container {
+    max-width: 800px;
+    width: 100%;
+}
+
+.header {
+    text-align: center;
+    margin-bottom: 48px;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 600;
+    margin: 0 0 12px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    max-width: 600px;
+    margin: 0 auto;
+    line-height: 1.5;
+}
+
+.showcase {
+    display: flex;
+    gap: 40px;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+.column {
+    flex: 1;
+    min-width: 280px;
+    background: #fff;
+    padding: 32px;
+    border-radius: 16px;
+    border: 1px solid #e5e5e5;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+}
+
+h3 {
+    margin: 0 0 8px 0;
+    font-size: 1.2rem;
+}
+
+.desc {
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+    line-height: 1.5;
+    margin-bottom: 24px;
+}
+
+.nav-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+/* =========================================
+   Button Base
+   ========================================= */
+.btn {
+    appearance: none;
+    background: var(--btn-bg);
+    border: 1px solid var(--btn-border);
+    border-radius: 8px;
+    padding: 14px 20px;
+    font-size: 1rem;
+    font-family: inherit;
+    font-weight: 500;
+    color: var(--text-primary);
+    cursor: pointer;
+    text-align: left;
+    width: 100%;
+}
+
+/* =========================================
+   Standard (Flashing issue)
+   ========================================= */
+.btn-standard {
+    /* Symmetric transition: instantly animates on hover, instantly animates out */
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.btn-standard:hover {
+    background: var(--btn-hover-bg);
+    color: var(--btn-hover-text);
+    border-color: var(--btn-hover-border);
+    transform: translateX(8px);
+}
+
+/* =========================================
+   Hover-Intent (Protected)
+   ========================================= */
+.btn-intent {
+    /* 
+      Asymmetric transition:
+      When leaving hover state, delay is 0ms (snaps back immediately).
+      Duration is slightly faster on exit.
+    */
+    transition: all 0.2s ease-out;
+    transition-delay: 0ms; 
+}
+
+.btn-intent:hover {
+    /* 
+      When entering hover state, we add a 100ms delay.
+      If the mouse leaves before 100ms is up, the animation never fires.
+    */
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    transition-delay: 100ms;
+    
+    background: var(--btn-hover-bg);
+    color: var(--btn-hover-text);
+    border-color: var(--btn-hover-border);
+    transform: translateX(8px);
+}


### PR DESCRIPTION
### Description
Added a new `hover-intent-buttons` example component. This submission demonstrates a pure-CSS solution to a common UX issue: accidental hover flashes when users swipe their cursor across navigational elements.

### What was changed
* Created `submissions/examples/hover-intent-buttons/demo.html` with a side-by-side comparison of standard symmetric transitions vs the asymmetric intent-based transitions.
* Created `submissions/examples/hover-intent-buttons/style.css` which introduces the `.btn-intent` class logic.
* Created `submissions/examples/hover-intent-buttons/README.md` containing usage documentation and the UX methodology.

### Why it matters
When navigational lists or dropdowns trigger animations the millisecond a cursor touches them, it can create chaotic, flashing UI if the user is just moving their mouse to another part of the screen. By utilizing asymmetric `transition-delay` (delaying the entrance but snapping back instantly on exit), we ensure the user actually *intends* to interact before triggering the animation.

### Verification
- [x] All files isolated to the `submissions/examples/` folder.
- [x] Verified side-by-side comparison works correctly in browser.