### PR TITLE
feat: add ease-rotate-fade-carousel component (#64417)

### DIFF
--- a/submissions/examples/ease-rotate-fade-carousel-sbh/README.md
+++ b/submissions/examples/ease-rotate-fade-carousel-sbh/README.md
@@ -1,0 +1,57 @@
+# ease-rotate-fade-carousel
+
+A carousel where each slide transitions with a combined rotate + fade motion — the outgoing slide fades while rotating away, and the incoming slide fades in while rotating to center.
+
+## What does this do?
+
+Adds a **rotate-fade carousel**: slides are absolutely stacked; only the active slide is visible. Navigating (next/prev buttons, dot tabs, or arrow keys) rotates and fades the outgoing slide out while the new slide rotates back to zero and fades in, creating a smooth 3D-feeling transition.
+
+## How is it used?
+
+1. Stack `.slide` elements inside a `.carousel__track` within a `.carousel__viewport`.
+2. Mark the initially visible slide with `is-active`.
+3. Wire next/prev buttons (`[data-next]` / `[data-prev]`) and dot tabs (`[data-dot="index"]`).
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<section class="carousel" aria-label="Highlights">
+  <div class="carousel__viewport">
+    <div class="carousel__track" id="track">
+      <div class="slide is-active" role="group" aria-roledescription="slide" aria-label="1 of 4">
+        <span class="slide__badge">01</span>
+        <h2 class="slide__title">First slide</h2>
+        <p class="slide__text">Slide content here.</p>
+      </div>
+      <!-- more slides -->
+    </div>
+  </div>
+  <div class="carousel__nav">
+    <button type="button" class="nav-btn" data-prev aria-label="Previous">&larr;</button>
+    <div class="dots" role="tablist" aria-label="Choose slide">
+      <button type="button" class="dot is-active" data-dot="0" role="tab" aria-selected="true" aria-label="Slide 1"></button>
+      <!-- more dots -->
+    </div>
+    <button type="button" class="nav-btn" data-next aria-label="Next">&rarr;</button>
+  </div>
+</section>
+```
+
+A tiny inline script toggles the `is-active` class on slides/dots and handles next/prev/dot/arrow-key navigation.
+
+## Why is this useful?
+
+- **Animation-first** — the signature transition is a combined `rotate(-12deg) scale(0.92)` → `rotate(0) scale(1)` paired with `opacity`, on a `cubic-bezier(0.22, 1, 0.36, 1)` ease for a polished, modern feel.
+- **Minimalist tech aesthetic** — dark gradient stage suited to product showcases and dashboards.
+- **Accessible** — `aria-roledescription="carousel"`, per-slide `aria-label`, `role="tab"` dots with `aria-selected`, keyboard arrow navigation, `:focus-visible` outlines, and full `prefers-reduced-motion` support.
+- **Reusable** — configurable via CSS custom properties (`--car-duration`, `--car-ease`, `--car-w`, `--car-h`, `--car-accent`).
+
+## Files
+
+- `demo.html` — self-contained interactive demo (open directly in a browser; no server, CDNs, or frameworks).
+- `style.css` — carousel layout, slide rotate-fade transition, nav/dots, responsive + reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-rotate-fade-carousel-sbh/demo.html
+++ b/submissions/examples/ease-rotate-fade-carousel-sbh/demo.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-rotate-fade-carousel — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-rotate-fade-carousel</h1>
+      <p>Slides transition with a combined rotate + fade motion. Use the dots or arrow keys to navigate.</p>
+    </header>
+
+    <section class="carousel" aria-roledescription="carousel" aria-label="Feature highlights">
+      <div class="carousel__viewport">
+        <div class="carousel__track" id="track">
+          <div class="slide is-active" role="group" aria-roledescription="slide" aria-label="1 of 4">
+            <span class="slide__badge">01</span>
+            <h2 class="slide__title">Zero Dependencies</h2>
+            <p class="slide__text">A single CSS file powers every animation. No build step, no runtime, no framework.</p>
+          </div>
+          <div class="slide" role="group" aria-roledescription="slide" aria-label="2 of 4">
+            <span class="slide__badge">02</span>
+            <h2 class="slide__title">GPU Accelerated</h2>
+            <p class="slide__text">All motion runs on transform and opacity so compositing stays on the GPU.</p>
+          </div>
+          <div class="slide" role="group" aria-roledescription="slide" aria-label="3 of 4">
+            <span class="slide__badge">03</span>
+            <h2 class="slide__title">Accessible</h2>
+            <p class="slide__text">Reduced-motion support and keyboard navigation are built in by default.</p>
+          </div>
+          <div class="slide" role="group" aria-roledescription="slide" aria-label="4 of 4">
+            <span class="slide__badge">04</span>
+            <h2 class="slide__title">Composable</h2>
+            <p class="slide__text">Drop a slide in, change the easing variable, ship the carousel.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="carousel__nav">
+        <button type="button" class="nav-btn" data-prev aria-label="Previous slide">&larr;</button>
+        <div class="dots" role="tablist" aria-label="Choose slide">
+          <button type="button" class="dot is-active" data-dot="0" role="tab" aria-selected="true" aria-label="Slide 1"></button>
+          <button type="button" class="dot" data-dot="1" role="tab" aria-selected="false" aria-label="Slide 2"></button>
+          <button type="button" class="dot" data-dot="2" role="tab" aria-selected="false" aria-label="Slide 3"></button>
+          <button type="button" class="dot" data-dot="3" role="tab" aria-selected="false" aria-label="Slide 4"></button>
+        </div>
+        <button type="button" class="nav-btn" data-next aria-label="Next slide">&rarr;</button>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    (function () {
+      var track = document.getElementById('track');
+      var slides = Array.prototype.slice.call(track.children);
+      var dots = Array.prototype.slice.call(document.querySelectorAll('[data-dot]'));
+      var current = 0;
+
+      function go(i) {
+        i = (i + slides.length) % slides.length;
+        slides[current].classList.remove('is-active');
+        dots[current].classList.remove('is-active');
+        dots[current].setAttribute('aria-selected', 'false');
+        current = i;
+        slides[current].classList.add('is-active');
+        dots[current].classList.add('is-active');
+        dots[current].setAttribute('aria-selected', 'true');
+      }
+
+      document.querySelector('[data-next]').addEventListener('click', function () { go(current + 1); });
+      document.querySelector('[data-prev]').addEventListener('click', function () { go(current - 1); });
+      dots.forEach(function (d) {
+        d.addEventListener('click', function () { go(parseInt(d.getAttribute('data-dot'), 10)); });
+      });
+      document.addEventListener('keydown', function (e) {
+        if (e.key === 'ArrowRight') go(current + 1);
+        else if (e.key === 'ArrowLeft') go(current - 1);
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-rotate-fade-carousel-sbh/style.css
+++ b/submissions/examples/ease-rotate-fade-carousel-sbh/style.css
@@ -1,0 +1,146 @@
+:root {
+  --car-duration: 0.6s;
+  --car-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --car-bg: #141a24;
+  --car-fg: #e8edf5;
+  --car-muted: #8a94a6;
+  --car-accent: #6ea8ff;
+  --car-radius: 1rem;
+  --car-w: 30rem;
+  --car-h: 16rem;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 25%, #161d29, #0a0d13 70%);
+  color: var(--car-fg);
+}
+
+.page__intro { text-align: center; max-width: 36rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, #6ea8ff, #b388ff);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+
+.carousel {
+  width: var(--car-w);
+  max-width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.carousel__viewport {
+  position: relative;
+  height: var(--car-h);
+  border-radius: var(--car-radius);
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: linear-gradient(160deg, #1a2230, #0f141d);
+  box-shadow: 0 18px 40px -18px rgba(0, 0, 0, 0.6);
+  perspective: 1000px;
+}
+
+.carousel__track {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.slide {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 2rem 2.2rem;
+  opacity: 0;
+  transform: rotate(-12deg) scale(0.92);
+  transform-origin: center center;
+  transition: opacity var(--car-duration) var(--car-ease),
+              transform var(--car-duration) var(--car-ease);
+  pointer-events: none;
+}
+.slide.is-active {
+  opacity: 1;
+  transform: rotate(0deg) scale(1);
+  pointer-events: auto;
+}
+
+.slide__badge {
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  color: var(--car-accent);
+}
+.slide__title {
+  margin: 0;
+  font-size: clamp(1.3rem, 4vw, 1.8rem);
+  letter-spacing: -0.01em;
+}
+.slide__text { margin: 0; max-width: 26rem; font-size: 0.95rem; line-height: 1.6; color: var(--car-muted); }
+
+.carousel__nav {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.nav-btn {
+  width: 2.4rem;
+  height: 2.4rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--car-fg);
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background 0.18s ease, border-color 0.18s ease, transform 0.18s ease;
+}
+.nav-btn:hover { background: rgba(110, 168, 255, 0.16); border-color: rgba(110, 168, 255, 0.6); transform: translateY(-1px); }
+.nav-btn:focus-visible { outline: 2px solid var(--car-accent); outline-offset: 3px; }
+
+.dots { display: inline-flex; gap: 0.5rem; }
+.dot {
+  width: 0.55rem;
+  height: 0.55rem;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.22);
+  cursor: pointer;
+  transition: background 0.18s ease, transform 0.18s ease, width 0.18s ease;
+}
+.dot.is-active { background: var(--car-accent); transform: scaleY(1.1); }
+.dot:focus-visible { outline: 2px solid var(--car-accent); outline-offset: 3px; }
+
+@media (max-width: 480px) {
+  :root { --car-w: 20rem; --car-h: 15rem; }
+  .slide { padding: 1.4rem 1.5rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .slide, .nav-btn, .dot { transition: none; }
+  .slide { transform: none; }
+  .nav-btn:hover, .dot.is-active { transform: none; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-rotate-fade-carousel** from issue #64417 — a carousel where each slide transitions with a combined rotate + fade motion.

Closes #64417.

## Feature

A rotate-fade carousel with a minimalist dark aesthetic. Slides are absolutely stacked; navigating (next/prev buttons, dot tabs, or arrow keys) rotates and fades the outgoing slide out while the new slide rotates back to zero and fades in.

## How it works

- Active slide: `transform: rotate(0) scale(1)` + `opacity: 1`; inactive: `rotate(-12deg) scale(0.92)` + `opacity: 0`.
- Spring-free smooth ease `cubic-bezier(0.22, 1, 0.36, 1)` on `transform` + `opacity`.
- A tiny inline script toggles `is-active` on slides/dots and handles next/prev/dot/arrow-key navigation.

## Accessibility

- `aria-roledescription="carousel"`, per-slide `aria-label`, `role="tab"` dots with `aria-selected`, arrow-key navigation, `:focus-visible` outlines.
- Full `prefers-reduced-motion` support (motion disabled when requested).
- Configurable via CSS custom properties (`--car-duration`, `--car-ease`, `--car-w`, `--car-h`).

## Submission structure

```
submissions/examples/ease-rotate-fade-carousel-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← carousel layout + rotate-fade transition + nav/dots
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally