### PR TITLE
docs: add prefers-reduced-motion guide submission (fixes #62615)

### DIFF
--- a/submissions/docs/prefers-reduced-motion-guide/README.md
+++ b/submissions/docs/prefers-reduced-motion-guide/README.md
@@ -1,0 +1,39 @@
+# Prefers-Reduced-Motion Guide
+
+Fixes #62615 — demonstrates the correct pattern for respecting `prefers-reduced-motion` across animated components.
+
+## Problem
+
+Multiple components in the framework are missing `prefers-reduced-motion` media query support, which violates WCAG 2.1 Success Criterion 2.3.3 and can cause motion sickness for users with vestibular disorders.
+
+## Solution
+
+Every animated component should disable or shorten motion when the user has requested reduced motion at the OS level:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  .component-class {
+    animation: none;
+    transition: none;
+  }
+}
+```
+
+This submission demonstrates the pattern applied to three common animation types:
+
+- A looping spinner (`animation`)
+- An on-load fade-in (`animation`)
+- A hover transition (`transition` + `transform`)
+
+## Files
+
+- `demo.html` — live example with all three animated components
+- `style.css` — includes the components' base animations plus the `prefers-reduced-motion` override block
+
+## How to view
+
+Open `demo.html` in a browser. In Chrome DevTools, open the Rendering tab and set "Emulate CSS media feature prefers-reduced-motion" to `reduce` to see all animations and transitions disable.
+
+## Reference
+
+Components like `modals.css`, `cards.css`, `buttons.css`, `forms.css`, and `command-palette.css` already implement this pattern correctly and were used as a reference for this guide.

--- a/submissions/docs/prefers-reduced-motion-guide/demo.html
+++ b/submissions/docs/prefers-reduced-motion-guide/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Prefers-Reduced-Motion Guide — Demo</title>
+  <link rel="stylesheet" href="../../../core/variables.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body style="padding: 2rem; font-family: sans-serif;">
+
+  <h1>Prefers-Reduced-Motion Guide</h1>
+  <p>
+    Toggle "Reduce motion" in your OS accessibility settings (or emulate
+    <code>prefers-reduced-motion: reduce</code> in devtools) to see all
+    animations and transitions below disable automatically.
+  </p>
+
+  <h2>Spinner</h2>
+  <div class="demo-spinner"></div>
+
+  <h2>Fade-in</h2>
+  <div class="demo-fade-in">
+    <p>This content fades and slides in on load.</p>
+  </div>
+
+  <h2>Button with hover transition</h2>
+  <button class="demo-button">Hover me</button>
+
+</body>
+</html>

--- a/submissions/docs/prefers-reduced-motion-guide/style.css
+++ b/submissions/docs/prefers-reduced-motion-guide/style.css
@@ -1,0 +1,68 @@
+/* ============================================================
+   Prefers-Reduced-Motion Guide
+   Demonstrates the correct pattern for respecting
+   prefers-reduced-motion across animated components.
+   Fixes #62615
+   ============================================================ */
+
+.demo-spinner {
+  width: 40px;
+  height: 40px;
+  border: 4px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-top-color: var(--ease-color-primary, #6c63ff);
+  border-radius: 50%;
+  animation: demo-spin 0.8s linear infinite;
+}
+
+@keyframes demo-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.demo-fade-in {
+  animation: demo-fade 0.6s ease-out;
+}
+
+@keyframes demo-fade {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.demo-button {
+  background: var(--ease-color-primary, #6c63ff);
+  color: var(--ease-color-surface, #ffffff);
+  border: none;
+  border-radius: var(--ease-radius-md, 0.5rem);
+  padding: var(--ease-space-3, 0.75rem) var(--ease-space-5, 1.25rem);
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.demo-button:hover {
+  transform: translateY(-2px);
+  background: var(--ease-color-primary-dark, #4b44cc);
+}
+
+/* ── The fix ──────────────────────────────────────────────
+   Every animated component should disable or shorten motion
+   when the user has requested reduced motion at the OS level.
+   ───────────────────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .demo-spinner,
+  .demo-fade-in,
+  .demo-button {
+    animation: none;
+    transition: none;
+  }
+
+  .demo-button:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a documentation submission demonstrating the correct pattern for respecting `prefers-reduced-motion` in animated components.
Closes #62615.

---

## Type of Change
- [x] 📝 Documentation improvement

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/docs/prefers-reduced-motion-guide/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A reference example showing how to wrap animations and transitions in a `prefers-reduced-motion: reduce` media query so motion-sensitive users aren't affected.

**How does a developer use it?**
```html
<div class="demo-spinner"></div>
<div class="demo-fade-in">Content</div>
<button class="demo-button">Hover me</button>
```

**Why does it fit EaseMotion CSS?**
As an animation-first framework, EaseMotion CSS should model accessible-by-default motion. This guide gives contributors a copy-pasteable pattern for disabling `animation`/`transition` under reduced motion, matching how `modals.css`, `cards.css`, `buttons.css`, `forms.css`, and `command-palette.css` already handle it.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

---

## Notes for Maintainer
This addresses #62615 as a documentation/reference submission rather than editing the listed `components/*.css` files directly, since the submission checklist explicitly disallows changes to `components/`. I noticed issue #62615 also has two linked PRs from saidai-bhuvanesh already open against the same issue — happy to close this one if that work already covers it, or if you'd prefer the fix applied directly to `components/` instead of as a reference guide, let me know and I'll adjust.