### PR TITLE
feat: add zoom-in-popover for minimalist tech layouts (#64444)

### DIFF
--- a/submissions/examples/zoom-in-popover-ak/README.md
+++ b/submissions/examples/zoom-in-popover-ak/README.md
@@ -1,0 +1,19 @@
+# zoom-in-popover
+
+### What does this do?
+A minimalist popover that scales up and fades in from its trigger, built with pure CSS transforms — no JS animation logic.
+
+### How is it used?
+```html
+<div class="popover-zoom">
+  <button class="popover-zoom__trigger">View Details</button>
+  <div class="popover-zoom__panel">
+    <p class="popover-zoom__title">Title</p>
+    <p class="popover-zoom__text">Body text here.</p>
+  </div>
+</div>
+```
+Opens on trigger `:focus` or panel `:hover` by default (keyboard-accessible), and can also be toggled manually by adding/removing the `is-open` class via JS if you want click-to-open behavior.
+
+### Why is it useful?
+Popovers are a common UI need in dashboards and tech landing pages, and this keeps the effect subtle and performant with only `transform`/`opacity` transitions (GPU-friendly, no layout thrashing). Fully responsive, works down to mobile widths, and respects `prefers-reduced-motion` by disabling the scale transform while keeping the fade.

--- a/submissions/examples/zoom-in-popover-ak/demo.html
+++ b/submissions/examples/zoom-in-popover-ak/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>zoom-in-popover demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body style="padding: 4rem; background:#fafafa;">
+
+  <div class="popover-zoom">
+    <button class="popover-zoom__trigger" onclick="this.nextElementSibling.classList.toggle('is-open')">
+      View Details
+    </button>
+    <div class="popover-zoom__panel">
+      <p class="popover-zoom__title">Minimalist Tech Card</p>
+      <p class="popover-zoom__text">
+        A lightweight zoom-in popover built with pure CSS transforms and opacity transitions — no JS animation libraries required.
+      </p>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/zoom-in-popover-ak/style.css
+++ b/submissions/examples/zoom-in-popover-ak/style.css
@@ -1,0 +1,68 @@
+.popover-zoom {
+  position: relative;
+  display: inline-block;
+  font-family: system-ui, sans-serif;
+}
+
+.popover-zoom__trigger {
+  padding: 0.6rem 1.2rem;
+  border: 1px solid #d4d4d8;
+  border-radius: 6px;
+  background: #fff;
+  color: #18181b;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: border-color 0.2s ease;
+}
+
+.popover-zoom__trigger:hover {
+  border-color: #a1a1aa;
+}
+
+.popover-zoom__panel {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  left: 0;
+  min-width: 220px;
+  padding: 1rem;
+  background: #fff;
+  border: 1px solid #e4e4e7;
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  transform: scale(0.85);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform-origin: top left;
+  transition: transform 0.18s ease, opacity 0.18s ease, visibility 0.18s;
+}
+
+.popover-zoom__trigger:focus + .popover-zoom__panel,
+.popover-zoom__panel:hover,
+.popover-zoom__panel.is-open {
+  transform: scale(1);
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.popover-zoom__title {
+  margin: 0 0 0.4rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #18181b;
+}
+
+.popover-zoom__text {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: #52525b;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .popover-zoom__panel {
+    transition: opacity 0.18s ease, visibility 0.18s;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a CSS zoom-in popover component for minimalist tech layouts, built with pure CSS transforms and opacity transitions. 
Closes #64444.

## Type of Change
- [x] 🧩 New component

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/zoom-in-popover-ak/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

## Feature Description
**What does this add?**
A minimalist popover that scales up and fades in from its trigger element using pure CSS.

**How does a developer use it?**
```html
<div class="popover-zoom">
  <button class="popover-zoom__trigger">View Details</button>
  <div class="popover-zoom__panel">
    <p class="popover-zoom__title">Title</p>
    <p class="popover-zoom__text">Body text here.</p>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
Popovers are common in dashboard/tech UIs, and this keeps the effect subtle and performant using only `transform`/`opacity` transitions — no JS animation logic, GPU-friendly, in line with EaseMotion's pure-CSS philosophy.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer
Opens on trigger `:focus` (keyboard-accessible) or panel `:hover` by default; also supports a manual `is-open` class toggle for click-based control, shown in the demo. Includes `prefers-reduced-motion` support (disables scale, keeps fade) and is responsive down to mobile widths.