### PR TITLE
feat: add ease-3d-flip-stepper component (#64385)

### DIFF
--- a/submissions/examples/ease-3d-flip-stepper-sbh/README.md
+++ b/submissions/examples/ease-3d-flip-stepper-sbh/README.md
@@ -1,0 +1,47 @@
+# ease-3d-flip-stepper
+
+A glassmorphism multi-step progress indicator. Completed steps flip 180° in 3D to reveal a check mark on the back face.
+
+## What does this do?
+
+Adds a **3D-flip stepper**: each step shows a numbered marker. When a step is completed, its marker flips around the Y axis (`rotateY(180deg)`) to show a check mark, and the connecting line to the next step fills with a success gradient. The active step is highlighted with a ring.
+
+## How is it used?
+
+1. Build an ordered list `.stepper` of `.step` items.
+2. Mark states with classes: `is-done` (flipped to check), `is-active` (current), or neither (upcoming).
+3. Each marker holds a `.step__num` (front) and `.step__check` (back) face.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<ol class="stepper">
+  <li class="step is-done" tabindex="0">
+    <span class="step__marker" aria-hidden="true">
+      <span class="step__num">1</span>
+      <span class="step__check">&#10003;</span>
+    </span>
+    <span class="step__label">Account</span>
+  </li>
+  <!-- more steps -->
+</ol>
+```
+
+A small inline "Replay flip" button re-triggers the flip animation for demo purposes.
+
+## Why is this useful?
+
+- **Animation-first** — the signature motion is a 3D Y-axis flip on the marker using `transform-style: preserve-3d` + `backface-visibility: hidden`; the number face rotates away as the check face rotates in.
+- **Glassmorphism aesthetic** — frosted panel via `backdrop-filter: blur()` over a translucent gradient.
+- **Accessible** — `aria-current="step"` on the active step, `tabindex` for keyboard focus, `:focus-visible` rings, and full `prefers-reduced-motion` support (flip still swaps faces via transform, no transition duration).
+- **Reusable** — configurable via CSS custom properties (`--step-duration`, `--step-ease`, `--marker`, `--glass-blur`, color tokens).
+
+## Files
+
+- `demo.html` — self-contained interactive demo (open directly in a browser; no server, CDNs, or frameworks).
+- `style.css` — glassmorphism panel, 3D flip marker, connector lines, responsive + reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-3d-flip-stepper-sbh/demo.html
+++ b/submissions/examples/ease-3d-flip-stepper-sbh/demo.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-3d-flip-stepper — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-3d-flip-stepper</h1>
+      <p>A multi-step progress indicator. Completed steps flip in 3D to a check state.</p>
+    </header>
+
+    <section class="panel" aria-label="3D flip stepper">
+      <ol class="stepper">
+        <li class="step is-done" tabindex="0" aria-current="false">
+          <span class="step__marker" aria-hidden="true">
+            <span class="step__num">1</span>
+            <span class="step__check">&#10003;</span>
+          </span>
+          <span class="step__label">Account</span>
+        </li>
+        <li class="step is-done" tabindex="0" aria-current="false">
+          <span class="step__marker" aria-hidden="true">
+            <span class="step__num">2</span>
+            <span class="step__check">&#10003;</span>
+          </span>
+          <span class="step__label">Profile</span>
+        </li>
+        <li class="step is-active" tabindex="0" aria-current="step">
+          <span class="step__marker" aria-hidden="true">
+            <span class="step__num">3</span>
+            <span class="step__check">&#10003;</span>
+          </span>
+          <span class="step__label">Billing</span>
+        </li>
+        <li class="step" tabindex="0" aria-current="false">
+          <span class="step__marker" aria-hidden="true">
+            <span class="step__num">4</span>
+            <span class="step__check">&#10003;</span>
+          </span>
+          <span class="step__label">Review</span>
+        </li>
+      </ol>
+
+      <div class="actions">
+        <button type="button" class="btn" data-replay>Replay flip</button>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    (function () {
+      document.querySelector('[data-replay]').addEventListener('click', function () {
+        document.querySelectorAll('.step').forEach(function (s) {
+          s.classList.remove('is-done');
+          requestAnimationFrame(function () {
+            requestAnimationFrame(function () {
+              if (s.classList.contains('is-active') || s.getAttribute('data-was-done') === '1') {
+                s.classList.add('is-done');
+              }
+            });
+          });
+        });
+        // restore original done state for steps 1-2 after replay
+        setTimeout(function () {
+          var steps = document.querySelectorAll('.step');
+          steps[0].classList.add('is-done');
+          steps[1].classList.add('is-done');
+        }, 50);
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-3d-flip-stepper-sbh/style.css
+++ b/submissions/examples/ease-3d-flip-stepper-sbh/style.css
@@ -1,0 +1,149 @@
+:root {
+  --step-duration: 0.55s;
+  --step-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --glass-bg: rgba(255, 255, 255, 0.06);
+  --glass-border: rgba(255, 255, 255, 0.12);
+  --glass-blur: 12px;
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --success: #34d399;
+  --marker: 2.6rem;
+  --radius: 0.75rem;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 20%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+}
+
+.page__intro { text-align: center; max-width: 36rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+
+.panel {
+  width: 34rem;
+  max-width: 100%;
+  padding: 2rem 1.8rem;
+  border-radius: calc(var(--radius) * 1.6);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  box-shadow: 0 20px 50px -24px rgba(0, 0, 0, 0.6);
+}
+
+.stepper {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.step {
+  position: relative;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.6rem;
+  perspective: 800px;
+}
+.step:focus-visible { outline: none; }
+.step:focus-visible .step__marker { box-shadow: 0 0 0 3px rgba(110, 168, 255, 0.5); }
+
+.step:not(:last-child)::before {
+  content: "";
+  position: absolute;
+  top: calc(var(--marker) / 2);
+  left: calc(50% + var(--marker) / 2 + 0.4rem);
+  right: calc(-50% + var(--marker) / 2 + 0.4rem);
+  height: 2px;
+  background: rgba(255, 255, 255, 0.14);
+  z-index: 0;
+}
+.step.is-done:not(:last-child)::before { background: linear-gradient(90deg, var(--success), var(--accent)); }
+
+.step__marker {
+  position: relative;
+  width: var(--marker);
+  height: var(--marker);
+  border-radius: 50%;
+  transform-style: preserve-3d;
+  transition: transform var(--step-duration) var(--step-ease);
+  z-index: 1;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+}
+.step.is-active .step__marker {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 4px rgba(110, 168, 255, 0.18);
+}
+.step.is-done .step__marker { transform: rotateY(180deg); background: var(--success); border-color: var(--success); }
+
+.step__num, .step__check {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-size: 0.95rem;
+  font-weight: 700;
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+}
+.step__num { color: var(--fg); }
+.step.is-active .step__num { color: var(--accent); }
+.step__check { transform: rotateY(180deg); color: #06231a; }
+
+.step__label { font-size: 0.82rem; color: var(--muted); text-align: center; }
+.step.is-active .step__label { color: var(--fg); font-weight: 600; }
+.step.is-done .step__label { color: var(--fg); }
+
+.actions { display: flex; justify-content: flex-end; margin-top: 1.6rem; }
+.btn {
+  font: inherit;
+  font-weight: 600;
+  font-size: 0.85rem;
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--glass-border);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--fg);
+  cursor: pointer;
+  transition: background 0.18s ease, transform 0.18s ease;
+}
+.btn:hover { background: rgba(110, 168, 255, 0.18); transform: translateY(-1px); }
+.btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; }
+
+@media (max-width: 520px) {
+  :root { --marker: 2.2rem; }
+  .step__label { font-size: 0.72rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .step__marker { transition: none; }
+  .step.is-done .step__marker { transform: rotateY(180deg); }
+  .btn:hover { transform: none; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-3d-flip-stepper** from issue #64385 — a glassmorphism multi-step progress indicator whose completed steps flip 180° in 3D to reveal a check mark.

Closes #64385.

## Feature

A 3D-flip stepper on a frosted-glass panel. Each step shows a numbered marker; when completed, the marker flips around the Y axis to show a check mark, and the connector line fills with a success gradient. The active step is highlighted with a ring.

## How it works

- Marker uses `transform-style: preserve-3d` + `rotateY(180deg)` with `backface-visibility: hidden`; the number face rotates away as the check face rotates in.
- States via classes: `is-done`, `is-active`, or neither.

## Accessibility

- `aria-current="step"` on the active step, `tabindex` for keyboard focus, `:focus-visible` rings.
- Full `prefers-reduced-motion` support (flip still swaps faces via transform, no transition duration).
- Configurable via CSS custom properties (`--step-duration`, `--step-ease`, `--marker`, `--glass-blur`).

## Submission structure

```
submissions/examples/ease-3d-flip-stepper-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← glassmorphism panel + 3D flip marker + connectors
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally