### PR TITLE
feat: add CSS glitch-flicker navbar for minimalist tech layouts

### DIFF
--- a/submissions/examples/glitch-flicker-navbar-minimalist-tech/README.md
+++ b/submissions/examples/glitch-flicker-navbar-minimalist-tech/README.md
@@ -1,0 +1,17 @@
+# Glitch-Flicker Navbar — Minimalist Tech Layouts
+
+A sticky navigation bar with a CSS glitch-flicker hover effect. When you hover a nav link, two color-shifted layers (cyan and pink) animate in with offset positions and clipped regions, creating a digital glitch look.
+
+## How It Works
+
+Each link stores its label text in a `data-text` attribute. The `::before` and `::after` pseudo-elements read that attribute and render duplicate text layers. On hover, keyframe animations move and clip these layers independently with a stepped timing function, producing the characteristic jitter and flicker of a glitch effect.
+
+## Keyframes
+
+Three keyframe sequences run together: `gfn-skew` tilts the main text slightly, while `gfn-glitch-cyan` and `gfn-glitch-pink` shift and reveal their respective color layers at different clip positions. All three complete in 0.4 seconds and use `steps()` easing for a digital, non-smooth feel.
+
+## Accessibility
+
+- Focus-visible outlines on all interactive elements
+- `prefers-reduced-motion` disables all glitch animations and transitions
+- Semantic `<nav>` element with `aria-label`

