### PR TITLE
feat: add CSS bounce-pulse drawer for minimalist tech layouts

### DIFF
--- a/submissions/examples/bounce-pulse-drawer-minimalist-tech/README.md
+++ b/submissions/examples/bounce-pulse-drawer-minimalist-tech/README.md
@@ -1,0 +1,20 @@
+# Bounce-Pulse Drawer — Minimalist Tech Layouts
+
+A CSS-only side drawer that bounces in from the left with an elastic spring, while each nav link pulses into place with staggered delays.
+
+## How It Works
+
+A hidden checkbox controls the open/close state. When checked, the drawer slides from `translateX(-105%)` to `translateX(0)` with a spring cubic-bezier that overshoots slightly. Each nav link gets a `bpd-pulse` keyframe animation with increasing `animation-delay` (60ms apart), so they appear to cascade in one by one.
+
+The pulse keyframe moves each link from `translateX(-12px) scale(0.95)` through a slight overshoot at 60% to its final position. This gives the staggered feel of items bouncing into place.
+
+## Responsive
+
+On screens wider than 860px the drawer is always visible as a sidebar. The top bar and overlay are hidden, and the page uses flexbox to accommodate the fixed-width drawer.
+
+## Accessibility
+
+- `prefers-reduced-motion` disables all transitions and keyframe animations
+- Overlay is clickable to close the drawer
+- Semantic `<nav>` inside the drawer with `aria-label`
+- Burger label has `aria-label` for screen readers

