### PR TITLE
feat: fade-in dropdown for product catalog layouts

### DIFF
--- a/submissions/examples/fade-in-dropdown-product-catalog/README.md
+++ b/submissions/examples/fade-in-dropdown-product-catalog/README.md
@@ -1,0 +1,23 @@
+# Fade-In Dropdown — Product Catalog
+
+A CSS-only dropdown that fades in from a slightly raised position. The dropdown menu starts with `opacity: 0` and `translateY(-6px)`, then transitions to full visibility when the checkbox is toggled.
+
+## How It Works
+
+A hidden checkbox controls the dropdown state. When checked, the dropdown transitions from transparent and slightly above to fully visible at its natural position. The `opacity` and `transform` properties animate together for a smooth entrance.
+
+The fade-in is subtle and professional — the menu appears to lower into place rather than just popping in. This works well for product catalogs where you want the navigation to feel polished but not distracting.
+
+## Customization
+
+- Change `--fid-cyan` for a different accent color
+- Adjust `translateY(-6px)` for more or less vertical offset
+- Modify the transition duration for faster or slower entrance
+- The dropdown width adapts to its content via `min-width`
+
+## Notes
+
+- Pure HTML + CSS, no JavaScript
+- `prefers-reduced-motion` disables the dropdown animation
+- Backdrop is not implemented (clicking elsewhere won't close it) — this is a pure CSS demo
+- Product cards have a subtle hover lift effect

--- a/submissions/examples/fade-in-dropdown-product-catalog/demo.html
+++ b/submissions/examples/fade-in-dropdown-product-catalog/demo.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS fade-in dropdown for product catalog layouts">
+  <title>Fade-In Dropdown — Product Catalog</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <nav class="fid-nav">
+    <span class="fid-nav__brand">ShopKit</span>
+    <span class="fid-nav__gap"></span>
+    <div class="fid-nav__menu">
+      <input type="checkbox" id="fid-cat" class="fid-sr">
+      <label for="fid-cat" class="fid-nav__item">Categories ▾</label>
+      <div class="fid-dropdown">
+        <a href="#" class="fid-dropdown__link">Electronics</a>
+        <a href="#" class="fid-dropdown__link">Clothing</a>
+        <a href="#" class="fid-dropdown__link">Home &amp; Garden</a>
+        <a href="#" class="fid-dropdown__link">Sports</a>
+      </div>
+    </div>
+    <span class="fid-nav__item">Deals</span>
+    <span class="fid-nav__item">Cart</span>
+  </nav>
+
+  <section class="fid-hero">
+    <h1 class="fid-hero__title">Product Catalog</h1>
+    <p class="fid-hero__sub">A dropdown that fades in from a slightly raised position. Click "Categories" to see it in action.</p>
+  </section>
+
+  <section class="fid-products">
+    <div class="fid-product">
+      <div class="fid-product__img"></div>
+      <h3 class="fid-product__name">Wireless Earbuds</h3>
+      <p class="fid-product__price">$49</p>
+    </div>
+    <div class="fid-product">
+      <div class="fid-product__img"></div>
+      <h3 class="fid-product__name">USB-C Hub</h3>
+      <p class="fid-product__price">$35</p>
+    </div>
+    <div class="fid-product">
+      <div class="fid-product__img"></div>
+      <h3 class="fid-product__name">Desk Lamp</h3>
+      <p class="fid-product__price">$28</p>
+    </div>
+    <div class="fid-product">
+      <div class="fid-product__img"></div>
+      <h3 class="fid-product__name">Mechanical Keyboard</h3>
+      <p class="fid-product__price">$89</p>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/fade-in-dropdown-product-catalog/style.css
+++ b/submissions/examples/fade-in-dropdown-product-catalog/style.css
@@ -1,0 +1,188 @@
+:root {
+  --fid-white: #ffffff;
+  --fid-bg: #fafafa;
+  --fid-text: #111827;
+  --fid-muted: #6b7280;
+  --fid-border: #e5e7eb;
+  --fid-cyan: #0891b2;
+  --fid-cyan-hover: #0e7490;
+  --fid-cyan-bg: rgba(8, 145, 178, 0.06);
+  --fid-radius: 8px;
+}
+
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  background: var(--fid-bg);
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--fid-text);
+  line-height: 1.55;
+}
+
+.fid-sr {
+  position: fixed;
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* ── nav ────────────────────────────────────────── */
+
+.fid-nav {
+  display: flex;
+  align-items: center;
+  height: 50px;
+  padding: 0 28px;
+  background: var(--fid-white);
+  border-bottom: 1px solid var(--fid-border);
+}
+
+.fid-nav__brand {
+  font-size: 0.82rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+
+.fid-nav__gap {
+  flex: 1;
+}
+
+.fid-nav__item {
+  font-size: 0.72rem;
+  color: var(--fid-muted);
+  margin-left: 20px;
+  cursor: pointer;
+}
+
+.fid-nav__item:hover {
+  color: var(--fid-text);
+}
+
+/* ── dropdown wrapper ───────────────────────────── */
+
+.fid-nav__menu {
+  position: relative;
+}
+
+/* ── dropdown ───────────────────────────────────── */
+
+.fid-dropdown {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%) translateY(-6px);
+  min-width: 160px;
+  background: var(--fid-white);
+  border: 1px solid var(--fid-border);
+  border-radius: var(--fid-radius);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
+  padding: 6px 0;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease,
+              transform 0.25s ease;
+}
+
+.fid-sr:checked ~ .fid-dropdown {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateX(-50%) translateY(0);
+}
+
+.fid-dropdown__link {
+  display: block;
+  padding: 8px 16px;
+  font-size: 0.7rem;
+  color: var(--fid-muted);
+  text-decoration: none;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+
+.fid-dropdown__link:hover {
+  background: var(--fid-cyan-bg);
+  color: var(--fid-cyan);
+}
+
+/* ── hero ───────────────────────────────────────── */
+
+.fid-hero {
+  text-align: center;
+  padding: 72px 28px 16px;
+}
+
+.fid-hero__title {
+  font-size: clamp(1.3rem, 3.5vw, 1.8rem);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+}
+
+.fid-hero__sub {
+  font-size: 0.74rem;
+  color: var(--fid-muted);
+  margin-top: 8px;
+  max-width: 44ch;
+  margin-left: auto;
+  margin-right: auto;
+  line-height: 1.7;
+}
+
+/* ── products ───────────────────────────────────── */
+
+.fid-products {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 40px 28px 80px;
+}
+
+.fid-product {
+  background: var(--fid-white);
+  border: 1px solid var(--fid-border);
+  border-radius: var(--fid-radius);
+  padding: 16px;
+  text-align: center;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  cursor: default;
+}
+
+.fid-product:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.06);
+}
+
+.fid-product__img {
+  width: 100%;
+  height: 120px;
+  background: var(--fid-cyan-bg);
+  border-radius: 6px;
+  margin-bottom: 12px;
+}
+
+.fid-product__name {
+  font-size: 0.76rem;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.fid-product__price {
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--fid-cyan);
+}
+
+/* ── reduced motion ─────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .fid-dropdown,
+  .fid-product {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Closes #62347

Adds a CSS fade-in dropdown for product catalog layouts.

**What this does:**
- Pure CSS dropdown using checkbox toggle
- Menu fades in from opacity 0 with translateY(-6px) offset
- Smooth opacity and transform transition on open
- Product catalog grid with hover lift effect
- Responsive layout
- No JavaScript

**Files added:**
- submissions/examples/fade-in-dropdown-product-catalog/demo.html
- submissions/examples/fade-in-dropdown-product-catalog/style.css
- submissions/examples/fade-in-dropdown-product-catalog/README.md