### PR TITLE
feat: add CSS Ripple-Wave Stepper for Minimalist Tech Layouts (#64649)

### DIFF
--- a/submissions/examples/minimalist-tech-ripple-wave-stepper/README.md
+++ b/submissions/examples/minimalist-tech-ripple-wave-stepper/README.md
@@ -1,0 +1,22 @@
+# CSS Ripple-Wave Stepper (Minimalist Tech)
+
+A pure CSS interactive stepper component designed for Minimalist Tech Layouts. It features a continuous, concentric "Ripple-Wave" animation that emanates from the currently active step circle, signifying active system processes.
+
+## Features
+- Pure CSS and HTML (No JavaScript required for interactions or animations).
+- **Minimalist Aesthetic**: Clean layout, sharp `Inter` typography, and distinct blue/purple/pink/emerald accent colors over a sterile `f8fafc` background.
+- **State Management**: The progression of the stepper is handled entirely via the hidden radio button hack (`<input type="radio">`). The circular step nodes act as `<label>` elements wired to these hidden inputs, allowing the user to click them to advance or reverse state.
+- **The Ripple-Wave Effect**: 
+- We use three absolutely positioned `.ripple` elements hidden inside each `.step-circle`.
+- When a specific step's radio button is checked, an `@keyframes` animation (`ripple-pulse`) is triggered *only* on the internal ripples of that active step via CSS sibling selectors (`#step-1:checked ~ .stepper-wrapper .step-item-1 .ripple`).
+- The keyframes expand the elements outward (`transform: scale(1.5)`) while fading to `opacity: 0`. We utilize the `currentColor` property on the ripples' borders so they automatically match the specific accent color assigned to their parent step.
+- We utilize utility classes (`.r-1`, `.r-2`, `.r-3`) with staggered `animation-delay` values (0s, 1s, 2s) to ensure the waves are generated continuously and concentrically as long as the step is active.
+- **Completed vs Active States**: Complex sibling selectors are used to alter the styles of steps appearing *before* the active step, filling them with solid color and swapping the step number for an SVG checkmark to indicate completion.
+- Fully accessible with `prefers-reduced-motion` support. For motion-sensitive users, the continuous ripple-wave keyframes and transition effects are completely disabled. The interactions safely fall back to static CSS state changes.
+
+## Usage
+Open `demo.html` in your browser. You will see a mock System Initialization stepper. Click the numbered circular nodes to advance or rewind the state. Observe how the active node pulses with a concentric colored ripple wave, while previous nodes mark themselves as completed with a solid fill and a checkmark.
+
+## Files
+- `demo.html`: The HTML structure for the layout, detailing the complex `<input type="radio">` setup and the hidden `.ripple` nodes required inside each step circle to achieve the effect.
+- `style.css`: The styling, minimalist tech design tokens, the complex sibling selector logic for tracking completed vs active states, and the staggered `@keyframes` driving the continuous ripple-wave mechanics.

--- a/submissions/examples/minimalist-tech-ripple-wave-stepper/demo.html
+++ b/submissions/examples/minimalist-tech-ripple-wave-stepper/demo.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Ripple-Wave Stepper - Minimalist Tech</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        <header class="section-header">
+            <h1 class="title">System Initialization</h1>
+            <p class="subtitle">A minimalist tech stepper featuring a concentric ripple-wave pulse for active states.</p>
+        </header>
+
+        <div class="dashboard-area">
+            
+            <div class="card">
+                
+                <!-- Pure CSS State Management -->
+                <input type="radio" id="step-1" name="stepper" class="step-input" checked>
+                <input type="radio" id="step-2" name="stepper" class="step-input">
+                <input type="radio" id="step-3" name="stepper" class="step-input">
+                <input type="radio" id="step-4" name="stepper" class="step-input">
+
+                <!-- The Stepper UI -->
+                <div class="stepper-wrapper">
+                    <!-- Progress Line (Background) -->
+                    <div class="stepper-track"></div>
+                    <!-- Progress Line (Fill) -->
+                    <div class="stepper-fill"></div>
+
+                    <!-- Step 1 -->
+                    <div class="step-item step-item-1">
+                        <label for="step-1" class="step-circle color-blue">
+                            <!-- Ripple elements hidden inside the circle -->
+                            <div class="ripple r-1"></div>
+                            <div class="ripple r-2"></div>
+                            <div class="ripple r-3"></div>
+                            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"></polyline></svg>
+                            <span class="step-num">1</span>
+                        </label>
+                        <div class="step-content">
+                            <h3>Verify Hardware</h3>
+                            <p>Checking peripheral connections.</p>
+                        </div>
+                    </div>
+
+                    <!-- Step 2 -->
+                    <div class="step-item step-item-2">
+                        <label for="step-2" class="step-circle color-purple">
+                            <div class="ripple r-1"></div>
+                            <div class="ripple r-2"></div>
+                            <div class="ripple r-3"></div>
+                            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"></polyline></svg>
+                            <span class="step-num">2</span>
+                        </label>
+                        <div class="step-content">
+                            <h3>Load Firmware</h3>
+                            <p>Flashing BIOS securely.</p>
+                        </div>
+                    </div>
+
+                    <!-- Step 3 -->
+                    <div class="step-item step-item-3">
+                        <label for="step-3" class="step-circle color-pink">
+                            <div class="ripple r-1"></div>
+                            <div class="ripple r-2"></div>
+                            <div class="ripple r-3"></div>
+                            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"></polyline></svg>
+                            <span class="step-num">3</span>
+                        </label>
+                        <div class="step-content">
+                            <h3>Mount Volumes</h3>
+                            <p>Decrypting storage arrays.</p>
+                        </div>
+                    </div>
+
+                    <!-- Step 4 -->
+                    <div class="step-item step-item-4">
+                        <label for="step-4" class="step-circle color-emerald">
+                            <div class="ripple r-1"></div>
+                            <div class="ripple r-2"></div>
+                            <div class="ripple r-3"></div>
+                            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"></polyline></svg>
+                            <span class="step-num">4</span>
+                        </label>
+                        <div class="step-content">
+                            <h3>Start Services</h3>
+                            <p>Initializing daemon processes.</p>
+                        </div>
+                    </div>
+
+                </div>
+
+            </div>
+            
+        </div>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/minimalist-tech-ripple-wave-stepper/style.css
+++ b/submissions/examples/minimalist-tech-ripple-wave-stepper/style.css
@@ -1,0 +1,295 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&display=swap');
+
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    --border-color: #e2e8f0;
+    
+    /* Tech Minimalist Accents */
+    --accent-blue: #0ea5e9;
+    --accent-purple: #8b5cf6;
+    --accent-pink: #ec4899;
+    --accent-emerald: #10b981;
+    
+    --surface-white: #ffffff;
+    --track-bg: #f1f5f9;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    width: 100%;
+    padding: 40px 20px;
+}
+
+.section-header {
+    text-align: center;
+    margin-bottom: 50px;
+}
+
+.title {
+    font-size: 2rem;
+    font-weight: 600;
+    margin: 0 0 12px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    margin: 0;
+}
+
+
+/* =========================================
+   Card Styling
+   ========================================= */
+
+.card {
+    background: var(--surface-white);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 40px;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+}
+
+
+/* =========================================
+   Stepper Structure & Logic
+   ========================================= */
+
+.step-input { display: none; }
+
+.stepper-wrapper {
+    display: flex;
+    justify-content: space-between;
+    position: relative;
+    /* Create a horizontal line across the top for the circles to sit on */
+    padding-top: 15px; 
+}
+
+/* Background Track */
+.stepper-track {
+    position: absolute;
+    top: 35px; /* Center with the circles (15px padding + 20px half-height) */
+    left: 0;
+    width: 100%;
+    height: 4px;
+    background: var(--track-bg);
+    z-index: 1;
+}
+
+/* Filled Track */
+.stepper-fill {
+    position: absolute;
+    top: 35px;
+    left: 0;
+    height: 4px;
+    background: var(--accent-blue);
+    z-index: 2;
+    width: 0%;
+    transition: width 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94), background-color 0.6s ease;
+}
+
+/* Update track width based on active step */
+#step-1:checked ~ .stepper-wrapper .stepper-fill { width: 0%; background: var(--accent-blue); }
+#step-2:checked ~ .stepper-wrapper .stepper-fill { width: 33.33%; background: var(--accent-purple); }
+#step-3:checked ~ .stepper-wrapper .stepper-fill { width: 66.66%; background: var(--accent-pink); }
+#step-4:checked ~ .stepper-wrapper .stepper-fill { width: 100%; background: var(--accent-emerald); }
+
+
+.step-item {
+    position: relative;
+    z-index: 3;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 25%;
+    text-align: center;
+}
+
+.step-circle {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background: var(--surface-white);
+    border: 2px solid var(--border-color);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-secondary);
+    font-weight: 600;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: all 0.4s ease;
+    margin-bottom: 16px;
+    position: relative;
+    /* Needs to be relative so absolute ripples position to it */
+}
+
+/* SVG Checkmark is hidden by default */
+.step-circle svg {
+    display: none;
+    color: white;
+}
+
+/* Colors for specific steps */
+.step-item-1 .step-circle { --step-color: var(--accent-blue); }
+.step-item-2 .step-circle { --step-color: var(--accent-purple); }
+.step-item-3 .step-circle { --step-color: var(--accent-pink); }
+.step-item-4 .step-circle { --step-color: var(--accent-emerald); }
+
+
+/* Content styling */
+.step-content h3 {
+    font-size: 1.05rem;
+    margin: 0 0 6px 0;
+    color: var(--text-secondary);
+    transition: color 0.3s ease;
+}
+
+.step-content p {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    margin: 0;
+    opacity: 0;
+    transform: translateY(5px);
+    transition: all 0.4s ease;
+}
+
+
+/* =========================================
+   State Modifications: ACTIVE Step
+   ========================================= */
+
+/* The active circle gets colored border and shadow */
+#step-1:checked ~ .stepper-wrapper .step-item-1 .step-circle,
+#step-2:checked ~ .stepper-wrapper .step-item-2 .step-circle,
+#step-3:checked ~ .stepper-wrapper .step-item-3 .step-circle,
+#step-4:checked ~ .stepper-wrapper .step-item-4 .step-circle {
+    border-color: var(--step-color);
+    color: var(--step-color);
+    box-shadow: 0 0 0 4px rgba(255,255,255,1), 0 0 0 6px var(--step-color);
+}
+
+/* The active content fades in */
+#step-1:checked ~ .stepper-wrapper .step-item-1 .step-content h3,
+#step-2:checked ~ .stepper-wrapper .step-item-2 .step-content h3,
+#step-3:checked ~ .stepper-wrapper .step-item-3 .step-content h3,
+#step-4:checked ~ .stepper-wrapper .step-item-4 .step-content h3 {
+    color: var(--text-primary);
+}
+
+#step-1:checked ~ .stepper-wrapper .step-item-1 .step-content p,
+#step-2:checked ~ .stepper-wrapper .step-item-2 .step-content p,
+#step-3:checked ~ .stepper-wrapper .step-item-3 .step-content p,
+#step-4:checked ~ .stepper-wrapper .step-item-4 .step-content p {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+
+/* =========================================
+   State Modifications: COMPLETED Steps
+   ========================================= */
+
+/* Any step BEFORE the checked one is considered completed */
+#step-2:checked ~ .stepper-wrapper .step-item-1 .step-circle,
+#step-3:checked ~ .stepper-wrapper .step-item-1 .step-circle,
+#step-3:checked ~ .stepper-wrapper .step-item-2 .step-circle,
+#step-4:checked ~ .stepper-wrapper .step-item-1 .step-circle,
+#step-4:checked ~ .stepper-wrapper .step-item-2 .step-circle,
+#step-4:checked ~ .stepper-wrapper .step-item-3 .step-circle {
+    background: var(--step-color);
+    border-color: var(--step-color);
+}
+
+/* Show checkmark, hide number */
+#step-2:checked ~ .stepper-wrapper .step-item-1 .step-circle svg,
+#step-3:checked ~ .stepper-wrapper .step-item-1 .step-circle svg,
+#step-3:checked ~ .stepper-wrapper .step-item-2 .step-circle svg,
+#step-4:checked ~ .stepper-wrapper .step-item-1 .step-circle svg,
+#step-4:checked ~ .stepper-wrapper .step-item-2 .step-circle svg,
+#step-4:checked ~ .stepper-wrapper .step-item-3 .step-circle svg {
+    display: block;
+}
+
+#step-2:checked ~ .stepper-wrapper .step-item-1 .step-circle .step-num,
+#step-3:checked ~ .stepper-wrapper .step-item-1 .step-circle .step-num,
+#step-3:checked ~ .stepper-wrapper .step-item-2 .step-circle .step-num,
+#step-4:checked ~ .stepper-wrapper .step-item-1 .step-circle .step-num,
+#step-4:checked ~ .stepper-wrapper .step-item-2 .step-circle .step-num,
+#step-4:checked ~ .stepper-wrapper .step-item-3 .step-circle .step-num {
+    display: none;
+}
+
+
+/* =========================================
+   The Ripple-Wave Effect (On Active Step)
+   ========================================= */
+
+.ripple {
+    position: absolute;
+    top: -20px;
+    left: -20px;
+    width: 80px;
+    height: 80px;
+    border-radius: 50%;
+    /* Subtle color, using currentColor allows it to adopt the text color of the parent */
+    border: 2px solid currentColor;
+    /* Start small and invisible */
+    transform: scale(0.5);
+    opacity: 0;
+    pointer-events: none;
+    z-index: -1;
+}
+
+/* Trigger animation only on the currently active step */
+#step-1:checked ~ .stepper-wrapper .step-item-1 .ripple,
+#step-2:checked ~ .stepper-wrapper .step-item-2 .ripple,
+#step-3:checked ~ .stepper-wrapper .step-item-3 .ripple,
+#step-4:checked ~ .stepper-wrapper .step-item-4 .ripple {
+    animation: ripple-pulse 3s cubic-bezier(0.215, 0.61, 0.355, 1) infinite;
+}
+
+/* Stagger the waves to create concentric ripples */
+.r-1 { animation-delay: 0s !important; }
+.r-2 { animation-delay: 1s !important; }
+.r-3 { animation-delay: 2s !important; }
+
+@keyframes ripple-pulse {
+    0% {
+        transform: scale(0.5);
+        opacity: 0.4;
+    }
+    100% {
+        transform: scale(1.5);
+        opacity: 0;
+    }
+}
+
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    .ripple {
+        animation: none !important;
+        display: none;
+    }
+    
+    .stepper-fill, .step-circle, .step-content p, .step-content h3 {
+        transition: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces the CSS Ripple-Wave Stepper designed for Minimalist Tech Layouts, resolving issue #64649. 

### Changes Made:
- Added `submissions/examples/minimalist-tech-ripple-wave-stepper/` directory.
- Created `demo.html` showcasing a mock System Initialization stepper. The layout utilizes the pure CSS radio button hack (`<input type="radio">` paired with `<label>` elements) to manage the progression of the steps without JavaScript.
- Created `style.css` featuring a clean, professional aesthetic utilizing the `Inter` font and distinct blue/purple/pink/emerald accent colors.
  - Implemented the Ripple-Wave system. Inside each `.step-circle`, there are three absolutely positioned `.ripple` elements hidden by default.
  - When a step's radio button is checked, an `@keyframes` animation (`ripple-pulse`) is triggered *only* on the internal ripples of that active step via CSS sibling selectors.
  - The keyframes expand the elements outward while fading their opacity. 
  - Utilized the `currentColor` property on the ripples' borders so they automatically match the specific accent color assigned to their active parent step. Staggered `animation-delay` values (0s, 1s, 2s) ensure the waves are generated continuously and concentrically.
  - Utilized complex sibling selectors to alter the styles of steps appearing *before* the active step, filling them with solid color and swapping the step number for an SVG checkmark to indicate completion.
- Added `README.md` documenting usage and technical features.
- Honors the `prefers-reduced-motion` accessibility standard. The continuous ripple-wave keyframes and transition effects are completely disabled. The interactions safely fall back to static CSS state changes for motion-sensitive users.

Closes #64649
