### PR TITLE
feat: add ease-fade-in-popover component (#64442)

### DIFF
--- a/submissions/examples/ease-fade-in-popover-sbh/README.md
+++ b/submissions/examples/ease-fade-in-popover-sbh/README.md
@@ -1,0 +1,45 @@
+# ease-fade-in-popover
+
+A minimal popover that fades and lifts into view when triggered, and fades out on dismiss. Built for clean, minimalist tech layouts.
+
+## What does this do?
+
+Adds a **fade-in popover** component: clicking a trigger button reveals a small floating panel that smoothly fades in (opacity + subtle upward lift) and fades out when dismissed via the close button, an outside click, or the `Escape` key.
+
+## How is it used?
+
+1. Wrap a trigger button and a `.popover` panel inside a `.popover-wrap` container.
+2. Link them with `data-popover="pop-id"` on the button and `id="pop-id"` on the panel.
+3. Include a `[data-close]` button inside the popover for an explicit dismiss control.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<div class="popover-wrap">
+  <button type="button" class="trigger" data-popover="pop-info" aria-expanded="false" aria-controls="pop-info">Show details</button>
+  <div id="pop-info" class="popover" role="dialog" hidden>
+    <p class="popover__title">Title</p>
+    <p class="popover__text">Your popover content here.</p>
+    <button type="button" class="popover__close" data-close aria-label="Close popover">&times;</button>
+  </div>
+</div>
+```
+
+A tiny inline script toggles the `is-open` class and the `hidden` attribute, handles outside-click + `Esc` dismissal, and keeps `aria-expanded` in sync for screen readers.
+
+## Why is this useful?
+
+- **Animation-first** — the fade + lift is the defining interaction, using CSS transitions on `opacity` and `transform` for GPU-friendly motion.
+- **Minimalist tech aesthetic** — dark, low-chrome panel that fits developer-tool / dashboard layouts.
+- **Accessible** — proper `role="dialog"`, `aria-expanded`, `aria-controls`, keyboard (`Esc`) dismiss, `:focus-visible` outlines, and full `prefers-reduced-motion` support (motion disabled when requested).
+- **Reusable** — configurable via CSS custom properties (`--pop-fade-duration`, `--pop-fade-ease`, `--pop-bg`, `--pop-radius`, `--pop-shadow`).
+
+## Files
+
+- `demo.html` — self-contained interactive demo (open directly in a browser; no server, CDNs, or frameworks).
+- `style.css` — popover styles, trigger variants, responsive + reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-fade-in-popover-sbh/demo.html
+++ b/submissions/examples/ease-fade-in-popover-sbh/demo.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-fade-in-popover — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-fade-in-popover</h1>
+      <p>Click a trigger to reveal a popover with a smooth fade + lift. Click again, elsewhere, or press Esc to dismiss.</p>
+    </header>
+
+    <section class="demo" aria-label="Fade-in popover demos">
+      <div class="popover-wrap">
+        <button type="button" class="trigger" aria-expanded="false" aria-controls="pop-info" data-popover="pop-info">Show details</button>
+        <div id="pop-info" class="popover" role="dialog" aria-modal="false" aria-label="Details popover" hidden>
+          <p class="popover__title">Project status</p>
+          <p class="popover__text">All systems nominal. The fade-in popover softly lifts into view with adjustable opacity and transform.</p>
+          <button type="button" class="popover__close" data-close aria-label="Close popover">&times;</button>
+        </div>
+      </div>
+
+      <div class="popover-wrap">
+        <button type="button" class="trigger trigger--alt" aria-expanded="false" aria-controls="pop-tip" data-popover="pop-tip">Tip</button>
+        <div id="pop-tip" class="popover popover--tip" role="tooltip" hidden>
+          <p class="popover__text">Press <kbd>Esc</kbd> to close any open popover.</p>
+          <button type="button" class="popover__close" data-close aria-label="Close popover">&times;</button>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    (function () {
+      var triggers = document.querySelectorAll('[data-popover]');
+      var open = null;
+
+      function show(btn) {
+        var id = btn.getAttribute('data-popover');
+        var pop = document.getElementById(id);
+        if (!pop) return;
+        hide();
+        pop.hidden = false;
+        btn.setAttribute('aria-expanded', 'true');
+        requestAnimationFrame(function () { pop.classList.add('is-open'); });
+        open = { btn: btn, pop: pop };
+      }
+
+      function hide() {
+        if (!open) return;
+        var pop = open.pop, btn = open.btn;
+        pop.classList.remove('is-open');
+        btn.setAttribute('aria-expanded', 'false');
+        pop.addEventListener('transitionend', function h() {
+          pop.removeEventListener('transitionend', h);
+          pop.hidden = true;
+        });
+        open = null;
+      }
+
+      triggers.forEach(function (btn) {
+        btn.addEventListener('click', function (e) {
+          e.stopPropagation();
+          if (open && open.btn === btn) { hide(); } else { show(btn); }
+        });
+      });
+
+      document.querySelectorAll('[data-close]').forEach(function (c) {
+        c.addEventListener('click', hide);
+      });
+
+      document.addEventListener('click', function (e) {
+        if (open && !open.pop.contains(e.target) && !open.btn.contains(e.target)) hide();
+      });
+
+      document.addEventListener('keydown', function (e) {
+        if (e.key === 'Escape' && open) hide();
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-fade-in-popover-sbh/style.css
+++ b/submissions/examples/ease-fade-in-popover-sbh/style.css
@@ -1,0 +1,132 @@
+:root {
+  --pop-fade-duration: 0.28s;
+  --pop-fade-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --pop-bg: #141a24;
+  --pop-fg: #e8edf5;
+  --pop-muted: #8a94a6;
+  --pop-accent: #6ea8ff;
+  --pop-radius: 0.75rem;
+  --pop-shadow: 0 18px 40px -16px rgba(0, 0, 0, 0.6);
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 25%, #161d29, #0a0d13 70%);
+  color: var(--pop-fg);
+}
+
+.page__intro { text-align: center; max-width: 36rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, #6ea8ff, #b388ff);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+
+.demo {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  align-items: flex-start;
+  justify-content: center;
+}
+
+.popover-wrap {
+  position: relative;
+  display: inline-block;
+}
+
+.trigger {
+  font: inherit;
+  font-weight: 600;
+  padding: 0.7rem 1.4rem;
+  border-radius: 0.6rem;
+  border: 1px solid rgba(110, 168, 255, 0.4);
+  background: linear-gradient(135deg, #4f7bff, #8a5bff);
+  color: #fff;
+  cursor: pointer;
+  transition: transform 0.2s var(--pop-fade-ease), box-shadow 0.2s var(--pop-fade-ease);
+}
+.trigger:hover { transform: translateY(-1px); box-shadow: 0 10px 24px -10px rgba(79, 123, 255, 0.7); }
+.trigger:focus-visible { outline: 2px solid var(--pop-accent); outline-offset: 3px; }
+.trigger--alt {
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--pop-fg);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+.popover {
+  position: absolute;
+  top: calc(100% + 0.6rem);
+  left: 0;
+  z-index: 20;
+  min-width: 16rem;
+  max-width: 22rem;
+  padding: 1rem 1.1rem;
+  background: var(--pop-bg);
+  color: var(--pop-fg);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--pop-radius);
+  box-shadow: var(--pop-shadow);
+  opacity: 0;
+  transform: translateY(8px) scale(0.98);
+  transform-origin: top left;
+  transition: opacity var(--pop-fade-duration) var(--pop-fade-ease),
+              transform var(--pop-fade-duration) var(--pop-fade-ease);
+}
+.popover.is-open { opacity: 1; transform: translateY(0) scale(1); }
+
+.popover--tip { min-width: 12rem; left: 0; }
+
+.popover__title {
+  margin: 0 0 0.35rem;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--pop-accent);
+}
+.popover__text { margin: 0; font-size: 0.9rem; line-height: 1.55; color: var(--pop-muted); }
+.popover__text kbd {
+  font: inherit;
+  padding: 0.1rem 0.4rem;
+  border-radius: 0.3rem;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+.popover__close {
+  position: absolute;
+  top: 0.4rem;
+  right: 0.5rem;
+  border: none;
+  background: transparent;
+  color: var(--pop-muted);
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0.2rem 0.4rem;
+  border-radius: 0.3rem;
+  transition: color 0.15s ease, background 0.15s ease;
+}
+.popover__close:hover { color: var(--pop-fg); background: rgba(255, 255, 255, 0.08); }
+
+@media (max-width: 480px) {
+  .popover { left: 0; right: 0; min-width: 0; max-width: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .popover { transition: none; transform: none; }
+  .trigger:hover { transform: none; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-fade-in-popover** from issue #64442 — a popover that fades and lifts into view when triggered and fades out on dismiss (close button, outside click, or Esc).

Closes #64442.

## Feature

A fade-in popover with a minimalist dark aesthetic. Clicking a trigger reveals a floating panel that smoothly fades in (opacity + subtle upward lift) and fades out when dismissed.

## How it works

- A tiny inline script toggles the `is-open` class + `hidden` attribute, handles outside-click + `Esc` dismissal, and syncs `aria-expanded`.
- Motion is GPU-friendly: CSS transitions on `opacity` and `transform` only.

## Accessibility

- `role="dialog"`, `aria-expanded`, `aria-controls`, keyboard (`Esc`) dismiss, `:focus-visible` outlines.
- Full `prefers-reduced-motion` support (motion disabled when requested).
- Configurable via CSS custom properties (`--pop-fade-duration`, `--pop-fade-ease`, `--pop-bg`, `--pop-radius`).

## Submission structure

```
submissions/examples/ease-fade-in-popover-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← popover styles + trigger variants
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally