### PR TITLE
feat: add ease-glitch-flicker-stepper component (#62158)

### DIFF
--- a/submissions/examples/ease-glitch-flicker-stepper-sbh/README.md
+++ b/submissions/examples/ease-glitch-flicker-stepper-sbh/README.md
@@ -1,0 +1,48 @@
+# ease-glitch-flicker-stepper
+
+A horizontal stepper whose current-step label glitches into view (RGB-split flicker) when advanced, with a connector that fills up to the current step. Pure CSS — advancing is driven by hidden radio inputs, so no JavaScript is required for the animation.
+
+## What does this do?
+
+Adds a **glitch-flicker-stepper**: a glassmorphism horizontal stepper. When a step becomes current, its label plays `@keyframes gfs-flicker` — a stepped, jittery entrance that flickers `opacity`/`brightness` and jitters `transform` — while two offset color-channel copies of the label (`--r` red, `--b` cyan, `mix-blend-mode: screen`) jitter separately to create an RGB-split glitch before settling. Completed nodes turn emerald; the current node scales up and glows; the connector line grows to the current step.
+
+## How is it used?
+
+1. Place N hidden `<input type="radio" class="stepper__radio">` (sharing one `name`) before the list.
+2. Each `.step__node` and nav button is a `<label for="...">` pointing at its radio. The CSS `:checked ~` rules set done/current states and replay the flicker on the current label.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<input type="radio" name="gfs" id="gfs-1" class="stepper__radio" checked aria-hidden="true" />
+<input type="radio" name="gfs" id="gfs-2" class="stepper__radio" aria-hidden="true" />
+…
+<ol class="stepper__list" role="list">
+  <li class="step">
+    <label for="gfs-1" class="step__node" tabindex="0" aria-label="Step 1: Account"></label>
+    <span class="step__label">
+      <span class="step__text">Account</span>
+      <span class="step__text step__text--r" aria-hidden="true">Account</span>
+      <span class="step__text step__text--b" aria-hidden="true">Account</span>
+    </span>
+  </li>
+  …
+</ol>
+```
+
+## Why is this useful?
+
+- **Animation-first** — the signature motion is `@keyframes gfs-flicker` (stepped `steps(2, end)`): flickers `opacity`, jitters `transform`, spikes `filter: brightness()`, with `@keyframes gfs-r`/`gfs-b` jittering the RGB channel copies for the glitch. The connector grows via `width` transition and the current node scales via `transform`. All via `transform`/`opacity`/`filter`/`width`.
+- **Glassmorphism aesthetic** — nodes are frosted pills via `backdrop-filter: blur()`; the glitch channels are screen-blended accents.
+- **Accessible** — nodes and nav buttons are focusable labels with `:focus-visible` rings; the decorative channel copies are `aria-hidden="true"`; each node has an `aria-label="Step N: name"`. Full `prefers-reduced-motion` support (states change instantly with no flicker; channel copies hidden).
+- **Reusable** — configurable via CSS custom properties (`--flicker-duration`, `--flicker-ease`, `--line-duration`, `--line-ease`, `--r-channel`, `--b-channel`).
+
+## Files
+
+- `demo.html` — self-contained demo (open directly in a browser; no server, CDNs, or frameworks). Pure CSS navigation, no JS required for the animation.
+- `style.css` — glassmorphism stepper, glitch-flicker label entrance, RGB-split channel copies, growing connector, done/current node states via radio `:checked ~`, focus-visible states, reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-glitch-flicker-stepper-sbh/demo.html
+++ b/submissions/examples/ease-glitch-flicker-stepper-sbh/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-glitch-flicker-stepper — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-glitch-flicker-stepper</h1>
+      <p>A horizontal stepper whose current step label glitches into view when advanced.</p>
+    </header>
+
+    <section class="stepper" aria-label="Onboarding progress">
+      <input type="radio" name="gfs" id="gfs-1" class="stepper__radio" checked aria-hidden="true" />
+      <input type="radio" name="gfs" id="gfs-2" class="stepper__radio" aria-hidden="true" />
+      <input type="radio" name="gfs" id="gfs-3" class="stepper__radio" aria-hidden="true" />
+      <input type="radio" name="gfs" id="gfs-4" class="stepper__radio" aria-hidden="true" />
+
+      <ol class="stepper__list" role="list">
+        <li class="step" aria-current="step">
+          <label for="gfs-1" class="step__node" tabindex="0" aria-label="Step 1: Account"></label>
+          <span class="step__label" data-text="Account">
+            <span class="step__text">Account</span>
+            <span class="step__text step__text--r" aria-hidden="true">Account</span>
+            <span class="step__text step__text--b" aria-hidden="true">Account</span>
+          </span>
+        </li>
+        <li class="step">
+          <label for="gfs-2" class="step__node" tabindex="0" aria-label="Step 2: Workspace"></label>
+          <span class="step__label" data-text="Workspace">
+            <span class="step__text">Workspace</span>
+            <span class="step__text step__text--r" aria-hidden="true">Workspace</span>
+            <span class="step__text step__text--b" aria-hidden="true">Workspace</span>
+          </span>
+        </li>
+        <li class="step">
+          <label for="gfs-3" class="step__node" tabindex="0" aria-label="Step 3: Invite"></label>
+          <span class="step__label" data-text="Invite">
+            <span class="step__text">Invite</span>
+            <span class="step__text step__text--r" aria-hidden="true">Invite</span>
+            <span class="step__text step__text--b" aria-hidden="true">Invite</span>
+          </span>
+        </li>
+        <li class="step">
+          <label for="gfs-4" class="step__node" tabindex="0" aria-label="Step 4: Done"></label>
+          <span class="step__label" data-text="Done">
+            <span class="step__text">Done</span>
+            <span class="step__text step__text--r" aria-hidden="true">Done</span>
+            <span class="step__text step__text--b" aria-hidden="true">Done</span>
+          </span>
+        </li>
+      </ol>
+
+      <div class="stepper__nav">
+        <label for="gfs-1" class="nav-btn" tabindex="0">First</label>
+        <label for="gfs-2" class="nav-btn" tabindex="0">2</label>
+        <label for="gfs-3" class="nav-btn" tabindex="0">3</label>
+        <label for="gfs-4" class="nav-btn" tabindex="0">Last</label>
+      </div>
+    </section>
+
+    <p class="hint">Click a node or nav button to advance; the current step label glitches in.</p>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-glitch-flicker-stepper-sbh/style.css
+++ b/submissions/examples/ease-glitch-flicker-stepper-sbh/style.css
@@ -1,0 +1,216 @@
+:root {
+  --flicker-duration: 0.5s;
+  --flicker-ease: steps(2, end);
+  --line-duration: 0.32s;
+  --line-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --done: #34d399;
+  --r-channel: #ff3b6b;
+  --b-channel: #34d3ff;
+  --glass-bg: rgba(255, 255, 255, 0.06);
+  --glass-border: rgba(255, 255, 255, 0.12);
+  --glass-blur: 10px;
+  --radius: 0.7rem;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 20%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+}
+
+.page__intro { text-align: center; max-width: 40rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+
+.stepper { width: min(42rem, 100%); display: flex; flex-direction: column; gap: 1.6rem; }
+.stepper__radio { position: absolute; opacity: 0; pointer-events: none; }
+.hint { font-size: 0.82rem; color: var(--muted); }
+
+.stepper__list {
+  list-style: none;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin: 0;
+  padding: 0;
+  position: relative;
+}
+.stepper__list::before {
+  content: "";
+  position: absolute;
+  top: 0.9rem;
+  left: 1.1rem;
+  right: 1.1rem;
+  height: 2px;
+  background: rgba(255, 255, 255, 0.14);
+  border-radius: 999px;
+  z-index: 0;
+}
+
+.step { position: relative; z-index: 1; display: flex; flex-direction: column; align-items: center; gap: 0.5rem; flex: 1; }
+
+.step__node {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.8rem;
+  height: 1.8rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--muted);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  cursor: pointer;
+  user-select: none;
+  transition: background var(--line-duration) var(--line-ease),
+              border-color var(--line-duration) var(--line-ease),
+              color var(--line-duration) var(--line-ease),
+              transform var(--line-duration) var(--line-ease);
+}
+.step__node:hover, .step__node:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(110,168,255,0.5); transform: scale(1.08); }
+
+/* done nodes (steps before the current) */
+#gfs-2:checked ~ .stepper__list .step:nth-child(1) .step__node,
+#gfs-3:checked ~ .stepper__list .step:nth-child(-n+2) .step__node,
+#gfs-4:checked ~ .stepper__list .step:nth-child(-n+3) .step__node {
+  color: #06231a;
+  background: linear-gradient(135deg, var(--done), #6ee7b7);
+  border-color: transparent;
+}
+
+/* current node */
+#gfs-1:checked ~ .stepper__list .step:nth-child(1) .step__node,
+#gfs-2:checked ~ .stepper__list .step:nth-child(2) .step__node,
+#gfs-3:checked ~ .stepper__list .step:nth-child(3) .step__node,
+#gfs-4:checked ~ .stepper__list .step:nth-child(4) .step__node {
+  color: #06231a;
+  background: linear-gradient(135deg, var(--accent), var(--accent2));
+  border-color: transparent;
+  transform: scale(1.12);
+  box-shadow: 0 0 0 4px rgba(110,168,255,0.25);
+}
+
+/* the connector fill grows up to the current step */
+.stepper__list::after {
+  content: "";
+  position: absolute;
+  top: 0.9rem;
+  left: 1.1rem;
+  height: 2px;
+  width: 0;
+  background: linear-gradient(90deg, var(--done), var(--accent));
+  border-radius: 999px;
+  z-index: 0;
+  transition: width var(--line-duration) var(--line-ease);
+}
+#gfs-1:checked ~ .stepper__list::after { width: 0%; }
+#gfs-2:checked ~ .stepper__list::after { width: calc(100% / 3 * 1 - 0.6rem); }
+#gfs-3:checked ~ .stepper__list::after { width: calc(100% / 3 * 2 - 0.6rem); }
+#gfs-4:checked ~ .stepper__list::after { width: calc(100% - 2.2rem); }
+
+/* step label: glitch text with RGB-split copies; current step flickers in */
+.step__label {
+  position: relative;
+  display: inline-block;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--muted);
+}
+.step__text { display: inline-block; position: relative; }
+.step__text--r, .step__text--b {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+.step__text--r { color: var(--r-channel); mix-blend-mode: screen; }
+.step__text--b { color: var(--b-channel); mix-blend-mode: screen; }
+
+/* current label is bright */
+#gfs-1:checked ~ .stepper__list .step:nth-child(1) .step__label,
+#gfs-2:checked ~ .stepper__list .step:nth-child(2) .step__label,
+#gfs-3:checked ~ .stepper__list .step:nth-child(3) .step__label,
+#gfs-4:checked ~ .stepper__list .step:nth-child(4) .step__label {
+  color: var(--fg);
+}
+/* current label flickers in */
+#gfs-1:checked ~ .stepper__list .step:nth-child(1) .step__text,
+#gfs-2:checked ~ .stepper__list .step:nth-child(2) .step__text,
+#gfs-3:checked ~ .stepper__list .step:nth-child(3) .step__text,
+#gfs-4:checked ~ .stepper__list .step:nth-child(4) .step__text { animation: gfs-flicker var(--flicker-duration) var(--flicker-ease); }
+
+#gfs-1:checked ~ .stepper__list .step:nth-child(1) .step__text--r,
+#gfs-2:checked ~ .stepper__list .step:nth-child(2) .step__text--r,
+#gfs-3:checked ~ .stepper__list .step:nth-child(3) .step__text--r,
+#gfs-4:checked ~ .stepper__list .step:nth-child(4) .step__text--r { animation: gfs-r var(--flicker-duration) steps(2, end); }
+#gfs-1:checked ~ .stepper__list .step:nth-child(1) .step__text--b,
+#gfs-2:checked ~ .stepper__list .step:nth-child(2) .step__text--b,
+#gfs-3:checked ~ .stepper__list .step:nth-child(3) .step__text--b,
+#gfs-4:checked ~ .stepper__list .step:nth-child(4) .step__text--b { animation: gfs-b var(--flicker-duration) steps(2, end); }
+
+@keyframes gfs-flicker {
+  0%   { opacity: 0; transform: translate(2px, 0); filter: brightness(2); }
+  20%  { opacity: 0.5; transform: translate(-2px, 0); }
+  40%  { opacity: 1; transform: translate(1px, 0); filter: brightness(1.6); }
+  60%  { opacity: 0.4; transform: translate(-1px, 0); }
+  100% { opacity: 1; transform: translate(0, 0); filter: none; }
+}
+@keyframes gfs-r {
+  0%, 100% { transform: translate(0, 0); }
+  25% { transform: translate(-2px, 0); }
+  50% { transform: translate(3px, 0); }
+  75% { transform: translate(-1px, 0); }
+}
+@keyframes gfs-b {
+  0%, 100% { transform: translate(0, 0); }
+  25% { transform: translate(2px, 0); }
+  50% { transform: translate(-3px, 0); }
+  75% { transform: translate(1px, 0); }
+}
+
+.stepper__nav { display: flex; gap: 0.4rem; justify-content: center; }
+.nav-btn {
+  display: inline-flex; align-items: center; justify-content: center;
+  min-width: 2rem; padding: 0.4rem 0.6rem;
+  font-size: 0.8rem; font-weight: 600;
+  color: var(--fg);
+  background: rgba(255,255,255,0.06);
+  border: 1px solid var(--glass-border);
+  border-radius: 0.5rem;
+  cursor: pointer; user-select: none;
+  transition: background 0.18s ease, transform 0.18s ease;
+}
+.nav-btn:hover, .nav-btn:focus-visible { background: rgba(110,168,255,0.16); transform: translateY(-1px); outline: none; box-shadow: 0 0 0 3px rgba(110,168,255,0.4); }
+
+@media (max-width: 480px) {
+  .step__label { font-size: 0.68rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .step__node, .stepper__list::after { transition: none; }
+  .step__text, .step__text--r, .step__text--b { animation: none; }
+  .step__text--r, .step__text--b { display: none; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-glitch-flicker-stepper** from issue #62158 — a Glitch-Flicker Stepper component, following the submission pattern in the issue.

Closes #62158.

## Feature

A horizontal stepper whose current-step label glitches into view when advanced: `@keyframes gfs-flicker` (stepped) flickers `opacity`/`brightness` and jitters `transform`, while two offset color-channel copies of the label (red/cyan, `mix-blend-mode: screen`) jitter separately via `gfs-r`/`gfs-b` for an RGB-split glitch before settling. Completed nodes turn emerald; the current node scales up + glows; the connector grows via `width` to the current step. Pure CSS via hidden radios + `:checked ~`.

## How it works

- `@keyframes gfs-flicker` (stepped) jitters `transform`, flickers `opacity`, spikes `filter: brightness()`; `@keyframes gfs-r`/`gfs-b` jitter the RGB channel copies. Connector grows via `width` transition; current node scales via `transform`. All via `transform`/`opacity`/`filter`/`width`.

## Accessibility

- Nodes/nav are focusable labels with `aria-label="Step N: name"`; channel copies `aria-hidden`; `:focus-visible` rings. Full `prefers-reduced-motion` support (states change instantly; channels hidden).

## Submission structure

```
submissions/examples/ease-glitch-flicker-stepper-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← glassmorphism stepper + glitch-flicker + RGB channels + connector
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally