### PR TITLE
feat: add ripple wave interactive button component

### DIFF
--- a/submissions/examples/ease-motion-ripple-wave-interactive-button-gssoc2026/README.md
+++ b/submissions/examples/ease-motion-ripple-wave-interactive-button-gssoc2026/README.md
@@ -1,0 +1,22 @@
+# Ripple Wave Interactive Button - EaseMotion CSS
+
+A micro-interaction action button component with pure CSS `:active` pseudo-element ripple expansion.
+
+## 1. What does this do?
+This component renders tactile action buttons that output expanding circular ripple wave feedback on mouse clicks and key presses.
+
+## 2. How is it used?
+Link `style.css` and wrap button labels inside a `.ripple-btn` element:
+
+```html
+<link rel="stylesheet" href="style.css">
+
+<button class="ripple-btn ripple-primary">
+  <span>Click Me</span>
+</button>
+```
+
+## 3. Why is it useful?
+- **Zero JavaScript:** Achieves radial ripple explosion effects using pure CSS pseudo-elements (`::after`).
+- **Tactile Feedback:** Enhances visual responsiveness for user submit and action triggers.
+- **Focus Visible Styling:** Includes explicit focus ring styles for WCAG accessibility.

--- a/submissions/examples/ease-motion-ripple-wave-interactive-button-gssoc2026/demo.html
+++ b/submissions/examples/ease-motion-ripple-wave-interactive-button-gssoc2026/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ripple Wave Interactive Button - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="button-showcase">
+    <header class="showcase-header">
+      <h1>Ripple Wave Button Collection</h1>
+      <p>Pure CSS pseudo-element wave expansion triggers micro-feedback on active and focus states.</p>
+    </header>
+
+    <div class="button-grid">
+      <button class="ripple-btn ripple-primary">
+        <span>Launch Console</span>
+      </button>
+
+      <button class="ripple-btn ripple-secondary">
+        <span>Download Artifacts</span>
+      </button>
+
+      <button class="ripple-btn ripple-accent">
+        <span>Deploy Cluster</span>
+      </button>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-motion-ripple-wave-interactive-button-gssoc2026/style.css
+++ b/submissions/examples/ease-motion-ripple-wave-interactive-button-gssoc2026/style.css
@@ -1,0 +1,103 @@
+:root {
+  --bg-dark: #080c14;
+  --btn-primary: #8b5cf6;
+  --btn-secondary: #06b6d4;
+  --btn-accent: #ec4899;
+  --text-main: #f8fafc;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  background-color: var(--bg-dark);
+  color: var(--text-main);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem;
+}
+
+.button-showcase {
+  max-width: 800px;
+  width: 100%;
+  text-align: center;
+}
+
+.showcase-header h1 {
+  font-size: 2.25rem;
+  margin-bottom: 0.5rem;
+  background: linear-gradient(135deg, #a78bfa, #f472b6);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.showcase-header p {
+  color: #94a3b8;
+  margin-bottom: 3rem;
+}
+
+.button-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  justify-content: center;
+}
+
+.ripple-btn {
+  position: relative;
+  padding: 1rem 2rem;
+  font-size: 1rem;
+  font-weight: 700;
+  border: none;
+  border-radius: 0.75rem;
+  color: #fff;
+  cursor: pointer;
+  overflow: hidden;
+  outline: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ripple-primary { background: var(--btn-primary); box-shadow: 0 4px 15px rgba(139, 92, 246, 0.4); }
+.ripple-secondary { background: var(--btn-secondary); box-shadow: 0 4px 15px rgba(6, 182, 212, 0.4); }
+.ripple-accent { background: var(--btn-accent); box-shadow: 0 4px 15px rgba(236, 72, 153, 0.4); }
+
+.ripple-btn span {
+  position: relative;
+  z-index: 2;
+}
+
+.ripple-btn::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 0;
+  height: 0;
+  background: rgba(255, 255, 255, 0.35);
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  opacity: 0;
+  transition: width 0.6s ease-out, height 0.6s ease-out, opacity 0.6s ease-out;
+}
+
+.ripple-btn:active::after {
+  width: 300px;
+  height: 300px;
+  opacity: 1;
+  transition: 0s;
+}
+
+.ripple-btn:hover {
+  transform: translateY(-3px);
+}
+
+.ripple-btn:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 4px;
+}


### PR DESCRIPTION
# Related Issue
Closes #66044 

# Summary
Adds a Ripple Wave Interactive Button component using pure CSS pseudo-element scale transitions.

# Changes Made
- Created `demo.html` showcasing primary, secondary, and accent ripple buttons.
- Created `style.css` with `:active::after` radial scale expansion and focus-visible rings.
- Created `README.md` documenting usage instructions and zero-JS advantages.

# Testing
- Verified ripple animation on mouse clicks and keyboard spacebar triggers.
- Inspected focus ring visibility during keyboard navigation.
- Tested color contrast across button theme variations.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered
