### PR TITLE
feat: add CSS-Only Cyberpunk Glitch Text Effect (#66793)

### DIFF
--- a/submissions/examples/glitch-text-effect/README.md
+++ b/submissions/examples/glitch-text-effect/README.md
@@ -1,0 +1,27 @@
+# CSS-Only Cyberpunk Glitch Text Effect
+
+A high-energy, cyberpunk-style glitching animation for typography using advanced CSS clipping and shadows.
+
+## Features
+- Pure CSS implementation using pseudo-elements (`::before` and `::after`).
+- Complex `@keyframes` animation utilizing `clip-path: polygon(...)` to randomly slice text clones.
+- Paired with rapid `transform: translate()` shifts for a chaotic glitch look.
+- Uses `data-text` attribute to sync content.
+- Two variations:
+  - Constant glitch effect.
+  - Hover-only glitch effect.
+
+## Usage
+
+1. Include the CSS file.
+2. Add the `.ease-glitch-text` class to your text element and provide the exact same text in the `data-text` attribute.
+
+```html
+<h1 class="ease-glitch-text" data-text="CYBERPUNK">CYBERPUNK</h1>
+```
+
+For a hover-only effect, add the `.ease-glitch-hover-only` class as well:
+
+```html
+<h1 class="ease-glitch-text ease-glitch-hover-only" data-text="HOVER ME">HOVER ME</h1>
+```

--- a/submissions/examples/glitch-text-effect/demo.html
+++ b/submissions/examples/glitch-text-effect/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cyberpunk Glitch Text Effect</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="glitch-container">
+    <div>
+      <p class="label">Constant Glitch</p>
+      <h1 class="ease-glitch-text" data-text="CYBERPUNK">CYBERPUNK</h1>
+    </div>
+    
+    <div>
+      <p class="label">Hover Glitch</p>
+      <h1 class="ease-glitch-text ease-glitch-hover-only" data-text="HOVER ME">HOVER ME</h1>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/glitch-text-effect/style.css
+++ b/submissions/examples/glitch-text-effect/style.css
@@ -1,0 +1,120 @@
+/* 
+  CSS-Only Cyberpunk Glitch Text Effect
+*/
+@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@700&display=swap');
+
+:root {
+  --glitch-color-1: #0ff; /* Cyan */
+  --glitch-color-2: #f00; /* Red */
+  --bg-color: #0a0a0a;
+  --text-color: #fff;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  background-color: var(--bg-color);
+  font-family: 'Orbitron', sans-serif;
+  color: var(--text-color);
+}
+
+.glitch-container {
+  display: flex;
+  flex-direction: column;
+  gap: 5rem;
+  text-align: center;
+}
+
+.label {
+  font-family: sans-serif;
+  font-size: 0.9rem;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: #888;
+  margin-bottom: 0.5rem;
+}
+
+.ease-glitch-text {
+  position: relative;
+  font-size: 4.5rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  color: var(--text-color);
+  letter-spacing: 0.1em;
+  margin: 0;
+  /* Prevent selecting multiple texts for pseudoelements */
+  user-select: none;
+}
+
+/* Pseudo-elements for the glitch layers */
+.ease-glitch-text::before,
+.ease-glitch-text::after {
+  content: attr(data-text);
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: var(--bg-color);
+}
+
+.ease-glitch-text::before {
+  left: 3px;
+  text-shadow: -3px 0 var(--glitch-color-2);
+  clip-path: polygon(0 0, 100% 0, 100% 0, 0 0);
+  animation: ease-glitch-anim-1 2.5s infinite linear alternate-reverse;
+}
+
+.ease-glitch-text::after {
+  left: -3px;
+  text-shadow: -3px 0 var(--glitch-color-1);
+  clip-path: polygon(0 0, 100% 0, 100% 0, 0 0);
+  animation: ease-glitch-anim-2 3s infinite linear alternate-reverse;
+}
+
+/* Hover-only variation */
+.ease-glitch-hover-only::before,
+.ease-glitch-hover-only::after {
+  animation-play-state: paused;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.ease-glitch-hover-only:hover::before,
+.ease-glitch-hover-only:hover::after {
+  animation-play-state: running;
+  opacity: 1;
+}
+
+/* Keyframes for constant glitch effect using polygon slices */
+@keyframes ease-glitch-anim-1 {
+  0% { clip-path: polygon(0 20%, 100% 20%, 100% 21%, 0 21%); transform: translate(-2px, 1px); }
+  10% { clip-path: polygon(0 50%, 100% 50%, 100% 55%, 0 55%); transform: translate(2px, -1px); }
+  20% { clip-path: polygon(0 10%, 100% 10%, 100% 15%, 0 15%); transform: translate(-2px, 2px); }
+  30% { clip-path: polygon(0 80%, 100% 80%, 100% 88%, 0 88%); transform: translate(2px, -2px); }
+  40% { clip-path: polygon(0 30%, 100% 30%, 100% 32%, 0 32%); transform: translate(-1px, 1px); }
+  50% { clip-path: polygon(0 60%, 100% 60%, 100% 63%, 0 63%); transform: translate(1px, -1px); }
+  60% { clip-path: polygon(0 5%, 100% 5%, 100% 10%, 0 10%); transform: translate(-2px, 2px); }
+  70% { clip-path: polygon(0 90%, 100% 90%, 100% 92%, 0 92%); transform: translate(2px, -2px); }
+  80% { clip-path: polygon(0 15%, 100% 15%, 100% 25%, 0 25%); transform: translate(-1px, 1px); }
+  90% { clip-path: polygon(0 40%, 100% 40%, 100% 45%, 0 45%); transform: translate(1px, -1px); }
+  100% { clip-path: polygon(0 70%, 100% 70%, 100% 74%, 0 74%); transform: translate(-2px, 2px); }
+}
+
+@keyframes ease-glitch-anim-2 {
+  0% { clip-path: polygon(0 10%, 100% 10%, 100% 12%, 0 12%); transform: translate(2px, -1px); }
+  10% { clip-path: polygon(0 80%, 100% 80%, 100% 85%, 0 85%); transform: translate(-2px, 1px); }
+  20% { clip-path: polygon(0 30%, 100% 30%, 100% 35%, 0 35%); transform: translate(2px, -2px); }
+  30% { clip-path: polygon(0 5%, 100% 5%, 100% 8%, 0 8%); transform: translate(-2px, 2px); }
+  40% { clip-path: polygon(0 60%, 100% 60%, 100% 65%, 0 65%); transform: translate(1px, -1px); }
+  50% { clip-path: polygon(0 90%, 100% 90%, 100% 95%, 0 95%); transform: translate(-1px, 1px); }
+  60% { clip-path: polygon(0 15%, 100% 15%, 100% 18%, 0 18%); transform: translate(2px, -2px); }
+  70% { clip-path: polygon(0 40%, 100% 40%, 100% 44%, 0 44%); transform: translate(-2px, 2px); }
+  80% { clip-path: polygon(0 50%, 100% 50%, 100% 53%, 0 53%); transform: translate(1px, -1px); }
+  90% { clip-path: polygon(0 20%, 100% 20%, 100% 22%, 0 22%); transform: translate(-1px, 1px); }
+  100% { clip-path: polygon(0 70%, 100% 70%, 100% 72%, 0 72%); transform: translate(2px, -2px); }
+}


### PR DESCRIPTION
## Pull Request Description

This PR introduces the `.ease-glitch-text` utility that applies a high-energy, cyberpunk-style glitching animation to typography using advanced CSS clipping and shadows. It addresses issue #66793.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Introduces a pure CSS cyberpunk-style text glitch effect utilizing rapid clipping path animations and translate shifts on pseudo-elements.

**How does a developer use it?**

```html
<!-- Constant glitch effect -->
<h1 class="ease-glitch-text" data-text="CYBERPUNK">CYBERPUNK</h1>

<!-- Hover-only glitch effect -->
<h1 class="ease-glitch-text ease-glitch-hover-only" data-text="HOVER ME">HOVER ME</h1>
```

**Why does it fit EaseMotion CSS?**

This fits the human-readable, animation-first philosophy by demonstrating how a heavy visual effect usually achieved via Canvas or SVG filters can be simplified into a pure, drop-in CSS class with engaging animations.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

I implemented the complex slices for the glitch effect using `clip-path: polygon(...)` to randomly slice the text clones as requested in the issue. I also included a variation for a hover-only trigger (`.ease-glitch-hover-only`). 

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!