### PR TITLE
feat: add copy confirmation button animation

### DIFF
--- a/submissions/examples/ease-copy-confirm/README.md
+++ b/submissions/examples/ease-copy-confirm/README.md
@@ -1,0 +1,37 @@
+# Ease Copy Confirm
+
+A lightweight, modern copy-to-clipboard confirmation button component built with pure CSS and minimal JavaScript. Features a smooth state transition and keyframe bounce animation.
+
+## 🚀 Features
+
+- **Smooth Transition:** Text and icons seamlessly slide and fade between "Copy" and "Copied!" states.
+- **Bounce Animation:** Uses a performant scale-based `@keyframes` animation for immediate click feedback, providing an engaging user experience.
+- **Minimal JavaScript:** JS is only used to toggle the `.success` class and set an automatic reset timeout. All styling and animations are handled strictly by CSS.
+- **Accessibility:** Uses semantic HTML (`<button>`) and `focus-visible` styling for keyboard navigation, plus SVG icons for crisp visuals.
+
+## 🛠️ Usage
+
+Copy the HTML structure from `demo.html` and link the styles from `style.css`. 
+
+```html
+<button class="copy-confirm" aria-label="Copy to clipboard">
+    <span class="copy-state">Copy</span>
+    <span class="success-state">Copied!</span>
+</button>
+```
+
+Add the minimal script included in `demo.html` to handle adding and removing the `.success` class on click.
+
+### State Animation
+The confirmation animation is triggered simply by adding the `.success` class to the `.copy-confirm` button:
+
+```css
+.copy-confirm.success {
+    animation: copySuccess .35s ease;
+}
+```
+
+## 📁 Files Included
+- `demo.html`: Functional demonstration showing the component layout and JS logic.
+- `style.css`: Contains all visual styles, hover states, transitions, and the `copySuccess` keyframes.
+- `README.md`: Component documentation.

--- a/submissions/examples/ease-copy-confirm/demo.html
+++ b/submissions/examples/ease-copy-confirm/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ease Copy Confirm Demo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="demo-container">
+        <button class="copy-confirm" aria-label="Copy to clipboard">
+            <span class="copy-state">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                </svg>
+                Copy
+            </span>
+            <span class="success-state">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <polyline points="20 6 9 17 4 12"></polyline>
+                </svg>
+                Copied!
+            </span>
+        </button>
+    </div>
+
+    <script>
+        const copyBtn = document.querySelector('.copy-confirm');
+        
+        copyBtn.addEventListener('click', () => {
+            // Prevent multiple clicks from breaking state
+            if (copyBtn.classList.contains('success')) return;
+
+            copyBtn.classList.add('success');
+            
+            // Auto reset after 2 seconds
+            setTimeout(() => {
+                copyBtn.classList.remove('success');
+            }, 2000);
+        });
+    </script>
+</body>
+</html>

--- a/submissions/examples/ease-copy-confirm/style.css
+++ b/submissions/examples/ease-copy-confirm/style.css
@@ -1,0 +1,101 @@
+/* Base demo container styling */
+body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: #f3f4f6;
+    font-family: system-ui, -apple-system, sans-serif;
+}
+
+.demo-container {
+    padding: 2rem;
+    background: #ffffff;
+    border-radius: 12px;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+}
+
+/* Base button styles */
+.copy-confirm {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: #374151;
+    background-color: #f3f4f6;
+    border: 1px solid #e5e7eb;
+    border-radius: 6px;
+    cursor: pointer;
+    overflow: hidden;
+    transition: all 0.2s ease;
+    min-width: 100px;
+    min-height: 38px;
+}
+
+.copy-confirm:hover {
+    background-color: #e5e7eb;
+    border-color: #d1d5db;
+}
+
+.copy-confirm:focus-visible {
+    outline: 2px solid #3b82f6;
+    outline-offset: 2px;
+}
+
+/* State wrappers */
+.copy-state,
+.success-state {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    position: absolute;
+    transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* Initial state */
+.copy-state {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.success-state {
+    opacity: 0;
+    transform: translateY(15px);
+    color: #10b981;
+}
+
+/* Success active state */
+.copy-confirm.success {
+    background-color: #ecfdf5;
+    border-color: #10b981;
+    color: #10b981;
+    animation: copySuccess .35s ease;
+}
+
+.copy-confirm.success .copy-state {
+    opacity: 0;
+    transform: translateY(-15px);
+}
+
+.copy-confirm.success .success-state {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+/* The provided animation */
+@keyframes copySuccess {
+    0% {
+        transform: scale(.9);
+    }
+    60% {
+        transform: scale(1.08);
+    }
+    100% {
+        transform: scale(1);
+    }
+}


### PR DESCRIPTION
## Pull Request Description

---

## Type of Change

* [x] ✨ New animation / hover effect
* [ ] 🧩 New component
* [ ] 📝 Documentation improvement
* [ ] 🐛 Bug fix in an existing submission
* [ ] Other (describe below)

---

## Submission Checklist

* [x] All changes are inside `submissions/`
* [x] Includes `demo.html` — self-contained, opens in browser with no server
* [x] Includes `style.css` — raw CSS for the proposed feature
* [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
* [x] **No changes to** **`core/`**
* [x] **No changes to** **`components/**
* [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds a lightweight copy confirmation button animation that transitions from a `Copy` state to a `✓ Copied!` success state after clicking, then automatically resets after a short delay.

**How does a developer use it?**

```html
<button class="copy-confirm">
    Copy
</button>
```

Add the provided `style.css` and the required interaction logic from `demo.html` to use the copy confirmation effect.

**Why does it fit EaseMotion CSS?**

It provides a lightweight, reusable interaction animation for a common UI action. The implementation uses raw CSS with minimal JavaScript and follows the project's submission-based animation approach.

---

## Demo

* [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

* [x] Chrome
* [ ] Firefox
* [ ] Edge
* [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Implemented specifically for **#64290**.

The submission is contained entirely within:

`submissions/examples/ease-copy-confirm/`

No existing core or component files were modified.

Closes #64290
