### PR TITLE
feat: add rtl aware slide animations example

### DIFF
--- a/submissions/examples/rtl-aware-slide-animations/README.md
+++ b/submissions/examples/rtl-aware-slide-animations/README.md
@@ -1,0 +1,22 @@
+# RTL-Aware Slide Animations
+
+A smart CSS architecture designed to make `transform: translateX()` animations fully compatible with Right-to-Left (RTL) reading directions (such as Arabic or Hebrew).
+
+## Features
+- **The Bug Context**: In CSS, `transform: translateX()` operates on physical coordinates, not logical coordinates. A `translateX(-100%)` will *always* slide an element in from the physical left side of the screen. If a website switches to RTL mode (`dir="rtl"`), the logical start of the page is now the right side, but the hardcoded animation will still slide in from the left, ruining the UI flow.
+- **The Fix**: Because there is currently no native `transform: translateInline()` supported in CSS, we use a CSS Variable Direction Multiplier.
+  - We declare `--dir-multiplier: 1` globally.
+  - We declare `--dir-multiplier: -1` on `[dir="rtl"]`.
+  - In our `@keyframes`, we wrap the translation in a `calc()`: `translateX(calc(-100px * var(--dir-multiplier)))`.
+  - The animation automatically flips its axis perfectly when the HTML direction changes!
+
+## Usage
+Open `demo.html` in your browser.
+1. Observe the animations sliding in from the Left (the logical start in LTR).
+2. Click the "Switch to RTL Mode" button.
+3. Observe the buggy animation still slides from the Left (which is now the logical *end*). 
+4. Observe the fixed animation perfectly flips its axis and slides in from the Right (the new logical start).
+
+## Files
+- `demo.html`: The HTML structure containing the toggle button to swap the `<html dir="...">` attribute.
+- `style.css`: The styling engine defining the multiplier logic and the `calc()` keyframes.

--- a/submissions/examples/rtl-aware-slide-animations/demo.html
+++ b/submissions/examples/rtl-aware-slide-animations/demo.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>RTL-Aware Slide Animations - EaseMotion</title>
+    <!-- Include EaseMotion CSS -->
+    <link rel="stylesheet" href="../../../easemotion.min.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="layout-container">
+        <header class="header">
+            <h1 class="title">RTL-Aware Slide Animations</h1>
+            <p class="subtitle">A smart CSS architecture using direction multipliers to make <code>transform: translateX()</code> animations fully compatible with Right-to-Left (RTL) languages.</p>
+        </header>
+
+        <main class="showcase">
+            <div class="controls">
+                <button class="btn" id="toggleDirBtn">Switch to RTL Mode</button>
+            </div>
+
+            <div class="demo-arena" id="arena">
+                <!-- Example 1: The Hardcoded Bug -->
+                <div class="demo-block">
+                    <h3>Hardcoded Slide-In (Buggy)</h3>
+                    <p>Uses a hardcoded <code>translateX(-100%)</code>. When switched to RTL, it slides in from the wrong logical side!</p>
+                    <div class="slide-container">
+                        <div class="slide-element slide-buggy">Hello World</div>
+                    </div>
+                </div>
+
+                <!-- Example 2: The RTL-Aware Fix -->
+                <div class="demo-block">
+                    <h3>Direction-Aware Slide-In (Fixed)</h3>
+                    <p>Uses <code>translateX(calc(-100% * var(--dir-multiplier)))</code>. This magically flips the axis when in RTL mode!</p>
+                    <div class="slide-container">
+                        <div class="slide-element slide-fixed">مرحبا بالعالم</div>
+                    </div>
+                </div>
+            </div>
+        </main>
+    </div>
+
+    <script>
+        const toggleBtn = document.getElementById('toggleDirBtn');
+        
+        toggleBtn.addEventListener('click', () => {
+            const htmlTag = document.documentElement;
+            const currentDir = htmlTag.getAttribute('dir') || 'ltr';
+            
+            if (currentDir === 'ltr') {
+                htmlTag.setAttribute('dir', 'rtl');
+                toggleBtn.textContent = 'Switch to LTR Mode';
+            } else {
+                htmlTag.setAttribute('dir', 'ltr');
+                toggleBtn.textContent = 'Switch to RTL Mode';
+            }
+            
+            // Force replay animations
+            const arena = document.getElementById('arena');
+            const clone = arena.cloneNode(true);
+            arena.parentNode.replaceChild(clone, arena);
+        });
+    </script>
+</body>
+</html>

--- a/submissions/examples/rtl-aware-slide-animations/style.css
+++ b/submissions/examples/rtl-aware-slide-animations/style.css
@@ -1,0 +1,158 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600&display=swap');
+
+/* =========================================
+   The Global Direction Multiplier
+   ========================================= */
+:root {
+    /* Default to LTR (Left-To-Right) multiplier */
+    --dir-multiplier: 1;
+}
+
+/* When the document is set to RTL (e.g. Arabic, Hebrew) */
+[dir="rtl"] {
+    /* Flip the multiplier to negative */
+    --dir-multiplier: -1;
+}
+
+/* =========================================
+   Base Layout
+   ========================================= */
+:root {
+    --bg-color: #f8fafc;
+    --card-bg: #ffffff;
+    --text-primary: #0f172a;
+    --text-secondary: #475569;
+    --primary: #14b8a6;
+    --primary-hover: #0d9488;
+    --danger: #ef4444;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    font-family: 'Outfit', system-ui, sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    padding: 40px 20px;
+}
+
+.layout-container {
+    max-width: 900px;
+    margin: 0 auto;
+}
+
+.header {
+    text-align: center;
+    margin-bottom: 40px;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 600;
+    margin: 0 0 12px 0;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    line-height: 1.5;
+    max-width: 700px;
+    margin: 0 auto;
+}
+
+.controls {
+    text-align: center;
+    margin-bottom: 40px;
+}
+
+.btn {
+    background: var(--primary);
+    color: white;
+    border: none;
+    padding: 12px 24px;
+    border-radius: 8px;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s;
+}
+.btn:hover { background: var(--primary-hover); }
+
+.demo-arena {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 32px;
+    justify-content: center;
+}
+
+.demo-block {
+    background: var(--card-bg);
+    padding: 24px;
+    border-radius: 12px;
+    box-shadow: 0 4px 6px -1px rgba(0,0,0,0.05);
+    border: 1px solid #e2e8f0;
+    width: 350px;
+}
+
+.demo-block h3 { margin: 0 0 8px 0; }
+.demo-block p { color: var(--text-secondary); margin: 0 0 24px 0; font-size: 0.95rem; line-height: 1.5; }
+
+.slide-container {
+    background: #e2e8f0;
+    height: 60px;
+    border-radius: 8px;
+    overflow: hidden;
+    position: relative;
+}
+
+.slide-element {
+    height: 100%;
+    width: 150px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: white;
+    font-weight: 600;
+    border-radius: 8px;
+}
+
+/* =========================================
+   Example 1: Hardcoded Bug
+   ========================================= */
+.slide-buggy {
+    background: var(--danger);
+    /* Hardcoded translation completely ignores reading direction */
+    animation: slideInHardcoded 1s ease-out forwards;
+}
+
+@keyframes slideInHardcoded {
+    0% { transform: translateX(-150px); }
+    100% { transform: translateX(0); }
+}
+
+/* =========================================
+   Example 2: RTL-Aware Fix
+   ========================================= */
+.slide-fixed {
+    background: var(--primary);
+    /* 
+       We use calc() to multiply the translation value by our --dir-multiplier.
+       In LTR mode, it multiplies by 1 (no change).
+       In RTL mode, it multiplies by -1 (flips the axis completely).
+    */
+    animation: slideInAware 1s ease-out forwards;
+}
+
+@keyframes slideInAware {
+    0% { transform: translateX(calc(-150px * var(--dir-multiplier))); }
+    100% { transform: translateX(0); }
+}
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    .slide-element {
+        animation: none !important;
+        transform: none !important;
+    }
+}


### PR DESCRIPTION
### Description
Closes #65803

Added a new `rtl-aware-slide-animations` component to the examples showcase. This submission provides a robust CSS architectural pattern that makes `transform: translateX()` animations fully compatible with Right-to-Left (RTL) reading directions (e.g., Arabic, Hebrew).

### What was changed
* Created `submissions/examples/rtl-aware-slide-animations/demo.html` showing a side-by-side comparison of a buggy hardcoded transform versus a fixed, direction-aware transform. Included a JS button to dynamically toggle the `<html dir="...">` attribute to prove the fix works instantly.
* Created `submissions/examples/rtl-aware-slide-animations/style.css` which introduces the `--dir-multiplier` CSS variable pattern. It defaults to `1` on LTR, and flips to `-1` on RTL. The `@keyframes` then use `calc(X * var(--dir-multiplier))` to perfectly invert the sliding axis based on context.
* Created `submissions/examples/rtl-aware-slide-animations/README.md` explaining why physical CSS transforms (`translateX`) fail in logical document layouts and how this multiplier formula resolves it.

### Why it matters
Internationalization (i18n) is critical for modern web apps. Because there is currently no native `transform: translateInline()` supported in CSS, developers often accidentally ruin RTL layouts by hardcoding `translateX(-100%)`. In LTR, this correctly slides from the logical start (left). In RTL, it still slides from the left, which is now the logical *end* of the document! By injecting a CSS variable multiplier, we can mathematically invert the physical axis at the global level, ensuring all entry animations perfectly adapt to the user's language direction.

### Accessibility
- Fully respects `@media (prefers-reduced-motion: reduce)` by removing the translation transform entirely and defaulting to standard block flow.

### Verification
- [x] All files isolated to the `submissions/examples/` folder.
- [x] Verified `calc()` multiplier perfectly flips the translation axis when `dir="rtl"` is present on the root element.