### PR TITLE
fix: add missing closing html tag in rotate-click-tabs demo (#60599)

### DIFF
--- a/submissions/examples/rotate-click-tabs-checkout-bhakkti/demo.html
+++ b/submissions/examples/rotate-click-tabs-checkout-bhakkti/demo.html
@@ -176,3 +176,4 @@
     </div>
   </div>
 </body>
+</html>


### PR DESCRIPTION
## Pull Request Description

Closes #60599 
`submissions/examples/rotate-click-tabs-checkout-bhakkti/demo.html` was missing its closing `</html>` tag, causing incomplete/invalid HTML. One-line fix, no other changes.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/rotate-click-tabs-checkout-bhakkti/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature *(unchanged, already present in the folder)*
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS *(unchanged, already present in the folder)*
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

No new feature — this fixes malformed HTML in an existing submission by adding the missing closing `</html>` tag.

**How does a developer use it?**

```html
<!-- No usage change. demo.html structure and classes are unaffected —
     only the missing closing tag was added at the end of the file. -->
```

**Why does it fit EaseMotion CSS?**

Valid, well-formed HTML is a baseline requirement for any demo in the library; this restores that without touching any styling, markup structure, or class names.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Minimal one-line diff — only adds `</html>` after the existing `</body>`. No visual, functional, or structural changes.