### PR TITLE
feat: SCSS stagger mixins with built-in reduced-motion cascade (closes #66265)

### DIFF
--- a/submissions/scss/stagger-advk/README.md
+++ b/submissions/scss/stagger-advk/README.md
@@ -1,0 +1,64 @@
+# stagger-advk
+
+SCSS mixins that generate cascade delays for a group of children, with a
+reduced-motion path built in.
+
+## Mixins
+
+### `stagger($count, $step, $start, $child, $reduced-step)`
+
+| Parameter | Default | Description |
+|---|---|---|
+| `$count` | `8` | Number of children to emit rules for. |
+| `$step` | `70ms` | Delay added per item. |
+| `$start` | `0ms` | Delay on the first item. |
+| `$child` | `"> *"` | Selector for the children. |
+| `$reduced-step` | `30ms` | Step used under `prefers-reduced-motion: reduce`. |
+
+### `stagger-over($count, $total, $child)`
+
+Spreads `$total` across the children, so a 4-item and a 20-item list finish
+their cascade in the same wall-clock time.
+
+### `stagger-reverse($count, $step, $child)`
+
+Same cascade, last child first — useful for exit animations.
+
+## Usage
+
+```scss
+@use "stagger-advk" as s;
+
+.card-grid {
+  > * {
+    animation: ease-kf-slide-up 500ms both;
+  }
+
+  @include s.stagger($count: 12, $step: 60ms);
+}
+
+.menu {
+  > li { animation: ease-kf-fade-in 400ms both; }
+
+  @include s.stagger-over($count: 6, $total: 360ms, $child: "> li");
+}
+```
+
+## Why it fits EaseMotion CSS
+
+Staggered entrances are one of the most-requested effects and one of the most
+tedious to hand-write, because every item needs its own `animation-delay` and the
+rule count grows with the list. Generating them from a loop keeps the authored
+source to one line while emitting exactly the CSS a browser needs, with no
+runtime cost — which matches EaseMotion's zero-dependency, no-JavaScript posture.
+
+The reason this belongs in the framework rather than in each project is the
+reduced-motion half. Hand-written stagger rules almost always omit it, so a
+20-item cascade at 70ms still runs for 1.4 seconds of sequential movement for a
+user who asked for less motion. The mixin emits a compressed second set
+automatically, so the ordering cue survives while the total duration shrinks —
+the correct treatment, and impossible to forget when it is generated.
+
+`stagger-over` exists because a fixed per-item step makes long lists feel broken:
+at 70ms a 30-item list takes over two seconds before the last item begins.
+Spreading a total keeps the effect proportionate as content grows.

--- a/submissions/scss/stagger-advk/_stagger-advk.scss
+++ b/submissions/scss/stagger-advk/_stagger-advk.scss
@@ -1,0 +1,74 @@
+// ---------------------------------------------------------------------------
+// stagger-advk
+// Generates cascade delays for a group of children without writing one
+// :nth-child rule per item, and degrades correctly under reduced motion.
+// ---------------------------------------------------------------------------
+
+@use "sass:math";
+
+/// Emit staggered animation-delay rules for `$count` children.
+///
+/// @param {Number} $count      How many children to target.
+/// @param {Number} $step       Delay added per item.
+/// @param {Number} $start      Delay applied to the first item.
+/// @param {String} $child      Selector for the children.
+/// @param {Number} $reduced-step  Step used under prefers-reduced-motion.
+@mixin stagger(
+  $count: 8,
+  $step: 70ms,
+  $start: 0ms,
+  $child: "> *",
+  $reduced-step: 30ms
+) {
+  @for $i from 1 through $count {
+    #{$child}:nth-child(#{$i}) {
+      animation-delay: $start + ($step * ($i - 1));
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    @for $i from 1 through $count {
+      #{$child}:nth-child(#{$i}) {
+        // Keep the ordering cue, compress the total so the group settles fast.
+        animation-delay: $start + ($reduced-step * ($i - 1));
+      }
+    }
+  }
+}
+
+/// Variant that spreads a fixed total duration across the children, so the
+/// cascade takes the same wall-clock time regardless of item count.
+///
+/// @param {Number} $count  How many children to target.
+/// @param {Number} $total  Total time from first to last item starting.
+@mixin stagger-over($count: 8, $total: 500ms, $child: "> *") {
+  $step: 0ms;
+
+  @if $count > 1 {
+    $step: math.div($total, $count - 1);
+  }
+
+  @include stagger(
+    $count: $count,
+    $step: $step,
+    $child: $child,
+    $reduced-step: math.div($step, 2)
+  );
+}
+
+/// Reverse cascade: last child animates first.
+@mixin stagger-reverse($count: 8, $step: 70ms, $child: "> *") {
+  @for $i from 1 through $count {
+    #{$child}:nth-child(#{$i}) {
+      animation-delay: $step * ($count - $i);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    @for $i from 1 through $count {
+      #{$child}:nth-child(#{$i}) {
+        animation-delay: math.div($step, 2) * ($count - $i);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #66265.

Adds `submissions/scss/stagger-advk/` (`_mixin.scss` + `README.md`).

SCSS mixins that generate cascade delays for a group of children, with a
reduced-motion path built in.

---

## Type of Change

- [x] 🧩 New component
- [ ] 🐛 Bug fix in an existing submission
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/scss/stagger-advk/`
- [x] Includes a real `.scss` partial building on EaseMotion tokens
- [x] Includes `README.md` documenting parameters and an `@include` example
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

SCSS mixins that generate cascade delays for a group of children, with a
reduced-motion path built in.

**How does a developer use it?**

```scss
@use "stagger-advk" as s;

.card-grid {
  > * {
    animation: ease-kf-slide-up 500ms both;
  }

  @include s.stagger($count: 12, $step: 60ms);
}

.menu {
  > li { animation: ease-kf-fade-in 400ms both; }

  @include s.stagger-over($count: 6, $total: 360ms, $child: "> li");
}
```

**Why does it fit EaseMotion CSS?**

Staggered entrances are one of the most-requested effects and one of the most
tedious to hand-write, because every item needs its own `animation-delay` and the
rule count grows with the list. Generating them from a loop keeps the authored
source to one line while emitting exactly the CSS a browser needs, with no
runtime cost — which matches EaseMotion's zero-dependency, no-JavaScript posture.

The reason this belongs in the framework rather than in each project is the
reduced-motion half. Hand-written stagger rules almost always omit it, so a
20-item cascade at 70ms still runs for 1.4 seconds of sequential movement for a
user who asked for less motion. The mixin emits a compressed second set
automatically, so the ordering cue survives while the total duration shrinks —
the correct treatment, and impossible to forget when it is generated.

`stagger-over` exists because a fixed per-item step makes long lists feel broken:
at 70ms a 30-item list takes over two seconds before the last item begins.
Spreading a total keeps the effect proportionate as content grows.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- CSS passes the repository's own `stylelint` config (`npx stylelint --config .stylelintrc.json`) with no errors.
- Every stylesheet includes a `prefers-reduced-motion` path and, where colour carries state, a `forced-colors` path.
- Naming uses the `-advk` suffix per the CONTRIBUTING uniqueness rule; happy to rename during standardization.