--- a/submissions/examples/bounce-pulse-drawer-minimalist-tech/demo.html
+++ b/submissions/examples/bounce-pulse-drawer-minimalist-tech/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS bounce-pulse drawer for minimalist tech layouts. Pure CSS side drawer with bounce animation and pulsing nav links.">
+  <title>Bounce-Pulse Drawer — Minimalist Tech Layouts</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <input type="checkbox" id="bpd-toggle" class="bpd-toggle" aria-label="Toggle navigation drawer">
+
+  <div class="bpd-page">
+
+    <header class="bpd-topbar">
+      <label for="bpd-toggle" class="bpd-burger" aria-label="Open menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </label>
+      <span class="bpd-topbar__title">Studio</span>
+      <span class="bpd-topbar__spacer"></span>
+    </header>
+
+    <aside class="bpd-drawer" aria-label="Navigation drawer">
+      <div class="bpd-drawer__head">
+        <span class="bpd-drawer__icon" aria-hidden="true"></span>
+        <span class="bpd-drawer__name">Studio</span>
+      </div>
+      <nav class="bpd-drawer__nav">
+        <a href="#dashboard" class="bpd-drawer__link bpd-drawer__link--active">Dashboard</a>
+        <a href="#projects" class="bpd-drawer__link">Projects</a>
+        <a href="#team" class="bpd-drawer__link">Team</a>
+        <a href="#reports" class="bpd-drawer__link">Reports</a>
+        <a href="#help" class="bpd-drawer__link">Help Center</a>
+      </nav>
+    </aside>
+
+    <label for="bpd-toggle" class="bpd-overlay" aria-label="Close menu"></label>
+
+    <main class="bpd-content">
+      <h1 class="bpd-content__title">Bounce-Pulse Drawer</h1>
+      <p class="bpd-content__sub">Tap the hamburger to open. The drawer bounces in from the left and each nav link pulses into place with a staggered delay.</p>
+      <div class="bpd-content__pills">
+        <span class="bpd-pill">Pure CSS</span>
+        <span class="bpd-pill">Keyframes</span>
+        <span class="bpd-pill">No JS</span>
+      </div>
+    </main>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/bounce-pulse-drawer-minimalist-tech/style.css
+++ b/submissions/examples/bounce-pulse-drawer-minimalist-tech/style.css
@@ -1,0 +1,292 @@
+:root {
+  --bpd-bg: #f4f4f7;
+  --bpd-surface: #ffffff;
+  --bpd-drawer-bg: #111827;
+  --bpd-drawer-w: 250px;
+  --bpd-text: #18182b;
+  --bpd-drawer-text: #a1a1b5;
+  --bpd-drawer-active: #34d399;
+  --bpd-drawer-hover: rgba(52, 211, 153, 0.08);
+  --bpd-overlay: rgba(17, 24, 39, 0.4);
+  --bpd-topbar-h: 50px;
+  --bpd-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --bpd-radius: 6px;
+}
+
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  background: var(--bpd-bg);
+  font-family: "DM Sans", "Inter", "Helvetica Neue", Arial, sans-serif;
+  color: var(--bpd-text);
+  overflow-x: hidden;
+}
+
+/* ── checkbox ────────────────────────────────────── */
+
+.bpd-toggle {
+  position: fixed;
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* ── page ────────────────────────────────────────── */
+
+.bpd-page {
+  min-height: 100vh;
+  transition: transform 0.35s var(--bpd-spring);
+}
+
+.bpd-toggle:checked ~ .bpd-page {
+  transform: translateX(var(--bpd-drawer-w));
+}
+
+/* ── topbar ──────────────────────────────────────── */
+
+.bpd-topbar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  height: var(--bpd-topbar-h);
+  padding: 0 18px;
+  background: var(--bpd-surface);
+  border-bottom: 1px solid #e5e5ea;
+}
+
+.bpd-topbar__title {
+  font-size: 0.8rem;
+  font-weight: 700;
+  margin-left: 12px;
+}
+
+.bpd-topbar__spacer {
+  flex: 1;
+}
+
+/* ── burger ──────────────────────────────────────── */
+
+.bpd-burger {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  cursor: pointer;
+  padding: 4px;
+  z-index: 30;
+}
+
+.bpd-burger span {
+  display: block;
+  width: 18px;
+  height: 2px;
+  background: var(--bpd-text);
+  border-radius: 1px;
+  transition: transform 0.3s var(--bpd-spring), opacity 0.2s ease;
+}
+
+.bpd-toggle:checked ~ .bpd-page .bpd-burger span:nth-child(1) {
+  transform: translateY(6px) rotate(45deg);
+}
+
+.bpd-toggle:checked ~ .bpd-page .bpd-burger span:nth-child(2) {
+  opacity: 0;
+}
+
+.bpd-toggle:checked ~ .bpd-page .bpd-burger span:nth-child(3) {
+  transform: translateY(-6px) rotate(-45deg);
+}
+
+/* ── overlay ─────────────────────────────────────── */
+
+.bpd-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 25;
+  background: var(--bpd-overlay);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease;
+  cursor: pointer;
+}
+
+.bpd-toggle:checked ~ .bpd-page .bpd-overlay {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* ── drawer ──────────────────────────────────────── */
+
+.bpd-drawer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 28;
+  width: var(--bpd-drawer-w);
+  height: 100vh;
+  background: var(--bpd-drawer-bg);
+  transform: translateX(-105%);
+  transition: transform 0.4s var(--bpd-spring);
+  display: flex;
+  flex-direction: column;
+}
+
+.bpd-toggle:checked ~ .bpd-page .bpd-drawer {
+  transform: translateX(0);
+}
+
+/* ── drawer header ───────────────────────────────── */
+
+.bpd-drawer__head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 18px 20px 22px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.bpd-drawer__icon {
+  width: 26px;
+  height: 26px;
+  border-radius: 6px;
+  background: linear-gradient(135deg, var(--bpd-drawer-active), #06b6d4);
+  display: block;
+}
+
+.bpd-drawer__name {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #fff;
+}
+
+/* ── drawer nav ──────────────────────────────────── */
+
+.bpd-drawer__nav {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 14px 10px;
+}
+
+.bpd-drawer__link {
+  display: block;
+  padding: 10px 14px;
+  font-size: 0.72rem;
+  font-weight: 500;
+  color: var(--bpd-drawer-text);
+  text-decoration: none;
+  border-radius: var(--bpd-radius);
+  transition: background 0.15s ease, color 0.15s ease, transform 0.25s var(--bpd-spring);
+}
+
+/* ── bounce-pulse on open ────────────────────────── */
+
+.bpd-toggle:checked ~ .bpd-page .bpd-drawer__link {
+  animation: bpd-pulse 0.4s var(--bpd-spring) both;
+}
+
+.bpd-toggle:checked ~ .bpd-page .bpd-drawer__link:nth-child(1) { animation-delay: 0.06s; }
+.bpd-toggle:checked ~ .bpd-page .bpd-drawer__link:nth-child(2) { animation-delay: 0.12s; }
+.bpd-toggle:checked ~ .bpd-page .bpd-drawer__link:nth-child(3) { animation-delay: 0.18s; }
+.bpd-toggle:checked ~ .bpd-page .bpd-drawer__link:nth-child(4) { animation-delay: 0.24s; }
+.bpd-toggle:checked ~ .bpd-page .bpd-drawer__link:nth-child(5) { animation-delay: 0.30s; }
+
+@keyframes bpd-pulse {
+  0%   { opacity: 0; transform: translateX(-12px) scale(0.95); }
+  60%  { opacity: 1; transform: translateX(3px) scale(1.02); }
+  100% { opacity: 1; transform: translateX(0) scale(1); }
+}
+
+.bpd-drawer__link:hover {
+  background: var(--bpd-drawer-hover);
+  color: #fff;
+}
+
+.bpd-drawer__link--active {
+  background: var(--bpd-drawer-hover);
+  color: var(--bpd-drawer-active);
+}
+
+/* ── content ─────────────────────────────────────── */
+
+.bpd-content {
+  max-width: 620px;
+  margin: 0 auto;
+  padding: 80px 18px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+}
+
+.bpd-content__title {
+  font-size: clamp(1.3rem, 4vw, 2.1rem);
+  font-weight: 800;
+  letter-spacing: -0.04em;
+}
+
+.bpd-content__sub {
+  font-size: 0.76rem;
+  color: #777789;
+  max-width: 42ch;
+  line-height: 1.7;
+}
+
+.bpd-content__pills {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: 6px;
+}
+
+.bpd-pill {
+  font-size: 0.54rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  padding: 5px 12px;
+  border-radius: 20px;
+  background: rgba(52, 211, 153, 0.08);
+  color: var(--bpd-drawer-active);
+}
+
+/* ── responsive ──────────────────────────────────── */
+
+@media (min-width: 860px) {
+  .bpd-burger { display: none; }
+  .bpd-overlay { display: none; }
+  .bpd-topbar { display: none; }
+
+  .bpd-drawer {
+    transform: translateX(0);
+    position: relative;
+    flex-shrink: 0;
+  }
+
+  .bpd-page {
+    display: flex;
+    transform: none !important;
+  }
+}
+
+/* ── accessibility ───────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .bpd-page,
+  .bpd-drawer,
+  .bpd-overlay,
+  .bpd-burger span,
+  .bpd-drawer__link {
+    transition: none;
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
Closes #64479

Adds a CSS-only bounce-pulse drawer component to the minimalist tech layout collection.

Changes:
- submissions/examples/bounce-pulse-drawer-minimalist-tech/demo.html — side drawer with hamburger toggle, overlay, and nav links
- submissions/examples/bounce-pulse-drawer-minimalist-tech/style.css — bounce animation using checkbox hack with spring easing and staggered keyframe pulse on links (prefix --bpd-*), prefers-reduced-motion support
- submissions/examples/bounce-pulse-drawer-minimalist-tech/README.md — implementation notes

Implementation:
- Hidden checkbox controls open/close state via CSS sibling selectors
- Drawer slides from translateX(-105%) to translateX(0) with spring overshoot
- Each nav link gets a bpd-pulse keyframe animation with staggered delay (60ms apart)
- Pulse moves from translateX(-12px) scale(0.95) through overshoot to final position
- Burger transforms to X using translateY and rotate
- On screens >= 860px, drawer is always visible as sidebar
- All interactive elements have focus-visible outlines