### PR TITLE
feat: add safari border radius bleed fix example

### DIFF
--- a/submissions/examples/safari-border-radius-bleed-fix/README.md
+++ b/submissions/examples/safari-border-radius-bleed-fix/README.md
@@ -1,0 +1,18 @@
+# Safari Border-Radius Bleed Fix
+
+A reliable CSS structural pattern that resolves the infamous WebKit rendering bug where hardware-accelerated child elements bleed outside the rounded corners of their `overflow: hidden` parent container during animations.
+
+## Features
+- **The Bug Context**: It is extremely common in modern web design to have a card with rounded corners (`border-radius`, `overflow: hidden`) and an image inside that scales up slightly on hover (`transform: scale()`). In Apple's WebKit engine (Safari on macOS and iOS), CSS transforms promote the child image to the hardware GPU compositor layer. However, because the parent wrapper remains on the CPU software layer, the GPU doesn't understand the parent's clipping boundaries. The result: during the transition, the sharp, square corners of the image pierce through the parent's rounded corners.
+- **The Fix**: To solve this, we must force Safari to process the parent's clipping mask on the hardware layer as well.
+  1. We apply `transform: translateZ(0)` to the parent. This elevates the parent to the GPU, syncing the clipping layers.
+  2. As a bulletproof fallback for older WebKit builds or complex nested layouts, we also apply `-webkit-mask-image: -webkit-radial-gradient(white, black);`, which mathematically forces a pixel-perfect alpha crop on the element.
+
+## Usage
+Open `demo.html` in Safari (macOS or iOS).
+- Hover over the **Buggy Card**. Look closely at the top corners. As the image scales, the sharp square corners of the photo will bleed outside the card's 24px border radius.
+- Hover over the **Fixed Card**. The hardware clipping masks perfectly contain the scaled image to the rounded corners throughout the entire transition.
+
+## Files
+- `demo.html`: The HTML structure demonstrating the side-by-side card comparison.
+- `style.css`: The styling engine containing the WebKit hardware mask fixes.

--- a/submissions/examples/safari-border-radius-bleed-fix/demo.html
+++ b/submissions/examples/safari-border-radius-bleed-fix/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Safari Border-Radius Bleed Fix - EaseMotion</title>
+    <!-- Include EaseMotion CSS -->
+    <link rel="stylesheet" href="../../../easemotion.min.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="layout-container">
+        <header class="header">
+            <h1 class="title">Safari Border-Radius Bleed Fix</h1>
+            <p class="subtitle">Resolving a notorious WebKit rendering bug where scaled child images bleed outside the rounded corners of an <code>overflow: hidden</code> parent container.</p>
+        </header>
+
+        <main class="showcase">
+            <!-- Buggy Implementation -->
+            <div class="demo-card">
+                <h3>The WebKit Bleed Bug</h3>
+                <p>Hover the image in Safari (iOS/macOS). The sharp square corners of the scaling image will suddenly pierce through the rounded corners of the card!</p>
+                
+                <div class="card buggy-card">
+                    <img src="https://images.unsplash.com/photo-1618005182384-a83a8bd57fbe?q=80&w=400&h=300&auto=format&fit=crop" alt="Abstract gradient" class="card-image">
+                    <div class="card-content">
+                        <h4>Buggy Card</h4>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Fixed Implementation -->
+            <div class="demo-card">
+                <h3>The Hardware Mask Fix</h3>
+                <p>Applying <code>transform: translateZ(0)</code> (or a webkit radial mask) forces Safari to process the border-radius clipping on the same hardware layer as the scaling image, stopping the bleed.</p>
+                
+                <div class="card fixed-card">
+                    <img src="https://images.unsplash.com/photo-1618005182384-a83a8bd57fbe?q=80&w=400&h=300&auto=format&fit=crop" alt="Abstract gradient" class="card-image">
+                    <div class="card-content">
+                        <h4>Fixed Card</h4>
+                    </div>
+                </div>
+            </div>
+        </main>
+    </div>
+</body>
+</html>

--- a/submissions/examples/safari-border-radius-bleed-fix/style.css
+++ b/submissions/examples/safari-border-radius-bleed-fix/style.css
@@ -1,0 +1,137 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600&display=swap');
+
+:root {
+    --bg-color: #f1f5f9;
+    --card-bg: #ffffff;
+    --text-primary: #0f172a;
+    --text-secondary: #475569;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    font-family: 'Outfit', system-ui, sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    box-sizing: border-box;
+    padding: 40px 20px;
+}
+
+.layout-container {
+    max-width: 900px;
+    width: 100%;
+}
+
+.header {
+    text-align: center;
+    margin-bottom: 48px;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 600;
+    margin: 0 0 12px 0;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    line-height: 1.5;
+}
+
+.showcase {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 32px;
+    justify-content: center;
+}
+
+.demo-card {
+    width: 350px;
+}
+
+.demo-card h3 { margin: 0 0 12px 0; font-size: 1.3rem; }
+.demo-card p { color: var(--text-secondary); margin: 0 0 24px 0; font-size: 0.95rem; line-height: 1.5; }
+
+/* =========================================
+   Base Card Styles
+   ========================================= */
+
+.card {
+    background: var(--card-bg);
+    border-radius: 24px;
+    box-shadow: 0 10px 15px -3px rgba(0,0,0,0.1);
+    
+    /* We expect this to clip the corners of the child image */
+    overflow: hidden; 
+    
+    position: relative;
+    cursor: pointer;
+}
+
+.card-image {
+    width: 100%;
+    height: 200px;
+    object-fit: cover;
+    display: block;
+    
+    /* A standard zoom effect on hover */
+    transition: transform 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.card:hover .card-image {
+    transform: scale(1.1);
+}
+
+.card-content {
+    padding: 24px;
+}
+
+.card-content h4 {
+    margin: 0;
+    font-size: 1.2rem;
+}
+
+/* =========================================
+   Example 1: The Buggy WebKit Implementation
+   ========================================= */
+
+.buggy-card {
+    /* 
+       THE BUG: In Safari, when the child `.card-image` transitions `transform: scale()`,
+       it is temporarily promoted to a hardware compositing layer. Because the parent `.buggy-card`
+       is sitting on the software CPU layer, the GPU doesn't know it's supposed to clip the
+       corners. As a result, the square edges of the scaled image bleed through the rounded corners!
+    */
+}
+
+/* =========================================
+   Example 2: The Safari Hardware Fix
+   ========================================= */
+
+.fixed-card {
+    /* 
+       THE FIX (Option 1): Force the parent onto the hardware compositor layer too, 
+       so the GPU understands it needs to calculate a hardware clipping mask.
+    */
+    transform: translateZ(0);
+    
+    /* 
+       THE FIX (Option 2 - The Bulletproof Fallback):
+       If translateZ doesn't work (due to nested transforms), explicitly creating a WebKit 
+       image mask forces Safari to mathematically crop the pixels during the animation.
+    */
+    -webkit-mask-image: -webkit-radial-gradient(white, black);
+}
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    .card-image {
+        transition: none !important;
+        transform: none !important;
+    }
+}


### PR DESCRIPTION
### Description
Closes #65795

Added a new `safari-border-radius-bleed-fix` component to the examples showcase. This submission resolves a notorious WebKit rendering bug where hardware-accelerated child elements (like scaling images) bleed outside the rounded corners of their `overflow: hidden` parent container during animations.

### What was changed
* Created `submissions/examples/safari-border-radius-bleed-fix/demo.html` showing a side-by-side comparison of a buggy image card in Safari versus a fixed card with clean corner clipping.
* Created `submissions/examples/safari-border-radius-bleed-fix/style.css` which introduces `transform: translateZ(0)` and a `-webkit-radial-gradient` mask-image fallback on the parent element.
* Created `submissions/examples/safari-border-radius-bleed-fix/README.md` explaining the difference between CPU software clipping and GPU hardware clipping in Apple's WebKit engine.

### Why it matters
It is extremely common in modern web design to have a card with rounded corners (`overflow: hidden`) and an image inside that scales up slightly on hover. In Safari on macOS and iOS, CSS transforms automatically promote the child image to the hardware GPU compositor layer. However, because the parent wrapper remains on the CPU software layer, the GPU doesn't understand the parent's clipping boundaries. As a result, the sharp, square corners of the image pierce through the parent's rounded corners. By applying hardware acceleration hints and WebKit masks to the parent, we sync the clipping layers and guarantee a pixel-perfect crop.

### Accessibility
- Fully respects `@media (prefers-reduced-motion: reduce)` by removing the scale transition on the image.

### Verification
- [x] All files isolated to the `submissions/examples/` folder.
- [x] Verified hardware clipping masks perfectly contain the scaled image to the rounded corners in Safari.