### PR TITLE
fix: sync ease-typewriter-loop steps with text length (closes #60102)

### DIFF
--- a/submissions/docs/ease-typewriter-fix-ak/README.md
+++ b/submissions/docs/ease-typewriter-fix-ak/README.md
@@ -1,0 +1,23 @@
+# ease-typewriter-loop fix (steps auto-sync)
+
+### What does this do?
+Fixes `.ease-typewriter-loop` so the `steps()` count in the reveal animation always matches the actual text length, instead of staying hardcoded at 12 — closes #60102.
+
+### How is it used?
+```html
+<span class="ease-typewriter-loop">
+  This is a much longer typewriter sentence
+</span>
+
+<script>
+  document.querySelectorAll('.ease-typewriter-loop').forEach(el => {
+    const len = el.textContent.trim().length;
+    el.style.setProperty('--ease-typewriter-length', len + 'ch');
+    el.style.setProperty('--ease-typewriter-steps', len);
+  });
+</script>
+```
+No other markup changes needed — just include the small script once per page (or per instance) after the DOM loads.
+
+### Why is it useful?
+Pure CSS has no way to measure a string's length, so any fixed `--ease-typewriter-length` override without a matching step count causes multiple characters to reveal per animation frame, making the effect look glitchy/stuttery instead of a clean one-character-at-a-time typewriter reveal. This fix keeps the component usable with text of any length while staying true to EaseMotion's "just add a class, it works" philosophy. Also includes a `prefers-reduced-motion` fallback that shows the full text immediately with no animation.

--- a/submissions/docs/ease-typewriter-fix-ak/demo.html
+++ b/submissions/docs/ease-typewriter-fix-ak/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-typewriter-loop fix demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <h2>Default length</h2>
+  <span class="ease-typewriter-loop" style="--ease-typewriter-length:12ch;">
+    Hello World!
+  </span>
+
+  <h2>Custom (longer) length</h2>
+  <span class="ease-typewriter-loop" style="--ease-typewriter-length:32ch;">
+    This is a much longer typewriter sentence
+  </span>
+
+  <script>
+    document.querySelectorAll('.ease-typewriter-loop').forEach(el => {
+      const len = el.textContent.trim().length;
+      el.style.setProperty('--ease-typewriter-length', len + 'ch');
+      el.style.setProperty('--ease-typewriter-steps', len);
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/docs/ease-typewriter-fix-ak/style.css
+++ b/submissions/docs/ease-typewriter-fix-ak/style.css
@@ -1,0 +1,28 @@
+.ease-typewriter-loop {
+  display: inline-block;
+  overflow: hidden;
+  white-space: nowrap;
+  border-right: 2px solid currentColor;
+  width: 0;
+  font-family: monospace;
+  animation:
+    ease-typewriter-reveal var(--ease-typewriter-duration, 3s) steps(var(--ease-typewriter-steps, 12)) forwards,
+    ease-typewriter-caret 0.75s step-end infinite;
+}
+
+@keyframes ease-typewriter-reveal {
+  from { width: 0; }
+  to { width: var(--ease-typewriter-length, 12ch); }
+}
+
+@keyframes ease-typewriter-caret {
+  50% { border-color: transparent; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-typewriter-loop {
+    animation: none;
+    width: var(--ease-typewriter-length, 12ch);
+    border-right-color: transparent;
+  }
+}


### PR DESCRIPTION
Closes #60102
## Pull Request Description
Fixes `.ease-typewriter-loop` so the CSS `steps()` count in the reveal animation stays in sync with the actual text length, instead of being hardcoded at 12. Closes #60102.

## Type of Change
- [x] 🐛 Bug fix in an existing submission

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/docs/ease-typewriter-fix-ak/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

## Feature Description
**What does this add?**
Auto-syncs `--ease-typewriter-steps` to the rendered text's character count so the typewriter reveal never stutters/skips when the length is customized.

**How does a developer use it?**
```html
<span class="ease-typewriter-loop">
  This is a much longer typewriter sentence
</span>

<script>
  document.querySelectorAll('.ease-typewriter-loop').forEach(el => {
    const len = el.textContent.trim().length;
    el.style.setProperty('--ease-typewriter-length', len + 'ch');
    el.style.setProperty('--ease-typewriter-steps', len);
  });
</script>
```

**Why does it fit EaseMotion CSS?**
Keeps the "just add a class, it works" philosophy intact for text of any length, without requiring developers to manually calculate step counts. Also adds a `prefers-reduced-motion` fallback.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer
Pure CSS can't measure string length, so this fix uses a tiny inline script in the demo to set `--ease-typewriter-steps`/`--ease-typewriter-length` dynamically. Happy to adjust the approach if you'd prefer a different pattern (e.g. a data attribute + CSS `counter()` trick) during integration into `core/`.