### PR TITLE
feat: add height auto animation fix example

### DIFF
--- a/submissions/examples/height-auto-animation-fix/README.md
+++ b/submissions/examples/height-auto-animation-fix/README.md
@@ -1,0 +1,17 @@
+# Height Auto Animation Fix
+
+A modern CSS architecture pattern demonstrating how to flawlessly animate an element's height to its natural content size without using Javascript or messy legacy hacks.
+
+## Features
+- **The Bug Context**: One of the longest-standing limitations in CSS is the inability to transition between `height: 0` and `height: auto`. If you try, the element simply snaps open instantly. For years, the standard workaround was the "Max-Height Hack": transitioning `max-height` from `0` to a massive number like `1000px`. However, this hack causes severe timing issues. When closing the accordion, the browser mathematically transitions from 1000px down to the actual height (say, 100px) before the element visually starts shrinking, resulting in a frustrating, unresponsive delay.
+- **The Modern Fix**: We use CSS Grid. By setting the container to `display: grid` and transitioning `grid-template-rows` from `0fr` to `1fr`, the browser natively understands how to animate from zero to the exact, dynamically calculated height of the inner content.
+- **Implementation Note**: The direct child of the grid container must have `overflow: hidden` to ensure the content doesn't bleed outside the boundaries while the grid rows are collapsing.
+
+## Usage
+Open `demo.html` in your browser. 
+- Click **Toggle Buggy Accordion** to open it. Now click it again to close it. Notice the awkward 0.3-second delay before the accordion actually begins to shrink.
+- Click **Toggle Fixed Accordion**. Notice how it perfectly and instantaneously responds to your clicks, expanding and collapsing with buttery smooth easing.
+
+## Files
+- `demo.html`: The HTML structure demonstrating the accordion markup.
+- `style.css`: The styling engine containing the elegant `grid-template-rows` transition logic.

--- a/submissions/examples/height-auto-animation-fix/demo.html
+++ b/submissions/examples/height-auto-animation-fix/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Height Auto Animation Fix - EaseMotion</title>
+    <!-- Include EaseMotion CSS -->
+    <link rel="stylesheet" href="../../../easemotion.min.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="layout-container">
+        <header class="header">
+            <h1 class="title">Height Auto Animation Fix</h1>
+            <p class="subtitle">Solving the infamous CSS bug where animating from <code>height: 0</code> to <code>height: auto</code> causes the transition to instantly jump to the end state without animating.</p>
+        </header>
+
+        <main class="showcase">
+            <!-- Buggy Implementation -->
+            <div class="demo-card">
+                <h3>The Max-Height Hack (Buggy)</h3>
+                <p>The legacy solution was animating <code>max-height</code> to a huge number. Notice the awkward timing delay when closing the accordion, because it's animating from 1000px down to the actual content height before hiding.</p>
+                
+                <div class="accordion">
+                    <button class="accordion-trigger" id="btnBuggy">Toggle Buggy Accordion</button>
+                    <div class="accordion-content buggy-content" id="contentBuggy">
+                        <div class="inner-padding">
+                            <p>This is some content inside the buggy accordion. Watch how it closes with a noticeable delay!</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Fixed Implementation -->
+            <div class="demo-card">
+                <h3>The CSS Grid Solution (Fixed)</h3>
+                <p>The modern, elegant solution uses CSS Grid to animate <code>grid-template-rows</code> from <code>0fr</code> to <code>1fr</code>. This perfectly smoothly animates exactly to the content's natural height without timing glitches.</p>
+                
+                <div class="accordion">
+                    <button class="accordion-trigger" id="btnFixed">Toggle Fixed Accordion</button>
+                    <div class="accordion-content fixed-content" id="contentFixed">
+                        <div class="inner-padding">
+                            <p>This is some content inside the fixed accordion. Watch how perfectly and smoothly it opens and closes!</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </main>
+    </div>
+
+    <script>
+        document.getElementById('btnBuggy').addEventListener('click', () => {
+            document.getElementById('contentBuggy').classList.toggle('is-open');
+        });
+
+        document.getElementById('btnFixed').addEventListener('click', () => {
+            document.getElementById('contentFixed').classList.toggle('is-open');
+        });
+    </script>
+</body>
+</html>

--- a/submissions/examples/height-auto-animation-fix/style.css
+++ b/submissions/examples/height-auto-animation-fix/style.css
@@ -1,0 +1,159 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600&display=swap');
+
+:root {
+    --bg-color: #f8fafc;
+    --card-bg: #ffffff;
+    --text-primary: #0f172a;
+    --text-secondary: #475569;
+    --primary: #3b82f6;
+    --border: #e2e8f0;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    font-family: 'Outfit', system-ui, sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    box-sizing: border-box;
+    padding: 40px 20px;
+}
+
+.layout-container {
+    max-width: 900px;
+    width: 100%;
+}
+
+.header {
+    text-align: center;
+    margin-bottom: 48px;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 600;
+    margin: 0 0 12px 0;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    line-height: 1.5;
+}
+
+.showcase {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 32px;
+    justify-content: center;
+}
+
+.demo-card {
+    background: var(--card-bg);
+    padding: 32px;
+    border-radius: 12px;
+    box-shadow: 0 4px 6px -1px rgba(0,0,0,0.05);
+    border: 1px solid var(--border);
+    width: 380px;
+}
+
+.demo-card h3 { margin: 0 0 12px 0; font-size: 1.3rem; }
+.demo-card p { color: var(--text-secondary); margin: 0 0 24px 0; font-size: 0.95rem; line-height: 1.5; }
+
+/* =========================================
+   Base Accordion Styles
+   ========================================= */
+
+.accordion {
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    overflow: hidden;
+}
+
+.accordion-trigger {
+    width: 100%;
+    background: #f1f5f9;
+    border: none;
+    padding: 16px;
+    font-size: 1rem;
+    font-weight: 600;
+    text-align: left;
+    cursor: pointer;
+    font-family: inherit;
+    color: var(--text-primary);
+    transition: background 0.2s ease;
+}
+
+.accordion-trigger:hover {
+    background: #e2e8f0;
+}
+
+.inner-padding {
+    padding: 16px;
+    background: #ffffff;
+    border-top: 1px solid var(--border);
+}
+
+.inner-padding p {
+    margin: 0;
+}
+
+/* =========================================
+   Example 1: The Buggy Max-Height Hack
+   ========================================= */
+
+.buggy-content {
+    /* 
+       THE BUG: CSS cannot animate from height: 0 to height: auto.
+       To bypass this, developers used to animate max-height to a huge arbitrary number (like 1000px).
+       This causes a massive timing issue when closing, because the browser takes time to 
+       animate from 1000px down to the actual content height (e.g. 100px) before anything visually changes!
+    */
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.5s cubic-bezier(0, 1, 0, 1); /* A hacked easing curve to try and hide the delay */
+}
+
+.buggy-content.is-open {
+    max-height: 1000px; /* Arbitrary magic number */
+    transition: max-height 0.5s ease-in-out;
+}
+
+/* =========================================
+   Example 2: The Modern CSS Grid Fix
+   ========================================= */
+
+.fixed-content {
+    /* 
+       THE FIX: By applying display: grid, we can animate the grid-template-rows property.
+       0fr acts as 0 height.
+       1fr acts as the exact, natural height of the content.
+       The browser smoothly calculates the transition between the two!
+    */
+    display: grid;
+    grid-template-rows: 0fr;
+    transition: grid-template-rows 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.fixed-content.is-open {
+    grid-template-rows: 1fr;
+}
+
+/* 
+   Important: The direct child of the grid MUST have overflow: hidden,
+   otherwise the content will spill out while the grid is collapsing.
+*/
+.fixed-content > .inner-padding {
+    overflow: hidden;
+}
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    .buggy-content, .fixed-content {
+        transition: none !important;
+    }
+}


### PR DESCRIPTION
### Description
Closes #65798

Added a new `height-auto-animation-fix` component to the examples showcase. This submission solves the infamous CSS bug where animating from `height: 0` to `height: auto` causes the transition to instantly jump to the end state without animating.

### What was changed
* Created `submissions/examples/height-auto-animation-fix/demo.html` showing a side-by-side comparison of a buggy accordion using the legacy max-height hack versus a smoothly animating modern accordion.
* Created `submissions/examples/height-auto-animation-fix/style.css` which introduces the modern CSS Grid solution, transitioning `grid-template-rows` from `0fr` to `1fr`.
* Created `submissions/examples/height-auto-animation-fix/README.md` explaining the timing delay flaws of the max-height hack.

### Why it matters
One of the longest-standing limitations in CSS is the inability to smoothly transition an element's height to `auto`. For years, the standard workaround was the "Max-Height Hack": transitioning `max-height` from `0` to a massive number like `1000px`. However, this hack causes severe timing issues—when closing the accordion, the browser mathematically transitions from 1000px down to the actual height before the element visually starts shrinking, resulting in a frustrating delay. By using CSS Grid and animating `grid-template-rows` to `1fr`, the browser natively understands how to animate from zero to the exact, dynamically calculated height of the inner content with buttery smooth easing.

### Accessibility
- Fully respects `@media (prefers-reduced-motion: reduce)` by removing the grid transitions, snapping the accordion open and closed instantly.

### Verification
- [x] All files isolated to the `submissions/examples/` folder.
- [x] Verified `grid-template-rows: 1fr` smoothly expands without timing delays on close.