### PR TITLE
feat: add ease-rotate-fade-hero-section component (#64340)

### DIFF
--- a/submissions/examples/ease-rotate-fade-hero-section-sbh/README.md
+++ b/submissions/examples/ease-rotate-fade-hero-section-sbh/README.md
@@ -1,0 +1,44 @@
+# ease-rotate-fade-hero-section
+
+A glassmorphism hero section whose headline, lead, eyebrow, and actions rotate and fade into view on load, staggered for a confident, unfolding reveal.
+
+## What does this do?
+
+Adds a **rotate-fade hero section**: a frosted-glass hero panel with a soft conic glow behind it. Each text block (eyebrow → title → lead → actions) enters rotated slightly counter-clockwise (`rotate(-5deg)`) and shifted down, then animates to its upright, resting position while fading in — staggered so the hero unfolds top-to-bottom.
+
+## How is it used?
+
+1. Build a `.hero` section with `.hero__eyebrow`, `.hero__title`, `.hero__lead`, and `.hero__actions`.
+2. Each block carries a `--rf` modifier that assigns its stagger slot.
+3. Tune the timing via the `--rf-stagger` custom property.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<section class="hero" aria-label="Hero">
+  <span class="hero__eyebrow hero__eyebrow--rf">New · v3.0</span>
+  <h1 class="hero__title hero__title--rf">Motion that turns heads.</h1>
+  <p class="hero__lead hero__lead--rf">A glassmorphism hero…</p>
+  <div class="hero__actions hero__actions--rf">
+    <a class="hero__cta" href="#start">Get started</a>
+    <a class="hero__cta hero__cta--ghost" href="#docs">Read the docs</a>
+  </div>
+</section>
+```
+
+## Why is this useful?
+
+- **Animation-first** — the signature motion is `@keyframes rf-in` interpolating `rotate(-5deg) → 0deg` together with `opacity` and `translateY`, applied per block with an increasing `animation-delay` via `--rf-stagger`.
+- **Glassmorphism aesthetic** — frosted panel via `backdrop-filter: blur()` with a blurred conic-gradient glow behind it.
+- **Accessible** — `aria-label` on the hero, `tabindex` + `:focus-visible` rings on CTAs, and full `prefers-reduced-motion` support (blocks appear instantly with no rotate/fade).
+- **Reusable** — configurable via CSS custom properties (`--rf-duration`, `--rf-ease`, `--rf-stagger`, `--glass-blur`).
+
+## Files
+
+- `demo.html` — self-contained demo (open directly in a browser; no server, CDNs, or frameworks).
+- `style.css` — glassmorphism hero, rotate-fade staggered keyframes, conic glow, CTA states, responsive + reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-rotate-fade-hero-section-sbh/demo.html
+++ b/submissions/examples/ease-rotate-fade-hero-section-sbh/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-rotate-fade-hero-section — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <section class="hero" aria-label="Hero">
+      <span class="hero__eyebrow hero__eyebrow--rf" aria-hidden="true">New · v3.0</span>
+      <h1 class="hero__title hero__title--rf">
+        Motion that <span class="hero__accent">turns heads</span>.
+      </h1>
+      <p class="hero__lead hero__lead--rf">
+        A glassmorphism hero section whose headline, lead, and eyebrow rotate and fade into view on load — staggered for a confident, unfolding reveal.
+      </p>
+      <div class="hero__actions hero__actions--rf">
+        <a class="hero__cta" href="#start" tabindex="0">Get started</a>
+        <a class="hero__cta hero__cta--ghost" href="#docs" tabindex="0">Read the docs</a>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-rotate-fade-hero-section-sbh/style.css
+++ b/submissions/examples/ease-rotate-fade-hero-section-sbh/style.css
@@ -1,0 +1,137 @@
+:root {
+  --rf-duration: 0.8s;
+  --rf-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --rf-stagger: 0.18s;
+  --glass-bg: rgba(255, 255, 255, 0.06);
+  --glass-border: rgba(255, 255, 255, 0.12);
+  --glass-blur: 14px;
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --radius: 1.2rem;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 18%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+  overflow: hidden;
+}
+
+.hero {
+  position: relative;
+  max-width: 44rem;
+  text-align: center;
+  padding: 3.2rem 2.4rem;
+  border-radius: var(--radius);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  box-shadow: 0 30px 70px -28px rgba(0, 0, 0, 0.7);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  overflow: hidden;
+}
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: -40%;
+  background: conic-gradient(from 0deg, rgba(110,168,255,0.18), rgba(179,136,255,0.18), rgba(110,168,255,0.18));
+  filter: blur(60px);
+  z-index: 0;
+  opacity: 0.6;
+}
+.hero > * { position: relative; z-index: 1; }
+
+.hero__eyebrow {
+  align-self: center;
+  padding: 0.3rem 0.9rem;
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+  background: rgba(110, 168, 255, 0.12);
+  border: 1px solid rgba(110, 168, 255, 0.3);
+  border-radius: 999px;
+  opacity: 0;
+}
+.hero__eyebrow--rf { animation: rf-in var(--rf-duration) var(--rf-ease) calc(var(--rf-stagger) * 0) forwards; }
+
+.hero__title {
+  margin: 0;
+  font-size: clamp(2rem, 6vw, 3.1rem);
+  font-weight: 800;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  opacity: 0;
+}
+.hero__title--rf { animation: rf-in var(--rf-duration) var(--rf-ease) calc(var(--rf-stagger) * 1) forwards; }
+.hero__accent {
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.hero__lead {
+  margin: 0;
+  max-width: 36rem;
+  font-size: 1rem;
+  line-height: 1.65;
+  color: var(--muted);
+  opacity: 0;
+}
+.hero__lead--rf { animation: rf-in var(--rf-duration) var(--rf-ease) calc(var(--rf-stagger) * 2) forwards; }
+
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  justify-content: center;
+  margin-top: 0.6rem;
+  opacity: 0;
+}
+.hero__actions--rf { animation: rf-in var(--rf-duration) var(--rf-ease) calc(var(--rf-stagger) * 3) forwards; }
+
+.hero__cta {
+  display: inline-block;
+  padding: 0.7rem 1.4rem;
+  border-radius: 0.7rem;
+  font-weight: 600;
+  text-decoration: none;
+  color: #06231a;
+  background: linear-gradient(135deg, var(--accent), var(--accent2));
+  transition: filter 0.2s ease, transform 0.2s ease;
+}
+.hero__cta:hover, .hero__cta:focus-visible { filter: brightness(1.08); transform: translateY(-2px); outline: none; }
+.hero__cta--ghost {
+  color: var(--fg);
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+.hero__cta:focus-visible { box-shadow: 0 0 0 3px rgba(110, 168, 255, 0.5); }
+
+@keyframes rf-in {
+  0% { opacity: 0; transform: rotate(-5deg) translateY(16px); }
+  100% { opacity: 1; transform: rotate(0deg) translateY(0); }
+}
+
+@media (max-width: 480px) {
+  .hero { padding: 2.4rem 1.4rem; }
+  .hero__lead { font-size: 0.92rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero__eyebrow--rf, .hero__title--rf, .hero__lead--rf, .hero__actions--rf { animation: none; opacity: 1; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-rotate-fade-hero-section** from issue #64340 — a glassmorphism hero section whose headline, lead, eyebrow, and actions rotate and fade into view on load, staggered for an unfolding reveal.

Closes #64340.

## Feature

A rotate-fade hero on a frosted-glass panel with a soft conic glow behind it. Each text block (eyebrow → title → lead → actions) enters rotated slightly counter-clockwise (`rotate(-5deg)`) and shifted down, then animates to its upright resting position while fading in — staggered so the hero unfolds top-to-bottom.

## How it works

- `@keyframes rf-in` interpolates `rotate(-5deg) → 0deg` together with `opacity` and `translateY`, applied per block with an increasing `animation-delay` via `--rf-stagger`.

## Accessibility

- `aria-label` on the hero, `tabindex` + `:focus-visible` rings on CTAs.
- Full `prefers-reduced-motion` support (blocks appear instantly with no rotate/fade).
- Configurable via CSS custom properties (`--rf-duration`, `--rf-ease`, `--rf-stagger`, `--glass-blur`).

## Submission structure

```
submissions/examples/ease-rotate-fade-hero-section-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← glassmorphism hero + rotate-fade staggered keyframes
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally