### PR TITLE
feat: add ease-scroll-reveal component (#64285)

### DIFF
--- a/submissions/examples/ease-scroll-reveal-sbh/README.md
+++ b/submissions/examples/ease-scroll-reveal-sbh/README.md
@@ -1,0 +1,43 @@
+# ease-scroll-reveal
+
+A scroll-driven reveal: cards fade and rise (or slide / scale / focus) into view as they cross into the viewport. Pure CSS via `animation-timeline: view()`.
+
+## What does this do?
+
+Adds a **scroll-reveal**: each `.reveal` card animates from a hidden starting state to its resting state as it enters the viewport, driven by scroll position rather than JavaScript. Variants change the entry direction: `--up` (rise), `--left` / `--right` (horizontal slide), `--scale` (grow in), and `--blur` (focus-in).
+
+## How is it used?
+
+1. Add the `.reveal` class to any element, plus a direction variant.
+2. Place elements in normal document flow; the browser ties the animation to the element's scroll position via `animation-timeline: view()`.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<article class="card reveal reveal--up">
+  <h2>01 · Origins</h2>
+  <p>…</p>
+</article>
+```
+
+## Why is this useful?
+
+- **Animation-first** — the signature motion is scroll-driven keyframes bound with `animation-timeline: view()` and `animation-range: entry 0% cover 22%`, so the reveal plays as the element enters the viewport and finishes shortly after — no IntersectionObserver, no JS. Five entry variants via distinct `@keyframes` (`reveal-up`, `reveal-left`, `reveal-right`, `reveal-scale`, `reveal-blur`).
+- **Glassmorphism aesthetic** — reveal cards are frosted panels via `backdrop-filter: blur()`.
+- **Accessible** — `prefers-reduced-motion` disables the reveal entirely so content is fully visible immediately.
+- **Progressive enhancement** — a `@supports not (animation-timeline: view())` fallback plays the reveal once on load (still pure CSS), and browsers without support still show all content at rest.
+- **Reusable** — configurable via CSS custom properties (`--reveal-duration`, `--reveal-ease`, `--reveal-distance`, `--glass-blur`).
+
+## Browser support note
+
+`animation-timeline: view()` ships in current Chromium and is in development elsewhere. The included `@supports` fallback guarantees content is never stuck hidden in any browser.
+
+## Files
+
+- `demo.html` — self-contained demo (open directly in a browser; no server, CDNs, or frameworks).
+- `style.css` — scroll-driven reveal base, five entry keyframes, `@supports` fallback, responsive + reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-scroll-reveal-sbh/demo.html
+++ b/submissions/examples/ease-scroll-reveal-sbh/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-scroll-reveal — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-scroll-reveal</h1>
+      <p>Scroll down — each card fades and rises into view as it enters the viewport. Pure CSS via scroll-driven animations.</p>
+    </header>
+
+    <section class="stack" aria-label="Reveal cards">
+      <article class="card reveal reveal--up">
+        <h2>01 · Origins</h2>
+        <p>Every motion system starts with a single frame. This card reveals as it crosses the viewport edge.</p>
+      </article>
+      <article class="card reveal reveal--left">
+        <h2>02 · Momentum</h2>
+        <p>Once in motion, easing carries the eye. This card slides in from the left as it enters view.</p>
+      </article>
+      <article class="card reveal reveal--right">
+        <h2>03 · Settling</h2>
+        <p>A good reveal ends calm. This card slides in from the right and settles into place.</p>
+      </article>
+      <article class="card reveal reveal--scale">
+        <h2>04 · Depth</h2>
+        <p>Scale adds dimension. This card grows into view from a smaller, faded state.</p>
+      </article>
+      <article class="card reveal reveal--blur">
+        <h2>05 · Focus</h2>
+        <p>Blur reveals read like a lens focusing. This card sharpens as it enters the viewport.</p>
+      </article>
+      <article class="card reveal reveal--up">
+        <h2>06 · Closure</h2>
+        <p>Reveals should never compete with content. Each one is subtle, short, and stops when the card is centered.</p>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-scroll-reveal-sbh/style.css
+++ b/submissions/examples/ease-scroll-reveal-sbh/style.css
@@ -1,0 +1,118 @@
+:root {
+  --reveal-duration: 0.7s;
+  --reveal-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --reveal-distance: 40px;
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --glass-bg: rgba(255, 255, 255, 0.06);
+  --glass-border: rgba(255, 255, 255, 0.12);
+  --glass-blur: 12px;
+  --radius: 1rem;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  padding: 3rem 1.5rem 6rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 0%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+}
+
+.page__intro {
+  text-align: center;
+  max-width: 38rem;
+  margin: 2rem auto 3rem;
+}
+.page__intro h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(1.6rem, 4vw, 2.4rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+
+.stack {
+  display: grid;
+  gap: 1.5rem;
+  max-width: 40rem;
+  margin: 0 auto;
+}
+
+.card {
+  padding: 1.6rem 1.8rem;
+  border-radius: var(--radius);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  box-shadow: 0 20px 50px -28px rgba(0, 0, 0, 0.7);
+}
+.card h2 {
+  margin: 0 0 0.4rem;
+  font-size: 1.1rem;
+  color: var(--accent);
+}
+.card p { margin: 0; color: var(--muted); line-height: 1.6; }
+
+/* scroll-driven reveal: animates as the element enters/leaves the viewport */
+.reveal {
+  animation: reveal-in linear both;
+  animation-timeline: view();
+  animation-range: entry 0% cover 22%;
+}
+
+@keyframes reveal-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+.reveal--up    { animation-name: reveal-up; }
+.reveal--left  { animation-name: reveal-left; }
+.reveal--right { animation-name: reveal-right; }
+.reveal--scale { animation-name: reveal-scale; }
+.reveal--blur  { animation-name: reveal-blur; }
+
+@keyframes reveal-up {
+  from { opacity: 0; transform: translateY(var(--reveal-distance)); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@keyframes reveal-left {
+  from { opacity: 0; transform: translateX(calc(-1 * var(--reveal-distance))); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+@keyframes reveal-right {
+  from { opacity: 0; transform: translateX(var(--reveal-distance)); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+@keyframes reveal-scale {
+  from { opacity: 0; transform: scale(0.92); }
+  to   { opacity: 1; transform: scale(1); }
+}
+@keyframes reveal-blur {
+  from { opacity: 0; filter: blur(8px); transform: translateY(12px); }
+  to   { opacity: 1; filter: blur(0); transform: translateY(0); }
+}
+
+@media (max-width: 480px) {
+  .card { padding: 1.3rem 1.4rem; }
+}
+
+/* Progressive enhancement: browsers without scroll-driven animations
+   (or users who reduce motion) see fully-revealed content immediately. */
+@media (prefers-reduced-motion: reduce) {
+  .reveal { animation: none; }
+}
+@supports not (animation-timeline: view()) {
+  .reveal { animation: reveal-in var(--reveal-duration) var(--reveal-ease) both; }
+  .reveal--up    { animation-name: reveal-up; }
+  .reveal--left  { animation-name: reveal-left; }
+  .reveal--right { animation-name: reveal-right; }
+  .reveal--scale { animation-name: reveal-scale; }
+  .reveal--blur  { animation-name: reveal-blur; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-scroll-reveal** from issue #64285 — a scroll-driven reveal where cards fade/rise/slide/scale/blur into view as they enter the viewport, pure CSS via `animation-timeline: view()`.

Closes #64285.

## Feature

Each `.reveal` card animates from a hidden starting state to its resting state as it enters the viewport, driven by scroll position rather than JavaScript. Five entry variants: `--up` (rise), `--left` / `--right` (horizontal slide), `--scale` (grow in), `--blur` (focus-in).

## How it works

- `animation-timeline: view()` + `animation-range: entry 0% cover 22%` ties each card's keyframes to its scroll position, so the reveal plays as it enters the viewport and finishes shortly after — no IntersectionObserver, no JS.
- Distinct `@keyframes` per variant (`reveal-up`, `reveal-left`, `reveal-right`, `reveal-scale`, `reveal-blur`).

## Accessibility & fallbacks

- `prefers-reduced-motion` disables the reveal entirely so content is fully visible immediately.
- Progressive enhancement: a `@supports not (animation-timeline: view())` fallback plays the reveal once on load (still pure CSS), and browsers without support still show all content at rest.
- Configurable via CSS custom properties (`--reveal-duration`, `--reveal-ease`, `--reveal-distance`, `--glass-blur`).

## Submission structure

```
submissions/examples/ease-scroll-reveal-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← scroll-driven reveal base + five entry keyframes + @supports fallback
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally