### PR TITLE
feat: add ease-progress-fill component (#64194)

### DIFF
--- a/submissions/examples/ease-progress-fill-sbh/README.md
+++ b/submissions/examples/ease-progress-fill-sbh/README.md
@@ -1,0 +1,37 @@
+# ease-progress-fill
+
+A progress bar that smoothly fills to a target width, with an animated shimmer sweeping across the filled area and a striped variant whose diagonal stripes march rightward. Great for loading states, downloads, and task completion.
+
+## What does this do?
+
+Adds a **progress-fill**: a glassmorphism track with an inner `.progress__fill` bar. The fill animates its `width` from `0` to a `--target` custom property (e.g. `42%`), so you set the value declaratively and the bar fills smoothly on load. The `--shimmer` variant adds a light band sweeping across the filled area; the `--striped` variant adds marching diagonal stripes for an "indeterminate activity" feel.
+
+## How is it used?
+
+1. Build a `.progress` track (a `role="progressbar"` with `aria-valuenow/min/max`) and put a `.progress__fill` inside it.
+2. Set the target via the `--target` inline custom property (a percentage), and add `--shimmer` or `--striped` for the activity effect.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<div class="progress" role="progressbar" aria-valuenow="42" aria-valuemin="0" aria-valuemax="100" aria-label="Download progress">
+  <div class="progress__fill progress__fill--shimmer" style="--target: 42%"></div>
+</div>
+```
+
+## Why is this useful?
+
+- **Animation-first** — the signature motion is `@keyframes pf-grow` animating the fill's `width` from `0` to `var(--target)`. The shimmer variant layers `@keyframes pf-shimmer` to sweep a translucent band across the filled area (via `background-position`), and the striped variant layers `@keyframes pf-march` to advance diagonal stripes rightward. All via `width`/`background-position`.
+- **Glassmorphism aesthetic** — the track is a frosted, translucent bar on the dark background; the fill is an accent gradient.
+- **Accessible** — semantic `role="progressbar"` with `aria-valuenow`/`aria-valuemin`/`aria-valuemax` and an `aria-label`, so screen readers announce the value. The animation is decorative; the value is conveyed via ARIA regardless of motion. Full `prefers-reduced-motion` support (fill snaps to target width; shimmer/stripes stop).
+- **Reusable** — configurable via CSS custom properties (`--fill-duration`, `--fill-ease`, `--fill-color`, `--target`).
+
+## Files
+
+- `demo.html` — self-contained demo (open directly in a browser; no server, CDNs, or frameworks). Pure CSS animation, no JS.
+- `style.css` — glassmorphism track, width-grow keyframes, shimmer + striped activity variants, responsive + reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-progress-fill-sbh/demo.html
+++ b/submissions/examples/ease-progress-fill-sbh/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-progress-fill — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-progress-fill</h1>
+      <p>Progress bars that smoothly fill to a target width — with an animated shimmer and a striped variant.</p>
+    </header>
+
+    <section class="bars" aria-label="Progress demos">
+      <div class="bar-block">
+        <div class="bar-block__meta">
+          <span>Downloading update</span>
+          <span class="bar-block__val">42%</span>
+        </div>
+        <div class="progress" role="progressbar" aria-valuenow="42" aria-valuemin="0" aria-valuemax="100" aria-label="Download progress">
+          <div class="progress__fill progress__fill--shimmer" style="--target: 42%"></div>
+        </div>
+      </div>
+
+      <div class="bar-block">
+        <div class="bar-block__meta">
+          <span>Uploading assets</span>
+          <span class="bar-block__val">78%</span>
+        </div>
+        <div class="progress" role="progressbar" aria-valuenow="78" aria-valuemin="0" aria-valuemax="100" aria-label="Upload progress">
+          <div class="progress__fill progress__fill--striped" style="--target: 78%"></div>
+        </div>
+      </div>
+
+      <div class="bar-block">
+        <div class="bar-block__meta">
+          <span>Compiling build</span>
+          <span class="bar-block__val">100%</span>
+        </div>
+        <div class="progress" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" aria-label="Build progress">
+          <div class="progress__fill progress__fill--shimmer" style="--target: 100%"></div>
+        </div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-progress-fill-sbh/style.css
+++ b/submissions/examples/ease-progress-fill-sbh/style.css
@@ -1,0 +1,122 @@
+:root {
+  --fill-duration: 1.1s;
+  --fill-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --fill-color: #6ea8ff;
+  --fill-color-2: #b388ff;
+  --track-bg: rgba(255, 255, 255, 0.08);
+  --track-border: rgba(255, 255, 255, 0.12);
+  --glass-blur: 8px;
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --radius: 0.7rem;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 20%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+}
+
+.page__intro { text-align: center; max-width: 36rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+
+.bars {
+  width: min(34rem, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+}
+.bar-block { display: flex; flex-direction: column; gap: 0.5rem; }
+.bar-block__meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+.bar-block__val { font-variant-numeric: tabular-nums; color: var(--fg); }
+
+.progress {
+  position: relative;
+  height: 0.7rem;
+  border-radius: var(--radius);
+  background: var(--track-bg);
+  border: 1px solid var(--track-border);
+  overflow: hidden;
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+}
+
+.progress__fill {
+  position: absolute;
+  top: 0; left: 0; bottom: 0;
+  width: 0;
+  border-radius: var(--radius);
+  background: linear-gradient(90deg, var(--fill-color), var(--fill-color-2));
+  transition: width var(--fill-duration) var(--fill-ease);
+  animation: pf-grow var(--fill-duration) var(--fill-ease) forwards;
+}
+
+/* shimmer: a light band sweeps across the filled area */
+.progress__fill--shimmer::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.45), transparent);
+  background-size: 200% 100%;
+  background-position: -150% 0;
+  animation: pf-shimmer 1.8s linear infinite;
+}
+
+/* striped: animated diagonal stripes that march rightward */
+.progress__fill--striped {
+  background-image:
+    repeating-linear-gradient(45deg,
+      rgba(255, 255, 255, 0.22) 0 8px,
+      transparent 8px 16px),
+    linear-gradient(90deg, var(--fill-color), var(--fill-color-2));
+  background-size: auto, 100% 100%;
+  animation: pf-grow var(--fill-duration) var(--fill-ease) forwards,
+             pf-march 0.7s linear infinite;
+}
+
+@keyframes pf-grow {
+  from { width: 0; }
+  to   { width: var(--target, 0%); }
+}
+@keyframes pf-shimmer {
+  from { background-position: -150% 0; }
+  to   { background-position: 150% 0; }
+}
+@keyframes pf-march {
+  from { background-position: 0 0, 0 0; }
+  to   { background-position: 16px 0, 0 0; }
+}
+
+@media (max-width: 480px) {
+  .progress { height: 0.6rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .progress__fill { animation: none; width: var(--target, 0%); transition: none; }
+  .progress__fill--shimmer::after, .progress__fill--striped { animation: none; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-progress-fill** from issue #64194.

Closes #64194.

## Feature

A progress bar that smoothly fills width 0 → `var(--target)` via `@keyframes pf-grow`. The `--shimmer` variant layers `pf-shimmer` to sweep a translucent band across the filled area (background-position); the `--striped` variant layers `pf-march` to advance diagonal stripes rightward.

## How it works

- `@keyframes pf-grow` animates the fill's `width` from `0` to `var(--target)`. Shimmer sweeps via `background-position`; striped variant marches diagonal stripes via `background-position`.

## Accessibility

- `role="progressbar"` with `aria-valuenow`/`aria-valuemin`/`aria-valuemax` + `aria-label` so screen readers announce the value. Full `prefers-reduced-motion` support (fill snaps to target; shimmer/stripes stop).

## Submission structure

```
submissions/examples/ease-progress-fill-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← glassmorphism track + width-grow + shimmer/striped variants
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally