### PR TITLE
feat: add glitch-flicker pricing table minimalist tech layouts for #64618

### DIFF
--- a/submissions/examples/glitch-flicker-pricing-table-minimalist-tech/README.md
+++ b/submissions/examples/glitch-flicker-pricing-table-minimalist-tech/README.md
@@ -1,0 +1,42 @@
+# Glitch-Flicker Pricing Table — Minimalist Tech Layouts
+
+A pure CSS pricing table with glitch-flicker entrance animation. Three tiered cards (Starter, Pro, Enterprise) flicker into view with a CRT-style effect on a clean light background with scanline overlay.
+
+## Features
+
+- **Glitch-flicker entrance** — cards appear through a rapid opacity flicker sequence mimicking a CRT boot
+- **Glitch text effect** — header title periodically shifts with red/cyan text-shadow offset
+- **Scanline background** — subtle horizontal scanlines across the entire page
+- **Staggered entrance** — each card has a different `animation-delay` (0.1s, 0.2s, 0.3s) for cascading flicker
+- **Minimalist tech aesthetic** — light background, monospace font, tilde (~) feature markers
+- **Featured card highlight** — Pro card has purple border, shadow, and accent colors
+- **Fully responsive** — stacks to single column on mobile, scanlines hidden
+- **Reduced-motion accessible** — all animations and glitch effects disabled when `prefers-reduced-motion: reduce`
+
+## CSS Custom Properties
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `--gfp-bg` | `#f7f7f9` | Page background |
+| `--gfp-surface` | `#ffffff` | Card fill |
+| `--gfp-border` | `#e2e2e6` | Border color |
+| `--gfp-text` | `#1a1a2e` | Primary text |
+| `--gfp-text-dim` | `#7a7a8c` | Secondary text |
+| `--gfp-accent` | `#6c5ce7` | Primary accent (purple) |
+| `--gfp-accent-dim` | `rgba(108,92,231,0.08)` | Accent background tint |
+| `--gfp-green` | `#00b894` | Feature marker color |
+| `--gfp-radius` | `8px` | Card border radius |
+| `--gfp-glitch-1` | `#ff6b6b` | Glitch offset color (red) |
+| `--gfp-glitch-2` | `#48dbfb` | Glitch offset color (cyan) |
+
+## How It Works
+
+1. Cards use `gfpFlickerIn` keyframes — rapid opacity jumps from 0 to 1, simulating a CRT flicker.
+2. Each card has a staggered `animation-delay` for a cascading entrance.
+3. The header title uses `gfpGlitchText` keyframes — periodic red/cyan text-shadow offsets.
+4. A repeating gradient creates subtle scanline overlay on the background.
+5. On `prefers-reduced-motion: reduce`, all animations are removed and cards display instantly.
+
+## Usage
+
+Copy `demo.html` and `style.css` into your project. No JavaScript or external dependencies needed. Override the CSS custom properties to adjust glitch colors, accent, or animation timing.

--- a/submissions/examples/glitch-flicker-pricing-table-minimalist-tech/demo.html
+++ b/submissions/examples/glitch-flicker-pricing-table-minimalist-tech/demo.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS Glitch-Flicker Pricing Table with minimalist tech styling. Pure CSS pricing cards with glitch text effects and flickering entrance animation.">
+  <title>Glitch-Flicker Pricing Table – Minimalist Tech Layouts</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="gfp-page">
+    <header class="gfp-header">
+      <span class="gfp-header__label">Minimalist Tech</span>
+      <h1 class="gfp-header__title">Pricing</h1>
+      <p class="gfp-header__sub">Plans that flicker into view. Glitch-tested, production-ready.</p>
+    </header>
+
+    <section class="gfp-pricing" aria-label="Pricing Plans">
+      <article class="gfp-card gfp-card--starter">
+        <div class="gfp-card__top">
+          <span class="gfp-card__tag">Starter</span>
+          <div class="gfp-card__price">
+            <span class="gfp-card__dollar">$</span>
+            <span class="gfp-card__val">0</span>
+          </div>
+          <span class="gfp-card__cycle">forever free</span>
+        </div>
+        <div class="gfp-card__divider"></div>
+        <ul class="gfp-card__perks">
+          <li>3 repos</li>
+          <li>500 MB storage</li>
+          <li>Basic CI/CD</li>
+        </ul>
+        <button class="gfp-card__btn">Start Free</button>
+      </article>
+
+      <article class="gfp-card gfp-card--pro">
+        <div class="gfp-card__top">
+          <span class="gfp-card__tag">Pro</span>
+          <div class="gfp-card__price">
+            <span class="gfp-card__dollar">$</span>
+            <span class="gfp-card__val">15</span>
+          </div>
+          <span class="gfp-card__cycle">per month</span>
+        </div>
+        <div class="gfp-card__divider"></div>
+        <ul class="gfp-card__perks">
+          <li>Unlimited repos</li>
+          <li>25 GB storage</li>
+          <li>Advanced CI/CD</li>
+          <li>Priority queues</li>
+        </ul>
+        <button class="gfp-card__btn gfp-card__btn--highlight">Go Pro</button>
+      </article>
+
+      <article class="gfp-card gfp-card--enterprise">
+        <div class="gfp-card__top">
+          <span class="gfp-card__tag">Enterprise</span>
+          <div class="gfp-card__price">
+            <span class="gfp-card__dollar">$</span>
+            <span class="gfp-card__val">49</span>
+          </div>
+          <span class="gfp-card__cycle">per month</span>
+        </div>
+        <div class="gfp-card__divider"></div>
+        <ul class="gfp-card__perks">
+          <li>Unlimited everything</li>
+          <li>200 GB storage</li>
+          <li>Dedicated support</li>
+          <li>Custom runners</li>
+          <li>Audit logs</li>
+        </ul>
+        <button class="gfp-card__btn">Contact Sales</button>
+      </article>
+    </section>
+
+    <div class="gfp-bg" aria-hidden="true">
+      <div class="gfp-bg__scan"></div>
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/glitch-flicker-pricing-table-minimalist-tech/style.css
+++ b/submissions/examples/glitch-flicker-pricing-table-minimalist-tech/style.css
@@ -1,0 +1,315 @@
+:root {
+  --gfp-bg: #f7f7f9;
+  --gfp-surface: #ffffff;
+  --gfp-border: #e2e2e6;
+  --gfp-text: #1a1a2e;
+  --gfp-text-dim: #7a7a8c;
+  --gfp-accent: #6c5ce7;
+  --gfp-accent-dim: rgba(108, 92, 231, 0.08);
+  --gfp-green: #00b894;
+  --gfp-radius: 8px;
+  --gfp-glitch-1: #ff6b6b;
+  --gfp-glitch-2: #48dbfb;
+}
+
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: var(--gfp-bg);
+  font-family: "IBM Plex Mono", "SF Mono", "Courier New", monospace;
+  color: var(--gfp-text);
+  overflow-x: hidden;
+}
+
+/* ── background scanline ─────────────────────────── */
+
+.gfp-bg {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+}
+
+.gfp-bg__scan {
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+    0deg,
+    transparent,
+    transparent 3px,
+    rgba(0, 0, 0, 0.015) 3px,
+    rgba(0, 0, 0, 0.015) 4px
+  );
+}
+
+/* ── page ────────────────────────────────────────── */
+
+.gfp-page {
+  position: relative;
+  z-index: 1;
+  width: min(840px, 92vw);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 36px;
+}
+
+/* ── header ──────────────────────────────────────── */
+
+.gfp-header {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+.gfp-header__label {
+  font-size: 0.55rem;
+  text-transform: uppercase;
+  letter-spacing: 0.35em;
+  color: var(--gfp-accent);
+  background: var(--gfp-accent-dim);
+  padding: 3px 12px;
+}
+
+.gfp-header__title {
+  font-size: clamp(1.5rem, 4vw, 2.4rem);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  position: relative;
+  animation: gfpGlitchText 4s infinite;
+}
+
+@keyframes gfpGlitchText {
+  0%, 92%, 100% { text-shadow: none; }
+  93% { text-shadow: 2px 0 var(--gfp-glitch-1), -2px 0 var(--gfp-glitch-2); }
+  94% { text-shadow: -1px 0 var(--gfp-glitch-2), 1px 0 var(--gfp-glitch-1); }
+  95% { text-shadow: none; }
+  96% { text-shadow: 3px 0 var(--gfp-glitch-1), -1px 0 var(--gfp-glitch-2); }
+  97% { text-shadow: none; }
+}
+
+.gfp-header__sub {
+  font-size: 0.74rem;
+  color: var(--gfp-text-dim);
+  max-width: 38ch;
+  line-height: 1.6;
+}
+
+/* ── pricing grid ────────────────────────────────── */
+
+.gfp-pricing {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  width: 100%;
+}
+
+/* ── card ────────────────────────────────────────── */
+
+.gfp-card {
+  position: relative;
+  background: var(--gfp-surface);
+  border: 1px solid var(--gfp-border);
+  border-radius: var(--gfp-radius);
+  padding: 28px 22px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  animation: gfpFlickerIn 0.5s ease-out both;
+}
+
+.gfp-card--starter   { animation-delay: 0.1s; }
+.gfp-card--pro       { animation-delay: 0.2s; }
+.gfp-card--enterprise { animation-delay: 0.3s; }
+
+.gfp-card--pro {
+  border-color: var(--gfp-accent);
+  box-shadow: 0 2px 16px rgba(108, 92, 231, 0.1);
+}
+
+/* ── flicker entrance keyframes ──────────────────── */
+
+@keyframes gfpFlickerIn {
+  0%   { opacity: 0; }
+  10%  { opacity: 0.8; }
+  12%  { opacity: 0.2; }
+  20%  { opacity: 0.9; }
+  22%  { opacity: 0.4; }
+  30%  { opacity: 1; }
+  32%  { opacity: 0.6; }
+  40%  { opacity: 1; }
+  100% { opacity: 1; }
+}
+
+/* ── card top ────────────────────────────────────── */
+
+.gfp-card__top {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+.gfp-card__tag {
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--gfp-text-dim);
+}
+
+.gfp-card--pro .gfp-card__tag {
+  color: var(--gfp-accent);
+}
+
+.gfp-card__price {
+  display: flex;
+  align-items: baseline;
+  gap: 1px;
+}
+
+.gfp-card__dollar {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--gfp-text-dim);
+}
+
+.gfp-card__val {
+  font-size: 2.6rem;
+  font-weight: 800;
+  letter-spacing: -0.04em;
+  line-height: 1;
+}
+
+.gfp-card--pro .gfp-card__val {
+  color: var(--gfp-accent);
+}
+
+.gfp-card__cycle {
+  font-size: 0.62rem;
+  color: var(--gfp-text-dim);
+  text-transform: lowercase;
+}
+
+/* ── divider ─────────────────────────────────────── */
+
+.gfp-card__divider {
+  width: 100%;
+  height: 1px;
+  background: var(--gfp-border);
+  margin: 16px 0;
+}
+
+.gfp-card--pro .gfp-card__divider {
+  background: var(--gfp-accent);
+  opacity: 0.3;
+}
+
+/* ── perks list ──────────────────────────────────── */
+
+.gfp-card__perks {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  flex: 1;
+  margin-bottom: 18px;
+}
+
+.gfp-card__perks li {
+  font-size: 0.72rem;
+  color: var(--gfp-text-dim);
+  padding-left: 16px;
+  position: relative;
+  line-height: 1.5;
+}
+
+.gfp-card__perks li::before {
+  content: "~";
+  position: absolute;
+  left: 0;
+  color: var(--gfp-green);
+  font-weight: 700;
+}
+
+.gfp-card--pro .gfp-card__perks li::before {
+  color: var(--gfp-accent);
+}
+
+/* ── button ──────────────────────────────────────── */
+
+.gfp-card__btn {
+  display: block;
+  width: 100%;
+  text-align: center;
+  font-family: inherit;
+  font-size: 0.66rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  padding: 10px 0;
+  border: 1px solid var(--gfp-border);
+  border-radius: 6px;
+  color: var(--gfp-text);
+  background: transparent;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  position: relative;
+}
+
+.gfp-card__btn:hover {
+  background: var(--gfp-text);
+  color: var(--gfp-surface);
+  border-color: var(--gfp-text);
+}
+
+.gfp-card__btn--highlight {
+  background: var(--gfp-accent);
+  color: #fff;
+  border-color: var(--gfp-accent);
+}
+
+.gfp-card__btn--highlight:hover {
+  background: #5a4bd1;
+  border-color: #5a4bd1;
+}
+
+/* ── responsive ──────────────────────────────────── */
+
+@media (max-width: 700px) {
+  .gfp-pricing {
+    grid-template-columns: 1fr;
+    max-width: 300px;
+  }
+
+  .gfp-card {
+    padding: 24px 18px 20px;
+  }
+
+  .gfp-bg__scan {
+    display: none;
+  }
+}
+
+/* ── accessibility ───────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .gfp-card {
+    animation: none;
+    opacity: 1;
+  }
+
+  .gfp-header__title {
+    animation: none;
+    text-shadow: none;
+  }
+}


### PR DESCRIPTION
## Summary
Adds a pure CSS Glitch-Flicker Pricing Table with minimalist tech styling for Issue #64618.

## What's Included
- **demo.html** — Three-tier pricing table (Starter, Pro, Enterprise) with CRT flicker entrance
- **style.css** — Pure CSS with flicker keyframes, glitch text-shadow, scanline overlay, minimalist light theme
- **README.md** — Documentation with custom properties table and usage guide

## CSS Features
- Glitch-flicker entrance animation (rapid opacity jumps mimicking CRT boot)
- Header glitch text effect with periodic red/cyan text-shadow offset
- Scanline background overlay (repeating-linear-gradient)
- Staggered card delays (0.1s, 0.2s, 0.3s) for cascading flicker
- Minimalist light theme with monospace typography and tilde feature markers
- Featured Pro card with purple accent border and shadow
- `prefers-reduced-motion` media query support (disables all animations and glitch effects)
- Fully responsive (single column stack under 700px, scanlines hidden on mobile)

## Validator Compliance
- Only adds files inside `submissions/examples/` — no existing files modified
- `demo.html`: has DOCTYPE, html, head, body, `<meta name="description">`, `<meta name="viewport">`, `<title>`, `<link rel="stylesheet">`
- `style.css`: has `:root` with CSS custom properties (`--gfp-*`), `*` box-sizing reset, `@keyframes`, `@media (prefers-reduced-motion)`
- `README.md`: 5+ non-empty non-header lines
- No `.js` files, no files outside `submissions/`

## Files Changed
- `submissions/examples/glitch-flicker-pricing-table-minimalist-tech/demo.html` (new)
- `submissions/examples/glitch-flicker-pricing-table-minimalist-tech/style.css` (new)
- `submissions/examples/glitch-flicker-pricing-table-minimalist-tech/README.md` (new)

Closes #64618