### PR TITLE
feat: add ease-skew-active-pricing component (#64347)

### DIFF
--- a/submissions/examples/ease-skew-active-pricing-sbh/README.md
+++ b/submissions/examples/ease-skew-active-pricing-sbh/README.md
@@ -1,0 +1,45 @@
+# ease-skew-active-pricing
+
+A glassmorphism pricing table whose cards skew (tilt) when active — hovered or keyboard-focused — for a tactile, playful feel.
+
+## What does this do?
+
+Adds a **skew-active pricing table**: each frosted-glass plan card tilts slightly (`skewX(-4deg)`) and lifts up when hovered or focused, then snaps back when inactive. The skew is GPU-only (`transform`), so it stays smooth. The featured plan is scaled up and violet-tinted, and its active state combines skew + scale.
+
+## How is it used?
+
+1. Build a `.table` grid of `.plan` cards.
+2. Mark the featured plan with `plan--featured` and add a `.plan__badge`.
+3. Add `tabindex="0"` so cards are keyboard-focusable (focus triggers the same skew as hover).
+4. Tune the skew angle via the `--skew-angle` custom property.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<section class="table" aria-label="Pricing plans">
+  <article class="plan" tabindex="0">
+    <h2 class="plan__name">Bronze</h2>
+    <p class="plan__price"><span class="plan__cur">$</span>8<span class="plan__per">/mo</span></p>
+    <ul class="plan__features"><li>1 project</li><li>Community support</li></ul>
+    <button type="button" class="plan__cta">Choose Bronze</button>
+  </article>
+  <!-- more plans; mark one plan--featured -->
+</section>
+```
+
+## Why is this useful?
+
+- **Animation-first** — the signature motion is a `transform: skewX()` transition on hover/focus, combined with a synchronized `translateY` lift and border/shadow shift. Pure `transform`/opacity only, so it's GPU-accelerated.
+- **Glassmorphism aesthetic** — frosted cards via `backdrop-filter: blur()`; the featured card gets a violet-tinted gradient accent.
+- **Accessible** — `tabindex="0"` + `aria-label` on the featured plan, `:focus-visible` triggers the same skew + lift as hover, and full `prefers-reduced-motion` support (skew disabled when requested).
+- **Reusable** — configurable via CSS custom properties (`--skew-angle`, `--skew-duration`, `--skew-ease`, `--glass-blur`).
+
+## Files
+
+- `demo.html` — self-contained demo (open directly in a browser; no server, CDNs, or frameworks).
+- `style.css` — glassmorphism plans, skew-active transition, hover/focus skew + lift, featured styling, responsive + reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-skew-active-pricing-sbh/demo.html
+++ b/submissions/examples/ease-skew-active-pricing-sbh/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-skew-active-pricing — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-skew-active-pricing</h1>
+      <p>A pricing table whose cards skew when active (hovered or focused) for a tactile feel.</p>
+    </header>
+
+    <section class="table" aria-label="Pricing plans">
+      <article class="plan" tabindex="0">
+        <h2 class="plan__name">Bronze</h2>
+        <p class="plan__price"><span class="plan__cur">$</span>8<span class="plan__per">/mo</span></p>
+        <ul class="plan__features">
+          <li>1 project</li>
+          <li>1 GB storage</li>
+          <li>Community support</li>
+        </ul>
+        <button type="button" class="plan__cta">Choose Bronze</button>
+      </article>
+
+      <article class="plan plan--featured" tabindex="0" aria-label="Silver plan, featured">
+        <span class="plan__badge">Best value</span>
+        <h2 class="plan__name">Silver</h2>
+        <p class="plan__price"><span class="plan__cur">$</span>19<span class="plan__per">/mo</span></p>
+        <ul class="plan__features">
+          <li>10 projects</li>
+          <li>20 GB storage</li>
+          <li>Email support</li>
+          <li>Custom domains</li>
+        </ul>
+        <button type="button" class="plan__cta plan__cta--featured">Choose Silver</button>
+      </article>
+
+      <article class="plan" tabindex="0">
+        <h2 class="plan__name">Gold</h2>
+        <p class="plan__price"><span class="plan__cur">$</span>49<span class="plan__per">/mo</span></p>
+        <ul class="plan__features">
+          <li>Unlimited projects</li>
+          <li>200 GB storage</li>
+          <li>Priority support</li>
+          <li>Audit logs</li>
+        </ul>
+        <button type="button" class="plan__cta">Choose Gold</button>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-skew-active-pricing-sbh/style.css
+++ b/submissions/examples/ease-skew-active-pricing-sbh/style.css
@@ -1,0 +1,132 @@
+:root {
+  --skew-angle: -4deg;
+  --skew-duration: 0.3s;
+  --skew-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --glass-bg: rgba(255, 255, 255, 0.06);
+  --glass-border: rgba(255, 255, 255, 0.12);
+  --glass-blur: 12px;
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --radius: 1rem;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 20%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+}
+
+.page__intro { text-align: center; max-width: 40rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+
+.table {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
+  gap: 1.2rem;
+  width: 48rem;
+  max-width: 100%;
+  align-items: center;
+}
+
+.plan {
+  position: relative;
+  padding: 1.8rem 1.4rem;
+  border-radius: var(--radius);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  box-shadow: 0 16px 36px -20px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  transform: skewX(0deg);
+  transition: transform var(--skew-duration) var(--skew-ease),
+              border-color var(--skew-duration) var(--skew-ease),
+              box-shadow var(--skew-duration) var(--skew-ease);
+  will-change: transform;
+}
+.plan:hover, .plan:focus-visible {
+  transform: skewX(var(--skew-angle)) translateY(-4px);
+  border-color: rgba(110, 168, 255, 0.55);
+  box-shadow: 0 24px 50px -20px rgba(110, 168, 255, 0.4);
+  outline: none;
+  z-index: 1;
+}
+
+.plan--featured {
+  background: linear-gradient(160deg, rgba(179, 136, 255, 0.18), rgba(110, 168, 255, 0.12));
+  border-color: rgba(179, 136, 255, 0.5);
+}
+@media (min-width: 48rem) {
+  .plan--featured { transform: scale(1.05); }
+  .plan--featured:hover, .plan--featured:focus-visible { transform: skewX(var(--skew-angle)) scale(1.05) translateY(-4px); }
+}
+
+.plan__badge {
+  position: absolute;
+  top: -0.7rem;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 0.2rem 0.8rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: #1a0f2e;
+  background: linear-gradient(90deg, var(--accent2), var(--accent));
+  border-radius: 999px;
+  white-space: nowrap;
+}
+
+.plan__name { margin: 0; font-size: 1.1rem; font-weight: 700; }
+.plan__price { margin: 0; font-size: 2.2rem; font-weight: 800; letter-spacing: -0.02em; display: flex; align-items: baseline; gap: 0.1rem; }
+.plan__cur { font-size: 1rem; opacity: 0.7; }
+.plan__per { font-size: 0.85rem; font-weight: 500; color: var(--muted); }
+
+.plan__features { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.4rem; }
+.plan__features li { font-size: 0.86rem; color: var(--muted); padding-left: 1.1rem; position: relative; }
+.plan__features li::before { content: "\2713"; position: absolute; left: 0; color: var(--accent2); font-weight: 700; }
+
+.plan__cta {
+  margin-top: auto;
+  font: inherit;
+  font-weight: 600;
+  padding: 0.65rem 1rem;
+  border-radius: 0.6rem;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--fg);
+  cursor: pointer;
+  transition: background 0.18s ease;
+}
+.plan__cta:hover { background: rgba(179, 136, 255, 0.2); }
+.plan__cta:focus-visible { outline: 2px solid var(--accent2); outline-offset: 3px; }
+.plan__cta--featured { background: linear-gradient(135deg, var(--accent2), var(--accent)); color: #fff; border-color: transparent; }
+
+@media (max-width: 480px) {
+  :root { --skew-angle: -2deg; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .plan { transition: none; }
+  .plan:hover, .plan:focus-visible { transform: none; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-skew-active-pricing** from issue #64347 — a glassmorphism pricing table whose cards skew (tilt) when active — hovered or keyboard-focused — for a tactile feel.

Closes #64347.

## Feature

A skew-active pricing table of frosted-glass plan cards. Each card tilts slightly (`skewX(-4deg)`) and lifts up when hovered or focused, then snaps back when inactive. The featured plan is scaled up and violet-tinted; its active state combines skew + scale.

## How it works

- `transform: skewX()` transition on hover/focus, combined with a synchronized `translateY` lift and border/shadow shift. GPU-only.

## Accessibility

- `tabindex="0"` + `aria-label` on the featured plan, `:focus-visible` triggers the same skew + lift as hover.
- Full `prefers-reduced-motion` support (skew disabled when requested).
- Configurable via CSS custom properties (`--skew-angle`, `--skew-duration`, `--skew-ease`, `--glass-blur`).

## Submission structure

```
submissions/examples/ease-skew-active-pricing-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← glassmorphism plans + skew-active transition
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally