### PR TITLE
feat: add ease-tab-underline component (#64193)

### DIFF
--- a/submissions/examples/ease-tab-underline-sbh/README.md
+++ b/submissions/examples/ease-tab-underline-sbh/README.md
@@ -1,0 +1,45 @@
+# ease-tab-underline
+
+A tab bar whose underline indicator glides beneath the active tab whenever you switch — adapting to each tab's width with no abrupt jumps.
+
+## What does this do?
+
+Adds a **tab-underline**: a glassmorphism tab list with an absolutely-positioned underline bar (`::after` on the list). When a tab is activated, the underline's `left` and `width` transition to that tab's position and width, so it glides smoothly between tabs of differing widths. A tiny included script measures the active tab and sets `--underline-left` / `--underline-width` custom properties on the list; the CSS does the animated glide.
+
+## How is it used?
+
+1. Build a `.tabs__list` (a `role="tablist"`) of `.tabs__tab` buttons, each `role="tab"` with `aria-selected`, `aria-controls`, and an `id`.
+2. Pair each tab with a `.tabs__panel` (`role="tabpanel"`, `aria-labelledby`, `hidden` when inactive).
+3. The included script sets the underline position on click, on load, and on resize, and implements the WAI-ARIA arrow-key pattern.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<div class="tabs__list" role="tablist">
+  <button class="tabs__tab" role="tab" aria-selected="true" aria-controls="tab-panel-1" id="tab-1" tabindex="0">General</button>
+  <button class="tabs__tab" role="tab" aria-selected="false" aria-controls="tab-panel-2" id="tab-2" tabindex="0">Appearance</button>
+  …
+</div>
+<div class="tabs__panels">
+  <div class="tabs__panel" role="tabpanel" id="tab-panel-1" aria-labelledby="tab-1"><p>…</p></div>
+  <div class="tabs__panel tabs__panel--hidden" role="tabpanel" id="tab-panel-2" aria-labelledby="tab-2" hidden><p>…</p></div>
+  …
+</div>
+```
+
+## Why is this useful?
+
+- **Animation-first** — the signature motion is the underline bar's `left` and `width` transitioning to the active tab's measured position (set via `--underline-left`/`--underline-width`), so it glides naturally between tabs of any width via `transform`-free `left`/`width` transitions with a springy ease.
+- **Glassmorphism aesthetic** — the tab bar is a frosted panel via `backdrop-filter: blur()`; the underline is an accent gradient.
+- **Accessible** — full WAI-ARIA tabs pattern: `role="tablist"`/`tab`/`tabpanel`, `aria-selected`, `aria-controls`/`aria-labelledby`, roving `tabindex`, and arrow-key navigation (Left/Right). `:focus-visible` rings. Hidden panels use the `hidden` attribute. Full `prefers-reduced-motion` support (underline snaps without transition).
+- **Reusable** — configurable via CSS custom properties (`--underline-duration`, `--underline-ease`, `--underline-height`).
+
+## Files
+
+- `demo.html` — self-contained demo (open directly in a browser; no server, CDNs, or frameworks). Includes a small script that measures the active tab to position the underline and implements the ARIA arrow-key pattern.
+- `style.css` — glassmorphism tab list, gliding underline via `::after` + `--underline-left`/`--underline-width`, focus-visible states, responsive horizontal-scroll on narrow screens, reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation. The underline glide requires the small JS in `demo.html` to measure tab positions; the maintainer may adapt this when curating into the framework.

--- a/submissions/examples/ease-tab-underline-sbh/demo.html
+++ b/submissions/examples/ease-tab-underline-sbh/demo.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-tab-underline — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-tab-underline</h1>
+      <p>An underline indicator that glides beneath the active tab as you switch — adapting to each tab's width.</p>
+    </header>
+
+    <section class="tabs" aria-label="Settings sections">
+      <div class="tabs__list" role="tablist">
+        <button type="button" class="tabs__tab" role="tab" aria-selected="true" aria-controls="tab-panel-1" id="tab-1" tabindex="0">General</button>
+        <button type="button" class="tabs__tab" role="tab" aria-selected="false" aria-controls="tab-panel-2" id="tab-2" tabindex="0">Appearance</button>
+        <button type="button" class="tabs__tab" role="tab" aria-selected="false" aria-controls="tab-panel-3" id="tab-3" tabindex="0">Notifications</button>
+        <button type="button" class="tabs__tab" role="tab" aria-selected="false" aria-controls="tab-panel-4" id="tab-4" tabindex="0">Privacy &amp; Security</button>
+      </div>
+
+      <div class="tabs__panels">
+        <div class="tabs__panel" role="tabpanel" id="tab-panel-1" aria-labelledby="tab-1">
+          <p>General settings — the underline glides here when this tab is active.</p>
+        </div>
+        <div class="tabs__panel tabs__panel--hidden" role="tabpanel" id="tab-panel-2" aria-labelledby="tab-2" hidden>
+          <p>Appearance settings — theme, density, and font choices.</p>
+        </div>
+        <div class="tabs__panel tabs__panel--hidden" role="tabpanel" id="tab-panel-3" aria-labelledby="tab-3" hidden>
+          <p>Notifications — email, push, and in-app preferences.</p>
+        </div>
+        <div class="tabs__panel tabs__panel--hidden" role="tabpanel" id="tab-panel-4" aria-labelledby="tab-4" hidden>
+          <p>Privacy &amp; Security — sessions, two-factor, and data controls.</p>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    // Minimal interaction: clicking a tab selects it and moves the underline.
+    // The underline position is set via a CSS custom property on the list.
+    var tabs = Array.prototype.slice.call(document.querySelectorAll('.tabs__tab'));
+    var list = document.querySelector('.tabs__list');
+    var panels = Array.prototype.slice.call(document.querySelectorAll('.tabs__panel'));
+
+    function selectTab(tab) {
+      tabs.forEach(function (t) {
+        var active = t === tab;
+        t.setAttribute('aria-selected', String(active));
+        t.tabIndex = active ? 0 : -1;
+      });
+      // position the underline: center of the active tab relative to the list
+      var rect = tab.getBoundingClientRect();
+      var listRect = list.getBoundingClientRect();
+      var left = rect.left - listRect.left;
+      var width = rect.width;
+      list.style.setProperty('--underline-left', left + 'px');
+      list.style.setProperty('--underline-width', width + 'px');
+
+      panels.forEach(function (p) {
+        var active = p.id === tab.getAttribute('aria-controls');
+        p.toggleAttribute('hidden', !active);
+        p.classList.toggle('tabs__panel--hidden', !active);
+      });
+    }
+
+    tabs.forEach(function (t) { t.addEventListener('click', function () { selectTab(t); }); });
+    // arrow-key navigation per the WAI-ARIA tabs pattern
+    list.addEventListener('keydown', function (e) {
+      var i = tabs.indexOf(document.querySelector('.tabs__tab[aria-selected="true"]'));
+      if (e.key === 'ArrowRight') { selectTab(tabs[(i + 1) % tabs.length]); tabs[(i + 1) % tabs.length].focus(); }
+      if (e.key === 'ArrowLeft')  { selectTab(tabs[(i - 1 + tabs.length) % tabs.length]); tabs[(i - 1 + tabs.length) % tabs.length].focus(); }
+    });
+
+    // position the underline on load for the initially-active tab
+    window.addEventListener('load', function () { selectTab(tabs[0]); });
+    window.addEventListener('resize', function () {
+      var active = document.querySelector('.tabs__tab[aria-selected="true"]');
+      if (active) selectTab(active);
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-tab-underline-sbh/style.css
+++ b/submissions/examples/ease-tab-underline-sbh/style.css
@@ -1,0 +1,115 @@
+:root {
+  --underline-duration: 0.3s;
+  --underline-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --underline-height: 3px;
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --glass-bg: rgba(255, 255, 255, 0.06);
+  --glass-border: rgba(255, 255, 255, 0.12);
+  --glass-blur: 10px;
+  --radius: 0.8rem;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 20%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+}
+
+.page__intro { text-align: center; max-width: 36rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+
+.tabs {
+  width: min(40rem, 100%);
+  border-radius: var(--radius);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  overflow: hidden;
+}
+
+.tabs__list {
+  position: relative;
+  display: flex;
+  gap: 0.2rem;
+  padding: 0 0.4rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  /* underline position driven by JS-set custom properties with sane defaults */
+  --underline-left: 0.4rem;
+  --underline-width: 4rem;
+}
+
+.tabs__tab {
+  position: relative;
+  z-index: 1;
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  font-size: 0.92rem;
+  font-weight: 600;
+  padding: 0.9rem 1rem;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color 0.2s ease;
+}
+.tabs__tab:hover { color: var(--fg); }
+.tabs__tab:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px rgba(110, 168, 255, 0.6);
+  border-radius: 0.4rem;
+}
+.tabs__tab[aria-selected="true"] { color: var(--fg); }
+
+/* the gliding underline: an absolutely-positioned bar whose left/width
+   transition to the active tab's position (set via --underline-left/width). */
+.tabs__list::after {
+  content: "";
+  position: absolute;
+  bottom: -1px;
+  left: var(--underline-left);
+  width: var(--underline-width);
+  height: var(--underline-height);
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  transition: left var(--underline-duration) var(--underline-ease),
+              width var(--underline-duration) var(--underline-ease);
+  z-index: 2;
+}
+
+.tabs__panels { padding: 1.4rem 1.2rem; }
+.tabs__panel { color: var(--muted); line-height: 1.6; font-size: 0.92rem; }
+.tabs__panel p { margin: 0; }
+.tabs__panel--hidden { display: none; }
+
+@media (max-width: 480px) {
+  .tabs__list { overflow-x: auto; scrollbar-width: none; }
+  .tabs__list::-webkit-scrollbar { display: none; }
+  .tabs__tab { padding: 0.75rem 0.8rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tabs__list::after { transition: none; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-tab-underline** from issue #64193.

Closes #64193.

## Feature

A tab bar whose underline indicator glides beneath the active tab. The underline is an absolutely-positioned `::after` bar whose `left`/`width` transition to the active tab's measured position (set via `--underline-left`/`--underline-width` custom properties), so it glides between tabs of any width with a springy ease.

## How it works

- The underline bar's `left` and `width` transition to the active tab's measured position (set via `--underline-left`/`--underline-width`). A small script measures tab positions on click/load/resize.

## Accessibility

- Full WAI-ARIA tabs pattern (`role="tablist"/`tab`/`tabpanel`, `aria-selected`, `aria-controls`/`aria-labelledby`, roving `tabindex`, Left/Right arrow-key nav). `:focus-visible` rings. Hidden panels use the `hidden` attribute. Full `prefers-reduced-motion` support.

## Submission structure

```
submissions/examples/ease-tab-underline-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← glassmorphism tabs + gliding underline + ARIA tabs
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally