### PR TITLE
docs(submissions): propose Stylelint CI workflow (submissions/docs/stylelint-ci) - fixes #63629

### DIFF
--- a/submissions/docs/stylelint-ci/.stylelintignore
+++ b/submissions/docs/stylelint-ci/.stylelintignore
@@ -1,0 +1,5 @@
+# Ignore build artifacts and node deps
+node_modules/
+dist/
+build/
+easemotion.min.css

--- a/submissions/docs/stylelint-ci/README.md
+++ b/submissions/docs/stylelint-ci/README.md
@@ -1,21 +1,63 @@
 # Stylelint CI - Submission
 
 ## Summary
+
 This submission proposes a candidate GitHub Actions workflow to run Stylelint across the repository's CSS files. It includes:
-- `stylelint-workflow.yml` (candidate workflow)
-- `.stylelintignore` (ignore list)
-- `demo.html` + `style.css` (demo)
-- this `README.md`
+
+* `stylelint-workflow.yml` (candidate workflow)
+* `.stylelintignore` (ignore list)
+* `demo.html` + `style.css` (demo)
+* this `README.md`
 
 Fixes: #63629
 
 ## Why this is needed
-- Ensures consistent CSS quality across the project by catching errors and style issues in CI before merging.
-- Keeps contributions under `submissions/` for maintainer review and controlled adoption.
+
+* Ensures consistent CSS quality across the project by catching errors and style issues in CI before merging.
+* Keeps contributions under `submissions/` for maintainer review and controlled adoption.
 
 ## Adoption (for maintainers)
+
 To enable the workflow, copy/merge the files into the repo root:
 
 1. Copy the workflow:
+
 ```bash
 cp submissions/docs/stylelint-ci/stylelint-workflow.yml .github/workflows/stylelint.yml
+```
+
+2. Copy the ignore file to the repo root (optional if maintainer already has an ignore):
+
+```bash
+cp submissions/docs/stylelint-ci/.stylelintignore .stylelintignore
+```
+
+3. Commit and push; the workflow triggers on pushes and PRs to `main`.
+
+## How a developer uses it
+
+* Contributors: ensure CSS passes stylelint locally before opening PRs:
+
+```bash
+npm ci
+npm run lint:css
+# or:
+npx stylelint "**/*.css" --ignore-path .stylelintignore --allow-empty-input --max-warnings=0
+```
+
+* Maintainers: copy the two files above to enable CI (or merge rules into existing root files).
+
+## How I tested this submission
+
+* Ran:
+
+```bash
+npx stylelint "submissions/docs/stylelint-ci/*.css" --ignore-path submissions/docs/stylelint-ci/.stylelintignore
+```
+
+* The demo styles pass linting for the provided rules.
+
+## Notes for reviewers
+
+* This submission re-uses the existing top-level `.stylelintrc.json` (no changes included).
+* If maintainers want inline PR annotations, I can submit a follow-up to add reviewdog.

--- a/submissions/docs/stylelint-ci/README.md
+++ b/submissions/docs/stylelint-ci/README.md
@@ -12,6 +12,11 @@ How to adopt (maintainer instructions)
 2. Merge `.stylelintignore` content into the repo root if desired.
 3. CI will run `npx stylelint "**/*.css" --max-warnings=0` (fail on warnings).
 
+Copy instruction:
+1.Copy stylelint-workflow.yml to .github/workflows/stylelint.yml.
+2.Copy .stylelintignore to the repository root (or merge its contents into the existing .stylelintignore).
+3.Run npm ci once in CI (the workflow already uses that).
+
 Local testing
 1. From repo root:
    - npm ci
@@ -20,3 +25,4 @@ Local testing
 
 Notes
 - This submission intentionally re-uses the existing top-level `.stylelintrc.json` and does not add another `.stylelintrc.json`.
+- "The workflow uses --ignore-path .stylelintignore and --allow-empty-input to avoid linting build artifacts and to avoid failing when no CSS files are present."

--- a/submissions/docs/stylelint-ci/README.md
+++ b/submissions/docs/stylelint-ci/README.md
@@ -1,29 +1,21 @@
-# Stylelint CI — Submission
+# Stylelint CI - Submission
 
 ## Summary
-This submission proposes a ready-to-use GitHub Actions workflow to run Stylelint on the repository's CSS files in CI. It includes:
-- a candidate workflow YAML (`stylelint-workflow.yml`),
-- a `.stylelintignore` to exclude build artifacts,
-- a small demo page, and
-- this README with adoption instructions.
+This submission proposes a candidate GitHub Actions workflow to run Stylelint across the repository's CSS files. It includes:
+- `stylelint-workflow.yml` (candidate workflow)
+- `.stylelintignore` (ignore list)
+- `demo.html` + `style.css` (demo)
+- this `README.md`
 
-Issue: Fixes / relates to #63629
+Fixes: #63629
 
----
+## Why this is needed
+- Ensures consistent CSS quality across the project by catching errors and style issues in CI before merging.
+- Keeps contributions under `submissions/` for maintainer review and controlled adoption.
 
-## Files included
-- `stylelint-workflow.yml` — Candidate GitHub Actions workflow (copy to `.github/workflows/stylelint.yml` to enable).
-- `.stylelintignore` — Files & directories to exclude from linting (copy to repo root or merge into existing ignore).
-- `demo.html` + `style.css` — Minimal demo files required by the `submissions/docs/` track.
-- `README.md` — This file (instructions and rationale).
+## Adoption (for maintainers)
+To enable the workflow, copy/merge the files into the repo root:
 
-All files live under `submissions/docs/stylelint-ci/` per the project’s submission model.
-
----
-
-## Adoption — step-by-step (for maintainers)
-If you accept this proposal, perform the following to enable the workflow:
-
-1. Copy the workflow YAML into the workflows folder:
+1. Copy the workflow:
 ```bash
 cp submissions/docs/stylelint-ci/stylelint-workflow.yml .github/workflows/stylelint.yml

--- a/submissions/docs/stylelint-ci/README.md
+++ b/submissions/docs/stylelint-ci/README.md
@@ -1,28 +1,29 @@
 # Stylelint CI — Submission
 
-What this submission does
-- Proposes a GitHub Actions workflow to run Stylelint on CSS files in CI.
-- Provides a `.stylelintignore` and a ready-to-copy workflow YAML (`stylelint-workflow.yml`) that maintainers can place in `.github/workflows/`.
+## Summary
+This submission proposes a ready-to-use GitHub Actions workflow to run Stylelint on the repository's CSS files in CI. It includes:
+- a candidate workflow YAML (`stylelint-workflow.yml`),
+- a `.stylelintignore` to exclude build artifacts,
+- a small demo page, and
+- this README with adoption instructions.
 
-Why this is in `submissions/`
-- EaseMotion CSS enforces a submission-first model: contributors add proposals under `submissions/` and the maintainer reviews and integrates accepted items into the repository root. This submission follows that model and avoids editing root config files directly.
+Issue: Fixes / relates to #63629
 
-How to adopt (maintainer instructions)
-1. If accepted, copy `stylelint-workflow.yml` to `.github/workflows/stylelint.yml`.
-2. Merge `.stylelintignore` content into the repo root if desired.
-3. CI will run `npx stylelint "**/*.css" --max-warnings=0` (fail on warnings).
+---
 
-Copy instruction:
-1.Copy stylelint-workflow.yml to .github/workflows/stylelint.yml.
-2.Copy .stylelintignore to the repository root (or merge its contents into the existing .stylelintignore).
-3.Run npm ci once in CI (the workflow already uses that).
+## Files included
+- `stylelint-workflow.yml` — Candidate GitHub Actions workflow (copy to `.github/workflows/stylelint.yml` to enable).
+- `.stylelintignore` — Files & directories to exclude from linting (copy to repo root or merge into existing ignore).
+- `demo.html` + `style.css` — Minimal demo files required by the `submissions/docs/` track.
+- `README.md` — This file (instructions and rationale).
 
-Local testing
-1. From repo root:
-   - npm ci
-   - npm run lint:css
-   (The repo already has stylelint in devDependencies and a `lint:css` script.)
+All files live under `submissions/docs/stylelint-ci/` per the project’s submission model.
 
-Notes
-- This submission intentionally re-uses the existing top-level `.stylelintrc.json` and does not add another `.stylelintrc.json`.
-- "The workflow uses --ignore-path .stylelintignore and --allow-empty-input to avoid linting build artifacts and to avoid failing when no CSS files are present."
+---
+
+## Adoption — step-by-step (for maintainers)
+If you accept this proposal, perform the following to enable the workflow:
+
+1. Copy the workflow YAML into the workflows folder:
+```bash
+cp submissions/docs/stylelint-ci/stylelint-workflow.yml .github/workflows/stylelint.yml

--- a/submissions/docs/stylelint-ci/README.md
+++ b/submissions/docs/stylelint-ci/README.md
@@ -1,0 +1,22 @@
+# Stylelint CI — Submission
+
+What this submission does
+- Proposes a GitHub Actions workflow to run Stylelint on CSS files in CI.
+- Provides a `.stylelintignore` and a ready-to-copy workflow YAML (`stylelint-workflow.yml`) that maintainers can place in `.github/workflows/`.
+
+Why this is in `submissions/`
+- EaseMotion CSS enforces a submission-first model: contributors add proposals under `submissions/` and the maintainer reviews and integrates accepted items into the repository root. This submission follows that model and avoids editing root config files directly.
+
+How to adopt (maintainer instructions)
+1. If accepted, copy `stylelint-workflow.yml` to `.github/workflows/stylelint.yml`.
+2. Merge `.stylelintignore` content into the repo root if desired.
+3. CI will run `npx stylelint "**/*.css" --max-warnings=0` (fail on warnings).
+
+Local testing
+1. From repo root:
+   - npm ci
+   - npm run lint:css
+   (The repo already has stylelint in devDependencies and a `lint:css` script.)
+
+Notes
+- This submission intentionally re-uses the existing top-level `.stylelintrc.json` and does not add another `.stylelintrc.json`.

--- a/submissions/docs/stylelint-ci/demo.html
+++ b/submissions/docs/stylelint-ci/demo.html
@@ -1,24 +1,29 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <title>Proposal: Stylelint CI for EaseMotion CSS</title>
-  <link rel="stylesheet" href="style.css">
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Stylelint CI Demo — EaseMotion CSS submission</title>
+  <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <main style="font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif; max-width:900px;margin:48px auto">
-    <h1>Stylelint CI — Submission</h1>
-    <p>This submission proposes a Stylelint GitHub Actions workflow to run CSS linting in CI. It contains a candidate workflow file, a .stylelintignore, and documentation for maintainers to adopt.</p>
+  <main style="max-width:900px;margin:48px auto;font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif">
+    <header>
+      <h1>Stylelint CI Demo</h1>
+      <p>This demo shows styles that will be checked by the proposed Stylelint CI workflow.</p>
+    </header>
 
-    <section>
-      <h2>What I am proposing</h2>
-      <ul>
-        <li>Provide a candidate workflow YAML (stylelint-workflow.yml) that maintainers can copy to <code>.github/workflows/stylelint.yml</code>.</li>
-        <li>Provide a <code>.stylelintignore</code> to exclude generated artifacts.</li>
-        <li>Do NOT duplicate or replace the repo's top-level <code>.stylelintrc.json</code>. This uses the existing config.</li>
-      </ul>
+    <section aria-label="Demo card examples">
+      <article class="ease-card ease-stylelint-example" role="region" aria-labelledby="card1">
+        <h2 id="card1" class="ease-card__title">Example Card</h2>
+        <p class="ease-card__body">This card uses <code>ease-stylelint-example</code> classes from <code>style.css</code>. The CI workflow will lint this CSS when enabled.</p>
+        <button class="ease-btn ease-btn--primary">Primary action</button>
+      </article>
     </section>
