### PR TITLE
Add ease-skateboard-ramp-roll component

### DIFF
--- a/submissions/examples/skateboard-ramp-roll-ij/README.md
+++ b/submissions/examples/skateboard-ramp-roll-ij/README.md
@@ -1,0 +1,11 @@
+# ease-skateboard-ramp-roll
+
+A halfpipe ramp where the skater drops and rolls on a tilting board while a scan line sweeps the run.
+
+## Run
+Open `demo.html` directly in a browser to watch the skater roll the ramp.
+
+## Notes
+- The skater bounces down the ramp.
+- The board tilts as the skater rides.
+

--- a/submissions/examples/skateboard-ramp-roll-ij/demo.html
+++ b/submissions/examples/skateboard-ramp-roll-ij/demo.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-skateboard-ramp-roll demo</title>
+</head>
+<body>
+<div class="srr-app">
+  <span class="srr-title">HALFPIPE</span>
+  <div class="srr-ramp">
+    <span class="srr-skater">
+      <span class="srr-head"></span>
+      <span class="srr-body"></span>
+      <span class="srr-board"></span>
+    </span>
+    <span class="srr-scan"></span>
+  </div>
+  <span class="srr-route">RUN</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/skateboard-ramp-roll-ij/style.css
+++ b/submissions/examples/skateboard-ramp-roll-ij/style.css
@@ -1,0 +1,15 @@
+:root{--srr-lime:#c6f135;--srr-concrete:#9aa1ad;--srr-night:#14161b}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#14161b,#0a0b0e);font-family:'Impact',sans-serif}
+.srr-app{position:relative;width:360px;height:420px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#1b1e25,#0e1014);box-shadow:0 16px 36px rgba(0,0,0,0.6)}
+.srr-title{position:absolute;top:14px;left:0;right:0;text-align:center;font-size:12px;font-weight:700;letter-spacing:7px;color:#c6f135}
+.srr-ramp{position:absolute;top:58px;left:30px;right:30px;height:284px;border-radius:16px;background:#0a0b0e;box-shadow:inset 0 0 0 4px #333a47;overflow:hidden}
+.srr-skater{position:absolute;left:50%;bottom:64px;width:64px;height:120px;margin-left:-32px;animation:deck-roll-skateboard-ramp-roll 2.4s ease-in-out infinite}
+.srr-head{position:absolute;top:0;left:50%;width:22px;height:22px;margin-left:-11px;border-radius:50%;background:#c6f135}
+.srr-body{position:absolute;top:22px;left:50%;width:14px;height:52px;margin-left:-7px;border-radius:7px;background:#e8e9ee}
+.srr-board{position:absolute;bottom:0;left:2px;width:60px;height:10px;border-radius:5px;background:#c6f135;transform-origin:50% 100%;animation:board-tilt-skateboard-ramp-roll 2.4s ease-in-out infinite}
+.srr-scan{position:absolute;left:0;right:0;top:0;height:5px;background:linear-gradient(90deg,transparent,#c6f135,transparent);animation:scan-sweep-skateboard-ramp-roll 2.4s ease-in-out infinite}
+.srr-route{position:absolute;bottom:12px;left:0;right:0;text-align:center;font-size:16px;font-weight:700;color:#c6f135;animation:route-blink-skateboard-ramp-roll 1s steps(1) infinite}
+@keyframes deck-roll-skateboard-ramp-roll{0%,100%{transform:translateY(0)}25%{transform:translateY(-28px)}50%{transform:translateY(0)}75%{transform:translateY(-14px)}}
+@keyframes board-tilt-skateboard-ramp-roll{0%,100%{transform:rotate(0)}25%{transform:rotate(28deg)}75%{transform:rotate(-28deg)}}
+@keyframes scan-sweep-skateboard-ramp-roll{0%,100%{top:0}50%{top:276px}}
+@keyframes route-blink-skateboard-ramp-roll{0%,49%{opacity:1}50%,100%{opacity:0.35}}


### PR DESCRIPTION
## Component: ease-skateboard-ramp-roll - halfpipe run with a rolling skater

**Closes #66763**

### What this adds
A halfpipe ramp where a skater with a tilting board bounces down the run while a scan line sweeps across.

### Acceptance Criteria covered
- Real, fully-rendered skateboard ramp UI, not a generic animated box
- Semantic HTML with actual component elements (ramp, skater, board, head, body)
- Unique component-specific CSS with named keyframes
- Three files under submissions/examples/skateboard-ramp-roll-ij/

### Files
- submissions/examples/skateboard-ramp-roll-ij/demo.html
- submissions/examples/skateboard-ramp-roll-ij/style.css
- submissions/examples/skateboard-ramp-roll-ij/README.md

### How to review
Open demo.html in a browser and watch the skater roll the ramp.