### PR TITLE
feat: add CSS blur-entrance navbar for minimalist tech layouts

### DIFF
--- a/submissions/examples/blur-entrance-navbar-minimalist-tech/README.md
+++ b/submissions/examples/blur-entrance-navbar-minimalist-tech/README.md
@@ -1,0 +1,19 @@
+# Blur-Entrance Navbar — Minimalist Tech Layouts
+
+A sticky navigation bar where each link starts slightly blurred and out of focus, then snaps sharply into view on hover with a smooth deblur transition.
+
+## How It Works
+
+Each nav link has `filter: blur(1.2px)` and `opacity: 0.7` in its resting state. On hover, both transition to `blur(0px)` and `opacity: 1`, creating the illusion of the text coming into focus. A small underline accent scales in from the left as a secondary cue.
+
+The CTA button also starts with a slight blur and becomes crisp on hover, with a subtle lift and sky-blue box-shadow. The brand mark intentionally blurs on hover instead, adding a playful contrast.
+
+## Customization
+
+Override `--ben-sky` to change the accent color. Tweak the initial `blur()` value on `.ben-nav__link` for more or less resting blur. The underline delay is set to `0.06s` for a staggered feel.
+
+## Accessibility
+
+- `prefers-reduced-motion` removes all blur transitions and restores full opacity
+- Focus-visible outlines on all interactive elements
+- Semantic `<nav>` with `aria-label`

--- a/submissions/examples/blur-entrance-navbar-minimalist-tech/demo.html
+++ b/submissions/examples/blur-entrance-navbar-minimalist-tech/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS blur-entrance navbar for minimalist tech layouts. Pure CSS blur-to-focus hover animation on navigation links.">
+  <title>Blur-Entrance Navbar — Minimalist Tech Layouts</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <nav class="ben-nav" aria-label="Main navigation">
+    <div class="ben-nav__inner">
+
+      <a href="#" class="ben-nav__brand">
+        <span class="ben-nav__mark" aria-hidden="true"></span>
+        <span class="ben-nav__name">Clarity</span>
+      </a>
+
+      <ul class="ben-nav__links">
+        <li class="ben-nav__item">
+          <a href="#features" class="ben-nav__link">Features</a>
+        </li>
+        <li class="ben-nav__item">
+          <a href="#workflow" class="ben-nav__link">Workflow</a>
+        </li>
+        <li class="ben-nav__item">
+          <a href="#pricing" class="ben-nav__link">Pricing</a>
+        </li>
+        <li class="ben-nav__item">
+          <a href="#changelog" class="ben-nav__link">Changelog</a>
+        </li>
+      </ul>
+
+      <a href="#start" class="ben-nav__cta">Get Started</a>
+
+    </div>
+  </nav>
+
+  <main class="ben-content">
+    <section class="ben-hero">
+      <h1 class="ben-hero__title">Blur-Entrance Navbar</h1>
+      <p class="ben-hero__sub">Hover any link above. It starts blurred and out of focus, then snaps sharply into view with a smooth deblur transition.</p>
+      <div class="ben-hero__badges">
+        <span class="ben-badge">Pure CSS</span>
+        <span class="ben-badge">Filter Blur</span>
+        <span class="ben-badge">No JS</span>
+      </div>
+    </section>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/blur-entrance-navbar-minimalist-tech/style.css
+++ b/submissions/examples/blur-entrance-navbar-minimalist-tech/style.css
@@ -1,0 +1,256 @@
+:root {
+  --ben-bg: #f2f2f5;
+  --ben-surface: #ffffff;
+  --ben-border: #e2e2e8;
+  --ben-text: #1b1b2a;
+  --ben-dim: #78788c;
+  --ben-sky: #0ea5e9;
+  --ben-sky-soft: rgba(14, 165, 233, 0.08);
+  --ben-nav-h: 52px;
+  --ben-radius: 6px;
+}
+
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  background: var(--ben-bg);
+  font-family: "DM Sans", "Inter", "Helvetica Neue", Arial, sans-serif;
+  color: var(--ben-text);
+  overflow-x: hidden;
+}
+
+/* ── nav ─────────────────────────────────────────── */
+
+.ben-nav {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  width: 100%;
+  background: var(--ben-surface);
+  border-bottom: 1px solid var(--ben-border);
+}
+
+.ben-nav__inner {
+  max-width: 1080px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: var(--ben-nav-h);
+  padding: 0 22px;
+}
+
+/* ── brand ───────────────────────────────────────── */
+
+.ben-nav__brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  text-decoration: none;
+  color: var(--ben-text);
+}
+
+.ben-nav__mark {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--ben-sky);
+  display: block;
+  filter: blur(0px);
+  transition: filter 0.3s ease, transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.ben-nav__brand:hover .ben-nav__mark {
+  filter: blur(3px);
+  transform: scale(1.1);
+}
+
+.ben-nav__name {
+  font-size: 0.86rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+/* ── links ───────────────────────────────────────── */
+
+.ben-nav__links {
+  display: flex;
+  gap: 2px;
+  list-style: none;
+}
+
+.ben-nav__item {
+  position: relative;
+}
+
+.ben-nav__link {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  height: var(--ben-nav-h);
+  padding: 0 13px;
+  font-size: 0.73rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  color: var(--ben-dim);
+  text-decoration: none;
+  filter: blur(1.2px);
+  opacity: 0.7;
+  transition: filter 0.35s ease, opacity 0.25s ease, color 0.2s ease;
+}
+
+/* ── underline accent ────────────────────────────── */
+
+.ben-nav__link::after {
+  content: "";
+  position: absolute;
+  bottom: 12px;
+  left: 13px;
+  right: 13px;
+  height: 2px;
+  background: var(--ben-sky);
+  border-radius: 1px;
+  transform: scaleX(0);
+  transform-origin: left center;
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1), opacity 0.2s ease;
+  opacity: 0;
+}
+
+.ben-nav__item:hover .ben-nav__link {
+  color: var(--ben-text);
+  filter: blur(0px);
+  opacity: 1;
+}
+
+.ben-nav__item:hover .ben-nav__link::after {
+  transform: scaleX(1);
+  opacity: 1;
+  transition-delay: 0.06s;
+}
+
+/* ── focus ───────────────────────────────────────── */
+
+.ben-nav__link:focus-visible {
+  outline: 2px solid var(--ben-sky);
+  outline-offset: 2px;
+  border-radius: 4px;
+  filter: blur(0px);
+  opacity: 1;
+}
+
+/* ── CTA ─────────────────────────────────────────── */
+
+.ben-nav__cta {
+  font-size: 0.68rem;
+  font-weight: 600;
+  padding: 7px 16px;
+  border-radius: var(--ben-radius);
+  background: var(--ben-sky);
+  color: #fff;
+  text-decoration: none;
+  letter-spacing: 0.02em;
+  filter: blur(0.8px);
+  opacity: 0.85;
+  transition: filter 0.3s ease, opacity 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ben-nav__cta:hover {
+  filter: blur(0px);
+  opacity: 1;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 14px rgba(14, 165, 233, 0.3);
+}
+
+.ben-nav__cta:focus-visible {
+  outline: 2px solid var(--ben-sky);
+  outline-offset: 2px;
+}
+
+/* ── page content ────────────────────────────────── */
+
+.ben-content {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 80px 22px;
+}
+
+.ben-hero {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+}
+
+.ben-hero__title {
+  font-size: clamp(1.4rem, 4vw, 2.2rem);
+  font-weight: 800;
+  letter-spacing: -0.04em;
+}
+
+.ben-hero__sub {
+  font-size: 0.78rem;
+  color: var(--ben-dim);
+  max-width: 44ch;
+  line-height: 1.7;
+}
+
+.ben-hero__badges {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: 6px;
+}
+
+.ben-badge {
+  font-size: 0.56rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  padding: 5px 12px;
+  border-radius: 20px;
+  background: var(--ben-sky-soft);
+  color: var(--ben-sky);
+}
+
+/* ── responsive ──────────────────────────────────── */
+
+@media (max-width: 660px) {
+  .ben-nav__links {
+    display: none;
+  }
+
+  .ben-nav__cta {
+    font-size: 0.64rem;
+    padding: 6px 14px;
+  }
+}
+
+/* ── accessibility ───────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .ben-nav__link,
+  .ben-nav__link::after,
+  .ben-nav__mark,
+  .ben-nav__cta {
+    transition: none;
+  }
+
+  .ben-nav__link {
+    filter: none;
+    opacity: 1;
+  }
+
+  .ben-nav__cta {
+    filter: none;
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
Closes #64508

Adds a CSS-only blur-entrance navbar component to the minimalist tech layout collection.

Changes:
- submissions/examples/blur-entrance-navbar-minimalist-tech/demo.html — sticky nav with brand, blurred links, and CTA
- submissions/examples/blur-entrance-navbar-minimalist-tech/style.css — blur-to-focus hover effect using CSS filter, underline reveal, CSS custom properties (prefix --ben-*), prefers-reduced-motion support
- submissions/examples/blur-entrance-navbar-minimalist-tech/README.md — implementation notes

Implementation:
- Links start at filter: blur(1.2px) with reduced opacity, then deblur to blur(0px) on hover
- Underline accent scales in from left with spring easing after a 0.06s delay
- Brand mark intentionally blurs on hover for a playful contrast
- CTA deblurs with lift and sky-blue box-shadow
- Responsive: nav links hide on mobile, CTA stays visible
- All interactive elements have focus-visible outlines