### PR TITLE
feat: Pulse Notification Dot (closes #66253)

### DIFF
--- a/submissions/examples/pulse-notification-dot-advk/README.md
+++ b/submissions/examples/pulse-notification-dot-advk/README.md
@@ -1,0 +1,36 @@
+# Pulse Notification Dot
+
+## What does this do?
+
+An unread-count badge that emits a small expanding ring three times when it
+appears, then goes quiet.
+
+## How is it used?
+
+```html
+<button class="pnd-icon" aria-label="Inbox, 3 unread">
+  <svg viewBox="0 0 24 24" aria-hidden="true"><!-- icon --></svg>
+  <span class="pnd-dot pnd-dot--count">3</span>
+</button>
+```
+
+Omit the text and the `--count` modifier for a plain unread dot.
+
+## Why is it useful?
+
+Notification badges that pulse on `infinite` are a recognised accessibility
+problem: a permanently animating element in the corner of the viewport competes
+for attention indefinitely, and WCAG 2.2.2 requires that any motion lasting more
+than five seconds be pausable or stoppable. A three-iteration ring satisfies that
+by construction — it stops on its own in about four seconds — while still being
+impossible to miss when the count first changes.
+
+The ring is a pseudo-element rather than an extra node, so a badge stays a single
+element in the markup, and it scales from the badge's own border radius so the
+same rule works for both the counted pill and the small plain dot.
+
+The accessible name carries the count (`aria-label="Inbox, 3 unread"`) rather
+than relying on the visual badge, which matters because the number is styled
+small and sits outside the button's own text flow. Under `forced-colors` the
+badge switches to `Highlight`/`HighlightText` so it remains distinguishable from
+the icon it overlaps.

--- a/submissions/examples/pulse-notification-dot-advk/demo.html
+++ b/submissions/examples/pulse-notification-dot-advk/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Pulse Notification Dot</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="pnd-wrap">
+  <h1 class="pnd-h1">Pulse Notification Dot</h1>
+  <p class="pnd-lede">An unread badge that emits a single expanding ring when it appears, then settles. Attention without a permanent loop.</p>
+
+  <div class="pnd-row">
+    <button class="pnd-icon" type="button" aria-label="Inbox, 3 unread">
+      <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true"><path fill="currentColor" d="M4 5h16v14H4z" opacity=".2"/><path fill="none" stroke="currentColor" stroke-width="2" d="M4 6l8 6 8-6M4 5h16v14H4z"/></svg>
+      <span class="pnd-dot pnd-dot--count">3</span>
+    </button>
+
+    <button class="pnd-icon" type="button" aria-label="Alerts, unread">
+      <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-width="2" d="M12 3a6 6 0 0 0-6 6v4l-2 3h16l-2-3V9a6 6 0 0 0-6-6zM10 19a2 2 0 0 0 4 0"/></svg>
+      <span class="pnd-dot"></span>
+    </button>
+
+    <button class="pnd-icon" type="button" aria-label="Messages, 12 unread">
+      <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-width="2" d="M21 12a8 8 0 0 1-8 8H7l-4 3V12a8 8 0 0 1 8-8h2a8 8 0 0 1 8 8z"/></svg>
+      <span class="pnd-dot pnd-dot--count">12</span>
+    </button>
+  </div>
+  <p class="pnd-note">The ring fires three times and stops. Reload to replay.</p>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/pulse-notification-dot-advk/style.css
+++ b/submissions/examples/pulse-notification-dot-advk/style.css
@@ -1,0 +1,89 @@
+/* Pulse Notification Dot
+   The ring is a ::after on the dot, scaled and faded outward. It runs a finite
+   iteration count rather than `infinite`: attention is drawn, then released. */
+
+.pnd-wrap {
+  max-width: 36rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1a1e27;
+}
+
+.pnd-h1 { margin: 0 0 0.4em; font-size: clamp(1.5rem, 4.5vw, 2.1rem); letter-spacing: -0.02em; }
+.pnd-lede { margin: 0 0 2rem; color: #566073; }
+.pnd-note { margin-top: 1.75rem; font-size: 0.85rem; color: #566073; }
+
+.pnd-row { display: flex; gap: 1.75rem; }
+
+.pnd-icon {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 3rem;
+  aspect-ratio: 1;
+  border: 1px solid #dde1ea;
+  border-radius: 0.65rem;
+  background: #fbfcfe;
+  color: #3b4762;
+  cursor: pointer;
+  transition: border-color 180ms ease, transform 180ms ease;
+}
+
+.pnd-icon:hover { border-color: #f0506e; transform: translateY(-2px); }
+.pnd-icon:focus-visible { outline: 3px solid #4c6ef5; outline-offset: 3px; }
+
+.pnd-dot {
+  position: absolute;
+  top: -0.35rem;
+  right: -0.35rem;
+  min-width: 1.15rem;
+  height: 1.15rem;
+  padding: 0 0.3em;
+  display: grid;
+  place-items: center;
+  border-radius: 999px;
+  background: #f0506e;
+  color: #fff;
+  font-size: 0.7rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  box-shadow: 0 0 0 2px #fbfcfe;
+}
+
+/* plain dot variant has no text, so shrink it */
+.pnd-dot:not(.pnd-dot--count) { min-width: 0.7rem; height: 0.7rem; padding: 0; }
+
+/* the emitted ring */
+.pnd-dot::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 2px solid #f0506e;
+  animation: pnd-ring 1.4s cubic-bezier(0.22, 1, 0.36, 1) 3;
+}
+
+@keyframes pnd-ring {
+  0%   { transform: scale(1);   opacity: 0.85; }
+  70%  { transform: scale(2.4); opacity: 0; }
+  100% { transform: scale(2.4); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  /* drop the emitted ring; the badge itself is already a sufficient signal */
+  .pnd-dot::after { animation: none; opacity: 0; }
+  .pnd-icon:hover { transform: none; }
+}
+
+@media (forced-colors: active) {
+  .pnd-dot { background: Highlight; color: HighlightText; box-shadow: none; border: 1px solid CanvasText; }
+  .pnd-dot::after { border-color: Highlight; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .pnd-wrap { color: #e6e9f2; }
+  .pnd-lede, .pnd-note { color: #98a1b3; }
+  .pnd-icon { background: #171b23; border-color: #2a303c; color: #c3cad9; }
+  .pnd-dot { box-shadow: 0 0 0 2px #171b23; }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #66253.

Adds `submissions/examples/pulse-notification-dot-advk/` (`demo.html` + `style.css` + `README.md`).

An unread-count badge that emits a small expanding ring three times when it
appears, then goes quiet.

---

## Type of Change

- [x] 🧩 New component
- [ ] 🐛 Bug fix in an existing submission
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/examples/pulse-notification-dot-advk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

An unread-count badge that emits a small expanding ring three times when it
appears, then goes quiet.

**How does a developer use it?**

```html
<button class="pnd-icon" aria-label="Inbox, 3 unread">
  <svg viewBox="0 0 24 24" aria-hidden="true"><!-- icon --></svg>
  <span class="pnd-dot pnd-dot--count">3</span>
</button>
```

Omit the text and the `--count` modifier for a plain unread dot.

**Why does it fit EaseMotion CSS?**

Notification badges that pulse on `infinite` are a recognised accessibility
problem: a permanently animating element in the corner of the viewport competes
for attention indefinitely, and WCAG 2.2.2 requires that any motion lasting more
than five seconds be pausable or stoppable. A three-iteration ring satisfies that
by construction — it stops on its own in about four seconds — while still being
impossible to miss when the count first changes.

The ring is a pseudo-element rather than an extra node, so a badge stays a single
element in the markup, and it scales from the badge's own border radius so the
same rule works for both the counted pill and the small plain dot.

The accessible name carries the count (`aria-label="Inbox, 3 unread"`) rather
than relying on the visual badge, which matters because the number is styled
small and sits outside the button's own text flow. Under `forced-colors` the
badge switches to `Highlight`/`HighlightText` so it remains distinguishable from
the icon it overlaps.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- CSS passes the repository's own `stylelint` config (`npx stylelint --config .stylelintrc.json`) with no errors.
- Every stylesheet includes a `prefers-reduced-motion` path and, where colour carries state, a `forced-colors` path.
- Naming uses the `-advk` suffix per the CONTRIBUTING uniqueness rule; happy to rename during standardization.
