### PR TITLE
feat: blur-entrance pricing table for SaaS showcase layouts

### DIFF
--- a/submissions/examples/blur-entrance-pricing-saas/README.md
+++ b/submissions/examples/blur-entrance-pricing-saas/README.md
@@ -1,0 +1,23 @@
+# Blur-Entrance Pricing Table — SaaS Showcase
+
+A pricing table where each card blurs in from a frosted state. Cards start with `filter: blur(12px)`, reduced opacity, and a downward offset, then resolve into focus with a staggered animation.
+
+## How It Works
+
+Three cards use a `@keyframes` animation that transitions from `blur(12px) opacity: 0 translateY(20px)` to `blur(0) opacity: 1 translateY(0)`. Each card has a different `animation-delay` so they enter in sequence — left to right, one after another.
+
+The blur creates a soft reveal effect, like cards materializing through fog. The staggered timing gives the entrance a rhythmic feel without being distracting.
+
+## Customization
+
+- Change `--bep-indigo` for a different accent color
+- Adjust the `animation-delay` offsets for faster or slower staggering
+- Modify the initial `blur()` and `translateY()` values for different entrance intensity
+- The featured card has a higher `padding-top` to accommodate the badge
+
+## Notes
+
+- Pure HTML + CSS, no JavaScript
+- `prefers-reduced-motion` disables the entrance animation while keeping cards fully visible
+- Responsive grid adapts from 3 columns to fewer on smaller screens
+- Featured card highlighted with accent border and shadow

--- a/submissions/examples/blur-entrance-pricing-saas/demo.html
+++ b/submissions/examples/blur-entrance-pricing-saas/demo.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS blur-entrance pricing table for SaaS showcase layouts">
+  <title>Blur-Entrance Pricing — SaaS Showcase</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <nav class="bep-nav">
+    <span class="bep-nav__brand">Finova</span>
+    <span class="bep-nav__gap"></span>
+    <span class="bep-nav__item">Product</span>
+    <span class="bep-nav__item">Solutions</span>
+    <span class="bep-nav__item">Pricing</span>
+  </nav>
+
+  <section class="bep-hero">
+    <h1 class="bep-hero__title">Simple, transparent pricing</h1>
+    <p class="bep-hero__sub">Pick the plan that fits your team. Upgrade or downgrade at any time.</p>
+  </section>
+
+  <section class="bep-grid">
+    <div class="bep-card">
+      <span class="bep-card__tier">Starter</span>
+      <p class="bep-card__price"><span class="bep-card__dollar">$</span>0<span class="bep-card__mo">/mo</span></p>
+      <p class="bep-card__desc">For side projects and experiments.</p>
+      <ul class="bep-card__list">
+        <li>1 project</li>
+        <li>1 GB storage</li>
+        <li>Community support</li>
+      </ul>
+      <a href="#" class="bep-card__cta">Start Free</a>
+    </div>
+
+    <div class="bep-card bep-card--featured">
+      <span class="bep-card__badge">Popular</span>
+      <span class="bep-card__tier">Pro</span>
+      <p class="bep-card__price"><span class="bep-card__dollar">$</span>29<span class="bep-card__mo">/mo</span></p>
+      <p class="bep-card__desc">For growing teams shipping fast.</p>
+      <ul class="bep-card__list">
+        <li>Unlimited projects</li>
+        <li>50 GB storage</li>
+        <li>Priority support</li>
+        <li>Custom domains</li>
+      </ul>
+      <a href="#" class="bep-card__cta bep-card__cta--accent">Get Pro</a>
+    </div>
+
+    <div class="bep-card">
+      <span class="bep-card__tier">Enterprise</span>
+      <p class="bep-card__price"><span class="bep-card__dollar">$</span>99<span class="bep-card__mo">/mo</span></p>
+      <p class="bep-card__desc">For orgs that need control and scale.</p>
+      <ul class="bep-card__list">
+        <li>Everything in Pro</li>
+        <li>Unlimited storage</li>
+        <li>Dedicated support</li>
+        <li>SSO &amp; audit logs</li>
+      </ul>
+      <a href="#" class="bep-card__cta">Contact Sales</a>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/blur-entrance-pricing-saas/style.css
+++ b/submissions/examples/blur-entrance-pricing-saas/style.css
@@ -1,0 +1,238 @@
+:root {
+  --bep-white: #ffffff;
+  --bep-bg: #f8f9fb;
+  --bep-text: #111827;
+  --bep-muted: #6b7280;
+  --bep-border: #e5e7eb;
+  --bep-indigo: #4f46e5;
+  --bep-indigo-hover: #4338ca;
+  --bep-indigo-bg: rgba(79, 70, 229, 0.06);
+  --bep-radius: 12px;
+}
+
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  background: var(--bep-bg);
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--bep-text);
+  line-height: 1.55;
+}
+
+/* ── nav ────────────────────────────────────────── */
+
+.bep-nav {
+  display: flex;
+  align-items: center;
+  height: 50px;
+  padding: 0 28px;
+  background: var(--bep-white);
+  border-bottom: 1px solid var(--bep-border);
+}
+
+.bep-nav__brand {
+  font-size: 0.82rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+
+.bep-nav__gap {
+  flex: 1;
+}
+
+.bep-nav__item {
+  font-size: 0.72rem;
+  color: var(--bep-muted);
+  margin-left: 20px;
+  cursor: pointer;
+}
+
+.bep-nav__item:hover {
+  color: var(--bep-text);
+}
+
+/* ── hero ───────────────────────────────────────── */
+
+.bep-hero {
+  text-align: center;
+  padding: 64px 28px 16px;
+}
+
+.bep-hero__title {
+  font-size: clamp(1.3rem, 3.5vw, 1.8rem);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+}
+
+.bep-hero__sub {
+  font-size: 0.74rem;
+  color: var(--bep-muted);
+  margin-top: 8px;
+}
+
+/* ── grid ───────────────────────────────────────── */
+
+.bep-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 18px;
+  max-width: 740px;
+  margin: 0 auto;
+  padding: 40px 28px 80px;
+  align-items: start;
+}
+
+/* ── card ───────────────────────────────────────── */
+
+.bep-card {
+  background: var(--bep-white);
+  border: 1px solid var(--bep-border);
+  border-radius: var(--bep-radius);
+  padding: 28px 24px;
+  position: relative;
+  opacity: 0;
+  filter: blur(12px);
+  transform: translateY(20px);
+  animation: bep-in 0.5s ease forwards;
+}
+
+.bep-card:nth-child(1) { animation-delay: 0s; }
+.bep-card:nth-child(2) { animation-delay: 0.12s; }
+.bep-card:nth-child(3) { animation-delay: 0.24s; }
+
+@keyframes bep-in {
+  to {
+    opacity: 1;
+    filter: blur(0);
+    transform: translateY(0);
+  }
+}
+
+.bep-card--featured {
+  border-color: var(--bep-indigo);
+  box-shadow: 0 4px 24px rgba(79, 70, 229, 0.1);
+  padding-top: 36px;
+}
+
+.bep-card__badge {
+  position: absolute;
+  top: -1px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--bep-indigo);
+  color: var(--bep-white);
+  font-size: 0.6rem;
+  font-weight: 700;
+  padding: 3px 12px;
+  border-radius: 0 0 8px 8px;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.bep-card__tier {
+  display: block;
+  font-size: 0.78rem;
+  font-weight: 700;
+  margin-bottom: 12px;
+}
+
+.bep-card__price {
+  font-size: 2rem;
+  font-weight: 800;
+  letter-spacing: -0.04em;
+  line-height: 1;
+  margin-bottom: 8px;
+}
+
+.bep-card__dollar {
+  font-size: 0.9rem;
+  font-weight: 600;
+  vertical-align: super;
+}
+
+.bep-card__mo {
+  font-size: 0.72rem;
+  font-weight: 500;
+  color: var(--bep-muted);
+}
+
+.bep-card__desc {
+  font-size: 0.7rem;
+  color: var(--bep-muted);
+  margin-bottom: 18px;
+  line-height: 1.6;
+}
+
+.bep-card__list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 22px;
+}
+
+.bep-card__list li {
+  font-size: 0.7rem;
+  color: var(--bep-muted);
+  padding-left: 18px;
+  position: relative;
+}
+
+.bep-card__list li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 6px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--bep-indigo-bg);
+  border: 1.5px solid var(--bep-indigo);
+}
+
+.bep-card__cta {
+  display: block;
+  text-align: center;
+  padding: 10px 0;
+  font-size: 0.72rem;
+  font-weight: 600;
+  border-radius: 8px;
+  border: 1px solid var(--bep-border);
+  color: var(--bep-text);
+  text-decoration: none;
+  transition: background 0.15s ease, transform 0.15s ease;
+}
+
+.bep-card__cta:hover {
+  background: var(--bep-bg);
+  transform: translateY(-1px);
+}
+
+.bep-card__cta--accent {
+  background: var(--bep-indigo);
+  color: var(--bep-white);
+  border: none;
+}
+
+.bep-card__cta--accent:hover {
+  background: var(--bep-indigo-hover);
+  box-shadow: 0 4px 14px rgba(79, 70, 229, 0.3);
+}
+
+/* ── reduced motion ─────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .bep-card {
+    animation: none;
+    opacity: 1;
+    filter: none;
+    transform: none;
+  }
+}


### PR DESCRIPTION
Closes #62124

Adds a CSS blur-entrance pricing table for SaaS showcase layouts.

**What this does:**
- Three-column pricing table with staggered blur entrance
- Cards start at blur(12px) with opacity 0 and translateY offset
- Resolve into focus with staggered animation delays
- Featured "Popular" card highlighted with accent border and shadow
- Responsive grid layout
- No JavaScript

**Files added:**
- submissions/examples/blur-entrance-pricing-saas/demo.html
- submissions/examples/blur-entrance-pricing-saas/style.css
- submissions/examples/blur-entrance-pricing-saas/README.md