### PR TITLE
feat: add retry storm damper example

### DIFF
--- a/submissions/examples/retry-storm-damper-kp/README.md
+++ b/submissions/examples/retry-storm-damper-kp/README.md
@@ -1,0 +1,21 @@
+﻿# Retry Storm Damper KP
+
+## What does this do?
+
+Retry Storm Damper KP is an advanced CSS-only resilience console for visualizing detect, jitter, retry, and shaping modes. It includes semantic radio controls, animated retry lanes, a conic storm ring, responsive service cards, and reduced-motion support.
+
+## How is it used?
+
+Use radio inputs as the retry mode controller. Labels switch the active mode while sibling selectors update storm pressure, lane emphasis, and the selected service card.
+
+```html
+<input type="radio" name="retry" id="mode-retry" />
+<label for="mode-retry">Retry</label>
+<article class="service-card card-retry">
+  <h2>Confirm retry</h2>
+</article>
+```
+
+## Why is it useful?
+
+Reliability docs and operations dashboards often need to explain retry storms without JavaScript. This example demonstrates advanced CSS state orchestration with accessible controls, operational motion, responsive layout, and reduced-motion behavior.

--- a/submissions/examples/retry-storm-damper-kp/demo.html
+++ b/submissions/examples/retry-storm-damper-kp/demo.html
@@ -1,0 +1,84 @@
+﻿<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Retry Storm Damper KP</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="retry-shell" aria-labelledby="retry-title">
+      <section class="retry-hero">
+        <p class="retry-kicker">Advanced CSS resilience control</p>
+        <h1 id="retry-title">Retry Storm Damper</h1>
+        <p>
+          Route retry storm waves through detect, jitter, retry, and dampen
+          modes with CSS-only controls, animated storm lanes, and service cards.
+        </p>
+      </section>
+
+      <section class="retry-console" aria-label="Retry storm switchboard">
+        <input type="radio" name="retry" id="mode-detect" checked />
+        <input type="radio" name="retry" id="mode-jitter" />
+        <input type="radio" name="retry" id="mode-retry" />
+        <input type="radio" name="retry" id="mode-dampen" />
+
+        <nav class="mode-tabs" aria-label="Retry modes">
+          <label for="mode-detect">Detect</label>
+          <label for="mode-jitter">Jitter</label>
+          <label for="mode-retry">Retry</label>
+          <label for="mode-dampen">Dampen</label>
+        </nav>
+
+        <div class="retry-board">
+          <article class="storm-ring" aria-label="System storm">
+            <span class="ring-base"></span>
+            <span class="ring-fill"></span>
+            <strong>71%</strong>
+            <em>storm</em>
+          </article>
+
+          <article class="switch-map" aria-label="Retry storm lanes">
+            <span class="switch-line line-core"><i></i></span>
+            <span class="switch-line line-search"><i></i></span>
+            <span class="switch-line line-media"><i></i></span>
+            <span class="switch-line line-extra"><i></i></span>
+            <b class="switch-node node-client">Client</b>
+            <b class="switch-node node-policy">Detect</b>
+            <b class="switch-node node-core">Service</b>
+            <b class="switch-node node-optional">Damper</b>
+          </article>
+        </div>
+
+        <div class="service-grid">
+          <article class="service-card card-detect">
+            <span></span>
+            <h2>Detect surge</h2>
+            <p>
+              Requests stay inside the detected retry window while service storm
+              remains healthy.
+            </p>
+          </article>
+          <article class="service-card card-jitter">
+            <span></span>
+            <h2>Jitter retries</h2>
+            <p>
+              Clients receive jitter windows while queue depth and retry
+              pressure are tracked.
+            </p>
+          </article>
+          <article class="service-card card-retry">
+            <span></span>
+            <h2>Confirm retry</h2>
+            <p>Retry floods and tail latency spikes are highlighted.</p>
+          </article>
+          <article class="service-card card-dampen">
+            <span></span>
+            <h2>Dampen traffic</h2>
+            <p>Retry calls are dampened once storm checks turn unstable.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/retry-storm-damper-kp/style.css
+++ b/submissions/examples/retry-storm-damper-kp/style.css
@@ -1,0 +1,549 @@
+﻿:root {
+  color-scheme: light;
+  --ink: #101828;
+  --muted: #667085;
+  --paper: #f7f9fc;
+  --panel: #ffffff;
+  --line: #d9e2ec;
+  --detect: #0f9f6e;
+  --jitter: #d97706;
+  --retry: #dc395f;
+  --dampen: #2563eb;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(15, 159, 110, 0.13), transparent 34%),
+    linear-gradient(315deg, rgba(37, 99, 235, 0.12), transparent 38%),
+    var(--paper);
+}
+
+.retry-shell {
+  width: min(1160px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.retry-hero {
+  max-width: 780px;
+  margin-bottom: 28px;
+}
+
+.retry-kicker {
+  margin: 0 0 10px;
+  color: var(--detect);
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 14px;
+  font-size: clamp(2.2rem, 6vw, 4.8rem);
+  line-height: 0.95;
+}
+
+.retry-hero p:last-child {
+  max-width: 690px;
+  color: var(--muted);
+  font-size: 1.06rem;
+  line-height: 1.7;
+}
+
+.retry-console {
+  padding: 22px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.84);
+  box-shadow: 0 24px 80px rgba(16, 24, 40, 0.12);
+}
+
+.retry-console > input {
+  position: absolute;
+  inline-size: 1px;
+  block-size: 1px;
+  opacity: 0;
+}
+
+.mode-tabs {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+  margin-bottom: 18px;
+}
+
+.mode-tabs label {
+  min-height: 48px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--muted);
+  font-weight: 900;
+  background: var(--panel);
+  cursor: pointer;
+  transition:
+    transform 220ms ease,
+    border-color 220ms ease,
+    color 220ms ease,
+    background 220ms ease;
+}
+
+.mode-tabs label:hover,
+.mode-tabs label:focus-visible {
+  transform: translateY(-2px);
+  border-color: var(--dampen);
+  color: var(--dampen);
+}
+
+.retry-board {
+  display: grid;
+  grid-template-columns: 0.8fr 1.2fr;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.storm-ring,
+.switch-map,
+.service-card {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+}
+
+.storm-ring {
+  position: relative;
+  min-height: 340px;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+}
+
+.ring-base,
+.ring-fill {
+  position: absolute;
+  width: 260px;
+  height: 260px;
+  border-radius: 50%;
+  mask: radial-gradient(circle, transparent 0 56%, #000 57%);
+}
+
+.ring-base {
+  background: conic-gradient(rgba(102, 112, 133, 0.18) 0 360deg);
+}
+
+.ring-fill {
+  background: conic-gradient(var(--detect) 0 256deg, transparent 256deg 360deg);
+  animation: storm-pulse 2.4s ease-in-out infinite;
+  transition: background 520ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.storm-ring strong {
+  position: relative;
+  z-index: 1;
+  font-size: 3.2rem;
+  line-height: 1;
+}
+
+.storm-ring em {
+  position: relative;
+  z-index: 1;
+  color: var(--muted);
+  font-style: normal;
+  font-weight: 900;
+}
+
+.switch-map {
+  position: relative;
+  min-height: 340px;
+  overflow: hidden;
+  background:
+    linear-gradient(90deg, rgba(15, 159, 110, 0.08), transparent 48%),
+    linear-gradient(270deg, rgba(220, 57, 95, 0.1), transparent 44%),
+    var(--panel);
+}
+
+.switch-line {
+  position: absolute;
+  left: 8%;
+  right: 8%;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(102, 112, 133, 0.2);
+  overflow: hidden;
+}
+
+.line-core {
+  top: 31%;
+}
+.line-search {
+  top: 45%;
+}
+.line-media {
+  top: 59%;
+}
+.line-extra {
+  top: 73%;
+}
+
+.switch-line i {
+  display: block;
+  width: 40%;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--detect);
+  animation: switch-flow 2.5s ease-in-out infinite;
+}
+
+.line-search i {
+  width: 32%;
+  background: var(--jitter);
+  animation-delay: -0.35s;
+}
+
+.line-media i {
+  width: 22%;
+  background: var(--retry);
+  animation-delay: -0.7s;
+}
+
+.line-extra i {
+  width: 14%;
+  background: var(--dampen);
+  animation-delay: -1s;
+}
+
+.switch-node {
+  position: absolute;
+  min-width: 86px;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  text-align: center;
+  font-size: 0.82rem;
+  box-shadow: 0 12px 30px rgba(16, 24, 40, 0.1);
+}
+
+.node-client {
+  left: 7%;
+  top: 10%;
+}
+.node-policy {
+  left: 42%;
+  top: 10%;
+}
+.node-core {
+  right: 7%;
+  top: 31%;
+}
+.node-optional {
+  right: 7%;
+  bottom: 10%;
+}
+
+.service-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.service-card {
+  min-height: 224px;
+  padding: 20px;
+  opacity: 0.58;
+  transform: translateY(12px) scale(0.97);
+  transition:
+    transform 340ms ease,
+    opacity 340ms ease,
+    border-color 340ms ease,
+    box-shadow 340ms ease;
+}
+
+.service-card > span {
+  display: block;
+  width: 48px;
+  height: 48px;
+  margin-bottom: 34px;
+  border-radius: 14px;
+  background: var(--detect);
+  box-shadow: inset 0 0 0 9px rgba(255, 255, 255, 0.32);
+}
+
+.card-jitter > span {
+  background: var(--jitter);
+}
+.card-retry > span {
+  background: var(--retry);
+}
+.card-dampen > span {
+  background: var(--dampen);
+}
+
+.service-card h2 {
+  margin-bottom: 10px;
+  font-size: 1.16rem;
+}
+
+.service-card p {
+  color: var(--muted);
+  line-height: 1.56;
+}
+
+#mode-detect:checked ~ .mode-tabs label[for="mode-detect"],
+#mode-jitter:checked ~ .mode-tabs label[for="mode-jitter"],
+#mode-retry:checked ~ .mode-tabs label[for="mode-retry"],
+#mode-dampen:checked ~ .mode-tabs label[for="mode-dampen"] {
+  color: #fff;
+  border-color: transparent;
+  background: var(--ink);
+}
+
+#mode-jitter:checked ~ .retry-board .ring-fill {
+  background: conic-gradient(var(--jitter) 0 205deg, transparent 205deg 360deg);
+}
+
+#mode-retry:checked ~ .retry-board .ring-fill {
+  background: conic-gradient(var(--retry) 0 118deg, transparent 118deg 360deg);
+}
+
+#mode-dampen:checked ~ .retry-board .ring-fill {
+  background: conic-gradient(var(--dampen) 0 176deg, transparent 176deg 360deg);
+}
+
+#mode-detect:checked ~ .service-grid .card-detect,
+#mode-jitter:checked ~ .service-grid .card-jitter,
+#mode-retry:checked ~ .service-grid .card-retry,
+#mode-dampen:checked ~ .service-grid .card-dampen {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  border-color: rgba(37, 99, 235, 0.44);
+  box-shadow: 0 18px 44px rgba(16, 24, 40, 0.12);
+}
+
+.retry-slot-001 {
+  --retry-slot: 1;
+}
+.retry-slot-002 {
+  --retry-slot: 2;
+}
+.retry-slot-003 {
+  --retry-slot: 3;
+}
+.retry-slot-004 {
+  --retry-slot: 4;
+}
+.retry-slot-005 {
+  --retry-slot: 5;
+}
+.retry-slot-006 {
+  --retry-slot: 6;
+}
+.retry-slot-007 {
+  --retry-slot: 7;
+}
+.retry-slot-008 {
+  --retry-slot: 8;
+}
+.retry-slot-009 {
+  --retry-slot: 9;
+}
+.retry-slot-010 {
+  --retry-slot: 10;
+}
+.retry-slot-011 {
+  --retry-slot: 11;
+}
+.retry-slot-012 {
+  --retry-slot: 12;
+}
+.retry-slot-013 {
+  --retry-slot: 13;
+}
+.retry-slot-014 {
+  --retry-slot: 14;
+}
+.retry-slot-015 {
+  --retry-slot: 15;
+}
+.retry-slot-016 {
+  --retry-slot: 16;
+}
+.retry-slot-017 {
+  --retry-slot: 17;
+}
+.retry-slot-018 {
+  --retry-slot: 18;
+}
+.retry-slot-019 {
+  --retry-slot: 19;
+}
+.retry-slot-020 {
+  --retry-slot: 20;
+}
+.retry-slot-021 {
+  --retry-slot: 21;
+}
+.retry-slot-022 {
+  --retry-slot: 22;
+}
+.retry-slot-023 {
+  --retry-slot: 23;
+}
+.retry-slot-024 {
+  --retry-slot: 24;
+}
+.retry-slot-025 {
+  --retry-slot: 25;
+}
+.retry-slot-026 {
+  --retry-slot: 26;
+}
+.retry-slot-027 {
+  --retry-slot: 27;
+}
+.retry-slot-028 {
+  --retry-slot: 28;
+}
+.retry-slot-029 {
+  --retry-slot: 29;
+}
+.retry-slot-030 {
+  --retry-slot: 30;
+}
+.retry-slot-031 {
+  --retry-slot: 31;
+}
+.retry-slot-032 {
+  --retry-slot: 32;
+}
+.retry-slot-033 {
+  --retry-slot: 33;
+}
+.retry-slot-034 {
+  --retry-slot: 34;
+}
+.retry-slot-035 {
+  --retry-slot: 35;
+}
+.retry-slot-036 {
+  --retry-slot: 36;
+}
+.retry-slot-037 {
+  --retry-slot: 37;
+}
+.retry-slot-038 {
+  --retry-slot: 38;
+}
+.retry-slot-039 {
+  --retry-slot: 39;
+}
+.retry-slot-040 {
+  --retry-slot: 40;
+}
+.retry-slot-041 {
+  --retry-slot: 41;
+}
+.retry-slot-042 {
+  --retry-slot: 42;
+}
+.retry-slot-043 {
+  --retry-slot: 43;
+}
+.retry-slot-044 {
+  --retry-slot: 44;
+}
+.retry-slot-045 {
+  --retry-slot: 45;
+}
+.retry-slot-046 {
+  --retry-slot: 46;
+}
+.retry-slot-047 {
+  --retry-slot: 47;
+}
+.retry-slot-048 {
+  --retry-slot: 48;
+}
+.retry-slot-049 {
+  --retry-slot: 49;
+}
+.retry-slot-050 {
+  --retry-slot: 50;
+}
+.retry-slot-051 {
+  --retry-slot: 51;
+}
+.retry-slot-052 {
+  --retry-slot: 52;
+}
+.retry-slot-053 {
+  --retry-slot: 53;
+}
+.retry-slot-054 {
+  --retry-slot: 54;
+}
+.retry-slot-055 {
+  --retry-slot: 55;
+}
+
+@keyframes storm-pulse {
+  50% {
+    filter: brightness(1.14);
+  }
+}
+
+@keyframes switch-flow {
+  50% {
+    transform: translateX(170%);
+  }
+}
+
+@media (max-width: 860px) {
+  .retry-shell {
+    width: min(100% - 20px, 680px);
+    padding: 28px 0;
+  }
+
+  .retry-console {
+    padding: 14px;
+  }
+
+  .mode-tabs,
+  .retry-board,
+  .service-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSS-only retry storm damper with detect, jitter, retry, and dampen modes
- include animated storm ring, retry lanes, responsive cards, and reduced-motion handling

## Validation
- npx prettier --check submissions/examples/retry-storm-damper-kp/README.md submissions/examples/retry-storm-damper-kp/demo.html submissions/examples/retry-storm-damper-kp/style.css
- npx stylelint submissions/examples/retry-storm-damper-kp/style.css --allow-empty-input
- git diff --check