### PR TITLE
docs: Modal focus restore is clobbered by a second hashchange while open (closes #66239)

### DIFF
--- a/submissions/docs/modal-focus-restore-advk/README.md
+++ b/submissions/docs/modal-focus-restore-advk/README.md
@@ -1,0 +1,39 @@
+# Modal Focus Restore
+
+## What does this do?
+
+Shows the correct way to record and restore the element that opened a modal, so
+closing the dialog always returns focus to the control the user activated.
+
+## How is it used?
+
+Open `demo.html`, tab to the button, press Enter, then close with `Esc`. The
+status line reports which element focus was restored to.
+
+```js
+// only capture on a genuine closed -> open transition
+if (!overlay.classList.contains('is-active')) {
+  previousFocusedElement = document.activeElement;
+}
+overlay.classList.add('is-active');
+```
+
+## Why is it useful?
+
+`core/modal.js` assigns `previousFocusedElement = document.activeElement`
+unconditionally, *before* adding `is-active`. It then re-checks
+`if (!overlay.classList.contains('is-active'))` — but that guard runs after the
+class was already added, so it is never true and never protects anything.
+
+`checkModal()` is bound to `hashchange`. Any second hashchange while the dialog
+is open — an in-dialog anchor, a router update, a back-button step between two
+modal hashes — re-runs the handler with focus already inside the dialog. The
+opener reference is overwritten with the dialog itself. On close the code then
+calls `.focus()` on a node inside a container that was just hidden, so focus
+falls back to `<body>` and keyboard users lose their place in the page.
+
+Restoring focus to the invoking element is a WCAG 2.4.3 (Focus Order)
+expectation, and it is the difference between a dialog that is usable by
+keyboard and one that silently dumps the user at the top of the document. The
+fix is to move the capture ahead of the state change and gate it on the actual
+transition.

--- a/submissions/docs/modal-focus-restore-advk/demo.html
+++ b/submissions/docs/modal-focus-restore-advk/demo.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Modal Focus Restore</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="fr-wrap">
+  <h1 class="fr-h1">Modal Focus Restore</h1>
+  <p class="fr-lede">
+    A modal must return focus to the control that opened it. If the opener is
+    recorded every time the open-handler runs, a second run overwrites it with a
+    node inside the dialog — and closing strands focus on a hidden element.
+  </p>
+
+  <div class="fr-demo">
+    <button class="fr-open" type="button" id="opener">Open dialog (correct restore)</button>
+    <p class="fr-status" id="status" role="status" aria-live="polite">Focus is on the page.</p>
+  </div>
+
+  <div class="fr-backdrop" id="backdrop" hidden>
+    <div class="fr-dialog" role="dialog" aria-modal="true" aria-labelledby="dlg-t" tabindex="-1" id="dialog">
+      <h2 class="fr-dialog__h" id="dlg-t">Dialog</h2>
+      <p class="fr-dialog__p">Press <kbd>Esc</kbd> or Close. Focus should land back on the opener button.</p>
+      <button class="fr-close" type="button" id="closer">Close</button>
+    </div>
+  </div>
+
+  <pre class="fr-code"><code>// guard the capture so re-entrant opens cannot clobber it
+if (!overlay.classList.contains('is-active')) {
+  previousFocusedElement = document.activeElement;
+}
+overlay.classList.add('is-active');</code></pre>
+</main>
+
+<script>
+(function () {
+  'use strict';
+  var opener = document.getElementById('opener');
+  var closer = document.getElementById('closer');
+  var backdrop = document.getElementById('backdrop');
+  var dialog = document.getElementById('dialog');
+  var status = document.getElementById('status');
+  var previousFocused = null;
+  var isOpen = false;
+
+  function open() {
+    // Capture BEFORE the dialog can take focus, and only on a real transition.
+    if (!isOpen) previousFocused = document.activeElement;
+    isOpen = true;
+    backdrop.hidden = false;
+    requestAnimationFrame(function () { backdrop.classList.add('is-active'); });
+    dialog.focus();
+    status.textContent = 'Dialog open. Opener recorded as: ' + (previousFocused && previousFocused.id || 'none');
+  }
+
+  function close() {
+    if (!isOpen) return;
+    isOpen = false;
+    backdrop.classList.remove('is-active');
+    backdrop.hidden = true;
+    if (previousFocused && typeof previousFocused.focus === 'function') {
+      previousFocused.focus();
+      status.textContent = 'Closed. Focus restored to #' + previousFocused.id + '.';
+      previousFocused = null;
+    }
+  }
+
+  opener.addEventListener('click', open);
+  closer.addEventListener('click', close);
+  backdrop.addEventListener('click', function (e) { if (e.target === backdrop) close(); });
+  document.addEventListener('keydown', function (e) { if (e.key === 'Escape' && isOpen) close(); });
+})();
+</script>
+</body>
+</html>

--- a/submissions/docs/modal-focus-restore-advk/style.css
+++ b/submissions/docs/modal-focus-restore-advk/style.css
@@ -1,0 +1,117 @@
+/* Modal Focus Restore — showcase for correct opener tracking.
+   Motion is limited to backdrop fade + dialog rise so the focus ring
+   stays the most visible thing on screen. */
+
+.fr-wrap {
+  max-width: 42rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.65 ui-sans-serif, system-ui, sans-serif;
+  color: #202124;
+}
+
+.fr-h1 { margin: 0 0 0.4em; font-size: clamp(1.6rem, 4.5vw, 2.2rem); letter-spacing: -0.02em; }
+.fr-lede { margin: 0 0 2rem; color: #5b6068; }
+
+.fr-demo {
+  padding: 1.5rem;
+  border: 1px dashed #c9ccd4;
+  border-radius: 0.7rem;
+  text-align: center;
+  background: #fafbfc;
+}
+
+.fr-open, .fr-close {
+  padding: 0.65em 1.3em;
+  border: 0;
+  border-radius: 0.45rem;
+  background: #2f6fed;
+  color: #fff;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 180ms ease, transform 180ms ease;
+}
+
+.fr-open:hover, .fr-close:hover { background: #1f57c8; transform: translateY(-1px); }
+
+.fr-open:focus-visible, .fr-close:focus-visible {
+  outline: 3px solid #f0a202;
+  outline-offset: 3px;
+}
+
+.fr-status {
+  margin: 1rem 0 0;
+  font-family: ui-monospace, Menlo, monospace;
+  font-size: 0.85rem;
+  color: #3c6e47;
+  min-height: 1.5em;
+}
+
+.fr-backdrop {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+  background: rgba(16, 18, 22, 0.55);
+  opacity: 0;
+  transition: opacity 220ms ease;
+}
+
+.fr-backdrop.is-active { opacity: 1; }
+.fr-backdrop[hidden] { display: none; }
+
+.fr-dialog {
+  width: min(26rem, 100%);
+  padding: 1.75rem;
+  border-radius: 0.9rem;
+  background: #fff;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.3);
+  transform: translateY(1rem) scale(0.97);
+  transition: transform 260ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.fr-backdrop.is-active .fr-dialog { transform: translateY(0) scale(1); }
+.fr-dialog:focus-visible { outline: 3px solid #2f6fed; outline-offset: 4px; }
+.fr-dialog__h { margin: 0 0 0.5rem; font-size: 1.2rem; }
+.fr-dialog__p { margin: 0 0 1.25rem; color: #5b6068; font-size: 0.95rem; }
+
+.fr-dialog kbd {
+  padding: 0.15em 0.45em;
+  border: 1px solid #c9ccd4;
+  border-bottom-width: 2px;
+  border-radius: 0.3rem;
+  background: #f3f4f6;
+  font-family: ui-monospace, Menlo, monospace;
+  font-size: 0.85em;
+}
+
+.fr-code {
+  margin: 2rem 0 0;
+  padding: 1em;
+  overflow-x: auto;
+  border-radius: 0.5rem;
+  background: #202124;
+  color: #e8eaed;
+  font-size: 0.85rem;
+  line-height: 1.6;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fr-backdrop, .fr-dialog, .fr-open, .fr-close { transition: none; }
+  .fr-open:hover, .fr-close:hover { transform: none; }
+}
+
+@media (forced-colors: active) {
+  .fr-dialog { border: 1px solid CanvasText; }
+  .fr-open:focus-visible, .fr-close:focus-visible { outline: 3px solid Highlight; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .fr-wrap { color: #e8eaed; }
+  .fr-lede, .fr-dialog__p, .fr-status { color: #9aa0a6; }
+  .fr-demo { background: #1b1d21; border-color: #35383e; }
+  .fr-dialog { background: #24262b; }
+  .fr-dialog kbd { background: #2f3237; border-color: #4a4e56; color: #e8eaed; }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #66239.

Adds `submissions/docs/modal-focus-restore-advk/` (`demo.html` + `style.css` + `README.md`).

Shows the correct way to record and restore the element that opened a modal, so
closing the dialog always returns focus to the control the user activated.

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission
- [ ] 🧩 New component
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/docs/modal-focus-restore-advk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Shows the correct way to record and restore the element that opened a modal, so
closing the dialog always returns focus to the control the user activated.

**How does a developer use it?**

Open `demo.html`, tab to the button, press Enter, then close with `Esc`. The
status line reports which element focus was restored to.

```js
// only capture on a genuine closed -> open transition
if (!overlay.classList.contains('is-active')) {
  previousFocusedElement = document.activeElement;
}
overlay.classList.add('is-active');
```

**Why does it fit EaseMotion CSS?**

`core/modal.js` assigns `previousFocusedElement = document.activeElement`
unconditionally, *before* adding `is-active`. It then re-checks
`if (!overlay.classList.contains('is-active'))` — but that guard runs after the
class was already added, so it is never true and never protects anything.

`checkModal()` is bound to `hashchange`. Any second hashchange while the dialog
is open — an in-dialog anchor, a router update, a back-button step between two
modal hashes — re-runs the handler with focus already inside the dialog. The
opener reference is overwritten with the dialog itself. On close the code then
calls `.focus()` on a node inside a container that was just hidden, so focus
falls back to `<body>` and keyboard users lose their place in the page.

Restoring focus to the invoking element is a WCAG 2.4.3 (Focus Order)
expectation, and it is the difference between a dialog that is usable by
keyboard and one that silently dumps the user at the top of the document. The
fix is to move the capture ahead of the state change and gate it on the actual
transition.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- CSS passes the repository's own `stylelint` config (`npx stylelint --config .stylelintrc.json`) with no errors.
- Every stylesheet includes a `prefers-reduced-motion` path and, where colour carries state, a `forced-colors` path.
- Naming uses the `-advk` suffix per the CONTRIBUTING uniqueness rule; happy to rename during standardization.
