### PR TITLE
feat: add ease-blur-entrance-navbar component (#62275)

### DIFF
--- a/submissions/examples/ease-blur-navbar-sbh/README.md
+++ b/submissions/examples/ease-blur-navbar-sbh/README.md
@@ -1,0 +1,47 @@
+# ease-blur-entrance-navbar
+
+A navbar that enters on page load by fading in and unblurring — from blurred and shifted up to sharp and in place — a polished entrance for product catalog layouts.
+
+## What does this do?
+
+Adds a **blur-entrance-navbar**: a sticky, glassmorphism navigation bar. On load it animates from `opacity: 0`, `filter: blur(14px)`, and `translateY(-12px)` to its resting sharp, in-place state, so the navbar materializes from soft blur into focus. Includes brand, link list with an active state, icon buttons, and a CTA.
+
+## How is it used?
+
+1. Build a `.navbar` with a `.navbar__brand`, a `.navbar__links` list, and `.navbar__actions`.
+2. Mark the current page link with `is-active` and `aria-current="page"`.
+3. The entrance plays automatically on load.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<nav class="navbar" aria-label="Primary">
+  <a class="navbar__brand" href="#home"><span class="navbar__logo" aria-hidden="true"></span><span>Lumio</span></a>
+  <ul class="navbar__links">
+    <li><a class="navbar__link is-active" href="#catalog" aria-current="page">Catalog</a></li>
+    <li><a class="navbar__link" href="#collections">Collections</a></li>
+    …
+  </ul>
+  <div class="navbar__actions">
+    <button class="navbar__icon-btn" aria-label="Search">⌕</button>
+    <a class="navbar__cta" href="#signin">Sign in</a>
+  </div>
+</nav>
+```
+
+## Why is this useful?
+
+- **Animation-first** — the signature motion is `@keyframes nb-enter` driving `opacity` (0 → 1), `filter: blur()` (14px → 0), and `transform: translateY()` (-12px → 0) together, so the navbar fades in while sharpening and settling into place. All via `opacity`/`filter`/`transform`.
+- **Glassmorphism aesthetic** — the navbar is a frosted, sticky panel via `backdrop-filter: blur()`; the entrance blur layers naturally on top.
+- **Accessible** — semantic `<nav aria-label>`, real links/buttons with `:focus-visible` rings, `aria-current="page"` on the active link, and `aria-label`s on icon-only buttons. Full `prefers-reduced-motion` support (navbar appears instantly, no blur/shift).
+- **Reusable** — configurable via CSS custom properties (`--enter-duration`, `--enter-ease`, `--blur-start`, `--glass-blur`).
+
+## Files
+
+- `demo.html` — self-contained demo (open directly in a browser; no server, CDNs, or frameworks). Pure CSS entrance, no JS. Includes a small catalog preview for context.
+- `style.css` — glassmorphism sticky navbar, blur-entrance keyframes, active link state, focus-visible states, responsive wrap on narrow screens, reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-blur-navbar-sbh/demo.html
+++ b/submissions/examples/ease-blur-navbar-sbh/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-blur-entrance-navbar — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-blur-entrance-navbar</h1>
+      <p>A navbar that fades in from blurred to sharp on load — a polished entrance for a product catalog.</p>
+    </header>
+
+    <nav class="navbar" aria-label="Primary">
+      <a class="navbar__brand" href="#home">
+        <span class="navbar__logo" aria-hidden="true"></span>
+        <span>Lumio</span>
+      </a>
+      <ul class="navbar__links">
+        <li><a class="navbar__link is-active" href="#catalog" aria-current="page">Catalog</a></li>
+        <li><a class="navbar__link" href="#collections">Collections</a></li>
+        <li><a class="navbar__link" href="#deals">Deals</a></li>
+        <li><a class="navbar__link" href="#about">About</a></li>
+      </ul>
+      <div class="navbar__actions">
+        <button type="button" class="navbar__icon-btn" aria-label="Search">⌕</button>
+        <button type="button" class="navbar__icon-btn" aria-label="Cart">🛒</button>
+        <a class="navbar__cta" href="#signin">Sign in</a>
+      </div>
+    </nav>
+
+    <section class="catalog" aria-label="Catalog preview">
+      <article class="card"><span class="card__tag">New</span><h2>Aurora Lamp</h2><p>$89</p></article>
+      <article class="card"><h2>Mist Mug</h2><p>$18</p></article>
+      <article class="card"><span class="card__tag">Sale</span><h2>Drift Speaker</h2><p>$129</p></article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-blur-navbar-sbh/style.css
+++ b/submissions/examples/ease-blur-navbar-sbh/style.css
@@ -1,0 +1,155 @@
+:root {
+  --enter-duration: 0.7s;
+  --enter-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --blur-start: 14px;
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --glass-bg: rgba(255, 255, 255, 0.06);
+  --glass-border: rgba(255, 255, 255, 0.12);
+  --glass-blur: 14px;
+  --radius: 0.9rem;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  padding: 2rem 1.5rem 4rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 0%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+}
+
+.page__intro { text-align: center; max-width: 36rem; margin: 1.5rem auto 0; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+
+/* navbar: enters by fading in + unblurring (filter blur) + sliding down */
+.navbar {
+  position: sticky;
+  top: 0.5rem;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.7rem 1rem;
+  border-radius: var(--radius);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  opacity: 0;
+  filter: blur(var(--blur-start));
+  transform: translateY(-12px);
+  animation: nb-enter var(--enter-duration) var(--enter-ease) forwards;
+}
+
+.navbar__brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  color: var(--fg);
+  text-decoration: none;
+}
+.navbar__logo {
+  width: 1.4rem;
+  height: 1.4rem;
+  border-radius: 0.4rem;
+  background: linear-gradient(135deg, var(--accent), var(--accent2));
+}
+
+.navbar__links {
+  display: flex;
+  gap: 0.3rem;
+  list-style: none;
+  margin: 0 auto;
+  padding: 0;
+}
+.navbar__link {
+  display: inline-block;
+  padding: 0.45rem 0.8rem;
+  border-radius: 0.5rem;
+  color: var(--muted);
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 600;
+  transition: color 0.2s ease, background 0.2s ease;
+}
+.navbar__link:hover, .navbar__link:focus-visible { color: var(--fg); background: rgba(255,255,255,0.06); outline: none; }
+.navbar__link.is-active { color: var(--fg); background: rgba(110,168,255,0.16); }
+
+.navbar__actions { display: flex; align-items: center; gap: 0.4rem; }
+.navbar__icon-btn {
+  width: 2rem; height: 2rem;
+  display: inline-flex; align-items: center; justify-content: center;
+  border: none; border-radius: 0.5rem;
+  background: rgba(255,255,255,0.06);
+  color: var(--fg); cursor: pointer; font-size: 1rem;
+  transition: background 0.2s ease;
+}
+.navbar__icon-btn:hover, .navbar__icon-btn:focus-visible { background: rgba(255,255,255,0.12); outline: none; }
+.navbar__cta {
+  padding: 0.45rem 0.9rem;
+  border-radius: 0.55rem;
+  font-size: 0.88rem;
+  font-weight: 700;
+  color: #06231a;
+  text-decoration: none;
+  background: linear-gradient(135deg, var(--accent), var(--accent2));
+  transition: filter 0.2s ease;
+}
+.navbar__cta:hover, .navbar__cta:focus-visible { filter: brightness(1.08); outline: none; box-shadow: 0 0 0 3px rgba(110,168,255,0.4); }
+
+@keyframes nb-enter {
+  from { opacity: 0; filter: blur(var(--blur-start)); transform: translateY(-12px); }
+  to   { opacity: 1; filter: blur(0); transform: translateY(0); }
+}
+
+/* catalog cards (context) */
+.catalog {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+  gap: 0.9rem;
+  max-width: 52rem;
+  width: 100%;
+  margin: 0 auto;
+}
+.card {
+  position: relative;
+  padding: 1.2rem;
+  border-radius: var(--radius);
+  background: rgba(255,255,255,0.05);
+  border: 1px solid rgba(255,255,255,0.1);
+}
+.card h2 { margin: 0 0 0.3rem; font-size: 1.05rem; }
+.card p { margin: 0; color: var(--muted); }
+.card__tag {
+  position: absolute; top: 0.7rem; right: 0.7rem;
+  font-size: 0.68rem; font-weight: 700; padding: 0.15rem 0.45rem;
+  border-radius: 999px; color: #06231a;
+  background: linear-gradient(135deg, var(--accent), var(--accent2));
+}
+
+@media (max-width: 640px) {
+  .navbar { flex-wrap: wrap; }
+  .navbar__links { margin: 0; flex: 1 1 100%; justify-content: center; order: 3; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .navbar { animation: none; opacity: 1; filter: none; transform: none; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-blur-navbar** from issue #62275 — a Blur-Entrance Navbar component, following the submission pattern in the issue.

Closes #62275.

## Feature

A sticky glassmorphism navbar that enters on load by fading in (`opacity` 0 → 1) while unblurring (`filter: blur` 14px → 0) and settling from `translateY(-12px)` to 0 (`@keyframes nb-enter`). Includes brand, link list with active state, icon buttons, and a CTA.

## How it works

- `@keyframes nb-enter` drives `opacity` (0 → 1), `filter: blur()` (14px → 0), and `transform: translateY()` (-12px → 0) together. All via `opacity`/`filter`/`transform`.

## Accessibility

- Semantic `<nav aria-label>`, real links/buttons with `:focus-visible` rings, `aria-current="page"` on the active link, `aria-label`s on icon-only buttons. Full `prefers-reduced-motion` support (navbar appears instantly).

## Submission structure

```
submissions/examples/ease-blur-navbar-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← glassmorphism sticky navbar + blur-entrance keyframes
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally