### PR TITLE
feat: add CSS fade-in cyberpunk carousel

### DIFF
--- a/submissions/examples/css-fade-in-cyberpunk-carousel/README.md
+++ b/submissions/examples/css-fade-in-cyberpunk-carousel/README.md
@@ -1,0 +1,50 @@
+# CSS Fade-In Carousel for Cyberpunk Neon Layouts
+
+## Overview
+
+A CSS-only fade-in carousel designed for futuristic and cyberpunk
+interface layouts.
+
+Multiple content cards occupy the same position and are displayed
+sequentially using CSS keyframe animations. Each card fades in,
+remains visible, and then fades out before the next card appears.
+
+No JavaScript or external framework is required.
+
+## Features
+
+- Pure HTML and CSS
+- CSS-only carousel
+- Sequential fade-in and fade-out transitions
+- Cyberpunk neon visual style
+- Layered gradients
+- Perspective grid background
+- Responsive desktop, tablet, and mobile layout
+- No JavaScript
+- No external dependencies
+- `prefers-reduced-motion` support
+
+## Files
+
+- `demo.html` — Self-contained carousel demonstration
+- `style.css` — Carousel styling and animations
+- `README.md` — Documentation
+
+## Usage
+
+Create multiple cards inside a `.carousel` container:
+
+```html
+<section class="carousel">
+
+    <article class="carousel-card card-one">
+        <h2>First Card</h2>
+        <p>Content for the first slide.</p>
+    </article>
+
+    <article class="carousel-card card-two">
+        <h2>Second Card</h2>
+        <p>Content for the second slide.</p>
+    </article>
+
+</section>

--- a/submissions/examples/css-fade-in-cyberpunk-carousel/demo.html
+++ b/submissions/examples/css-fade-in-cyberpunk-carousel/demo.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cyberpunk Neon Fade-In Carousel</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <main class="cyberpunk-demo">
+
+        <header class="hero-header">
+            <p class="eyebrow">EASEMOTION // SYSTEM 09</p>
+            <h1>NEON <span>FRONTIER</span></h1>
+            <p class="intro">
+                A CSS-only fade-in carousel inspired by futuristic
+                cyberpunk interfaces.
+            </p>
+        </header>
+
+        <section class="carousel" aria-label="Cyberpunk feature carousel">
+
+            <article class="carousel-card card-one">
+                <div class="card-number">01</div>
+                <p class="card-label">SECTOR</p>
+                <h2>Neon District</h2>
+                <p>
+                    Explore a glowing cityscape built from layered
+                    gradients and atmospheric lighting.
+                </p>
+            </article>
+
+            <article class="carousel-card card-two">
+                <div class="card-number">02</div>
+                <p class="card-label">PROTOCOL</p>
+                <h2>Cyber Pulse</h2>
+                <p>
+                    High-energy interface motion combines sharp
+                    transitions with luminous neon accents.
+                </p>
+            </article>
+
+            <article class="carousel-card card-three">
+                <div class="card-number">03</div>
+                <p class="card-label">NETWORK</p>
+                <h2>Night Grid</h2>
+                <p>
+                    A futuristic data layer emerges through subtle
+                    grid patterns and glowing surfaces.
+                </p>
+            </article>
+
+            <article class="carousel-card card-four">
+                <div class="card-number">04</div>
+                <p class="card-label">SYSTEM</p>
+                <h2>Quantum Core</h2>
+                <p>
+                    A dramatic visual endpoint combining depth,
+                    contrast, and cyberpunk-inspired motion.
+                </p>
+            </article>
+
+        </section>
+
+        <div class="carousel-indicator" aria-hidden="true">
+            <span></span>
+            <span></span>
+            <span></span>
+            <span></span>
+        </div>
+
+    </main>
+
+</body>
+</html>

--- a/submissions/examples/css-fade-in-cyberpunk-carousel/style.css
+++ b/submissions/examples/css-fade-in-cyberpunk-carousel/style.css
@@ -1,0 +1,421 @@
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+:root {
+    --background: #05020b;
+    --panel: #10091b;
+    --neon-pink: #ff2bd6;
+    --neon-cyan: #00f5ff;
+    --neon-purple: #9d4edd;
+    --text: #f8f7ff;
+    --muted: #a7a1b5;
+}
+
+body {
+    min-height: 100vh;
+
+    font-family:
+        Arial,
+        Helvetica,
+        sans-serif;
+
+    background: var(--background);
+    color: var(--text);
+}
+
+.cyberpunk-demo {
+    position: relative;
+    min-height: 100vh;
+    overflow: hidden;
+    isolation: isolate;
+
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+
+    padding: 70px 20px;
+
+    background:
+        radial-gradient(
+            circle at 50% 45%,
+            #24113b 0%,
+            #0e0719 38%,
+            #05020b 72%,
+            #020106 100%
+        );
+}
+
+/* Neon grid */
+
+.cyberpunk-demo::before {
+    content: "";
+
+    position: absolute;
+    inset: 0;
+
+    background-image:
+        linear-gradient(#ff2bd60d 1px, transparent 1px),
+        linear-gradient(90deg, #00f5ff0d 1px, transparent 1px);
+
+    background-size: 55px 55px;
+
+    transform:
+        perspective(500px)
+        rotateX(55deg)
+        scale(1.7)
+        translateY(18%);
+
+    transform-origin: center bottom;
+
+    mask-image:
+        linear-gradient(
+            to top,
+            black,
+            transparent 80%
+        );
+
+    z-index: -3;
+}
+
+/* Atmospheric glow */
+
+.cyberpunk-demo::after {
+    content: "";
+
+    position: absolute;
+    inset: 0;
+
+    background:
+        radial-gradient(
+            circle at 20% 50%,
+            #ff2bd61c,
+            transparent 28%
+        ),
+        radial-gradient(
+            circle at 80% 45%,
+            #00f5ff18,
+            transparent 30%
+        );
+
+    pointer-events: none;
+
+    z-index: -2;
+}
+
+/* Header */
+
+.hero-header {
+    position: relative;
+    z-index: 5;
+
+    width: min(800px, 100%);
+
+    margin-bottom: 45px;
+
+    text-align: center;
+}
+
+.eyebrow {
+    margin-bottom: 15px;
+
+    color: var(--neon-cyan);
+
+    font-size: 0.7rem;
+    font-weight: 800;
+    letter-spacing: 0.3em;
+}
+
+h1 {
+    font-size: clamp(3.2rem, 10vw, 7rem);
+    line-height: 0.85;
+    letter-spacing: -0.07em;
+
+    text-shadow:
+        0 0 12px #ff2bd688,
+        0 0 40px #ff2bd644;
+}
+
+h1 span {
+    color: var(--neon-pink);
+}
+
+.intro {
+    max-width: 560px;
+
+    margin: 24px auto 0;
+
+    color: var(--muted);
+
+    line-height: 1.7;
+}
+
+/* Carousel */
+
+.carousel {
+    position: relative;
+
+    width: min(720px, 100%);
+    height: 330px;
+}
+
+/*
+ * Every card occupies the same space.
+ *
+ * The animation controls opacity and visibility,
+ * producing a CSS-only fade carousel.
+ */
+
+.carousel-card {
+    position: absolute;
+    inset: 0;
+
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+
+    padding: 45px;
+
+    border: 1px solid #ffffff18;
+    border-radius: 22px;
+
+    background:
+        linear-gradient(
+            135deg,
+            #ffffff0d,
+            #ffffff03
+        );
+
+    backdrop-filter: blur(12px);
+
+    box-shadow:
+        0 25px 70px #00000088;
+
+    opacity: 0;
+
+    animation:
+        cyber-carousel 16s infinite ease-in-out;
+}
+
+/*
+ * Individual timing offsets.
+ *
+ * Four cards share one animation timeline.
+ */
+
+.card-one {
+    border-color: #ff2bd655;
+
+    box-shadow:
+        0 0 35px #ff2bd61c,
+        0 25px 70px #00000088;
+
+    animation-delay: 0s;
+}
+
+.card-two {
+    border-color: #00f5ff55;
+
+    box-shadow:
+        0 0 35px #00f5ff1c,
+        0 25px 70px #00000088;
+
+    animation-delay: 4s;
+}
+
+.card-three {
+    border-color: #9d4edd55;
+
+    box-shadow:
+        0 0 35px #9d4edd1c,
+        0 25px 70px #00000088;
+
+    animation-delay: 8s;
+}
+
+.card-four {
+    border-color: #ff2bd655;
+
+    box-shadow:
+        0 0 35px #ff2bd61c,
+        0 25px 70px #00000088;
+
+    animation-delay: 12s;
+}
+
+/* Card content */
+
+.card-number {
+    margin-bottom: 18px;
+
+    color: var(--neon-cyan);
+
+    font-size: 0.75rem;
+    font-weight: 800;
+    letter-spacing: 0.15em;
+}
+
+.card-label {
+    margin-bottom: 10px;
+
+    color: var(--neon-pink);
+
+    font-size: 0.7rem;
+    font-weight: 800;
+    letter-spacing: 0.25em;
+}
+
+.carousel-card h2 {
+    margin-bottom: 15px;
+
+    font-size: clamp(2rem, 6vw, 3.8rem);
+
+    text-shadow:
+        0 0 15px #00f5ff44;
+}
+
+.carousel-card p:last-child {
+    max-width: 530px;
+
+    color: var(--muted);
+
+    line-height: 1.7;
+}
+
+/*
+ * 16 second timeline:
+ *
+ * 0-5%     fade in
+ * 5-20%    visible
+ * 20-25%   fade out
+ * remaining time hidden
+ */
+
+@keyframes cyber-carousel {
+    0% {
+        opacity: 0;
+        transform: translateY(18px) scale(0.98);
+    }
+
+    5% {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+
+    20% {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+
+    25% {
+        opacity: 0;
+        transform: translateY(-18px) scale(0.98);
+    }
+
+    100% {
+        opacity: 0;
+        transform: translateY(-18px) scale(0.98);
+    }
+}
+
+/* Indicators */
+
+.carousel-indicator {
+    display: flex;
+    gap: 8px;
+
+    margin-top: 24px;
+}
+
+.carousel-indicator span {
+    width: 28px;
+    height: 3px;
+
+    border-radius: 999px;
+
+    background: #ffffff22;
+}
+
+/*
+ * Approximate active indicator timing.
+ */
+
+.carousel-indicator span {
+    animation: indicator-pulse 16s infinite;
+}
+
+.carousel-indicator span:nth-child(1) {
+    animation-delay: 0s;
+}
+
+.carousel-indicator span:nth-child(2) {
+    animation-delay: 4s;
+}
+
+.carousel-indicator span:nth-child(3) {
+    animation-delay: 8s;
+}
+
+.carousel-indicator span:nth-child(4) {
+    animation-delay: 12s;
+}
+
+@keyframes indicator-pulse {
+    0%,
+    25% {
+        background: #ffffff22;
+        box-shadow: none;
+    }
+
+    5%,
+    20% {
+        background: var(--neon-cyan);
+        box-shadow: 0 0 10px var(--neon-cyan);
+    }
+
+    26%,
+    100% {
+        background: #ffffff22;
+        box-shadow: none;
+    }
+}
+
+/* Responsive */
+
+@media (max-width: 600px) {
+    .cyberpunk-demo {
+        padding: 50px 18px;
+    }
+
+    .hero-header {
+        margin-bottom: 30px;
+    }
+
+    .carousel {
+        height: 360px;
+    }
+
+    .carousel-card {
+        padding: 30px 24px;
+    }
+}
+
+/* Reduced motion */
+
+@media (prefers-reduced-motion: reduce) {
+    .carousel-card {
+        animation: none;
+    }
+
+    .carousel-card:first-child {
+        opacity: 1;
+        transform: none;
+    }
+
+    .carousel-indicator {
+        display: none;
+    }
+}


### PR DESCRIPTION
## Pull Request Description

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to** `core/`
- [x] **No changes to** `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds a CSS-only fade-in carousel designed for cyberpunk and neon-themed
layouts.

The carousel displays multiple cards sequentially using CSS keyframe
animations. Each card fades in, remains visible, and fades out before
the next card appears.

**How does a developer use it?**

```html
<section class="carousel">
    <article class="carousel-card card-one">
        <h2>First Card</h2>
        <p>Content for the first slide.</p>
    </article>

    <article class="carousel-card card-two">
        <h2>Second Card</h2>
        <p>Content for the second slide.</p>
    </article>
</section>