### PR TITLE
feat: add ease-glitch-flicker-hero-section component (#64343)

### DIFF
--- a/submissions/examples/ease-glitch-flicker-hero-section-sbh/README.md
+++ b/submissions/examples/ease-glitch-flicker-hero-section-sbh/README.md
@@ -1,0 +1,45 @@
+# ease-glitch-flicker-hero-section
+
+A glassmorphism hero section with a glitch-flicker headline — the title RGB-splits and flickers on load, then settles into a steady state with occasional twitches. A scanline overlay completes the retro-terminal feel.
+
+## What does this do?
+
+Adds a **glitch-flicker hero section**: a frosted-glass hero panel. The headline uses `::before`/`::after` pseudo-elements cloned from `data-text` to create red/cyan RGB-split copies that jitter into place on load (stepped keyframes for a digital glitch), then settle and occasionally twitch on an infinite loop. The eyebrow badge flickers, and a subtle scanline texture overlays the panel.
+
+## How is it used?
+
+1. Build a `.hero` section. The `.hero__title` must carry a `data-text` attribute equal to its visible text — the pseudo-elements read it to render the RGB-split clones.
+2. Keep the visible text in a `.hero__title-main` span so only the pseudo-elements animate.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<section class="hero" aria-label="Hero">
+  <span class="hero__eyebrow">SYSTEM ONLINE</span>
+  <h1 class="hero__title" data-text="BUILD THE FUTURE">
+    <span class="hero__title-main">BUILD THE FUTURE</span>
+  </h1>
+  <p class="hero__lead">A glassmorphism hero with a glitch-flicker headline…</p>
+  <div class="hero__actions">
+    <a class="hero__cta" href="#start">Initialize</a>
+    <a class="hero__cta hero__cta--ghost" href="#docs">View manifest</a>
+  </div>
+</section>
+```
+
+## Why is this useful?
+
+- **Animation-first** — the signature motion is two-layer glitch: `@keyframes gf-glitch-r`/`gf-glitch-b` run a stepped (`steps(8, end)`) intro that RGB-splits and jitters the headline into place, followed by `@keyframes gf-twitch-r`/`gf-twitch-b` infinite loops that fire brief twitches. The eyebrow runs `gf-flicker` for an intermittent opacity blink. All via `transform`/`opacity`/`clip-path`.
+- **Glassmorphism aesthetic** — frosted panel via `backdrop-filter: blur()` with a repeating scanline overlay.
+- **Accessible** — the visible `.hero__title-main` carries the real text for screen readers; the pseudo-element clones are decorative. `tabindex` + `:focus-visible` rings on CTAs, and full `prefers-reduced-motion` support (glitch/flicker disabled; clones shown as a static, low-opacity RGB split).
+- **Reusable** — configurable via CSS custom properties (`--gf-intro-duration`, `--gf-twitch-duration`, `--glitch-r`, `--glitch-b`, `--glass-blur`).
+
+## Files
+
+- `demo.html` — self-contained demo (open directly in a browser; no server, CDNs, or frameworks).
+- `style.css` — glassmorphism hero, RGB-split glitch keyframes (intro + twitch), eyebrow flicker, scanline overlay, CTA states, responsive + reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-glitch-flicker-hero-section-sbh/demo.html
+++ b/submissions/examples/ease-glitch-flicker-hero-section-sbh/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-glitch-flicker-hero-section — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <section class="hero" aria-label="Hero">
+      <span class="hero__eyebrow" aria-hidden="true">SYSTEM ONLINE</span>
+      <h1 class="hero__title" data-text="BUILD THE FUTURE">
+        <span class="hero__title-main">BUILD THE FUTURE</span>
+      </h1>
+      <p class="hero__lead">
+        A glassmorphism hero section with a glitch-flicker headline — the title RGB-splits and flickers on load, then settles into a steady state with an occasional twitch.
+      </p>
+      <div class="hero__actions">
+        <a class="hero__cta" href="#start" tabindex="0">Initialize</a>
+        <a class="hero__cta hero__cta--ghost" href="#docs" tabindex="0">View manifest</a>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-glitch-flicker-hero-section-sbh/style.css
+++ b/submissions/examples/ease-glitch-flicker-hero-section-sbh/style.css
@@ -1,0 +1,173 @@
+:root {
+  --gf-intro-duration: 1.4s;
+  --gf-twitch-duration: 4s;
+  --gf-ease: steps(8, end);
+  --glass-bg: rgba(255, 255, 255, 0.06);
+  --glass-border: rgba(255, 255, 255, 0.12);
+  --glass-blur: 14px;
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --glitch-r: #ff3b6b;
+  --glitch-b: #00e0ff;
+  --radius: 1.2rem;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 18%, #14182b, #06080f 70%);
+  color: var(--fg);
+  overflow: hidden;
+}
+
+.hero {
+  position: relative;
+  max-width: 44rem;
+  text-align: center;
+  padding: 3.2rem 2.4rem;
+  border-radius: var(--radius);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  box-shadow: 0 30px 70px -28px rgba(0, 0, 0, 0.7);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  overflow: hidden;
+}
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(0deg, rgba(255,255,255,0.03) 0 1px, transparent 1px 3px);
+  pointer-events: none;
+  opacity: 0.5;
+}
+
+.hero__eyebrow {
+  position: relative;
+  padding: 0.3rem 0.9rem;
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--glitch-b);
+  background: rgba(0, 224, 255, 0.1);
+  border: 1px solid rgba(0, 224, 255, 0.3);
+  border-radius: 999px;
+  animation: gf-flicker 3.5s linear infinite;
+}
+
+.hero__title {
+  position: relative;
+  margin: 0;
+  font-size: clamp(2rem, 7vw, 3.4rem);
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  line-height: 1.1;
+}
+.hero__title-main { position: relative; display: inline-block; }
+.hero__title::before,
+.hero__title::after {
+  content: attr(data-text);
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+.hero__title::before {
+  color: var(--glitch-r);
+  animation: gf-glitch-r var(--gf-intro-duration) var(--gf-ease) forwards,
+             gf-twitch-r var(--gf-twitch-duration) var(--gf-intro-duration) infinite;
+  clip-path: inset(0 0 60% 0);
+}
+.hero__title::after {
+  color: var(--glitch-b);
+  animation: gf-glitch-b var(--gf-intro-duration) var(--gf-ease) forwards,
+             gf-twitch-b var(--gf-twitch-duration) var(--gf-intro-duration) infinite;
+  clip-path: inset(60% 0 0 0);
+}
+
+.hero__lead {
+  margin: 0;
+  max-width: 36rem;
+  font-size: 1rem;
+  line-height: 1.65;
+  color: var(--muted);
+}
+
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  justify-content: center;
+  margin-top: 0.6rem;
+}
+.hero__cta {
+  display: inline-block;
+  padding: 0.7rem 1.4rem;
+  border-radius: 0.7rem;
+  font-weight: 600;
+  text-decoration: none;
+  color: #06231a;
+  background: linear-gradient(135deg, var(--accent), var(--accent2));
+  transition: filter 0.2s ease, transform 0.2s ease;
+}
+.hero__cta:hover, .hero__cta:focus-visible { filter: brightness(1.08); transform: translateY(-2px); outline: none; }
+.hero__cta--ghost { color: var(--fg); background: rgba(255,255,255,0.06); border: 1px solid rgba(255,255,255,0.2); }
+.hero__cta:focus-visible { box-shadow: 0 0 0 3px rgba(0, 224, 255, 0.5); }
+
+@keyframes gf-glitch-r {
+  0% { transform: translate(0); opacity: 0; }
+  10% { transform: translate(-3px, 1px); opacity: 0.9; }
+  20% { transform: translate(2px, -1px); }
+  30% { transform: translate(-2px, 0); }
+  45% { transform: translate(1px, 1px); }
+  60% { transform: translate(-1px, 0); }
+  100% { transform: translate(0); opacity: 0.7; }
+}
+@keyframes gf-glitch-b {
+  0% { transform: translate(0); opacity: 0; }
+  12% { transform: translate(3px, -1px); opacity: 0.9; }
+  24% { transform: translate(-2px, 1px); }
+  36% { transform: translate(2px, 0); }
+  50% { transform: translate(-1px, -1px); }
+  65% { transform: translate(1px, 0); }
+  100% { transform: translate(0); opacity: 0.7; }
+}
+@keyframes gf-twitch-r {
+  0%, 92%, 100% { transform: translate(0); opacity: 0.7; }
+  94% { transform: translate(-3px, 1px); opacity: 0.95; }
+  96% { transform: translate(2px, -1px); }
+}
+@keyframes gf-twitch-b {
+  0%, 90%, 100% { transform: translate(0); opacity: 0.7; }
+  91% { transform: translate(3px, -1px); opacity: 0.95; }
+  93% { transform: translate(-2px, 1px); }
+}
+@keyframes gf-flicker {
+  0%, 100% { opacity: 1; }
+  3% { opacity: 0.3; }
+  6% { opacity: 1; }
+  40% { opacity: 1; }
+  42% { opacity: 0.4; }
+  44% { opacity: 1; }
+}
+
+@media (max-width: 480px) {
+  .hero { padding: 2.4rem 1.4rem; }
+  .hero__lead { font-size: 0.92rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero__title::before, .hero__title::after { animation: none; opacity: 0.55; transform: translate(0); }
+  .hero__eyebrow { animation: none; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-glitch-flicker-hero-section** from issue #64343 — a glassmorphism hero section with a glitch-flicker headline that RGB-splits and flickers on load, then settles with occasional twitches.

Closes #64343.

## Feature

A glitch-flicker hero on a frosted-glass panel with a scanline overlay. The headline uses `::before`/`::after` pseudo-elements cloned from `data-text` to render red/cyan RGB-split copies that jitter into place on load (stepped keyframes), then settle and occasionally twitch on an infinite loop. The eyebrow badge flickers.

## How it works

- `@keyframes gf-glitch-r`/`gf-glitch-b` run a stepped (`steps(8, end)`) intro that RGB-splits and jitters the headline into place; `@keyframes gf-twitch-r`/`gf-twitch-b` fire brief twitches on infinite loops. The eyebrow runs `gf-flicker`. All via `transform`/`opacity`/`clip-path`.

## Accessibility

- The visible `.hero__title-main` carries the real text for screen readers; the pseudo-element clones are decorative.
- `tabindex` + `:focus-visible` rings on CTAs; full `prefers-reduced-motion` support (glitch/flicker disabled; clones shown as a static, low-opacity RGB split).
- Configurable via CSS custom properties (`--gf-intro-duration`, `--gf-twitch-duration`, `--glitch-r`, `--glitch-b`, `--glass-blur`).

## Submission structure

```
submissions/examples/ease-glitch-flicker-hero-section-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← glassmorphism hero + RGB-split glitch keyframes
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally