### PR TITLE
feat: add touch sticky hover fix example

### DIFF
--- a/submissions/examples/touch-sticky-hover-fix/README.md
+++ b/submissions/examples/touch-sticky-hover-fix/README.md
@@ -1,0 +1,21 @@
+# Touch Sticky Hover Fix
+
+A responsive CSS architectural pattern that resolves the incredibly frustrating mobile UI bug where CSS `:hover` animations become permanently "stuck" active after a user taps an element on a touchscreen device.
+
+## Features
+- **The Bug Context**: Writing a standard global `:hover` pseudo-class (e.g., `.button:hover { transform: scale(1.1) }`) assumes every device operates with a mouse. On mobile touchscreens (iOS/Android), tapping a button technically triggers the hover state for a split second before the click event fires. However, because a finger leaves the screen immediately and there is no mouse pointer to technically "leave" the bounding box, the mobile browser often gets confused and keeps the element permanently locked in the `:hover` state until the user taps somewhere else on the screen to reset it.
+- **The Fix**: We wrap all hover-based animations and styles inside an Interaction Media Feature query: `@media (hover: hover) and (pointer: fine) { ... }`. 
+  - `hover: hover` checks if the device's primary input mechanism can hover over elements with ease.
+  - `pointer: fine` checks if the primary input is a precise pointing device (like a mouse or stylus, rather than a coarse finger).
+  - Mobile devices will safely ignore this block, entirely eliminating the sticky hover bug, while desktop users still get the full animated experience!
+- **Feedback**: We intentionally leave the `:active` pseudo-class outside the media query, ensuring mobile users still get immediate tactile feedback (like a slight scale down) while their finger is touching the glass.
+
+## Usage
+Open `demo.html` in your browser. 
+1. Open Developer Tools (F12) and toggle the "Device Toolbar" (Ctrl+Shift+M on Windows) to simulate a mobile device (like an iPhone or Pixel).
+2. Tap the **Buggy Button**. Notice how it turns red and stays permanently scaled up, ruining the UI layout.
+3. Tap the **Fixed Button**. Notice how it shrinks slightly when tapped (tactile feedback via `:active`), but safely returns to its normal state the moment you lift your finger.
+
+## Files
+- `demo.html`: The HTML structure demonstrating the side-by-side button comparison.
+- `style.css`: The styling engine containing the `@media (hover: hover)` interaction query.

--- a/submissions/examples/touch-sticky-hover-fix/demo.html
+++ b/submissions/examples/touch-sticky-hover-fix/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Touch Sticky Hover Fix - EaseMotion</title>
+    <!-- Include EaseMotion CSS -->
+    <link rel="stylesheet" href="../../../easemotion.min.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="layout-container">
+        <header class="header">
+            <h1 class="title">Touch Sticky Hover Fix</h1>
+            <p class="subtitle">Resolving the frustrating mobile UI bug where CSS <code>:hover</code> animations become permanently "stuck" active after a user taps an element on a touchscreen device.</p>
+        </header>
+
+        <main class="showcase">
+            <!-- Buggy Demo -->
+            <div class="demo-card">
+                <h3>The Sticky Hover (Buggy)</h3>
+                <p>If you view this on a touchscreen device (or simulate one in DevTools) and tap the button below, it will remain permanently scaled and red, even after you move your finger away!</p>
+                
+                <div class="btn-container">
+                    <button class="btn buggy-btn">Tap Me on Mobile</button>
+                </div>
+            </div>
+
+            <!-- Fixed Demo -->
+            <div class="demo-card">
+                <h3>The Media Query Fix (Fixed)</h3>
+                <p>By wrapping the hover state in an interaction media query, the hover animation only applies if the device actually has a fine-pointing device (like a mouse).</p>
+                
+                <div class="btn-container">
+                    <button class="btn fixed-btn">Tap Me on Mobile</button>
+                </div>
+            </div>
+            
+            <div class="info-box">
+                <h4>How to test this locally:</h4>
+                <p>Open your browser's Developer Tools (F12) and toggle the "Device Toolbar" to simulate a mobile phone (e.g., iPhone 14). Tap the buttons to see the difference.</p>
+            </div>
+        </main>
+    </div>
+</body>
+</html>

--- a/submissions/examples/touch-sticky-hover-fix/style.css
+++ b/submissions/examples/touch-sticky-hover-fix/style.css
@@ -1,0 +1,148 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+:root {
+    --bg-color: #f1f5f9;
+    --card-bg: #ffffff;
+    --text-primary: #0f172a;
+    --text-secondary: #475569;
+    --primary: #3b82f6;
+    --danger: #ef4444;
+    --success: #10b981;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    font-family: 'Inter', system-ui, sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    box-sizing: border-box;
+    padding: 40px 20px;
+}
+
+.layout-container {
+    max-width: 900px;
+    width: 100%;
+}
+
+.header {
+    text-align: center;
+    margin-bottom: 48px;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 600;
+    margin: 0 0 12px 0;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    line-height: 1.5;
+}
+
+.showcase {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 32px;
+    justify-content: center;
+}
+
+.demo-card {
+    background: var(--card-bg);
+    padding: 32px;
+    border-radius: 12px;
+    box-shadow: 0 4px 6px -1px rgba(0,0,0,0.05);
+    border: 1px solid #e2e8f0;
+    width: 350px;
+    text-align: center;
+}
+
+.demo-card h3 { margin: 0 0 12px 0; font-size: 1.3rem; }
+.demo-card p { color: var(--text-secondary); margin: 0 0 32px 0; font-size: 0.95rem; line-height: 1.5; }
+
+.btn-container {
+    height: 80px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.info-box {
+    width: 100%;
+    background: #e0f2fe;
+    border: 1px solid #bae6fd;
+    padding: 20px;
+    border-radius: 8px;
+    margin-top: 20px;
+    text-align: center;
+}
+.info-box h4 { margin: 0 0 8px 0; color: #0284c7; }
+.info-box p { margin: 0; color: #0369a1; font-size: 0.9rem; }
+
+/* =========================================
+   Base Button Styles
+   ========================================= */
+
+.btn {
+    background: var(--primary);
+    color: white;
+    border: none;
+    padding: 16px 32px;
+    border-radius: 8px;
+    font-size: 1.1rem;
+    font-weight: 500;
+    cursor: pointer;
+    font-family: inherit;
+    transition: transform 0.3s ease, background 0.3s ease;
+}
+
+/* We still apply an :active state for touch feedback! */
+.btn:active {
+    transform: scale(0.95);
+}
+
+/* =========================================
+   Example 1: The Buggy Implementation
+   ========================================= */
+
+/* 
+   THE BUG: Writing a global :hover selector assumes every device has a mouse.
+   On mobile touchscreens, tapping a button briefly triggers :hover. However, because 
+   there is no mouse pointer to "move away", the browser keeps the element in the :hover 
+   state until the user taps somewhere else on the page!
+*/
+.buggy-btn:hover {
+    transform: scale(1.1);
+    background: var(--danger);
+}
+
+/* =========================================
+   Example 2: The Fixed Implementation
+   ========================================= */
+
+/* 
+   THE FIX: We wrap ALL hover interactions inside an Interaction Media Feature query.
+   (hover: hover) ensures the device is capable of hovering (not just touch).
+   (pointer: fine) ensures the primary input mechanism is an accurate pointing device (like a mouse/stylus).
+   Now, mobile devices simply ignore this block and never get "stuck" in a hover state!
+*/
+@media (hover: hover) and (pointer: fine) {
+    .fixed-btn:hover {
+        transform: scale(1.1);
+        background: var(--success);
+    }
+}
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    .btn, .btn:active {
+        transition: background 0.3s ease !important;
+        transform: none !important;
+    }
+}


### PR DESCRIPTION
### Description
Closes #65785

Added a new `touch-sticky-hover-fix` component to the examples showcase. This submission resolves the incredibly frustrating mobile UI bug where CSS `:hover` animations become permanently "stuck" active after a user taps an element on a touchscreen device.

### What was changed
* Created `submissions/examples/touch-sticky-hover-fix/demo.html` showing a side-by-side comparison of a buggy hover button and a responsive button protected by Interaction Media Features.
* Created `submissions/examples/touch-sticky-hover-fix/style.css` which introduces the `@media (hover: hover) and (pointer: fine)` query wrapper, safely sandboxing hover effects away from mobile touch interactions while preserving `:active` tactile feedback.
* Created `submissions/examples/touch-sticky-hover-fix/README.md` explaining why mobile browsers misinterpret touch events as permanent hovers when no mouse is present.

### Why it matters
Writing a standard global `:hover` pseudo-class assumes every device operates with a mouse. On iOS and Android touchscreens, tapping a button technically triggers the hover state for a split second. However, because a finger leaves the screen immediately and there is no mouse pointer to "leave" the bounding box, the mobile browser gets confused and keeps the element permanently locked in the `:hover` state until the user taps somewhere else on the screen to reset it. By wrapping hover logic inside `(hover: hover)`, we instruct mobile devices to safely ignore the block, completely eliminating the sticky hover bug, while desktop users still get the full animated experience!

### Accessibility
- Fully respects `@media (prefers-reduced-motion: reduce)` by removing the scale transition entirely.
- Retains tactile `:active` state for mobile users so they still receive immediate visual feedback when pressing the glass.

### Verification
- [x] All files isolated to the `submissions/examples/` folder.
- [x] Verified in Chrome DevTools Device Emulator that mobile taps do not leave the `.fixed-btn` permanently scaled.