### PR TITLE
feat: add ease-link-card component

### DIFF
--- a/submissions/examples/ease-link-card-vd/README.md
+++ b/submissions/examples/ease-link-card-vd/README.md
@@ -1,0 +1,42 @@
+# Ease Link Card
+
+## What does this do?
+
+A compact link preview card displaying a title, URL, and small icon with a subtle hover effect.
+
+---
+
+## How is it used?
+
+Open `demo.html` directly in any modern browser.
+
+Example:
+
+```html
+<a class="link-card" href="https://example.com">
+    <div class="link-icon">↗</div>
+
+    <div class="link-info">
+        <h3>Example Website</h3>
+        <p>example.com</p>
+    </div>
+</a>
+```
+
+### Features
+
+- Title
+- URL display
+- Small icon
+- Hover lift animation
+- Icon scale animation
+- Responsive layout
+- Clickable card
+
+---
+
+## Why is it useful?
+
+Link preview cards are commonly used in documentation, resource pages, dashboards, and knowledge bases.
+
+This component provides a lightweight and reusable way to present links while adding subtle interaction feedback in line with the animation-first philosophy of EaseMotion CSS.

--- a/submissions/examples/ease-link-card-vd/demo.html
+++ b/submissions/examples/ease-link-card-vd/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ease Link Card</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<a class="link-card" href="https://example.com" target="_blank" rel="noopener noreferrer">
+
+    <div class="link-icon">↗</div>
+
+    <div class="link-info">
+        <h3>EaseMotion CSS</h3>
+        <p>github.com/SAPTARSHI-coder/EaseMotion-css</p>
+    </div>
+
+</a>
+
+</body>
+</html>

--- a/submissions/examples/ease-link-card-vd/style.css
+++ b/submissions/examples/ease-link-card-vd/style.css
@@ -1,0 +1,81 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 2rem;
+    background: #0f172a;
+    font-family: Arial, Helvetica, sans-serif;
+}
+
+.link-card {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    width: min(420px, 100%);
+    padding: 18px;
+    border: 1px solid #334155;
+    border-radius: 16px;
+    background: #111827;
+    color: #f8fafc;
+    text-decoration: none;
+    box-shadow: 0 10px 25px rgba(0, 0, 0, .25);
+    transition: transform .25s ease, box-shadow .25s ease;
+}
+
+.link-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 16px 32px rgba(0, 0, 0, .35);
+}
+
+.link-icon {
+    width: 42px;
+    height: 42px;
+    flex-shrink: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border-radius: 10px;
+    background: #2563eb;
+    color: #fff;
+    font-size: 1.2rem;
+    font-weight: 700;
+    transition: transform .25s ease;
+}
+
+.link-card:hover .link-icon {
+    transform: scale(1.08);
+}
+
+.link-info {
+    min-width: 0;
+}
+
+.link-info h3 {
+    margin-bottom: 5px;
+    font-size: 1rem;
+}
+
+.link-info p {
+    overflow: hidden;
+    color: #94a3b8;
+    font-size: .82rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+@media (max-width: 600px) {
+    .link-card {
+        padding: 14px;
+    }
+
+    .link-info h3 {
+        font-size: .9rem;
+    }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #65845

This PR adds a new **Ease Link Card** component under `submissions/examples/ease-link-card-vd`.

The component provides a compact clickable link preview with a title, URL, small icon, and subtle hover animation.

---

## Type of Change

* [ ] ✨ New animation / hover effect
* [x] 🧩 New component
* [ ] 📝 Documentation improvement
* [ ] 🐛 Bug fix in an existing submission
* [ ] Other (describe below)

---

## Submission Checklist

* [x] All changes are inside `submissions/`
* [x] Includes `demo.html` — self-contained, opens in browser with no server
* [x] Includes `style.css` — raw CSS for the proposed feature
* [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
* [x] **No changes to** **`core/`**
* [x] **No changes to** **`components/`**
* [x] One feature per PR

---

## Feature Description

**What does this add?**

A reusable compact link preview card with a title, URL, small icon, and hover effect.

**How does a developer use it?**

```html
<a class="link-card" href="https://example.com">
    <div class="link-icon">↗</div>

    <div class="link-info">
        <h3>Example Website</h3>
        <p>example.com</p>
    </div>
</a>
```

**Why does it fit EaseMotion CSS?**

The component is lightweight, human-readable, reusable, and animation-first. It adds subtle interaction feedback to a common documentation and resource-link pattern while remaining simple to integrate.

---

## Demo

* [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

* [x] Chrome
* [x] Firefox
* [x] Edge
* [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

This submission is fully self-contained within `submissions/examples/ease-link-card-vd` and adheres to the repository contribution guidelines.

Related issue: #65845
