### PR TITLE
feat: Parallax Card Tilt (closes #66252)

### DIFF
--- a/submissions/examples/parallax-card-tilt-advk/README.md
+++ b/submissions/examples/parallax-card-tilt-advk/README.md
@@ -1,0 +1,43 @@
+# Parallax Card Tilt
+
+## What does this do?
+
+A card that tilts in 3D on hover or focus, with its label, title and body text
+separating to different depths so they travel by different amounts.
+
+## How is it used?
+
+```html
+<div class="pct-row">
+  <article class="pct-card" tabindex="0">
+    <span class="pct-tag">Engine</span>
+    <h2 class="pct-title">Motion DSL</h2>
+    <p class="pct-copy">Description.</p>
+  </article>
+</div>
+```
+
+`perspective` belongs on the row, not the card, so sibling cards share one
+vanishing point.
+
+## Why is it useful?
+
+Tilt effects are almost always shipped as a JavaScript library that reads
+`mousemove` coordinates and writes an inline `transform` on every event. That is
+a main-thread handler firing at pointer frequency, and it makes the effect
+unavailable to keyboard users entirely, since there is no pointer position to
+read.
+
+Doing it with `:hover` and `:focus-visible` costs no script and gives keyboard
+users the same affordance — the card responds when tabbed to. The trade-off is a
+fixed tilt angle rather than one that tracks the cursor, which for a card grid is
+a reasonable exchange.
+
+The parallax itself is genuine 3D rather than staged offsets: one rotation on the
+parent, with children at different `translateZ` depths inside `preserve-3d`. The
+perspective divide then makes nearer layers sweep further across the screen than
+distant ones automatically, so depths can be tuned by changing one number per
+layer instead of hand-computing per-layer translations.
+
+Reduced motion removes the rotation and all depth travel, substituting a border
+colour change so hover still gives feedback.

--- a/submissions/examples/parallax-card-tilt-advk/demo.html
+++ b/submissions/examples/parallax-card-tilt-advk/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Parallax Card Tilt</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="pct-wrap">
+  <h1 class="pct-h1">Parallax Card Tilt</h1>
+  <p class="pct-lede">A card whose layers separate in Z on hover. Depth comes from translateZ inside a shared perspective, so the parallax is real rather than faked with offsets.</p>
+  <div class="pct-row">
+    <article class="pct-card" tabindex="0">
+      <span class="pct-glow" aria-hidden="true"></span>
+      <span class="pct-tag">Engine</span>
+      <h2 class="pct-title">Motion DSL</h2>
+      <p class="pct-copy">Parse, compile and inject animations straight from an attribute.</p>
+    </article>
+    <article class="pct-card pct-card--alt" tabindex="0">
+      <span class="pct-glow" aria-hidden="true"></span>
+      <span class="pct-tag">Core</span>
+      <h2 class="pct-title">Zero deps</h2>
+      <p class="pct-copy">One stylesheet, no build step, no runtime requirement.</p>
+    </article>
+  </div>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/parallax-card-tilt-advk/style.css
+++ b/submissions/examples/parallax-card-tilt-advk/style.css
@@ -1,0 +1,98 @@
+/* Parallax Card Tilt
+   The card rotates inside a perspective set on the row. Children are pushed to
+   different translateZ depths, so a single rotation makes them travel by
+   different screen distances -- that difference is the parallax. */
+
+.pct-wrap {
+  max-width: 42rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #eaeefb;
+  background: #0d1017;
+  min-height: 100vh;
+}
+
+.pct-h1 { margin: 0 0 0.4em; font-size: clamp(1.5rem, 4.5vw, 2.1rem); letter-spacing: -0.02em; }
+.pct-lede { margin: 0 0 2.25rem; color: #949db6; }
+
+.pct-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+  gap: 1.25rem;
+  perspective: 900px;
+}
+
+.pct-card {
+  position: relative;
+  padding: 1.5rem;
+  border: 1px solid #262d3d;
+  border-radius: 0.85rem;
+  background: linear-gradient(160deg, #1a2030, #141824);
+  transform-style: preserve-3d;
+  transition: transform 420ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.pct-card:hover,
+.pct-card:focus-visible {
+  transform: rotateX(7deg) rotateY(-9deg);
+}
+
+.pct-card:focus-visible { outline: 3px solid #6d8cff; outline-offset: 4px; }
+
+/* each layer sits at a different depth */
+.pct-tag, .pct-title, .pct-copy, .pct-glow {
+  transition: transform 420ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.pct-tag {
+  display: inline-block;
+  margin-bottom: 0.75rem;
+  padding: 0.2em 0.7em;
+  border-radius: 999px;
+  background: #2b3550;
+  color: #9fb3ff;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.pct-title { margin: 0 0 0.5rem; font-size: 1.35rem; letter-spacing: -0.01em; }
+.pct-copy  { margin: 0; font-size: 0.9rem; color: #949db6; }
+
+.pct-glow {
+  position: absolute;
+  inset: -30% 10% 40%;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(109, 140, 255, 0.35), transparent 70%);
+  opacity: 0;
+  pointer-events: none;
+}
+
+.pct-card:hover .pct-glow,
+.pct-card:focus-visible .pct-glow { opacity: 1; transform: translateZ(10px); }
+
+.pct-card:hover .pct-tag,
+.pct-card:focus-visible .pct-tag { transform: translateZ(35px); }
+
+.pct-card:hover .pct-title,
+.pct-card:focus-visible .pct-title { transform: translateZ(55px); }
+
+.pct-card:hover .pct-copy,
+.pct-card:focus-visible .pct-copy { transform: translateZ(25px); }
+
+@media (prefers-reduced-motion: reduce) {
+  .pct-card, .pct-tag, .pct-title, .pct-copy, .pct-glow { transition: none; }
+  .pct-card:hover, .pct-card:focus-visible { transform: none; }
+
+  .pct-card:hover .pct-tag, .pct-card:focus-visible .pct-tag,
+  .pct-card:hover .pct-title, .pct-card:focus-visible .pct-title,
+  .pct-card:hover .pct-copy, .pct-card:focus-visible .pct-copy { transform: none; }
+  .pct-card:hover { border-color: #6d8cff; }
+}
+
+@media (forced-colors: active) {
+  .pct-card { border-color: CanvasText; }
+  .pct-glow { display: none; }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #66252.

Adds `submissions/examples/parallax-card-tilt-advk/` (`demo.html` + `style.css` + `README.md`).

A card that tilts in 3D on hover or focus, with its label, title and body text
separating to different depths so they travel by different amounts.

---

## Type of Change

- [x] 🧩 New component
- [ ] 🐛 Bug fix in an existing submission
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/examples/parallax-card-tilt-advk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A card that tilts in 3D on hover or focus, with its label, title and body text
separating to different depths so they travel by different amounts.

**How does a developer use it?**

```html
<div class="pct-row">
  <article class="pct-card" tabindex="0">
    <span class="pct-tag">Engine</span>
    <h2 class="pct-title">Motion DSL</h2>
    <p class="pct-copy">Description.</p>
  </article>
</div>
```

`perspective` belongs on the row, not the card, so sibling cards share one
vanishing point.

**Why does it fit EaseMotion CSS?**

Tilt effects are almost always shipped as a JavaScript library that reads
`mousemove` coordinates and writes an inline `transform` on every event. That is
a main-thread handler firing at pointer frequency, and it makes the effect
unavailable to keyboard users entirely, since there is no pointer position to
read.

Doing it with `:hover` and `:focus-visible` costs no script and gives keyboard
users the same affordance — the card responds when tabbed to. The trade-off is a
fixed tilt angle rather than one that tracks the cursor, which for a card grid is
a reasonable exchange.

The parallax itself is genuine 3D rather than staged offsets: one rotation on the
parent, with children at different `translateZ` depths inside `preserve-3d`. The
perspective divide then makes nearer layers sweep further across the screen than
distant ones automatically, so depths can be tuned by changing one number per
layer instead of hand-computing per-layer translations.

Reduced motion removes the rotation and all depth travel, substituting a border
colour change so hover still gives feedback.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- CSS passes the repository's own `stylelint` config (`npx stylelint --config .stylelintrc.json`) with no errors.
- Every stylesheet includes a `prefers-reduced-motion` path and, where colour carries state, a `forced-colors` path.
- Naming uses the `-advk` suffix per the CONTRIBUTING uniqueness rule; happy to rename during standardization.
