### PR TITLE
feat: add ease-blur-entrance-feature-grid component (#64370)

### DIFF
--- a/submissions/examples/ease-blur-entrance-feature-grid-sbh/README.md
+++ b/submissions/examples/ease-blur-entrance-feature-grid-sbh/README.md
@@ -1,0 +1,43 @@
+# ease-blur-entrance-feature-grid
+
+A glassmorphism feature grid whose cards enter from a blurred, dim state and focus into clarity in a staggered cascade.
+
+## What does this do?
+
+Adds a **blur-entrance feature grid**: each frosted-glass card starts blurred (`filter: blur(10px)`) and translucent, then animates to sharp focus and full opacity — with each card delayed slightly more than the previous, so the grid "focuses into" place card by card.
+
+## How is it used?
+
+1. Build a `.grid` of `.card` elements.
+2. Assign each card a stagger variant (`card--b1` … `card--b6`) to control the focus order.
+3. Add `tabindex="0"` so cards are keyboard-focusable.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<section class="grid" aria-label="Features">
+  <article class="card card--b1" tabindex="0">
+    <span class="card__icon">&#127919;</span>
+    <h2 class="card__title">Goals</h2>
+    <p class="card__text">Track progress with live updates.</p>
+  </article>
+  <!-- more cards with --b2, --b3, ... -->
+</section>
+```
+
+## Why is this useful?
+
+- **Animation-first** — the signature motion is `@keyframes be-in` interpolating `filter: blur(10px) → 0` together with `opacity` and a small `translateY`, applied per card with an increasing `animation-delay` via `--be-stagger` for a focusing cascade.
+- **Glassmorphism aesthetic** — frosted cards via `backdrop-filter: blur()` over a translucent gradient.
+- **Accessible** — `tabindex="0"` for keyboard focus, `:focus-visible` highlights, and full `prefers-reduced-motion` support (cards appear sharp instantly with no blur/translate).
+- **Reusable** — configurable via CSS custom properties (`--be-duration`, `--be-ease`, `--be-stagger`, `--glass-blur`, color tokens).
+
+## Files
+
+- `demo.html` — self-contained demo (open directly in a browser; no server, CDNs, or frameworks).
+- `style.css` — glassmorphism grid, blur-entrance cascade keyframes + stagger, hover/focus highlight, responsive + reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-blur-entrance-feature-grid-sbh/demo.html
+++ b/submissions/examples/ease-blur-entrance-feature-grid-sbh/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-blur-entrance-feature-grid — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-blur-entrance-feature-grid</h1>
+      <p>A feature grid whose cards enter from a blurred state, focusing into clarity in a stagger.</p>
+    </header>
+
+    <section class="grid" aria-label="Blur-entrance feature grid">
+      <article class="card card--b1" tabindex="0">
+        <span class="card__icon" aria-hidden="true">&#127919;</span>
+        <h2 class="card__title">Goals</h2>
+        <p class="card__text">Define targets and track progress with live status updates.</p>
+      </article>
+
+      <article class="card card--b2" tabindex="0">
+        <span class="card__icon" aria-hidden="true">&#128202;</span>
+        <h2 class="card__title">Insights</h2>
+        <p class="card__text">Dashboards turn raw events into actionable trends automatically.</p>
+      </article>
+
+      <article class="card card--b3" tabindex="0">
+        <span class="card__icon" aria-hidden="true">&#128229;</span>
+        <h2 class="card__title">Imports</h2>
+        <p class="card__text">Drag in a file and we parse, validate, and stage it for you.</p>
+      </article>
+
+      <article class="card card--b4" tabindex="0">
+        <span class="card__icon" aria-hidden="true">&#128276;</span>
+        <h2 class="card__title">Alerts</h2>
+        <p class="card__text">Get notified the moment a threshold is crossed or a job fails.</p>
+      </article>
+
+      <article class="card card--b5" tabindex="0">
+        <span class="card__icon" aria-hidden="true">&#129518;</span>
+        <h2 class="card__title">Integrations</h2>
+        <p class="card__text">Connect the tools you already use with one-click bridges.</p>
+      </article>
+
+      <article class="card card--b6" tabindex="0">
+        <span class="card__icon" aria-hidden="true">&#128737;</span>
+        <h2 class="card__title">Compliance</h2>
+        <p class="card__text">Stay audit-ready with immutable history and role-based access.</p>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-blur-entrance-feature-grid-sbh/style.css
+++ b/submissions/examples/ease-blur-entrance-feature-grid-sbh/style.css
@@ -1,0 +1,100 @@
+:root {
+  --be-duration: 0.7s;
+  --be-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --be-stagger: 0.12s;
+  --glass-bg: rgba(255, 255, 255, 0.06);
+  --glass-border: rgba(255, 255, 255, 0.12);
+  --glass-blur: 12px;
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --radius: 0.9rem;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 20%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+}
+
+.page__intro { text-align: center; max-width: 40rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+  gap: 1.2rem;
+  width: 46rem;
+  max-width: 100%;
+}
+
+.card {
+  padding: 1.6rem;
+  border-radius: var(--radius);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  box-shadow: 0 16px 36px -20px rgba(0, 0, 0, 0.6);
+  opacity: 0;
+  filter: blur(10px);
+  transform: translateY(8px);
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+.card:hover, .card:focus-visible {
+  border-color: rgba(110, 168, 255, 0.5);
+  box-shadow: 0 24px 48px -20px rgba(0, 0, 0, 0.7);
+  outline: none;
+}
+
+.card--b1 { animation: be-in var(--be-duration) var(--be-ease) calc(var(--be-stagger) * 0) forwards; }
+.card--b2 { animation: be-in var(--be-duration) var(--be-ease) calc(var(--be-stagger) * 1) forwards; }
+.card--b3 { animation: be-in var(--be-duration) var(--be-ease) calc(var(--be-stagger) * 2) forwards; }
+.card--b4 { animation: be-in var(--be-duration) var(--be-ease) calc(var(--be-stagger) * 3) forwards; }
+.card--b5 { animation: be-in var(--be-duration) var(--be-ease) calc(var(--be-stagger) * 4) forwards; }
+.card--b6 { animation: be-in var(--be-duration) var(--be-ease) calc(var(--be-stagger) * 5) forwards; }
+
+@keyframes be-in {
+  0% { opacity: 0; filter: blur(10px); transform: translateY(8px); }
+  100% { opacity: 1; filter: blur(0); transform: translateY(0); }
+}
+
+.card__icon {
+  display: inline-block;
+  font-size: 1.6rem;
+  margin-bottom: 0.6rem;
+  background: linear-gradient(135deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.card__title { margin: 0 0 0.35rem; font-size: 1.1rem; font-weight: 700; }
+.card__text { margin: 0; font-size: 0.88rem; line-height: 1.55; color: var(--muted); }
+
+@media (max-width: 480px) {
+  .grid { gap: 1rem; }
+  .card { padding: 1.3rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card { animation: none; opacity: 1; filter: none; transform: none; transition: none; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-blur-entrance-feature-grid** from issue #64370 — a glassmorphism feature grid whose cards enter from a blurred, dim state and focus into clarity in a staggered cascade.

Closes #64370.

## Feature

A blur-entrance feature grid of frosted-glass cards. Each card starts blurred (`filter: blur(10px)`) and translucent, then animates to sharp focus and full opacity — with each card delayed slightly more than the previous, so the grid "focuses into" place card by card.

## How it works

- `@keyframes be-in` interpolates `filter: blur(10px) → 0` together with `opacity` and a small `translateY`, applied per card with an increasing `animation-delay` via `--be-stagger`.

## Accessibility

- `tabindex="0"` for keyboard focus, `:focus-visible` highlights.
- Full `prefers-reduced-motion` support (cards appear sharp instantly with no blur/translate).
- Configurable via CSS custom properties (`--be-duration`, `--be-ease`, `--be-stagger`, `--glass-blur`).

## Submission structure

```
submissions/examples/ease-blur-entrance-feature-grid-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← glassmorphism grid + blur-entrance cascade keyframes
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally