### PR TITLE
feat: add CSS zoom-in toast for product catalog layouts (#62333)

### DIFF
--- a/submissions/examples/zoom-in-toast-catalog/README.md
+++ b/submissions/examples/zoom-in-toast-catalog/README.md
@@ -1,0 +1,109 @@
+# Zoom-In Toast for Product Catalog Layouts
+
+A lightweight, pure CSS/HTML toast notification designed for e-commerce and
+product catalog pages — perfect for "Added to cart" style confirmations.
+The toast **zooms in** with a subtle overshoot, then **zooms out** on
+dismissal. No JS frameworks required; the demo uses a few lines of vanilla
+JS purely to spawn/remove toast markup on click.
+
+## ✨ Features
+
+- Pure CSS animation (`scale` + `opacity`) — no animation libraries
+- Smooth zoom-in entrance with a slight overshoot for a "pop" feel
+- Zoom-out exit animation on manual dismiss or auto-timeout
+- Dark mode support (via `data-theme="dark"` attribute or OS-level
+  `prefers-color-scheme`)
+- Fully responsive — stacks and centers on mobile viewports
+- Respects `prefers-reduced-motion` (falls back to an opacity-only fade)
+- BEM-style class naming, namespaced under `ease-*` to avoid collisions
+
+## 📦 Files
+
+| File          | Purpose                                                |
+| ------------- | ------------------------------------------------------- |
+| `demo.html`   | Showcase page — a small product catalog wired up to fire toasts |
+| `style.css`   | The reusable component styles + demo page styles         |
+| `README.md`   | This file                                                |
+
+## 🚀 Usage
+
+1. Add the container once per page (usually right before `</body>`):
+
+   ```html
+   <div class="ease-toast-container" aria-live="polite" aria-atomic="true"></div>
+   ```
+
+2. Append a toast into the container whenever you need to show one:
+
+   ```html
+   <div class="ease-toast" role="status">
+     <div class="ease-toast__icon">✅</div>
+     <div class="ease-toast__body">
+       <span class="ease-toast__title">Wireless Headphones</span>
+       <span class="ease-toast__meta">
+         Added to cart · <span class="ease-toast__price">$79.99</span>
+       </span>
+     </div>
+     <button class="ease-toast__close" type="button" aria-label="Dismiss notification">✕</button>
+   </div>
+   ```
+
+3. To dismiss with the zoom-out animation, add the `ease-toast--leaving`
+   modifier class, then remove the element from the DOM once the animation
+   finishes (~260ms):
+
+   ```js
+   toastEl.classList.add("ease-toast--leaving");
+   setTimeout(() => toastEl.remove(), 260);
+   ```
+
+   See `demo.html` for a complete working example, including auto-dismiss
+   and hover-to-pause behavior.
+
+## 🎨 Customization
+
+All colors, spacing, and timing are exposed as CSS custom properties on
+`:root`, so consuming projects can override them without touching the
+component rules:
+
+```css
+:root {
+  --ease-toast-bg: #ffffff;
+  --ease-toast-text: #1a1a1a;
+  --ease-toast-accent: #16a34a;
+  --ease-toast-accent-bg: #dcfce7;
+  --ease-toast-radius: 14px;
+  --ease-toast-duration: 420ms;
+  --ease-toast-easing: cubic-bezier(0.16, 1, 0.3, 1);
+}
+```
+
+### Dark mode
+
+Dark mode activates automatically based on `prefers-color-scheme: dark`,
+or can be forced with:
+
+```html
+<html data-theme="dark">
+```
+
+## ♿ Accessibility
+
+- The toast container uses `aria-live="polite"` + `aria-atomic="true"` so
+  screen readers announce new toasts without interrupting the user.
+- Each toast has `role="status"` and an accessible close button
+  (`aria-label="Dismiss notification"`).
+- Users with `prefers-reduced-motion: reduce` get a simple opacity fade
+  instead of the scale/zoom animation.
+
+## 📱 Responsive Behavior
+
+- **Desktop/Tablet:** Toasts anchor to the bottom-right corner and zoom in
+  from that corner.
+- **Mobile (≤640px):** Toasts span the full width (minus side margins) and
+  zoom in from the bottom-center for easier thumb reach.
+
+## 🧪 Browser Support
+
+Uses only standard CSS (custom properties, `@keyframes`, `@media` queries)
+supported by all current major browsers — Chrome, Firefox, Safari, and Edge.

--- a/submissions/examples/zoom-in-toast-catalog/demo.html
+++ b/submissions/examples/zoom-in-toast-catalog/demo.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EaseMotion CSS — Zoom-In Toast for Product Catalog Layouts</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <header class="demo-header">
+    <h1>🛍️ Product Catalog — Zoom-In Toast Demo</h1>
+    <button class="theme-toggle" id="themeToggle" type="button" aria-pressed="false">
+      🌙 Dark mode
+    </button>
+  </header>
+
+  <main class="catalog">
+    <article class="product-card">
+      <div class="product-card__image" aria-hidden="true">🎧</div>
+      <div class="product-card__name">Wireless Headphones</div>
+      <div class="product-card__price">$79.99</div>
+      <button
+        class="product-card__btn"
+        type="button"
+        data-name="Wireless Headphones"
+        data-price="$79.99"
+        data-icon="✅"
+      >
+        Add to Cart
+      </button>
+    </article>
+
+    <article class="product-card">
+      <div class="product-card__image" aria-hidden="true">⌚</div>
+      <div class="product-card__name">Smart Watch</div>
+      <div class="product-card__price">$129.00</div>
+      <button
+        class="product-card__btn"
+        type="button"
+        data-name="Smart Watch"
+        data-price="$129.00"
+        data-icon="✅"
+      >
+        Add to Cart
+      </button>
+    </article>
+
+    <article class="product-card">
+      <div class="product-card__image" aria-hidden="true">🎒</div>
+      <div class="product-card__name">Travel Backpack</div>
+      <div class="product-card__price">$54.50</div>
+      <button
+        class="product-card__btn"
+        type="button"
+        data-name="Travel Backpack"
+        data-price="$54.50"
+        data-icon="✅"
+      >
+        Add to Cart
+      </button>
+    </article>
+
+    <article class="product-card">
+      <div class="product-card__image" aria-hidden="true">📷</div>
+      <div class="product-card__name">Instant Camera</div>
+      <div class="product-card__price">$99.99</div>
+      <button
+        class="product-card__btn"
+        type="button"
+        data-name="Instant Camera"
+        data-price="$99.99"
+        data-icon="✅"
+      >
+        Add to Cart
+      </button>
+    </article>
+  </main>
+
+  <!-- Component mount point — place once per page -->
+  <div class="ease-toast-container" id="toastContainer" aria-live="polite" aria-atomic="true"></div>
+
+  <script>
+    // --------------------------------------------------------------------
+    // Demo wiring only. The .ease-toast component itself is pure CSS/HTML;
+    // this script just creates + removes toast markup on click.
+    // --------------------------------------------------------------------
+    const toastContainer = document.getElementById("toastContainer");
+    const AUTO_DISMISS_MS = 3200;
+    const LEAVE_ANIMATION_MS = 260;
+
+    function showToast({ name, price, icon }) {
+      const toast = document.createElement("div");
+      toast.className = "ease-toast";
+      toast.setAttribute("role", "status");
+
+      toast.innerHTML = `
+        <div class="ease-toast__icon">${icon}</div>
+        <div class="ease-toast__body">
+          <span class="ease-toast__title">${name}</span>
+          <span class="ease-toast__meta">
+            Added to cart · <span class="ease-toast__price">${price}</span>
+          </span>
+        </div>
+        <button class="ease-toast__close" type="button" aria-label="Dismiss notification">✕</button>
+      `;
+
+      toastContainer.appendChild(toast);
+
+      const dismiss = () => {
+        toast.classList.add("ease-toast--leaving");
+        setTimeout(() => toast.remove(), LEAVE_ANIMATION_MS);
+      };
+
+      toast.querySelector(".ease-toast__close").addEventListener("click", dismiss);
+      const timer = setTimeout(dismiss, AUTO_DISMISS_MS);
+      toast.addEventListener("mouseenter", () => clearTimeout(timer));
+    }
+
+    document.querySelectorAll(".product-card__btn").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        showToast({
+          name: btn.dataset.name,
+          price: btn.dataset.price,
+          icon: btn.dataset.icon,
+        });
+      });
+    });
+
+    // Dark mode toggle
+    const themeToggle = document.getElementById("themeToggle");
+    themeToggle.addEventListener("click", () => {
+      const isDark = document.documentElement.getAttribute("data-theme") === "dark";
+      const next = isDark ? "light" : "dark";
+      document.documentElement.setAttribute("data-theme", next);
+      themeToggle.setAttribute("aria-pressed", String(!isDark));
+      themeToggle.textContent = next === "dark" ? "☀️ Light mode" : "🌙 Dark mode";
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/zoom-in-toast-catalog/style.css
+++ b/submissions/examples/zoom-in-toast-catalog/style.css
@@ -1,0 +1,348 @@
+/* ==========================================================================
+   EaseMotion CSS — Zoom-In Toast for Product Catalog Layouts
+   Pure CSS/HTML component. No JS frameworks required.
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Custom Properties (Theming)
+   -------------------------------------------------------------------------- */
+:root {
+  --ease-toast-bg: #ffffff;
+  --ease-toast-text: #1a1a1a;
+  --ease-toast-muted: #6b7280;
+  --ease-toast-border: #e5e7eb;
+  --ease-toast-shadow: 0 10px 30px rgba(0, 0, 0, 0.12), 0 2px 8px rgba(0, 0, 0, 0.08);
+  --ease-toast-accent: #16a34a;
+  --ease-toast-accent-bg: #dcfce7;
+  --ease-toast-price: #111827;
+  --ease-toast-radius: 14px;
+  --ease-toast-duration: 420ms;
+  --ease-toast-easing: cubic-bezier(0.16, 1, 0.3, 1);
+
+  --ease-page-bg: #f4f5f7;
+  --ease-page-text: #1a1a1a;
+  --ease-card-bg: #ffffff;
+  --ease-card-border: #e5e7eb;
+}
+
+[data-theme="dark"] {
+  --ease-toast-bg: #1f2430;
+  --ease-toast-text: #f3f4f6;
+  --ease-toast-muted: #9ca3af;
+  --ease-toast-border: #333a4a;
+  --ease-toast-shadow: 0 10px 30px rgba(0, 0, 0, 0.45), 0 2px 8px rgba(0, 0, 0, 0.3);
+  --ease-toast-accent: #4ade80;
+  --ease-toast-accent-bg: #14311f;
+  --ease-toast-price: #f9fafb;
+
+  --ease-page-bg: #12141c;
+  --ease-page-text: #f3f4f6;
+  --ease-card-bg: #1c2029;
+  --ease-card-border: #2a2f3a;
+}
+
+/* Respect OS-level preference when no explicit theme is set */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --ease-toast-bg: #1f2430;
+    --ease-toast-text: #f3f4f6;
+    --ease-toast-muted: #9ca3af;
+    --ease-toast-border: #333a4a;
+    --ease-toast-shadow: 0 10px 30px rgba(0, 0, 0, 0.45), 0 2px 8px rgba(0, 0, 0, 0.3);
+    --ease-toast-accent: #4ade80;
+    --ease-toast-accent-bg: #14311f;
+    --ease-toast-price: #f9fafb;
+
+    --ease-page-bg: #12141c;
+    --ease-page-text: #f3f4f6;
+    --ease-card-bg: #1c2029;
+    --ease-card-border: #2a2f3a;
+  }
+}
+
+/* --------------------------------------------------------------------------
+   2. Demo Page Shell (not part of the reusable component)
+   -------------------------------------------------------------------------- */
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--ease-page-bg);
+  color: var(--ease-page-text);
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+  transition: background-color 300ms ease, color 300ms ease;
+}
+
+.demo-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem 2rem;
+  border-bottom: 1px solid var(--ease-card-border);
+}
+
+.demo-header h1 {
+  font-size: 1.25rem;
+  margin: 0;
+}
+
+.theme-toggle {
+  border: 1px solid var(--ease-card-border);
+  background: var(--ease-card-bg);
+  color: var(--ease-page-text);
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.catalog {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 1.25rem;
+  padding: 2rem;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.product-card {
+  background: var(--ease-card-bg);
+  border: 1px solid var(--ease-card-border);
+  border-radius: 12px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.product-card__image {
+  height: 120px;
+  border-radius: 8px;
+  background: linear-gradient(135deg, #a5b4fc, #f9a8d4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+}
+
+.product-card__name {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.product-card__price {
+  color: var(--ease-toast-muted);
+  font-size: 0.85rem;
+}
+
+.product-card__btn {
+  margin-top: 0.4rem;
+  border: none;
+  background: #111827;
+  color: #fff;
+  padding: 0.55rem 0.75rem;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: transform 150ms ease, background-color 150ms ease;
+}
+
+[data-theme="dark"] .product-card__btn {
+  background: #4ade80;
+  color: #0b1a10;
+}
+
+.product-card__btn:hover {
+  transform: translateY(-1px);
+  background-color: #1f2937;
+}
+
+[data-theme="dark"] .product-card__btn:hover {
+  background-color: #86efac;
+}
+
+.product-card__btn:active {
+  transform: translateY(0);
+}
+
+/* --------------------------------------------------------------------------
+   3. Component: ease-toast-container
+   Fixed positioning wrapper. Place once per page.
+   -------------------------------------------------------------------------- */
+.ease-toast-container {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column-reverse;
+  gap: 0.75rem;
+  pointer-events: none;
+  max-width: min(360px, calc(100vw - 2rem));
+}
+
+/* --------------------------------------------------------------------------
+   4. Component: ease-toast
+   -------------------------------------------------------------------------- */
+.ease-toast {
+  pointer-events: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: var(--ease-toast-bg);
+  color: var(--ease-toast-text);
+  border: 1px solid var(--ease-toast-border);
+  border-radius: var(--ease-toast-radius);
+  box-shadow: var(--ease-toast-shadow);
+  padding: 0.85rem 1rem;
+
+  /* Start state before animation kicks in */
+  opacity: 0;
+  transform: scale(0.55);
+  transform-origin: bottom right;
+
+  animation: ease-toast-zoom-in var(--ease-toast-duration) var(--ease-toast-easing) forwards;
+}
+
+.ease-toast--leaving {
+  animation: ease-toast-zoom-out 260ms cubic-bezier(0.4, 0, 1, 1) forwards;
+}
+
+.ease-toast__icon {
+  flex-shrink: 0;
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  background: var(--ease-toast-accent-bg);
+  color: var(--ease-toast-accent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.2rem;
+}
+
+.ease-toast__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.ease-toast__title {
+  font-weight: 600;
+  font-size: 0.9rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ease-toast__meta {
+  font-size: 0.8rem;
+  color: var(--ease-toast-muted);
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+}
+
+.ease-toast__price {
+  font-weight: 600;
+  color: var(--ease-toast-price);
+}
+
+.ease-toast__close {
+  margin-left: auto;
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: var(--ease-toast-muted);
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0.25rem;
+  border-radius: 6px;
+}
+
+.ease-toast__close:hover {
+  color: var(--ease-toast-text);
+  background: rgba(128, 128, 128, 0.15);
+}
+
+/* --------------------------------------------------------------------------
+   5. Keyframes
+   -------------------------------------------------------------------------- */
+@keyframes ease-toast-zoom-in {
+  0% {
+    opacity: 0;
+    transform: scale(0.55);
+  }
+  60% {
+    opacity: 1;
+    transform: scale(1.03);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes ease-toast-zoom-out {
+  0% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(0.6);
+  }
+}
+
+/* --------------------------------------------------------------------------
+   6. Responsive
+   -------------------------------------------------------------------------- */
+@media (max-width: 640px) {
+  .ease-toast-container {
+    left: 1rem;
+    right: 1rem;
+    bottom: 1rem;
+    max-width: none;
+  }
+
+  .ease-toast {
+    transform-origin: bottom center;
+  }
+
+  .catalog {
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+    padding: 1.25rem;
+  }
+}
+
+@media (max-width: 400px) {
+  .ease-toast__title {
+    max-width: 140px;
+  }
+}
+
+/* --------------------------------------------------------------------------
+   7. Accessibility — Reduced Motion
+   -------------------------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  .ease-toast,
+  .ease-toast--leaving {
+    animation: none !important;
+    opacity: 1;
+    transform: none;
+    transition: opacity 200ms ease;
+  }
+
+  .ease-toast--leaving {
+    opacity: 0;
+  }
+
+  .product-card__btn {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Closes #62333. 
## Pull Request Description

Adds a pure CSS/HTML zoom-in toast notification component for product catalog layouts, addressing #62333. Includes a demo showcasing "Added to cart" style toasts triggered from a small product grid.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/zoom-in-toast-catalog/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A `.ease-toast` notification component that zooms in with a slight overshoot when it appears and zooms out when dismissed — built for confirming actions like "added to cart" in product catalog UIs.

**How does a developer use it?**

```html
<div class="ease-toast-container" aria-live="polite" aria-atomic="true"></div>

<div class="ease-toast" role="status">
  <div class="ease-toast__icon">✅</div>
  <div class="ease-toast__body">
    <span class="ease-toast__title">Wireless Headphones</span>
    <span class="ease-toast__meta">
      Added to cart · <span class="ease-toast__price">$79.99</span>
    </span>
  </div>
  <button class="ease-toast__close" type="button" aria-label="Dismiss notification">✕</button>
</div>
```

To dismiss with the exit animation, add `ease-toast--leaving` and remove the element after ~260ms. See `demo.html` for a full working example with auto-dismiss and hover-to-pause.

**Why does it fit EaseMotion CSS?**

It's pure CSS keyframe animation (`scale` + `opacity`), fully human-readable BEM-style class names namespaced under `ease-*`, themeable through CSS custom properties, and respects `prefers-reduced-motion` — in line with the animation-first, no-JS-framework philosophy of the library.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Toast anchors bottom-right on desktop and switches to full-width bottom-center on mobile (≤640px) for easier thumb reach. Dark mode responds to both `data-theme="dark"` and OS-level `prefers-color-scheme`. Happy to adjust timing/easing if you'd like a snappier or slower feel.