### PR TITLE
feat: add ease-bounce-pulse-pricing component (#64357)

### DIFF
--- a/submissions/examples/ease-bounce-pulse-pricing-sbh/README.md
+++ b/submissions/examples/ease-bounce-pulse-pricing-sbh/README.md
@@ -1,0 +1,45 @@
+# ease-bounce-pulse-pricing
+
+A glassmorphism pricing table where the featured plan bounces in on load and continuously pulses its glow to draw attention.
+
+## What does this do?
+
+Adds a **bounce-pulse pricing table**: three frosted-glass plan cards. The featured ("Pro") plan scales up slightly, bounces in with a spring overshoot on page load, and then softly pulses its box-shadow glow forever after — making it the visual focal point.
+
+## How is it used?
+
+1. Build a `.table` grid of `.plan` cards.
+2. Mark the featured plan with `plan--featured`; add a `.plan__badge` for the "Most popular" tag.
+3. Each plan holds name, price, feature list, and CTA button.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<section class="table" aria-label="Pricing plans">
+  <article class="plan plan--featured" tabindex="0">
+    <span class="plan__badge">Most popular</span>
+    <h2 class="plan__name">Pro</h2>
+    <p class="plan__price"><span class="plan__cur">$</span>29<span class="plan__per">/mo</span></p>
+    <ul class="plan__features"><li>Unlimited projects</li><li>Priority support</li></ul>
+    <button type="button" class="plan__cta plan__cta--featured">Choose Pro</button>
+  </article>
+  <!-- more plans -->
+</section>
+```
+
+## Why is this useful?
+
+- **Animation-first** — two layered motions: `@keyframes bp-bounce` uses a spring `cubic-bezier(0.34, 1.56, 0.64, 1)` for the entrance overshoot; `@keyframes bp-pulse` gently breathes the glow `box-shadow` on a loop.
+- **Glassmorphism aesthetic** — frosted cards via `backdrop-filter: blur()`; the featured card gets a tinted gradient accent.
+- **Accessible** — `tabindex="0"` + `aria-label` on the featured plan, `:focus-visible` outlines on cards and CTAs, and full `prefers-reduced-motion` support (bounce and pulse both disabled when requested).
+- **Reusable** — configurable via CSS custom properties (`--bp-bounce-duration`, `--bp-pulse-duration`, `--bp-ease`, `--glass-blur`, color tokens).
+
+## Files
+
+- `demo.html` — self-contained demo (open directly in a browser; no server, CDNs, or frameworks).
+- `style.css` — glassmorphism plans, bounce + pulse keyframes, featured styling, responsive + reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-bounce-pulse-pricing-sbh/demo.html
+++ b/submissions/examples/ease-bounce-pulse-pricing-sbh/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-bounce-pulse-pricing — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-bounce-pulse-pricing</h1>
+      <p>A pricing table where the featured plan bounces in and pulses to draw attention.</p>
+    </header>
+
+    <section class="table" aria-label="Pricing plans">
+      <article class="plan" tabindex="0">
+        <h2 class="plan__name">Starter</h2>
+        <p class="plan__price"><span class="plan__cur">$</span>9<span class="plan__per">/mo</span></p>
+        <ul class="plan__features">
+          <li>1 project</li>
+          <li>2 GB storage</li>
+          <li>Community support</li>
+        </ul>
+        <button type="button" class="plan__cta">Choose Starter</button>
+      </article>
+
+      <article class="plan plan--featured" tabindex="0" aria-label="Pro plan, featured">
+        <span class="plan__badge">Most popular</span>
+        <h2 class="plan__name">Pro</h2>
+        <p class="plan__price"><span class="plan__cur">$</span>29<span class="plan__per">/mo</span></p>
+        <ul class="plan__features">
+          <li>Unlimited projects</li>
+          <li>50 GB storage</li>
+          <li>Priority support</li>
+          <li>Advanced analytics</li>
+        </ul>
+        <button type="button" class="plan__cta plan__cta--featured">Choose Pro</button>
+      </article>
+
+      <article class="plan" tabindex="0">
+        <h2 class="plan__name">Team</h2>
+        <p class="plan__price"><span class="plan__cur">$</span>79<span class="plan__per">/mo</span></p>
+        <ul class="plan__features">
+          <li>Everything in Pro</li>
+          <li>500 GB storage</li>
+          <li>SSO + roles</li>
+          <li>Dedicated manager</li>
+        </ul>
+        <button type="button" class="plan__cta">Choose Team</button>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-bounce-pulse-pricing-sbh/style.css
+++ b/submissions/examples/ease-bounce-pulse-pricing-sbh/style.css
@@ -1,0 +1,157 @@
+:root {
+  --bp-bounce-duration: 0.9s;
+  --bp-pulse-duration: 2.4s;
+  --bp-ease: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --glass-bg: rgba(255, 255, 255, 0.06);
+  --glass-border: rgba(255, 255, 255, 0.12);
+  --glass-blur: 12px;
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --radius: 1rem;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 20%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+}
+
+.page__intro { text-align: center; max-width: 40rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+
+.table {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
+  gap: 1.2rem;
+  width: 48rem;
+  max-width: 100%;
+  align-items: center;
+}
+
+.plan {
+  position: relative;
+  padding: 1.8rem 1.4rem;
+  border-radius: var(--radius);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  box-shadow: 0 16px 36px -20px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  transition: transform 0.3s var(--bp-ease), border-color 0.3s ease;
+}
+.plan:hover, .plan:focus-visible { transform: translateY(-4px); border-color: rgba(110, 168, 255, 0.5); outline: none; }
+
+.plan--featured {
+  background: linear-gradient(160deg, rgba(110, 168, 255, 0.18), rgba(179, 136, 255, 0.12));
+  border-color: rgba(110, 168, 255, 0.55);
+  box-shadow: 0 24px 60px -22px rgba(110, 168, 255, 0.5);
+  animation: bp-bounce var(--bp-bounce-duration) var(--bp-ease) both, bp-pulse var(--bp-pulse-duration) ease-in-out 1s infinite;
+  z-index: 1;
+}
+@media (min-width: 48rem) {
+  .plan--featured { transform: scale(1.06); }
+  .plan--featured:hover, .plan--featured:focus-visible { transform: scale(1.06) translateY(-4px); }
+}
+
+.plan__badge {
+  position: absolute;
+  top: -0.7rem;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 0.2rem 0.8rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: #06231a;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  border-radius: 999px;
+  white-space: nowrap;
+}
+
+.plan__name { margin: 0; font-size: 1.1rem; font-weight: 700; }
+.plan__price {
+  margin: 0;
+  font-size: 2.2rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  display: flex;
+  align-items: baseline;
+  gap: 0.1rem;
+}
+.plan__cur { font-size: 1rem; opacity: 0.7; }
+.plan__per { font-size: 0.85rem; font-weight: 500; color: var(--muted); }
+
+.plan__features { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.4rem; }
+.plan__features li { font-size: 0.86rem; color: var(--muted); padding-left: 1.1rem; position: relative; }
+.plan__features li::before { content: "\2713"; position: absolute; left: 0; color: var(--accent); font-weight: 700; }
+
+.plan__cta {
+  margin-top: auto;
+  font: inherit;
+  font-weight: 600;
+  padding: 0.65rem 1rem;
+  border-radius: 0.6rem;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--fg);
+  cursor: pointer;
+  transition: background 0.18s ease, transform 0.18s ease;
+}
+.plan__cta:hover { background: rgba(110, 168, 255, 0.18); transform: translateY(-1px); }
+.plan__cta:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; }
+.plan__cta--featured {
+  background: linear-gradient(135deg, var(--accent), var(--accent2));
+  color: #fff;
+  border-color: transparent;
+}
+
+@keyframes bp-bounce {
+  0% { opacity: 0; transform: translateY(40px) scale(0.9); }
+  60% { opacity: 1; transform: translateY(-10px) scale(1.04); }
+  100% { opacity: 1; transform: translateY(0) scale(1); }
+}
+@media (min-width: 48rem) {
+  @keyframes bp-bounce {
+    0% { opacity: 0; transform: translateY(40px) scale(0.96); }
+    60% { opacity: 1; transform: translateY(-10px) scale(1.1); }
+    100% { opacity: 1; transform: translateY(0) scale(1.06); }
+  }
+}
+
+@keyframes bp-pulse {
+  0%, 100% { box-shadow: 0 24px 60px -22px rgba(110, 168, 255, 0.45); }
+  50% { box-shadow: 0 24px 70px -18px rgba(110, 168, 255, 0.75); }
+}
+
+@media (max-width: 480px) {
+  .plan--featured { animation: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .plan--featured { animation: none; }
+  .plan, .plan__cta { transition: none; }
+  .plan:hover, .plan:focus-visible { transform: none; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-bounce-pulse-pricing** from issue #64357 — a glassmorphism pricing table where the featured plan bounces in on load and continuously pulses its glow.

Closes #64357.

## Feature

A bounce-pulse pricing table of frosted-glass plan cards. The featured ("Pro") plan scales up, bounces in with a spring overshoot on page load, then softly pulses its glow `box-shadow` forever after.

## How it works

- `@keyframes bp-bounce` uses a spring `cubic-bezier(0.34, 1.56, 0.64, 1)` for the entrance overshoot.
- `@keyframes bp-pulse` gently breathes the glow `box-shadow` on a loop.

## Accessibility

- `tabindex="0"` + `aria-label` on the featured plan, `:focus-visible` outlines on cards and CTAs.
- Full `prefers-reduced-motion` support (bounce and pulse both disabled when requested).
- Configurable via CSS custom properties (`--bp-bounce-duration`, `--bp-pulse-duration`, `--bp-ease`, `--glass-blur`).

## Submission structure

```
submissions/examples/ease-bounce-pulse-pricing-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← glassmorphism plans + bounce/pulse keyframes
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally