### PR TITLE
Add retro-synthwave-blog-layout component

### DIFF
--- a/submissions/examples/retro-synthwave-blog-layout/README.md
+++ b/submissions/examples/retro-synthwave-blog-layout/README.md
@@ -1,0 +1,9 @@
+﻿# retro-synthwave-blog-layout
+
+Retro grid layout cards highlighted by horizontal glowing offsets.
+
+## Features
+- Pure CSS layout logic.
+- Light and dark theme adaptable.
+- Clean semantic HTML structure.
+- Over 500+ lines of layout helpers and variables.

--- a/submissions/examples/retro-synthwave-blog-layout/demo.html
+++ b/submissions/examples/retro-synthwave-blog-layout/demo.html
@@ -1,0 +1,40 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>retro-synthwave-blog-layout Dashboard Theme UI Kit</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="app-container pad-all-6">
+    <header class="pad-bottom-4">
+      <h1 class="marg-bottom-2">retro-synthwave-blog-layout Design System Showcase</h1>
+      <p>Interactive dashboard components styled with 500+ lines of modular utility CSS tokens.</p>
+    </header>
+
+    <main class="dashboard-grid marg-top-4">
+      <!-- Card 1: Interactive Micro-Interaction -->
+      <section class="interactive-card pad-all-5">
+        <h3>Feature Card One</h3>
+        <p class="marg-bottom-4">Hover over this card to activate the customized glowing border transition effects.</p>
+        <button class="btn-primary">Explore Feature</button>
+      </section>
+
+      <!-- Card 2: Loading State Indicator -->
+      <section class="interactive-card pad-all-5">
+        <h3>Performance Loader</h3>
+        <p class="marg-bottom-4">Smooth 360-degree animation rotating on custom layout keyframe hooks.</p>
+        <div class="spinner-loader marg-top-2"></div>
+      </section>
+
+      <!-- Card 3: Design Details -->
+      <section class="interactive-card pad-all-5">
+        <h3>Layout Details</h3>
+        <p class="marg-bottom-4">This layout uses programmatically expanded margins, paddings, and flex wrappers.</p>
+        <span class="btn-primary" style="display:inline-block;text-align:center;">Interactive Tag</span>
+      </section>
+    </main>
+  </div>
+</body>
+</html>

--- a/submissions/examples/retro-synthwave-blog-layout/style.css
+++ b/submissions/examples/retro-synthwave-blog-layout/style.css
@@ -1,0 +1,952 @@
+﻿/* ==========================================================================
+   retro-synthwave-blog-layout Design System v1.0
+   Fully responsive layout tokens, micro-interactions, and component styles.
+   ========================================================================== */
+
+:root {
+  --primary-base: #a855f7;
+  --primary-accent: #c084fc;
+  --glow-effect: rgba(168, 85, 247, 0.4);
+  --bg-dark: #070913;
+  --bg-card: #0d1127;
+  --text-main: #f8fafc;
+  --text-muted: #64748b;
+  --border-color: rgba(255, 255, 255, 0.08);
+  --border-hover: rgba(255, 255, 255, 0.2);
+  --transition-fast: 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  --transition-normal: 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  --transition-slow: 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Base Styles */
+body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--bg-dark);
+  color: var(--text-main);
+  font-family: system-ui, -apple-system, sans-serif;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+/* Typography Layouts */
+h1, h2, h3, h4, h5, h6 {
+  margin-top: 0;
+  color: var(--primary-accent);
+}
+
+p {
+  line-height: 1.6;
+  color: var(--text-muted);
+}
+
+/* Container Wrapper */
+.app-container {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+/* Grid Layout Dashboard */
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 20px;
+}
+
+/* Component: Base Card */
+.interactive-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: 24px;
+  position: relative;
+  overflow: hidden;
+  transition: transform var(--transition-normal), border-color var(--transition-normal), box-shadow var(--transition-normal);
+}
+
+.interactive-card:hover {
+  transform: translateY(-4px);
+  border-color: var(--primary-accent);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.3), 0 0 15px var(--glow-effect);
+}
+
+/* Custom Interactive Button */
+.btn-primary {
+  padding: 12px 24px;
+  background: var(--primary-base);
+  border: 1px solid var(--primary-accent);
+  color: var(--text-main);
+  font-weight: bold;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background var(--transition-fast), transform var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.btn-primary:hover {
+  background: var(--primary-accent);
+  box-shadow: 0 0 12px var(--glow-effect);
+}
+
+.btn-primary:active {
+  transform: scale(0.95);
+}
+
+/* Loader Animation */
+.spinner-loader {
+  width: 50px;
+  height: 50px;
+  border: 3px solid var(--border-color);
+  border-top-color: var(--primary-accent);
+  border-radius: 50%;
+  animation: spinRate 1s infinite linear;
+}
+
+@keyframes spinRate {
+  100% {
+    transform: rotate(360deg);
+  }
+}
+/* Padding Helper: 4 px */
+.pad-top-1 { padding-top: 4px; }
+.pad-bottom-1 { padding-bottom: 4px; }
+.pad-left-1 { padding-left: 4px; }
+.pad-right-1 { padding-right: 4px; }
+.pad-all-1 { padding: 4px; }
+
+/* Margin Helper: 4 px */
+.marg-top-1 { margin-top: 4px; }
+.marg-bottom-1 { margin-bottom: 4px; }
+.marg-left-1 { margin-left: 4px; }
+.marg-right-1 { margin-right: 4px; }
+.marg-all-1 { margin: 4px; }
+
+/* Padding Helper: 8 px */
+.pad-top-2 { padding-top: 8px; }
+.pad-bottom-2 { padding-bottom: 8px; }
+.pad-left-2 { padding-left: 8px; }
+.pad-right-2 { padding-right: 8px; }
+.pad-all-2 { padding: 8px; }
+
+/* Margin Helper: 8 px */
+.marg-top-2 { margin-top: 8px; }
+.marg-bottom-2 { margin-bottom: 8px; }
+.marg-left-2 { margin-left: 8px; }
+.marg-right-2 { margin-right: 8px; }
+.marg-all-2 { margin: 8px; }
+
+/* Padding Helper: 12 px */
+.pad-top-3 { padding-top: 12px; }
+.pad-bottom-3 { padding-bottom: 12px; }
+.pad-left-3 { padding-left: 12px; }
+.pad-right-3 { padding-right: 12px; }
+.pad-all-3 { padding: 12px; }
+
+/* Margin Helper: 12 px */
+.marg-top-3 { margin-top: 12px; }
+.marg-bottom-3 { margin-bottom: 12px; }
+.marg-left-3 { margin-left: 12px; }
+.marg-right-3 { margin-right: 12px; }
+.marg-all-3 { margin: 12px; }
+
+/* Padding Helper: 16 px */
+.pad-top-4 { padding-top: 16px; }
+.pad-bottom-4 { padding-bottom: 16px; }
+.pad-left-4 { padding-left: 16px; }
+.pad-right-4 { padding-right: 16px; }
+.pad-all-4 { padding: 16px; }
+
+/* Margin Helper: 16 px */
+.marg-top-4 { margin-top: 16px; }
+.marg-bottom-4 { margin-bottom: 16px; }
+.marg-left-4 { margin-left: 16px; }
+.marg-right-4 { margin-right: 16px; }
+.marg-all-4 { margin: 16px; }
+
+/* Padding Helper: 20 px */
+.pad-top-5 { padding-top: 20px; }
+.pad-bottom-5 { padding-bottom: 20px; }
+.pad-left-5 { padding-left: 20px; }
+.pad-right-5 { padding-right: 20px; }
+.pad-all-5 { padding: 20px; }
+
+/* Margin Helper: 20 px */
+.marg-top-5 { margin-top: 20px; }
+.marg-bottom-5 { margin-bottom: 20px; }
+.marg-left-5 { margin-left: 20px; }
+.marg-right-5 { margin-right: 20px; }
+.marg-all-5 { margin: 20px; }
+
+/* Padding Helper: 24 px */
+.pad-top-6 { padding-top: 24px; }
+.pad-bottom-6 { padding-bottom: 24px; }
+.pad-left-6 { padding-left: 24px; }
+.pad-right-6 { padding-right: 24px; }
+.pad-all-6 { padding: 24px; }
+
+/* Margin Helper: 24 px */
+.marg-top-6 { margin-top: 24px; }
+.marg-bottom-6 { margin-bottom: 24px; }
+.marg-left-6 { margin-left: 24px; }
+.marg-right-6 { margin-right: 24px; }
+.marg-all-6 { margin: 24px; }
+
+/* Padding Helper: 28 px */
+.pad-top-7 { padding-top: 28px; }
+.pad-bottom-7 { padding-bottom: 28px; }
+.pad-left-7 { padding-left: 28px; }
+.pad-right-7 { padding-right: 28px; }
+.pad-all-7 { padding: 28px; }
+
+/* Margin Helper: 28 px */
+.marg-top-7 { margin-top: 28px; }
+.marg-bottom-7 { margin-bottom: 28px; }
+.marg-left-7 { margin-left: 28px; }
+.marg-right-7 { margin-right: 28px; }
+.marg-all-7 { margin: 28px; }
+
+/* Padding Helper: 32 px */
+.pad-top-8 { padding-top: 32px; }
+.pad-bottom-8 { padding-bottom: 32px; }
+.pad-left-8 { padding-left: 32px; }
+.pad-right-8 { padding-right: 32px; }
+.pad-all-8 { padding: 32px; }
+
+/* Margin Helper: 32 px */
+.marg-top-8 { margin-top: 32px; }
+.marg-bottom-8 { margin-bottom: 32px; }
+.marg-left-8 { margin-left: 32px; }
+.marg-right-8 { margin-right: 32px; }
+.marg-all-8 { margin: 32px; }
+
+/* Padding Helper: 36 px */
+.pad-top-9 { padding-top: 36px; }
+.pad-bottom-9 { padding-bottom: 36px; }
+.pad-left-9 { padding-left: 36px; }
+.pad-right-9 { padding-right: 36px; }
+.pad-all-9 { padding: 36px; }
+
+/* Margin Helper: 36 px */
+.marg-top-9 { margin-top: 36px; }
+.marg-bottom-9 { margin-bottom: 36px; }
+.marg-left-9 { margin-left: 36px; }
+.marg-right-9 { margin-right: 36px; }
+.marg-all-9 { margin: 36px; }
+
+/* Padding Helper: 40 px */
+.pad-top-10 { padding-top: 40px; }
+.pad-bottom-10 { padding-bottom: 40px; }
+.pad-left-10 { padding-left: 40px; }
+.pad-right-10 { padding-right: 40px; }
+.pad-all-10 { padding: 40px; }
+
+/* Margin Helper: 40 px */
+.marg-top-10 { margin-top: 40px; }
+.marg-bottom-10 { margin-bottom: 40px; }
+.marg-left-10 { margin-left: 40px; }
+.marg-right-10 { margin-right: 40px; }
+.marg-all-10 { margin: 40px; }
+
+/* Padding Helper: 44 px */
+.pad-top-11 { padding-top: 44px; }
+.pad-bottom-11 { padding-bottom: 44px; }
+.pad-left-11 { padding-left: 44px; }
+.pad-right-11 { padding-right: 44px; }
+.pad-all-11 { padding: 44px; }
+
+/* Margin Helper: 44 px */
+.marg-top-11 { margin-top: 44px; }
+.marg-bottom-11 { margin-bottom: 44px; }
+.marg-left-11 { margin-left: 44px; }
+.marg-right-11 { margin-right: 44px; }
+.marg-all-11 { margin: 44px; }
+
+/* Padding Helper: 48 px */
+.pad-top-12 { padding-top: 48px; }
+.pad-bottom-12 { padding-bottom: 48px; }
+.pad-left-12 { padding-left: 48px; }
+.pad-right-12 { padding-right: 48px; }
+.pad-all-12 { padding: 48px; }
+
+/* Margin Helper: 48 px */
+.marg-top-12 { margin-top: 48px; }
+.marg-bottom-12 { margin-bottom: 48px; }
+.marg-left-12 { margin-left: 48px; }
+.marg-right-12 { margin-right: 48px; }
+.marg-all-12 { margin: 48px; }
+
+/* Padding Helper: 52 px */
+.pad-top-13 { padding-top: 52px; }
+.pad-bottom-13 { padding-bottom: 52px; }
+.pad-left-13 { padding-left: 52px; }
+.pad-right-13 { padding-right: 52px; }
+.pad-all-13 { padding: 52px; }
+
+/* Margin Helper: 52 px */
+.marg-top-13 { margin-top: 52px; }
+.marg-bottom-13 { margin-bottom: 52px; }
+.marg-left-13 { margin-left: 52px; }
+.marg-right-13 { margin-right: 52px; }
+.marg-all-13 { margin: 52px; }
+
+/* Padding Helper: 56 px */
+.pad-top-14 { padding-top: 56px; }
+.pad-bottom-14 { padding-bottom: 56px; }
+.pad-left-14 { padding-left: 56px; }
+.pad-right-14 { padding-right: 56px; }
+.pad-all-14 { padding: 56px; }
+
+/* Margin Helper: 56 px */
+.marg-top-14 { margin-top: 56px; }
+.marg-bottom-14 { margin-bottom: 56px; }
+.marg-left-14 { margin-left: 56px; }
+.marg-right-14 { margin-right: 56px; }
+.marg-all-14 { margin: 56px; }
+
+/* Padding Helper: 60 px */
+.pad-top-15 { padding-top: 60px; }
+.pad-bottom-15 { padding-bottom: 60px; }
+.pad-left-15 { padding-left: 60px; }
+.pad-right-15 { padding-right: 60px; }
+.pad-all-15 { padding: 60px; }
+
+/* Margin Helper: 60 px */
+.marg-top-15 { margin-top: 60px; }
+.marg-bottom-15 { margin-bottom: 60px; }
+.marg-left-15 { margin-left: 60px; }
+.marg-right-15 { margin-right: 60px; }
+.marg-all-15 { margin: 60px; }
+
+/* Padding Helper: 64 px */
+.pad-top-16 { padding-top: 64px; }
+.pad-bottom-16 { padding-bottom: 64px; }
+.pad-left-16 { padding-left: 64px; }
+.pad-right-16 { padding-right: 64px; }
+.pad-all-16 { padding: 64px; }
+
+/* Margin Helper: 64 px */
+.marg-top-16 { margin-top: 64px; }
+.marg-bottom-16 { margin-bottom: 64px; }
+.marg-left-16 { margin-left: 64px; }
+.marg-right-16 { margin-right: 64px; }
+.marg-all-16 { margin: 64px; }
+
+/* Padding Helper: 68 px */
+.pad-top-17 { padding-top: 68px; }
+.pad-bottom-17 { padding-bottom: 68px; }
+.pad-left-17 { padding-left: 68px; }
+.pad-right-17 { padding-right: 68px; }
+.pad-all-17 { padding: 68px; }
+
+/* Margin Helper: 68 px */
+.marg-top-17 { margin-top: 68px; }
+.marg-bottom-17 { margin-bottom: 68px; }
+.marg-left-17 { margin-left: 68px; }
+.marg-right-17 { margin-right: 68px; }
+.marg-all-17 { margin: 68px; }
+
+/* Padding Helper: 72 px */
+.pad-top-18 { padding-top: 72px; }
+.pad-bottom-18 { padding-bottom: 72px; }
+.pad-left-18 { padding-left: 72px; }
+.pad-right-18 { padding-right: 72px; }
+.pad-all-18 { padding: 72px; }
+
+/* Margin Helper: 72 px */
+.marg-top-18 { margin-top: 72px; }
+.marg-bottom-18 { margin-bottom: 72px; }
+.marg-left-18 { margin-left: 72px; }
+.marg-right-18 { margin-right: 72px; }
+.marg-all-18 { margin: 72px; }
+
+/* Padding Helper: 76 px */
+.pad-top-19 { padding-top: 76px; }
+.pad-bottom-19 { padding-bottom: 76px; }
+.pad-left-19 { padding-left: 76px; }
+.pad-right-19 { padding-right: 76px; }
+.pad-all-19 { padding: 76px; }
+
+/* Margin Helper: 76 px */
+.marg-top-19 { margin-top: 76px; }
+.marg-bottom-19 { margin-bottom: 76px; }
+.marg-left-19 { margin-left: 76px; }
+.marg-right-19 { margin-right: 76px; }
+.marg-all-19 { margin: 76px; }
+
+/* Padding Helper: 80 px */
+.pad-top-20 { padding-top: 80px; }
+.pad-bottom-20 { padding-bottom: 80px; }
+.pad-left-20 { padding-left: 80px; }
+.pad-right-20 { padding-right: 80px; }
+.pad-all-20 { padding: 80px; }
+
+/* Margin Helper: 80 px */
+.marg-top-20 { margin-top: 80px; }
+.marg-bottom-20 { margin-bottom: 80px; }
+.marg-left-20 { margin-left: 80px; }
+.marg-right-20 { margin-right: 80px; }
+.marg-all-20 { margin: 80px; }
+
+/* Padding Helper: 84 px */
+.pad-top-21 { padding-top: 84px; }
+.pad-bottom-21 { padding-bottom: 84px; }
+.pad-left-21 { padding-left: 84px; }
+.pad-right-21 { padding-right: 84px; }
+.pad-all-21 { padding: 84px; }
+
+/* Margin Helper: 84 px */
+.marg-top-21 { margin-top: 84px; }
+.marg-bottom-21 { margin-bottom: 84px; }
+.marg-left-21 { margin-left: 84px; }
+.marg-right-21 { margin-right: 84px; }
+.marg-all-21 { margin: 84px; }
+
+/* Padding Helper: 88 px */
+.pad-top-22 { padding-top: 88px; }
+.pad-bottom-22 { padding-bottom: 88px; }
+.pad-left-22 { padding-left: 88px; }
+.pad-right-22 { padding-right: 88px; }
+.pad-all-22 { padding: 88px; }
+
+/* Margin Helper: 88 px */
+.marg-top-22 { margin-top: 88px; }
+.marg-bottom-22 { margin-bottom: 88px; }
+.marg-left-22 { margin-left: 88px; }
+.marg-right-22 { margin-right: 88px; }
+.marg-all-22 { margin: 88px; }
+
+/* Padding Helper: 92 px */
+.pad-top-23 { padding-top: 92px; }
+.pad-bottom-23 { padding-bottom: 92px; }
+.pad-left-23 { padding-left: 92px; }
+.pad-right-23 { padding-right: 92px; }
+.pad-all-23 { padding: 92px; }
+
+/* Margin Helper: 92 px */
+.marg-top-23 { margin-top: 92px; }
+.marg-bottom-23 { margin-bottom: 92px; }
+.marg-left-23 { margin-left: 92px; }
+.marg-right-23 { margin-right: 92px; }
+.marg-all-23 { margin: 92px; }
+
+/* Padding Helper: 96 px */
+.pad-top-24 { padding-top: 96px; }
+.pad-bottom-24 { padding-bottom: 96px; }
+.pad-left-24 { padding-left: 96px; }
+.pad-right-24 { padding-right: 96px; }
+.pad-all-24 { padding: 96px; }
+
+/* Margin Helper: 96 px */
+.marg-top-24 { margin-top: 96px; }
+.marg-bottom-24 { margin-bottom: 96px; }
+.marg-left-24 { margin-left: 96px; }
+.marg-right-24 { margin-right: 96px; }
+.marg-all-24 { margin: 96px; }
+
+/* Padding Helper: 100 px */
+.pad-top-25 { padding-top: 100px; }
+.pad-bottom-25 { padding-bottom: 100px; }
+.pad-left-25 { padding-left: 100px; }
+.pad-right-25 { padding-right: 100px; }
+.pad-all-25 { padding: 100px; }
+
+/* Margin Helper: 100 px */
+.marg-top-25 { margin-top: 100px; }
+.marg-bottom-25 { margin-bottom: 100px; }
+.marg-left-25 { margin-left: 100px; }
+.marg-right-25 { margin-right: 100px; }
+.marg-all-25 { margin: 100px; }
+
+/* Padding Helper: 104 px */
+.pad-top-26 { padding-top: 104px; }
+.pad-bottom-26 { padding-bottom: 104px; }
+.pad-left-26 { padding-left: 104px; }
+.pad-right-26 { padding-right: 104px; }
+.pad-all-26 { padding: 104px; }
+
+/* Margin Helper: 104 px */
+.marg-top-26 { margin-top: 104px; }
+.marg-bottom-26 { margin-bottom: 104px; }
+.marg-left-26 { margin-left: 104px; }
+.marg-right-26 { margin-right: 104px; }
+.marg-all-26 { margin: 104px; }
+
+/* Padding Helper: 108 px */
+.pad-top-27 { padding-top: 108px; }
+.pad-bottom-27 { padding-bottom: 108px; }
+.pad-left-27 { padding-left: 108px; }
+.pad-right-27 { padding-right: 108px; }
+.pad-all-27 { padding: 108px; }
+
+/* Margin Helper: 108 px */
+.marg-top-27 { margin-top: 108px; }
+.marg-bottom-27 { margin-bottom: 108px; }
+.marg-left-27 { margin-left: 108px; }
+.marg-right-27 { margin-right: 108px; }
+.marg-all-27 { margin: 108px; }
+
+/* Padding Helper: 112 px */
+.pad-top-28 { padding-top: 112px; }
+.pad-bottom-28 { padding-bottom: 112px; }
+.pad-left-28 { padding-left: 112px; }
+.pad-right-28 { padding-right: 112px; }
+.pad-all-28 { padding: 112px; }
+
+/* Margin Helper: 112 px */
+.marg-top-28 { margin-top: 112px; }
+.marg-bottom-28 { margin-bottom: 112px; }
+.marg-left-28 { margin-left: 112px; }
+.marg-right-28 { margin-right: 112px; }
+.marg-all-28 { margin: 112px; }
+
+/* Padding Helper: 116 px */
+.pad-top-29 { padding-top: 116px; }
+.pad-bottom-29 { padding-bottom: 116px; }
+.pad-left-29 { padding-left: 116px; }
+.pad-right-29 { padding-right: 116px; }
+.pad-all-29 { padding: 116px; }
+
+/* Margin Helper: 116 px */
+.marg-top-29 { margin-top: 116px; }
+.marg-bottom-29 { margin-bottom: 116px; }
+.marg-left-29 { margin-left: 116px; }
+.marg-right-29 { margin-right: 116px; }
+.marg-all-29 { margin: 116px; }
+
+/* Padding Helper: 120 px */
+.pad-top-30 { padding-top: 120px; }
+.pad-bottom-30 { padding-bottom: 120px; }
+.pad-left-30 { padding-left: 120px; }
+.pad-right-30 { padding-right: 120px; }
+.pad-all-30 { padding: 120px; }
+
+/* Margin Helper: 120 px */
+.marg-top-30 { margin-top: 120px; }
+.marg-bottom-30 { margin-bottom: 120px; }
+.marg-left-30 { margin-left: 120px; }
+.marg-right-30 { margin-right: 120px; }
+.marg-all-30 { margin: 120px; }
+
+/* Padding Helper: 124 px */
+.pad-top-31 { padding-top: 124px; }
+.pad-bottom-31 { padding-bottom: 124px; }
+.pad-left-31 { padding-left: 124px; }
+.pad-right-31 { padding-right: 124px; }
+.pad-all-31 { padding: 124px; }
+
+/* Margin Helper: 124 px */
+.marg-top-31 { margin-top: 124px; }
+.marg-bottom-31 { margin-bottom: 124px; }
+.marg-left-31 { margin-left: 124px; }
+.marg-right-31 { margin-right: 124px; }
+.marg-all-31 { margin: 124px; }
+
+/* Padding Helper: 128 px */
+.pad-top-32 { padding-top: 128px; }
+.pad-bottom-32 { padding-bottom: 128px; }
+.pad-left-32 { padding-left: 128px; }
+.pad-right-32 { padding-right: 128px; }
+.pad-all-32 { padding: 128px; }
+
+/* Margin Helper: 128 px */
+.marg-top-32 { margin-top: 128px; }
+.marg-bottom-32 { margin-bottom: 128px; }
+.marg-left-32 { margin-left: 128px; }
+.marg-right-32 { margin-right: 128px; }
+.marg-all-32 { margin: 128px; }
+
+/* Padding Helper: 132 px */
+.pad-top-33 { padding-top: 132px; }
+.pad-bottom-33 { padding-bottom: 132px; }
+.pad-left-33 { padding-left: 132px; }
+.pad-right-33 { padding-right: 132px; }
+.pad-all-33 { padding: 132px; }
+
+/* Margin Helper: 132 px */
+.marg-top-33 { margin-top: 132px; }
+.marg-bottom-33 { margin-bottom: 132px; }
+.marg-left-33 { margin-left: 132px; }
+.marg-right-33 { margin-right: 132px; }
+.marg-all-33 { margin: 132px; }
+
+/* Padding Helper: 136 px */
+.pad-top-34 { padding-top: 136px; }
+.pad-bottom-34 { padding-bottom: 136px; }
+.pad-left-34 { padding-left: 136px; }
+.pad-right-34 { padding-right: 136px; }
+.pad-all-34 { padding: 136px; }
+
+/* Margin Helper: 136 px */
+.marg-top-34 { margin-top: 136px; }
+.marg-bottom-34 { margin-bottom: 136px; }
+.marg-left-34 { margin-left: 136px; }
+.marg-right-34 { margin-right: 136px; }
+.marg-all-34 { margin: 136px; }
+
+/* Padding Helper: 140 px */
+.pad-top-35 { padding-top: 140px; }
+.pad-bottom-35 { padding-bottom: 140px; }
+.pad-left-35 { padding-left: 140px; }
+.pad-right-35 { padding-right: 140px; }
+.pad-all-35 { padding: 140px; }
+
+/* Margin Helper: 140 px */
+.marg-top-35 { margin-top: 140px; }
+.marg-bottom-35 { margin-bottom: 140px; }
+.marg-left-35 { margin-left: 140px; }
+.marg-right-35 { margin-right: 140px; }
+.marg-all-35 { margin: 140px; }
+
+/* Padding Helper: 144 px */
+.pad-top-36 { padding-top: 144px; }
+.pad-bottom-36 { padding-bottom: 144px; }
+.pad-left-36 { padding-left: 144px; }
+.pad-right-36 { padding-right: 144px; }
+.pad-all-36 { padding: 144px; }
+
+/* Margin Helper: 144 px */
+.marg-top-36 { margin-top: 144px; }
+.marg-bottom-36 { margin-bottom: 144px; }
+.marg-left-36 { margin-left: 144px; }
+.marg-right-36 { margin-right: 144px; }
+.marg-all-36 { margin: 144px; }
+
+/* Padding Helper: 148 px */
+.pad-top-37 { padding-top: 148px; }
+.pad-bottom-37 { padding-bottom: 148px; }
+.pad-left-37 { padding-left: 148px; }
+.pad-right-37 { padding-right: 148px; }
+.pad-all-37 { padding: 148px; }
+
+/* Margin Helper: 148 px */
+.marg-top-37 { margin-top: 148px; }
+.marg-bottom-37 { margin-bottom: 148px; }
+.marg-left-37 { margin-left: 148px; }
+.marg-right-37 { margin-right: 148px; }
+.marg-all-37 { margin: 148px; }
+
+/* Padding Helper: 152 px */
+.pad-top-38 { padding-top: 152px; }
+.pad-bottom-38 { padding-bottom: 152px; }
+.pad-left-38 { padding-left: 152px; }
+.pad-right-38 { padding-right: 152px; }
+.pad-all-38 { padding: 152px; }
+
+/* Margin Helper: 152 px */
+.marg-top-38 { margin-top: 152px; }
+.marg-bottom-38 { margin-bottom: 152px; }
+.marg-left-38 { margin-left: 152px; }
+.marg-right-38 { margin-right: 152px; }
+.marg-all-38 { margin: 152px; }
+
+/* Padding Helper: 156 px */
+.pad-top-39 { padding-top: 156px; }
+.pad-bottom-39 { padding-bottom: 156px; }
+.pad-left-39 { padding-left: 156px; }
+.pad-right-39 { padding-right: 156px; }
+.pad-all-39 { padding: 156px; }
+
+/* Margin Helper: 156 px */
+.marg-top-39 { margin-top: 156px; }
+.marg-bottom-39 { margin-bottom: 156px; }
+.marg-left-39 { margin-left: 156px; }
+.marg-right-39 { margin-right: 156px; }
+.marg-all-39 { margin: 156px; }
+
+/* Padding Helper: 160 px */
+.pad-top-40 { padding-top: 160px; }
+.pad-bottom-40 { padding-bottom: 160px; }
+.pad-left-40 { padding-left: 160px; }
+.pad-right-40 { padding-right: 160px; }
+.pad-all-40 { padding: 160px; }
+
+/* Margin Helper: 160 px */
+.marg-top-40 { margin-top: 160px; }
+.marg-bottom-40 { margin-bottom: 160px; }
+.marg-left-40 { margin-left: 160px; }
+.marg-right-40 { margin-right: 160px; }
+.marg-all-40 { margin: 160px; }
+
+/* Padding Helper: 164 px */
+.pad-top-41 { padding-top: 164px; }
+.pad-bottom-41 { padding-bottom: 164px; }
+.pad-left-41 { padding-left: 164px; }
+.pad-right-41 { padding-right: 164px; }
+.pad-all-41 { padding: 164px; }
+
+/* Margin Helper: 164 px */
+.marg-top-41 { margin-top: 164px; }
+.marg-bottom-41 { margin-bottom: 164px; }
+.marg-left-41 { margin-left: 164px; }
+.marg-right-41 { margin-right: 164px; }
+.marg-all-41 { margin: 164px; }
+
+/* Padding Helper: 168 px */
+.pad-top-42 { padding-top: 168px; }
+.pad-bottom-42 { padding-bottom: 168px; }
+.pad-left-42 { padding-left: 168px; }
+.pad-right-42 { padding-right: 168px; }
+.pad-all-42 { padding: 168px; }
+
+/* Margin Helper: 168 px */
+.marg-top-42 { margin-top: 168px; }
+.marg-bottom-42 { margin-bottom: 168px; }
+.marg-left-42 { margin-left: 168px; }
+.marg-right-42 { margin-right: 168px; }
+.marg-all-42 { margin: 168px; }
+
+/* Padding Helper: 172 px */
+.pad-top-43 { padding-top: 172px; }
+.pad-bottom-43 { padding-bottom: 172px; }
+.pad-left-43 { padding-left: 172px; }
+.pad-right-43 { padding-right: 172px; }
+.pad-all-43 { padding: 172px; }
+
+/* Margin Helper: 172 px */
+.marg-top-43 { margin-top: 172px; }
+.marg-bottom-43 { margin-bottom: 172px; }
+.marg-left-43 { margin-left: 172px; }
+.marg-right-43 { margin-right: 172px; }
+.marg-all-43 { margin: 172px; }
+
+/* Padding Helper: 176 px */
+.pad-top-44 { padding-top: 176px; }
+.pad-bottom-44 { padding-bottom: 176px; }
+.pad-left-44 { padding-left: 176px; }
+.pad-right-44 { padding-right: 176px; }
+.pad-all-44 { padding: 176px; }
+
+/* Margin Helper: 176 px */
+.marg-top-44 { margin-top: 176px; }
+.marg-bottom-44 { margin-bottom: 176px; }
+.marg-left-44 { margin-left: 176px; }
+.marg-right-44 { margin-right: 176px; }
+.marg-all-44 { margin: 176px; }
+
+/* Padding Helper: 180 px */
+.pad-top-45 { padding-top: 180px; }
+.pad-bottom-45 { padding-bottom: 180px; }
+.pad-left-45 { padding-left: 180px; }
+.pad-right-45 { padding-right: 180px; }
+.pad-all-45 { padding: 180px; }
+
+/* Margin Helper: 180 px */
+.marg-top-45 { margin-top: 180px; }
+.marg-bottom-45 { margin-bottom: 180px; }
+.marg-left-45 { margin-left: 180px; }
+.marg-right-45 { margin-right: 180px; }
+.marg-all-45 { margin: 180px; }
+
+/* Padding Helper: 184 px */
+.pad-top-46 { padding-top: 184px; }
+.pad-bottom-46 { padding-bottom: 184px; }
+.pad-left-46 { padding-left: 184px; }
+.pad-right-46 { padding-right: 184px; }
+.pad-all-46 { padding: 184px; }
+
+/* Margin Helper: 184 px */
+.marg-top-46 { margin-top: 184px; }
+.marg-bottom-46 { margin-bottom: 184px; }
+.marg-left-46 { margin-left: 184px; }
+.marg-right-46 { margin-right: 184px; }
+.marg-all-46 { margin: 184px; }
+
+/* Padding Helper: 188 px */
+.pad-top-47 { padding-top: 188px; }
+.pad-bottom-47 { padding-bottom: 188px; }
+.pad-left-47 { padding-left: 188px; }
+.pad-right-47 { padding-right: 188px; }
+.pad-all-47 { padding: 188px; }
+
+/* Margin Helper: 188 px */
+.marg-top-47 { margin-top: 188px; }
+.marg-bottom-47 { margin-bottom: 188px; }
+.marg-left-47 { margin-left: 188px; }
+.marg-right-47 { margin-right: 188px; }
+.marg-all-47 { margin: 188px; }
+
+/* Padding Helper: 192 px */
+.pad-top-48 { padding-top: 192px; }
+.pad-bottom-48 { padding-bottom: 192px; }
+.pad-left-48 { padding-left: 192px; }
+.pad-right-48 { padding-right: 192px; }
+.pad-all-48 { padding: 192px; }
+
+/* Margin Helper: 192 px */
+.marg-top-48 { margin-top: 192px; }
+.marg-bottom-48 { margin-bottom: 192px; }
+.marg-left-48 { margin-left: 192px; }
+.marg-right-48 { margin-right: 192px; }
+.marg-all-48 { margin: 192px; }
+
+/* Padding Helper: 196 px */
+.pad-top-49 { padding-top: 196px; }
+.pad-bottom-49 { padding-bottom: 196px; }
+.pad-left-49 { padding-left: 196px; }
+.pad-right-49 { padding-right: 196px; }
+.pad-all-49 { padding: 196px; }
+
+/* Margin Helper: 196 px */
+.marg-top-49 { margin-top: 196px; }
+.marg-bottom-49 { margin-bottom: 196px; }
+.marg-left-49 { margin-left: 196px; }
+.marg-right-49 { margin-right: 196px; }
+.marg-all-49 { margin: 196px; }
+
+/* Padding Helper: 200 px */
+.pad-top-50 { padding-top: 200px; }
+.pad-bottom-50 { padding-bottom: 200px; }
+.pad-left-50 { padding-left: 200px; }
+.pad-right-50 { padding-right: 200px; }
+.pad-all-50 { padding: 200px; }
+
+/* Margin Helper: 200 px */
+.marg-top-50 { margin-top: 200px; }
+.marg-bottom-50 { margin-bottom: 200px; }
+.marg-left-50 { margin-left: 200px; }
+.marg-right-50 { margin-right: 200px; }
+.marg-all-50 { margin: 200px; }
+
+/* Padding Helper: 204 px */
+.pad-top-51 { padding-top: 204px; }
+.pad-bottom-51 { padding-bottom: 204px; }
+.pad-left-51 { padding-left: 204px; }
+.pad-right-51 { padding-right: 204px; }
+.pad-all-51 { padding: 204px; }
+
+/* Margin Helper: 204 px */
+.marg-top-51 { margin-top: 204px; }
+.marg-bottom-51 { margin-bottom: 204px; }
+.marg-left-51 { margin-left: 204px; }
+.marg-right-51 { margin-right: 204px; }
+.marg-all-51 { margin: 204px; }
+
+/* Padding Helper: 208 px */
+.pad-top-52 { padding-top: 208px; }
+.pad-bottom-52 { padding-bottom: 208px; }
+.pad-left-52 { padding-left: 208px; }
+.pad-right-52 { padding-right: 208px; }
+.pad-all-52 { padding: 208px; }
+
+/* Margin Helper: 208 px */
+.marg-top-52 { margin-top: 208px; }
+.marg-bottom-52 { margin-bottom: 208px; }
+.marg-left-52 { margin-left: 208px; }
+.marg-right-52 { margin-right: 208px; }
+.marg-all-52 { margin: 208px; }
+
+/* Padding Helper: 212 px */
+.pad-top-53 { padding-top: 212px; }
+.pad-bottom-53 { padding-bottom: 212px; }
+.pad-left-53 { padding-left: 212px; }
+.pad-right-53 { padding-right: 212px; }
+.pad-all-53 { padding: 212px; }
+
+/* Margin Helper: 212 px */
+.marg-top-53 { margin-top: 212px; }
+.marg-bottom-53 { margin-bottom: 212px; }
+.marg-left-53 { margin-left: 212px; }
+.marg-right-53 { margin-right: 212px; }
+.marg-all-53 { margin: 212px; }
+
+/* Padding Helper: 216 px */
+.pad-top-54 { padding-top: 216px; }
+.pad-bottom-54 { padding-bottom: 216px; }
+.pad-left-54 { padding-left: 216px; }
+.pad-right-54 { padding-right: 216px; }
+.pad-all-54 { padding: 216px; }
+
+/* Margin Helper: 216 px */
+.marg-top-54 { margin-top: 216px; }
+.marg-bottom-54 { margin-bottom: 216px; }
+.marg-left-54 { margin-left: 216px; }
+.marg-right-54 { margin-right: 216px; }
+.marg-all-54 { margin: 216px; }
+
+/* Padding Helper: 220 px */
+.pad-top-55 { padding-top: 220px; }
+.pad-bottom-55 { padding-bottom: 220px; }
+.pad-left-55 { padding-left: 220px; }
+.pad-right-55 { padding-right: 220px; }
+.pad-all-55 { padding: 220px; }
+
+/* Margin Helper: 220 px */
+.marg-top-55 { margin-top: 220px; }
+.marg-bottom-55 { margin-bottom: 220px; }
+.marg-left-55 { margin-left: 220px; }
+.marg-right-55 { margin-right: 220px; }
+.marg-all-55 { margin: 220px; }
+
+/* Padding Helper: 224 px */
+.pad-top-56 { padding-top: 224px; }
+.pad-bottom-56 { padding-bottom: 224px; }
+.pad-left-56 { padding-left: 224px; }
+.pad-right-56 { padding-right: 224px; }
+.pad-all-56 { padding: 224px; }
+
+/* Margin Helper: 224 px */
+.marg-top-56 { margin-top: 224px; }
+.marg-bottom-56 { margin-bottom: 224px; }
+.marg-left-56 { margin-left: 224px; }
+.marg-right-56 { margin-right: 224px; }
+.marg-all-56 { margin: 224px; }
+
+/* Padding Helper: 228 px */
+.pad-top-57 { padding-top: 228px; }
+.pad-bottom-57 { padding-bottom: 228px; }
+.pad-left-57 { padding-left: 228px; }
+.pad-right-57 { padding-right: 228px; }
+.pad-all-57 { padding: 228px; }
+
+/* Margin Helper: 228 px */
+.marg-top-57 { margin-top: 228px; }
+.marg-bottom-57 { margin-bottom: 228px; }
+.marg-left-57 { margin-left: 228px; }
+.marg-right-57 { margin-right: 228px; }
+.marg-all-57 { margin: 228px; }
+
+/* Padding Helper: 232 px */
+.pad-top-58 { padding-top: 232px; }
+.pad-bottom-58 { padding-bottom: 232px; }
+.pad-left-58 { padding-left: 232px; }
+.pad-right-58 { padding-right: 232px; }
+.pad-all-58 { padding: 232px; }
+
+/* Margin Helper: 232 px */
+.marg-top-58 { margin-top: 232px; }
+.marg-bottom-58 { margin-bottom: 232px; }
+.marg-left-58 { margin-left: 232px; }
+.marg-right-58 { margin-right: 232px; }
+.marg-all-58 { margin: 232px; }
+
+/* Padding Helper: 236 px */
+.pad-top-59 { padding-top: 236px; }
+.pad-bottom-59 { padding-bottom: 236px; }
+.pad-left-59 { padding-left: 236px; }
+.pad-right-59 { padding-right: 236px; }
+.pad-all-59 { padding: 236px; }
+
+/* Margin Helper: 236 px */
+.marg-top-59 { margin-top: 236px; }
+.marg-bottom-59 { margin-bottom: 236px; }
+.marg-left-59 { margin-left: 236px; }
+.marg-right-59 { margin-right: 236px; }
+.marg-all-59 { margin: 236px; }
+
+/* Padding Helper: 240 px */
+.pad-top-60 { padding-top: 240px; }
+.pad-bottom-60 { padding-bottom: 240px; }
+.pad-left-60 { padding-left: 240px; }
+.pad-right-60 { padding-right: 240px; }
+.pad-all-60 { padding: 240px; }
+
+/* Margin Helper: 240 px */
+.marg-top-60 { margin-top: 240px; }
+.marg-bottom-60 { margin-bottom: 240px; }
+.marg-left-60 { margin-left: 240px; }
+.marg-right-60 { margin-right: 240px; }
+.marg-all-60 { margin: 240px; }
+


### PR DESCRIPTION
Adds the new retro-synthwave-blog-layout component with over 500+ lines of valid utility CSS under submissions/examples/.