### PR TITLE
feat: add fade-in pricing table minimalist tech layouts for #64609

### DIFF
--- a/submissions/examples/fade-in-pricing-table-minimalist-tech/README.md
+++ b/submissions/examples/fade-in-pricing-table-minimalist-tech/README.md
@@ -1,0 +1,38 @@
+# Fade-In Pricing Table — Minimalist Tech Layouts
+
+A pure CSS pricing table with smooth fade-and-scale entrance animation. Three tiered cards (Solo, Team, Business) fade in with a subtle scale effect on a dot-grid light background.
+
+## Features
+
+- **Fade-in entrance** — cards start transparent and scaled down, fading in with `opacity` and `scale` transition
+- **Staggered timing** — each card has a different `animation-delay` (0.06s, 0.16s, 0.26s) for cascading reveal
+- **Dot-grid background** — subtle repeating dot pattern at 24px intervals
+- **Minimalist styling** — light background, sans-serif font, colored marker bars, rounded card corners
+- **Featured card highlight** — Team card has teal border, shadow, flag badge, and accent button
+- **Fully responsive** — stacks to single column on mobile
+- **Reduced-motion accessible** — all animations disabled, cards shown immediately when `prefers-reduced-motion: reduce`
+
+## CSS Custom Properties
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `--fip-bg` | `#f2f2f5` | Page background |
+| `--fip-surface` | `#ffffff` | Card fill |
+| `--fip-border` | `#dcdce0` | Border color |
+| `--fip-text` | `#1e1e2a` | Primary text |
+| `--fip-dim` | `#6e6e80` | Secondary text |
+| `--fip-teal` | `#0d9488` | Primary accent (teal) |
+| `--fip-teal-bg` | `rgba(13,148,136,0.06)` | Accent background tint |
+| `--fip-radius` | `14px` | Card border radius |
+
+## How It Works
+
+1. Cards are initially set to `opacity: 0` and `scale(0.94)`.
+2. The `fipFadeIn` keyframe animates both properties to their final values.
+3. Each card has a staggered `animation-delay` for a cascading entrance.
+4. The background uses a `radial-gradient` dot pattern for a minimalist texture.
+5. On `prefers-reduced-motion: reduce`, all animations are removed and cards display instantly.
+
+## Usage
+
+Copy `demo.html` and `style.css` into your project. No JavaScript or external dependencies needed. Override the CSS custom properties to adjust accent colors, border radius, or animation timing.

--- a/submissions/examples/fade-in-pricing-table-minimalist-tech/demo.html
+++ b/submissions/examples/fade-in-pricing-table-minimalist-tech/demo.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS Fade-In Pricing Table with minimalist tech styling. Pure CSS pricing cards with smooth fade and scale entrance on a clean light background.">
+  <title>Fade-In Pricing Table – Minimalist Tech Layouts</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="fip-page">
+    <header class="fip-header">
+      <span class="fip-header__label">Minimalist Tech</span>
+      <h1 class="fip-header__title">Choose Your Plan</h1>
+      <p class="fip-header__sub">Straightforward pricing. No surprises. Pick what fits.</p>
+    </header>
+
+    <section class="fip-plans" aria-label="Pricing Plans">
+      <article class="fip-card fip-card--solo">
+        <div class="fip-card__marker"></div>
+        <h2 class="fip-card__name">Solo</h2>
+        <div class="fip-card__rate">
+          <span class="fip-card__cur">$</span><span class="fip-card__num">0</span>
+          <span class="fip-card__freq">/mo</span>
+        </div>
+        <p class="fip-card__about">Good enough for personal side projects and experiments.</p>
+        <div class="fip-card__sep"></div>
+        <ul class="fip-card__opts">
+          <li>2 active projects</li>
+          <li>1 GB storage</li>
+          <li>Standard build queue</li>
+        </ul>
+        <a href="#" class="fip-card__link">Start Free</a>
+      </article>
+
+      <article class="fip-card fip-card--team">
+        <div class="fip-card__marker fip-card__marker--highlight"></div>
+        <div class="fip-card__flag">Recommended</div>
+        <h2 class="fip-card__name">Team</h2>
+        <div class="fip-card__rate">
+          <span class="fip-card__cur">$</span><span class="fip-card__num fip-card__num--accent">24</span>
+          <span class="fip-card__freq">/mo</span>
+        </div>
+        <p class="fip-card__about">For small teams shipping production work together.</p>
+        <div class="fip-card__sep fip-card__sep--accent"></div>
+        <ul class="fip-card__opts">
+          <li>Unlimited projects</li>
+          <li>80 GB storage</li>
+          <li>Fast build queue</li>
+          <li>Team analytics</li>
+        </ul>
+        <a href="#" class="fip-card__link fip-card__link--accent">Get Team</a>
+      </article>
+
+      <article class="fip-card fip-card--biz">
+        <div class="fip-card__marker"></div>
+        <h2 class="fip-card__name">Business</h2>
+        <div class="fip-card__rate">
+          <span class="fip-card__cur">$</span><span class="fip-card__num">68</span>
+          <span class="fip-card__freq">/mo</span>
+        </div>
+        <p class="fip-card__about">For orgs that need compliance, SLA, and dedicated infra.</p>
+        <div class="fip-card__sep"></div>
+        <ul class="fip-card__opts">
+          <li>Unlimited everything</li>
+          <li>500 GB storage</li>
+          <li>Dedicated runners</li>
+          <li>SSO & audit trail</li>
+          <li>99.9% SLA</li>
+        </ul>
+        <a href="#" class="fip-card__link">Contact Sales</a>
+      </article>
+    </section>
+
+    <div class="fip-bg" aria-hidden="true"></div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/fade-in-pricing-table-minimalist-tech/style.css
+++ b/submissions/examples/fade-in-pricing-table-minimalist-tech/style.css
@@ -1,0 +1,309 @@
+:root {
+  --fip-bg: #f2f2f5;
+  --fip-surface: #ffffff;
+  --fip-border: #dcdce0;
+  --fip-text: #1e1e2a;
+  --fip-dim: #6e6e80;
+  --fip-teal: #0d9488;
+  --fip-teal-bg: rgba(13, 148, 136, 0.06);
+  --fip-radius: 14px;
+}
+
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: var(--fip-bg);
+  font-family: "Inter", "Helvetica Neue", Arial, sans-serif;
+  color: var(--fip-text);
+  overflow-x: hidden;
+}
+
+/* ── background dot ──────────────────────────────── */
+
+.fip-bg {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background-image: radial-gradient(circle, var(--fip-border) 1px, transparent 1px);
+  background-size: 24px 24px;
+  opacity: 0.35;
+}
+
+/* ── page ────────────────────────────────────────── */
+
+.fip-page {
+  position: relative;
+  z-index: 1;
+  width: min(880px, 92vw);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 40px;
+}
+
+/* ── header ──────────────────────────────────────── */
+
+.fip-header {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+
+.fip-header__label {
+  font-size: 0.6rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.28em;
+  color: var(--fip-teal);
+  background: var(--fip-teal-bg);
+  padding: 4px 14px;
+  border-radius: 20px;
+}
+
+.fip-header__title {
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.fip-header__sub {
+  font-size: 0.82rem;
+  color: var(--fip-dim);
+  max-width: 38ch;
+  line-height: 1.6;
+}
+
+/* ── plans grid ──────────────────────────────────── */
+
+.fip-plans {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  width: 100%;
+}
+
+/* ── card ────────────────────────────────────────── */
+
+.fip-card {
+  position: relative;
+  background: var(--fip-surface);
+  border: 1px solid var(--fip-border);
+  border-radius: var(--fip-radius);
+  padding: 32px 24px 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  opacity: 0;
+  transform: scale(0.94);
+  animation: fipFadeIn 0.5s ease-out forwards;
+}
+
+.fip-card--solo { animation-delay: 0.06s; }
+.fip-card--team { animation-delay: 0.16s; }
+.fip-card--biz  { animation-delay: 0.26s; }
+
+.fip-card--team {
+  border-color: var(--fip-teal);
+  box-shadow: 0 4px 20px rgba(13, 148, 136, 0.08);
+}
+
+/* ── fade-in keyframes ───────────────────────────── */
+
+@keyframes fipFadeIn {
+  0% {
+    opacity: 0;
+    transform: scale(0.94);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+/* ── marker ──────────────────────────────────────── */
+
+.fip-card__marker {
+  width: 32px;
+  height: 3px;
+  border-radius: 2px;
+  background: var(--fip-border);
+  margin-bottom: 6px;
+}
+
+.fip-card__marker--highlight {
+  background: var(--fip-teal);
+  width: 40px;
+}
+
+/* ── flag ────────────────────────────────────────── */
+
+.fip-card__flag {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  font-size: 0.52rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--fip-teal);
+  background: var(--fip-teal-bg);
+  padding: 3px 8px;
+  border-radius: 4px;
+}
+
+/* ── card content ────────────────────────────────── */
+
+.fip-card__name {
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--fip-dim);
+}
+
+.fip-card--team .fip-card__name {
+  color: var(--fip-teal);
+}
+
+.fip-card__rate {
+  display: flex;
+  align-items: baseline;
+  gap: 1px;
+}
+
+.fip-card__cur {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--fip-dim);
+}
+
+.fip-card__num {
+  font-size: 2.6rem;
+  font-weight: 800;
+  letter-spacing: -0.04em;
+  line-height: 1;
+}
+
+.fip-card__num--accent {
+  color: var(--fip-teal);
+}
+
+.fip-card__freq {
+  font-size: 0.7rem;
+  color: var(--fip-dim);
+}
+
+.fip-card__about {
+  font-size: 0.78rem;
+  color: var(--fip-dim);
+  line-height: 1.55;
+  margin-top: 2px;
+}
+
+/* ── separator ───────────────────────────────────── */
+
+.fip-card__sep {
+  width: 100%;
+  height: 1px;
+  background: var(--fip-border);
+  margin: 10px 0;
+}
+
+.fip-card__sep--accent {
+  background: var(--fip-teal);
+  opacity: 0.25;
+}
+
+/* ── options list ────────────────────────────────── */
+
+.fip-card__opts {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  flex: 1;
+  margin-bottom: 14px;
+}
+
+.fip-card__opts li {
+  font-size: 0.75rem;
+  color: var(--fip-dim);
+  padding-left: 18px;
+  position: relative;
+  line-height: 1.5;
+}
+
+.fip-card__opts li::before {
+  content: "\2022";
+  position: absolute;
+  left: 4px;
+  color: var(--fip-teal);
+  font-weight: 900;
+}
+
+/* ── link / button ───────────────────────────────── */
+
+.fip-card__link {
+  display: block;
+  text-align: center;
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-decoration: none;
+  padding: 10px 0;
+  border: 1px solid var(--fip-border);
+  border-radius: 8px;
+  color: var(--fip-text);
+  transition: background 0.2s, color 0.2s, border-color 0.2s;
+}
+
+.fip-card__link:hover {
+  background: var(--fip-text);
+  color: var(--fip-surface);
+  border-color: var(--fip-text);
+}
+
+.fip-card__link--accent {
+  background: var(--fip-teal);
+  color: #fff;
+  border-color: var(--fip-teal);
+}
+
+.fip-card__link--accent:hover {
+  background: #0b7a70;
+  border-color: #0b7a70;
+}
+
+/* ── responsive ──────────────────────────────────── */
+
+@media (max-width: 700px) {
+  .fip-plans {
+    grid-template-columns: 1fr;
+    max-width: 320px;
+  }
+
+  .fip-card {
+    padding: 26px 20px 22px;
+  }
+}
+
+/* ── accessibility ───────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .fip-card {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
Adds a pure CSS Fade-In Pricing Table with minimalist tech styling for Issue #64609.

## What's Included
- **demo.html** — Three-tier pricing table (Solo, Team, Business) with smooth fade-and-scale entrance
- **style.css** — Pure CSS with opacity/scale animation, staggered delays, dot-grid background, minimalist light theme
- **README.md** — Documentation with custom properties table and usage guide

## CSS Features
- Fade-in entrance with opacity and scale (0.94 → 1)
- Staggered card delays (0.06s, 0.16s, 0.26s) for cascading reveal
- Dot-grid background using radial-gradient at 24px intervals
- Minimalist light theme with sans-serif font, colored marker bars, rounded corners
- Featured Team card with teal accent border, shadow, flag badge, and accent button
- `prefers-reduced-motion` media query support (disables all animations)
- Fully responsive (single column stack under 700px)

## Validator Compliance
- Only adds files inside `submissions/examples/` — no existing files modified
- `demo.html`: has DOCTYPE, html, head, body, `<meta name="description">`, `<meta name="viewport">`, `<title>`, `<link rel="stylesheet">`
- `style.css`: has `:root` with CSS custom properties (`--fip-*`), `*` box-sizing reset, `@keyframes`, `@media (prefers-reduced-motion)`
- `README.md`: 5+ non-empty non-header lines
- No `.js` files, no files outside `submissions/`

## Files Changed
- `submissions/examples/fade-in-pricing-table-minimalist-tech/demo.html` (new)
- `submissions/examples/fade-in-pricing-table-minimalist-tech/style.css` (new)
- `submissions/examples/fade-in-pricing-table-minimalist-tech/README.md` (new)

Closes #64609