### PR TITLE
feat: Typewriter Caret (closes #66260)

### DIFF
--- a/submissions/examples/typewriter-caret-advk/README.md
+++ b/submissions/examples/typewriter-caret-advk/README.md
@@ -1,0 +1,33 @@
+# Typewriter Caret
+
+## What does this do?
+
+Types a line of text out character by character with a blinking caret, using
+only a `width` animation and a `steps()` timing function.
+
+## How is it used?
+
+```html
+<p class="twc-line" style="--chars: 27; --dur: 2.4s">Animation you can actually read</p>
+```
+
+`--chars` must equal the character count of the string; `--dur` sets the total
+type time. Chain lines by giving later ones an `animation-delay`.
+
+## Why is it useful?
+
+Typewriter effects are usually done in JavaScript by appending one character per
+`setInterval` tick, which forces a text-node mutation and a layout pass on every
+character and leaves the element empty in the DOM until the animation finishes —
+bad for screen readers and worse for anyone who reads the page with JS disabled.
+
+The CSS approach keeps the complete string in the markup from the start, so
+assistive technology and search crawlers see the full sentence immediately while
+sighted users get the reveal. `steps(var(--chars), end)` quantises the width
+animation so each frame lands exactly on a glyph boundary rather than clipping
+mid-character, which is what separates this from a plain width transition.
+
+This suits EaseMotion's no-build promise: the effect is two keyframes and one
+declaration, configured entirely through custom properties in the markup. Under
+reduced motion the line is shown complete with a steady caret — the blink is
+removed outright, since a repeating flash is itself a motion trigger.

--- a/submissions/examples/typewriter-caret-advk/demo.html
+++ b/submissions/examples/typewriter-caret-advk/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Typewriter Caret</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="twc-wrap">
+  <h1 class="twc-h1">Typewriter Caret</h1>
+  <p class="twc-lede">Types a line out character by character using a steps() timing function over a ch-based width. No JavaScript, no per-character spans.</p>
+
+  <p class="twc-line" style="--chars: 27; --dur: 2.4s">Animation you can actually read</p>
+  <p class="twc-line twc-line--alt" style="--chars: 22; --dur: 2s">Zero dependencies. No build.</p>
+
+  <p class="twc-note">The caret keeps blinking after the line completes, so the element still reads as a live terminal.</p>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/typewriter-caret-advk/style.css
+++ b/submissions/examples/typewriter-caret-advk/style.css
@@ -1,0 +1,62 @@
+/* Typewriter Caret
+   The reveal is a width animation from 0 to <n>ch driven by steps(n), so each
+   step lands exactly on a character boundary. Requires a monospace face for the
+   ch unit to match glyph advance. */
+
+.twc-wrap {
+  max-width: 38rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #d8e0e8;
+  background: #10141a;
+  min-height: 100vh;
+}
+
+.twc-h1 { margin: 0 0 0.4em; font-size: clamp(1.5rem, 4.5vw, 2.1rem); letter-spacing: -0.02em; }
+.twc-lede { margin: 0 0 2rem; color: #8b98a8; }
+.twc-note { margin-top: 2rem; font-size: 0.85rem; color: #8b98a8; }
+
+.twc-line {
+  /* width animation only works on a non-wrapping inline-ish box */
+  display: block;
+  width: 0;
+  max-width: max-content;
+  margin: 0 0 1rem;
+  overflow: hidden;
+  white-space: nowrap;
+  border-right: 0.12em solid #4ade80;
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: clamp(1rem, 3.4vw, 1.5rem);
+  color: #4ade80;
+  animation:
+    twc-type var(--dur, 2.4s) steps(var(--chars), end) forwards,
+    twc-blink 900ms step-end infinite;
+}
+
+.twc-line--alt { color: #60a5fa; border-right-color: #60a5fa; animation-delay: var(--dur, 2.4s), 0s; }
+
+@keyframes twc-type {
+  from { width: 0; }
+  to   { width: calc(var(--chars) * 1ch); }
+}
+
+@keyframes twc-blink {
+  0%, 100% { border-right-color: currentcolor; }
+  50%      { border-right-color: transparent; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  /* show the full line immediately; a blinking caret is itself a motion
+     trigger for some users, so it is dropped rather than slowed */
+  .twc-line {
+    width: calc(var(--chars) * 1ch);
+    animation: none;
+    border-right-color: currentcolor;
+  }
+  .twc-line--alt { animation: none; }
+}
+
+@media (forced-colors: active) {
+  .twc-line { color: CanvasText; border-right-color: CanvasText; }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #66260.

Adds `submissions/examples/typewriter-caret-advk/` (`demo.html` + `style.css` + `README.md`).

Types a line of text out character by character with a blinking caret, using
only a `width` animation and a `steps()` timing function.

---

## Type of Change

- [x] 🧩 New component
- [ ] 🐛 Bug fix in an existing submission
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/examples/typewriter-caret-advk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Types a line of text out character by character with a blinking caret, using
only a `width` animation and a `steps()` timing function.

**How does a developer use it?**

```html
<p class="twc-line" style="--chars: 27; --dur: 2.4s">Animation you can actually read</p>
```

`--chars` must equal the character count of the string; `--dur` sets the total
type time. Chain lines by giving later ones an `animation-delay`.

**Why does it fit EaseMotion CSS?**

Typewriter effects are usually done in JavaScript by appending one character per
`setInterval` tick, which forces a text-node mutation and a layout pass on every
character and leaves the element empty in the DOM until the animation finishes —
bad for screen readers and worse for anyone who reads the page with JS disabled.

The CSS approach keeps the complete string in the markup from the start, so
assistive technology and search crawlers see the full sentence immediately while
sighted users get the reveal. `steps(var(--chars), end)` quantises the width
animation so each frame lands exactly on a glyph boundary rather than clipping
mid-character, which is what separates this from a plain width transition.

This suits EaseMotion's no-build promise: the effect is two keyframes and one
declaration, configured entirely through custom properties in the markup. Under
reduced motion the line is shown complete with a steady caret — the blink is
removed outright, since a repeating flash is itself a motion trigger.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- CSS passes the repository's own `stylelint` config (`npx stylelint --config .stylelintrc.json`) with no errors.
- Every stylesheet includes a `prefers-reduced-motion` path and, where colour carries state, a `forced-colors` path.
- Naming uses the `-advk` suffix per the CONTRIBUTING uniqueness rule; happy to rename during standardization.
