### PR TITLE
feat: skew-active feature grid for SaaS showcase layouts

### DIFF
--- a/submissions/examples/skew-active-feature-grid-saas/README.md
+++ b/submissions/examples/skew-active-feature-grid-saas/README.md
@@ -1,0 +1,23 @@
+# Skew-Active Feature Grid — SaaS Showcase
+
+A feature grid where each card starts with a subtle skew and un-skews on hover. The tilt gives the grid a dynamic, angular feel that resolves when the user interacts with a card.
+
+## How It Works
+
+Cards have `skewX(-2deg)` applied by default. On hover, the skew transitions to `skewX(0deg)` using a decelerating cubic-bezier curve. The card also lifts with a shadow. The combination of un-skewing and shadow-lift makes the card feel like it's snapping into focus.
+
+The skew is intentionally small (-2deg) so the effect is noticeable but not disorienting. It works well for feature grids where you want a bit of visual tension that resolves on interaction.
+
+## Customization
+
+- Change `--saf-orange` for a different accent color
+- Adjust the initial `skewX()` for more or less tilt
+- Modify the cubic-bezier for different deceleration feels
+- The grid adapts automatically via `auto-fit` and `minmax`
+
+## Notes
+
+- Pure HTML + CSS, no JavaScript
+- `prefers-reduced-motion` disables the skew transition
+- Responsive from mobile to wide desktop
+- 6 cards in a flexible grid layout

--- a/submissions/examples/skew-active-feature-grid-saas/demo.html
+++ b/submissions/examples/skew-active-feature-grid-saas/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS skew-active feature grid for SaaS showcase layouts">
+  <title>Skew-Active Feature Grid — SaaS Showcase</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <nav class="saf-nav">
+    <span class="saf-nav__brand">Veltrix</span>
+    <span class="saf-nav__gap"></span>
+    <span class="saf-nav__item">Features</span>
+    <span class="saf-nav__item">Pricing</span>
+    <span class="saf-nav__item">Blog</span>
+  </nav>
+
+  <section class="saf-head">
+    <h1 class="saf-head__title">Built for modern teams</h1>
+    <p class="saf-head__sub">Everything you need to ship faster, stay organized, and keep your users happy.</p>
+  </section>
+
+  <section class="saf-grid">
+    <div class="saf-card">
+      <div class="saf-card__icon">A</div>
+      <h3 class="saf-card__h">Instant Deploys</h3>
+      <p class="saf-card__p">Push to git and your changes go live in seconds. No CI pipelines to configure, no build scripts to maintain.</p>
+    </div>
+    <div class="saf-card">
+      <div class="saf-card__icon">B</div>
+      <h3 class="saf-card__h">Edge Functions</h3>
+      <p class="saf-card__p">Run server code at the edge with zero cold starts. Your API responds in under 50ms from anywhere in the world.</p>
+    </div>
+    <div class="saf-card">
+      <div class="saf-card__icon">C</div>
+      <h3 class="saf-card__h">Real-Time Logs</h3>
+      <p class="saf-card__p">Stream logs, metrics, and traces in real time. Debug production issues without leaving your browser.</p>
+    </div>
+    <div class="saf-card">
+      <div class="saf-card__icon">D</div>
+      <h3 class="saf-card__h">Team Workspaces</h3>
+      <p class="saf-card__p">Separate environments for staging, preview, and production. Invite teammates with role-based access.</p>
+    </div>
+    <div class="saf-card">
+      <div class="saf-card__icon">E</div>
+      <h3 class="saf-card__h">Analytics</h3>
+      <p class="saf-card__p">Page views, Core Web Vitals, and custom events — all built in. No third-party scripts required.</p>
+    </div>
+    <div class="saf-card">
+      <div class="saf-card__icon">F</div>
+      <h3 class="saf-card__h">Global CDN</h3>
+      <p class="saf-card__p">Static assets served from 200+ edge locations. Automatic cache invalidation on every deploy.</p>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/skew-active-feature-grid-saas/style.css
+++ b/submissions/examples/skew-active-feature-grid-saas/style.css
@@ -1,0 +1,144 @@
+:root {
+  --saf-white: #ffffff;
+  --saf-bg: #fafafa;
+  --saf-text: #111827;
+  --saf-muted: #6b7280;
+  --saf-border: #e5e7eb;
+  --saf-orange: #ea580c;
+  --saf-orange-hover: #c2410c;
+  --saf-orange-bg: rgba(234, 88, 12, 0.06);
+  --saf-radius: 10px;
+}
+
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  background: var(--saf-bg);
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--saf-text);
+  line-height: 1.55;
+}
+
+/* ── nav ────────────────────────────────────────── */
+
+.saf-nav {
+  display: flex;
+  align-items: center;
+  height: 50px;
+  padding: 0 28px;
+  background: var(--saf-white);
+  border-bottom: 1px solid var(--saf-border);
+}
+
+.saf-nav__brand {
+  font-size: 0.82rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+
+.saf-nav__gap {
+  flex: 1;
+}
+
+.saf-nav__item {
+  font-size: 0.72rem;
+  color: var(--saf-muted);
+  margin-left: 20px;
+  cursor: pointer;
+}
+
+.saf-nav__item:hover {
+  color: var(--saf-text);
+}
+
+/* ── head ───────────────────────────────────────── */
+
+.saf-head {
+  text-align: center;
+  padding: 64px 28px 16px;
+}
+
+.saf-head__title {
+  font-size: clamp(1.3rem, 3.5vw, 1.8rem);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+}
+
+.saf-head__sub {
+  font-size: 0.74rem;
+  color: var(--saf-muted);
+  margin-top: 8px;
+  max-width: 42ch;
+  margin-left: auto;
+  margin-right: auto;
+  line-height: 1.7;
+}
+
+/* ── grid ───────────────────────────────────────── */
+
+.saf-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 16px;
+  max-width: 700px;
+  margin: 0 auto;
+  padding: 40px 28px 80px;
+}
+
+/* ── card ───────────────────────────────────────── */
+
+.saf-card {
+  background: var(--saf-white);
+  border: 1px solid var(--saf-border);
+  border-radius: var(--saf-radius);
+  padding: 22px;
+  transform: skewX(-2deg);
+  transition: transform 0.3s cubic-bezier(0.33, 1, 0.68, 1),
+              box-shadow 0.3s ease;
+  cursor: default;
+}
+
+.saf-card:hover {
+  transform: skewX(0deg);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.08);
+}
+
+.saf-card__icon {
+  width: 34px;
+  height: 34px;
+  line-height: 34px;
+  text-align: center;
+  font-size: 0.7rem;
+  font-weight: 800;
+  color: var(--saf-orange);
+  background: var(--saf-orange-bg);
+  border-radius: 8px;
+  margin-bottom: 14px;
+}
+
+.saf-card__h {
+  font-size: 0.78rem;
+  font-weight: 700;
+  margin-bottom: 6px;
+}
+
+.saf-card__p {
+  font-size: 0.7rem;
+  color: var(--saf-muted);
+  line-height: 1.65;
+}
+
+/* ── reduced motion ─────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .saf-card {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Closes #62132

Adds a CSS skew-active feature grid for SaaS showcase layouts.

**What this does:**
- 6-card feature grid with subtle skew entrance
- Cards start at skewX(-2deg) and un-skew on hover
- Smooth deceleration with cubic-bezier timing
- Shadow lift on hover for depth
- Responsive grid layout
- No JavaScript

**Files added:**
- submissions/examples/skew-active-feature-grid-saas/demo.html
- submissions/examples/skew-active-feature-grid-saas/style.css
- submissions/examples/skew-active-feature-grid-saas/README.md