--- a/submissions/examples/glitch-flicker-navbar-minimalist-tech/demo.html
+++ b/submissions/examples/glitch-flicker-navbar-minimalist-tech/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS glitch-flicker navbar for minimalist tech layouts. Pure CSS glitch animation on hover with clean light UI.">
+  <title>Glitch-Flicker Navbar — Minimalist Tech Layouts</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <nav class="gfn-nav" aria-label="Main navigation">
+    <div class="gfn-nav__inner">
+
+      <a href="#" class="gfn-nav__brand">
+        <span class="gfn-nav__logo" aria-hidden="true"></span>
+        <span class="gfn-nav__name">Arc</span>
+      </a>
+
+      <ul class="gfn-nav__links">
+        <li class="gfn-nav__item">
+          <a href="#platform" class="gfn-nav__link" data-text="Platform">Platform</a>
+        </li>
+        <li class="gfn-nav__item">
+          <a href="#solutions" class="gfn-nav__link" data-text="Solutions">Solutions</a>
+        </li>
+        <li class="gfn-nav__item">
+          <a href="#pricing" class="gfn-nav__link" data-text="Pricing">Pricing</a>
+        </li>
+        <li class="gfn-nav__item">
+          <a href="#company" class="gfn-nav__link" data-text="Company">Company</a>
+        </li>
+      </ul>
+
+      <a href="#start" class="gfn-nav__cta">Start Free Trial</a>
+
+    </div>
+  </nav>
+
+  <main class="gfn-content">
+    <section class="gfn-hero">
+      <h1 class="gfn-hero__title">Glitch-Flicker Navbar</h1>
+      <p class="gfn-hero__sub">Hover any navigation link above to trigger a glitch flicker effect. The text splits into offset color layers that jitter and recombine.</p>
+      <div class="gfn-hero__tags">
+        <span class="gfn-tag">Pure CSS</span>
+        <span class="gfn-tag">Keyframes</span>
+        <span class="gfn-tag">No JavaScript</span>
+      </div>
+    </section>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/glitch-flicker-navbar-minimalist-tech/style.css
+++ b/submissions/examples/glitch-flicker-navbar-minimalist-tech/style.css
@@ -1,0 +1,289 @@
+:root {
+  --gfn-bg: #f5f5f8;
+  --gfn-surface: #ffffff;
+  --gfn-border: #e0e0e7;
+  --gfn-text: #1a1a2e;
+  --gfn-dim: #757589;
+  --gfn-cyan: #06b6d4;
+  --gfn-pink: #ec4899;
+  --gfn-cyan-soft: rgba(6, 182, 212, 0.08);
+  --gfn-nav-h: 54px;
+  --gfn-radius: 6px;
+}
+
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  background: var(--gfn-bg);
+  font-family: "Space Grotesk", "Inter", "Helvetica Neue", Arial, sans-serif;
+  color: var(--gfn-text);
+  overflow-x: hidden;
+}
+
+/* ── nav ─────────────────────────────────────────── */
+
+.gfn-nav {
+  position: sticky;
+  top: 0;
+  z-index: 60;
+  width: 100%;
+  background: var(--gfn-surface);
+  border-bottom: 1px solid var(--gfn-border);
+}
+
+.gfn-nav__inner {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: var(--gfn-nav-h);
+  padding: 0 24px;
+}
+
+/* ── brand ───────────────────────────────────────── */
+
+.gfn-nav__brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  text-decoration: none;
+  color: var(--gfn-text);
+}
+
+.gfn-nav__logo {
+  width: 24px;
+  height: 24px;
+  border-radius: 5px;
+  background: linear-gradient(135deg, var(--gfn-cyan), var(--gfn-pink));
+  display: block;
+  transition: transform 0.2s ease;
+}
+
+.gfn-nav__brand:hover .gfn-nav__logo {
+  transform: rotate(-6deg) scale(1.1);
+}
+
+.gfn-nav__name {
+  font-size: 0.88rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+/* ── links ───────────────────────────────────────── */
+
+.gfn-nav__links {
+  display: flex;
+  gap: 2px;
+  list-style: none;
+}
+
+.gfn-nav__item {
+  position: relative;
+}
+
+.gfn-nav__link {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  height: var(--gfn-nav-h);
+  padding: 0 14px;
+  font-size: 0.74rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  color: var(--gfn-dim);
+  text-decoration: none;
+  transition: color 0.15s ease;
+}
+
+/* ── glitch layers ───────────────────────────────── */
+
+.gfn-nav__link::before,
+.gfn-nav__link::after {
+  content: attr(data-text);
+  position: absolute;
+  left: 14px;
+  top: 50%;
+  transform: translateY(-50%);
+  opacity: 0;
+  pointer-events: none;
+  font-size: inherit;
+  font-weight: inherit;
+  letter-spacing: inherit;
+  white-space: nowrap;
+}
+
+.gfn-nav__link::before {
+  color: var(--gfn-cyan);
+  z-index: -1;
+}
+
+.gfn-nav__link::after {
+  color: var(--gfn-pink);
+  z-index: -1;
+}
+
+/* ── hover: glitch flicker ──────────────────────── */
+
+.gfn-nav__item:hover .gfn-nav__link {
+  color: var(--gfn-text);
+  animation: gfn-skew 0.4s steps(2, end) both;
+}
+
+.gfn-nav__item:hover .gfn-nav__link::before {
+  opacity: 0.7;
+  animation: gfn-glitch-cyan 0.4s steps(3, end) both;
+}
+
+.gfn-nav__item:hover .gfn-nav__link::after {
+  opacity: 0.7;
+  animation: gfn-glitch-pink 0.4s steps(3, end) both;
+}
+
+/* ── keyframes ───────────────────────────────────── */
+
+@keyframes gfn-skew {
+  0%   { transform: translateY(-50%) skewX(0deg); }
+  20%  { transform: translateY(-50%) skewX(-2deg); }
+  40%  { transform: translateY(-50%) skewX(1.5deg); }
+  60%  { transform: translateY(-50%) skewX(-1deg); }
+  80%  { transform: translateY(-50%) skewX(0.5deg); }
+  100% { transform: translateY(-50%) skewX(0deg); }
+}
+
+@keyframes gfn-glitch-cyan {
+  0%   { transform: translateY(-50%) translate(0, 0); clip-path: inset(0 0 85% 0); }
+  15%  { transform: translateY(-50%) translate(-3px, 1px); clip-path: inset(10% 0 60% 0); }
+  30%  { transform: translateY(-50%) translate(2px, -1px); clip-path: inset(30% 0 40% 0); }
+  45%  { transform: translateY(-50%) translate(-1px, 2px); clip-path: inset(50% 0 20% 0); }
+  60%  { transform: translateY(-50%) translate(3px, 0); clip-path: inset(20% 0 50% 0); }
+  75%  { transform: translateY(-50%) translate(-2px, -1px); clip-path: inset(60% 0 10% 0); }
+  100% { transform: translateY(-50%) translate(0, 0); clip-path: inset(0 0 100% 0); }
+}
+
+@keyframes gfn-glitch-pink {
+  0%   { transform: translateY(-50%) translate(0, 0); clip-path: inset(85% 0 0 0); }
+  15%  { transform: translateY(-50%) translate(2px, -2px); clip-path: inset(50% 0 20% 0); }
+  30%  { transform: translateY(-50%) translate(-3px, 1px); clip-path: inset(10% 0 70% 0); }
+  45%  { transform: translateY(-50%) translate(1px, -1px); clip-path: inset(40% 0 30% 0); }
+  60%  { transform: translateY(-50%) translate(-2px, 2px); clip-path: inset(70% 0 5% 0); }
+  75%  { transform: translateY(-50%) translate(3px, 0); clip-path: inset(15% 0 60% 0); }
+  100% { transform: translateY(-50%) translate(0, 0); clip-path: inset(100% 0 0 0); }
+}
+
+/* ── focus ───────────────────────────────────────── */
+
+.gfn-nav__link:focus-visible {
+  outline: 2px solid var(--gfn-cyan);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* ── CTA ─────────────────────────────────────────── */
+
+.gfn-nav__cta {
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 8px 16px;
+  border-radius: var(--gfn-radius);
+  background: var(--gfn-text);
+  color: #fff;
+  text-decoration: none;
+  letter-spacing: 0.02em;
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+.gfn-nav__cta:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(26, 26, 46, 0.2);
+}
+
+.gfn-nav__cta:focus-visible {
+  outline: 2px solid var(--gfn-cyan);
+  outline-offset: 2px;
+}
+
+/* ── page ────────────────────────────────────────── */
+
+.gfn-content {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 80px 24px;
+}
+
+.gfn-hero {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+}
+
+.gfn-hero__title {
+  font-size: clamp(1.5rem, 4vw, 2.3rem);
+  font-weight: 800;
+  letter-spacing: -0.04em;
+}
+
+.gfn-hero__sub {
+  font-size: 0.8rem;
+  color: var(--gfn-dim);
+  max-width: 46ch;
+  line-height: 1.7;
+}
+
+.gfn-hero__tags {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: 6px;
+}
+
+.gfn-tag {
+  font-size: 0.58rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  padding: 5px 12px;
+  border-radius: 20px;
+  background: var(--gfn-cyan-soft);
+  color: var(--gfn-cyan);
+}
+
+/* ── responsive ──────────────────────────────────── */
+
+@media (max-width: 680px) {
+  .gfn-nav__links {
+    display: none;
+  }
+
+  .gfn-nav__cta {
+    font-size: 0.66rem;
+    padding: 6px 14px;
+  }
+}
+
+/* ── accessibility ───────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .gfn-nav__link,
+  .gfn-nav__link::before,
+  .gfn-nav__link::after,
+  .gfn-nav__logo {
+    animation: none !important;
+    transition: none;
+  }
+
+  .gfn-nav__item:hover .gfn-nav__link::before,
+  .gfn-nav__item:hover .gfn-nav__link::after {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
Closes #64512

Adds a CSS-only glitch-flicker navbar component to the minimalist tech layout collection.

Changes:
- submissions/examples/glitch-flicker-navbar-minimalist-tech/demo.html — sticky nav with brand, links, and CTA
- submissions/examples/glitch-flicker-navbar-minimalist-tech/style.css — glitch hover effect using ::before/::after pseudo-elements with data-text attribute, keyframe animations (prefix --gfn-*), prefers-reduced-motion support
- submissions/examples/glitch-flicker-navbar-minimalist-tech/README.md — implementation notes

Implementation:
- Two color-shifted text layers (cyan and pink) animate with offset positions and clip-path on hover
- Three keyframe sequences run together: skew, cyan glitch, pink glitch — all complete in 0.4s with steps() easing
- Uses data-text attribute on links for the pseudo-element content
- Responsive: nav links hide on mobile, CTA stays visible
- All interactive elements have focus-visible outlines