### PR TITLE
Add ease-tape-measure-coil component

### DIFF
--- a/submissions/examples/tape-measure-coil-ij/README.md
+++ b/submissions/examples/tape-measure-coil-ij/README.md
@@ -1,0 +1,10 @@
+# ease-tape-measure-coil
+
+A workshop tape where the reel spins inside the housing, the tape pulls out and back, and the lock slides.
+
+## Run
+Open `demo.html` directly in a browser to watch the tape pull.
+
+## Notes
+- The reel spins inside the housing.
+- The tape pulls out and back.

--- a/submissions/examples/tape-measure-coil-ij/demo.html
+++ b/submissions/examples/tape-measure-coil-ij/demo.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-tape-measure-coil demo</title>
+</head>
+<body>
+<div class="tmc-app">
+  <span class="tmc-title">WORKSHOP</span>
+  <div class="tmc-housing">
+    <div class="tmc-reel"></div>
+    <div class="tmc-tape"><div class="tmc-hook"></div></div>
+    <div class="tmc-lock"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/tape-measure-coil-ij/style.css
+++ b/submissions/examples/tape-measure-coil-ij/style.css
@@ -1,0 +1,12 @@
+:root{--tmc-yellow:#f2c832;--tmc-dark:#1c1a14}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#1c1a14,#0d0c08);font-family:'Consolas',monospace}
+.tmc-app{position:relative;width:360px;height:400px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#2e2a1c,#16130a);box-shadow:0 16px 36px rgba(0,0,0,0.6)}
+.tmc-title{position:absolute;top:14px;left:0;right:0;text-align:center;font-size:11px;font-weight:700;letter-spacing:7px;color:#f2c832}
+.tmc-housing{position:absolute;top:90px;left:50%;margin-left:-142px;width:284px;height:200px;border-radius:16px;background:#3a3420;box-shadow:inset 0 0 0 5px #1a1608;overflow:hidden}
+.tmc-reel{position:absolute;top:56px;left:56px;width:88px;height:88px;border-radius:50%;background:#1a1608;box-shadow:inset 0 0 0 6px #f2c832,0 0 0 6px #5a521c;animation:reel-spin-tape-measure-coil 2s linear infinite}
+.tmc-tape{position:absolute;top:48px;left:160px;width:120px;height:26px;border-radius:4px;background:repeating-linear-gradient(90deg,#f2c832 0 10px,#d8b024 10px 20px);box-shadow:inset 0 0 0 2px #5a521c;animation:tape-pull-tape-measure-coil 2.4s ease-in-out infinite}
+.tmc-hook{position:absolute;top:4px;right:-10px;width:10px;height:18px;border-radius:3px;background:#a8942a;box-shadow:inset 0 0 0 2px #5a521c}
+.tmc-lock{position:absolute;bottom:20px;right:20px;width:16px;height:30px;border-radius:5px;background:#6a622c;box-shadow:inset 0 0 0 2px #2a2410;animation:lock-slide-tape-measure-coil 2.4s ease-in-out infinite}
+@keyframes reel-spin-tape-measure-coil{0%{transform:rotate(0)}100%{transform:rotate(360deg)}}
+@keyframes tape-pull-tape-measure-coil{0%,100%{transform:translateX(0)}50%{transform:translateX(-60px)}}
+@keyframes lock-slide-tape-measure-coil{0%,100%{transform:translateX(0)}50%{transform:translateX(8px)}}


### PR DESCRIPTION
## Component: ease-tape-measure-coil — reel spins, tape pulls, and lock slides

**Closes #66692**

### What this adds
A workshop tape: the reel spins in the housing, the tape pulls out and back, and the lock slides.

### Acceptance Criteria covered
- Reel spins inside the housing
- Tape pulls out and back
- Lock slides in place

### Files
- `submissions/examples/tape-measure-coil-ij/demo.html`
- `submissions/examples/tape-measure-coil-ij/style.css`
- `submissions/examples/tape-measure-coil-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the tape pull.