### PR TITLE
feat: Elastic Tabs (closes #66246)

### DIFF
--- a/submissions/examples/elastic-tabs-advk/README.md
+++ b/submissions/examples/elastic-tabs-advk/README.md
@@ -1,0 +1,36 @@
+# Elastic Tabs
+
+## What does this do?
+
+A tab strip with an underline that slides between tabs on a spring curve, driven
+entirely by radio inputs.
+
+## How is it used?
+
+```html
+<div class="etb-tabs" style="--count: 4">
+  <input class="etb-radio" type="radio" name="etb" id="etb1" checked />
+  <label class="etb-tab" for="etb1">Overview</label>
+  <!-- ...more pairs... -->
+  <span class="etb-ink" aria-hidden="true"></span>
+</div>
+```
+
+Set `--count` to the number of tabs; the ink bar sizes itself from it.
+
+## Why is it useful?
+
+`components/tabs.css` ships with `core/tabs.js` to manage the active state.
+A radio group gets the same behaviour from the platform: exactly one selection at
+a time, arrow-key navigation within the group, and correct exposure to assistive
+technology as a radio set — none of which has to be written or maintained.
+
+Sizing the ink bar as `100% / var(--count)` and moving it with `translateX`
+percentages means the bar never needs measuring, so there is no
+`getBoundingClientRect` call and no resize listener to keep it aligned when the
+container reflows.
+
+The elastic feel comes from a single cubic-bezier whose second control point
+exceeds 1, producing overshoot and settle. Under reduced motion the same
+transition is kept but shortened to a fast linear move — the selection still
+reads as a movement between tabs, without the spring.

--- a/submissions/examples/elastic-tabs-advk/demo.html
+++ b/submissions/examples/elastic-tabs-advk/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Elastic Tabs</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="etb-wrap">
+  <h1 class="etb-h1">Elastic Tabs</h1>
+  <p class="etb-lede">A tab strip whose underline stretches toward the destination before settling, using radio inputs so the active state needs no script.</p>
+  <div class="etb-tabs" style="--count: 4">
+    <input class="etb-radio" type="radio" name="etb" id="etb1" checked /><label class="etb-tab" for="etb1">Overview</label>
+    <input class="etb-radio" type="radio" name="etb" id="etb2" /><label class="etb-tab" for="etb2">Engine</label>
+    <input class="etb-radio" type="radio" name="etb" id="etb3" /><label class="etb-tab" for="etb3">Tokens</label>
+    <input class="etb-radio" type="radio" name="etb" id="etb4" /><label class="etb-tab" for="etb4">Docs</label>
+    <span class="etb-ink" aria-hidden="true"></span>
+  </div>
+  <p class="etb-note">Click a tab, or focus one and use the arrow keys.</p>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/elastic-tabs-advk/style.css
+++ b/submissions/examples/elastic-tabs-advk/style.css
@@ -1,0 +1,65 @@
+/* Elastic Tabs
+   The ink bar is one element translated by --i * 100%. A slight scaleX
+   overshoot on the transition makes it stretch as it travels. */
+
+.etb-wrap { max-width: 36rem; margin: 0 auto; padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif; color: #1a1e27; }
+.etb-h1 { margin: 0 0 0.4em; font-size: clamp(1.5rem, 4.5vw, 2.1rem); letter-spacing: -0.02em; }
+.etb-lede { margin: 0 0 2rem; color: #566073; }
+.etb-note { margin-top: 1rem; font-size: 0.85rem; color: #566073; }
+
+.etb-tabs {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(var(--count), 1fr);
+  border-bottom: 1px solid #dde1ea;
+}
+
+.etb-radio { position: absolute; opacity: 0; pointer-events: none; }
+
+.etb-tab {
+  padding: 0.8em 0.5em;
+  text-align: center;
+  font-weight: 600;
+  font-size: 0.92rem;
+  color: #6b7488;
+  cursor: pointer;
+  transition: color 220ms ease;
+}
+
+.etb-radio:checked + .etb-tab { color: #4c6ef5; }
+.etb-radio:focus-visible + .etb-tab { outline: 3px solid #4c6ef5; outline-offset: -3px; border-radius: 0.3rem; }
+
+.etb-ink {
+  position: absolute;
+  bottom: -1px;
+  left: 0;
+  height: 3px;
+  width: calc(100% / var(--count));
+  border-radius: 2px;
+  background: #4c6ef5;
+  transform-origin: center;
+
+  /* the overshoot curve is what produces the stretch */
+  transition: transform 460ms cubic-bezier(0.34, 1.42, 0.5, 1);
+}
+
+#etb1:checked ~ .etb-ink { transform: translateX(0)    scaleX(1); }
+#etb2:checked ~ .etb-ink { transform: translateX(100%) scaleX(1); }
+#etb3:checked ~ .etb-ink { transform: translateX(200%) scaleX(1); }
+#etb4:checked ~ .etb-ink { transform: translateX(300%) scaleX(1); }
+
+@media (prefers-reduced-motion: reduce) {
+  .etb-ink { transition: transform 120ms linear; }
+}
+
+@media (forced-colors: active) {
+  .etb-ink { background: Highlight; }
+  .etb-radio:checked + .etb-tab { color: Highlight; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .etb-wrap { color: #e6e9f2; }
+  .etb-lede, .etb-note { color: #98a1b3; }
+  .etb-tabs { border-bottom-color: #2a303c; }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #66246.

Adds `submissions/examples/elastic-tabs-advk/` (`demo.html` + `style.css` + `README.md`).

A tab strip with an underline that slides between tabs on a spring curve, driven
entirely by radio inputs.

---

## Type of Change

- [x] 🧩 New component
- [ ] 🐛 Bug fix in an existing submission
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/examples/elastic-tabs-advk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A tab strip with an underline that slides between tabs on a spring curve, driven
entirely by radio inputs.

**How does a developer use it?**

```html
<div class="etb-tabs" style="--count: 4">
  <input class="etb-radio" type="radio" name="etb" id="etb1" checked />
  <label class="etb-tab" for="etb1">Overview</label>
  <!-- ...more pairs... -->
  <span class="etb-ink" aria-hidden="true"></span>
</div>
```

Set `--count` to the number of tabs; the ink bar sizes itself from it.

**Why does it fit EaseMotion CSS?**

`components/tabs.css` ships with `core/tabs.js` to manage the active state.
A radio group gets the same behaviour from the platform: exactly one selection at
a time, arrow-key navigation within the group, and correct exposure to assistive
technology as a radio set — none of which has to be written or maintained.

Sizing the ink bar as `100% / var(--count)` and moving it with `translateX`
percentages means the bar never needs measuring, so there is no
`getBoundingClientRect` call and no resize listener to keep it aligned when the
container reflows.

The elastic feel comes from a single cubic-bezier whose second control point
exceeds 1, producing overshoot and settle. Under reduced motion the same
transition is kept but shortened to a fast linear move — the selection still
reads as a movement between tabs, without the spring.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- CSS passes the repository's own `stylelint` config (`npx stylelint --config .stylelintrc.json`) with no errors.
- Every stylesheet includes a `prefers-reduced-motion` path and, where colour carries state, a `forced-colors` path.
- Naming uses the `-advk` suffix per the CONTRIBUTING uniqueness rule; happy to rename during standardization.
