### PR TITLE
feat: add ease-elastic-slide-feature-grid component (#64373)

### DIFF
--- a/submissions/examples/ease-elastic-slide-feature-grid-sbh/README.md
+++ b/submissions/examples/ease-elastic-slide-feature-grid-sbh/README.md
@@ -1,0 +1,43 @@
+# ease-elastic-slide-feature-grid
+
+A glassmorphism feature grid whose cards slide in from the left with an elastic spring overshoot, staggered per card.
+
+## What does this do?
+
+Adds an **elastic-slide feature grid**: each frosted-glass card enters from the left (`translateX(-60px)`), overshoots its resting position to the right, then settles back — a classic spring/elastic feel. Each card is delayed slightly more than the previous, so the grid slides into place as a sequence.
+
+## How is it used?
+
+1. Build a `.grid` of `.card` elements.
+2. Assign each card a stagger variant (`card--e1` … `card--e6`) to control the slide order.
+3. Add `tabindex="0"` so cards are keyboard-focusable.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<section class="grid" aria-label="Features">
+  <article class="card card--e1" tabindex="0">
+    <span class="card__icon">&#128640;</span>
+    <h2 class="card__title">Launch</h2>
+    <p class="card__text">Zero to deployed in one command.</p>
+  </article>
+  <!-- more cards with --e2, --e3, ... -->
+</section>
+```
+
+## Why is this useful?
+
+- **Animation-first** — the signature motion is `@keyframes es-slide` using a spring `cubic-bezier(0.34, 1.56, 0.64, 1)` for the entrance, with a multi-step keyframe that overshoots right (`translateX(10px)`) then settles back through a small recoil (`-4px`) before resting at 0. Staggered via `--es-stagger`.
+- **Glassmorphism aesthetic** — frosted cards via `backdrop-filter: blur()` over a translucent gradient.
+- **Accessible** — `tabindex="0"` for keyboard focus, `:focus-visible` highlights, and full `prefers-reduced-motion` support (cards appear in place instantly with no slide).
+- **Reusable** — configurable via CSS custom properties (`--es-duration`, `--es-ease`, `--es-stagger`, `--glass-blur`).
+
+## Files
+
+- `demo.html` — self-contained demo (open directly in a browser; no server, CDNs, or frameworks).
+- `style.css` — glassmorphism grid, elastic-slide spring keyframes + stagger, hover/focus highlight, responsive + reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-elastic-slide-feature-grid-sbh/demo.html
+++ b/submissions/examples/ease-elastic-slide-feature-grid-sbh/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-elastic-slide-feature-grid — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-elastic-slide-feature-grid</h1>
+      <p>A feature grid whose cards slide in from the side with an elastic overshoot.</p>
+    </header>
+
+    <section class="grid" aria-label="Elastic-slide feature grid">
+      <article class="card card--e1" tabindex="0">
+        <span class="card__icon" aria-hidden="true">&#128640;</span>
+        <h2 class="card__title">Launch</h2>
+        <p class="card__text">Go from zero to deployed in a single command.</p>
+      </article>
+
+      <article class="card card--e2" tabindex="0">
+        <span class="card__icon" aria-hidden="true">&#127919;</span>
+        <h2 class="card__title">Aim</h2>
+        <p class="card__text">Set goals and let progress surface where it matters.</p>
+      </article>
+
+      <article class="card card--e3" tabindex="0">
+        <span class="card__icon" aria-hidden="true">&#128202;</span>
+        <h2 class="card__title">Measure</h2>
+        <p class="card__text">See every metric update in real time, no refresh needed.</p>
+      </article>
+
+      <article class="card card--e4" tabindex="0">
+        <span class="card__icon" aria-hidden="true">&#129518;</span>
+        <h2 class="card__title">Connect</h2>
+        <p class="card__text">Bridge to the tools your team already lives in.</p>
+      </article>
+
+      <article class="card card--e5" tabindex="0">
+        <span class="card__icon" aria-hidden="true">&#128276;</span>
+        <h2 class="card__title">Notify</h2>
+        <p class="card__text">Alerts reach the right person on the right channel.</p>
+      </article>
+
+      <article class="card card--e6" tabindex="0">
+        <span class="card__icon" aria-hidden="true">&#129302;</span>
+        <h2 class="card__title">Automate</h2>
+        <p class="card__text">Routine work runs itself while you focus on the big picture.</p>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-elastic-slide-feature-grid-sbh/style.css
+++ b/submissions/examples/ease-elastic-slide-feature-grid-sbh/style.css
@@ -1,0 +1,103 @@
+:root {
+  --es-duration: 0.8s;
+  --es-ease: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --es-stagger: 0.12s;
+  --glass-bg: rgba(255, 255, 255, 0.06);
+  --glass-border: rgba(255, 255, 255, 0.12);
+  --glass-blur: 12px;
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --radius: 0.9rem;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 20%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+  overflow: hidden;
+}
+
+.page__intro { text-align: center; max-width: 40rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+  gap: 1.2rem;
+  width: 46rem;
+  max-width: 100%;
+}
+
+.card {
+  padding: 1.6rem;
+  border-radius: var(--radius);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  box-shadow: 0 16px 36px -20px rgba(0, 0, 0, 0.6);
+  opacity: 0;
+  transform: translateX(-60px);
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+.card:hover, .card:focus-visible {
+  border-color: rgba(110, 168, 255, 0.5);
+  box-shadow: 0 24px 48px -20px rgba(0, 0, 0, 0.7);
+  outline: none;
+}
+
+.card--e1 { animation: es-slide var(--es-duration) var(--es-ease) calc(var(--es-stagger) * 0) forwards; }
+.card--e2 { animation: es-slide var(--es-duration) var(--es-ease) calc(var(--es-stagger) * 1) forwards; }
+.card--e3 { animation: es-slide var(--es-duration) var(--es-ease) calc(var(--es-stagger) * 2) forwards; }
+.card--e4 { animation: es-slide var(--es-duration) var(--es-ease) calc(var(--es-stagger) * 3) forwards; }
+.card--e5 { animation: es-slide var(--es-duration) var(--es-ease) calc(var(--es-stagger) * 4) forwards; }
+.card--e6 { animation: es-slide var(--es-duration) var(--es-ease) calc(var(--es-stagger) * 5) forwards; }
+
+@keyframes es-slide {
+  0% { opacity: 0; transform: translateX(-60px); }
+  60% { opacity: 1; transform: translateX(10px); }
+  80% { transform: translateX(-4px); }
+  100% { opacity: 1; transform: translateX(0); }
+}
+
+.card__icon {
+  display: inline-block;
+  font-size: 1.6rem;
+  margin-bottom: 0.6rem;
+  background: linear-gradient(135deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.card__title { margin: 0 0 0.35rem; font-size: 1.1rem; font-weight: 700; }
+.card__text { margin: 0; font-size: 0.88rem; line-height: 1.55; color: var(--muted); }
+
+@media (max-width: 480px) {
+  .grid { gap: 1rem; }
+  .card { padding: 1.3rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card { animation: none; opacity: 1; transform: none; transition: none; }
+  .card:hover, .card:focus-visible { transform: none; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-elastic-slide-feature-grid** from issue #64373 — a glassmorphism feature grid whose cards slide in from the left with an elastic spring overshoot, staggered per card.

Closes #64373.

## Feature

An elastic-slide feature grid of frosted-glass cards. Each card enters from the left (`translateX(-60px)`), overshoots its resting position to the right, then settles back — a classic spring/elastic feel. Each card is delayed slightly more than the previous.

## How it works

- `@keyframes es-slide` uses a spring `cubic-bezier(0.34, 1.56, 0.64, 1)` with a multi-step keyframe that overshoots right (`translateX(10px)`) then recoils (`-4px`) before resting at 0. Staggered via `--es-stagger`.

## Accessibility

- `tabindex="0"` for keyboard focus, `:focus-visible` highlights.
- Full `prefers-reduced-motion` support (cards appear in place instantly with no slide).
- Configurable via CSS custom properties (`--es-duration`, `--es-ease`, `--es-stagger`, `--glass-blur`).

## Submission structure

```
submissions/examples/ease-elastic-slide-feature-grid-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← glassmorphism grid + elastic-slide spring keyframes
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally