### PR TITLE
feat: Scroll Spy Rail (closes #66255)

### DIFF
--- a/submissions/examples/scroll-spy-rail-advk/README.md
+++ b/submissions/examples/scroll-spy-rail-advk/README.md
@@ -1,0 +1,34 @@
+# Scroll Spy Rail
+
+## What does this do?
+
+A sticky table-of-contents rail whose vertical line fills in proportion to how
+far the reader has scrolled through the document.
+
+## How is it used?
+
+```css
+.ssr-rail::before {
+  animation: ssr-fill linear both;
+  animation-timeline: scroll(root block);
+}
+@keyframes ssr-fill { to { transform: scaleY(1); } }
+```
+
+## Why is it useful?
+
+Reading-progress indicators are traditionally a `scroll` handler that divides
+`scrollTop` by `scrollHeight` and writes a width every event. That runs script on
+the main thread during the one interaction where jank is most visible, and it
+forces a layout read (`scrollHeight`) on each tick.
+
+A `scroll()` progress timeline expresses the same mapping declaratively and is
+sampled by the compositor, so the rail stays smooth even while the main thread is
+busy. Because the fill is `transform: scaleY()` rather than `height`, it never
+triggers layout either.
+
+The rail degrades sensibly: browsers without scroll-driven animation support
+leave the fill at its static state, so the table of contents still renders and
+still navigates — the progress line is an enhancement, not a dependency. That is
+the same graceful-degradation contract the EaseMotion engine already documents
+for `em=""` attributes when JavaScript is unavailable.

--- a/submissions/examples/scroll-spy-rail-advk/demo.html
+++ b/submissions/examples/scroll-spy-rail-advk/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Scroll Spy Rail</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="ssr-page">
+  <nav class="ssr-rail" aria-label="On this page">
+    <a href="#s1">Parser</a><a href="#s2">Compiler</a><a href="#s3">Optimizer</a><a href="#s4">Runtime</a>
+  </nav>
+  <div class="ssr-body">
+    <h1 class="ssr-h1">Scroll Spy Rail</h1>
+    <p class="ssr-lede">A reading-progress bar filled by a scroll timeline, with section anchors. No scroll listener.</p>
+    <section id="s1"><h2>Parser</h2><p>Tokenises the em string into typed AST nodes.</p></section>
+    <section id="s2"><h2>Compiler</h2><p>Turns the AST into CSS rule text and a stable hashed class name.</p></section>
+    <section id="s3"><h2>Optimizer</h2><p>Strips keyframes and classes no document references at build time.</p></section>
+    <section id="s4"><h2>Runtime</h2><p>Observes the DOM and injects rules for elements as they appear.</p></section>
+  </div>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/scroll-spy-rail-advk/style.css
+++ b/submissions/examples/scroll-spy-rail-advk/style.css
@@ -1,0 +1,77 @@
+/* Scroll Spy Rail
+   The rail's fill is scaleY driven by a scroll() progress timeline over the
+   whole document, so it tracks reading position with no JS. */
+
+* { box-sizing: border-box; }
+
+.ssr-page {
+  display: grid;
+  grid-template-columns: 10rem 1fr;
+  gap: 2rem;
+  max-width: 48rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.65 ui-sans-serif, system-ui, sans-serif;
+  color: #1b1f28;
+}
+
+@media (max-width: 40rem) { .ssr-page { grid-template-columns: 1fr; } }
+
+.ssr-rail {
+  position: sticky;
+  top: 2rem;
+  align-self: start;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  padding-left: 1rem;
+  border-left: 2px solid #e2e6ef;
+}
+
+/* the progress fill, overlaid on the rail's own border */
+.ssr-rail::before {
+  content: "";
+  position: absolute;
+  left: -2px;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: #4c6ef5;
+  transform-origin: top;
+  transform: scaleY(0);
+  animation: ssr-fill linear both;
+  animation-timeline: scroll(root block);
+}
+
+@keyframes ssr-fill { to { transform: scaleY(1); } }
+
+.ssr-rail a {
+  font-size: 0.85rem;
+  color: #6b7488;
+  text-decoration: none;
+  transition: color 180ms ease;
+}
+
+.ssr-rail a:hover, .ssr-rail a:target { color: #4c6ef5; }
+.ssr-rail a:focus-visible { outline: 3px solid #4c6ef5; outline-offset: 2px; border-radius: 0.2rem; }
+
+.ssr-h1 { margin: 0 0 0.4em; font-size: clamp(1.5rem, 4.5vw, 2.1rem); letter-spacing: -0.02em; }
+.ssr-lede { margin: 0 0 2rem; color: #576073; }
+.ssr-body section { min-height: 70vh; padding-top: 1rem; }
+.ssr-body h2 { margin: 0 0 0.5rem; font-size: 1.15rem; }
+.ssr-body p { margin: 0; color: #576073; }
+
+@media (prefers-reduced-motion: reduce) {
+  .ssr-rail::before { animation: none; transform: scaleY(1); opacity: 0.35; }
+}
+
+@media (forced-colors: active) {
+  .ssr-rail { border-left-color: CanvasText; }
+  .ssr-rail::before { background: Highlight; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .ssr-page { color: #e6e9f2; background: #10131a; }
+  .ssr-lede, .ssr-body p, .ssr-rail a { color: #98a1b3; }
+  .ssr-rail { border-left-color: #2a303c; }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #66255.

Adds `submissions/examples/scroll-spy-rail-advk/` (`demo.html` + `style.css` + `README.md`).

A sticky table-of-contents rail whose vertical line fills in proportion to how
far the reader has scrolled through the document.

---

## Type of Change

- [x] 🧩 New component
- [ ] 🐛 Bug fix in an existing submission
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/examples/scroll-spy-rail-advk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A sticky table-of-contents rail whose vertical line fills in proportion to how
far the reader has scrolled through the document.

**How does a developer use it?**

```css
.ssr-rail::before {
  animation: ssr-fill linear both;
  animation-timeline: scroll(root block);
}
@keyframes ssr-fill { to { transform: scaleY(1); } }
```

**Why does it fit EaseMotion CSS?**

Reading-progress indicators are traditionally a `scroll` handler that divides
`scrollTop` by `scrollHeight` and writes a width every event. That runs script on
the main thread during the one interaction where jank is most visible, and it
forces a layout read (`scrollHeight`) on each tick.

A `scroll()` progress timeline expresses the same mapping declaratively and is
sampled by the compositor, so the rail stays smooth even while the main thread is
busy. Because the fill is `transform: scaleY()` rather than `height`, it never
triggers layout either.

The rail degrades sensibly: browsers without scroll-driven animation support
leave the fill at its static state, so the table of contents still renders and
still navigates — the progress line is an enhancement, not a dependency. That is
the same graceful-degradation contract the EaseMotion engine already documents
for `em=""` attributes when JavaScript is unavailable.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- CSS passes the repository's own `stylelint` config (`npx stylelint --config .stylelintrc.json`) with no errors.
- Every stylesheet includes a `prefers-reduced-motion` path and, where colour carries state, a `forced-colors` path.
- Naming uses the `-advk` suffix per the CONTRIBUTING uniqueness rule; happy to rename during standardization.
