### PR TITLE
feat: add rotate-fade popover for e-commerce checkout layouts

### DIFF
--- a/submissions/examples/rotate-fade-popover-checkout/README.md
+++ b/submissions/examples/rotate-fade-popover-checkout/README.md
@@ -1,0 +1,25 @@
+# CSS Rotate-Fade Popover — E-Commerce Checkout
+
+## 1. What does this do?
+A pure CSS popover that fades, rotates, and scales into view to show a checkout order summary — no JavaScript.
+
+## 2. How is it used?
+Wrap a trigger and panel in `.popover-wrap`; it reveals on `:hover` / `:focus-within`.
+
+```html
+<div class="popover-wrap">
+  <button class="popover-trigger">View Order Summary</button>
+  <div class="popover">
+    <p class="popover__title">Order Summary</p>
+    <ul class="popover__list">
+      <li><span>Item</span><span>$79.00</span></li>
+    </ul>
+    <p class="popover__total"><span>Total</span><span>$90.72</span></p>
+  </div>
+</div>
+```
+
+Key custom properties: `--popover-duration`, `--popover-rotate`, `--popover-scale`, `--popover-ease`.
+
+## 3. Why is it useful?
+Fits EaseMotion's philosophy: a raw, GPU-friendly (`transform`/`opacity` only) demo with zero JS, ready for the maintainer to standardize and merge — perfect for checkout confirmations where motion should feel light, not heavy.

--- a/submissions/examples/rotate-fade-popover-checkout/demo.html
+++ b/submissions/examples/rotate-fade-popover-checkout/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Rotate-Fade Popover — E-Commerce Checkout</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="page">
+
+    <span class="badge">E-COMMERCE CHECKOUT</span>
+    <h1>Rotate-Fade Popover</h1>
+    <p class="lead">A pure CSS popover that fades, rotates and pops into view — built for order summaries and cart confirmations.</p>
+
+    <section class="checkout-card">
+
+      <div class="checkout-card__thumb" aria-hidden="true"></div>
+
+      <div class="checkout-card__info">
+        <h2 class="checkout-card__name">Wireless Headphones</h2>
+        <p class="checkout-card__price">$79.00</p>
+
+        <div class="popover-wrap">
+
+          <button type="button" class="popover-trigger" aria-describedby="checkout-popover">
+            View Order Summary
+          </button>
+
+          <div class="popover" id="checkout-popover" role="tooltip">
+            <p class="popover__title">Order Summary</p>
+
+            <ul class="popover__list">
+              <li><span>Wireless Headphones</span><span>$79.00</span></li>
+              <li><span>Shipping</span><span>$5.00</span></li>
+              <li><span>Tax</span><span>$6.72</span></li>
+            </ul>
+
+            <p class="popover__total"><span>Total</span><span>$90.72</span></p>
+          </div>
+
+        </div>
+      </div>
+
+    </section>
+
+    <p class="hint">Hover or tab to the button to preview the popover.</p>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/rotate-fade-popover-checkout/style.css
+++ b/submissions/examples/rotate-fade-popover-checkout/style.css
@@ -1,0 +1,265 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+:root {
+  /* Palette */
+  --bg: #0f1115;
+  --surface: #ffffff;
+  --text: #1a1c20;
+  --muted: #6b7280;
+  --accent: #2f6b4f;
+  --accent-soft: #e6f2ec;
+  --border: #e5e7eb;
+
+  /* Popover motion — override these on .popover to retune the effect */
+  --popover-duration: 320ms;
+  --popover-ease: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --popover-rotate: -6deg;
+  --popover-scale: 0.85;
+  --popover-offset: 10px;
+  --popover-width: 260px;
+}
+
+body {
+  min-height: 100vh;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+  background: var(--bg);
+  color: #f3f4f6;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 60px 20px;
+}
+
+.page {
+  width: 100%;
+  max-width: 480px;
+  text-align: center;
+}
+
+.badge {
+  display: inline-block;
+  padding: 6px 16px;
+  border-radius: 999px;
+  background: rgba(47, 107, 79, 0.25);
+  color: #8fd6b4;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  margin-bottom: 16px;
+}
+
+.page h1 {
+  font-size: clamp(24px, 5vw, 32px);
+  margin-bottom: 10px;
+}
+
+.lead {
+  color: #9ca3af;
+  font-size: 15px;
+  line-height: 1.6;
+  margin-bottom: 32px;
+}
+
+/* ---- Checkout card ---- */
+
+.checkout-card {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  background: var(--surface);
+  color: var(--text);
+  border-radius: 14px;
+  padding: 20px;
+  text-align: left;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
+}
+
+.checkout-card__thumb {
+  flex: 0 0 64px;
+  width: 64px;
+  height: 64px;
+  border-radius: 10px;
+  background: linear-gradient(135deg, #a7f3d0, #2f6b4f);
+}
+
+.checkout-card__info {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.checkout-card__name {
+  font-size: 16px;
+  margin-bottom: 2px;
+}
+
+.checkout-card__price {
+  color: var(--muted);
+  font-size: 14px;
+  margin-bottom: 14px;
+}
+
+/* ---- Popover trigger ---- */
+
+.popover-wrap {
+  position: relative;
+  display: inline-block;
+}
+
+.popover-trigger {
+  font: inherit;
+  font-size: 14px;
+  font-weight: 600;
+  color: #fff;
+  background: var(--accent);
+  border: none;
+  border-radius: 8px;
+  padding: 10px 16px;
+  cursor: pointer;
+  transition: background 150ms ease, transform 120ms ease;
+}
+
+.popover-trigger:hover {
+  background: #275c43;
+}
+
+.popover-trigger:active {
+  transform: scale(0.97);
+}
+
+.popover-trigger:focus-visible {
+  outline: 3px solid #8fd6b4;
+  outline-offset: 3px;
+}
+
+/* ---- Popover: fade + rotate + scale/pop ---- */
+
+.popover {
+  position: absolute;
+  left: 0;
+  bottom: calc(100% + var(--popover-offset));
+  z-index: 10;
+  width: var(--popover-width);
+  max-width: calc(100vw - 40px);
+
+  background: var(--surface);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: 0 18px 38px rgba(0, 0, 0, 0.28);
+  padding: 16px 18px;
+
+  transform-origin: bottom left;
+  opacity: 0;
+  visibility: hidden;
+  transform: scale(var(--popover-scale)) rotate(var(--popover-rotate));
+  transition:
+    opacity var(--popover-duration) var(--popover-ease),
+    transform var(--popover-duration) var(--popover-ease),
+    visibility 0s linear var(--popover-duration);
+}
+
+.popover-wrap:hover .popover,
+.popover-wrap:focus-within .popover {
+  opacity: 1;
+  visibility: visible;
+  transform: scale(1) rotate(0deg);
+  transition:
+    opacity var(--popover-duration) var(--popover-ease),
+    transform var(--popover-duration) var(--popover-ease),
+    visibility 0s linear;
+}
+
+.popover__title {
+  font-size: 13px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+  margin-bottom: 10px;
+}
+
+.popover__list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 10px;
+}
+
+.popover__list li {
+  display: flex;
+  justify-content: space-between;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.popover__total {
+  display: flex;
+  justify-content: space-between;
+  padding-top: 10px;
+  border-top: 1px solid var(--border);
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.hint {
+  margin-top: 28px;
+  font-size: 13px;
+  color: #6b7280;
+}
+
+/* ---- Reduced motion ---- */
+
+@media (prefers-reduced-motion: reduce) {
+  .popover {
+    transition: opacity 120ms linear !important;
+    transform: none !important;
+  }
+
+  .popover-wrap:hover .popover,
+  .popover-wrap:focus-within .popover {
+    transform: none !important;
+  }
+
+  .popover-trigger {
+    transition: none;
+  }
+}
+
+/* ---- Responsive ---- */
+
+@media (max-width: 640px) {
+  .checkout-card {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .popover-wrap {
+    width: 100%;
+  }
+
+  .popover-trigger {
+    width: 100%;
+  }
+
+  .popover {
+    left: 50%;
+    transform: translateX(-50%) scale(var(--popover-scale)) rotate(var(--popover-rotate));
+  }
+
+  .popover-wrap:hover .popover,
+  .popover-wrap:focus-within .popover {
+    transform: translateX(-50%) scale(1) rotate(0deg);
+  }
+}
+
+@media (max-width: 380px) {
+  .popover {
+    --popover-width: 100%;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS rotate-fade popover for e-commerce checkout layouts. Reveals an order summary from a "View Order Summary" button using a fade + rotate + scale/pop entrance, triggered via `:hover`/`:focus-within` with no JavaScript.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/rotate-fade-popover-checkout/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A pure CSS popover that fades, rotates, and scales into view to show a checkout order summary — no JavaScript.

**How does a developer use it?**
```html
<div class="popover-wrap">
  <button class="popover-trigger">View Order Summary</button>
  <div class="popover">
    <p class="popover__title">Order Summary</p>
    <ul class="popover__list">
      <li><span>Item</span><span>$79.00</span></li>
    </ul>
    <p class="popover__total"><span>Total</span><span>$90.72</span></p>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It's a raw, GPU-friendly (`transform`/`opacity` only) demo with zero JS and zero external assets — lightweight, purposeful motion for a high-visibility checkout moment, ready for the maintainer to standardize into `ease-*` naming.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Named `rotate-fade-popover-checkout` instead of `rotate-fade-popover` since that folder was already taken by another contributor's submission — wanted to avoid overwriting existing work per the naming-conflict guidance. Motion values (rotation, scale, duration, easing) are all exposed as custom properties on `:root` if you'd like different defaults during standardization.

---

> **Reminder:** Only the repository maintainer may merge pull requests.
> Do not self-merge, even if you have write access.
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
>
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!