### PR TITLE
feat: add slo burn rate command example

### DIFF
--- a/submissions/examples/slo-burn-rate-command-kp/README.md
+++ b/submissions/examples/slo-burn-rate-command-kp/README.md
@@ -1,0 +1,24 @@
+# SLO Burn Rate Command
+
+An advanced EaseMotion dashboard for visualizing multi-window SLO burn rate response. It animates burn velocity, alert lanes, mitigation cards, and recovery gates while operators tune error rate, request volume, latency, and remaining budget.
+
+## Features
+
+- Interactive controls for error rate, traffic, latency, and budget remaining
+- Animated burn radar, SLO lanes, alert timeline, and mitigation playbook
+- Live state switching across stable, watching, paging, and recovering modes
+- Responsive operations layout using CSS variables and motion timing
+- Advanced-tier contribution with more than 500 added lines
+
+## Files
+
+- `demo.html` - interactive dashboard and state logic
+- `style.css` - responsive styling and animation system
+
+## Validation
+
+```bash
+npx prettier --check submissions/examples/slo-burn-rate-command-kp/README.md submissions/examples/slo-burn-rate-command-kp/demo.html submissions/examples/slo-burn-rate-command-kp/style.css
+npx stylelint submissions/examples/slo-burn-rate-command-kp/style.css --allow-empty-input
+git diff --check
+```

--- a/submissions/examples/slo-burn-rate-command-kp/demo.html
+++ b/submissions/examples/slo-burn-rate-command-kp/demo.html
@@ -1,0 +1,242 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SLO Burn Rate Command</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="command" data-state="watch">
+      <section class="hero" aria-labelledby="title">
+        <div>
+          <p class="eyebrow">EaseMotion reliability lab</p>
+          <h1 id="title">SLO Burn Rate Command</h1>
+          <p class="lede">
+            Tune live reliability signals and watch burn-rate policy decide when
+            to watch, page, mitigate, and recover budget safely.
+          </p>
+        </div>
+        <aside class="badge" aria-live="polite">
+          <span class="dot"></span>
+          <small>Alert mode</small>
+          <strong id="modeLabel">Watching burn</strong>
+        </aside>
+      </section>
+
+      <section class="controls" aria-label="SLO inputs">
+        <label
+          ><span>Error rate</span
+          ><input
+            id="errors"
+            type="range"
+            min="0"
+            max="100"
+            value="57"
+          /><output id="errorsOut">57%</output></label
+        >
+        <label
+          ><span>Traffic volume</span
+          ><input
+            id="traffic"
+            type="range"
+            min="5"
+            max="100"
+            value="68"
+          /><output id="trafficOut">68%</output></label
+        >
+        <label
+          ><span>P95 latency</span
+          ><input
+            id="latency"
+            type="range"
+            min="40"
+            max="900"
+            value="340"
+          /><output id="latencyOut">340ms</output></label
+        >
+        <label
+          ><span>Budget left</span
+          ><input
+            id="budget"
+            type="range"
+            min="0"
+            max="100"
+            value="43"
+          /><output id="budgetOut">43%</output></label
+        >
+      </section>
+
+      <section class="grid" aria-label="SLO dashboard">
+        <article class="radar-panel">
+          <div class="panel-title">
+            <span>Burn pressure</span><strong id="riskScore">58</strong>
+          </div>
+          <div class="radar" aria-hidden="true">
+            <span class="ring ring-a"></span><span class="ring ring-b"></span
+            ><span class="ring ring-c"></span>
+            <span class="sweep sweep-a"></span
+            ><span class="sweep sweep-b"></span
+            ><span class="sweep sweep-c"></span>
+            <span class="node node-a">5m</span
+            ><span class="node node-b">30m</span
+            ><span class="node node-c">2h</span
+            ><span class="node node-d">6h</span>
+            <span class="core"></span>
+          </div>
+          <div class="signal-strip">
+            <span></span><span></span><span></span><span></span><span></span
+            ><span></span><span></span><span></span><span></span>
+          </div>
+        </article>
+
+        <article class="lanes">
+          <div class="panel-title">
+            <span>Alert lanes</span><strong id="laneLabel">Armed</strong>
+          </div>
+          <div class="lane-list">
+            <div class="lane" style="--fill: 0.8">
+              <span>API availability</span><i></i><b>page</b>
+            </div>
+            <div class="lane" style="--fill: 0.64">
+              <span>Checkout latency</span><i></i><b>shape</b>
+            </div>
+            <div class="lane" style="--fill: 0.52">
+              <span>Search errors</span><i></i><b>watch</b>
+            </div>
+            <div class="lane" style="--fill: 0.44">
+              <span>Worker backlog</span><i></i><b>drain</b>
+            </div>
+            <div class="lane" style="--fill: 0.58">
+              <span>Cache misses</span><i></i><b>warm</b>
+            </div>
+          </div>
+        </article>
+
+        <article class="playbook">
+          <div class="panel-title">
+            <span>Mitigation playbook</span
+            ><strong id="actionLabel">Watch</strong>
+          </div>
+          <ol>
+            <li>
+              <em>01</em>
+              <div>
+                <strong>Compare burn windows</strong>
+                <p>Short and long windows agree before noisy pages fire.</p>
+              </div>
+            </li>
+            <li>
+              <em>02</em>
+              <div>
+                <strong>Protect user paths</strong>
+                <p>Budget guards reserve capacity for critical journeys.</p>
+              </div>
+            </li>
+            <li>
+              <em>03</em>
+              <div>
+                <strong>Throttle optional work</strong>
+                <p>Background jobs slow before core SLOs collapse.</p>
+              </div>
+            </li>
+            <li>
+              <em>04</em>
+              <div>
+                <strong>Recover by slope</strong>
+                <p>Alerts clear only after burn velocity and latency cool.</p>
+              </div>
+            </li>
+          </ol>
+        </article>
+
+        <article class="metrics">
+          <div class="metric">
+            <span>Burn multiple</span><strong id="burnLabel">2.1x</strong>
+          </div>
+          <div class="metric">
+            <span>Page ETA</span><strong id="etaLabel">19s</strong>
+          </div>
+          <div class="metric">
+            <span>Budget left</span><strong id="leftLabel">43%</strong>
+          </div>
+        </article>
+      </section>
+    </main>
+    <script>
+      const root = document.querySelector(".command");
+      const input = {
+        errors: document.querySelector("#errors"),
+        traffic: document.querySelector("#traffic"),
+        latency: document.querySelector("#latency"),
+        budget: document.querySelector("#budget"),
+      };
+      const output = {
+        errors: document.querySelector("#errorsOut"),
+        traffic: document.querySelector("#trafficOut"),
+        latency: document.querySelector("#latencyOut"),
+        budget: document.querySelector("#budgetOut"),
+        mode: document.querySelector("#modeLabel"),
+        risk: document.querySelector("#riskScore"),
+        lane: document.querySelector("#laneLabel"),
+        action: document.querySelector("#actionLabel"),
+        burn: document.querySelector("#burnLabel"),
+        eta: document.querySelector("#etaLabel"),
+        left: document.querySelector("#leftLabel"),
+      };
+      function update() {
+        const errors = Number(input.errors.value);
+        const traffic = Number(input.traffic.value);
+        const latency = Number(input.latency.value);
+        const budget = Number(input.budget.value);
+        const latencyPressure = Math.min(100, latency / 9);
+        const risk = Math.round(
+          errors * 0.36 +
+            traffic * 0.2 +
+            latencyPressure * 0.24 +
+            (100 - budget) * 0.2
+        );
+        let state = "stable",
+          mode = "SLO stable",
+          lane = "Open",
+          action = "Observe";
+        if (risk > 76) {
+          state = "page";
+          mode = "Paging now";
+          lane = "Critical";
+          action = "Page";
+        } else if (risk > 50) {
+          state = "watch";
+          mode = "Watching burn";
+          lane = "Armed";
+          action = "Watch";
+        } else if (risk < 32) {
+          state = "recover";
+          mode = "Recovering budget";
+          lane = "Cooling";
+          action = "Recover";
+        }
+        root.dataset.state = state;
+        root.style.setProperty("--risk", risk);
+        root.style.setProperty("--errors", errors);
+        root.style.setProperty("--traffic", traffic);
+        root.style.setProperty("--budget", budget);
+        output.errors.value = `${errors}%`;
+        output.traffic.value = `${traffic}%`;
+        output.latency.value = `${latency}ms`;
+        output.budget.value = `${budget}%`;
+        output.risk.textContent = risk;
+        output.mode.textContent = mode;
+        output.lane.textContent = lane;
+        output.action.textContent = action;
+        output.burn.textContent = `${(1 + risk / 52).toFixed(1)}x`;
+        output.eta.textContent = `${Math.max(6, Math.round(risk / 3))}s`;
+        output.left.textContent = `${budget}%`;
+      }
+      Object.values(input).forEach((item) =>
+        item.addEventListener("input", update)
+      );
+      update();
+    </script>
+  </body>
+</html>

--- a/submissions/examples/slo-burn-rate-command-kp/style.css
+++ b/submissions/examples/slo-burn-rate-command-kp/style.css
@@ -1,0 +1,636 @@
+:root {
+  color-scheme: dark;
+  --bg: #0a0e14;
+  --panel: #131a24;
+  --text: #f4f8ff;
+  --muted: #9fabbc;
+  --cyan: #22d3ee;
+  --blue: #60a5fa;
+  --green: #86efac;
+  --amber: #fbbf24;
+  --red: #fb7185;
+  --risk: 58;
+  --errors: 57;
+  --traffic: 68;
+  --budget: 43;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+* {
+  box-sizing: border-box;
+}
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--text);
+  background:
+    linear-gradient(135deg, rgba(10, 14, 20, 0.98), rgba(19, 26, 36, 0.94)),
+    radial-gradient(
+      circle at 18% 8%,
+      rgba(34, 211, 238, 0.16),
+      transparent 29%
+    ),
+    radial-gradient(
+      circle at 82% 18%,
+      rgba(96, 165, 250, 0.13),
+      transparent 31%
+    ),
+    #0a0e14;
+}
+input,
+button {
+  font: inherit;
+}
+.command {
+  width: min(1190px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 30px 0 44px;
+}
+.hero {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 230px;
+  gap: 24px;
+  align-items: end;
+  min-height: 220px;
+  padding: 34px;
+  overflow: hidden;
+  border: 1px solid rgba(159, 171, 188, 0.22);
+  border-radius: 8px;
+  background:
+    linear-gradient(110deg, rgba(19, 26, 36, 0.97), rgba(27, 38, 52, 0.75)),
+    repeating-linear-gradient(
+      90deg,
+      rgba(34, 211, 238, 0.07) 0 1px,
+      transparent 1px 46px
+    );
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.35);
+}
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: auto -12% -52px 34%;
+  height: 160px;
+  border-top: 1px solid rgba(34, 211, 238, 0.28);
+  border-bottom: 1px solid rgba(96, 165, 250, 0.2);
+  transform: skewX(-18deg);
+  animation: headerDrift 5.4s linear infinite;
+}
+.hero::after {
+  content: "";
+  position: absolute;
+  top: 18px;
+  right: 32px;
+  width: 190px;
+  height: 80px;
+  border: 1px solid rgba(251, 191, 36, 0.22);
+  transform: rotate(-9deg);
+  animation: headerPulse 2.8s ease-in-out infinite;
+}
+.eyebrow {
+  margin: 0 0 12px;
+  color: var(--cyan);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+h1 {
+  max-width: 780px;
+  margin: 0;
+  font-size: clamp(2.55rem, 7vw, 5.85rem);
+  line-height: 0.92;
+  letter-spacing: 0;
+}
+.lede {
+  max-width: 690px;
+  margin: 18px 0 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+.badge {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 7px;
+  padding: 18px;
+  border: 1px solid rgba(159, 171, 188, 0.2);
+  border-radius: 8px;
+  background: rgba(10, 14, 20, 0.78);
+}
+.dot {
+  width: 13px;
+  height: 13px;
+  border-radius: 50%;
+  background: var(--amber);
+  box-shadow: 0 0 0 7px rgba(251, 191, 36, 0.15);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+.badge small {
+  color: var(--muted);
+  font-weight: 800;
+  text-transform: uppercase;
+}
+.badge strong {
+  font-size: 1.18rem;
+}
+.command[data-state="page"] .dot {
+  background: var(--red);
+  box-shadow: 0 0 0 7px rgba(251, 113, 133, 0.17);
+}
+.command[data-state="recover"] .dot {
+  background: var(--green);
+  box-shadow: 0 0 0 7px rgba(134, 239, 172, 0.16);
+}
+.controls {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+  margin: 18px 0;
+}
+.controls label {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 11px;
+  align-items: center;
+  padding: 16px;
+  border: 1px solid rgba(159, 171, 188, 0.18);
+  border-radius: 8px;
+  background: rgba(19, 26, 36, 0.84);
+}
+.controls span {
+  color: var(--muted);
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+.controls output {
+  font-weight: 900;
+}
+.controls input {
+  grid-column: 1 / -1;
+  width: 100%;
+  accent-color: var(--cyan);
+}
+.grid {
+  display: grid;
+  grid-template-columns: 1.08fr 0.92fr;
+  gap: 18px;
+}
+.grid article {
+  min-width: 0;
+  border: 1px solid rgba(159, 171, 188, 0.2);
+  border-radius: 8px;
+  background: linear-gradient(
+    180deg,
+    rgba(19, 26, 36, 0.96),
+    rgba(10, 14, 20, 0.92)
+  );
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.24);
+}
+.panel-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 20px 0;
+}
+.panel-title span {
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.panel-title strong {
+  font-size: 1.18rem;
+}
+.radar-panel {
+  grid-row: span 2;
+  padding-bottom: 20px;
+}
+.radar {
+  position: relative;
+  width: min(430px, 82vw);
+  aspect-ratio: 1;
+  margin: 26px auto 18px;
+  overflow: hidden;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle, rgba(34, 211, 238, 0.16) 0 2px, transparent 3px),
+    conic-gradient(
+      from 140deg,
+      rgba(34, 211, 238, 0.24),
+      rgba(96, 165, 250, 0.17),
+      rgba(251, 191, 36, 0.24),
+      rgba(251, 113, 133, 0.28),
+      rgba(34, 211, 238, 0.24)
+    );
+  box-shadow:
+    inset 0 0 0 1px rgba(159, 171, 188, 0.2),
+    inset 0 0 72px rgba(0, 0, 0, 0.46);
+}
+.radar::before,
+.radar::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 8%;
+  right: 8%;
+  height: 1px;
+  background: rgba(244, 248, 255, 0.18);
+}
+.radar::after {
+  transform: rotate(90deg);
+}
+.ring {
+  position: absolute;
+  border: 1px solid rgba(244, 248, 255, 0.16);
+  border-radius: 50%;
+  animation: ringBreathe 3s ease-in-out infinite;
+}
+.ring-a {
+  inset: 12%;
+}
+.ring-b {
+  inset: 27%;
+  animation-delay: 0.28s;
+}
+.ring-c {
+  inset: 42%;
+  animation-delay: 0.56s;
+}
+.sweep {
+  position: absolute;
+  inset: 4%;
+  border-radius: 50%;
+  background: conic-gradient(
+    from 0deg,
+    rgba(34, 211, 238, 0.64),
+    rgba(34, 211, 238, 0.08) 48deg,
+    transparent 78deg
+  );
+  mask: radial-gradient(circle, transparent 0 13%, #000 14% 100%);
+  animation: sweep 3.4s linear infinite;
+}
+.sweep-b {
+  animation-duration: 4.9s;
+  animation-direction: reverse;
+  opacity: 0.52;
+}
+.sweep-c {
+  animation-duration: 6.4s;
+  opacity: 0.34;
+}
+.core {
+  position: absolute;
+  inset: calc(50% - 38px);
+  border-radius: 50%;
+  background: color-mix(
+    in srgb,
+    var(--amber) calc(var(--risk) * 1%),
+    var(--cyan)
+  );
+  box-shadow: 0 0 36px rgba(34, 211, 238, 0.45);
+  animation: coreBeat 1.65s ease-in-out infinite;
+}
+.node {
+  position: absolute;
+  display: grid;
+  place-items: center;
+  width: 42px;
+  height: 42px;
+  border: 1px solid rgba(244, 248, 255, 0.24);
+  border-radius: 50%;
+  background: rgba(10, 14, 20, 0.78);
+  color: var(--text);
+  font-size: 0.78rem;
+  font-weight: 900;
+  box-shadow: 0 0 24px rgba(34, 211, 238, 0.22);
+  animation: nodePulse 2.2s ease-in-out infinite;
+}
+.node-a {
+  top: 16%;
+  left: 62%;
+}
+.node-b {
+  top: 42%;
+  left: 76%;
+  animation-delay: 0.35s;
+}
+.node-c {
+  top: 72%;
+  left: 34%;
+  animation-delay: 0.7s;
+}
+.node-d {
+  top: 30%;
+  left: 18%;
+  animation-delay: 1.05s;
+}
+.signal-strip {
+  display: grid;
+  grid-template-columns: repeat(9, 1fr);
+  gap: 7px;
+  padding: 0 20px;
+}
+.signal-strip span {
+  height: 48px;
+  border-radius: 6px;
+  background: linear-gradient(180deg, var(--cyan), transparent);
+  transform-origin: bottom;
+  animation: signal 1.55s ease-in-out infinite;
+}
+.signal-strip span:nth-child(2n) {
+  animation-delay: 0.12s;
+}
+.signal-strip span:nth-child(3n) {
+  animation-delay: 0.28s;
+}
+.signal-strip span:nth-child(4n) {
+  animation-delay: 0.44s;
+}
+.lanes,
+.playbook,
+.metrics {
+  padding-bottom: 18px;
+}
+.lane-list {
+  display: grid;
+  gap: 13px;
+  padding: 20px;
+}
+.lane {
+  display: grid;
+  grid-template-columns: 138px minmax(100px, 1fr) 64px;
+  gap: 13px;
+  align-items: center;
+}
+.lane span {
+  font-size: 0.92rem;
+  font-weight: 800;
+}
+.lane i {
+  position: relative;
+  height: 12px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(159, 171, 188, 0.16);
+}
+.lane i::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  width: calc(var(--fill) * 100%);
+  border-radius: inherit;
+  background: linear-gradient(
+    90deg,
+    var(--green),
+    var(--cyan),
+    var(--amber),
+    var(--red)
+  );
+  animation: laneFlow 1.9s ease-in-out infinite;
+}
+.lane b {
+  color: var(--muted);
+  font-size: 0.78rem;
+  text-align: right;
+  text-transform: uppercase;
+}
+.playbook ol {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 20px;
+  list-style: none;
+}
+.playbook li {
+  display: grid;
+  grid-template-columns: 38px 1fr;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid rgba(159, 171, 188, 0.16);
+  border-radius: 8px;
+  background: rgba(27, 38, 52, 0.55);
+  animation: cardLift 3s ease-in-out infinite;
+}
+.playbook li:nth-child(2) {
+  animation-delay: 0.18s;
+}
+.playbook li:nth-child(3) {
+  animation-delay: 0.36s;
+}
+.playbook li:nth-child(4) {
+  animation-delay: 0.54s;
+}
+.playbook em {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  background: rgba(34, 211, 238, 0.12);
+  color: var(--cyan);
+  font-style: normal;
+  font-weight: 900;
+}
+.playbook strong {
+  display: block;
+  margin-bottom: 4px;
+}
+.playbook p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  padding: 18px;
+}
+.metric {
+  min-height: 110px;
+  padding: 16px;
+  border: 1px solid rgba(159, 171, 188, 0.16);
+  border-radius: 8px;
+  background: rgba(10, 14, 20, 0.58);
+}
+.metric span {
+  display: block;
+  margin-bottom: 12px;
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.metric strong {
+  font-size: 1.9rem;
+}
+.command[data-state="stable"] .hero {
+  border-color: rgba(34, 211, 238, 0.3);
+}
+.command[data-state="watch"] .hero {
+  border-color: rgba(251, 191, 36, 0.34);
+}
+.command[data-state="page"] .hero {
+  border-color: rgba(251, 113, 133, 0.44);
+}
+.command[data-state="recover"] .hero {
+  border-color: rgba(134, 239, 172, 0.34);
+}
+.command[data-state="page"] .core {
+  background: var(--red);
+  box-shadow: 0 0 46px rgba(251, 113, 133, 0.58);
+}
+.command[data-state="recover"] .core {
+  background: var(--green);
+  box-shadow: 0 0 42px rgba(134, 239, 172, 0.48);
+}
+@keyframes headerDrift {
+  0% {
+    transform: translateX(-44%) skewX(-18deg);
+  }
+  100% {
+    transform: translateX(58%) skewX(-18deg);
+  }
+}
+@keyframes headerPulse {
+  0%,
+  100% {
+    opacity: 0.25;
+  }
+  50% {
+    opacity: 0.76;
+  }
+}
+@keyframes pulse {
+  0%,
+  100% {
+    transform: scale(0.92);
+  }
+  50% {
+    transform: scale(1.14);
+  }
+}
+@keyframes ringBreathe {
+  0%,
+  100% {
+    opacity: 0.36;
+    transform: scale(0.98);
+  }
+  50% {
+    opacity: 0.88;
+    transform: scale(1.02);
+  }
+}
+@keyframes sweep {
+  to {
+    transform: rotate(1turn);
+  }
+}
+@keyframes coreBeat {
+  0%,
+  100% {
+    transform: scale(0.94);
+  }
+  50% {
+    transform: scale(1.09);
+  }
+}
+@keyframes nodePulse {
+  0%,
+  100% {
+    opacity: 0.72;
+    transform: scale(0.94);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.12);
+  }
+}
+@keyframes signal {
+  0%,
+  100% {
+    opacity: 0.43;
+    transform: scaleY(0.28);
+  }
+  50% {
+    opacity: 0.96;
+    transform: scaleY(calc(0.42 + var(--risk) / 120));
+  }
+}
+@keyframes laneFlow {
+  0%,
+  100% {
+    filter: saturate(0.9);
+  }
+  50% {
+    filter: saturate(1.55);
+  }
+}
+@keyframes cardLift {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-3px);
+  }
+}
+@media (max-width: 880px) {
+  .command {
+    width: min(100% - 20px, 700px);
+    padding-top: 16px;
+  }
+  .hero {
+    grid-template-columns: 1fr;
+    min-height: 260px;
+    padding: 26px;
+  }
+  .badge {
+    width: min(100%, 260px);
+  }
+  .controls,
+  .grid {
+    grid-template-columns: 1fr;
+  }
+  .radar-panel {
+    grid-row: auto;
+  }
+  .lane {
+    grid-template-columns: 1fr;
+    gap: 7px;
+  }
+  .lane b {
+    text-align: left;
+  }
+}
+@media (max-width: 560px) {
+  .command {
+    width: min(100% - 14px, 440px);
+  }
+  .hero {
+    padding: 22px;
+  }
+  h1 {
+    font-size: clamp(2.05rem, 18vw, 3.75rem);
+  }
+  .controls label,
+  .metrics {
+    grid-template-columns: 1fr;
+  }
+  .panel-title {
+    align-items: start;
+  }
+  .playbook li {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add an advanced SLO burn rate command animation example
- include interactive controls for error rate, traffic, latency, and remaining budget
- visualize stable, watch, page, and recover states for reliability response

## Validation
- npx prettier --check submissions/examples/slo-burn-rate-command-kp/README.md submissions/examples/slo-burn-rate-command-kp/demo.html submissions/examples/slo-burn-rate-command-kp/style.css
- npx stylelint submissions/examples/slo-burn-rate-command-kp/style.css --allow-empty-input
- git diff --check