### PR TITLE
feat: add modal reduced motion accessibility fix example

### DIFF
--- a/submissions/examples/modal-reduced-motion-fix/README.md
+++ b/submissions/examples/modal-reduced-motion-fix/README.md
@@ -1,0 +1,18 @@
+# Modal Reduced Motion Fix
+
+A vital accessibility pattern demonstrating how to respect the user's OS-level settings by gracefully downgrading complex, potentially dizzying modal animations into simple, accessible opacity cross-fades.
+
+## Features
+- **The Context**: EaseMotion CSS is known for its beautiful, bouncy, scaling, and sliding entrance animations. However, for users with vestibular disorders or motion sensitivity, complex animations (especially elements flying towards the screen via `scale` or panning quickly via `translate`) can cause severe nausea, dizziness, or migraines.
+- **The Core Solution**: Modern operating systems (Windows, macOS, iOS, Android) all feature an accessibility setting to "Reduce Motion". Browsers expose this setting to CSS via the `@media (prefers-reduced-motion: reduce)` media query. 
+- **The Implementation**: We use this media query to act as an override block at the bottom of our stylesheets. If motion sensitivity is detected, we aggressively strip the `transform` properties from our modal dialogs using `transform: none !important`, and we modify the `transition` timing rules to exclusively animate `opacity`. The user still gets a smooth, polished UI experience (a soft fade-in), but without the physical motion triggers.
+
+## Usage
+Open `demo.html` in your browser. 
+- Click the "Open Modal" button to view the standard, energetic entrance animation (scaling up and bouncing in from the bottom).
+- Now, go to your OS settings and enable reduced motion (e.g., Windows: Settings > Accessibility > Visual Effects > Turn off "Animation effects"). 
+- Refresh the browser and click the button again. The modal will now smoothly and safely fade into existence without any movement.
+
+## Files
+- `demo.html`: The HTML structure demonstrating the modal layout.
+- `style.css`: The styling engine contrasting the standard spring animation with the `@media (prefers-reduced-motion)` override block.

--- a/submissions/examples/modal-reduced-motion-fix/demo.html
+++ b/submissions/examples/modal-reduced-motion-fix/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Modal Reduced Motion Fix - EaseMotion</title>
+    <!-- Include EaseMotion CSS -->
+    <link rel="stylesheet" href="../../../easemotion.min.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="layout-container">
+        <header class="header">
+            <h1 class="title">Modal Reduced Motion Fix</h1>
+            <p class="subtitle">Ensuring our UI components respect the user's OS-level accessibility preferences for reduced motion by safely downgrading dizzying transform animations to simple opacity cross-fades.</p>
+        </header>
+
+        <main class="showcase">
+            <div class="demo-card">
+                <h3>Accessible Modal Dialog</h3>
+                <p>Click the button below to open the modal. If your OS settings have "Reduce Motion" enabled, the modal will bypass the complex 3D scale and slide animation, and instead perform a gentle, accessible fade-in.</p>
+                
+                <button class="btn open-modal-btn" id="openBtn">Open Modal</button>
+            </div>
+            
+            <!-- Modal Overlay -->
+            <div class="modal-overlay" id="modalOverlay">
+                <div class="modal-dialog">
+                    <h2 class="modal-title">System Alert</h2>
+                    <p class="modal-body">This is an accessible modal dialog. Its entrance animation intelligently adapts based on the user's system preferences.</p>
+                    <button class="btn close-modal-btn" id="closeBtn">Acknowledge</button>
+                </div>
+            </div>
+            
+            <div class="info-box">
+                <h4>How to test this locally:</h4>
+                <p><strong>Windows:</strong> Settings > Accessibility > Visual Effects > Turn off "Animation effects".<br>
+                   <strong>macOS:</strong> System Settings > Accessibility > Display > Turn on "Reduce motion".</p>
+            </div>
+        </main>
+    </div>
+
+    <script>
+        const overlay = document.getElementById('modalOverlay');
+        const openBtn = document.getElementById('openBtn');
+        const closeBtn = document.getElementById('closeBtn');
+
+        openBtn.addEventListener('click', () => {
+            overlay.classList.add('is-open');
+        });
+
+        closeBtn.addEventListener('click', () => {
+            overlay.classList.remove('is-open');
+        });
+        
+        // Close on clicking outside
+        overlay.addEventListener('click', (e) => {
+            if (e.target === overlay) {
+                overlay.classList.remove('is-open');
+            }
+        });
+    </script>
+</body>
+</html>

--- a/submissions/examples/modal-reduced-motion-fix/style.css
+++ b/submissions/examples/modal-reduced-motion-fix/style.css
@@ -1,0 +1,168 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600&display=swap');
+
+:root {
+    --bg-color: #f1f5f9;
+    --card-bg: #ffffff;
+    --text-primary: #0f172a;
+    --text-secondary: #475569;
+    --primary: #4f46e5;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    font-family: 'Outfit', system-ui, sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    box-sizing: border-box;
+    padding: 40px 20px;
+}
+
+.layout-container {
+    max-width: 900px;
+    width: 100%;
+}
+
+.header {
+    text-align: center;
+    margin-bottom: 48px;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 600;
+    margin: 0 0 12px 0;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    line-height: 1.5;
+}
+
+.showcase {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 32px;
+    justify-content: center;
+}
+
+.demo-card {
+    background: var(--card-bg);
+    padding: 32px;
+    border-radius: 12px;
+    box-shadow: 0 4px 6px -1px rgba(0,0,0,0.05);
+    border: 1px solid #e2e8f0;
+    width: 100%;
+    max-width: 600px;
+    text-align: center;
+}
+
+.demo-card h3 { margin: 0 0 12px 0; font-size: 1.3rem; }
+.demo-card p { color: var(--text-secondary); margin: 0 0 24px 0; font-size: 0.95rem; line-height: 1.5; }
+
+.btn {
+    background: var(--primary);
+    color: white;
+    border: none;
+    padding: 12px 24px;
+    border-radius: 8px;
+    font-size: 1rem;
+    font-weight: 500;
+    cursor: pointer;
+    font-family: inherit;
+    transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.btn:hover {
+    background: #4338ca;
+}
+
+.info-box {
+    width: 100%;
+    max-width: 600px;
+    background: #eff6ff;
+    border: 1px solid #bfdbfe;
+    padding: 20px;
+    border-radius: 8px;
+    text-align: center;
+}
+.info-box h4 { margin: 0 0 8px 0; color: #1d4ed8; }
+.info-box p { margin: 0; color: #1e40af; font-size: 0.9rem; }
+
+/* =========================================
+   Modal Base Styles (Standard Animation)
+   ========================================= */
+
+.modal-overlay {
+    position: fixed;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background: rgba(15, 23, 42, 0.6);
+    backdrop-filter: blur(4px);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+    
+    /* Starting state */
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.4s ease, visibility 0.4s ease;
+}
+
+.modal-dialog {
+    background: white;
+    padding: 32px;
+    border-radius: 16px;
+    width: 90%;
+    max-width: 400px;
+    box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+    
+    /* Starting state: scaled down and pushed down */
+    transform: scale(0.9) translateY(30px);
+    opacity: 0;
+    transition: transform 0.5s cubic-bezier(0.34, 1.56, 0.64, 1), opacity 0.5s ease;
+}
+
+/* Open State */
+.modal-overlay.is-open {
+    opacity: 1;
+    visibility: visible;
+}
+
+.modal-overlay.is-open .modal-dialog {
+    /* Ending state: normal size and position */
+    transform: scale(1) translateY(0);
+    opacity: 1;
+}
+
+.modal-title { margin: 0 0 12px 0; }
+.modal-body { color: var(--text-secondary); margin: 0 0 24px 0; line-height: 1.5; }
+
+/* =========================================
+   THE FIX: Prefers-Reduced-Motion Fallback
+   ========================================= */
+
+/* 
+   We wrap our overrides in a media query that listens to the user's OS settings.
+   If they have vestibular motion sensitivity, we completely disable the 3D scale
+   and Y-axis translations, leaving only the safe opacity cross-fade.
+*/
+@media (prefers-reduced-motion: reduce) {
+    .modal-dialog {
+        /* Strip the movement transitions, keep only the opacity transition */
+        transition: opacity 0.3s ease !important;
+        
+        /* Force the resting state to immediately be at the final position */
+        transform: none !important;
+    }
+    
+    /* Optionally speed up the overlay fade to reduce waiting time */
+    .modal-overlay {
+        transition: opacity 0.2s ease, visibility 0.2s ease !important;
+    }
+}


### PR DESCRIPTION
### Description
Closes #65786

Added a new `modal-reduced-motion-fix` component to the examples showcase. This submission ensures our modal UI components respect the user's OS-level accessibility preferences for reduced motion by safely downgrading dizzying transform animations to simple opacity cross-fades.

### What was changed
* Created `submissions/examples/modal-reduced-motion-fix/demo.html` demonstrating a standard modal dialog overlay.
* Created `submissions/examples/modal-reduced-motion-fix/style.css` which introduces the `@media (prefers-reduced-motion: reduce)` media query to aggressively strip `transform` properties while retaining smooth `opacity` transitions.
* Created `submissions/examples/modal-reduced-motion-fix/README.md` explaining the severe impact of vestibular motion sensitivity and how to test the fix via Windows/macOS accessibility settings.

### Verification
- [x] Verified the modal intelligently drops its bouncing scale/slide animation in favor of a gentle fade-in when the OS "Reduce Motion" setting is toggled on.