### PR TITLE
feat: add scale-hover tooltip minimalist tech layouts for #64521

### DIFF
--- a/submissions/examples/scale-hover-tooltip-minimalist-tech/README.md
+++ b/submissions/examples/scale-hover-tooltip-minimalist-tech/README.md
@@ -1,0 +1,39 @@
+# Scale-Hover Tooltip — Minimalist Tech Layouts
+
+A pure CSS tooltip component where triggers scale up on hover and tooltips fade in with a matching scale transform. Supports four positions (top, bottom, left, right) using `data-pos` attributes.
+
+## Features
+
+- **Scale hover** — trigger elements scale to 1.08x with elastic easing on hover
+- **Scale-in tooltip** — tooltips appear with `scale(0.85)` → `scale(1)` transition
+- **Four positions** — top, bottom, left, right via `data-pos` attribute
+- **Three trigger variants** — default (white), accent (coral fill), outline (coral border)
+- **Minimalist tech aesthetic** — light grid background, monospace font, dark tooltip
+- **Fully responsive** — left/right tooltips collapse to bottom on narrow screens
+- **Reduced-motion accessible** — all scale transforms and transitions disabled when `prefers-reduced-motion: reduce`
+
+## CSS Custom Properties
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `--sht-bg` | `#f0f0f4` | Page background |
+| `--sht-surface` | `#ffffff` | Trigger fill |
+| `--sht-border` | `#d6d6dc` | Border color |
+| `--sht-text` | `#1c1c28` | Primary text |
+| `--sht-dim` | `#7a7a8c` | Secondary text |
+| `--sht-coral` | `#ef4444` | Primary accent (coral) |
+| `--sht-coral-soft` | `rgba(239,68,68,0.06)` | Accent background tint |
+| `--sht-tip-bg` | `#1c1c28` | Tooltip background |
+| `--sht-tip-text` | `#f0f0f4` | Tooltip text |
+| `--sht-radius` | `8px` | Trigger border radius |
+
+## How It Works
+
+1. Triggers use `::before` pseudo-element with `content: attr(data-tip)` for tooltip text.
+2. Tooltips start at `opacity: 0` and `scale(0.85)`, transitioning to visible on hover.
+3. Each position uses `transform-origin` to scale from the correct direction.
+4. Triggers use `cubic-bezier(0.34, 1.56, 0.64, 1)` for elastic scale effect.
+
+## Usage
+
+Copy `demo.html` and `style.css` into your project. No JavaScript or external dependencies needed. Add `data-tip="text"` and `data-pos="top|bottom|left|right"` to any element.

--- a/submissions/examples/scale-hover-tooltip-minimalist-tech/demo.html
+++ b/submissions/examples/scale-hover-tooltip-minimalist-tech/demo.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS Scale-Hover Tooltip with minimalist tech styling. Pure CSS tooltips that scale on hover with clean monospace UI.">
+  <title>Scale-Hover Tooltip – Minimalist Tech Layouts</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="sht-page">
+    <header class="sht-header">
+      <span class="sht-header__label">Minimalist Tech</span>
+      <h1 class="sht-header__title">Scale-Hover Tooltips</h1>
+      <p class="sht-header__sub">Hover the elements below to see tooltips scale into view.</p>
+    </header>
+
+    <section class="sht-demo" aria-label="Tooltip Demos">
+      <div class="sht-row">
+        <span class="sht-trigger" data-tip="Project repository name" data-pos="top">
+          Repo
+        </span>
+        <span class="sht-trigger" data-tip="Continuous integration pipeline" data-pos="top">
+          CI/CD
+        </span>
+        <span class="sht-trigger" data-tip="Deployment environment configuration" data-pos="top">
+          Deploy
+        </span>
+      </div>
+
+      <div class="sht-row">
+        <span class="sht-trigger sht-trigger--accent" data-tip="Serverless function endpoint" data-pos="bottom">
+          Functions
+        </span>
+        <span class="sht-trigger sht-trigger--accent" data-tip="Edge network cache layer" data-pos="bottom">
+          Edge
+        </span>
+        <span class="sht-trigger sht-trigger--accent" data-tip="Observability and metrics dashboard" data-pos="bottom">
+          Metrics
+        </span>
+      </div>
+
+      <div class="sht-row">
+        <span class="sht-trigger sht-trigger--outline" data-tip="API rate limiting policy" data-pos="left">
+          Rate Limit
+        </span>
+        <span class="sht-trigger sht-trigger--outline" data-tip="OAuth 2.0 token refresh flow" data-pos="right">
+          Auth
+        </span>
+      </div>
+    </section>
+
+    <div class="sht-bg" aria-hidden="true"></div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/scale-hover-tooltip-minimalist-tech/style.css
+++ b/submissions/examples/scale-hover-tooltip-minimalist-tech/style.css
@@ -1,0 +1,271 @@
+:root {
+  --sht-bg: #f0f0f4;
+  --sht-surface: #ffffff;
+  --sht-border: #d6d6dc;
+  --sht-text: #1c1c28;
+  --sht-dim: #7a7a8c;
+  --sht-coral: #ef4444;
+  --sht-coral-soft: rgba(239, 68, 68, 0.06);
+  --sht-tip-bg: #1c1c28;
+  --sht-tip-text: #f0f0f4;
+  --sht-radius: 8px;
+}
+
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: var(--sht-bg);
+  font-family: "IBM Plex Mono", "SF Mono", "Courier New", monospace;
+  color: var(--sht-text);
+  overflow-x: hidden;
+}
+
+/* ── background grid ─────────────────────────────── */
+
+.sht-bg {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(var(--sht-border) 1px, transparent 1px),
+    linear-gradient(90deg, var(--sht-border) 1px, transparent 1px);
+  background-size: 48px 48px;
+  opacity: 0.18;
+}
+
+/* ── page ────────────────────────────────────────── */
+
+.sht-page {
+  position: relative;
+  z-index: 1;
+  width: min(680px, 92vw);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 36px;
+}
+
+/* ── header ──────────────────────────────────────── */
+
+.sht-header {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+.sht-header__label {
+  font-size: 0.55rem;
+  text-transform: uppercase;
+  letter-spacing: 0.32em;
+  color: var(--sht-coral);
+  background: var(--sht-coral-soft);
+  padding: 3px 12px;
+}
+
+.sht-header__title {
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+}
+
+.sht-header__sub {
+  font-size: 0.76rem;
+  color: var(--sht-dim);
+  max-width: 36ch;
+  line-height: 1.6;
+}
+
+/* ── demo section ────────────────────────────────── */
+
+.sht-demo {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 28px;
+}
+
+.sht-row {
+  display: flex;
+  gap: 14px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+/* ── trigger element ─────────────────────────────── */
+
+.sht-trigger {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 22px;
+  background: var(--sht-surface);
+  border: 1px solid var(--sht-border);
+  border-radius: var(--sht-radius);
+  font-family: inherit;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--sht-text);
+  cursor: default;
+  transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 0.2s ease;
+}
+
+.sht-trigger:hover {
+  transform: scale(1.08);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.06);
+}
+
+.sht-trigger--accent {
+  background: var(--sht-coral);
+  color: #fff;
+  border-color: var(--sht-coral);
+}
+
+.sht-trigger--accent:hover {
+  box-shadow: 0 4px 16px rgba(239, 68, 68, 0.2);
+}
+
+.sht-trigger--outline {
+  background: transparent;
+  color: var(--sht-coral);
+  border-color: var(--sht-coral);
+}
+
+.sht-trigger--outline:hover {
+  background: var(--sht-coral-soft);
+  box-shadow: 0 4px 16px rgba(239, 68, 68, 0.1);
+}
+
+/* ── tooltip ─────────────────────────────────────── */
+
+.sht-trigger::before {
+  content: attr(data-tip);
+  position: absolute;
+  padding: 6px 12px;
+  background: var(--sht-tip-bg);
+  color: var(--sht-tip-text);
+  font-size: 0.62rem;
+  font-weight: 500;
+  letter-spacing: 0.03em;
+  text-transform: none;
+  white-space: nowrap;
+  border-radius: 5px;
+  opacity: 0;
+  pointer-events: none;
+  transform: scale(0.85);
+  transition: opacity 0.2s ease, transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+  z-index: 10;
+}
+
+.sht-trigger:hover::before {
+  opacity: 1;
+  transform: scale(1);
+}
+
+/* ── tooltip positions ───────────────────────────── */
+
+.sht-trigger[data-pos="top"]::before {
+  bottom: calc(100% + 10px);
+  left: 50%;
+  transform-origin: bottom center;
+  transform: translateX(-50%) scale(0.85);
+}
+
+.sht-trigger[data-pos="top"]:hover::before {
+  transform: translateX(-50%) scale(1);
+}
+
+.sht-trigger[data-pos="bottom"]::before {
+  top: calc(100% + 10px);
+  left: 50%;
+  transform-origin: top center;
+  transform: translateX(-50%) scale(0.85);
+}
+
+.sht-trigger[data-pos="bottom"]:hover::before {
+  transform: translateX(-50%) scale(1);
+}
+
+.sht-trigger[data-pos="left"]::before {
+  right: calc(100% + 10px);
+  top: 50%;
+  transform-origin: right center;
+  transform: translateY(-50%) scale(0.85);
+}
+
+.sht-trigger[data-pos="left"]:hover::before {
+  transform: translateY(-50%) scale(1);
+}
+
+.sht-trigger[data-pos="right"]::before {
+  left: calc(100% + 10px);
+  top: 50%;
+  transform-origin: left center;
+  transform: translateY(-50%) scale(0.85);
+}
+
+.sht-trigger[data-pos="right"]:hover::before {
+  transform: translateY(-50%) scale(1);
+}
+
+/* ── responsive ──────────────────────────────────── */
+
+@media (max-width: 500px) {
+  .sht-trigger[data-pos="left"]::before,
+  .sht-trigger[data-pos="right"]::before {
+    left: 50%;
+    right: auto;
+    top: calc(100% + 10px);
+    transform-origin: top center;
+    transform: translateX(-50%) scale(0.85);
+  }
+
+  .sht-trigger[data-pos="left"]:hover::before,
+  .sht-trigger[data-pos="right"]:hover::before {
+    transform: translateX(-50%) scale(1);
+  }
+}
+
+/* ── accessibility ───────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .sht-trigger {
+    transition: none;
+  }
+
+  .sht-trigger:hover {
+    transform: none;
+  }
+
+  .sht-trigger::before {
+    transition: none;
+  }
+
+  .sht-trigger:hover::before {
+    transform: none;
+  }
+
+  .sht-trigger[data-pos="top"]::before,
+  .sht-trigger[data-pos="bottom"]::before {
+    transform: translateX(-50%);
+  }
+
+  .sht-trigger[data-pos="left"]::before,
+  .sht-trigger[data-pos="right"]::before {
+    transform: translateY(-50%);
+  }
+}


### PR DESCRIPTION
## Summary
Adds a pure CSS Scale-Hover Tooltip with minimalist tech styling for Issue #64521.

## What's Included
- **demo.html** — Tooltip showcase with 8 triggers in 3 variants (default, accent, outline) and 4 positions
- **style.css** — Pure CSS with scale hover effect, elastic tooltip entrance, grid background, monospace font
- **README.md** — Documentation with custom properties table and usage guide

## CSS Features
- Scale hover effect (1.08x) with elastic easing on trigger elements
- Tooltip scale-in animation (0.85 → 1) with position-aware transform-origin
- Four tooltip positions (top, bottom, left, right) via `data-pos` attribute
- Three trigger variants (white, coral fill, coral outline)
- Subtle grid background overlay
- `prefers-reduced-motion` media query support (disables all scale transforms)
- Fully responsive (left/right tooltips collapse to bottom on narrow screens)

## Validator Compliance
- Only adds files inside `submissions/examples/` — no existing files modified
- `demo.html`: has DOCTYPE, html, head, body, `<meta name="description">`, `<meta name="viewport">`, `<title>`, `<link rel="stylesheet">`
- `style.css`: has `:root` with CSS custom properties (`--sht-*`), `*` box-sizing reset, transitions, `@media (prefers-reduced-motion)`
- `README.md`: 5+ non-empty non-header lines
- No `.js` files, no files outside `submissions/`

## Files Changed
- `submissions/examples/scale-hover-tooltip-minimalist-tech/demo.html` (new)
- `submissions/examples/scale-hover-tooltip-minimalist-tech/style.css` (new)
- `submissions/examples/scale-hover-tooltip-minimalist-tech/README.md` (new)

Closes #64521