### PR TITLE
feat: add rotate-click-tabs demo

### DIFF
--- a/submissions/examples/rotate-click-tabs-ak/README.md
+++ b/submissions/examples/rotate-click-tabs-ak/README.md
@@ -1,0 +1,19 @@
+# rotate-click-tabs
+
+### What does this do?
+A tab switcher where the active tab button gets a small playful rotate + scale effect on click, instead of a plain color change.
+
+### How is it used?
+```html
+<div class="tabs-rotate">
+  <button class="tabs-rotate__btn is-active" data-tab="1">Tab One</button>
+  <button class="tabs-rotate__btn" data-tab="2">Tab Two</button>
+</div>
+
+<div class="tabs-rotate__panel is-active" data-panel="1">Content one</div>
+<div class="tabs-rotate__panel" data-panel="2">Content two</div>
+```
+Add `is-active` to the button and matching panel you want shown by default. Clicking a button toggles `is-active` on itself and its matching panel via `data-tab` / `data-panel`.
+
+### Why is it useful?
+Standard tabs just swap color/underline on click — this adds a bit of tactile motion (rotate + scale) that makes clicking feel more responsive, fitting EaseMotion's animation-first philosophy. Includes a `prefers-reduced-motion` fallback that disables all transforms/transitions.

--- a/submissions/examples/rotate-click-tabs-ak/demo.html
+++ b/submissions/examples/rotate-click-tabs-ak/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>rotate-click-tabs demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="tabs-rotate">
+    <button class="tabs-rotate__btn is-active" data-tab="1">Tab One</button>
+    <button class="tabs-rotate__btn" data-tab="2">Tab Two</button>
+    <button class="tabs-rotate__btn" data-tab="3">Tab Three</button>
+  </div>
+
+  <div class="tabs-rotate__panel is-active" data-panel="1">Content for tab one.</div>
+  <div class="tabs-rotate__panel" data-panel="2">Content for tab two.</div>
+  <div class="tabs-rotate__panel" data-panel="3">Content for tab three.</div>
+
+  <script>
+    document.querySelectorAll('.tabs-rotate__btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.tabs-rotate__btn').forEach(b => b.classList.remove('is-active'));
+        document.querySelectorAll('.tabs-rotate__panel').forEach(p => p.classList.remove('is-active'));
+
+        btn.classList.add('is-active');
+        document.querySelector(`[data-panel="${btn.dataset.tab}"]`).classList.add('is-active');
+      });
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/rotate-click-tabs-ak/style.css
+++ b/submissions/examples/rotate-click-tabs-ak/style.css
@@ -1,0 +1,54 @@
+.tabs-rotate {
+  display: flex;
+  gap: 0.5rem;
+  border-bottom: 2px solid #e2e2e2;
+  font-family: system-ui, sans-serif;
+}
+
+.tabs-rotate__btn {
+  padding: 0.6rem 1.2rem;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-size: 0.95rem;
+  color: #555;
+  transform-origin: center bottom;
+  transition: transform 0.3s ease, color 0.3s ease;
+}
+
+.tabs-rotate__btn:hover {
+  color: #222;
+}
+
+.tabs-rotate__btn.is-active {
+  color: #2563eb;
+  transform: rotate(-3deg) scale(1.05);
+}
+
+.tabs-rotate__btn:active {
+  transform: rotate(3deg) scale(0.97);
+}
+
+.tabs-rotate__panel {
+  display: none;
+  padding: 1rem 0;
+  animation: tabs-rotate-fade 0.3s ease;
+}
+
+.tabs-rotate__panel.is-active {
+  display: block;
+}
+
+@keyframes tabs-rotate-fade {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tabs-rotate__btn,
+  .tabs-rotate__panel {
+    animation: none;
+    transition: none;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
Closes https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/60599
## Pull Request Description
Adds a new tab-switcher component where the active tab button gets a small rotate + scale animation on click, instead of a plain color/underline change.

## Type of Change
- [x] 🧩 New component

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/rotate-click-tabs-ak/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

## Feature Description
**What does this add?**
A click-based tab switcher with a playful rotate + scale animation on the active tab button.

**How does a developer use it?**
```html
<div class="tabs-rotate">
  <button class="tabs-rotate__btn is-active" data-tab="1">Tab One</button>
  <button class="tabs-rotate__btn" data-tab="2">Tab Two</button>
</div>

<div class="tabs-rotate__panel is-active" data-panel="1">Content one</div>
<div class="tabs-rotate__panel" data-panel="2">Content two</div>
```

**Why does it fit EaseMotion CSS?**
Adds tactile motion feedback to a common UI pattern (tabs) rather than a static color swap, in line with EaseMotion's animation-first, class-based philosophy. Includes a `prefers-reduced-motion` fallback.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer
New folder, no existing files touched. Open to adjusting rotation degree/timing during standardization.