### PR TITLE
feat: add failover drain orchestrator example

### DIFF
--- a/submissions/examples/failover-drain-orchestrator-kp/README.md
+++ b/submissions/examples/failover-drain-orchestrator-kp/README.md
@@ -1,0 +1,24 @@
+# Failover Drain Orchestrator
+
+An advanced EaseMotion example for visualizing service failover during zone pressure. The dashboard animates evacuation lanes, health probes, drain queues, and recovery gates while operators tune blast radius and replica health.
+
+## Features
+
+- Interactive controls for zone stress, replica health, drain backlog, and quorum margin
+- Animated topology rings, evacuation beams, and drain-lane progress
+- Live mode switching across steady, draining, isolated, and restored states
+- Responsive control-room layout with CSS variable driven motion
+- More than 500 added lines for an advanced contribution tier
+
+## Files
+
+- `demo.html` - interactive dashboard and mode logic
+- `style.css` - animation system and responsive visual design
+
+## Validation
+
+```bash
+npx prettier --check submissions/examples/failover-drain-orchestrator-kp/README.md submissions/examples/failover-drain-orchestrator-kp/demo.html submissions/examples/failover-drain-orchestrator-kp/style.css
+npx stylelint submissions/examples/failover-drain-orchestrator-kp/style.css --allow-empty-input
+git diff --check
+```

--- a/submissions/examples/failover-drain-orchestrator-kp/demo.html
+++ b/submissions/examples/failover-drain-orchestrator-kp/demo.html
@@ -1,0 +1,239 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Failover Drain Orchestrator</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="orchestrator" data-state="drain">
+      <section class="hero" aria-labelledby="title">
+        <div>
+          <p class="eyebrow">EaseMotion availability lab</p>
+          <h1 id="title">Failover Drain Orchestrator</h1>
+          <p class="lede">
+            Tune failover signals and watch the control plane drain traffic,
+            isolate weak zones, and reopen replicas only after quorum
+            stabilizes.
+          </p>
+        </div>
+        <aside class="state-badge" aria-live="polite">
+          <span class="pulse"></span>
+          <small>Failover state</small>
+          <strong id="stateLabel">Controlled drain</strong>
+        </aside>
+      </section>
+
+      <section class="controls" aria-label="Failover inputs">
+        <label>
+          <span>Zone stress</span>
+          <input id="stress" type="range" min="0" max="100" value="67" />
+          <output id="stressOut">67%</output>
+        </label>
+        <label>
+          <span>Replica health</span>
+          <input id="health" type="range" min="15" max="100" value="61" />
+          <output id="healthOut">61%</output>
+        </label>
+        <label>
+          <span>Drain backlog</span>
+          <input id="backlog" type="range" min="0" max="100" value="58" />
+          <output id="backlogOut">58%</output>
+        </label>
+        <label>
+          <span>Quorum margin</span>
+          <input id="quorum" type="range" min="0" max="100" value="42" />
+          <output id="quorumOut">42%</output>
+        </label>
+      </section>
+
+      <section class="grid" aria-label="Failover dashboard">
+        <article class="topology">
+          <div class="panel-title">
+            <span>Topology pressure</span>
+            <strong id="riskScore">61</strong>
+          </div>
+          <div class="map" aria-hidden="true">
+            <span class="ring ring-a"></span>
+            <span class="ring ring-b"></span>
+            <span class="ring ring-c"></span>
+            <span class="sweep"></span>
+            <span class="zone zone-a">A</span>
+            <span class="zone zone-b">B</span>
+            <span class="zone zone-c">C</span>
+            <span class="zone zone-d">D</span>
+            <span class="core"></span>
+          </div>
+          <div class="probe-strip">
+            <span></span><span></span><span></span><span></span><span></span>
+            <span></span><span></span><span></span><span></span>
+          </div>
+        </article>
+
+        <article class="lanes">
+          <div class="panel-title">
+            <span>Drain lanes</span>
+            <strong id="laneLabel">Rerouting</strong>
+          </div>
+          <div class="lane-list">
+            <div class="lane" style="--fill: 0.82">
+              <span>Checkout primary</span><i></i><b>drain</b>
+            </div>
+            <div class="lane" style="--fill: 0.68">
+              <span>Search replicas</span><i></i><b>shift</b>
+            </div>
+            <div class="lane" style="--fill: 0.51">
+              <span>Billing workers</span><i></i><b>hold</b>
+            </div>
+            <div class="lane" style="--fill: 0.43">
+              <span>Event pipeline</span><i></i><b>buffer</b>
+            </div>
+            <div class="lane" style="--fill: 0.59">
+              <span>Cache warmers</span><i></i><b>prime</b>
+            </div>
+          </div>
+        </article>
+
+        <article class="playbook">
+          <div class="panel-title">
+            <span>Failover playbook</span>
+            <strong id="playbookLabel">Drain</strong>
+          </div>
+          <ol>
+            <li>
+              <em>01</em>
+              <div>
+                <strong>Freeze new placement</strong>
+                <p>Stop scheduling fresh work into the stressed zone.</p>
+              </div>
+            </li>
+            <li>
+              <em>02</em>
+              <div>
+                <strong>Drain active sessions</strong>
+                <p>
+                  Move traffic by weighted endpoints and bounded connection age.
+                </p>
+              </div>
+            </li>
+            <li>
+              <em>03</em>
+              <div>
+                <strong>Fence unsafe replicas</strong>
+                <p>Health probes isolate nodes before quorum gets thin.</p>
+              </div>
+            </li>
+            <li>
+              <em>04</em>
+              <div>
+                <strong>Restore by quorum trend</strong>
+                <p>
+                  Reopen capacity only after probe slope and backlog recover.
+                </p>
+              </div>
+            </li>
+          </ol>
+        </article>
+
+        <article class="metrics">
+          <div class="metric">
+            <span>Drain ETA</span>
+            <strong id="etaLabel">22s</strong>
+          </div>
+          <div class="metric">
+            <span>Isolation risk</span>
+            <strong id="isolationLabel">19%</strong>
+          </div>
+          <div class="metric">
+            <span>Safe capacity</span>
+            <strong id="capacityLabel">58%</strong>
+          </div>
+        </article>
+      </section>
+    </main>
+
+    <script>
+      const root = document.querySelector(".orchestrator");
+      const input = {
+        stress: document.querySelector("#stress"),
+        health: document.querySelector("#health"),
+        backlog: document.querySelector("#backlog"),
+        quorum: document.querySelector("#quorum"),
+      };
+      const output = {
+        stress: document.querySelector("#stressOut"),
+        health: document.querySelector("#healthOut"),
+        backlog: document.querySelector("#backlogOut"),
+        quorum: document.querySelector("#quorumOut"),
+        state: document.querySelector("#stateLabel"),
+        risk: document.querySelector("#riskScore"),
+        lane: document.querySelector("#laneLabel"),
+        playbook: document.querySelector("#playbookLabel"),
+        eta: document.querySelector("#etaLabel"),
+        isolation: document.querySelector("#isolationLabel"),
+        capacity: document.querySelector("#capacityLabel"),
+      };
+
+      function update() {
+        const stress = Number(input.stress.value);
+        const health = Number(input.health.value);
+        const backlog = Number(input.backlog.value);
+        const quorum = Number(input.quorum.value);
+        const risk = Math.round(
+          stress * 0.38 +
+            backlog * 0.28 +
+            (100 - health) * 0.22 +
+            (100 - quorum) * 0.12
+        );
+        const capacity = Math.max(
+          12,
+          Math.round((health + quorum) / 2 - backlog * 0.16)
+        );
+        let state = "steady";
+        let label = "Steady routing";
+        let lane = "Balanced";
+        let playbook = "Watch";
+
+        if (risk > 78) {
+          state = "isolate";
+          label = "Zone isolation";
+          lane = "Fenced";
+          playbook = "Isolate";
+        } else if (risk > 52) {
+          state = "drain";
+          label = "Controlled drain";
+          lane = "Rerouting";
+          playbook = "Drain";
+        } else if (risk < 34) {
+          state = "restore";
+          label = "Replica restore";
+          lane = "Cooling";
+          playbook = "Restore";
+        }
+
+        root.dataset.state = state;
+        root.style.setProperty("--risk", risk);
+        root.style.setProperty("--stress", stress);
+        root.style.setProperty("--backlog", backlog);
+        root.style.setProperty("--health", health);
+        output.stress.value = `${stress}%`;
+        output.health.value = `${health}%`;
+        output.backlog.value = `${backlog}%`;
+        output.quorum.value = `${quorum}%`;
+        output.risk.textContent = risk;
+        output.state.textContent = label;
+        output.lane.textContent = lane;
+        output.playbook.textContent = playbook;
+        output.eta.textContent = `${Math.max(8, Math.round(risk / 2.8))}s`;
+        output.isolation.textContent = `${Math.max(0, risk - 48)}%`;
+        output.capacity.textContent = `${capacity}%`;
+      }
+
+      Object.values(input).forEach((item) =>
+        item.addEventListener("input", update)
+      );
+      update();
+    </script>
+  </body>
+</html>

--- a/submissions/examples/failover-drain-orchestrator-kp/style.css
+++ b/submissions/examples/failover-drain-orchestrator-kp/style.css
@@ -1,0 +1,731 @@
+:root {
+  color-scheme: dark;
+  --bg: #0a0f16;
+  --panel: #121a24;
+  --panel-2: #192535;
+  --line: #304052;
+  --text: #f4f8ff;
+  --muted: #9caabd;
+  --cyan: #22d3ee;
+  --violet: #a78bfa;
+  --green: #86efac;
+  --amber: #f59e0b;
+  --red: #fb7185;
+  --risk: 61;
+  --stress: 67;
+  --backlog: 58;
+  --health: 61;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--text);
+  background:
+    linear-gradient(135deg, rgba(10, 15, 22, 0.98), rgba(20, 29, 42, 0.94)),
+    radial-gradient(
+      circle at 16% 8%,
+      rgba(34, 211, 238, 0.16),
+      transparent 29%
+    ),
+    radial-gradient(
+      circle at 82% 16%,
+      rgba(167, 139, 250, 0.13),
+      transparent 31%
+    ),
+    #0a0f16;
+}
+
+input,
+button {
+  font: inherit;
+}
+
+.orchestrator {
+  width: min(1190px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 30px 0 44px;
+}
+
+.hero {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 230px;
+  gap: 24px;
+  align-items: end;
+  min-height: 220px;
+  padding: 34px;
+  overflow: hidden;
+  border: 1px solid rgba(156, 170, 189, 0.22);
+  border-radius: 8px;
+  background:
+    linear-gradient(110deg, rgba(18, 26, 36, 0.97), rgba(25, 37, 53, 0.75)),
+    repeating-linear-gradient(
+      90deg,
+      rgba(34, 211, 238, 0.07) 0 1px,
+      transparent 1px 46px
+    );
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.35);
+}
+
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: auto -12% -52px 34%;
+  height: 160px;
+  border-top: 1px solid rgba(34, 211, 238, 0.28);
+  border-bottom: 1px solid rgba(167, 139, 250, 0.2);
+  transform: skewX(-18deg);
+  animation: headerDrift 5.4s linear infinite;
+}
+
+.hero::after {
+  content: "";
+  position: absolute;
+  top: 18px;
+  right: 32px;
+  width: 190px;
+  height: 80px;
+  border: 1px solid rgba(245, 158, 11, 0.22);
+  transform: rotate(-9deg);
+  animation: headerPulse 2.8s ease-in-out infinite;
+}
+
+.eyebrow {
+  margin: 0 0 12px;
+  color: var(--cyan);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 780px;
+  margin: 0;
+  font-size: clamp(2.55rem, 7vw, 5.85rem);
+  line-height: 0.92;
+  letter-spacing: 0;
+}
+
+.lede {
+  max-width: 690px;
+  margin: 18px 0 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
+.state-badge {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 7px;
+  padding: 18px;
+  border: 1px solid rgba(156, 170, 189, 0.2);
+  border-radius: 8px;
+  background: rgba(10, 15, 22, 0.78);
+}
+
+.pulse {
+  width: 13px;
+  height: 13px;
+  border-radius: 50%;
+  background: var(--amber);
+  box-shadow: 0 0 0 7px rgba(245, 158, 11, 0.15);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.state-badge small {
+  color: var(--muted);
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.state-badge strong {
+  font-size: 1.18rem;
+}
+
+.orchestrator[data-state="isolate"] .pulse {
+  background: var(--red);
+  box-shadow: 0 0 0 7px rgba(251, 113, 133, 0.17);
+}
+
+.orchestrator[data-state="restore"] .pulse {
+  background: var(--green);
+  box-shadow: 0 0 0 7px rgba(134, 239, 172, 0.16);
+}
+
+.controls {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+  margin: 18px 0;
+}
+
+.controls label {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 11px;
+  align-items: center;
+  padding: 16px;
+  border: 1px solid rgba(156, 170, 189, 0.18);
+  border-radius: 8px;
+  background: rgba(18, 26, 36, 0.84);
+}
+
+.controls span {
+  color: var(--muted);
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+
+.controls output {
+  font-weight: 900;
+}
+
+.controls input {
+  grid-column: 1 / -1;
+  width: 100%;
+  accent-color: var(--cyan);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1.08fr 0.92fr;
+  gap: 18px;
+}
+
+.grid article {
+  min-width: 0;
+  border: 1px solid rgba(156, 170, 189, 0.2);
+  border-radius: 8px;
+  background: linear-gradient(
+    180deg,
+    rgba(18, 26, 36, 0.96),
+    rgba(10, 15, 22, 0.92)
+  );
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.24);
+}
+
+.panel-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 20px 0;
+}
+
+.panel-title span {
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.panel-title strong {
+  font-size: 1.18rem;
+}
+
+.topology {
+  grid-row: span 2;
+  padding-bottom: 20px;
+}
+
+.map {
+  position: relative;
+  width: min(430px, 82vw);
+  aspect-ratio: 1;
+  margin: 26px auto 18px;
+  overflow: hidden;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle, rgba(34, 211, 238, 0.16) 0 2px, transparent 3px),
+    conic-gradient(
+      from 140deg,
+      rgba(34, 211, 238, 0.24),
+      rgba(167, 139, 250, 0.17),
+      rgba(245, 158, 11, 0.24),
+      rgba(251, 113, 133, 0.28),
+      rgba(34, 211, 238, 0.24)
+    );
+  box-shadow:
+    inset 0 0 0 1px rgba(156, 170, 189, 0.2),
+    inset 0 0 72px rgba(0, 0, 0, 0.46);
+}
+
+.map::before,
+.map::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 8%;
+  right: 8%;
+  height: 1px;
+  background: rgba(244, 248, 255, 0.18);
+}
+
+.map::after {
+  transform: rotate(90deg);
+}
+
+.ring {
+  position: absolute;
+  border: 1px solid rgba(244, 248, 255, 0.16);
+  border-radius: 50%;
+  animation: ringBreathe 3s ease-in-out infinite;
+}
+
+.ring-a {
+  inset: 12%;
+}
+
+.ring-b {
+  inset: 27%;
+  animation-delay: 0.28s;
+}
+
+.ring-c {
+  inset: 42%;
+  animation-delay: 0.56s;
+}
+
+.sweep {
+  position: absolute;
+  inset: 4%;
+  border-radius: 50%;
+  background: conic-gradient(
+    from 0deg,
+    rgba(34, 211, 238, 0.64),
+    rgba(34, 211, 238, 0.08) 48deg,
+    transparent 78deg
+  );
+  mask: radial-gradient(circle, transparent 0 13%, #000 14% 100%);
+  animation: sweep 3.4s linear infinite;
+}
+
+.core {
+  position: absolute;
+  inset: calc(50% - 38px);
+  border-radius: 50%;
+  background: color-mix(
+    in srgb,
+    var(--amber) calc(var(--risk) * 1%),
+    var(--cyan)
+  );
+  box-shadow: 0 0 36px rgba(34, 211, 238, 0.45);
+  animation: coreBeat 1.65s ease-in-out infinite;
+}
+
+.zone {
+  position: absolute;
+  display: grid;
+  place-items: center;
+  width: 36px;
+  height: 36px;
+  border: 1px solid rgba(244, 248, 255, 0.24);
+  border-radius: 50%;
+  background: rgba(10, 15, 22, 0.78);
+  color: var(--text);
+  font-weight: 900;
+  box-shadow: 0 0 24px rgba(34, 211, 238, 0.22);
+  animation: zonePulse 2.2s ease-in-out infinite;
+}
+
+.zone-a {
+  top: 16%;
+  left: 62%;
+}
+
+.zone-b {
+  top: 42%;
+  left: 78%;
+  animation-delay: 0.35s;
+}
+
+.zone-c {
+  top: 72%;
+  left: 34%;
+  animation-delay: 0.7s;
+}
+
+.zone-d {
+  top: 30%;
+  left: 18%;
+  animation-delay: 1.05s;
+}
+
+.probe-strip {
+  display: grid;
+  grid-template-columns: repeat(9, 1fr);
+  gap: 7px;
+  padding: 0 20px;
+}
+
+.probe-strip span {
+  height: 48px;
+  border-radius: 6px;
+  background: linear-gradient(180deg, var(--cyan), transparent);
+  transform-origin: bottom;
+  animation: probe 1.55s ease-in-out infinite;
+}
+
+.probe-strip span:nth-child(2n) {
+  animation-delay: 0.12s;
+}
+
+.probe-strip span:nth-child(3n) {
+  animation-delay: 0.28s;
+}
+
+.probe-strip span:nth-child(4n) {
+  animation-delay: 0.44s;
+}
+
+.lanes,
+.playbook,
+.metrics {
+  padding-bottom: 18px;
+}
+
+.lane-list {
+  display: grid;
+  gap: 13px;
+  padding: 20px;
+}
+
+.lane {
+  display: grid;
+  grid-template-columns: 136px minmax(100px, 1fr) 64px;
+  gap: 13px;
+  align-items: center;
+}
+
+.lane span {
+  font-size: 0.92rem;
+  font-weight: 800;
+}
+
+.lane i {
+  position: relative;
+  height: 12px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(156, 170, 189, 0.16);
+}
+
+.lane i::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  width: calc(var(--fill) * 100%);
+  border-radius: inherit;
+  background: linear-gradient(
+    90deg,
+    var(--green),
+    var(--cyan),
+    var(--amber),
+    var(--red)
+  );
+  animation: laneFlow 1.9s ease-in-out infinite;
+}
+
+.lane b {
+  color: var(--muted);
+  font-size: 0.78rem;
+  text-align: right;
+  text-transform: uppercase;
+}
+
+.playbook ol {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 20px;
+  list-style: none;
+}
+
+.playbook li {
+  display: grid;
+  grid-template-columns: 38px 1fr;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid rgba(156, 170, 189, 0.16);
+  border-radius: 8px;
+  background: rgba(25, 37, 53, 0.55);
+  animation: playbookLift 3s ease-in-out infinite;
+}
+
+.playbook li:nth-child(2) {
+  animation-delay: 0.18s;
+}
+
+.playbook li:nth-child(3) {
+  animation-delay: 0.36s;
+}
+
+.playbook li:nth-child(4) {
+  animation-delay: 0.54s;
+}
+
+.playbook em {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  background: rgba(34, 211, 238, 0.12);
+  color: var(--cyan);
+  font-style: normal;
+  font-weight: 900;
+}
+
+.playbook strong {
+  display: block;
+  margin-bottom: 4px;
+}
+
+.playbook p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  padding: 18px;
+}
+
+.metric {
+  min-height: 110px;
+  padding: 16px;
+  border: 1px solid rgba(156, 170, 189, 0.16);
+  border-radius: 8px;
+  background: rgba(10, 15, 22, 0.58);
+}
+
+.metric span {
+  display: block;
+  margin-bottom: 12px;
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.metric strong {
+  font-size: 1.9rem;
+}
+
+.orchestrator[data-state="steady"] .hero {
+  border-color: rgba(34, 211, 238, 0.3);
+}
+
+.orchestrator[data-state="drain"] .hero {
+  border-color: rgba(245, 158, 11, 0.34);
+}
+
+.orchestrator[data-state="isolate"] .hero {
+  border-color: rgba(251, 113, 133, 0.44);
+}
+
+.orchestrator[data-state="restore"] .hero {
+  border-color: rgba(134, 239, 172, 0.34);
+}
+
+.orchestrator[data-state="isolate"] .core {
+  background: var(--red);
+  box-shadow: 0 0 46px rgba(251, 113, 133, 0.58);
+}
+
+.orchestrator[data-state="restore"] .core {
+  background: var(--green);
+  box-shadow: 0 0 42px rgba(134, 239, 172, 0.48);
+}
+
+@keyframes headerDrift {
+  0% {
+    transform: translateX(-44%) skewX(-18deg);
+  }
+
+  100% {
+    transform: translateX(58%) skewX(-18deg);
+  }
+}
+
+@keyframes headerPulse {
+  0%,
+  100% {
+    opacity: 0.25;
+  }
+
+  50% {
+    opacity: 0.76;
+  }
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    transform: scale(0.92);
+  }
+
+  50% {
+    transform: scale(1.14);
+  }
+}
+
+@keyframes ringBreathe {
+  0%,
+  100% {
+    opacity: 0.36;
+    transform: scale(0.98);
+  }
+
+  50% {
+    opacity: 0.88;
+    transform: scale(1.02);
+  }
+}
+
+@keyframes sweep {
+  to {
+    transform: rotate(1turn);
+  }
+}
+
+@keyframes coreBeat {
+  0%,
+  100% {
+    transform: scale(0.94);
+  }
+
+  50% {
+    transform: scale(1.09);
+  }
+}
+
+@keyframes zonePulse {
+  0%,
+  100% {
+    opacity: 0.72;
+    transform: scale(0.94);
+  }
+
+  50% {
+    opacity: 1;
+    transform: scale(1.12);
+  }
+}
+
+@keyframes probe {
+  0%,
+  100% {
+    opacity: 0.43;
+    transform: scaleY(0.28);
+  }
+
+  50% {
+    opacity: 0.96;
+    transform: scaleY(calc(0.42 + var(--risk) / 120));
+  }
+}
+
+@keyframes laneFlow {
+  0%,
+  100% {
+    filter: saturate(0.9);
+  }
+
+  50% {
+    filter: saturate(1.55);
+  }
+}
+
+@keyframes playbookLift {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+
+  50% {
+    transform: translateY(-3px);
+  }
+}
+
+@media (max-width: 880px) {
+  .orchestrator {
+    width: min(100% - 20px, 700px);
+    padding-top: 16px;
+  }
+
+  .hero {
+    grid-template-columns: 1fr;
+    min-height: 260px;
+    padding: 26px;
+  }
+
+  .state-badge {
+    width: min(100%, 260px);
+  }
+
+  .controls,
+  .grid {
+    grid-template-columns: 1fr;
+  }
+
+  .topology {
+    grid-row: auto;
+  }
+
+  .lane {
+    grid-template-columns: 1fr;
+    gap: 7px;
+  }
+
+  .lane b {
+    text-align: left;
+  }
+}
+
+@media (max-width: 560px) {
+  .orchestrator {
+    width: min(100% - 14px, 440px);
+  }
+
+  .hero {
+    padding: 22px;
+  }
+
+  h1 {
+    font-size: clamp(2.05rem, 18vw, 3.75rem);
+  }
+
+  .controls label,
+  .metrics {
+    grid-template-columns: 1fr;
+  }
+
+  .panel-title {
+    align-items: start;
+  }
+
+  .playbook li {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add an advanced failover drain orchestrator animation example
- include interactive controls for zone stress, replica health, backlog, and quorum margin
- visualize steady, drain, isolate, and restore states for resilient failover

## Validation
- npx prettier --check submissions/examples/failover-drain-orchestrator-kp/README.md submissions/examples/failover-drain-orchestrator-kp/demo.html submissions/examples/failover-drain-orchestrator-kp/style.css
- npx stylelint submissions/examples/failover-drain-orchestrator-kp/style.css --allow-empty-input
- git diff --check