### PR TITLE
feat(scss): add flowing gradient text mixin

### DIFF
--- a/submissions/scss/ease-gradient-text/README.md
+++ b/submissions/scss/ease-gradient-text/README.md
@@ -1,0 +1,42 @@
+# SCSS Flowing Gradient Text Mixin
+
+Web3 and modern AI SaaS sites frequently use text where a vibrant gradient continuously flows across the letters (popularized by Apple and Stripe). Writing the keyframes, `background-size` math, and vendor prefixes for this is highly repetitive. This SCSS mixin generates a flawless loop based on an arbitrary list of colors.
+
+## Features
+- Accepts any number of `$colors` using SCSS `Arglist` spread syntax.
+- Dynamically appends the first color to the end of the gradient to ensure a perfectly seamless infinite loop.
+- Automatically handles `-webkit-background-clip: text` and transparency fallbacks.
+- Exposes a global `@keyframes` animation that scales and pans the background smoothly.
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `$animation-speed` | `Time` | `3s` | How fast the gradient pans across the text. |
+| `$colors...` | `Arglist` | `(#3b82f6, #8b5cf6, #ec4899)` | A comma-separated list of colors. |
+
+## Usage
+
+Import the mixin and use it on any text element.
+
+```scss
+@import 'ease-gradient-text';
+
+// Using the default speed (3s) and colors (blue, purple, pink)
+h1 {
+  @include ease-gradient-text();
+}
+
+// Custom speed and custom colors (Sunset theme)
+h2 {
+  @include ease-gradient-text(4s, #fbbf24, #f97316, #e11d48);
+}
+
+// Slow Cyberpunk theme
+.tagline {
+  @include ease-gradient-text(6s, #00ffcc, #ff00ff, #ffff00, #00ffcc);
+}
+```
+
+## Why it fits EaseMotion CSS
+Achieving this aesthetic requires a very specific combination of CSS properties (`color: transparent`, `background-clip: text`, `background-size: 200%`, and a precisely mapped `background-position` keyframe). By abstracting these mechanics into a single, highly configurable mixin, we eliminate boilerplate and ensure developers can focus purely on the visual design rather than the underlying CSS mechanics.

--- a/submissions/scss/ease-gradient-text/_ease-gradient-text.scss
+++ b/submissions/scss/ease-gradient-text/_ease-gradient-text.scss
@@ -1,0 +1,47 @@
+/// EaseMotion Animated Flowing Gradient Text Mixin
+/// Generates a perfectly looping, vibrant gradient that pans continuously across text.
+/// 
+/// @param {Time} $animation-speed [3s] - How fast the gradient pans across the text.
+/// @param {Arglist} $colors - A comma-separated list of colors to form the gradient.
+
+@mixin ease-gradient-text($animation-speed: 3s, $colors...) {
+  // Fallback if no colors are provided
+  @if length($colors) == 0 {
+    $colors: (#3b82f6, #8b5cf6, #ec4899);
+  }
+
+  // Create the linear-gradient string from the arbitrary list of colors.
+  // We append the first color to the end of the list to ensure a seamless loop!
+  $first-color: nth($colors, 1);
+  $gradient: linear-gradient(
+    to right,
+    join($colors, $first-color, comma)
+  );
+
+  // Apply the gradient and clip it to the text
+  background-image: $gradient;
+  -webkit-background-clip: text;
+  background-clip: text;
+  
+  // Make the text transparent so the background shows through
+  color: transparent;
+  
+  // Scale the background massively so there is room for it to pan
+  background-size: 200% auto;
+  
+  // Apply the animation
+  animation: ease-kf-gradient-pan $animation-speed linear infinite;
+}
+
+// Global keyframe definition
+// We check if it's already defined to prevent duplication if the mixin is used multiple times
+@if not variable-exists(ease-gradient-keyframes-defined) {
+  $ease-gradient-keyframes-defined: true !global;
+  
+  @keyframes ease-kf-gradient-pan {
+    to {
+      // Pan the scaled background perfectly across its width
+      background-position: 200% center;
+    }
+  }
+}


### PR DESCRIPTION
fixes #66774 

## Pull Request Description

Adds an `ease-gradient-text` SCSS mixin. Web3 and modern AI SaaS sites frequently use text where a vibrant gradient continuously flows across the letters (a classic aesthetic popularized by Stripe and Apple). Manually writing the keyframes, `background-size` scaling math, and clipping prefixes for this effect is highly repetitive. This mixin automates the entire process, generating a flawless, infinite animation loop based on any arbitrary list of colors.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component (SCSS Track)
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/scss/ease-gradient-text/`)
- [x] Includes `_ease-gradient-text.scss` — raw SCSS mixin code for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A highly reusable SCSS mixin (`_ease-gradient-text.scss`) that accepts an animation speed parameter and an arbitrary list of colors via SCSS `Arglist` spread syntax (`$colors...`). 

It dynamically:
1. Generates a `linear-gradient` string.
2. Crucially, it appends the first color in the list to the very end of the gradient to ensure a perfectly seamless infinite visual loop.
3. Applies `-webkit-background-clip: text` and `color: transparent`.
4. Scales the `background-size` to `200%` and injects a globally scoped `@keyframes` definition to pan the background horizontally.

**How does a developer use it?**

```scss
@import 'ease-gradient-text';

// Use default colors (blue, purple, pink) panning over 3s
h1 {
  @include ease-gradient-text();
}

// Use a custom Sunset theme panning slowly over 5s
.tagline {
  @include ease-gradient-text(5s, #fbbf24, #f97316, #e11d48);
}
