### PR TITLE
feat(submissions): add holographic glass card example

### DIFF
--- a/submissions/examples/holographic-glass-card-gssoc/README.md
+++ b/submissions/examples/holographic-glass-card-gssoc/README.md
@@ -1,0 +1,17 @@
+# Holographic Glass Card
+
+1. **What does this do?**  
+Adds a glassmorphism card container with dynamic holographic shimmer reflections and subtle 3D hover elevation.
+
+2. **How is it used?**  
+Apply the `.holographic-card` class to a wrapper element containing card content:
+```html
+<div class="holographic-card">
+  <div class="holographic-sheen"></div>
+  <h2>Card Title</h2>
+  <p>Card description text...</p>
+</div>
+```
+
+3. **Why is it useful?**  
+It provides a state-of-the-art visual container for hero highlights, pricing tiers, or web3/tech feature showcases while maintaining accessibility through `prefers-reduced-motion` compliance.

--- a/submissions/examples/holographic-glass-card-gssoc/demo.html
+++ b/submissions/examples/holographic-glass-card-gssoc/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Holographic Glass Card Demo</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="demo-wrapper">
+    <div class="holographic-card">
+      <div class="holographic-sheen"></div>
+      
+      <div class="card-header">
+        <span class="card-badge">PRO PASS</span>
+        <span class="card-status-dot"></span>
+      </div>
+
+      <div class="card-body">
+        <h2 class="card-title">Cybernetic Access</h2>
+        <p class="card-subtitle">Next-generation motion interface with real-time holographic shimmer reflections.</p>
+
+        <ul class="card-features">
+          <li class="feature-item">
+            <span class="feature-icon">✦</span>
+            <span>Zero-latency CSS shaders</span>
+          </li>
+          <li class="feature-item">
+            <span class="feature-icon">✦</span>
+            <span>Hardware accelerated blur</span>
+          </li>
+          <li class="feature-item">
+            <span class="feature-icon">✦</span>
+            <span>Adaptive reduced motion</span>
+          </li>
+        </ul>
+      </div>
+
+      <div class="card-footer">
+        <button type="button" class="card-button">
+          <span>Activate Node</span>
+          <span class="button-arrow">→</span>
+        </button>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/holographic-glass-card-gssoc/style.css
+++ b/submissions/examples/holographic-glass-card-gssoc/style.css
@@ -1,0 +1,214 @@
+/* Reset and layout setup */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  align-items: center;
+  background-color: #0b0f19;
+  background-image:
+    radial-gradient(circle at 15% 20%, rgba(99, 102, 241, 0.25) 0%, transparent 40%),
+    radial-gradient(circle at 85% 80%, rgba(236, 72, 153, 0.2) 0%, transparent 40%);
+  color: #f8fafc;
+  display: flex;
+  font-family: system-ui, -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 1.5rem;
+}
+
+.demo-wrapper {
+  perspective: 1000px;
+}
+
+/* Holographic Glass Card */
+.holographic-card {
+  background: rgba(255, 255, 255, 0.05);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 20px;
+  box-shadow:
+    0 20px 40px rgba(0, 0, 0, 0.4),
+    inset 0 1px 0 rgba(255, 255, 255, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  max-width: 360px;
+  overflow: hidden;
+  padding: 2rem;
+  position: relative;
+  transition: transform 400ms cubic-bezier(0.16, 1, 0.3, 1), box-shadow 400ms ease, border-color 400ms ease;
+  width: 100%;
+}
+
+/* Holographic Shimmer Overlay */
+.holographic-sheen {
+  background: linear-gradient(
+    135deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.05) 30%,
+    rgba(147, 197, 253, 0.25) 45%,
+    rgba(244, 114, 182, 0.25) 55%,
+    rgba(255, 255, 255, 0.05) 70%,
+    transparent 100%
+  );
+  background-size: 200% 200%;
+  inset: 0;
+  opacity: 0.6;
+  pointer-events: none;
+  position: absolute;
+  transition: opacity 400ms ease;
+}
+
+.holographic-card:hover {
+  border-color: rgba(147, 197, 253, 0.4);
+  box-shadow:
+    0 30px 60px rgba(0, 0, 0, 0.5),
+    0 0 30px rgba(99, 102, 241, 0.2),
+    inset 0 1px 0 rgba(255, 255, 255, 0.4);
+  transform: translateY(-8px) rotateX(4deg) rotateY(-2deg) scale(1.02);
+}
+
+.holographic-card:hover .holographic-sheen {
+  animation: holo-shimmer 2.5s infinite linear;
+  opacity: 1;
+}
+
+@keyframes holo-shimmer {
+  0% {
+    background-position: 200% 0%;
+  }
+
+  100% {
+    background-position: -200% 100%;
+  }
+}
+
+/* Card Content Elements */
+.card-header {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  z-index: 1;
+}
+
+.card-badge {
+  background: rgba(99, 102, 241, 0.2);
+  border: 1px solid rgba(129, 140, 248, 0.4);
+  border-radius: 9999px;
+  color: #a5b4fc;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  padding: 0.35rem 0.85rem;
+  text-transform: uppercase;
+}
+
+.card-status-dot {
+  background-color: #34d399;
+  border-radius: 50%;
+  box-shadow: 0 0 8px #34d399;
+  height: 8px;
+  width: 8px;
+}
+
+.card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  z-index: 1;
+}
+
+.card-title {
+  color: #ffffff;
+  font-size: 1.5rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.card-subtitle {
+  color: #94a3b8;
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+.card-features {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  list-style: none;
+  margin-top: 0.5rem;
+}
+
+.feature-item {
+  align-items: center;
+  color: #cbd5e1;
+  display: flex;
+  font-size: 0.85rem;
+  gap: 0.6rem;
+}
+
+.feature-icon {
+  color: #818cf8;
+}
+
+/* Interactive CTA Button */
+.card-footer {
+  margin-top: 0.5rem;
+  z-index: 1;
+}
+
+.card-button {
+  align-items: center;
+  background: linear-gradient(135deg, #6366f1 0%, #a855f7 100%);
+  border: none;
+  border-radius: 12px;
+  color: #ffffff;
+  cursor: pointer;
+  display: flex;
+  font-size: 0.9rem;
+  font-weight: 600;
+  justify-content: center;
+  padding: 0.85rem 1.25rem;
+  position: relative;
+  transition: filter 200ms ease, transform 200ms ease;
+  width: 100%;
+}
+
+.card-button:hover {
+  filter: brightness(1.15);
+  transform: translateY(-2px);
+}
+
+.card-button:active {
+  transform: translateY(0);
+}
+
+.button-arrow {
+  margin-left: 0.5rem;
+  transition: transform 200ms ease;
+}
+
+.card-button:hover .button-arrow {
+  transform: translateX(4px);
+}
+
+/* Accessibility: Respect Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+  .holographic-card,
+  .holographic-sheen,
+  .card-button,
+  .button-arrow {
+    animation: none !important;
+    transition: none !important;
+  }
+
+  .holographic-card:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #66055

Adds a standalone glassmorphism holographic card example submission under `submissions/examples/holographic-glass-card-gssoc/`. The component features custom backdrop-filter blur, dynamic holographic shimmer gradient keyframes, subtle 3D hover perspective transform, interactive call-to-action button styling, and `@media (prefers-reduced-motion: reduce)` accessibility support.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A glassmorphism card container with real-time holographic shimmer reflections and 3D hover elevation.

**How does a developer use it?**

```html
<div class="holographic-card">
  <div class="holographic-sheen"></div>
  <h2>Card Title</h2>
  <p>Card description text...</p>
</div>
```

**Why does it fit EaseMotion CSS?**

It provides an expressive, animation-first card container that enhances visual hierarchy and micro-interactions without requiring JavaScript dependencies.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

- Ran `npm run release:check` locally stylelint, duplicate keyframe checks, Vitest (61/61 tests), and package pack dry-run all passed 100% cleanly.
- Raw CSS in `style.css` intentionally omits `ease-` prefix in accordance with contributor rules for maintainer standardization.
