### PR TITLE
feat: add ease-star-rating component (#64267)

### DIFF
--- a/submissions/examples/ease-star-rating-sbh/README.md
+++ b/submissions/examples/ease-star-rating-sbh/README.md
@@ -1,0 +1,42 @@
+# ease-star-rating
+
+A star rating widget where stars smoothly fill with color on hover and selection — instant, tactile feedback for reviews, feedback forms, and e-commerce.
+
+## What does this do?
+
+Adds a **star-rating**: five star-shaped labels driven by hidden radio inputs. Hovering a star previews the fill up to that point, and clicking selects that rating (the fill persists). Stars are CSS-masked SVG stars whose gold gradient `background-size` animates from `0%` to `100%`, so the fill wipes in smoothly. The row is `flex-direction: row-reverse` so a simple `:checked ~ label` (and `:hover ~ label`) selects all stars to the left of the target.
+
+## How is it used?
+
+1. Build a `.star-rating` with `role="radiogroup"`, containing five `<input type="radio">` + `<label class="star-rating__star">` pairs in descending value order (5 → 1).
+2. Each label's `for` points to its input; each input shares the same `name` so only one rating is selected.
+3. Hover previews the fill; clicking a star sets `:checked`, which fills that star and all to its left.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<div class="star-rating" role="radiogroup" aria-labelledby="rate-label">
+  <input type="radio" class="star-rating__input" id="sr-5" name="sr" value="5" /><label for="sr-5" class="star-rating__star" aria-label="5 stars"></label>
+  <input type="radio" class="star-rating__input" id="sr-4" name="sr" value="4" /><label for="sr-4" class="star-rating__star" aria-label="4 stars"></label>
+  <input type="radio" class="star-rating__input" id="sr-3" name="sr" value="3" /><label for="sr-3" class="star-rating__star" aria-label="3 stars"></label>
+  <input type="radio" class="star-rating__input" id="sr-2" name="sr" value="2" /><label for="sr-2" class="star-rating__star" aria-label="2 stars"></label>
+  <input type="radio" class="star-rating__input" id="sr-1" name="sr" value="1" /><label for="sr-1" class="star-rating__star" aria-label="1 star"></label>
+</div>
+```
+
+## Why is this useful?
+
+- **Animation-first** — the signature motion is the fill wipe: each star is a CSS-masked star shape with a two-layer background (gold gradient + empty color); the gold layer's `background-size` transitions `0% → 100%` on `:hover`/`:checked`. Stars also scale up slightly on hover for tactile feedback. All via `background-size`/`transform`.
+- **Glassmorphism aesthetic** — empty stars are translucent on the frosted dark background; filled stars are a warm gold gradient.
+- **Accessible** — semantic `role="radiogroup"` with real radio inputs (keyboard operable: arrow keys / space) and `aria-label`s per star. `:focus-visible` highlights the focused star with a glow. Full `prefers-reduced-motion` support (no transitions; hover scale disabled).
+- **Reusable** — configurable via CSS custom properties (`--star-duration`, `--star-ease`, `--star-size`, `--star-gap`, `--star-full`).
+
+## Files
+
+- `demo.html` — self-contained demo (open directly in a browser; no server, CDNs, or frameworks). Pure CSS interaction, no JS.
+- `style.css` — CSS-masked stars, fill-wipe via `background-size`, hover-preview + checked-fill via sibling combinators, focus-visible glow, responsive + reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-star-rating-sbh/demo.html
+++ b/submissions/examples/ease-star-rating-sbh/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-star-rating — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-star-rating</h1>
+      <p>Stars that smoothly fill with color on hover and selection — instant, tactile feedback.</p>
+    </header>
+
+    <section class="ratings" aria-label="Star rating demos">
+      <div class="rating-block">
+        <span class="rating-block__label" id="rate-label-1">Rate this product</span>
+        <div class="star-rating" role="radiogroup" aria-labelledby="rate-label-1">
+          <input type="radio" class="star-rating__input" id="sr1-5" name="sr1" value="5" /><label for="sr1-5" class="star-rating__star" aria-label="5 stars"></label>
+          <input type="radio" class="star-rating__input" id="sr1-4" name="sr1" value="4" /><label for="sr1-4" class="star-rating__star" aria-label="4 stars"></label>
+          <input type="radio" class="star-rating__input" id="sr1-3" name="sr1" value="3" /><label for="sr1-3" class="star-rating__star" aria-label="3 stars"></label>
+          <input type="radio" class="star-rating__input" id="sr1-2" name="sr1" value="2" /><label for="sr1-2" class="star-rating__star" aria-label="2 stars"></label>
+          <input type="radio" class="star-rating__input" id="sr1-1" name="sr1" value="1" /><label for="sr1-1" class="star-rating__star" aria-label="1 star"></label>
+        </div>
+        <span class="rating-block__hint">Hover to preview, click to select.</span>
+      </div>
+
+      <div class="rating-block">
+        <span class="rating-block__label" id="rate-label-2">Rate the service</span>
+        <div class="star-rating" role="radiogroup" aria-labelledby="rate-label-2">
+          <input type="radio" class="star-rating__input" id="sr2-5" name="sr2" value="5" /><label for="sr2-5" class="star-rating__star" aria-label="5 stars"></label>
+          <input type="radio" class="star-rating__input" id="sr2-4" name="sr2" value="4" /><label for="sr2-4" class="star-rating__star" aria-label="4 stars"></label>
+          <input type="radio" class="star-rating__input" id="sr2-3" name="sr2" value="3" /><label for="sr2-3" class="star-rating__star" aria-label="3 stars"></label>
+          <input type="radio" class="star-rating__input" id="sr2-2" name="sr2" value="2" /><label for="sr2-2" class="star-rating__star" aria-label="2 stars"></label>
+          <input type="radio" class="star-rating__input" id="sr2-1" name="sr2" value="1" /><label for="sr2-1" class="star-rating__star" aria-label="1 star"></label>
+        </div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-star-rating-sbh/style.css
+++ b/submissions/examples/ease-star-rating-sbh/style.css
@@ -1,0 +1,96 @@
+:root {
+  --star-duration: 0.28s;
+  --star-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --star-size: 2rem;
+  --star-gap: 0.35rem;
+  --star-empty: rgba(255, 255, 255, 0.18);
+  --star-full: #fbbf24;
+  --star-full-2: #f59e0b;
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2.2rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 20%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+}
+
+.page__intro { text-align: center; max-width: 36rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+
+.ratings { display: flex; flex-direction: column; gap: 1.8rem; align-items: center; }
+.rating-block { display: flex; flex-direction: column; align-items: center; gap: 0.55rem; }
+.rating-block__label { font-size: 0.95rem; color: var(--muted); }
+.rating-block__hint { font-size: 0.78rem; color: var(--muted); opacity: 0.7; }
+
+.star-rating {
+  display: inline-flex;
+  flex-direction: row-reverse;   /* so :checked ~ label selects stars to the left */
+  gap: var(--star-gap);
+}
+.star-rating__input {
+  position: absolute;
+  width: 1px; height: 1px;
+  opacity: 0; pointer-events: none;
+}
+.star-rating__star {
+  width: var(--star-size);
+  height: var(--star-size);
+  cursor: pointer;
+  background:
+    linear-gradient(var(--star-full), var(--star-full-2)) no-repeat,
+    var(--star-empty);
+  -webkit-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M12 2.5l2.9 6 6.6.9-4.8 4.6 1.2 6.5L12 18.9 6.1 20.5l1.2-6.5L2.5 9.4l6.6-.9z'/></svg>") center / contain no-repeat;
+          mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M12 2.5l2.9 6 6.6.9-4.8 4.6 1.2 6.5L12 18.9 6.1 20.5l1.2-6.5L2.5 9.4l6.6-.9z'/></svg>") center / contain no-repeat;
+  background-size: 0% 100%, 100% 100%;
+  background-position: left center;
+  transition: background-size var(--star-duration) var(--star-ease),
+              transform var(--star-duration) var(--star-ease);
+}
+.star-rating__star:hover, .star-rating__star:focus-visible {
+  transform: scale(1.12);
+  outline: none;
+}
+
+/* fill via mask trick: the gold gradient is sized 0% -> 100% on hover/checked */
+.star-rating__star:hover,
+.star-rating__star:hover ~ .star-rating__star,
+.star-rating__input:checked ~ .star-rating__star,
+.star-rating__input:checked ~ .star-rating__star:hover {
+  background-size: 100% 100%, 100% 100%;
+}
+
+/* keyboard focus ring on the focused star's input sibling */
+.star-rating__input:focus-visible ~ .star-rating__star {
+  filter: drop-shadow(0 0 4px rgba(110, 168, 255, 0.9));
+}
+
+@media (max-width: 480px) {
+  :root { --star-size: 1.7rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .star-rating__star { transition: none; }
+  .star-rating__star:hover, .star-rating__star:focus-visible { transform: none; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-star-rating** from issue #64267.

Closes #64267.

## Feature

A 5-star rating widget where stars smoothly fill with color on hover and selection. CSS-masked SVG stars whose gold gradient `background-size` wipes 0% → 100% on hover/checked. The row is `flex-direction: row-reverse` so `:checked ~ label` and `:hover ~ label` fill all stars to the left of the target. Stars scale on hover for tactile feedback.

## How it works

- `@keyframes`-free fill wipe: two-layer background (gold gradient + empty color) on a CSS-masked star; the gold layer's `background-size` transitions `0% → 100%` on `:hover`/`:checked`. Sibling combinators select all stars to the left.

## Accessibility

- `role="radiogroup"` with real radio inputs (keyboard operable) and `aria-label`s per star. `:focus-visible` glow. Full `prefers-reduced-motion` support.

## Submission structure

```
submissions/examples/ease-star-rating-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← masked stars + fill-wipe + sibling-combinator logic
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally