### PR TITLE
feat: add 3d flip z-index fix example

### DIFF
--- a/submissions/examples/3d-flip-zindex-fix/README.md
+++ b/submissions/examples/3d-flip-zindex-fix/README.md
@@ -1,0 +1,18 @@
+# 3D Flip Z-Index Fix
+
+A CSS architectural pattern resolving the infamous stacking context bug where absolute child elements inside a `transform: rotateY()` container get flattened, trapping their `z-index` inside the parent's plane and clipping into backgrounds during 3D rotations.
+
+## Features
+- **The Bug**: Applying any CSS `transform` creates a new stacking context. When doing a 3D flip (e.g. `rotateY(180deg)`), the browser takes all the children of that flipped element and mathematically flattens them onto a 2D plane. This means if you put a `z-index: 9999` on a badge inside the card, it is trapped *inside* that flat plane. During rotation, the badge will clip through the parent wrapper instead of floating above it.
+- **The Fix**: 
+  1. **Preserve 3D**: We apply `transform-style: preserve-3d` to the rotating parent container (`.flip-card`). This instructs the browser rendering engine to stop flattening the children and let them exist in true 3D space.
+  2. **Translate Z**: Since we are now in true 3D space, `z-index` is no longer the correct tool for layering. Instead, we use `transform: translateZ(30px)` on the absolute badge to physically push it forward off the card's surface. When the card rotates, the badge will beautifully orbit above it.
+
+## Usage
+Open `demo.html` in your browser. 
+- Hover over the **Buggy Flip** card. Watch the red "Sale!" badge carefully. Because it is flattened, it clips directly through the card edges and the background during the rotation.
+- Hover over the **Fixed Flip** card. The badge physically hovers off the surface of the card in 3D space, preventing any clipping.
+
+## Files
+- `demo.html`: The HTML structure demonstrating the parent `.perspective-wrapper` and the `.flip-card` inner mechanics.
+- `style.css`: The styling engine containing the `preserve-3d` and `translateZ` physics rules.

--- a/submissions/examples/3d-flip-zindex-fix/demo.html
+++ b/submissions/examples/3d-flip-zindex-fix/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>3D Flip Z-Index Fix - EaseMotion</title>
+    <!-- Include EaseMotion CSS -->
+    <link rel="stylesheet" href="../../../easemotion.min.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="layout-container">
+        <header class="header">
+            <h1 class="title">3D Flip Z-Index Fix</h1>
+            <p class="subtitle">Solving the infamous stacking context bug where <code>transform: rotateY()</code> forcibly flattens absolute child elements, trapping their z-index inside the parent plane.</p>
+        </header>
+
+        <main class="showcase">
+            <!-- Buggy Demo -->
+            <div class="demo-card perspective-wrapper">
+                <h3>The Buggy Flip</h3>
+                <p>Hover the card. The "Sale!" badge has <code>z-index: 999</code>, but it gets flattened into the card and clips into the background because the 3D transform creates a trapped stacking context.</p>
+                
+                <div class="flip-card buggy-flip">
+                    <div class="flip-front">Front</div>
+                    <div class="flip-back">
+                        Back
+                        <!-- Bug: Badge clips during rotation -->
+                        <div class="floating-badge">Sale!</div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Fixed Demo -->
+            <div class="demo-card perspective-wrapper">
+                <h3>The Fixed Flip</h3>
+                <p>By applying <code>transform-style: preserve-3d</code> to the parent and translating the badge along the Z-axis, it beautifully breaks out of the flat plane and orbits above the card.</p>
+                
+                <div class="flip-card fixed-flip">
+                    <div class="flip-front">Front</div>
+                    <div class="flip-back">
+                        Back
+                        <!-- Fix: Badge floats above the plane -->
+                        <div class="floating-badge badge-fixed">Sale!</div>
+                    </div>
+                </div>
+            </div>
+        </main>
+    </div>
+</body>
+</html>

--- a/submissions/examples/3d-flip-zindex-fix/style.css
+++ b/submissions/examples/3d-flip-zindex-fix/style.css
@@ -1,0 +1,180 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap');
+
+:root {
+    --bg-color: #f1f5f9;
+    --card-bg: #ffffff;
+    --text-primary: #0f172a;
+    --text-secondary: #475569;
+    --front-bg: #3b82f6;
+    --back-bg: #1e293b;
+    --badge-bg: #ef4444;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    font-family: 'Inter', system-ui, sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    box-sizing: border-box;
+    padding: 40px 20px;
+}
+
+.layout-container {
+    max-width: 900px;
+    width: 100%;
+}
+
+.header {
+    text-align: center;
+    margin-bottom: 48px;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 700;
+    margin: 0 0 12px 0;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    line-height: 1.5;
+}
+
+.showcase {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 40px;
+    justify-content: center;
+}
+
+.demo-card {
+    background: var(--card-bg);
+    padding: 32px;
+    border-radius: 12px;
+    box-shadow: 0 4px 6px -1px rgba(0,0,0,0.05);
+    border: 1px solid #e2e8f0;
+    width: 320px;
+    text-align: center;
+}
+
+.demo-card h3 { margin: 0 0 12px 0; }
+.demo-card p { color: var(--text-secondary); margin: 0 0 32px 0; font-size: 0.95rem; line-height: 1.5; }
+
+/* =========================================
+   Base 3D Flip Card Styles
+   ========================================= */
+
+.perspective-wrapper {
+    /* Perspective must be applied to a parent wrapper to give depth to the 3D space */
+    perspective: 1000px;
+}
+
+.flip-card {
+    position: relative;
+    width: 200px;
+    height: 250px;
+    margin: 0 auto;
+    transition: transform 0.8s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+.demo-card:hover .flip-card {
+    transform: rotateY(180deg);
+}
+
+.flip-front, .flip-back {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border-radius: 12px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: white;
+    backface-visibility: hidden; /* Hides the back of the panel when turned around */
+    box-shadow: 0 10px 15px -3px rgba(0,0,0,0.2);
+}
+
+.flip-front {
+    background: var(--front-bg);
+}
+
+.flip-back {
+    background: var(--back-bg);
+    transform: rotateY(180deg); /* Start flipped */
+}
+
+/* =========================================
+   Example 1: The Buggy Implementation
+   ========================================= */
+
+.buggy-flip {
+    /* 
+       THE BUG: Missing transform-style: preserve-3d.
+       Without this, the browser flattens all children into the 2D plane of .flip-card.
+       The z-index below is completely ignored in 3D space.
+    */
+}
+
+.floating-badge {
+    position: absolute;
+    top: -15px;
+    right: -15px;
+    background: var(--badge-bg);
+    color: white;
+    padding: 8px 16px;
+    border-radius: 20px;
+    font-size: 1rem;
+    font-weight: 600;
+    box-shadow: 0 4px 6px rgba(0,0,0,0.3);
+    z-index: 999; /* This will fail to pop out during 3D rotation */
+}
+
+/* =========================================
+   Example 2: The Fixed Implementation
+   ========================================= */
+
+.fixed-flip {
+    /* 
+       THE FIX 1: Allow children to exist in their own 3D space, 
+       breaking them out of the flattened 2D parent plane.
+    */
+    transform-style: preserve-3d;
+}
+
+.badge-fixed {
+    /* 
+       THE FIX 2: Instead of relying on z-index (which only handles 2D stacking),
+       we physically push the badge forward in 3D space along the Z-axis.
+       Now it orbits above the card during the flip!
+    */
+    transform: translateZ(30px);
+}
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    .flip-card {
+        /* Remove 3D rotation entirely if user prefers reduced motion */
+        transition: opacity 0.3s ease;
+        transform: none !important;
+    }
+    
+    .demo-card:hover .flip-card .flip-front { opacity: 0; }
+    
+    .demo-card:hover .flip-card .flip-back {
+        transform: none !important;
+        opacity: 1;
+        z-index: 2;
+    }
+    
+    .flip-back { opacity: 0; transform: none; }
+}


### PR DESCRIPTION
### Description
Closes #65796

Added a new `3d-flip-zindex-fix` component to the examples showcase. This submission resolves the infamous stacking context bug where absolute child elements inside a `transform: rotateY()` container get flattened, trapping their `z-index` inside the parent's plane and clipping into backgrounds during 3D rotations.

### What was changed
* Created `submissions/examples/3d-flip-zindex-fix/demo.html` showing a side-by-side comparison of a buggy flattened flip card versus a true 3D flip card.
* Created `submissions/examples/3d-flip-zindex-fix/style.css` which introduces `transform-style: preserve-3d` on the parent to stop the flattening engine, and `transform: translateZ(30px)` on the child badge to physically elevate it off the card's surface.
* Created `submissions/examples/3d-flip-zindex-fix/README.md` explaining why `z-index` completely fails inside 3D transform contexts and why the Z-axis is the only solution.

### Why it matters
Applying any CSS `transform` creates a new stacking context. When doing a 3D flip (e.g. `rotateY(180deg)`), the browser takes all the children of that flipped element and mathematically flattens them onto a 2D plane. This means if you put a `z-index: 9999` on a badge inside the card, it is trapped *inside* that flat plane, causing it to clip through the card geometry during rotation. By preserving the 3D space and pushing the badge forward on the physical Z-axis, it beautifully orbits above the card's surface.

### Accessibility
- Fully respects `@media (prefers-reduced-motion: reduce)`.
- Replaces the 3D rotation with a simple opacity cross-fade to prevent vestibular nausea, while ensuring the back panel correctly sits above the front panel in 2D space.

### Verification
- [x] All files isolated to the `submissions/examples/` folder.
- [x] Verified `transform-style: preserve-3d` allows the badge to float above the rotating card geometry without clipping.