### PR TITLE
feat: add zindex position fix example

### DIFF
--- a/submissions/examples/zindex-position-fix/README.md
+++ b/submissions/examples/zindex-position-fix/README.md
@@ -1,0 +1,17 @@
+# Z-Index Position Fix
+
+A fundamental CSS architectural pattern that clarifies and resolves the incredibly common beginner mistake where `z-index` mysteriously fails to work because the element lacks a valid positioning context.
+
+## Features
+- **The Bug Context**: In CSS, elements that overlap are painted in the order they appear in the HTML DOM (elements lower in the file are painted on top of elements higher up). When a developer wants to force an earlier element to the front, they typically write `z-index: 9999`. However, they are often bewildered when nothing happens. 
+- **The Core Rule**: The `z-index` property *only works* on "positioned" elements. By default, all elements have `position: static`. The browser strictly ignores `z-index` on static elements.
+- **The Fix**: The safest way to activate `z-index` without breaking your layout is to apply `position: relative`. This creates a new stacking context for the element and enables `z-index`, while leaving the element exactly where it currently sits in the normal document flow. (Note: `absolute`, `fixed`, and `sticky` also enable `z-index`, as does being a direct child of a Flex or Grid container).
+
+## Usage
+Open `demo.html` in your browser. 
+- Look at the **Buggy Demo**. The green box explicitly declares `z-index: 9999`, but because it lacks a position, the red box (which comes later in the HTML) is painted over it.
+- Look at the **Fixed Demo**. The exact same HTML structure is used, but the green box has `position: relative` added to it. The `z-index: 9999` is successfully activated, pushing the green box firmly in front of the red box.
+
+## Files
+- `demo.html`: The HTML structure demonstrating two overlapping boxes using negative margins.
+- `style.css`: The styling engine contrasting a static z-index with a relative z-index.

--- a/submissions/examples/zindex-position-fix/demo.html
+++ b/submissions/examples/zindex-position-fix/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Z-Index Position Fix - EaseMotion</title>
+    <!-- Include EaseMotion CSS -->
+    <link rel="stylesheet" href="../../../easemotion.min.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="layout-container">
+        <header class="header">
+            <h1 class="title">Z-Index Position Fix</h1>
+            <p class="subtitle">Resolving the incredibly common beginner mistake where <code>z-index</code> mysteriously fails to work because the element lacks a positioning context.</p>
+        </header>
+
+        <main class="showcase">
+            <!-- Buggy Demo -->
+            <div class="demo-card">
+                <h3>The Failing Z-Index (Buggy)</h3>
+                <p>The green box has <code>z-index: 9999</code>, but it is rendering <em>behind</em> the red box! Why? Because it has the default <code>position: static</code>.</p>
+                
+                <div class="box-stack buggy-stack">
+                    <div class="box green-box buggy-box">I have z-index 9999!</div>
+                    <div class="box red-box">I have no z-index.</div>
+                </div>
+            </div>
+
+            <!-- Fixed Demo -->
+            <div class="demo-card">
+                <h3>The Relative Fix (Fixed)</h3>
+                <p>By simply adding <code>position: relative</code> to the green box, we activate its stacking context without moving it. The <code>z-index: 9999</code> now successfully pushes it to the front!</p>
+                
+                <div class="box-stack fixed-stack">
+                    <div class="box green-box fixed-box">I have z-index 9999!</div>
+                    <div class="box red-box">I have no z-index.</div>
+                </div>
+            </div>
+            
+            <div class="info-box">
+                <h4>Golden Rule of CSS:</h4>
+                <p><code>z-index</code> only applies to positioned elements (<code>relative</code>, <code>absolute</code>, <code>fixed</code>, <code>sticky</code>) or children of Flex/Grid containers!</p>
+            </div>
+        </main>
+    </div>
+</body>
+</html>

--- a/submissions/examples/zindex-position-fix/style.css
+++ b/submissions/examples/zindex-position-fix/style.css
@@ -1,0 +1,142 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600&display=swap');
+
+:root {
+    --bg-color: #f1f5f9;
+    --card-bg: #ffffff;
+    --text-primary: #0f172a;
+    --text-secondary: #475569;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    font-family: 'Outfit', system-ui, sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    box-sizing: border-box;
+    padding: 40px 20px;
+}
+
+.layout-container {
+    max-width: 900px;
+    width: 100%;
+}
+
+.header {
+    text-align: center;
+    margin-bottom: 48px;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 600;
+    margin: 0 0 12px 0;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    line-height: 1.5;
+}
+
+.showcase {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 32px;
+    justify-content: center;
+}
+
+.demo-card {
+    background: var(--card-bg);
+    padding: 32px;
+    border-radius: 12px;
+    box-shadow: 0 4px 6px -1px rgba(0,0,0,0.05);
+    border: 1px solid #e2e8f0;
+    width: 350px;
+}
+
+.demo-card h3 { margin: 0 0 12px 0; font-size: 1.3rem; }
+.demo-card p { color: var(--text-secondary); margin: 0 0 24px 0; font-size: 0.95rem; line-height: 1.5; }
+code { background: #f1f5f9; padding: 4px 8px; border-radius: 4px; color: #b91c1c; }
+
+.info-box {
+    width: 100%;
+    max-width: 732px;
+    background: #fffbeb;
+    border: 1px solid #fde68a;
+    padding: 20px;
+    border-radius: 8px;
+    text-align: center;
+    margin: 32px auto 0 auto;
+}
+.info-box h4 { margin: 0 0 8px 0; color: #d97706; }
+.info-box p { margin: 0; color: #b45309; font-size: 0.9rem; }
+
+/* =========================================
+   Base Box Stack Styles
+   ========================================= */
+
+.box-stack {
+    position: relative;
+    height: 160px;
+    margin-top: 30px;
+}
+
+.box {
+    width: 160px;
+    height: 100px;
+    border-radius: 8px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: white;
+    font-weight: 600;
+    font-size: 0.9rem;
+    text-align: center;
+    padding: 10px;
+    box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1);
+}
+
+.green-box { background: #10b981; }
+.red-box { background: #ef4444; }
+
+/* 
+   We push the red box UP using a negative margin so it intentionally 
+   overlaps the green box. Since red is defined LAST in the HTML DOM, 
+   the browser natively paints it ON TOP of green.
+*/
+.red-box {
+    margin-top: -50px;
+    margin-left: 40px;
+}
+
+/* =========================================
+   Example 1: The Buggy Implementation
+   ========================================= */
+
+.buggy-box {
+    /* 
+       THE BUG: A developer tries to force the green box to the front 
+       using a massive z-index. But because they didn't define a 'position', 
+       the browser ignores the z-index entirely!
+    */
+    z-index: 9999;
+}
+
+/* =========================================
+   Example 2: The Fixed Implementation
+   ========================================= */
+
+.fixed-box {
+    /* 
+       THE FIX: By adding position: relative, we activate the z-index property
+       WITHOUT pulling the element out of the normal document flow. 
+       Now the green box successfully jumps to the front!
+    */
+    position: relative;
+    z-index: 9999;
+}


### PR DESCRIPTION
### Description
Closes #65773

Added a new `zindex-position-fix` component to the examples showcase. This submission resolves an incredibly common beginner layout bug where `z-index` mysteriously fails to work because the element lacks a valid positioning context in the CSS object model.

### What was changed
* Created `submissions/examples/zindex-position-fix/demo.html` showing a side-by-side comparison of two overlapping boxes: one where `z-index` is failing, and one where it succeeds.
* Created `submissions/examples/zindex-position-fix/style.css` which introduces `position: relative` to safely activate the stacking context without altering the element's layout flow.
* Created `submissions/examples/zindex-position-fix/README.md` explaining the Golden Rule of CSS: `z-index` only applies to positioned elements (`relative`, `absolute`, `fixed`, `sticky`) or children of Flex/Grid containers.

### Why it matters
In CSS, elements that overlap are natively painted in the exact order they appear in the HTML DOM (elements lower in the file are painted on top of elements higher up). When developers want to force an earlier element to the front, they typically write `z-index: 9999`. However, they are often bewildered