+
+    <footer>
+      <p>Open this file directly in your browser to preview the demo.</p>
+    </footer>
   </main>
 </body>
 </html>

--- a/submissions/docs/stylelint-ci/demo.html
+++ b/submissions/docs/stylelint-ci/demo.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <title>Proposal: Stylelint CI for EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main style="font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif; max-width:900px;margin:48px auto">
+    <h1>Stylelint CI — Submission</h1>
+    <p>This submission proposes a Stylelint GitHub Actions workflow to run CSS linting in CI. It contains a candidate workflow file, a .stylelintignore, and documentation for maintainers to adopt.</p>
+
+    <section>
+      <h2>What I am proposing</h2>
+      <ul>
+        <li>Provide a candidate workflow YAML (stylelint-workflow.yml) that maintainers can copy to <code>.github/workflows/stylelint.yml</code>.</li>
+        <li>Provide a <code>.stylelintignore</code> to exclude generated artifacts.</li>
+        <li>Do NOT duplicate or replace the repo's top-level <code>.stylelintrc.json</code>. This uses the existing config.</li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/docs/stylelint-ci/style.css
+++ b/submissions/docs/stylelint-ci/style.css
@@ -1,3 +1,52 @@
-body { background: #fbfbff; color: #111827; margin: 0; padding: 0; }
-main { padding: 48px; }
-h1 { color: #6c63ff; margin-top: 0; }
+:root {
+  --demo-bg: #ffffff;
+  --demo-border: #e6e9ef;
+  --demo-accent: #6c63ff;
+  --demo-text: #111827;
+}
+
+body {
+  background: #fbfbff;
+  color: var(--demo-text);
+  margin: 0;
+  padding: 0;
+}
+
+.ease-card {
+  background: var(--demo-bg);
+  border: 1px solid var(--demo-border);
+  border-radius: 10px;
+  padding: 1rem;
+  max-width: 560px;
+  margin: 1rem 0;
+  box-shadow: 0 6px 18px rgba(15,23,42,0.03);
+}
+
+.ease-card__title {
+  margin: 0 0 0.5rem 0;
+  font-size: 1.125rem;
+  color: var(--demo-accent);
+}
+
+.ease-card__body {
+  margin: 0 0 1rem 0;
+  color: #374151;
+  line-height: 1.5;
+}
+
+.ease-btn {
+  display: inline-block;
+  padding: 0.5rem 0.9rem;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  background: #f3f4ff;
+  color: var(--demo-accent);
+  transition: transform 0.12s ease, box-shadow 0.12s ease;
+}
+
+.ease-btn--primary:hover,
+.ease-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(15,23,42,0.06);
+}

--- a/submissions/docs/stylelint-ci/style.css
+++ b/submissions/docs/stylelint-ci/style.css
@@ -1,0 +1,3 @@
+body { background: #fbfbff; color: #111827; margin: 0; padding: 0; }
+main { padding: 48px; }
+h1 { color: #6c63ff; margin-top: 0; }

--- a/submissions/docs/stylelint-ci/stylelint-workflow.yml
+++ b/submissions/docs/stylelint-ci/stylelint-workflow.yml
@@ -19,10 +19,16 @@ jobs:
         with:
           node-version: "18"
 
+      - name: Cache node modules
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
       - name: Install dependencies
-        run: |
-          npm ci
+        run: npm ci
 
       - name: Run Stylelint (fail on warnings)
-        run: |
-          npx stylelint "**/*.css" --max-warnings=0
+        run: npx stylelint "**/*.css" --ignore-path .stylelintignore --allow-empty-input --max-warnings=0

--- a/submissions/docs/stylelint-ci/stylelint-workflow.yml
+++ b/submissions/docs/stylelint-ci/stylelint-workflow.yml
@@ -1,0 +1,28 @@
+name: Stylelint
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  stylelint:
+    name: Stylelint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+
+      - name: Install dependencies
+        run: |
+          npm ci
+
+      - name: Run Stylelint (fail on warnings)
+        run: |
+          npx stylelint "**/*.css" --max-warnings=0


### PR DESCRIPTION
## Pull Request Description

Proposes a candidate GitHub Actions workflow to run Stylelint on the repository's CSS files, plus a .stylelintignore kept inside the submission, demo files, and adoption instructions. All files are placed under submissions/docs/stylelint-ci/ so the maintainer can review and integrate the workflow into the repository root if accepted.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [X] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [X] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [X] Includes `demo.html` — self-contained, opens in browser with no server
- [X] Includes `style.css` — raw CSS for the proposed feature
- [X] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [X] **No changes to `core/`**
- [X] **No changes to `components/`**
- [X] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A proposal for a Stylelint CI workflow and supporting demo files so maintainers can adopt automated CSS linting. Files included under submissions/docs/stylelint-ci/:

- stylelint-workflow.yml (candidate workflow)
- .stylelintignore (ignore list inside the submission)
- demo.html
- style.css
- README.md

**How does a developer use it?**

```html
<!-- Show the class usage in HTML -->
<!doctype html>
<html lang="en">
<head>
  <meta charset="utf-8" />
  <meta name="viewport" content="width=device-width,initial-scale=1" />
  <title>Stylelint CI Demo</title>
  <link rel="stylesheet" href="style.css" />
</head>
<body>
  <main>
    <div class="ease-card ease-stylelint-example">
      <h1 class="ease-card__title">Stylelint CI Demo</h1>
      <p class="ease-card__body">This demo uses style.css and demonstrates classes that will be linted by the proposed CI workflow.</p>
      <button class="ease-btn ease-btn--primary">Primary action</button>
    </div>
  </main>
</body>
</html>
```
Contributors: run Stylelint locally before opening a PR:
- npm ci
- npm run lint:css
- or: npx stylelint "**/*.css" --ignore-path .stylelintignore --allow-empty-input --max-warnings=0

**Why does it fit EaseMotion CSS?**

- Encourages consistent, high-quality CSS across the project and submissions.
- Follows the repository’s submission-first model: the workflow is proposed under submissions/ so maintainers can review and adopt it into the repo root.
- Non-invasive: retains the repo’s top-level .stylelintrc.json rules (no rule changes included).

---

## Demo

- [X] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

1. Files to review (in this PR):
- submissions/docs/stylelint-ci/stylelint-workflow.yml
- submissions/docs/stylelint-ci/.stylelintignore
- submissions/docs/stylelint-ci/README.md
- submissions/docs/stylelint-ci/demo.html
- submissions/docs/stylelint-ci/style.css

2. To enable the workflow, maintainers can copy (or move) these files into the repository root:
- Copy the workflow to the workflows folder: cp submissions/docs/stylelint-ci/stylelint-workflow.yml .github/workflows/stylelint.yml
- Copy or merge the ignore file to repo root: cp submissions/docs/stylelint-ci/.stylelintignore .stylelintignore Note: I see the repository already has a root .stylelintignore in main - maintainers may prefer to keep or adjust the existing root ignore instead of copying this one verbatim.

3. The workflow runs:
- npm ci
- npx stylelint "**/*.css" --ignore-path .stylelintignore --allow-empty-input --max-warnings=0

4. This submission intentionally avoids changing .stylelintrc.json or other root configs; rule edits should be done by maintainers.

5. Optional follow-ups I can provide on request:

- Add reviewdog integration for inline PR annotations.
- Propose curated .stylelintrc.json rule changes for stricter enforcement.
- Add lint-staged/Husky hooks for local pre-commit checks.

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
