### PR TITLE
feat: add ease-morph-glow-carousel component (#62190)

### DIFF
--- a/submissions/examples/ease-morph-glow-carousel-sbh/README.md
+++ b/submissions/examples/ease-morph-glow-carousel-sbh/README.md
@@ -1,0 +1,53 @@
+# ease-morph-glow-carousel
+
+A carousel whose active slide morphs its corner radius and pulses a soft accent glow. Pure CSS — navigation is driven by hidden radio inputs, so no JavaScript is required for the animation.
+
+## What does this do?
+
+Adds a **morph-glow-carousel**: a glassmorphism carousel that slides between slides. The active slide morphs its `border-radius` from a small idle value to a larger value and gains a soft accent `box-shadow` glow, while the active dot indicator fills and scales up. Clicking a dot (a `<label>` for a hidden radio) switches slides; the CSS uses `:checked ~` to shift the track and highlight the active slide.
+
+## How is it used?
+
+1. Place N hidden `<input type="radio" class="carousel__radio">` (all sharing one `name`) before the viewport and dots.
+2. Each `.carousel__dot` is a `<label for="...">` pointing at its radio. The CSS `:checked ~` rules shift the track and glow the active slide.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<section class="carousel" aria-label="Featured products carousel">
+  <input type="radio" name="mgc" id="mgc-1" class="carousel__radio" checked aria-hidden="true" />
+  <input type="radio" name="mgc" id="mgc-2" class="carousel__radio" aria-hidden="true" />
+  <input type="radio" name="mgc" id="mgc-3" class="carousel__radio" aria-hidden="true" />
+
+  <div class="carousel__viewport" role="region" aria-roledescription="carousel" aria-label="Featured products">
+    <ul class="carousel__track">
+      <li class="slide" role="group" aria-roledescription="slide" aria-label="1 of 3">…</li>
+      <li class="slide" role="group" aria-roledescription="slide" aria-label="2 of 3">…</li>
+      <li class="slide" role="group" aria-roledescription="slide" aria-label="3 of 3">…</li>
+    </ul>
+  </div>
+
+  <div class="carousel__dots" role="tablist" aria-label="Choose slide">
+    <label for="mgc-1" class="carousel__dot" tabindex="0" role="tab" aria-selected="true">1</label>
+    <label for="mgc-2" class="carousel__dot" tabindex="0" role="tab" aria-selected="false">2</label>
+    <label for="mgc-3" class="carousel__dot" tabindex="0" role="tab" aria-selected="false">3</label>
+  </div>
+</section>
+```
+
+## Why is this useful?
+
+- **Animation-first** — the signature motion is the track sliding via `transform: translateX()` (`0` → `-1/N` → `-2/N` of 100%) while the active slide morphs `border-radius` (`--radius-idle` → `--radius-active`) and gains a `box-shadow` glow, and the active dot scales up with a glow. All via `transform`/`border-radius`/`box-shadow`.
+- **Glassmorphism aesthetic** — slides are frosted panels via `backdrop-filter: blur()`; the glow is an accent gradient.
+- **Accessible** — `role="region"` + `aria-roledescription="carousel"` on the viewport, each slide `role="group"` + `aria-roledescription="slide"` + `aria-label="N of M"`, and a `role="tablist"` of dot labels. Dots are focusable labels with `:focus-visible` rings. Full `prefers-reduced-motion` support (track and slides snap without transition; the radius/glow still apply).
+- **Reusable** — configurable via CSS custom properties (`--slide-duration`, `--slide-ease`, `--radius-active`, `--radius-idle`, `--glow`, `--slide-count`).
+
+## Files
+
+- `demo.html` — self-contained demo (open directly in a browser; no server, CDNs, or frameworks). Pure CSS navigation, no JS required for the animation.
+- `style.css` — glassmorphism carousel, track-slide + active-slide radius-morph + glow via radio `:checked ~`, dot indicators with active fill, focus-visible states, reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation. Note: keeping `aria-selected` perfectly in sync with `:checked` requires a small JS; the demo's CSS drives the visual active state from `:checked`, and `aria-roledescription` slide labels convey position to AT.

--- a/submissions/examples/ease-morph-glow-carousel-sbh/demo.html
+++ b/submissions/examples/ease-morph-glow-carousel-sbh/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-morph-glow-carousel — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-morph-glow-carousel</h1>
+      <p>A carousel whose active slide morphs its shape and glows — pure CSS via radio inputs.</p>
+    </header>
+
+    <section class="carousel" aria-label="Featured products carousel">
+      <input type="radio" name="mgc" id="mgc-1" class="carousel__radio" checked aria-hidden="true" />
+      <input type="radio" name="mgc" id="mgc-2" class="carousel__radio" aria-hidden="true" />
+      <input type="radio" name="mgc" id="mgc-3" class="carousel__radio" aria-hidden="true" />
+
+      <div class="carousel__viewport" role="region" aria-roledescription="carousel" aria-label="Featured products">
+        <ul class="carousel__track">
+          <li class="slide" id="mgc-slide-1" role="group" aria-roledescription="slide" aria-label="1 of 3">
+            <span class="slide__badge">New</span>
+            <h2 class="slide__title">Aurora Lamp</h2>
+            <p class="slide__desc">A soft, adjustable glow for calm evenings.</p>
+          </li>
+          <li class="slide" id="mgc-slide-2" role="group" aria-roledescription="slide" aria-label="2 of 3">
+            <span class="slide__badge">Sale</span>
+            <h2 class="slide__title">Drift Speaker</h2>
+            <p class="slide__desc">Room-filling sound in a pebble form.</p>
+          </li>
+          <li class="slide" id="mgc-slide-3" role="group" aria-roledescription="slide" aria-label="3 of 3">
+            <span class="slide__badge">Top</span>
+            <h2 class="slide__title">Mist Mug</h2>
+            <p class="slide__desc">Keeps heat twice as long, feels like a cloud.</p>
+          </li>
+        </ul>
+      </div>
+
+      <div class="carousel__dots" role="tablist" aria-label="Choose slide">
+        <label for="mgc-1" class="carousel__dot" tabindex="0" role="tab" aria-selected="true">1</label>
+        <label for="mgc-2" class="carousel__dot" tabindex="0" role="tab" aria-selected="false">2</label>
+        <label for="mgc-3" class="carousel__dot" tabindex="0" role="tab" aria-selected="false">3</label>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-morph-glow-carousel-sbh/style.css
+++ b/submissions/examples/ease-morph-glow-carousel-sbh/style.css
@@ -1,0 +1,126 @@
+:root {
+  --slide-duration: 0.5s;
+  --slide-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --glow: rgba(110, 168, 255, 0.45);
+  --glass-bg: rgba(255, 255, 255, 0.06);
+  --glass-border: rgba(255, 255, 255, 0.12);
+  --glass-blur: 14px;
+  --radius-active: 1.4rem;
+  --radius-idle: 0.7rem;
+  --slide-count: 3;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 20%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+}
+
+.page__intro { text-align: center; max-width: 36rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+
+.carousel { display: flex; flex-direction: column; align-items: center; gap: 1rem; width: min(30rem, 92vw); }
+.carousel__radio { position: absolute; opacity: 0; pointer-events: none; }
+
+.carousel__viewport {
+  width: 100%;
+  overflow: hidden;
+  border-radius: var(--radius-active);
+}
+.carousel__track {
+  display: flex;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  transition: transform var(--slide-duration) var(--slide-ease);
+}
+/* shift the track left by 1/N (100%) per checked radio */
+#mgc-1:checked ~ .carousel__viewport .carousel__track { transform: translateX(0); }
+#mgc-2:checked ~ .carousel__viewport .carousel__track { transform: translateX(calc(-1 / var(--slide-count) * 100%)); }
+#mgc-3:checked ~ .carousel__viewport .carousel__track { transform: translateX(calc(-2 / var(--slide-count) * 100%)); }
+
+.slide {
+  flex: 0 0 calc(100% / var(--slide-count));
+  position: relative;
+  padding: 2.2rem 1.6rem;
+  min-height: 12rem;
+  border-radius: var(--radius-idle);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  transition: border-radius var(--slide-duration) var(--slide-ease),
+              box-shadow var(--slide-duration) var(--slide-ease);
+}
+
+/* active slide: morph radius to a larger value + glow */
+#mgc-1:checked ~ .carousel__viewport .carousel__track .slide:nth-child(1),
+#mgc-2:checked ~ .carousel__viewport .carousel__track .slide:nth-child(2),
+#mgc-3:checked ~ .carousel__viewport .carousel__track .slide:nth-child(3) {
+  border-radius: var(--radius-active);
+  box-shadow: 0 0 30px 0 var(--glow), 0 24px 60px -28px rgba(0,0,0,0.8);
+}
+
+.slide__badge {
+  position: absolute; top: 1rem; right: 1rem;
+  font-size: 0.68rem; font-weight: 700; padding: 0.18rem 0.5rem;
+  border-radius: 999px; color: #06231a;
+  background: linear-gradient(135deg, var(--accent), var(--accent2));
+}
+.slide__title { margin: 0 0 0.4rem; font-size: 1.4rem; }
+.slide__desc { margin: 0; color: var(--muted); line-height: 1.6; font-size: 0.9rem; }
+
+.carousel__dots { display: flex; gap: 0.5rem; }
+.carousel__dot {
+  width: 0.6rem; height: 0.6rem;
+  border-radius: 999px;
+  background: rgba(255,255,255,0.22);
+  cursor: pointer;
+  text-indent: -9999px;
+  font-size: 0;
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+.carousel__dot:hover, .carousel__dot:focus-visible { background: rgba(255,255,255,0.4); transform: scale(1.2); outline: none; box-shadow: 0 0 0 3px rgba(110,168,255,0.5); }
+
+/* active dot fills + glows */
+#mgc-1:checked ~ .carousel__dots .carousel__dot:nth-child(1),
+#mgc-2:checked ~ .carousel__dots .carousel__dot:nth-child(2),
+#mgc-3:checked ~ .carousel__dots .carousel__dot:nth-child(3) {
+  background: linear-gradient(135deg, var(--accent), var(--accent2));
+  transform: scale(1.25);
+  box-shadow: 0 0 10px 0 var(--glow);
+}
+
+/* keep ARIA tab selected state in sync visually is handled by :checked above */
+.carousel__dot[aria-selected="true"] { background: linear-gradient(135deg, var(--accent), var(--accent2)); }
+
+@media (max-width: 480px) {
+  .slide { padding: 1.6rem 1.2rem; min-height: 10rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .carousel__track, .slide, .carousel__dot { transition: none; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-morph-glow-carousel** from issue #62190 — a Morph-Glow Carousel component, following the submission pattern in the issue.

Closes #62190.

## Feature

A carousel whose active slide morphs its `border-radius` (`--radius-idle` → `--radius-active`) and gains a soft accent `box-shadow` glow while the track slides via `translateX`. Active dot fills + scales up. Pure CSS via hidden radios + `:checked ~`.

## How it works

- Track `transform: translateX` shifts by `-1/N` per checked radio; active slide `border-radius` morph + `box-shadow` glow via `:checked ~`. All via `transform`/`border-radius`/`box-shadow`.

## Accessibility

- `role="region"` + `aria-roledescription="carousel"`; slides `role="group"` + `aria-roledescription="slide"` + `aria-label="N of M"`; dots `role="tablist"` with `:focus-visible` rings. Full `prefers-reduced-motion` support (snaps; radius/glow still apply).

## Submission structure

```
submissions/examples/ease-morph-glow-carousel-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← glassmorphism carousel + track-slide + radius-morph + glow
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally