### PR TITLE
feat: add pure css spring physics example

### DIFF
--- a/submissions/examples/css-spring-physics/README.md
+++ b/submissions/examples/css-spring-physics/README.md
@@ -1,0 +1,28 @@
+# CSS Spring Physics Component
+
+A demonstration of the modern CSS `linear()` easing function to replicate complex physics (springs, overshoots, and dampening) entirely in CSS.
+
+## Features
+- **Zero Animation Libraries**: Historically, achieving realistic spring physics required heavy JavaScript libraries like Framer Motion, React Spring, or GSAP. By using the new CSS `linear()` easing function, we can approximate the exact mathematical curve of a spring using a multi-point linear graph.
+- **Hardware Accelerated**: Because the transition is purely CSS, properties like `transform` run entirely on the GPU, avoiding main-thread blocking.
+- **Accessible Fallback**: Complex spring curves inherently overshoot (`> 1.0` multiplier on the animation end state) and wobble. This can trigger vestibular disorders. This component gracefully falls back to a standard, non-wobbly `ease-out` transition if `@media (prefers-reduced-motion: reduce)` is detected.
+
+## Usage
+Open `demo.html` in a modern browser.
+- **Spring Modal**: Click the "Toggle Modal" button. The modal will slide up, shoot past its final resting position, and wobble back into place—just like a physical spring attached to a rubber band.
+- **Overshoot Button**: Hover over the "Hover Me" button. The scale transform will bounce elastically before settling.
+
+The magic lives in this single CSS variable:
+```css
+--spring-easing: linear(
+    0, 0.057, 0.198, 0.395, 0.612, 0.812, 0.972, 1.082, 
+    1.147, 1.171, 1.166, 1.137, 1.092, 1.042, 0.999, 
+    0.967, 0.951, 0.947, 0.953, 0.968, 0.985, 1.002, 
+    1.013, 1.019, 1.018, 1.013, 1.007, 1.001, 0.997, 
+    0.995, 0.995, 0.996, 0.998, 1.000, 1.001, 1.002, 1
+);
+```
+
+## Files
+- `demo.html`: The HTML structure containing the interactive triggers.
+- `style.css`: The styling rules where the complex `linear()` approximation curve is defined and applied to the transforms.

--- a/submissions/examples/css-spring-physics/demo.html
+++ b/submissions/examples/css-spring-physics/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Spring Physics - EaseMotion</title>
+    <!-- Include EaseMotion CSS -->
+    <link rel="stylesheet" href="../../../easemotion.min.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="layout-container">
+        <header class="header">
+            <h1 class="title">Spring Physics via CSS <code>linear()</code></h1>
+            <p class="subtitle">Using the modern CSS <code>linear()</code> easing function to achieve realistic, complex bounce and spring physics without JavaScript.</p>
+        </header>
+
+        <main class="showcase">
+            <!-- Example 1: Bouncy Modal -->
+            <div class="interaction-card">
+                <h3>Spring Modal</h3>
+                <p>Click the button to toggle a modal using a heavy spring animation.</p>
+                <button class="trigger-btn" id="modalTrigger">Toggle Modal</button>
+                
+                <!-- The actual modal -->
+                <div class="spring-modal" id="springModal">
+                    <div class="modal-content">
+                        <h4>Success</h4>
+                        <p>This modal bounced into place using pure CSS math.</p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Example 2: Overshoot Button -->
+            <div class="interaction-card">
+                <h3>Overshoot Hover</h3>
+                <p>Hover over this button to see a satisfying "wobbly" overshoot effect on scale.</p>
+                <button class="spring-btn">Hover Me</button>
+            </div>
+        </main>
+    </div>
+
+    <script>
+        const trigger = document.getElementById('modalTrigger');
+        const modal = document.getElementById('springModal');
+        
+        trigger.addEventListener('click', () => {
+            modal.classList.toggle('is-open');
+        });
+    </script>
+</body>
+</html>

