### PR TITLE
feat: skew-active modal for minimalist tech layouts

### DIFF
--- a/submissions/examples/css-skew-modal-minimalist/README.md
+++ b/submissions/examples/css-skew-modal-minimalist/README.md
@@ -1,0 +1,22 @@
+# Skew-Active Modal — Minimalist Tech
+
+A CSS-only modal that enters with a horizontal skew. The dialog frame starts tilted at `skewX(-8deg)` offset to the left, then un-skews and slides into position when opened via a checkbox toggle.
+
+## Behavior
+
+When the trigger is clicked, the backdrop fades in and the modal frame transitions from `skewX(-8deg) translateX(-40px) scaleY(0.96) opacity: 0` to its resting state. The cubic-bezier timing gives a smooth deceleration as the card settles into place. Clicking the backdrop or any close button reverses the animation.
+
+The skew gives the entrance a directional quality — the card appears to come from the left edge while straightening out, which feels more intentional than a basic fade or scale.
+
+## Customization
+
+- Swap `--csm-accent` to change the button and highlight color
+- Adjust `skewX()` and `translateX()` values for a more aggressive or subtle effect
+- The easing curve can be changed to `ease-out` for a less springy feel
+
+## Notes
+
+- Pure HTML + CSS, no JavaScript
+- `prefers-reduced-motion` disables all transitions
+- Semantic `role="dialog"` and `aria-modal="true"` on the dialog element
+- Backdrop is clickable to dismiss

--- a/submissions/examples/css-skew-modal-minimalist/demo.html
+++ b/submissions/examples/css-skew-modal-minimalist/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS skew-active modal for minimalist tech layouts">
+  <title>Skew Modal — Minimalist Tech</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <input type="checkbox" id="csm-toggle" class="csm-sr" aria-label="Open modal">
+
+  <div class="csm-shell">
+    <nav class="csm-nav">
+      <span class="csm-nav__logo">MNTC</span>
+      <span class="csm-nav__spacer"></span>
+      <span class="csm-nav__item">Pricing</span>
+      <span class="csm-nav__item">Docs</span>
+    </nav>
+
+    <main class="csm-main">
+      <h1 class="csm-main__heading">Skew-Active Modal</h1>
+      <p class="csm-main__copy">Click the button and watch the modal skew in from the left. It starts tilted and slides into place with a smooth un-skew.</p>
+      <label for="csm-toggle" class="csm-cta">Launch Modal</label>
+    </main>
+
+    <section class="csm-grid">
+      <article class="csm-tile">
+        <h3 class="csm-tile__h">Zero JS</h3>
+        <p class="csm-tile__p">Entirely CSS-driven using a checkbox toggle.</p>
+      </article>
+      <article class="csm-tile">
+        <h3 class="csm-tile__h">Responsive</h3>
+        <p class="csm-tile__p">Adapts cleanly from mobile to wide screens.</p>
+      </article>
+      <article class="csm-tile">
+        <h3 class="csm-tile__h">Motion Safe</h3>
+        <p class="csm-tile__p">Honors prefers-reduced-motion preferences.</p>
+      </article>
+    </section>
+  </div>
+
+  <label for="csm-toggle" class="csm-backdrop" aria-label="Close modal"></label>
+
+  <div class="csm-dialog" role="dialog" aria-modal="true" aria-label="Example dialog">
+    <div class="csm-dialog__frame">
+      <div class="csm-dialog__top">
+        <span class="csm-dialog__label">Heads up</span>
+        <label for="csm-toggle" class="csm-dialog__x" aria-label="Close">&times;</label>
+      </div>
+      <p class="csm-dialog__msg">You have unsaved changes on this page. If you leave now, your progress may be lost. Want to save first?</p>
+      <div class="csm-dialog__row">
+        <label for="csm-toggle" class="csm-btn csm-btn--outline">Leave</label>
+        <label for="csm-toggle" class="csm-btn csm-btn--fill">Save</label>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/css-skew-modal-minimalist/style.css
+++ b/submissions/examples/css-skew-modal-minimalist/style.css
@@ -1,0 +1,289 @@
+:root {
+  --csm-bg: #f7f7f8;
+  --csm-surface: #ffffff;
+  --csm-text: #1c1c1e;
+  --csm-muted: #6e6e73;
+  --csm-border: #d2d2d7;
+  --csm-accent: #6366f1;
+  --csm-accent-hover: #4f46e5;
+  --csm-radius: 8px;
+  --csm-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+}
+
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  background: var(--csm-bg);
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--csm-text);
+  line-height: 1.6;
+}
+
+.csm-sr {
+  position: fixed;
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* ── nav ────────────────────────────────────────── */
+
+.csm-nav {
+  display: flex;
+  align-items: center;
+  height: 50px;
+  padding: 0 24px;
+  background: var(--csm-surface);
+  border-bottom: 1px solid var(--csm-border);
+}
+
+.csm-nav__logo {
+  font-size: 0.82rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+}
+
+.csm-nav__spacer {
+  flex: 1;
+}
+
+.csm-nav__item {
+  font-size: 0.72rem;
+  color: var(--csm-muted);
+  margin-left: 18px;
+  cursor: pointer;
+}
+
+.csm-nav__item:hover {
+  color: var(--csm-text);
+}
+
+/* ── main ───────────────────────────────────────── */
+
+.csm-main {
+  max-width: 500px;
+  margin: 0 auto;
+  padding: 72px 24px 40px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
+.csm-main__heading {
+  font-size: clamp(1.3rem, 3.5vw, 1.8rem);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+}
+
+.csm-main__copy {
+  font-size: 0.74rem;
+  color: var(--csm-muted);
+  max-width: 42ch;
+  line-height: 1.7;
+}
+
+/* ── cta ────────────────────────────────────────── */
+
+.csm-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 8px;
+  padding: 10px 24px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  border-radius: var(--csm-radius);
+  background: var(--csm-accent);
+  color: #fff;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.csm-cta:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 14px rgba(99, 102, 241, 0.35);
+}
+
+/* ── grid ───────────────────────────────────────── */
+
+.csm-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 14px;
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 24px 24px 80px;
+}
+
+.csm-tile {
+  background: var(--csm-surface);
+  border: 1px solid var(--csm-border);
+  border-radius: var(--csm-radius);
+  padding: 18px;
+}
+
+.csm-tile__h {
+  font-size: 0.76rem;
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+
+.csm-tile__p {
+  font-size: 0.68rem;
+  color: var(--csm-muted);
+  line-height: 1.6;
+}
+
+/* ── backdrop ───────────────────────────────────── */
+
+.csm-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  background: rgba(28, 28, 30, 0.45);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease;
+  cursor: pointer;
+}
+
+#csm-toggle:checked ~ .csm-backdrop {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* ── dialog ─────────────────────────────────────── */
+
+.csm-dialog {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+#csm-toggle:checked ~ .csm-dialog {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* ── frame with skew entrance ───────────────────── */
+
+.csm-dialog__frame {
+  width: 100%;
+  max-width: 380px;
+  background: var(--csm-surface);
+  border: 1px solid var(--csm-border);
+  border-radius: 12px;
+  box-shadow: var(--csm-shadow);
+  overflow: hidden;
+  transform: skewX(-8deg) translateX(-40px) scaleY(0.96);
+  opacity: 0;
+  transition: transform 0.42s cubic-bezier(0.22, 1, 0.36, 1),
+              opacity 0.32s ease;
+}
+
+#csm-toggle:checked ~ .csm-dialog .csm-dialog__frame {
+  transform: skewX(0) translateX(0) scaleY(1);
+  opacity: 1;
+}
+
+/* ── dialog internals ───────────────────────────── */
+
+.csm-dialog__top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 14px 18px 8px;
+}
+
+.csm-dialog__label {
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.csm-dialog__x {
+  font-size: 1.2rem;
+  color: var(--csm-muted);
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 4px;
+  line-height: 1;
+  transition: background 0.12s ease;
+}
+
+.csm-dialog__x:hover {
+  background: rgba(0, 0, 0, 0.05);
+}
+
+.csm-dialog__msg {
+  padding: 0 18px 16px;
+  font-size: 0.72rem;
+  color: var(--csm-muted);
+  line-height: 1.7;
+}
+
+.csm-dialog__row {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  padding: 0 18px 16px;
+}
+
+.csm-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 18px;
+  font-size: 0.68rem;
+  font-weight: 600;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.12s ease, transform 0.12s ease;
+}
+
+.csm-btn--outline {
+  background: transparent;
+  color: var(--csm-muted);
+  border: 1px solid var(--csm-border);
+}
+
+.csm-btn--outline:hover {
+  background: rgba(0, 0, 0, 0.04);
+}
+
+.csm-btn--fill {
+  background: var(--csm-accent);
+  color: #fff;
+  border: none;
+}
+
+.csm-btn--fill:hover {
+  background: var(--csm-accent-hover);
+  transform: translateY(-1px);
+}
+
+/* ── reduced motion ─────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .csm-backdrop,
+  .csm-dialog,
+  .csm-dialog__frame,
+  .csm-cta,
+  .csm-btn {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Closes #64455

Adds a CSS skew-active modal for minimalist tech layouts.

**What this does:**
- Pure CSS modal with skew entrance animation
- Dialog frame starts at skewX(-8deg) with translateX offset and reduced opacity
- Un-skews to skewX(0), slides to center, fades in when toggled
- Smooth cubic-bezier deceleration on entrance
- Click-outside-to-close via backdrop
- No JavaScript — uses checkbox toggle

**Files added:**
- submissions/examples/css-skew-modal-minimalist/demo.html
- submissions/examples/css-skew-modal-minimalist/style.css
- submissions/examples/css-skew-modal-minimalist/README.md