### PR TITLE
feat(scss): add realistic neon glow mixin

### DIFF
--- a/submissions/scss/ease-neon-glow/README.md
+++ b/submissions/scss/ease-neon-glow/README.md
@@ -1,0 +1,47 @@
+# SCSS Realistic Neon Glow
+
+A highly realistic, volumetric "neon tube" text glow generator.
+
+## Features
+- Generates a mathematically precise 7-layer `text-shadow` stack.
+- Simulates real-world light falloff by mixing tight, high-opacity cores with massive, low-opacity ambient blurs.
+- Allows scaling the overall size of the glow using the `$intensity` multiplier.
+- Keeps the core text pure white (or a custom color) to simulate the hot center of a neon gas tube.
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `$base-color` | `Color` | Required | The core color of the neon light. |
+| `$intensity` | `Number` | `1` | A multiplier for the blur spread (e.g. `1.5` for a wider glow). |
+| `$text-color` | `Color` | `#ffffff` | The color of the physical text itself. |
+
+## Usage
+
+Import the mixin and apply it to any text element (works best on dark backgrounds).
+
+```scss
+@import 'ease-neon-glow';
+
+body {
+  background-color: #000000;
+}
+
+// Standard Pink Neon
+.neon-pink {
+  @include ease-neon-glow(#ec4899);
+}
+
+// Massive Cyberpunk Blue Neon
+.neon-blue-massive {
+  @include ease-neon-glow(#0ea5e9, 2.5);
+}
+
+// Custom core text color
+.neon-custom {
+  @include ease-neon-glow(#10b981, 1, #d1fae5);
+}
+```
+
+## Why it fits EaseMotion CSS
+Creating a realistic, glowing "neon tube" text effect manually requires stacking up to 7 different `text-shadow` layers with expanding blur radii and decreasing opacities. Typing this out manually every time you need a new glowing color is extremely tedious and error-prone. This mixin perfectly encapsulates the EaseMotion philosophy of abstracting complex, repetitive CSS math into a single, intuitive utility function.

--- a/submissions/scss/ease-neon-glow/_ease-neon-glow.scss
+++ b/submissions/scss/ease-neon-glow/_ease-neon-glow.scss
@@ -1,0 +1,33 @@
+/// EaseMotion Realistic Neon Glow Mixin
+/// Generates a complex, multi-layered text-shadow stack to simulate 
+/// physically accurate volumetric light diffusion (neon tubes).
+/// 
+/// @param {Color} $base-color - The core color of the neon light.
+/// @param {Number} $intensity [1] - Multiplier for the blur spread (e.g. 1.5 for a wider glow).
+/// @param {Color} $text-color [#ffffff] - The actual text color (usually white for the hot center of the tube).
+
+@mixin ease-neon-glow(
+  $base-color, 
+  $intensity: 1, 
+  $text-color: #ffffff
+) {
+  // The hot core of the light tube is usually pure white
+  color: $text-color;
+
+  // Generate the volumetric light diffusion stack.
+  // We stack progressively larger blurs to mimic real-world light falloff.
+  // We also use varying opacities of the base color to create depth.
+  text-shadow: 
+    /* The immediate core burn (tight blur, high opacity) */
+    0 0 (2px * $intensity) #ffffff,
+    0 0 (5px * $intensity) $base-color,
+    
+    /* The mid-level diffusion (medium blur, solid color) */
+    0 0 (10px * $intensity) $base-color,
+    0 0 (20px * $intensity) $base-color,
+    
+    /* The wide ambient glow (massive blur, lower opacity for softness) */
+    0 0 (40px * $intensity) rgba($base-color, 0.8),
+    0 0 (80px * $intensity) rgba($base-color, 0.6),
+    0 0 (120px * $intensity) rgba($base-color, 0.4);
+}


### PR DESCRIPTION
fixes #66881 

## Pull Request Description

Adds an `ease-neon-glow` SCSS mixin. Creating a realistic, glowing "neon tube" text effect manually requires stacking up to 7 different `text-shadow` layers with expanding blur radii and decreasing opacities. Typing this out manually every time a developer needs a new glowing color is extremely tedious and error-prone. This submission abstracts that complex volumetric lighting math into a single, intuitive mixin.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component (SCSS Track)
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/scss/ease-neon-glow/`)
- [x] Includes `_ease-neon-glow.scss` — raw SCSS mixin code for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A highly reusable SCSS mixin (`_ease-neon-glow.scss`) that generates a physically accurate volumetric light diffusion stack. 

**How does it work?**

1. It accepts a `$base-color`, an optional `$intensity` multiplier, and an optional `$text-color` (defaulting to pure white to mimic the hot core of a neon gas tube).
2. It dynamically generates a 7-layer `text-shadow` stack.
3. The stack simulates real-world light falloff by mixing tight, high-opacity cores (`2px`, `5px`) with massive, lower-opacity ambient blurs (`80px`, `120px` utilizing `rgba()`).
4. The blur radius math scales dynamically based on the `$intensity` multiplier provided.

**How does a developer use it?**

```scss
@import 'ease-neon-glow';

.neon-pink {
  @include ease-neon-glow(#ec4899);
}

// Massive Cyberpunk Blue Neon (2.5x spread)
.neon-blue-massive {
  @include ease-neon-glow(#0ea5e9, 2.5);
}
