### PR TITLE
feat: Gradient Border Spin (closes #66248)

### DIFF
--- a/submissions/examples/gradient-border-spin-advk/README.md
+++ b/submissions/examples/gradient-border-spin-advk/README.md
@@ -1,0 +1,39 @@
+# Gradient Border Spin
+
+## What does this do?
+
+Rotates a conic gradient around the border of a card while leaving the card's
+interior completely static.
+
+## How is it used?
+
+```html
+<article class="gbs-card">
+  <h2 class="gbs-card__h">Pro</h2>
+  <p class="gbs-card__p">Recommended tier.</p>
+</article>
+```
+
+Add `gbs-card--hover` to hold the sweep paused until hover or `:focus-within`.
+
+## Why is it useful?
+
+Highlighting a "recommended" card usually means a static accent border or a
+pulsing box-shadow. A travelling gradient draws attention far more effectively,
+but the common implementations put the gradient on the element background and
+animate `background-position`, which drags the interior along with it and makes
+body text shimmer — unpleasant to read and a contrast hazard.
+
+Masking the gradient to the padding ring with `mask-composite` isolates the
+motion to the frame. The interior keeps a solid background and a fixed contrast
+ratio, so the card stays readable while its edge animates.
+
+Registering `--gbs-angle` with `@property` is what makes the rotation possible at
+all: an unregistered custom property is an untyped token and cannot be
+interpolated, so `@keyframes` would step from `0deg` to `360deg` with no
+in-between. Declaring `syntax: "<angle>"` lets the browser animate it smoothly on
+the compositor.
+
+Under `forced-colors` the gradient is dropped for a plain `CanvasText` border,
+since gradients are not painted in High Contrast mode and the card would
+otherwise lose its edge entirely.

--- a/submissions/examples/gradient-border-spin-advk/demo.html
+++ b/submissions/examples/gradient-border-spin-advk/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Gradient Border Spin</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="gbs-wrap">
+  <h1 class="gbs-h1">Gradient Border Spin</h1>
+  <p class="gbs-lede">A conic gradient rotates behind the element and is masked to the border box, so only the frame animates. The card interior stays a flat, readable surface.</p>
+
+  <div class="gbs-row">
+    <article class="gbs-card">
+      <h2 class="gbs-card__h">Pro</h2>
+      <p class="gbs-card__p">Continuous sweep. Draws the eye to the recommended tier without moving the text.</p>
+    </article>
+    <article class="gbs-card gbs-card--hover">
+      <h2 class="gbs-card__h">Team</h2>
+      <p class="gbs-card__p">Sweeps only on hover or focus. Hover me.</p>
+    </article>
+  </div>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/gradient-border-spin-advk/style.css
+++ b/submissions/examples/gradient-border-spin-advk/style.css
@@ -1,0 +1,83 @@
+/* Gradient Border Spin
+   The frame is painted by a rotating conic-gradient on a pseudo-element sized
+   to the border box, then masked so only the ring shows. Animating the angle
+   via @property keeps it on one compositable custom property. */
+
+@property --gbs-angle {
+  syntax: "<angle>";
+  initial-value: 0deg;
+  inherits: false;
+}
+
+.gbs-wrap {
+  max-width: 42rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #e8ebf3;
+  background: #0f1219;
+  min-height: 100vh;
+}
+
+.gbs-h1 { margin: 0 0 0.4em; font-size: clamp(1.5rem, 4.5vw, 2.1rem); letter-spacing: -0.02em; }
+.gbs-lede { margin: 0 0 2.25rem; color: #939cb2; }
+
+.gbs-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+  gap: 1.25rem;
+}
+
+.gbs-card {
+  --gbs-ring: 2px;
+
+  position: relative;
+  padding: 1.5rem;
+  border-radius: 0.85rem;
+  background: #171b25;
+  isolation: isolate;
+}
+
+.gbs-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: var(--gbs-ring);
+  background: conic-gradient(
+    from var(--gbs-angle),
+    #5b6ef5, #b45bf5, #f55b9c, #f5b45b, #5bf5c4, #5b6ef5
+  );
+
+  /* mask out the middle so only the padding ring is painted */
+  mask:
+    linear-gradient(#000 0 0) content-box exclude,
+    linear-gradient(#000 0 0);
+  -webkit-mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  animation: gbs-turn 4s linear infinite;
+  z-index: -1;
+}
+
+.gbs-card--hover::before { animation-play-state: paused; }
+
+.gbs-card--hover:hover::before,
+.gbs-card--hover:focus-within::before { animation-play-state: running; }
+
+.gbs-card__h { margin: 0 0 0.5rem; font-size: 1.1rem; }
+.gbs-card__p { margin: 0; font-size: 0.92rem; color: #939cb2; }
+
+@keyframes gbs-turn { to { --gbs-angle: 360deg; } }
+
+@media (prefers-reduced-motion: reduce) {
+  /* keep the gradient frame, drop the rotation entirely */
+  .gbs-card::before { animation: none; }
+  .gbs-card--hover:hover::before { animation: none; }
+}
+
+@media (forced-colors: active) {
+  .gbs-card::before { display: none; }
+  .gbs-card { border: 1px solid CanvasText; }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #66248.

Adds `submissions/examples/gradient-border-spin-advk/` (`demo.html` + `style.css` + `README.md`).

Rotates a conic gradient around the border of a card while leaving the card's
interior completely static.

---

## Type of Change

- [x] 🧩 New component
- [ ] 🐛 Bug fix in an existing submission
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/examples/gradient-border-spin-advk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Rotates a conic gradient around the border of a card while leaving the card's
interior completely static.

**How does a developer use it?**

```html
<article class="gbs-card">
  <h2 class="gbs-card__h">Pro</h2>
  <p class="gbs-card__p">Recommended tier.</p>
</article>
```

Add `gbs-card--hover` to hold the sweep paused until hover or `:focus-within`.

**Why does it fit EaseMotion CSS?**

Highlighting a "recommended" card usually means a static accent border or a
pulsing box-shadow. A travelling gradient draws attention far more effectively,
but the common implementations put the gradient on the element background and
animate `background-position`, which drags the interior along with it and makes
body text shimmer — unpleasant to read and a contrast hazard.

Masking the gradient to the padding ring with `mask-composite` isolates the
motion to the frame. The interior keeps a solid background and a fixed contrast
ratio, so the card stays readable while its edge animates.

Registering `--gbs-angle` with `@property` is what makes the rotation possible at
all: an unregistered custom property is an untyped token and cannot be
interpolated, so `@keyframes` would step from `0deg` to `360deg` with no
in-between. Declaring `syntax: "<angle>"` lets the browser animate it smoothly on
the compositor.

Under `forced-colors` the gradient is dropped for a plain `CanvasText` border,
since gradients are not painted in High Contrast mode and the card would
otherwise lose its edge entirely.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- CSS passes the repository's own `stylelint` config (`npx stylelint --config .stylelintrc.json`) with no errors.
- Every stylesheet includes a `prefers-reduced-motion` path and, where colour carries state, a `forced-colors` path.
- Naming uses the `-advk` suffix per the CONTRIBUTING uniqueness rule; happy to rename during standardization.
