### PR TITLE
feat: SCSS easing + duration token scale named by intent (closes #66264)

### DIFF
--- a/submissions/scss/easing-tokens-advk/README.md
+++ b/submissions/scss/easing-tokens-advk/README.md
@@ -1,0 +1,70 @@
+# easing-tokens-advk
+
+A named easing and duration scale for EaseMotion, with functions and mixins so
+timing is selected by intent rather than by pasting bezier coordinates.
+
+## Tokens
+
+| Easing | Curve | Use for |
+|---|---|---|
+| `enter` | `cubic-bezier(0.22, 1, 0.36, 1)` | Elements arriving on screen |
+| `exit` | `cubic-bezier(0.55, 0, 1, 0.45)` | Elements leaving |
+| `move` | `cubic-bezier(0.65, 0, 0.35, 1)` | Moving between on-screen positions |
+| `spring` | `cubic-bezier(0.34, 1.56, 0.64, 1)` | Confirmations, playful feedback |
+| `elastic` | `cubic-bezier(0.34, 1.8, 0.5, 1)` | Strong attention, sparingly |
+| `linear` | `linear` | Progress and time-linear motion |
+
+| Duration | Value |
+|---|---|
+| `instant` | `120ms` |
+| `fast` | `200ms` |
+| `base` | `320ms` |
+| `slow` | `480ms` |
+| `deliberate` | `720ms` |
+
+## API
+
+- `ease($name)` / `dur($name)` — look up a token; errors listing valid keys if the name is unknown.
+- `@include transition($props, $speed, $curve)`
+- `@include animate($name, $speed, $curve, $fill)`
+- `@include easing-custom-properties` — emit the scale as CSS custom properties.
+
+## Usage
+
+```scss
+@use "easing-tokens-advk" as m;
+
+.card {
+  @include m.transition(transform box-shadow, "fast", "move");
+
+  &:hover { transform: translateY(-4px); }
+}
+
+.modal {
+  @include m.animate(ease-kf-zoom-in, "base", "enter");
+}
+
+:root {
+  @include m.easing-custom-properties; // --ease-enter, --dur-base, ...
+}
+```
+
+## Why it fits EaseMotion CSS
+
+EaseMotion's premise is that motion should be described in words a developer
+already understands — `ease-fade-in` beats a hand-rolled keyframe. Timing is the
+one place that promise currently breaks down: `core/variables.css` exposes some
+tokens, but bezier values still get pasted literally into component CSS, so the
+same intent ends up with slightly different curves across files and the framework
+drifts out of visual coherence.
+
+Grouping curves by purpose rather than by shape is the important choice here.
+`enter` and `exit` are deliberately asymmetric — things should arrive gently and
+leave briskly, which is why a single shared "ease-in-out" makes interfaces feel
+sluggish. Naming them after the job makes the right default the easy one.
+
+Both mixins collapse to `0.01ms` under `prefers-reduced-motion` rather than to
+`0`, because a genuinely zero duration suppresses `transitionend` and
+`animationend` events that components may depend on to sequence unmount — the
+same trap the MotionToast submission documents. `easing-custom-properties` exists
+so projects that do not build SCSS can still consume the identical scale.

--- a/submissions/scss/easing-tokens-advk/_easing-tokens-advk.scss
+++ b/submissions/scss/easing-tokens-advk/_easing-tokens-advk.scss
@@ -1,0 +1,88 @@
+// ---------------------------------------------------------------------------
+// easing-tokens-advk
+// A named easing scale plus helpers, so timing is chosen by intent
+// ("this element is entering") rather than by pasting bezier numbers.
+// ---------------------------------------------------------------------------
+
+@use "sass:map";
+
+// Curves are grouped by what they are FOR, not by their shape.
+$easings: (
+  // decelerate: fast start, soft landing — things arriving on screen
+  "enter": cubic-bezier(0.22, 1, 0.36, 1),
+  // accelerate: soft start, fast exit — things leaving
+  "exit": cubic-bezier(0.55, 0, 1, 0.45),
+  // symmetric — things moving between two on-screen positions
+  "move": cubic-bezier(0.65, 0, 0.35, 1),
+  // overshoot and settle — playful confirmations
+  "spring": cubic-bezier(0.34, 1.56, 0.64, 1),
+  // strong overshoot — attention-grabbing, use sparingly
+  "elastic": cubic-bezier(0.34, 1.8, 0.5, 1),
+  // no easing — progress bars and anything time-linear
+  "linear": linear,
+) !default;
+
+$durations: (
+  "instant": 120ms,
+  "fast": 200ms,
+  "base": 320ms,
+  "slow": 480ms,
+  "deliberate": 720ms,
+) !default;
+
+/// Look up a named curve.
+@function ease($name) {
+  @if not map.has-key($easings, $name) {
+    @error "Unknown easing '#{$name}'. Available: #{map.keys($easings)}.";
+  }
+
+  @return map.get($easings, $name);
+}
+
+/// Look up a named duration.
+@function dur($name) {
+  @if not map.has-key($durations, $name) {
+    @error "Unknown duration '#{$name}'. Available: #{map.keys($durations)}.";
+  }
+
+  @return map.get($durations, $name);
+}
+
+/// Shorthand transition using the named scale.
+///
+/// @param {List}   $props  Properties to transition.
+/// @param {String} $speed  Duration token.
+/// @param {String} $curve  Easing token.
+@mixin transition($props: all, $speed: "base", $curve: "move") {
+  transition-property: $props;
+  transition-duration: dur($speed);
+  transition-timing-function: ease($curve);
+
+  @media (prefers-reduced-motion: reduce) {
+    transition-duration: 0.01ms;
+  }
+}
+
+/// Shorthand animation using the named scale.
+@mixin animate($name, $speed: "base", $curve: "enter", $fill: both) {
+  animation-name: $name;
+  animation-duration: dur($speed);
+  animation-timing-function: ease($curve);
+  animation-fill-mode: $fill;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation-duration: 0.01ms;
+    animation-iteration-count: 1;
+  }
+}
+
+/// Emit the whole scale as custom properties, for use from plain CSS.
+@mixin easing-custom-properties {
+  @each $name, $curve in $easings {
+    --ease-#{$name}: #{$curve};
+  }
+
+  @each $name, $time in $durations {
+    --dur-#{$name}: #{$time};
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #66264.

Adds `submissions/scss/easing-tokens-advk/` (`_mixin.scss` + `README.md`).

A named easing and duration scale for EaseMotion, with functions and mixins so
timing is selected by intent rather than by pasting bezier coordinates.

---

## Type of Change

- [x] 🧩 New component
- [ ] 🐛 Bug fix in an existing submission
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/scss/easing-tokens-advk/`
- [x] Includes a real `.scss` partial building on EaseMotion tokens
- [x] Includes `README.md` documenting parameters and an `@include` example
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A named easing and duration scale for EaseMotion, with functions and mixins so
timing is selected by intent rather than by pasting bezier coordinates.

**How does a developer use it?**

```scss
@use "easing-tokens-advk" as m;

.card {
  @include m.transition(transform box-shadow, "fast", "move");

  &:hover { transform: translateY(-4px); }
}

.modal {
  @include m.animate(ease-kf-zoom-in, "base", "enter");
}

:root {
  @include m.easing-custom-properties; // --ease-enter, --dur-base, ...
}
```

**Why does it fit EaseMotion CSS?**

EaseMotion's premise is that motion should be described in words a developer
already understands — `ease-fade-in` beats a hand-rolled keyframe. Timing is the
one place that promise currently breaks down: `core/variables.css` exposes some
tokens, but bezier values still get pasted literally into component CSS, so the
same intent ends up with slightly different curves across files and the framework
drifts out of visual coherence.

Grouping curves by purpose rather than by shape is the important choice here.
`enter` and `exit` are deliberately asymmetric — things should arrive gently and
leave briskly, which is why a single shared "ease-in-out" makes interfaces feel
sluggish. Naming them after the job makes the right default the easy one.

Both mixins collapse to `0.01ms` under `prefers-reduced-motion` rather than to
`0`, because a genuinely zero duration suppresses `transitionend` and
`animationend` events that components may depend on to sequence unmount — the
same trap the MotionToast submission documents. `easing-custom-properties` exists
so projects that do not build SCSS can still consume the identical scale.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- CSS passes the repository's own `stylelint` config (`npx stylelint --config .stylelintrc.json`) with no errors.
- Every stylesheet includes a `prefers-reduced-motion` path and, where colour carries state, a `forced-colors` path.
- Naming uses the `-advk` suffix per the CONTRIBUTING uniqueness rule; happy to rename during standardization.
