### PR TITLE
feat: add CSS Rotate-Fade Tooltip for Minimalist Tech Layouts (#64524)

### DIFF
--- a/submissions/examples/minimalist-tech-rotate-fade-tooltip/README.md
+++ b/submissions/examples/minimalist-tech-rotate-fade-tooltip/README.md
@@ -1,0 +1,22 @@
+# CSS Rotate-Fade Tooltip (Minimalist Tech)
+
+A pure CSS interactive tooltip component designed for Minimalist Tech Layouts. It features a spatial "Rotate-Fade" entrance animation, where the tooltip container swings into view from the Z-axis, pivoting like a hinge connected to the trigger element.
+
+## Features
+- Pure CSS and HTML (No JavaScript required for interactions or animations).
+- **Minimalist Tech Aesthetic**: Clean layout, sharp `Inter` typography, robust subtitle descriptors, and a dark slate tooltip container for high contrast against a light UI.
+- **State Management**: The tooltip visibility is handled entirely via CSS `:hover` and `:focus-within` pseudo-classes on a wrapper element (`.tooltip-wrapper`), ensuring accessibility for keyboard navigation.
+- **The Rotate-Fade Entrance Effect**: 
+- A dedicated utility class `.rotate-fade-tooltip` handles the hover interactions and triggers the child animations.
+- We establish a 3D context by applying `perspective: 1500px` to the parent containers (all the way up to the body for a true global camera view) and `transform-style: preserve-3d` to the wrapper.
+- We set the hinge point using `transform-origin: top center` on the tooltip content.
+- The initial state of the tooltip is swung backwards `-60deg` into the screen (`transform: rotateX(-60deg)`) and faded out (`opacity: 0`).
+- When hovered, an `@keyframes` animation (`tooltip-rotate`) rotates the tooltip down to `0deg` while fading to `opacity: 1`. We use a bouncy `cubic-bezier(0.175, 0.885, 0.32, 1.275)` timing function, allowing the tooltip to swing slightly past 0 degrees before settling flat, giving it physical weight.
+- Fully accessible with `prefers-reduced-motion` support. For motion-sensitive users, the 3D hinge rotation and the hover-nudging on the buttons are completely disabled, safely falling back to a simple, immediate opacity fade.
+
+## Usage
+Open `demo.html` in your browser. You will see a mock group of "Action Buttons". Hover your mouse over any of the buttons. The tooltip will appear by swinging outward from the screen towards you, hinging from its top edge. Move your mouse away to hide the tooltip. You can also use the `Tab` key to navigate the buttons and trigger the tooltips via keyboard focus.
+
+## Files
+- `demo.html`: The HTML structure for the tooltips, detailing the `.tooltip-wrapper` setup and the required DOM structure for the action buttons.
+- `style.css`: The styling, minimalist tech design tokens, the required `perspective` rules to establish the 3D space, and the `@keyframes` driving the 3D hinge rotation.

--- a/submissions/examples/minimalist-tech-rotate-fade-tooltip/demo.html
+++ b/submissions/examples/minimalist-tech-rotate-fade-tooltip/demo.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Rotate-Fade Tooltip - Minimalist Tech</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Action Tooltips</h1>
+            <p class="subtitle">Hover over the action buttons to see a pure CSS tooltip with a spatial 3D rotate-fade entrance.</p>
+        </header>
+
+        <div class="dashboard-area">
+            
+            <div class="card">
+                
+                <div class="actions-group">
+                    
+                    <!-- Tooltip Container 1 -->
+                    <div class="tooltip-wrapper rotate-fade-tooltip" tabindex="0">
+                        <!-- The Trigger Element -->
+                        <button class="action-btn btn-primary">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="17 8 12 3 7 8"></polyline><line x1="12" y1="3" x2="12" y2="15"></line></svg>
+                        </button>
+                        
+                        <!-- The Tooltip Content (Bottom position) -->
+                        <div class="tooltip-content bottom">
+                            <span class="title">Deploy to Production</span>
+                            <span class="desc">Push current main branch to edge network.</span>
+                        </div>
+                    </div>
+                    
+                    <!-- Tooltip Container 2 -->
+                    <div class="tooltip-wrapper rotate-fade-tooltip" tabindex="0">
+                        <button class="action-btn btn-secondary">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path></svg>
+                        </button>
+                        
+                        <div class="tooltip-content bottom">
+                            <span class="title">Environment Settings</span>
+                            <span class="desc">Configure environment variables and routing.</span>
+                        </div>
+                    </div>
+                    
+                    <!-- Tooltip Container 3 -->
+                    <div class="tooltip-wrapper rotate-fade-tooltip" tabindex="0">
+                        <button class="action-btn btn-danger">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"></polyline><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path><line x1="10" y1="11" x2="10" y2="17"></line><line x1="14" y1="11" x2="14" y2="17"></line></svg>
+                        </button>
+                        
+                        <div class="tooltip-content bottom">
+                            <span class="title">Delete Project</span>
+                            <span class="desc">Permanently remove this project and all data.</span>
+                        </div>
+                    </div>
+                    
+                </div>
+                
+            </div>
+            
+        </div>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/minimalist-tech-rotate-fade-tooltip/style.css
+++ b/submissions/examples/minimalist-tech-rotate-fade-tooltip/style.css
@@ -1,0 +1,260 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&display=swap');
+
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    --border-color: #e2e8f0;
+    
+    /* Tech Minimalist Accents */
+    --accent-blue: #0ea5e9;
+    --accent-red: #ef4444;
+    
+    --surface-white: #ffffff;
+    --surface-hover: #f1f5f9;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    -webkit-font-smoothing: antialiased;
+    /* Important: Establish a 3D perspective context for the whole body */
+    perspective: 1500px;
+}
+
+.layout-container {
+    max-width: 800px;
+    width: 100%;
+    padding: 40px 20px;
+    perspective: 1500px; /* Pass down the 3D context */
+}
+
+.section-header {
+    text-align: center;
+    margin-bottom: 50px;
+}
+
+.title {
+    font-size: 2rem;
+    font-weight: 600;
+    margin: 0 0 12px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    margin: 0;
+}
+
+
+/* =========================================
+   Card Styling (Environment)
+   ========================================= */
+
+.card {
+    background: var(--surface-white);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 80px 40px 140px 40px; /* Lots of bottom padding to give tooltips room */
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+    display: flex;
+    justify-content: center;
+}
+
+.actions-group {
+    display: flex;
+    gap: 24px;
+}
+
+
+/* =========================================
+   Tooltip Trigger Styling
+   ========================================= */
+
+.tooltip-wrapper {
+    position: relative;
+    display: inline-block;
+    /* Needed so the 3D transform on the child tooltip renders correctly */
+    transform-style: preserve-3d; 
+    perspective: 800px;
+    /* Required to remove focus outline if tabindex="0" is used for click fallback */
+    outline: none; 
+}
+
+.action-btn {
+    width: 48px;
+    height: 48px;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    box-shadow: 0 4px 6px -1px rgba(0,0,0,0.05);
+}
+
+.action-btn svg {
+    width: 20px;
+    height: 20px;
+}
+
+/* Button Variants */
+.btn-primary {
+    background: var(--text-primary);
+    color: white;
+}
+.btn-primary:hover {
+    background: #1e293b;
+    transform: translateY(-2px);
+    box-shadow: 0 10px 15px -3px rgba(0,0,0,0.1);
+}
+
+.btn-secondary {
+    background: var(--surface-white);
+    color: var(--text-primary);
+    border: 1px solid var(--border-color);
+}
+.btn-secondary:hover {
+    background: var(--surface-hover);
+    border-color: #cbd5e1;
+    transform: translateY(-2px);
+    box-shadow: 0 10px 15px -3px rgba(0,0,0,0.05);
+}
+
+.btn-danger {
+    background: rgba(239, 68, 68, 0.1);
+    color: var(--accent-red);
+}
+.btn-danger:hover {
+    background: rgba(239, 68, 68, 0.15);
+    transform: translateY(-2px);
+    box-shadow: 0 10px 15px -3px rgba(239, 68, 68, 0.1);
+}
+
+
+/* =========================================
+   Tooltip Content Styling
+   ========================================= */
+
+.tooltip-content {
+    position: absolute;
+    width: 220px;
+    background: #1e293b; /* Dark slate background */
+    border-radius: 8px;
+    box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.2);
+    padding: 12px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    
+    /* 
+      Hide it initially. 
+      Pointer-events ensures it doesn't block clicks when invisible.
+    */
+    visibility: hidden;
+    pointer-events: none;
+    z-index: 50;
+    
+    /* A tiny, invisible border to prevent sub-pixel rendering jitter during 3D transform */
+    border: 1px solid transparent; 
+}
+
+/* Position Bottom (Below the trigger) */
+.tooltip-content.bottom {
+    top: calc(100% + 16px);
+    left: 50%;
+    /* We handle the translateX center in the keyframe to avoid conflict */
+    transform-origin: top center; /* Hinge from the top edge */
+}
+
+/* The little triangle pointer at the top */
+.tooltip-content.bottom::before {
+    content: '';
+    position: absolute;
+    top: -6px;
+    left: 50%;
+    margin-left: -6px;
+    width: 12px;
+    height: 12px;
+    background: #1e293b;
+    transform: rotate(45deg);
+    border-radius: 2px;
+}
+
+.tooltip-content .title {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: #f8fafc;
+    letter-spacing: 0.5px;
+}
+
+.tooltip-content .desc {
+    font-size: 0.8rem;
+    line-height: 1.5;
+    color: #94a3b8;
+}
+
+
+/* =========================================
+   The Rotate-Fade Animation
+   ========================================= */
+
+/* Trigger Animation on Hover or Focus */
+.rotate-fade-tooltip:hover .tooltip-content,
+.rotate-fade-tooltip:focus-within .tooltip-content {
+    visibility: visible;
+    /* Ensure the 3D space is preserved during the animation */
+    transform-style: preserve-3d;
+    backface-visibility: hidden;
+    
+    /* 
+       tooltip-rotate: Flips the tooltip down like a hinge.
+    */
+    animation: tooltip-rotate 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards;
+}
+
+/* 
+  The tooltip starts swung backwards 60 degrees into the screen on the X-axis 
+  and faded out. It swings down into 0 degrees like a hinge.
+  Note we keep the translateX(-50%) for centering throughout the keyframes.
+*/
+@keyframes tooltip-rotate {
+    0% {
+        opacity: 0;
+        transform: translateX(-50%) rotateX(-60deg);
+    }
+    100% {
+        opacity: 1;
+        transform: translateX(-50%) rotateX(0deg);
+    }
+}
+
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    .rotate-fade-tooltip:hover .tooltip-content,
+    .rotate-fade-tooltip:focus-within .tooltip-content {
+        animation: simple-fade-tooltip 0.2s ease forwards !important;
+    }
+    
+    @keyframes simple-fade-tooltip {
+        0% { opacity: 0; transform: translateX(-50%); }
+        100% { opacity: 1; transform: translateX(-50%); }
+    }
+    
+    .action-btn {
+        transition: background-color 0.2s ease !important;
+    }
+    .action-btn:hover {
+        transform: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces the CSS Rotate-Fade Tooltip designed for Minimalist Tech Layouts, resolving issue #64524. 

### Changes Made:
- Added `submissions/examples/minimalist-tech-rotate-fade-tooltip/` directory.
- Created `demo.html` showcasing a mock group of "Action Buttons". The tooltips are triggered via pure CSS `:hover` and `:focus-within` on a wrapper element, ensuring keyboard accessibility.
- Created `style.css` featuring a clean, professional aesthetic utilizing the `Inter` font, button interaction states, and a dark slate tooltip container for high contrast.
  - Implemented the Rotate-Fade system. A dedicated utility class `.rotate-fade-tooltip` handles the hover interactions and triggers the child animations.
  - Established a 3D context by applying `perspective: 1500px` to the parent containers and `transform-style: preserve-3d` to the wrapper, setting the hinge point with `transform-origin: top center` on the tooltip itself.
  - The initial state of the tooltip is swung backwards `-60deg` into the screen (`transform: rotateX(-60deg)`) and faded out.
  - When hovered, an `@keyframes` animation (`tooltip-rotate`) rotates the tooltip down to `0deg` while fading to `opacity: 1`. Used a bouncy `cubic-bezier` timing function, allowing the tooltip to swing slightly past 0 degrees before settling flat, giving it physical weight.
- Added `README.md` documenting usage and technical features.
- Honors the `prefers-reduced-motion` accessibility standard. The 3D hinge rotation and the physical hover-nudging on the buttons are completely disabled, safely falling back to a simple, immediate opacity fade for motion-sensitive users.

Closes #64524
