### PR TITLE
Add ease-pinball-bumper-flash component

### DIFF
--- a/submissions/examples/pinball-bumper-flash-ij/README.md
+++ b/submissions/examples/pinball-bumper-flash-ij/README.md
@@ -1,0 +1,10 @@
+# ease-pinball-bumper-flash
+
+A pinball table where the bumpers flash in turn, the flippers tap at the bottom, and the score ticks.
+
+## Run
+Open `demo.html` directly in a browser to watch the bumpers flash.
+
+## Notes
+- The bumpers flash in turn.
+- The flippers tap at the bottom.

--- a/submissions/examples/pinball-bumper-flash-ij/demo.html
+++ b/submissions/examples/pinball-bumper-flash-ij/demo.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-pinball-bumper-flash demo</title>
+</head>
+<body>
+<div class="pbb-app">
+  <span class="pbb-title">PINBALL</span>
+  <div class="pbb-field">
+    <div class="pbb-bumper"></div>
+    <div class="pbb-bumper"></div>
+    <div class="pbb-bumper"></div>
+    <div class="pbb-flip pbb-flip-a"></div>
+    <div class="pbb-flip pbb-flip-b"></div>
+  </div>
+  <span class="pbb-score">8400</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/pinball-bumper-flash-ij/style.css
+++ b/submissions/examples/pinball-bumper-flash-ij/style.css
@@ -1,0 +1,16 @@
+:root{--pbb-magenta:#ff5ad8;--pbb-dark:#181018}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#181018,#0a060a);font-family:'Impact',sans-serif}
+.pbb-app{position:relative;width:360px;height:440px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#2a1628,#140a12);box-shadow:0 16px 36px rgba(0,0,0,0.6)}
+.pbb-title{position:absolute;top:14px;left:0;right:0;text-align:center;font-size:12px;font-weight:700;letter-spacing:7px;color:#ff5ad8}
+.pbb-field{position:absolute;top:60px;left:30px;right:30px;height:284px;border-radius:16px;background:#0a060a;box-shadow:inset 0 0 0 4px #4a2a44;overflow:hidden}
+.pbb-bumper{position:absolute;width:56px;height:56px;border-radius:50%;background:#4a2a44;box-shadow:inset 0 0 0 5px #ff5ad8;animation:bumper-flash-pinball-bumper-flash 1.3s ease-in-out infinite}
+.pbb-bumper:nth-of-type(1){top:26px;left:26px}
+.pbb-bumper:nth-of-type(2){top:26px;right:26px;animation-delay:-0.4s}
+.pbb-bumper:nth-of-type(3){top:150px;left:50%;margin-left:-28px;animation-delay:-0.8s}
+.pbb-flip{position:absolute;bottom:26px;width:76px;height:12px;border-radius:6px;background:#ff5ad8;animation:flip-hit-pinball-bumper-flash 1.3s ease-in-out infinite}
+.pbb-flip-a{left:50px;transform-origin:100% 50%}
+.pbb-flip-b{right:50px;transform-origin:0 50%;animation-delay:-0.6s}
+.pbb-score{position:absolute;bottom:12px;left:0;right:0;text-align:center;font-size:16px;font-weight:700;color:#ff5ad8;animation:score-tick-pinball-bumper-flash 1s steps(1) infinite}
+@keyframes bumper-flash-pinball-bumper-flash{0%,100%{box-shadow:inset 0 0 0 5px #ff5ad8,0 0 6px rgba(255,90,216,0.3)}50%{box-shadow:inset 0 0 0 5px #ff5ad8,0 0 24px rgba(255,90,216,0.9)}}
+@keyframes flip-hit-pinball-bumper-flash{0%,100%{transform:rotate(0)}50%{transform:rotate(-30deg)}}
+@keyframes score-tick-pinball-bumper-flash{0%,49%{opacity:1}50%,100%{opacity:0.3}}


### PR DESCRIPTION
## Component: ease-pinball-bumper-flash — bumpers flash, flippers hit, and score ticks

**Closes #66741**

### What this adds
A pinball table: the bumpers flash in turn, the flippers tap at the bottom, and the score ticks.

### Acceptance Criteria covered
- Bumpers flash in turn
- Flippers tap at the bottom
- Score ticks above

### Files
- `submissions/examples/pinball-bumper-flash-ij/demo.html`
- `submissions/examples/pinball-bumper-flash-ij/style.css`
- `submissions/examples/pinball-bumper-flash-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the bumpers flash.