### PR TITLE
feat: rotate-fade modal for minimalist tech layouts

### DIFF
--- a/submissions/examples/rotate-fade-modal-minimalist-tech/README.md
+++ b/submissions/examples/rotate-fade-modal-minimalist-tech/README.md
@@ -1,0 +1,20 @@
+# Rotate-Fade Modal — Minimalist Tech Layouts
+
+A CSS-only modal that enters with a rotation and fade. The card starts tilted at -4 degrees with reduced scale and opacity, then rotates to level while scaling up and fading in.
+
+## How It Works
+
+A hidden checkbox controls the open/close state. When checked, the backdrop fades in and the modal card transitions from `rotate(-4deg) scale(0.9) translateY(16px) opacity: 0` to its resting position. The spring cubic-bezier gives a slight overshoot as the card settles.
+
+The rotation creates a more dynamic entrance than a simple scale, making the modal feel like it's being placed onto the screen rather than just appearing.
+
+## Customization
+
+Override `--rfm-emerald` to change the accent color. Adjust the initial `rotate()` and `scale()` values for more or less dramatic entrances. The spring easing can be replaced with `ease-out` for a more subdued feel.
+
+## Accessibility
+
+- `prefers-reduced-motion` disables all transitions while keeping the modal functional
+- Backdrop is clickable to close
+- Semantic `role="dialog"` and `aria-modal="true"` on the modal
+- Close buttons have `aria-label` for screen readers

--- a/submissions/examples/rotate-fade-modal-minimalist-tech/demo.html
+++ b/submissions/examples/rotate-fade-modal-minimalist-tech/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS rotate-fade modal for minimalist tech layouts. Pure CSS modal with rotate and fade entrance using checkbox hack.">
+  <title>Rotate-Fade Modal — Minimalist Tech Layouts</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <input type="checkbox" id="rfm-toggle" class="rfm-toggle" aria-label="Open modal">
+
+  <div class="rfm-page">
+
+    <header class="rfm-topbar">
+      <span class="rfm-topbar__title">Workspace</span>
+    </header>
+
+    <main class="rfm-content">
+      <h1 class="rfm-content__title">Rotate-Fade Modal</h1>
+      <p class="rfm-content__sub">Click the button below to open the modal. It rotates in from a tilted angle while fading into view.</p>
+
+      <label for="rfm-toggle" class="rfm-trigger">Open Modal</label>
+    </main>
+
+  </div>
+
+  <label for="rfm-toggle" class="rfm-backdrop" aria-label="Close modal"></label>
+
+  <div class="rfm-modal" role="dialog" aria-modal="true" aria-label="Example modal">
+    <div class="rfm-modal__card">
+      <div class="rfm-modal__head">
+        <span class="rfm-modal__label">Notice</span>
+        <label for="rfm-toggle" class="rfm-modal__close" aria-label="Close modal">&times;</label>
+      </div>
+      <p class="rfm-modal__body">Your session is about to expire. Please save your work. This modal uses a rotate-fade entrance that tilts the card into place as it appears.</p>
+      <div class="rfm-modal__actions">
+        <label for="rfm-toggle" class="rfm-btn rfm-btn--ghost">Later</label>
+        <label for="rfm-toggle" class="rfm-btn rfm-btn--primary">Save Now</label>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/rotate-fade-modal-minimalist-tech/style.css
+++ b/submissions/examples/rotate-fade-modal-minimalist-tech/style.css
@@ -1,0 +1,250 @@
+:root {
+  --rfm-bg: #f5f5f8;
+  --rfm-surface: #ffffff;
+  --rfm-text: #1a1a2e;
+  --rfm-dim: #767689;
+  --rfm-emerald: #10b981;
+  --rfm-emerald-soft: rgba(16, 185, 129, 0.08);
+  --rfm-border: #e2e2e8;
+  --rfm-overlay: rgba(26, 26, 46, 0.45);
+  --rfm-radius: 8px;
+}
+
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  background: var(--rfm-bg);
+  font-family: "DM Sans", "Inter", "Helvetica Neue", Arial, sans-serif;
+  color: var(--rfm-text);
+  overflow-x: hidden;
+}
+
+/* ── checkbox ────────────────────────────────────── */
+
+.rfm-toggle {
+  position: fixed;
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* ── topbar ──────────────────────────────────────── */
+
+.rfm-topbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  height: 48px;
+  padding: 0 20px;
+  background: var(--rfm-surface);
+  border-bottom: 1px solid var(--rfm-border);
+}
+
+.rfm-topbar__title {
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+/* ── content ─────────────────────────────────────── */
+
+.rfm-content {
+  max-width: 560px;
+  margin: 0 auto;
+  padding: 80px 20px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+.rfm-content__title {
+  font-size: clamp(1.3rem, 4vw, 2rem);
+  font-weight: 800;
+  letter-spacing: -0.04em;
+}
+
+.rfm-content__sub {
+  font-size: 0.76rem;
+  color: var(--rfm-dim);
+  max-width: 42ch;
+  line-height: 1.7;
+}
+
+/* ── trigger ─────────────────────────────────────── */
+
+.rfm-trigger {
+  display: inline-block;
+  margin-top: 8px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  padding: 10px 22px;
+  border-radius: var(--rfm-radius);
+  background: var(--rfm-emerald);
+  color: #fff;
+  cursor: pointer;
+  letter-spacing: 0.02em;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.rfm-trigger:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 14px rgba(16, 185, 129, 0.3);
+}
+
+/* ── backdrop ────────────────────────────────────── */
+
+.rfm-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  background: var(--rfm-overlay);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+  cursor: pointer;
+}
+
+.rfm-toggle:checked ~ .rfm-backdrop {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* ── modal ───────────────────────────────────────── */
+
+.rfm-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+
+.rfm-toggle:checked ~ .rfm-modal {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* ── card with rotate-fade ───────────────────────── */
+
+.rfm-modal__card {
+  width: 100%;
+  max-width: 400px;
+  background: var(--rfm-surface);
+  border-radius: 12px;
+  border: 1px solid var(--rfm-border);
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.1);
+  transform: rotate(-4deg) scale(0.9) translateY(16px);
+  opacity: 0;
+  transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1),
+              opacity 0.3s ease;
+  overflow: hidden;
+}
+
+.rfm-toggle:checked ~ .rfm-modal .rfm-modal__card {
+  transform: rotate(0deg) scale(1) translateY(0);
+  opacity: 1;
+}
+
+/* ── modal head ──────────────────────────────────── */
+
+.rfm-modal__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px 12px;
+}
+
+.rfm-modal__label {
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.rfm-modal__close {
+  font-size: 1.1rem;
+  color: var(--rfm-dim);
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 4px;
+  transition: background 0.15s ease, color 0.15s ease;
+  line-height: 1;
+}
+
+.rfm-modal__close:hover {
+  background: rgba(0, 0, 0, 0.06);
+  color: var(--rfm-text);
+}
+
+/* ── modal body ──────────────────────────────────── */
+
+.rfm-modal__body {
+  padding: 0 20px 18px;
+  font-size: 0.74rem;
+  color: var(--rfm-dim);
+  line-height: 1.7;
+}
+
+/* ── modal actions ───────────────────────────────── */
+
+.rfm-modal__actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  padding: 0 20px 18px;
+}
+
+.rfm-btn {
+  font-size: 0.68rem;
+  font-weight: 600;
+  padding: 7px 16px;
+  border-radius: 6px;
+  cursor: pointer;
+  letter-spacing: 0.02em;
+  transition: background 0.15s ease, transform 0.15s ease;
+}
+
+.rfm-btn--ghost {
+  background: transparent;
+  color: var(--rfm-dim);
+  border: 1px solid var(--rfm-border);
+}
+
+.rfm-btn--ghost:hover {
+  background: rgba(0, 0, 0, 0.04);
+}
+
+.rfm-btn--primary {
+  background: var(--rfm-emerald);
+  color: #fff;
+  border: none;
+}
+
+.rfm-btn--primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 3px 10px rgba(16, 185, 129, 0.25);
+}
+
+/* ── accessibility ───────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .rfm-backdrop,
+  .rfm-modal,
+  .rfm-modal__card,
+  .rfm-trigger,
+  .rfm-btn {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Closes #64463

Adds a CSS rotate-fade modal for minimalist tech layouts.

**What this PR does:**
- Pure CSS modal with rotate and fade entrance animation
- Modal card starts tilted at -4° with scale 0.9 and opacity 0
- Rotates to level (0°), scales to 1, fades in when toggled
- Spring cubic-bezier overshoot on card entrance
- Click-outside-to-close via backdrop
- No JavaScript — uses checkbox hack for toggle

**Files added:**
- submissions/examples/rotate-fade-modal-minimalist-tech/demo.html
- submissions/examples/rotate-fade-modal-minimalist-tech/style.css
- submissions/examples/rotate-fade-modal-minimalist-tech/README.md