### PR TITLE
feat: add CSS Ripple-Wave Tooltip for Minimalist Tech Layouts (#64529)

### DIFF
--- a/submissions/examples/minimalist-tech-ripple-wave-tooltip/README.md
+++ b/submissions/examples/minimalist-tech-ripple-wave-tooltip/README.md
@@ -1,0 +1,21 @@
+# CSS Ripple-Wave Tooltip (Minimalist Tech)
+
+A pure CSS interactive tooltip component designed for Minimalist Tech Layouts. It features a fluid "Ripple-Wave" entrance animation, where a secondary background color expands radially from the tooltip's pointer, followed by a soft, delayed reveal of the text content.
+
+## Features
+- Pure CSS and HTML (No JavaScript required for interactions or animations).
+- **Minimalist Aesthetic**: Clean layout, sharp `Inter` typography, distinct accent-colored indicator dots, and a dark slate tooltip container for high contrast.
+- **State Management**: The tooltip visibility is handled entirely via CSS `:hover` and `:focus-within` pseudo-classes on a wrapper element (`.tooltip-wrapper`), ensuring accessibility for keyboard navigation.
+- **The Ripple-Wave Entrance Effect**: 
+- A dedicated utility class `.ripple-wave-tooltip` handles the hover interactions and triggers the child animations.
+- The effect is achieved by placing a small, hidden circular `div` (`.ripple-bg`) near the bottom-center of the tooltip container, positioned right above the little directional arrow/pointer.
+- When the wrapper is hovered, an `@keyframes` animation (`ripple-expand-tooltip`) scales this circular `div` up by 35x. Because the tooltip container has `overflow: hidden` applied, this rapid radial expansion fills the entire rectangular bounds of the tooltip like a wave.
+- A split-second after the ripple expansion begins (`0.15s` delay), the interior `.tooltip-inner` text content gently fades in and translates upwards (`content-reveal`). This timing creates the illusion that the ripple wave is "washing over" and revealing the text.
+- Fully accessible with `prefers-reduced-motion` support. For motion-sensitive users, the radial ripple expansion and the translated text reveal are completely disabled, safely falling back to a simple, immediate opacity fade.
+
+## Usage
+Open `demo.html` in your browser. You will see a mock row of "Status Indicators". Hover your mouse over any of the colored icons. The tooltip will appear, the darker background will ripple outwards from the pointer at the bottom, and the text will softly fade in. Move your mouse away to hide the tooltip. You can also use the `Tab` key to navigate to the indicators and trigger the tooltips via keyboard focus.
+
+## Files
+- `demo.html`: The HTML structure for the tooltips, detailing the `.tooltip-wrapper` setup and the required `.ripple-bg` inner element.
+- `style.css`: The styling, minimalist tech design tokens, the `transform: scale` keyframes driving the radial ripple expansion from the bottom-center origin, and the delayed content reveal keyframes.

--- a/submissions/examples/minimalist-tech-ripple-wave-tooltip/demo.html
+++ b/submissions/examples/minimalist-tech-ripple-wave-tooltip/demo.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Ripple-Wave Tooltip - Minimalist Tech</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Status Indicators</h1>
+            <p class="subtitle">Hover over the indicators to see a pure CSS tooltip with a radial ripple-wave entrance.</p>
+        </header>
+
+        <div class="dashboard-area">
+            
+            <div class="card">
+                
+                <div class="status-grid">
+                    
+                    <!-- Tooltip Container 1 -->
+                    <div class="tooltip-wrapper ripple-wave-tooltip" tabindex="0">
+                        <!-- The Trigger Element -->
+                        <div class="status-dot color-emerald">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"></polyline></svg>
+                        </div>
+                        
+                        <!-- The Tooltip Content -->
+                        <div class="tooltip-content top">
+                            <div class="ripple-bg"></div>
+                            <div class="tooltip-inner">
+                                <span class="title">Database Cluster Active</span>
+                                <span class="desc">All primary and read-replica nodes are healthy and responding within 5ms.</span>
+                            </div>
+                        </div>
+                    </div>
+                    
+                    <!-- Tooltip Container 2 -->
+                    <div class="tooltip-wrapper ripple-wave-tooltip" tabindex="0">
+                        <div class="status-dot color-blue">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"></polyline></svg>
+                        </div>
+                        
+                        <div class="tooltip-content top">
+                            <div class="ripple-bg"></div>
+                            <div class="tooltip-inner">
+                                <span class="title">Background Job Processing</span>
+                                <span class="desc">Currently re-indexing the main Elasticsearch cluster. Expected completion in 12m.</span>
+                            </div>
+                        </div>
+                    </div>
+                    
+                    <!-- Tooltip Container 3 -->
+                    <div class="tooltip-wrapper ripple-wave-tooltip" tabindex="0">
+                        <div class="status-dot color-red">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><line x1="12" y1="9" x2="12" y2="13"></line><line x1="12" y1="17" x2="12.01" y2="17"></line><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path></svg>
+                        </div>
+                        
+                        <div class="tooltip-content top">
+                            <div class="ripple-bg"></div>
+                            <div class="tooltip-inner">
+                                <span class="title">API Rate Limit Exceeded</span>
+                                <span class="desc">Endpoint /v2/users is experiencing degraded performance due to high traffic volume.</span>
+                            </div>
+                        </div>
+                    </div>
+                    
+                </div>
+                
+            </div>
+            
+        </div>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/minimalist-tech-ripple-wave-tooltip/style.css
+++ b/submissions/examples/minimalist-tech-ripple-wave-tooltip/style.css
@@ -1,0 +1,264 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&display=swap');
+
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    --border-color: #e2e8f0;
+    
+    /* Tech Minimalist Accents */
+    --accent-emerald: #10b981;
+    --accent-blue: #0ea5e9;
+    --accent-red: #ef4444;
+    
+    --surface-white: #ffffff;
+    --surface-hover: #f1f5f9;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    width: 100%;
+    padding: 40px 20px;
+}
+
+.section-header {
+    text-align: center;
+    margin-bottom: 50px;
+}
+
+.title {
+    font-size: 2rem;
+    font-weight: 600;
+    margin: 0 0 12px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    margin: 0;
+}
+
+
+/* =========================================
+   Card Styling (Environment)
+   ========================================= */
+
+.card {
+    background: var(--surface-white);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 140px 40px 80px 40px; /* Lots of top padding to give tooltips room */
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+    display: flex;
+    justify-content: center;
+}
+
+.status-grid {
+    display: flex;
+    gap: 32px;
+}
+
+
+/* =========================================
+   Tooltip Trigger Styling
+   ========================================= */
+
+.tooltip-wrapper {
+    position: relative;
+    display: inline-block;
+    cursor: pointer;
+    /* Required to remove focus outline if tabindex="0" is used for click fallback */
+    outline: none; 
+}
+
+.status-dot {
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--surface-white);
+    border: 1px solid var(--border-color);
+    box-shadow: 0 4px 6px -1px rgba(0,0,0,0.05);
+    transition: all 0.3s ease;
+}
+
+.status-dot svg {
+    width: 20px;
+    height: 20px;
+}
+
+/* Base Colors */
+.color-emerald { color: var(--accent-emerald); }
+.color-blue { color: var(--accent-blue); }
+.color-red { color: var(--accent-red); }
+
+/* Hover States for Trigger */
+.tooltip-wrapper:hover .color-emerald { border-color: var(--accent-emerald); background: rgba(16, 185, 129, 0.05); box-shadow: 0 0 0 4px rgba(16, 185, 129, 0.1); }
+.tooltip-wrapper:hover .color-blue { border-color: var(--accent-blue); background: rgba(14, 165, 233, 0.05); box-shadow: 0 0 0 4px rgba(14, 165, 233, 0.1); }
+.tooltip-wrapper:hover .color-red { border-color: var(--accent-red); background: rgba(239, 68, 68, 0.05); box-shadow: 0 0 0 4px rgba(239, 68, 68, 0.1); }
+
+
+/* =========================================
+   Tooltip Content Styling
+   ========================================= */
+
+.tooltip-content {
+    position: absolute;
+    width: 240px;
+    background: #1e293b; /* Dark slate background */
+    border-radius: 8px;
+    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.2);
+    
+    /* Center it above the trigger */
+    left: 50%;
+    bottom: calc(100% + 16px);
+    transform: translateX(-50%);
+    
+    /* 
+      Hide it initially. 
+      Pointer-events ensures it doesn't block clicks when invisible.
+    */
+    visibility: hidden;
+    pointer-events: none;
+    z-index: 50;
+    
+    /* Keep the expanding ripple contained */
+    overflow: hidden;
+    
+    /* A tiny, invisible border to prevent sub-pixel rendering jitter */
+    border: 1px solid transparent; 
+}
+
+/* The little triangle pointer at the bottom */
+.tooltip-content::after {
+    content: '';
+    position: absolute;
+    bottom: -6px;
+    left: 50%;
+    margin-left: -6px;
+    width: 12px;
+    height: 12px;
+    background: #1e293b;
+    transform: rotate(45deg);
+    border-radius: 2px;
+    z-index: 0;
+}
+
+/* The Ripple Background Element */
+.ripple-bg {
+    position: absolute;
+    /* Position the center of the ripple at the bottom middle, near the arrow */
+    bottom: -10px;
+    left: 50%;
+    margin-left: -10px; /* offset by half width to true center */
+    width: 20px;
+    height: 20px;
+    background: #0f172a; /* Slightly darker than container for contrast */
+    border-radius: 50%;
+    transform: scale(0);
+    z-index: 1;
+}
+
+/* The Text Content */
+.tooltip-inner {
+    position: relative;
+    z-index: 2; /* Sit above the ripple */
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    
+    /* Initial state for cascading reveal */
+    opacity: 0;
+    transform: translateY(-5px);
+}
+
+.tooltip-inner .title {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: #f8fafc;
+    letter-spacing: 0.5px;
+}
+
+.tooltip-inner .desc {
+    font-size: 0.8rem;
+    line-height: 1.5;
+    color: #94a3b8;
+}
+
+
+/* =========================================
+   The Ripple-Wave Animation
+   ========================================= */
+
+/* Trigger Animation on Hover or Focus */
+.ripple-wave-tooltip:hover .tooltip-content,
+.ripple-wave-tooltip:focus-within .tooltip-content {
+    visibility: visible;
+}
+
+/* 1. Expand the Ripple Background */
+.ripple-wave-tooltip:hover .ripple-bg,
+.ripple-wave-tooltip:focus-within .ripple-bg {
+    /* Scale up massively to cover the whole rect */
+    animation: ripple-expand-tooltip 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
+}
+
+@keyframes ripple-expand-tooltip {
+    0% { transform: scale(0); }
+    100% { transform: scale(35); } /* 35x easily covers the 240px wide box from bottom center */
+}
+
+
+/* 2. Fade/Translate the Inner Content */
+.ripple-wave-tooltip:hover .tooltip-inner,
+.ripple-wave-tooltip:focus-within .tooltip-inner {
+    /* Slight delay so it appears as the ripple washes over it */
+    animation: content-reveal 0.3s ease-out forwards 0.15s;
+}
+
+@keyframes content-reveal {
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    .ripple-wave-tooltip:hover .ripple-bg,
+    .ripple-wave-tooltip:focus-within .ripple-bg {
+        animation: none !important;
+        transform: scale(35); /* Instantly cover */
+    }
+    
+    .ripple-wave-tooltip:hover .tooltip-inner,
+    .ripple-wave-tooltip:focus-within .tooltip-inner {
+        animation: simple-fade-tooltip 0.2s ease forwards !important;
+    }
+    
+    @keyframes simple-fade-tooltip {
+        to { opacity: 1; transform: translateY(0); }
+    }
+    
+    .status-dot {
+        transition: background-color 0.2s ease !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces the CSS Ripple-Wave Tooltip designed for Minimalist Tech Layouts, resolving issue #64529. 

### Changes Made:
- Added `submissions/examples/minimalist-tech-ripple-wave-tooltip/` directory.
- Created `demo.html` showcasing a mock row of "Status Indicators". The tooltips are triggered via pure CSS `:hover` and `:focus-within` on a wrapper element, ensuring keyboard accessibility.
- Created `style.css` featuring a clean, professional aesthetic utilizing the `Inter` font, distinct accent-colored indicator dots, and a dark slate tooltip container for high contrast.
  - Implemented the Ripple-Wave system. A dedicated utility class `.ripple-wave-tooltip` handles the hover interactions and triggers the child animations.
  - Placed a small, hidden circular `div` (`.ripple-bg`) near the bottom-center of the tooltip container, positioned right above the directional pointer.
  - When the wrapper is hovered, an `@keyframes` animation (`ripple-expand-tooltip`) scales this circular `div` up by 35x. Because the tooltip container has `overflow: hidden` applied, this rapid radial expansion fills the entire bounds of the tooltip like a wave.
  - Engineered the interior `.tooltip-inner` text content to gently fade in and translate upwards a split-second after the ripple begins (`content-reveal`). This timing creates the illusion that the ripple wave is "washing over" and revealing the text.
- Added `README.md` documenting usage and technical features.
- Honors the `prefers-reduced-motion` accessibility standard. The radial ripple expansion and the translated text reveal are completely disabled, safely falling back to a simple, immediate opacity fade for motion-sensitive users.

Closes #64529
