### PR TITLE
feat: add skew-active-hero for glassmorphism UI layouts (#64331)

### DIFF
--- a/submissions/examples/skew-active-hero-ak/README.md
+++ b/submissions/examples/skew-active-hero-ak/README.md
@@ -1,0 +1,19 @@
+# skew-active-hero
+
+### What does this do?
+A glassmorphism hero section with a skewed gradient background panel that straightens out and the frosted-glass card lifts slightly on hover/active.
+
+### How is it used?
+```html
+<section class="hero-skew">
+  <div class="hero-skew__panel"></div>
+  <div class="hero-skew__card">
+    <h1 class="hero-skew__title">Your Headline</h1>
+    <p class="hero-skew__text">Supporting copy goes here.</p>
+  </div>
+</section>
+```
+Add the `is-active` class to `.hero-skew` to trigger the effect via JS/state toggle instead of relying on `:hover` alone.
+
+### Why is it useful?
+Skewed panels give a hero section dynamic energy without heavy JS, and pairing it with a glassmorphism card keeps it aligned with modern tech landing page trends. Pure CSS transforms/transitions, GPU-friendly, no JS required for the base hover interaction. Fully responsive down to mobile, and disables all transitions under `prefers-reduced-motion`.

--- a/submissions/examples/skew-active-hero-ak/demo.html
+++ b/submissions/examples/skew-active-hero-ak/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>skew-active-hero demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body style="margin:0; padding:3rem; background:#020617;">
+
+  <section class="hero-skew">
+    <div class="hero-skew__panel"></div>
+    <div class="hero-skew__card">
+      <h1 class="hero-skew__title">Design With Motion</h1>
+      <p class="hero-skew__text">
+        A glassmorphism hero section with a skewed gradient panel that straightens and lifts the card on hover or active state — pure CSS, no JS.
+      </p>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/skew-active-hero-ak/style.css
+++ b/submissions/examples/skew-active-hero-ak/style.css
@@ -1,0 +1,75 @@
+.hero-skew {
+  position: relative;
+  min-height: 420px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  border-radius: 20px;
+  background: linear-gradient(135deg, #1e1b4b, #312e81);
+  font-family: system-ui, sans-serif;
+}
+
+.hero-skew__panel {
+  position: absolute;
+  inset: -10% -20%;
+  background: linear-gradient(120deg, rgba(129, 140, 248, 0.35), rgba(236, 72, 153, 0.25));
+  transform: skewY(-6deg);
+  transition: transform 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.hero-skew:hover .hero-skew__panel,
+.hero-skew.is-active .hero-skew__panel {
+  transform: skewY(-2deg) scale(1.03);
+}
+
+.hero-skew__card {
+  position: relative;
+  z-index: 1;
+  max-width: 440px;
+  padding: 2.2rem;
+  text-align: center;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 16px;
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  color: #f1f5f9;
+  transition: transform 0.4s ease;
+}
+
+.hero-skew:hover .hero-skew__card,
+.hero-skew.is-active .hero-skew__card {
+  transform: translateY(-4px);
+}
+
+.hero-skew__title {
+  margin: 0 0 0.6rem;
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.hero-skew__text {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: #cbd5e1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-skew__panel,
+  .hero-skew__card {
+    transition: none;
+  }
+}
+
+@media (max-width: 480px) {
+  .hero-skew {
+    min-height: 320px;
+    border-radius: 14px;
+  }
+  .hero-skew__card {
+    padding: 1.5rem;
+    max-width: 88%;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a glassmorphism hero section with a skewed gradient panel that straightens out and lifts the frosted-glass card on hover/active state. 
Closes #64331.

## Type of Change
- [x] 🧩 New component

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/skew-active-hero-ak/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

## Feature Description
**What does this add?**
A glassmorphism hero section with a skewed gradient background panel that straightens and lifts the card on hover/active.

**How does a developer use it?**
```html
<section class="hero-skew">
  <div class="hero-skew__panel"></div>
  <div class="hero-skew__card">
    <h1 class="hero-skew__title">Your Headline</h1>
    <p class="hero-skew__text">Supporting copy goes here.</p>
  </div>
</section>
```

**Why does it fit EaseMotion CSS?**
Skewed panels give a hero section dynamic energy without heavy JS, and pairing it with a glassmorphism card keeps it aligned with modern tech landing page trends. Pure CSS transforms/transitions, GPU-friendly, no JS required for the base interaction.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Notes for Maintainer
Effect triggers on `:hover` by default; also supports an `is-active` class on `.hero-skew` for JS-driven toggling if a click/tap-triggered version is preferred. Fully responsive down to mobile widths, and all transitions are disabled under `prefers-reduced-motion`.