### PR TITLE
feat: Breathing CTA (closes #66244)

### DIFF
--- a/submissions/examples/breathing-cta-advk/README.md
+++ b/submissions/examples/breathing-cta-advk/README.md
@@ -1,0 +1,32 @@
+# Breathing CTA
+
+## What does this do?
+
+A primary call-to-action with a slow expanding halo and a sheen that sweeps
+across the button once on hover or focus.
+
+## How is it used?
+
+```html
+<a class="bcta" href="#start"><span class="bcta__label">Get started</span></a>
+<a class="bcta bcta--quiet" href="#docs"><span class="bcta__label">Read the docs</span></a>
+```
+
+## Why is it useful?
+
+Attention-drawing buttons usually pulse `opacity` or `scale`, which makes the
+label itself move or fade — the text becomes harder to read exactly while the
+effect is asking you to read it. Animating an outward `box-shadow` instead keeps
+the button box, and therefore the label, perfectly still: only the halo around it
+changes, so legibility is never traded for emphasis. It also costs no layout,
+since `box-shadow` is painted outside the border box.
+
+Splitting the halo loop from the hover sheen matters for the reduced-motion path.
+They can be treated differently: the autonomous 3.6s loop is the part that
+qualifies as unsolicited motion and is replaced with a static ring, while the
+sheen is user-initiated and could be kept — this implementation drops both for
+safety, but the structure makes either choice a one-line change.
+
+The `--quiet` modifier shares the geometry with no animation at all, so primary
+and secondary actions stay visually related while only one competes for
+attention.

--- a/submissions/examples/breathing-cta-advk/demo.html
+++ b/submissions/examples/breathing-cta-advk/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Breathing CTA</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="bcta-wrap">
+  <h1 class="bcta-h1">Breathing CTA</h1>
+  <p class="bcta-lede">A primary button with a slow halo that breathes rather than blinks, and a sheen that crosses only on hover.</p>
+  <p><a class="bcta" href="#start"><span class="bcta__label">Get started</span></a></p>
+  <p><a class="bcta bcta--quiet" href="#docs"><span class="bcta__label">Read the docs</span></a></p>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/breathing-cta-advk/style.css
+++ b/submissions/examples/breathing-cta-advk/style.css
@@ -1,0 +1,65 @@
+/* Breathing CTA
+   Two separable layers: a slow box-shadow halo that loops, and a sheen sweep
+   that runs once per hover. Keeping them apart lets reduced-motion drop only
+   the loop while preserving the hover feedback. */
+
+.bcta-wrap { max-width: 34rem; margin: 0 auto; padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif; color: #eef1f7; background: #11141b; min-height: 100vh; }
+.bcta-h1 { margin: 0 0 0.4em; font-size: clamp(1.5rem, 4.5vw, 2.1rem); letter-spacing: -0.02em; }
+.bcta-lede { margin: 0 0 2.25rem; color: #98a1b5; }
+
+.bcta {
+  position: relative;
+  display: inline-block;
+  overflow: hidden;
+  padding: 0.85em 1.9em;
+  border-radius: 0.6rem;
+  background: linear-gradient(135deg, #5b6ef5, #8b5bf5);
+  color: #fff;
+  font-weight: 600;
+  text-decoration: none;
+  animation: bcta-breathe 3.6s ease-in-out infinite;
+}
+
+.bcta--quiet {
+  background: transparent;
+  box-shadow: inset 0 0 0 1px #39415a;
+  color: #c3cad9;
+  animation: none;
+}
+
+.bcta__label { position: relative; z-index: 1; }
+
+/* sheen: parked off-frame, crosses once per hover */
+.bcta::before {
+  content: "";
+  position: absolute;
+  top: 0; bottom: 0;
+  left: -60%;
+  width: 45%;
+  background: linear-gradient(100deg, transparent, rgba(255, 255, 255, 0.38), transparent);
+  transform: skewX(-18deg);
+}
+
+.bcta:hover::before,
+.bcta:focus-visible::before { animation: bcta-sheen 750ms ease-out; }
+
+.bcta:focus-visible { outline: 3px solid #ffd166; outline-offset: 3px; }
+
+@keyframes bcta-breathe {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(91, 110, 245, 0.45); }
+  50%      { box-shadow: 0 0 0 0.7rem rgba(91, 110, 245, 0); }
+}
+
+@keyframes bcta-sheen { to { left: 115%; } }
+
+@media (prefers-reduced-motion: reduce) {
+  /* drop the loop, keep a static ring so the CTA still reads as primary */
+  .bcta { animation: none; box-shadow: 0 0 0 3px rgba(91, 110, 245, 0.35); }
+  .bcta:hover::before, .bcta:focus-visible::before { animation: none; }
+}
+
+@media (forced-colors: active) {
+  .bcta { border: 1px solid CanvasText; background: Canvas; color: CanvasText; }
+  .bcta::before { display: none; }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #66244.

Adds `submissions/examples/breathing-cta-advk/` (`demo.html` + `style.css` + `README.md`).

A primary call-to-action with a slow expanding halo and a sheen that sweeps
across the button once on hover or focus.

---

## Type of Change

- [x] 🧩 New component
- [ ] 🐛 Bug fix in an existing submission
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/examples/breathing-cta-advk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A primary call-to-action with a slow expanding halo and a sheen that sweeps
across the button once on hover or focus.

**How does a developer use it?**

```html
<a class="bcta" href="#start"><span class="bcta__label">Get started</span></a>
<a class="bcta bcta--quiet" href="#docs"><span class="bcta__label">Read the docs</span></a>
```

**Why does it fit EaseMotion CSS?**

Attention-drawing buttons usually pulse `opacity` or `scale`, which makes the
label itself move or fade — the text becomes harder to read exactly while the
effect is asking you to read it. Animating an outward `box-shadow` instead keeps
the button box, and therefore the label, perfectly still: only the halo around it
changes, so legibility is never traded for emphasis. It also costs no layout,
since `box-shadow` is painted outside the border box.

Splitting the halo loop from the hover sheen matters for the reduced-motion path.
They can be treated differently: the autonomous 3.6s loop is the part that
qualifies as unsolicited motion and is replaced with a static ring, while the
sheen is user-initiated and could be kept — this implementation drops both for
safety, but the structure makes either choice a one-line change.

The `--quiet` modifier shares the geometry with no animation at all, so primary
and secondary actions stay visually related while only one competes for
attention.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- CSS passes the repository's own `stylelint` config (`npx stylelint --config .stylelintrc.json`) with no errors.
- Every stylesheet includes a `prefers-reduced-motion` path and, where colour carries state, a `forced-colors` path.
- Naming uses the `-advk` suffix per the CONTRIBUTING uniqueness rule; happy to rename during standardization.
