### PR TITLE
feat: add ease-shimmer-sweep-feature-grid component (#64364)

### DIFF
--- a/submissions/examples/ease-shimmer-sweep-feature-grid-sbh/README.md
+++ b/submissions/examples/ease-shimmer-sweep-feature-grid-sbh/README.md
@@ -1,0 +1,44 @@
+# ease-shimmer-sweep-feature-grid
+
+A glassmorphism feature grid whose cards sweep a shimmer highlight diagonally across their surface on hover or keyboard focus.
+
+## What does this do?
+
+Adds a **shimmer-sweep feature grid**: each frosted-glass card lifts slightly on hover/focus while a bright diagonal shimmer band sweeps across the card from left to right, giving a polished sheen effect. No JavaScript required — the shimmer is a pure CSS `@keyframes` animation triggered by `:hover` / `:focus-visible`.
+
+## How is it used?
+
+1. Build a `.grid` of `.card` elements.
+2. Inside each card, place a `.card__shine` element (the shimmer band) plus your icon, title, and text.
+3. Add `tabindex="0"` so cards are keyboard-focusable (focus also triggers the shimmer).
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<section class="grid" aria-label="Features">
+  <article class="card" tabindex="0">
+    <div class="card__shine" aria-hidden="true"></div>
+    <span class="card__icon">&#9889;</span>
+    <h2 class="card__title">Fast</h2>
+    <p class="card__text">Sub-50ms interactions.</p>
+  </article>
+  <!-- more cards -->
+</section>
+```
+
+## Why is this useful?
+
+- **Animation-first** — the signature motion is the `@keyframes ss-sweep` that translates a `skewX`-gradient band across the card (`left: -75% → 150%`) with an opacity rise/fall, combined with a gentle lift on `transform`.
+- **Glassmorphism aesthetic** — frosted cards via `backdrop-filter: blur()` over a translucent gradient.
+- **Accessible** — `tabindex="0"` for keyboard focus, `:focus-visible` triggers the same shimmer as hover, and full `prefers-reduced-motion` support (lift and shimmer both disabled when requested).
+- **Reusable** — configurable via CSS custom properties (`--ss-hover-duration`, `--ss-ease`, `--glass-blur`, color tokens).
+
+## Files
+
+- `demo.html` — self-contained interactive demo (open directly in a browser; no server, CDNs, or frameworks).
+- `style.css` — glassmorphism grid, shimmer-sweep keyframes, hover/focus lift, responsive + reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-shimmer-sweep-feature-grid-sbh/demo.html
+++ b/submissions/examples/ease-shimmer-sweep-feature-grid-sbh/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-shimmer-sweep-feature-grid — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-shimmer-sweep-feature-grid</h1>
+      <p>A feature grid whose cards sweep a shimmer highlight across their surface on hover.</p>
+    </header>
+
+    <section class="grid" aria-label="Shimmer sweep feature grid">
+      <article class="card" tabindex="0">
+        <div class="card__shine" aria-hidden="true"></div>
+        <span class="card__icon" aria-hidden="true">&#9889;</span>
+        <h2 class="card__title">Fast</h2>
+        <p class="card__text">Sub-50ms interactions thanks to GPU-only transforms and opacity.</p>
+      </article>
+
+      <article class="card" tabindex="0">
+        <div class="card__shine" aria-hidden="true"></div>
+        <span class="card__icon" aria-hidden="true">&#128274;</span>
+        <h2 class="card__title">Secure</h2>
+        <p class="card__text">Zero-trust defaults with rotating keys and signed payloads.</p>
+      </article>
+
+      <article class="card" tabindex="0">
+        <div class="card__shine" aria-hidden="true"></div>
+        <span class="card__icon" aria-hidden="true">&#128202;</span>
+        <h2 class="card__title">Observable</h2>
+        <p class="card__text">Structured logs and traces flow into your dashboard in real time.</p>
+      </article>
+
+      <article class="card" tabindex="0">
+        <div class="card__shine" aria-hidden="true"></div>
+        <span class="card__icon" aria-hidden="true">&#127795;</span>
+        <h2 class="card__title">Scalable</h2>
+        <p class="card__text">Horizontal scaling with stateless workers and shared nothing.</p>
+      </article>
+
+      <article class="card" tabindex="0">
+        <div class="card__shine" aria-hidden="true"></div>
+        <span class="card__icon" aria-hidden="true">&#9881;</span>
+        <h2 class="card__title">Configurable</h2>
+        <p class="card__text">Every behavior is a CSS custom property away from a tweak.</p>
+      </article>
+
+      <article class="card" tabindex="0">
+        <div class="card__shine" aria-hidden="true"></div>
+        <span class="card__icon" aria-hidden="true">&#129302;</span>
+        <h2 class="card__title">Automated</h2>
+        <p class="card__text">Pipelines test, build, and ship without a human in the loop.</p>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-shimmer-sweep-feature-grid-sbh/style.css
+++ b/submissions/examples/ease-shimmer-sweep-feature-grid-sbh/style.css
@@ -1,0 +1,112 @@
+:root {
+  --ss-hover-duration: 0.7s;
+  --ss-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --glass-bg: rgba(255, 255, 255, 0.06);
+  --glass-border: rgba(255, 255, 255, 0.12);
+  --glass-blur: 12px;
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --radius: 0.9rem;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 20%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+}
+
+.page__intro { text-align: center; max-width: 40rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+  gap: 1.2rem;
+  width: 46rem;
+  max-width: 100%;
+}
+
+.card {
+  position: relative;
+  overflow: hidden;
+  padding: 1.6rem;
+  border-radius: var(--radius);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  box-shadow: 0 16px 36px -20px rgba(0, 0, 0, 0.6);
+  transition: transform var(--ss-hover-duration) var(--ss-ease),
+              border-color var(--ss-hover-duration) var(--ss-ease),
+              box-shadow var(--ss-hover-duration) var(--ss-ease);
+}
+.card:hover, .card:focus-visible {
+  transform: translateY(-4px);
+  border-color: rgba(110, 168, 255, 0.5);
+  box-shadow: 0 24px 48px -20px rgba(0, 0, 0, 0.7);
+  outline: none;
+}
+
+.card__shine {
+  position: absolute;
+  top: 0;
+  left: -75%;
+  width: 50%;
+  height: 100%;
+  background: linear-gradient(115deg, transparent 0%, rgba(255, 255, 255, 0.16) 45%, rgba(255, 255, 255, 0.28) 50%, rgba(255, 255, 255, 0.16) 55%, transparent 100%);
+  transform: skewX(-18deg);
+  pointer-events: none;
+  opacity: 0;
+}
+.card:hover .card__shine, .card:focus-visible .card__shine {
+  animation: ss-sweep var(--ss-hover-duration) var(--ss-ease) forwards;
+}
+
+@keyframes ss-sweep {
+  0% { left: -75%; opacity: 0; }
+  20% { opacity: 1; }
+  100% { left: 150%; opacity: 0; }
+}
+
+.card__icon {
+  display: inline-block;
+  font-size: 1.6rem;
+  margin-bottom: 0.6rem;
+  background: linear-gradient(135deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.card__title { margin: 0 0 0.35rem; font-size: 1.1rem; font-weight: 700; }
+.card__text { margin: 0; font-size: 0.88rem; line-height: 1.55; color: var(--muted); }
+
+@media (max-width: 480px) {
+  .grid { gap: 1rem; }
+  .card { padding: 1.3rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card { transition: none; }
+  .card:hover, .card:focus-visible { transform: none; }
+  .card:hover .card__shine, .card:focus-visible .card__shine { animation: none; display: none; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-shimmer-sweep-feature-grid** from issue #64364 — a glassmorphism feature grid whose cards sweep a shimmer highlight diagonally across their surface on hover/focus.

Closes #64364.

## Feature

A shimmer-sweep feature grid of frosted-glass cards. On hover or keyboard focus, each card lifts slightly while a bright diagonal shimmer band sweeps across it from left to right. Pure CSS — no JavaScript required.

## How it works

- `@keyframes ss-sweep` translates a `skewX`-gradient band across the card (`left: -75% → 150%`) with an opacity rise/fall.
- Combined with a gentle `translateY` lift on `transform`.
- Triggered by `:hover` and `:focus-visible` alike.

## Accessibility

- `tabindex="0"` for keyboard focus, `:focus-visible` triggers the same shimmer as hover.
- Full `prefers-reduced-motion` support (lift and shimmer both disabled when requested).
- Configurable via CSS custom properties (`--ss-hover-duration`, `--ss-ease`, `--glass-blur`).

## Submission structure

```
submissions/examples/ease-shimmer-sweep-feature-grid-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← glassmorphism grid + shimmer-sweep keyframes
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally