### PR TITLE
feat: Add custom cross-browser animated range slider (#66756)

### DIFF
--- a/submissions/examples/custom-range-slider/README.md
+++ b/submissions/examples/custom-range-slider/README.md
@@ -1,0 +1,49 @@
+# Custom Cross-Browser Animated Range Slider
+
+A fully custom-styled, premium animated `<input type="range">` component designed for modern web applications. It provides a consistent, high-quality visual experience across Chrome, Safari, Edge, and Firefox.
+
+## Features
+
+- **Premium Aesthetics:** Dark mode glassmorphism container, vibrant gradient track, and a clean glowing thumb.
+- **Dynamic Track Fill:** The track visually fills up to the thumb's current position.
+- **Micro-animations:** The thumb scales and its glow intensifies smoothly on hover and focus.
+- **Cross-Browser Consistency:** Carefully targeted pseudo-elements ensure the slider looks identical across all major browsers.
+
+## Cross-Browser Quirks & Solutions
+
+Native range sliders are notoriously difficult to style consistently because different browser engines implement them using entirely different internal Shadow DOM structures. Here is how we solved the major quirks:
+
+### 1. Removing Native Appearance
+We start by stripping the default OS styling from the input element:
+```css
+.custom-range {
+    appearance: none;
+    -webkit-appearance: none;
+    background: transparent;
+}
+```
+
+### 2. Track Styling
+- **Webkit/Blink (Chrome, Safari, Edge):** Uses `::-webkit-slider-runnable-track`. Webkit does not have a native way to color just the "filled" portion of the track. To solve this, we use a CSS `linear-gradient` background combined with a CSS Custom Property (`--val`). A tiny inline JavaScript snippet (`oninput="this.style.setProperty('--val', this.value)"`) updates this variable, allowing the gradient to dynamically stop exactly at the thumb's location.
+- **Gecko (Firefox):** Uses `::-moz-range-track` for the track background. Firefox provides a dedicated pseudo-element `::-moz-range-progress` specifically for the filled portion of the track, making dynamic filling much easier and purely CSS-driven without needing the CSS variable trick (though they are styled to match visually).
+
+### 3. Thumb Styling
+- **Webkit/Blink:** Uses `::-webkit-slider-thumb`. It requires `-webkit-appearance: none` again. Crucially, in Webkit, the thumb needs a negative `margin-top` to perfectly center it vertically over the track if the track and thumb have different heights.
+- **Gecko:** Uses `::-moz-range-thumb`. Firefox generally centers the thumb automatically, so the negative `margin-top` is not required. Furthermore, Firefox sometimes includes borders in dimensions differently, so setting explicit widths/heights ensuring `box-sizing: border-box` helps maintain consistency.
+
+## Usage
+
+Simply copy the HTML structure from `demo.html` and the styles from `style.css` into your project.
+
+```html
+<!-- Example Usage -->
+<input 
+    type="range" 
+    class="custom-range" 
+    min="0" 
+    max="100" 
+    value="50"
+    oninput="this.style.setProperty('--val', this.value)"
+    style="--val: 50"
+>
+```

--- a/submissions/examples/custom-range-slider/demo.html
+++ b/submissions/examples/custom-range-slider/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Custom Cross-Browser Animated Range Slider</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="slider-container">
+        <h2>Volume Control</h2>
+        <!-- 
+          The inline JS `--val` calculation helps visually fill the track dynamically 
+          (especially useful for Webkit browsers).
+        -->
+        <input 
+            type="range" 
+            class="custom-range" 
+            min="0" 
+            max="100" 
+            value="50"
+            oninput="this.style.setProperty('--val', this.value)"
+            style="--val: 50"
+            aria-label="Volume Control"
+        >
+        <div class="slider-value-display">
+            <span>0</span>
+            <span>100</span>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/custom-range-slider/style.css
+++ b/submissions/examples/custom-range-slider/style.css
@@ -1,0 +1,180 @@
+/* Reset and basic layout */
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: 'Inter', 'Roboto', sans-serif;
+    background-color: #0d0f12;
+    color: #e5e7eb;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+}
+
+/* Premium Container */
+.slider-container {
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    border-radius: 20px;
+    padding: 40px;
+    width: 400px;
+    max-width: 90vw;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.1);
+    backdrop-filter: blur(10px);
+}
+
+.slider-container h2 {
+    font-size: 1.2rem;
+    margin-bottom: 30px;
+    font-weight: 500;
+    text-align: center;
+    letter-spacing: 0.5px;
+    color: #f3f4f6;
+    text-shadow: 0 2px 4px rgba(0,0,0,0.5);
+}
+
+/* 
+  =========================================
+  CUSTOM RANGE SLIDER CORE STYLES
+  =========================================
+*/
+.custom-range {
+    /* Strip default OS styling */
+    appearance: none;
+    -webkit-appearance: none;
+    width: 100%;
+    background: transparent; /* Track is styled separately */
+    outline: none;
+    margin: 15px 0;
+    cursor: pointer;
+}
+
+/* Focus states for accessibility */
+.custom-range:focus {
+    outline: none;
+}
+
+/* 
+  =========================================
+  TRACK STYLING
+  =========================================
+*/
+/* Webkit (Chrome, Safari, Edge) */
+.custom-range::-webkit-slider-runnable-track {
+    width: 100%;
+    height: 8px;
+    border-radius: 4px;
+    /* 
+      We use a linear-gradient that leverages the --val CSS variable
+      to fill the track dynamically up to the thumb's current position.
+    */
+    background: linear-gradient(
+        to right, 
+        #3b82f6 0%, 
+        #8b5cf6 calc(var(--val) * 1%), 
+        rgba(255, 255, 255, 0.1) calc(var(--val) * 1%), 
+        rgba(255, 255, 255, 0.1) 100%
+    );
+    border: 1px solid rgba(0, 0, 0, 0.5);
+    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.5);
+    transition: background 0.15s ease;
+}
+
+/* Mozilla (Firefox) */
+.custom-range::-moz-range-track {
+    width: 100%;
+    height: 8px;
+    border-radius: 4px;
+    background: rgba(255, 255, 255, 0.1);
+    border: 1px solid rgba(0, 0, 0, 0.5);
+    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.5);
+}
+
+/* Firefox supports a dedicated progress pseudo-element for the filled track */
+.custom-range::-moz-range-progress {
+    height: 8px;
+    border-radius: 4px;
+    background: linear-gradient(to right, #3b82f6, #8b5cf6);
+}
+
+/* 
+  =========================================
+  THUMB STYLING
+  =========================================
+*/
+/* Webkit Thumb */
+.custom-range::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: #ffffff;
+    /* Adjust thumb position relative to the track */
+    margin-top: -8px; 
+    border: 2px solid #8b5cf6;
+    box-shadow: 0 0 10px rgba(139, 92, 246, 0.3), 0 2px 4px rgba(0,0,0,0.3);
+    transition: transform 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275), box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+/* Firefox Thumb */
+.custom-range::-moz-range-thumb {
+    width: 20px; /* Firefox includes borders in width/height differently sometimes, but standardizing helps */
+    height: 20px;
+    border-radius: 50%;
+    background: #ffffff;
+    border: 2px solid #8b5cf6;
+    box-shadow: 0 0 10px rgba(139, 92, 246, 0.3), 0 2px 4px rgba(0,0,0,0.3);
+    transition: transform 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275), box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+/* 
+  =========================================
+  HOVER & ACTIVE STATES (Micro-animations)
+  =========================================
+*/
+.custom-range:hover::-webkit-slider-thumb {
+    transform: scale(1.15);
+    box-shadow: 0 0 20px rgba(139, 92, 246, 0.6), 0 4px 8px rgba(0,0,0,0.4);
+    background: #f8fafc;
+}
+
+.custom-range:hover::-moz-range-thumb {
+    transform: scale(1.15);
+    box-shadow: 0 0 20px rgba(139, 92, 246, 0.6), 0 4px 8px rgba(0,0,0,0.4);
+    background: #f8fafc;
+}
+
+.custom-range:active::-webkit-slider-thumb {
+    transform: scale(0.95);
+    box-shadow: 0 0 8px rgba(139, 92, 246, 0.4);
+}
+
+.custom-range:active::-moz-range-thumb {
+    transform: scale(0.95);
+    box-shadow: 0 0 8px rgba(139, 92, 246, 0.4);
+}
+
+/* Focus outline for accessibility */
+.custom-range:focus-visible::-webkit-slider-thumb {
+    outline: 2px solid #3b82f6;
+    outline-offset: 3px;
+}
+.custom-range:focus-visible::-moz-range-thumb {
+    outline: 2px solid #3b82f6;
+    outline-offset: 3px;
+}
+
+/* Value Display Under Slider */
+.slider-value-display {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 15px;
+    font-size: 0.85rem;
+    color: #9ca3af;
+    font-weight: 500;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a fully custom-styled, premium animated `<input type="range">` component that looks identical across Chrome, Safari, and Firefox. It features a glowing thumb and dynamic track colors to solve the issue of native OS range sliders looking drastically different and difficult to standardize. Fixes #66756.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A unified, custom-styled range slider component featuring a glassmorphism container, a glowing thumb that expands on interaction, and a dynamic gradient track.

**How does a developer use it?**

```html
<input 
    type="range" 
    class="custom-range" 
    min="0" 
    max="100" 
    value="50"
    oninput="this.style.setProperty('--val', this.value)"
    style="--val: 50"
>
```

**Why does it fit EaseMotion CSS?**

Native range sliders are notoriously difficult to standardize and often look outdated. This component fits the EaseMotion CSS philosophy by providing a highly animated, premium UI element out of the box that relies primarily on CSS and standard micro-animations (like the scaling and glowing thumb on hover/active states), drastically improving the user experience over standard OS inputs.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari *(optional but appreciated)*

---

## Notes for Maintainer

This implementation leverages a CSS variable (`--val`) dynamically updated via a tiny inline Javascript snippet `oninput` to handle the track's visual "fill" effect on Webkit browsers since they lack Firefox's `::-moz-range-progress` pseudo-element. The `README.md` documents these cross-browser Shadow DOM quirks thoroughly.
