### PR TITLE
feat: scale-hover hero section for SaaS showcase layouts

### DIFF
--- a/submissions/examples/scale-hover-hero-saas/README.md
+++ b/submissions/examples/scale-hover-hero-saas/README.md
@@ -1,0 +1,23 @@
+# Scale-Hover Hero — SaaS Showcase
+
+A SaaS-style hero section with scale-on-hover cards and buttons. Interactive elements scale up smoothly using an elastic cubic-bezier timing function.
+
+## How It Works
+
+The hero section uses a centered layout with an eyebrow badge, headline, description, and two CTA buttons. The primary button and ghost button both scale up to 1.05x on hover. The feature cards below scale to 1.03x with a subtle shadow lift.
+
+The `cubic-bezier(0.34, 1.56, 0.64, 1)` timing gives the scale a slight overshoot — elements pop up slightly past their target size then settle, which feels snappy and responsive.
+
+## Customization
+
+- Change `--shh-violet` for a different brand color
+- Adjust the `scale()` values for more or less dramatic hover
+- The border-radius and shadow can be tuned for different densities
+- Add more cards to the grid — the layout adapts automatically
+
+## Notes
+
+- Pure HTML + CSS, no JavaScript
+- `prefers-reduced-motion` disables all hover transitions
+- Fully responsive from mobile to wide desktop
+- Grid adapts via `auto-fit` and `minmax`

--- a/submissions/examples/scale-hover-hero-saas/demo.html
+++ b/submissions/examples/scale-hover-hero-saas/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS scale-hover hero section for SaaS showcase layouts">
+  <title>Scale-Hover Hero — SaaS Showcase</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <nav class="shh-nav">
+    <span class="shh-nav__brand">Cloudly</span>
+    <span class="shh-nav__gap"></span>
+    <span class="shh-nav__link">Product</span>
+    <span class="shh-nav__link">Pricing</span>
+    <span class="shh-nav__link">Blog</span>
+  </nav>
+
+  <section class="shh-hero">
+    <p class="shh-hero__eyebrow">Now in public beta</p>
+    <h1 class="shh-hero__title">Ship faster with<br>less friction</h1>
+    <p class="shh-hero__desc">A developer platform that handles the boring stuff so you can focus on building great products. Deploys in seconds, scales automatically.</p>
+    <div class="shh-hero__btns">
+      <a href="#" class="shh-btn shh-btn--primary">Get Started Free</a>
+      <a href="#" class="shh-btn shh-btn--ghost">View Docs</a>
+    </div>
+  </section>
+
+  <section class="shh-cards">
+    <div class="shh-card">
+      <span class="shh-card__icon">01</span>
+      <h3 class="shh-card__h">Push & Deploy</h3>
+      <p class="shh-card__p">Push to git and your site goes live. Zero config deploys with automatic SSL and edge caching.</p>
+    </div>
+    <div class="shh-card">
+      <span class="shh-card__icon">02</span>
+      <h3 class="shh-card__h">Scale Automatically</h3>
+      <p class="shh-card__p">From zero to millions of requests. No capacity planning, no cold starts, no surprises on the bill.</p>
+    </div>
+    <div class="shh-card">
+      <span class="shh-card__icon">03</span>
+      <h3 class="shh-card__h">Observe Everything</h3>
+      <p class="shh-card__p">Real-time logs, metrics, and traces. Know exactly what's happening in production at all times.</p>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/scale-hover-hero-saas/style.css
+++ b/submissions/examples/scale-hover-hero-saas/style.css
@@ -1,0 +1,205 @@
+:root {
+  --shh-white: #ffffff;
+  --shh-bg: #fafafa;
+  --shh-text: #111827;
+  --shh-muted: #6b7280;
+  --shh-border: #e5e7eb;
+  --shh-violet: #7c3aed;
+  --shh-violet-hover: #6d28d9;
+  --shh-violet-bg: rgba(124, 58, 237, 0.05);
+  --shh-radius: 10px;
+}
+
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  background: var(--shh-bg);
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--shh-text);
+  line-height: 1.55;
+}
+
+/* ── nav ────────────────────────────────────────── */
+
+.shh-nav {
+  display: flex;
+  align-items: center;
+  height: 52px;
+  padding: 0 28px;
+  background: var(--shh-white);
+  border-bottom: 1px solid var(--shh-border);
+}
+
+.shh-nav__brand {
+  font-size: 0.84rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+
+.shh-nav__gap {
+  flex: 1;
+}
+
+.shh-nav__link {
+  font-size: 0.72rem;
+  color: var(--shh-muted);
+  margin-left: 20px;
+  cursor: pointer;
+}
+
+.shh-nav__link:hover {
+  color: var(--shh-text);
+}
+
+/* ── hero ───────────────────────────────────────── */
+
+.shh-hero {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 80px 28px 48px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+}
+
+.shh-hero__eyebrow {
+  font-size: 0.68rem;
+  font-weight: 600;
+  color: var(--shh-violet);
+  background: var(--shh-violet-bg);
+  padding: 4px 12px;
+  border-radius: 20px;
+  letter-spacing: 0.02em;
+}
+
+.shh-hero__title {
+  font-size: clamp(1.6rem, 4.5vw, 2.4rem);
+  font-weight: 800;
+  letter-spacing: -0.04em;
+  line-height: 1.15;
+}
+
+.shh-hero__desc {
+  font-size: 0.78rem;
+  color: var(--shh-muted);
+  max-width: 46ch;
+  line-height: 1.7;
+}
+
+.shh-hero__btns {
+  display: flex;
+  gap: 10px;
+  margin-top: 8px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+/* ── btn ────────────────────────────────────────── */
+
+.shh-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 22px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  border-radius: var(--shh-radius);
+  text-decoration: none;
+  cursor: pointer;
+  transition: transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1),
+              box-shadow 0.2s ease,
+              background 0.2s ease;
+}
+
+.shh-btn--primary {
+  background: var(--shh-violet);
+  color: var(--shh-white);
+}
+
+.shh-btn--primary:hover {
+  transform: scale(1.05);
+  box-shadow: 0 6px 20px rgba(124, 58, 237, 0.3);
+  background: var(--shh-violet-hover);
+}
+
+.shh-btn--ghost {
+  background: transparent;
+  color: var(--shh-muted);
+  border: 1px solid var(--shh-border);
+}
+
+.shh-btn--ghost:hover {
+  transform: scale(1.05);
+  border-color: #d1d5db;
+  color: var(--shh-text);
+}
+
+/* ── cards ──────────────────────────────────────── */
+
+.shh-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 16px;
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 32px 28px 80px;
+}
+
+.shh-card {
+  background: var(--shh-white);
+  border: 1px solid var(--shh-border);
+  border-radius: var(--shh-radius);
+  padding: 22px;
+  transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1),
+              box-shadow 0.25s ease;
+  cursor: default;
+}
+
+.shh-card:hover {
+  transform: scale(1.03);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.08);
+}
+
+.shh-card__icon {
+  display: inline-block;
+  font-size: 0.68rem;
+  font-weight: 800;
+  color: var(--shh-violet);
+  background: var(--shh-violet-bg);
+  width: 30px;
+  height: 30px;
+  line-height: 30px;
+  text-align: center;
+  border-radius: 8px;
+  margin-bottom: 12px;
+}
+
+.shh-card__h {
+  font-size: 0.8rem;
+  font-weight: 700;
+  margin-bottom: 6px;
+}
+
+.shh-card__p {
+  font-size: 0.7rem;
+  color: var(--shh-muted);
+  line-height: 1.65;
+}
+
+/* ── reduced motion ─────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .shh-btn,
+  .shh-card {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Closes #62106

Adds a CSS scale-hover hero section for SaaS showcase layouts.

**What this does:**
- SaaS-style hero with eyebrow badge, headline, and dual CTAs
- Buttons scale to 1.05x on hover with elastic cubic-bezier
- Feature cards scale to 1.03x with shadow lift on hover
- Elastic overshoot timing for snappy interaction feel
- Fully responsive grid layout
- No JavaScript

**Files added:**
- submissions/examples/scale-hover-hero-saas/demo.html
- submissions/examples/scale-hover-hero-saas/style.css
- submissions/examples/scale-hover-hero-saas/README.md