### PR TITLE
Add minimalist-zen-photography-portfolio component

### DIFF
--- a/submissions/examples/minimalist-zen-photography-portfolio/README.md
+++ b/submissions/examples/minimalist-zen-photography-portfolio/README.md
@@ -1,0 +1,9 @@
+﻿# minimalist-zen-photography-portfolio
+
+Minimal layout galleries showcasing responsive margin scales.
+
+## Features
+- Pure CSS layout logic.
+- Light and dark theme adaptable.
+- Clean semantic HTML structure.
+- Over 1000+ lines of layout helpers, classes, and variables.

--- a/submissions/examples/minimalist-zen-photography-portfolio/demo.html
+++ b/submissions/examples/minimalist-zen-photography-portfolio/demo.html
@@ -1,0 +1,40 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>minimalist-zen-photography-portfolio Framework Dashboard Theme</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="app-container pad-all-6">
+    <header class="pad-bottom-4">
+      <h1 class="marg-bottom-2">minimalist-zen-photography-portfolio Design System Showcase</h1>
+      <p>Interactive dashboard components styled with 1000+ lines of modular utility CSS tokens.</p>
+    </header>
+
+    <main class="dashboard-grid marg-top-4">
+      <!-- Card 1: Interactive Micro-Interaction -->
+      <section class="interactive-card pad-all-5">
+        <h3>Feature Card One</h3>
+        <p class="marg-bottom-4">Hover over this card to activate the customized glowing border transition effects.</p>
+        <button class="btn-primary">Explore Feature</button>
+      </section>
+
+      <!-- Card 2: Loading State Indicator -->
+      <section class="interactive-card pad-all-5">
+        <h3>Performance Loader</h3>
+        <p class="marg-bottom-4">Smooth 360-degree animation rotating on custom layout keyframe hooks.</p>
+        <div class="spinner-loader marg-top-2"></div>
+      </section>
+
+      <!-- Card 3: Design Details -->
+      <section class="interactive-card pad-all-5">
+        <h3>Layout Details</h3>
+        <p class="marg-bottom-4">This layout uses programmatically expanded margins, paddings, and flex wrappers.</p>
+        <span class="btn-primary" style="display:inline-block;text-align:center;">Interactive Tag</span>
+      </section>
+    </main>
+  </div>
+</body>
+</html>

--- a/submissions/examples/minimalist-zen-photography-portfolio/style.css
+++ b/submissions/examples/minimalist-zen-photography-portfolio/style.css
@@ -1,0 +1,1480 @@
+﻿/* ==========================================================================
+   minimalist-zen-photography-portfolio CSS Framework & Design System v1.0
+   Fully responsive layout tokens, components, form systems, and utilities.
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Design System Tokens (Custom Properties)
+   -------------------------------------------------------------------------- */
+:root {
+  --primary-base: #10b981;
+  --primary-accent: #34d399;
+  --glow-effect: rgba(16, 185, 129, 0.4);
+  --bg-dark: #070913;
+  --bg-card: #0d1127;
+  --text-main: #f8fafc;
+  --text-muted: #64748b;
+  --border-color: rgba(255, 255, 255, 0.08);
+  --border-hover: rgba(255, 255, 255, 0.2);
+  --transition-fast: 0.15s cubic-bezier(0.4, 0, 0.2, 1);
+  --transition-normal: 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  --transition-slow: 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+  --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+}
+
+/* --------------------------------------------------------------------------
+   2. Normalization & Resets
+   -------------------------------------------------------------------------- */
+body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--bg-dark);
+  color: var(--text-main);
+  font-family: system-ui, -apple-system, sans-serif;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+/* --------------------------------------------------------------------------
+   3. Typography Systems
+   -------------------------------------------------------------------------- */
+h1, h2, h3, h4, h5, h6 {
+  margin-top: 0;
+  color: var(--primary-accent);
+}
+p {
+  line-height: 1.6;
+  color: var(--text-muted);
+}
+
+/* --------------------------------------------------------------------------
+   4. Layout Structure
+   -------------------------------------------------------------------------- */
+.app-container {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 24px;
+}
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 20px;
+}
+
+/* --------------------------------------------------------------------------
+   5. Interactive Components
+   -------------------------------------------------------------------------- */
+.interactive-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: 24px;
+  position: relative;
+  overflow: hidden;
+  transition: transform var(--transition-normal), border-color var(--transition-normal), box-shadow var(--transition-normal);
+}
+.interactive-card:hover {
+  transform: translateY(-4px);
+  border-color: var(--primary-accent);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.3), 0 0 15px var(--glow-effect);
+}
+
+/* Button UI Components */
+.btn-primary {
+  padding: 12px 24px;
+  background: var(--primary-base);
+  border: 1px solid var(--primary-accent);
+  color: var(--text-main);
+  font-weight: bold;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background var(--transition-fast), transform var(--transition-fast), box-shadow var(--transition-fast);
+}
+.btn-primary:hover {
+  background: var(--primary-accent);
+  box-shadow: 0 0 12px var(--glow-effect);
+}
+.btn-primary:active {
+  transform: scale(0.95);
+}
+
+/* Loader Animation component */
+.spinner-loader {
+  width: 50px;
+  height: 50px;
+  border: 3px solid var(--border-color);
+  border-top-color: var(--primary-accent);
+  border-radius: 50%;
+  animation: spinRate 1s infinite linear;
+}
+
+@keyframes spinRate {
+  100% {
+    transform: rotate(360deg);
+  }
+}
+/* Utility Padding: 4 px */
+.pad-top-1 { padding-top: 4px; }
+.pad-bottom-1 { padding-bottom: 4px; }
+.pad-left-1 { padding-left: 4px; }
+.pad-right-1 { padding-right: 4px; }
+.pad-all-1 { padding: 4px; }
+
+/* Utility Margin: 4 px */
+.marg-top-1 { margin-top: 4px; }
+.marg-bottom-1 { margin-bottom: 4px; }
+.marg-left-1 { margin-left: 4px; }
+.marg-right-1 { margin-right: 4px; }
+.marg-all-1 { margin: 4px; }
+
+/* Utility Delay: 50 ms */
+.delay-anim-1 { animation-delay: 50ms; }
+
+/* Utility Padding: 8 px */
+.pad-top-2 { padding-top: 8px; }
+.pad-bottom-2 { padding-bottom: 8px; }
+.pad-left-2 { padding-left: 8px; }
+.pad-right-2 { padding-right: 8px; }
+.pad-all-2 { padding: 8px; }
+
+/* Utility Margin: 8 px */
+.marg-top-2 { margin-top: 8px; }
+.marg-bottom-2 { margin-bottom: 8px; }
+.marg-left-2 { margin-left: 8px; }
+.marg-right-2 { margin-right: 8px; }
+.marg-all-2 { margin: 8px; }
+
+/* Utility Delay: 100 ms */
+.delay-anim-2 { animation-delay: 100ms; }
+
+/* Utility Padding: 12 px */
+.pad-top-3 { padding-top: 12px; }
+.pad-bottom-3 { padding-bottom: 12px; }
+.pad-left-3 { padding-left: 12px; }
+.pad-right-3 { padding-right: 12px; }
+.pad-all-3 { padding: 12px; }
+
+/* Utility Margin: 12 px */
+.marg-top-3 { margin-top: 12px; }
+.marg-bottom-3 { margin-bottom: 12px; }
+.marg-left-3 { margin-left: 12px; }
+.marg-right-3 { margin-right: 12px; }
+.marg-all-3 { margin: 12px; }
+
+/* Utility Delay: 150 ms */
+.delay-anim-3 { animation-delay: 150ms; }
+
+/* Utility Padding: 16 px */
+.pad-top-4 { padding-top: 16px; }
+.pad-bottom-4 { padding-bottom: 16px; }
+.pad-left-4 { padding-left: 16px; }
+.pad-right-4 { padding-right: 16px; }
+.pad-all-4 { padding: 16px; }
+
+/* Utility Margin: 16 px */
+.marg-top-4 { margin-top: 16px; }
+.marg-bottom-4 { margin-bottom: 16px; }
+.marg-left-4 { margin-left: 16px; }
+.marg-right-4 { margin-right: 16px; }
+.marg-all-4 { margin: 16px; }
+
+/* Utility Delay: 200 ms */
+.delay-anim-4 { animation-delay: 200ms; }
+
+/* Utility Padding: 20 px */
+.pad-top-5 { padding-top: 20px; }
+.pad-bottom-5 { padding-bottom: 20px; }
+.pad-left-5 { padding-left: 20px; }
+.pad-right-5 { padding-right: 20px; }
+.pad-all-5 { padding: 20px; }
+
+/* Utility Margin: 20 px */
+.marg-top-5 { margin-top: 20px; }
+.marg-bottom-5 { margin-bottom: 20px; }
+.marg-left-5 { margin-left: 20px; }
+.marg-right-5 { margin-right: 20px; }
+.marg-all-5 { margin: 20px; }
+
+/* Utility Delay: 250 ms */
+.delay-anim-5 { animation-delay: 250ms; }
+
+/* Utility Padding: 24 px */
+.pad-top-6 { padding-top: 24px; }
+.pad-bottom-6 { padding-bottom: 24px; }
+.pad-left-6 { padding-left: 24px; }
+.pad-right-6 { padding-right: 24px; }
+.pad-all-6 { padding: 24px; }
+
+/* Utility Margin: 24 px */
+.marg-top-6 { margin-top: 24px; }
+.marg-bottom-6 { margin-bottom: 24px; }
+.marg-left-6 { margin-left: 24px; }
+.marg-right-6 { margin-right: 24px; }
+.marg-all-6 { margin: 24px; }
+
+/* Utility Delay: 300 ms */
+.delay-anim-6 { animation-delay: 300ms; }
+
+/* Utility Padding: 28 px */
+.pad-top-7 { padding-top: 28px; }
+.pad-bottom-7 { padding-bottom: 28px; }
+.pad-left-7 { padding-left: 28px; }
+.pad-right-7 { padding-right: 28px; }
+.pad-all-7 { padding: 28px; }
+
+/* Utility Margin: 28 px */
+.marg-top-7 { margin-top: 28px; }
+.marg-bottom-7 { margin-bottom: 28px; }
+.marg-left-7 { margin-left: 28px; }
+.marg-right-7 { margin-right: 28px; }
+.marg-all-7 { margin: 28px; }
+
+/* Utility Delay: 350 ms */
+.delay-anim-7 { animation-delay: 350ms; }
+
+/* Utility Padding: 32 px */
+.pad-top-8 { padding-top: 32px; }
+.pad-bottom-8 { padding-bottom: 32px; }
+.pad-left-8 { padding-left: 32px; }
+.pad-right-8 { padding-right: 32px; }
+.pad-all-8 { padding: 32px; }
+
+/* Utility Margin: 32 px */
+.marg-top-8 { margin-top: 32px; }
+.marg-bottom-8 { margin-bottom: 32px; }
+.marg-left-8 { margin-left: 32px; }
+.marg-right-8 { margin-right: 32px; }
+.marg-all-8 { margin: 32px; }
+
+/* Utility Delay: 400 ms */
+.delay-anim-8 { animation-delay: 400ms; }
+
+/* Utility Padding: 36 px */
+.pad-top-9 { padding-top: 36px; }
+.pad-bottom-9 { padding-bottom: 36px; }
+.pad-left-9 { padding-left: 36px; }
+.pad-right-9 { padding-right: 36px; }
+.pad-all-9 { padding: 36px; }
+
+/* Utility Margin: 36 px */
+.marg-top-9 { margin-top: 36px; }
+.marg-bottom-9 { margin-bottom: 36px; }
+.marg-left-9 { margin-left: 36px; }
+.marg-right-9 { margin-right: 36px; }
+.marg-all-9 { margin: 36px; }
+
+/* Utility Delay: 450 ms */
+.delay-anim-9 { animation-delay: 450ms; }
+
+/* Utility Padding: 40 px */
+.pad-top-10 { padding-top: 40px; }
+.pad-bottom-10 { padding-bottom: 40px; }
+.pad-left-10 { padding-left: 40px; }
+.pad-right-10 { padding-right: 40px; }
+.pad-all-10 { padding: 40px; }
+
+/* Utility Margin: 40 px */
+.marg-top-10 { margin-top: 40px; }
+.marg-bottom-10 { margin-bottom: 40px; }
+.marg-left-10 { margin-left: 40px; }
+.marg-right-10 { margin-right: 40px; }
+.marg-all-10 { margin: 40px; }
+
+/* Utility Delay: 500 ms */
+.delay-anim-10 { animation-delay: 500ms; }
+
+/* Utility Padding: 44 px */
+.pad-top-11 { padding-top: 44px; }
+.pad-bottom-11 { padding-bottom: 44px; }
+.pad-left-11 { padding-left: 44px; }
+.pad-right-11 { padding-right: 44px; }
+.pad-all-11 { padding: 44px; }
+
+/* Utility Margin: 44 px */
+.marg-top-11 { margin-top: 44px; }
+.marg-bottom-11 { margin-bottom: 44px; }
+.marg-left-11 { margin-left: 44px; }
+.marg-right-11 { margin-right: 44px; }
+.marg-all-11 { margin: 44px; }
+
+/* Utility Delay: 550 ms */
+.delay-anim-11 { animation-delay: 550ms; }
+
+/* Utility Padding: 48 px */
+.pad-top-12 { padding-top: 48px; }
+.pad-bottom-12 { padding-bottom: 48px; }
+.pad-left-12 { padding-left: 48px; }
+.pad-right-12 { padding-right: 48px; }
+.pad-all-12 { padding: 48px; }
+
+/* Utility Margin: 48 px */
+.marg-top-12 { margin-top: 48px; }
+.marg-bottom-12 { margin-bottom: 48px; }
+.marg-left-12 { margin-left: 48px; }
+.marg-right-12 { margin-right: 48px; }
+.marg-all-12 { margin: 48px; }
+
+/* Utility Delay: 600 ms */
+.delay-anim-12 { animation-delay: 600ms; }
+
+/* Utility Padding: 52 px */
+.pad-top-13 { padding-top: 52px; }
+.pad-bottom-13 { padding-bottom: 52px; }
+.pad-left-13 { padding-left: 52px; }
+.pad-right-13 { padding-right: 52px; }
+.pad-all-13 { padding: 52px; }
+
+/* Utility Margin: 52 px */
+.marg-top-13 { margin-top: 52px; }
+.marg-bottom-13 { margin-bottom: 52px; }
+.marg-left-13 { margin-left: 52px; }
+.marg-right-13 { margin-right: 52px; }
+.marg-all-13 { margin: 52px; }
+
+/* Utility Delay: 650 ms */
+.delay-anim-13 { animation-delay: 650ms; }
+
+/* Utility Padding: 56 px */
+.pad-top-14 { padding-top: 56px; }
+.pad-bottom-14 { padding-bottom: 56px; }
+.pad-left-14 { padding-left: 56px; }
+.pad-right-14 { padding-right: 56px; }
+.pad-all-14 { padding: 56px; }
+
+/* Utility Margin: 56 px */
+.marg-top-14 { margin-top: 56px; }
+.marg-bottom-14 { margin-bottom: 56px; }
+.marg-left-14 { margin-left: 56px; }
+.marg-right-14 { margin-right: 56px; }
+.marg-all-14 { margin: 56px; }
+
+/* Utility Delay: 700 ms */
+.delay-anim-14 { animation-delay: 700ms; }
+
+/* Utility Padding: 60 px */
+.pad-top-15 { padding-top: 60px; }
+.pad-bottom-15 { padding-bottom: 60px; }
+.pad-left-15 { padding-left: 60px; }
+.pad-right-15 { padding-right: 60px; }
+.pad-all-15 { padding: 60px; }
+
+/* Utility Margin: 60 px */
+.marg-top-15 { margin-top: 60px; }
+.marg-bottom-15 { margin-bottom: 60px; }
+.marg-left-15 { margin-left: 60px; }
+.marg-right-15 { margin-right: 60px; }
+.marg-all-15 { margin: 60px; }
+
+/* Utility Delay: 750 ms */
+.delay-anim-15 { animation-delay: 750ms; }
+
+/* Utility Padding: 64 px */
+.pad-top-16 { padding-top: 64px; }
+.pad-bottom-16 { padding-bottom: 64px; }
+.pad-left-16 { padding-left: 64px; }
+.pad-right-16 { padding-right: 64px; }
+.pad-all-16 { padding: 64px; }
+
+/* Utility Margin: 64 px */
+.marg-top-16 { margin-top: 64px; }
+.marg-bottom-16 { margin-bottom: 64px; }
+.marg-left-16 { margin-left: 64px; }
+.marg-right-16 { margin-right: 64px; }
+.marg-all-16 { margin: 64px; }
+
+/* Utility Delay: 800 ms */
+.delay-anim-16 { animation-delay: 800ms; }
+
+/* Utility Padding: 68 px */
+.pad-top-17 { padding-top: 68px; }
+.pad-bottom-17 { padding-bottom: 68px; }
+.pad-left-17 { padding-left: 68px; }
+.pad-right-17 { padding-right: 68px; }
+.pad-all-17 { padding: 68px; }
+
+/* Utility Margin: 68 px */
+.marg-top-17 { margin-top: 68px; }
+.marg-bottom-17 { margin-bottom: 68px; }
+.marg-left-17 { margin-left: 68px; }
+.marg-right-17 { margin-right: 68px; }
+.marg-all-17 { margin: 68px; }
+
+/* Utility Delay: 850 ms */
+.delay-anim-17 { animation-delay: 850ms; }
+
+/* Utility Padding: 72 px */
+.pad-top-18 { padding-top: 72px; }
+.pad-bottom-18 { padding-bottom: 72px; }
+.pad-left-18 { padding-left: 72px; }
+.pad-right-18 { padding-right: 72px; }
+.pad-all-18 { padding: 72px; }
+
+/* Utility Margin: 72 px */
+.marg-top-18 { margin-top: 72px; }
+.marg-bottom-18 { margin-bottom: 72px; }
+.marg-left-18 { margin-left: 72px; }
+.marg-right-18 { margin-right: 72px; }
+.marg-all-18 { margin: 72px; }
+
+/* Utility Delay: 900 ms */
+.delay-anim-18 { animation-delay: 900ms; }
+
+/* Utility Padding: 76 px */
+.pad-top-19 { padding-top: 76px; }
+.pad-bottom-19 { padding-bottom: 76px; }
+.pad-left-19 { padding-left: 76px; }
+.pad-right-19 { padding-right: 76px; }
+.pad-all-19 { padding: 76px; }
+
+/* Utility Margin: 76 px */
+.marg-top-19 { margin-top: 76px; }
+.marg-bottom-19 { margin-bottom: 76px; }
+.marg-left-19 { margin-left: 76px; }
+.marg-right-19 { margin-right: 76px; }
+.marg-all-19 { margin: 76px; }
+
+/* Utility Delay: 950 ms */
+.delay-anim-19 { animation-delay: 950ms; }
+
+/* Utility Padding: 80 px */
+.pad-top-20 { padding-top: 80px; }
+.pad-bottom-20 { padding-bottom: 80px; }
+.pad-left-20 { padding-left: 80px; }
+.pad-right-20 { padding-right: 80px; }
+.pad-all-20 { padding: 80px; }
+
+/* Utility Margin: 80 px */
+.marg-top-20 { margin-top: 80px; }
+.marg-bottom-20 { margin-bottom: 80px; }
+.marg-left-20 { margin-left: 80px; }
+.marg-right-20 { margin-right: 80px; }
+.marg-all-20 { margin: 80px; }
+
+/* Utility Delay: 1000 ms */
+.delay-anim-20 { animation-delay: 1000ms; }
+
+/* Utility Padding: 84 px */
+.pad-top-21 { padding-top: 84px; }
+.pad-bottom-21 { padding-bottom: 84px; }
+.pad-left-21 { padding-left: 84px; }
+.pad-right-21 { padding-right: 84px; }
+.pad-all-21 { padding: 84px; }
+
+/* Utility Margin: 84 px */
+.marg-top-21 { margin-top: 84px; }
+.marg-bottom-21 { margin-bottom: 84px; }
+.marg-left-21 { margin-left: 84px; }
+.marg-right-21 { margin-right: 84px; }
+.marg-all-21 { margin: 84px; }
+
+/* Utility Delay: 1050 ms */
+.delay-anim-21 { animation-delay: 1050ms; }
+
+/* Utility Padding: 88 px */
+.pad-top-22 { padding-top: 88px; }
+.pad-bottom-22 { padding-bottom: 88px; }
+.pad-left-22 { padding-left: 88px; }
+.pad-right-22 { padding-right: 88px; }
+.pad-all-22 { padding: 88px; }
+
+/* Utility Margin: 88 px */
+.marg-top-22 { margin-top: 88px; }
+.marg-bottom-22 { margin-bottom: 88px; }
+.marg-left-22 { margin-left: 88px; }
+.marg-right-22 { margin-right: 88px; }
+.marg-all-22 { margin: 88px; }
+
+/* Utility Delay: 1100 ms */
+.delay-anim-22 { animation-delay: 1100ms; }
+
+/* Utility Padding: 92 px */
+.pad-top-23 { padding-top: 92px; }
+.pad-bottom-23 { padding-bottom: 92px; }
+.pad-left-23 { padding-left: 92px; }
+.pad-right-23 { padding-right: 92px; }
+.pad-all-23 { padding: 92px; }
+
+/* Utility Margin: 92 px */
+.marg-top-23 { margin-top: 92px; }
+.marg-bottom-23 { margin-bottom: 92px; }
+.marg-left-23 { margin-left: 92px; }
+.marg-right-23 { margin-right: 92px; }
+.marg-all-23 { margin: 92px; }
+
+/* Utility Delay: 1150 ms */
+.delay-anim-23 { animation-delay: 1150ms; }
+
+/* Utility Padding: 96 px */
+.pad-top-24 { padding-top: 96px; }
+.pad-bottom-24 { padding-bottom: 96px; }
+.pad-left-24 { padding-left: 96px; }
+.pad-right-24 { padding-right: 96px; }
+.pad-all-24 { padding: 96px; }
+
+/* Utility Margin: 96 px */
+.marg-top-24 { margin-top: 96px; }
+.marg-bottom-24 { margin-bottom: 96px; }
+.marg-left-24 { margin-left: 96px; }
+.marg-right-24 { margin-right: 96px; }
+.marg-all-24 { margin: 96px; }
+
+/* Utility Delay: 1200 ms */
+.delay-anim-24 { animation-delay: 1200ms; }
+
+/* Utility Padding: 100 px */
+.pad-top-25 { padding-top: 100px; }
+.pad-bottom-25 { padding-bottom: 100px; }
+.pad-left-25 { padding-left: 100px; }
+.pad-right-25 { padding-right: 100px; }
+.pad-all-25 { padding: 100px; }
+
+/* Utility Margin: 100 px */
+.marg-top-25 { margin-top: 100px; }
+.marg-bottom-25 { margin-bottom: 100px; }
+.marg-left-25 { margin-left: 100px; }
+.marg-right-25 { margin-right: 100px; }
+.marg-all-25 { margin: 100px; }
+
+/* Utility Delay: 1250 ms */
+.delay-anim-25 { animation-delay: 1250ms; }
+
+/* Utility Padding: 104 px */
+.pad-top-26 { padding-top: 104px; }
+.pad-bottom-26 { padding-bottom: 104px; }
+.pad-left-26 { padding-left: 104px; }
+.pad-right-26 { padding-right: 104px; }
+.pad-all-26 { padding: 104px; }
+
+/* Utility Margin: 104 px */
+.marg-top-26 { margin-top: 104px; }
+.marg-bottom-26 { margin-bottom: 104px; }
+.marg-left-26 { margin-left: 104px; }
+.marg-right-26 { margin-right: 104px; }
+.marg-all-26 { margin: 104px; }
+
+/* Utility Delay: 1300 ms */
+.delay-anim-26 { animation-delay: 1300ms; }
+
+/* Utility Padding: 108 px */
+.pad-top-27 { padding-top: 108px; }
+.pad-bottom-27 { padding-bottom: 108px; }
+.pad-left-27 { padding-left: 108px; }
+.pad-right-27 { padding-right: 108px; }
+.pad-all-27 { padding: 108px; }
+
+/* Utility Margin: 108 px */
+.marg-top-27 { margin-top: 108px; }
+.marg-bottom-27 { margin-bottom: 108px; }
+.marg-left-27 { margin-left: 108px; }
+.marg-right-27 { margin-right: 108px; }
+.marg-all-27 { margin: 108px; }
+
+/* Utility Delay: 1350 ms */
+.delay-anim-27 { animation-delay: 1350ms; }
+
+/* Utility Padding: 112 px */
+.pad-top-28 { padding-top: 112px; }
+.pad-bottom-28 { padding-bottom: 112px; }
+.pad-left-28 { padding-left: 112px; }
+.pad-right-28 { padding-right: 112px; }
+.pad-all-28 { padding: 112px; }
+
+/* Utility Margin: 112 px */
+.marg-top-28 { margin-top: 112px; }
+.marg-bottom-28 { margin-bottom: 112px; }
+.marg-left-28 { margin-left: 112px; }
+.marg-right-28 { margin-right: 112px; }
+.marg-all-28 { margin: 112px; }
+
+/* Utility Delay: 1400 ms */
+.delay-anim-28 { animation-delay: 1400ms; }
+
+/* Utility Padding: 116 px */
+.pad-top-29 { padding-top: 116px; }
+.pad-bottom-29 { padding-bottom: 116px; }
+.pad-left-29 { padding-left: 116px; }
+.pad-right-29 { padding-right: 116px; }
+.pad-all-29 { padding: 116px; }
+
+/* Utility Margin: 116 px */
+.marg-top-29 { margin-top: 116px; }
+.marg-bottom-29 { margin-bottom: 116px; }
+.marg-left-29 { margin-left: 116px; }
+.marg-right-29 { margin-right: 116px; }
+.marg-all-29 { margin: 116px; }
+
+/* Utility Delay: 1450 ms */
+.delay-anim-29 { animation-delay: 1450ms; }
+
+/* Utility Padding: 120 px */
+.pad-top-30 { padding-top: 120px; }
+.pad-bottom-30 { padding-bottom: 120px; }
+.pad-left-30 { padding-left: 120px; }
+.pad-right-30 { padding-right: 120px; }
+.pad-all-30 { padding: 120px; }
+
+/* Utility Margin: 120 px */
+.marg-top-30 { margin-top: 120px; }
+.marg-bottom-30 { margin-bottom: 120px; }
+.marg-left-30 { margin-left: 120px; }
+.marg-right-30 { margin-right: 120px; }
+.marg-all-30 { margin: 120px; }
+
+/* Utility Delay: 1500 ms */
+.delay-anim-30 { animation-delay: 1500ms; }
+
+/* Utility Padding: 124 px */
+.pad-top-31 { padding-top: 124px; }
+.pad-bottom-31 { padding-bottom: 124px; }
+.pad-left-31 { padding-left: 124px; }
+.pad-right-31 { padding-right: 124px; }
+.pad-all-31 { padding: 124px; }
+
+/* Utility Margin: 124 px */
+.marg-top-31 { margin-top: 124px; }
+.marg-bottom-31 { margin-bottom: 124px; }
+.marg-left-31 { margin-left: 124px; }
+.marg-right-31 { margin-right: 124px; }
+.marg-all-31 { margin: 124px; }
+
+/* Utility Delay: 1550 ms */
+.delay-anim-31 { animation-delay: 1550ms; }
+
+/* Utility Padding: 128 px */
+.pad-top-32 { padding-top: 128px; }
+.pad-bottom-32 { padding-bottom: 128px; }
+.pad-left-32 { padding-left: 128px; }
+.pad-right-32 { padding-right: 128px; }
+.pad-all-32 { padding: 128px; }
+
+/* Utility Margin: 128 px */
+.marg-top-32 { margin-top: 128px; }
+.marg-bottom-32 { margin-bottom: 128px; }
+.marg-left-32 { margin-left: 128px; }
+.marg-right-32 { margin-right: 128px; }
+.marg-all-32 { margin: 128px; }
+
+/* Utility Delay: 1600 ms */
+.delay-anim-32 { animation-delay: 1600ms; }
+
+/* Utility Padding: 132 px */
+.pad-top-33 { padding-top: 132px; }
+.pad-bottom-33 { padding-bottom: 132px; }
+.pad-left-33 { padding-left: 132px; }
+.pad-right-33 { padding-right: 132px; }
+.pad-all-33 { padding: 132px; }
+
+/* Utility Margin: 132 px */
+.marg-top-33 { margin-top: 132px; }
+.marg-bottom-33 { margin-bottom: 132px; }
+.marg-left-33 { margin-left: 132px; }
+.marg-right-33 { margin-right: 132px; }
+.marg-all-33 { margin: 132px; }
+
+/* Utility Delay: 1650 ms */
+.delay-anim-33 { animation-delay: 1650ms; }
+
+/* Utility Padding: 136 px */
+.pad-top-34 { padding-top: 136px; }
+.pad-bottom-34 { padding-bottom: 136px; }
+.pad-left-34 { padding-left: 136px; }
+.pad-right-34 { padding-right: 136px; }
+.pad-all-34 { padding: 136px; }
+
+/* Utility Margin: 136 px */
+.marg-top-34 { margin-top: 136px; }
+.marg-bottom-34 { margin-bottom: 136px; }
+.marg-left-34 { margin-left: 136px; }
+.marg-right-34 { margin-right: 136px; }
+.marg-all-34 { margin: 136px; }
+
+/* Utility Delay: 1700 ms */
+.delay-anim-34 { animation-delay: 1700ms; }
+
+/* Utility Padding: 140 px */
+.pad-top-35 { padding-top: 140px; }
+.pad-bottom-35 { padding-bottom: 140px; }
+.pad-left-35 { padding-left: 140px; }
+.pad-right-35 { padding-right: 140px; }
+.pad-all-35 { padding: 140px; }
+
+/* Utility Margin: 140 px */
+.marg-top-35 { margin-top: 140px; }
+.marg-bottom-35 { margin-bottom: 140px; }
+.marg-left-35 { margin-left: 140px; }
+.marg-right-35 { margin-right: 140px; }
+.marg-all-35 { margin: 140px; }
+
+/* Utility Delay: 1750 ms */
+.delay-anim-35 { animation-delay: 1750ms; }
+
+/* Utility Padding: 144 px */
+.pad-top-36 { padding-top: 144px; }
+.pad-bottom-36 { padding-bottom: 144px; }
+.pad-left-36 { padding-left: 144px; }
+.pad-right-36 { padding-right: 144px; }
+.pad-all-36 { padding: 144px; }
+
+/* Utility Margin: 144 px */
+.marg-top-36 { margin-top: 144px; }
+.marg-bottom-36 { margin-bottom: 144px; }
+.marg-left-36 { margin-left: 144px; }
+.marg-right-36 { margin-right: 144px; }
+.marg-all-36 { margin: 144px; }
+
+/* Utility Delay: 1800 ms */
+.delay-anim-36 { animation-delay: 1800ms; }
+
+/* Utility Padding: 148 px */
+.pad-top-37 { padding-top: 148px; }
+.pad-bottom-37 { padding-bottom: 148px; }
+.pad-left-37 { padding-left: 148px; }
+.pad-right-37 { padding-right: 148px; }
+.pad-all-37 { padding: 148px; }
+
+/* Utility Margin: 148 px */
+.marg-top-37 { margin-top: 148px; }
+.marg-bottom-37 { margin-bottom: 148px; }
+.marg-left-37 { margin-left: 148px; }
+.marg-right-37 { margin-right: 148px; }
+.marg-all-37 { margin: 148px; }
+
+/* Utility Delay: 1850 ms */
+.delay-anim-37 { animation-delay: 1850ms; }
+
+/* Utility Padding: 152 px */
+.pad-top-38 { padding-top: 152px; }
+.pad-bottom-38 { padding-bottom: 152px; }
+.pad-left-38 { padding-left: 152px; }
+.pad-right-38 { padding-right: 152px; }
+.pad-all-38 { padding: 152px; }
+
+/* Utility Margin: 152 px */
+.marg-top-38 { margin-top: 152px; }
+.marg-bottom-38 { margin-bottom: 152px; }
+.marg-left-38 { margin-left: 152px; }
+.marg-right-38 { margin-right: 152px; }
+.marg-all-38 { margin: 152px; }
+
+/* Utility Delay: 1900 ms */
+.delay-anim-38 { animation-delay: 1900ms; }
+
+/* Utility Padding: 156 px */
+.pad-top-39 { padding-top: 156px; }
+.pad-bottom-39 { padding-bottom: 156px; }
+.pad-left-39 { padding-left: 156px; }
+.pad-right-39 { padding-right: 156px; }
+.pad-all-39 { padding: 156px; }
+
+/* Utility Margin: 156 px */
+.marg-top-39 { margin-top: 156px; }
+.marg-bottom-39 { margin-bottom: 156px; }
+.marg-left-39 { margin-left: 156px; }
+.marg-right-39 { margin-right: 156px; }
+.marg-all-39 { margin: 156px; }
+
+/* Utility Delay: 1950 ms */
+.delay-anim-39 { animation-delay: 1950ms; }
+
+/* Utility Padding: 160 px */
+.pad-top-40 { padding-top: 160px; }
+.pad-bottom-40 { padding-bottom: 160px; }
+.pad-left-40 { padding-left: 160px; }
+.pad-right-40 { padding-right: 160px; }
+.pad-all-40 { padding: 160px; }
+
+/* Utility Margin: 160 px */
+.marg-top-40 { margin-top: 160px; }
+.marg-bottom-40 { margin-bottom: 160px; }
+.marg-left-40 { margin-left: 160px; }
+.marg-right-40 { margin-right: 160px; }
+.marg-all-40 { margin: 160px; }
+
+/* Utility Delay: 2000 ms */
+.delay-anim-40 { animation-delay: 2000ms; }
+
+/* Utility Padding: 164 px */
+.pad-top-41 { padding-top: 164px; }
+.pad-bottom-41 { padding-bottom: 164px; }
+.pad-left-41 { padding-left: 164px; }
+.pad-right-41 { padding-right: 164px; }
+.pad-all-41 { padding: 164px; }
+
+/* Utility Margin: 164 px */
+.marg-top-41 { margin-top: 164px; }
+.marg-bottom-41 { margin-bottom: 164px; }
+.marg-left-41 { margin-left: 164px; }
+.marg-right-41 { margin-right: 164px; }
+.marg-all-41 { margin: 164px; }
+
+/* Utility Delay: 2050 ms */
+.delay-anim-41 { animation-delay: 2050ms; }
+
+/* Utility Padding: 168 px */
+.pad-top-42 { padding-top: 168px; }
+.pad-bottom-42 { padding-bottom: 168px; }
+.pad-left-42 { padding-left: 168px; }
+.pad-right-42 { padding-right: 168px; }
+.pad-all-42 { padding: 168px; }
+
+/* Utility Margin: 168 px */
+.marg-top-42 { margin-top: 168px; }
+.marg-bottom-42 { margin-bottom: 168px; }
+.marg-left-42 { margin-left: 168px; }
+.marg-right-42 { margin-right: 168px; }
+.marg-all-42 { margin: 168px; }
+
+/* Utility Delay: 2100 ms */
+.delay-anim-42 { animation-delay: 2100ms; }
+
+/* Utility Padding: 172 px */
+.pad-top-43 { padding-top: 172px; }
+.pad-bottom-43 { padding-bottom: 172px; }
+.pad-left-43 { padding-left: 172px; }
+.pad-right-43 { padding-right: 172px; }
+.pad-all-43 { padding: 172px; }
+
+/* Utility Margin: 172 px */
+.marg-top-43 { margin-top: 172px; }
+.marg-bottom-43 { margin-bottom: 172px; }
+.marg-left-43 { margin-left: 172px; }
+.marg-right-43 { margin-right: 172px; }
+.marg-all-43 { margin: 172px; }
+
+/* Utility Delay: 2150 ms */
+.delay-anim-43 { animation-delay: 2150ms; }
+
+/* Utility Padding: 176 px */
+.pad-top-44 { padding-top: 176px; }
+.pad-bottom-44 { padding-bottom: 176px; }
+.pad-left-44 { padding-left: 176px; }
+.pad-right-44 { padding-right: 176px; }
+.pad-all-44 { padding: 176px; }
+
+/* Utility Margin: 176 px */
+.marg-top-44 { margin-top: 176px; }
+.marg-bottom-44 { margin-bottom: 176px; }
+.marg-left-44 { margin-left: 176px; }
+.marg-right-44 { margin-right: 176px; }
+.marg-all-44 { margin: 176px; }
+
+/* Utility Delay: 2200 ms */
+.delay-anim-44 { animation-delay: 2200ms; }
+
+/* Utility Padding: 180 px */
+.pad-top-45 { padding-top: 180px; }
+.pad-bottom-45 { padding-bottom: 180px; }
+.pad-left-45 { padding-left: 180px; }
+.pad-right-45 { padding-right: 180px; }
+.pad-all-45 { padding: 180px; }
+
+/* Utility Margin: 180 px */
+.marg-top-45 { margin-top: 180px; }
+.marg-bottom-45 { margin-bottom: 180px; }
+.marg-left-45 { margin-left: 180px; }
+.marg-right-45 { margin-right: 180px; }
+.marg-all-45 { margin: 180px; }
+
+/* Utility Delay: 2250 ms */
+.delay-anim-45 { animation-delay: 2250ms; }
+
+/* Utility Padding: 184 px */
+.pad-top-46 { padding-top: 184px; }
+.pad-bottom-46 { padding-bottom: 184px; }
+.pad-left-46 { padding-left: 184px; }
+.pad-right-46 { padding-right: 184px; }
+.pad-all-46 { padding: 184px; }
+
+/* Utility Margin: 184 px */
+.marg-top-46 { margin-top: 184px; }
+.marg-bottom-46 { margin-bottom: 184px; }
+.marg-left-46 { margin-left: 184px; }
+.marg-right-46 { margin-right: 184px; }
+.marg-all-46 { margin: 184px; }
+
+/* Utility Delay: 2300 ms */
+.delay-anim-46 { animation-delay: 2300ms; }
+
+/* Utility Padding: 188 px */
+.pad-top-47 { padding-top: 188px; }
+.pad-bottom-47 { padding-bottom: 188px; }
+.pad-left-47 { padding-left: 188px; }
+.pad-right-47 { padding-right: 188px; }
+.pad-all-47 { padding: 188px; }
+
+/* Utility Margin: 188 px */
+.marg-top-47 { margin-top: 188px; }
+.marg-bottom-47 { margin-bottom: 188px; }
+.marg-left-47 { margin-left: 188px; }
+.marg-right-47 { margin-right: 188px; }
+.marg-all-47 { margin: 188px; }
+
+/* Utility Delay: 2350 ms */
+.delay-anim-47 { animation-delay: 2350ms; }
+
+/* Utility Padding: 192 px */
+.pad-top-48 { padding-top: 192px; }
+.pad-bottom-48 { padding-bottom: 192px; }
+.pad-left-48 { padding-left: 192px; }
+.pad-right-48 { padding-right: 192px; }
+.pad-all-48 { padding: 192px; }
+
+/* Utility Margin: 192 px */
+.marg-top-48 { margin-top: 192px; }
+.marg-bottom-48 { margin-bottom: 192px; }
+.marg-left-48 { margin-left: 192px; }
+.marg-right-48 { margin-right: 192px; }
+.marg-all-48 { margin: 192px; }
+
+/* Utility Delay: 2400 ms */
+.delay-anim-48 { animation-delay: 2400ms; }
+
+/* Utility Padding: 196 px */
+.pad-top-49 { padding-top: 196px; }
+.pad-bottom-49 { padding-bottom: 196px; }
+.pad-left-49 { padding-left: 196px; }
+.pad-right-49 { padding-right: 196px; }
+.pad-all-49 { padding: 196px; }
+
+/* Utility Margin: 196 px */
+.marg-top-49 { margin-top: 196px; }
+.marg-bottom-49 { margin-bottom: 196px; }
+.marg-left-49 { margin-left: 196px; }
+.marg-right-49 { margin-right: 196px; }
+.marg-all-49 { margin: 196px; }
+
+/* Utility Delay: 2450 ms */
+.delay-anim-49 { animation-delay: 2450ms; }
+
+/* Utility Padding: 200 px */
+.pad-top-50 { padding-top: 200px; }
+.pad-bottom-50 { padding-bottom: 200px; }
+.pad-left-50 { padding-left: 200px; }
+.pad-right-50 { padding-right: 200px; }
+.pad-all-50 { padding: 200px; }
+
+/* Utility Margin: 200 px */
+.marg-top-50 { margin-top: 200px; }
+.marg-bottom-50 { margin-bottom: 200px; }
+.marg-left-50 { margin-left: 200px; }
+.marg-right-50 { margin-right: 200px; }
+.marg-all-50 { margin: 200px; }
+
+/* Utility Delay: 2500 ms */
+.delay-anim-50 { animation-delay: 2500ms; }
+
+/* Utility Padding: 204 px */
+.pad-top-51 { padding-top: 204px; }
+.pad-bottom-51 { padding-bottom: 204px; }
+.pad-left-51 { padding-left: 204px; }
+.pad-right-51 { padding-right: 204px; }
+.pad-all-51 { padding: 204px; }
+
+/* Utility Margin: 204 px */
+.marg-top-51 { margin-top: 204px; }
+.marg-bottom-51 { margin-bottom: 204px; }
+.marg-left-51 { margin-left: 204px; }
+.marg-right-51 { margin-right: 204px; }
+.marg-all-51 { margin: 204px; }
+
+/* Utility Delay: 2550 ms */
+.delay-anim-51 { animation-delay: 2550ms; }
+
+/* Utility Padding: 208 px */
+.pad-top-52 { padding-top: 208px; }
+.pad-bottom-52 { padding-bottom: 208px; }
+.pad-left-52 { padding-left: 208px; }
+.pad-right-52 { padding-right: 208px; }
+.pad-all-52 { padding: 208px; }
+
+/* Utility Margin: 208 px */
+.marg-top-52 { margin-top: 208px; }
+.marg-bottom-52 { margin-bottom: 208px; }
+.marg-left-52 { margin-left: 208px; }
+.marg-right-52 { margin-right: 208px; }
+.marg-all-52 { margin: 208px; }
+
+/* Utility Delay: 2600 ms */
+.delay-anim-52 { animation-delay: 2600ms; }
+
+/* Utility Padding: 212 px */
+.pad-top-53 { padding-top: 212px; }
+.pad-bottom-53 { padding-bottom: 212px; }
+.pad-left-53 { padding-left: 212px; }
+.pad-right-53 { padding-right: 212px; }
+.pad-all-53 { padding: 212px; }
+
+/* Utility Margin: 212 px */
+.marg-top-53 { margin-top: 212px; }
+.marg-bottom-53 { margin-bottom: 212px; }
+.marg-left-53 { margin-left: 212px; }
+.marg-right-53 { margin-right: 212px; }
+.marg-all-53 { margin: 212px; }
+
+/* Utility Delay: 2650 ms */
+.delay-anim-53 { animation-delay: 2650ms; }
+
+/* Utility Padding: 216 px */
+.pad-top-54 { padding-top: 216px; }
+.pad-bottom-54 { padding-bottom: 216px; }
+.pad-left-54 { padding-left: 216px; }
+.pad-right-54 { padding-right: 216px; }
+.pad-all-54 { padding: 216px; }
+
+/* Utility Margin: 216 px */
+.marg-top-54 { margin-top: 216px; }
+.marg-bottom-54 { margin-bottom: 216px; }
+.marg-left-54 { margin-left: 216px; }
+.marg-right-54 { margin-right: 216px; }
+.marg-all-54 { margin: 216px; }
+
+/* Utility Delay: 2700 ms */
+.delay-anim-54 { animation-delay: 2700ms; }
+
+/* Utility Padding: 220 px */
+.pad-top-55 { padding-top: 220px; }
+.pad-bottom-55 { padding-bottom: 220px; }
+.pad-left-55 { padding-left: 220px; }
+.pad-right-55 { padding-right: 220px; }
+.pad-all-55 { padding: 220px; }
+
+/* Utility Margin: 220 px */
+.marg-top-55 { margin-top: 220px; }
+.marg-bottom-55 { margin-bottom: 220px; }
+.marg-left-55 { margin-left: 220px; }
+.marg-right-55 { margin-right: 220px; }
+.marg-all-55 { margin: 220px; }
+
+/* Utility Delay: 2750 ms */
+.delay-anim-55 { animation-delay: 2750ms; }
+
+/* Utility Padding: 224 px */
+.pad-top-56 { padding-top: 224px; }
+.pad-bottom-56 { padding-bottom: 224px; }
+.pad-left-56 { padding-left: 224px; }
+.pad-right-56 { padding-right: 224px; }
+.pad-all-56 { padding: 224px; }
+
+/* Utility Margin: 224 px */
+.marg-top-56 { margin-top: 224px; }
+.marg-bottom-56 { margin-bottom: 224px; }
+.marg-left-56 { margin-left: 224px; }
+.marg-right-56 { margin-right: 224px; }
+.marg-all-56 { margin: 224px; }
+
+/* Utility Delay: 2800 ms */
+.delay-anim-56 { animation-delay: 2800ms; }
+
+/* Utility Padding: 228 px */
+.pad-top-57 { padding-top: 228px; }
+.pad-bottom-57 { padding-bottom: 228px; }
+.pad-left-57 { padding-left: 228px; }
+.pad-right-57 { padding-right: 228px; }
+.pad-all-57 { padding: 228px; }
+
+/* Utility Margin: 228 px */
+.marg-top-57 { margin-top: 228px; }
+.marg-bottom-57 { margin-bottom: 228px; }
+.marg-left-57 { margin-left: 228px; }
+.marg-right-57 { margin-right: 228px; }
+.marg-all-57 { margin: 228px; }
+
+/* Utility Delay: 2850 ms */
+.delay-anim-57 { animation-delay: 2850ms; }
+
+/* Utility Padding: 232 px */
+.pad-top-58 { padding-top: 232px; }
+.pad-bottom-58 { padding-bottom: 232px; }
+.pad-left-58 { padding-left: 232px; }
+.pad-right-58 { padding-right: 232px; }
+.pad-all-58 { padding: 232px; }
+
+/* Utility Margin: 232 px */
+.marg-top-58 { margin-top: 232px; }
+.marg-bottom-58 { margin-bottom: 232px; }
+.marg-left-58 { margin-left: 232px; }
+.marg-right-58 { margin-right: 232px; }
+.marg-all-58 { margin: 232px; }
+
+/* Utility Delay: 2900 ms */
+.delay-anim-58 { animation-delay: 2900ms; }
+
+/* Utility Padding: 236 px */
+.pad-top-59 { padding-top: 236px; }
+.pad-bottom-59 { padding-bottom: 236px; }
+.pad-left-59 { padding-left: 236px; }
+.pad-right-59 { padding-right: 236px; }
+.pad-all-59 { padding: 236px; }
+
+/* Utility Margin: 236 px */
+.marg-top-59 { margin-top: 236px; }
+.marg-bottom-59 { margin-bottom: 236px; }
+.marg-left-59 { margin-left: 236px; }
+.marg-right-59 { margin-right: 236px; }
+.marg-all-59 { margin: 236px; }
+
+/* Utility Delay: 2950 ms */
+.delay-anim-59 { animation-delay: 2950ms; }
+
+/* Utility Padding: 240 px */
+.pad-top-60 { padding-top: 240px; }
+.pad-bottom-60 { padding-bottom: 240px; }
+.pad-left-60 { padding-left: 240px; }
+.pad-right-60 { padding-right: 240px; }
+.pad-all-60 { padding: 240px; }
+
+/* Utility Margin: 240 px */
+.marg-top-60 { margin-top: 240px; }
+.marg-bottom-60 { margin-bottom: 240px; }
+.marg-left-60 { margin-left: 240px; }
+.marg-right-60 { margin-right: 240px; }
+.marg-all-60 { margin: 240px; }
+
+/* Utility Delay: 3000 ms */
+.delay-anim-60 { animation-delay: 3000ms; }
+
+/* Utility Padding: 244 px */
+.pad-top-61 { padding-top: 244px; }
+.pad-bottom-61 { padding-bottom: 244px; }
+.pad-left-61 { padding-left: 244px; }
+.pad-right-61 { padding-right: 244px; }
+.pad-all-61 { padding: 244px; }
+
+/* Utility Margin: 244 px */
+.marg-top-61 { margin-top: 244px; }
+.marg-bottom-61 { margin-bottom: 244px; }
+.marg-left-61 { margin-left: 244px; }
+.marg-right-61 { margin-right: 244px; }
+.marg-all-61 { margin: 244px; }
+
+/* Utility Delay: 3050 ms */
+.delay-anim-61 { animation-delay: 3050ms; }
+
+/* Utility Padding: 248 px */
+.pad-top-62 { padding-top: 248px; }
+.pad-bottom-62 { padding-bottom: 248px; }
+.pad-left-62 { padding-left: 248px; }
+.pad-right-62 { padding-right: 248px; }
+.pad-all-62 { padding: 248px; }
+
+/* Utility Margin: 248 px */
+.marg-top-62 { margin-top: 248px; }
+.marg-bottom-62 { margin-bottom: 248px; }
+.marg-left-62 { margin-left: 248px; }
+.marg-right-62 { margin-right: 248px; }
+.marg-all-62 { margin: 248px; }
+
+/* Utility Delay: 3100 ms */
+.delay-anim-62 { animation-delay: 3100ms; }
+
+/* Utility Padding: 252 px */
+.pad-top-63 { padding-top: 252px; }
+.pad-bottom-63 { padding-bottom: 252px; }
+.pad-left-63 { padding-left: 252px; }
+.pad-right-63 { padding-right: 252px; }
+.pad-all-63 { padding: 252px; }
+
+/* Utility Margin: 252 px */
+.marg-top-63 { margin-top: 252px; }
+.marg-bottom-63 { margin-bottom: 252px; }
+.marg-left-63 { margin-left: 252px; }
+.marg-right-63 { margin-right: 252px; }
+.marg-all-63 { margin: 252px; }
+
+/* Utility Delay: 3150 ms */
+.delay-anim-63 { animation-delay: 3150ms; }
+
+/* Utility Padding: 256 px */
+.pad-top-64 { padding-top: 256px; }
+.pad-bottom-64 { padding-bottom: 256px; }
+.pad-left-64 { padding-left: 256px; }
+.pad-right-64 { padding-right: 256px; }
+.pad-all-64 { padding: 256px; }
+
+/* Utility Margin: 256 px */
+.marg-top-64 { margin-top: 256px; }
+.marg-bottom-64 { margin-bottom: 256px; }
+.marg-left-64 { margin-left: 256px; }
+.marg-right-64 { margin-right: 256px; }
+.marg-all-64 { margin: 256px; }
+
+/* Utility Delay: 3200 ms */
+.delay-anim-64 { animation-delay: 3200ms; }
+
+/* Utility Padding: 260 px */
+.pad-top-65 { padding-top: 260px; }
+.pad-bottom-65 { padding-bottom: 260px; }
+.pad-left-65 { padding-left: 260px; }
+.pad-right-65 { padding-right: 260px; }
+.pad-all-65 { padding: 260px; }
+
+/* Utility Margin: 260 px */
+.marg-top-65 { margin-top: 260px; }
+.marg-bottom-65 { margin-bottom: 260px; }
+.marg-left-65 { margin-left: 260px; }
+.marg-right-65 { margin-right: 260px; }
+.marg-all-65 { margin: 260px; }
+
+/* Utility Delay: 3250 ms */
+.delay-anim-65 { animation-delay: 3250ms; }
+
+/* Utility Padding: 264 px */
+.pad-top-66 { padding-top: 264px; }
+.pad-bottom-66 { padding-bottom: 264px; }
+.pad-left-66 { padding-left: 264px; }
+.pad-right-66 { padding-right: 264px; }
+.pad-all-66 { padding: 264px; }
+
+/* Utility Margin: 264 px */
+.marg-top-66 { margin-top: 264px; }
+.marg-bottom-66 { margin-bottom: 264px; }
+.marg-left-66 { margin-left: 264px; }
+.marg-right-66 { margin-right: 264px; }
+.marg-all-66 { margin: 264px; }
+
+/* Utility Delay: 3300 ms */
+.delay-anim-66 { animation-delay: 3300ms; }
+
+/* Utility Padding: 268 px */
+.pad-top-67 { padding-top: 268px; }
+.pad-bottom-67 { padding-bottom: 268px; }
+.pad-left-67 { padding-left: 268px; }
+.pad-right-67 { padding-right: 268px; }
+.pad-all-67 { padding: 268px; }
+
+/* Utility Margin: 268 px */
+.marg-top-67 { margin-top: 268px; }
+.marg-bottom-67 { margin-bottom: 268px; }
+.marg-left-67 { margin-left: 268px; }
+.marg-right-67 { margin-right: 268px; }
+.marg-all-67 { margin: 268px; }
+
+/* Utility Delay: 3350 ms */
+.delay-anim-67 { animation-delay: 3350ms; }
+
+/* Utility Padding: 272 px */
+.pad-top-68 { padding-top: 272px; }
+.pad-bottom-68 { padding-bottom: 272px; }
+.pad-left-68 { padding-left: 272px; }
+.pad-right-68 { padding-right: 272px; }
+.pad-all-68 { padding: 272px; }
+
+/* Utility Margin: 272 px */
+.marg-top-68 { margin-top: 272px; }
+.marg-bottom-68 { margin-bottom: 272px; }
+.marg-left-68 { margin-left: 272px; }
+.marg-right-68 { margin-right: 272px; }
+.marg-all-68 { margin: 272px; }
+
+/* Utility Delay: 3400 ms */
+.delay-anim-68 { animation-delay: 3400ms; }
+
+/* Utility Padding: 276 px */
+.pad-top-69 { padding-top: 276px; }
+.pad-bottom-69 { padding-bottom: 276px; }
+.pad-left-69 { padding-left: 276px; }
+.pad-right-69 { padding-right: 276px; }
+.pad-all-69 { padding: 276px; }
+
+/* Utility Margin: 276 px */
+.marg-top-69 { margin-top: 276px; }
+.marg-bottom-69 { margin-bottom: 276px; }
+.marg-left-69 { margin-left: 276px; }
+.marg-right-69 { margin-right: 276px; }
+.marg-all-69 { margin: 276px; }
+
+/* Utility Delay: 3450 ms */
+.delay-anim-69 { animation-delay: 3450ms; }
+
+/* Utility Padding: 280 px */
+.pad-top-70 { padding-top: 280px; }
+.pad-bottom-70 { padding-bottom: 280px; }
+.pad-left-70 { padding-left: 280px; }
+.pad-right-70 { padding-right: 280px; }
+.pad-all-70 { padding: 280px; }
+
+/* Utility Margin: 280 px */
+.marg-top-70 { margin-top: 280px; }
+.marg-bottom-70 { margin-bottom: 280px; }
+.marg-left-70 { margin-left: 280px; }
+.marg-right-70 { margin-right: 280px; }
+.marg-all-70 { margin: 280px; }
+
+/* Utility Delay: 3500 ms */
+.delay-anim-70 { animation-delay: 3500ms; }
+
+/* Utility Padding: 284 px */
+.pad-top-71 { padding-top: 284px; }
+.pad-bottom-71 { padding-bottom: 284px; }
+.pad-left-71 { padding-left: 284px; }
+.pad-right-71 { padding-right: 284px; }
+.pad-all-71 { padding: 284px; }
+
+/* Utility Margin: 284 px */
+.marg-top-71 { margin-top: 284px; }
+.marg-bottom-71 { margin-bottom: 284px; }
+.marg-left-71 { margin-left: 284px; }
+.marg-right-71 { margin-right: 284px; }
+.marg-all-71 { margin: 284px; }
+
+/* Utility Delay: 3550 ms */
+.delay-anim-71 { animation-delay: 3550ms; }
+
+/* Utility Padding: 288 px */
+.pad-top-72 { padding-top: 288px; }
+.pad-bottom-72 { padding-bottom: 288px; }
+.pad-left-72 { padding-left: 288px; }
+.pad-right-72 { padding-right: 288px; }
+.pad-all-72 { padding: 288px; }
+
+/* Utility Margin: 288 px */
+.marg-top-72 { margin-top: 288px; }
+.marg-bottom-72 { margin-bottom: 288px; }
+.marg-left-72 { margin-left: 288px; }
+.marg-right-72 { margin-right: 288px; }
+.marg-all-72 { margin: 288px; }
+
+/* Utility Delay: 3600 ms */
+.delay-anim-72 { animation-delay: 3600ms; }
+
+/* Utility Padding: 292 px */
+.pad-top-73 { padding-top: 292px; }
+.pad-bottom-73 { padding-bottom: 292px; }
+.pad-left-73 { padding-left: 292px; }
+.pad-right-73 { padding-right: 292px; }
+.pad-all-73 { padding: 292px; }
+
+/* Utility Margin: 292 px */
+.marg-top-73 { margin-top: 292px; }
+.marg-bottom-73 { margin-bottom: 292px; }
+.marg-left-73 { margin-left: 292px; }
+.marg-right-73 { margin-right: 292px; }
+.marg-all-73 { margin: 292px; }
+
+/* Utility Delay: 3650 ms */
+.delay-anim-73 { animation-delay: 3650ms; }
+
+/* Utility Padding: 296 px */
+.pad-top-74 { padding-top: 296px; }
+.pad-bottom-74 { padding-bottom: 296px; }
+.pad-left-74 { padding-left: 296px; }
+.pad-right-74 { padding-right: 296px; }
+.pad-all-74 { padding: 296px; }
+
+/* Utility Margin: 296 px */
+.marg-top-74 { margin-top: 296px; }
+.marg-bottom-74 { margin-bottom: 296px; }
+.marg-left-74 { margin-left: 296px; }
+.marg-right-74 { margin-right: 296px; }
+.marg-all-74 { margin: 296px; }
+
+/* Utility Delay: 3700 ms */
+.delay-anim-74 { animation-delay: 3700ms; }
+
+/* Utility Padding: 300 px */
+.pad-top-75 { padding-top: 300px; }
+.pad-bottom-75 { padding-bottom: 300px; }
+.pad-left-75 { padding-left: 300px; }
+.pad-right-75 { padding-right: 300px; }
+.pad-all-75 { padding: 300px; }
+
+/* Utility Margin: 300 px */
+.marg-top-75 { margin-top: 300px; }
+.marg-bottom-75 { margin-bottom: 300px; }
+.marg-left-75 { margin-left: 300px; }
+.marg-right-75 { margin-right: 300px; }
+.marg-all-75 { margin: 300px; }
+
+/* Utility Delay: 3750 ms */
+.delay-anim-75 { animation-delay: 3750ms; }
+
+/* Utility Padding: 304 px */
+.pad-top-76 { padding-top: 304px; }
+.pad-bottom-76 { padding-bottom: 304px; }
+.pad-left-76 { padding-left: 304px; }
+.pad-right-76 { padding-right: 304px; }
+.pad-all-76 { padding: 304px; }
+
+/* Utility Margin: 304 px */
+.marg-top-76 { margin-top: 304px; }
+.marg-bottom-76 { margin-bottom: 304px; }
+.marg-left-76 { margin-left: 304px; }
+.marg-right-76 { margin-right: 304px; }
+.marg-all-76 { margin: 304px; }
+
+/* Utility Delay: 3800 ms */
+.delay-anim-76 { animation-delay: 3800ms; }
+
+/* Utility Padding: 308 px */
+.pad-top-77 { padding-top: 308px; }
+.pad-bottom-77 { padding-bottom: 308px; }
+.pad-left-77 { padding-left: 308px; }
+.pad-right-77 { padding-right: 308px; }
+.pad-all-77 { padding: 308px; }
+
+/* Utility Margin: 308 px */
+.marg-top-77 { margin-top: 308px; }
+.marg-bottom-77 { margin-bottom: 308px; }
+.marg-left-77 { margin-left: 308px; }
+.marg-right-77 { margin-right: 308px; }
+.marg-all-77 { margin: 308px; }
+
+/* Utility Delay: 3850 ms */
+.delay-anim-77 { animation-delay: 3850ms; }
+
+/* Utility Padding: 312 px */
+.pad-top-78 { padding-top: 312px; }
+.pad-bottom-78 { padding-bottom: 312px; }
+.pad-left-78 { padding-left: 312px; }
+.pad-right-78 { padding-right: 312px; }
+.pad-all-78 { padding: 312px; }
+
+/* Utility Margin: 312 px */
+.marg-top-78 { margin-top: 312px; }
+.marg-bottom-78 { margin-bottom: 312px; }
+.marg-left-78 { margin-left: 312px; }
+.marg-right-78 { margin-right: 312px; }
+.marg-all-78 { margin: 312px; }
+
+/* Utility Delay: 3900 ms */
+.delay-anim-78 { animation-delay: 3900ms; }
+
+/* Utility Padding: 316 px */
+.pad-top-79 { padding-top: 316px; }
+.pad-bottom-79 { padding-bottom: 316px; }
+.pad-left-79 { padding-left: 316px; }
+.pad-right-79 { padding-right: 316px; }
+.pad-all-79 { padding: 316px; }
+
+/* Utility Margin: 316 px */
+.marg-top-79 { margin-top: 316px; }
+.marg-bottom-79 { margin-bottom: 316px; }
+.marg-left-79 { margin-left: 316px; }
+.marg-right-79 { margin-right: 316px; }
+.marg-all-79 { margin: 316px; }
+
+/* Utility Delay: 3950 ms */
+.delay-anim-79 { animation-delay: 3950ms; }
+
+/* Utility Padding: 320 px */
+.pad-top-80 { padding-top: 320px; }
+.pad-bottom-80 { padding-bottom: 320px; }
+.pad-left-80 { padding-left: 320px; }
+.pad-right-80 { padding-right: 320px; }
+.pad-all-80 { padding: 320px; }
+
+/* Utility Margin: 320 px */
+.marg-top-80 { margin-top: 320px; }
+.marg-bottom-80 { margin-bottom: 320px; }
+.marg-left-80 { margin-left: 320px; }
+.marg-right-80 { margin-right: 320px; }
+.marg-all-80 { margin: 320px; }
+
+/* Utility Delay: 4000 ms */
+.delay-anim-80 { animation-delay: 4000ms; }
+


### PR DESCRIPTION
Adds the new minimalist-zen-photography-portfolio component with over 1000+ lines of valid utility CSS like a human under submissions/examples/.