### PR TITLE
feat: add ease-search-expand-sap

### DIFF
--- a/submissions/examples/ease-search-expand-sap/README.md
+++ b/submissions/examples/ease-search-expand-sap/README.md
@@ -1,0 +1,18 @@
+# ease-search-expand-sap
+
+A circular search icon button that expands into a full text input on click, and collapses on outside click.
+
+## Usage
+1. Include `style.css`.
+2. Add markup with the input placed before the toggle button (see `demo.html`) so it can expand from under the button.
+3. Attach the toggle/outside-click listeners from `demo.html`.
+
+## Customization
+- `width: 260px` on `.search-expand.active .search-input`: expanded width.
+- Transition duration/easing for expand speed.
+- Icon swap: replace the inline search `<svg>`.
+
+## Notes
+- Input sits behind the toggle button (`z-index: 2` on button) at rest, hidden by `width: 48px` + `opacity: 0`, so the collapsed state looks like a plain icon button.
+- Clicking outside the component collapses it and clears the value, keeping the UI tidy.
+- Respects `prefers-reduced-motion`: the expand/collapse becomes an instant width change instead of an eased transition.

--- a/submissions/examples/ease-search-expand-sap/demo.html
+++ b/submissions/examples/ease-search-expand-sap/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-search-expand-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      height: 100vh;
+      margin: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #f4f4f5;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="search-expand" id="searchExpand">
+    <input type="text" class="search-input" id="searchInput" placeholder="Search...">
+    <button class="search-toggle" id="searchToggle" aria-label="Toggle search">
+      <svg viewBox="0 0 24 24">
+        <circle cx="11" cy="11" r="7"/>
+        <path d="M21 21l-4.3-4.3"/>
+      </svg>
+    </button>
+  </div>
+
+  <script>
+    const wrap = document.getElementById('searchExpand');
+    const toggle = document.getElementById('searchToggle');
+    const input = document.getElementById('searchInput');
+
+    toggle.addEventListener('click', () => {
+      wrap.classList.toggle('active');
+      if (wrap.classList.contains('active')) {
+        input.focus();
+      } else {
+        input.value = '';
+      }
+    });
+
+    document.addEventListener('click', (e) => {
+      if (!wrap.contains(e.target)) {
+        wrap.classList.remove('active');
+      }
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-search-expand-sap/style.css
+++ b/submissions/examples/ease-search-expand-sap/style.css
@@ -1,0 +1,60 @@
+.search-expand {
+  position: relative;
+  display: flex;
+  align-items: center;
+  height: 48px;
+  font-family: system-ui, sans-serif;
+}
+
+.search-expand .search-toggle {
+  width: 48px;
+  height: 48px;
+  border: none;
+  border-radius: 50%;
+  background: #111;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 2;
+  flex-shrink: 0;
+  transition: background 0.25s ease;
+}
+
+.search-expand .search-toggle svg {
+  width: 20px;
+  height: 20px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+}
+
+.search-expand .search-input {
+  position: absolute;
+  right: 0;
+  height: 48px;
+  width: 48px;
+  padding: 0 0 0 20px;
+  border: none;
+  border-radius: 24px;
+  background: #f1f5f9;
+  font-size: 14px;
+  color: #111;
+  opacity: 0;
+  outline: none;
+  transition: width 0.4s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.3s ease, padding 0.4s ease;
+}
+
+.search-expand.active .search-input {
+  width: 260px;
+  padding-right: 56px;
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .search-expand .search-input {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-search-expand-sap`, a click-to-expand circular search input.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-search-expand-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Input is layered behind the toggle button at rest and revealed purely via `width`/`opacity` transition, avoiding any layout shift of surrounding elements.
- Outside-click listener collapses and clears the field automatically for a tidy default state.
- `prefers-reduced-motion` removes the expand transition, keeping instant open/close only.

## Feature Description

Adds a reusable expanding search input component, commonly used in compact navbars.

Level: Intermediate

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.