### PR TITLE
feat: add CSS Scale-Hover Dropdown for Minimalist Tech Layouts (#64582)

### DIFF
--- a/submissions/examples/minimalist-tech-scale-hover-dropdown/README.md
+++ b/submissions/examples/minimalist-tech-scale-hover-dropdown/README.md
@@ -1,0 +1,23 @@
+# CSS Scale-Hover Dropdown (Minimalist Tech)
+
+A pure CSS interactive dropdown component designed for Minimalist Tech Layouts. It focuses on providing tactile, responsive feedback by utilizing a bouncy "Scale-Hover" interaction on both the trigger button and the individual menu items.
+
+## Features
+- Pure CSS and HTML (No JavaScript required for interactions or animations).
+- **Minimalist Tech Aesthetic**: Clean layout, sharp `Inter` typography, robust subtitle descriptors, and distinct accent-colored icon boxes.
+- **State Management**: The opening and closing of the dropdown is handled entirely via a hidden checkbox hack (`<input type="checkbox">`). A `<label>` acts as the trigger button.
+- **The Scale-Hover Effect**: 
+- A dedicated utility class `.scale-hover-item` handles the interaction styling on the targeted elements.
+- Uses `transition: transform 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275)` to smoothly manage scale changes with a slight bouncy physical spring.
+- On `:hover`, the trigger button expands slightly (`transform: scale(1.03)`). 
+- Crucially, when hovering over individual `.menu-item` elements, they also scale up (`scale(1.03)`) and lift off the menu background by dynamically applying a `box-shadow` and a subtle `border`. This creates a satisfying, physical "card pop" effect.
+- We utilize a transparent `border: 1px solid transparent` on the base `.menu-item` state to ensure the physical dimensions of the element don't jump when the colored border is applied on hover.
+- On `:active` (when the mouse is clicked down), elements slightly depress (`transform: scale(0.97) !important`) to provide universal tactile, button-like feedback.
+- Fully accessible with `prefers-reduced-motion` support. For motion-sensitive users, the hover/active scaling transitions, the dynamic drop shadows, and the icon rotations are completely disabled to prevent sudden screen movement. The menu items safely fall back to a simple, color-only hover state.
+
+## Usage
+Open `demo.html` in your browser. You will see a mock "Export Data" action button. Hover over it to feel the slight bounce, then click it to toggle the dropdown. Once open, run your mouse down the list items to experience the satisfying, physical "card pop" scaling effect. Try clicking them to feel the tactile depression feedback.
+
+## Files
+- `demo.html`: The HTML structure for the dropdown, detailing the pure CSS checkbox hack setup and the application of the `.scale-hover-item` utility class across varying element types.
+- `style.css`: The styling, minimalist tech design tokens, the specific CSS transition logic driving the smooth scale interactions, and the jitter-prevention border logic on the list items.

--- a/submissions/examples/minimalist-tech-scale-hover-dropdown/demo.html
+++ b/submissions/examples/minimalist-tech-scale-hover-dropdown/demo.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Scale-Hover Dropdown - Minimalist Tech</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Export Menu</h1>
+            <p class="subtitle">A minimalist tech dropdown featuring tactile scale-hover feedback on menu items.</p>
+        </header>
+
+        <div class="dashboard-area">
+            
+            <div class="card">
+                
+                <!-- 
+                   Pure CSS State Management for Dropdown 
+                   We use a checkbox to toggle the state of the dropdown menu.
+                -->
+                <div class="dropdown-wrapper">
+                    <input type="checkbox" id="dropdown-toggle" class="dropdown-input">
+                    
+                    <label for="dropdown-toggle" class="btn btn-trigger scale-hover-item">
+                        <svg class="icon-download" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                            <polyline points="7 10 12 15 17 10"></polyline>
+                            <line x1="12" y1="15" x2="12" y2="3"></line>
+                        </svg>
+                        <span>Export Data</span>
+                        <svg class="chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <polyline points="6 9 12 15 18 9"></polyline>
+                        </svg>
+                    </label>
+
+                    <!-- The Dropdown Menu -->
+                    <div class="dropdown-menu simple-fade">
+                        <div class="menu-content">
+                            
+                            <div class="menu-header">
+                                <span>Export Format</span>
+                            </div>
+                            
+                            <a href="#" class="menu-item scale-hover-item">
+                                <div class="item-icon color-blue">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+                                </div>
+                                <div class="item-text">
+                                    <span class="main">CSV Document</span>
+                                    <span class="sub">Raw tabular data</span>
+                                </div>
+                            </a>
+                            
+                            <a href="#" class="menu-item scale-hover-item">
+                                <div class="item-icon color-emerald">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+                                </div>
+                                <div class="item-text">
+                                    <span class="main">Excel Spreadsheet</span>
+                                    <span class="sub">Formatted .xlsx file</span>
+                                </div>
+                            </a>
+                            
+                            <a href="#" class="menu-item scale-hover-item">
+                                <div class="item-icon color-purple">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+                                </div>
+                                <div class="item-text">
+                                    <span class="main">JSON Array</span>
+                                    <span class="sub">For API integrations</span>
+                                </div>
+                            </a>
+
+                        </div>
+                    </div> <!-- End Dropdown Menu -->
+                </div> <!-- End Dropdown Wrapper -->
+                
+            </div>
+            
+        </div>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/minimalist-tech-scale-hover-dropdown/style.css
+++ b/submissions/examples/minimalist-tech-scale-hover-dropdown/style.css
@@ -1,0 +1,315 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&display=swap');
+
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    --border-color: #e2e8f0;
+    
+    /* Tech Minimalist Accents */
+    --accent-blue: #0ea5e9;
+    --accent-emerald: #10b981;
+    --accent-purple: #8b5cf6;
+    
+    --surface-white: #ffffff;
+    --surface-hover: #f1f5f9;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    width: 100%;
+    padding: 40px 20px;
+}
+
+.section-header {
+    text-align: center;
+    margin-bottom: 50px;
+}
+
+.title {
+    font-size: 2rem;
+    font-weight: 600;
+    margin: 0 0 12px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    margin: 0;
+}
+
+
+/* =========================================
+   Card Styling (Environment)
+   ========================================= */
+
+.card {
+    background: var(--surface-white);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 120px 40px; /* Lots of padding to give dropdown room */
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+    display: flex;
+    justify-content: center;
+}
+
+
+/* =========================================
+   Dropdown Structure & Logic
+   ========================================= */
+
+.dropdown-wrapper {
+    position: relative;
+    display: inline-block;
+}
+
+.dropdown-input {
+    display: none;
+}
+
+.btn-trigger {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 24px;
+    background: var(--surface-white);
+    color: var(--text-primary);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    font-size: 0.95rem;
+    font-weight: 500;
+    cursor: pointer;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.02);
+    user-select: none;
+}
+
+.icon-download {
+    width: 18px;
+    height: 18px;
+    color: var(--text-primary);
+}
+
+.chevron {
+    width: 16px;
+    height: 16px;
+    color: var(--text-secondary);
+    transition: transform 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+/* Rotate Chevron on Open */
+.dropdown-input:checked + .btn-trigger .chevron {
+    transform: rotate(180deg);
+}
+
+
+/* =========================================
+   Dropdown Menu Styling
+   ========================================= */
+
+.dropdown-menu {
+    position: absolute;
+    top: calc(100% + 12px); /* Offset below button */
+    left: 50%;
+    transform: translateX(-50%); /* Center horizontally */
+    width: 260px;
+    background: var(--surface-white);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.1);
+    
+    /* 
+      We hide it initially. 
+      Visibility and pointer-events ensure it can't be interacted with while hidden.
+    */
+    visibility: hidden;
+    pointer-events: none;
+    z-index: 50;
+}
+
+.menu-content {
+    padding: 12px;
+}
+
+
+/* Menu Header */
+.menu-header {
+    margin-bottom: 8px;
+    padding: 0 8px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-secondary);
+}
+
+
+/* Interactive Checkbox Items */
+.menu-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 10px;
+    border-radius: 8px;
+    cursor: pointer;
+    text-decoration: none;
+    user-select: none;
+    margin-bottom: 4px; /* Slight gap between items */
+}
+
+.item-icon {
+    width: 36px;
+    height: 36px;
+    border-radius: 8px;
+    background: var(--surface-hover);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    transition: background 0.3s ease;
+}
+
+.item-icon svg { width: 18px; height: 18px; }
+
+.color-emerald { color: var(--accent-emerald); background: rgba(16, 185, 129, 0.1); }
+.color-blue { color: var(--accent-blue); background: rgba(14, 165, 233, 0.1); }
+.color-purple { color: var(--accent-purple); background: rgba(139, 92, 246, 0.1); }
+
+.item-text {
+    display: flex;
+    flex-direction: column;
+}
+
+.item-text .main {
+    font-size: 0.95rem;
+    font-weight: 500;
+    color: var(--text-primary);
+}
+
+.item-text .sub {
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    margin-top: 2px;
+}
+
+
+/* =========================================
+   The Scale-Hover Effect Logic
+   ========================================= */
+
+/* Apply base transition to all target elements */
+.scale-hover-item {
+    transition: transform 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275), 
+                box-shadow 0.3s ease, 
+                background-color 0.3s ease,
+                border-color 0.3s ease;
+    
+    transform-origin: center center; 
+}
+
+
+/* Specific Hover Behaviors */
+
+.btn-trigger.scale-hover-item:hover {
+    transform: scale(1.03);
+    background: var(--surface-hover);
+    border-color: #cbd5e1;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+}
+
+.menu-item.scale-hover-item:hover {
+    background: var(--surface-white);
+    /* Scale up the menu item slightly */
+    transform: scale(1.03);
+    /* Add a shadow to lift it off the menu background */
+    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.08), 0 4px 6px -2px rgba(0, 0, 0, 0.04);
+    /* Add a subtle border to define it */
+    border: 1px solid var(--border-color);
+    z-index: 2; /* Ensure shadow sits above siblings */
+}
+
+/* 
+  Because we add a border on hover, we must subtract it from the padding 
+  on the base state, otherwise the item will jitter physically in the DOM 
+  when hovered. 
+*/
+.menu-item {
+    border: 1px solid transparent; 
+}
+
+
+/* Active (Click) State for tactile feedback */
+.scale-hover-item:active {
+    transform: scale(0.97) !important;
+}
+
+
+/* =========================================
+   The Menu Entrance Animation
+   ========================================= */
+
+/* State when checked (open) */
+.dropdown-input:checked ~ .simple-fade {
+    visibility: visible;
+    pointer-events: auto;
+    
+    /* 
+       A simple opacity/translate fade. The focus of this component 
+       is the hover interaction, not the entrance.
+    */
+    animation: menu-fade 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards;
+}
+
+@keyframes menu-fade {
+    0% {
+        opacity: 0;
+        transform: translateX(-50%) translateY(-10px);
+    }
+    100% {
+        opacity: 1;
+        transform: translateX(-50%) translateY(0);
+    }
+}
+
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    .scale-hover-item {
+        transition: background-color 0.2s ease !important;
+    }
+    
+    .scale-hover-item:hover,
+    .scale-hover-item:active {
+        transform: none !important;
+        box-shadow: none !important;
+        border-color: transparent !important;
+    }
+    
+    /* Fallback hover effect for menu items */
+    .menu-item:hover {
+        background: var(--surface-hover);
+    }
+    
+    .dropdown-input:checked + .btn-trigger .chevron {
+        transition: none !important;
+    }
+    
+    .dropdown-input:checked ~ .simple-fade {
+        animation: none !important;
+        opacity: 1;
+        transform: translateX(-50%);
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces the CSS Scale-Hover Dropdown designed for Minimalist Tech Layouts, resolving issue #64582. 

### Changes Made:
- Added `submissions/examples/minimalist-tech-scale-hover-dropdown/` directory.
- Created `demo.html` showcasing a mock "Export Data" action menu. The layout utilizes a pure CSS checkbox hack (`<input type="checkbox">`) to allow users to toggle the dropdown open and closed without JavaScript.
- Created `style.css` featuring a clean, professional aesthetic utilizing the `Inter` font, distinct accent-colored icon boxes, and robust subtitle descriptors for the menu items.
  - Implemented the Scale-Hover system. A dedicated utility class `.scale-hover-item` handles the interaction styling on the targeted elements, driven by a bouncy `cubic-bezier` timing function on the `transform` property.
  - On `:hover`, the trigger button expands slightly (`scale(1.03)`). 
  - Crucially, when hovering over individual `.menu-item` elements, they also scale up and dynamically apply a `box-shadow` and subtle `border` to physically lift off the menu background, creating a satisfying "card pop" effect.
  - Utilized a transparent `border: 1px solid transparent` on the base `.menu-item` state to ensure the physical dimensions of the element don't jump when the colored hover border is applied.
  - Added an `:active` state that slightly depresses elements (`scale(0.97)`) to provide universal tactile, button-like feedback upon clicking.
- Added `README.md` documenting usage and technical features.
- Honors the `prefers-reduced-motion` accessibility standard. The hover/active scaling transitions, the dynamic drop shadows, and the icon rotations are completely disabled to prevent sudden screen movement for motion-sensitive users. The menu items safely fall back to a simple, color-only hover state.

Closes #64582
