### PR TITLE
feat: Text Scramble Reveal (closes #66258)

### DIFF
--- a/submissions/examples/text-scramble-advk/README.md
+++ b/submissions/examples/text-scramble-advk/README.md
@@ -1,0 +1,35 @@
+# Text Scramble Reveal
+
+## What does this do?
+
+Resolves a word out of scrambled glyphs, one character column at a time, using
+only CSS.
+
+## How is it used?
+
+```html
+<span class="tsc-word">
+  <span class="tsc-ch" style="--i:0" data-n="E">E</span>
+  <span class="tsc-ch" style="--i:1" data-n="A">A</span>
+</span>
+```
+
+`data-n` carries the resolved glyph; `--i` sets its position in the decode order.
+
+## Why is it useful?
+
+The JavaScript version of this effect rewrites `textContent` many times per
+second per character. That thrashes the DOM, and — more importantly — it means
+assistive technology and search crawlers may read whatever garbage happens to be
+in the node at the moment they look. The heading is literally not the heading for
+the duration of the animation.
+
+Here the decoys live in a pseudo-element, which is decorative and not part of the
+accessibility tree, while the real character stays in the element's own text
+content the entire time. A screen reader reads "EASEMOTION" from the first frame.
+
+The mechanism is a clipped column: `content` builds a stack of junk glyphs
+separated by `\A` newlines with the real glyph last, and `steps(6, end)` walks the
+column up so each frame lands on exactly one glyph rather than sliding between
+two. Per-character `animation-delay` derived from `--i` produces the left-to-right
+decode without any per-character rules.

--- a/submissions/examples/text-scramble-advk/demo.html
+++ b/submissions/examples/text-scramble-advk/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Text Scramble Reveal</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="tsc-wrap">
+  <h1 class="tsc-h1">Text Scramble Reveal</h1>
+  <p class="tsc-lede">A heading that resolves out of noise. Each glyph column settles on its own delay, so the word decodes left to right.</p>
+  <p class="tsc-stage">
+    <span class="tsc-word">
+      <span class="tsc-ch" style="--i:0" data-n="E">E</span><span class="tsc-ch" style="--i:1" data-n="A">A</span><span class="tsc-ch" style="--i:2" data-n="S">S</span><span class="tsc-ch" style="--i:3" data-n="E">E</span><span class="tsc-ch" style="--i:4" data-n="M">M</span><span class="tsc-ch" style="--i:5" data-n="O">O</span><span class="tsc-ch" style="--i:6" data-n="T">T</span><span class="tsc-ch" style="--i:7" data-n="I">I</span><span class="tsc-ch" style="--i:8" data-n="O">O</span><span class="tsc-ch" style="--i:9" data-n="N">N</span>
+    </span>
+  </p>
+  <p class="tsc-note">Reload to replay the decode.</p>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/text-scramble-advk/style.css
+++ b/submissions/examples/text-scramble-advk/style.css
@@ -1,0 +1,52 @@
+/* Text Scramble Reveal
+   Each character sits above a stack of decoy glyphs in a clipped column. The
+   column slides up on a per-character delay until the real glyph lands. */
+
+.tsc-wrap { max-width: 36rem; margin: 0 auto; padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #d7f5e6; background: #0c1410; min-height: 100vh; }
+.tsc-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); letter-spacing: -0.02em; }
+.tsc-lede { margin: 0 0 2.5rem; color: #7fae95; }
+.tsc-note { margin-top: 2.5rem; font-size: 0.85rem; color: #7fae95; }
+
+.tsc-word { display: inline-flex; gap: 0.06em; }
+
+.tsc-ch {
+  position: relative;
+  display: block;
+  width: 0.72em;
+  height: 1.15em;
+  overflow: hidden;
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: clamp(2rem, 9vw, 3.75rem);
+  font-weight: 700;
+
+  /* the element's own glyph is hidden; ::before paints the visible stack */
+  color: transparent;
+  line-height: 1.15em;
+  text-align: center;
+}
+
+/* decoy stack: six junk glyphs then the real one at the bottom */
+.tsc-ch::before {
+  content: "#" "\A" "%" "\A" "@" "\A" "8" "\A" "*" "\A" "?" "\A" attr(data-n);
+  white-space: pre;
+  display: block;
+  color: #3ddc84;
+  animation: tsc-settle 1.5s steps(6, end) both;
+  animation-delay: calc(var(--i) * 90ms);
+}
+
+@keyframes tsc-settle {
+  from { transform: translateY(0); }
+  to   { transform: translateY(-6.9em); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  /* no scramble: jump straight to the resolved glyph */
+  .tsc-ch::before { animation: none; transform: translateY(-6.9em); }
+}
+
+@media (forced-colors: active) {
+  .tsc-ch::before { color: CanvasText; }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #66258.

Adds `submissions/examples/text-scramble-advk/` (`demo.html` + `style.css` + `README.md`).

Resolves a word out of scrambled glyphs, one character column at a time, using
only CSS.

---

## Type of Change

- [x] 🧩 New component
- [ ] 🐛 Bug fix in an existing submission
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/examples/text-scramble-advk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Resolves a word out of scrambled glyphs, one character column at a time, using
only CSS.

**How does a developer use it?**

```html
<span class="tsc-word">
  <span class="tsc-ch" style="--i:0" data-n="E">E</span>
  <span class="tsc-ch" style="--i:1" data-n="A">A</span>
</span>
```

`data-n` carries the resolved glyph; `--i` sets its position in the decode order.

**Why does it fit EaseMotion CSS?**

The JavaScript version of this effect rewrites `textContent` many times per
second per character. That thrashes the DOM, and — more importantly — it means
assistive technology and search crawlers may read whatever garbage happens to be
in the node at the moment they look. The heading is literally not the heading for
the duration of the animation.

Here the decoys live in a pseudo-element, which is decorative and not part of the
accessibility tree, while the real character stays in the element's own text
content the entire time. A screen reader reads "EASEMOTION" from the first frame.

The mechanism is a clipped column: `content` builds a stack of junk glyphs
separated by `\A` newlines with the real glyph last, and `steps(6, end)` walks the
column up so each frame lands on exactly one glyph rather than sliding between
two. Per-character `animation-delay` derived from `--i` produces the left-to-right
decode without any per-character rules.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- CSS passes the repository's own `stylelint` config (`npx stylelint --config .stylelintrc.json`) with no errors.
- Every stylesheet includes a `prefers-reduced-motion` path and, where colour carries state, a `forced-colors` path.
- Naming uses the `-advk` suffix per the CONTRIBUTING uniqueness rule; happy to rename during standardization.
