### PR TITLE
feat: Smooth Accordion (closes #66243)

### DIFF
--- a/submissions/examples/accordion-smooth-advk/README.md
+++ b/submissions/examples/accordion-smooth-advk/README.md
@@ -1,0 +1,37 @@
+# Smooth Accordion
+
+## What does this do?
+
+Animates a native `<details>` element open and closed to its true content
+height, using a `grid-template-rows: 0fr -> 1fr` transition.
+
+## How is it used?
+
+```html
+<details class="acs-item">
+  <summary class="acs-sum">Question</summary>
+  <div class="acs-panel"><div class="acs-inner">
+    <p>Answer.</p>
+  </div></div>
+</details>
+```
+
+The double wrapper is required: `.acs-panel` is the grid, `.acs-inner` supplies
+the `overflow: hidden` that a `0fr` track does not clip on its own.
+
+## Why is it useful?
+
+`<details>` cannot be transitioned directly, so accordions are normally rebuilt
+in JavaScript with a measured `max-height`, or given a guessed ceiling. A guessed
+ceiling is wrong in both directions — too low clips long answers, too high wastes
+most of the easing curve on empty space so the panel appears to snap open and
+then crawl.
+
+Transitioning a grid track avoids the guess entirely: `1fr` resolves to the
+content's actual height, so the easing maps onto the real distance for any
+content length, including text that reflows at narrow widths.
+
+Keeping the native element means keyboard support, the expanded/collapsed state
+exposed to assistive technology, and browser find-in-page opening the right
+section all come free, rather than being reimplemented with ARIA that has to stay
+in sync.

--- a/submissions/examples/accordion-smooth-advk/demo.html
+++ b/submissions/examples/accordion-smooth-advk/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Smooth Accordion</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="acs-wrap">
+  <h1 class="acs-h1">Smooth Accordion</h1>
+  <p class="acs-lede">Native &lt;details&gt; that animates open and closed using grid-template-rows, so the panel transitions to its real height without a hard-coded max-height.</p>
+
+  <details class="acs-item" open>
+    <summary class="acs-sum">Why not max-height?</summary>
+    <div class="acs-panel"><div class="acs-inner">
+      <p>A max-height transition needs a guessed ceiling. Too low clips the content; too high makes the easing feel wrong, because the visible part of the transition is only a fraction of the declared range.</p>
+    </div></div>
+  </details>
+
+  <details class="acs-item">
+    <summary class="acs-sum">What does grid do instead?</summary>
+    <div class="acs-panel"><div class="acs-inner">
+      <p>A single-row grid can transition <code>grid-template-rows</code> from <code>0fr</code> to <code>1fr</code>. The browser resolves <code>1fr</code> to the content's real height, so the easing curve maps onto the true distance.</p>
+    </div></div>
+  </details>
+
+  <details class="acs-item">
+    <summary class="acs-sum">Is it accessible?</summary>
+    <div class="acs-panel"><div class="acs-inner">
+      <p>It is a native disclosure widget. Keyboard behaviour, the expanded state and in-page find all come from the browser rather than from ARIA you have to maintain.</p>
+    </div></div>
+  </details>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/accordion-smooth-advk/style.css
+++ b/submissions/examples/accordion-smooth-advk/style.css
@@ -1,0 +1,87 @@
+/* Smooth Accordion
+   The panel is a 1-row grid whose track animates 0fr -> 1fr. The inner div
+   must carry overflow:hidden, because a 0fr track still lets content overflow. */
+
+.acs-wrap {
+  max-width: 38rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.65 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.acs-h1 { margin: 0 0 0.4em; font-size: clamp(1.5rem, 4.5vw, 2.1rem); letter-spacing: -0.02em; }
+.acs-lede { margin: 0 0 2rem; color: #576073; }
+
+.acs-item {
+  border: 1px solid #dfe3ec;
+  border-radius: 0.6rem;
+  background: #fbfcfe;
+  margin-bottom: 0.6rem;
+  overflow: hidden;
+}
+
+.acs-sum {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  padding: 0.95em 1.1em;
+  font-weight: 600;
+  cursor: pointer;
+  list-style: none;
+  transition: background 180ms ease;
+}
+
+.acs-sum::-webkit-details-marker { display: none; }
+.acs-sum:hover { background: #f1f4fa; }
+.acs-sum:focus-visible { outline: 3px solid #4c6ef5; outline-offset: -3px; }
+
+/* chevron */
+.acs-sum::before {
+  content: "";
+  width: 0.55rem;
+  height: 0.55rem;
+  flex: none;
+  border-right: 2px solid #4c6ef5;
+  border-bottom: 2px solid #4c6ef5;
+  transform: rotate(-45deg);
+  transition: transform 300ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.acs-item[open] .acs-sum::before { transform: rotate(45deg); }
+
+.acs-panel {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 340ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.acs-item[open] .acs-panel { grid-template-rows: 1fr; }
+
+.acs-inner { overflow: hidden; }
+.acs-inner p { margin: 0; padding: 0 1.1em 1.1em; color: #576073; font-size: 0.94rem; }
+
+.acs-inner code {
+  padding: 0.1em 0.35em;
+  border-radius: 0.25rem;
+  background: #e8ecf4;
+  font-family: ui-monospace, Menlo, monospace;
+  font-size: 0.88em;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .acs-panel, .acs-sum::before, .acs-sum { transition: none; }
+}
+
+@media (forced-colors: active) {
+  .acs-item { border-color: CanvasText; }
+  .acs-sum::before { border-color: CanvasText; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .acs-wrap { color: #e6e9f2; }
+  .acs-lede, .acs-inner p { color: #99a1b4; }
+  .acs-item { background: #171b23; border-color: #2a303c; }
+  .acs-sum:hover { background: #1e2430; }
+  .acs-inner code { background: #2a303c; }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #66243.

Adds `submissions/examples/accordion-smooth-advk/` (`demo.html` + `style.css` + `README.md`).

Animates a native `<details>` element open and closed to its true content
height, using a `grid-template-rows: 0fr -> 1fr` transition.

---

## Type of Change

- [x] 🧩 New component
- [ ] 🐛 Bug fix in an existing submission
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/examples/accordion-smooth-advk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Animates a native `<details>` element open and closed to its true content
height, using a `grid-template-rows: 0fr -> 1fr` transition.

**How does a developer use it?**

```html
<details class="acs-item">
  <summary class="acs-sum">Question</summary>
  <div class="acs-panel"><div class="acs-inner">
    <p>Answer.</p>
  </div></div>
</details>
```

The double wrapper is required: `.acs-panel` is the grid, `.acs-inner` supplies
the `overflow: hidden` that a `0fr` track does not clip on its own.

**Why does it fit EaseMotion CSS?**

`<details>` cannot be transitioned directly, so accordions are normally rebuilt
in JavaScript with a measured `max-height`, or given a guessed ceiling. A guessed
ceiling is wrong in both directions — too low clips long answers, too high wastes
most of the easing curve on empty space so the panel appears to snap open and
then crawl.

Transitioning a grid track avoids the guess entirely: `1fr` resolves to the
content's actual height, so the easing maps onto the real distance for any
content length, including text that reflows at narrow widths.

Keeping the native element means keyboard support, the expanded/collapsed state
exposed to assistive technology, and browser find-in-page opening the right
section all come free, rather than being reimplemented with ARIA that has to stay
in sync.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- CSS passes the repository's own `stylelint` config (`npx stylelint --config .stylelintrc.json`) with no errors.
- Every stylesheet includes a `prefers-reduced-motion` path and, where colour carries state, a `forced-colors` path.
- Naming uses the `-advk` suffix per the CONTRIBUTING uniqueness rule; happy to rename during standardization.
