### PR TITLE
feat: add CSS Ripple-Wave Toast for Minimalist Tech Layouts (#64574)

### DIFF
--- a/submissions/examples/minimalist-tech-ripple-wave-toast/README.md
+++ b/submissions/examples/minimalist-tech-ripple-wave-toast/README.md
@@ -1,0 +1,22 @@
+# CSS Ripple-Wave Toast (Minimalist Tech)
+
+A pure CSS toast notification component designed for Minimalist Tech Layouts. It focuses on a visually striking "Ripple-Wave" entrance animation, where a colored wave expands outwards from the notification icon across the entire toast background.
+
+## Features
+- Pure CSS and HTML (No JavaScript required for the ripple or entrance animations).
+- **Minimalist Tech Aesthetic**: Clean panel layout, perfectly aligned iconography, solid icon background accents, and inline action buttons.
+- **The Ripple-Wave Animation System**: 
+- **The Engine**: Inside each `.toast`, we place a purely decorative `.ripple-element`. This element is initially a tiny (`1px` by `1px`), invisible dot centered exactly behind the toast's icon wrapper. 
+- **The Expansion**: When triggered, a specific `@keyframes` animation (`ripple-expand`) is applied to the `.ripple-element`. It uses a massive `transform: scale(800)` to rapidly expand the circular dot outwards. Because the parent `.toast` has `overflow: hidden`, the expanding circle creates a perfect "wave" washing across the background.
+- **The Polish**: The wave uses a crisp `cubic-bezier(0.16, 1, 0.3, 1)` easing curve so it explodes quickly but finishes smoothly. It simultaneously transitions from `opacity: 1` to `0`, causing the wave to dissipate right as it reaches the edges of the toast.
+- **Z-Indexing**: Proper stacking contexts (`z-index: 10` for content, `z-index: 1` for the ripple) ensure the text and icons remain perfectly legible *above* the wash of color.
+- **Cascading Delays**: We utilize staggered `animation-delay` utility classes (`.delay-1`, `.delay-2`). Crucially, we apply a slightly longer delay to the `.ripple-element` itself (`0.15s` vs `0.1s`), ensuring the toast fades in first, and *then* the ripple triggers, making it look like the icon initialized the wave.
+- **State Management (Demo)**: The demo uses a hidden checkbox hack (`<input type="checkbox">`) connected to a "Trigger Toasts" button to allow users to easily re-trigger the entrance sequence without reloading the page.
+- Fully accessible with `prefers-reduced-motion` support. For motion-sensitive users, the expansive decorative ripple animation is completely disabled and hidden (`display: none`). The entrance safely falls back to a simple, immediate opacity fade.
+
+## Usage
+Open `demo.html` in your browser. You will see a mock group of "Network Events". Upon load, they will fade in and immediately trigger a colored ripple wave expanding from their icons. You can click the "Trigger Toasts" button to toggle the state and watch the Ripple-Wave sequence run again.
+
+## Files
+- `demo.html`: The HTML structure for the toasts, detailing the pure CSS checkbox hack setup for the trigger button, the placement of the decorative `.ripple-element`, and the application of the staggered delay classes.
+- `style.css`: The styling, minimalist tech design tokens, the `overflow/z-index` logic necessary to contain the ripple, and the massive `scale(800)` keyframe driving the wave effect.

--- a/submissions/examples/minimalist-tech-ripple-wave-toast/demo.html
+++ b/submissions/examples/minimalist-tech-ripple-wave-toast/demo.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Ripple-Wave Toast - Minimalist Tech</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Network Events</h1>
+            <p class="subtitle">A minimalist tech toast component featuring an expanding, radial ripple-wave entrance animation.</p>
+        </header>
+
+        <div class="dashboard-area">
+            
+            <div class="card">
+                
+                <!-- 
+                   Pure CSS State Management for Toast Demo
+                   We use a checkbox to toggle the state to replay the entrance animation.
+                -->
+                <div class="controls">
+                    <input type="checkbox" id="replay-toggle" class="replay-input" checked>
+                    <label for="replay-toggle" class="btn-replay">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="1 4 1 10 7 10"></polyline><polyline points="23 20 23 14 17 14"></polyline><path d="M20.49 9A9 9 0 0 0 5.64 5.64L1 10m22 4l-4.64 4.36A9 9 0 0 1 3.51 15"></path></svg>
+                        Trigger Toasts
+                    </label>
+                    
+                    <div class="toast-container ripple-wave-group">
+                        
+                        <!-- Toast 1: Connection Restored -->
+                        <div class="toast toast-emerald delay-1">
+                            <div class="toast-icon-wrapper">
+                                <svg class="toast-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12.55a11 11 0 0 1 14.08 0"></path><path d="M1.42 9a16 16 0 0 1 21.16 0"></path><path d="M8.53 16.11a6 6 0 0 1 6.95 0"></path><line x1="12" y1="20" x2="12.01" y2="20"></line></svg>
+                            </div>
+                            <div class="toast-content">
+                                <span class="toast-title">Uplink Restored</span>
+                                <span class="toast-desc">Connection to the central message broker has been successfully re-established.</span>
+                            </div>
+                            <button class="toast-close" aria-label="Close notification">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+                            </button>
+                            <!-- The purely decorative ripple element -->
+                            <div class="ripple-element"></div>
+                        </div>
+                        
+                        <!-- Toast 2: Packet Loss -->
+                        <div class="toast toast-purple delay-2">
+                            <div class="toast-icon-wrapper">
+                                <svg class="toast-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"></polyline></svg>
+                            </div>
+                            <div class="toast-content">
+                                <span class="toast-title">Telemetry Interrupted</span>
+                                <span class="toast-desc">Experiencing intermittent packet loss from edge device Node-7A.</span>
+                            </div>
+                            <div class="toast-actions">
+                                <button class="action-btn">Run Diagnostics</button>
+                            </div>
+                            <div class="ripple-element"></div>
+                        </div>
+
+                    </div>
+                </div>
+                
+            </div>
+            
+        </div>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/minimalist-tech-ripple-wave-toast/style.css
+++ b/submissions/examples/minimalist-tech-ripple-wave-toast/style.css
@@ -1,0 +1,342 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    --border-color: #e2e8f0;
+    
+    /* Tech Minimalist Accents */
+    --accent-emerald: #10b981;
+    --accent-purple: #8b5cf6;
+    
+    --surface-white: #ffffff;
+    --surface-hover: #f1f5f9;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    width: 100%;
+    padding: 40px 20px;
+}
+
+.section-header {
+    text-align: center;
+    margin-bottom: 50px;
+}
+
+.title {
+    font-size: 2rem;
+    font-weight: 600;
+    margin: 0 0 12px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    margin: 0;
+}
+
+
+/* =========================================
+   Card Styling (Environment)
+   ========================================= */
+
+.card {
+    background: var(--surface-white);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 60px 40px; 
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+    display: flex;
+    justify-content: center;
+    /* Ensure toast container stays within card bounds */
+    position: relative; 
+}
+
+
+/* =========================================
+   Demo Controls
+   ========================================= */
+
+.controls {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 32px;
+    width: 100%;
+}
+
+.replay-input {
+    display: none;
+}
+
+.btn-replay {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 16px;
+    background: var(--surface-white);
+    color: var(--text-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    font-size: 0.9rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    user-select: none;
+}
+
+.btn-replay:hover {
+    background: var(--surface-hover);
+    color: var(--text-primary);
+}
+
+.btn-replay svg {
+    width: 16px;
+    height: 16px;
+}
+
+
+/* =========================================
+   Toast Container & Structure
+   ========================================= */
+
+.toast-container {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    width: 100%;
+    max-width: 420px;
+}
+
+.toast {
+    display: flex;
+    align-items: flex-start;
+    flex-wrap: wrap; 
+    gap: 16px;
+    padding: 16px;
+    background: var(--surface-white);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    box-shadow: 0 4px 12px -2px rgba(0, 0, 0, 0.05);
+    
+    /* Required to contain the expanding ripple */
+    position: relative;
+    overflow: hidden;
+    
+    /* Initial state for the container's entrance animation */
+    opacity: 0;
+    transform: scale(0.98);
+}
+
+/* Base styles for the icon wrapper */
+.toast-icon-wrapper {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    margin-top: 2px;
+    position: relative;
+    z-index: 10; /* Ensure icon stays above the ripple */
+}
+
+.toast-icon {
+    width: 14px;
+    height: 14px;
+}
+
+/* Content layout */
+.toast-content {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    flex-grow: 1;
+    min-width: 200px;
+    position: relative;
+    z-index: 10; /* Ensure text stays above the ripple */
+}
+
+.toast-title {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.toast-desc {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    line-height: 1.4;
+}
+
+/* Actions area */
+.toast-actions {
+    width: 100%;
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 4px;
+    position: relative;
+    z-index: 10;
+}
+
+.action-btn {
+    padding: 6px 12px;
+    background: var(--surface-white);
+    color: var(--text-primary);
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    font-size: 0.8rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+.action-btn:hover {
+    background: var(--surface-hover);
+}
+
+/* Close button (top right) */
+.toast-close {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    background: transparent;
+    border: none;
+    color: var(--text-secondary);
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background-color 0.2s ease, color 0.2s ease;
+    z-index: 10;
+}
+
+.toast-close:hover {
+    background: rgba(0,0,0,0.05);
+    color: var(--text-primary);
+}
+.toast-close svg { width: 16px; height: 16px; }
+
+
+/* =========================================
+   The Ripple Element (Purely Decorative)
+   ========================================= */
+
+.ripple-element {
+    position: absolute;
+    /* Center it behind the icon */
+    top: 28px; 
+    left: 28px;
+    width: 1px;
+    height: 1px;
+    border-radius: 50%;
+    /* Colors applied by variants below */
+    z-index: 1;
+    
+    /* Initial state before animation */
+    transform: scale(0);
+    opacity: 0;
+}
+
+
+/* =========================================
+   Toast Variants (Colors)
+   ========================================= */
+
+.toast-emerald .toast-icon-wrapper {
+    background-color: var(--accent-emerald);
+    color: var(--surface-white);
+}
+.toast-emerald .ripple-element {
+    background-color: rgba(16, 185, 129, 0.15); /* Light emerald ripple */
+}
+
+.toast-purple .toast-icon-wrapper {
+    background-color: var(--accent-purple);
+    color: var(--surface-white);
+}
+.toast-purple .ripple-element {
+    background-color: rgba(139, 92, 246, 0.15); /* Light purple ripple */
+}
+
+
+/* =========================================
+   The Ripple-Wave Animation System
+   ========================================= */
+
+/* 1. Base Toast Entrance */
+.replay-input:checked ~ .ripple-wave-group .toast {
+    animation: toast-fade-in 0.3s ease-out forwards;
+}
+
+@keyframes toast-fade-in {
+    0% { opacity: 0; transform: scale(0.98); }
+    100% { opacity: 1; transform: scale(1); }
+}
+
+/* 2. The Internal Ripple Expansion */
+.replay-input:checked ~ .ripple-wave-group .toast .ripple-element {
+    /* Explodes outwards rapidly, fading out slightly as it reaches the edges */
+    animation: ripple-expand 0.6s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+@keyframes ripple-expand {
+    0% {
+        transform: scale(0);
+        opacity: 1;
+    }
+    100% {
+        /* Scale massive enough to cover the entire container */
+        transform: scale(800);
+        opacity: 0;
+    }
+}
+
+/* 
+  Staggered Delays for Cascading Effect 
+*/
+.delay-1 { animation-delay: 0.1s !important; }
+.delay-1 .ripple-element { animation-delay: 0.15s !important; } /* Ripple starts just after toast appears */
+
+.delay-2 { animation-delay: 0.3s !important; }
+.delay-2 .ripple-element { animation-delay: 0.35s !important; }
+
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    /* Disable the base entrance scaling */
+    .replay-input:checked ~ .ripple-wave-group .toast {
+        animation: simple-fade 0.3s ease forwards !important;
+        transform: none !important;
+    }
+    
+    @keyframes simple-fade {
+        0% { opacity: 0; }
+        100% { opacity: 1; }
+    }
+    
+    /* Completely hide and disable the decorative ripple */
+    .ripple-element {
+        display: none !important;
+        animation: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces the CSS Ripple-Wave Toast designed for Minimalist Tech Layouts, resolving issue #64574. 

### Changes Made:
- Added `submissions/examples/minimalist-tech-ripple-wave-toast/` directory.
- Created `demo.html` showcasing a mock group of "Network Events". The layout utilizes a pure CSS checkbox hack (`<input type="checkbox">`) connected to a "Trigger Toasts" button to allow users to easily re-trigger the entrance sequence without reloading the page.
- Created `style.css` featuring a clean aesthetic utilizing perfectly aligned iconography, solid icon background accents, and inline action buttons.
  - Implemented the Ripple-Wave Animation System. 
  - Inside each `.toast`, we placed a purely decorative `.ripple-element`, initially a tiny invisible dot centered behind the icon. 
  - When triggered, a specific `@keyframes` animation (`ripple-expand`) uses a massive `transform: scale(800)` to rapidly expand the circular dot outwards. Combined with `overflow: hidden` on the parent, this creates a perfect color wave washing across the background.
  - The wave uses a crisp `cubic-bezier` curve to explode quickly but finish smoothly, fading to `opacity: 0` right as it reaches the edges.
  - Engineered precise stacking contexts (`z-index`) to ensure text and icons remain legible *above* the color wave.
  - Utilized staggered delays. Crucially, the ripple receives a slightly longer delay than the toast entrance itself, making it look as though the icon's appearance initialized the wave.
- Added `README.md` documenting usage and technical features.
- Honors the `prefers-reduced-motion` accessibility standard. The expansive ripple animation is completely disabled and hidden (`display: none`), safely falling back to a simple, immediate opacity fade for motion-sensitive users.

Closes #64574
