### PR TITLE
feat: add ease-float-drift-tabs component (#62206)

### DIFF
--- a/submissions/examples/ease-float-drift-tabs-sbh/README.md
+++ b/submissions/examples/ease-float-drift-tabs-sbh/README.md
@@ -1,0 +1,45 @@
+# ease-float-drift-tabs
+
+Tabs that gently float and drift into place on load (staggered), with a floating active indicator that glides between tabs and idles with a subtle bob.
+
+## What does this do?
+
+Adds a **float-drift-tabs**: a glassmorphism tab bar. On load, each tab drifts down and fades in, staggered by index. A floating active indicator (a translucent accent pill) glides to the active tab's position when you switch, and idles with a gentle vertical bob. A tiny included script measures the active tab and sets `--float-left` / `--float-width`; the CSS does the glide.
+
+## How is it used?
+
+1. Build a `.tabs__list` (a `role="tablist"`) of `.tabs__tab` buttons, each with `style="--i:n"` for the stagger, `role="tab"`, `aria-selected`, `aria-controls`, and an `id`.
+2. Pair each tab with a `.tabs__panel` (`role="tabpanel"`, `aria-labelledby`, `hidden` when inactive).
+3. The included script positions the floating indicator on click/load/resize and implements the WAI-ARIA arrow-key pattern.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<div class="tabs__list" role="tablist">
+  <button class="tabs__tab" role="tab" aria-selected="true" aria-controls="fd-panel-1" id="fd-tab-1" tabindex="0" style="--i:0">Overview</button>
+  <button class="tabs__tab" role="tab" aria-selected="false" aria-controls="fd-panel-2" id="fd-tab-2" tabindex="0" style="--i:1">Specs</button>
+  …
+</div>
+<div class="tabs__panels">
+  <div class="tabs__panel" role="tabpanel" id="fd-panel-1" aria-labelledby="fd-tab-1"><p>…</p></div>
+  <div class="tabs__panel tabs__panel--hidden" role="tabpanel" id="fd-panel-2" aria-labelledby="fd-tab-2" hidden><p>…</p></div>
+  …
+</div>
+```
+
+## Why is this useful?
+
+- **Animation-first** — the signature motion is twofold: `@keyframes fd-drift` floats each tab down (`translateY(-10px) → 3px → 0`) and fades it in, staggered by `--i` (`calc(var(--i) * 0.08s)`); and `@keyframes fd-idle` gives the active indicator a gentle 3.6s vertical bob. The indicator glides between tabs via `left`/`width` transitions to `--float-left`/`--float-width`. All via `transform`/`opacity`/`left`/`width`.
+- **Glassmorphism aesthetic** — the tab bar is a frosted panel via `backdrop-filter: blur()`; the indicator is a translucent accent pill.
+- **Accessible** — full WAI-ARIA tabs pattern: `role="tablist"`/`tab`/`tabpanel`, `aria-selected`, `aria-controls`/`aria-labelledby`, roving `tabindex`, and arrow-key navigation (Left/Right). `:focus-visible` rings. Hidden panels use the `hidden` attribute. Full `prefers-reduced-motion` support (tabs appear instantly; indicator snaps without glide or idle bob).
+- **Reusable** — configurable via CSS custom properties (`--drift-duration`, `--drift-ease`, `--indicator-duration`, `--indicator-ease`).
+
+## Files
+
+- `demo.html` — self-contained demo (open directly in a browser; no server, CDNs, or frameworks). Includes a small script that measures the active tab to position the indicator and implements the ARIA arrow-key pattern.
+- `style.css` — glassmorphism tab list, staggered drift-in keyframes, floating gliding indicator with idle bob, focus-visible states, responsive horizontal-scroll on narrow screens, reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation. The indicator glide requires the small JS in `demo.html` to measure tab positions; the maintainer may adapt this when curating into the framework.

--- a/submissions/examples/ease-float-drift-tabs-sbh/demo.html
+++ b/submissions/examples/ease-float-drift-tabs-sbh/demo.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-float-drift-tabs — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-float-drift-tabs</h1>
+      <p>Tabs that gently float and drift on load, then settle — with a gliding active indicator.</p>
+    </header>
+
+    <section class="tabs" aria-label="Catalog sections">
+      <div class="tabs__list" role="tablist">
+        <button type="button" class="tabs__tab" role="tab" aria-selected="true" aria-controls="fd-panel-1" id="fd-tab-1" tabindex="0" style="--i:0">Overview</button>
+        <button type="button" class="tabs__tab" role="tab" aria-selected="false" aria-controls="fd-panel-2" id="fd-tab-2" tabindex="0" style="--i:1">Specs</button>
+        <button type="button" class="tabs__tab" role="tab" aria-selected="false" aria-controls="fd-panel-3" id="fd-tab-3" tabindex="0" style="--i:2">Reviews</button>
+        <button type="button" class="tabs__tab" role="tab" aria-selected="false" aria-controls="fd-panel-4" id="fd-tab-4" tabindex="0" style="--i:3">Shipping</button>
+      </div>
+
+      <div class="tabs__panels">
+        <div class="tabs__panel" role="tabpanel" id="fd-panel-1" aria-labelledby="fd-tab-1">
+          <p>The Aurora Lamp diffuses a soft, adjustable glow. Tabs drifted in gently on load.</p>
+        </div>
+        <div class="tabs__panel tabs__panel--hidden" role="tabpanel" id="fd-panel-2" aria-labelledby="fd-tab-2" hidden>
+          <p>12W LED, 2700–6500K, USB-C powered, 8-hour battery.</p>
+        </div>
+        <div class="tabs__panel tabs__panel--hidden" role="tabpanel" id="fd-panel-3" aria-labelledby="fd-tab-3" hidden>
+          <p>4.8★ from 1,204 reviews — "Calming, beautiful on a desk."</p>
+        </div>
+        <div class="tabs__panel tabs__panel--hidden" role="tabpanel" id="fd-panel-4" aria-labelledby="fd-tab-4" hidden>
+          <p>Free shipping over $50. Ships in 1–2 business days.</p>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    // Minimal interaction: clicking a tab selects it and moves the floating indicator.
+    var tabs = Array.prototype.slice.call(document.querySelectorAll('.tabs__tab'));
+    var list = document.querySelector('.tabs__list');
+    var panels = Array.prototype.slice.call(document.querySelectorAll('.tabs__panel'));
+
+    function selectTab(tab) {
+      tabs.forEach(function (t) {
+        var active = t === tab;
+        t.setAttribute('aria-selected', String(active));
+        t.tabIndex = active ? 0 : -1;
+      });
+      var rect = tab.getBoundingClientRect();
+      var listRect = list.getBoundingClientRect();
+      list.style.setProperty('--float-left', (rect.left - listRect.left) + 'px');
+      list.style.setProperty('--float-width', rect.width + 'px');
+      panels.forEach(function (p) {
+        var active = p.id === tab.getAttribute('aria-controls');
+        p.toggleAttribute('hidden', !active);
+        p.classList.toggle('tabs__panel--hidden', !active);
+      });
+    }
+
+    tabs.forEach(function (t) { t.addEventListener('click', function () { selectTab(t); }); });
+    list.addEventListener('keydown', function (e) {
+      var i = tabs.indexOf(document.querySelector('.tabs__tab[aria-selected="true"]'));
+      if (e.key === 'ArrowRight') { selectTab(tabs[(i + 1) % tabs.length]); tabs[(i + 1) % tabs.length].focus(); }
+      if (e.key === 'ArrowLeft')  { selectTab(tabs[(i - 1 + tabs.length) % tabs.length]); tabs[(i - 1 + tabs.length) % tabs.length].focus(); }
+    });
+    window.addEventListener('load', function () { selectTab(tabs[0]); });
+    window.addEventListener('resize', function () {
+      var active = document.querySelector('.tabs__tab[aria-selected="true"]');
+      if (active) selectTab(active);
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-float-drift-tabs-sbh/style.css
+++ b/submissions/examples/ease-float-drift-tabs-sbh/style.css
@@ -1,0 +1,130 @@
+:root {
+  --drift-duration: 0.7s;
+  --drift-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --indicator-duration: 0.3s;
+  --indicator-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --glass-bg: rgba(255, 255, 255, 0.06);
+  --glass-border: rgba(255, 255, 255, 0.12);
+  --glass-blur: 10px;
+  --radius: 0.8rem;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 20%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+}
+
+.page__intro { text-align: center; max-width: 36rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+
+.tabs {
+  width: min(40rem, 100%);
+  border-radius: var(--radius);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  overflow: hidden;
+}
+
+.tabs__list {
+  position: relative;
+  display: flex;
+  gap: 0.2rem;
+  padding: 0.4rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  --float-left: 0.4rem;
+  --float-width: 5rem;
+}
+
+/* the floating active indicator: glides to the active tab */
+.tabs__list::after {
+  content: "";
+  position: absolute;
+  top: 0.4rem;
+  left: var(--float-left);
+  width: var(--float-width);
+  height: calc(100% - 0.8rem);
+  border-radius: 0.6rem;
+  background: linear-gradient(135deg, rgba(110,168,255,0.28), rgba(179,136,255,0.28));
+  border: 1px solid rgba(110,168,255,0.45);
+  transition: left var(--indicator-duration) var(--indicator-ease),
+              width var(--indicator-duration) var(--indicator-ease);
+  z-index: 0;
+  /* gentle idle float on the indicator */
+  animation: fd-idle 3.6s ease-in-out infinite;
+}
+
+.tabs__tab {
+  position: relative;
+  z-index: 1;
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  font-size: 0.92rem;
+  font-weight: 600;
+  padding: 0.7rem 1rem;
+  cursor: pointer;
+  white-space: nowrap;
+  border-radius: 0.6rem;
+  /* drift-in entrance: each tab floats down + fades in, staggered by --i */
+  opacity: 0;
+  transform: translateY(-10px);
+  animation: fd-drift var(--drift-duration) var(--drift-ease) forwards;
+  animation-delay: calc(var(--i) * 0.08s);
+  transition: color 0.2s ease;
+}
+.tabs__tab:hover { color: var(--fg); }
+.tabs__tab:focus-visible { outline: none; box-shadow: inset 0 0 0 2px rgba(110,168,255,0.6); }
+.tabs__tab[aria-selected="true"] { color: var(--fg); }
+
+@keyframes fd-drift {
+  0%   { opacity: 0; transform: translateY(-10px); }
+  60%  { opacity: 1; transform: translateY(3px); }
+  100% { opacity: 1; transform: translateY(0); }
+}
+@keyframes fd-idle {
+  0%, 100% { transform: translateY(0); }
+  50%      { transform: translateY(-2px); }
+}
+
+.tabs__panels { padding: 1.3rem 1.2rem; }
+.tabs__panel { color: var(--muted); line-height: 1.6; font-size: 0.92rem; }
+.tabs__panel p { margin: 0; }
+.tabs__panel--hidden { display: none; }
+
+@media (max-width: 480px) {
+  .tabs__list { overflow-x: auto; scrollbar-width: none; }
+  .tabs__list::-webkit-scrollbar { display: none; }
+  .tabs__tab { padding: 0.6rem 0.8rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tabs__tab { animation: none; opacity: 1; transform: none; }
+  .tabs__list::after { animation: none; transition: none; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-float-drift-tabs** from issue #62206 — a Float-Drift Tabs component, following the submission pattern in the issue.

Closes #62206.

## Feature

Tabs that gently float and drift into place on load (`@keyframes fd-drift` floats each tab down and fades in, staggered by `--i`), with a floating active indicator that glides to the active tab and idles with a gentle vertical bob (`@keyframes fd-idle`).

## How it works

- `@keyframes fd-drift` floats each tab down (`translateY(-10px → 3px → 0`) and fades in, staggered by `--i`. `@keyframes fd-idle` bobs the indicator. The indicator glides via `left`/`width` transitions to `--float-left`/`--float-width`.

## Accessibility

- Full WAI-ARIA tabs pattern (`role="tablist"`/`tab`/`tabpanel`, `aria-selected`, `aria-controls`/`aria-labelledby`, roving `tabindex`, Left/Right arrow-key nav). `:focus-visible` rings. Hidden panels use the `hidden` attribute. Full `prefers-reduced-motion` support.

## Submission structure

```
submissions/examples/ease-float-drift-tabs-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← glassmorphism tabs + staggered drift + floating indicator
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally