### PR TITLE
feat: add ease-bento-hover-zoom component (#64180)

### DIFF
--- a/submissions/examples/ease-bento-hover-zoom-sbh/README.md
+++ b/submissions/examples/ease-bento-hover-zoom-sbh/README.md
@@ -1,0 +1,42 @@
+# ease-bento-hover-zoom
+
+A modern Bento grid where each tile smoothly scales up and illuminates its border with a vibrant gradient highlight on hover — a sleek dashboard/portfolio layout block.
+
+## What does this do?
+
+Adds a **bento-hover-zoom**: a responsive grid of glassmorphism tiles. On hover (and keyboard focus), a tile scales up slightly (`scale(1.035)`), its plain border fades out, and a gradient border (drawn via a masked `::before` layer) fades in, accompanied by a soft accent glow shadow. Tiles include a large feature tile (`--lg`) and a wide tile (`--wide`) for layout variety.
+
+## How is it used?
+
+1. Build a `.bento` grid of `.bento__tile` articles. Add `--lg` or `--wide` to span columns/rows.
+2. Tiles are focusable (`tabindex="0"`) so keyboard users get the same zoom + highlight.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<section class="bento" aria-label="Dashboard bento grid">
+  <article class="bento__tile bento__tile--lg" tabindex="0">
+    <h2 class="bento__title">Revenue</h2>
+    <p class="bento__value">$48,210</p>
+    <p class="bento__sub">+12.4% vs last month</p>
+  </article>
+  <article class="bento__tile" tabindex="0">…</article>
+</section>
+```
+
+## Why is this useful?
+
+- **Animation-first** — the signature motion is the hover zoom (`transform: scale(1.035)`) paired with a border-highlight reveal: a `::before` pseudo-element paints a gradient border via the `padding` + `mask` (content-box/xor) technique, fading in (`opacity`) while the base border fades out. A soft `box-shadow` glow completes the lift. All via `transform`/`opacity`/`box-shadow`.
+- **Glassmorphism aesthetic** — tiles are frosted panels via `backdrop-filter: blur()`; the hover border is an accent gradient.
+- **Accessible** — tiles are focusable and the zoom + highlight fire on `:focus-visible` too (not just `:hover`), so keyboard users get identical feedback. Full `prefers-reduced-motion` support (no transform; highlight still toggles via opacity but instantly).
+- **Reusable** — configurable via CSS custom properties (`--zoom-duration`, `--zoom-ease`, `--tile-hover-border`, `--glow`, `--glass-blur`).
+
+## Files
+
+- `demo.html` — self-contained demo (open directly in a browser; no server, CDNs, or frameworks). Pure CSS interaction, no JS.
+- `style.css` — responsive Bento grid, hover zoom + gradient-border reveal via masked `::before`, focus-visible parity, glow shadow, reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-bento-hover-zoom-sbh/demo.html
+++ b/submissions/examples/ease-bento-hover-zoom-sbh/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-bento-hover-zoom — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-bento-hover-zoom</h1>
+      <p>A Bento grid where each tile scales up and lights its border on hover — a sleek dashboard block.</p>
+    </header>
+
+    <section class="bento" aria-label="Dashboard bento grid">
+      <article class="bento__tile bento__tile--lg" tabindex="0">
+        <h2 class="bento__title">Revenue</h2>
+        <p class="bento__value">$48,210</p>
+        <p class="bento__sub">+12.4% vs last month</p>
+      </article>
+
+      <article class="bento__tile" tabindex="0">
+        <h2 class="bento__title">Active users</h2>
+        <p class="bento__value">8,902</p>
+        <p class="bento__sub">+3.1%</p>
+      </article>
+
+      <article class="bento__tile" tabindex="0">
+        <h2 class="bento__title">Conversion</h2>
+        <p class="bento__value">4.7%</p>
+        <p class="bento__sub">+0.6 pt</p>
+      </article>
+
+      <article class="bento__tile bento__tile--wide" tabindex="0">
+        <h2 class="bento__title">Top channel</h2>
+        <p class="bento__value">Organic search</p>
+        <p class="bento__sub">62% of sessions</p>
+      </article>
+
+      <article class="bento__tile" tabindex="0">
+        <h2 class="bento__title">Refunds</h2>
+        <p class="bento__value">$312</p>
+        <p class="bento__sub">-1.8%</p>
+      </article>
+
+      <article class="bento__tile" tabindex="0">
+        <h2 class="bento__title">NPS</h2>
+        <p class="bento__value">62</p>
+        <p class="bento__sub">+4</p>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-bento-hover-zoom-sbh/style.css
+++ b/submissions/examples/ease-bento-hover-zoom-sbh/style.css
@@ -1,0 +1,112 @@
+:root {
+  --zoom-duration: 0.3s;
+  --zoom-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --tile-bg: rgba(255, 255, 255, 0.05);
+  --tile-border: rgba(255, 255, 255, 0.12);
+  --tile-hover-border: #6ea8ff;
+  --glow: rgba(110, 168, 255, 0.45);
+  --glass-blur: 12px;
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --radius: 1.1rem;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2rem;
+  padding: 3rem 1.5rem 4rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 0%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+}
+
+.page__intro { text-align: center; max-width: 36rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+
+.bento {
+  width: min(52rem, 100%);
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-auto-rows: minmax(7rem, auto);
+  gap: 0.9rem;
+}
+
+.bento__tile {
+  position: relative;
+  padding: 1.3rem 1.3rem;
+  border-radius: var(--radius);
+  background: var(--tile-bg);
+  border: 1px solid var(--tile-border);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  cursor: pointer;
+  transform: scale(1);
+  transform-origin: center;
+  transition: transform var(--zoom-duration) var(--zoom-ease),
+              border-color var(--zoom-duration) var(--zoom-ease),
+              box-shadow var(--zoom-duration) var(--zoom-ease);
+  /* gradient border reveal: a masked gradient layer that fades in on hover */
+  overflow: hidden;
+}
+.bento__tile::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 1px;
+  background: linear-gradient(135deg, var(--accent), var(--accent2));
+  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+          mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+          mask-composite: exclude;
+  opacity: 0;
+  transition: opacity var(--zoom-duration) var(--zoom-ease);
+  pointer-events: none;
+}
+
+.bento__tile:hover,
+.bento__tile:focus-visible {
+  transform: scale(1.035);
+  border-color: transparent;
+  box-shadow: 0 18px 45px -18px var(--glow);
+  outline: none;
+}
+.bento__tile:hover::before,
+.bento__tile:focus-visible::before { opacity: 1; }
+
+.bento__tile--lg  { grid-column: span 2; grid-row: span 2; }
+.bento__tile--wide { grid-column: span 2; }
+
+.bento__title { margin: 0 0 0.5rem; font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); }
+.bento__value { margin: 0 0 0.3rem; font-size: clamp(1.4rem, 3vw, 2rem); font-weight: 700; font-variant-numeric: tabular-nums; }
+.bento__sub { margin: 0; font-size: 0.82rem; color: var(--muted); }
+
+@media (max-width: 640px) {
+  .bento { grid-template-columns: repeat(2, 1fr); }
+  .bento__tile--lg { grid-column: span 2; grid-row: span 1; }
+}
+@media (max-width: 420px) {
+  .bento { grid-template-columns: 1fr; }
+  .bento__tile--lg, .bento__tile--wide { grid-column: span 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bento__tile, .bento__tile::before { transition: none; }
+  .bento__tile:hover, .bento__tile:focus-visible { transform: none; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-bento-hover-zoom** from issue #64180 — a Bento Grid Hover Zoom & Border Highlight component, following the submission pattern in the issue.

Closes #64180.

## Feature

A responsive Bento grid where each tile smoothly scales up (`scale(1.035)`) on hover/focus and reveals a gradient border (via a masked `::before` layer) while the base border fades out, plus a soft accent glow `box-shadow`. Includes `--lg` (2x2) and `--wide` (2-col) tiles for layout variety.

## How it works

- Hover zoom (`transform: scale`) paired with a gradient-border reveal: a `::before` pseudo paints a gradient border via the `padding` + `mask` (content-box/xor) technique, fading in while the base border fades out. Soft `box-shadow` glow. All via `transform`/`opacity`/`box-shadow`.

## Accessibility

- Tiles are focusable (`tabindex="0"`); zoom + highlight fire on `:focus-visible` too. Full `prefers-reduced-motion` support (no transform).

## Submission structure

```
submissions/examples/ease-bento-hover-zoom-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← Bento grid + hover zoom + gradient-border reveal
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally