### PR TITLE
feat: add prefix customizer script example

### DIFF
--- a/submissions/examples/prefix-customizer-script/README.md
+++ b/submissions/examples/prefix-customizer-script/README.md
@@ -1,0 +1,22 @@
+# EaseMotion Prefix Customizer
+
+A standalone Node.js post-processing utility that allows developers to safely customize the default `.em-` CSS namespace prefix in the compiled library without modifying the core source code.
+
+## Features
+- **The Problem**: Frameworks often use a namespace prefix (like `.em-` for EaseMotion) to prevent class name collisions. However, if a developer imports two libraries that coincidentally use the same prefix, their styles will clash and break the UI.
+- **The Solution**: Rather than asking developers to setup a complex build pipeline (like PostCSS or Webpack) just to rename classes, this submission provides a zero-dependency, plug-and-play Node script that uses RegEx to intelligently swap out the prefix across the minified CSS bundle.
+- **Variable Support**: The script correctly identifies and renames associated CSS Custom Properties (e.g., `--em-duration` becomes `--custom-duration`) to ensure the animation engine remains perfectly functional under the new namespace.
+
+## Usage
+1. Open your terminal.
+2. Navigate to this directory: `cd submissions/examples/prefix-customizer-script/`
+3. Run the script and pass your desired prefix as an argument:
+   ```bash
+   node customize.js cool-motion-
+   ```
+4. The script will locate the root `easemotion.min.css`, parse it, and generate a new `easemotion.custom.css` file in this directory.
+5. You can now use classes like `class="cool-motion-fade-in"` in your HTML!
+
+## Files
+- `customize.js`: The zero-dependency Node.js string-replacement engine.
+- `demo.html`: Documentation and usage instructions.

--- a/submissions/examples/prefix-customizer-script/customize.js
+++ b/submissions/examples/prefix-customizer-script/customize.js
@@ -1,0 +1,68 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * EaseMotion Prefix Customizer
+ * 
+ * This script demonstrates how developers can customize the default `.em-` prefix
+ * in the pre-compiled `easemotion.min.css` file to match their own design system,
+ * avoiding naming collisions with other libraries (like Tailwind or Bootstrap).
+ * 
+ * Usage: node customize.js <new-prefix>
+ * Example: node customize.js myapp-
+ */
+
+function customizePrefix() {
+    // 1. Get the new prefix from command line arguments
+    const args = process.argv.slice(2);
+    if (args.length === 0) {
+        console.error('❌ Error: Please provide a new prefix.');
+        console.log('💡 Example: node customize.js custom-');
+        process.exit(1);
+    }
+    
+    const newPrefix = args[0];
+    
+    // 2. Define paths
+    // We are looking for the compiled CSS file in the root directory
+    const sourcePath = path.resolve(__dirname, '../../../easemotion.min.css');
+    const outputPath = path.resolve(__dirname, 'easemotion.custom.css');
+    
+    console.log(`🔍 Reading source file: ${sourcePath}`);
+    
+    try {
+        // 3. Read the original CSS file
+        if (!fs.existsSync(sourcePath)) {
+            throw new Error(`Source file not found at ${sourcePath}`);
+        }
+        
+        let cssContent = fs.readFileSync(sourcePath, 'utf8');
+        
+        // 4. Perform the Regex replacement
+        // We are looking for classes that start with .em- (or inside attribute selectors)
+        // Note: EaseMotion core classes always start with .em-
+        
+        const defaultPrefix = '.em-';
+        const newClassPrefix = `.${newPrefix}`;
+        
+        // Replace standard classes (e.g., .em-fade-in -> .custom-fade-in)
+        const regexStandard = new RegExp('\\.em-', 'g');
+        let newCssContent = cssContent.replace(regexStandard, newClassPrefix);
+        
+        // Also handle potential CSS variables (e.g., --em-duration -> --custom-duration)
+        const regexVars = new RegExp('--em-', 'g');
+        newCssContent = newCssContent.replace(regexVars, `--${newPrefix}`);
+        
+        // 5. Write the output
+        fs.writeFileSync(outputPath, newCssContent, 'utf8');
+        
+        console.log(`✅ Success! Customized CSS generated at:`);
+        console.log(`   ${outputPath}`);
+        console.log(`\n🎉 You can now use classes like: .${newPrefix}fade-in`);
+        
+    } catch (err) {
+        console.error('❌ Failed to customize CSS:', err.message);
+    }
+}
+
+customizePrefix();

--- a/submissions/examples/prefix-customizer-script/demo.html
+++ b/submissions/examples/prefix-customizer-script/demo.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Prefix Customizer Script - EaseMotion</title>
+    
+    <!-- We load a dummy custom CSS file here just to show intent. 
+         Normally, the user generates this file via the Node script. -->
+    <style>
+        body { font-family: system-ui; padding: 40px; background: #f8fafc; color: #0f172a; }
+        .demo-card { background: white; padding: 30px; border-radius: 12px; box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1); max-width: 600px; margin: 0 auto; }
+        h1 { margin-top: 0; }
+        code { background: #e2e8f0; padding: 4px 8px; border-radius: 4px; color: #b91c1c; }
+        .terminal { background: #1e293b; color: #a5b4fc; padding: 20px; border-radius: 8px; font-family: monospace; line-height: 1.5; margin-bottom: 20px; }
+        .terminal-comment { color: #64748b; }
+        .terminal-cmd { color: #10b981; }
+    </style>
+</head>
+<body>
+    <div class="demo-card">
+        <h1>Prefix Customizer Script</h1>
+        <p>This submission provides a Node.js utility to safely customize the default <code>.em-</code> prefix inside the compiled <code>easemotion.min.css</code> file.</p>
+        
+        <h3>Why do this?</h3>
+        <p>If your codebase already has another library that uses <code>.em-</code> classes, you can use this script to easily rename all EaseMotion classes to something unique like <code>.motion-</code> or <code>.mybrand-</code>, avoiding CSS namespace collisions without having to fork the core library.</p>
+        
+        <h3>How to use:</h3>
+        <div class="terminal">
+            <span class="terminal-comment"># Navigate to this example folder</span><br>
+            cd submissions/examples/prefix-customizer-script/<br><br>
+            
+            <span class="terminal-comment"># Run the script with your desired prefix</span><br>
+            <span class="terminal-cmd">node customize.js myapp-</span><br><br>
+            
+            <span class="terminal-comment"># The script will generate a new file:</span><br>
+            easemotion.custom.css
+        </div>
+        
+        <p>You can then link <code>easemotion.custom.css</code> in your HTML and use <code>class="myapp-fade-in"</code>!</p>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
### Description
Closes #65816

Added a new `prefix-customizer-script` utility to the examples showcase. This submission resolves requests for customizing the `.em-` prefix while strictly adhering to the repository's policy of not modifying the core build system. It provides a zero-dependency Node.js script that developers can use to rename the CSS namespace in the pre-compiled output.

### What was changed
* Created `submissions/examples/prefix-customizer-script/customize.js` containing a Node script that reads the root `easemotion.min.css` file and safely uses Regex to swap `.em-` and `--em-` with a user-provided custom string.
* Created `submissions/examples/prefix-customizer-script/demo.html` to act as an instructional landing page showing the CLI commands.
* Created `submissions/examples/prefix-customizer-script/README.md` explaining why namespace collisions happen and how this post-processing script avoids the need for complex Webpack/PostCSS setups.

### Why it matters
CSS namespace collisions are incredibly frustrating. If a developer uses EaseMotion alongside another library that coincidentally uses the `.em-` prefix, their styles will clash and break the UI. By providing this standalone script, we empower users to easily rename all EaseMotion classes to something unique like `.motion-` or `.mybrand-`, avoiding collisions without forcing them to fork the repository or compile from SCSS/SASS source.

### Verification
- [x] All files isolated to the `submissions/examples/` folder.
- [x] Verified script correctly targets both standard classes (`.em-fade-in`) and CSS Custom Properties (`--em-duration`).