### PR TITLE
feat: add rollback checkpoint sentinel example

### DIFF
--- a/submissions/examples/rollback-checkpoint-sentinel-kp/README.md
+++ b/submissions/examples/rollback-checkpoint-sentinel-kp/README.md
@@ -1,0 +1,24 @@
+# Rollback Checkpoint Sentinel
+
+An advanced EaseMotion dashboard for visualizing rollback checkpoints in distributed releases. It shows how a sentinel scores deployment drift, chooses a checkpoint, drains risky traffic, and replays safe work after recovery.
+
+## Features
+
+- Interactive controls for drift, error rate, replay queue, and checkpoint freshness
+- Animated checkpoint radar, rollback lanes, and recovery playbook cards
+- Live JavaScript mode switching across observe, checkpoint, rollback, and replay states
+- Responsive operations layout using CSS variables and animation timing
+- Advanced-tier contribution with more than 500 added lines
+
+## Files
+
+- `demo.html` - interactive dashboard and state logic
+- `style.css` - responsive styling and motion system
+
+## Validation
+
+```bash
+npx prettier --check submissions/examples/rollback-checkpoint-sentinel-kp/README.md submissions/examples/rollback-checkpoint-sentinel-kp/demo.html submissions/examples/rollback-checkpoint-sentinel-kp/style.css
+npx stylelint submissions/examples/rollback-checkpoint-sentinel-kp/style.css --allow-empty-input
+git diff --check
+```

