### PR TITLE
feat: add pure CSS sibling dim magnetic hover effect

### DIFF
--- a/submissions/examples/ease-sibling-dim/README.md
+++ b/submissions/examples/ease-sibling-dim/README.md
@@ -1,0 +1,21 @@
+# Magnetic Sibling Dim Hover
+
+A premium UX pattern commonly used on pricing tiers, feature grids, or team pages. When a user hovers over a grid of cards, all the *other* cards gracefully dim and blur slightly to make the hovered one "pop".
+
+### Usage
+```html
+<div class="ease-sibling-dim-container">
+    <div class="ease-sibling-card">Card 1</div>
+    <div class="ease-sibling-card">Card 2</div>
+    <div class="ease-sibling-card">Card 3</div>
+</div>
+```
+
+### Why is it useful?
+Historically, achieving this "magnetic focus" effect required JavaScript. Developers would have to attach `onMouseEnter` and `onMouseLeave` event listeners to every card, update a state manager with the currently hovered ID, and re-render the sibling components with an inactive CSS class.
+
+This submission implements a flawless pure CSS alternative using basic CSS selector cascading. 
+1. When the `.ease-sibling-dim-container` (parent) is hovered, a CSS rule dims *every* `.ease-sibling-card` inside it.
+2. Simultaneously, a more specific rule targets `.ease-sibling-card:hover`, overriding the parent's dimming effect and restoring full brightness (and optionally scaling it up) exclusively for the card the user is actively hovering.
+
+This achieves a highly complex, state-driven visual effect natively in the browser with absolutely zero JavaScript overhead.

--- a/submissions/examples/ease-sibling-dim/demo.html
+++ b/submissions/examples/ease-sibling-dim/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ease Sibling Dim Hover</title>
+    <link rel="stylesheet" href="../../../easemotion.min.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="ease-sibling-dim-container">
+        
+        <div class="ease-sibling-card ease-hover-lift">
+            <h3>Starter</h3>
+            <p>Perfect for side projects.</p>
+            <div class="price">$9<span>/mo</span></div>
+        </div>
+        
+        <div class="ease-sibling-card ease-hover-lift">
+            <h3>Pro</h3>
+            <p>For growing teams.</p>
+            <div class="price">$29<span>/mo</span></div>
+        </div>
+        
+        <div class="ease-sibling-card ease-hover-lift">
+            <h3>Enterprise</h3>
+            <p>Advanced security.</p>
+            <div class="price">$99<span>/mo</span></div>
+        </div>
+
+    </div>
+</body>
+</html>

--- a/submissions/examples/ease-sibling-dim/style.css
+++ b/submissions/examples/ease-sibling-dim/style.css
@@ -1,0 +1,86 @@
+body {
+    margin: 0;
+    padding: 0;
+    font-family: sans-serif;
+    background-color: #0f172a;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+}
+
+.ease-sibling-dim-container {
+    display: flex;
+    gap: 24px;
+    padding: 40px;
+}
+
+/* 
+  Base Card Styling 
+*/
+.ease-sibling-card {
+    background-color: #1e293b;
+    border: 1px solid #334155;
+    border-radius: 16px;
+    padding: 32px;
+    width: 200px;
+    color: white;
+    
+    /* 
+      The core transition that handles the dimming effect.
+      We transition opacity and filter (for the blur).
+    */
+    transition: opacity 0.4s ease, filter 0.4s ease, transform 0.4s ease;
+}
+
+.ease-sibling-card h3 {
+    margin: 0 0 8px 0;
+    font-size: 20px;
+    color: #f8fafc;
+}
+
+.ease-sibling-card p {
+    margin: 0 0 24px 0;
+    font-size: 14px;
+    color: #94a3b8;
+}
+
+.ease-sibling-card .price {
+    font-size: 32px;
+    font-weight: bold;
+    color: #3b82f6;
+}
+
+.ease-sibling-card .price span {
+    font-size: 14px;
+    color: #64748b;
+    font-weight: normal;
+}
+
+/* 
+  The Magic "Sibling Dim" Logic 
+*/
+
+/* 
+  Step 1: When the PARENT container is hovered, dim EVERYTHING inside it.
+  We lower the opacity and add a slight blur to create depth.
+*/
+.ease-sibling-dim-container:hover .ease-sibling-card {
+    opacity: 0.4;
+    filter: blur(2px);
+}
+
+/* 
+  Step 2: When a SPECIFIC card is hovered, restore its brightness and clarity.
+  Because this rule is more specific and triggers on the direct element, 
+  it overrides the parent's general dimming rule.
+*/
+.ease-sibling-dim-container .ease-sibling-card:hover {
+    opacity: 1;
+    filter: blur(0);
+    
+    /* Optional: Enhance the "magnetic" pop with a slight scale and shadow */
+    transform: scale(1.05);
+    box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.3), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
+    border-color: #475569;
+}


### PR DESCRIPTION
fixes #66821 

## Pull Request Description

Adds an `ease-sibling-dim` interaction pattern. When a user hovers over a grid of cards (like a pricing tier, feature list, or team roster), it's a premium UX pattern to gently dim and blur all the *other* cards to make the hovered one "pop". Historically, achieving this "magnetic focus" effect required complex JavaScript state management across sibling React components. This submission implements the exact same effect flawlessly using pure CSS.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component (Standard Track)
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/ease-sibling-dim/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A grid of cards with a dynamic, state-driven focus effect implemented entirely in CSS.

**How does it work without JS?**

It utilizes CSS selector cascading and specificity:
1. We apply a hover rule to the parent container (`.ease-sibling-dim-container:hover .ease-sibling-card`). When the grid itself is hovered anywhere, *every single card* inside it has its opacity lowered and a slight `blur()` filter applied.
2. We simultaneously apply a more specific hover rule directly to the child cards (`.ease-sibling-dim-container .ease-sibling-card:hover`). Because this rule is more specific and triggers on the actively targeted element, it overrides the parent's general dimming rule.
3. The actively hovered card restores its opacity to `1`, removes the blur, and scales up slightly.

**Why does it fit EaseMotion CSS?**

Managing `onMouseEnter` and `onMouseLeave` states in Javascript to pass active IDs between sibling components is overkill and often leads to visual jank if the user moves their mouse rapidly. By leveraging CSS selector specificity, we pass the "state management" directly to the browser's native rendering engine, creating a buttery-smooth, magnetic focus effect with zero performance overhead.

---

## Demo

- [x] Demo added (`demo.html` features a standard 3-tier SaaS pricing grid. Hovering any tier seamlessly dims and blurs the other two tiers while elevating the active one)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari *(optional but appreciated)*

---

## Notes for Maintainer

This submission belongs to the **Standard Track** (`submissions/examples/`). The `filter: blur(2px)` transition is handled on the base `.ease-sibling-card` class (`transition: opacity 0.4s ease, filter 0.4s ease, transform 0.4s ease`). 

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
