### PR TITLE
feat: fade-in pricing table for SaaS showcase layouts

### DIFF
--- a/submissions/examples/fade-in-pricing-saas/README.md
+++ b/submissions/examples/fade-in-pricing-saas/README.md
@@ -1,0 +1,23 @@
+# Fade-In Pricing Table — SaaS Showcase
+
+A pricing table where each card fades in from a slightly offset position. Cards start with `opacity: 0` and `translateY(14px)`, then slide up and fade into place with staggered timing.
+
+## How It Works
+
+Three pricing cards use a `@keyframes` animation that transitions from transparent and slightly below to fully visible at their natural position. Each card has a different `animation-delay` so they enter one after another — a subtle cascade effect.
+
+The fade-in is intentionally understated compared to blur or scale entrances. It gives a clean, professional feel that works well for pricing sections where you don't want the animation to distract from the content.
+
+## Customization
+
+- Change `--fip-teal` for a different accent color
+- Adjust `animation-delay` values for faster or slower staggering
+- Modify the initial `translateY()` for more vertical offset
+- The featured card has extra top padding to make room for the ribbon badge
+
+## Notes
+
+- Pure HTML + CSS, no JavaScript
+- `prefers-reduced-motion` disables the entrance animation
+- Responsive grid adapts to screen width
+- Featured card highlighted with accent border and shadow

--- a/submissions/examples/fade-in-pricing-saas/demo.html
+++ b/submissions/examples/fade-in-pricing-saas/demo.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS fade-in pricing table for SaaS showcase layouts">
+  <title>Fade-In Pricing — SaaS Showcase</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <nav class="fip-nav">
+    <span class="fip-nav__brand">Apex</span>
+    <span class="fip-nav__gap"></span>
+    <span class="fip-nav__item">Product</span>
+    <span class="fip-nav__item">Changelog</span>
+    <span class="fip-nav__item">Pricing</span>
+  </nav>
+
+  <section class="fip-hero">
+    <h1 class="fip-hero__title">Choose your plan</h1>
+    <p class="fip-hero__sub">No hidden fees. Cancel anytime. All plans include a 14-day free trial.</p>
+  </section>
+
+  <section class="fip-grid">
+    <div class="fip-card">
+      <span class="fip-card__name">Solo</span>
+      <p class="fip-card__price">$0<small>/mo</small></p>
+      <p class="fip-card__desc">Good for personal projects and side hustles.</p>
+      <ul class="fip-card__feats">
+        <li>1 workspace</li>
+        <li>500 MB storage</li>
+        <li>Basic analytics</li>
+      </ul>
+      <a href="#" class="fip-card__btn">Get Started</a>
+    </div>
+
+    <div class="fip-card fip-card--hot">
+      <span class="fip-card__ribbon">Best Value</span>
+      <span class="fip-card__name">Team</span>
+      <p class="fip-card__price">$29<small>/mo</small></p>
+      <p class="fip-card__desc">For teams that ship features every week.</p>
+      <ul class="fip-card__feats">
+        <li>Unlimited workspaces</li>
+        <li>25 GB storage</li>
+        <li>Advanced analytics</li>
+        <li>Priority support</li>
+      </ul>
+      <a href="#" class="fip-card__btn fip-card__btn--fill">Start Free Trial</a>
+    </div>
+
+    <div class="fip-card">
+      <span class="fip-card__name">Scale</span>
+      <p class="fip-card__price">$79<small>/mo</small></p>
+      <p class="fip-card__desc">For companies that need reliability and compliance.</p>
+      <ul class="fip-card__feats">
+        <li>Everything in Team</li>
+        <li>Unlimited storage</li>
+        <li>SSO &amp; SAML</li>
+        <li>Dedicated account manager</li>
+      </ul>
+      <a href="#" class="fip-card__btn">Contact Sales</a>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/fade-in-pricing-saas/style.css
+++ b/submissions/examples/fade-in-pricing-saas/style.css
@@ -1,0 +1,229 @@
+:root {
+  --fip-white: #ffffff;
+  --fip-bg: #fafafa;
+  --fip-text: #111827;
+  --fip-muted: #6b7280;
+  --fip-border: #e5e7eb;
+  --fip-teal: #0d9488;
+  --fip-teal-hover: #0f766e;
+  --fip-teal-bg: rgba(13, 148, 136, 0.06);
+  --fip-radius: 12px;
+}
+
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  background: var(--fip-bg);
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--fip-text);
+  line-height: 1.55;
+}
+
+/* ── nav ────────────────────────────────────────── */
+
+.fip-nav {
+  display: flex;
+  align-items: center;
+  height: 50px;
+  padding: 0 28px;
+  background: var(--fip-white);
+  border-bottom: 1px solid var(--fip-border);
+}
+
+.fip-nav__brand {
+  font-size: 0.82rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+
+.fip-nav__gap {
+  flex: 1;
+}
+
+.fip-nav__item {
+  font-size: 0.72rem;
+  color: var(--fip-muted);
+  margin-left: 20px;
+  cursor: pointer;
+}
+
+.fip-nav__item:hover {
+  color: var(--fip-text);
+}
+
+/* ── hero ───────────────────────────────────────── */
+
+.fip-hero {
+  text-align: center;
+  padding: 64px 28px 16px;
+}
+
+.fip-hero__title {
+  font-size: clamp(1.3rem, 3.5vw, 1.8rem);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+}
+
+.fip-hero__sub {
+  font-size: 0.74rem;
+  color: var(--fip-muted);
+  margin-top: 8px;
+}
+
+/* ── grid ───────────────────────────────────────── */
+
+.fip-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 18px;
+  max-width: 740px;
+  margin: 0 auto;
+  padding: 40px 28px 80px;
+  align-items: start;
+}
+
+/* ── card ───────────────────────────────────────── */
+
+.fip-card {
+  background: var(--fip-white);
+  border: 1px solid var(--fip-border);
+  border-radius: var(--fip-radius);
+  padding: 28px 24px;
+  position: relative;
+  opacity: 0;
+  transform: translateY(14px);
+  animation: fip-up 0.45s ease forwards;
+}
+
+.fip-card:nth-child(1) { animation-delay: 0s; }
+.fip-card:nth-child(2) { animation-delay: 0.1s; }
+.fip-card:nth-child(3) { animation-delay: 0.2s; }
+
+@keyframes fip-up {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.fip-card--hot {
+  border-color: var(--fip-teal);
+  box-shadow: 0 4px 20px rgba(13, 148, 136, 0.1);
+  padding-top: 36px;
+}
+
+.fip-card__ribbon {
+  position: absolute;
+  top: -1px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--fip-teal);
+  color: var(--fip-white);
+  font-size: 0.6rem;
+  font-weight: 700;
+  padding: 3px 12px;
+  border-radius: 0 0 8px 8px;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.fip-card__name {
+  display: block;
+  font-size: 0.78rem;
+  font-weight: 700;
+  margin-bottom: 12px;
+}
+
+.fip-card__price {
+  font-size: 2rem;
+  font-weight: 800;
+  letter-spacing: -0.04em;
+  line-height: 1;
+  margin-bottom: 8px;
+}
+
+.fip-card__price small {
+  font-size: 0.72rem;
+  font-weight: 500;
+  color: var(--fip-muted);
+}
+
+.fip-card__desc {
+  font-size: 0.7rem;
+  color: var(--fip-muted);
+  margin-bottom: 18px;
+  line-height: 1.6;
+}
+
+.fip-card__feats {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 22px;
+}
+
+.fip-card__feats li {
+  font-size: 0.7rem;
+  color: var(--fip-muted);
+  padding-left: 18px;
+  position: relative;
+}
+
+.fip-card__feats li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 6px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--fip-teal-bg);
+  border: 1.5px solid var(--fip-teal);
+}
+
+.fip-card__btn {
+  display: block;
+  text-align: center;
+  padding: 10px 0;
+  font-size: 0.72rem;
+  font-weight: 600;
+  border-radius: 8px;
+  border: 1px solid var(--fip-border);
+  color: var(--fip-text);
+  text-decoration: none;
+  transition: background 0.15s ease, transform 0.15s ease;
+}
+
+.fip-card__btn:hover {
+  background: var(--fip-bg);
+  transform: translateY(-1px);
+}
+
+.fip-card__btn--fill {
+  background: var(--fip-teal);
+  color: var(--fip-white);
+  border: none;
+}
+
+.fip-card__btn--fill:hover {
+  background: var(--fip-teal-hover);
+  box-shadow: 0 4px 14px rgba(13, 148, 136, 0.3);
+}
+
+/* ── reduced motion ─────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .fip-card {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}


### PR DESCRIPTION
Closes #62118

Adds a CSS fade-in pricing table for SaaS showcase layouts.

**What this does:**
- Three-column pricing table with staggered fade-in entrance
- Cards start at opacity 0 with translateY(14px) offset
- Fade and slide up into position with staggered delays
- Featured "Best Value" card highlighted with accent border
- Responsive grid layout
- No JavaScript

**Files added:**
- submissions/examples/fade-in-pricing-saas/demo.html
- submissions/examples/fade-in-pricing-saas/style.css
- submissions/examples/fade-in-pricing-saas/README.md