### PR TITLE
feat: add css has fallback example

### DIFF
--- a/submissions/examples/css-has-fallback/README.md
+++ b/submissions/examples/css-has-fallback/README.md
@@ -1,0 +1,18 @@
+# CSS :has() Fallback Pattern
+
+A progressive enhancement architecture demonstrating how to safely use the modern CSS `:has()` parent selector without breaking layouts or animations on legacy browsers (like older Firefox ESR builds) that do not support it.
+
+## Features
+- **The Problem**: The `:has()` pseudo-class is incredibly powerful, allowing developers to style a parent element based on the state or presence of its children (e.g., `.card:has(img:hover)`). However, if a developer writes this selector globally, any browser that doesn't understand `:has()` will instantly invalidate the entire CSS rule block, potentially breaking critical layout structures.
+- **The Solution**: 
+  1. **Feature Detection**: We wrap the modern logic inside an `@supports selector(:has(*))` query. This ensures legacy browsers safely ignore the cutting-edge syntax rather than throwing a parsing error.
+  2. **Progressive Enhancement**: We provide a sturdy baseline design using traditional selectors (like `.card:hover` or `.card:focus-within`). If the browser supports `:has()`, the `@supports` block kicks in and provides the enhanced, highly-specific interactive experience on top of the baseline.
+
+## Usage
+Open `demo.html` in your browser. 
+- On a modern browser (Chrome 105+, Safari 15.4+, Firefox 121+), hovering *specifically* over the image in the **Modern Pattern** card will trigger the parent's blue border and lift animation, while dimming the text. 
+- The **Fallback Pattern** demonstrates what a legacy browser would see: a safe, traditional hover state applied to the entire card, ensuring the UI remains perfectly functional and aesthetically pleasing even without cutting-edge CSS features.
+
+## Files
+- `demo.html`: The HTML structure containing the two interactive cards.
+- `style.css`: The styling engine featuring the `@supports selector(:has(*))` feature detection query and traditional fallbacks.

--- a/submissions/examples/css-has-fallback/demo.html
+++ b/submissions/examples/css-has-fallback/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS :has() Fallback - EaseMotion</title>
+    <!-- Include EaseMotion CSS -->
+    <link rel="stylesheet" href="../../../easemotion.min.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="layout-container">
+        <header class="header">
+            <h1 class="title">CSS :has() Fallback Pattern</h1>
+            <p class="subtitle">A progressive enhancement architecture that gracefully degrades layout and animation logic for older browsers (like Firefox ESR) that do not support the modern <code>:has()</code> parent selector.</p>
+        </header>
+
+        <main class="showcase">
+            <!-- Modern implementation with :has() -->
+            <div class="demo-card">
+                <h3>The Modern Pattern (:has)</h3>
+                <p>Hover the image. The entire parent card's border turns blue and scales slightly because it <code>:has(:hover)</code> on the child image.</p>
+                
+                <div class="hover-card modern-card">
+                    <img src="https://via.placeholder.com/300x150" alt="Placeholder">
+                    <div class="card-content">
+                        <h4>Hover the Image</h4>
+                        <p>Modern browsers can style the parent based on child state.</p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Fallback implementation -->
+            <div class="demo-card">
+                <h3>The Fallback Pattern (@supports)</h3>
+                <p>If <code>:has()</code> is unsupported, the browser uses a traditional <code>:focus-within</code> and standard direct hovers as a safe, static fallback, preventing broken layouts.</p>
+                
+                <div class="hover-card fallback-card">
+                    <img src="https://via.placeholder.com/300x150" alt="Placeholder">
+                    <div class="card-content">
+                        <h4>Hover the Card (Fallback)</h4>
+                        <p>Falls back to standard CSS rules cleanly via @supports.</p>
+                    </div>
+                </div>
+            </div>
+        </main>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-has-fallback/style.css
+++ b/submissions/examples/css-has-fallback/style.css
@@ -1,0 +1,138 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+:root {
+    --bg-color: #f8fafc;
+    --card-bg: #ffffff;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    --primary: #3b82f6;
+    --border: #e2e8f0;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    font-family: 'Inter', system-ui, sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    padding: 40px 20px;
+}
+
+.layout-container {
+    max-width: 900px;
+    margin: 0 auto;
+}
+
+.header {
+    text-align: center;
+    margin-bottom: 48px;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 600;
+    margin: 0 0 12px 0;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    line-height: 1.6;
+}
+
+.showcase {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 32px;
+    justify-content: center;
+}
+
+.demo-card {
+    width: 350px;
+    background: transparent;
+}
+
+.demo-card h3 { margin: 0 0 8px 0; }
+.demo-card p { color: var(--text-secondary); margin: 0 0 24px 0; font-size: 0.95rem; line-height: 1.5; }
+
+/* =========================================
+   Base Card Styles
+   ========================================= */
+
+.hover-card {
+    background: var(--card-bg);
+    border-radius: 12px;
+    overflow: hidden;
+    border: 2px solid var(--border);
+    transition: transform 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.hover-card img {
+    display: block;
+    width: 100%;
+    height: auto;
+    transition: opacity 0.3s ease;
+}
+
+.card-content {
+    padding: 20px;
+}
+
+.card-content h4 { margin: 0 0 8px 0; }
+.card-content p { margin: 0; font-size: 0.9rem; }
+
+/* =========================================
+   Example 1: The Modern :has() pattern
+   ========================================= */
+
+/* 
+   We wrap the cutting-edge selector in an @supports block 
+   so legacy browsers don't choke on the syntax and invalidate the entire stylesheet.
+*/
+@supports selector(:has(*)) {
+    
+    /* If the card HAS an image that is currently hovered... */
+    .modern-card:has(img:hover) {
+        border-color: var(--primary);
+        transform: translateY(-5px);
+        box-shadow: 0 10px 15px -3px rgba(59, 130, 246, 0.2);
+    }
+    
+    /* Dim the text when the image is hovered */
+    .modern-card:has(img:hover) .card-content {
+        opacity: 0.5;
+    }
+}
+
+/* =========================================
+   Example 2: The Progressive Enhancement Fallback
+   ========================================= */
+
+/* 
+   For legacy browsers (or simply as a base default), we use the traditional method:
+   We style the parent based on hovering the parent itself, rather than a specific child.
+   If :has() is supported, the @supports block above will layer on top of this.
+*/
+.fallback-card:hover {
+    border-color: #94a3b8; /* A softer fallback color */
+}
+
+.fallback-card img:hover {
+    opacity: 0.8; /* Localized child hover instead of parent-driving */
+}
+
+/* 
+   For focus states, we CAN safely use :focus-within on legacy browsers!
+*/
+.fallback-card:focus-within {
+    border-color: var(--primary);
+}
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    .hover-card, .hover-card img {
+        transition: none !important;
+        transform: none !important;
+    }
+}


### PR DESCRIPTION
### Description
Closes #65799

Added a new `css-has-fallback` component to the examples showcase. This submission provides a progressive enhancement architecture that gracefully degrades layout and animation logic for older browsers (like Firefox ESR or older Safari builds) that do not support the modern `:has()` parent selector.

### What was changed
* Created `submissions/examples/css-has-fallback/demo.html` showing a side-by-side comparison of a cutting-edge `:has()` parent-driving hover interaction, and a safe legacy fallback interaction.
* Created `submissions/examples/css-has-fallback/style.css` which introduces the `@supports selector(:has(*))` feature detection query to safely sandbox modern syntax away from legacy parsers.
* Created `submissions/examples/css-has-fallback/README.md` explaining why un-sandboxed modern selectors can invalidate entire stylesheets and break layouts.

### Why it matters
The `:has()` pseudo-class is incredibly powerful, allowing developers to style a parent element based on the state of its children (e.g., `.card:has(img:hover)`). However, if a developer writes this selector globally, any browser that doesn't understand `:has()` will instantly invalidate the *entire* CSS rule block, potentially breaking critical layout structures. By wrapping the modern logic inside an `@supports` block, legacy browsers safely ignore the cutting-edge syntax. We then provide a sturdy baseline design using traditional selectors (like `.card:focus-within` and `.card:hover`) to ensure the UI remains perfectly functional and aesthetically pleasing for all users.

### Accessibility
- Fully respects `@media (prefers-reduced-motion: reduce)` by disabling the scale transformations and fallback opacity fades.

### Verification
- [x] All files isolated to the `submissions/examples/` folder.
- [x] Verified `@supports` safely sandboxes the new pseudo-class from legacy parsers.