### PR TITLE
feat: add CSS rotate-fade navbar for minimalist tech layouts

### DIFF
--- a/submissions/examples/rotate-fade-navbar-minimalist-tech/README.md
+++ b/submissions/examples/rotate-fade-navbar-minimalist-tech/README.md
@@ -1,0 +1,19 @@
+# Rotate-Fade Navbar — Minimalist Tech Layouts
+
+A sticky navigation bar with a rotating underline reveal effect on hover. Each nav link gets a small teal underline that scales in from the left with a slight rotation, while the text lifts and shifts color.
+
+## How It Works
+
+The underline is a `::after` pseudo-element with `transform: scaleX(0) rotate(-12deg)`. On hover it transitions to `scaleX(1) rotate(0deg)` using a spring-eased cubic-bezier. The text itself transitions color and translates upward by 1px for a subtle depth cue.
+
+The brand dot rotates 180 degrees on hover. The CTA button uses a `::before` overlay that slides up from below to create a color-fill transition.
+
+## Customization
+
+Override `--rfn-teal` to change the accent color. Adjust `--rfn-nav-h` for a taller or shorter bar. The underline rotation angle is hardcoded in the hover rule for `::after`.
+
+## Accessibility
+
+- Focus-visible outlines on all interactive elements
+- `prefers-reduced-motion` disables all transitions
+- Semantic `<nav>` with `aria-label`

--- a/submissions/examples/rotate-fade-navbar-minimalist-tech/demo.html
+++ b/submissions/examples/rotate-fade-navbar-minimalist-tech/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS rotate-fade navbar for minimalist tech layouts. Pure CSS hover animation with rotating underline and fading text.">
+  <title>Rotate-Fade Navbar — Minimalist Tech Layouts</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <nav class="rfn-nav" aria-label="Main navigation">
+    <div class="rfn-nav__inner">
+
+      <a href="#" class="rfn-nav__brand">
+        <span class="rfn-nav__dot" aria-hidden="true"></span>
+        <span class="rfn-nav__name">Vertex</span>
+      </a>
+
+      <ul class="rfn-nav__links">
+        <li class="rfn-nav__item">
+          <a href="#product" class="rfn-nav__link">Product</a>
+        </li>
+        <li class="rfn-nav__item">
+          <a href="#engineers" class="rfn-nav__link">Engineers</a>
+        </li>
+        <li class="rfn-nav__item">
+          <a href="#enterprise" class="rfn-nav__link">Enterprise</a>
+        </li>
+        <li class="rfn-nav__item">
+          <a href="#resources" class="rfn-nav__link">Resources</a>
+        </li>
+      </ul>
+
+      <a href="#signup" class="rfn-nav__cta">Sign Up</a>
+
+    </div>
+  </nav>
+
+  <main class="rfn-content">
+    <section class="rfn-hero">
+      <h1 class="rfn-hero__title">Rotate-Fade Navbar</h1>
+      <p class="rfn-hero__sub">Hover the links above. Each one reveals a small rotating underline that fades in, while the text itself shifts opacity for a layered entrance feel.</p>
+      <div class="rfn-hero__badges">
+        <span class="rfn-badge">Pure CSS</span>
+        <span class="rfn-badge">Transitions</span>
+        <span class="rfn-badge">No JS</span>
+      </div>
+    </section>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/rotate-fade-navbar-minimalist-tech/style.css
+++ b/submissions/examples/rotate-fade-navbar-minimalist-tech/style.css
@@ -1,0 +1,264 @@
+:root {
+  --rfn-bg: #f6f6f9;
+  --rfn-surface: #ffffff;
+  --rfn-border: #e4e4eb;
+  --rfn-text: #1c1c2d;
+  --rfn-dim: #7a7a8f;
+  --rfn-teal: #14b8a6;
+  --rfn-teal-soft: rgba(20, 184, 166, 0.08);
+  --rfn-nav-h: 52px;
+  --rfn-radius: 6px;
+}
+
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  background: var(--rfn-bg);
+  font-family: "DM Sans", "Inter", "Helvetica Neue", Arial, sans-serif;
+  color: var(--rfn-text);
+  overflow-x: hidden;
+}
+
+/* ── nav ─────────────────────────────────────────── */
+
+.rfn-nav {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  width: 100%;
+  background: var(--rfn-surface);
+  border-bottom: 1px solid var(--rfn-border);
+}
+
+.rfn-nav__inner {
+  max-width: 1080px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: var(--rfn-nav-h);
+  padding: 0 22px;
+}
+
+/* ── brand ───────────────────────────────────────── */
+
+.rfn-nav__brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  text-decoration: none;
+  color: var(--rfn-text);
+}
+
+.rfn-nav__dot {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: var(--rfn-teal);
+  display: block;
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.rfn-nav__brand:hover .rfn-nav__dot {
+  transform: rotate(180deg) scale(1.15);
+}
+
+.rfn-nav__name {
+  font-size: 0.86rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+/* ── links ───────────────────────────────────────── */
+
+.rfn-nav__links {
+  display: flex;
+  gap: 2px;
+  list-style: none;
+}
+
+.rfn-nav__item {
+  position: relative;
+}
+
+.rfn-nav__link {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  height: var(--rfn-nav-h);
+  padding: 0 13px;
+  font-size: 0.73rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  color: var(--rfn-dim);
+  text-decoration: none;
+  transition: color 0.2s ease, transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* ── rotating underline ──────────────────────────── */
+
+.rfn-nav__link::after {
+  content: "";
+  position: absolute;
+  bottom: 12px;
+  left: 13px;
+  right: 13px;
+  height: 2px;
+  background: var(--rfn-teal);
+  border-radius: 1px;
+  transform: scaleX(0) rotate(-12deg);
+  transform-origin: left center;
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1), opacity 0.2s ease;
+  opacity: 0;
+}
+
+.rfn-nav__item:hover .rfn-nav__link {
+  color: var(--rfn-text);
+  transform: translateY(-1px);
+}
+
+.rfn-nav__item:hover .rfn-nav__link::after {
+  transform: scaleX(1) rotate(0deg);
+  opacity: 1;
+  transition-delay: 0.04s;
+}
+
+/* ── focus ───────────────────────────────────────── */
+
+.rfn-nav__link:focus-visible {
+  outline: 2px solid var(--rfn-teal);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* ── CTA ─────────────────────────────────────────── */
+
+.rfn-nav__cta {
+  font-size: 0.68rem;
+  font-weight: 600;
+  padding: 7px 16px;
+  border-radius: var(--rfn-radius);
+  background: var(--rfn-text);
+  color: #fff;
+  text-decoration: none;
+  letter-spacing: 0.02em;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.rfn-nav__cta::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: var(--rfn-teal);
+  transform: translateY(100%);
+  transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+  border-radius: inherit;
+}
+
+.rfn-nav__cta:hover {
+  box-shadow: 0 4px 12px rgba(28, 28, 45, 0.18);
+}
+
+.rfn-nav__cta:hover::before {
+  transform: translateY(0);
+}
+
+.rfn-nav__cta span,
+.rfn-nav__cta {
+  position: relative;
+  z-index: 1;
+}
+
+.rfn-nav__cta:focus-visible {
+  outline: 2px solid var(--rfn-teal);
+  outline-offset: 2px;
+}
+
+/* ── page content ────────────────────────────────── */
+
+.rfn-content {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 80px 22px;
+}
+
+.rfn-hero {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+}
+
+.rfn-hero__title {
+  font-size: clamp(1.4rem, 4vw, 2.2rem);
+  font-weight: 800;
+  letter-spacing: -0.04em;
+}
+
+.rfn-hero__sub {
+  font-size: 0.78rem;
+  color: var(--rfn-dim);
+  max-width: 44ch;
+  line-height: 1.7;
+}
+
+.rfn-hero__badges {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: 6px;
+}
+
+.rfn-badge {
+  font-size: 0.56rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  padding: 5px 12px;
+  border-radius: 20px;
+  background: var(--rfn-teal-soft);
+  color: var(--rfn-teal);
+}
+
+/* ── responsive ──────────────────────────────────── */
+
+@media (max-width: 660px) {
+  .rfn-nav__links {
+    display: none;
+  }
+
+  .rfn-nav__cta {
+    font-size: 0.64rem;
+    padding: 6px 14px;
+  }
+}
+
+/* ── accessibility ───────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .rfn-nav__link,
+  .rfn-nav__link::after,
+  .rfn-nav__dot,
+  .rfn-nav__cta::before {
+    transition: none;
+  }
+
+  .rfn-nav__item:hover .rfn-nav__link {
+    transform: none;
+  }
+
+  .rfn-nav__item:hover .rfn-nav__link::after {
+    transform: scaleX(1) rotate(0deg);
+  }
+}


### PR DESCRIPTION
Closes #64509

Adds a CSS-only rotate-fade navbar component to the minimalist tech layout collection.

Changes:
- submissions/examples/rotate-fade-navbar-minimalist-tech/demo.html — sticky nav with brand, links, and CTA
- submissions/examples/rotate-fade-navbar-minimalist-tech/style.css — rotating underline reveal on hover using ::after pseudo-element, CSS custom properties (prefix --rfn-*), prefers-reduced-motion support
- submissions/examples/rotate-fade-navbar-minimalist-tech/README.md — implementation notes

Implementation:
- Underline scales in from left with scaleX(0) rotate(-12deg) to scaleX(1) rotate(0deg) using spring-eased cubic-bezier
- Text shifts color and translates up 1px on hover for depth
- Brand dot rotates 180 degrees on hover
- CTA uses ::before overlay that slides up for color-fill transition
- Responsive: nav links hide on mobile, CTA stays visible
- All interactive elements have focus-visible outlines