--- a/submissions/examples/rollback-checkpoint-sentinel-kp/demo.html
+++ b/submissions/examples/rollback-checkpoint-sentinel-kp/demo.html
@@ -1,0 +1,236 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Rollback Checkpoint Sentinel</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="sentinel" data-state="checkpoint">
+      <section class="hero" aria-labelledby="title">
+        <div>
+          <p class="eyebrow">EaseMotion release safety</p>
+          <h1 id="title">Rollback Checkpoint Sentinel</h1>
+          <p class="lede">
+            Tune release signals and watch the sentinel select the safest
+            checkpoint, drain risky traffic, and replay healthy work after
+            rollback.
+          </p>
+        </div>
+        <aside class="badge" aria-live="polite">
+          <span class="dot"></span>
+          <small>Sentinel mode</small>
+          <strong id="modeLabel">Checkpoint armed</strong>
+        </aside>
+      </section>
+
+      <section class="controls" aria-label="Rollback inputs">
+        <label
+          ><span>Release drift</span
+          ><input id="drift" type="range" min="0" max="100" value="61" /><output
+            id="driftOut"
+            >61%</output
+          ></label
+        >
+        <label
+          ><span>Error rate</span
+          ><input
+            id="errors"
+            type="range"
+            min="0"
+            max="100"
+            value="46"
+          /><output id="errorsOut">46%</output></label
+        >
+        <label
+          ><span>Replay queue</span
+          ><input
+            id="replay"
+            type="range"
+            min="0"
+            max="100"
+            value="52"
+          /><output id="replayOut">52%</output></label
+        >
+        <label
+          ><span>Checkpoint fresh</span
+          ><input id="fresh" type="range" min="0" max="100" value="69" /><output
+            id="freshOut"
+            >69%</output
+          ></label
+        >
+      </section>
+
+      <section class="grid" aria-label="Rollback dashboard">
+        <article class="radar-panel">
+          <div class="panel-title">
+            <span>Rollback risk</span><strong id="riskScore">50</strong>
+          </div>
+          <div class="radar" aria-hidden="true">
+            <span class="ring ring-a"></span><span class="ring ring-b"></span
+            ><span class="ring ring-c"></span>
+            <span class="sweep sweep-a"></span
+            ><span class="sweep sweep-b"></span
+            ><span class="sweep sweep-c"></span>
+            <span class="marker marker-a">C1</span
+            ><span class="marker marker-b">C2</span
+            ><span class="marker marker-c">C3</span
+            ><span class="marker marker-d">R</span>
+            <span class="core"></span>
+          </div>
+          <div class="signal-strip">
+            <span></span><span></span><span></span><span></span><span></span
+            ><span></span><span></span><span></span><span></span>
+          </div>
+        </article>
+
+        <article class="lanes">
+          <div class="panel-title">
+            <span>Rollback lanes</span><strong id="laneLabel">Guarded</strong>
+          </div>
+          <div class="lane-list">
+            <div class="lane" style="--fill: 0.78">
+              <span>API shard</span><i></i><b>freeze</b>
+            </div>
+            <div class="lane" style="--fill: 0.63">
+              <span>Worker pool</span><i></i><b>drain</b>
+            </div>
+            <div class="lane" style="--fill: 0.49">
+              <span>Cache layer</span><i></i><b>warm</b>
+            </div>
+            <div class="lane" style="--fill: 0.42">
+              <span>Event stream</span><i></i><b>replay</b>
+            </div>
+            <div class="lane" style="--fill: 0.57">
+              <span>Search index</span><i></i><b>sync</b>
+            </div>
+          </div>
+        </article>
+
+        <article class="playbook">
+          <div class="panel-title">
+            <span>Recovery playbook</span><strong id="actionLabel">Arm</strong>
+          </div>
+          <ol>
+            <li>
+              <em>01</em>
+              <div>
+                <strong>Score release drift</strong>
+                <p>Compare live errors with deployment and schema changes.</p>
+              </div>
+            </li>
+            <li>
+              <em>02</em>
+              <div>
+                <strong>Select checkpoint</strong>
+                <p>
+                  Pick the newest state with stable probes and replay coverage.
+                </p>
+              </div>
+            </li>
+            <li>
+              <em>03</em>
+              <div>
+                <strong>Drain unsafe traffic</strong>
+                <p>Stop writes through risky paths before rollback begins.</p>
+              </div>
+            </li>
+            <li>
+              <em>04</em>
+              <div>
+                <strong>Replay safe work</strong>
+                <p>Restore queued operations once the checkpoint is healthy.</p>
+              </div>
+            </li>
+          </ol>
+        </article>
+
+        <article class="metrics">
+          <div class="metric">
+            <span>Rollback ETA</span><strong id="etaLabel">18s</strong>
+          </div>
+          <div class="metric">
+            <span>Replay load</span><strong id="loadLabel">52%</strong>
+          </div>
+          <div class="metric">
+            <span>Safe point</span><strong id="safeLabel">69%</strong>
+          </div>
+        </article>
+      </section>
+    </main>
+    <script>
+      const root = document.querySelector(".sentinel");
+      const input = {
+        drift: document.querySelector("#drift"),
+        errors: document.querySelector("#errors"),
+        replay: document.querySelector("#replay"),
+        fresh: document.querySelector("#fresh"),
+      };
+      const output = {
+        drift: document.querySelector("#driftOut"),
+        errors: document.querySelector("#errorsOut"),
+        replay: document.querySelector("#replayOut"),
+        fresh: document.querySelector("#freshOut"),
+        mode: document.querySelector("#modeLabel"),
+        risk: document.querySelector("#riskScore"),
+        lane: document.querySelector("#laneLabel"),
+        action: document.querySelector("#actionLabel"),
+        eta: document.querySelector("#etaLabel"),
+        load: document.querySelector("#loadLabel"),
+        safe: document.querySelector("#safeLabel"),
+      };
+
+      function update() {
+        const drift = Number(input.drift.value);
+        const errors = Number(input.errors.value);
+        const replay = Number(input.replay.value);
+        const fresh = Number(input.fresh.value);
+        const risk = Math.round(
+          drift * 0.34 + errors * 0.3 + replay * 0.18 + (100 - fresh) * 0.18
+        );
+        let state = "observe",
+          mode = "Observing release",
+          lane = "Open",
+          action = "Observe";
+        if (risk > 76) {
+          state = "rollback";
+          mode = "Rollback active";
+          lane = "Draining";
+          action = "Rollback";
+        } else if (risk > 50) {
+          state = "checkpoint";
+          mode = "Checkpoint armed";
+          lane = "Guarded";
+          action = "Arm";
+        } else if (risk < 32) {
+          state = "replay";
+          mode = "Replay recovery";
+          lane = "Cooling";
+          action = "Replay";
+        }
+        root.dataset.state = state;
+        root.style.setProperty("--risk", risk);
+        root.style.setProperty("--drift", drift);
+        root.style.setProperty("--errors", errors);
+        root.style.setProperty("--replay", replay);
+        output.drift.value = `${drift}%`;
+        output.errors.value = `${errors}%`;
+        output.replay.value = `${replay}%`;
+        output.fresh.value = `${fresh}%`;
+        output.risk.textContent = risk;
+        output.mode.textContent = mode;
+        output.lane.textContent = lane;
+        output.action.textContent = action;
+        output.eta.textContent = `${Math.max(7, Math.round(risk / 3))}s`;
+        output.load.textContent = `${replay}%`;
+        output.safe.textContent = `${fresh}%`;
+      }
+
+      Object.values(input).forEach((item) =>
+        item.addEventListener("input", update)
+      );
+      update();
+    </script>
+  </body>
+</html>

--- a/submissions/examples/rollback-checkpoint-sentinel-kp/style.css
+++ b/submissions/examples/rollback-checkpoint-sentinel-kp/style.css
@@ -1,0 +1,638 @@
+:root {
+  color-scheme: dark;
+  --bg: #0b0f14;
+  --panel: #141b24;
+  --line: #2e3b4c;
+  --text: #f5f8ff;
+  --muted: #9eabba;
+  --cyan: #22d3ee;
+  --indigo: #818cf8;
+  --green: #86efac;
+  --amber: #fbbf24;
+  --red: #fb7185;
+  --risk: 50;
+  --drift: 61;
+  --errors: 46;
+  --replay: 52;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--text);
+  background:
+    linear-gradient(135deg, rgba(11, 15, 20, 0.98), rgba(20, 27, 36, 0.94)),
+    radial-gradient(
+      circle at 18% 8%,
+      rgba(34, 211, 238, 0.16),
+      transparent 29%
+    ),
+    radial-gradient(
+      circle at 82% 18%,
+      rgba(129, 140, 248, 0.13),
+      transparent 31%
+    ),
+    #0b0f14;
+}
+input,
+button {
+  font: inherit;
+}
+.sentinel {
+  width: min(1190px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 30px 0 44px;
+}
+.hero {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 230px;
+  gap: 24px;
+  align-items: end;
+  min-height: 220px;
+  padding: 34px;
+  overflow: hidden;
+  border: 1px solid rgba(158, 171, 186, 0.22);
+  border-radius: 8px;
+  background:
+    linear-gradient(110deg, rgba(20, 27, 36, 0.97), rgba(28, 38, 52, 0.75)),
+    repeating-linear-gradient(
+      90deg,
+      rgba(34, 211, 238, 0.07) 0 1px,
+      transparent 1px 46px
+    );
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.35);
+}
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: auto -12% -52px 34%;
+  height: 160px;
+  border-top: 1px solid rgba(34, 211, 238, 0.28);
+  border-bottom: 1px solid rgba(129, 140, 248, 0.2);
+  transform: skewX(-18deg);
+  animation: headerDrift 5.4s linear infinite;
+}
+.hero::after {
+  content: "";
+  position: absolute;
+  top: 18px;
+  right: 32px;
+  width: 190px;
+  height: 80px;
+  border: 1px solid rgba(251, 191, 36, 0.22);
+  transform: rotate(-9deg);
+  animation: headerPulse 2.8s ease-in-out infinite;
+}
+.eyebrow {
+  margin: 0 0 12px;
+  color: var(--cyan);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+h1 {
+  max-width: 780px;
+  margin: 0;
+  font-size: clamp(2.55rem, 7vw, 5.85rem);
+  line-height: 0.92;
+  letter-spacing: 0;
+}
+.lede {
+  max-width: 690px;
+  margin: 18px 0 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+.badge {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 7px;
+  padding: 18px;
+  border: 1px solid rgba(158, 171, 186, 0.2);
+  border-radius: 8px;
+  background: rgba(11, 15, 20, 0.78);
+}
+.dot {
+  width: 13px;
+  height: 13px;
+  border-radius: 50%;
+  background: var(--amber);
+  box-shadow: 0 0 0 7px rgba(251, 191, 36, 0.15);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+.badge small {
+  color: var(--muted);
+  font-weight: 800;
+  text-transform: uppercase;
+}
+.badge strong {
+  font-size: 1.18rem;
+}
+.sentinel[data-state="rollback"] .dot {
+  background: var(--red);
+  box-shadow: 0 0 0 7px rgba(251, 113, 133, 0.17);
+}
+.sentinel[data-state="replay"] .dot {
+  background: var(--green);
+  box-shadow: 0 0 0 7px rgba(134, 239, 172, 0.16);
+}
+.controls {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+  margin: 18px 0;
+}
+.controls label {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 11px;
+  align-items: center;
+  padding: 16px;
+  border: 1px solid rgba(158, 171, 186, 0.18);
+  border-radius: 8px;
+  background: rgba(20, 27, 36, 0.84);
+}
+.controls span {
+  color: var(--muted);
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+.controls output {
+  font-weight: 900;
+}
+.controls input {
+  grid-column: 1 / -1;
+  width: 100%;
+  accent-color: var(--cyan);
+}
+.grid {
+  display: grid;
+  grid-template-columns: 1.08fr 0.92fr;
+  gap: 18px;
+}
+.grid article {
+  min-width: 0;
+  border: 1px solid rgba(158, 171, 186, 0.2);
+  border-radius: 8px;
+  background: linear-gradient(
+    180deg,
+    rgba(20, 27, 36, 0.96),
+    rgba(11, 15, 20, 0.92)
+  );
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.24);
+}
+.panel-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 20px 0;
+}
+.panel-title span {
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.panel-title strong {
+  font-size: 1.18rem;
+}
+.radar-panel {
+  grid-row: span 2;
+  padding-bottom: 20px;
+}
+.radar {
+  position: relative;
+  width: min(430px, 82vw);
+  aspect-ratio: 1;
+  margin: 26px auto 18px;
+  overflow: hidden;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle, rgba(34, 211, 238, 0.16) 0 2px, transparent 3px),
+    conic-gradient(
+      from 140deg,
+      rgba(34, 211, 238, 0.24),
+      rgba(129, 140, 248, 0.17),
+      rgba(251, 191, 36, 0.24),
+      rgba(251, 113, 133, 0.28),
+      rgba(34, 211, 238, 0.24)
+    );
+  box-shadow:
+    inset 0 0 0 1px rgba(158, 171, 186, 0.2),
+    inset 0 0 72px rgba(0, 0, 0, 0.46);
+}
+.radar::before,
+.radar::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 8%;
+  right: 8%;
+  height: 1px;
+  background: rgba(245, 248, 255, 0.18);
+}
+.radar::after {
+  transform: rotate(90deg);
+}
+.ring {
+  position: absolute;
+  border: 1px solid rgba(245, 248, 255, 0.16);
+  border-radius: 50%;
+  animation: ringBreathe 3s ease-in-out infinite;
+}
+.ring-a {
+  inset: 12%;
+}
+.ring-b {
+  inset: 27%;
+  animation-delay: 0.28s;
+}
+.ring-c {
+  inset: 42%;
+  animation-delay: 0.56s;
+}
+.sweep {
+  position: absolute;
+  inset: 4%;
+  border-radius: 50%;
+  background: conic-gradient(
+    from 0deg,
+    rgba(34, 211, 238, 0.64),
+    rgba(34, 211, 238, 0.08) 48deg,
+    transparent 78deg
+  );
+  mask: radial-gradient(circle, transparent 0 13%, #000 14% 100%);
+  animation: sweep 3.4s linear infinite;
+}
+.sweep-b {
+  animation-duration: 4.9s;
+  animation-direction: reverse;
+  opacity: 0.52;
+}
+.sweep-c {
+  animation-duration: 6.4s;
+  opacity: 0.34;
+}
+.core {
+  position: absolute;
+  inset: calc(50% - 38px);
+  border-radius: 50%;
+  background: color-mix(
+    in srgb,
+    var(--amber) calc(var(--risk) * 1%),
+    var(--cyan)
+  );
+  box-shadow: 0 0 36px rgba(34, 211, 238, 0.45);
+  animation: coreBeat 1.65s ease-in-out infinite;
+}
+.marker {
+  position: absolute;
+  display: grid;
+  place-items: center;
+  width: 38px;
+  height: 38px;
+  border: 1px solid rgba(245, 248, 255, 0.24);
+  border-radius: 50%;
+  background: rgba(11, 15, 20, 0.78);
+  color: var(--text);
+  font-size: 0.78rem;
+  font-weight: 900;
+  box-shadow: 0 0 24px rgba(34, 211, 238, 0.22);
+  animation: markerPulse 2.2s ease-in-out infinite;
+}
+.marker-a {
+  top: 16%;
+  left: 62%;
+}
+.marker-b {
+  top: 42%;
+  left: 78%;
+  animation-delay: 0.35s;
+}
+.marker-c {
+  top: 72%;
+  left: 34%;
+  animation-delay: 0.7s;
+}
+.marker-d {
+  top: 30%;
+  left: 18%;
+  animation-delay: 1.05s;
+}
+.signal-strip {
+  display: grid;
+  grid-template-columns: repeat(9, 1fr);
+  gap: 7px;
+  padding: 0 20px;
+}
+.signal-strip span {
+  height: 48px;
+  border-radius: 6px;
+  background: linear-gradient(180deg, var(--cyan), transparent);
+  transform-origin: bottom;
+  animation: signal 1.55s ease-in-out infinite;
+}
+.signal-strip span:nth-child(2n) {
+  animation-delay: 0.12s;
+}
+.signal-strip span:nth-child(3n) {
+  animation-delay: 0.28s;
+}
+.signal-strip span:nth-child(4n) {
+  animation-delay: 0.44s;
+}
+.lanes,
+.playbook,
+.metrics {
+  padding-bottom: 18px;
+}
+.lane-list {
+  display: grid;
+  gap: 13px;
+  padding: 20px;
+}
+.lane {
+  display: grid;
+  grid-template-columns: 136px minmax(100px, 1fr) 64px;
+  gap: 13px;
+  align-items: center;
+}
+.lane span {
+  font-size: 0.92rem;
+  font-weight: 800;
+}
+.lane i {
+  position: relative;
+  height: 12px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(158, 171, 186, 0.16);
+}
+.lane i::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  width: calc(var(--fill) * 100%);
+  border-radius: inherit;
+  background: linear-gradient(
+    90deg,
+    var(--green),
+    var(--cyan),
+    var(--amber),
+    var(--red)
+  );
+  animation: laneFlow 1.9s ease-in-out infinite;
+}
+.lane b {
+  color: var(--muted);
+  font-size: 0.78rem;
+  text-align: right;
+  text-transform: uppercase;
+}
+.playbook ol {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 20px;
+  list-style: none;
+}
+.playbook li {
+  display: grid;
+  grid-template-columns: 38px 1fr;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid rgba(158, 171, 186, 0.16);
+  border-radius: 8px;
+  background: rgba(28, 38, 52, 0.55);
+  animation: cardLift 3s ease-in-out infinite;
+}
+.playbook li:nth-child(2) {
+  animation-delay: 0.18s;
+}
+.playbook li:nth-child(3) {
+  animation-delay: 0.36s;
+}
+.playbook li:nth-child(4) {
+  animation-delay: 0.54s;
+}
+.playbook em {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  background: rgba(34, 211, 238, 0.12);
+  color: var(--cyan);
+  font-style: normal;
+  font-weight: 900;
+}
+.playbook strong {
+  display: block;
+  margin-bottom: 4px;
+}
+.playbook p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  padding: 18px;
+}
+.metric {
+  min-height: 110px;
+  padding: 16px;
+  border: 1px solid rgba(158, 171, 186, 0.16);
+  border-radius: 8px;
+  background: rgba(11, 15, 20, 0.58);
+}
+.metric span {
+  display: block;
+  margin-bottom: 12px;
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.metric strong {
+  font-size: 1.9rem;
+}
+.sentinel[data-state="observe"] .hero {
+  border-color: rgba(34, 211, 238, 0.3);
+}
+.sentinel[data-state="checkpoint"] .hero {
+  border-color: rgba(251, 191, 36, 0.34);
+}
+.sentinel[data-state="rollback"] .hero {
+  border-color: rgba(251, 113, 133, 0.44);
+}
+.sentinel[data-state="replay"] .hero {
+  border-color: rgba(134, 239, 172, 0.34);
+}
+.sentinel[data-state="rollback"] .core {
+  background: var(--red);
+  box-shadow: 0 0 46px rgba(251, 113, 133, 0.58);
+}
+.sentinel[data-state="replay"] .core {
+  background: var(--green);
+  box-shadow: 0 0 42px rgba(134, 239, 172, 0.48);
+}
+@keyframes headerDrift {
+  0% {
+    transform: translateX(-44%) skewX(-18deg);
+  }
+  100% {
+    transform: translateX(58%) skewX(-18deg);
+  }
+}
+@keyframes headerPulse {
+  0%,
+  100% {
+    opacity: 0.25;
+  }
+  50% {
+    opacity: 0.76;
+  }
+}
+@keyframes pulse {
+  0%,
+  100% {
+    transform: scale(0.92);
+  }
+  50% {
+    transform: scale(1.14);
+  }
+}
+@keyframes ringBreathe {
+  0%,
+  100% {
+    opacity: 0.36;
+    transform: scale(0.98);
+  }
+  50% {
+    opacity: 0.88;
+    transform: scale(1.02);
+  }
+}
+@keyframes sweep {
+  to {
+    transform: rotate(1turn);
+  }
+}
+@keyframes coreBeat {
+  0%,
+  100% {
+    transform: scale(0.94);
+  }
+  50% {
+    transform: scale(1.09);
+  }
+}
+@keyframes markerPulse {
+  0%,
+  100% {
+    opacity: 0.72;
+    transform: scale(0.94);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.12);
+  }
+}
+@keyframes signal {
+  0%,
+  100% {
+    opacity: 0.43;
+    transform: scaleY(0.28);
+  }
+  50% {
+    opacity: 0.96;
+    transform: scaleY(calc(0.42 + var(--risk) / 120));
+  }
+}
+@keyframes laneFlow {
+  0%,
+  100% {
+    filter: saturate(0.9);
+  }
+  50% {
+    filter: saturate(1.55);
+  }
+}
+@keyframes cardLift {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-3px);
+  }
+}
+@media (max-width: 880px) {
+  .sentinel {
+    width: min(100% - 20px, 700px);
+    padding-top: 16px;
+  }
+  .hero {
+    grid-template-columns: 1fr;
+    min-height: 260px;
+    padding: 26px;
+  }
+  .badge {
+    width: min(100%, 260px);
+  }
+  .controls,
+  .grid {
+    grid-template-columns: 1fr;
+  }
+  .radar-panel {
+    grid-row: auto;
+  }
+  .lane {
+    grid-template-columns: 1fr;
+    gap: 7px;
+  }
+  .lane b {
+    text-align: left;
+  }
+}
+@media (max-width: 560px) {
+  .sentinel {
+    width: min(100% - 14px, 440px);
+  }
+  .hero {
+    padding: 22px;
+  }
+  h1 {
+    font-size: clamp(2.05rem, 18vw, 3.75rem);
+  }
+  .controls label,
+  .metrics {
+    grid-template-columns: 1fr;
+  }
+  .panel-title {
+    align-items: start;
+  }
+  .playbook li {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add an advanced rollback checkpoint sentinel animation example
- include interactive controls for release drift, error rate, replay queue, and checkpoint freshness
- visualize observe, checkpoint, rollback, and replay states for safer recovery

## Validation
- npx prettier --check submissions/examples/rollback-checkpoint-sentinel-kp/README.md submissions/examples/rollback-checkpoint-sentinel-kp/demo.html submissions/examples/rollback-checkpoint-sentinel-kp/style.css
- npx stylelint submissions/examples/rollback-checkpoint-sentinel-kp/style.css --allow-empty-input
- git diff --check