### PR TITLE
feat: add CSS ripple-wave navbar for minimalist tech layouts

### DIFF
--- a/submissions/examples/ripple-wave-navbar-minimalist-tech/README.md
+++ b/submissions/examples/ripple-wave-navbar-minimalist-tech/README.md
@@ -1,0 +1,21 @@
+# Ripple-Wave Navbar — Minimalist Tech Layouts
+
+A clean, sticky navigation bar with a radial ripple-wave hover effect. When you hover a link, two staggered circular waves expand outward from the center, creating a subtle ripple feel without JavaScript.
+
+## Features
+
+- **Dual ripple waves**: Two pseudo-elements expand in sequence with different timing, producing a layered ripple that feels organic
+- **Sticky positioning**: Navbar stays visible as you scroll, with a frosted-glass blur backdrop
+- **Brand animation**: The logo square tilts and scales on hover for a playful micro-interaction
+- **CTA glow**: The call-to-action button uses a radial gradient sweep to draw attention
+- **Responsive**: Nav links collapse on small screens; CTA stays visible
+
+## Customization
+
+All values are controlled through CSS custom properties in `:root`. Override `--rwn-indigo` to change the accent color, or tweak `--rwn-nav-h` for a taller or shorter bar. The ripple diameter is set in the hover rules for `::before` and `::after`.
+
+## Accessibility
+
+- Focus-visible outlines on all interactive elements
+- `prefers-reduced-motion` disables all transitions and ripple animations
+- Semantic `<nav>` with `aria-label`

--- a/submissions/examples/ripple-wave-navbar-minimalist-tech/demo.html
+++ b/submissions/examples/ripple-wave-navbar-minimalist-tech/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS ripple-wave navbar component for minimalist tech layouts. Pure CSS hover ripple effects on a clean navigation bar.">
+  <title>Ripple-Wave Navbar — Minimalist Tech Layouts</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <nav class="rwn-nav" aria-label="Main navigation">
+    <div class="rwn-nav__inner">
+
+      <a href="#" class="rwn-nav__brand">
+        <span class="rwn-nav__logo"></span>
+        <span class="rwn-nav__name">Nexus</span>
+      </a>
+
+      <ul class="rwn-nav__links">
+        <li class="rwn-nav__item">
+          <a href="#features" class="rwn-nav__link">Features</a>
+        </li>
+        <li class="rwn-nav__item">
+          <a href="#pricing" class="rwn-nav__link">Pricing</a>
+        </li>
+        <li class="rwn-nav__item">
+          <a href="#docs" class="rwn-nav__link">Docs</a>
+        </li>
+        <li class="rwn-nav__item">
+          <a href="#blog" class="rwn-nav__link">Blog</a>
+        </li>
+      </ul>
+
+      <a href="#cta" class="rwn-nav__cta">Get Started</a>
+
+    </div>
+  </nav>
+
+  <main class="rwn-content">
+    <section class="rwn-hero">
+      <h1 class="rwn-hero__title">Ripple-Wave Navbar</h1>
+      <p class="rwn-hero__sub">Hover over the navigation links above to see the ripple-wave effect. Each link produces a radial wave that expands outward from your cursor.</p>
+      <div class="rwn-hero__tags">
+        <span class="rwn-tag">Pure CSS</span>
+        <span class="rwn-tag">No JS</span>
+        <span class="rwn-tag">Responsive</span>
+        <span class="rwn-tag">Accessible</span>
+      </div>
+    </section>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/ripple-wave-navbar-minimalist-tech/style.css
+++ b/submissions/examples/ripple-wave-navbar-minimalist-tech/style.css
@@ -1,0 +1,298 @@
+:root {
+  --rwn-bg: #f4f4f7;
+  --rwn-surface: #ffffff;
+  --rwn-border: #e2e2e8;
+  --rwn-text: #18182a;
+  --rwn-dim: #6e6e82;
+  --rwn-indigo: #6366f1;
+  --rwn-indigo-soft: rgba(99, 102, 241, 0.08);
+  --rwn-indigo-wave: rgba(99, 102, 241, 0.12);
+  --rwn-nav-h: 56px;
+  --rwn-radius: 8px;
+}
+
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  background: var(--rwn-bg);
+  font-family: "DM Sans", "Inter", "Helvetica Neue", Arial, sans-serif;
+  color: var(--rwn-text);
+  overflow-x: hidden;
+}
+
+/* ── nav bar ─────────────────────────────────────── */
+
+.rwn-nav {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  width: 100%;
+  background: var(--rwn-surface);
+  border-bottom: 1px solid var(--rwn-border);
+  backdrop-filter: blur(12px);
+}
+
+.rwn-nav__inner {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: var(--rwn-nav-h);
+  padding: 0 24px;
+}
+
+/* ── brand ───────────────────────────────────────── */
+
+.rwn-nav__brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  text-decoration: none;
+  color: var(--rwn-text);
+}
+
+.rwn-nav__logo {
+  width: 26px;
+  height: 26px;
+  border-radius: 6px;
+  background: var(--rwn-indigo);
+  display: block;
+  transition: transform 0.25s ease;
+}
+
+.rwn-nav__brand:hover .rwn-nav__logo {
+  transform: rotate(8deg) scale(1.08);
+}
+
+.rwn-nav__name {
+  font-size: 0.92rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+/* ── links ───────────────────────────────────────── */
+
+.rwn-nav__links {
+  display: flex;
+  gap: 4px;
+  list-style: none;
+}
+
+.rwn-nav__item {
+  position: relative;
+}
+
+.rwn-nav__link {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  height: var(--rwn-nav-h);
+  padding: 0 14px;
+  font-size: 0.76rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  color: var(--rwn-dim);
+  text-decoration: none;
+  overflow: hidden;
+  transition: color 0.2s ease;
+}
+
+/* ── ripple wave pseudo-element ──────────────────── */
+
+.rwn-nav__link::before {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 0;
+  height: 0;
+  border-radius: 50%;
+  background: var(--rwn-indigo-wave);
+  transform: translate(-50%, -50%);
+  transition: width 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+              height 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+              opacity 0.3s ease;
+  opacity: 0;
+  z-index: 0;
+}
+
+.rwn-nav__link::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 0;
+  height: 0;
+  border-radius: 50%;
+  background: var(--rwn-indigo-wave);
+  transform: translate(-50%, -50%);
+  transition: width 0.6s cubic-bezier(0.22, 1, 0.36, 1),
+              height 0.6s cubic-bezier(0.22, 1, 0.36, 1),
+              opacity 0.4s ease;
+  opacity: 0;
+  z-index: 0;
+}
+
+.rwn-nav__link span,
+.rwn-nav__link {
+  position: relative;
+  z-index: 1;
+}
+
+/* ── hover: two staggered ripples ────────────────── */
+
+.rwn-nav__item:hover .rwn-nav__link {
+  color: var(--rwn-indigo);
+}
+
+.rwn-nav__item:hover .rwn-nav__link::before {
+  width: 220px;
+  height: 220px;
+  opacity: 1;
+}
+
+.rwn-nav__item:hover .rwn-nav__link::after {
+  width: 320px;
+  height: 320px;
+  opacity: 1;
+  transition-delay: 0.08s;
+}
+
+/* ── focus visible ───────────────────────────────── */
+
+.rwn-nav__link:focus-visible {
+  outline: 2px solid var(--rwn-indigo);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* ── CTA button ──────────────────────────────────── */
+
+.rwn-nav__cta {
+  font-size: 0.72rem;
+  font-weight: 600;
+  padding: 8px 18px;
+  border-radius: var(--rwn-radius);
+  background: var(--rwn-indigo);
+  color: #fff;
+  text-decoration: none;
+  letter-spacing: 0.02em;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.rwn-nav__cta::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at center, rgba(255,255,255,0.25) 0%, transparent 70%);
+  transform: scale(0);
+  transition: transform 0.35s cubic-bezier(0.22, 1, 0.36, 1);
+  border-radius: inherit;
+}
+
+.rwn-nav__cta:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 14px rgba(99, 102, 241, 0.3);
+}
+
+.rwn-nav__cta:hover::before {
+  transform: scale(1.6);
+}
+
+.rwn-nav__cta:focus-visible {
+  outline: 2px solid var(--rwn-indigo);
+  outline-offset: 2px;
+}
+
+/* ── page content ────────────────────────────────── */
+
+.rwn-content {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 80px 24px;
+}
+
+.rwn-hero {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+.rwn-hero__title {
+  font-size: clamp(1.6rem, 4vw, 2.4rem);
+  font-weight: 800;
+  letter-spacing: -0.04em;
+}
+
+.rwn-hero__sub {
+  font-size: 0.82rem;
+  color: var(--rwn-dim);
+  max-width: 48ch;
+  line-height: 1.7;
+}
+
+.rwn-hero__tags {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: 8px;
+}
+
+.rwn-tag {
+  font-size: 0.6rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  padding: 5px 12px;
+  border-radius: 20px;
+  background: var(--rwn-indigo-soft);
+  color: var(--rwn-indigo);
+}
+
+/* ── responsive ──────────────────────────────────── */
+
+@media (max-width: 680px) {
+  .rwn-nav__links {
+    display: none;
+  }
+
+  .rwn-nav__cta {
+    font-size: 0.68rem;
+    padding: 6px 14px;
+  }
+}
+
+/* ── accessibility ───────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .rwn-nav__link::before,
+  .rwn-nav__link::after,
+  .rwn-nav__cta::before,
+  .rwn-nav__logo {
+    transition: none;
+  }
+
+  .rwn-nav__item:hover .rwn-nav__link::before,
+  .rwn-nav__item:hover .rwn-nav__link::after {
+    width: 0;
+    height: 0;
+    opacity: 0;
+  }
+
+  .rwn-nav__cta:hover::before {
+    transform: none;
+  }
+}


### PR DESCRIPTION
Closes #64513

Adds a CSS-only ripple-wave navbar component to the minimalist tech layout collection.

Changes:
- submissions/examples/ripple-wave-navbar-minimalist-tech/demo.html — sticky navbar with brand, nav links, and CTA button
- submissions/examples/ripple-wave-navbar-minimalist-tech/style.css — dual ripple wave hover animation using ::before and ::after pseudo-elements, CSS custom properties (prefix --rwn-*), prefers-reduced-motion support
- submissions/examples/ripple-wave-navbar-minimalist-tech/README.md — usage notes and customization guide

Implementation:
- Two staggered pseudo-elements expand as radial circles on link hover, creating a layered ripple effect
- Navbar is sticky with backdrop-filter blur for frosted-glass feel
- Brand logo tilts and scales on hover; CTA uses radial gradient sweep
- Responsive: nav links hide on mobile, CTA stays visible
- All interactive elements have focus-visible outlines