### PR TITLE
docs: components/skeleton.css shimmer ignores prefers-reduced-motion (closes #66241)

### DIFF
--- a/submissions/docs/reduced-motion-skeleton-advk/README.md
+++ b/submissions/docs/reduced-motion-skeleton-advk/README.md
@@ -1,0 +1,35 @@
+# Reduced-motion Skeleton
+
+## What does this do?
+
+An article skeleton whose shimmer sweep degrades to a static tonal placeholder
+when the user has asked for reduced motion.
+
+## How is it used?
+
+```html
+<section class="rms-card" aria-busy="true" aria-label="Loading article">
+  <div class="rms-media"></div>
+  <div class="rms-line rms-line--title"></div>
+  <div class="rms-line"></div>
+</section>
+```
+
+## Why is it useful?
+
+`components/skeleton.css` animates a shimmer with no `prefers-reduced-motion`
+block. A shimmer is a gradient travelling across the element on a loop — a
+large-area, continuously repeating translation, which is precisely the class of
+effect WCAG 2.3.3 asks authors to make suppressible.
+
+Skeletons make the gap worse than most components because they tile: a list view
+may show twenty of them at once, all sweeping on the same loop, filling the
+viewport with synchronised movement while the user is trying to read the page
+around them.
+
+Simply setting `animation: none` is not sufficient either — with the sweep
+removed, the leftover `background-image` freezes mid-gradient and the block reads
+as broken UI. This showcase removes the gradient as well and substitutes a flat
+fill plus a hairline border, so the element still says "content is loading here"
+through contrast and shape rather than through movement. The `aria-busy="true"`
+attribute carries the same message to assistive technology in both states.

--- a/submissions/docs/reduced-motion-skeleton-advk/demo.html
+++ b/submissions/docs/reduced-motion-skeleton-advk/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Reduced-motion Skeleton</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="rms-wrap">
+  <h1 class="rms-h1">Reduced-motion Skeleton</h1>
+  <p class="rms-lede">
+    A shimmer sweep is a travelling gradient — the exact pattern that triggers
+    discomfort for motion-sensitive users. Under <code>prefers-reduced-motion</code>
+    this skeleton swaps the sweep for a static tonal contrast that still reads as
+    placeholder content.
+  </p>
+
+  <section class="rms-card" aria-busy="true" aria-label="Loading article">
+    <div class="rms-media"></div>
+    <div class="rms-body">
+      <div class="rms-line rms-line--title"></div>
+      <div class="rms-line"></div>
+      <div class="rms-line"></div>
+      <div class="rms-line rms-line--short"></div>
+      <div class="rms-meta">
+        <div class="rms-avatar"></div>
+        <div class="rms-line rms-line--tiny"></div>
+      </div>
+    </div>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/docs/reduced-motion-skeleton-advk/style.css
+++ b/submissions/docs/reduced-motion-skeleton-advk/style.css
@@ -1,0 +1,98 @@
+/* Reduced-motion skeleton.
+   The shimmer is a background-position sweep; under reduce we drop the sweep
+   and rely on a fixed tonal step, keeping the placeholder legible as a
+   placeholder without any travelling highlight. */
+
+.rms-wrap {
+  max-width: 40rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.65 ui-sans-serif, system-ui, sans-serif;
+  color: #1a1d23;
+}
+
+.rms-h1 { margin: 0 0 0.4em; font-size: clamp(1.6rem, 4.5vw, 2.2rem); letter-spacing: -0.02em; }
+.rms-lede { margin: 0 0 2rem; color: #575e6c; }
+
+.rms-lede code {
+  padding: 0.1em 0.35em; border-radius: 0.25rem; background: #e8ebf1;
+  font-family: ui-monospace, Menlo, monospace; font-size: 0.88em;
+}
+
+.rms-card {
+  display: grid;
+  grid-template-columns: 9rem 1fr;
+  gap: 1.25rem;
+  padding: 1.25rem;
+  border: 1px solid #e0e3ea;
+  border-radius: 0.8rem;
+  background: #fff;
+}
+
+@media (max-width: 34rem) {
+  .rms-card { grid-template-columns: 1fr; }
+}
+
+.rms-media, .rms-line, .rms-avatar {
+  --rms-base: #e4e7ee;
+  --rms-sheen: #f4f6fa;
+
+  border-radius: 0.4rem;
+  background-color: var(--rms-base);
+  background-image: linear-gradient(
+    100deg,
+    transparent 20%,
+    var(--rms-sheen) 42%,
+    var(--rms-sheen) 50%,
+    transparent 72%
+  );
+  background-size: 220% 100%;
+  background-repeat: no-repeat;
+  animation: rms-sweep 1.6s ease-in-out infinite;
+}
+
+.rms-media { aspect-ratio: 4 / 3; border-radius: 0.55rem; }
+.rms-body  { display: flex; flex-direction: column; gap: 0.6rem; }
+
+.rms-line { height: 0.75rem; }
+.rms-line--title { height: 1.15rem; width: 70%; margin-bottom: 0.35rem; }
+.rms-line--short { width: 45%; }
+.rms-line--tiny  { height: 0.65rem; width: 6rem; }
+
+.rms-meta { display: flex; align-items: center; gap: 0.6rem; margin-top: 0.6rem; }
+.rms-avatar { width: 1.75rem; aspect-ratio: 1; border-radius: 50%; }
+
+@keyframes rms-sweep {
+  from { background-position: 180% 0; }
+  to   { background-position: -80% 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rms-media, .rms-line, .rms-avatar {
+    /* no sweep, no travel: a flat tone that still reads as "not content yet" */
+    animation: none;
+    background-image: none;
+    background-color: var(--rms-base);
+    border: 1px solid #d3d8e2;
+  }
+}
+
+@media (forced-colors: active) {
+  .rms-media, .rms-line, .rms-avatar {
+    background-image: none;
+    background-color: Canvas;
+    border: 1px solid GrayText;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .rms-wrap { color: #e6e8ee; }
+  .rms-lede { color: #99a0b0; }
+  .rms-lede code { background: #2a2f3a; }
+  .rms-card { background: #15181e; border-color: #2a2f3a; }
+  .rms-media, .rms-line, .rms-avatar { --rms-base: #262b35; --rms-sheen: #333a47; }
+
+  @media (prefers-reduced-motion: reduce) {
+    .rms-media, .rms-line, .rms-avatar { border-color: #3a4250; }
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #66241.

Adds `submissions/docs/reduced-motion-skeleton-advk/` (`demo.html` + `style.css` + `README.md`).

An article skeleton whose shimmer sweep degrades to a static tonal placeholder
when the user has asked for reduced motion.

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission
- [ ] 🧩 New component
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/docs/reduced-motion-skeleton-advk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

An article skeleton whose shimmer sweep degrades to a static tonal placeholder
when the user has asked for reduced motion.

**How does a developer use it?**

```html
<section class="rms-card" aria-busy="true" aria-label="Loading article">
  <div class="rms-media"></div>
  <div class="rms-line rms-line--title"></div>
  <div class="rms-line"></div>
</section>
```

**Why does it fit EaseMotion CSS?**

`components/skeleton.css` animates a shimmer with no `prefers-reduced-motion`
block. A shimmer is a gradient travelling across the element on a loop — a
large-area, continuously repeating translation, which is precisely the class of
effect WCAG 2.3.3 asks authors to make suppressible.

Skeletons make the gap worse than most components because they tile: a list view
may show twenty of them at once, all sweeping on the same loop, filling the
viewport with synchronised movement while the user is trying to read the page
around them.

Simply setting `animation: none` is not sufficient either — with the sweep
removed, the leftover `background-image` freezes mid-gradient and the block reads
as broken UI. This showcase removes the gradient as well and substitutes a flat
fill plus a hairline border, so the element still says "content is loading here"
through contrast and shape rather than through movement. The `aria-busy="true"`
attribute carries the same message to assistive technology in both states.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- CSS passes the repository's own `stylelint` config (`npx stylelint --config .stylelintrc.json`) with no errors.
- Every stylesheet includes a `prefers-reduced-motion` path and, where colour carries state, a `forced-colors` path.
- Naming uses the `-advk` suffix per the CONTRIBUTING uniqueness rule; happy to rename during standardization.
