### PR TITLE
feat: add ease-elastic-slide-popover component (#64450)

### DIFF
--- a/submissions/examples/ease-elastic-slide-popover-sbh/README.md
+++ b/submissions/examples/ease-elastic-slide-popover-sbh/README.md
@@ -1,0 +1,43 @@
+# ease-elastic-slide-popover
+
+A popover that slides into view with an elastic overshoot on hover/focus and slides back when the pointer leaves or the trigger blurs. Minimalist dark aesthetic for tech layouts.
+
+## What does this do?
+
+Adds an **elastic-slide popover**: hovering or focusing a trigger button reveals a small panel that slides in with a spring overshoot (scale + translate), then slides back out when dismissed. Pure CSS — no JavaScript framework required (a one-line script only wires `Escape` to blur).
+
+## How is it used?
+
+1. Wrap a `.trig` button and a `.pop` panel inside a `.pop-wrap` container.
+2. Choose direction with `pop--down` (below the trigger) or `pop--up` (above).
+3. Link semantics with `aria-describedby` on the trigger pointing to the popover's `id`.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<div class="pop-wrap pop-wrap--down">
+  <button type="button" class="trig" aria-describedby="pop-share">Share</button>
+  <div id="pop-share" class="pop pop--down" role="tooltip">
+    <p class="pop__text">Copy link, send via email, or broadcast to your team.</p>
+  </div>
+</div>
+```
+
+The reveal is driven entirely by `:hover` and `:focus-within` on the wrapper, so it works with mouse, touch, and keyboard without JS.
+
+## Why is this useful?
+
+- **Animation-first** — the elastic overshoot is the signature motion, using a spring `cubic-bezier(0.34, 1.56, 0.64, 1)` on `transform` (translate + scale) for a lively entrance and exit.
+- **Minimalist tech aesthetic** — dark, low-chrome tooltip suited to dashboards and developer tooling.
+- **Accessible** — `role="tooltip"`, `aria-describedby`, keyboard focus reveal, and full `prefers-reduced-motion` support (motion disabled when requested).
+- **Reusable** — configurable via CSS custom properties (`--slide-duration`, `--slide-ease`, `--slide-bg`, `--slide-accent`, `--slide-radius`, `--slide-shadow`).
+
+## Files
+
+- `demo.html` — self-contained interactive demo (open directly in a browser; no server, CDNs, or frameworks).
+- `style.css` — elastic slide popover styles, direction variants, responsive + reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-elastic-slide-popover-sbh/demo.html
+++ b/submissions/examples/ease-elastic-slide-popover-sbh/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-elastic-slide-popover — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-elastic-slide-popover</h1>
+      <p>Hover or focus a trigger to slide in a popover with an elastic overshoot. Move away or blur to dismiss.</p>
+    </header>
+
+    <section class="demo" aria-label="Elastic slide popover demos">
+      <div class="pop-wrap pop-wrap--down">
+        <button type="button" class="trig" aria-describedby="pop-share">Share</button>
+        <div id="pop-share" class="pop pop--down" role="tooltip">
+          <p class="pop__text">Copy link, send via email, or broadcast to your team.</p>
+        </div>
+      </div>
+
+      <div class="pop-wrap pop-wrap--up">
+        <button type="button" class="trig trig--alt" aria-describedby="pop-stat">Stats</button>
+        <div id="pop-stat" class="pop pop--up" role="tooltip">
+          <p class="pop__text">1.2k views this week, up 18% from last week.</p>
+        </div>
+      </div>
+
+      <div class="pop-wrap pop-wrap--down">
+        <button type="button" class="trig trig--ghost" aria-describedby="pop-help">Help</button>
+        <div id="pop-help" class="pop pop--down" role="tooltip">
+          <p class="pop__text">Press <kbd>?</kbd> anywhere to open the command palette.</p>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    // CSS handles hover/focus reveal; this wires keyboard Esc to dismiss the focused trigger's popover.
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape') { document.activeElement && document.activeElement.blur(); }
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-elastic-slide-popover-sbh/style.css
+++ b/submissions/examples/ease-elastic-slide-popover-sbh/style.css
@@ -1,0 +1,129 @@
+:root {
+  --slide-duration: 0.5s;
+  --slide-ease: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --slide-bg: #141a24;
+  --slide-fg: #e8edf5;
+  --slide-muted: #8a94a6;
+  --slide-accent: #6ea8ff;
+  --slide-radius: 0.7rem;
+  --slide-shadow: 0 16px 36px -16px rgba(0, 0, 0, 0.6);
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 25%, #161d29, #0a0d13 70%);
+  color: var(--slide-fg);
+}
+
+.page__intro { text-align: center; max-width: 36rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, #6ea8ff, #b388ff);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+
+.demo {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  align-items: center;
+  justify-content: center;
+}
+
+.pop-wrap {
+  position: relative;
+  display: inline-block;
+}
+
+.trig {
+  font: inherit;
+  font-weight: 600;
+  padding: 0.65rem 1.3rem;
+  border-radius: 0.55rem;
+  border: 1px solid rgba(110, 168, 255, 0.4);
+  background: linear-gradient(135deg, #4f7bff, #8a5bff);
+  color: #fff;
+  cursor: pointer;
+  transition: transform 0.2s var(--slide-ease), box-shadow 0.2s var(--slide-ease);
+}
+.trig:hover, .trig:focus-visible { transform: translateY(-1px); box-shadow: 0 10px 22px -10px rgba(79, 123, 255, 0.7); outline: none; }
+.trig:focus-visible { box-shadow: 0 0 0 3px rgba(110, 168, 255, 0.4); }
+.trig--alt { background: linear-gradient(135deg, #b388ff, #6ea8ff); }
+.trig--ghost {
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--slide-fg);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+.pop {
+  position: absolute;
+  z-index: 20;
+  min-width: 13rem;
+  max-width: 19rem;
+  padding: 0.85rem 1rem;
+  background: var(--slide-bg);
+  color: var(--slide-fg);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--slide-radius);
+  box-shadow: var(--slide-shadow);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity var(--slide-duration) var(--slide-ease),
+              transform var(--slide-duration) var(--slide-ease),
+              visibility 0s linear var(--slide-duration);
+}
+
+.pop--down {
+  top: calc(100% + 0.55rem);
+  left: 0;
+  transform: translateY(-14px) scaleX(0.96);
+  transform-origin: top center;
+}
+.pop--up {
+  bottom: calc(100% + 0.55rem);
+  left: 0;
+  transform: translateY(14px) scaleX(0.96);
+  transform-origin: bottom center;
+}
+
+.pop-wrap:hover .pop,
+.pop-wrap:focus-within .pop {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transform: translateY(0) scaleX(1);
+  transition-delay: 0s;
+}
+
+.pop__text { margin: 0; font-size: 0.88rem; line-height: 1.5; color: var(--slide-muted); }
+.pop__text kbd {
+  font: inherit;
+  padding: 0.1rem 0.4rem;
+  border-radius: 0.3rem;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+@media (max-width: 480px) {
+  .pop { left: 0; right: 0; min-width: 0; max-width: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pop { transition: none; transform: none; }
+  .trig:hover, .trig:focus-visible { transform: none; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-elastic-slide-popover** from issue #64450 — a popover that slides into view with an elastic spring overshoot on hover/focus and slides back on dismiss.

Closes #64450.

## Feature

An elastic-slide popover with a minimalist dark aesthetic. Hovering or focusing a trigger reveals a panel that slides in with a spring overshoot (scale + translate), then slides back out when the pointer leaves or the trigger blurs. Pure CSS reveal — no JS framework required.

## How it works

- Reveal driven entirely by `:hover` and `:focus-within` on the wrapper (mouse, touch, keyboard).
- Spring easing `cubic-bezier(0.34, 1.56, 0.64, 1)` on `transform` for the elastic overshoot.
- Direction variants: `pop--down` (below trigger) and `pop--up` (above).

## Accessibility

- `role="tooltip"`, `aria-describedby`, keyboard focus reveal, `:focus-visible` outlines.
- Full `prefers-reduced-motion` support (motion disabled when requested).
- Configurable via CSS custom properties (`--slide-duration`, `--slide-ease`, `--slide-bg`, `--slide-accent`).

## Submission structure

```
submissions/examples/ease-elastic-slide-popover-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← elastic slide popover styles + direction variants
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally