### PR TITLE
feat: add will-change memory optimization example

### DIFF
--- a/submissions/examples/will-change-memory-fix/README.md
+++ b/submissions/examples/will-change-memory-fix/README.md
@@ -1,0 +1,16 @@
+# Will-Change Memory Optimization
+
+A critical performance architecture pattern demonstrating how to properly utilize the CSS `will-change` property without causing severe VRAM memory leaks or browser crashes on low-end devices.
+
+## Features
+- **The Bug Context**: The `will-change` property is a hint to the browser's rendering engine that an element is going to be animated. The browser responds by immediately promoting that element to its own hardware-accelerated compositor layer on the GPU (consuming VRAM). Many developers erroneously apply `will-change: transform` universally to all list items or buttons in a UI. If a page has 500 interactive list items, the browser suddenly attempts to allocate 500 GPU layers on page load, which drastically throttles performance and crashes low-end mobile devices (OOM - Out of Memory).
+- **The Fix**: "Lazy Allocation". The `will-change` property is designed to be applied *just before* an animation happens, and removed when finished. In CSS, the best proxy for "about to animate" is the `:hover` pseudo-class (for scale/translate effects) or applying it via a parent `.is-animating` class. By moving `will-change` into the `:hover` state, we ensure that the browser only allocates VRAM for the 1 specific element the user is actively engaging with, completely fixing the memory leak.
+
+## Usage
+Open `demo.html` in your browser. 
+- Look at the **Buggy** side. If you were to inspect this in Chrome DevTools > Rendering > Layer Borders, you would see that every single buggy element has an orange border permanently drawn around it, signifying a permanent GPU layer allocation.
+- Look at the **Fixed** side. The GPU layer is only created dynamically the moment your mouse enters the element's bounding box, and is released when you leave.
+
+## Files
+- `demo.html`: The HTML structure demonstrating the side-by-side comparison of list items.
+- `style.css`: The styling engine containing the optimized `:hover` state memory allocation.

--- a/submissions/examples/will-change-memory-fix/demo.html
+++ b/submissions/examples/will-change-memory-fix/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Will-Change Memory Fix - EaseMotion</title>
+    <!-- Include EaseMotion CSS -->
+    <link rel="stylesheet" href="../../../easemotion.min.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="layout-container">
+        <header class="header">
+            <h1 class="title">Will-Change Memory Optimization</h1>
+            <p class="subtitle">Solving severe browser memory leaks and crashes on low-end devices caused by the overzealous use of the <code>will-change</code> CSS property.</p>
+        </header>
+
+        <main class="showcase">
+            <!-- Buggy Implementation -->
+            <div class="demo-card">
+                <h3>The Memory Hog (Buggy)</h3>
+                <p>These elements have <code>will-change: transform</code> permanently applied. On a large list (e.g. 500 items), the browser allocates hundreds of Megabytes of VRAM immediately, potentially crashing mobile devices.</p>
+                
+                <div class="list-container">
+                    <div class="list-item buggy-item">Interactive Item 1</div>
+                    <div class="list-item buggy-item">Interactive Item 2</div>
+                    <div class="list-item buggy-item">Interactive Item 3</div>
+                    <div class="list-item buggy-item">Interactive Item 4</div>
+                </div>
+            </div>
+
+            <!-- Fixed Implementation -->
+            <div class="demo-card">
+                <h3>The Lazy Allocation (Fixed)</h3>
+                <p>These elements only trigger <code>will-change: transform</code> on <code>:hover</code>. VRAM is dynamically allocated only when the user is actively interacting with the specific element.</p>
+                
+                <div class="list-container">
+                    <div class="list-item fixed-item">Interactive Item 1</div>
+                    <div class="list-item fixed-item">Interactive Item 2</div>
+                    <div class="list-item fixed-item">Interactive Item 3</div>
+                    <div class="list-item fixed-item">Interactive Item 4</div>
+                </div>
+            </div>
+        </main>
+    </div>
+</body>
+</html>

--- a/submissions/examples/will-change-memory-fix/style.css
+++ b/submissions/examples/will-change-memory-fix/style.css
@@ -1,0 +1,129 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+:root {
+    --bg-color: #f8fafc;
+    --card-bg: #ffffff;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    --danger: #ef4444;
+    --success: #10b981;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    font-family: 'Inter', system-ui, sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    box-sizing: border-box;
+    padding: 40px 20px;
+}
+
+.layout-container {
+    max-width: 900px;
+    width: 100%;
+}
+
+.header {
+    text-align: center;
+    margin-bottom: 48px;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 600;
+    margin: 0 0 12px 0;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    line-height: 1.5;
+}
+
+.showcase {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+    gap: 32px;
+}
+
+.demo-card {
+    background: var(--card-bg);
+    padding: 32px;
+    border-radius: 12px;
+    box-shadow: 0 4px 6px -1px rgba(0,0,0,0.05);
+    border: 1px solid #e2e8f0;
+}
+
+.demo-card h3 { margin: 0 0 12px 0; font-size: 1.3rem; }
+.demo-card p { color: var(--text-secondary); margin: 0 0 24px 0; font-size: 0.95rem; line-height: 1.5; }
+
+.list-container {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.list-item {
+    background: #f1f5f9;
+    padding: 16px 24px;
+    border-radius: 8px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1), background 0.3s ease, color 0.3s ease;
+}
+
+/* =========================================
+   Example 1: The Buggy Implementation
+   ========================================= */
+
+.buggy-item {
+    /* 
+       THE BUG: 
+       Applying will-change globally like this forces the browser to 
+       create a new hardware compositing layer (and allocate VRAM) for EVERY 
+       SINGLE item in the DOM immediately on page load, even if the user never interacts with them.
+    */
+    will-change: transform;
+}
+
+.buggy-item:hover {
+    transform: translateX(10px);
+    background: var(--danger);
+    color: white;
+}
+
+/* =========================================
+   Example 2: The Fixed Implementation
+   ========================================= */
+
+.fixed-item {
+    /* Notice: No will-change declared on the base state! */
+}
+
+/* 
+   THE FIX: 
+   We only apply will-change when we are reasonably certain an animation is about to happen. 
+   Hovering is an excellent trigger. The browser allocates the GPU layer dynamically just in time.
+*/
+.fixed-item:hover {
+    will-change: transform;
+    transform: translateX(10px);
+    background: var(--success);
+    color: white;
+}
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    .list-item {
+        will-change: auto !important; /* Fully release memory if motion is disabled */
+        transition: background 0.3s ease, color 0.3s ease !important;
+    }
+    .list-item:hover {
+        transform: none !important;
+    }
+}


### PR DESCRIPTION
### Description
Closes #65800

Added a new `will-change-memory-fix` component to the examples showcase. This submission resolves severe browser memory leaks and crashes on low-end devices caused by the overzealous use of the `will-change` CSS property.

### What was changed
* Created `submissions/examples/will-change-memory-fix/demo.html` showing a side-by-side comparison of a buggy list versus an optimized list.
* Created `submissions/examples/will-change-memory-fix/style.css` which moves the `will-change: transform` declaration off the base class and strictly onto the `:hover` pseudo-class.
* Created `submissions/examples/will-change-memory-fix/README.md` explaining the GPU layer allocation mechanics of modern browsers.

### Why it matters
The `will-change` property is a hint to the browser's rendering engine that an element is going to be animated. The browser responds by immediately promoting that element to its own hardware-accelerated compositor layer on the GPU (consuming VRAM). Many developers erroneously apply `will-change` universally to all list items in a UI. If a page has 500 interactive list items, the browser suddenly attempts to allocate 500 GPU layers immediately on page load, which drastically throttles performance and crashes low-end mobile devices. By using "Lazy Allocation" (moving `will-change` to the `:hover` state), we ensure the browser only allocates VRAM for the 1 specific element the user is actively engaging with.

### Accessibility
- Fully respects `@media (prefers-reduced-motion: reduce)`.
- If motion is disabled, the `will-change` hint is forcefully wiped via `will-change: auto !important`, instantly releasing GPU memory back to the system since no animations will occur.

### Verification
- [x] All files isolated to the `submissions/examples/` folder.
- [x] Verified VRAM allocation dynamically triggers on `:hover` instead of page load.