### PR TITLE
feat: add grid autofit vs autofill layout fix example

### DIFF
--- a/submissions/examples/grid-autofit-vs-autofill/README.md
+++ b/submissions/examples/grid-autofit-vs-autofill/README.md
@@ -1,0 +1,21 @@
+# Grid Auto-Fit vs Auto-Fill
+
+A visual CSS layout pattern that clarifies and resolves one of the most commonly misunderstood CSS Grid layout bugs: why responsive grid items unexpectedly stretch or leave awkward blank whitespace on wide screens.
+
+## Features
+- **The Bug Context**: Developers often write `grid-template-columns: repeat(auto-fill, minmax(200px, 1fr))` expecting a responsive, flexible grid. However, if the container is 1000px wide and there are only 2 items, the items will stay squished at 200px each, leaving 600px of awkward blank space on the right side of the screen. 
+- **The Core Difference**: 
+  - **`auto-fill`**: Fills the row with as many columns as it can fit. If you only have a few items, it creates invisible "ghost" columns to fill the rest of the space. Your items won't stretch because the space is occupied by ghost columns.
+  - **`auto-fit`**: Creates the columns, but then mathematically collapses any completely empty columns down to 0px width. The `1fr` property then tells the browser to distribute the remaining free space to the existing items, making them stretch beautifully to fill the entire container.
+- **The Fix**: In 95% of UI responsive card layouts, developers actually want `auto-fit`, not `auto-fill`.
+
+## Usage
+Open `demo.html` in your browser. 
+- Ensure your browser window is wide (at least 800px).
+- Look at the **Auto-Fill** grid. Notice how the two items are bunched up on the left side, leaving a huge empty void on the right.
+- Look at the **Auto-Fit** grid. Notice how the two items dynamically stretch to divide the full width of the container evenly. 
+- Slowly resize your browser window to make it narrow, and watch how both grids flawlessly wrap the items to the next row when they hit their `150px` minimum threshold.
+
+## Files
+- `demo.html`: The HTML structure demonstrating the side-by-side grid comparison.
+- `style.css`: The styling engine contrasting `auto-fill` with `auto-fit`.

--- a/submissions/examples/grid-autofit-vs-autofill/demo.html
+++ b/submissions/examples/grid-autofit-vs-autofill/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Grid Auto-Fit vs Auto-Fill - EaseMotion</title>
+    <!-- Include EaseMotion CSS -->
+    <link rel="stylesheet" href="../../../easemotion.min.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="layout-container">
+        <header class="header">
+            <h1 class="title">Grid Auto-Fit vs Auto-Fill</h1>
+            <p class="subtitle">Clarifying the most commonly misunderstood CSS Grid layout bug: why grid items unexpectedly stretch or leave blank whitespace on wide screens.</p>
+        </header>
+
+        <main class="showcase">
+            <!-- Buggy/Auto-fill Demo -->
+            <div class="demo-card">
+                <h3>Auto-Fill (Leaves whitespace)</h3>
+                <p><code>repeat(auto-fill, minmax(150px, 1fr))</code></p>
+                <p class="note">If the screen is wide, the browser "fills" the remaining space with invisible grid tracks, leaving the actual items small and bunched to the left.</p>
+                
+                <div class="grid-container grid-autofill">
+                    <div class="grid-item">Item 1</div>
+                    <div class="grid-item">Item 2</div>
+                </div>
+            </div>
+
+            <!-- Fixed/Auto-fit Demo -->
+            <div class="demo-card">
+                <h3>Auto-Fit (Stretches perfectly)</h3>
+                <p><code>repeat(auto-fit, minmax(150px, 1fr))</code></p>
+                <p class="note">The browser collapses the empty tracks to 0px, allowing the actual items to stretch and "fit" the entire available width evenly.</p>
+                
+                <div class="grid-container grid-autofit">
+                    <div class="grid-item">Item 1</div>
+                    <div class="grid-item">Item 2</div>
+                </div>
+            </div>
+            
+            <div class="info-box">
+                <h4>How to test this locally:</h4>
+                <p>Resize your browser window so it is very wide. Watch how the items in the Auto-Fill grid stay small and leave empty space on the right, while the items in the Auto-Fit grid expand to take up the full width.</p>
+            </div>
+        </main>
+    </div>
+</body>
+</html>

