### PR TITLE
feat: add ease-shimmer-sweep-drawer component (#62238)

### DIFF
--- a/submissions/examples/ease-shimmer-sweep-drawer-sbh/README.md
+++ b/submissions/examples/ease-shimmer-sweep-drawer-sbh/README.md
@@ -1,0 +1,47 @@
+# ease-shimmer-sweep-drawer
+
+A drawer that slides in from the side with a continuous shimmering light sweep traveling diagonally across its surface while open. Pure CSS — open/close is driven by a hidden checkbox, so no JavaScript is required for the animation.
+
+## What does this do?
+
+Adds a **shimmer-sweep-drawer**: a glassmorphism panel that slides in from the right (or up from the bottom on mobile). While open, a translucent diagonal light band (`::before`) sweeps across the drawer surface via `background-position`, giving a subtle "loading glass" sheen. A dimmed scrim fades in behind it. The close button and action buttons are `<label for="drawer-toggle">`, so they close the drawer with no JS.
+
+## How is it used?
+
+1. Place a hidden `<input type="checkbox" class="drawer-toggle">`, an `.opener` label, a `.scrim` label, and the `.drawer` as siblings (the CSS uses the `~` sibling combinator).
+2. The close button and action buttons are also labels pointing at the checkbox.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<input type="checkbox" id="ssd-toggle" class="drawer-toggle" aria-hidden="true" />
+<label for="ssd-toggle" class="opener" tabindex="0">Open cart</label>
+<label for="ssd-toggle" class="scrim" aria-hidden="true"></label>
+<aside class="drawer" role="region" aria-label="Shopping cart">
+  <div class="drawer__head">
+    <h2 class="drawer__title">Your cart</h2>
+    <label for="ssd-toggle" class="drawer__close" tabindex="0" aria-label="Close drawer">&times;</label>
+  </div>
+  <div class="drawer__body">…</div>
+  <div class="drawer__foot">
+    <label for="ssd-toggle" class="drawer__btn drawer__btn--primary" tabindex="0">Checkout</label>
+  </div>
+</aside>
+```
+
+## Why is this useful?
+
+- **Animation-first** — the signature motion is twofold: the drawer slides in (`transform: translate(100%, -50%) → translate(0, -50%)`) with an `opacity` fade, and while open `@keyframes ssd-sweep` drives a translucent diagonal gradient band across the surface via `background-position` (`180% → -80%`) on a loop. The scrim fades via `opacity` + `visibility` (deferred on close). All via `transform`/`opacity`/`background-position`.
+- **Glassmorphism aesthetic** — the drawer is a frosted panel via `backdrop-filter: blur()`; the shimmer is a translucent sheen layered on top.
+- **Accessible** — `role="region"` + `aria-label`; the trigger, close, and action buttons are focusable labels with `:focus-visible` rings. Full `prefers-reduced-motion` support (drawer snaps without transition; shimmer is stationary).
+- **Reusable** — configurable via CSS custom properties (`--slide-duration`, `--slide-ease`, `--shimmer-duration`, `--glass-blur`).
+
+## Files
+
+- `demo.html` — self-contained demo (open directly in a browser; no server, CDNs, or frameworks). Pure CSS animation, no JS required for the animation. Includes a cart preview for context.
+- `style.css` — glassmorphism drawer, slide-in + shimmer-sweep via checkbox state, scrim, focus-visible states, mobile bottom-sheet variant, reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-shimmer-sweep-drawer-sbh/demo.html
+++ b/submissions/examples/ease-shimmer-sweep-drawer-sbh/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-shimmer-sweep-drawer — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-shimmer-sweep-drawer</h1>
+      <p>A drawer that slides in with a shimmering light sweep traveling across its surface while open.</p>
+    </header>
+
+    <section class="stage" aria-label="Drawer demo">
+      <input type="checkbox" id="ssd-toggle" class="drawer-toggle" aria-hidden="true" />
+      <label for="ssd-toggle" class="opener" tabindex="0">Open cart</label>
+
+      <label for="ssd-toggle" class="scrim" aria-hidden="true"></label>
+
+      <aside class="drawer" role="region" aria-label="Shopping cart">
+        <div class="drawer__head">
+          <h2 class="drawer__title">Your cart</h2>
+          <label for="ssd-toggle" class="drawer__close" tabindex="0" aria-label="Close drawer">&times;</label>
+        </div>
+        <div class="drawer__body">
+          <ul class="cart">
+            <li class="cart__item"><span>Aurora Lamp</span><span>$89</span></li>
+            <li class="cart__item"><span>Mist Mug</span><span>$18</span></li>
+            <li class="cart__item"><span>Drift Speaker</span><span>$129</span></li>
+          </ul>
+        </div>
+        <div class="drawer__foot">
+          <span class="drawer__total">Total <strong>$236</strong></span>
+          <label for="ssd-toggle" class="drawer__btn drawer__btn--primary" tabindex="0">Checkout</label>
+        </div>
+      </aside>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-shimmer-sweep-drawer-sbh/style.css
+++ b/submissions/examples/ease-shimmer-sweep-drawer-sbh/style.css
@@ -1,0 +1,161 @@
+:root {
+  --slide-duration: 0.42s;
+  --slide-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --shimmer-duration: 2.6s;
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --glass-bg: rgba(255, 255, 255, 0.07);
+  --glass-border: rgba(255, 255, 255, 0.14);
+  --glass-blur: 16px;
+  --radius: 1.2rem;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 20%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+}
+
+.page__intro { text-align: center; max-width: 36rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+
+.drawer-toggle { position: absolute; opacity: 0; pointer-events: none; }
+
+.stage { position: relative; display: flex; flex-direction: column; align-items: center; }
+
+.opener {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.7rem 1.4rem;
+  border-radius: 0.7rem;
+  font-weight: 600;
+  color: #06231a;
+  background: linear-gradient(135deg, var(--accent), var(--accent2));
+  cursor: pointer;
+  user-select: none;
+  transition: filter 0.2s ease, transform 0.2s ease;
+}
+.opener:hover, .opener:focus-visible { filter: brightness(1.08); transform: translateY(-2px); outline: none; box-shadow: 0 0 0 3px rgba(110,168,255,0.5); }
+
+.scrim {
+  position: fixed;
+  inset: 0;
+  background: rgba(4, 7, 14, 0.55);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity var(--slide-duration) ease, visibility 0s linear var(--slide-duration);
+  z-index: 40;
+  cursor: pointer;
+}
+.drawer-toggle:checked ~ .scrim {
+  opacity: 1;
+  visibility: visible;
+  transition: opacity var(--slide-duration) ease, visibility 0s linear 0s;
+}
+
+/* drawer: slides in from the right; shimmer sweep travels across it while open */
+.drawer {
+  position: fixed;
+  top: 50%;
+  right: 1rem;
+  transform: translate(100%, -50%);
+  width: min(22rem, 88vw);
+  max-height: 86vh;
+  display: flex;
+  flex-direction: column;
+  padding: 1.3rem;
+  border-radius: var(--radius);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  box-shadow: 0 30px 70px -30px rgba(0, 0, 0, 0.8);
+  opacity: 0;
+  visibility: hidden;
+  overflow: hidden; /* clip the shimmer sweep */
+  transition: transform var(--slide-duration) var(--slide-ease),
+              opacity var(--slide-duration) ease,
+              visibility 0s linear var(--slide-duration);
+  z-index: 50;
+}
+.drawer-toggle:checked ~ .drawer {
+  transform: translate(0, -50%);
+  opacity: 1;
+  visibility: visible;
+  transition: transform var(--slide-duration) var(--slide-ease),
+              opacity var(--slide-duration) ease,
+              visibility 0s linear 0s;
+}
+
+/* shimmer: a diagonal light band sweeps across the drawer surface via background-position */
+.drawer::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(110deg, transparent 30%, rgba(255, 255, 255, 0.12) 48%, rgba(255, 255, 255, 0.22) 50%, rgba(255, 255, 255, 0.12) 52%, transparent 70%);
+  background-size: 220% 100%;
+  background-position: 180% 0;
+  pointer-events: none;
+  z-index: 0;
+}
+.drawer-toggle:checked ~ .drawer::before {
+  animation: ssd-sweep var(--shimmer-duration) linear infinite;
+}
+@keyframes ssd-sweep {
+  from { background-position: 180% 0; }
+  to   { background-position: -80% 0; }
+}
+
+.drawer__head, .drawer__body, .drawer__foot { position: relative; z-index: 1; }
+.drawer__head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0.8rem; }
+.drawer__title { margin: 0; font-size: 1.1rem; }
+.drawer__close {
+  font-size: 1.5rem; line-height: 1; color: var(--muted); cursor: pointer; user-select: none;
+  padding: 0.15rem 0.5rem; border-radius: 0.4rem; transition: color 0.18s ease, background 0.18s ease;
+}
+.drawer__close:hover, .drawer__close:focus-visible { color: var(--fg); background: rgba(255,255,255,0.08); outline: none; box-shadow: 0 0 0 2px rgba(110,168,255,0.6); }
+
+.drawer__body { overflow-y: auto; flex: 1; }
+.cart { list-style: none; margin: 0; padding: 0; }
+.cart__item { display: flex; justify-content: space-between; padding: 0.5rem 0; border-bottom: 1px solid rgba(255,255,255,0.08); font-size: 0.9rem; }
+
+.drawer__foot { display: flex; align-items: center; justify-content: space-between; margin-top: 0.8rem; }
+.drawer__total { font-size: 0.9rem; color: var(--muted); }
+.drawer__total strong { color: var(--fg); font-size: 1.1rem; }
+.drawer__btn {
+  display: inline-flex; align-items: center; padding: 0.5rem 1rem; border-radius: 0.6rem;
+  font-weight: 600; font-size: 0.9rem; cursor: pointer; user-select: none;
+  color: #06231a; background: linear-gradient(135deg, var(--accent), var(--accent2));
+  transition: filter 0.18s ease, transform 0.18s ease;
+}
+.drawer__btn:hover, .drawer__btn:focus-visible { filter: brightness(1.08); transform: translateY(-1px); outline: none; box-shadow: 0 0 0 3px rgba(110,168,255,0.5); }
+
+@media (max-width: 480px) {
+  .drawer { right: 0; top: auto; bottom: 0; transform: translate(0, 100%); width: 100vw; max-height: 80vh; border-radius: var(--radius) var(--radius) 0 0; }
+  .drawer-toggle:checked ~ .drawer { transform: translate(0, 0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .drawer, .scrim { transition: none; }
+  .drawer-toggle:checked ~ .drawer::before { animation: none; background-position: 180% 0; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-shimmer-sweep-drawer** from issue #62238 — a Shimmer-Sweep Drawer component, following the submission pattern in the issue.

Closes #62238.

## Feature

A drawer that slides in from the side with an opacity fade, and while open a translucent diagonal light band sweeps across its surface via `@keyframes ssd-sweep` (`background-position` `180% → -80%` on a loop). A dimmed scrim fades in behind it. Pure CSS via a hidden checkbox.

## How it works

- Slide-in (`transform: translate`) + `opacity` fade; `@keyframes ssd-sweep` drives a translucent diagonal gradient band across the surface via `background-position` on a loop while open; scrim fades via `opacity` + `visibility` (deferred on close). All via `transform`/`opacity`/`background-position`.

## Accessibility

- `role="region"` + `aria-label`; trigger/close/actions are focusable labels with `:focus-visible` rings. Full `prefers-reduced-motion` support (drawer snaps; shimmer stationary).

## Submission structure

```
submissions/examples/ease-shimmer-sweep-drawer-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← glassmorphism drawer + slide-in + shimmer-sweep
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally