### PR TITLE
feat: add CSS skew-active navbar for minimalist tech layouts

### DIFF
--- a/submissions/examples/skew-active-navbar-minimalist-tech/README.md
+++ b/submissions/examples/skew-active-navbar-minimalist-tech/README.md
@@ -1,0 +1,19 @@
+# Skew-Active Navbar — Minimalist Tech Layouts
+
+A sticky navigation bar with a skew transform reveal on hover. Each link has a background shape that slides in from the left with a skew angle, while the text itself skews slightly in the opposite direction.
+
+## How It Works
+
+The `::before` pseudo-element on each link is a rounded rectangle that sits off-screen with `translateX(-110%)` and `skewX(-12deg)`. On hover it transitions to `translateX(0)`, sliding in behind the text. The text `<span>` inside the link skews to `6deg` for a counter-angle effect. Both use a spring-eased cubic-bezier for a snappy, bouncy feel.
+
+The CTA button skews `-4deg` on hover with a violet box-shadow for emphasis. The brand glyph also skews and scales on hover.
+
+## Customization
+
+Override `--san-violet` to change the accent color. Adjust the skew angles in the hover rules for more or less dramatic tilts. The background inset padding controls how much the skew shape extends beyond the text.
+
+## Accessibility
+
+- Focus-visible outlines on all interactive elements
+- `prefers-reduced-motion` disables all skew and translate transitions
+- Semantic `<nav>` with `aria-label`

--- a/submissions/examples/skew-active-navbar-minimalist-tech/demo.html
+++ b/submissions/examples/skew-active-navbar-minimalist-tech/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS skew-active navbar for minimalist tech layouts. Pure CSS skew animation on hover with clean light UI.">
+  <title>Skew-Active Navbar — Minimalist Tech Layouts</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <nav class="san-nav" aria-label="Main navigation">
+    <div class="san-nav__inner">
+
+      <a href="#" class="san-nav__brand">
+        <span class="san-nav__glyph" aria-hidden="true">S</span>
+        <span class="san-nav__name">Slate</span>
+      </a>
+
+      <ul class="san-nav__links">
+        <li class="san-nav__item">
+          <a href="#platform" class="san-nav__link">Platform</a>
+        </li>
+        <li class="san-nav__item">
+          <a href="#about" class="san-nav__link">About</a>
+        </li>
+        <li class="san-nav__item">
+          <a href="#careers" class="san-nav__link">Careers</a>
+        </li>
+        <li class="san-nav__item">
+          <a href="#blog" class="san-nav__link">Blog</a>
+        </li>
+      </ul>
+
+      <a href="#contact" class="san-nav__cta">Contact</a>
+
+    </div>
+  </nav>
+
+  <main class="san-content">
+    <section class="san-hero">
+      <h1 class="san-hero__title">Skew-Active Navbar</h1>
+      <p class="san-hero__sub">Hover any link above. The text skews forward while a background shape slides in from behind, creating a quick angular reveal.</p>
+      <div class="san-hero__pills">
+        <span class="san-pill">Pure CSS</span>
+        <span class="san-pill">Skew Transform</span>
+        <span class="san-pill">No JS</span>
+      </div>
+    </section>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/skew-active-navbar-minimalist-tech/style.css
+++ b/submissions/examples/skew-active-navbar-minimalist-tech/style.css
@@ -1,0 +1,259 @@
+:root {
+  --san-bg: #f3f3f6;
+  --san-surface: #ffffff;
+  --san-border: #e0e0e6;
+  --san-text: #191930;
+  --san-dim: #777789;
+  --san-violet: #8b5cf6;
+  --san-violet-soft: rgba(139, 92, 246, 0.08);
+  --san-violet-mid: rgba(139, 92, 246, 0.14);
+  --san-nav-h: 50px;
+  --san-radius: 6px;
+}
+
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  background: var(--san-bg);
+  font-family: "DM Sans", "Inter", "Helvetica Neue", Arial, sans-serif;
+  color: var(--san-text);
+  overflow-x: hidden;
+}
+
+/* ── nav ─────────────────────────────────────────── */
+
+.san-nav {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  width: 100%;
+  background: var(--san-surface);
+  border-bottom: 1px solid var(--san-border);
+}
+
+.san-nav__inner {
+  max-width: 1060px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: var(--san-nav-h);
+  padding: 0 20px;
+}
+
+/* ── brand ───────────────────────────────────────── */
+
+.san-nav__brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  text-decoration: none;
+  color: var(--san-text);
+}
+
+.san-nav__glyph {
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+  background: var(--san-violet);
+  color: #fff;
+  font-size: 0.68rem;
+  font-weight: 700;
+  display: grid;
+  place-items: center;
+  transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.san-nav__brand:hover .san-nav__glyph {
+  transform: skewX(-8deg) scale(1.12);
+}
+
+.san-nav__name {
+  font-size: 0.84rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+/* ── links ───────────────────────────────────────── */
+
+.san-nav__links {
+  display: flex;
+  gap: 2px;
+  list-style: none;
+}
+
+.san-nav__item {
+  position: relative;
+}
+
+.san-nav__link {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  height: var(--san-nav-h);
+  padding: 0 13px;
+  font-size: 0.72rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  color: var(--san-dim);
+  text-decoration: none;
+  overflow: hidden;
+  transition: color 0.2s ease;
+}
+
+/* ── skew background ─────────────────────────────── */
+
+.san-nav__link::before {
+  content: "";
+  position: absolute;
+  inset: 6px 4px;
+  border-radius: 4px;
+  background: var(--san-violet-mid);
+  transform: skewX(-12deg) translateX(-110%);
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+  z-index: 0;
+}
+
+.san-nav__item:hover .san-nav__link {
+  color: var(--san-violet);
+}
+
+.san-nav__item:hover .san-nav__link::before {
+  transform: skewX(-12deg) translateX(0);
+}
+
+/* ── text skew on hover ──────────────────────────── */
+
+.san-nav__link span {
+  position: relative;
+  z-index: 1;
+  display: inline-block;
+  transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.san-nav__item:hover .san-nav__link span {
+  transform: skewX(6deg);
+}
+
+/* ── focus ───────────────────────────────────────── */
+
+.san-nav__link:focus-visible {
+  outline: 2px solid var(--san-violet);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* ── CTA ─────────────────────────────────────────── */
+
+.san-nav__cta {
+  font-size: 0.68rem;
+  font-weight: 600;
+  padding: 7px 16px;
+  border-radius: var(--san-radius);
+  background: var(--san-violet);
+  color: #fff;
+  text-decoration: none;
+  letter-spacing: 0.02em;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.san-nav__cta:hover {
+  transform: skewX(-4deg);
+  box-shadow: 0 4px 14px rgba(139, 92, 246, 0.3);
+}
+
+.san-nav__cta:focus-visible {
+  outline: 2px solid var(--san-violet);
+  outline-offset: 2px;
+}
+
+/* ── page content ────────────────────────────────── */
+
+.san-content {
+  max-width: 1060px;
+  margin: 0 auto;
+  padding: 80px 20px;
+}
+
+.san-hero {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+}
+
+.san-hero__title {
+  font-size: clamp(1.4rem, 4vw, 2.2rem);
+  font-weight: 800;
+  letter-spacing: -0.04em;
+}
+
+.san-hero__sub {
+  font-size: 0.78rem;
+  color: var(--san-dim);
+  max-width: 44ch;
+  line-height: 1.7;
+}
+
+.san-hero__pills {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: 6px;
+}
+
+.san-pill {
+  font-size: 0.56rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  padding: 5px 12px;
+  border-radius: 20px;
+  background: var(--san-violet-soft);
+  color: var(--san-violet);
+}
+
+/* ── responsive ──────────────────────────────────── */
+
+@media (max-width: 640px) {
+  .san-nav__links {
+    display: none;
+  }
+
+  .san-nav__cta {
+    font-size: 0.64rem;
+    padding: 6px 14px;
+  }
+}
+
+/* ── accessibility ───────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .san-nav__link::before,
+  .san-nav__link span,
+  .san-nav__glyph,
+  .san-nav__cta {
+    transition: none;
+  }
+
+  .san-nav__item:hover .san-nav__link::before {
+    transform: skewX(-12deg) translateX(-110%);
+  }
+
+  .san-nav__item:hover .san-nav__link span {
+    transform: none;
+  }
+
+  .san-nav__cta:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
Closes #64501

Adds a CSS-only skew-active navbar component to the minimalist tech layout collection.

Changes:
- submissions/examples/skew-active-navbar-minimalist-tech/demo.html — sticky nav with brand, links, and CTA
- submissions/examples/skew-active-navbar-minimalist-tech/style.css — skew transform reveal on hover using ::before background and text counter-skew, CSS custom properties (prefix --san-*), prefers-reduced-motion support
- submissions/examples/skew-active-navbar-minimalist-tech/README.md — implementation notes

Implementation:
- ::before pseudo-element slides in from left with skewX(-12deg) using translateX(-110%) to translateX(0)
- Text span counter-skews to 6deg on hover for a layered angular effect
- Brand glyph skews and scales on hover
- CTA button skews -4deg with violet box-shadow
- Spring-eased cubic-bezier for snappy, bouncy transitions
- Responsive: nav links hide on mobile, CTA stays visible
- All interactive elements have focus-visible outlines