### PR TITLE
feat: Sticky Header Shrink (closes #66257)

### DIFF
--- a/submissions/examples/sticky-header-shrink-advk/README.md
+++ b/submissions/examples/sticky-header-shrink-advk/README.md
@@ -1,0 +1,37 @@
+# Sticky Header Shrink
+
+## What does this do?
+
+Condenses a sticky header — padding, logo size and title size — as the page
+scrolls, driven entirely by CSS scroll-driven animations.
+
+## How is it used?
+
+```css
+.shs-head {
+  animation: shs-condense linear both;
+  animation-timeline: scroll(root block);
+  animation-range: 0 120px;
+}
+```
+
+Scroll `demo.html` and the header interpolates across the first 120px.
+
+## Why is it useful?
+
+The standard implementation attaches a `scroll` listener, compares
+`window.scrollY` against a threshold, and toggles a class. That runs JavaScript
+on the main thread for every scroll event, and because it toggles a boolean it
+can only snap between two states — so the header pops at the threshold instead of
+tracking the scroll.
+
+`animation-timeline: scroll()` binds animation progress directly to scroll
+position. The browser samples it off the main thread, and because progress is
+continuous the header interpolates smoothly across the range rather than
+switching. `animation-range: 0 120px` states the mapping declaratively, which is
+far easier to tune than a magic number buried in a listener.
+
+The degradation story is good: a browser without scroll-driven animation support
+ignores `animation-timeline`, the keyframes never advance, and the header stays
+at full size — a correct static header rather than a broken one. That matches
+EaseMotion's no-build, no-JavaScript posture.

--- a/submissions/examples/sticky-header-shrink-advk/demo.html
+++ b/submissions/examples/sticky-header-shrink-advk/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Sticky Header Shrink</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="shs-page">
+  <header class="shs-head">
+    <a class="shs-brand" href="#top"><span class="shs-mark"></span><span class="shs-name">EaseMotion</span></a>
+    <nav class="shs-nav"><a href="#a">Docs</a><a href="#b">Engine</a><a href="#c">Examples</a></nav>
+  </header>
+
+  <div class="shs-sentinel"></div>
+
+  <section class="shs-body">
+    <h1 class="shs-h1">Sticky Header Shrink</h1>
+    <p class="shs-lede">Scroll down. The header condenses when it leaves the top of the page, detected with a scroll-driven animation timeline instead of a scroll listener.</p>
+    <p>The effect is driven by <code>animation-timeline: scroll()</code>, so the browser samples it off the main thread. There is no scroll handler, no <code>IntersectionObserver</code>, and no class toggling.</p>
+    <p>Browsers without scroll-driven animation support simply keep the full-size header, which is the correct fallback rather than a broken one.</p>
+    <div class="shs-filler"></div>
+    <p class="shs-end">End of demo.</p>
+  </section>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/sticky-header-shrink-advk/style.css
+++ b/submissions/examples/sticky-header-shrink-advk/style.css
@@ -1,0 +1,98 @@
+/* Sticky Header Shrink
+   Uses a scroll-progress timeline over the first 120px of document scroll to
+   interpolate the header between its tall and condensed states. */
+
+* { box-sizing: border-box; }
+
+.shs-page {
+  margin: 0;
+  font: 400 1rem/1.65 ui-sans-serif, system-ui, sans-serif;
+  color: #1b1f28;
+}
+
+.shs-head {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.5rem 1.5rem;
+  background: #ffffffee;
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid transparent;
+  animation: shs-condense linear both;
+  animation-timeline: scroll(root block);
+  animation-range: 0 120px;
+}
+
+@keyframes shs-condense {
+  to {
+    padding-block: 0.6rem;
+    border-bottom-color: #dfe3ec;
+    box-shadow: 0 4px 18px rgba(16, 20, 30, 0.07);
+  }
+}
+
+.shs-brand { display: flex; align-items: center; gap: 0.6rem; text-decoration: none; color: inherit; }
+
+.shs-mark {
+  width: 2rem;
+  aspect-ratio: 1;
+  border-radius: 0.45rem;
+  background: linear-gradient(135deg, #5b6ef5, #a05bf5);
+  animation: shs-mark-shrink linear both;
+  animation-timeline: scroll(root block);
+  animation-range: 0 120px;
+}
+
+@keyframes shs-mark-shrink { to { width: 1.4rem; border-radius: 0.3rem; } }
+
+.shs-name {
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  font-size: 1.15rem;
+  animation: shs-name-shrink linear both;
+  animation-timeline: scroll(root block);
+  animation-range: 0 120px;
+}
+
+@keyframes shs-name-shrink { to { font-size: 0.95rem; } }
+
+.shs-nav { display: flex; gap: 1.1rem; font-size: 0.9rem; }
+.shs-nav a { color: #4a5468; text-decoration: none; }
+.shs-nav a:hover { color: #5b6ef5; }
+.shs-nav a:focus-visible { outline: 3px solid #5b6ef5; outline-offset: 3px; border-radius: 0.2rem; }
+
+.shs-body { max-width: 38rem; margin: 0 auto; padding: 2.5rem 1.25rem 4rem; }
+.shs-h1 { margin: 0 0 0.4em; font-size: clamp(1.5rem, 4.5vw, 2.1rem); letter-spacing: -0.02em; }
+.shs-lede { margin: 0 0 1.5rem; color: #576073; }
+.shs-body p { margin: 0 0 1.1rem; }
+
+.shs-body code {
+  padding: 0.1em 0.35em; border-radius: 0.25rem; background: #e8ecf4;
+  font-family: ui-monospace, Menlo, monospace; font-size: 0.88em;
+}
+.shs-filler { height: 90vh; }
+.shs-end { color: #576073; }
+
+@media (prefers-reduced-motion: reduce) {
+  .shs-head, .shs-mark, .shs-name { animation: none; }
+  .shs-head { border-bottom-color: #dfe3ec; }
+}
+
+@media (forced-colors: active) {
+  .shs-head { border-bottom: 1px solid CanvasText; background: Canvas; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .shs-page { color: #e6e9f2; background: #10131a; }
+  .shs-head { background: #10131aee; }
+  .shs-lede, .shs-end, .shs-nav a { color: #99a1b4; }
+  .shs-body code { background: #262c38; }
+
+  @keyframes shs-condense {
+    to { padding-block: 0.6rem; border-bottom-color: #2a303c; box-shadow: 0 4px 18px rgba(0, 0, 0, 0.4); }
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #66257.

Adds `submissions/examples/sticky-header-shrink-advk/` (`demo.html` + `style.css` + `README.md`).

Condenses a sticky header — padding, logo size and title size — as the page
scrolls, driven entirely by CSS scroll-driven animations.

---

## Type of Change

- [x] 🧩 New component
- [ ] 🐛 Bug fix in an existing submission
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/examples/sticky-header-shrink-advk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Condenses a sticky header — padding, logo size and title size — as the page
scrolls, driven entirely by CSS scroll-driven animations.

**How does a developer use it?**

```css
.shs-head {
  animation: shs-condense linear both;
  animation-timeline: scroll(root block);
  animation-range: 0 120px;
}
```

Scroll `demo.html` and the header interpolates across the first 120px.

**Why does it fit EaseMotion CSS?**

The standard implementation attaches a `scroll` listener, compares
`window.scrollY` against a threshold, and toggles a class. That runs JavaScript
on the main thread for every scroll event, and because it toggles a boolean it
can only snap between two states — so the header pops at the threshold instead of
tracking the scroll.

`animation-timeline: scroll()` binds animation progress directly to scroll
position. The browser samples it off the main thread, and because progress is
continuous the header interpolates smoothly across the range rather than
switching. `animation-range: 0 120px` states the mapping declaratively, which is
far easier to tune than a magic number buried in a listener.

The degradation story is good: a browser without scroll-driven animation support
ignores `animation-timeline`, the keyframes never advance, and the header stays
at full size — a correct static header rather than a broken one. That matches
EaseMotion's no-build, no-JavaScript posture.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- CSS passes the repository's own `stylelint` config (`npx stylelint --config .stylelintrc.json`) with no errors.
- Every stylesheet includes a `prefers-reduced-motion` path and, where colour carries state, a `forced-colors` path.
- Naming uses the `-advk` suffix per the CONTRIBUTING uniqueness rule; happy to rename during standardization.
