### PR TITLE
feat: blur-entrance tabs for minimalist tech layouts

### DIFF
--- a/submissions/examples/blur-entrance-tabs-minimalist-tech/README.md
+++ b/submissions/examples/blur-entrance-tabs-minimalist-tech/README.md
@@ -1,0 +1,23 @@
+# Blur-Entrance Tabs — Minimalist Tech
+
+CSS-only tab component where each panel enters with a blur-to-sharp transition. When switching tabs, the active panel starts blurred and slightly offset, then sharpens into place.
+
+## How It Works
+
+Three radio inputs control which tab is active. Only the panel matching the checked radio is visible. Inactive panels have `filter: blur(10px)`, reduced opacity, and a small vertical offset. The active panel transitions to `blur(0)`, full opacity, and its natural position.
+
+The blur creates a frosted-glass feel — the content appears to resolve from a soft haze into focus, which fits well with minimalist tech aesthetics.
+
+## Customization
+
+- Change `--bet-blue` for a different active tab color
+- Adjust the `blur()` value for more or less dramatic entrance
+- Modify `translateY()` for vertical offset control
+- Swap the easing to `ease-out` for less spring
+
+## Notes
+
+- Pure HTML + CSS, no JavaScript
+- `prefers-reduced-motion` disables the blur animation
+- Radio inputs give keyboard accessibility for free
+- Panels use `position: absolute` with `min-height` to prevent layout shift

--- a/submissions/examples/blur-entrance-tabs-minimalist-tech/demo.html
+++ b/submissions/examples/blur-entrance-tabs-minimalist-tech/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS blur-entrance tabs for minimalist tech layouts">
+  <title>Blur-Entrance Tabs — Minimalist Tech</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <nav class="bet-bar">
+    <span class="bet-bar__logo">FLUX</span>
+    <span class="bet-bar__space"></span>
+    <span class="bet-bar__link">Overview</span>
+    <span class="bet-bar__link">Docs</span>
+    <span class="bet-bar__link">Contact</span>
+  </nav>
+
+  <section class="bet-wrap">
+    <h1 class="bet-title">Blur-Entrance Tabs</h1>
+    <p class="bet-sub">Tabs that blur into view when switched. Each panel fades in from a blurred state using pure CSS.</p>
+
+    <div class="bet-tabs">
+      <input type="radio" name="bet-group" id="bet-1" class="bet-sr" checked>
+      <input type="radio" name="bet-group" id="bet-2" class="bet-sr">
+      <input type="radio" name="bet-group" id="bet-3" class="bet-sr">
+
+      <div class="bet-bar__row">
+        <label for="bet-1" class="bet-tab">Overview</label>
+        <label for="bet-2" class="bet-tab">Features</label>
+        <label for="bet-3" class="bet-tab">Pricing</label>
+      </div>
+
+      <div class="bet-panels">
+        <div class="bet-panel bet-panel--1">
+          <h2 class="bet-panel__h">What is this?</h2>
+          <p class="bet-panel__p">A lightweight tab component built entirely with CSS. The active panel blurs in from a frosted state, giving a smooth reveal effect without any JavaScript.</p>
+        </div>
+        <div class="bet-panel bet-panel--2">
+          <h2 class="bet-panel__h">Key Features</h2>
+          <p class="bet-panel__p">Pure CSS, no dependencies. Keyboard accessible with radio inputs. Honors reduced motion preferences. Works across all modern browsers.</p>
+        </div>
+        <div class="bet-panel bet-panel--3">
+          <h2 class="bet-panel__h">Pricing</h2>
+          <p class="bet-panel__p">Free to use in personal and commercial projects. No attribution required. MIT licensed.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/blur-entrance-tabs-minimalist-tech/style.css
+++ b/submissions/examples/blur-entrance-tabs-minimalist-tech/style.css
@@ -1,0 +1,186 @@
+:root {
+  --bet-white: #ffffff;
+  --bet-gray-50: #fafafa;
+  --bet-gray-100: #f3f3f5;
+  --bet-gray-200: #e5e5ea;
+  --bet-gray-400: #8e8e93;
+  --bet-gray-600: #48484a;
+  --bet-gray-900: #1d1d1f;
+  --bet-blue: #007aff;
+  --bet-blue-bg: rgba(0, 122, 255, 0.06);
+  --bet-radius: 8px;
+}
+
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  background: var(--bet-gray-50);
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Inter", sans-serif;
+  color: var(--bet-gray-900);
+  line-height: 1.55;
+}
+
+/* ── nav ────────────────────────────────────────── */
+
+.bet-bar {
+  display: flex;
+  align-items: center;
+  height: 46px;
+  padding: 0 22px;
+  background: var(--bet-white);
+  border-bottom: 1px solid var(--bet-gray-200);
+}
+
+.bet-bar__logo {
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+}
+
+.bet-bar__space {
+  flex: 1;
+}
+
+.bet-bar__link {
+  font-size: 0.68rem;
+  color: var(--bet-gray-400);
+  margin-left: 16px;
+  cursor: pointer;
+}
+
+.bet-bar__link:hover {
+  color: var(--bet-gray-600);
+}
+
+/* ── wrap ───────────────────────────────────────── */
+
+.bet-wrap {
+  max-width: 520px;
+  margin: 0 auto;
+  padding: 64px 22px 80px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.bet-title {
+  font-size: clamp(1.3rem, 3.5vw, 1.8rem);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  text-align: center;
+}
+
+.bet-sub {
+  font-size: 0.72rem;
+  color: var(--bet-gray-400);
+  max-width: 40ch;
+  text-align: center;
+  margin-top: 8px;
+  line-height: 1.7;
+  margin-bottom: 32px;
+}
+
+/* ── tabs container ─────────────────────────────── */
+
+.bet-tabs {
+  width: 100%;
+}
+
+.bet-sr {
+  position: fixed;
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* ── tab bar ────────────────────────────────────── */
+
+.bet-bar__row {
+  display: flex;
+  gap: 4px;
+  border-bottom: 1px solid var(--bet-gray-200);
+  margin-bottom: 0;
+}
+
+.bet-tab {
+  flex: 1;
+  text-align: center;
+  padding: 10px 0;
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--bet-gray-400);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  transition: color 0.2s ease, border-color 0.2s ease;
+}
+
+.bet-tab:hover {
+  color: var(--bet-gray-600);
+}
+
+#bet-1:checked ~ .bet-bar__row label[for="bet-1"],
+#bet-2:checked ~ .bet-bar__row label[for="bet-2"],
+#bet-3:checked ~ .bet-bar__row label[for="bet-3"] {
+  color: var(--bet-blue);
+  border-bottom-color: var(--bet-blue);
+}
+
+/* ── panels ─────────────────────────────────────── */
+
+.bet-panels {
+  position: relative;
+  min-height: 160px;
+  overflow: hidden;
+}
+
+.bet-panel {
+  position: absolute;
+  inset: 0;
+  padding: 20px;
+  background: var(--bet-white);
+  border: 1px solid var(--bet-gray-200);
+  border-top: none;
+  border-radius: 0 0 var(--bet-radius) var(--bet-radius);
+  opacity: 0;
+  filter: blur(10px);
+  transform: translateY(8px) scale(0.98);
+  transition: opacity 0.35s ease,
+              filter 0.35s ease,
+              transform 0.35s ease;
+  pointer-events: none;
+}
+
+.bet-panel__h {
+  font-size: 0.8rem;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.bet-panel__p {
+  font-size: 0.7rem;
+  color: var(--bet-gray-400);
+  line-height: 1.7;
+}
+
+#bet-1:checked ~ .bet-panels .bet-panel--1,
+#bet-2:checked ~ .bet-panels .bet-panel--2,
+#bet-3:checked ~ .bet-panels .bet-panel--3 {
+  opacity: 1;
+  filter: blur(0);
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+/* ── reduced motion ─────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .bet-panel {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Closes #64431

Adds CSS blur-entrance tabs for minimalist tech layouts.

**What this does:**
- Pure CSS tab component using radio inputs
- Active panel enters with blur-to-sharp transition (filter: blur(10px) → blur(0))
- Panel starts blurred, offset, and scaled down — sharpens into place
- Frosted-glass feel that fits minimalist tech aesthetics
- Keyboard accessible via radio inputs
- No JavaScript

**Files added:**
- submissions/examples/blur-entrance-tabs-minimalist-tech/demo.html
- submissions/examples/blur-entrance-tabs-minimalist-tech/style.css
- submissions/examples/blur-entrance-tabs-minimalist-tech/README.md