### PR TITLE
feat: add ghost click fix example

### DIFF
--- a/submissions/examples/ghost-click-fix/README.md
+++ b/submissions/examples/ghost-click-fix/README.md
@@ -1,0 +1,20 @@
+# Ghost Click Fix
+
+A CSS pattern that solves the incredibly common layout bug where elements that have faded out (using `opacity: 0`) act as invisible shields, intercepting and swallowing mouse clicks meant for the interactive UI elements beneath them.
+
+## Features
+- **The Bug Context**: In CSS, `opacity: 0` makes an element invisible, but it *does not* remove it from the browser's interaction layer (hit-testing). If a toast notification, a modal, or an absolute overlay simply animates to `opacity: 0` and remains in the DOM, it will invisibly cover the buttons beneath it, causing "ghost clicks" where the user clicks a visible button but nothing happens.
+- **The Fix**: 
+  - Instead of relying on JavaScript to calculate when the animation ends and apply `display: none`, we can handle this purely in CSS.
+  - By adding `visibility: visible` at the start of the `@keyframes` and `visibility: hidden` at the `100%` mark, the browser is smart enough to wait for the `opacity` transition to finish before flipping the `visibility` state.
+  - Unlike `opacity: 0`, `visibility: hidden` physically removes the element from the mouse interaction tree, allowing clicks to pass directly through it to the elements below.
+
+## Usage
+Open `demo.html` in your browser. 
+Wait 3 seconds for the notifications to fade out, then attempt to click the blue buttons.
+- On the **Buggy** side, clicking the button does nothing, because the invisible orange toast is blocking your cursor.
+- On the **Fixed** side, clicking the button successfully triggers the alert, because the green toast properly set `visibility: hidden` at the end of its fade.
+
+## Files
+- `demo.html`: The HTML structure demonstrating the stacked absolute positioning.
+- `style.css`: The styling engine containing the `@keyframes` that combine `opacity` and `visibility`.

--- a/submissions/examples/ghost-click-fix/demo.html
+++ b/submissions/examples/ghost-click-fix/demo.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ghost Click Fix - EaseMotion</title>
+    <!-- Include EaseMotion CSS -->
+    <link rel="stylesheet" href="../../../easemotion.min.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="layout-container">
+        <header class="header">
+            <h1 class="title">Ghost Click Fix</h1>
+            <p class="subtitle">Solving the common bug where faded-out CSS elements (opacity: 0) invisibly block clicks on the interactive elements beneath them.</p>
+        </header>
+
+        <main class="showcase">
+            <!-- Buggy Demo -->
+            <div class="demo-card">
+                <h3>The Buggy Implementation</h3>
+                <p>When the notification fades out, it remains in the DOM and intercepts clicks, making the button underneath unclickable!</p>
+                
+                <div class="interaction-zone">
+                    <button class="underlying-btn" onclick="alert('Buggy button clicked!')">Click Me (If You Can)</button>
+                    
+                    <div class="toast-notification buggy-toast">
+                        Notice: I fade out, but I secretly block your clicks!
+                    </div>
+                </div>
+                
+                <button class="replay-btn" id="replayBuggy">Reset Buggy Toast</button>
+            </div>
+
+            <!-- Fixed Demo -->
+            <div class="demo-card">
+                <h3>The Fixed Implementation</h3>
+                <p>By animating <code>visibility: hidden</code> alongside <code>opacity</code>, the faded element is successfully removed from the interaction tree.</p>
+                
+                <div class="interaction-zone">
+                    <button class="underlying-btn" onclick="alert('Fixed button clicked successfully!')">Click Me (Easily)</button>
+                    
+                    <div class="toast-notification fixed-toast">
+                        Notice: I fade out and release my grip on the mouse!
+                    </div>
+                </div>
+                
+                <button class="replay-btn" id="replayFixed">Reset Fixed Toast</button>
+            </div>
+        </main>
+    </div>
+
+    <script>
+        document.getElementById('replayBuggy').addEventListener('click', () => {
+            const toast = document.querySelector('.buggy-toast');
+            toast.style.animation = 'none';
+            toast.offsetHeight; // trigger reflow
+            toast.style.animation = null; 
+        });
+
+        document.getElementById('replayFixed').addEventListener('click', () => {
+            const toast = document.querySelector('.fixed-toast');
+            toast.style.animation = 'none';
+            toast.offsetHeight; // trigger reflow
+            toast.style.animation = null; 
+        });
+    </script>
+</body>
+</html>

--- a/submissions/examples/ghost-click-fix/style.css
+++ b/submissions/examples/ghost-click-fix/style.css
@@ -1,0 +1,179 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+:root {
+    --bg-color: #f1f5f9;
+    --card-bg: #ffffff;
+    --text-primary: #0f172a;
+    --text-secondary: #475569;
+    --primary: #3b82f6;
+    --primary-hover: #2563eb;
+    --warning: #f59e0b;
+    --success: #10b981;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    font-family: 'Inter', system-ui, sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    padding: 40px 20px;
+}
+
+.layout-container {
+    max-width: 900px;
+    margin: 0 auto;
+}
+
+.header {
+    text-align: center;
+    margin-bottom: 40px;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 600;
+    margin: 0 0 12px 0;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    line-height: 1.5;
+    max-width: 700px;
+    margin: 0 auto;
+}
+
+.showcase {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 32px;
+    justify-content: center;
+}
+
+.demo-card {
+    background: var(--card-bg);
+    padding: 32px;
+    border-radius: 12px;
+    box-shadow: 0 4px 6px -1px rgba(0,0,0,0.05);
+    border: 1px solid #e2e8f0;
+    width: 350px;
+    display: flex;
+    flex-direction: column;
+}
+
+.demo-card h3 { margin: 0 0 8px 0; }
+.demo-card p { color: var(--text-secondary); margin: 0 0 24px 0; font-size: 0.95rem; line-height: 1.5; }
+
+.interaction-zone {
+    position: relative;
+    height: 150px;
+    background: #f8fafc;
+    border: 1px dashed #cbd5e1;
+    border-radius: 8px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-bottom: 24px;
+}
+
+.underlying-btn {
+    background: var(--primary);
+    color: white;
+    border: none;
+    padding: 12px 24px;
+    border-radius: 6px;
+    font-size: 1rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: transform 0.1s, background 0.2s;
+}
+
+.underlying-btn:active {
+    transform: scale(0.95);
+}
+
+.underlying-btn:hover {
+    background: var(--primary-hover);
+}
+
+.replay-btn {
+    margin-top: auto;
+    background: transparent;
+    color: var(--text-secondary);
+    border: 1px solid #cbd5e1;
+    padding: 8px 16px;
+    border-radius: 6px;
+    cursor: pointer;
+}
+
+.replay-btn:hover {
+    background: #f1f5f9;
+}
+
+/* =========================================
+   Toast Notification Base
+   ========================================= */
+.toast-notification {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: #1e293b;
+    color: white;
+    padding: 16px;
+    border-radius: 8px;
+    text-align: center;
+    font-size: 0.9rem;
+    width: 80%;
+    box-shadow: 0 10px 15px -3px rgba(0,0,0,0.1);
+}
+
+/* =========================================
+   Example 1: The Buggy Implementation
+   ========================================= */
+.buggy-toast {
+    background: var(--warning);
+    /* The bug: opacity alone does NOT remove the element from the hit-testing layer */
+    animation: buggyFadeOut 3s forwards;
+}
+
+@keyframes buggyFadeOut {
+    0%, 50% { opacity: 1; }
+    100% { opacity: 0; }
+}
+
+/* =========================================
+   Example 2: The Fixed Implementation
+   ========================================= */
+.fixed-toast {
+    background: var(--success);
+    /* 
+       The fix: Animate `visibility` alongside `opacity`.
+       CSS intelligently waits for opacity to hit 0 before toggling 
+       visibility to `hidden`, completely removing it from the interaction tree.
+    */
+    animation: fixedFadeOut 3s forwards;
+}
+
+@keyframes fixedFadeOut {
+    0%, 50% { 
+        opacity: 1; 
+        visibility: visible; 
+    }
+    100% { 
+        opacity: 0; 
+        visibility: hidden; 
+    }
+}
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    .toast-notification {
+        /* If user prefers reduced motion, hide the toast instantly after the delay */
+        animation: none !important;
+        opacity: 0;
+        visibility: hidden;
+    }
+}


### PR DESCRIPTION
### Description
Closes #65801

Added a new `ghost-click-fix` component to the examples showcase. This submission provides a pure CSS solution to the incredibly common layout bug where elements that have faded out (using `opacity: 0`) act as invisible shields, intercepting and swallowing mouse clicks meant for the interactive UI elements beneath them.

### What was changed
* Created `submissions/examples/ghost-click-fix/demo.html` showing a side-by-side comparison. One side contains an invisible buggy toast that blocks a button, and the other side contains the fixed version that lets clicks pass through.
* Created `submissions/examples/ghost-click-fix/style.css` which introduces a specific `@keyframes` pattern that pairs `visibility: hidden` with `opacity: 0`. 
* Created `submissions/examples/ghost-click-fix/README.md` explaining how the browser interaction (hit-testing) tree works with these properties.

### Why it matters
In CSS, `opacity: 0` makes an element visually disappear, but it *does not* remove it from the browser's interaction layer. If a toast notification, a modal, or an absolute overlay simply animates to `opacity: 0` and remains in the DOM, it will invisibly cover the buttons beneath it. Often, developers resort to writing extra JavaScript to set `display: none` after a `setTimeout`. However, we can handle this purely in CSS. By adding `visibility: hidden` at the `100%` mark of our keyframes, the browser is smart enough to wait for the opacity transition to finish, and then physically removes the element from the mouse interaction tree.

### Accessibility
- Fully respects `@media (prefers-reduced-motion: reduce)`.
- Faded elements instantly snap to `opacity: 0` and `visibility: hidden` without transition if motion is disabled, instantly freeing up the interaction layer.

### Verification
- [x] All files isolated to the `submissions/examples/` folder.
- [x] Verified that buttons underneath a faded-out `.fixed-toast` are perfectly clickable.