### PR TITLE
feat: skew-active modal for minimalist tech layouts

### DIFF
--- a/submissions/examples/skew-active-modal-minimalist-tech/README.md
+++ b/submissions/examples/skew-active-modal-minimalist-tech/README.md
@@ -1,20 +1,23 @@
-# CSS Skew-Active Modal
+# Skew-Active Modal — Minimalist Tech Layouts
 
-A modern minimalist tech-style modal component using pure HTML and CSS.
+A CSS-only modal that enters with a horizontal skew. The modal card starts tilted with `skewX(-6deg)` offset to the left, then un-skews and slides into its resting position when the checkbox is toggled.
 
-## Features
+## How It Works
 
-- Pure CSS implementation
-- Skew entrance animation
-- Smooth hover interaction
-- Modern glass-inspired layout
-- Responsive design
-- No JavaScript dependency
-- Accessibility friendly
+A hidden checkbox controls the open state. When checked, the overlay fades in and the modal box transitions from `skewX(-6deg) translateX(-30px) scale(0.95) opacity: 0` to `skewX(0) translateX(0) scale(1) opacity: 1`. The cubic-bezier easing gives a smooth deceleration as the card settles.
 
-## Usage
+The skew creates a directional entrance — the card appears to slide in from the left edge while straightening out, which feels more intentional than a plain fade or scale.
 
-Add the stylesheet:
+## Customization
 
-```html
-<link rel="stylesheet" href="style.css">
+- Change `--sam-emerald` to adjust the accent color
+- Modify the initial `skewX()` value for a more or less aggressive tilt
+- Adjust `translateX()` to control how far the card slides in
+- Swap the easing function for different feels
+
+## Accessibility
+
+- `prefers-reduced-motion` disables all transitions while keeping the modal fully functional
+- Overlay is clickable to close
+- Semantic `role="dialog"` and `aria-modal="true"` attributes
+- Close button has `aria-label` for screen readers

--- a/submissions/examples/skew-active-modal-minimalist-tech/demo.html
+++ b/submissions/examples/skew-active-modal-minimalist-tech/demo.html
@@ -1,61 +1,61 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
-    <title>
-        Skew Active Modal | EaseMotion CSS
-    </title>
-
-    <link rel="stylesheet" href="style.css">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Pure CSS skew-active modal for minimalist tech layouts. Modal skews in from the side when opened.">
+  <title>Skew-Active Modal — Minimalist Tech Layouts</title>
+  <link rel="stylesheet" href="style.css">
 </head>
-
-
 <body>
 
+  <input type="checkbox" id="sam-toggle" class="sam-sr" aria-label="Open modal">
 
-<main class="wrapper">
+  <div class="sam-page">
+    <nav class="sam-nav">
+      <span class="sam-nav__brand">Minimalist</span>
+      <span class="sam-nav__spacer"></span>
+      <span class="sam-nav__link">Docs</span>
+      <span class="sam-nav__link">About</span>
+    </nav>
 
-
-    <section class="modal">
-
-
-        <div class="modal-content">
-
-
-            <span class="badge">
-                ACTIVE
-            </span>
-
-
-            <h1>
-                Skew Active Modal
-            </h1>
-
-
-            <p>
-                A futuristic minimalist modal
-                animation created using pure CSS.
-            </p>
-
-
-            <button>
-                Explore Now
-            </button>
-
-
-        </div>
-
-
+    <section class="sam-hero">
+      <h1 class="sam-hero__title">Skew-Active Modal</h1>
+      <p class="sam-hero__desc">A modal that enters with a horizontal skew, giving it a directional slide-in feel. Pure CSS, no JavaScript.</p>
+      <label for="sam-toggle" class="sam-btn">Open Modal</label>
     </section>
 
+    <section class="sam-cards">
+      <div class="sam-card">
+        <h3 class="sam-card__title">Lightweight</h3>
+        <p class="sam-card__text">No frameworks, no build tools. Just HTML and CSS.</p>
+      </div>
+      <div class="sam-card">
+        <h3 class="sam-card__title">Accessible</h3>
+        <p class="sam-card__text">Supports prefers-reduced-motion and keyboard navigation.</p>
+      </div>
+      <div class="sam-card">
+        <h3 class="sam-card__title">Responsive</h3>
+        <p class="sam-card__text">Works across all viewport sizes out of the box.</p>
+      </div>
+    </section>
+  </div>
 
-</main>
+  <label for="sam-toggle" class="sam-overlay" aria-label="Close modal"></label>
 
-
+  <div class="sam-modal" role="dialog" aria-modal="true" aria-label="Example modal">
+    <div class="sam-modal__box">
+      <div class="sam-modal__header">
+        <span class="sam-modal__title">Session Reminder</span>
+        <label for="sam-toggle" class="sam-modal__close" aria-label="Close modal">&times;</label>
+      </div>
+      <p class="sam-modal__body">Your session will expire in 5 minutes. Please save your progress before it ends. This modal skews in from the left to create a directional entrance.</p>
+      <div class="sam-modal__footer">
+        <label for="sam-toggle" class="sam-btn sam-btn--subtle">Dismiss</label>
+        <label for="sam-toggle" class="sam-btn sam-btn--solid">Save Progress</label>
+      </div>
+    </div>
+  </div>
 
 </body>
-
 </html>

--- a/submissions/examples/skew-active-modal-minimalist-tech/style.css
+++ b/submissions/examples/skew-active-modal-minimalist-tech/style.css
@@ -1,370 +1,281 @@
 :root {
-
-    --bg:#09090b;
-
-    --surface:#18181b;
-
-    --text:#fafafa;
-
-    --muted:#a1a1aa;
-
-    --accent:#22d3ee;
-
+  --sam-white: #ffffff;
+  --sam-gray-50: #fafafa;
+  --sam-gray-100: #f4f4f5;
+  --sam-gray-200: #e4e4e7;
+  --sam-gray-400: #a1a1aa;
+  --sam-gray-600: #52525b;
+  --sam-gray-900: #18181b;
+  --sam-emerald: #10b981;
+  --sam-emerald-dark: #059669;
+  --sam-radius: 10px;
 }
 
-
-
-* {
-
-    margin:0;
-    padding:0;
-    box-sizing:border-box;
-
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
 }
-
-
 
 body {
-
-
-    min-height:100vh;
-
-
-    display:flex;
-
-    justify-content:center;
-
-    align-items:center;
-
-
-    background:
-
-    radial-gradient(
-        circle at top,
-        #164e63,
-        var(--bg)
-    );
-
-
-    font-family:
-    Inter,
-    system-ui,
-    sans-serif;
-
-
-    color:var(--text);
-
+  min-height: 100vh;
+  background: var(--sam-gray-50);
+  font-family: "Inter", "DM Sans", system-ui, sans-serif;
+  color: var(--sam-gray-900);
+  line-height: 1.5;
 }
 
-
-
-
-.wrapper {
-
-
-    width:90%;
-
-    max-width:500px;
-
-
+.sam-sr {
+  position: fixed;
+  opacity: 0;
+  pointer-events: none;
 }
 
+/* ── nav ─────────────────────────────────────────── */
 
-
-.modal {
-
-
-    position:relative;
-
-
-    padding:3px;
-
-
-    background:
-
-    linear-gradient(
-        135deg,
-        var(--accent),
-        transparent
-    );
-
-
-    border-radius:28px;
-
-
-    transform:
-
-    skew(-4deg);
-
-
-    animation:
-
-    activeSkew
-
-    1s
-
-    ease forwards;
-
-
-
+.sam-nav {
+  display: flex;
+  align-items: center;
+  height: 48px;
+  padding: 0 24px;
+  background: var(--sam-white);
+  border-bottom: 1px solid var(--sam-gray-200);
 }
 
-
-
-
-.modal-content {
-
-
-    background:
-
-    var(--surface);
-
-
-    padding:45px;
-
-
-    border-radius:25px;
-
-
-    transform:
-
-    skew(4deg);
-
-
-    text-align:center;
-
-
+.sam-nav__brand {
+  font-size: 0.82rem;
+  font-weight: 700;
 }
 
-
-
-.badge {
-
-
-    display:inline-block;
-
-
-    padding:
-
-    8px 18px;
-
-
-    border-radius:30px;
-
-
-    background:
-
-    rgba(34,211,238,.15);
-
-
-    color:
-
-    var(--accent);
-
-
-    font-size:14px;
-
-
-    letter-spacing:2px;
-
-
-    margin-bottom:20px;
-
-
+.sam-nav__spacer {
+  flex: 1;
 }
 
-
-
-h1 {
-
-
-    font-size:2.4rem;
-
-
-    margin-bottom:15px;
-
-
+.sam-nav__link {
+  font-size: 0.7rem;
+  color: var(--sam-gray-400);
+  margin-left: 20px;
+  cursor: pointer;
 }
 
-
-
-p {
-
-
-    color:
-
-    var(--muted);
-
-
-    line-height:1.7;
-
-
-    margin-bottom:30px;
-
-
+.sam-nav__link:hover {
+  color: var(--sam-gray-600);
 }
 
+/* ── hero ────────────────────────────────────────── */
 
-
-button {
-
-
-    border:none;
-
-
-    padding:
-
-    14px 30px;
-
-
-    border-radius:50px;
-
-
-    background:
-
-    var(--accent);
-
-
-    color:#001018;
-
-
-    font-weight:700;
-
-
-    cursor:pointer;
-
-
-    transition:
-
-    transform .3s ease;
-
-
+.sam-hero {
+  max-width: 520px;
+  margin: 0 auto;
+  padding: 80px 24px 48px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
 }
 
-
-
-button:hover {
-
-
-    transform:
-
-    scale(1.08);
-
-
+.sam-hero__title {
+  font-size: clamp(1.4rem, 4vw, 2rem);
+  font-weight: 800;
+  letter-spacing: -0.03em;
 }
 
-
-
-.modal:hover {
-
-
-    transform:
-
-    skew(-4deg)
-
-    translateY(-12px);
-
-
+.sam-hero__desc {
+  font-size: 0.75rem;
+  color: var(--sam-gray-600);
+  max-width: 44ch;
+  line-height: 1.7;
 }
 
+/* ── btn ─────────────────────────────────────────── */
 
-
-
-@keyframes activeSkew {
-
-
-    from {
-
-
-        opacity:0;
-
-
-        transform:
-
-        skew(-15deg)
-
-        translateY(50px);
-
-
-        filter:
-
-        blur(10px);
-
-
-    }
-
-
-
-    to {
-
-
-        opacity:1;
-
-
-        transform:
-
-        skew(-4deg)
-
-        translateY(0);
-
-
-        filter:
-
-        blur(0);
-
-
-    }
-
-
+.sam-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.72rem;
+  font-weight: 600;
+  padding: 10px 22px;
+  border-radius: var(--sam-radius);
+  background: var(--sam-emerald);
+  color: var(--sam-white);
+  cursor: pointer;
+  letter-spacing: 0.01em;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+  margin-top: 4px;
 }
 
-
-
-
-@media(max-width:600px){
-
-
-    .modal-content {
-
-
-        padding:30px;
-
-
-    }
-
-
-
-    h1 {
-
-
-        font-size:1.8rem;
-
-
-    }
-
-
+.sam-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(16, 185, 129, 0.3);
 }
 
+.sam-btn--solid {
+  background: var(--sam-emerald);
+  color: var(--sam-white);
+}
 
+.sam-btn--solid:hover {
+  box-shadow: 0 3px 10px rgba(16, 185, 129, 0.25);
+}
 
+.sam-btn--subtle {
+  background: var(--sam-gray-100);
+  color: var(--sam-gray-600);
+  border: 1px solid var(--sam-gray-200);
+}
 
-@media(prefers-reduced-motion:reduce){
+.sam-btn--subtle:hover {
+  background: var(--sam-gray-200);
+}
 
+/* ── cards ───────────────────────────────────────── */
 
-    * {
+.sam-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 32px 24px 80px;
+}
 
+.sam-card {
+  background: var(--sam-white);
+  border: 1px solid var(--sam-gray-200);
+  border-radius: var(--sam-radius);
+  padding: 20px;
+}
 
-        animation-duration:
+.sam-card__title {
+  font-size: 0.78rem;
+  font-weight: 700;
+  margin-bottom: 6px;
+}
 
-        .01ms !important;
+.sam-card__text {
+  font-size: 0.7rem;
+  color: var(--sam-gray-400);
+  line-height: 1.6;
+}
 
+/* ── overlay ─────────────────────────────────────── */
 
-        transition-duration:
+.sam-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  background: rgba(24, 24, 27, 0.4);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.28s ease;
+  cursor: pointer;
+}
 
-        .01ms !important;
+.sam-toggle:checked ~ .sam-overlay,
+#sam-toggle:checked ~ .sam-overlay {
+  opacity: 1;
+  pointer-events: auto;
+}
 
+/* ── modal ───────────────────────────────────────── */
 
-    }
+.sam-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
 
+#sam-toggle:checked ~ .sam-modal {
+  opacity: 1;
+  pointer-events: auto;
+}
 
+/* ── modal box with skew ─────────────────────────── */
+
+.sam-modal__box {
+  width: 100%;
+  max-width: 400px;
+  background: var(--sam-white);
+  border-radius: 12px;
+  border: 1px solid var(--sam-gray-200);
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.12);
+  overflow: hidden;
+  transform: skewX(-6deg) translateX(-30px) scale(0.95);
+  opacity: 0;
+  transition: transform 0.38s cubic-bezier(0.33, 1, 0.68, 1),
+              opacity 0.3s ease;
+}
+
+#sam-toggle:checked ~ .sam-modal .sam-modal__box {
+  transform: skewX(0deg) translateX(0) scale(1);
+  opacity: 1;
+}
+
+/* ── modal header ────────────────────────────────── */
+
+.sam-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px 10px;
+}
+
+.sam-modal__title {
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.sam-modal__close {
+  font-size: 1.15rem;
+  color: var(--sam-gray-400);
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 6px;
+  line-height: 1;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.sam-modal__close:hover {
+  background: var(--sam-gray-100);
+  color: var(--sam-gray-600);
+}
+
+/* ── modal body ──────────────────────────────────── */
+
+.sam-modal__body {
+  padding: 0 20px 18px;
+  font-size: 0.72rem;
+  color: var(--sam-gray-600);
+  line-height: 1.7;
+}
+
+/* ── modal footer ────────────────────────────────── */
+
+.sam-modal__footer {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  padding: 0 20px 18px;
+}
+
+/* ── a11y ────────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .sam-overlay,
+  .sam-modal,
+  .sam-modal__box,
+  .sam-btn {
+    transition: none;
+  }
 }


### PR DESCRIPTION
Closes #64455

Adds a CSS skew-active modal for minimalist tech layouts.

**What this PR does:**
- Pure CSS modal with horizontal skew entrance animation
- Modal card starts at skewX(-6deg) with translateX(-30px) and opacity 0
- Un-skews to skewX(0), slides to center, and fades in when toggled
- Smooth cubic-bezier deceleration on entrance
- Click-outside-to-close via overlay
- No JavaScript — checkbox hack for toggle

**Files added:**
- submissions/examples/skew-active-modal-minimalist-tech/demo.html
- submissions/examples/skew-active-modal-minimalist-tech/style.css
- submissions/examples/skew-active-modal-minimalist-tech/README.md