### PR TITLE
feat: add ease-3d-flip-popover component (#64446)

### DIFF
--- a/submissions/examples/ease-3d-flip-popover-sbh/README.md
+++ b/submissions/examples/ease-3d-flip-popover-sbh/README.md
@@ -1,0 +1,51 @@
+# ease-3d-flip-popover
+
+A popover that flips in 3D space (Y-axis rotation) to reveal details on the card's back face. Minimalist dark aesthetic for tech layouts.
+
+## What does this do?
+
+Adds a **3D flip popover**: each card has a front face (icon + title) and a back face (details). Clicking or pressing Enter/Space flips the card 180° around its vertical axis to reveal the back content; clicking again, pressing the close button, or pressing Escape flips it back.
+
+## How is it used?
+
+1. Use the `.flip` element as the card container with `tabindex="0"` and `role="button"` for keyboard access.
+2. Inside, place a `.flip__inner` wrapper holding two `.flip__face` elements: `--front` and `--back`.
+3. The back face holds a `[data-close]` button to flip back.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<article class="flip" tabindex="0" role="button" aria-pressed="false" aria-label="Flip card: Details">
+  <div class="flip__inner">
+    <div class="flip__face flip__face--front">
+      <span class="flip__icon">&#9728;</span>
+      <h2 class="flip__title">Details</h2>
+      <p class="flip__hint">Click to flip</p>
+    </div>
+    <div class="flip__face flip__face--back">
+      <h2 class="flip__title flip__title--back">Details</h2>
+      <p class="flip__text">Your revealed content here.</p>
+      <button type="button" class="flip__close" data-close aria-label="Flip back">&times;</button>
+    </div>
+  </div>
+</article>
+```
+
+A tiny inline script toggles the `is-flipped` class and syncs `aria-pressed`; it supports click, keyboard (Enter/Space/Escape), and the close button.
+
+## Why is this useful?
+
+- **Animation-first** — the defining interaction is a true 3D Y-axis flip using `transform-style: preserve-3d` and `rotateY(180deg)`, with `backface-visibility: hidden` for clean face culling.
+- **Minimalist tech aesthetic** — dark gradient cards suited to dashboards and developer tooling.
+- **Accessible** — `role="button"`, `aria-pressed`, full keyboard support, `:focus-visible` outlines, and `prefers-reduced-motion` (the flip still swaps faces via transform but with no transition duration).
+- **Reusable** — card size, duration, easing, and colors are configurable via CSS custom properties (`--flip-duration`, `--flip-ease`, `--flip-card-w`, `--flip-card-h`, `--flip-accent`).
+
+## Files
+
+- `demo.html` — self-contained interactive demo (open directly in a browser; no server, CDNs, or frameworks).
+- `style.css` — 3D flip card styles, faces, responsive + reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-3d-flip-popover-sbh/demo.html
+++ b/submissions/examples/ease-3d-flip-popover-sbh/demo.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-3d-flip-popover — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-3d-flip-popover</h1>
+      <p>Click a card to flip it in 3D and reveal details on the back. Click again to flip back.</p>
+    </header>
+
+    <section class="grid" aria-label="3D flip popover cards">
+      <article class="flip" tabindex="0" role="button" aria-pressed="false" aria-label="Flip card: Deployment">
+        <div class="flip__inner">
+          <div class="flip__face flip__face--front">
+            <span class="flip__icon" aria-hidden="true">&#9728;</span>
+            <h2 class="flip__title">Deployment</h2>
+            <p class="flip__hint">Click to flip</p>
+          </div>
+          <div class="flip__face flip__face--back">
+            <h2 class="flip__title flip__title--back">Deployment</h2>
+            <p class="flip__text">Ships to production via blue-green rollout. Rollback is automatic on health-check failure.</p>
+            <button type="button" class="flip__close" data-close aria-label="Flip back">&times;</button>
+          </div>
+        </div>
+      </article>
+
+      <article class="flip" tabindex="0" role="button" aria-pressed="false" aria-label="Flip card: Cache">
+        <div class="flip__inner">
+          <div class="flip__face flip__face--front">
+            <span class="flip__icon" aria-hidden="true">&#9889;</span>
+            <h2 class="flip__title">Cache</h2>
+            <p class="flip__hint">Click to flip</p>
+          </div>
+          <div class="flip__face flip__face--back">
+            <h2 class="flip__title flip__title--back">Cache</h2>
+            <p class="flip__text">Edge cache TTL is 60s with stale-while-revalidate. Invalidation propagates in under 2s.</p>
+            <button type="button" class="flip__close" data-close aria-label="Flip back">&times;</button>
+          </div>
+        </div>
+      </article>
+
+      <article class="flip" tabindex="0" role="button" aria-pressed="false" aria-label="Flip card: Telemetry">
+        <div class="flip__inner">
+          <div class="flip__face flip__face--front">
+            <span class="flip__icon" aria-hidden="true">&#128202;</span>
+            <h2 class="flip__title">Telemetry</h2>
+            <p class="flip__hint">Click to flip</p>
+          </div>
+          <div class="flip__face flip__face--back">
+            <h2 class="flip__title flip__title--back">Telemetry</h2>
+            <p class="flip__text">p95 latency is sampled at 5% with tail-based tracing. Dashboards refresh every 10s.</p>
+            <button type="button" class="flip__close" data-close aria-label="Flip back">&times;</button>
+          </div>
+        </div>
+      </article>
+    </section>
+  </main>
+
+  <script>
+    (function () {
+      document.querySelectorAll('.flip').forEach(function (card) {
+        function toggle() {
+          var open = card.classList.toggle('is-flipped');
+          card.setAttribute('aria-pressed', open ? 'true' : 'false');
+        }
+        card.addEventListener('click', function (e) {
+          if (e.target.closest('[data-close]')) { card.classList.remove('is-flipped'); card.setAttribute('aria-pressed', 'false'); return; }
+          toggle();
+        });
+        card.addEventListener('keydown', function (e) {
+          if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggle(); }
+          else if (e.key === 'Escape') { card.classList.remove('is-flipped'); card.setAttribute('aria-pressed', 'false'); }
+        });
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-3d-flip-popover-sbh/style.css
+++ b/submissions/examples/ease-3d-flip-popover-sbh/style.css
@@ -1,0 +1,126 @@
+:root {
+  --flip-duration: 0.6s;
+  --flip-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --flip-card-w: 15rem;
+  --flip-card-h: 11rem;
+  --flip-bg: #141a24;
+  --flip-fg: #e8edf5;
+  --flip-muted: #8a94a6;
+  --flip-accent: #6ea8ff;
+  --flip-radius: 0.85rem;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 25%, #161d29, #0a0d13 70%);
+  color: var(--flip-fg);
+  perspective: 1200px;
+}
+
+.page__intro { text-align: center; max-width: 36rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, #6ea8ff, #b388ff);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+
+.grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  justify-content: center;
+}
+
+.flip {
+  position: relative;
+  width: var(--flip-card-w);
+  height: var(--flip-card-h);
+  cursor: pointer;
+  border: none;
+  background: transparent;
+  padding: 0;
+  perspective: 1000px;
+}
+.flip:focus-visible { outline: 2px solid var(--flip-accent); outline-offset: 4px; border-radius: var(--flip-radius); }
+
+.flip__inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transform-style: preserve-3d;
+  transition: transform var(--flip-duration) var(--flip-ease);
+}
+.flip.is-flipped .flip__inner { transform: rotateY(180deg); }
+
+.flip__face {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 1.2rem;
+  border-radius: var(--flip-radius);
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 14px 30px -16px rgba(0, 0, 0, 0.6);
+}
+
+.flip__face--front {
+  background: linear-gradient(160deg, #1a2230, #0f141d);
+  color: var(--flip-fg);
+}
+.flip__face--back {
+  background: linear-gradient(160deg, #1c2433, #0d1219);
+  color: var(--flip-fg);
+  transform: rotateY(180deg);
+  align-items: flex-start;
+  text-align: left;
+}
+
+.flip__icon { font-size: 1.8rem; color: var(--flip-accent); }
+.flip__title { margin: 0; font-size: 1.05rem; font-weight: 700; }
+.flip__title--back { color: var(--flip-accent); }
+.flip__hint { margin: 0; font-size: 0.78rem; color: var(--flip-muted); }
+.flip__text { margin: 0.3rem 0 0; font-size: 0.86rem; line-height: 1.5; color: var(--flip-muted); }
+
+.flip__close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.6rem;
+  border: none;
+  background: transparent;
+  color: var(--flip-muted);
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0.2rem 0.45rem;
+  border-radius: 0.3rem;
+  transition: color 0.15s ease, background 0.15s ease;
+}
+.flip__close:hover { color: var(--flip-fg); background: rgba(255, 255, 255, 0.08); }
+
+@media (max-width: 480px) {
+  :root { --flip-card-w: 13rem; --flip-card-h: 10rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .flip__inner { transition: none; }
+  .flip.is-flipped .flip__inner { transform: rotateY(180deg); }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-3d-flip-popover** from issue #64446 — a popover card that flips in 3D (Y-axis rotation) to reveal details on the back face.

Closes #64446.

## Feature

A 3D flip popover with a minimalist dark aesthetic. Each card has a front face (icon + title) and a back face (details). Clicking or pressing Enter/Space flips the card 180° to reveal the back; clicking again, the close button, or Escape flips it back.

## How it works

- Uses `transform-style: preserve-3d` + `rotateY(180deg)` with `backface-visibility: hidden` for clean face culling.
- A tiny inline script toggles the `is-flipped` class and syncs `aria-pressed`.

## Accessibility

- `role="button"`, `aria-pressed`, keyboard (Enter/Space/Escape), `:focus-visible` outlines.
- Full `prefers-reduced-motion` support (faces still swap via transform, no transition duration).
- Configurable via CSS custom properties (`--flip-duration`, `--flip-ease`, `--flip-card-w`, `--flip-card-h`).

## Submission structure

```
submissions/examples/ease-3d-flip-popover-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← 3D flip card styles
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally