### PR TITLE
feat: add CSS Slide-Up Carousel for Cyberpunk Neon Layouts (#64670)

### DIFF
--- a/submissions/examples/cyberpunk-neon-slide-up-carousel/README.md
+++ b/submissions/examples/cyberpunk-neon-slide-up-carousel/README.md
@@ -1,0 +1,22 @@
+# CSS Slide-Up Carousel (Cyberpunk Neon)
+
+A pure CSS interactive carousel component designed for Cyberpunk Neon Layouts. It features a heavy sci-fi aesthetic, distinct neon color-coding per slide, and a bouncy "Slide-Up" entrance animation.
+
+## Features
+- Pure CSS and HTML (No JavaScript required for state management or animations).
+- **Cyberpunk Aesthetic**: Utilizes raw technical fonts (`Share Tech Mono` and `Rajdhani`), a CRT scanline overlay, absolute-positioned cut corners, and intense neon color tokens (`--neon-pink`, `--neon-blue`, `--neon-yellow`) set against a dark grid background.
+- **State Management**: The switching of slides is handled entirely via the hidden radio button hack (`<input type="radio">`). The navigation dots at the bottom are `<label>` elements wired to these hidden inputs.
+- **The Slide-Up Effect**: 
+- The `.slides-wrapper` uses `overflow: hidden` to mask the slides before they arrive and sets a fixed height.
+- By default, all `.slide` containers are hidden (`opacity: 0`, `visibility: hidden`) and pushed downward (`transform: translateY(100%)`).
+- When a slide's radio button is checked, it becomes visible and translates up to `translateY(0)`.
+- The transition utilizes a custom cubic-bezier easing (`cubic-bezier(0.175, 0.885, 0.32, 1.275)`) which creates a satisfying, physical "bounce" as the slide springs up into place.
+- **Dynamic Indicators**: As the user clicks the navigation dots, CSS sibling selectors (`~`) update the active dot's background color and neon box-shadow to match the specific color theme of the currently active slide.
+- Fully accessible with `prefers-reduced-motion` support. For motion-sensitive users, the bouncy slide-up translation and the continuous CRT scanline are completely disabled, safely falling back to immediate opacity cross-fades.
+
+## Usage
+Open `demo.html` in your browser. You will see a mock cyberware catalog interface. Click the navigation dots at the bottom. Observe how the active dot changes color to match the theme, while the new cyberware schematic bounces up rapidly from below into view.
+
+## Files
+- `demo.html`: The HTML structure for the layout, detailing the complex `<input type="radio">` setup required for JS-free carousel state management.
+- `style.css`: The styling, cyberpunk design tokens, CRT animations, and the complex sibling CSS selector (`~`) logic driving the dynamic colored indicators and bouncy slide-up mechanics.

--- a/submissions/examples/cyberpunk-neon-slide-up-carousel/demo.html
+++ b/submissions/examples/cyberpunk-neon-slide-up-carousel/demo.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Slide-Up Carousel - Cyberpunk Neon</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">BME_CATALOG_v7</h1>
+            <p class="subtitle">Accessing classified cyberware schematics via slide-up protocols.</p>
+        </header>
+
+        <!-- Cyberpunk Container -->
+        <div class="cyber-box">
+            <div class="scanline"></div>
+            
+            <div class="carousel-container">
+                <!-- Pure CSS State Management (Hidden Radios) -->
+                <input type="radio" id="slide-1" name="cyber-carousel" class="slide-input" checked>
+                <input type="radio" id="slide-2" name="cyber-carousel" class="slide-input">
+                <input type="radio" id="slide-3" name="cyber-carousel" class="slide-input">
+                
+                <!-- The Slides Wrapper (Hidden Overflow) -->
+                <div class="slides-wrapper">
+                    
+                    <!-- Slide 1 -->
+                    <div class="slide slide-1">
+                        <div class="slide-content border-pink">
+                            <h2 class="glow-pink">Optic_Implant_MK3</h2>
+                            <div class="stats-grid">
+                                <div class="stat"><span class="label">ZOOM</span><span class="value">50X_OPTICAL</span></div>
+                                <div class="stat"><span class="label">MODE</span><span class="value">THERMAL/NV</span></div>
+                            </div>
+                            <p class="desc">Military-grade ocular replacement. Grants extended spectrum visibility and real-time threat highlighting overlay.</p>
+                            <div class="price-tag color-pink">€$ 14,500</div>
+                        </div>
+                    </div>
+
+                    <!-- Slide 2 -->
+                    <div class="slide slide-2">
+                        <div class="slide-content border-blue">
+                            <h2 class="glow-blue">Mantis_Blades_v2</h2>
+                            <div class="stats-grid">
+                                <div class="stat"><span class="label">DAMAGE</span><span class="value">SLASH/PIERCE</span></div>
+                                <div class="stat"><span class="label">ALLOY</span><span class="value">TITANIUM_C</span></div>
+                            </div>
+                            <p class="desc">Concealed forearm armaments. Deploys lethally sharp mono-molecular blades in under 0.4 seconds.</p>
+                            <div class="price-tag color-blue">€$ 32,200</div>
+                        </div>
+                    </div>
+
+                    <!-- Slide 3 -->
+                    <div class="slide slide-3">
+                        <div class="slide-content border-yellow">
+                            <h2 class="glow-yellow">Synaptic_Accelerator</h2>
+                            <div class="stats-grid">
+                                <div class="stat"><span class="label">BOOST</span><span class="value">+300%_REFLEX</span></div>
+                                <div class="stat"><span class="label">DRAW</span><span class="value">HIGH_NEURAL</span></div>
+                            </div>
+                            <p class="desc">Spinal column attachment. Dramatically slows perception of time during combat stress events.</p>
+                            <div class="price-tag color-yellow">€$ 88,000</div>
+                        </div>
+                    </div>
+
+                </div>
+
+                <!-- Carousel Controls (Nav) -->
+                <div class="carousel-nav">
+                    <label for="slide-1" class="nav-dot" aria-label="View slide 1"></label>
+                    <label for="slide-2" class="nav-dot" aria-label="View slide 2"></label>
+                    <label for="slide-3" class="nav-dot" aria-label="View slide 3"></label>
+                </div>
+
+            </div>
+            
+            <!-- Cyberpunk decorative corners -->
+            <div class="corner top-left"></div>
+            <div class="corner top-right"></div>
+            <div class="corner bottom-left"></div>
+            <div class="corner bottom-right"></div>
+        </div>
+
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/cyberpunk-neon-slide-up-carousel/style.css
+++ b/submissions/examples/cyberpunk-neon-slide-up-carousel/style.css
@@ -1,0 +1,287 @@
+@import url('https://fonts.googleapis.com/css2?family=Share+Tech+Mono&family=Rajdhani:wght@500;600;700&display=swap');
+
+:root {
+    --bg-dark: #0a0a0c;
+    --bg-panel: #121216;
+    --grid-color: rgba(0, 255, 255, 0.03);
+    
+    /* Cyberpunk Neon Palette */
+    --neon-pink: #ff0055;
+    --neon-blue: #00f0ff;
+    --neon-yellow: #fcee0a;
+    
+    --text-main: #e0e0e0;
+    --text-muted: #6b7280;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-dark);
+    /* Cyber grid background */
+    background-image: 
+        linear-gradient(var(--grid-color) 1px, transparent 1px),
+        linear-gradient(90deg, var(--grid-color) 1px, transparent 1px);
+    background-size: 30px 30px;
+    font-family: 'Share Tech Mono', monospace;
+    color: var(--text-main);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 60px 20px;
+    box-sizing: border-box;
+}
+
+.layout-container {
+    max-width: 700px;
+    width: 100%;
+}
+
+.section-header {
+    margin-bottom: 40px;
+    font-family: 'Rajdhani', sans-serif;
+    text-transform: uppercase;
+}
+
+.title {
+    font-size: 2.5rem;
+    font-weight: 700;
+    margin: 0 0 5px 0;
+    color: var(--neon-blue);
+    text-shadow: 0 0 10px rgba(0, 240, 255, 0.5);
+    letter-spacing: 2px;
+}
+
+.subtitle {
+    color: var(--text-muted);
+    font-size: 1.1rem;
+    margin: 0;
+    font-family: 'Share Tech Mono', monospace;
+}
+
+
+/* =========================================
+   Cyber Box Container
+   ========================================= */
+
+.cyber-box {
+    position: relative;
+    background: var(--bg-panel);
+    border: 1px solid rgba(255,255,255,0.1);
+    padding: 40px 30px;
+    box-shadow: 0 20px 50px rgba(0,0,0,0.5);
+}
+
+/* Decorative Corners */
+.corner {
+    position: absolute;
+    width: 15px;
+    height: 15px;
+    border: 2px solid var(--text-muted);
+    opacity: 0.5;
+}
+.top-left { top: 0; left: 0; border-right: none; border-bottom: none; }
+.top-right { top: 0; right: 0; border-left: none; border-bottom: none; }
+.bottom-left { bottom: 0; left: 0; border-right: none; border-top: none; }
+.bottom-right { bottom: 0; right: 0; border-left: none; border-top: none; }
+
+/* CRT Scanline Effect */
+.scanline {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 10px;
+    background: linear-gradient(to bottom, transparent, rgba(255,255,255,0.05), transparent);
+    opacity: 0.5;
+    animation: scanline 6s linear infinite;
+    pointer-events: none;
+    z-index: 10;
+}
+@keyframes scanline {
+    0% { transform: translateY(-100%); }
+    100% { transform: translateY(1000%); }
+}
+
+
+/* =========================================
+   Carousel Layout & Logic
+   ========================================= */
+
+.carousel-container {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+}
+
+/* Hidden inputs */
+.slide-input { display: none; }
+
+/* Wrapper masks out slides that are pushed down */
+.slides-wrapper {
+    position: relative;
+    width: 100%;
+    height: 350px;
+    overflow: hidden; 
+}
+
+.slide {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    
+    /* Hidden State: Transparent and pushed down heavily */
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(100%);
+    
+    /* Slide-Up Transition */
+    transition: all 0.6s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+/* Active State: Opaque and positioned at 0 */
+#slide-1:checked ~ .slides-wrapper .slide-1,
+#slide-2:checked ~ .slides-wrapper .slide-2,
+#slide-3:checked ~ .slides-wrapper .slide-3 {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+    z-index: 5;
+}
+
+
+/* =========================================
+   Internal Slide Content Styling
+   ========================================= */
+
+.slide-content {
+    height: 100%;
+    padding: 30px;
+    background: rgba(255,255,255,0.02);
+    border-top: 3px solid transparent;
+    display: flex;
+    flex-direction: column;
+    box-sizing: border-box;
+}
+
+.border-pink { border-color: var(--neon-pink); }
+.border-blue { border-color: var(--neon-blue); }
+.border-yellow { border-color: var(--neon-yellow); }
+
+.slide-content h2 {
+    font-family: 'Rajdhani', sans-serif;
+    font-size: 2rem;
+    margin: 0 0 20px 0;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+}
+
+.glow-pink { color: var(--neon-pink); text-shadow: 0 0 10px rgba(255,0,85,0.4); }
+.glow-blue { color: var(--neon-blue); text-shadow: 0 0 10px rgba(0,240,255,0.4); }
+.glow-yellow { color: var(--neon-yellow); text-shadow: 0 0 10px rgba(252,238,10,0.4); }
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 15px;
+    margin-bottom: 20px;
+}
+
+.stat {
+    background: rgba(255,255,255,0.05);
+    padding: 10px;
+    border-left: 2px solid var(--text-muted);
+}
+
+.stat .label {
+    display: block;
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    margin-bottom: 5px;
+}
+
+.stat .value {
+    font-size: 1.1rem;
+    font-weight: 600;
+}
+
+.desc {
+    color: var(--text-muted);
+    font-size: 1rem;
+    line-height: 1.5;
+    margin: 0 0 20px 0;
+    flex-grow: 1;
+}
+
+.price-tag {
+    font-family: 'Rajdhani', sans-serif;
+    font-size: 1.8rem;
+    font-weight: 700;
+    text-align: right;
+}
+.color-pink { color: var(--neon-pink); }
+.color-blue { color: var(--neon-blue); }
+.color-yellow { color: var(--neon-yellow); }
+
+
+/* =========================================
+   Carousel Navigation Dots
+   ========================================= */
+
+.carousel-nav {
+    display: flex;
+    justify-content: center;
+    gap: 15px;
+    margin-top: 30px;
+}
+
+.nav-dot {
+    width: 25px;
+    height: 5px;
+    background: var(--text-muted);
+    cursor: pointer;
+    transition: all 0.3s ease;
+    opacity: 0.5;
+}
+
+.nav-dot:hover {
+    opacity: 0.8;
+}
+
+/* Light up the active dot based on the checked radio */
+#slide-1:checked ~ .carousel-nav label[for="slide-1"] {
+    background: var(--neon-pink);
+    box-shadow: 0 0 10px var(--neon-pink);
+    opacity: 1;
+}
+#slide-2:checked ~ .carousel-nav label[for="slide-2"] {
+    background: var(--neon-blue);
+    box-shadow: 0 0 10px var(--neon-blue);
+    opacity: 1;
+}
+#slide-3:checked ~ .carousel-nav label[for="slide-3"] {
+    background: var(--neon-yellow);
+    box-shadow: 0 0 10px var(--neon-yellow);
+    opacity: 1;
+}
+
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    .slide {
+        transition: opacity 0.3s ease, visibility 0.3s ease !important;
+        transform: none !important;
+    }
+    
+    .scanline {
+        animation: none !important;
+        display: none;
+    }
+    
+    .nav-dot {
+        transition: background-color 0.2s ease, opacity 0.2s ease !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces the CSS Slide-Up Carousel designed for Cyberpunk Neon Layouts, resolving issue #64670. 

### Changes Made:
- Added `submissions/examples/cyberpunk-neon-slide-up-carousel/` directory.
- Created `demo.html` showcasing a mock cyberware catalog interface. The layout utilizes the pure CSS radio button hack (`<input type="radio">` paired with `<label>` elements) to manage the switching of the carousel slides without JavaScript.
- Created `style.css` featuring a heavy sci-fi aesthetic utilizing raw technical fonts (`Share Tech Mono` and `Rajdhani`), a continuous CRT scanline animation overlay, absolute-positioned cut corners, and intense neon color tokens (`--neon-pink`, `--neon-blue`, `--neon-yellow`) set against a dark grid background.
  - Implemented the Slide-Up system. The `.slides-wrapper` uses `overflow: hidden` to mask the slides before they arrive.
  - When a slide's radio button is checked, it becomes visible and translates from a hidden state pushed down (`translateY(100%)`) up to `0`. 
  - The transition utilizes a custom bouncy cubic-bezier easing curve to give the slide a physical, snapping entrance.
  - As the user clicks the navigation dots, CSS sibling selectors (`~`) update the active dot's background color and neon box-shadow to match the specific color theme of the currently active slide.
- Added `README.md` documenting usage and technical features.
- Honors the `prefers-reduced-motion` accessibility standard. The bouncy slide-up translation and the continuous CRT scanline are completely disabled. The interactions safely fall back to immediate opacity cross-fades for motion-sensitive users.

Closes #64670