--- a/submissions/examples/grid-autofit-vs-autofill/style.css
+++ b/submissions/examples/grid-autofit-vs-autofill/style.css
@@ -1,0 +1,138 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600&display=swap');
+
+:root {
+    --bg-color: #f1f5f9;
+    --card-bg: #ffffff;
+    --text-primary: #0f172a;
+    --text-secondary: #475569;
+    --primary: #0ea5e9;
+    --secondary: #6366f1;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    font-family: 'Outfit', system-ui, sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    box-sizing: border-box;
+    padding: 40px 20px;
+}
+
+.layout-container {
+    max-width: 900px;
+    width: 100%;
+}
+
+.header {
+    text-align: center;
+    margin-bottom: 48px;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 600;
+    margin: 0 0 12px 0;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    line-height: 1.5;
+}
+
+.showcase {
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+    align-items: center;
+}
+
+.demo-card {
+    background: var(--card-bg);
+    padding: 32px;
+    border-radius: 12px;
+    box-shadow: 0 4px 6px -1px rgba(0,0,0,0.05);
+    border: 1px solid #e2e8f0;
+    width: 100%;
+    max-width: 800px;
+}
+
+.demo-card h3 { margin: 0 0 8px 0; font-size: 1.3rem; }
+.demo-card p { margin: 0 0 8px 0; font-size: 0.95rem; }
+.demo-card code { background: #f1f5f9; padding: 4px 8px; border-radius: 4px; color: #b91c1c; font-size: 0.9rem;}
+.demo-card p.note { color: var(--text-secondary); margin-bottom: 24px; font-style: italic; }
+
+.info-box {
+    width: 100%;
+    max-width: 800px;
+    background: #e0f2fe;
+    border: 1px solid #bae6fd;
+    padding: 20px;
+    border-radius: 8px;
+    text-align: center;
+}
+.info-box h4 { margin: 0 0 8px 0; color: #0284c7; }
+.info-box p { margin: 0; color: #0369a1; font-size: 0.9rem; }
+
+/* =========================================
+   Base Grid Container Styles
+   ========================================= */
+
+.grid-container {
+    display: grid;
+    gap: 16px;
+    background: #f8fafc;
+    border: 2px dashed #cbd5e1;
+    padding: 16px;
+    border-radius: 8px;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.grid-item {
+    background: var(--primary);
+    color: white;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 1.1rem;
+    font-weight: 600;
+    height: 80px;
+    border-radius: 6px;
+    transition: all 0.3s ease;
+}
+
+/* =========================================
+   Example 1: Auto-Fill (Often causes bugs)
+   ========================================= */
+
+.grid-autofill {
+    /* 
+       AUTO-FILL: The browser creates as many 150px columns as possible to fill the width.
+       Even if there are only 2 items, it creates invisible columns for the empty space.
+       As a result, the 2 items do not stretch to fill the container!
+    */
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+}
+
+/* =========================================
+   Example 2: Auto-Fit (Usually the intended layout)
+   ========================================= */
+
+.grid-autofit {
+    /* 
+       AUTO-FIT: The browser creates the columns, but then it collapses all EMPTY columns to 0px.
+       The remaining space is then distributed to the existing items (the 1fr part), 
+       allowing the 2 items to stretch beautifully and fit the entire container width!
+    */
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+}
+
+.grid-autofit .grid-item {
+    background: var(--secondary);
+}


### PR DESCRIPTION
### Description
Closes #65775

Added a new `grid-autofit-vs-autofill` component to the examples showcase. This submission resolves a widely misunderstood CSS Grid layout bug where responsive grid items unexpectedly stretch or leave awkward blank whitespace on wide screens due to confusion between `auto-fill` and `auto-fit`.

### What was changed
* Created `submissions/examples/grid-autofit-vs-autofill/demo.html` showing a side-by-side comparison of a broken `auto-fill` grid that leaves empty space, and a perfectly responsive `auto-fit` grid that stretches correctly.
* Created `submissions/examples/grid-autofit-vs-autofill/style.css` which contrasts the two properties.
* Created `submissions/examples/grid-autofit-vs-autofill/README.md` explaining how the browser rendering engine mathematically collapses empty columns down to 0px when using `auto-fit`.

### Why it matters
Developers often write `grid-template-columns: repeat(auto-fill, minmax(200px, 1fr))` expecting a responsive, flexible grid. However, if the container is 1000px wide and there are only 2 items, the `auto-fill` algorithm creates invisible "ghost" columns to fill the rest of the space, causing the actual items to stay squished at 200px each and leaving 600px of awkward blank space on the right side of the screen. By switching to `auto-fit`, the browser collapses the empty ghost columns to 0px, allowing the actual items to stretch and fill the entire available width evenly.

### Accessibility
- Fully responsive layout that gracefully wraps on smaller screens without requiring explicit media queries.

### Verification
- [x] All files isolated to the `submissions/examples/` folder.
- [x] Verified `auto-fit` dynamically stretches grid items on wide viewports without leaving blank space.