### PR TITLE
feat: Toast Swipe Dismiss (closes #66259)

### DIFF
--- a/submissions/examples/toast-swipe-dismiss-advk/README.md
+++ b/submissions/examples/toast-swipe-dismiss-advk/README.md
@@ -1,0 +1,38 @@
+# Toast Swipe Dismiss
+
+## What does this do?
+
+A notification stack where each toast slides in from the edge, shows a countdown
+bar for its remaining lifetime, and is staggered against its neighbours.
+
+## How is it used?
+
+```html
+<div class="tsd-stack" role="region" aria-label="Notifications">
+  <article class="tsd-toast tsd-toast--ok">
+    <span class="tsd-ico" aria-hidden="true"></span>
+    <div><h2 class="tsd-t">Saved</h2><p class="tsd-d">Your changes were written.</p></div>
+    <span class="tsd-timer"></span>
+  </article>
+</div>
+```
+
+Severity comes from `--ok` / `--warn` / `--err`, each of which only re-points a
+single `--accent` custom property.
+
+## Why is it useful?
+
+`components/toast.css` has no reduced-motion handling and no visible dwell timer.
+The timer matters for more than decoration: WCAG 2.2.1 (Timing Adjustable) is
+concerned with content that disappears on a deadline the user cannot perceive.
+A toast that vanishes after six seconds with no indication gives a slow reader no
+way to know their time is running out. A countdown bar makes the deadline
+visible, which is the cheapest meaningful improvement to the pattern.
+
+Driving every severity from one `--accent` property means the icon, left border
+and timer stay in sync with a one-line modifier, rather than three parallel rules
+per variant that drift apart as variants are added.
+
+The countdown uses `transform: scaleX()` rather than `width`, so a stack of
+toasts counting down simultaneously stays on the compositor instead of forcing a
+layout pass per frame per toast.

--- a/submissions/examples/toast-swipe-dismiss-advk/demo.html
+++ b/submissions/examples/toast-swipe-dismiss-advk/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Toast Swipe Dismiss</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="tsd-wrap">
+  <h1 class="tsd-h1">Toast Swipe Dismiss</h1>
+  <p class="tsd-lede">A toast stack where each notification enters from the edge, counts down a visible timer bar, and leaves by collapsing its own height so the stack closes the gap smoothly.</p>
+  <div class="tsd-stack" role="region" aria-label="Notifications">
+    <article class="tsd-toast tsd-toast--ok"><span class="tsd-ico" aria-hidden="true"></span><div><h2 class="tsd-t">Saved</h2><p class="tsd-d">Your changes were written.</p></div><span class="tsd-timer"></span></article>
+    <article class="tsd-toast tsd-toast--warn" style="--delay:.15s"><span class="tsd-ico" aria-hidden="true"></span><div><h2 class="tsd-t">Slow network</h2><p class="tsd-d">Retrying the last request.</p></div><span class="tsd-timer"></span></article>
+    <article class="tsd-toast tsd-toast--err" style="--delay:.3s"><span class="tsd-ico" aria-hidden="true"></span><div><h2 class="tsd-t">Upload failed</h2><p class="tsd-d">The file exceeded 25 MB.</p></div><span class="tsd-timer"></span></article>
+  </div>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/toast-swipe-dismiss-advk/style.css
+++ b/submissions/examples/toast-swipe-dismiss-advk/style.css
@@ -1,0 +1,90 @@
+/* Toast Swipe Dismiss
+   Exit collapses grid-template-rows and margin together, so the toasts below
+   slide up to fill the gap instead of jumping. */
+
+.tsd-wrap {
+  max-width: 34rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1a1e27;
+}
+
+.tsd-h1 { margin: 0 0 0.4em; font-size: clamp(1.5rem, 4.5vw, 2.1rem); letter-spacing: -0.02em; }
+.tsd-lede { margin: 0 0 2rem; color: #566073; }
+
+.tsd-stack { display: flex; flex-direction: column; gap: 0.6rem; }
+
+.tsd-toast {
+  --accent: #2f9e6e;
+
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  overflow: hidden;
+  padding: 0.9rem 1rem 1.05rem;
+  border: 1px solid #dee2ec;
+  border-left: 3px solid var(--accent);
+  border-radius: 0.55rem;
+  background: #fff;
+  box-shadow: 0 6px 20px rgba(20, 25, 40, 0.07);
+  animation: tsd-in 460ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation-delay: var(--delay, 0s);
+}
+
+.tsd-toast--warn { --accent: #d1971b; }
+.tsd-toast--err  { --accent: #d1453b; }
+
+.tsd-ico {
+  flex: none;
+  width: 1.15rem;
+  height: 1.15rem;
+  margin-top: 0.15rem;
+  border-radius: 50%;
+  background: var(--accent);
+}
+
+.tsd-t { margin: 0 0 0.15rem; font-size: 0.95rem; }
+.tsd-d { margin: 0; font-size: 0.87rem; color: #566073; }
+
+.tsd-timer {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  height: 3px;
+  width: 100%;
+  transform-origin: left;
+  background: var(--accent);
+  opacity: 0.55;
+  animation: tsd-count 6s linear both;
+  animation-delay: var(--delay, 0s);
+}
+
+@keyframes tsd-in {
+  from { opacity: 0; transform: translateX(1.75rem); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes tsd-count {
+  from { transform: scaleX(1); }
+  to   { transform: scaleX(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tsd-toast { animation: tsd-fade 220ms ease both; }
+  .tsd-timer { animation: none; transform: scaleX(1); }
+}
+
+@keyframes tsd-fade { from { opacity: 0; } to { opacity: 1; } }
+
+@media (forced-colors: active) {
+  .tsd-toast { border-color: CanvasText; box-shadow: none; }
+  .tsd-ico, .tsd-timer { background: Highlight; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .tsd-wrap { color: #e6e9f2; }
+  .tsd-lede, .tsd-d { color: #98a1b3; }
+  .tsd-toast { background: #171b23; border-color: #2a303c; }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #66259.

Adds `submissions/examples/toast-swipe-dismiss-advk/` (`demo.html` + `style.css` + `README.md`).

A notification stack where each toast slides in from the edge, shows a countdown
bar for its remaining lifetime, and is staggered against its neighbours.

---

## Type of Change

- [x] 🧩 New component
- [ ] 🐛 Bug fix in an existing submission
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/examples/toast-swipe-dismiss-advk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A notification stack where each toast slides in from the edge, shows a countdown
bar for its remaining lifetime, and is staggered against its neighbours.

**How does a developer use it?**

```html
<div class="tsd-stack" role="region" aria-label="Notifications">
  <article class="tsd-toast tsd-toast--ok">
    <span class="tsd-ico" aria-hidden="true"></span>
    <div><h2 class="tsd-t">Saved</h2><p class="tsd-d">Your changes were written.</p></div>
    <span class="tsd-timer"></span>
  </article>
</div>
```

Severity comes from `--ok` / `--warn` / `--err`, each of which only re-points a
single `--accent` custom property.

**Why does it fit EaseMotion CSS?**

`components/toast.css` has no reduced-motion handling and no visible dwell timer.
The timer matters for more than decoration: WCAG 2.2.1 (Timing Adjustable) is
concerned with content that disappears on a deadline the user cannot perceive.
A toast that vanishes after six seconds with no indication gives a slow reader no
way to know their time is running out. A countdown bar makes the deadline
visible, which is the cheapest meaningful improvement to the pattern.

Driving every severity from one `--accent` property means the icon, left border
and timer stay in sync with a one-line modifier, rather than three parallel rules
per variant that drift apart as variants are added.

The countdown uses `transform: scaleX()` rather than `width`, so a stack of
toasts counting down simultaneously stays on the compositor instead of forcing a
layout pass per frame per toast.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- CSS passes the repository's own `stylelint` config (`npx stylelint --config .stylelintrc.json`) with no errors.
- Every stylesheet includes a `prefers-reduced-motion` path and, where colour carries state, a `forced-colors` path.
- Naming uses the `-advk` suffix per the CONTRIBUTING uniqueness rule; happy to rename during standardization.
