### PR TITLE
feat: add ease-fade-in-feature-grid component (#64365)

### DIFF
--- a/submissions/examples/ease-fade-in-feature-grid-sbh/README.md
+++ b/submissions/examples/ease-fade-in-feature-grid-sbh/README.md
@@ -1,0 +1,43 @@
+# ease-fade-in-feature-grid
+
+A glassmorphism feature grid whose cards fade in and lift into view one after another with a staggered cascade.
+
+## What does this do?
+
+Adds a **fade-in feature grid**: each frosted-glass card starts invisible and shifted down, then animates to full opacity and its resting position — with each card delayed slightly more than the previous, creating a cascading reveal. Hovering or focusing a card highlights its border.
+
+## How is it used?
+
+1. Build a `.grid` of `.card` elements.
+2. Assign each card a delay variant (`card--d1` … `card--d6`) to control the stagger order.
+3. Add `tabindex="0"` so cards are keyboard-focusable.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<section class="grid" aria-label="Features">
+  <article class="card card--d1" tabindex="0">
+    <span class="card__icon">&#128640;</span>
+    <h2 class="card__title">Ship faster</h2>
+    <p class="card__text">One-command deploys.</p>
+  </article>
+  <!-- more cards with --d2, --d3, ... -->
+</section>
+```
+
+## Why is this useful?
+
+- **Animation-first** — the signature motion is `@keyframes fi-in` (opacity + `translateY`) applied per card with an increasing `animation-delay` via `--fi-stagger`, so the grid reveals as a cascade rather than all at once.
+- **Glassmorphism aesthetic** — frosted cards via `backdrop-filter: blur()` over a translucent gradient.
+- **Accessible** — `tabindex="0"` for keyboard focus, `:focus-visible` highlights, and full `prefers-reduced-motion` support (cards appear instantly with no fade/translate).
+- **Reusable** — configurable via CSS custom properties (`--fi-duration`, `--fi-ease`, `--fi-stagger`, `--glass-blur`, color tokens).
+
+## Files
+
+- `demo.html` — self-contained demo (open directly in a browser; no server, CDNs, or frameworks).
+- `style.css` — glassmorphism grid, fade-in cascade keyframes + stagger, hover/focus highlight, responsive + reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-fade-in-feature-grid-sbh/demo.html
+++ b/submissions/examples/ease-fade-in-feature-grid-sbh/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-fade-in-feature-grid — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-fade-in-feature-grid</h1>
+      <p>A feature grid whose cards fade and lift into view one after another.</p>
+    </header>
+
+    <section class="grid" aria-label="Fade-in feature grid">
+      <article class="card card--d1" tabindex="0">
+        <span class="card__icon" aria-hidden="true">&#128640;</span>
+        <h2 class="card__title">Ship faster</h2>
+        <p class="card__text">From idea to production in minutes with one-command deploys.</p>
+      </article>
+
+      <article class="card card--d2" tabindex="0">
+        <span class="card__icon" aria-hidden="true">&#128737;</span>
+        <h2 class="card__title">Built secure</h2>
+        <p class="card__text">Encryption at rest and in transit, with audit-ready logs.</p>
+      </article>
+
+      <article class="card card--d3" tabindex="0">
+        <span class="card__icon" aria-hidden="true">&#128202;</span>
+        <h2 class="card__title">Measure everything</h2>
+        <p class="card__text">Real-time metrics and traces across every request path.</p>
+      </article>
+
+      <article class="card card--d4" tabindex="0">
+        <span class="card__icon" aria-hidden="true">&#129520;</span>
+        <h2 class="card__title">Edge-ready</h2>
+        <p class="card__text">Run close to users with global edge regions and low latency.</p>
+      </article>
+
+      <article class="card card--d5" tabindex="0">
+        <span class="card__icon" aria-hidden="true">&#9881;</span>
+        <h2 class="card__title">Tweakable</h2>
+        <p class="card__text">Every value is a variable, so theming is trivial.</p>
+      </article>
+
+      <article class="card card--d6" tabindex="0">
+        <span class="card__icon" aria-hidden="true">&#129302;</span>
+        <h2 class="card__title">Automated</h2>
+        <p class="card__text">CI tests and ships on every commit without manual steps.</p>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-fade-in-feature-grid-sbh/style.css
+++ b/submissions/examples/ease-fade-in-feature-grid-sbh/style.css
@@ -1,0 +1,103 @@
+:root {
+  --fi-duration: 0.6s;
+  --fi-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --fi-stagger: 0.1s;
+  --glass-bg: rgba(255, 255, 255, 0.06);
+  --glass-border: rgba(255, 255, 255, 0.12);
+  --glass-blur: 12px;
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --radius: 0.9rem;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 20%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+}
+
+.page__intro { text-align: center; max-width: 40rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+  gap: 1.2rem;
+  width: 46rem;
+  max-width: 100%;
+}
+
+.card {
+  padding: 1.6rem;
+  border-radius: var(--radius);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  box-shadow: 0 16px 36px -20px rgba(0, 0, 0, 0.6);
+  opacity: 0;
+  transform: translateY(18px);
+  transition: opacity var(--fi-duration) var(--fi-ease),
+              transform var(--fi-duration) var(--fi-ease),
+              border-color 0.3s ease,
+              box-shadow 0.3s ease;
+}
+.card:hover, .card:focus-visible {
+  border-color: rgba(110, 168, 255, 0.5);
+  box-shadow: 0 24px 48px -20px rgba(0, 0, 0, 0.7);
+  outline: none;
+}
+
+.card--d1 { animation: fi-in var(--fi-duration) var(--fi-ease) calc(var(--fi-stagger) * 0) forwards; }
+.card--d2 { animation: fi-in var(--fi-duration) var(--fi-ease) calc(var(--fi-stagger) * 1) forwards; }
+.card--d3 { animation: fi-in var(--fi-duration) var(--fi-ease) calc(var(--fi-stagger) * 2) forwards; }
+.card--d4 { animation: fi-in var(--fi-duration) var(--fi-ease) calc(var(--fi-stagger) * 3) forwards; }
+.card--d5 { animation: fi-in var(--fi-duration) var(--fi-ease) calc(var(--fi-stagger) * 4) forwards; }
+.card--d6 { animation: fi-in var(--fi-duration) var(--fi-ease) calc(var(--fi-stagger) * 5) forwards; }
+
+@keyframes fi-in {
+  0% { opacity: 0; transform: translateY(18px); }
+  100% { opacity: 1; transform: translateY(0); }
+}
+
+.card__icon {
+  display: inline-block;
+  font-size: 1.6rem;
+  margin-bottom: 0.6rem;
+  background: linear-gradient(135deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.card__title { margin: 0 0 0.35rem; font-size: 1.1rem; font-weight: 700; }
+.card__text { margin: 0; font-size: 0.88rem; line-height: 1.55; color: var(--muted); }
+
+@media (max-width: 480px) {
+  .grid { gap: 1rem; }
+  .card { padding: 1.3rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card { animation: none; opacity: 1; transform: none; transition: none; }
+  .card:hover, .card:focus-visible { transform: none; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-fade-in-feature-grid** from issue #64365 — a glassmorphism feature grid whose cards fade in and lift into view one after another with a staggered cascade.

Closes #64365.

## Feature

A fade-in feature grid of frosted-glass cards. Each card starts invisible and shifted down, then animates to full opacity and its resting position — with each card delayed slightly more than the previous, creating a cascading reveal.

## How it works

- `@keyframes fi-in` (opacity + `translateY`) applied per card with an increasing `animation-delay` via `--fi-stagger`.

## Accessibility

- `tabindex="0"` for keyboard focus, `:focus-visible` highlights.
- Full `prefers-reduced-motion` support (cards appear instantly with no fade/translate).
- Configurable via CSS custom properties (`--fi-duration`, `--fi-ease`, `--fi-stagger`, `--glass-blur`).

## Submission structure

```
submissions/examples/ease-fade-in-feature-grid-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← glassmorphism grid + fade-in cascade keyframes
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally