### PR TITLE
feat: add text highlight animations example

### DIFF
--- a/submissions/examples/text-highlight-animations/README.md
+++ b/submissions/examples/text-highlight-animations/README.md
@@ -1,0 +1,18 @@
+# Text Selection & Highlight Animations
+
+A collection of pure CSS typographic emphasis effects. These micro-interactions help guide users' eyes to important links, keywords, or contextual information within dense text blocks.
+
+## Features
+- **Marker Sweep**: Simulates a physical highlighter pen swiping across the text. Built using a pseudo-element (`::before`) layered beneath the text via `z-index: -1` and animated using `transform: scaleX()`.
+- **Underline Reveal**: A clean, expanding underline perfect for inline hyperlinks. Uses `transform-origin: left` to draw the line organically outward.
+- **Custom Native Selection**: Uses the `::selection` pseudo-selector to override the browser's default highlight color (usually blue) with a branded color, ensuring the text remains legible when selected by the user.
+
+## Usage
+Open `demo.html` in your browser.
+- Hover over the "magic marker sweep" text to see the yellow highlight grow.
+- Hover over the "smooth underline reveal" text to see the blue stroke expand.
+- Click and drag your mouse across the final paragraph to see the custom purple `::selection` highlight.
+
+## Files
+- `demo.html`: The HTML structure applying the highlight classes to `<span>` tags.
+- `style.css`: The styling rules defining the GPU-accelerated `scaleX()` transitions.

--- a/submissions/examples/text-highlight-animations/demo.html
+++ b/submissions/examples/text-highlight-animations/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Text Highlight Animations - EaseMotion</title>
+    <!-- Include EaseMotion CSS -->
+    <link rel="stylesheet" href="../../../easemotion.min.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="layout-container">
+        <header class="header">
+            <h1 class="title">Text Highlight Animations</h1>
+            <p class="subtitle">Beautiful, pure CSS text marker and selection animations for emphasizing typography.</p>
+        </header>
+
+        <main class="showcase">
+            <div class="text-block">
+                <h3>1. The Marker Sweep</h3>
+                <p>
+                    Hover over this text to see the 
+                    <span class="highlight-marker">magic marker sweep</span> 
+                    effect, which simulates a yellow highlighter pen drawing across the text.
+                </p>
+            </div>
+
+            <div class="text-block">
+                <h3>2. The Underline Reveal</h3>
+                <p>
+                    This is perfect for links. Hover here to trigger a 
+                    <span class="highlight-underline">smooth underline reveal</span> 
+                    that grows from left to right.
+                </p>
+            </div>
+
+            <div class="text-block">
+                <h3>3. Custom Selection Color</h3>
+                <p class="custom-selection">
+                    Try clicking and dragging your mouse to select this text. Notice how the native browser selection color has been elegantly styled to match the theme.
+                </p>
+            </div>
+        </main>
+    </div>
+</body>
+</html>

--- a/submissions/examples/text-highlight-animations/style.css
+++ b/submissions/examples/text-highlight-animations/style.css
@@ -1,0 +1,154 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;700&display=swap');
+
+:root {
+    --bg-color: #fafaf9;
+    --text-primary: #1c1917;
+    --text-secondary: #57534e;
+    
+    --highlight-yellow: #fde047;
+    --highlight-blue: #3b82f6;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    font-family: 'Outfit', system-ui, sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    box-sizing: border-box;
+    padding: 40px 20px;
+}
+
+.layout-container {
+    max-width: 600px;
+    width: 100%;
+}
+
+.header {
+    margin-bottom: 48px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.5rem;
+    font-weight: 700;
+    margin: 0 0 12px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    line-height: 1.5;
+}
+
+.showcase {
+    display: flex;
+    flex-direction: column;
+    gap: 40px;
+}
+
+.text-block {
+    background: #ffffff;
+    padding: 24px 32px;
+    border-radius: 12px;
+    box-shadow: 0 4px 6px -1px rgba(0,0,0,0.05);
+    border: 1px solid #e7e5e4;
+}
+
+.text-block h3 {
+    margin: 0 0 12px 0;
+    font-size: 1.2rem;
+    color: #44403c;
+}
+
+.text-block p {
+    margin: 0;
+    font-size: 1.1rem;
+    line-height: 1.6;
+    color: var(--text-secondary);
+}
+
+/* =========================================
+   1. The Marker Sweep
+   ========================================= */
+.highlight-marker {
+    position: relative;
+    color: var(--text-primary);
+    font-weight: 600;
+    z-index: 1;
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.highlight-marker::before {
+    content: '';
+    position: absolute;
+    bottom: 2px;
+    left: -2px;
+    right: -2px;
+    height: 12px;
+    background-color: var(--highlight-yellow);
+    z-index: -1;
+    transform: scaleX(0);
+    transform-origin: left center;
+    transition: transform 0.4s cubic-bezier(0.22, 1, 0.36, 1);
+    border-radius: 2px;
+}
+
+.highlight-marker:hover::before {
+    transform: scaleX(1);
+}
+
+/* =========================================
+   2. The Underline Reveal
+   ========================================= */
+.highlight-underline {
+    position: relative;
+    color: var(--highlight-blue);
+    font-weight: 600;
+    text-decoration: none;
+    cursor: pointer;
+}
+
+.highlight-underline::after {
+    content: '';
+    position: absolute;
+    bottom: -2px;
+    left: 0;
+    width: 100%;
+    height: 2px;
+    background-color: var(--highlight-blue);
+    transform: scaleX(0);
+    transform-origin: left;
+    transition: transform 0.3s ease-out;
+}
+
+.highlight-underline:hover::after {
+    transform: scaleX(1);
+}
+
+/* =========================================
+   3. Custom Native Selection
+   ========================================= */
+.custom-selection::selection {
+    background-color: #a78bfa;
+    color: #ffffff;
+}
+
+.custom-selection::-moz-selection {
+    background-color: #a78bfa;
+    color: #ffffff;
+}
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    .highlight-marker::before,
+    .highlight-underline::after {
+        transition: none;
+    }
+}


### PR DESCRIPTION
### Description
Closes #65824

Added a new `text-highlight-animations` component to the examples showcase. This submission provides pure CSS typographic emphasis effects, including marker sweeps, underline reveals, and customized native selections.

### What was changed
* Created `submissions/examples/text-highlight-animations/demo.html` showing a magic marker sweep, underline reveal, and customized selection colors.
* Created `submissions/examples/text-highlight-animations/style.css` utilizing pseudo-elements (`::before`, `::after`, and `::selection`) to drive the styling and `scaleX()` transitions.
* Created `submissions/examples/text-highlight-animations/README.md` containing usage documentation.

### Why it matters
Micro-interactions on typography help guide users' eyes to important links or keywords within dense text blocks. Using pseudo-elements ensures we don't need extra HTML spans wrapping every character, and `transform: scaleX()` ensures the animation is highly performant.

### Accessibility
- Fully respects `@media (prefers-reduced-motion: reduce)`.
- If a user has motion sensitivity enabled, the expanding transitions are removed.

### Verification
- [x] All files isolated to the `submissions/examples/` folder.
- [x] Verified `::selection` overrides work seamlessly.