### PR TITLE
feat: add animating css gaps example

### DIFF
--- a/submissions/examples/animating-css-gaps/README.md
+++ b/submissions/examples/animating-css-gaps/README.md
@@ -1,0 +1,17 @@
+# Animating CSS Gaps
+
+A modern CSS interaction pattern demonstrating how to natively animate the `gap` property in Flexbox and Grid layouts, completely eliminating the need for messy negative-margin hacks or JavaScript layout thrashing.
+
+## Features
+- **The Historical Context**: For years, `gap` (or `grid-gap`) was considered an un-animatable CSS property. If you tried to transition it, the browser would simply instantly snap from the starting value to the ending value. To simulate a fluidly expanding grid, developers had to use complex systems involving transitioning `margin` on all child items while wrapping the grid in a container with negative margins to hide the overflow.
+- **The Modern Pattern**: Browsers engines have successfully implemented layout interpolation algorithms. You can now simply declare `transition: gap 0.5s ease;` and the browser will natively mathematically interpolate the spacing between every row and column simultaneously!
+
+## Usage
+Open `demo.html` in a modern browser (Chrome 107+, Safari 16.4+, Firefox 116+). 
+- Hover anywhere inside the dashed boundary of the grid container.
+- Watch as all 9 items push away from each other simultaneously, fluidly animating the internal gutter size from `8px` to `32px` with a slight spring bounce effect (`cubic-bezier`).
+- If you run this in an outdated browser, it will safely degrade by simply snapping the gap to 32px instantly without breaking the layout.
+
+## Files
+- `demo.html`: The HTML structure demonstrating a standard 3x3 CSS grid.
+- `style.css`: The styling engine containing the native `transition: gap` logic.

--- a/submissions/examples/animating-css-gaps/demo.html
+++ b/submissions/examples/animating-css-gaps/demo.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Animating CSS Gaps - EaseMotion</title>
+    <!-- Include EaseMotion CSS -->
+    <link rel="stylesheet" href="../../../easemotion.min.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="layout-container">
+        <header class="header">
+            <h1 class="title">Animating CSS Gaps</h1>
+            <p class="subtitle">Showcasing the modern ability to natively transition <code>gap</code> properties in Flexbox and Grid layouts without relying on messy margin hacks or JavaScript.</p>
+        </header>
+
+        <main class="showcase">
+            <div class="demo-card">
+                <h3>The Dynamic Grid</h3>
+                <p>Hover anywhere inside the container below. Watch how the spacing between all the items fluidly expands from 8px to 32px using a single line of modern CSS.</p>
+                
+                <div class="grid-container">
+                    <div class="grid-item">1</div>
+                    <div class="grid-item">2</div>
+                    <div class="grid-item">3</div>
+                    <div class="grid-item">4</div>
+                    <div class="grid-item">5</div>
+                    <div class="grid-item">6</div>
+                    <div class="grid-item">7</div>
+                    <div class="grid-item">8</div>
+                    <div class="grid-item">9</div>
+                </div>
+            </div>
+            
+            <div class="info-box">
+                <h4>Browser Support Note:</h4>
+                <p>Animating the <code>gap</code> property natively is supported in Chrome 107+, Safari 16.4+, and Firefox 116+. In older browsers, the gap will still work but it will instantly snap to the new value instead of animating smoothly.</p>
+            </div>
+        </main>
+    </div>
+</body>
+</html>

--- a/submissions/examples/animating-css-gaps/style.css
+++ b/submissions/examples/animating-css-gaps/style.css
@@ -1,0 +1,127 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600&display=swap');
+
+:root {
+    --bg-color: #f1f5f9;
+    --card-bg: #ffffff;
+    --text-primary: #0f172a;
+    --text-secondary: #475569;
+    --primary: #8b5cf6;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    font-family: 'Outfit', system-ui, sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    box-sizing: border-box;
+    padding: 40px 20px;
+}
+
+.layout-container {
+    max-width: 900px;
+    width: 100%;
+}
+
+.header {
+    text-align: center;
+    margin-bottom: 48px;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 600;
+    margin: 0 0 12px 0;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    line-height: 1.5;
+}
+
+.showcase {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 32px;
+    justify-content: center;
+}
+
+.demo-card {
+    background: var(--card-bg);
+    padding: 32px;
+    border-radius: 12px;
+    box-shadow: 0 4px 6px -1px rgba(0,0,0,0.05);
+    border: 1px solid #e2e8f0;
+    width: 100%;
+    max-width: 500px;
+    text-align: center;
+}
+
+.demo-card h3 { margin: 0 0 12px 0; font-size: 1.3rem; }
+.demo-card p { color: var(--text-secondary); margin: 0 0 32px 0; font-size: 0.95rem; line-height: 1.5; }
+
+.info-box {
+    width: 100%;
+    max-width: 500px;
+    background: #fdf4ff;
+    border: 1px solid #f5d0fe;
+    padding: 20px;
+    border-radius: 8px;
+    text-align: center;
+}
+.info-box h4 { margin: 0 0 8px 0; color: #86198f; }
+.info-box p { margin: 0; color: #a21caf; font-size: 0.9rem; }
+
+/* =========================================
+   Example: Animating CSS Gaps
+   ========================================= */
+
+.grid-container {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    
+    /* Starting Gap */
+    gap: 8px;
+    background: #f8fafc;
+    border: 1px dashed #cbd5e1;
+    padding: 20px;
+    border-radius: 12px;
+    
+    /* 
+       THE MAGIC: We can now natively transition the gap property!
+       No more messy margin negative-space calculations.
+    */
+    transition: gap 0.6s cubic-bezier(0.34, 1.56, 0.64, 1);
+    cursor: pointer;
+}
+
+.grid-container:hover {
+    /* Ending Gap */
+    gap: 32px;
+}
+
+.grid-item {
+    background: var(--primary);
+    color: white;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 1.5rem;
+    font-weight: 600;
+    height: 80px;
+    border-radius: 8px;
+    box-shadow: 0 4px 6px -1px rgba(139, 92, 246, 0.3);
+}
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    .grid-container {
+        /* Disables the spring transition, letting it snap instantly */
+        transition: none !important;
+    }
+}


### PR DESCRIPTION
### Description
Closes #65780

Added a new `animating-css-gaps` component to the examples showcase. This submission highlights a modern CSS interaction pattern demonstrating how to natively animate the `gap` property in Flexbox and Grid layouts, completely eliminating the need for messy negative-margin hacks or JavaScript layout thrashing.

### What was changed
* Created `submissions/examples/animating-css-gaps/demo.html` showing a 3x3 CSS grid filled with interactive cards.
* Created `submissions/examples/animating-css-gaps/style.css` which introduces `transition: gap 0.6s cubic-bezier` to fluidly animate the gutter spacing on hover.
* Created `submissions/examples/animating-css-gaps/README.md` explaining the historical limitations of animating `gap` and the modern browser support for layout interpolation.

### Why it matters
For years, `gap` (or `grid-gap`) was considered an un-animatable CSS property. If you tried to transition it, the browser would instantly snap from the starting value to the ending value. To simulate a fluidly expanding grid, developers had to resort to extremely complex systems involving transitioning `margin` on all child items while wrapping the entire grid in a container with negative margins to hide the overflow. Now that modern rendering engines have successfully implemented gap interpolation algorithms, we can simply declare `transition: gap 0.5s` and the browser will natively mathematically interpolate the spacing between every row and column simultaneously!

### Accessibility
- Fully respects `@media (prefers-reduced-motion: reduce)`.
- If motion sensitivity is detected, the `transition` is stripped, and the grid safely degrades by simply snapping the gap to 32px instantly without breaking the layout.

### Verification
- [x] All files isolated to the `submissions/examples/` folder.
- [x] Verified `gap` property smoothly animates in Chrome 107+, Safari 16.4+, and Firefox 116+.