### PR TITLE
feat: add CSS fade-in drawer for minimalist tech layouts

### DIFF
--- a/submissions/examples/fade-in-drawer-minimalist-tech/README.md
+++ b/submissions/examples/fade-in-drawer-minimalist-tech/README.md
@@ -1,0 +1,20 @@
+# Fade-In Drawer — Minimalist Tech Layouts
+
+A CSS-only side drawer that fades in while sliding from the left. Each nav link appears with a staggered delay for a smooth cascading entrance.
+
+## How It Works
+
+A hidden checkbox controls the open/close state. When checked, the drawer transitions from `translateX(-100%) opacity: 0` to `translateX(0) opacity: 1`. Each nav link starts at `opacity: 0 translateX(-8px)` and transitions to full opacity and position with increasing `transition-delay` values (60ms, 100ms, 140ms, 180ms, 220ms).
+
+This staggered approach means links don't use keyframes — they rely on the transition delay being removed when the checkbox is unchecked, creating a reverse cascade on close.
+
+## Responsive
+
+On screens wider than 840px the drawer is always visible as a sidebar with all links at full opacity. The top bar and overlay are hidden.
+
+## Accessibility
+
+- `prefers-reduced-motion` disables all transitions
+- Overlay is clickable to close the drawer
+- Semantic `<nav>` inside the drawer with `aria-label`
+- Burger label has `aria-label` for screen readers

--- a/submissions/examples/fade-in-drawer-minimalist-tech/demo.html
+++ b/submissions/examples/fade-in-drawer-minimalist-tech/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS fade-in drawer for minimalist tech layouts. Pure CSS side drawer with smooth opacity and slide transition.">
+  <title>Fade-In Drawer — Minimalist Tech Layouts</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <input type="checkbox" id="fid-toggle" class="fid-toggle" aria-label="Toggle navigation drawer">
+
+  <div class="fid-page">
+
+    <header class="fid-topbar">
+      <label for="fid-toggle" class="fid-burger" aria-label="Open menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </label>
+      <span class="fid-topbar__title">Panel</span>
+      <span class="fid-topbar__spacer"></span>
+    </header>
+
+    <aside class="fid-drawer" aria-label="Navigation drawer">
+      <div class="fid-drawer__head">
+        <span class="fid-drawer__mark" aria-hidden="true"></span>
+        <span class="fid-drawer__name">Panel</span>
+      </div>
+      <nav class="fid-drawer__nav">
+        <a href="#home" class="fid-drawer__link fid-drawer__link--active">Home</a>
+        <a href="#inbox" class="fid-drawer__link">Inbox</a>
+        <a href="#calendar" class="fid-drawer__link">Calendar</a>
+        <a href="#files" class="fid-drawer__link">Files</a>
+        <a href="#trash" class="fid-drawer__link">Trash</a>
+      </nav>
+    </aside>
+
+    <label for="fid-toggle" class="fid-overlay" aria-label="Close menu"></label>
+
+    <main class="fid-content">
+      <h1 class="fid-content__title">Fade-In Drawer</h1>
+      <p class="fid-content__sub">Tap the hamburger to open. The drawer fades in while sliding from the left, and each nav link appears with a staggered fade.</p>
+      <div class="fid-content__pills">
+        <span class="fid-pill">Pure CSS</span>
+        <span class="fid-pill">Fade + Slide</span>
+        <span class="fid-pill">No JS</span>
+      </div>
+    </main>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/fade-in-drawer-minimalist-tech/style.css
+++ b/submissions/examples/fade-in-drawer-minimalist-tech/style.css
@@ -1,0 +1,296 @@
+:root {
+  --fid-bg: #f5f5f8;
+  --fid-surface: #ffffff;
+  --fid-drawer-bg: #0f172a;
+  --fid-drawer-w: 240px;
+  --fid-text: #1a1a2e;
+  --fid-drawer-text: #94a3b8;
+  --fid-drawer-active: #f59e0b;
+  --fid-drawer-hover: rgba(245, 158, 11, 0.07);
+  --fid-overlay: rgba(15, 23, 42, 0.45);
+  --fid-topbar-h: 50px;
+  --fid-radius: 5px;
+}
+
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  background: var(--fid-bg);
+  font-family: "DM Sans", "Inter", "Helvetica Neue", Arial, sans-serif;
+  color: var(--fid-text);
+  overflow-x: hidden;
+}
+
+/* ── checkbox ────────────────────────────────────── */
+
+.fid-toggle {
+  position: fixed;
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* ── page ────────────────────────────────────────── */
+
+.fid-page {
+  min-height: 100vh;
+  transition: transform 0.32s ease;
+}
+
+.fid-toggle:checked ~ .fid-page {
+  transform: translateX(var(--fid-drawer-w));
+}
+
+/* ── topbar ──────────────────────────────────────── */
+
+.fid-topbar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  height: var(--fid-topbar-h);
+  padding: 0 18px;
+  background: var(--fid-surface);
+  border-bottom: 1px solid #e5e5ea;
+}
+
+.fid-topbar__title {
+  font-size: 0.8rem;
+  font-weight: 700;
+  margin-left: 12px;
+}
+
+.fid-topbar__spacer {
+  flex: 1;
+}
+
+/* ── burger ──────────────────────────────────────── */
+
+.fid-burger {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  cursor: pointer;
+  padding: 4px;
+  z-index: 30;
+}
+
+.fid-burger span {
+  display: block;
+  width: 18px;
+  height: 2px;
+  background: var(--fid-text);
+  border-radius: 1px;
+  transition: transform 0.28s ease, opacity 0.2s ease;
+}
+
+.fid-toggle:checked ~ .fid-page .fid-burger span:nth-child(1) {
+  transform: translateY(6px) rotate(45deg);
+}
+
+.fid-toggle:checked ~ .fid-page .fid-burger span:nth-child(2) {
+  opacity: 0;
+}
+
+.fid-toggle:checked ~ .fid-page .fid-burger span:nth-child(3) {
+  transform: translateY(-6px) rotate(-45deg);
+}
+
+/* ── overlay ─────────────────────────────────────── */
+
+.fid-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 25;
+  background: var(--fid-overlay);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.28s ease;
+  cursor: pointer;
+}
+
+.fid-toggle:checked ~ .fid-page .fid-overlay {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* ── drawer ──────────────────────────────────────── */
+
+.fid-drawer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 28;
+  width: var(--fid-drawer-w);
+  height: 100vh;
+  background: var(--fid-drawer-bg);
+  transform: translateX(-100%);
+  opacity: 0;
+  transition: transform 0.32s ease, opacity 0.28s ease;
+  display: flex;
+  flex-direction: column;
+}
+
+.fid-toggle:checked ~ .fid-page .fid-drawer {
+  transform: translateX(0);
+  opacity: 1;
+}
+
+/* ── drawer header ───────────────────────────────── */
+
+.fid-drawer__head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 18px 20px 22px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.fid-drawer__mark {
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+  background: var(--fid-drawer-active);
+  display: block;
+}
+
+.fid-drawer__name {
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: #fff;
+}
+
+/* ── drawer nav ──────────────────────────────────── */
+
+.fid-drawer__nav {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 14px 10px;
+}
+
+.fid-drawer__link {
+  display: block;
+  padding: 10px 14px;
+  font-size: 0.72rem;
+  font-weight: 500;
+  color: var(--fid-drawer-text);
+  text-decoration: none;
+  border-radius: var(--fid-radius);
+  opacity: 0;
+  transform: translateX(-8px);
+  transition: background 0.15s ease, color 0.15s ease, opacity 0.25s ease, transform 0.25s ease;
+}
+
+/* ── staggered fade-in ───────────────────────────── */
+
+.fid-toggle:checked ~ .fid-page .fid-drawer__link {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.fid-toggle:checked ~ .fid-page .fid-drawer__link:nth-child(1) { transition-delay: 0.06s; }
+.fid-toggle:checked ~ .fid-page .fid-drawer__link:nth-child(2) { transition-delay: 0.10s; }
+.fid-toggle:checked ~ .fid-page .fid-drawer__link:nth-child(3) { transition-delay: 0.14s; }
+.fid-toggle:checked ~ .fid-page .fid-drawer__link:nth-child(4) { transition-delay: 0.18s; }
+.fid-toggle:checked ~ .fid-page .fid-drawer__link:nth-child(5) { transition-delay: 0.22s; }
+
+.fid-drawer__link:hover {
+  background: var(--fid-drawer-hover);
+  color: #fff;
+}
+
+.fid-drawer__link--active {
+  background: var(--fid-drawer-hover);
+  color: var(--fid-drawer-active);
+}
+
+/* ── content ─────────────────────────────────────── */
+
+.fid-content {
+  max-width: 620px;
+  margin: 0 auto;
+  padding: 80px 18px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+}
+
+.fid-content__title {
+  font-size: clamp(1.3rem, 4vw, 2.1rem);
+  font-weight: 800;
+  letter-spacing: -0.04em;
+}
+
+.fid-content__sub {
+  font-size: 0.76rem;
+  color: #777789;
+  max-width: 42ch;
+  line-height: 1.7;
+}
+
+.fid-content__pills {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: 6px;
+}
+
+.fid-pill {
+  font-size: 0.54rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  padding: 5px 12px;
+  border-radius: 20px;
+  background: rgba(245, 158, 11, 0.08);
+  color: var(--fid-drawer-active);
+}
+
+/* ── responsive ──────────────────────────────────── */
+
+@media (min-width: 840px) {
+  .fid-burger { display: none; }
+  .fid-overlay { display: none; }
+  .fid-topbar { display: none; }
+
+  .fid-drawer {
+    transform: translateX(0);
+    opacity: 1;
+    position: relative;
+    flex-shrink: 0;
+  }
+
+  .fid-drawer__link {
+    opacity: 1;
+    transform: none;
+    transition-delay: 0s;
+  }
+
+  .fid-page {
+    display: flex;
+    transform: none !important;
+  }
+}
+
+/* ── accessibility ───────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .fid-page,
+  .fid-drawer,
+  .fid-overlay,
+  .fid-burger span,
+  .fid-drawer__link {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Closes #64472

Adds a CSS-only fade-in drawer component to the minimalist tech layout collection.

Changes:
- submissions/examples/fade-in-drawer-minimalist-tech/demo.html — side drawer with hamburger toggle, overlay, and nav links
- submissions/examples/fade-in-drawer-minimalist-tech/style.css — fade and slide animation using checkbox hack with staggered transition-delay on links (prefix --fid-*), prefers-reduced-motion support
- submissions/examples/fade-in-drawer-minimalist-tech/README.md — implementation notes

Implementation:
- Hidden checkbox controls open/close state via CSS sibling selectors
- Drawer transitions from translateX(-100%) opacity:0 to translateX(0) opacity:1
- Each nav link starts at opacity:0 translateX(-8px) and transitions with staggered delays (60ms apart)
- Staggered fade creates cascading entrance without keyframes
- Burger transforms to X using translateY and rotate
- On screens >= 840px, drawer is always visible as sidebar
- All interactive elements have focus-visible outlines