### PR TITLE
fix: add ARIA progressbar semantics to password strength meter (#60878)

### DIFF
--- a/submissions/examples/password-strength-aria-fix-60878/README.md
+++ b/submissions/examples/password-strength-aria-fix-60878/README.md
@@ -1,0 +1,81 @@
+# Fix: Password Strength Meter ARIA Semantics
+
+**Fixes:** [#60878](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/60878)
+
+---
+
+## 🐛 Bug Description
+
+The Password Strength component (`components/password-strength.css`, used
+via the `.ease-password-strength` / `.ease-password-strength-bar` markup)
+changes color and width dynamically as password strength changes, but the
+bar is a plain unlabeled `<div>` with no semantic role or exposed value.
+
+Screen reader users get no indication that:
+
+- The element is a progress/strength indicator at all
+- What the current strength level is
+- When the strength level changes as they type
+
+This fails WCAG 4.1.2 (Name, Role, Value) for a dynamic status indicator.
+
+---
+
+## ✅ Fix
+
+Add standard ARIA progressbar semantics to the bar element, and mark the
+adjacent strength label as a live region so assistive tech announces
+changes as they happen:
+
+```diff
+ <div class="ease-password-strength">
+   <div
+     class="ease-password-strength-bar is-weak"
++    role="progressbar"
++    aria-label="Password strength"
++    aria-valuemin="0"
++    aria-valuemax="100"
++    aria-valuenow="25"
++    aria-valuetext="Weak"
+   ></div>
+   <div class="ease-password-strength-label">
+     <span>Strength</span>
+-    <span>Weak</span>
++    <span aria-live="polite">Weak</span>
+   </div>
+ </div>
+```
+
+Whenever a strength level changes (weak → medium → strong), the
+implementation should update **both**:
+
+- `aria-valuenow` — a numeric value (this demo uses 25 / 60 / 100 to match
+  the existing `.is-weak` / `.is-medium` / `.is-strong` bar widths)
+- `aria-valuetext` — a human-readable value ("Weak" / "Medium" / "Strong"),
+  which screen readers announce in place of the raw number
+
+No visual styling changes are required — `components/password-strength.css`
+is untouched. This is purely additive markup, so it's fully backward
+compatible with any existing usage.
+
+---
+
+## 📁 Submission Contents
+
+| File        | Purpose                                                                 |
+| ----------- | ------------------------------------------------------------------------ |
+| `demo.html` | Side-by-side before/after comparison — type a password or use the preset buttons to see the fixed version update its ARIA values live |
+| `style.css` | Demo page layout styles only (no changes to the actual component)        |
+| `README.md` | This documentation file                                                  |
+
+## 🧪 How to Verify
+
+1. Open `demo.html` in a browser with a screen reader running (NVDA,
+   VoiceOver, etc.), or inspect the **Accessibility** tab in Chrome/Firefox
+   DevTools.
+2. Interact with the **"Before"** panel — the accessibility tree shows a
+   generic, unnamed `group`/`div` with no exposed value.
+3. Interact with the **"After"** panel — the accessibility tree shows a
+   `progressbar` named "Password strength" with a live numeric value and
+   text description, and the strength label announces changes via its
+   `aria-live="polite"` region.

--- a/submissions/examples/password-strength-aria-fix-60878/demo.html
+++ b/submissions/examples/password-strength-aria-fix-60878/demo.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fix #60878 — Password Strength Meter ARIA Semantics | EaseMotion CSS</title>
+  <link rel="stylesheet" href="../../../easemotion.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="container">
+    <header>
+      <div>
+        <h1>Fix #60878 — Password Strength Meter ARIA Semantics</h1>
+        <p>
+          Type in either field, or use the buttons below each panel to change
+          strength. Turn on a screen reader (or check the accessibility tree
+          in DevTools) to hear the difference.
+        </p>
+      </div>
+      <button class="toggle-btn" id="theme-toggle">🌙 Dark Mode</button>
+    </header>
+
+    <div class="panels">
+      <!-- ============================================================ -->
+      <!-- BEFORE: current markup, no semantic roles/values             -->
+      <!-- ============================================================ -->
+      <section class="panel">
+        <span class="badge bug">❌ Before (Bug)</span>
+        <p class="panel-note">
+          The bar is a plain, unlabeled <code>&lt;div&gt;</code>. Screen
+          readers announce nothing when strength changes.
+        </p>
+
+        <div class="demo-box">
+          <label for="pw-before" class="field-label">Password</label>
+          <input
+            id="pw-before"
+            class="pw-input"
+            type="password"
+            placeholder="Type a password…"
+            data-target="before"
+          />
+
+          <div class="ease-password-strength">
+            <div class="ease-password-strength-bar" id="bar-before"></div>
+            <div class="ease-password-strength-label">
+              <span>Strength</span>
+              <span id="text-before">Empty</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="demo-buttons" data-target="before">
+          <button type="button" data-level="weak">Weak</button>
+          <button type="button" data-level="medium">Medium</button>
+          <button type="button" data-level="strong">Strong</button>
+        </div>
+
+        <pre class="code-peek"><code>&lt;div class="ease-password-strength"&gt;
+  &lt;div class="ease-password-strength-bar is-weak"&gt;&lt;/div&gt;
+  &lt;div class="ease-password-strength-label"&gt;
+    &lt;span&gt;Strength&lt;/span&gt;
+    &lt;span&gt;Weak&lt;/span&gt;
+  &lt;/div&gt;
+&lt;/div&gt;</code></pre>
+      </section>
+
+      <!-- ============================================================ -->
+      <!-- AFTER: role="progressbar" + live ARIA values                 -->
+      <!-- ============================================================ -->
+      <section class="panel">
+        <span class="badge fix">✅ After (Fix)</span>
+        <p class="panel-note">
+          The bar exposes <code>role="progressbar"</code> with live
+          <code>aria-valuenow</code>/<code>aria-valuetext</code>, and the
+          label is an <code>aria-live</code> region.
+        </p>
+
+        <div class="demo-box">
+          <label for="pw-after" class="field-label">Password</label>
+          <input
+            id="pw-after"
+            class="pw-input"
+            type="password"
+            placeholder="Type a password…"
+            data-target="after"
+          />
+
+          <div class="ease-password-strength">
+            <div
+              class="ease-password-strength-bar"
+              id="bar-after"
+              role="progressbar"
+              aria-label="Password strength"
+              aria-valuemin="0"
+              aria-valuemax="100"
+              aria-valuenow="0"
+              aria-valuetext="Empty"
+            ></div>
+            <div class="ease-password-strength-label">
+              <span id="label-caption-after">Strength</span>
+              <span id="text-after" aria-live="polite">Empty</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="demo-buttons" data-target="after">
+          <button type="button" data-level="weak">Weak</button>
+          <button type="button" data-level="medium">Medium</button>
+          <button type="button" data-level="strong">Strong</button>
+        </div>
+
+        <pre class="code-peek"><code>&lt;div
+  class="ease-password-strength-bar is-weak"
+  role="progressbar"
+  aria-label="Password strength"
+  aria-valuemin="0"
+  aria-valuemax="100"
+  aria-valuenow="25"
+  aria-valuetext="Weak"
+&gt;&lt;/div&gt;
+&lt;div class="ease-password-strength-label"&gt;
+  &lt;span&gt;Strength&lt;/span&gt;
+  &lt;span aria-live="polite"&gt;Weak&lt;/span&gt;
+&lt;/div&gt;</code></pre>
+      </section>
+    </div>
+  </div>
+
+  <script>
+    // --------------------------------------------------------------------
+    // Demo wiring only. Illustrates how a real implementation would keep
+    // the ARIA values (aria-valuenow / aria-valuetext) in sync with the
+    // visual state whenever strength changes — whether from typing or
+    // (in this demo) the preset buttons.
+    // --------------------------------------------------------------------
+    const LEVELS = {
+      weak: { className: "is-weak", value: 25, label: "Weak" },
+      medium: { className: "is-medium", value: 60, label: "Medium" },
+      strong: { className: "is-strong", value: 100, label: "Strong" },
+    };
+
+    function applyLevel(target, levelKey) {
+      const bar = document.getElementById(`bar-${target}`);
+      const text = document.getElementById(`text-${target}`);
+      const level = LEVELS[levelKey];
+
+      bar.classList.remove("is-weak", "is-medium", "is-strong");
+
+      if (level) {
+        bar.classList.add(level.className);
+        text.textContent = level.label;
+
+        // Only the "after" bar carries these attributes, but setting them
+        // unconditionally is harmless for "before" (they're simply ignored
+        // since that markup has no role="progressbar").
+        bar.setAttribute("aria-valuenow", level.value);
+        bar.setAttribute("aria-valuetext", level.label);
+      } else {
+        text.textContent = "Empty";
+        bar.setAttribute("aria-valuenow", 0);
+        bar.setAttribute("aria-valuetext", "Empty");
+      }
+    }
+
+    // Preset buttons
+    document.querySelectorAll(".demo-buttons").forEach((group) => {
+      const target = group.dataset.target;
+      group.querySelectorAll("button").forEach((btn) => {
+        btn.addEventListener("click", () => applyLevel(target, btn.dataset.level));
+      });
+    });
+
+    // Simple live typing → strength mapping (length-based, for demo purposes)
+    function strengthFromPassword(pw) {
+      if (!pw) return null;
+      if (pw.length < 6) return "weak";
+      if (pw.length < 10) return "medium";
+      return "strong";
+    }
+
+    document.querySelectorAll(".pw-input").forEach((input) => {
+      input.addEventListener("input", () => {
+        applyLevel(input.dataset.target, strengthFromPassword(input.value));
+      });
+    });
+
+    // Dark mode toggle
+    const btn = document.getElementById("theme-toggle");
+    const html = document.documentElement;
+
+    btn.addEventListener("click", function () {
+      const isDark = html.getAttribute("data-theme") === "dark";
+      if (isDark) {
+        html.removeAttribute("data-theme");
+        btn.textContent = "🌙 Dark Mode";
+      } else {
+        html.setAttribute("data-theme", "dark");
+        btn.textContent = "☀️ Light Mode";
+      }
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/password-strength-aria-fix-60878/style.css
+++ b/submissions/examples/password-strength-aria-fix-60878/style.css
@@ -1,0 +1,181 @@
+/*
+ * EaseMotion CSS — Fix: Password Strength Meter ARIA Semantics
+ * Issue: https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/60878
+ */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: "Inter", system-ui, sans-serif;
+  min-height: 100vh;
+  background: var(--ease-color-bg, #f8fafc);
+  color: var(--ease-color-text, #1e293b);
+  padding: 2rem;
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+header h1 {
+  font-size: 1.35rem;
+  margin-bottom: 0.4rem;
+}
+
+header p {
+  font-size: 0.9rem;
+  color: var(--ease-color-muted, #64748b);
+  max-width: 46ch;
+}
+
+.toggle-btn {
+  padding: 0.5rem 1rem;
+  border-radius: 9999px;
+  border: 1.5px solid var(--ease-color-primary, #6c63ff);
+  background: transparent;
+  color: var(--ease-color-primary, #6c63ff);
+  font-weight: 600;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.panels {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+}
+
+.panel {
+  background: var(--ease-color-surface, #ffffff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: 1rem;
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+
+.badge {
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  width: fit-content;
+}
+
+.badge.bug {
+  background: #fee2e2;
+  color: #ef4444;
+}
+
+.badge.fix {
+  background: #dcfce7;
+  color: #22c55e;
+}
+
+.panel-note {
+  font-size: 0.82rem;
+  color: var(--ease-color-muted, #64748b);
+  line-height: 1.5;
+}
+
+.panel-note code {
+  background: var(--ease-color-neutral-100, #f1f5f9);
+  padding: 0.1rem 0.35rem;
+  border-radius: 4px;
+  font-size: 0.78rem;
+}
+
+.demo-box {
+  padding: 1.25rem;
+  background: var(--ease-color-bg, #f8fafc);
+  border-radius: 0.6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.field-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--ease-color-text, #1e293b);
+}
+
+.pw-input {
+  padding: 0.55rem 0.7rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  font-size: 0.9rem;
+  background: var(--ease-color-surface, #ffffff);
+  color: var(--ease-color-text, #1e293b);
+}
+
+.pw-input:focus-visible {
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 1px;
+}
+
+.demo-buttons {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.demo-buttons button {
+  padding: 0.4rem 0.85rem;
+  border-radius: 8px;
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  background: var(--ease-color-surface, #ffffff);
+  color: var(--ease-color-text, #1e293b);
+  font-size: 0.78rem;
+  cursor: pointer;
+  transition: transform 150ms ease, border-color 150ms ease;
+}
+
+.demo-buttons button:hover {
+  transform: translateY(-1px);
+  border-color: var(--ease-color-primary, #6c63ff);
+}
+
+.code-peek {
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 0.85rem 1rem;
+  border-radius: 0.6rem;
+  font-size: 0.72rem;
+  line-height: 1.55;
+  overflow-x: auto;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+}
+
+/* --------------------------------------------------------------------------
+   Responsive
+   -------------------------------------------------------------------------- */
+@media (max-width: 760px) {
+  .panels {
+    grid-template-columns: 1fr;
+  }
+
+  body {
+    padding: 1.25rem;
+  }
+}


### PR DESCRIPTION
Closes #60878
## Pull Request Description

Fixes #60878 — the Password Strength component (`components/password-strength.css`) lacks ARIA semantics, so screen readers can't announce the current strength or detect when it changes. This adds `role="progressbar"` with live `aria-valuenow`/`aria-valuetext`, plus an `aria-live` region on the label, without touching the component's actual CSS.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/password-strength-aria-fix-60878/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Standard ARIA progressbar semantics (`role`, `aria-valuemin/max/now`, `aria-valuetext`) plus an `aria-live` region, so the existing `.ease-password-strength-bar` is announced correctly by screen readers.

**How does a developer use it?**

```html
<div class="ease-password-strength">
  <div
    class="ease-password-strength-bar is-weak"
    role="progressbar"
    aria-label="Password strength"
    aria-valuemin="0"
    aria-valuemax="100"
    aria-valuenow="25"
    aria-valuetext="Weak"
  ></div>
  <div class="ease-password-strength-label">
    <span>Strength</span>
    <span aria-live="polite">Weak</span>
  </div>
</div>
```

Whenever the strength level updates, `aria-valuenow` and `aria-valuetext` should be updated alongside the existing `is-weak`/`is-medium`/`is-strong` class swap.

**Why does it fit EaseMotion CSS?**

This is a purely additive, backward-compatible markup fix for an existing shipped component — no visual or CSS changes, no new dependencies. It closes a real WCAG 4.1.2 gap (Name, Role, Value) while keeping the component's existing human-readable class names untouched.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

`demo.html` links to the real `../../../easemotion.css` so the "Before" panel shows the actual unfixed component, not a mock-up. `aria-valuenow` values (25/60/100) are chosen to match the existing `.is-weak`/`.is-medium`/`.is-strong` bar widths in `components/password-strength.css` — happy to adjust if you'd prefer different thresholds. Since `components/` can't be edited directly per the current PR restrictions, this submission demonstrates the fix as a drop-in markup pattern for maintainers to apply upstream.