### PR TITLE
feat: Liquid Progress (closes #66250)

### DIFF
--- a/submissions/examples/liquid-progress-advk/README.md
+++ b/submissions/examples/liquid-progress-advk/README.md
@@ -1,0 +1,37 @@
+# Liquid Progress
+
+## What does this do?
+
+A circular progress gauge that fills like liquid in a vessel, with a moving
+surface built from two offset wave layers.
+
+## How is it used?
+
+```html
+<div class="lqp-gauge" style="--fill: 61%" role="progressbar"
+     aria-valuenow="61" aria-valuemin="0" aria-valuemax="100" aria-label="Memory">
+  <span class="lqp-liquid"></span>
+  <span class="lqp-value">61%</span>
+</div>
+```
+
+Set `--fill` to any percentage; the waterline follows and transitions smoothly
+when the value changes.
+
+## Why is it useful?
+
+`components/progress.css` covers linear bars only. A radial fill communicates
+"capacity remaining" far better than a bar for quantities that have a natural
+ceiling — disk usage, quota, battery — because the container itself represents
+the maximum.
+
+The implementation is worth having as a reference because the naive version
+(animating `height`) triggers layout on every frame. Here the liquid block is a
+fixed size and only `transform: translateY()` changes, which stays on the
+compositor. The waves are a `repeating` radial-gradient scrolled with
+`background-position`, so the surface costs no extra elements.
+
+The percentage label stays legible against both the empty track and the fill by
+using `mix-blend-mode: difference` rather than a second clipped copy of the text.
+Under `forced-colors` that blend is switched off and the label reverts to
+`CanvasText`, since blend modes do not survive High Contrast substitution.

--- a/submissions/examples/liquid-progress-advk/demo.html
+++ b/submissions/examples/liquid-progress-advk/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Liquid Progress</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="lqp-wrap">
+  <h1 class="lqp-h1">Liquid Progress</h1>
+  <p class="lqp-lede">A circular gauge that fills like a vessel. The waterline is set by one custom property; two offset wave layers give it surface motion.</p>
+
+  <div class="lqp-row">
+    <div class="lqp-gauge" style="--fill: 24%" role="progressbar" aria-valuenow="24" aria-valuemin="0" aria-valuemax="100" aria-label="Disk usage">
+      <span class="lqp-liquid"></span><span class="lqp-value">24%</span>
+    </div>
+    <div class="lqp-gauge" style="--fill: 61%" role="progressbar" aria-valuenow="61" aria-valuemin="0" aria-valuemax="100" aria-label="Memory">
+      <span class="lqp-liquid"></span><span class="lqp-value">61%</span>
+    </div>
+    <div class="lqp-gauge lqp-gauge--full" style="--fill: 92%" role="progressbar" aria-valuenow="92" aria-valuemin="0" aria-valuemax="100" aria-label="Storage">
+      <span class="lqp-liquid"></span><span class="lqp-value">92%</span>
+    </div>
+  </div>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/liquid-progress-advk/style.css
+++ b/submissions/examples/liquid-progress-advk/style.css
@@ -1,0 +1,105 @@
+/* Liquid Progress — circular fill gauge.
+   .lqp-liquid is a tall block whose top edge is the waterline, positioned by
+   translateY off --fill. Two repeating-radial wave crests scroll across it at
+   different speeds so the surface never looks like a straight line. */
+
+.lqp-wrap {
+  max-width: 40rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #0e2233;
+}
+
+.lqp-h1 { margin: 0 0 0.4em; font-size: clamp(1.5rem, 4.5vw, 2.1rem); letter-spacing: -0.02em; }
+.lqp-lede { margin: 0 0 2.25rem; color: #4a6478; }
+
+.lqp-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  justify-content: center;
+}
+
+.lqp-gauge {
+  --tint: #1c9ad6;
+
+  position: relative;
+  width: 8rem;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  overflow: hidden;
+  background: #e8f1f7;
+  box-shadow: inset 0 0 0 3px var(--tint);
+  isolation: isolate;
+}
+
+.lqp-gauge--full { --tint: #d6541c; }
+
+.lqp-liquid {
+  position: absolute;
+  inset-inline: -50%;
+  top: 0;
+  height: 200%;
+  background: var(--tint);
+
+  /* waterline: 0% fill pushes the block fully below the circle */
+  transform: translateY(calc(100% - var(--fill)));
+  transition: transform 900ms cubic-bezier(0.22, 1, 0.36, 1);
+  animation: lqp-drift 7s linear infinite;
+}
+
+/* wave crests riding the surface */
+.lqp-liquid::before,
+.lqp-liquid::after {
+  content: "";
+  position: absolute;
+  inset-inline: 0;
+  top: -0.7rem;
+  height: 1.4rem;
+  background: radial-gradient(ellipse 1.6rem 0.7rem at 50% 100%, var(--tint) 98%, transparent 100%) repeat-x;
+  background-size: 3.2rem 1.4rem;
+}
+
+.lqp-liquid::after {
+  top: -0.55rem;
+  opacity: 0.55;
+  animation: lqp-crest 3.4s linear infinite reverse;
+}
+
+.lqp-liquid::before { animation: lqp-crest 5.1s linear infinite; }
+
+.lqp-value {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-size: 1.35rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: #0e2233;
+  mix-blend-mode: difference;
+  filter: invert(1) grayscale(1) contrast(9);
+  z-index: 2;
+}
+
+@keyframes lqp-crest { from { background-position-x: 0; } to { background-position-x: 3.2rem; } }
+
+@keyframes lqp-drift { 0%, 100% { margin-left: 0; } 50% { margin-left: -0.4rem; } }
+
+@media (prefers-reduced-motion: reduce) {
+  .lqp-liquid { animation: none; transition: none; }
+  .lqp-liquid::before, .lqp-liquid::after { animation: none; }
+}
+
+@media (forced-colors: active) {
+  .lqp-gauge  { border: 1px solid CanvasText; }
+  .lqp-liquid { background: Highlight; }
+  .lqp-value  { mix-blend-mode: normal; filter: none; color: CanvasText; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .lqp-wrap  { color: #e2edf5; }
+  .lqp-lede  { color: #8ba6ba; }
+  .lqp-gauge { background: #132531; }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #66250.

Adds `submissions/examples/liquid-progress-advk/` (`demo.html` + `style.css` + `README.md`).

A circular progress gauge that fills like liquid in a vessel, with a moving
surface built from two offset wave layers.

---

## Type of Change

- [x] 🧩 New component
- [ ] 🐛 Bug fix in an existing submission
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/examples/liquid-progress-advk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A circular progress gauge that fills like liquid in a vessel, with a moving
surface built from two offset wave layers.

**How does a developer use it?**

```html
<div class="lqp-gauge" style="--fill: 61%" role="progressbar"
     aria-valuenow="61" aria-valuemin="0" aria-valuemax="100" aria-label="Memory">
  <span class="lqp-liquid"></span>
  <span class="lqp-value">61%</span>
</div>
```

Set `--fill` to any percentage; the waterline follows and transitions smoothly
when the value changes.

**Why does it fit EaseMotion CSS?**

`components/progress.css` covers linear bars only. A radial fill communicates
"capacity remaining" far better than a bar for quantities that have a natural
ceiling — disk usage, quota, battery — because the container itself represents
the maximum.

The implementation is worth having as a reference because the naive version
(animating `height`) triggers layout on every frame. Here the liquid block is a
fixed size and only `transform: translateY()` changes, which stays on the
compositor. The waves are a `repeating` radial-gradient scrolled with
`background-position`, so the surface costs no extra elements.

The percentage label stays legible against both the empty track and the fill by
using `mix-blend-mode: difference` rather than a second clipped copy of the text.
Under `forced-colors` that blend is switched off and the label reverts to
`CanvasText`, since blend modes do not survive High Contrast substitution.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- CSS passes the repository's own `stylelint` config (`npx stylelint --config .stylelintrc.json`) with no errors.
- Every stylesheet includes a `prefers-reduced-motion` path and, where colour carries state, a `forced-colors` path.
- Naming uses the `-advk` suffix per the CONTRIBUTING uniqueness rule; happy to rename during standardization.
