### PR TITLE
feat: add CSS Blur-Entrance Tooltip for Minimalist Tech Layouts

### DIFF
--- a/submissions/examples/blur-entrance-tooltip-ks-64523/README.md
+++ b/submissions/examples/blur-entrance-tooltip-ks-64523/README.md
@@ -1,0 +1,96 @@
+# CSS Blur-Entrance Tooltip
+
+A highly polished, pure CSS tooltip component featuring a sophisticated blur-to-focus entrance animation, designed specifically for minimalist technology interfaces.
+
+## Feature Overview
+
+This component provides a lightweight, fully accessible tooltip system requiring zero JavaScript. By combining CSS filters (`blur()`), transforms, and `@keyframes` animations, the tooltip smoothly comes into focus when triggered, creating a premium depth-of-field effect.
+
+## Blur-Entrance Behavior
+
+- **Hidden State**: The tooltip content is hidden (`opacity: 0`, `visibility: hidden`), intentionally blurred (`filter: blur(8px)`), and slightly offset downwards.
+- **Hover/Focus Reveal**: When the user hovers over or focuses the trigger button, the tooltip smoothly fades in.
+- **Entrance Animation**: A targeted `@keyframes` animation rapidly interpolates the blur value from `8px` to `0` while sliding the tooltip into its final resting position. This mimics an optical lens bringing the element into sharp focus.
+- **Exit Transition**: When the cursor leaves, a standard CSS `transition` smoothly returns the tooltip to its blurred, hidden state.
+
+## Tooltip Structure
+
+```html
+<div class="tooltip tooltip-top">
+    <!-- Interactive Trigger -->
+    <button class="tooltip-trigger" type="button" aria-describedby="tooltip-example">
+        Core
+        <div class="tooltip-icon" aria-hidden="true"><div class="icon-node"></div></div>
+    </button>
+    
+    <!-- Tooltip content -->
+    <span class="tooltip-content" id="tooltip-example" role="tooltip">
+        Core system is operational
+    </span>
+</div>
+```
+
+- **`aria-describedby`**: The semantic `<button>` trigger uses `aria-describedby` to reference the `id` of the tooltip content. Screen readers will read the tooltip text when the button receives focus.
+- **`role="tooltip"`**: The content container is explicitly marked with `role="tooltip"`.
+- **Decorative Icons**: Pure CSS decorative icons within the trigger are hidden from assistive technology using `aria-hidden="true"`.
+
+## Features
+
+- Pure HTML and CSS (Zero JavaScript)
+- Three directional variants (Top, Bottom, Right)
+- Sophisticated `@keyframes` Blur-Entrance effect (`filter: blur()`)
+- Glassmorphism backing (`backdrop-filter: blur()`)
+- Smooth CSS exit transitions
+- Fully responsive layout across desktop, tablet, and mobile
+- Custom CSS-only decorative signal icons
+- Highly customizable via CSS custom properties
+- 100% Keyboard accessible (`:focus-within`)
+- Distinctive `:focus-visible` offset outlines
+- Comprehensive `prefers-reduced-motion` support
+- No external dependencies, fonts, or images
+
+## CSS Custom Properties
+
+Easily theme the component by adjusting these root variables:
+
+- `--page-bg`: Background color of the main page container.
+- `--tooltip-bg`: Background color of the tooltip bubble.
+- `--tooltip-surface`: Background color of the trigger button.
+- `--tooltip-text`: Text color inside the tooltip.
+- `--tooltip-muted`: Color for introductory or muted text.
+- `--tooltip-accent`: Primary brand color used for borders, signal nodes, and focus rings.
+- `--tooltip-border`: Default border color for the trigger and tooltip.
+- `--tooltip-radius`: Border radius applied to elements.
+- `--tooltip-shadow`: Elevation shadow for the tooltip bubble.
+
+## Responsive Behavior
+
+- **Desktop (`> 850px`)**: Tooltips are displayed in a spacious 3-column grid layout. Directional classes (`tooltip-top`, `tooltip-bottom`, `tooltip-right`) perform their respective offsets.
+- **Tablet (`<= 850px`)**: The grid smartly reduces to 2 columns. To prevent the right-aligned tooltip from overflowing the viewport edge, the `tooltip-right` variant intelligently overrides its animation to behave identically to a `tooltip-bottom` element.
+- **Mobile (`<= 600px`)**: The grid collapses into a single column stack. Tooltip content width is safely constrained using `max-width: min(260px, calc(100vw - 2rem))` to guarantee it never extends beyond narrow screens.
+
+## Accessibility
+
+- **Semantic HTML**: Interactive triggers use `<button type="button">` exclusively.
+- **Keyboard Interaction**: Tooltips reliably appear on both `:hover` (mouse users) and `:focus-within` (keyboard users).
+- **Focus-Visible**: Custom `:focus-visible` outlines ensure keyboard users always know what element has focus, providing clear, theme-aligned outlines that bypass default browser rings.
+- **Contrast**: Both light and dark themes offer sufficient visual contrast.
+- **ARIA Tooltip Relationship**: The `aria-describedby` attribute properly associates the descriptive tooltip content with its trigger.
+
+## Reduced Motion
+
+The component includes comprehensive `prefers-reduced-motion: reduce` support. When enabled at the OS level, all animations and transitions are forced to `0.01ms`. Furthermore, the `filter` property is forcibly set to `none !important`. This completely disables the blur animation and sliding reveal effect, causing the tooltip to snap instantly and clearly into place for users sensitive to motion.
+
+## Usage
+
+Simply copy the HTML structure into your document and link `style.css`. Adjust the positioning classes (`tooltip-top`, `tooltip-bottom`, `tooltip-right`) on the outer wrapper as needed. Open `demo.html` in any modern browser to see the effect in action.
+
+## Browser Compatibility
+
+This component uses modern web standards supported by all major browsers (Chrome, Firefox, Safari, Edge), including:
+- CSS Custom Properties (Variables)
+- CSS Grid layout
+- CSS Animations and Transitions
+- `filter: blur()` and `backdrop-filter: blur()`
+- `:focus-visible` and `:focus-within` pseudo-classes
+- `@media (prefers-reduced-motion)`

--- a/submissions/examples/blur-entrance-tooltip-ks-64523/demo.html
+++ b/submissions/examples/blur-entrance-tooltip-ks-64523/demo.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Blur-Entrance Tooltip</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <main>
+        <section class="showcase" aria-labelledby="page-title">
+            <header>
+                <p class="eyebrow">CSS INTERFACE EFFECT</p>
+                <h1 id="page-title">Blur-Entrance Tooltip</h1>
+                <p class="intro">
+                    A sleek, pure CSS tooltip utilizing a smooth blur-to-focus entrance animation for modern, minimalist interfaces.
+                </p>
+            </header>
+
+            <div class="tooltip-showcase">
+                <!-- Tooltip 1: Top -->
+                <div class="tooltip tooltip-top">
+                    <button class="tooltip-trigger" type="button" aria-describedby="tooltip-core">
+                        Core
+                        <div class="tooltip-icon" aria-hidden="true"><div class="icon-node"></div></div>
+                    </button>
+                    <span class="tooltip-content" id="tooltip-core" role="tooltip">
+                        Core system is operational and stabilized
+                    </span>
+                </div>
+
+                <!-- Tooltip 2: Bottom -->
+                <div class="tooltip tooltip-bottom">
+                    <button class="tooltip-trigger" type="button" aria-describedby="tooltip-signal">
+                        Signal
+                        <div class="tooltip-icon" aria-hidden="true"><div class="icon-signal"></div></div>
+                    </button>
+                    <span class="tooltip-content" id="tooltip-signal" role="tooltip">
+                        Signal processing is actively routing data
+                    </span>
+                </div>
+
+                <!-- Tooltip 3: Right -->
+                <div class="tooltip tooltip-right">
+                    <button class="tooltip-trigger" type="button" aria-describedby="tooltip-network">
+                        Network
+                        <div class="tooltip-icon" aria-hidden="true"><div class="icon-network"></div></div>
+                    </button>
+                    <span class="tooltip-content" id="tooltip-network" role="tooltip">
+                        Network connection is perfectly stable
+                    </span>
+                </div>
+            </div>
+        </section>
+    </main>
+</body>
+</html>

--- a/submissions/examples/blur-entrance-tooltip-ks-64523/style.css
+++ b/submissions/examples/blur-entrance-tooltip-ks-64523/style.css
@@ -1,0 +1,385 @@
+:root {
+    --page-bg: #09090b;
+    --text-main: #f4f4f5;
+    
+    /* Tooltip Tokens */
+    --tooltip-bg: rgba(24, 24, 27, 0.85);
+    --tooltip-surface: rgba(39, 39, 42, 0.4);
+    --tooltip-text: #e4e4e7;
+    --tooltip-muted: #a1a1aa;
+    --tooltip-accent: #10b981; /* Emerald */
+    --tooltip-border: rgba(255, 255, 255, 0.15);
+    --tooltip-radius: 8px;
+    --tooltip-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.5);
+}
+
+@media (prefers-color-scheme: light) {
+    :root {
+        --page-bg: #fafafa;
+        --text-main: #09090b;
+        
+        --tooltip-bg: rgba(255, 255, 255, 0.95);
+        --tooltip-surface: #f4f4f5;
+        --tooltip-text: #18181b;
+        --tooltip-muted: #71717a;
+        --tooltip-accent: #059669;
+        --tooltip-border: rgba(0, 0, 0, 0.12);
+        --tooltip-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.1);
+    }
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    background-color: var(--page-bg);
+    color: var(--text-main);
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 2rem;
+}
+
+.showcase {
+    max-width: 800px;
+    width: 100%;
+    text-align: center;
+}
+
+header {
+    margin-bottom: 4rem;
+}
+
+.eyebrow {
+    font-size: 0.85rem;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    color: var(--tooltip-accent);
+    text-transform: uppercase;
+    margin-bottom: 1rem;
+}
+
+h1 {
+    font-size: 2.5rem;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    margin-bottom: 1rem;
+}
+
+.intro {
+    font-size: 1.1rem;
+    color: var(--tooltip-muted);
+    line-height: 1.6;
+    max-width: 500px;
+    margin: 0 auto;
+}
+
+/* ----------------------------------
+   Showcase Grid
+   ---------------------------------- */
+.tooltip-showcase {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 3rem;
+    place-items: center;
+}
+
+/* ----------------------------------
+   Tooltip Trigger (Button)
+   ---------------------------------- */
+.tooltip {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+}
+
+.tooltip-trigger {
+    background: var(--tooltip-surface);
+    color: var(--text-main);
+    border: 1px solid var(--tooltip-border);
+    padding: 0.75rem 1.5rem;
+    border-radius: 100px; /* Pill shape */
+    font-size: 1rem;
+    font-weight: 500;
+    cursor: help;
+    transition: background-color 200ms ease, border-color 200ms ease;
+    outline: none;
+    
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.tooltip-trigger:hover,
+.tooltip-trigger:focus-visible {
+    background: rgba(255, 255, 255, 0.05);
+    border-color: var(--tooltip-accent);
+}
+
+@media (prefers-color-scheme: light) {
+    .tooltip-trigger:hover,
+    .tooltip-trigger:focus-visible {
+        background: rgba(0, 0, 0, 0.03);
+    }
+}
+
+.tooltip-trigger:focus-visible {
+    outline: 2px solid var(--tooltip-accent);
+    outline-offset: 3px;
+}
+
+/* ----------------------------------
+   Decorative Icons
+   ---------------------------------- */
+.tooltip-icon {
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    position: relative;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+/* Node Icon */
+.icon-node {
+    width: 6px;
+    height: 6px;
+    background: var(--tooltip-accent);
+    border-radius: 50%;
+    box-shadow: 0 0 6px var(--tooltip-accent);
+}
+
+/* Signal Icon */
+.icon-signal {
+    width: 12px;
+    height: 2px;
+    background: var(--tooltip-accent);
+    position: relative;
+}
+.icon-signal::before, .icon-signal::after {
+    content: "";
+    position: absolute;
+    width: 4px;
+    height: 2px;
+    background: var(--tooltip-accent);
+    top: -4px;
+}
+.icon-signal::before { left: 0; }
+.icon-signal::after { right: 0; }
+
+/* Network Icon */
+.icon-network {
+    width: 10px;
+    height: 10px;
+    border: 1.5px solid var(--tooltip-accent);
+    border-radius: 3px;
+    transform: rotate(45deg);
+}
+
+/* ----------------------------------
+   Tooltip Content Container
+   ---------------------------------- */
+.tooltip-content {
+    position: absolute;
+    z-index: 10;
+    width: max-content;
+    max-width: min(260px, calc(100vw - 2rem));
+    padding: 0.75rem 1rem;
+    
+    /* Blurry Glassmorphism Background */
+    background: var(--tooltip-bg);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    
+    color: var(--tooltip-text);
+    font-size: 0.9rem;
+    font-weight: 400;
+    line-height: 1.4;
+    text-align: left;
+    
+    border: 1px solid var(--tooltip-border);
+    border-radius: var(--tooltip-radius);
+    box-shadow: var(--tooltip-shadow);
+    
+    /* Default hidden state (with blur) */
+    opacity: 0;
+    visibility: hidden;
+    filter: blur(8px);
+    pointer-events: none;
+    
+    /* Base transforms will be overridden by position classes */
+    transform: translateY(6px);
+    
+    /* Smooth exit transitions */
+    transition: 
+        opacity 220ms ease,
+        filter 220ms ease,
+        transform 220ms ease,
+        visibility 220ms ease;
+}
+
+/* ----------------------------------
+   Tooltip Positions & Entrance
+   ---------------------------------- */
+
+/* TOP */
+.tooltip-top .tooltip-content {
+    bottom: calc(100% + 0.75rem);
+    left: 50%;
+    transform: translate(-50%, 6px);
+}
+.tooltip-top:hover .tooltip-content,
+.tooltip-top:focus-within .tooltip-content {
+    /* Target state */
+    opacity: 1;
+    visibility: visible;
+    filter: blur(0);
+    transform: translate(-50%, 0);
+    
+    /* Apply Entrance Animation */
+    animation: blur-entrance-top 300ms cubic-bezier(0.2, 0, 0, 1) forwards;
+}
+
+/* BOTTOM */
+.tooltip-bottom .tooltip-content {
+    top: calc(100% + 0.75rem);
+    left: 50%;
+    transform: translate(-50%, -6px);
+}
+.tooltip-bottom:hover .tooltip-content,
+.tooltip-bottom:focus-within .tooltip-content {
+    opacity: 1;
+    visibility: visible;
+    filter: blur(0);
+    transform: translate(-50%, 0);
+    animation: blur-entrance-bottom 300ms cubic-bezier(0.2, 0, 0, 1) forwards;
+}
+
+/* RIGHT */
+.tooltip-right .tooltip-content {
+    top: 50%;
+    left: calc(100% + 0.75rem);
+    transform: translate(-6px, -50%);
+}
+.tooltip-right:hover .tooltip-content,
+.tooltip-right:focus-within .tooltip-content {
+    opacity: 1;
+    visibility: visible;
+    filter: blur(0);
+    transform: translate(0, -50%);
+    animation: blur-entrance-right 300ms cubic-bezier(0.2, 0, 0, 1) forwards;
+}
+
+/* ----------------------------------
+   Keyframes for Entrance
+   ---------------------------------- */
+@keyframes blur-entrance-top {
+    0% {
+        opacity: 0;
+        filter: blur(8px);
+        transform: translate(-50%, 6px);
+    }
+    100% {
+        opacity: 1;
+        filter: blur(0);
+        transform: translate(-50%, 0);
+    }
+}
+
+@keyframes blur-entrance-bottom {
+    0% {
+        opacity: 0;
+        filter: blur(8px);
+        transform: translate(-50%, -6px);
+    }
+    100% {
+        opacity: 1;
+        filter: blur(0);
+        transform: translate(-50%, 0);
+    }
+}
+
+@keyframes blur-entrance-right {
+    0% {
+        opacity: 0;
+        filter: blur(8px);
+        transform: translate(-6px, -50%);
+    }
+    100% {
+        opacity: 1;
+        filter: blur(0);
+        transform: translate(0, -50%);
+    }
+}
+
+/* ----------------------------------
+   Reduced Motion
+   ---------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
+    
+    .tooltip-content {
+        filter: none !important;
+    }
+}
+
+/* ----------------------------------
+   Responsive Design
+   ---------------------------------- */
+@media (max-width: 850px) {
+    .tooltip-showcase {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 2rem;
+    }
+    
+    /* Prevent right tooltip from overflowing horizontally */
+    .tooltip-right .tooltip-content {
+        top: calc(100% + 0.75rem);
+        left: 50%;
+        transform: translate(-50%, -6px);
+    }
+    .tooltip-right:hover .tooltip-content,
+    .tooltip-right:focus-within .tooltip-content {
+        transform: translate(-50%, 0);
+        animation: blur-entrance-bottom 300ms cubic-bezier(0.2, 0, 0, 1) forwards;
+    }
+}
+
+@media (max-width: 600px) {
+    body {
+        align-items: flex-start;
+        padding-top: 3rem;
+    }
+    
+    h1 {
+        font-size: 2rem;
+    }
+    
+    header {
+        margin-bottom: 2rem;
+    }
+    
+    .tooltip-showcase {
+        grid-template-columns: 1fr;
+        gap: 2rem;
+    }
+    
+    .tooltip-trigger {
+        width: 100%;
+        max-width: 300px;
+        justify-content: center;
+    }
+}


### PR DESCRIPTION
## Description

Implements #64523 by adding a pure HTML/CSS Blur-Entrance Tooltip for minimalist tech layouts.

## Features

- Pure HTML and CSS
- Three tooltip examples
- Top, right, and bottom tooltip positioning
- Blur-Entrance animation
- Smooth CSS transitions
- Hover interaction
- Keyboard-focus interaction
- Responsive desktop, tablet, and mobile layouts
- CSS custom properties
- Semantic HTML
- `aria-describedby` and `role="tooltip"`
- Visible `:focus-visible` states
- `prefers-reduced-motion` support
- No JavaScript
- No external dependencies
- No external fonts or images

## Files Added

- `submissions/examples/blur-entrance-tooltip-ks-64523/demo.html`
- `submissions/examples/blur-entrance-tooltip-ks-64523/style.css`
- `submissions/examples/blur-entrance-tooltip-ks-64523/README.md`

## Checklist

- [x] Pure HTML/CSS
- [x] No JavaScript
- [x] No external dependencies
- [x] Three tooltip examples
- [x] Hover interaction
- [x] Keyboard-focus interaction
- [x] Blur-Entrance effect
- [x] Top/right/bottom positioning
- [x] Smooth transitions
- [x] Responsive design
- [x] Mobile overflow handled
- [x] Semantic HTML
- [x] `aria-describedby`
- [x] `role="tooltip"`
- [x] Visible focus states
- [x] Reduced-motion support
- [x] CSS custom properties
- [x] README documentation
- [x] Changes limited to the requested submission folder
- [x] No unrelated files modified

Closes #64523
