### PR TITLE
feat: elastic-slide accordion for SaaS showcase layouts

### DIFF
--- a/submissions/examples/elastic-slide-accordion-saas/README.md
+++ b/submissions/examples/elastic-slide-accordion-saas/README.md
@@ -1,0 +1,21 @@
+# Elastic-Slide Accordion — SaaS Showcase
+
+A CSS-only accordion with an elastic slide animation. Panels stretch open with a springy cubic-bezier timing function that overshoots slightly before settling.
+
+## How It Works
+
+Hidden checkbox inputs control each panel. When checked, the panel's `max-height` transitions from 0 to 200px using `cubic-bezier(0.34, 1.56, 0.64, 1)`. The overshoot in the timing curve creates the elastic feel — the content stretches past its target before snapping back. The plus icon rotates into an X at the same elastic rate.
+
+## Customization
+
+- Change `--esa-accent` for a different highlight color
+- Adjust the cubic-bezier values for more or less spring
+- Modify `max-height` to accommodate longer content
+- The gap and border-radius can be tuned for different densities
+
+## Notes
+
+- Pure CSS, no JavaScript
+- `prefers-reduced-motion` disables the elastic transitions
+- Works with any number of panels
+- Responsive across all viewport sizes

--- a/submissions/examples/elastic-slide-accordion-saas/demo.html
+++ b/submissions/examples/elastic-slide-accordion-saas/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS elastic-slide accordion for SaaS showcase layouts">
+  <title>Elastic-Slide Accordion — SaaS Showcase</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <nav class="esa-nav">
+    <span class="esa-nav__logo">SaaSKit</span>
+    <span class="esa-nav__fill"></span>
+    <span class="esa-nav__item">Features</span>
+    <span class="esa-nav__item">Pricing</span>
+    <span class="esa-nav__item">Docs</span>
+  </nav>
+
+  <main class="esa-wrap">
+    <h1 class="esa-heading">Frequently Asked Questions</h1>
+    <p class="esa-sub">An elastic-slide accordion that stretches open and squishes closed. Pure CSS, no JavaScript.</p>
+
+    <div class="esa-acc">
+      <input type="checkbox" id="esa-1" class="esa-sr" checked>
+      <div class="esa-row">
+        <label for="esa-1" class="esa-row__head">
+          <span class="esa-row__title">How does the elastic animation work?</span>
+          <span class="esa-row__icon"></span>
+        </label>
+        <div class="esa-row__body">
+          <p class="esa-row__text">The accordion uses a combination of max-height and a custom cubic-bezier timing function that overshoots, creating a springy elastic feel. The content stretches slightly beyond its target height before settling.</p>
+        </div>
+      </div>
+
+      <input type="checkbox" id="esa-2" class="esa-sr">
+      <div class="esa-row">
+        <label for="esa-2" class="esa-row__head">
+          <span class="esa-row__title">Is this pure CSS?</span>
+          <span class="esa-row__icon"></span>
+        </label>
+        <div class="esa-row__body">
+          <p class="esa-row__text">Yes. The entire component is built with HTML checkboxes and CSS transitions. No JavaScript is used anywhere. The checkbox state controls which panel is open.</p>
+        </div>
+      </div>
+
+      <input type="checkbox" id="esa-3" class="esa-sr">
+      <div class="esa-row">
+        <label for="esa-3" class="esa-row__head">
+          <span class="esa-row__title">Can I customize the colors?</span>
+          <span class="esa-row__icon"></span>
+        </label>
+        <div class="esa-row__body">
+          <p class="esa-row__text">All colors are controlled through CSS custom properties on the :root element. Change --esa-accent to update the highlight color across the entire component.</p>
+        </div>
+      </div>
+
+      <input type="checkbox" id="esa-4" class="esa-sr">
+      <div class="esa-row">
+        <label for="esa-4" class="esa-row__head">
+          <span class="esa-row__title">Does it work on mobile?</span>
+          <span class="esa-row__icon"></span>
+        </label>
+        <div class="esa-row__body">
+          <p class="esa-row__text">The accordion is fully responsive and adapts to any screen size. Touch targets are appropriately sized for mobile interaction.</p>
+        </div>
+      </div>
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/elastic-slide-accordion-saas/style.css
+++ b/submissions/examples/elastic-slide-accordion-saas/style.css
@@ -1,0 +1,199 @@
+:root {
+  --esa-white: #ffffff;
+  --esa-bg: #f5f5f7;
+  --esa-text: #1d1d1f;
+  --esa-muted: #6e6e73;
+  --esa-border: #d2d2d7;
+  --esa-accent: #5856d6;
+  --esa-accent-light: rgba(88, 86, 214, 0.06);
+  --esa-radius: 10px;
+}
+
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  background: var(--esa-bg);
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Inter", sans-serif;
+  color: var(--esa-text);
+  line-height: 1.55;
+}
+
+/* ── nav ────────────────────────────────────────── */
+
+.esa-nav {
+  display: flex;
+  align-items: center;
+  height: 48px;
+  padding: 0 22px;
+  background: var(--esa-white);
+  border-bottom: 1px solid var(--esa-border);
+}
+
+.esa-nav__logo {
+  font-size: 0.8rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+}
+
+.esa-nav__fill {
+  flex: 1;
+}
+
+.esa-nav__item {
+  font-size: 0.7rem;
+  color: var(--esa-muted);
+  margin-left: 18px;
+  cursor: pointer;
+}
+
+.esa-nav__item:hover {
+  color: var(--esa-text);
+}
+
+/* ── wrap ───────────────────────────────────────── */
+
+.esa-wrap {
+  max-width: 540px;
+  margin: 0 auto;
+  padding: 64px 22px 80px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.esa-heading {
+  font-size: clamp(1.3rem, 3.5vw, 1.8rem);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  text-align: center;
+}
+
+.esa-sub {
+  font-size: 0.72rem;
+  color: var(--esa-muted);
+  max-width: 42ch;
+  text-align: center;
+  margin-top: 8px;
+  line-height: 1.7;
+  margin-bottom: 36px;
+}
+
+/* ── accordion ──────────────────────────────────── */
+
+.esa-acc {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.esa-sr {
+  position: fixed;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.esa-row {
+  background: var(--esa-white);
+  border: 1px solid var(--esa-border);
+  border-radius: var(--esa-radius);
+  overflow: hidden;
+}
+
+/* ── header ─────────────────────────────────────── */
+
+.esa-row__head {
+  display: flex;
+  align-items: center;
+  padding: 14px 18px;
+  cursor: pointer;
+  user-select: none;
+  transition: background 0.15s ease;
+}
+
+.esa-row__head:hover {
+  background: var(--esa-accent-light);
+}
+
+.esa-row__title {
+  flex: 1;
+  font-size: 0.76rem;
+  font-weight: 600;
+}
+
+.esa-row__icon {
+  position: relative;
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+}
+
+.esa-row__icon::before,
+.esa-row__icon::after {
+  content: "";
+  position: absolute;
+  background: var(--esa-muted);
+  border-radius: 1px;
+}
+
+.esa-row__icon::before {
+  width: 12px;
+  height: 2px;
+  top: 8px;
+  left: 3px;
+  transition: transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.esa-row__icon::after {
+  width: 2px;
+  height: 12px;
+  top: 3px;
+  left: 8px;
+  transition: transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* ── body ───────────────────────────────────────── */
+
+.esa-row__body {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.45s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.esa-row__text {
+  padding: 0 18px 16px;
+  font-size: 0.72rem;
+  color: var(--esa-muted);
+  line-height: 1.7;
+}
+
+/* ── checked states ─────────────────────────────── */
+
+.esa-sr:checked + .esa-row .esa-row__body {
+  max-height: 200px;
+}
+
+.esa-sr:checked + .esa-row .esa-row__icon::after {
+  transform: rotate(90deg);
+}
+
+.esa-sr:checked + .esa-row .esa-row__head {
+  border-bottom: 1px solid var(--esa-border);
+}
+
+/* ── reduced motion ─────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .esa-row__body,
+  .esa-row__icon::before,
+  .esa-row__icon::after {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Closes #62065

Adds a CSS elastic-slide accordion for SaaS showcase layouts.

**What this does:**
- Pure CSS accordion using checkbox inputs
- Panels slide open with elastic cubic-bezier timing that overshoots
- Content stretches slightly beyond target then snaps back
- Plus icon rotates into X with same spring easing
- First panel starts open by default
- No JavaScript

**Files added:**
- submissions/examples/elastic-slide-accordion-saas/demo.html
- submissions/examples/elastic-slide-accordion-saas/style.css
- submissions/examples/elastic-slide-accordion-saas/README.md