--- a/submissions/examples/css-spring-physics/style.css
+++ b/submissions/examples/css-spring-physics/style.css
@@ -1,0 +1,174 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;700&display=swap');
+
+:root {
+    --bg-color: #faf5ff;
+    --text-primary: #3b0764;
+    --text-secondary: #6b21a8;
+    --card-bg: #ffffff;
+    
+    /* 
+       The Magic Formula:
+       This linear() function approximates a complex spring physics curve. 
+       Generated using a spring parameter generator (stiffness: 300, damping: 15, mass: 1).
+    */
+    --spring-easing: linear(
+        0, 0.057, 0.198, 0.395, 0.612, 0.812, 0.972, 1.082, 
+        1.147, 1.171, 1.166, 1.137, 1.092, 1.042, 0.999, 
+        0.967, 0.951, 0.947, 0.953, 0.968, 0.985, 1.002, 
+        1.013, 1.019, 1.018, 1.013, 1.007, 1.001, 0.997, 
+        0.995, 0.995, 0.996, 0.998, 1.000, 1.001, 1.002, 1
+    );
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    font-family: 'Outfit', system-ui, sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    box-sizing: border-box;
+    padding: 40px 20px;
+}
+
+.layout-container {
+    max-width: 800px;
+    width: 100%;
+}
+
+.header {
+    margin-bottom: 48px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 700;
+    margin: 0 0 12px 0;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    line-height: 1.5;
+}
+
+.showcase {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 32px;
+    justify-content: center;
+}
+
+.interaction-card {
+    background: var(--card-bg);
+    padding: 32px;
+    border-radius: 16px;
+    border: 1px solid #e9d5ff;
+    box-shadow: 0 10px 15px -3px rgba(107, 33, 168, 0.05);
+    flex: 1;
+    min-width: 300px;
+    text-align: center;
+    position: relative;
+    overflow: hidden;
+}
+
+.interaction-card h3 {
+    margin: 0 0 12px 0;
+    font-size: 1.4rem;
+}
+
+.interaction-card p {
+    color: var(--text-secondary);
+    margin: 0 0 24px 0;
+    line-height: 1.5;
+}
+
+.trigger-btn {
+    background: #d8b4fe;
+    color: #4c1d95;
+    border: none;
+    padding: 12px 24px;
+    border-radius: 8px;
+    font-weight: 600;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: background 0.2s;
+}
+
+.trigger-btn:hover {
+    background: #c084fc;
+}
+
+/* =========================================
+   Example 1: Spring Modal
+   ========================================= */
+
+.spring-modal {
+    position: absolute;
+    bottom: -100%;
+    left: 0;
+    width: 100%;
+    padding: 24px;
+    box-sizing: border-box;
+    z-index: 10;
+    /* Use the spring easing for the transform transition */
+    transition: transform 1s var(--spring-easing);
+}
+
+.spring-modal.is-open {
+    /* Translating up allows the spring curve (which goes above 1.0) to overshoot visually */
+    transform: translateY(-120%);
+}
+
+.modal-content {
+    background: #8b5cf6;
+    color: white;
+    padding: 24px;
+    border-radius: 12px;
+    box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1);
+}
+
+.modal-content h4 {
+    margin: 0 0 8px 0;
+    font-size: 1.2rem;
+}
+
+.modal-content p {
+    color: #ede9fe;
+    margin: 0;
+}
+
+/* =========================================
+   Example 2: Overshoot Button
+   ========================================= */
+
+.spring-btn {
+    background: #8b5cf6;
+    color: white;
+    border: none;
+    padding: 16px 32px;
+    border-radius: 50px;
+    font-weight: 600;
+    font-size: 1.1rem;
+    cursor: pointer;
+    /* Use the spring easing on hover scale */
+    transition: transform 0.8s var(--spring-easing), background 0.2s;
+}
+
+.spring-btn:hover {
+    transform: scale(1.15);
+    background: #7c3aed;
+}
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    .spring-modal,
+    .spring-btn {
+        /* Fallback to a standard, snappy ease-out without overshoot */
+        transition: transform 0.3s ease-out !important;
+    }
+}


### PR DESCRIPTION
### Description
Closes #65812

Added a new `css-spring-physics` component to the examples showcase. This submission introduces the modern CSS `linear()` easing function to replicate complex physics (springs, overshoots, and dampening) entirely in CSS, bypassing the need for JavaScript animation libraries.

### What was changed
* Created `submissions/examples/css-spring-physics/demo.html` showcasing a spring-loaded modal and an overshoot hover button.
* Created `submissions/examples/css-spring-physics/style.css` which defines the `--spring-easing` variable using a highly complex `linear()` multi-point graph to approximate mathematical spring physics.
* Created `submissions/examples/css-spring-physics/README.md` explaining the technique and providing the mathematical formula.

### Why it matters
Historically, achieving realistic spring physics required heavy JavaScript libraries like Framer Motion, React Spring, or GSAP. By using the new CSS `linear()` easing function, we can approximate the exact mathematical curve of a spring using a multi-point linear graph. Because the transition is purely CSS, properties like `transform` run entirely on the GPU, avoiding main-thread blocking and improving performance drastically.

### Accessibility
- Fully respects `@media (prefers-reduced-motion: reduce)`.
- Complex spring curves inherently overshoot (`> 1.0` multiplier on the animation end state) and wobble, which can trigger vestibular disorders. This component gracefully falls back to a standard, non-wobbly `ease-out` transition if motion sensitivity is detected.

### Verification
- [x] All files isolated to the `submissions/examples/` folder.
- [x] Verified spring wobble and overshoot behavior.
- [x] Verified flat `ease-out` fallback for reduced motion.