### PR TITLE
feat: add ease-float-drift-pricing component (#64362)

### DIFF
--- a/submissions/examples/ease-float-drift-pricing-sbh/README.md
+++ b/submissions/examples/ease-float-drift-pricing-sbh/README.md
@@ -1,0 +1,44 @@
+# ease-float-drift-pricing
+
+A glassmorphism pricing table whose cards gently float and drift up and down, each at its own rhythm and phase, for a calm, living feel.
+
+## What does this do?
+
+Adds a **float-drift pricing table**: three frosted-glass plan cards that continuously drift vertically with a tiny rotation, each on a different delay so they never move in lockstep. The featured plan is scaled up and tinted.
+
+## How is it used?
+
+1. Build a `.table` grid of `.plan` cards.
+2. Assign each a drift variant class (`plan--a`, `plan--b`, `plan--c`) so they animate out of phase.
+3. Mark the featured plan with `plan--featured` and add a `.plan__badge`.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<section class="table" aria-label="Pricing plans">
+  <article class="plan plan--a" tabindex="0">
+    <h2 class="plan__name">Hobby</h2>
+    <p class="plan__price"><span class="plan__cur">$</span>0<span class="plan__per">/mo</span></p>
+    <ul class="plan__features"><li>1 project</li><li>Community support</li></ul>
+    <button type="button" class="plan__cta">Get started</button>
+  </article>
+  <!-- more plans with --b, --c -->
+</section>
+```
+
+## Why is this useful?
+
+- **Animation-first** — three distinct `@keyframes` (`fd-drift-a/b/c`) with staggered `animation-delay` values so the cards drift at their own cadence and phase, avoiding mechanical sync. Each combines a small `translateY` with a subtle `rotate`.
+- **Glassmorphism aesthetic** — frosted cards via `backdrop-filter: blur()`; the featured card gets a violet-tinted gradient accent.
+- **Accessible** — `tabindex="0"` + `aria-label` on the featured plan, `:focus-visible` outlines on cards and CTAs, and full `prefers-reduced-motion` support (drift disabled when requested — cards sit still).
+- **Reusable** — configurable via CSS custom properties (`--fd-duration`, `--fd-ease`, `--glass-blur`, color tokens).
+
+## Files
+
+- `demo.html` — self-contained demo (open directly in a browser; no server, CDNs, or frameworks).
+- `style.css` — glassmorphism plans, three drift keyframes, featured styling, responsive + reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-float-drift-pricing-sbh/demo.html
+++ b/submissions/examples/ease-float-drift-pricing-sbh/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-float-drift-pricing — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-float-drift-pricing</h1>
+      <p>A pricing table whose cards gently float and drift, each at its own rhythm.</p>
+    </header>
+
+    <section class="table" aria-label="Pricing plans">
+      <article class="plan plan--a" tabindex="0">
+        <h2 class="plan__name">Hobby</h2>
+        <p class="plan__price"><span class="plan__cur">$</span>0<span class="plan__per">/mo</span></p>
+        <ul class="plan__features">
+          <li>1 project</li>
+          <li>Community support</li>
+          <li>1 GB storage</li>
+        </ul>
+        <button type="button" class="plan__cta">Get started</button>
+      </article>
+
+      <article class="plan plan--b plan--featured" tabindex="0" aria-label="Studio plan, featured">
+        <span class="plan__badge">Best value</span>
+        <h2 class="plan__name">Studio</h2>
+        <p class="plan__price"><span class="plan__cur">$</span>24<span class="plan__per">/mo</span></p>
+        <ul class="plan__features">
+          <li>10 projects</li>
+          <li>Email support</li>
+          <li>20 GB storage</li>
+          <li>Custom domains</li>
+        </ul>
+        <button type="button" class="plan__cta plan__cta--featured">Choose Studio</button>
+      </article>
+
+      <article class="plan plan--c" tabindex="0">
+        <h2 class="plan__name">Enterprise</h2>
+        <p class="plan__price"><span class="plan__cur">$</span>99<span class="plan__per">/mo</span></p>
+        <ul class="plan__features">
+          <li>Unlimited projects</li>
+          <li>Dedicated support</li>
+          <li>500 GB storage</li>
+          <li>SSO + audit logs</li>
+        </ul>
+        <button type="button" class="plan__cta">Contact sales</button>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-float-drift-pricing-sbh/style.css
+++ b/submissions/examples/ease-float-drift-pricing-sbh/style.css
@@ -1,0 +1,144 @@
+:root {
+  --fd-duration: 6s;
+  --fd-ease: ease-in-out;
+  --glass-bg: rgba(255, 255, 255, 0.06);
+  --glass-border: rgba(255, 255, 255, 0.12);
+  --glass-blur: 12px;
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --radius: 1rem;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 20%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+}
+
+.page__intro { text-align: center; max-width: 40rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+
+.table {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
+  gap: 1.4rem;
+  width: 48rem;
+  max-width: 100%;
+  align-items: center;
+}
+
+.plan {
+  position: relative;
+  padding: 1.8rem 1.4rem;
+  border-radius: var(--radius);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  box-shadow: 0 16px 36px -20px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+  will-change: transform;
+}
+.plan:hover, .plan:focus-visible { border-color: rgba(110, 168, 255, 0.55); box-shadow: 0 24px 50px -20px rgba(110, 168, 255, 0.4); outline: none; }
+
+.plan--a { animation: fd-drift-a var(--fd-duration) var(--fd-ease) infinite alternate; }
+.plan--b { animation: fd-drift-b var(--fd-duration) var(--fd-ease) infinite alternate; animation-delay: -2s; }
+.plan--c { animation: fd-drift-c var(--fd-duration) var(--fd-ease) infinite alternate; animation-delay: -4s; }
+
+.plan--featured {
+  background: linear-gradient(160deg, rgba(179, 136, 255, 0.18), rgba(110, 168, 255, 0.12));
+  border-color: rgba(179, 136, 255, 0.5);
+}
+@media (min-width: 48rem) {
+  .plan--featured { transform: scale(1.05); }
+}
+
+.plan__badge {
+  position: absolute;
+  top: -0.7rem;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 0.2rem 0.8rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: #1a0f2e;
+  background: linear-gradient(90deg, var(--accent2), var(--accent));
+  border-radius: 999px;
+  white-space: nowrap;
+}
+
+.plan__name { margin: 0; font-size: 1.1rem; font-weight: 700; }
+.plan__price { margin: 0; font-size: 2.2rem; font-weight: 800; letter-spacing: -0.02em; display: flex; align-items: baseline; gap: 0.1rem; }
+.plan__cur { font-size: 1rem; opacity: 0.7; }
+.plan__per { font-size: 0.85rem; font-weight: 500; color: var(--muted); }
+
+.plan__features { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.4rem; }
+.plan__features li { font-size: 0.86rem; color: var(--muted); padding-left: 1.1rem; position: relative; }
+.plan__features li::before { content: "\2713"; position: absolute; left: 0; color: var(--accent2); font-weight: 700; }
+
+.plan__cta {
+  margin-top: auto;
+  font: inherit;
+  font-weight: 600;
+  padding: 0.65rem 1rem;
+  border-radius: 0.6rem;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--fg);
+  cursor: pointer;
+  transition: background 0.18s ease;
+}
+.plan__cta:hover { background: rgba(179, 136, 255, 0.2); }
+.plan__cta:focus-visible { outline: 2px solid var(--accent2); outline-offset: 3px; }
+.plan__cta--featured { background: linear-gradient(135deg, var(--accent2), var(--accent)); color: #fff; border-color: transparent; }
+
+@keyframes fd-drift-a {
+  0% { transform: translateY(-6px) rotate(-0.4deg); }
+  100% { transform: translateY(6px) rotate(0.4deg); }
+}
+@keyframes fd-drift-b {
+  0% { transform: translateY(5px) rotate(0.3deg); }
+  100% { transform: translateY(-7px) rotate(-0.3deg); }
+}
+@keyframes fd-drift-c {
+  0% { transform: translateY(-4px) rotate(0.5deg); }
+  100% { transform: translateY(7px) rotate(-0.2deg); }
+}
+@media (min-width: 48rem) {
+  @keyframes fd-drift-b {
+    0% { transform: translateY(5px) rotate(0.3deg) scale(1.05); }
+    100% { transform: translateY(-7px) rotate(-0.3deg) scale(1.05); }
+  }
+}
+
+@media (max-width: 480px) {
+  .plan--a, .plan--b, .plan--c { animation: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .plan--a, .plan--b, .plan--c { animation: none; }
+  .plan, .plan__cta { transition: none; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-float-drift-pricing** from issue #64362 — a glassmorphism pricing table whose cards gently float and drift up and down, each at its own rhythm and phase.

Closes #64362.

## Feature

A float-drift pricing table of frosted-glass plan cards that continuously drift vertically with a tiny rotation, each on a different delay so they never move in lockstep. The featured plan is scaled up and violet-tinted.

## How it works

- Three distinct `@keyframes` (`fd-drift-a/b/c`) with staggered `animation-delay` values so cards drift out of phase.
- Each combines a small `translateY` with a subtle `rotate`.

## Accessibility

- `tabindex="0"` + `aria-label` on the featured plan, `:focus-visible` outlines on cards and CTAs.
- Full `prefers-reduced-motion` support (drift disabled when requested — cards sit still).
- Configurable via CSS custom properties (`--fd-duration`, `--fd-ease`, `--glass-blur`).

## Submission structure

```
submissions/examples/ease-float-drift-pricing-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← glassmorphism plans + three drift keyframes
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally