### PR TITLE
feat: add ease-drawer-slide component (#64271)

### DIFF
--- a/submissions/examples/ease-drawer-slide-sbh/README.md
+++ b/submissions/examples/ease-drawer-slide-sbh/README.md
@@ -1,0 +1,44 @@
+# ease-drawer-slide
+
+An off-canvas side drawer that slides into view from the left while a backdrop overlay fades in. Pure CSS — open/close state is driven by a hidden checkbox, so no JavaScript is required for the animation.
+
+## What does this do?
+
+Adds a **drawer-slide**: a frosted-glass side panel anchored to the viewport. Toggling a hidden checkbox (via the "Open menu" label) slides the drawer in from the left (`translateX(-100%) → 0`) and fades in a dimmed, slightly blurred backdrop that covers the page. Clicking the backdrop or the close button closes the drawer.
+
+## How is it used?
+
+1. Place a hidden `<input type="checkbox" class="drawer-toggle">`, an `.opener` label, a `.backdrop` label, and the `.drawer` aside as siblings (the CSS uses the `~` sibling combinator).
+2. The `.opener`, `.backdrop`, and `.drawer__close` are all `<label for="drawer-toggle">`, so they toggle state with no JS.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<input type="checkbox" id="drawer-toggle" class="drawer-toggle" aria-hidden="true" />
+<label for="drawer-toggle" class="opener" tabindex="0">Open menu</label>
+<label for="drawer-toggle" class="backdrop" aria-hidden="true"></label>
+<aside class="drawer" role="dialog" aria-modal="true" aria-label="Site menu">
+  <div class="drawer__head">
+    <span class="drawer__title">Menu</span>
+    <label for="drawer-toggle" class="drawer__close" tabindex="0" aria-label="Close menu">&times;</label>
+  </div>
+  <nav class="drawer__nav">…</nav>
+</aside>
+```
+
+## Why is this useful?
+
+- **Animation-first** — the signature motion is the drawer's `transform: translateX(-100%) → 0` slide on `--drawer-duration`, paired with the backdrop's `opacity` + `visibility` fade. Visibility is deferred on close so the backdrop doesn't trap clicks while hiding. All via `transform`/`opacity`.
+- **Glassmorphism aesthetic** — the drawer is a frosted panel via `backdrop-filter: blur()`; the backdrop adds a light blur over the page.
+- **Accessible** — `role="dialog"` + `aria-modal="true"` + `aria-label` on the drawer; the trigger and close are focusable labels with `:focus-visible` rings; `tabindex="0"` on interactive labels so keyboard users can open/close. Full `prefers-reduced-motion` support (drawer and backdrop snap without transition).
+- **Reusable** — configurable via CSS custom properties (`--drawer-duration`, `--drawer-ease`, `--drawer-width`, `--glass-blur`).
+
+## Files
+
+- `demo.html` — self-contained demo (open directly in a browser; no server, CDNs, or frameworks, and no JS required for the animation).
+- `style.css` — glassmorphism drawer, slide + backdrop-fade transitions via checkbox state, focus-visible states, responsive + reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-drawer-slide-sbh/demo.html
+++ b/submissions/examples/ease-drawer-slide-sbh/demo.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-drawer-slide — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-drawer-slide</h1>
+      <p>An off-canvas side drawer that slides into view while a backdrop fades in. Pure CSS, toggled by a checkbox.</p>
+    </header>
+
+    <div class="stage">
+      <input type="checkbox" id="drawer-toggle" class="drawer-toggle" aria-hidden="true" />
+      <label for="drawer-toggle" class="opener" tabindex="0">
+        <span>Open menu</span>
+      </label>
+
+      <label for="drawer-toggle" class="backdrop" aria-hidden="true"></label>
+
+      <aside class="drawer" role="dialog" aria-modal="true" aria-label="Site menu">
+        <div class="drawer__head">
+          <span class="drawer__title">Menu</span>
+          <label for="drawer-toggle" class="drawer__close" tabindex="0" aria-label="Close menu">&times;</label>
+        </div>
+        <nav class="drawer__nav" aria-label="Primary">
+          <a href="#home" class="drawer__link" tabindex="0">Home</a>
+          <a href="#docs" class="drawer__link" tabindex="0">Documentation</a>
+          <a href="#examples" class="drawer__link" tabindex="0">Examples</a>
+          <a href="#pricing" class="drawer__link" tabindex="0">Pricing</a>
+          <a href="#account" class="drawer__link" tabindex="0">Account</a>
+        </nav>
+        <div class="drawer__foot">
+          <a href="#signout" class="drawer__link drawer__link--muted" tabindex="0">Sign out</a>
+        </div>
+      </aside>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-drawer-slide-sbh/style.css
+++ b/submissions/examples/ease-drawer-slide-sbh/style.css
@@ -1,0 +1,146 @@
+:root {
+  --drawer-duration: 0.4s;
+  --drawer-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --drawer-width: 18rem;
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --glass-bg: rgba(255, 255, 255, 0.06);
+  --glass-border: rgba(255, 255, 255, 0.12);
+  --glass-blur: 16px;
+  --radius: 1rem;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 20%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+}
+
+.page__intro { text-align: center; max-width: 36rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+
+/* hide the native checkbox; it only drives state */
+.drawer-toggle { position: absolute; opacity: 0; pointer-events: none; }
+
+.stage { position: relative; display: flex; flex-direction: column; align-items: center; gap: 1.5rem; }
+
+.opener {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.7rem 1.4rem;
+  border-radius: 0.7rem;
+  font-weight: 600;
+  color: #06231a;
+  background: linear-gradient(135deg, var(--accent), var(--accent2));
+  cursor: pointer;
+  user-select: none;
+  transition: filter 0.2s ease, transform 0.2s ease;
+}
+.opener:hover, .opener:focus-visible { filter: brightness(1.08); transform: translateY(-2px); outline: none; box-shadow: 0 0 0 3px rgba(110,168,255,0.5); }
+
+/* backdrop: covers the viewport, fades in when drawer open */
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(4, 7, 14, 0.6);
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity var(--drawer-duration) var(--drawer-ease),
+              visibility 0s linear var(--drawer-duration);
+  z-index: 40;
+  cursor: pointer;
+}
+.drawer-toggle:checked ~ .backdrop {
+  opacity: 1;
+  visibility: visible;
+  transition: opacity var(--drawer-duration) var(--drawer-ease), visibility 0s linear 0s;
+}
+
+/* drawer: slides in from the left */
+.drawer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: var(--drawer-width);
+  max-width: 85vw;
+  display: flex;
+  flex-direction: column;
+  padding: 1.2rem;
+  gap: 0.6rem;
+  background: var(--glass-bg);
+  border-right: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  box-shadow: 30px 0 70px -30px rgba(0, 0, 0, 0.8);
+  transform: translateX(-100%);
+  transition: transform var(--drawer-duration) var(--drawer-ease);
+  z-index: 50;
+}
+.drawer-toggle:checked ~ .drawer { transform: translateX(0); }
+
+.drawer__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.2rem 0.4rem 0.8rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+.drawer__title { font-weight: 700; font-size: 1.05rem; }
+.drawer__close {
+  font-size: 1.5rem;
+  line-height: 1;
+  color: var(--muted);
+  cursor: pointer;
+  user-select: none;
+  padding: 0.2rem 0.5rem;
+  border-radius: 0.4rem;
+  transition: color 0.18s ease, background 0.18s ease;
+}
+.drawer__close:hover, .drawer__close:focus-visible { color: var(--fg); background: rgba(255,255,255,0.08); outline: none; box-shadow: 0 0 0 2px rgba(110,168,255,0.6); }
+
+.drawer__nav { display: flex; flex-direction: column; gap: 0.2rem; }
+.drawer__link {
+  display: block;
+  padding: 0.6rem 0.7rem;
+  border-radius: 0.6rem;
+  color: var(--fg);
+  text-decoration: none;
+  font-size: 0.92rem;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.drawer__link:hover, .drawer__link:focus-visible { background: rgba(110, 168, 255, 0.18); outline: none; }
+.drawer__link--muted { color: var(--muted); margin-top: 0.4rem; }
+
+.drawer__foot { margin-top: auto; padding-top: 0.6rem; border-top: 1px solid rgba(255, 255, 255, 0.1); }
+
+@media (max-width: 480px) {
+  .drawer { padding: 1rem; }
+  :root { --drawer-width: 16rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .drawer, .backdrop { transition: none; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-drawer-slide** from issue #64271 — an off-canvas side drawer that slides into view while a backdrop fades in. Pure CSS.

Closes #64271.

## Feature

A frosted-glass side panel anchored to the viewport. Toggling a hidden checkbox (via the "Open menu" label) slides the drawer in from the left (`translateX(-100%) → 0`) and fades in a dimmed, slightly blurred backdrop that covers the page. Clicking the backdrop or the close button closes the drawer.

## How it works

- The drawer's `transform: translateX(-100%) → 0` slide on `--drawer-duration` is paired with the backdrop's `opacity` + `visibility` fade. Visibility is deferred on close so the backdrop doesn't trap clicks while hiding. All via `transform`/`opacity`, driven by a hidden checkbox + sibling combinator (no JS).

## Accessibility

- `role="dialog"` + `aria-modal="true"` + `aria-label` on the drawer; the trigger and close are focusable labels with `:focus-visible` rings; `tabindex="0"` on interactive labels so keyboard users can open/close.
- Full `prefers-reduced-motion` support (drawer and backdrop snap without transition).
- Configurable via CSS custom properties (`--drawer-duration`, `--drawer-ease`, `--drawer-width`, `--glass-blur`).

## Submission structure

```
submissions/examples/ease-drawer-slide-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← glassmorphism drawer + slide/backdrop-fade via checkbox state
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally