### PR TITLE
docs: modal.js clears body inline overflow it did not set (closes #66242)

### DIFF
--- a/submissions/docs/scroll-lock-restore-advk/README.md
+++ b/submissions/docs/scroll-lock-restore-advk/README.md
@@ -1,0 +1,36 @@
+# Non-destructive Scroll Lock
+
+## What does this do?
+
+Demonstrates a modal scroll lock that saves and restores the host page's
+existing inline `overflow` value instead of blanking it.
+
+## How is it used?
+
+The page presets `body { overflow: clip }` inline, as an app shell might. Press
+each button and watch the readout: the clobbering path loses `clip`, the
+restoring path keeps it.
+
+```js
+let saved = null;
+function lock()   { saved = document.body.style.overflow; document.body.style.overflow = 'hidden'; }
+function unlock() { document.body.style.overflow = saved ?? ''; saved = null; }
+```
+
+## Why is it useful?
+
+`core/modal.js` sets `body.style.overflow = 'hidden'` when a modal opens and
+then unconditionally runs `body.style.overflow = ''` on every path where no
+active modal is found — including the very first `checkModal()` call on page
+load, before any modal has ever opened.
+
+That means simply loading a page with EaseMotion's modal script clears any
+inline `overflow` the host application set on `<body>`. Apps that pin scroll for
+a drawer, a full-bleed canvas, or their own scroll container silently lose that
+style, and the symptom (a page that scrolls when it should not) appears far from
+the cause.
+
+Saving the prior value and writing it back keeps the framework a good citizen in
+pages it does not own — the same discipline EaseMotion already applies by
+namespacing every class with `ease-`. The lock also becomes safely re-entrant,
+which matters once more than one overlay can be open across a session.

--- a/submissions/docs/scroll-lock-restore-advk/demo.html
+++ b/submissions/docs/scroll-lock-restore-advk/demo.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Non-destructive Scroll Lock</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body class="sl-preset">
+<main class="sl-wrap">
+  <h1 class="sl-h1">Non-destructive Scroll Lock</h1>
+  <p class="sl-lede">
+    Locking page scroll by writing <code>body.style.overflow = 'hidden'</code> and
+    later clearing it with <code>''</code> destroys whatever inline value the host
+    page already had. Save and restore instead.
+  </p>
+
+  <div class="sl-panel">
+    <p class="sl-readout">Current <code>body</code> inline overflow:
+      <strong id="readout">—</strong></p>
+    <button class="sl-btn" type="button" id="lock-bad">Lock &amp; unlock (clobbering)</button>
+    <button class="sl-btn sl-btn--good" type="button" id="lock-good">Lock &amp; unlock (restoring)</button>
+    <button class="sl-btn sl-btn--ghost" type="button" id="reset">Reset preset</button>
+  </div>
+
+  <pre class="sl-code"><code>let saved = null;
+
+function lock() {
+  saved = document.body.style.overflow;   // remember, may be '' or a real value
+  document.body.style.overflow = 'hidden';
+}
+
+function unlock() {
+  document.body.style.overflow = saved ?? '';
+  saved = null;
+}</code></pre>
+</main>
+
+<script>
+(function () {
+  'use strict';
+  var body = document.body;
+  var readout = document.getElementById('readout');
+  var saved = null;
+
+  function preset() { body.style.overflow = 'clip'; render(); }
+  function render() {
+    readout.textContent = body.style.overflow === '' ? '(empty)' : body.style.overflow;
+    readout.className = body.style.overflow === 'clip' ? 'sl-ok' : 'sl-lost';
+  }
+
+  document.getElementById('lock-bad').addEventListener('click', function () {
+    body.style.overflow = 'hidden';
+    setTimeout(function () { body.style.overflow = ''; render(); }, 400);
+    render();
+  });
+
+  document.getElementById('lock-good').addEventListener('click', function () {
+    saved = body.style.overflow;
+    body.style.overflow = 'hidden';
+    setTimeout(function () {
+      body.style.overflow = saved !== null ? saved : '';
+      saved = null;
+      render();
+    }, 400);
+    render();
+  });
+
+  document.getElementById('reset').addEventListener('click', preset);
+  preset();
+})();
+</script>
+</body>
+</html>

--- a/submissions/docs/scroll-lock-restore-advk/style.css
+++ b/submissions/docs/scroll-lock-restore-advk/style.css
@@ -1,0 +1,91 @@
+/* Non-destructive scroll lock showcase.
+   The readout colour is the whole point: green = host value survived,
+   red = it was wiped by the unlock path. */
+
+.sl-wrap {
+  max-width: 42rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.65 ui-sans-serif, system-ui, sans-serif;
+  color: #1c1f26;
+}
+
+.sl-h1 { margin: 0 0 0.4em; font-size: clamp(1.6rem, 4.5vw, 2.2rem); letter-spacing: -0.02em; }
+.sl-lede { margin: 0 0 2rem; color: #565d6b; }
+
+.sl-lede code, .sl-readout code {
+  padding: 0.1em 0.35em;
+  border-radius: 0.25rem;
+  background: #e9ecf3;
+  font-family: ui-monospace, Menlo, monospace;
+  font-size: 0.88em;
+}
+
+.sl-panel {
+  padding: 1.5rem;
+  border-radius: 0.7rem;
+  border: 1px solid #dce0e9;
+  background: #f8f9fc;
+}
+
+.sl-readout {
+  margin: 0 0 1.1rem;
+  font-size: 0.95rem;
+}
+
+.sl-readout strong {
+  display: inline-block;
+  padding: 0.2em 0.6em;
+  border-radius: 0.35rem;
+  font-family: ui-monospace, Menlo, monospace;
+  transition: background 240ms ease, color 240ms ease;
+}
+
+.sl-ok   { background: #ddf3e6; color: #17663f; }
+.sl-lost { background: #fbe0e4; color: #9b1c32; }
+
+.sl-btn {
+  padding: 0.6em 1.15em;
+  margin: 0 0.45rem 0.5rem 0;
+  border: 0;
+  border-radius: 0.45rem;
+  background: #b3243f;
+  color: #fff;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  transition: filter 160ms ease, transform 160ms ease;
+}
+
+.sl-btn--good  { background: #17663f; }
+.sl-btn--ghost { background: transparent; color: #565d6b; border: 1px solid #c3c8d4; }
+.sl-btn:hover  { filter: brightness(1.1); transform: translateY(-1px); }
+.sl-btn:focus-visible { outline: 3px solid #3b5bdb; outline-offset: 3px; }
+
+.sl-code {
+  margin: 2rem 0 0;
+  padding: 1em;
+  overflow-x: auto;
+  border-radius: 0.5rem;
+  background: #1c1f26;
+  color: #e4e7ee;
+  font-size: 0.85rem;
+  line-height: 1.6;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sl-btn, .sl-readout strong { transition: none; }
+  .sl-btn:hover { transform: none; }
+}
+
+@media (forced-colors: active) {
+  .sl-ok, .sl-lost { forced-color-adjust: none; }
+  .sl-btn:focus-visible { outline: 3px solid Highlight; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .sl-wrap { color: #e4e7ee; }
+  .sl-lede { color: #99a1b3; }
+  .sl-panel { background: #171a21; border-color: #2b3038; }
+  .sl-lede code, .sl-readout code { background: #2b3038; }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #66242.

Adds `submissions/docs/scroll-lock-restore-advk/` (`demo.html` + `style.css` + `README.md`).

Demonstrates a modal scroll lock that saves and restores the host page's
existing inline `overflow` value instead of blanking it.

---

## Type of Change

- [x] 🐛 Bug fix in an existing submission
- [ ] 🧩 New component
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/docs/scroll-lock-restore-advk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Demonstrates a modal scroll lock that saves and restores the host page's
existing inline `overflow` value instead of blanking it.

**How does a developer use it?**

The page presets `body { overflow: clip }` inline, as an app shell might. Press
each button and watch the readout: the clobbering path loses `clip`, the
restoring path keeps it.

```js
let saved = null;
function lock()   { saved = document.body.style.overflow; document.body.style.overflow = 'hidden'; }
function unlock() { document.body.style.overflow = saved ?? ''; saved = null; }
```

**Why does it fit EaseMotion CSS?**

`core/modal.js` sets `body.style.overflow = 'hidden'` when a modal opens and
then unconditionally runs `body.style.overflow = ''` on every path where no
active modal is found — including the very first `checkModal()` call on page
load, before any modal has ever opened.

That means simply loading a page with EaseMotion's modal script clears any
inline `overflow` the host application set on `<body>`. Apps that pin scroll for
a drawer, a full-bleed canvas, or their own scroll container silently lose that
style, and the symptom (a page that scrolls when it should not) appears far from
the cause.

Saving the prior value and writing it back keeps the framework a good citizen in
pages it does not own — the same discipline EaseMotion already applies by
namespacing every class with `ease-`. The lock also becomes safely re-entrant,
which matters once more than one overlay can be open across a session.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- CSS passes the repository's own `stylelint` config (`npx stylelint --config .stylelintrc.json`) with no errors.
- Every stylesheet includes a `prefers-reduced-motion` path and, where colour carries state, a `forced-colors` path.
- Naming uses the `-advk` suffix per the CONTRIBUTING uniqueness rule; happy to rename during standardization.
