### PR TITLE
Add ease-cinema-ticket-stub component

### DIFF
--- a/submissions/examples/cinema-ticket-stub-ij/README.md
+++ b/submissions/examples/cinema-ticket-stub-ij/README.md
@@ -1,0 +1,10 @@
+# ease-cinema-ticket-stub
+
+A cinema stub where the ticket barcode blinks, the perforation edge bobs, and the seat tag blinks.
+
+## Run
+Open `demo.html` directly in a browser to watch the stub blink.
+
+## Notes
+- The ticket barcode blinks in place.
+- The seat tag blinks on the ticket.

--- a/submissions/examples/cinema-ticket-stub-ij/demo.html
+++ b/submissions/examples/cinema-ticket-stub-ij/demo.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-cinema-ticket-stub demo</title>
+</head>
+<body>
+<div class="cts-app">
+  <span class="cts-title">CINEMA</span>
+  <div class="cts-ticket">
+    <span class="cts-movie">MIDNIGHT RUN</span>
+    <span class="cts-time">21:40</span>
+    <span class="cts-seat">ROW C</span>
+    <div class="cts-perf"></div>
+    <div class="cts-barcode"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/cinema-ticket-stub-ij/style.css
+++ b/submissions/examples/cinema-ticket-stub-ij/style.css
@@ -1,0 +1,13 @@
+:root{--cts-red:#e85a4a;--cts-dark:#241418}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#241418,#0f090a);font-family:'Copperplate Gothic',sans-serif}
+.cts-app{position:relative;width:376px;height:420px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#38201e,#1a0e0c);box-shadow:0 16px 36px rgba(0,0,0,0.6)}
+.cts-title{position:absolute;top:14px;left:0;right:0;text-align:center;font-size:11px;font-weight:700;letter-spacing:7px;color:#e85a4a}
+.cts-ticket{position:absolute;top:76px;left:50%;margin-left:-142px;width:284px;height:160px;border-radius:12px;background:#f2e6d0;box-shadow:inset 0 0 0 3px #d8c49a}
+.cts-movie{position:absolute;top:20px;left:22px;font-size:12px;font-weight:700;letter-spacing:2px;color:#241418}
+.cts-time{position:absolute;top:20px;right:22px;font-size:12px;font-weight:700;color:#241418}
+.cts-seat{position:absolute;top:54px;left:22px;font-size:10px;letter-spacing:3px;color:#8a6a4a;animation:seat-blink-cinema-ticket-stub 1.8s steps(1) infinite}
+.cts-perf{position:absolute;top:94px;left:0;right:0;height:2px;background:repeating-linear-gradient(90deg,#241418 0 8px,#f2e6d0 8px 16px);animation:stub-tear-cinema-ticket-stub 1.4s ease-in-out infinite}
+.cts-barcode{position:absolute;bottom:18px;right:22px;width:90px;height:30px;background:repeating-linear-gradient(90deg,#241418 0 4px,#f2e6d0 4px 10px);animation:barcode-scan-cinema-ticket-stub 2s steps(1) infinite}
+@keyframes barcode-scan-cinema-ticket-stub{0%,49%{opacity:1}50%,100%{opacity:0.4}}
+@keyframes stub-tear-cinema-ticket-stub{0%,100%{transform:translateY(0)}50%{transform:translateY(3px)}}
+@keyframes seat-blink-cinema-ticket-stub{0%,49%{opacity:1}50%,100%{opacity:0.3}}


### PR DESCRIPTION
## Component: ease-cinema-ticket-stub — barcode blinks, stub bobs, and seat blinks

**Closes #66649**

### What this adds
A cinema stub: the ticket barcode blinks, the perforation edge bobs, and the seat tag blinks.

### Acceptance Criteria covered
- Ticket barcode blinks in place
- Perforation edge bobs along the stub
- Seat tag blinks on the ticket

### Files
- `submissions/examples/cinema-ticket-stub-ij/demo.html`
- `submissions/examples/cinema-ticket-stub-ij/style.css`
- `submissions/examples/cinema-ticket-stub-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the stub blink.