### PR TITLE
feat: add CSS Morph-Glow Dropdown for Minimalist Tech Layouts (#64590)

### DIFF
--- a/submissions/examples/minimalist-tech-morph-glow-dropdown/README.md
+++ b/submissions/examples/minimalist-tech-morph-glow-dropdown/README.md
@@ -1,0 +1,22 @@
+# CSS Morph-Glow Dropdown (Minimalist Tech)
+
+A pure CSS interactive dropdown component designed for Minimalist Tech Layouts. It features a sophisticated "Morph-Glow" entrance animation, where the menu structurally morphs from a small, highly rounded pill shape into a full rectangular menu, followed by a continuous ambient blue glow.
+
+## Features
+- Pure CSS and HTML (No JavaScript required for interactions or animations).
+- **Minimalist Aesthetic**: Clean layout, sharp `Inter` typography, distinct accent-colored icon boxes, and categorized sections separated by subtle borders.
+- **State Management**: The opening and closing of the dropdown is handled entirely via a hidden checkbox hack (`<input type="checkbox">`). A `<label>` acts as the trigger button.
+- **The Morph-Glow Entrance Effect**: 
+- A dedicated utility class `.morph-glow` handles the animation on the dropdown menu container.
+- We chain two `@keyframes` animations when the menu is opened.
+- The first animation (`menu-morph`) handles the structural entrance. The menu starts small and highly rounded (`transform: scale(0.6)`, `border-radius: 40px`). It then scales up and morphs its `border-radius` down to `12px`. We use a bouncy `cubic-bezier(0.175, 0.885, 0.32, 1.275)` timing function to give this morph a physical, elastic pop.
+- The second animation (`ambient-glow`) runs infinitely (`infinite alternate`) after the morph finishes. It pulses a soft, tech-blue `box-shadow` to visually indicate that the menu is active and awaiting interaction.
+- The inner menu content has a slight delayed fade-in (`content-fade`) to ensure the text doesn't look squished during the initial morph phase.
+- Fully accessible with `prefers-reduced-motion` support. For motion-sensitive users, the morphing scale, shape changes, and infinite glow are completely disabled, safely falling back to a simple, immediate opacity fade and a static drop shadow.
+
+## Usage
+Open `demo.html` in your browser. You will see a mock "Deploy Project" action button. Click the button to toggle the dropdown. Watch closely as the menu expands and morphs its shape, followed by the soft blue ambient glow. Click the button again to close it.
+
+## Files
+- `demo.html`: The HTML structure for the dropdown, detailing the pure CSS checkbox hack setup required for JS-free state management.
+- `style.css`: The styling, minimalist tech design tokens, the chained `@keyframes` driving the morph and glow effects, and the delayed content fade logic.

--- a/submissions/examples/minimalist-tech-morph-glow-dropdown/demo.html
+++ b/submissions/examples/minimalist-tech-morph-glow-dropdown/demo.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Morph-Glow Dropdown - Minimalist Tech</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Action Menu</h1>
+            <p class="subtitle">A minimalist tech dropdown featuring a fluid morphing entrance and continuous ambient glow.</p>
+        </header>
+
+        <div class="dashboard-area">
+            
+            <div class="card">
+                
+                <!-- 
+                   Pure CSS State Management for Dropdown 
+                   We use a checkbox to toggle the state of the dropdown menu.
+                   We place it in a wrapper so clicking outside the menu (if we used an overlay) 
+                   or toggling the label works.
+                -->
+                <div class="dropdown-wrapper">
+                    <input type="checkbox" id="dropdown-toggle" class="dropdown-input">
+                    
+                    <label for="dropdown-toggle" class="btn btn-trigger">
+                        <span>Deploy Project</span>
+                        <svg class="chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <polyline points="6 9 12 15 18 9"></polyline>
+                        </svg>
+                    </label>
+
+                    <!-- The Dropdown Menu -->
+                    <div class="dropdown-menu morph-glow">
+                        <div class="menu-content">
+                            
+                            <div class="menu-section">
+                                <span class="section-title">Environments</span>
+                                <a href="#" class="menu-item">
+                                    <div class="icon-box color-emerald"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><polyline points="12 6 12 12 16 14"></polyline></svg></div>
+                                    <div class="item-text">
+                                        <span class="main">Production</span>
+                                        <span class="sub">main branch</span>
+                                    </div>
+                                </a>
+                                <a href="#" class="menu-item">
+                                    <div class="icon-box color-blue"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><polyline points="12 6 12 12 16 14"></polyline></svg></div>
+                                    <div class="item-text">
+                                        <span class="main">Staging</span>
+                                        <span class="sub">dev branch</span>
+                                    </div>
+                                </a>
+                            </div>
+
+                            <div class="menu-divider"></div>
+
+                            <div class="menu-section">
+                                <span class="section-title">Options</span>
+                                <a href="#" class="menu-item">
+                                    <div class="icon-box color-purple"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect><path d="M7 11V7a5 5 0 0 1 10 0v4"></path></svg></div>
+                                    <div class="item-text">
+                                        <span class="main">Run Security Scan</span>
+                                    </div>
+                                </a>
+                                <a href="#" class="menu-item">
+                                    <div class="icon-box color-pink"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 2v6h-6"></path><path d="M3 12a9 9 0 1 0 2.13-5.88L2 10"></path></svg></div>
+                                    <div class="item-text">
+                                        <span class="main">Clear CDN Cache</span>
+                                    </div>
+                                </a>
+                            </div>
+
+                        </div>
+                    </div> <!-- End Dropdown Menu -->
+                </div> <!-- End Dropdown Wrapper -->
+                
+            </div>
+            
+        </div>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/minimalist-tech-morph-glow-dropdown/style.css
+++ b/submissions/examples/minimalist-tech-morph-glow-dropdown/style.css
@@ -1,0 +1,294 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&display=swap');
+
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    --border-color: #e2e8f0;
+    
+    /* Tech Minimalist Accents */
+    --accent-blue: #0ea5e9;
+    --accent-purple: #8b5cf6;
+    --accent-pink: #ec4899;
+    --accent-emerald: #10b981;
+    
+    --surface-white: #ffffff;
+    --surface-hover: #f1f5f9;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    width: 100%;
+    padding: 40px 20px;
+}
+
+.section-header {
+    text-align: center;
+    margin-bottom: 50px;
+}
+
+.title {
+    font-size: 2rem;
+    font-weight: 600;
+    margin: 0 0 12px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    margin: 0;
+}
+
+
+/* =========================================
+   Card Styling (Environment)
+   ========================================= */
+
+.card {
+    background: var(--surface-white);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 120px 40px; /* Lots of padding to give dropdown room */
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+    display: flex;
+    justify-content: center;
+}
+
+
+/* =========================================
+   Dropdown Structure & Logic
+   ========================================= */
+
+.dropdown-wrapper {
+    position: relative;
+    display: inline-block;
+}
+
+.dropdown-input {
+    display: none;
+}
+
+.btn-trigger {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 24px;
+    background: var(--text-primary);
+    color: white;
+    border-radius: 8px;
+    font-size: 1rem;
+    font-weight: 500;
+    cursor: pointer;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+    transition: background 0.2s ease, transform 0.2s ease;
+    user-select: none;
+}
+
+.btn-trigger:hover {
+    background: #1e293b;
+    transform: translateY(-1px);
+}
+
+.chevron {
+    width: 16px;
+    height: 16px;
+    transition: transform 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+/* Rotate Chevron on Open */
+.dropdown-input:checked + .btn-trigger .chevron {
+    transform: rotate(180deg);
+}
+
+
+/* =========================================
+   Dropdown Menu Styling
+   ========================================= */
+
+.dropdown-menu {
+    position: absolute;
+    top: calc(100% + 12px); /* Offset below button */
+    left: 50%;
+    transform: translateX(-50%); /* Center horizontally */
+    width: 260px;
+    background: var(--surface-white);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    
+    /* 
+      We hide it initially. 
+      Visibility and pointer-events ensure it can't be interacted with while hidden.
+    */
+    visibility: hidden;
+    pointer-events: none;
+    z-index: 50;
+}
+
+.menu-content {
+    padding: 8px 0;
+}
+
+.menu-section {
+    padding: 4px 0;
+}
+
+.section-title {
+    display: block;
+    padding: 8px 16px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-secondary);
+}
+
+.menu-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 16px;
+    text-decoration: none;
+    transition: background 0.2s ease;
+}
+
+.menu-item:hover {
+    background: var(--surface-hover);
+}
+
+.icon-box {
+    width: 32px;
+    height: 32px;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.icon-box svg { width: 16px; height: 16px; }
+
+.color-blue { background: rgba(14, 165, 233, 0.1); color: var(--accent-blue); }
+.color-purple { background: rgba(139, 92, 246, 0.1); color: var(--accent-purple); }
+.color-pink { background: rgba(236, 72, 153, 0.1); color: var(--accent-pink); }
+.color-emerald { background: rgba(16, 185, 129, 0.1); color: var(--accent-emerald); }
+
+.item-text {
+    display: flex;
+    flex-direction: column;
+}
+
+.item-text .main {
+    font-size: 0.95rem;
+    font-weight: 500;
+    color: var(--text-primary);
+}
+
+.item-text .sub {
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    margin-top: 2px;
+}
+
+.menu-divider {
+    height: 1px;
+    background: var(--border-color);
+    margin: 4px 0;
+}
+
+
+/* =========================================
+   The Morph-Glow Animation
+   ========================================= */
+
+/* State when checked (open) */
+.dropdown-input:checked ~ .morph-glow {
+    visibility: visible;
+    pointer-events: auto;
+    
+    /* 
+       1. menu-morph: A complex keyframe that scales and shapes the container.
+       2. ambient-glow: An infinite pulsing box-shadow indicating it's active.
+    */
+    animation: menu-morph 0.6s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards,
+               ambient-glow 3s ease-in-out infinite alternate;
+}
+
+/* We also need to fade the content in slightly after the morph starts */
+.dropdown-input:checked ~ .morph-glow .menu-content {
+    opacity: 0;
+    animation: content-fade 0.4s ease forwards 0.15s; /* Slight delay */
+}
+
+
+/* 
+  The menu starts as a small, highly rounded pill shape and 
+  morphs into its full rectangular size.
+*/
+@keyframes menu-morph {
+    0% {
+        opacity: 0;
+        /* Start small and very rounded */
+        transform: translateX(-50%) scale(0.6) translateY(-20px);
+        border-radius: 40px; 
+    }
+    50% {
+        opacity: 1;
+        /* Keep it somewhat rounded as it expands */
+        border-radius: 20px;
+    }
+    100% {
+        opacity: 1;
+        /* Final state */
+        transform: translateX(-50%) scale(1) translateY(0);
+        border-radius: 12px;
+    }
+}
+
+/* 
+  A continuous, soft, tech-blue glow indicating the menu is open and active.
+*/
+@keyframes ambient-glow {
+    0% {
+        box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.1), 0 0 0 0 rgba(14, 165, 233, 0);
+    }
+    100% {
+        box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.1), 0 0 20px 0 rgba(14, 165, 233, 0.15);
+    }
+}
+
+@keyframes content-fade {
+    to { opacity: 1; }
+}
+
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    .dropdown-input:checked ~ .morph-glow {
+        animation: simple-fade 0.2s ease forwards !important;
+        box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.1); /* Static shadow */
+    }
+    
+    .dropdown-input:checked ~ .morph-glow .menu-content {
+        animation: none !important;
+        opacity: 1;
+    }
+    
+    @keyframes simple-fade {
+        0% { opacity: 0; transform: translateX(-50%) translateY(-10px); }
+        100% { opacity: 1; transform: translateX(-50%) translateY(0); }
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces the CSS Morph-Glow Dropdown designed for Minimalist Tech Layouts, resolving issue #64590. 

### Changes Made:
- Added `submissions/examples/minimalist-tech-morph-glow-dropdown/` directory.
- Created `demo.html` showcasing a mock "Deploy Project" action menu. The layout utilizes a pure CSS checkbox hack (`<input type="checkbox">`) to allow users to toggle the dropdown open and closed without JavaScript.
- Created `style.css` featuring a clean, professional aesthetic utilizing the `Inter` font, distinct accent-colored icon boxes, and categorized sections separated by subtle borders.
  - Implemented the Morph-Glow system. A dedicated utility class `.morph-glow` handles the animation on the dropdown menu container.
  - Chained two `@keyframes` animations together.
  - The first animation (`menu-morph`) handles the structural entrance. The menu starts small and highly rounded (`transform: scale(0.6)`, `border-radius: 40px`). It then scales up and morphs its `border-radius` down to a standard rectangle. We use a bouncy `cubic-bezier` timing function to give this morph a physical, elastic pop.
  - The second animation (`ambient-glow`) runs infinitely after the morph finishes, pulsing a soft, tech-blue `box-shadow` to visually indicate that the menu is active.
  - Delayed the inner menu content fade-in (`content-fade`) to ensure the text doesn't look squished during the initial structural morph phase.
- Added `README.md` documenting usage and technical features.
- Honors the `prefers-reduced-motion` accessibility standard. The morphing scale, shape changes, and infinite glow are completely disabled, safely falling back to a simple, immediate opacity fade and a static drop shadow for motion-sensitive users.

Closes #64590
