### PR TITLE
feat: add text rendering jitter fix example

### DIFF
--- a/submissions/examples/text-rendering-jitter-fix/README.md
+++ b/submissions/examples/text-rendering-jitter-fix/README.md
@@ -1,0 +1,18 @@
+# Text Rendering Jitter Fix
+
+A CSS architectural pattern that resolves the infamous sub-pixel font wobbling and weight-shifting bug that occurs when animating elements containing text via CSS transforms (like `transform: scale()` or `transform: translateY()`).
+
+## Features
+- **The Bug Context**: When you apply a `transform` animation (like a hover scale) to a button, modern browsers temporarily promote that element to a hardware-accelerated GPU layer for smooth animation. However, standard text rendering on the CPU uses sub-pixel anti-aliasing (making text look slightly bolder), while GPU rendering uses grayscale anti-aliasing (making text look slightly thinner). As the animation starts, the text becomes blurry and thin. The moment the animation ends, the element drops off the GPU, and the text aggressively snaps back to being sharp and bold. This creates an incredibly jarring "wobble" or "jitter" effect.
+- **The Fix**: 
+  1. We apply `transform: translateZ(0)` and `backface-visibility: hidden` to permanently elevate the element to the GPU layer, avoiding the hardware-to-software snapping transition at the end of the animation.
+  2. We apply `-webkit-font-smoothing: antialiased` and `-moz-osx-font-smoothing: grayscale` to force the text to render with standard grayscale anti-aliasing *all the time*. This guarantees the text weight remains perfectly mathematically consistent before, during, and after the scale animation.
+
+## Usage
+Open `demo.html` in a WebKit browser (Chrome or Safari). 
+- Hover the **Buggy Button** and release. Watch the text weight specifically right at the moment the animation ends; you will see it "pop" or snap slightly heavier.
+- Hover the **Fixed Button** and release. The text remains flawlessly crisp and consistent throughout the entire interaction lifecycle.
+
+## Files
+- `demo.html`: The HTML structure demonstrating the side-by-side button comparison.
+- `style.css`: The styling engine containing the font-smoothing and GPU layering fixes.

--- a/submissions/examples/text-rendering-jitter-fix/demo.html
+++ b/submissions/examples/text-rendering-jitter-fix/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Text Rendering Jitter Fix - EaseMotion</title>
+    <!-- Include EaseMotion CSS -->
+    <link rel="stylesheet" href="../../../easemotion.min.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="layout-container">
+        <header class="header">
+            <h1 class="title">Text Rendering Jitter Fix</h1>
+            <p class="subtitle">Solving the infamous sub-pixel font wobbling and weight-shifting bug that occurs when animating elements containing text via CSS transforms.</p>
+        </header>
+
+        <main class="showcase">
+            <!-- Buggy Demo -->
+            <div class="demo-card">
+                <h3>The Jittery Text (Buggy)</h3>
+                <p>Hover this button. Watch the text closely as the button scales up and down. The text shifts weight, becomes blurry, and nervously snaps back to sharpness when the animation ends.</p>
+                
+                <div class="btn-container">
+                    <button class="btn buggy-btn">Hover for Wobble</button>
+                </div>
+            </div>
+
+            <!-- Fixed Demo -->
+            <div class="demo-card">
+                <h3>The Crisp Text (Fixed)</h3>
+                <p>By applying anti-aliasing constraints and forcing hardware acceleration ahead of time, the text remains perfectly crisp and stable throughout the entire scaling transition.</p>
+                
+                <div class="btn-container">
+                    <button class="btn fixed-btn">Hover for Smoothness</button>
+                </div>
+            </div>
+        </main>
+    </div>
+</body>
+</html>

--- a/submissions/examples/text-rendering-jitter-fix/style.css
+++ b/submissions/examples/text-rendering-jitter-fix/style.css
@@ -1,0 +1,139 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600&display=swap');
+
+:root {
+    --bg-color: #f8fafc;
+    --card-bg: #ffffff;
+    --text-primary: #0f172a;
+    --text-secondary: #475569;
+    --primary: #f59e0b;
+    --primary-hover: #d97706;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    font-family: 'Outfit', system-ui, sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    box-sizing: border-box;
+    padding: 40px 20px;
+}
+
+.layout-container {
+    max-width: 900px;
+    width: 100%;
+}
+
+.header {
+    text-align: center;
+    margin-bottom: 48px;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 600;
+    margin: 0 0 12px 0;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    line-height: 1.5;
+}
+
+.showcase {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 32px;
+    justify-content: center;
+}
+
+.demo-card {
+    background: var(--card-bg);
+    padding: 32px;
+    border-radius: 12px;
+    box-shadow: 0 4px 6px -1px rgba(0,0,0,0.05);
+    border: 1px solid #e2e8f0;
+    width: 350px;
+    text-align: center;
+}
+
+.demo-card h3 { margin: 0 0 12px 0; font-size: 1.3rem; }
+.demo-card p { color: var(--text-secondary); margin: 0 0 32px 0; font-size: 0.95rem; line-height: 1.5; }
+
+.btn-container {
+    height: 80px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+/* =========================================
+   Base Button Styles
+   ========================================= */
+
+.btn {
+    background: var(--primary);
+    color: white;
+    border: none;
+    padding: 16px 32px;
+    border-radius: 8px;
+    font-size: 1.1rem;
+    font-weight: 500;
+    cursor: pointer;
+    font-family: inherit;
+    transition: transform 0.4s cubic-bezier(0.16, 1, 0.3, 1), background 0.3s ease;
+}
+
+.btn:hover {
+    transform: scale(1.15);
+    background: var(--primary-hover);
+}
+
+/* =========================================
+   Example 1: The Buggy Implementation
+   ========================================= */
+
+.buggy-btn {
+    /* 
+       THE BUG: When transitioning scale(), the browser promotes the element to the GPU.
+       During this transition, the text is re-rendered with grayscale anti-aliasing instead 
+       of sub-pixel anti-aliasing. When the animation ends, it demotes the layer back to the CPU, 
+       causing the text to abruptly snap back to sub-pixel rendering (changing weight and crispness).
+    */
+}
+
+/* =========================================
+   Example 2: The Fixed Implementation
+   ========================================= */
+
+.fixed-btn {
+    /* 
+       THE FIX 1: Force the element onto the GPU permanently. 
+       This prevents the transition between CPU/GPU layers, eliminating the snap at the end.
+    */
+    transform: translateZ(0);
+    backface-visibility: hidden;
+    
+    /* 
+       THE FIX 2: Force grayscale anti-aliasing permanently.
+       By explicitly opting out of sub-pixel rendering on macOS/iOS, the font weight 
+       remains completely stable before, during, and after the scaling animation.
+    */
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    .btn {
+        transition: background 0.3s ease !important;
+    }
+    .btn:hover {
+        transform: none !important;
+    }
+}


### PR DESCRIPTION
### Description
Closes #65789

Added a new `text-rendering-jitter-fix` component to the examples showcase. This submission resolves the incredibly jarring sub-pixel font wobbling and weight-shifting bug that occurs when animating elements containing text via CSS transforms (like `transform: scale()`).

### What was changed
* Created `submissions/examples/text-rendering-jitter-fix/demo.html` showing a side-by-side comparison of a buggy button that "wobbles" on hover versus a perfectly crisp fixed button.
* Created `submissions/examples/text-rendering-jitter-fix/style.css` which introduces `transform: translateZ(0)` and `-webkit-font-smoothing: antialiased` to permanently lock the text into consistent GPU rendering.
* Created `submissions/examples/text-rendering-jitter-fix/README.md` explaining the difference between CPU sub-pixel anti-aliasing and GPU grayscale anti-aliasing.

### Why it matters
When you apply a `transform` animation (like a hover scale) to a button, modern browsers temporarily promote that element to a hardware-accelerated GPU layer for smooth animation. However, standard text rendering on the CPU uses sub-pixel anti-aliasing (making text look slightly bolder), while GPU rendering uses grayscale anti-aliasing (making text look slightly thinner). The moment the animation ends, the element drops off the GPU, and the text aggressively snaps back to being sharp and bold. By forcing the element to remain on the GPU and explicitly locking the font-smoothing to grayscale at all times, we guarantee the text weight remains perfectly mathematically consistent before, during, and after the scale animation.

### Accessibility
- Fully respects `@media (prefers-reduced-motion: reduce)` by removing the scale transition on the button.

### Verification
- [x] All files isolated to the `submissions/examples/` folder.
- [x] Verified text remains flawlessly crisp and consistent at the end of the transition in WebKit/Blink browsers.
- [ ] 