### PR TITLE
feat: add ease-magnetic-btn component (#64934)

### DIFF
--- a/submissions/examples/ease-magnetic-btn-sbh/README.md
+++ b/submissions/examples/ease-magnetic-btn-sbh/README.md
@@ -1,0 +1,44 @@
+# ease-magnetic-btn
+
+An interactive button that gently drifts toward the cursor on hover and springs back to its origin when the pointer leaves.
+
+## What does this do?
+
+Adds a **magnetic hover interaction** to buttons: each button subtly follows the user's cursor while hovered, creating a premium, tactile feel, then eases back with a soft overshoot (spring) when the pointer exits.
+
+## How is it used?
+
+1. Add the `mag-btn` class to a `<button>` and the `data-magnetic` attribute to enable tracking.
+2. Optionally set `data-strength` (0–1) to control how strongly the button follows the cursor (default `0.4`).
+3. Wrap the visible text in a `.mag-btn__label` span — it drifts slightly more than the button for a layered parallax effect.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<button type="button" class="mag-btn mag-btn--primary" data-magnetic data-strength="0.4">
+  <span class="mag-btn__label">Primary Action</span>
+</button>
+```
+
+The demo ships four variants — `mag-btn--primary`, `mag-btn--ghost`, `mag-btn--pill`, and `mag-btn--icon` — to show how the magnetic effect adapts to different button shapes.
+
+### How it works under the hood
+
+A tiny inline script reads the pointer position relative to each button's center and writes it to the `--mx` / `--my` CSS custom properties (as percentages). The CSS drives the actual motion with `transform: translate3d(var(--mx), var(--my), 0)`, so the GPU handles compositing. A separate spring easing curve (`cubic-bezier(0.34, 1.56, 0.64, 1)`) is applied only on the *return* so the button bounces back naturally while tracking stays 1:1 with the cursor.
+
+## Why is this useful?
+
+- **Animation-first philosophy** — it is a reusable motion utility, not a static component, matching EaseMotion CSS's core mission.
+- **Performance-friendly** — motion runs on `transform` + CSS variables (no per-frame layout thrash), and `will-change: transform` keeps it on the compositor.
+- **Accessible by default** — respects `prefers-reduced-motion` (motion is fully disabled), keeps semantic `<button>` elements, and exposes `:focus-visible` outlines for keyboard users.
+- **Reusable & composable** — the strength is data-driven per button, and the four modifier classes show it slots into any button style without restructuring markup.
+
+## Files
+
+- `demo.html` — self-contained interactive demo (open directly in a browser; no server, CDNs, or build step required).
+- `style.css` — the magnetic button styles and variants.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation, as described in the contribution guide.

--- a/submissions/examples/ease-magnetic-btn-sbh/demo.html
+++ b/submissions/examples/ease-magnetic-btn-sbh/demo.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-magnetic-btn — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="stage">
+    <header class="stage__intro">
+      <h1>ease-magnetic-btn</h1>
+      <p>Hover the buttons — each one gently drifts toward your cursor and snaps back when you leave.</p>
+    </header>
+
+    <section class="showcase" aria-label="Magnetic button variants">
+      <button type="button" class="mag-btn mag-btn--primary" data-magnetic data-strength="0.4">
+        <span class="mag-btn__label">Primary Action</span>
+      </button>
+
+      <button type="button" class="mag-btn mag-btn--ghost" data-magnetic data-strength="0.6">
+        <span class="mag-btn__label">Ghost</span>
+      </button>
+
+      <button type="button" class="mag-btn mag-btn--pill" data-magnetic data-strength="0.3">
+        <span class="mag-btn__label">Pill</span>
+      </button>
+
+      <button type="button" class="mag-btn mag-btn--icon" data-magnetic data-strength="0.8" aria-label="Magnetic icon button">
+        <span class="mag-btn__label" aria-hidden="true">+</span>
+      </button>
+    </section>
+
+    <footer class="stage__hint">
+      <small>Move the pointer slowly across a button to see the magnetic pull track your cursor.</small>
+    </footer>
+  </main>
+
+  <script>
+    (function () {
+      var buttons = document.querySelectorAll('[data-magnetic]');
+      buttons.forEach(function (btn) {
+        var strength = parseFloat(btn.getAttribute('data-strength')) || 0.4;
+        var label = btn.querySelector('.mag-btn__label');
+
+        btn.addEventListener('pointermove', function (e) {
+          var rect = btn.getBoundingClientRect();
+          var relX = (e.clientX - (rect.left + rect.width / 2)) / (rect.width / 2);
+          var relY = (e.clientY - (rect.top + rect.height / 2)) / (rect.height / 2);
+          btn.style.setProperty('--mx', (relX * strength * 100).toFixed(2) + '%');
+          btn.style.setProperty('--my', (relY * strength * 100).toFixed(2) + '%');
+          if (label) {
+            label.style.setProperty('--lx', (relX * strength * 60).toFixed(2) + '%');
+            label.style.setProperty('--ly', (relY * strength * 60).toFixed(2) + '%');
+          }
+        });
+
+        btn.addEventListener('pointerleave', function () {
+          btn.style.setProperty('--mx', '0%');
+          btn.style.setProperty('--my', '0%');
+          if (label) {
+            label.style.setProperty('--lx', '0%');
+            label.style.setProperty('--ly', '0%');
+          }
+        });
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-magnetic-btn-sbh/style.css
+++ b/submissions/examples/ease-magnetic-btn-sbh/style.css
@@ -1,0 +1,159 @@
+:root {
+  --mag-ease: cubic-bezier(0.16, 1, 0.3, 1);
+  --mag-return: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --mag-duration: 0.35s;
+}
+
+.stage {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 30%, #1b2230, #0b0e14 70%);
+  color: #e8edf5;
+}
+
+.stage__intro {
+  text-align: center;
+  max-width: 38rem;
+}
+
+.stage__intro h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(1.6rem, 4vw, 2.4rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, #6ea8ff, #b388ff);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.stage__intro p {
+  margin: 0;
+  opacity: 0.7;
+  line-height: 1.6;
+}
+
+.showcase {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.75rem;
+  align-items: center;
+  justify-content: center;
+}
+
+.mag-btn {
+  --mx: 0%;
+  --my: 0%;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  padding: 0.9rem 1.75rem;
+  border-radius: 0.85rem;
+  will-change: transform;
+  transform: translate3d(var(--mx), var(--my), 0);
+  transition: transform var(--mag-duration) var(--mag-ease),
+              box-shadow var(--mag-duration) var(--mag-ease),
+              background var(--mag-duration) var(--mag-ease);
+}
+
+.mag-btn:focus-visible {
+  outline: 2px solid #6ea8ff;
+  outline-offset: 3px;
+}
+
+.mag-btn:hover {
+  transition-duration: var(--mag-duration);
+}
+
+.mag-btn:not(:hover) {
+  transition-timing-function: var(--mag-return);
+}
+
+.mag-btn__label {
+  --lx: 0%;
+  --ly: 0%;
+  display: inline-block;
+  transform: translate3d(var(--lx), var(--ly), 0);
+  transition: transform var(--mag-duration) var(--mag-ease);
+}
+
+.mag-btn:not(:hover) .mag-btn__label {
+  transition-timing-function: var(--mag-return);
+}
+
+.mag-btn--primary {
+  background: linear-gradient(135deg, #4f7bff, #8a5bff);
+  color: #fff;
+  box-shadow: 0 10px 30px -12px rgba(79, 123, 255, 0.65);
+}
+
+.mag-btn--primary:hover {
+  box-shadow: 0 18px 44px -12px rgba(138, 91, 255, 0.85);
+}
+
+.mag-btn--ghost {
+  background: rgba(255, 255, 255, 0.04);
+  color: #cdd6e6;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  backdrop-filter: blur(6px);
+}
+
+.mag-btn--ghost:hover {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(110, 168, 255, 0.6);
+}
+
+.mag-btn--pill {
+  background: #11161f;
+  color: #6ea8ff;
+  border-radius: 999px;
+  padding: 0.75rem 1.9rem;
+  box-shadow: inset 0 0 0 1px rgba(110, 168, 255, 0.35);
+}
+
+.mag-btn--pill:hover {
+  color: #b388ff;
+  box-shadow: inset 0 0 0 1px rgba(179, 136, 255, 0.7),
+              0 12px 30px -14px rgba(179, 136, 255, 0.6);
+}
+
+.mag-btn--icon {
+  width: 3.25rem;
+  height: 3.25rem;
+  padding: 0;
+  border-radius: 50%;
+  font-size: 1.5rem;
+  background: linear-gradient(135deg, #151b26, #0c1119);
+  color: #6ea8ff;
+  box-shadow: inset 0 0 0 1px rgba(110, 168, 255, 0.3);
+}
+
+.mag-btn--icon:hover {
+  color: #fff;
+  box-shadow: inset 0 0 0 1px rgba(110, 168, 255, 0.8),
+              0 0 28px -4px rgba(110, 168, 255, 0.55);
+}
+
+.stage__hint {
+  opacity: 0.5;
+  font-size: 0.85rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mag-btn,
+  .mag-btn__label {
+    transition: none;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## 🎯 What this PR does

Implements **`ease-magnetic-btn`** from issue #64934 — an interactive button that gently drifts toward the cursor on hover and springs back with a soft overshoot when the pointer leaves.

Closes #64934.

---

## ✨ Feature

A magnetic hover interaction where a button subtly follows the cursor before smoothly returning to its original position. Four variants ship in the demo to show the effect adapting to different button shapes:

| Variant | Class |
|---|---|
| Solid gradient | `mag-btn--primary` |
| Glass / ghost | `mag-btn--ghost` |
| Rounded pill | `mag-btn--pill` |
| Circular icon | `mag-btn--icon` |

---

## 🛠️ How it works

- A tiny inline script reads the pointer position relative to each button's center and writes it to the `--mx` / `--my` CSS custom properties (as percentages).
- The CSS drives the actual motion with `transform: translate3d(var(--mx), var(--my), 0)`, so compositing stays on the GPU (no per-frame layout thrash).
- A spring easing curve (`cubic-bezier(0.34, 1.56, 0.64, 1)`) is applied **only on the return**, so the button bounces back naturally while tracking stays 1:1 with the cursor.
- The inner `.mag-btn__label` drifts slightly more than the button itself for a layered parallax effect.
- `data-strength` (0–1) controls how strongly each button follows the cursor.

---

## ♿ Accessibility & performance

- Respects `prefers-reduced-motion` — motion is fully disabled when the user opts out.
- Keeps semantic `<button>` elements and exposes `:focus-visible` outlines for keyboard users.
- Motion runs on `transform` + CSS variables only; `will-change: transform` keeps it on the compositor.

---

## 📁 Submission structure

```
submissions/examples/ease-magnetic-btn-sbh/
├── demo.html      ← self-contained interactive demo (DOCTYPE + html + head + body)
├── style.css      ← magnetic button styles + 4 variants
└── README.md      ← what / how / why documentation
```

Placed under `submissions/examples/` per the contribution guide. The `-sbh` suffix is appended per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

---

## ✅ Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` are all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>`
- [x] Demo is self-contained — opens directly in a browser, no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root are modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally