### PR TITLE
Add shimmer sweep pricing table example

### DIFF
--- a/submissions/examples/shimmer-sweep-pricings-table/README.md
+++ b/submissions/examples/shimmer-sweep-pricings-table/README.md
@@ -1,0 +1,44 @@
+# Shimmer-Sweep Pricing Table
+
+## What does this do?
+A 3-tier pricing table where the featured plan is a dark card with a "Recommended" ribbon that shimmers on a slow ambient loop, plus a light sweep across the whole card surface while it's hovered or keyboard-focused.
+
+## How is it used?
+Add the `ease-pricing-shimmer-vt` class to the plan card you want to feature, and include the ribbon and shine elements as its first two children:
+
+```html
+<article class="ease-pricing-shimmer-vt pricing-card pricing-card--featured">
+  <span class="ease-pricing-shimmer-vt__ribbon">Recommended</span>
+  <span class="ease-pricing-shimmer-vt__shine" aria-hidden="true"></span>
+
+  <h2 class="pricing-card__name">Pro</h2>
+  <p class="pricing-card__price">
+    <span class="pricing-card__amount">$24</span>
+    <span class="pricing-card__period">/ month</span>
+  </p>
+  <!-- description, feature list, CTA -->
+</article>
+```
+
+Regular (non-featured) cards only need the shared `pricing-card` classes — see `demo.html` for the full 3-card layout.
+
+## CSS custom properties
+
+| Property | Default | Controls |
+|---|---|---|
+| `--shimmer-band-color` | `rgba(255,255,255,0.45)` | Color/opacity of the light band |
+| `--shimmer-hover-duration` | `650ms` | Length of the hover sweep across the card |
+| `--shimmer-hover-easing` | `ease-out` | Easing for the hover sweep |
+| `--shimmer-loop-duration` | `3600ms` | Length of one ambient ribbon sweep + pause cycle |
+| `--pt-accent` | `#4A55E0` | CTA and shimmer tint color |
+| `--pt-ink` | `#14161C` | Featured card background |
+
+## Features
+- **Two shimmer layers, two techniques** — the ribbon uses an infinite `@keyframes` loop (sweep, then pause, repeat); the full-card shine uses a `transition` on `transform` that's driven purely by `:hover` / `:focus-within`, so it plays once and settles back the moment focus leaves.
+- **Performant** — both shimmer bands are pseudo-elements animated only on `transform` and `opacity`; nothing triggers layout or repaint.
+- **Keyboard accessible** — the card-wide sweep also responds to `:focus-within`, so tabbing to the CTA inside the featured card triggers the same effect as hovering it.
+- **Fully responsive** — the grid uses `auto-fit`/`minmax`, so it reflows from 3 columns down to 1 with no manual breakpoints beyond a mobile safety rule that also removes the featured card's `scale(1.035)` lift.
+- **`prefers-reduced-motion` support** — both shimmer animations are disabled; the ribbon and card remain fully visible with no motion.
+
+## Why it's useful
+Pricing tables are one of the highest-attention areas of a marketing site, and a restrained shimmer is a common way premium products draw the eye to a recommended plan without shouting. Keeping it to two small, independently-tunable pseudo-elements — rather than animating the whole page — fits EaseMotion's philosophy of small, token-driven motion that a site can restyle or disable by overriding a couple of custom properties.

--- a/submissions/examples/shimmer-sweep-pricings-table/demo.html
+++ b/submissions/examples/shimmer-sweep-pricings-table/demo.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Shimmer-Sweep Pricing Table — EaseMotion Tech Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="pricing-page">
+    <header class="pricing-page__header">
+      <p class="pricing-page__eyebrow">Plans</p>
+      <h1 class="pricing-page__title">Simple, usage-based pricing</h1>
+      <p class="pricing-page__sub">Switch or cancel anytime. No hidden fees.</p>
+    </header>
+
+    <section class="pricing-table" aria-label="Pricing plans">
+
+      <article class="pricing-card">
+        <h2 class="pricing-card__name">Starter</h2>
+        <p class="pricing-card__price">
+          <span class="pricing-card__amount">$0</span>
+          <span class="pricing-card__period">/ month</span>
+        </p>
+        <p class="pricing-card__desc">For trying things out and small side projects.</p>
+        <ul class="pricing-card__features">
+          <li>1 project</li>
+          <li>Community support</li>
+          <li>1 GB storage</li>
+        </ul>
+        <a class="pricing-card__cta pricing-card__cta--ghost" href="#">Start free</a>
+      </article>
+
+      <article class="ease-pricing-shimmer-vt pricing-card pricing-card--featured">
+        <span class="ease-pricing-shimmer-vt__ribbon">Recommended</span>
+        <span class="ease-pricing-shimmer-vt__shine" aria-hidden="true"></span>
+
+        <h2 class="pricing-card__name">Pro</h2>
+        <p class="pricing-card__price">
+          <span class="pricing-card__amount">$24</span>
+          <span class="pricing-card__period">/ month</span>
+        </p>
+        <p class="pricing-card__desc">For freelancers and small teams shipping weekly.</p>
+        <ul class="pricing-card__features">
+          <li>Unlimited projects</li>
+          <li>Priority support</li>
+          <li>50 GB storage</li>
+          <li>Custom domains</li>
+        </ul>
+        <a class="pricing-card__cta pricing-card__cta--solid" href="#">Start free trial</a>
+      </article>
+
+      <article class="pricing-card">
+        <h2 class="pricing-card__name">Team</h2>
+        <p class="pricing-card__price">
+          <span class="pricing-card__amount">$64</span>
+          <span class="pricing-card__period">/ month</span>
+        </p>
+        <p class="pricing-card__desc">For growing teams that need shared workspaces.</p>
+        <ul class="pricing-card__features">
+          <li>Everything in Pro</li>
+          <li>Unlimited seats</li>
+          <li>500 GB storage</li>
+          <li>SSO &amp; audit logs</li>
+        </ul>
+        <a class="pricing-card__cta pricing-card__cta--ghost" href="#">Talk to sales</a>
+      </article>
+
+    </section>
+
+    <footer class="pricing-page__footer">
+      <p>Part of the <strong>EaseMotion CSS</strong> examples track — pure CSS, no dependencies.</p>
+    </footer>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/shimmer-sweep-pricings-table/style.css
+++ b/submissions/examples/shimmer-sweep-pricings-table/style.css
@@ -1,0 +1,351 @@
+/* =========================================================================
+   Shimmer-Sweep Pricing Table — pure CSS, no dependencies
+   Design: minimalist tech pricing grid. The featured plan is a dark card
+   with a shimmer that sweeps its "Recommended" ribbon on an ambient loop,
+   and sweeps the whole card surface once while it's hovered/focused.
+   ========================================================================= */
+
+:root {
+  /* -- palette: light page, one dark "featured" card ------------------- */
+  --pt-bg:      #FAFAFB;  /* page background                          */
+  --pt-surface: #FFFFFF;  /* regular card background                  */
+  --pt-line:    #E4E4EA;  /* hairline border on regular cards          */
+  --pt-text:      #14161C;
+  --pt-text-dim:  #6B6E78;
+
+  --pt-ink:            #14161C; /* featured card background           */
+  --pt-text-on-dark:     #F4F4F6;
+  --pt-text-on-dark-dim: #9A9DAA;
+
+  --pt-accent:      #4A55E0; /* solid CTA + shimmer tint               */
+  --pt-accent-soft:  rgba(74, 85, 224, 0.12);
+
+  /* -- shimmer motion tokens (tune these to restyle the effect) -------- */
+  --shimmer-band-color: rgba(255, 255, 255, 0.45);
+  --shimmer-hover-duration: 650ms;
+  --shimmer-hover-easing: ease-out;
+  --shimmer-loop-duration: 3600ms;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--pt-bg);
+  color: var(--pt-text);
+  font-family: system-ui, -apple-system, 'Segoe UI', sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* -------------------------------------------------------------------
+   Page header
+   ------------------------------------------------------------------- */
+
+.pricing-page {
+  max-width: 1040px;
+  margin: 0 auto;
+  padding: clamp(2rem, 6vw, 4.5rem) 1.5rem;
+}
+
+.pricing-page__header {
+  text-align: center;
+  margin-bottom: clamp(2rem, 5vw, 3.5rem);
+}
+
+.pricing-page__eyebrow {
+  margin: 0 0 0.6rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--pt-accent);
+}
+
+.pricing-page__title {
+  margin: 0;
+  font-size: clamp(1.7rem, 4vw, 2.4rem);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.pricing-page__sub {
+  margin: 0.7rem 0 0;
+  color: var(--pt-text-dim);
+  font-size: 1rem;
+}
+
+/* -------------------------------------------------------------------
+   Grid — auto-fit keeps this responsive without extra breakpoints
+   ------------------------------------------------------------------- */
+
+.pricing-table {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+  align-items: start;
+}
+
+@media (max-width: 640px) {
+  .pricing-table {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* -------------------------------------------------------------------
+   Card
+   ------------------------------------------------------------------- */
+
+.pricing-card {
+  display: flex;
+  flex-direction: column;
+  background: var(--pt-surface);
+  border: 1px solid var(--pt-line);
+  border-radius: 14px;
+  padding: 1.75rem 1.5rem 2rem;
+}
+
+.pricing-card__name {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.pricing-card__price {
+  margin: 0 0 0.85rem;
+  display: flex;
+  align-items: baseline;
+  gap: 0.35rem;
+}
+
+.pricing-card__amount {
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: 2.1rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.pricing-card__period {
+  font-size: 0.85rem;
+  color: var(--pt-text-dim);
+}
+
+.pricing-card__desc {
+  margin: 0 0 1.25rem;
+  font-size: 0.9rem;
+  color: var(--pt-text-dim);
+  line-height: 1.5;
+}
+
+.pricing-card__features {
+  list-style: none;
+  margin: 0 0 1.5rem;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  font-size: 0.9rem;
+}
+
+.pricing-card__features li {
+  padding-left: 1.3rem;
+  position: relative;
+}
+
+.pricing-card__features li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.5em;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--pt-accent-soft);
+  border: 1px solid var(--pt-accent);
+}
+
+.pricing-card__cta {
+  margin-top: auto;
+  display: block;
+  text-align: center;
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 600;
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  transition: background-color 200ms ease, border-color 200ms ease, color 200ms ease;
+}
+
+.pricing-card__cta--ghost {
+  color: var(--pt-text);
+  border: 1px solid var(--pt-line);
+  background: transparent;
+}
+
+.pricing-card__cta--ghost:hover,
+.pricing-card__cta--ghost:focus-visible {
+  border-color: var(--pt-accent);
+  color: var(--pt-accent);
+}
+
+.pricing-card__cta--solid {
+  color: var(--pt-text-on-dark);
+  background: var(--pt-accent);
+  border: 1px solid var(--pt-accent);
+}
+
+.pricing-card__cta--solid:hover,
+.pricing-card__cta--solid:focus-visible {
+  background: #5B65EA;
+  border-color: #5B65EA;
+}
+
+.pricing-card__cta:focus-visible {
+  outline: 2px solid var(--pt-accent);
+  outline-offset: 2px;
+}
+
+/* -------------------------------------------------------------------
+   Featured card
+   ------------------------------------------------------------------- */
+
+.pricing-card--featured {
+  position: relative;
+  overflow: hidden; /* clips the shimmer band to the card's edges */
+  background: var(--pt-ink);
+  border-color: var(--pt-ink);
+  color: var(--pt-text-on-dark);
+  transform: scale(1.035);
+}
+
+@media (max-width: 640px) {
+  .pricing-card--featured {
+    transform: none; /* keep flush with the stack on small screens */
+  }
+}
+
+.pricing-card--featured .pricing-card__name,
+.pricing-card--featured .pricing-card__amount {
+  color: var(--pt-text-on-dark);
+}
+
+.pricing-card--featured .pricing-card__period,
+.pricing-card--featured .pricing-card__desc {
+  color: var(--pt-text-on-dark-dim);
+}
+
+.pricing-card--featured .pricing-card__features li::before {
+  background: rgba(74, 85, 224, 0.35);
+}
+
+.pricing-card--featured .pricing-card__cta--solid {
+  background: var(--pt-accent);
+  border-color: var(--pt-accent);
+}
+
+/* -------------------------------------------------------------------
+   Ribbon — ambient shimmer sweeps across it on a slow, paused loop
+   ------------------------------------------------------------------- */
+
+.ease-pricing-shimmer-vt__ribbon {
+  position: relative;
+  overflow: hidden;
+  align-self: flex-start;
+  margin-bottom: 1.1rem;
+  padding: 0.3rem 0.7rem;
+  border-radius: 999px;
+  background: var(--pt-accent-soft);
+  color: #B9BEFF;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-pricing-shimmer-vt__ribbon::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -60%;
+  width: 45%;
+  height: 100%;
+  background: linear-gradient(100deg, transparent, var(--shimmer-band-color), transparent);
+  transform: translateX(-10%);
+  animation: ribbonShimmerSweep var(--shimmer-loop-duration) ease-in-out infinite;
+}
+
+@keyframes ribbonShimmerSweep {
+  0%   { transform: translateX(-10%); opacity: 0; }
+  8%   { opacity: 1; }
+  35%  { transform: translateX(320%); opacity: 0; }
+  100% { transform: translateX(320%); opacity: 0; }
+}
+
+/* -------------------------------------------------------------------
+   Card-wide shine — sweeps once while the featured card is
+   hovered/focused, driven by a transition (not a keyframe loop) so it
+   settles back to rest the moment the pointer leaves
+   ------------------------------------------------------------------- */
+
+.ease-pricing-shimmer-vt__shine {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.ease-pricing-shimmer-vt__shine::before {
+  content: "";
+  position: absolute;
+  top: -20%;
+  left: -60%;
+  width: 40%;
+  height: 140%;
+  background: linear-gradient(100deg, transparent, var(--shimmer-band-color), transparent);
+  transform: skewX(-18deg) translateX(0%);
+  transition: transform var(--shimmer-hover-duration) var(--shimmer-hover-easing);
+}
+
+.ease-pricing-shimmer-vt:hover .ease-pricing-shimmer-vt__shine::before,
+.ease-pricing-shimmer-vt:focus-within .ease-pricing-shimmer-vt__shine::before {
+  transform: skewX(-18deg) translateX(420%);
+}
+
+/* -------------------------------------------------------------------
+   Footer
+   ------------------------------------------------------------------- */
+
+.pricing-page__footer {
+  margin-top: 3rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--pt-line);
+  text-align: center;
+  font-size: 0.82rem;
+  color: var(--pt-text-dim);
+}
+
+.pricing-page__footer strong {
+  color: var(--pt-text);
+}
+
+/* -------------------------------------------------------------------
+   Reduced motion — stop the ambient loop and the hover sweep, keep
+   the ribbon and card fully visible with no motion
+   ------------------------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-pricing-shimmer-vt__ribbon::after {
+    animation: none;
+    opacity: 0;
+  }
+
+  .ease-pricing-shimmer-vt__shine::before {
+    transition: none;
+  }
+
+  .ease-pricing-shimmer-vt:hover .ease-pricing-shimmer-vt__shine::before,
+  .ease-pricing-shimmer-vt:focus-within .ease-pricing-shimmer-vt__shine::before {
+    transform: skewX(-18deg) translateX(0%);
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure-CSS **Shimmer-Sweep Pricing Table** for minimalist tech layouts — a 3-tier pricing grid where the featured plan is a dark card with a "Recommended" ribbon that shimmers on an ambient loop, plus a light sweep across the whole card while it's hovered or focused, addressing the request for a shimmer-sweep pricing component.

---
## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---
## Submission Checklist
> ⚠️ PRs that fail this checklist will be **closed without review**.
- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---
## Feature Description
**What does this add?**
A pricing table whose featured plan shimmers — an ambient sweep on its "Recommended" ribbon, and a one-time light sweep across the card on hover/focus.

**How does a developer use it?**
```html
<article class="ease-pricing-shimmer-vt pricing-card pricing-card--featured">
  <span class="ease-pricing-shimmer-vt__ribbon">Recommended</span>
  <span class="ease-pricing-shimmer-vt__shine" aria-hidden="true"></span>

  <h2 class="pricing-card__name">Pro</h2>
  <p class="pricing-card__price">
    <span class="pricing-card__amount">$24</span>
    <span class="pricing-card__period">/ month</span>
  </p>
  <!-- description, feature list, CTA -->
</article>
```

**Why does it fit EaseMotion CSS?**
Both shimmer layers are small, independently-tunable pseudo-elements animated only on `transform` and `opacity` — no layout thrashing, no JavaScript. The ribbon uses an infinite `@keyframes` loop and the card-wide shine uses a `transition` driven by `:hover`/`:focus-within`, showing two different but equally simple motion techniques in one component, in line with EaseMotion's token-driven, human-readable philosophy.

---
## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---
## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---
## Notes for Maintainer
The card-wide shine is intentionally transition-based rather than a looping keyframe, so it sweeps once and settles back the moment the pointer/focus leaves rather than repeating — happy to tune `--shimmer-hover-duration` or the ribbon's `--shimmer-loop-duration` if the pacing feels off. The featured card also gets a `scale(1.035)` lift on desktop, which is removed under the mobile breakpoint.

---
> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
>
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!