### PR TITLE
feat: Stagger List Reveal (closes #66256)

### DIFF
--- a/submissions/examples/stagger-list-reveal-advk/README.md
+++ b/submissions/examples/stagger-list-reveal-advk/README.md
@@ -1,0 +1,36 @@
+# Stagger List Reveal
+
+## What does this do?
+
+Reveals list rows one after another using a single `--slr-step` custom property
+on the container and an index `--i` on each row — no per-item selectors, no JS.
+
+## How is it used?
+
+```html
+<ul class="slr-list is-in" style="--slr-step: 70ms">
+  <li class="slr-item" style="--i:0"><span class="slr-dot"></span>First</li>
+  <li class="slr-item" style="--i:1"><span class="slr-dot"></span>Second</li>
+  <li class="slr-item" style="--i:2"><span class="slr-dot"></span>Third</li>
+</ul>
+```
+
+Change the cascade speed by editing one value; add rows by incrementing `--i`.
+
+## Why is it useful?
+
+Staggered entrances are normally written as a stack of
+`:nth-child(n) { animation-delay: ... }` rules, which caps the list at whatever
+count the author hard-coded and bloats the stylesheet. Moving the multiplication
+into `calc(var(--i) * var(--slr-step))` makes the delay a function of data
+rather than of selector position, so a server-rendered list of any length works
+with the same two rules.
+
+That is a good fit for EaseMotion's stated goals: the markup stays readable
+(`--i:3` says exactly what it means), the effect is composable with the existing
+`ease-*` entrance utilities, and it costs no JavaScript.
+
+The reduced-motion path is designed rather than disabled — the sequence is kept
+so the eye still tracks the order of items, but translation and the spring
+overshoot are dropped in favour of a shorter plain fade, and the step is tightened
+from 70ms to 40ms so the whole list settles quickly.

--- a/submissions/examples/stagger-list-reveal-advk/demo.html
+++ b/submissions/examples/stagger-list-reveal-advk/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Stagger List Reveal</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="slr-wrap">
+  <h1 class="slr-h1">Stagger List Reveal</h1>
+  <p class="slr-lede">
+    Each row enters on its own delay, derived from a single custom property so
+    the cascade needs no per-item CSS and no JavaScript.
+  </p>
+  <button class="slr-replay" type="button" onclick="var l=document.getElementById('list');l.classList.remove('is-in');void l.offsetWidth;l.classList.add('is-in');">
+    Replay
+  </button>
+
+  <ul class="slr-list is-in" id="list" style="--slr-step: 70ms">
+    <li class="slr-item" style="--i:0"><span class="slr-dot"></span>Parse the em attribute</li>
+    <li class="slr-item" style="--i:1"><span class="slr-dot"></span>Build the animation AST</li>
+    <li class="slr-item" style="--i:2"><span class="slr-dot"></span>Hash into a class name</li>
+    <li class="slr-item" style="--i:3"><span class="slr-dot"></span>Compile the CSS rule</li>
+    <li class="slr-item" style="--i:4"><span class="slr-dot"></span>Insert into the sheet</li>
+    <li class="slr-item" style="--i:5"><span class="slr-dot"></span>Apply to the element</li>
+  </ul>
+</main>
+</body>
+</html>

--- a/submissions/examples/stagger-list-reveal-advk/style.css
+++ b/submissions/examples/stagger-list-reveal-advk/style.css
@@ -1,0 +1,105 @@
+/* Stagger List Reveal
+   One --slr-step on the container plus --i on each row produces the cascade.
+   calc() does the multiplication, so adding a row needs no new CSS. */
+
+.slr-wrap {
+  max-width: 34rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1b1f2a;
+}
+
+.slr-h1 { margin: 0 0 0.4em; font-size: clamp(1.5rem, 4.5vw, 2.1rem); letter-spacing: -0.02em; }
+.slr-lede { margin: 0 0 1.5rem; color: #59617a; }
+
+.slr-replay {
+  padding: 0.55em 1.2em;
+  margin-bottom: 1.75rem;
+  border: 1px solid #c6ccdc;
+  border-radius: 0.45rem;
+  background: #fff;
+  font: inherit;
+  font-weight: 600;
+  color: #2f3a55;
+  cursor: pointer;
+  transition: border-color 160ms ease, transform 160ms ease;
+}
+
+.slr-replay:hover { border-color: #5b6ef5; transform: translateY(-1px); }
+.slr-replay:focus-visible { outline: 3px solid #5b6ef5; outline-offset: 3px; }
+
+.slr-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.slr-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.85em 1em;
+  border: 1px solid #e2e6f0;
+  border-radius: 0.55rem;
+  background: #fbfcfe;
+  opacity: 0;
+  transform: translateX(-1.25rem);
+}
+
+.slr-list.is-in .slr-item {
+  animation: slr-enter 520ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation-delay: calc(var(--i) * var(--slr-step, 70ms));
+}
+
+.slr-dot {
+  width: 0.55rem;
+  aspect-ratio: 1;
+  flex: none;
+  border-radius: 50%;
+  background: #5b6ef5;
+}
+
+.slr-list.is-in .slr-dot {
+  animation: slr-pop 420ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
+  animation-delay: calc(var(--i) * var(--slr-step, 70ms) + 120ms);
+}
+
+@keyframes slr-enter {
+  from { opacity: 0; transform: translateX(-1.25rem); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes slr-pop {
+  from { transform: scale(0.2); }
+  to   { transform: scale(1); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .slr-item, .slr-dot { transform: none; }
+
+  .slr-list.is-in .slr-item,
+  .slr-list.is-in .slr-dot {
+    /* keep the sequencing as a fade only: no travel, no overshoot */
+    animation: slr-fade 260ms ease both;
+    animation-delay: calc(var(--i) * 40ms);
+  }
+  .slr-replay:hover { transform: none; }
+}
+
+@keyframes slr-fade { from { opacity: 0; } to { opacity: 1; } }
+
+@media (forced-colors: active) {
+  .slr-item { border-color: CanvasText; }
+  .slr-dot  { background: Highlight; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .slr-wrap { color: #e7eaf2; }
+  .slr-lede { color: #98a1ba; }
+  .slr-item { background: #171b24; border-color: #2a3040; }
+  .slr-replay { background: #171b24; border-color: #2a3040; color: #c8cee0; }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #66256.

Adds `submissions/examples/stagger-list-reveal-advk/` (`demo.html` + `style.css` + `README.md`).

Reveals list rows one after another using a single `--slr-step` custom property
on the container and an index `--i` on each row — no per-item selectors, no JS.

---

## Type of Change

- [x] 🧩 New component
- [ ] 🐛 Bug fix in an existing submission
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/examples/stagger-list-reveal-advk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Reveals list rows one after another using a single `--slr-step` custom property
on the container and an index `--i` on each row — no per-item selectors, no JS.

**How does a developer use it?**

```html
<ul class="slr-list is-in" style="--slr-step: 70ms">
  <li class="slr-item" style="--i:0"><span class="slr-dot"></span>First</li>
  <li class="slr-item" style="--i:1"><span class="slr-dot"></span>Second</li>
  <li class="slr-item" style="--i:2"><span class="slr-dot"></span>Third</li>
</ul>
```

Change the cascade speed by editing one value; add rows by incrementing `--i`.

**Why does it fit EaseMotion CSS?**

Staggered entrances are normally written as a stack of
`:nth-child(n) { animation-delay: ... }` rules, which caps the list at whatever
count the author hard-coded and bloats the stylesheet. Moving the multiplication
into `calc(var(--i) * var(--slr-step))` makes the delay a function of data
rather than of selector position, so a server-rendered list of any length works
with the same two rules.

That is a good fit for EaseMotion's stated goals: the markup stays readable
(`--i:3` says exactly what it means), the effect is composable with the existing
`ease-*` entrance utilities, and it costs no JavaScript.

The reduced-motion path is designed rather than disabled — the sequence is kept
so the eye still tracks the order of items, but translation and the spring
overshoot are dropped in favour of a shorter plain fade, and the step is tightened
from 70ms to 40ms so the whole list settles quickly.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- CSS passes the repository's own `stylelint` config (`npx stylelint --config .stylelintrc.json`) with no errors.
- Every stylesheet includes a `prefers-reduced-motion` path and, where colour carries state, a `forced-colors` path.
- Naming uses the `-advk` suffix per the CONTRIBUTING uniqueness rule; happy to rename during standardization.
