### PR TITLE
feat: Copy Feedback (closes #66245)

### DIFF
--- a/submissions/examples/copy-feedback-advk/README.md
+++ b/submissions/examples/copy-feedback-advk/README.md
@@ -1,0 +1,38 @@
+# Copy Feedback
+
+## What does this do?
+
+A copy-to-clipboard button that confirms success in place — the label swaps to a
+checkmark, the button pulses once, and the result is announced to screen readers.
+
+## How is it used?
+
+```html
+<button class="cpf-btn" data-target="snippet">
+  <span class="cpf-btn__idle">Copy</span>
+  <span class="cpf-btn__done">Copied</span>
+</button>
+<p class="cpf-sr" role="status" aria-live="polite"></p>
+```
+
+Adding `is-done` to the button drives the entire visual transition; the class is
+removed after a timeout.
+
+## Why is it useful?
+
+Copy buttons are the most common interactive element in documentation, and the
+usual versions have two flaws. They swap the label text directly, so the button
+changes width between "Copy" and "Copied" and shoves the surrounding layout
+sideways at the exact moment the user is looking at it. And they communicate
+success only visually, so a screen-reader user gets no confirmation that anything
+happened.
+
+Stacking both labels in a single CSS grid cell fixes the first: the button is
+always as wide as its widest state, and the swap is a pure opacity and transform
+crossfade with no reflow. The `role="status"` live region fixes the second at the
+cost of one visually hidden element.
+
+The pulse uses a spring curve and completes in 420ms, short enough to read as
+acknowledgement rather than decoration. Under reduced motion the scale pulse and
+label travel are dropped, but the colour change and the announcement both remain,
+so no user loses the confirmation itself.

--- a/submissions/examples/copy-feedback-advk/demo.html
+++ b/submissions/examples/copy-feedback-advk/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Copy Feedback</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="cpf-wrap">
+  <h1 class="cpf-h1">Copy Feedback</h1>
+  <p class="cpf-lede">A copy button that confirms the action in place: the label swaps to a checkmark, the button pulses once, and a live region announces it to screen readers.</p>
+
+  <div class="cpf-block">
+    <code class="cpf-code" id="snippet">npm install easemotion-css</code>
+    <button class="cpf-btn" type="button" data-target="snippet">
+      <span class="cpf-btn__idle">Copy</span>
+      <span class="cpf-btn__done">Copied</span>
+    </button>
+  </div>
+
+  <p class="cpf-sr" role="status" aria-live="polite" id="announce"></p>
+
+  <script>
+  document.querySelectorAll('.cpf-btn').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      var text = document.getElementById(btn.dataset.target).textContent;
+      var done = function () {
+        btn.classList.add('is-done');
+        document.getElementById('announce').textContent = 'Copied to clipboard';
+        setTimeout(function () {
+          btn.classList.remove('is-done');
+          document.getElementById('announce').textContent = '';
+        }, 1800);
+      };
+      if (navigator.clipboard) { navigator.clipboard.writeText(text).then(done, done); }
+      else { done(); }
+    });
+  });
+  </script>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/copy-feedback-advk/style.css
+++ b/submissions/examples/copy-feedback-advk/style.css
@@ -1,0 +1,102 @@
+/* Copy Feedback
+   Both labels are stacked in the same grid cell so the button never changes
+   width when the text swaps -- no layout shift mid-interaction. */
+
+.cpf-wrap {
+  max-width: 36rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1a1e26;
+}
+
+.cpf-h1 { margin: 0 0 0.4em; font-size: clamp(1.5rem, 4.5vw, 2.1rem); letter-spacing: -0.02em; }
+.cpf-lede { margin: 0 0 2rem; color: #566072; }
+
+.cpf-block {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.6rem 0.6rem 0.6rem 1rem;
+  border: 1px solid #dee2ec;
+  border-radius: 0.6rem;
+  background: #f7f9fc;
+}
+
+.cpf-code {
+  flex: 1;
+  overflow-x: auto;
+  font-family: ui-monospace, Menlo, Consolas, monospace;
+  font-size: 0.92rem;
+  white-space: nowrap;
+}
+
+.cpf-btn {
+  position: relative;
+  display: grid;
+  flex: none;
+  padding: 0.5em 1em;
+  border: 0;
+  border-radius: 0.4rem;
+  background: #2f6fed;
+  color: #fff;
+  font: inherit;
+  font-weight: 600;
+  font-size: 0.88rem;
+  cursor: pointer;
+  transition: background 200ms ease, transform 200ms ease;
+}
+
+/* stack both labels in one cell -> constant width */
+.cpf-btn__idle, .cpf-btn__done {
+  grid-area: 1 / 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35em;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+.cpf-btn__done { opacity: 0; transform: translateY(0.45rem); }
+.cpf-btn__done::before { content: "\2713"; font-weight: 700; }
+
+.cpf-btn.is-done { background: #14855f; animation: cpf-pulse 420ms cubic-bezier(0.34, 1.56, 0.64, 1); }
+.cpf-btn.is-done .cpf-btn__idle { opacity: 0; transform: translateY(-0.45rem); }
+.cpf-btn.is-done .cpf-btn__done { opacity: 1; transform: translateY(0); }
+
+.cpf-btn:hover { background: #1f57c8; }
+.cpf-btn.is-done:hover { background: #14855f; }
+.cpf-btn:focus-visible { outline: 3px solid #1a1e26; outline-offset: 3px; }
+
+@keyframes cpf-pulse {
+  0%   { transform: scale(1); }
+  45%  { transform: scale(1.08); }
+  100% { transform: scale(1); }
+}
+
+/* visually hidden live region */
+.cpf-sr {
+  position: absolute;
+  width: 1px; height: 1px;
+  margin: -1px; padding: 0;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cpf-btn, .cpf-btn__idle, .cpf-btn__done { transition: opacity 150ms ease; }
+  .cpf-btn.is-done { animation: none; }
+  .cpf-btn__done { transform: none; }
+  .cpf-btn.is-done .cpf-btn__idle { transform: none; }
+}
+
+@media (forced-colors: active) {
+  .cpf-btn { border: 1px solid CanvasText; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .cpf-wrap { color: #e6e9f1; }
+  .cpf-lede { color: #98a0b2; }
+  .cpf-block { background: #161a21; border-color: #292f3a; }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #66245.

Adds `submissions/examples/copy-feedback-advk/` (`demo.html` + `style.css` + `README.md`).

A copy-to-clipboard button that confirms success in place — the label swaps to a
checkmark, the button pulses once, and the result is announced to screen readers.

---

## Type of Change

- [x] 🧩 New component
- [ ] 🐛 Bug fix in an existing submission
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/examples/copy-feedback-advk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A copy-to-clipboard button that confirms success in place — the label swaps to a
checkmark, the button pulses once, and the result is announced to screen readers.

**How does a developer use it?**

```html
<button class="cpf-btn" data-target="snippet">
  <span class="cpf-btn__idle">Copy</span>
  <span class="cpf-btn__done">Copied</span>
</button>
<p class="cpf-sr" role="status" aria-live="polite"></p>
```

Adding `is-done` to the button drives the entire visual transition; the class is
removed after a timeout.

**Why does it fit EaseMotion CSS?**

Copy buttons are the most common interactive element in documentation, and the
usual versions have two flaws. They swap the label text directly, so the button
changes width between "Copy" and "Copied" and shoves the surrounding layout
sideways at the exact moment the user is looking at it. And they communicate
success only visually, so a screen-reader user gets no confirmation that anything
happened.

Stacking both labels in a single CSS grid cell fixes the first: the button is
always as wide as its widest state, and the swap is a pure opacity and transform
crossfade with no reflow. The `role="status"` live region fixes the second at the
cost of one visually hidden element.

The pulse uses a spring curve and completes in 420ms, short enough to read as
acknowledgement rather than decoration. Under reduced motion the scale pulse and
label travel are dropped, but the colour change and the announcement both remain,
so no user loses the confirmation itself.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- CSS passes the repository's own `stylelint` config (`npx stylelint --config .stylelintrc.json`) with no errors.
- Every stylesheet includes a `prefers-reduced-motion` path and, where colour carries state, a `forced-colors` path.
- Naming uses the `-advk` suffix per the CONTRIBUTING uniqueness rule; happy to rename during standardization.
