### PR TITLE
feat: add ease-rotate-fade-pricing component (#64356)

### DIFF
--- a/submissions/examples/ease-rotate-fade-pricing-sbh/README.md
+++ b/submissions/examples/ease-rotate-fade-pricing-sbh/README.md
@@ -1,0 +1,44 @@
+# ease-rotate-fade-pricing
+
+A glassmorphism pricing table whose cards rotate and fade into view on load, staggered per card.
+
+## What does this do?
+
+Adds a **rotate-fade pricing table**: each frosted-glass plan card enters rotated slightly counter-clockwise (`rotate(-6deg)`) and shifted down, then animates to its upright, resting position while fading in — with each card delayed slightly more than the previous. The featured plan is scaled up and tinted.
+
+## How is it used?
+
+1. Build a `.table` grid of `.plan` cards.
+2. Assign each plan a stagger variant (`plan--r1`, `plan--r2`, `plan--r3`) to control the entrance order.
+3. Mark the featured plan with `plan--featured` and add a `.plan__badge`.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<section class="table" aria-label="Pricing plans">
+  <article class="plan plan--r1" tabindex="0">
+    <h2 class="plan__name">Solo</h2>
+    <p class="plan__price"><span class="plan__cur">$</span>12<span class="plan__per">/mo</span></p>
+    <ul class="plan__features"><li>3 projects</li><li>Email support</li></ul>
+    <button type="button" class="plan__cta">Choose Solo</button>
+  </article>
+  <!-- more plans with --r2, --r3 -->
+</section>
+```
+
+## Why is this useful?
+
+- **Animation-first** — the signature motion is `@keyframes rf-in` interpolating `rotate(-6deg) → 0deg` together with `opacity` and `translateY`, applied per card with an increasing `animation-delay` via `--rf-stagger`. The featured plan's keyframe also folds in its `scale(1.05)` so it settles at the larger size.
+- **Glassmorphism aesthetic** — frosted cards via `backdrop-filter: blur()`; the featured card gets a tinted gradient accent.
+- **Accessible** — `tabindex="0"` + `aria-label` on the featured plan, `:focus-visible` outlines on cards and CTAs, and full `prefers-reduced-motion` support (cards appear upright instantly with no rotate/fade).
+- **Reusable** — configurable via CSS custom properties (`--rf-duration`, `--rf-ease`, `--rf-stagger`, `--glass-blur`).
+
+## Files
+
+- `demo.html` — self-contained demo (open directly in a browser; no server, CDNs, or frameworks).
+- `style.css` — glassmorphism plans, rotate-fade keyframes + stagger, featured styling, responsive + reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-rotate-fade-pricing-sbh/demo.html
+++ b/submissions/examples/ease-rotate-fade-pricing-sbh/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-rotate-fade-pricing — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-rotate-fade-pricing</h1>
+      <p>A pricing table whose cards rotate and fade into view on load.</p>
+    </header>
+
+    <section class="table" aria-label="Pricing plans">
+      <article class="plan plan--r1" tabindex="0">
+        <h2 class="plan__name">Solo</h2>
+        <p class="plan__price"><span class="plan__cur">$</span>12<span class="plan__per">/mo</span></p>
+        <ul class="plan__features">
+          <li>3 projects</li>
+          <li>5 GB storage</li>
+          <li>Email support</li>
+        </ul>
+        <button type="button" class="plan__cta">Choose Solo</button>
+      </article>
+
+      <article class="plan plan--r2 plan--featured" tabindex="0" aria-label="Team plan, featured">
+        <span class="plan__badge">Popular</span>
+        <h2 class="plan__name">Team</h2>
+        <p class="plan__price"><span class="plan__cur">$</span>39<span class="plan__per">/mo</span></p>
+        <ul class="plan__features">
+          <li>Unlimited projects</li>
+          <li>100 GB storage</li>
+          <li>Priority support</li>
+          <li>SSO + roles</li>
+        </ul>
+        <button type="button" class="plan__cta plan__cta--featured">Choose Team</button>
+      </article>
+
+      <article class="plan plan--r3" tabindex="0">
+        <h2 class="plan__name">Enterprise</h2>
+        <p class="plan__price"><span class="plan__cur">$</span>149<span class="plan__per">/mo</span></p>
+        <ul class="plan__features">
+          <li>Everything in Team</li>
+          <li>1 TB storage</li>
+          <li>Dedicated manager</li>
+          <li>Custom SLAs</li>
+        </ul>
+        <button type="button" class="plan__cta">Contact sales</button>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-rotate-fade-pricing-sbh/style.css
+++ b/submissions/examples/ease-rotate-fade-pricing-sbh/style.css
@@ -1,0 +1,141 @@
+:root {
+  --rf-duration: 0.7s;
+  --rf-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --rf-stagger: 0.15s;
+  --glass-bg: rgba(255, 255, 255, 0.06);
+  --glass-border: rgba(255, 255, 255, 0.12);
+  --glass-blur: 12px;
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --radius: 1rem;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 20%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+  overflow: hidden;
+}
+
+.page__intro { text-align: center; max-width: 40rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+
+.table {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
+  gap: 1.2rem;
+  width: 48rem;
+  max-width: 100%;
+  align-items: center;
+}
+
+.plan {
+  position: relative;
+  padding: 1.8rem 1.4rem;
+  border-radius: var(--radius);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  box-shadow: 0 16px 36px -20px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  opacity: 0;
+  transform: rotate(-6deg) translateY(20px);
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+.plan:hover, .plan:focus-visible {
+  border-color: rgba(110, 168, 255, 0.55);
+  box-shadow: 0 24px 50px -20px rgba(110, 168, 255, 0.4);
+  outline: none;
+}
+
+.plan--r1 { animation: rf-in var(--rf-duration) var(--rf-ease) calc(var(--rf-stagger) * 0) forwards; }
+.plan--r2 { animation: rf-in var(--rf-duration) var(--rf-ease) calc(var(--rf-stagger) * 1) forwards; }
+.plan--r3 { animation: rf-in var(--rf-duration) var(--rf-ease) calc(var(--rf-stagger) * 2) forwards; }
+
+@keyframes rf-in {
+  0% { opacity: 0; transform: rotate(-6deg) translateY(20px); }
+  100% { opacity: 1; transform: rotate(0deg) translateY(0); }
+}
+
+.plan--featured {
+  background: linear-gradient(160deg, rgba(110, 168, 255, 0.18), rgba(179, 136, 255, 0.12));
+  border-color: rgba(110, 168, 255, 0.5);
+}
+@media (min-width: 48rem) {
+  .plan--featured { transform: scale(1.05); }
+  @keyframes rf-in {
+    0% { opacity: 0; transform: rotate(-6deg) translateY(20px) scale(0.98); }
+    100% { opacity: 1; transform: rotate(0deg) translateY(0) scale(1.05); }
+  }
+}
+
+.plan__badge {
+  position: absolute;
+  top: -0.7rem;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 0.2rem 0.8rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: #06231a;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  border-radius: 999px;
+  white-space: nowrap;
+}
+
+.plan__name { margin: 0; font-size: 1.1rem; font-weight: 700; }
+.plan__price { margin: 0; font-size: 2.2rem; font-weight: 800; letter-spacing: -0.02em; display: flex; align-items: baseline; gap: 0.1rem; }
+.plan__cur { font-size: 1rem; opacity: 0.7; }
+.plan__per { font-size: 0.85rem; font-weight: 500; color: var(--muted); }
+
+.plan__features { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.4rem; }
+.plan__features li { font-size: 0.86rem; color: var(--muted); padding-left: 1.1rem; position: relative; }
+.plan__features li::before { content: "\2713"; position: absolute; left: 0; color: var(--accent); font-weight: 700; }
+
+.plan__cta {
+  margin-top: auto;
+  font: inherit;
+  font-weight: 600;
+  padding: 0.65rem 1rem;
+  border-radius: 0.6rem;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--fg);
+  cursor: pointer;
+  transition: background 0.18s ease;
+}
+.plan__cta:hover { background: rgba(110, 168, 255, 0.18); }
+.plan__cta:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; }
+.plan__cta--featured { background: linear-gradient(135deg, var(--accent), var(--accent2)); color: #fff; border-color: transparent; }
+
+@media (max-width: 480px) {
+  .plan { transform: none; }
+  .plan--r1, .plan--r2, .plan--r3 { animation: none; opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .plan { animation: none; opacity: 1; transform: none; transition: none; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-rotate-fade-pricing** from issue #64356 — a glassmorphism pricing table whose cards rotate and fade into view on load, staggered per card.

Closes #64356.

## Feature

A rotate-fade pricing table of frosted-glass plan cards. Each card enters rotated slightly counter-clockwise (`rotate(-6deg)`) and shifted down, then animates to its upright, resting position while fading in — staggered per card. The featured plan is scaled up and tinted.

## How it works

- `@keyframes rf-in` interpolates `rotate(-6deg) → 0deg` together with `opacity` and `translateY`, applied per card with an increasing `animation-delay` via `--rf-stagger`. The featured plan's keyframe folds in its `scale(1.05)`.

## Accessibility

- `tabindex="0"` + `aria-label` on the featured plan, `:focus-visible` outlines on cards and CTAs.
- Full `prefers-reduced-motion` support (cards appear upright instantly with no rotate/fade).
- Configurable via CSS custom properties (`--rf-duration`, `--rf-ease`, `--rf-stagger`, `--glass-blur`).

## Submission structure

```
submissions/examples/ease-rotate-fade-pricing-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← glassmorphism plans + rotate-fade keyframes
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally