### PR TITLE
feat: add CSS Blur-Entrance Toast for Minimalist Tech Layouts (#64569)

### DIFF
--- a/submissions/examples/minimalist-tech-blur-entrance-toast/README.md
+++ b/submissions/examples/minimalist-tech-blur-entrance-toast/README.md
@@ -1,0 +1,21 @@
+# CSS Blur-Entrance Toast (Minimalist Tech)
+
+A pure CSS toast notification component designed for Minimalist Tech Layouts. It features a cinematic "Blur-Entrance" animation, where the notification smoothly resolves into focus from a blurred, scaled-down state.
+
+## Features
+- Pure CSS and HTML (No JavaScript required for the entrance animation).
+- **Minimalist Tech Aesthetic**: Clean, structured layout, sharp `Inter` typography, distinct semantic color variants (Success, Warning), and perfectly aligned iconography.
+- **The Blur-Entrance Effect**: 
+- The entrance animation is applied directly to the `.toast` elements (`toast-blur-in`).
+- The initial state of each toast is transparent (`opacity: 0`), slightly lowered (`transform: translateY(20px)`), scaled down (`scale(0.95)`), and heavily blurred (`filter: blur(8px)`).
+- When triggered, the animation uses a smooth easing curve (`cubic-bezier(0.16, 1, 0.3, 1)`) over `0.6s` to resolve the toast into perfect clarity. It simultaneously fades to `opacity: 1`, translates to its resting position `translateY(0)`, scales to `1.0`, and removes the blur filter `blur(0px)`. This combination creates a highly premium, cinematic entrance.
+- **Cascading Delays**: To create an elegant notification sequence (e.g., when multiple toasts fire at once), we utilize staggered `animation-delay` utility classes (`.delay-1`, `.delay-2`).
+- **State Management (Demo)**: The demo uses a hidden checkbox hack (`<input type="checkbox">`) connected to a "Trigger Toasts" button to allow users to easily re-trigger the entrance sequence without reloading the page.
+- Fully accessible with `prefers-reduced-motion` support. For motion-sensitive users, the `filter: blur` and spatial translations are completely disabled. The entrance safely falls back to a simple, immediate opacity fade.
+
+## Usage
+Open `demo.html` in your browser. You will see a mock group of "System Notifications". Upon load, they will smoothly blur into view. You can click the "Trigger Toasts" button to toggle the state and watch the cinematic blur entrance sequence run again.
+
+## Files
+- `demo.html`: The HTML structure for the toasts, detailing the pure CSS checkbox hack setup for the trigger button, and the application of the staggered delay classes.
+- `style.css`: The styling, minimalist tech design tokens, the specific `@keyframes` driving the blur and spatial resolution logic, and the semantic color setups.

--- a/submissions/examples/minimalist-tech-blur-entrance-toast/demo.html
+++ b/submissions/examples/minimalist-tech-blur-entrance-toast/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Blur-Entrance Toast - Minimalist Tech</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">System Notifications</h1>
+            <p class="subtitle">A minimalist tech toast component featuring a smooth, cinematic blur-entrance animation.</p>
+        </header>
+
+        <div class="dashboard-area">
+            
+            <div class="card">
+                
+                <!-- 
+                   Pure CSS State Management for Toast Demo
+                   We use a checkbox to toggle the state to replay the entrance animation.
+                -->
+                <div class="controls">
+                    <input type="checkbox" id="replay-toggle" class="replay-input" checked>
+                    <label for="replay-toggle" class="btn-replay">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="1 4 1 10 7 10"></polyline><polyline points="23 20 23 14 17 14"></polyline><path d="M20.49 9A9 9 0 0 0 5.64 5.64L1 10m22 4l-4.64 4.36A9 9 0 0 1 3.51 15"></path></svg>
+                        Trigger Toasts
+                    </label>
+                    
+                    <div class="toast-container blur-entrance-group">
+                        
+                        <!-- Toast 1: Success -->
+                        <div class="toast toast-success delay-1">
+                            <div class="toast-icon-wrapper">
+                                <svg class="toast-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="22 4 12 14.01 9 11.01"></polyline></svg>
+                            </div>
+                            <div class="toast-content">
+                                <span class="toast-title">Deployment Successful</span>
+                                <span class="toast-desc">Version v4.2.0 is now live on edge servers.</span>
+                            </div>
+                            <button class="toast-close" aria-label="Close notification">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+                            </button>
+                        </div>
+                        
+                        <!-- Toast 2: Warning -->
+                        <div class="toast toast-warning delay-2">
+                            <div class="toast-icon-wrapper">
+                                <svg class="toast-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path><line x1="12" y1="9" x2="12" y2="13"></line><line x1="12" y1="17" x2="12.01" y2="17"></line></svg>
+                            </div>
+                            <div class="toast-content">
+                                <span class="toast-title">High Memory Usage</span>
+                                <span class="toast-desc">Node-04 is operating at 92% memory capacity.</span>
+                            </div>
+                            <button class="toast-close" aria-label="Close notification">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+                            </button>
+                        </div>
+
+                    </div>
+                </div>
+                
+            </div>
+            
+        </div>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/minimalist-tech-blur-entrance-toast/style.css
+++ b/submissions/examples/minimalist-tech-blur-entrance-toast/style.css
@@ -1,0 +1,276 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    --border-color: #e2e8f0;
+    
+    /* Tech Minimalist Accents */
+    --accent-emerald: #10b981;
+    --accent-orange: #f59e0b;
+    
+    --surface-white: #ffffff;
+    --surface-hover: #f1f5f9;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    width: 100%;
+    padding: 40px 20px;
+}
+
+.section-header {
+    text-align: center;
+    margin-bottom: 50px;
+}
+
+.title {
+    font-size: 2rem;
+    font-weight: 600;
+    margin: 0 0 12px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    margin: 0;
+}
+
+
+/* =========================================
+   Card Styling (Environment)
+   ========================================= */
+
+.card {
+    background: var(--surface-white);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 60px 40px; 
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+    display: flex;
+    justify-content: center;
+    /* Ensure toast container stays within card bounds if absolute positioning used */
+    position: relative; 
+}
+
+
+/* =========================================
+   Demo Controls
+   ========================================= */
+
+.controls {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 32px;
+    width: 100%;
+}
+
+.replay-input {
+    display: none;
+}
+
+.btn-replay {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 16px;
+    background: var(--surface-white);
+    color: var(--text-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    font-size: 0.9rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    user-select: none;
+}
+
+.btn-replay:hover {
+    background: var(--surface-hover);
+    color: var(--text-primary);
+}
+
+.btn-replay svg {
+    width: 16px;
+    height: 16px;
+}
+
+
+/* =========================================
+   Toast Container & Structure
+   ========================================= */
+
+.toast-container {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    width: 100%;
+    max-width: 400px;
+    
+    /* In a real app, this might be fixed to top-right/bottom-right */
+    /* position: fixed; right: 24px; top: 24px; z-index: 1000; */
+}
+
+.toast {
+    display: flex;
+    align-items: flex-start;
+    gap: 16px;
+    padding: 16px;
+    background: var(--surface-white);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    position: relative;
+    
+    /* Initial state for the blur-entrance animation */
+    opacity: 0;
+    transform: translateY(20px) scale(0.95);
+    filter: blur(8px);
+}
+
+/* Base styles for the icon wrapper */
+.toast-icon-wrapper {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    margin-top: 2px;
+}
+
+.toast-icon {
+    width: 14px;
+    height: 14px;
+}
+
+/* Content layout */
+.toast-content {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    flex-grow: 1;
+}
+
+.toast-title {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.toast-desc {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    line-height: 1.4;
+}
+
+/* Close button */
+.toast-close {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    background: transparent;
+    border: none;
+    color: var(--text-secondary);
+    border-radius: 4px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    flex-shrink: 0;
+}
+
+.toast-close:hover {
+    background: var(--surface-hover);
+    color: var(--text-primary);
+}
+.toast-close svg { width: 16px; height: 16px; }
+
+
+/* =========================================
+   Toast Variants (Colors)
+   ========================================= */
+
+.toast-success .toast-icon-wrapper {
+    background-color: rgba(16, 185, 129, 0.1);
+    color: var(--accent-emerald);
+}
+
+.toast-warning .toast-icon-wrapper {
+    background-color: rgba(245, 158, 11, 0.1);
+    color: var(--accent-orange);
+}
+
+
+/* =========================================
+   The Blur-Entrance Animation
+   ========================================= */
+
+/* 
+  We use the checkbox trick on the parent container to allow 
+  re-triggering the animation for demonstration purposes.
+*/
+.replay-input:checked ~ .blur-entrance-group .toast {
+    /* Uses a standard ease-out curve to settle smoothly */
+    animation: toast-blur-in 0.6s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+/* 
+  Cinematic Blur Entrance:
+  The toast starts slightly lowered, scaled down, heavily blurred, and transparent.
+  It smoothly resolves into perfect clarity and position.
+*/
+@keyframes toast-blur-in {
+    0% {
+        opacity: 0;
+        transform: translateY(20px) scale(0.95);
+        filter: blur(8px);
+    }
+    100% {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+        filter: blur(0px);
+    }
+}
+
+/* 
+  Staggered Delays for Cascading Effect 
+*/
+.delay-1 { animation-delay: 0.1s !important; }
+.delay-2 { animation-delay: 0.25s !important; }
+
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    /* Replace translation and blur with a simple opacity fade */
+    .toast {
+        filter: none !important; /* Ensure blur is off */
+    }
+    
+    .replay-input:checked ~ .blur-entrance-group .toast {
+        animation: simple-fade 0.3s ease forwards !important;
+        transform: none !important;
+    }
+    
+    @keyframes simple-fade {
+        0% { opacity: 0; }
+        100% { opacity: 1; }
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces the CSS Blur-Entrance Toast designed for Minimalist Tech Layouts, resolving issue #64569. 

### Changes Made:
- Added `submissions/examples/minimalist-tech-blur-entrance-toast/` directory.
- Created `demo.html` showcasing a mock group of "System Notifications". The layout utilizes a pure CSS checkbox hack (`<input type="checkbox">`) connected to a "Trigger Toasts" button to allow users to easily re-trigger the entrance sequence without reloading the page.
- Created `style.css` featuring a clean, structured aesthetic utilizing the `Inter` font, distinct semantic color variants (Success, Warning), and perfectly aligned iconography.
  - Implemented the Blur-Entrance System directly on the `.toast` elements (`toast-blur-in`).
  - The initial state of each toast is transparent (`opacity: 0`), slightly lowered (`transform: translateY(20px)`), scaled down (`scale(0.95)`), and heavily blurred (`filter: blur(8px)`).
  - When triggered, the `@keyframes` animation uses a smooth easing curve over `0.6s` to resolve the toast into perfect clarity. It simultaneously fades to `opacity: 1`, translates to its resting position `translateY(0)`, scales to `1.0`, and removes the blur filter `blur(0px)`. This creates a highly premium, cinematic entrance.
  - Engineered cascading delays utilizing staggered `animation-delay` utility classes (`.delay-1`, `.delay-2`) to create an elegant sequence when multiple toasts fire at once.
- Added `README.md` documenting usage and technical features.
- Honors the `prefers-reduced-motion` accessibility standard. The `filter: blur` and spatial translations are completely disabled, safely falling back to a simple, immediate opacity fade for motion-sensitive users.

Closes #64569
