### PR TITLE
feat: add elastic-slide-tabs for minimalist tech layouts (#64434)

### DIFF
--- a/submissions/examples/elastic-slide-tabs-ak/README.md
+++ b/submissions/examples/elastic-slide-tabs-ak/README.md
@@ -1,0 +1,17 @@
+# elastic-slide-tabs
+
+### What does this do?
+A pill-style tab switcher where a sliding background "elastically" snaps to the active tab using a spring-like `cubic-bezier` easing curve.
+
+### How is it used?
+```html
+<div class="tabs-elastic">
+  <span class="tabs-elastic__slider"></span>
+  <button class="tabs-elastic__btn is-active">Overview</button>
+  <button class="tabs-elastic__btn">Analytics</button>
+</div>
+```
+On click, JS measures the target button's width/offset and updates `--tabs-elastic-width` / `--tabs-elastic-offset` on the wrapper — the CSS transition on the slider handles the elastic motion.
+
+### Why is it useful?
+Gives minimalist tech dashboards a tactile, modern tab-switching feel (similar to iOS segmented controls) using pure CSS custom properties and transitions rather than a JS animation library. Fully responsive (stacks to full-width pills on small screens) and falls back to a faster linear ease under `prefers-reduced-motion`.

--- a/submissions/examples/elastic-slide-tabs-ak/demo.html
+++ b/submissions/examples/elastic-slide-tabs-ak/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>elastic-slide-tabs demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body style="padding: 4rem; background:#fafafa;">
+
+  <div class="tabs-elastic" id="tabsElastic">
+    <span class="tabs-elastic__slider"></span>
+    <button class="tabs-elastic__btn is-active">Overview</button>
+    <button class="tabs-elastic__btn">Analytics</button>
+    <button class="tabs-elastic__btn">Settings</button>
+  </div>
+
+  <script>
+    const wrap = document.getElementById('tabsElastic');
+    const btns = wrap.querySelectorAll('.tabs-elastic__btn');
+    const slider = wrap.querySelector('.tabs-elastic__slider');
+
+    function moveSlider(btn) {
+      const wrapRect = wrap.getBoundingClientRect();
+      const btnRect = btn.getBoundingClientRect();
+      wrap.style.setProperty('--tabs-elastic-width', btnRect.width + 'px');
+      wrap.style.setProperty('--tabs-elastic-offset', (btnRect.left - wrapRect.left - 4) + 'px');
+    }
+
+    btns.forEach(btn => {
+      btn.addEventListener('click', () => {
+        btns.forEach(b => b.classList.remove('is-active'));
+        btn.classList.add('is-active');
+        moveSlider(btn);
+      });
+    });
+
+    window.addEventListener('load', () => moveSlider(wrap.querySelector('.is-active')));
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/elastic-slide-tabs-ak/style.css
+++ b/submissions/examples/elastic-slide-tabs-ak/style.css
@@ -1,0 +1,54 @@
+.tabs-elastic {
+  position: relative;
+  display: inline-flex;
+  background: #f4f4f5;
+  border-radius: 999px;
+  padding: 4px;
+  font-family: system-ui, sans-serif;
+}
+
+.tabs-elastic__btn {
+  position: relative;
+  z-index: 1;
+  border: none;
+  background: transparent;
+  padding: 0.55rem 1.4rem;
+  font-size: 0.9rem;
+  color: #52525b;
+  cursor: pointer;
+  transition: color 0.3s ease;
+}
+
+.tabs-elastic__btn.is-active {
+  color: #18181b;
+}
+
+.tabs-elastic__slider {
+  position: absolute;
+  top: 4px;
+  bottom: 4px;
+  left: 4px;
+  width: var(--tabs-elastic-width, 33.33%);
+  background: #fff;
+  border-radius: 999px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+  transform: translateX(var(--tabs-elastic-offset, 0%));
+  transition: transform 0.45s cubic-bezier(0.34, 1.56, 0.64, 1),
+              width 0.45s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tabs-elastic__slider {
+    transition: transform 0.2s ease, width 0.2s ease;
+  }
+}
+
+@media (max-width: 480px) {
+  .tabs-elastic {
+    width: 100%;
+  }
+  .tabs-elastic__btn {
+    flex: 1;
+    padding: 0.55rem 0.6rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pill-style elastic-slide tabs component for minimalist tech layouts, where a sliding background snaps to the active tab with a spring-like easing curve. 
Closes #64434.

## Type of Change
- [x] 🧩 New component

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/elastic-slide-tabs-ak/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

## Feature Description
**What does this add?**
A pill-style tab switcher where a sliding background elastically snaps to the active tab.

**How does a developer use it?**
```html
<div class="tabs-elastic">
  <span class="tabs-elastic__slider"></span>
  <button class="tabs-elastic__btn is-active">Overview</button>
  <button class="tabs-elastic__btn">Analytics</button>
</div>
```

**Why does it fit EaseMotion CSS?**
Gives minimalist dashboards a tactile, iOS-segmented-control feel using CSS custom properties and `cubic-bezier` transitions rather than a JS animation library, staying true to EaseMotion's pure-CSS, class-based philosophy.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer
JS is used only to measure the clicked button's width/offset and set `--tabs-elastic-width`/`--tabs-elastic-offset` — all actual motion is handled by the CSS transition on the slider. Fully responsive (stacks to full-width pills below 480px) and uses a faster linear ease under `prefers-reduced-motion`.