### PR TITLE
feat: add congestion collapse guardian example

### DIFF
--- a/submissions/examples/congestion-collapse-guardian-kp/README.md
+++ b/submissions/examples/congestion-collapse-guardian-kp/README.md
@@ -1,0 +1,30 @@
+# Congestion Collapse Guardian
+
+A control-room style EaseMotion example for protecting busy systems from retry amplification, queue overload, and cascading latency. The screen models a traffic governor that reads live pressure signals, animates queue risk, and switches between absorb, shape, shed, and recover states.
+
+## Features
+
+- Animated congestion radar with rotating pressure sweep
+- Queue-depth lanes with adaptive fill and warning pulses
+- Load-shedding decision stack with staggered motion
+- Retry-amplification meter and cooldown timeline
+- Interactive sliders for ingress, retries, latency, and buffer size
+- JavaScript-driven status mode that updates CSS variables
+- Responsive operations dashboard layout
+
+## Files
+
+- `demo.html` - dashboard markup and control logic
+- `style.css` - advanced animation, responsive layout, and visual states
+
+## How to Run
+
+Open `demo.html` in a browser.
+
+## Validation
+
+```bash
+npx prettier --check submissions/examples/congestion-collapse-guardian-kp/README.md submissions/examples/congestion-collapse-guardian-kp/demo.html submissions/examples/congestion-collapse-guardian-kp/style.css
+npx stylelint submissions/examples/congestion-collapse-guardian-kp/style.css --allow-empty-input
+git diff --check
+```

--- a/submissions/examples/congestion-collapse-guardian-kp/demo.html
+++ b/submissions/examples/congestion-collapse-guardian-kp/demo.html
@@ -1,0 +1,251 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Congestion Collapse Guardian</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="guardian-shell" data-mode="shape">
+      <section class="hero-band" aria-labelledby="page-title">
+        <div class="hero-copy">
+          <p class="eyebrow">EaseMotion resilient systems lab</p>
+          <h1 id="page-title">Congestion Collapse Guardian</h1>
+          <p>
+            Watch the governor absorb bursts, shape retries, shed non-critical
+            work, and recover once pressure drops.
+          </p>
+        </div>
+        <div class="mode-pill" aria-live="polite">
+          <span class="mode-dot"></span>
+          <strong id="modeLabel">Traffic shaping</strong>
+        </div>
+      </section>
+
+      <section class="control-grid" aria-label="Congestion controls">
+        <label class="control">
+          <span>Ingress rate</span>
+          <input id="ingress" type="range" min="15" max="98" value="62" />
+          <output id="ingressOut">62%</output>
+        </label>
+        <label class="control">
+          <span>Retry pressure</span>
+          <input id="retry" type="range" min="0" max="100" value="44" />
+          <output id="retryOut">44%</output>
+        </label>
+        <label class="control">
+          <span>P95 latency</span>
+          <input id="latency" type="range" min="40" max="900" value="320" />
+          <output id="latencyOut">320ms</output>
+        </label>
+        <label class="control">
+          <span>Buffer depth</span>
+          <input id="buffer" type="range" min="20" max="100" value="68" />
+          <output id="bufferOut">68%</output>
+        </label>
+      </section>
+
+      <section class="dashboard" aria-label="Guardian dashboard">
+        <article class="radar-panel">
+          <div class="panel-heading">
+            <p>Pressure radar</p>
+            <strong id="riskScore">54</strong>
+          </div>
+          <div class="radar" aria-hidden="true">
+            <span class="ring ring-one"></span>
+            <span class="ring ring-two"></span>
+            <span class="ring ring-three"></span>
+            <span class="sweep"></span>
+            <span class="risk-node node-a"></span>
+            <span class="risk-node node-b"></span>
+            <span class="risk-node node-c"></span>
+            <span class="risk-node node-d"></span>
+            <span class="risk-core"></span>
+          </div>
+          <div class="signal-strip">
+            <span></span>
+            <span></span>
+            <span></span>
+            <span></span>
+            <span></span>
+            <span></span>
+            <span></span>
+            <span></span>
+          </div>
+        </article>
+
+        <article class="queue-panel">
+          <div class="panel-heading">
+            <p>Queue lanes</p>
+            <strong id="queueLabel">Nominal</strong>
+          </div>
+          <div class="lane-list">
+            <div class="lane" style="--lane: 0.35">
+              <span>Checkout writes</span>
+              <i></i>
+              <b>35%</b>
+            </div>
+            <div class="lane" style="--lane: 0.58">
+              <span>Inventory sync</span>
+              <i></i>
+              <b>58%</b>
+            </div>
+            <div class="lane" style="--lane: 0.72">
+              <span>Search fanout</span>
+              <i></i>
+              <b>72%</b>
+            </div>
+            <div class="lane" style="--lane: 0.46">
+              <span>Notification bus</span>
+              <i></i>
+              <b>46%</b>
+            </div>
+            <div class="lane" style="--lane: 0.64">
+              <span>Analytics mirror</span>
+              <i></i>
+              <b>64%</b>
+            </div>
+          </div>
+        </article>
+
+        <article class="decision-panel">
+          <div class="panel-heading">
+            <p>Decision stack</p>
+            <strong id="actionLabel">Shape</strong>
+          </div>
+          <ol class="decision-stack">
+            <li>
+              <span class="step-icon">1</span>
+              <div>
+                <strong>Token bucket clamps ingress</strong>
+                <p>
+                  Accepted requests drain smoothly instead of spiking worker
+                  pools.
+                </p>
+              </div>
+            </li>
+            <li>
+              <span class="step-icon">2</span>
+              <div>
+                <strong>Retries get jittered windows</strong>
+                <p>Amplified clients receive staggered retry-after timing.</p>
+              </div>
+            </li>
+            <li>
+              <span class="step-icon">3</span>
+              <div>
+                <strong>Optional work moves to brownout</strong>
+                <p>
+                  Low-priority enrichment pauses before core traffic is
+                  affected.
+                </p>
+              </div>
+            </li>
+            <li>
+              <span class="step-icon">4</span>
+              <div>
+                <strong>Recovery opens by slope</strong>
+                <p>
+                  Capacity returns only after latency and queue slope cool down.
+                </p>
+              </div>
+            </li>
+          </ol>
+        </article>
+
+        <article class="timeline-panel">
+          <div class="panel-heading">
+            <p>Cooldown timeline</p>
+            <strong id="cooldownLabel">18s</strong>
+          </div>
+          <div class="timeline">
+            <span class="tick active">Detect</span>
+            <span class="tick active">Shape</span>
+            <span class="tick">Shed</span>
+            <span class="tick">Recover</span>
+          </div>
+          <div class="retry-meter">
+            <span>Retry amplification</span>
+            <strong id="retryLabel">1.4x</strong>
+            <i></i>
+          </div>
+        </article>
+      </section>
+    </main>
+
+    <script>
+      const shell = document.querySelector(".guardian-shell");
+      const controls = {
+        ingress: document.querySelector("#ingress"),
+        retry: document.querySelector("#retry"),
+        latency: document.querySelector("#latency"),
+        buffer: document.querySelector("#buffer"),
+      };
+      const outputs = {
+        ingress: document.querySelector("#ingressOut"),
+        retry: document.querySelector("#retryOut"),
+        latency: document.querySelector("#latencyOut"),
+        buffer: document.querySelector("#bufferOut"),
+        risk: document.querySelector("#riskScore"),
+        mode: document.querySelector("#modeLabel"),
+        action: document.querySelector("#actionLabel"),
+        queue: document.querySelector("#queueLabel"),
+        cooldown: document.querySelector("#cooldownLabel"),
+        retryLabel: document.querySelector("#retryLabel"),
+      };
+
+      function updateGuardian() {
+        const ingress = Number(controls.ingress.value);
+        const retry = Number(controls.retry.value);
+        const latency = Number(controls.latency.value);
+        const buffer = Number(controls.buffer.value);
+        const latencyPressure = Math.min(100, latency / 9);
+        const risk = Math.round(
+          ingress * 0.3 + retry * 0.28 + latencyPressure * 0.24 + buffer * 0.18
+        );
+        let mode = "absorb";
+        let modeText = "Absorbing burst";
+        let action = "Absorb";
+        let queue = "Nominal";
+
+        if (risk > 76) {
+          mode = "shed";
+          modeText = "Load shedding";
+          action = "Shed";
+          queue = "Critical";
+        } else if (risk > 58) {
+          mode = "shape";
+          modeText = "Traffic shaping";
+          action = "Shape";
+          queue = "Elevated";
+        } else if (risk < 38) {
+          mode = "recover";
+          modeText = "Controlled recovery";
+          action = "Recover";
+          queue = "Cooling";
+        }
+
+        shell.dataset.mode = mode;
+        shell.style.setProperty("--risk", risk);
+        shell.style.setProperty("--retry", retry);
+        shell.style.setProperty("--buffer", buffer);
+        outputs.ingress.value = `${ingress}%`;
+        outputs.retry.value = `${retry}%`;
+        outputs.latency.value = `${latency}ms`;
+        outputs.buffer.value = `${buffer}%`;
+        outputs.risk.textContent = risk;
+        outputs.mode.textContent = modeText;
+        outputs.action.textContent = action;
+        outputs.queue.textContent = queue;
+        outputs.cooldown.textContent = `${Math.max(6, Math.round(risk / 3))}s`;
+        outputs.retryLabel.textContent = `${(1 + retry / 100).toFixed(1)}x`;
+      }
+
+      Object.values(controls).forEach((control) => {
+        control.addEventListener("input", updateGuardian);
+      });
+      updateGuardian();
+    </script>
+  </body>
+</html>

--- a/submissions/examples/congestion-collapse-guardian-kp/style.css
+++ b/submissions/examples/congestion-collapse-guardian-kp/style.css
@@ -1,0 +1,776 @@
+:root {
+  color-scheme: dark;
+  --bg: #0d1117;
+  --panel: #151b23;
+  --panel-strong: #1f2937;
+  --line: #2f3a4a;
+  --text: #edf3ff;
+  --muted: #9aa8bd;
+  --cyan: #35d4ff;
+  --green: #4ade80;
+  --amber: #fbbf24;
+  --red: #fb7185;
+  --blue: #60a5fa;
+  --risk: 54;
+  --retry: 44;
+  --buffer: 68;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--text);
+  background:
+    linear-gradient(135deg, rgba(13, 17, 23, 0.96), rgba(17, 24, 39, 0.92)),
+    radial-gradient(
+      circle at 20% 0%,
+      rgba(53, 212, 255, 0.16),
+      transparent 32%
+    ),
+    radial-gradient(
+      circle at 80% 20%,
+      rgba(74, 222, 128, 0.12),
+      transparent 34%
+    ),
+    #0d1117;
+}
+
+button,
+input {
+  font: inherit;
+}
+
+.guardian-shell {
+  width: min(1180px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 32px 0 42px;
+}
+
+.hero-band {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 24px;
+  align-items: end;
+  min-height: 210px;
+  padding: 36px;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 8px;
+  background:
+    linear-gradient(100deg, rgba(21, 27, 35, 0.96), rgba(31, 41, 55, 0.72)),
+    repeating-linear-gradient(
+      90deg,
+      rgba(53, 212, 255, 0.08) 0 1px,
+      transparent 1px 48px
+    );
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.32);
+  position: relative;
+}
+
+.hero-band::after {
+  content: "";
+  position: absolute;
+  inset: auto -12% -45% 38%;
+  height: 170px;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(53, 212, 255, 0.2),
+    transparent
+  );
+  transform: rotate(-8deg);
+  animation: scanner 4.8s linear infinite;
+}
+
+.hero-copy {
+  position: relative;
+  z-index: 1;
+}
+
+.eyebrow {
+  margin: 0 0 12px;
+  color: var(--cyan);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 780px;
+  margin: 0;
+  font-size: clamp(2.5rem, 7vw, 5.8rem);
+  line-height: 0.92;
+  letter-spacing: 0;
+}
+
+.hero-copy p:last-child {
+  max-width: 650px;
+  margin: 18px 0 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
+.mode-pill {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 190px;
+  padding: 12px 16px;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 999px;
+  background: rgba(13, 17, 23, 0.78);
+  color: var(--text);
+  white-space: nowrap;
+}
+
+.mode-dot {
+  width: 11px;
+  height: 11px;
+  border-radius: 999px;
+  background: var(--amber);
+  box-shadow: 0 0 0 6px rgba(251, 191, 36, 0.18);
+  animation: dotPulse 1.6s ease-in-out infinite;
+}
+
+.guardian-shell[data-mode="shed"] .mode-dot {
+  background: var(--red);
+  box-shadow: 0 0 0 6px rgba(251, 113, 133, 0.18);
+}
+
+.guardian-shell[data-mode="recover"] .mode-dot {
+  background: var(--green);
+  box-shadow: 0 0 0 6px rgba(74, 222, 128, 0.18);
+}
+
+.control-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+  margin: 18px 0;
+}
+
+.control {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 12px;
+  align-items: center;
+  padding: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 8px;
+  background: rgba(21, 27, 35, 0.84);
+}
+
+.control span {
+  color: var(--muted);
+  font-size: 0.88rem;
+}
+
+.control output {
+  color: var(--text);
+  font-weight: 800;
+}
+
+.control input {
+  grid-column: 1 / -1;
+  width: 100%;
+  accent-color: var(--cyan);
+}
+
+.dashboard {
+  display: grid;
+  grid-template-columns: 1.05fr 0.95fr;
+  gap: 18px;
+}
+
+.dashboard article {
+  min-width: 0;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 8px;
+  background:
+    linear-gradient(180deg, rgba(21, 27, 35, 0.96), rgba(13, 17, 23, 0.92)),
+    var(--panel);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.24);
+}
+
+.panel-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 20px 0;
+}
+
+.panel-heading p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.panel-heading strong {
+  font-size: 1.18rem;
+}
+
+.radar-panel {
+  grid-row: span 2;
+  padding-bottom: 20px;
+}
+
+.radar {
+  position: relative;
+  width: min(420px, 82vw);
+  aspect-ratio: 1;
+  margin: 24px auto 18px;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle, rgba(53, 212, 255, 0.16) 0 2px, transparent 3px),
+    radial-gradient(circle, rgba(96, 165, 250, 0.12), transparent 58%),
+    conic-gradient(
+      from 180deg,
+      rgba(74, 222, 128, 0.2),
+      rgba(251, 191, 36, 0.24),
+      rgba(251, 113, 133, 0.3),
+      rgba(53, 212, 255, 0.18),
+      rgba(74, 222, 128, 0.2)
+    );
+  box-shadow:
+    inset 0 0 0 1px rgba(148, 163, 184, 0.22),
+    inset 0 0 70px rgba(0, 0, 0, 0.45);
+}
+
+.radar::before,
+.radar::after {
+  content: "";
+  position: absolute;
+  inset: 50% 8%;
+  height: 1px;
+  background: rgba(237, 243, 255, 0.2);
+}
+
+.radar::after {
+  transform: rotate(90deg);
+}
+
+.ring {
+  position: absolute;
+  border: 1px solid rgba(237, 243, 255, 0.16);
+  border-radius: 50%;
+  animation: ringBreathe 3s ease-in-out infinite;
+}
+
+.ring-one {
+  inset: 16%;
+}
+
+.ring-two {
+  inset: 30%;
+  animation-delay: 0.4s;
+}
+
+.ring-three {
+  inset: 43%;
+  animation-delay: 0.8s;
+}
+
+.sweep {
+  position: absolute;
+  inset: 4%;
+  border-radius: 50%;
+  background: conic-gradient(
+    from 0deg,
+    rgba(53, 212, 255, 0.65),
+    rgba(53, 212, 255, 0.08) 42deg,
+    transparent 72deg
+  );
+  mask: radial-gradient(circle, transparent 0 10%, #000 11% 100%);
+  animation: sweep 3.2s linear infinite;
+}
+
+.risk-core {
+  position: absolute;
+  inset: calc(50% - 34px);
+  border-radius: 50%;
+  background: color-mix(
+    in srgb,
+    var(--amber) calc(var(--risk) * 1%),
+    var(--cyan)
+  );
+  box-shadow: 0 0 34px rgba(53, 212, 255, 0.42);
+  animation: corePulse 1.8s ease-in-out infinite;
+}
+
+.risk-node {
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--cyan);
+  box-shadow: 0 0 22px currentcolor;
+  animation: nodePing 2.4s ease-in-out infinite;
+}
+
+.node-a {
+  top: 22%;
+  left: 68%;
+}
+
+.node-b {
+  top: 62%;
+  left: 76%;
+  color: var(--amber);
+  animation-delay: 0.4s;
+}
+
+.node-c {
+  top: 72%;
+  left: 28%;
+  color: var(--green);
+  animation-delay: 0.8s;
+}
+
+.node-d {
+  top: 34%;
+  left: 21%;
+  color: var(--red);
+  animation-delay: 1.2s;
+}
+
+.signal-strip {
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  gap: 8px;
+  padding: 0 20px;
+}
+
+.signal-strip span {
+  height: 46px;
+  border-radius: 6px;
+  background: linear-gradient(180deg, var(--cyan), transparent);
+  transform-origin: bottom;
+  animation: signal 1.6s ease-in-out infinite;
+}
+
+.signal-strip span:nth-child(2n) {
+  animation-delay: 0.2s;
+}
+
+.signal-strip span:nth-child(3n) {
+  animation-delay: 0.45s;
+}
+
+.signal-strip span:nth-child(4n) {
+  animation-delay: 0.7s;
+}
+
+.queue-panel,
+.decision-panel,
+.timeline-panel {
+  padding-bottom: 18px;
+}
+
+.lane-list {
+  display: grid;
+  gap: 14px;
+  padding: 20px;
+}
+
+.lane {
+  display: grid;
+  grid-template-columns: 150px minmax(90px, 1fr) 48px;
+  gap: 14px;
+  align-items: center;
+}
+
+.lane span {
+  color: var(--text);
+  font-size: 0.92rem;
+  font-weight: 700;
+}
+
+.lane i {
+  position: relative;
+  height: 12px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.16);
+}
+
+.lane i::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  width: calc(var(--lane) * 100%);
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--green), var(--amber), var(--red));
+  animation: laneFlow 1.9s ease-in-out infinite;
+}
+
+.lane b {
+  color: var(--muted);
+  font-size: 0.86rem;
+  text-align: right;
+}
+
+.decision-stack {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 20px;
+  list-style: none;
+}
+
+.decision-stack li {
+  display: grid;
+  grid-template-columns: 38px 1fr;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  border-radius: 8px;
+  background: rgba(31, 41, 55, 0.56);
+  animation: cardLift 3s ease-in-out infinite;
+}
+
+.decision-stack li:nth-child(2) {
+  animation-delay: 0.18s;
+}
+
+.decision-stack li:nth-child(3) {
+  animation-delay: 0.36s;
+}
+
+.decision-stack li:nth-child(4) {
+  animation-delay: 0.54s;
+}
+
+.step-icon {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  background: rgba(53, 212, 255, 0.12);
+  color: var(--cyan);
+  font-weight: 900;
+}
+
+.decision-stack strong {
+  display: block;
+  margin-bottom: 4px;
+}
+
+.decision-stack p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.timeline {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+  padding: 22px 20px 16px;
+}
+
+.tick {
+  position: relative;
+  min-height: 76px;
+  padding: 14px 10px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 8px;
+  background: rgba(31, 41, 55, 0.42);
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 800;
+  text-align: center;
+}
+
+.tick::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  bottom: 12px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: currentcolor;
+  transform: translateX(-50%);
+}
+
+.tick.active {
+  color: var(--cyan);
+  border-color: rgba(53, 212, 255, 0.4);
+  animation: timelineGlow 1.8s ease-in-out infinite;
+}
+
+.retry-meter {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 10px;
+  align-items: center;
+  margin: 0 20px;
+  padding: 16px;
+  border-radius: 8px;
+  background: rgba(13, 17, 23, 0.58);
+}
+
+.retry-meter span {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.retry-meter strong {
+  color: var(--amber);
+}
+
+.retry-meter i {
+  grid-column: 1 / -1;
+  height: 10px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.16);
+}
+
+.retry-meter i::before {
+  content: "";
+  display: block;
+  width: calc(var(--retry) * 1%);
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--cyan), var(--amber), var(--red));
+  animation: retrySlide 1.4s ease-in-out infinite;
+}
+
+.guardian-shell[data-mode="absorb"] .hero-band {
+  border-color: rgba(74, 222, 128, 0.28);
+}
+
+.guardian-shell[data-mode="shape"] .hero-band {
+  border-color: rgba(251, 191, 36, 0.32);
+}
+
+.guardian-shell[data-mode="shed"] .hero-band {
+  border-color: rgba(251, 113, 133, 0.42);
+}
+
+.guardian-shell[data-mode="recover"] .hero-band {
+  border-color: rgba(53, 212, 255, 0.34);
+}
+
+.guardian-shell[data-mode="shed"] .risk-core {
+  background: var(--red);
+  box-shadow: 0 0 46px rgba(251, 113, 133, 0.58);
+}
+
+.guardian-shell[data-mode="recover"] .risk-core {
+  background: var(--green);
+  box-shadow: 0 0 42px rgba(74, 222, 128, 0.48);
+}
+
+@keyframes scanner {
+  0% {
+    transform: translateX(-50%) rotate(-8deg);
+  }
+
+  100% {
+    transform: translateX(60%) rotate(-8deg);
+  }
+}
+
+@keyframes dotPulse {
+  0%,
+  100% {
+    transform: scale(0.92);
+  }
+
+  50% {
+    transform: scale(1.12);
+  }
+}
+
+@keyframes sweep {
+  to {
+    transform: rotate(1turn);
+  }
+}
+
+@keyframes ringBreathe {
+  0%,
+  100% {
+    opacity: 0.38;
+    transform: scale(0.98);
+  }
+
+  50% {
+    opacity: 0.9;
+    transform: scale(1.02);
+  }
+}
+
+@keyframes corePulse {
+  0%,
+  100% {
+    transform: scale(0.94);
+  }
+
+  50% {
+    transform: scale(1.08);
+  }
+}
+
+@keyframes nodePing {
+  0%,
+  100% {
+    opacity: 0.55;
+    transform: scale(0.82);
+  }
+
+  50% {
+    opacity: 1;
+    transform: scale(1.18);
+  }
+}
+
+@keyframes signal {
+  0%,
+  100% {
+    transform: scaleY(0.34);
+    opacity: 0.46;
+  }
+
+  50% {
+    transform: scaleY(calc(0.45 + var(--risk) / 120));
+    opacity: 0.95;
+  }
+}
+
+@keyframes laneFlow {
+  0%,
+  100% {
+    filter: saturate(0.9);
+  }
+
+  50% {
+    filter: saturate(1.5);
+  }
+}
+
+@keyframes cardLift {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+
+  50% {
+    transform: translateY(-3px);
+  }
+}
+
+@keyframes timelineGlow {
+  0%,
+  100% {
+    box-shadow: inset 0 0 0 rgba(53, 212, 255, 0);
+  }
+
+  50% {
+    box-shadow: inset 0 -34px 38px rgba(53, 212, 255, 0.12);
+  }
+}
+
+@keyframes retrySlide {
+  0%,
+  100% {
+    opacity: 0.75;
+  }
+
+  50% {
+    opacity: 1;
+  }
+}
+
+@media (max-width: 860px) {
+  .guardian-shell {
+    width: min(100% - 20px, 680px);
+    padding-top: 16px;
+  }
+
+  .hero-band {
+    grid-template-columns: 1fr;
+    min-height: 250px;
+    padding: 26px;
+  }
+
+  .mode-pill {
+    width: max-content;
+  }
+
+  .control-grid,
+  .dashboard {
+    grid-template-columns: 1fr;
+  }
+
+  .radar-panel {
+    grid-row: auto;
+  }
+
+  .lane {
+    grid-template-columns: 1fr;
+    gap: 7px;
+  }
+
+  .lane b {
+    text-align: left;
+  }
+
+  .timeline {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 520px) {
+  .guardian-shell {
+    width: min(100% - 14px, 440px);
+  }
+
+  .hero-band {
+    padding: 22px;
+  }
+
+  h1 {
+    font-size: clamp(2.1rem, 18vw, 3.8rem);
+  }
+
+  .control {
+    grid-template-columns: 1fr;
+  }
+
+  .panel-heading,
+  .retry-meter {
+    align-items: start;
+  }
+
+  .decision-stack li {
+    grid-template-columns: 1fr;
+  }
+
+  .timeline {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add an advanced congestion collapse guardian animation example
- include interactive pressure sliders for ingress, retries, latency, and buffer depth
- model traffic shaping, load shedding, cooldown, and recovery states

## Validation
- npx prettier --check submissions/examples/congestion-collapse-guardian-kp/README.md submissions/examples/congestion-collapse-guardian-kp/demo.html submissions/examples/congestion-collapse-guardian-kp/style.css
- npx stylelint submissions/examples/congestion-collapse-guardian-kp/style.css --allow-empty-input
- git diff --check