### PR TITLE
feat: add CSS shimmer-sweep drawer for minimalist tech layouts

### DIFF
--- a/submissions/examples/shimmer-sweep-drawer-minimalist-tech/README.md
+++ b/submissions/examples/shimmer-sweep-drawer-minimalist-tech/README.md
@@ -1,0 +1,20 @@
+# Shimmer-Sweep Drawer — Minimalist Tech Layouts
+
+A CSS-only side drawer with a shimmer highlight that sweeps across the background when the drawer opens, while nav links fade in with staggered delays.
+
+## How It Works
+
+A hidden checkbox controls the open/close state. When checked, the drawer slides in with a spring cubic-bezier. A `::before` pseudo-element on the drawer — a skewed gradient band — runs a `ssd-shimmer` keyframe animation that moves from `-80%` to `130%` across the drawer width. The shimmer starts 100ms after the drawer opens for a natural sequence.
+
+Each nav link starts at `opacity: 0 translateX(-8px)` and transitions to its resting state with staggered `transition-delay` values (120ms, 160ms, 200ms, 240ms, 280ms). This creates a cascading entrance that follows the shimmer sweep.
+
+## Responsive
+
+On screens wider than 840px the drawer is always visible as a sidebar. The shimmer animation is disabled and all links are immediately visible.
+
+## Accessibility
+
+- `prefers-reduced-motion` disables all transitions and the shimmer animation
+- Overlay is clickable to close the drawer
+- Semantic `<nav>` inside the drawer with `aria-label`
+- Burger label has `aria-label` for screen readers

--- a/submissions/examples/shimmer-sweep-drawer-minimalist-tech/demo.html
+++ b/submissions/examples/shimmer-sweep-drawer-minimalist-tech/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS shimmer-sweep drawer for minimalist tech layouts. Pure CSS side drawer with a shimmer highlight sweeping across on open.">
+  <title>Shimmer-Sweep Drawer — Minimalist Tech Layouts</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <input type="checkbox" id="ssd-toggle" class="ssd-toggle" aria-label="Toggle navigation drawer">
+
+  <div class="ssd-page">
+
+    <header class="ssd-topbar">
+      <label for="ssd-toggle" class="ssd-burger" aria-label="Open menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </label>
+      <span class="ssd-topbar__title">Dashboard</span>
+      <span class="ssd-topbar__spacer"></span>
+    </header>
+
+    <aside class="ssd-drawer" aria-label="Navigation drawer">
+      <div class="ssd-drawer__head">
+        <span class="ssd-drawer__logo" aria-hidden="true"></span>
+        <span class="ssd-drawer__name">Atlas</span>
+      </div>
+      <nav class="ssd-drawer__nav">
+        <a href="#overview" class="ssd-drawer__link ssd-drawer__link--active">Overview</a>
+        <a href="#analytics" class="ssd-drawer__link">Analytics</a>
+        <a href="#invoices" class="ssd-drawer__link">Invoices</a>
+        <a href="#team" class="ssd-drawer__link">Team</a>
+        <a href="#settings" class="ssd-drawer__link">Settings</a>
+      </nav>
+    </aside>
+
+    <label for="ssd-toggle" class="ssd-overlay" aria-label="Close menu"></label>
+
+    <main class="ssd-content">
+      <h1 class="ssd-content__title">Shimmer-Sweep Drawer</h1>
+      <p class="ssd-content__sub">Tap the hamburger to open. A shimmer highlight sweeps across the drawer background while nav links fade in with a staggered delay.</p>
+      <div class="ssd-content__pills">
+        <span class="ssd-pill">Pure CSS</span>
+        <span class="ssd-pill">Keyframes</span>
+        <span class="ssd-pill">No JS</span>
+      </div>
+    </main>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/shimmer-sweep-drawer-minimalist-tech/style.css
+++ b/submissions/examples/shimmer-sweep-drawer-minimalist-tech/style.css
@@ -1,0 +1,335 @@
+:root {
+  --ssd-bg: #f4f4f7;
+  --ssd-surface: #ffffff;
+  --ssd-drawer-bg: #1e1e32;
+  --ssd-drawer-w: 250px;
+  --ssd-text: #1a1a2d;
+  --ssd-drawer-text: #a0a0b8;
+  --ssd-drawer-active: #f59e0b;
+  --ssd-drawer-hover: rgba(245, 158, 11, 0.07);
+  --ssd-overlay: rgba(30, 30, 50, 0.45);
+  --ssd-topbar-h: 50px;
+  --ssd-radius: 6px;
+}
+
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  background: var(--ssd-bg);
+  font-family: "DM Sans", "Inter", "Helvetica Neue", Arial, sans-serif;
+  color: var(--ssd-text);
+  overflow-x: hidden;
+}
+
+/* ── checkbox ────────────────────────────────────── */
+
+.ssd-toggle {
+  position: fixed;
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* ── page ────────────────────────────────────────── */
+
+.ssd-page {
+  min-height: 100vh;
+  transition: transform 0.32s ease;
+}
+
+.ssd-toggle:checked ~ .ssd-page {
+  transform: translateX(var(--ssd-drawer-w));
+}
+
+/* ── topbar ──────────────────────────────────────── */
+
+.ssd-topbar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  height: var(--ssd-topbar-h);
+  padding: 0 18px;
+  background: var(--ssd-surface);
+  border-bottom: 1px solid #e5e5ea;
+}
+
+.ssd-topbar__title {
+  font-size: 0.8rem;
+  font-weight: 700;
+  margin-left: 12px;
+}
+
+.ssd-topbar__spacer {
+  flex: 1;
+}
+
+/* ── burger ──────────────────────────────────────── */
+
+.ssd-burger {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  cursor: pointer;
+  padding: 4px;
+  z-index: 30;
+}
+
+.ssd-burger span {
+  display: block;
+  width: 18px;
+  height: 2px;
+  background: var(--ssd-text);
+  border-radius: 1px;
+  transition: transform 0.28s ease, opacity 0.2s ease;
+}
+
+.ssd-toggle:checked ~ .ssd-page .ssd-burger span:nth-child(1) {
+  transform: translateY(6px) rotate(45deg);
+}
+
+.ssd-toggle:checked ~ .ssd-page .ssd-burger span:nth-child(2) {
+  opacity: 0;
+}
+
+.ssd-toggle:checked ~ .ssd-page .ssd-burger span:nth-child(3) {
+  transform: translateY(-6px) rotate(-45deg);
+}
+
+/* ── overlay ─────────────────────────────────────── */
+
+.ssd-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 25;
+  background: var(--ssd-overlay);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.28s ease;
+  cursor: pointer;
+}
+
+.ssd-toggle:checked ~ .ssd-page .ssd-overlay {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* ── drawer ──────────────────────────────────────── */
+
+.ssd-drawer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 28;
+  width: var(--ssd-drawer-w);
+  height: 100vh;
+  background: var(--ssd-drawer-bg);
+  transform: translateX(-100%);
+  transition: transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.ssd-toggle:checked ~ .ssd-page .ssd-drawer {
+  transform: translateX(0);
+}
+
+/* ── shimmer sweep ───────────────────────────────── */
+
+.ssd-drawer::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -80%;
+  width: 50%;
+  height: 100%;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(245, 158, 11, 0.06) 40%,
+    rgba(245, 158, 11, 0.12) 50%,
+    rgba(245, 158, 11, 0.06) 60%,
+    transparent 100%
+  );
+  z-index: 0;
+  transform: skewX(-15deg);
+  animation: none;
+}
+
+.ssd-toggle:checked ~ .ssd-page .ssd-drawer::before {
+  animation: ssd-shimmer 0.7s 0.1s ease-out both;
+}
+
+@keyframes ssd-shimmer {
+  0%   { left: -80%; }
+  100% { left: 130%; }
+}
+
+/* ── drawer header ───────────────────────────────── */
+
+.ssd-drawer__head {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 18px 20px 22px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.ssd-drawer__logo {
+  width: 26px;
+  height: 26px;
+  border-radius: 6px;
+  background: linear-gradient(135deg, var(--ssd-drawer-active), #ef4444);
+  display: block;
+}
+
+.ssd-drawer__name {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #fff;
+}
+
+/* ── drawer nav ──────────────────────────────────── */
+
+.ssd-drawer__nav {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 14px 10px;
+}
+
+.ssd-drawer__link {
+  display: block;
+  padding: 10px 14px;
+  font-size: 0.72rem;
+  font-weight: 500;
+  color: var(--ssd-drawer-text);
+  text-decoration: none;
+  border-radius: var(--ssd-radius);
+  opacity: 0;
+  transform: translateX(-8px);
+  transition: background 0.15s ease, color 0.15s ease, opacity 0.25s ease, transform 0.25s ease;
+}
+
+.ssd-toggle:checked ~ .ssd-page .ssd-drawer__link {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.ssd-toggle:checked ~ .ssd-page .ssd-drawer__link:nth-child(1) { transition-delay: 0.12s; }
+.ssd-toggle:checked ~ .ssd-page .ssd-drawer__link:nth-child(2) { transition-delay: 0.16s; }
+.ssd-toggle:checked ~ .ssd-page .ssd-drawer__link:nth-child(3) { transition-delay: 0.20s; }
+.ssd-toggle:checked ~ .ssd-page .ssd-drawer__link:nth-child(4) { transition-delay: 0.24s; }
+.ssd-toggle:checked ~ .ssd-page .ssd-drawer__link:nth-child(5) { transition-delay: 0.28s; }
+
+.ssd-drawer__link:hover {
+  background: var(--ssd-drawer-hover);
+  color: #fff;
+}
+
+.ssd-drawer__link--active {
+  background: var(--ssd-drawer-hover);
+  color: var(--ssd-drawer-active);
+}
+
+/* ── content ─────────────────────────────────────── */
+
+.ssd-content {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 80px 18px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+}
+
+.ssd-content__title {
+  font-size: clamp(1.3rem, 4vw, 2.1rem);
+  font-weight: 800;
+  letter-spacing: -0.04em;
+}
+
+.ssd-content__sub {
+  font-size: 0.76rem;
+  color: #777789;
+  max-width: 42ch;
+  line-height: 1.7;
+}
+
+.ssd-content__pills {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: 6px;
+}
+
+.ssd-pill {
+  font-size: 0.54rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  padding: 5px 12px;
+  border-radius: 20px;
+  background: rgba(245, 158, 11, 0.08);
+  color: var(--ssd-drawer-active);
+}
+
+/* ── responsive ──────────────────────────────────── */
+
+@media (min-width: 840px) {
+  .ssd-burger { display: none; }
+  .ssd-overlay { display: none; }
+  .ssd-topbar { display: none; }
+
+  .ssd-drawer {
+    transform: translateX(0);
+    position: relative;
+    flex-shrink: 0;
+  }
+
+  .ssd-drawer::before {
+    animation: none;
+  }
+
+  .ssd-drawer__link {
+    opacity: 1;
+    transform: none;
+    transition-delay: 0s;
+  }
+
+  .ssd-page {
+    display: flex;
+    transform: none !important;
+  }
+}
+
+/* ── accessibility ───────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .ssd-page,
+  .ssd-drawer,
+  .ssd-overlay,
+  .ssd-burger span,
+  .ssd-drawer__link {
+    transition: none;
+  }
+
+  .ssd-drawer::before {
+    animation: none;
+  }
+}


### PR DESCRIPTION
Closes #64471

Adds a CSS-only shimmer-sweep drawer component to the minimalist tech layout collection.

Changes:
- submissions/examples/shimmer-sweep-drawer-minimalist-tech/demo.html — side drawer with hamburger toggle, overlay, and nav links
- submissions/examples/shimmer-sweep-drawer-minimalist-tech/style.css — shimmer highlight sweep using ::before gradient with keyframe animation, staggered link fade-in, CSS custom properties (prefix --ssd-*), prefers-reduced-motion support
- submissions/examples/shimmer-sweep-drawer-minimalist-tech/README.md — implementation notes

Implementation:
- Hidden checkbox controls open/close state via CSS sibling selectors
- Drawer slides in with spring cubic-bezier(0.34, 1.56, 0.64, 1)
- ::before pseudo-element runs a shimmer gradient from -80% to 130% using ssd-shimmer keyframe
- Each nav link fades in with staggered transition-delay (120ms apart)
- Burger transforms to X using translateY and rotate
- On screens >= 840px, drawer is always visible as sidebar with shimmer disabled
- All interactive elements have focus-visible outlines