### PR TITLE
feat: add ease-fade-in-stepper component (#64380)

### DIFF
--- a/submissions/examples/ease-fade-in-stepper-sbh/README.md
+++ b/submissions/examples/ease-fade-in-stepper-sbh/README.md
@@ -1,0 +1,42 @@
+# ease-fade-in-stepper
+
+A glassmorphism multi-step progress indicator whose steps fade and lift into view one after another in a staggered cascade.
+
+## What does this do?
+
+Adds a **fade-in stepper**: each step marker and label starts invisible and shifted down, then animates to full opacity and its resting position — with each step delayed slightly more than the previous, creating a cascading reveal. Completed steps fill their marker with a success color and the connector line fills with a gradient. The active step is highlighted with a ring.
+
+## How is it used?
+
+1. Build an ordered list `.stepper` of `.step` items.
+2. Assign each step a delay variant (`step--f1` … `step--f4`) to control the fade order.
+3. Mark states with classes: `is-done`, `is-active`, or neither.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<ol class="stepper">
+  <li class="step step--f1 is-done" tabindex="0">
+    <span class="step__marker" aria-hidden="true">1</span>
+    <span class="step__label">Connect</span>
+  </li>
+  <!-- more steps with --f2, --f3, --f4 -->
+</ol>
+```
+
+## Why is this useful?
+
+- **Animation-first** — the signature motion is `@keyframes fi-step` (opacity + `translateY`) applied per step with an increasing `animation-delay` via `--fi-stagger`, so the stepper reveals as a cascade rather than all at once.
+- **Glassmorphism aesthetic** — frosted panel via `backdrop-filter: blur()` over a translucent gradient.
+- **Accessible** — `aria-current="step"` on the active step, `tabindex` for keyboard focus, `:focus-visible` rings, and full `prefers-reduced-motion` support (steps appear instantly with no fade/translate).
+- **Reusable** — configurable via CSS custom properties (`--fi-duration`, `--fi-ease`, `--fi-stagger`, `--marker`, `--glass-blur`).
+
+## Files
+
+- `demo.html` — self-contained demo (open directly in a browser; no server, CDNs, or frameworks).
+- `style.css` — glassmorphism panel, fade-in cascade keyframes + stagger, marker/connector states, responsive + reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-fade-in-stepper-sbh/demo.html
+++ b/submissions/examples/ease-fade-in-stepper-sbh/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-fade-in-stepper — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-fade-in-stepper</h1>
+      <p>A multi-step progress indicator whose steps fade in one after another.</p>
+    </header>
+
+    <section class="panel" aria-label="Fade-in stepper">
+      <ol class="stepper">
+        <li class="step step--f1 is-done" tabindex="0" aria-current="false">
+          <span class="step__marker" aria-hidden="true">1</span>
+          <span class="step__label">Connect</span>
+        </li>
+        <li class="step step--f2 is-done" tabindex="0" aria-current="false">
+          <span class="step__marker" aria-hidden="true">2</span>
+          <span class="step__label">Map fields</span>
+        </li>
+        <li class="step step--f3 is-active" tabindex="0" aria-current="step">
+          <span class="step__marker" aria-hidden="true">3</span>
+          <span class="step__label">Review</span>
+        </li>
+        <li class="step step--f4" tabindex="0" aria-current="false">
+          <span class="step__marker" aria-hidden="true">4</span>
+          <span class="step__label">Finish</span>
+        </li>
+      </ol>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-fade-in-stepper-sbh/style.css
+++ b/submissions/examples/ease-fade-in-stepper-sbh/style.css
@@ -1,0 +1,136 @@
+:root {
+  --fi-duration: 0.5s;
+  --fi-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --fi-stagger: 0.18s;
+  --glass-bg: rgba(255, 255, 255, 0.06);
+  --glass-border: rgba(255, 255, 255, 0.12);
+  --glass-blur: 12px;
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --success: #34d399;
+  --marker: 2.4rem;
+  --radius: 0.75rem;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 20%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+}
+
+.page__intro { text-align: center; max-width: 36rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+
+.panel {
+  width: 34rem;
+  max-width: 100%;
+  padding: 2rem 1.8rem;
+  border-radius: calc(var(--radius) * 1.6);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  box-shadow: 0 20px 50px -24px rgba(0, 0, 0, 0.6);
+}
+
+.stepper {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.step {
+  position: relative;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.55rem;
+  opacity: 0;
+}
+.step:focus-visible { outline: none; }
+.step:focus-visible .step__marker { box-shadow: 0 0 0 3px rgba(110, 168, 255, 0.5); }
+
+.step--f1 { animation: fi-step var(--fi-duration) var(--fi-ease) calc(var(--fi-stagger) * 0) forwards; }
+.step--f2 { animation: fi-step var(--fi-duration) var(--fi-ease) calc(var(--fi-stagger) * 1) forwards; }
+.step--f3 { animation: fi-step var(--fi-duration) var(--fi-ease) calc(var(--fi-stagger) * 2) forwards; }
+.step--f4 { animation: fi-step var(--fi-duration) var(--fi-ease) calc(var(--fi-stagger) * 3) forwards; }
+
+@keyframes fi-step {
+  0% { opacity: 0; transform: translateY(8px); }
+  100% { opacity: 1; transform: translateY(0); }
+}
+
+.step:not(:last-child)::before {
+  content: "";
+  position: absolute;
+  top: calc(var(--marker) / 2);
+  left: calc(50% + var(--marker) / 2 + 0.4rem);
+  right: calc(-50% + var(--marker) / 2 + 0.4rem);
+  height: 2px;
+  background: rgba(255, 255, 255, 0.14);
+  z-index: 0;
+}
+.step.is-done:not(:last-child)::before { background: linear-gradient(90deg, var(--success), var(--accent)); }
+
+.step__marker {
+  position: relative;
+  z-index: 1;
+  width: var(--marker);
+  height: var(--marker);
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-size: 0.9rem;
+  font-weight: 700;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  color: var(--fg);
+}
+.step.is-active .step__marker {
+  border-color: var(--accent);
+  color: var(--accent);
+  box-shadow: 0 0 0 4px rgba(110, 168, 255, 0.18);
+}
+.step.is-done .step__marker {
+  background: var(--success);
+  border-color: var(--success);
+  color: #06231a;
+}
+
+.step__label { font-size: 0.82rem; color: var(--muted); text-align: center; }
+.step.is-active .step__label { color: var(--fg); font-weight: 600; }
+.step.is-done .step__label { color: var(--fg); }
+
+@media (max-width: 520px) {
+  :root { --marker: 2rem; }
+  .step__label { font-size: 0.72rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .step { animation: none; opacity: 1; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-fade-in-stepper** from issue #64380 — a glassmorphism multi-step progress indicator whose steps fade and lift into view one after another in a staggered cascade.

Closes #64380.

## Feature

A fade-in stepper on a frosted-glass panel. Each step marker and label starts invisible and shifted down, then animates to full opacity and its resting position — staggered per step. Completed steps fill their marker with a success color and the connector line fills with a gradient. The active step is highlighted with a ring.

## How it works

- `@keyframes fi-step` (opacity + `translateY`) applied per step with an increasing `animation-delay` via `--fi-stagger`.

## Accessibility

- `aria-current="step"` on the active step, `tabindex` for keyboard focus, `:focus-visible` rings.
- Full `prefers-reduced-motion` support (steps appear instantly with no fade/translate).
- Configurable via CSS custom properties (`--fi-duration`, `--fi-ease`, `--fi-stagger`, `--marker`, `--glass-blur`).

## Submission structure

```
submissions/examples/ease-fade-in-stepper-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← glassmorphism panel + fade-in cascade keyframes
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally