### PR TITLE
feat: add ease-bounce-pulse-feature-grid component (#64372)

### DIFF
--- a/submissions/examples/ease-bounce-pulse-feature-grid-sbh/README.md
+++ b/submissions/examples/ease-bounce-pulse-feature-grid-sbh/README.md
@@ -1,0 +1,43 @@
+# ease-bounce-pulse-feature-grid
+
+A glassmorphism feature grid whose cards bounce in on load with a spring overshoot and then softly pulse their glow to stay alive.
+
+## What does this do?
+
+Adds a **bounce-pulse feature grid**: each frosted-glass card enters with a spring overshoot (`translateY` + `scale`), staggered per card, then settles into a gentle, continuous glow `box-shadow` pulse so the grid never feels static.
+
+## How is it used?
+
+1. Build a `.grid` of `.card` elements.
+2. Assign each card a stagger variant (`card--p1` … `card--p6`) to control the bounce order.
+3. Add `tabindex="0"` so cards are keyboard-focusable.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<section class="grid" aria-label="Features">
+  <article class="card card--p1" tabindex="0">
+    <span class="card__icon">&#128171;</span>
+    <h2 class="card__title">Boost</h2>
+    <p class="card__text">Accelerate workflows.</p>
+  </article>
+  <!-- more cards with --p2, --p3, ... -->
+</section>
+```
+
+## Why is this useful?
+
+- **Animation-first** — two layered motions per card: `@keyframes bp-bounce` uses a spring `cubic-bezier(0.34, 1.56, 0.64, 1)` for the entrance overshoot (`translateY` + `scale`); `@keyframes bp-pulse` gently breathes the glow `box-shadow` on an infinite loop, started after the bounce finishes. Staggered via `--bp-stagger`.
+- **Glassmorphism aesthetic** — frosted cards via `backdrop-filter: blur()` over a translucent gradient.
+- **Accessible** — `tabindex="0"` for keyboard focus, `:focus-visible` highlights, and full `prefers-reduced-motion` support (bounce and pulse both disabled when requested; cards appear instantly).
+- **Reusable** — configurable via CSS custom properties (`--bp-bounce-duration`, `--bp-pulse-duration`, `--bp-ease`, `--bp-stagger`, `--glass-blur`).
+
+## Files
+
+- `demo.html` — self-contained demo (open directly in a browser; no server, CDNs, or frameworks).
+- `style.css` — glassmorphism grid, bounce + pulse keyframes with stagger, hover/focus highlight, responsive + reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-bounce-pulse-feature-grid-sbh/demo.html
+++ b/submissions/examples/ease-bounce-pulse-feature-grid-sbh/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-bounce-pulse-feature-grid — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-bounce-pulse-feature-grid</h1>
+      <p>A feature grid whose cards bounce in on load and softly pulse to stay alive.</p>
+    </header>
+
+    <section class="grid" aria-label="Bounce-pulse feature grid">
+      <article class="card card--p1" tabindex="0">
+        <span class="card__icon" aria-hidden="true">&#128171;</span>
+        <h2 class="card__title">Boost</h2>
+        <p class="card__text">Accelerate workflows with cached, parallelized pipelines.</p>
+      </article>
+
+      <article class="card card--p2" tabindex="0">
+        <span class="card__icon" aria-hidden="true">&#129529;</span>
+        <h2 class="card__title">Recipes</h2>
+        <p class="card__text">Reusable templates wire common tasks into one click.</p>
+      </article>
+
+      <article class="card card--p3" tabindex="0">
+        <span class="card__icon" aria-hidden="true">&#128260;</span>
+        <h2 class="card__title">Sync</h2>
+        <p class="card__text">Two-way sync keeps your sources and destinations consistent.</p>
+      </article>
+
+      <article class="card card--p4" tabindex="0">
+        <span class="card__icon" aria-hidden="true">&#128269;</span>
+        <h2 class="card__title">Search</h2>
+        <p class="card__text">Full-text search across everything in milliseconds.</p>
+      </article>
+
+      <article class="card card--p5" tabindex="0">
+        <span class="card__icon" aria-hidden="true">&#128279;</span>
+        <h2 class="card__title">Webhooks</h2>
+        <p class="card__text">Fire signed webhooks on every meaningful state change.</p>
+      </article>
+
+      <article class="card card--p6" tabindex="0">
+        <span class="card__icon" aria-hidden="true">&#129302;</span>
+        <h2 class="card__title">Bots</h2>
+        <p class="card__text">Automate routine replies and escalations with rules.</p>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-bounce-pulse-feature-grid-sbh/style.css
+++ b/submissions/examples/ease-bounce-pulse-feature-grid-sbh/style.css
@@ -1,0 +1,101 @@
+:root {
+  --bp-bounce-duration: 0.9s;
+  --bp-pulse-duration: 2.6s;
+  --bp-ease: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --bp-stagger: 0.1s;
+  --glass-bg: rgba(255, 255, 255, 0.06);
+  --glass-border: rgba(255, 255, 255, 0.12);
+  --glass-blur: 12px;
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --radius: 0.9rem;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 20%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+}
+
+.page__intro { text-align: center; max-width: 40rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+  gap: 1.2rem;
+  width: 46rem;
+  max-width: 100%;
+}
+
+.card {
+  padding: 1.6rem;
+  border-radius: var(--radius);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  box-shadow: 0 16px 36px -20px rgba(0, 0, 0, 0.6);
+  opacity: 0;
+  transition: border-color 0.3s ease;
+}
+.card:hover, .card:focus-visible { border-color: rgba(110, 168, 255, 0.55); outline: none; }
+
+.card--p1 { animation: bp-bounce var(--bp-bounce-duration) var(--bp-ease) calc(var(--bp-stagger) * 0) both, bp-pulse var(--bp-pulse-duration) ease-in-out calc(var(--bp-stagger) * 0 + var(--bp-bounce-duration)) infinite; }
+.card--p2 { animation: bp-bounce var(--bp-bounce-duration) var(--bp-ease) calc(var(--bp-stagger) * 1) both, bp-pulse var(--bp-pulse-duration) ease-in-out calc(var(--bp-stagger) * 1 + var(--bp-bounce-duration)) infinite; }
+.card--p3 { animation: bp-bounce var(--bp-bounce-duration) var(--bp-ease) calc(var(--bp-stagger) * 2) both, bp-pulse var(--bp-pulse-duration) ease-in-out calc(var(--bp-stagger) * 2 + var(--bp-bounce-duration)) infinite; }
+.card--p4 { animation: bp-bounce var(--bp-bounce-duration) var(--bp-ease) calc(var(--bp-stagger) * 3) both, bp-pulse var(--bp-pulse-duration) ease-in-out calc(var(--bp-stagger) * 3 + var(--bp-bounce-duration)) infinite; }
+.card--p5 { animation: bp-bounce var(--bp-bounce-duration) var(--bp-ease) calc(var(--bp-stagger) * 4) both, bp-pulse var(--bp-pulse-duration) ease-in-out calc(var(--bp-stagger) * 4 + var(--bp-bounce-duration)) infinite; }
+.card--p6 { animation: bp-bounce var(--bp-bounce-duration) var(--bp-ease) calc(var(--bp-stagger) * 5) both, bp-pulse var(--bp-pulse-duration) ease-in-out calc(var(--bp-stagger) * 5 + var(--bp-bounce-duration)) infinite; }
+
+@keyframes bp-bounce {
+  0% { opacity: 0; transform: translateY(30px) scale(0.92); }
+  55% { opacity: 1; transform: translateY(-8px) scale(1.04); }
+  100% { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+@keyframes bp-pulse {
+  0%, 100% { box-shadow: 0 16px 36px -20px rgba(0, 0, 0, 0.6); }
+  50% { box-shadow: 0 20px 50px -18px rgba(110, 168, 255, 0.55); }
+}
+
+.card__icon {
+  display: inline-block;
+  font-size: 1.6rem;
+  margin-bottom: 0.6rem;
+  background: linear-gradient(135deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.card__title { margin: 0 0 0.35rem; font-size: 1.1rem; font-weight: 700; }
+.card__text { margin: 0; font-size: 0.88rem; line-height: 1.55; color: var(--muted); }
+
+@media (max-width: 480px) {
+  .grid { gap: 1rem; }
+  .card { padding: 1.3rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card { animation: none; opacity: 1; transition: none; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-bounce-pulse-feature-grid** from issue #64372 — a glassmorphism feature grid whose cards bounce in on load with a spring overshoot and then softly pulse their glow to stay alive.

Closes #64372.

## Feature

A bounce-pulse feature grid of frosted-glass cards. Each card enters with a spring overshoot (`translateY` + `scale`), staggered per card, then settles into a gentle, continuous glow `box-shadow` pulse so the grid never feels static.

## How it works

- Two layered motions per card: `@keyframes bp-bounce` (spring `cubic-bezier(0.34, 1.56, 0.64, 1)` entrance overshoot) + `@keyframes bp-pulse` (looping glow `box-shadow`), staggered via `--bp-stagger`.

## Accessibility

- `tabindex="0"` for keyboard focus, `:focus-visible` highlights.
- Full `prefers-reduced-motion` support (bounce and pulse both disabled when requested; cards appear instantly).
- Configurable via CSS custom properties (`--bp-bounce-duration`, `--bp-pulse-duration`, `--bp-ease`, `--bp-stagger`, `--glass-blur`).

## Submission structure

```
submissions/examples/ease-bounce-pulse-feature-grid-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← glassmorphism grid + bounce/pulse keyframes
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally