### PR TITLE
feat: add CSS Slide-Up Toast for Minimalist Tech Layouts (#64565)

### DIFF
--- a/submissions/examples/minimalist-tech-slide-up-toast/README.md
+++ b/submissions/examples/minimalist-tech-slide-up-toast/README.md
@@ -1,0 +1,21 @@
+# CSS Slide-Up Toast (Minimalist Tech)
+
+A pure CSS toast notification component designed for Minimalist Tech Layouts. It focuses on a clean, snappy "Slide-Up" vertical entrance animation, common in modern dashboard interfaces.
+
+## Features
+- Pure CSS and HTML (No JavaScript required for the entrance animation).
+- **Minimalist Tech Aesthetic**: Clean, structured layout, sharp `Inter` typography, distinct semantic color variants (Info, Error), perfectly aligned iconography, and inline action links.
+- **The Slide-Up Effect**: 
+- The entrance animation is applied directly to the `.toast` elements (`toast-slide-up`).
+- The initial state of each toast is transparent (`opacity: 0`) and pushed significantly downwards (`transform: translateY(30px)`).
+- When triggered, the animation uses a snappy easing curve (`cubic-bezier(0.16, 1, 0.3, 1)`) over `0.5s` to slide the toast up into its baseline position (`translateY(0)`) while fading to `opacity: 1`. This creates a crisp, responsive entrance.
+- **Cascading Delays**: To create an elegant notification sequence (e.g., when multiple toasts fire at once on page load), we utilize staggered `animation-delay` utility classes (`.delay-1`, `.delay-2`).
+- **State Management (Demo)**: The demo uses a hidden checkbox hack (`<input type="checkbox">`) connected to a "Trigger Toasts" button to allow users to easily re-trigger the entrance sequence without reloading the page.
+- Fully accessible with `prefers-reduced-motion` support. For motion-sensitive users, the spatial translations are completely disabled. The entrance safely falls back to a simple, immediate opacity fade.
+
+## Usage
+Open `demo.html` in your browser. You will see a mock group of "Action Alerts". Upon load, they will slide up into view. You can click the "Trigger Toasts" button to toggle the state and watch the vertical slide-up sequence run again.
+
+## Files
+- `demo.html`: The HTML structure for the toasts, detailing the pure CSS checkbox hack setup for the trigger button, the inline action links, and the application of the staggered delay classes.
+- `style.css`: The styling, minimalist tech design tokens, the specific `@keyframes` driving the slide-up translation logic, and the semantic color setups.

--- a/submissions/examples/minimalist-tech-slide-up-toast/demo.html
+++ b/submissions/examples/minimalist-tech-slide-up-toast/demo.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Slide-Up Toast - Minimalist Tech</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Action Alerts</h1>
+            <p class="subtitle">A minimalist tech toast component featuring a smooth, vertical slide-up entrance animation.</p>
+        </header>
+
+        <div class="dashboard-area">
+            
+            <div class="card">
+                
+                <!-- 
+                   Pure CSS State Management for Toast Demo
+                   We use a checkbox to toggle the state to replay the entrance animation.
+                -->
+                <div class="controls">
+                    <input type="checkbox" id="replay-toggle" class="replay-input" checked>
+                    <label for="replay-toggle" class="btn-replay">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="1 4 1 10 7 10"></polyline><polyline points="23 20 23 14 17 14"></polyline><path d="M20.49 9A9 9 0 0 0 5.64 5.64L1 10m22 4l-4.64 4.36A9 9 0 0 1 3.51 15"></path></svg>
+                        Trigger Toasts
+                    </label>
+                    
+                    <div class="toast-container slide-up-group">
+                        
+                        <!-- Toast 1: System Info -->
+                        <div class="toast toast-info delay-1">
+                            <div class="toast-icon-wrapper">
+                                <svg class="toast-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="16" x2="12" y2="12"></line><line x1="12" y1="8" x2="12.01" y2="8"></line></svg>
+                            </div>
+                            <div class="toast-content">
+                                <span class="toast-title">Backup Complete</span>
+                                <span class="toast-desc">Database snapshot captured successfully at 04:00 UTC.</span>
+                            </div>
+                            <div class="toast-actions">
+                                <button class="action-link">View Log</button>
+                                <button class="toast-close" aria-label="Dismiss">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+                                </button>
+                            </div>
+                        </div>
+                        
+                        <!-- Toast 2: Error -->
+                        <div class="toast toast-error delay-2">
+                            <div class="toast-icon-wrapper">
+                                <svg class="toast-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="15" y1="9" x2="9" y2="15"></line><line x1="9" y1="9" x2="15" y2="15"></line></svg>
+                            </div>
+                            <div class="toast-content">
+                                <span class="toast-title">Connection Failed</span>
+                                <span class="toast-desc">Unable to reach the primary API endpoint.</span>
+                            </div>
+                            <div class="toast-actions">
+                                <button class="action-link">Retry</button>
+                                <button class="toast-close" aria-label="Dismiss">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+                                </button>
+                            </div>
+                        </div>
+
+                    </div>
+                </div>
+                
+            </div>
+            
+        </div>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/minimalist-tech-slide-up-toast/style.css
+++ b/submissions/examples/minimalist-tech-slide-up-toast/style.css
@@ -1,0 +1,290 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    --border-color: #e2e8f0;
+    
+    /* Tech Minimalist Accents */
+    --accent-blue: #0ea5e9;
+    --accent-red: #ef4444;
+    
+    --surface-white: #ffffff;
+    --surface-hover: #f1f5f9;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    width: 100%;
+    padding: 40px 20px;
+}
+
+.section-header {
+    text-align: center;
+    margin-bottom: 50px;
+}
+
+.title {
+    font-size: 2rem;
+    font-weight: 600;
+    margin: 0 0 12px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    margin: 0;
+}
+
+
+/* =========================================
+   Card Styling (Environment)
+   ========================================= */
+
+.card {
+    background: var(--surface-white);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 60px 40px; 
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+    display: flex;
+    justify-content: center;
+    /* Ensure toast container stays within card bounds for demo purposes */
+    position: relative; 
+}
+
+
+/* =========================================
+   Demo Controls
+   ========================================= */
+
+.controls {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 32px;
+    width: 100%;
+}
+
+.replay-input {
+    display: none;
+}
+
+.btn-replay {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 16px;
+    background: var(--surface-white);
+    color: var(--text-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    font-size: 0.9rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    user-select: none;
+}
+
+.btn-replay:hover {
+    background: var(--surface-hover);
+    color: var(--text-primary);
+}
+
+.btn-replay svg {
+    width: 16px;
+    height: 16px;
+}
+
+
+/* =========================================
+   Toast Container & Structure
+   ========================================= */
+
+.toast-container {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    width: 100%;
+    max-width: 420px;
+    
+    /* In a real app, this might be fixed to bottom-right */
+    /* position: fixed; right: 24px; bottom: 24px; z-index: 1000; */
+}
+
+.toast {
+    display: flex;
+    align-items: flex-start;
+    gap: 16px;
+    padding: 16px;
+    background: var(--surface-white);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    position: relative;
+    
+    /* Initial state for the slide-up animation */
+    opacity: 0;
+    /* Start pushed down vertically */
+    transform: translateY(30px);
+}
+
+/* Base styles for the icon wrapper */
+.toast-icon-wrapper {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    margin-top: 2px;
+}
+
+.toast-icon {
+    width: 14px;
+    height: 14px;
+}
+
+/* Content layout */
+.toast-content {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    flex-grow: 1;
+}
+
+.toast-title {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.toast-desc {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    line-height: 1.4;
+}
+
+/* Actions area */
+.toast-actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-top: 2px;
+}
+
+.action-link {
+    background: transparent;
+    border: none;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--accent-blue);
+    cursor: pointer;
+    padding: 0;
+}
+.action-link:hover { text-decoration: underline; }
+
+/* Close button */
+.toast-close {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    background: transparent;
+    border: none;
+    color: var(--text-secondary);
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background-color 0.2s ease, color 0.2s ease;
+    flex-shrink: 0;
+}
+
+.toast-close:hover {
+    background: var(--surface-hover);
+    color: var(--text-primary);
+}
+.toast-close svg { width: 16px; height: 16px; }
+
+
+/* =========================================
+   Toast Variants (Colors)
+   ========================================= */
+
+.toast-info .toast-icon-wrapper {
+    background-color: rgba(14, 165, 233, 0.1);
+    color: var(--accent-blue);
+}
+
+.toast-error .toast-icon-wrapper {
+    background-color: rgba(239, 68, 68, 0.1);
+    color: var(--accent-red);
+}
+
+
+/* =========================================
+   The Slide-Up Animation
+   ========================================= */
+
+/* 
+  We use the checkbox trick on the parent container to allow 
+  re-triggering the animation for demonstration purposes.
+*/
+.replay-input:checked ~ .slide-up-group .toast {
+    /* Uses a snappy cubic-bezier curve to slide up and settle */
+    animation: toast-slide-up 0.5s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+/* 
+  Slide-Up Entrance:
+  The toast starts pushed down (translateY 30px) and transparent.
+  It smoothly slides up into its resting position.
+*/
+@keyframes toast-slide-up {
+    0% {
+        opacity: 0;
+        transform: translateY(30px);
+    }
+    100% {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+/* 
+  Staggered Delays for Cascading Effect 
+  If multiple toasts appear at once (e.g. on page load), they cascade.
+*/
+.delay-1 { animation-delay: 0.1s !important; }
+.delay-2 { animation-delay: 0.2s !important; }
+
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    /* Replace translation with a simple opacity fade */
+    .replay-input:checked ~ .slide-up-group .toast {
+        animation: simple-fade 0.3s ease forwards !important;
+        transform: none !important;
+    }
+    
+    @keyframes simple-fade {
+        0% { opacity: 0; }
+        100% { opacity: 1; }
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces the CSS Slide-Up Toast designed for Minimalist Tech Layouts, resolving issue #64565. 

### Changes Made:
- Added `submissions/examples/minimalist-tech-slide-up-toast/` directory.
- Created `demo.html` showcasing a mock group of "Action Alerts". The layout utilizes a pure CSS checkbox hack (`<input type="checkbox">`) connected to a "Trigger Toasts" button to allow users to easily re-trigger the entrance sequence without reloading the page.
- Created `style.css` featuring a clean, structured aesthetic utilizing the `Inter` font, distinct semantic color variants (Info, Error), perfectly aligned iconography, and inline action links.
  - Implemented the Slide-Up System directly on the `.toast` elements (`toast-slide-up`).
  - The initial state of each toast is transparent (`opacity: 0`) and pushed significantly downwards (`transform: translateY(30px)`).
  - When triggered, the `@keyframes` animation uses a snappy easing curve over `0.5s` to slide the toast up into its baseline position (`translateY(0)`) while fading to `opacity: 1`. This creates a crisp, responsive entrance.
  - Engineered cascading delays utilizing staggered `animation-delay` utility classes (`.delay-1`, `.delay-2`) to create an elegant sequence when multiple toasts fire at once.
- Added `README.md` documenting usage and technical features.
- Honors the `prefers-reduced-motion` accessibility standard. The spatial translations are completely disabled, safely falling back to a simple, immediate opacity fade for motion-sensitive users.

Closes #64565
