### PR TITLE
feat: add ease-scale-hover-feature-grid component (#64368)

### DIFF
--- a/submissions/examples/ease-scale-hover-feature-grid-sbh/README.md
+++ b/submissions/examples/ease-scale-hover-feature-grid-sbh/README.md
@@ -1,0 +1,43 @@
+# ease-scale-hover-feature-grid
+
+A glassmorphism feature grid whose cards scale up smoothly on hover or keyboard focus, pushing depth forward.
+
+## What does this do?
+
+Adds a **scale-hover feature grid**: each frosted-glass card grows by a configurable factor (`--sh-scale`, default 1.06) on hover/focus, with its border brightening and shadow deepening to sell the lift. The transform is GPU-only (`scale`), so it stays smooth.
+
+## How is it used?
+
+1. Build a `.grid` of `.card` elements.
+2. Add `tabindex="0"` so cards are keyboard-focusable (focus triggers the same scale as hover).
+3. Tune the scale via the `--sh-scale` custom property.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<section class="grid" aria-label="Features">
+  <article class="card" tabindex="0">
+    <span class="card__icon">&#128161;</span>
+    <h2 class="card__title">Smart ideas</h2>
+    <p class="card__text">Context-aware suggestions.</p>
+  </article>
+  <!-- more cards -->
+</section>
+```
+
+## Why is this useful?
+
+- **Animation-first** — the signature motion is a `transform: scale()` transition on hover/focus, combined with a synchronized border-color and box-shadow shift for a coherent depth push. Pure `transform`/opacity only, so it's GPU-accelerated.
+- **Glassmorphism aesthetic** — frosted cards via `backdrop-filter: blur()` over a translucent gradient.
+- **Accessible** — `tabindex="0"` for keyboard focus, `:focus-visible` triggers the same scale + glow as hover, and full `prefers-reduced-motion` support (scale disabled when requested).
+- **Reusable** — configurable via CSS custom properties (`--sh-scale`, `--sh-duration`, `--sh-ease`, `--glass-blur`, color tokens).
+
+## Files
+
+- `demo.html` — self-contained demo (open directly in a browser; no server, CDNs, or frameworks).
+- `style.css` — glassmorphism grid, scale-hover transition, hover/focus glow, responsive + reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-scale-hover-feature-grid-sbh/demo.html
+++ b/submissions/examples/ease-scale-hover-feature-grid-sbh/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-scale-hover-feature-grid — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-scale-hover-feature-grid</h1>
+      <p>A feature grid whose cards scale up smoothly on hover, pushing depth forward.</p>
+    </header>
+
+    <section class="grid" aria-label="Scale-hover feature grid">
+      <article class="card" tabindex="0">
+        <span class="card__icon" aria-hidden="true">&#128161;</span>
+        <h2 class="card__title">Smart ideas</h2>
+        <p class="card__text">Surface suggestions based on your recent activity and context.</p>
+      </article>
+
+      <article class="card" tabindex="0">
+        <span class="card__icon" aria-hidden="true">&#128229;</span>
+        <h2 class="card__title">Instant import</h2>
+        <p class="card__text">Drop a file and we parse, validate, and stage it automatically.</p>
+      </article>
+
+      <article class="card" tabindex="0">
+        <span class="card__icon" aria-hidden="true">&#128241;</span>
+        <h2 class="card__title">Works anywhere</h2>
+        <p class="card__text">Responsive layouts adapt from phone to desktop without a hitch.</p>
+      </article>
+
+      <article class="card" tabindex="0">
+        <span class="card__icon" aria-hidden="true">&#128274;</span>
+        <h2 class="card__title">Private by default</h2>
+        <p class="card__text">Your data is encrypted and never leaves your workspace.</p>
+      </article>
+
+      <article class="card" tabindex="0">
+        <span class="card__icon" aria-hidden="true">&#9889;</span>
+        <h2 class="card__title">Snappy</h2>
+        <p class="card__text">Interactions stay under 100ms thanks to GPU-only transforms.</p>
+      </article>
+
+      <article class="card" tabindex="0">
+        <span class="card__icon" aria-hidden="true">&#127919;</span>
+        <h2 class="card__title">Goal tracking</h2>
+        <p class="card__text">Set targets and watch progress update in real time.</p>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-scale-hover-feature-grid-sbh/style.css
+++ b/submissions/examples/ease-scale-hover-feature-grid-sbh/style.css
@@ -1,0 +1,94 @@
+:root {
+  --sh-scale: 1.06;
+  --sh-duration: 0.32s;
+  --sh-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --glass-bg: rgba(255, 255, 255, 0.06);
+  --glass-border: rgba(255, 255, 255, 0.12);
+  --glass-blur: 12px;
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --radius: 0.9rem;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 20%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+}
+
+.page__intro { text-align: center; max-width: 40rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+  gap: 1.2rem;
+  width: 46rem;
+  max-width: 100%;
+}
+
+.card {
+  padding: 1.6rem;
+  border-radius: var(--radius);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  box-shadow: 0 16px 36px -20px rgba(0, 0, 0, 0.6);
+  transform: scale(1);
+  transform-origin: center;
+  transition: transform var(--sh-duration) var(--sh-ease),
+              border-color var(--sh-duration) var(--sh-ease),
+              box-shadow var(--sh-duration) var(--sh-ease);
+  will-change: transform;
+}
+.card:hover, .card:focus-visible {
+  transform: scale(var(--sh-scale));
+  border-color: rgba(110, 168, 255, 0.55);
+  box-shadow: 0 28px 60px -22px rgba(110, 168, 255, 0.45);
+  outline: none;
+  z-index: 1;
+}
+
+.card__icon {
+  display: inline-block;
+  font-size: 1.6rem;
+  margin-bottom: 0.6rem;
+  background: linear-gradient(135deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.card__title { margin: 0 0 0.35rem; font-size: 1.1rem; font-weight: 700; }
+.card__text { margin: 0; font-size: 0.88rem; line-height: 1.55; color: var(--muted); }
+
+@media (max-width: 480px) {
+  .grid { gap: 1rem; }
+  .card { padding: 1.3rem; }
+  :root { --sh-scale: 1.04; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card { transition: none; }
+  .card:hover, .card:focus-visible { transform: none; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-scale-hover-feature-grid** from issue #64368 — a glassmorphism feature grid whose cards scale up smoothly on hover/focus, pushing depth forward.

Closes #64368.

## Feature

A scale-hover feature grid of frosted-glass cards. On hover or keyboard focus, each card grows by a configurable factor (`--sh-scale`, default 1.06) with its border brightening and shadow deepening to sell the lift. GPU-only `transform: scale()` keeps it smooth.

## How it works

- `transform: scale()` transition on hover/focus, synchronized with border-color and box-shadow shifts.

## Accessibility

- `tabindex="0"` for keyboard focus, `:focus-visible` triggers the same scale + glow as hover.
- Full `prefers-reduced-motion` support (scale disabled when requested).
- Configurable via CSS custom properties (`--sh-scale`, `--sh-duration`, `--sh-ease`, `--glass-blur`).

## Submission structure

```
submissions/examples/ease-scale-hover-feature-grid-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← glassmorphism grid + scale-hover transition
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally