### PR TITLE
feat: add ease-slide-up-feature-grid component (#64366)

### DIFF
--- a/submissions/examples/ease-slide-up-feature-grid-sbh/README.md
+++ b/submissions/examples/ease-slide-up-feature-grid-sbh/README.md
@@ -1,0 +1,43 @@
+# ease-slide-up-feature-grid
+
+A glassmorphism feature grid whose cards slide up into place from below in a staggered sequence.
+
+## What does this do?
+
+Adds a **slide-up feature grid**: each frosted-glass card starts below its resting position and translated down, then slides up to its slot with an increasing delay per card — creating a rising cascade. Hovering or focusing a card lifts it slightly and highlights its border.
+
+## How is it used?
+
+1. Build a `.grid` of `.card` elements.
+2. Assign each card a stagger variant (`card--s1` … `card--s6`) to control the slide order.
+3. Add `tabindex="0"` so cards are keyboard-focusable.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<section class="grid" aria-label="Features">
+  <article class="card card--s1" tabindex="0">
+    <span class="card__tag">Core</span>
+    <h2 class="card__title">Edge runtime</h2>
+    <p class="card__text">Executes in milliseconds near your users.</p>
+  </article>
+  <!-- more cards with --s2, --s3, ... -->
+</section>
+```
+
+## Why is this useful?
+
+- **Animation-first** — the signature motion is `@keyframes su-up` (a larger `translateY(48px) → 0` than a fade, with opacity gating) applied per card with an increasing `animation-delay` via `--su-stagger`, so the grid rises into place as a sequence. Hover adds an interactive lift on `transform`.
+- **Glassmorphism aesthetic** — frosted cards via `backdrop-filter: blur()` over a translucent gradient.
+- **Accessible** — `tabindex="0"` for keyboard focus, `:focus-visible` highlights, and full `prefers-reduced-motion` support (cards appear in place instantly with no slide).
+- **Reusable** — configurable via CSS custom properties (`--su-duration`, `--su-ease`, `--su-stagger`, `--glass-blur`, color tokens).
+
+## Files
+
+- `demo.html` — self-contained demo (open directly in a browser; no server, CDNs, or frameworks).
+- `style.css` — glassmorphism grid, slide-up cascade keyframes + stagger, hover/focus lift, responsive + reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-slide-up-feature-grid-sbh/demo.html
+++ b/submissions/examples/ease-slide-up-feature-grid-sbh/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-slide-up-feature-grid — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-slide-up-feature-grid</h1>
+      <p>A feature grid whose cards slide up into place from below in a staggered sequence.</p>
+    </header>
+
+    <section class="grid" aria-label="Slide-up feature grid">
+      <article class="card card--s1" tabindex="0">
+        <span class="card__tag">Core</span>
+        <h2 class="card__title">Edge runtime</h2>
+        <p class="card__text">Executes in milliseconds near your users across 30+ regions.</p>
+      </article>
+
+      <article class="card card--s2" tabindex="0">
+        <span class="card__tag">Core</span>
+        <h2 class="card__title">Smart caching</h2>
+        <p class="card__text">Stale-while-revalidate keeps responses fresh and instant.</p>
+      </article>
+
+      <article class="card card--s3" tabindex="0">
+        <span class="card__tag">Scale</span>
+        <h2 class="card__title">Auto-scaling</h2>
+        <p class="card__text">Workers scale to zero and back to thousands with no config.</p>
+      </article>
+
+      <article class="card card--s4" tabindex="0">
+        <span class="card__tag">Scale</span>
+        <h2 class="card__title">Global queue</h2>
+        <p class="card__text">Durable queues survive restarts and replay on failure.</p>
+      </article>
+
+      <article class="card card--s5" tabindex="0">
+        <span class="card__tag">Trust</span>
+        <h2 class="card__title">Signed secrets</h2>
+        <p class="card__text">Secrets are encrypted at rest and injected at runtime only.</p>
+      </article>
+
+      <article class="card card--s6" tabindex="0">
+        <span class="card__tag">Trust</span>
+        <h2 class="card__title">Audit logs</h2>
+        <p class="card__text">Every action is recorded and exportable to your SIEM.</p>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-slide-up-feature-grid-sbh/style.css
+++ b/submissions/examples/ease-slide-up-feature-grid-sbh/style.css
@@ -1,0 +1,108 @@
+:root {
+  --su-duration: 0.7s;
+  --su-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --su-stagger: 0.12s;
+  --glass-bg: rgba(255, 255, 255, 0.06);
+  --glass-border: rgba(255, 255, 255, 0.12);
+  --glass-blur: 12px;
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --radius: 0.9rem;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 20%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+  overflow: hidden;
+}
+
+.page__intro { text-align: center; max-width: 40rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+  gap: 1.2rem;
+  width: 46rem;
+  max-width: 100%;
+}
+
+.card {
+  position: relative;
+  padding: 1.6rem;
+  border-radius: var(--radius);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  box-shadow: 0 16px 36px -20px rgba(0, 0, 0, 0.6);
+  opacity: 0;
+  transform: translateY(48px);
+  transition: border-color 0.3s ease, box-shadow 0.3s ease, transform 0.3s var(--su-ease);
+}
+.card:hover, .card:focus-visible {
+  border-color: rgba(110, 168, 255, 0.5);
+  box-shadow: 0 24px 48px -20px rgba(0, 0, 0, 0.7);
+  transform: translateY(-4px);
+  outline: none;
+}
+
+.card--s1 { animation: su-up var(--su-duration) var(--su-ease) calc(var(--su-stagger) * 0) forwards; }
+.card--s2 { animation: su-up var(--su-duration) var(--su-ease) calc(var(--su-stagger) * 1) forwards; }
+.card--s3 { animation: su-up var(--su-duration) var(--su-ease) calc(var(--su-stagger) * 2) forwards; }
+.card--s4 { animation: su-up var(--su-duration) var(--su-ease) calc(var(--su-stagger) * 3) forwards; }
+.card--s5 { animation: su-up var(--su-duration) var(--su-ease) calc(var(--su-stagger) * 4) forwards; }
+.card--s6 { animation: su-up var(--su-duration) var(--su-ease) calc(var(--su-stagger) * 5) forwards; }
+
+@keyframes su-up {
+  0% { opacity: 0; transform: translateY(48px); }
+  60% { opacity: 1; }
+  100% { opacity: 1; transform: translateY(0); }
+}
+
+.card__tag {
+  display: inline-block;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0.18rem 0.55rem;
+  margin-bottom: 0.7rem;
+  border-radius: 999px;
+  color: var(--accent);
+  background: rgba(110, 168, 255, 0.12);
+  border: 1px solid rgba(110, 168, 255, 0.3);
+}
+.card__title { margin: 0 0 0.35rem; font-size: 1.1rem; font-weight: 700; }
+.card__text { margin: 0; font-size: 0.88rem; line-height: 1.55; color: var(--muted); }
+
+@media (max-width: 480px) {
+  .grid { gap: 1rem; }
+  .card { padding: 1.3rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card { animation: none; opacity: 1; transform: none; transition: none; }
+  .card:hover, .card:focus-visible { transform: none; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-slide-up-feature-grid** from issue #64366 — a glassmorphism feature grid whose cards slide up into place from below in a staggered sequence.

Closes #64366.

## Feature

A slide-up feature grid of frosted-glass cards. Each card starts below its resting position, then slides up to its slot with an increasing delay per card — creating a rising cascade. Hovering or focusing a card lifts it slightly.

## How it works

- `@keyframes su-up` (a larger `translateY(48px) → 0` than a fade, with opacity gating) applied per card with an increasing `animation-delay` via `--su-stagger`.
- Hover adds an interactive lift on `transform`.

## Accessibility

- `tabindex="0"` for keyboard focus, `:focus-visible` highlights.
- Full `prefers-reduced-motion` support (cards appear in place instantly with no slide).
- Configurable via CSS custom properties (`--su-duration`, `--su-ease`, `--su-stagger`, `--glass-blur`).

## Submission structure

```
submissions/examples/ease-slide-up-feature-grid-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← glassmorphism grid + slide-up cascade keyframes
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally