### PR TITLE
feat: add ease-modal-pop component (#64196)

### DIFF
--- a/submissions/examples/ease-modal-pop-sbh/README.md
+++ b/submissions/examples/ease-modal-pop-sbh/README.md
@@ -1,0 +1,48 @@
+# ease-modal-pop
+
+A modal dialog that pops in with a subtle scale-up (and slight overshoot) while the backdrop fades and blurs in. Pure CSS — open/close is driven by a hidden checkbox, so no JavaScript is required for the animation.
+
+## What does this do?
+
+Adds a **modal-pop**: a centered frosted-glass dialog. Toggling a hidden checkbox (via the "Open modal" label) scales the dialog up (`scale(0.85) → 1` with an overshoot easing) and fades it in, while a dimmed, lightly blurred backdrop fades in behind it. Closing reverses both. The backdrop and any action buttons are all `<label for="modal-toggle">`, so they close the modal with no JS.
+
+## How is it used?
+
+1. Place a hidden `<input type="checkbox" class="modal-toggle">`, an `.opener` label, a `.backdrop` label, and the `.modal` as siblings (the CSS uses the `~` sibling combinator).
+2. The close button and action buttons are also labels pointing at the checkbox.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<input type="checkbox" id="modal-toggle" class="modal-toggle" aria-hidden="true" />
+<label for="modal-toggle" class="opener" tabindex="0">Open modal</label>
+<label for="modal-toggle" class="backdrop" aria-hidden="true"></label>
+<div class="modal" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+  <div class="modal__head">
+    <h2 class="modal__title" id="modal-title">Title</h2>
+    <label for="modal-toggle" class="modal__close" tabindex="0" aria-label="Close dialog">&times;</label>
+  </div>
+  <div class="modal__body"><p>…</p></div>
+  <div class="modal__actions">
+    <label for="modal-toggle" class="modal__btn modal__btn--ghost" tabindex="0">Cancel</label>
+    <label for="modal-toggle" class="modal__btn modal__btn--primary" tabindex="0">Confirm</label>
+  </div>
+</div>
+```
+
+## Why is this useful?
+
+- **Animation-first** — the signature motion is the dialog's `transform: translate(-50%,-50%) scale(0.85) → scale(1)` with an overshoot easing (`cubic-bezier(0.34, 1.56, 0.64, 1)`) paired with an `opacity` fade, while the backdrop fades via `opacity` + `visibility` (deferred on close so it doesn't trap clicks while hiding). All via `transform`/`opacity`.
+- **Glassmorphism aesthetic** — the dialog is a frosted panel via `backdrop-filter: blur()`; the backdrop adds a light blur over the page.
+- **Accessible** — `role="dialog"` + `aria-modal="true"` + `aria-labelledby` on the modal; the trigger, close, and action buttons are focusable labels with `:focus-visible` rings. Full `prefers-reduced-motion` support (modal and backdrop snap without transition).
+- **Reusable** — configurable via CSS custom properties (`--modal-duration`, `--modal-ease`, `--glass-blur`).
+
+## Files
+
+- `demo.html` — self-contained demo (open directly in a browser; no server, CDNs, or frameworks, and no JS required for the animation).
+- `style.css` — glassmorphism modal, scale-up + backdrop-fade via checkbox state, focus-visible states, responsive + reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-modal-pop-sbh/demo.html
+++ b/submissions/examples/ease-modal-pop-sbh/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-modal-pop — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-modal-pop</h1>
+      <p>A modal that pops in with a subtle scale-up while the backdrop fades in. Pure CSS, toggled by a checkbox.</p>
+    </header>
+
+    <div class="stage">
+      <input type="checkbox" id="modal-toggle" class="modal-toggle" aria-hidden="true" />
+      <label for="modal-toggle" class="opener" tabindex="0">Open modal</label>
+
+      <label for="modal-toggle" class="backdrop" aria-hidden="true"></label>
+
+      <div class="modal" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+        <div class="modal__head">
+          <h2 class="modal__title" id="modal-title">Confirm action</h2>
+          <label for="modal-toggle" class="modal__close" tabindex="0" aria-label="Close dialog">&times;</label>
+        </div>
+        <div class="modal__body">
+          <p>This dialog pops in with a scale-up and fades out on close. The backdrop dims and blurs the page behind it.</p>
+        </div>
+        <div class="modal__actions">
+          <label for="modal-toggle" class="modal__btn modal__btn--ghost" tabindex="0">Cancel</label>
+          <label for="modal-toggle" class="modal__btn modal__btn--primary" tabindex="0">Confirm</label>
+        </div>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-modal-pop-sbh/style.css
+++ b/submissions/examples/ease-modal-pop-sbh/style.css
@@ -1,0 +1,154 @@
+:root {
+  --modal-duration: 0.32s;
+  --modal-ease: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --modal-bg-duration: 0.32s;
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --glass-bg: rgba(255, 255, 255, 0.08);
+  --glass-border: rgba(255, 255, 255, 0.14);
+  --glass-blur: 18px;
+  --radius: 1rem;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 20%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+}
+
+.page__intro { text-align: center; max-width: 36rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+
+.modal-toggle { position: absolute; opacity: 0; pointer-events: none; }
+
+.stage { position: relative; display: flex; flex-direction: column; align-items: center; gap: 1.5rem; }
+
+.opener {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.7rem 1.4rem;
+  border-radius: 0.7rem;
+  font-weight: 600;
+  color: #06231a;
+  background: linear-gradient(135deg, var(--accent), var(--accent2));
+  cursor: pointer;
+  user-select: none;
+  transition: filter 0.2s ease, transform 0.2s ease;
+}
+.opener:hover, .opener:focus-visible { filter: brightness(1.08); transform: translateY(-2px); outline: none; box-shadow: 0 0 0 3px rgba(110,168,255,0.5); }
+
+/* backdrop */
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(4, 7, 14, 0.62);
+  backdrop-filter: blur(3px);
+  -webkit-backdrop-filter: blur(3px);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity var(--modal-bg-duration) ease,
+              visibility 0s linear var(--modal-bg-duration);
+  z-index: 40;
+  cursor: pointer;
+}
+.modal-toggle:checked ~ .backdrop {
+  opacity: 1;
+  visibility: visible;
+  transition: opacity var(--modal-bg-duration) ease, visibility 0s linear 0s;
+}
+
+/* modal: scale-up + fade */
+.modal {
+  position: fixed;
+  top: 50%; left: 50%;
+  width: min(26rem, 90vw);
+  transform: translate(-50%, -50%) scale(0.85);
+  opacity: 0;
+  visibility: hidden;
+  padding: 1.4rem;
+  border-radius: var(--radius);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  box-shadow: 0 40px 90px -30px rgba(0, 0, 0, 0.85);
+  transition: transform var(--modal-duration) var(--modal-ease),
+              opacity var(--modal-duration) ease,
+              visibility 0s linear var(--modal-duration);
+  z-index: 50;
+}
+.modal-toggle:checked ~ .modal {
+  transform: translate(-50%, -50%) scale(1);
+  opacity: 1;
+  visibility: visible;
+  transition: transform var(--modal-duration) var(--modal-ease),
+              opacity var(--modal-duration) ease,
+              visibility 0s linear 0s;
+}
+
+.modal__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.7rem;
+}
+.modal__title { margin: 0; font-size: 1.15rem; }
+.modal__close {
+  font-size: 1.5rem;
+  line-height: 1;
+  color: var(--muted);
+  cursor: pointer;
+  user-select: none;
+  padding: 0.15rem 0.5rem;
+  border-radius: 0.4rem;
+  transition: color 0.18s ease, background 0.18s ease;
+}
+.modal__close:hover, .modal__close:focus-visible { color: var(--fg); background: rgba(255,255,255,0.08); outline: none; box-shadow: 0 0 0 2px rgba(110,168,255,0.6); }
+
+.modal__body p { margin: 0; color: var(--muted); line-height: 1.6; font-size: 0.92rem; }
+
+.modal__actions { display: flex; gap: 0.6rem; justify-content: flex-end; margin-top: 1.3rem; }
+.modal__btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  border-radius: 0.6rem;
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+  user-select: none;
+  transition: filter 0.18s ease, transform 0.18s ease, background 0.18s ease;
+}
+.modal__btn--ghost { color: var(--fg); background: rgba(255,255,255,0.08); }
+.modal__btn--ghost:hover, .modal__btn--ghost:focus-visible { background: rgba(255,255,255,0.14); outline: none; box-shadow: 0 0 0 2px rgba(110,168,255,0.5); }
+.modal__btn--primary { color: #06231a; background: linear-gradient(135deg, var(--accent), var(--accent2)); }
+.modal__btn--primary:hover, .modal__btn--primary:focus-visible { filter: brightness(1.08); transform: translateY(-1px); outline: none; box-shadow: 0 0 0 3px rgba(110,168,255,0.5); }
+
+@media (max-width: 480px) {
+  .modal { padding: 1.1rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .modal, .backdrop { transition: none; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-modal-pop** from issue #64196.

Closes #64196.

## Feature

A modal dialog that pops in with a scale-up (0.85 → 1, overshoot easing) + opacity fade while a dimmed, lightly blurred backdrop fades in (opacity + visibility, deferred on close). Pure CSS via a hidden checkbox + sibling combinator (no JS); backdrop/close/action buttons are labels pointing at the checkbox.

## How it works

- `transform: translate(-50%,-50%) scale(0.85) → scale(1)` with an overshoot easing (`cubic-bezier(0.34, 1.56, 0.64, 1)`) + `opacity` fade on the modal; backdrop fades via `opacity` + `visibility` (deferred on close). All via `transform`/`opacity`.

## Accessibility

- `role="dialog"` + `aria-modal="true"` + `aria-labelledby`; trigger/close/actions are focusable labels with `:focus-visible` rings. Full `prefers-reduced-motion` support.

## Submission structure

```
submissions/examples/ease-modal-pop-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← glassmorphism modal + scale-up + backdrop-fade
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally