### PR TITLE
feat: add CSS slide up dropdown

### DIFF
--- a/submissions/examples/slide-up-dropdown-ks-64580/README.md
+++ b/submissions/examples/slide-up-dropdown-ks-64580/README.md
@@ -1,0 +1,76 @@
+# Slide-Up Dropdown
+
+A pure HTML/CSS dropdown menu powered by the native `<details>` element, featuring a smooth and highly performant "slide-up" entrance animation. Designed for minimalist technology interfaces and modern web applications.
+
+## 1. What the Slide-Up Dropdown Does
+This component provides a lightweight, interactive dropdown menu without relying on any JavaScript for state management. By utilizing the native `<details>` and `<summary>` HTML tags, it automatically handles click toggles while applying a CSS `@keyframes` animation (`transform` and `opacity`) to gracefully slide the menu into view when opened.
+
+## 2. Main Features
+- **Pure HTML and CSS**: Zero JavaScript required for state or animation.
+- **Native Interaction**: Built on `<details>` and `<summary>` for semantic, out-of-the-box browser support.
+- **Slide-Up Animation**: Hardware-accelerated CSS animations make the menu appear seamlessly.
+- **Minimalist Tech UI**: Clean typography, subtle borders, SVG icons, and grouped layouts.
+- **Theming**: Inherently supports both Light and Dark mode via `prefers-color-scheme`.
+- **Responsive**: Adapts to mobile viewports without overflowing horizontally.
+- **Accessible**: Features explicit `:focus-visible` styling and disables animations for users preferring reduced motion.
+
+## 3. How to Use It
+Simply drop the CSS into your stylesheet and use the structure provided in the example. No JavaScript initialization is necessary.
+
+```html
+<!-- Example Usage -->
+<details class="dropdown" name="my-dropdown">
+    <summary class="dropdown-trigger" tabindex="0">
+        <span class="trigger-text">Options</span>
+        <span class="trigger-icon" aria-hidden="true"><!-- SVG --></span>
+    </summary>
+
+    <div class="dropdown-menu">
+        <div class="dropdown-group">
+            <a href="#" class="dropdown-item">Action 1</a>
+            <a href="#" class="dropdown-item">Action 2</a>
+        </div>
+    </div>
+</details>
+```
+
+## 4. HTML Class Structure
+- `.dropdown`: Applied to the `<details>` element; establishes the absolute positioning context.
+- `.dropdown-trigger`: Applied to the `<summary>`; styles the main button and handles the click target.
+- `.trigger-icon`: Wraps the chevron SVG and rotates when the dropdown is open.
+- `.dropdown-menu`: The absolute container for the menu items that receives the slide-up animation.
+- `.dropdown-group`: A flex container for grouping related items.
+- `.dropdown-divider`: A 1px line separator.
+- `.dropdown-item`: The interactive anchors/buttons inside the menu.
+- `.item-danger`: An optional modifier class for destructive actions (e.g., Delete).
+
+## 5. CSS Custom Properties
+Customize the dropdown extensively via these variables:
+- `--dropdown-bg`, `--dropdown-border`, `--dropdown-text`: Base surface styling.
+- `--dropdown-border-hover`, `--dropdown-item-hover`: Interactive hover states.
+- `--dropdown-accent`: Primary highlight color for focus states and borders.
+- `--dropdown-danger`: Color scheme applied to destructive items.
+- `--dropdown-shadow`: Soft drop shadow for depth.
+- `--dropdown-radius`: Corner rounding.
+- `--dropdown-duration`: Animation timing (default `0.25s`).
+
+## 6. How the Slide-Up animation works
+When a user clicks the `<summary>`, the browser natively applies the `[open]` attribute to the `<details>` parent, causing the `.dropdown-menu` to render. Immediately upon rendering, the `slide-up-dropdown` animation triggers. It interpolates from `opacity: 0`, `translateY(14px)` and `scale(0.98)` to its natural resting state at `(0, 0, 0)` with a smooth `cubic-bezier(0.16, 1, 0.3, 1)` deceleration.
+
+## 7. Responsive Behavior
+On desktop and tablet, the dropdown conforms to its internal content width (min-width `220px`). On mobile viewports (`max-width: 480px`), the trigger and menu naturally expand to fill `100%` of their container block, ensuring touch targets are large enough and no horizontal scrolling occurs.
+
+## 8. Accessibility Support
+- Automatically inherits click and keyboard `Space` / `Enter` interactions via the native `<summary>`.
+- Provides high-contrast `:focus-visible` outlines.
+- Decorative icons are hidden via `aria-hidden="true"`.
+- Menu items should use standard anchor (`<a>`) or button (`<button>`) tags to ensure they remain focusable.
+
+## 9. `prefers-reduced-motion` Support
+A media query ensures that if a user has requested reduced motion at the OS level, all slide animations and chevron rotations are bypassed. The menu immediately appears fully opaque, prioritizing usability and comfort.
+
+## 10. Example Usage
+Open `demo.html` in a browser for a live demonstration of the component, including grouped items and destructive actions.
+
+## 11. Why it fits EaseMotion CSS
+This dropdown component exemplifies EaseMotion CSS by combining complex micro-interactions (drifting, scaling, fading) into a highly optimized, performant CSS structure. It requires zero JavaScript, relying purely on native HTML APIs while delivering a highly polished aesthetic.

--- a/submissions/examples/slide-up-dropdown-ks-64580/demo.html
+++ b/submissions/examples/slide-up-dropdown-ks-64580/demo.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Slide-Up Dropdown | EaseMotion</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <main class="showcase">
+        <header class="showcase-header">
+            <h1>Slide-Up Dropdown</h1>
+            <p>A pure CSS responsive dropdown menu featuring a smooth slide-up entrance animation using native HTML <code>&lt;details&gt;</code>.</p>
+        </header>
+
+        <section class="demo-area">
+            <!-- Dropdown Component -->
+            <details class="dropdown" name="tech-dropdown">
+                <summary class="dropdown-trigger" tabindex="0">
+                    <span class="trigger-text">Deploy Options</span>
+                    <span class="trigger-icon" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                            <polyline points="6 9 12 15 18 9"></polyline>
+                        </svg>
+                    </span>
+                </summary>
+
+                <div class="dropdown-menu">
+                    <div class="dropdown-group">
+                        <div class="dropdown-group-title">Environments</div>
+                        <a href="#" class="dropdown-item">
+                            <span class="item-icon">
+                                <svg viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                                    <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line>
+                                </svg>
+                            </span>
+                            Production
+                        </a>
+                        <a href="#" class="dropdown-item">
+                            <span class="item-icon">
+                                <svg viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                                    <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon>
+                                </svg>
+                            </span>
+                            Staging
+                        </a>
+                    </div>
+                    
+                    <div class="dropdown-divider"></div>
+                    
+                    <div class="dropdown-group">
+                        <a href="#" class="dropdown-item">
+                            <span class="item-icon">
+                                <svg viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                                    <circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
+                                </svg>
+                            </span>
+                            Configure Node
+                        </a>
+                        <a href="#" class="dropdown-item item-danger">
+                            <span class="item-icon">
+                                <svg viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                                    <polyline points="3 6 5 6 21 6"></polyline><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+                                </svg>
+                            </span>
+                            Delete Environment
+                        </a>
+                    </div>
+                </div>
+            </details>
+        </section>
+    </main>
+</body>
+</html>

--- a/submissions/examples/slide-up-dropdown-ks-64580/style.css
+++ b/submissions/examples/slide-up-dropdown-ks-64580/style.css
@@ -1,0 +1,287 @@
+/* submissions/examples/slide-up-dropdown-ks-64580/style.css */
+
+:root {
+    /* Base Colors */
+    --bg-main: #fafafa;
+    --text-main: #171717;
+    --text-muted: #737373;
+    
+    /* Dropdown Variables */
+    --dropdown-bg: #ffffff;
+    --dropdown-border: #e5e5e5;
+    --dropdown-border-hover: #d4d4d4;
+    --dropdown-text: #262626;
+    --dropdown-text-hover: #0a0a0a;
+    --dropdown-item-hover: #f5f5f5;
+    --dropdown-accent: #2563eb;
+    --dropdown-danger: #dc2626;
+    --dropdown-danger-bg: #fef2f2;
+    --dropdown-shadow: rgba(0, 0, 0, 0.08);
+    --dropdown-radius: 8px;
+    --dropdown-duration: 0.25s;
+    
+    /* Typography */
+    --font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-main: #0a0a0a;
+        --text-main: #f5f5f5;
+        --text-muted: #a3a3a3;
+        
+        --dropdown-bg: #171717;
+        --dropdown-border: #262626;
+        --dropdown-border-hover: #404040;
+        --dropdown-text: #e5e5e5;
+        --dropdown-text-hover: #ffffff;
+        --dropdown-item-hover: #262626;
+        --dropdown-accent: #3b82f6;
+        --dropdown-danger: #ef4444;
+        --dropdown-danger-bg: rgba(220, 38, 38, 0.1);
+        --dropdown-shadow: rgba(0, 0, 0, 0.4);
+    }
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    background-color: var(--bg-main);
+    color: var(--text-main);
+    font-family: var(--font-family);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    padding: 4rem 2rem;
+    line-height: 1.5;
+}
+
+.showcase {
+    max-width: 600px;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 3rem;
+}
+
+.showcase-header {
+    text-align: center;
+}
+
+.showcase-header h1 {
+    font-size: 2rem;
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+    letter-spacing: -0.02em;
+}
+
+.showcase-header p {
+    color: var(--text-muted);
+}
+
+.showcase-header code {
+    background: var(--dropdown-border);
+    padding: 0.125rem 0.375rem;
+    border-radius: 4px;
+    font-size: 0.9em;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    width: 100%;
+}
+
+/* Dropdown Container */
+.dropdown {
+    position: relative;
+    /* Ensure the details acts as a positioning context for the absolute menu */
+}
+
+/* Dropdown Trigger */
+.dropdown-trigger {
+    display: inline-flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.75rem 1.25rem;
+    background-color: var(--dropdown-bg);
+    border: 1px solid var(--dropdown-border);
+    border-radius: var(--dropdown-radius);
+    color: var(--dropdown-text);
+    font-size: 0.95rem;
+    font-weight: 500;
+    cursor: pointer;
+    user-select: none;
+    outline: none;
+    transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
+    min-width: 200px;
+}
+
+/* Hide native details marker */
+.dropdown-trigger::-webkit-details-marker,
+.dropdown-trigger::marker {
+    display: none;
+}
+
+.dropdown-trigger:hover {
+    background-color: var(--dropdown-item-hover);
+    border-color: var(--dropdown-border-hover);
+}
+
+.dropdown-trigger:focus-visible {
+    box-shadow: 0 0 0 2px var(--bg-main), 0 0 0 4px var(--dropdown-accent);
+}
+
+.trigger-icon {
+    display: flex;
+    align-items: center;
+    color: var(--text-muted);
+    transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Trigger Icon Rotation */
+.dropdown[open] .trigger-icon {
+    transform: rotate(180deg);
+}
+
+.dropdown[open] .dropdown-trigger {
+    border-color: var(--dropdown-accent);
+    background-color: var(--dropdown-bg);
+}
+
+/* Dropdown Menu */
+.dropdown-menu {
+    position: absolute;
+    top: calc(100% + 0.5rem);
+    left: 0;
+    width: 100%;
+    min-width: 220px;
+    background-color: var(--dropdown-bg);
+    border: 1px solid var(--dropdown-border);
+    border-radius: var(--dropdown-radius);
+    box-shadow: 0 10px 15px -3px var(--dropdown-shadow), 0 4px 6px -2px var(--dropdown-shadow);
+    z-index: 50;
+    overflow: hidden;
+    
+    /* Slide-Up Animation execution */
+    opacity: 0;
+    transform: translateY(14px) scale(0.98);
+    transform-origin: top center;
+    animation: slide-up-dropdown var(--dropdown-duration) cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+@keyframes slide-up-dropdown {
+    from {
+        opacity: 0;
+        transform: translateY(14px) scale(0.98);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
+/* Menu Internals */
+.dropdown-group {
+    padding: 0.5rem;
+    display: flex;
+    flex-direction: column;
+}
+
+.dropdown-group-title {
+    padding: 0.5rem 0.75rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-muted);
+}
+
+.dropdown-divider {
+    height: 1px;
+    background-color: var(--dropdown-border);
+    width: 100%;
+}
+
+.dropdown-item {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.625rem 0.75rem;
+    color: var(--dropdown-text);
+    text-decoration: none;
+    font-size: 0.9rem;
+    border-radius: 4px;
+    transition: background-color 0.2s, color 0.2s;
+    outline: none;
+}
+
+.item-icon {
+    display: flex;
+    align-items: center;
+    color: var(--text-muted);
+    transition: color 0.2s;
+}
+
+.dropdown-item:hover,
+.dropdown-item:focus-visible {
+    background-color: var(--dropdown-item-hover);
+    color: var(--dropdown-text-hover);
+}
+
+.dropdown-item:hover .item-icon,
+.dropdown-item:focus-visible .item-icon {
+    color: var(--dropdown-text-hover);
+}
+
+/* Danger Item Styling */
+.dropdown-item.item-danger {
+    color: var(--dropdown-danger);
+}
+
+.dropdown-item.item-danger .item-icon {
+    color: var(--dropdown-danger);
+}
+
+.dropdown-item.item-danger:hover,
+.dropdown-item.item-danger:focus-visible {
+    background-color: var(--dropdown-danger-bg);
+    color: var(--dropdown-danger);
+}
+
+/* Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+    .dropdown-menu {
+        animation: none;
+        opacity: 1;
+        transform: none;
+    }
+    
+    .trigger-icon {
+        transition: none;
+    }
+}
+
+/* Responsive Handling */
+@media (max-width: 480px) {
+    .dropdown {
+        width: 100%;
+    }
+    
+    .dropdown-trigger {
+        width: 100%;
+    }
+    
+    .dropdown-menu {
+        width: 100%;
+        /* Ensure it doesn't cause horizontal overflow on very small devices */
+        left: 0;
+        right: 0;
+    }
+}


### PR DESCRIPTION
## Pull Request Description

Implements #64580 by adding a pure HTML/CSS Slide-Up Dropdown for minimalist tech layouts.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A pure HTML/CSS dropdown menu powered by the native `<details>` element, featuring a smooth and highly performant "slide-up" entrance animation.

**How does a developer use it?**

```html
<details class="dropdown" name="my-dropdown">
    <summary class="dropdown-trigger" tabindex="0">
        <span class="trigger-text">Deploy Options</span>
        <span class="trigger-icon" aria-hidden="true"><!-- SVG --></span>
    </summary>

    <div class="dropdown-menu">
        <div class="dropdown-group">
            <a href="#" class="dropdown-item">Production</a>
            <a href="#" class="dropdown-item">Staging</a>
        </div>
    </div>
</details>
