### PR TITLE
feat: Image Compare Slider (closes #66249)

### DIFF
--- a/submissions/examples/image-compare-slider-advk/README.md
+++ b/submissions/examples/image-compare-slider-advk/README.md
@@ -1,0 +1,39 @@
+# Image Compare Slider
+
+## What does this do?
+
+A before/after comparison wipe where the divider position is controlled by a
+native `<input type="range">`.
+
+## How is it used?
+
+```html
+<div class="ics-frame" style="--pos: 50%">
+  <div class="ics-layer ics-layer--before"></div>
+  <div class="ics-layer ics-layer--after"></div>
+  <span class="ics-divider" aria-hidden="true"></span>
+  <input class="ics-range" type="range" min="0" max="100" value="50"
+         aria-label="Reveal after image" />
+</div>
+```
+
+One line of script mirrors the input value onto `--pos`; everything else is CSS.
+
+## Why is it useful?
+
+Comparison sliders are nearly always built from `mousedown`/`mousemove`/`mouseup`
+handlers on a `<div>`. That version needs a parallel touch implementation, breaks
+when the pointer leaves the frame mid-drag, and is completely inoperable by
+keyboard because a `div` has no value and no focus behaviour.
+
+Using a real range input removes all of it. Dragging, touch, and arrow-key
+stepping are the browser's job. The control reports its value to assistive
+technology as a slider with a percentage, which no amount of `div` plus ARIA
+replicates as reliably. The input is stretched over the whole frame at
+`opacity: 0`, so the visible handle is styling while the actual control is native.
+
+The wipe itself is `clip-path: inset(0 0 0 var(--pos))`, which is composited and
+does not trigger layout, so dragging stays smooth even at large image sizes. No
+reduced-motion block is needed because nothing animates on its own — all movement
+is directly user-driven, which WCAG 2.3.3 treats differently from autonomous
+animation.

--- a/submissions/examples/image-compare-slider-advk/demo.html
+++ b/submissions/examples/image-compare-slider-advk/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Image Compare Slider</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="ics-wrap">
+  <h1 class="ics-h1">Image Compare Slider</h1>
+  <p class="ics-lede">A before/after wipe driven by a native range input. The handle is the input itself, so it is keyboard-operable and announced correctly with no ARIA to maintain.</p>
+
+  <div class="ics-frame" style="--pos: 50%">
+    <div class="ics-layer ics-layer--before"><span class="ics-tag">Before</span></div>
+    <div class="ics-layer ics-layer--after"><span class="ics-tag">After</span></div>
+    <span class="ics-divider" aria-hidden="true"></span>
+    <input class="ics-range" type="range" min="0" max="100" value="50" aria-label="Reveal after image"
+           oninput="this.closest('.ics-frame').style.setProperty('--pos', this.value + '%')" />
+  </div>
+  <p class="ics-note">Drag the handle, or focus it and use the arrow keys.</p>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/image-compare-slider-advk/style.css
+++ b/submissions/examples/image-compare-slider-advk/style.css
@@ -1,0 +1,114 @@
+/* Image Compare Slider
+   The "after" layer is clipped by an inset() rectangle whose left edge tracks
+   --pos. A range input sits on top at full size, invisible but operable. */
+
+.ics-wrap {
+  max-width: 40rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1a1f28;
+}
+
+.ics-h1 { margin: 0 0 0.4em; font-size: clamp(1.5rem, 4.5vw, 2.1rem); letter-spacing: -0.02em; }
+.ics-lede { margin: 0 0 1.75rem; color: #576073; }
+.ics-note { margin-top: 1rem; font-size: 0.85rem; color: #576073; }
+
+.ics-frame {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  border-radius: 0.7rem;
+  overflow: hidden;
+  border: 1px solid #dde1ea;
+}
+
+.ics-layer {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: flex-end;
+  padding: 0.9rem;
+}
+
+/* stand-in artwork: two visibly different generated backgrounds */
+.ics-layer--before {
+  background:
+    repeating-linear-gradient(45deg, #4a5568 0 12px, #3d4757 12px 24px);
+}
+
+.ics-layer--after {
+  background:
+    radial-gradient(circle at 30% 30%, #ffd166, transparent 55%),
+    linear-gradient(135deg, #ef476f, #6a4c93);
+
+  /* only the region right of --pos is painted */
+  clip-path: inset(0 0 0 var(--pos));
+}
+
+.ics-tag {
+  padding: 0.25em 0.7em;
+  border-radius: 999px;
+  background: rgba(12, 15, 20, 0.7);
+  color: #fff;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+
+.ics-layer--after .ics-tag { margin-left: auto; }
+
+.ics-divider {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: var(--pos);
+  width: 2px;
+  margin-left: -1px;
+  background: #fff;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.25);
+  pointer-events: none;
+}
+
+.ics-divider::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 2.1rem;
+  aspect-ratio: 1;
+  transform: translate(-50%, -50%);
+  border: 2px solid #fff;
+  border-radius: 50%;
+  background: rgba(12, 15, 20, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+/* the real control, stretched over the frame and made invisible */
+.ics-range {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  opacity: 0;
+  cursor: ew-resize;
+  appearance: none;
+  background: none;
+}
+
+.ics-range::-webkit-slider-thumb { appearance: none; width: 3rem; height: 100%; }
+.ics-range::-moz-range-thumb { width: 3rem; height: 100%; border: 0; }
+
+.ics-range:focus-visible + .ics-divider,
+.ics-frame:focus-within .ics-divider { box-shadow: 0 0 0 3px #4c6ef5; }
+
+@media (forced-colors: active) {
+  .ics-divider { background: CanvasText; }
+  .ics-tag { background: Canvas; color: CanvasText; border: 1px solid CanvasText; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .ics-wrap { color: #e5e9f1; }
+  .ics-lede, .ics-note { color: #98a1b3; }
+  .ics-frame { border-color: #2a303c; }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #66249.

Adds `submissions/examples/image-compare-slider-advk/` (`demo.html` + `style.css` + `README.md`).

A before/after comparison wipe where the divider position is controlled by a
native `<input type="range">`.

---

## Type of Change

- [x] 🧩 New component
- [ ] 🐛 Bug fix in an existing submission
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/examples/image-compare-slider-advk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A before/after comparison wipe where the divider position is controlled by a
native `<input type="range">`.

**How does a developer use it?**

```html
<div class="ics-frame" style="--pos: 50%">
  <div class="ics-layer ics-layer--before"></div>
  <div class="ics-layer ics-layer--after"></div>
  <span class="ics-divider" aria-hidden="true"></span>
  <input class="ics-range" type="range" min="0" max="100" value="50"
         aria-label="Reveal after image" />
</div>
```

One line of script mirrors the input value onto `--pos`; everything else is CSS.

**Why does it fit EaseMotion CSS?**

Comparison sliders are nearly always built from `mousedown`/`mousemove`/`mouseup`
handlers on a `<div>`. That version needs a parallel touch implementation, breaks
when the pointer leaves the frame mid-drag, and is completely inoperable by
keyboard because a `div` has no value and no focus behaviour.

Using a real range input removes all of it. Dragging, touch, and arrow-key
stepping are the browser's job. The control reports its value to assistive
technology as a slider with a percentage, which no amount of `div` plus ARIA
replicates as reliably. The input is stretched over the whole frame at
`opacity: 0`, so the visible handle is styling while the actual control is native.

The wipe itself is `clip-path: inset(0 0 0 var(--pos))`, which is composited and
does not trigger layout, so dragging stays smooth even at large image sizes. No
reduced-motion block is needed because nothing animates on its own — all movement
is directly user-driven, which WCAG 2.3.3 treats differently from autonomous
animation.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- CSS passes the repository's own `stylelint` config (`npx stylelint --config .stylelintrc.json`) with no errors.
- Every stylesheet includes a `prefers-reduced-motion` path and, where colour carries state, a `forced-colors` path.
- Naming uses the `-advk` suffix per the CONTRIBUTING uniqueness rule; happy to rename during standardization.
