### PR TITLE
feat: add svg scale distortion fix example

### DIFF
--- a/submissions/examples/svg-scale-distortion-fix/README.md
+++ b/submissions/examples/svg-scale-distortion-fix/README.md
@@ -1,0 +1,17 @@
+# SVG Scale Distortion Fix
+
+A targeted pattern to resolve rendering bugs (sub-pixel blurring and stroke flickering) that occur in Firefox and Safari when an inline `<svg>` is a child of an element undergoing a `transform: scale()` transition.
+
+## Features
+- **The Bug**: When a parent button has `transform: scale(1.15)` applied on hover, the browser attempts to scale the child SVG. In Webkit and Gecko engines, this continuous re-rasterization of the vector path during the transition often results in a jagged, flickering, or blurred stroke.
+- **The Fix**: We apply `transform: translateZ(0)` and `backface-visibility: hidden` directly to the child `.svg-fixed` element. This forces the browser to promote the SVG to its own hardware-accelerated compositor layer *before* the parent scale happens, ensuring the vector is scaled smoothly on the GPU without triggering layout recalculations or sub-pixel snapping on the CPU.
+- **Optimization**: We include `will-change: transform` as a hint to the browser to further optimize the compositor layer.
+
+## Usage
+Open `demo.html` in Firefox or Safari.
+- Hover over the "Buggy Button" and watch the stroke width of the SVG icon carefully as it scales. You may notice subtle jaggedness or "snapping".
+- Hover over the "Fixed Button". The transition should be perfectly buttery smooth.
+
+## Files
+- `demo.html`: The HTML structure demonstrating the before-and-after states.
+- `style.css`: The styling engine containing the hardware acceleration fixes.

--- a/submissions/examples/svg-scale-distortion-fix/demo.html
+++ b/submissions/examples/svg-scale-distortion-fix/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SVG Scale Distortion Fix - EaseMotion</title>
+    <!-- Include EaseMotion CSS -->
+    <link rel="stylesheet" href="../../../easemotion.min.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="layout-container">
+        <header class="header">
+            <h1 class="title">SVG Scale Distortion Fix</h1>
+            <p class="subtitle">A robust CSS pattern to prevent child inline SVGs from experiencing sub-pixel blurring and rendering distortion when their parent button is scaled (specifically targeting a known bug in Firefox and Safari).</p>
+        </header>
+
+        <main class="showcase">
+            <!-- Problem Demo -->
+            <div class="demo-card">
+                <h3>The Problem</h3>
+                <p>Scaling a button directly often causes the child SVG stroke to flicker or blur during the transition.</p>
+                <button class="btn btn-buggy">
+                    <svg viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                        <circle cx="12" cy="12" r="10"></circle>
+                        <line x1="12" y1="8" x2="12" y2="16"></line>
+                        <line x1="8" y1="12" x2="16" y2="12"></line>
+                    </svg>
+                    <span>Buggy Button</span>
+                </button>
+            </div>
+
+            <!-- Solution Demo -->
+            <div class="demo-card">
+                <h3>The Fix</h3>
+                <p>Applying hardware acceleration and preserving 3D context on the SVG stops the sub-pixel rendering engine from snapping.</p>
+                <button class="btn btn-fixed">
+                    <svg class="svg-fixed" viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                        <circle cx="12" cy="12" r="10"></circle>
+                        <line x1="12" y1="8" x2="12" y2="16"></line>
+                        <line x1="8" y1="12" x2="16" y2="12"></line>
+                    </svg>
+                    <span>Fixed Button</span>
+                </button>
+            </div>
+        </main>
+    </div>
+</body>
+</html>

--- a/submissions/examples/svg-scale-distortion-fix/style.css
+++ b/submissions/examples/svg-scale-distortion-fix/style.css
@@ -1,0 +1,138 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+:root {
+    --bg-color: #f1f5f9;
+    --card-bg: #ffffff;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    --btn-bg: #3b82f6;
+    --btn-hover: #2563eb;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    font-family: 'Inter', system-ui, sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    box-sizing: border-box;
+    padding: 40px 20px;
+}
+
+.layout-container {
+    max-width: 800px;
+    width: 100%;
+}
+
+.header {
+    text-align: center;
+    margin-bottom: 48px;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 600;
+    margin: 0 0 12px 0;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    line-height: 1.6;
+}
+
+.showcase {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 32px;
+}
+
+.demo-card {
+    background: var(--card-bg);
+    padding: 32px;
+    border-radius: 16px;
+    box-shadow: 0 4px 6px -1px rgba(0,0,0,0.05);
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.demo-card h3 {
+    margin: 0 0 12px 0;
+    font-size: 1.4rem;
+}
+
+.demo-card p {
+    color: var(--text-secondary);
+    margin: 0 0 32px 0;
+    line-height: 1.5;
+    font-size: 0.95rem;
+}
+
+/* =========================================
+   Base Button Styles
+   ========================================= */
+.btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    background: var(--btn-bg);
+    color: white;
+    border: none;
+    padding: 14px 28px;
+    border-radius: 12px;
+    font-size: 1.1rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1), background 0.3s ease;
+}
+
+.btn:hover {
+    background: var(--btn-hover);
+    transform: scale(1.15); /* The scale that causes the bug */
+}
+
+/* =========================================
+   The Bug (Unfixed SVG)
+   ========================================= */
+.btn-buggy svg {
+    /* No fixes applied. 
+       In Firefox/Safari, this may cause sub-pixel stroke flickering 
+       while the parent's scale(1.15) transition runs. */
+}
+
+/* =========================================
+   The Fix
+   ========================================= */
+.btn-fixed .svg-fixed {
+    /* 
+      Fix 1: Force hardware acceleration on the child SVG to prevent 
+      the browser from continuously rasterizing the vector path during the scale.
+    */
+    transform: translateZ(0);
+    
+    /* 
+      Fix 2: Prevent backface rendering artifacts during the parent's transform.
+    */
+    backface-visibility: hidden;
+    
+    /* 
+      Fix 3: Inform the browser that this element will be part of a transform composite.
+    */
+    will-change: transform;
+}
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    .btn {
+        transition: background 0.3s ease;
+    }
+    .btn:hover {
+        transform: none; /* Disable scale entirely */
+    }
+}


### PR DESCRIPTION
### Description
Closes #65810

Added a new `svg-scale-distortion-fix` component to the examples showcase. This submission provides a targeted CSS hardware-acceleration pattern to resolve known rendering bugs (sub-pixel blurring and stroke flickering) that occur in Firefox and Safari when an inline `<svg>` is a child of an element undergoing a `transform: scale()` transition.

### What was changed
* Created `submissions/examples/svg-scale-distortion-fix/demo.html` showing a side-by-side comparison of a buggy scaled button versus the fixed version.
* Created `submissions/examples/svg-scale-distortion-fix/style.css` which introduces the `.svg-fixed` class, utilizing `transform: translateZ(0)` and `backface-visibility: hidden` to promote the vector graphic to the compositor layer.
* Created `submissions/examples/svg-scale-distortion-fix/README.md` explaining why Webkit/Gecko rendering engines struggle with scalable vectors inside transformed parents and how this fix prevents continuous CPU re-rasterization.

### Why it matters
Hovering over a button is one of the most common micro-interactions on the web. When that hover triggers a scale transform, the browser attempts to mathematically scale all children. For vectors (like SVGs), this forces constant sub-pixel layout recalculations during the transition, causing visual flickering. By forcing the SVG onto the GPU *before* the parent scales, the transition becomes flawlessly smooth.

### Accessibility
- Fully respects `@media (prefers-reduced-motion: reduce)` by removing the scale transition on hover. 

### Verification
- [x] All files isolated to the `submissions/examples/` folder.
- [x] Verified hardware acceleration forces GPU scaling, eliminating Firefox/Safari stroke jitter.