### PR TITLE
feat: Morph Menu Icon (closes #66251)

### DIFF
--- a/submissions/examples/morph-menu-icon-advk/README.md
+++ b/submissions/examples/morph-menu-icon-advk/README.md
@@ -1,0 +1,33 @@
+# Morph Menu Icon
+
+## What does this do?
+
+A three-bar menu icon that morphs into a close cross, a back arrow, or a vertical
+kebab — three variants sharing identical markup.
+
+## How is it used?
+
+```html
+<label class="mmi-cell">
+  <input class="mmi-input" type="checkbox" />
+  <span class="mmi-icon"><i></i><i></i><i></i></span>
+</label>
+```
+
+Add `mmi-icon--arrow` or `mmi-icon--kebab` for the other two targets.
+
+## Why is it useful?
+
+Icon morphs are usually shipped as SVG path interpolation or an icon-font swap.
+Both replace one shape with another, so the transition is a crossfade and the
+user does not see *where* the old icon went. Transforming three persistent bars
+keeps object identity: the top bar visibly becomes the top stroke of the cross.
+
+Because the state lives on a checkbox, the component works with no script and
+stays keyboard-operable for free — `:focus-visible` on the input drives the ring
+on the icon via the adjacent sibling selector.
+
+Reduced motion keeps the state change but drops the rotation and travel to a
+short opacity transition, so the icon still updates without a spinning element.
+The bars use `background: CanvasText` under `forced-colors` so the icon survives
+High Contrast, which an icon font set via `color` would not reliably do.

--- a/submissions/examples/morph-menu-icon-advk/demo.html
+++ b/submissions/examples/morph-menu-icon-advk/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Morph Menu Icon</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="mmi-wrap">
+  <h1 class="mmi-h1">Morph Menu Icon</h1>
+  <p class="mmi-lede">Three bars that morph into a close cross, a back arrow, or a kebab. One checkbox drives the state; each variant is a modifier class.</p>
+
+  <div class="mmi-row">
+    <label class="mmi-cell">
+      <input class="mmi-input" type="checkbox" />
+      <span class="mmi-icon"><i></i><i></i><i></i></span>
+      <span class="mmi-cap">to close</span>
+    </label>
+    <label class="mmi-cell">
+      <input class="mmi-input" type="checkbox" />
+      <span class="mmi-icon mmi-icon--arrow"><i></i><i></i><i></i></span>
+      <span class="mmi-cap">to back arrow</span>
+    </label>
+    <label class="mmi-cell">
+      <input class="mmi-input" type="checkbox" />
+      <span class="mmi-icon mmi-icon--kebab"><i></i><i></i><i></i></span>
+      <span class="mmi-cap">to kebab</span>
+    </label>
+  </div>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/morph-menu-icon-advk/style.css
+++ b/submissions/examples/morph-menu-icon-advk/style.css
@@ -1,0 +1,98 @@
+/* Morph Menu Icon
+   Three <i> bars inside a fixed box. Each variant re-targets the same three
+   bars with different transforms, so the markup never changes between states. */
+
+.mmi-wrap {
+  max-width: 38rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1a1e27;
+}
+
+.mmi-h1 { margin: 0 0 0.4em; font-size: clamp(1.5rem, 4.5vw, 2.1rem); letter-spacing: -0.02em; }
+.mmi-lede { margin: 0 0 2.25rem; color: #565e72; }
+
+.mmi-row { display: flex; flex-wrap: wrap; gap: 1.25rem; }
+
+.mmi-cell {
+  display: grid;
+  justify-items: center;
+  gap: 0.75rem;
+  padding: 1.5rem 1.25rem;
+  border: 1px solid #dfe3ec;
+  border-radius: 0.7rem;
+  background: #fbfcfe;
+  cursor: pointer;
+}
+
+.mmi-cap { font-size: 0.8rem; color: #565e72; }
+
+.mmi-input { position: absolute; opacity: 0; pointer-events: none; }
+
+.mmi-icon {
+  position: relative;
+  display: block;
+  width: 2.25rem;
+  height: 1.5rem;
+}
+
+.mmi-icon i {
+  position: absolute;
+  inset-inline: 0;
+  height: 3px;
+  border-radius: 2px;
+  background: #3b4a66;
+  transition: transform 380ms cubic-bezier(0.65, 0, 0.35, 1),
+              opacity 220ms ease,
+              width 380ms cubic-bezier(0.65, 0, 0.35, 1);
+  transform-origin: center;
+}
+
+.mmi-icon i:nth-child(1) { top: 0; }
+.mmi-icon i:nth-child(2) { top: calc(50% - 1.5px); }
+.mmi-icon i:nth-child(3) { bottom: 0; }
+
+.mmi-input:focus-visible + .mmi-icon { outline: 3px solid #4c6ef5; outline-offset: 6px; border-radius: 0.25rem; }
+
+/* ── variant 1: hamburger -> close ── */
+.mmi-input:checked + .mmi-icon i:nth-child(1) { transform: translateY(calc(0.75rem - 1.5px)) rotate(45deg); }
+.mmi-input:checked + .mmi-icon i:nth-child(2) { opacity: 0; transform: scaleX(0.2); }
+.mmi-input:checked + .mmi-icon i:nth-child(3) { transform: translateY(calc(-0.75rem + 1.5px)) rotate(-45deg); }
+
+/* ── variant 2: hamburger -> back arrow ── */
+.mmi-input:checked + .mmi-icon--arrow i:nth-child(1) {
+  width: 60%; transform: translate(0, calc(0.4rem)) rotate(-45deg);
+}
+.mmi-input:checked + .mmi-icon--arrow i:nth-child(2) { opacity: 1; transform: none; }
+
+.mmi-input:checked + .mmi-icon--arrow i:nth-child(3) {
+  width: 60%; transform: translate(0, calc(-0.4rem)) rotate(45deg);
+}
+
+/* ── variant 3: hamburger -> vertical kebab ── */
+.mmi-input:checked + .mmi-icon--kebab i {
+  width: 3px;
+  left: calc(50% - 1.5px);
+  right: auto;
+  border-radius: 50%;
+  height: 3px;
+}
+.mmi-input:checked + .mmi-icon--kebab i:nth-child(1) { transform: translateY(0.25rem); }
+.mmi-input:checked + .mmi-icon--kebab i:nth-child(2) { transform: translateY(0); }
+.mmi-input:checked + .mmi-icon--kebab i:nth-child(3) { transform: translateY(-0.25rem); }
+
+@media (prefers-reduced-motion: reduce) {
+  .mmi-icon i { transition: opacity 150ms ease; }
+}
+
+@media (forced-colors: active) {
+  .mmi-icon i { background: CanvasText; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .mmi-wrap { color: #e6e9f2; }
+  .mmi-lede, .mmi-cap { color: #99a1b6; }
+  .mmi-cell { background: #171b23; border-color: #2a303d; }
+  .mmi-icon i { background: #c3cad9; }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #66251.

Adds `submissions/examples/morph-menu-icon-advk/` (`demo.html` + `style.css` + `README.md`).

A three-bar menu icon that morphs into a close cross, a back arrow, or a vertical
kebab — three variants sharing identical markup.

---

## Type of Change

- [x] 🧩 New component
- [ ] 🐛 Bug fix in an existing submission
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/examples/morph-menu-icon-advk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A three-bar menu icon that morphs into a close cross, a back arrow, or a vertical
kebab — three variants sharing identical markup.

**How does a developer use it?**

```html
<label class="mmi-cell">
  <input class="mmi-input" type="checkbox" />
  <span class="mmi-icon"><i></i><i></i><i></i></span>
</label>
```

Add `mmi-icon--arrow` or `mmi-icon--kebab` for the other two targets.

**Why does it fit EaseMotion CSS?**

Icon morphs are usually shipped as SVG path interpolation or an icon-font swap.
Both replace one shape with another, so the transition is a crossfade and the
user does not see *where* the old icon went. Transforming three persistent bars
keeps object identity: the top bar visibly becomes the top stroke of the cross.

Because the state lives on a checkbox, the component works with no script and
stays keyboard-operable for free — `:focus-visible` on the input drives the ring
on the icon via the adjacent sibling selector.

Reduced motion keeps the state change but drops the rotation and travel to a
short opacity transition, so the icon still updates without a spinning element.
The bars use `background: CanvasText` under `forced-colors` so the icon survives
High Contrast, which an icon font set via `color` would not reliably do.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- CSS passes the repository's own `stylelint` config (`npx stylelint --config .stylelintrc.json`) with no errors.
- Every stylesheet includes a `prefers-reduced-motion` path and, where colour carries state, a `forced-colors` path.
- Naming uses the `-advk` suffix per the CONTRIBUTING uniqueness rule; happy to rename during standardization.
