### PR TITLE
feat: add ease-glitch-flicker-popover component (#62218)

### DIFF
--- a/submissions/examples/ease-glitch-flicker-popover-sbh/README.md
+++ b/submissions/examples/ease-glitch-flicker-popover-sbh/README.md
@@ -1,0 +1,43 @@
+# ease-glitch-flicker-popover
+
+A popover that pops in with a glitchy flicker — RGB-split text copies and jittery transforms during the entrance, then settles. Revealed on hover or keyboard focus of its trigger.
+
+## What does this do?
+
+Adds a **glitch-flicker-popover**: a glassmorphism tooltip-style popover that appears when its trigger is hovered or focused. On reveal it plays `@keyframes gf-flicker` — a stepped, jittery entrance that flickers opacity, jitters `transform` (small x/y offsets + scale), and spikes brightness — while two offset color-channel copies of the heading text (`--r` red, `--b` cyan, `mix-blend-mode: screen`) jitter separately to create the RGB-split glitch effect before settling.
+
+## How is it used?
+
+1. Wrap a `.trigger` button and a `.popover` (with `role="tooltip"`) inside a `.pop-host`.
+2. The heading is rendered three times: the visible `.popover__text` plus `.popover__text--r` and `.popover__text--b` (both `aria-hidden="true"`), each carrying the same `data-text`. The CSS reveals the popover on `:hover`/`:focus-within` of the host.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<div class="pop-host">
+  <button type="button" class="trigger" aria-describedby="gf-pop-1">Hover/focus me</button>
+  <div class="popover" id="gf-pop-1" role="tooltip">
+    <span class="popover__text" data-text="New drop!">New drop!</span>
+    <span class="popover__text popover__text--r" data-text="New drop!" aria-hidden="true">New drop!</span>
+    <span class="popover__text popover__text--b" data-text="New drop!" aria-hidden="true">New drop!</span>
+    <p class="popover__sub">…</p>
+  </div>
+</div>
+```
+
+## Why is this useful?
+
+- **Animation-first** — the signature motion is `@keyframes gf-flicker`: a stepped (`steps(2, end)`) entrance that flickers `opacity`, jitters `transform` (x offsets + scale), and spikes `filter: brightness()`. The two channel copies run `@keyframes gf-r`/`gf-b` with opposing x offsets to produce the RGB-split glitch. All via `transform`/`opacity`/`filter`.
+- **Glassmorphism aesthetic** — the popover is a frosted panel via `backdrop-filter: blur()`; the glitch channels are screen-blended accents.
+- **Accessible** — `role="tooltip"` + `aria-describedby` linking trigger to popover; the decorative color-channel copies are `aria-hidden="true"`. Trigger is a real `<button>` with `:focus-visible` ring, so keyboard focus reveals the popover too. Full `prefers-reduced-motion` support (popover appears instantly with no flicker; channel copies hidden).
+- **Reusable** — configurable via CSS custom properties (`--flicker-duration`, `--flicker-ease`, `--r-channel`, `--b-channel`, `--glass-blur`). A `--bottom` modifier flips placement.
+
+## Files
+
+- `demo.html` — self-contained demo (open directly in a browser; no server, CDNs, or frameworks). Pure CSS reveal, no JS.
+- `style.css` — glassmorphism popover, glitch-flicker entrance keyframes, RGB-split channel copies, hover/focus-within reveal, focus-visible states, reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-glitch-flicker-popover-sbh/demo.html
+++ b/submissions/examples/ease-glitch-flicker-popover-sbh/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-glitch-flicker-popover — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-glitch-flicker-popover</h1>
+      <p>A popover that pops in with a glitchy flicker — RGB-split text and jittery transforms on entrance.</p>
+    </header>
+
+    <section class="stage" aria-label="Popover demos">
+      <div class="pop-host">
+        <button type="button" class="trigger" id="tr1" aria-describedby="gf-pop-1">Hover/focus me</button>
+        <div class="popover" id="gf-pop-1" role="tooltip">
+          <span class="popover__text" data-text="New drop!">New drop!</span>
+          <span class="popover__text popover__text--r" data-text="New drop!" aria-hidden="true">New drop!</span>
+          <span class="popover__text popover__text--b" data-text="New drop!" aria-hidden="true">New drop!</span>
+          <p class="popover__sub">Limited Aurora Lamp restock — glitchy entrance on open.</p>
+        </div>
+      </div>
+
+      <div class="pop-host">
+        <button type="button" class="trigger" id="tr2" aria-describedby="gf-pop-2">Sale details</button>
+        <div class="popover popover--bottom" id="gf-pop-2" role="tooltip">
+          <span class="popover__text" data-text="-30% off">-30% off</span>
+          <span class="popover__text popover__text--r" data-text="-30% off" aria-hidden="true">-30% off</span>
+          <span class="popover__text popover__text--b" data-text="-30% off" aria-hidden="true">-30% off</span>
+          <p class="popover__sub">This weekend only. Flickers in on reveal.</p>
+        </div>
+      </div>
+    </section>
+
+    <p class="hint">Hover or keyboard-focus a trigger to reveal the popover.</p>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-glitch-flicker-popover-sbh/style.css
+++ b/submissions/examples/ease-glitch-flicker-popover-sbh/style.css
@@ -1,0 +1,153 @@
+:root {
+  --flicker-duration: 0.55s;
+  --flicker-ease: steps(2, end);
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --r-channel: #ff3b6b;
+  --b-channel: #34d3ff;
+  --glass-bg: rgba(255, 255, 255, 0.07);
+  --glass-border: rgba(255, 255, 255, 0.14);
+  --glass-blur: 14px;
+  --radius: 0.7rem;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 20%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+}
+
+.page__intro { text-align: center; max-width: 36rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+
+.stage { display: flex; flex-wrap: wrap; gap: 2rem; justify-content: center; }
+.hint { font-size: 0.82rem; color: var(--muted); }
+
+.pop-host { position: relative; display: inline-flex; }
+
+.trigger {
+  appearance: none;
+  border: 1px solid rgba(255,255,255,0.18);
+  background: rgba(255,255,255,0.06);
+  color: var(--fg);
+  font: inherit;
+  font-weight: 600;
+  padding: 0.7rem 1.2rem;
+  border-radius: 0.6rem;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+.trigger:hover, .trigger:focus-visible { border-color: var(--accent); background: rgba(110,168,255,0.12); outline: none; box-shadow: 0 0 0 3px rgba(110,168,255,0.4); }
+
+/* popover: hidden by default, revealed on trigger hover/focus via :hover/:focus-within */
+.popover {
+  position: absolute;
+  bottom: calc(100% + 0.6rem);
+  left: 50%;
+  transform: translate(-50%, 6px) scale(0.9);
+  width: max-content;
+  max-width: 16rem;
+  padding: 0.8rem 0.9rem;
+  border-radius: var(--radius);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  box-shadow: 0 18px 40px -18px rgba(0, 0, 0, 0.8);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.18s ease, visibility 0s linear 0.18s, transform 0.18s ease;
+  pointer-events: none;
+  z-index: 10;
+}
+.popover--bottom {
+  bottom: auto;
+  top: calc(100% + 0.6rem);
+  transform: translate(-50%, -6px) scale(0.9);
+}
+
+.pop-host:hover .popover,
+.pop-host:focus-within .popover {
+  opacity: 1;
+  visibility: visible;
+  transform: translate(-50%, 0) scale(1);
+  transition: opacity 0.18s ease, visibility 0s linear 0s, transform 0.18s ease;
+  animation: gf-flicker var(--flicker-duration) var(--flicker-ease) 1;
+}
+
+/* glitch text: three offset copies (base + R + B) that jitter during flicker */
+.popover__text {
+  display: block;
+  position: relative;
+  font-weight: 800;
+  font-size: 1.05rem;
+  color: var(--fg);
+}
+.popover__text--r, .popover__text--b {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+.popover__text--r { color: var(--r-channel); mix-blend-mode: screen; }
+.popover__text--b { color: var(--b-channel); mix-blend-mode: screen; }
+
+@keyframes gf-flicker {
+  0%   { opacity: 0; transform: translate(-50%, 0) scale(0.9); filter: brightness(2); }
+  10%  { opacity: 0.6; transform: translate(calc(-50% + 0px), 0) scale(0.96); }
+  20%  { transform: translate(calc(-50% - 3px), 1px) scale(0.98); }
+  30%  { transform: translate(calc(-50% + 3px), -1px) scale(1); }
+  40%  { transform: translate(calc(-50% - 2px), 0) scale(1.01); filter: brightness(1.6); }
+  55%  { opacity: 0.3; transform: translate(calc(-50% + 2px), 0) scale(0.99); }
+  70%  { opacity: 1; transform: translate(-50%, 0) scale(1); filter: brightness(1); }
+  100% { opacity: 1; transform: translate(-50%, 0) scale(1); filter: none; }
+}
+
+/* channel copies jitter while flickering */
+.pop-host:hover .popover__text--r,
+.pop-host:focus-within .popover__text--r { animation: gf-r var(--flicker-duration) steps(2, end) 1; }
+.pop-host:hover .popover__text--b,
+.pop-host:focus-within .popover__text--b { animation: gf-b var(--flicker-duration) steps(2, end) 1; }
+@keyframes gf-r {
+  0%, 100% { transform: translate(0, 0); }
+  25% { transform: translate(-2px, 0); }
+  50% { transform: translate(3px, 0); }
+  75% { transform: translate(-1px, 0); }
+}
+@keyframes gf-b {
+  0%, 100% { transform: translate(0, 0); }
+  25% { transform: translate(2px, 0); }
+  50% { transform: translate(-3px, 0); }
+  75% { transform: translate(1px, 0); }
+}
+
+.popover__sub { margin: 0.4rem 0 0; font-size: 0.82rem; color: var(--muted); }
+
+@media (max-width: 480px) {
+  .popover { max-width: 12rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .popover, .popover__text--r, .popover__text--b { transition: none; animation: none; }
+  .pop-host:hover .popover, .pop-host:focus-within .popover { opacity: 1; visibility: visible; transform: translate(-50%, 0) scale(1); filter: none; }
+  .popover__text--r, .popover__text--b { display: none; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-glitch-flicker-popover** from issue #62218 — a Glitch-Flicker Popover component, following the submission pattern in the issue.

Closes #62218.

## Feature

A popover that pops in with a glitchy flicker on reveal — `@keyframes gf-flicker` jitters `transform` and flickers `opacity`/`brightness`, while two offset color-channel copies of the heading (red/cyan, `mix-blend-mode: screen`) jitter separately for an RGB-split glitch before settling.

## How it works

- `@keyframes gf-flicker` (stepped) jitters `transform`, flickers `opacity`, spikes `filter: brightness()`; `@keyframes gf-r`/`gf-b` jitter the RGB channel copies. Revealed on `hover`/`focus-within`. All via `transform`/`opacity`/`filter`.

## Accessibility

- `role="tooltip"` + `aria-describedby`; channel copies `aria-hidden`; trigger is a real `<button>` with `:focus-visible` ring (keyboard focus reveals it). Full `prefers-reduced-motion` support (appears instantly; channels hidden).

## Submission structure

```
submissions/examples/ease-glitch-flicker-popover-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← glassmorphism popover + glitch-flicker + RGB-split channels
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally