### PR TITLE
feat: add ease-bounce-pulse-drawer component (#62246)

### DIFF
--- a/submissions/examples/ease-bounce-pulse-drawer-sbh/README.md
+++ b/submissions/examples/ease-bounce-pulse-drawer-sbh/README.md
@@ -1,0 +1,48 @@
+# ease-bounce-pulse-drawer
+
+A drawer that bounces in on open (overshoot easing) and pulses a gentle scale breathing while open. Pure CSS — open/close is driven by a hidden checkbox, so no JavaScript is required for the animation.
+
+## What does this do?
+
+Adds a **bounce-pulse-drawer**: a glassmorphism panel that slides in from the right (or up from the bottom on mobile). On open it uses an overshoot easing (`cubic-bezier(0.34, 1.56, 0.64, 1)`) so the drawer springs past its rest point and settles, then `@keyframes bpd-pulse` gently breathes its scale (`1 → 1.012 → 1`) while open. A dimmed scrim fades in behind it. The close button and action buttons are `<label for="drawer-toggle">`, so they close the drawer with no JS.
+
+## How is it used?
+
+1. Place a hidden `<input type="checkbox" class="drawer-toggle">`, an `.opener` label, a `.scrim` label, and the `.drawer` as siblings (the CSS uses the `~` sibling combinator).
+2. The close button and action buttons are also labels pointing at the checkbox.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<input type="checkbox" id="bpd-toggle" class="drawer-toggle" aria-hidden="true" />
+<label for="bpd-toggle" class="opener" tabindex="0">Filters</label>
+<label for="bpd-toggle" class="scrim" aria-hidden="true"></label>
+<aside class="drawer" role="region" aria-label="Filters">
+  <div class="drawer__head">
+    <h2 class="drawer__title">Filters</h2>
+    <label for="bpd-toggle" class="drawer__close" tabindex="0" aria-label="Close drawer">&times;</label>
+  </div>
+  <div class="drawer__body">…</div>
+  <div class="drawer__actions">
+    <label for="bpd-toggle" class="drawer__btn drawer__btn--ghost" tabindex="0">Reset</label>
+    <label for="bpd-toggle" class="drawer__btn drawer__btn--primary" tabindex="0">Apply</label>
+  </div>
+</aside>
+```
+
+## Why is this useful?
+
+- **Animation-first** — the signature motion is twofold: the drawer slides in (`transform: translate(100%, -50%) → translate(0, -50%)`) with an overshoot easing so it bounces past rest and settles, then `@keyframes bpd-pulse` gently breathes its `scale` while open (delayed until the slide finishes). The scrim fades via `opacity` + `visibility` (deferred on close). All via `transform`/`opacity`.
+- **Glassmorphism aesthetic** — the drawer is a frosted panel via `backdrop-filter: blur()`; the pulse is a subtle scale breathing.
+- **Accessible** — `role="region"` + `aria-label`; the trigger, close, and action buttons are focusable labels with `:focus-visible` rings. Full `prefers-reduced-motion` support (drawer snaps without transition or pulse).
+- **Reusable** — configurable via CSS custom properties (`--slide-duration`, `--bounce-ease`, `--pulse-duration`, `--glass-blur`).
+
+## Files
+
+- `demo.html` — self-contained demo (open directly in a browser; no server, CDNs, or frameworks). Pure CSS animation, no JS required for the animation. Includes filter controls for context.
+- `style.css` — glassmorphism drawer, bounce-in + pulse via checkbox state, scrim, focus-visible states, mobile bottom-sheet variant, reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-bounce-pulse-drawer-sbh/demo.html
+++ b/submissions/examples/ease-bounce-pulse-drawer-sbh/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-bounce-pulse-drawer — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-bounce-pulse-drawer</h1>
+      <p>A drawer that bounces in on open and pulses softly while open.</p>
+    </header>
+
+    <section class="stage" aria-label="Drawer demo">
+      <input type="checkbox" id="bpd-toggle" class="drawer-toggle" aria-hidden="true" />
+      <label for="bpd-toggle" class="opener" tabindex="0">Filters</label>
+
+      <label for="bpd-toggle" class="scrim" aria-hidden="true"></label>
+
+      <aside class="drawer" role="region" aria-label="Filters">
+        <div class="drawer__head">
+          <h2 class="drawer__title">Filters</h2>
+          <label for="bpd-toggle" class="drawer__close" tabindex="0" aria-label="Close drawer">&times;</label>
+        </div>
+        <div class="drawer__body">
+          <fieldset class="filter-group">
+            <legend>Category</legend>
+            <label><input type="radio" name="cat" checked /> All</label>
+            <label><input type="radio" name="cat" /> Lighting</label>
+            <label><input type="radio" name="cat" /> Audio</label>
+          </fieldset>
+          <fieldset class="filter-group">
+            <legend>Price</legend>
+            <label><input type="checkbox" checked /> Under $50</label>
+            <label><input type="checkbox" /> $50–$150</label>
+          </fieldset>
+        </div>
+        <div class="drawer__actions">
+          <label for="bpd-toggle" class="drawer__btn drawer__btn--ghost" tabindex="0">Reset</label>
+          <label for="bpd-toggle" class="drawer__btn drawer__btn--primary" tabindex="0">Apply</label>
+        </div>
+      </aside>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-bounce-pulse-drawer-sbh/style.css
+++ b/submissions/examples/ease-bounce-pulse-drawer-sbh/style.css
@@ -1,0 +1,153 @@
+:root {
+  --slide-duration: 0.6s;
+  --bounce-ease: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --pulse-duration: 2.6s;
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --glass-bg: rgba(255, 255, 255, 0.07);
+  --glass-border: rgba(255, 255, 255, 0.14);
+  --glass-blur: 16px;
+  --radius: 1.2rem;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 20%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+}
+
+.page__intro { text-align: center; max-width: 36rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+
+.drawer-toggle { position: absolute; opacity: 0; pointer-events: none; }
+
+.stage { position: relative; display: flex; flex-direction: column; align-items: center; }
+
+.opener {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.7rem 1.4rem;
+  border-radius: 0.7rem;
+  font-weight: 600;
+  color: #06231a;
+  background: linear-gradient(135deg, var(--accent), var(--accent2));
+  cursor: pointer;
+  user-select: none;
+  transition: filter 0.2s ease, transform 0.2s ease;
+}
+.opener:hover, .opener:focus-visible { filter: brightness(1.08); transform: translateY(-2px); outline: none; box-shadow: 0 0 0 3px rgba(110,168,255,0.5); }
+
+.scrim {
+  position: fixed;
+  inset: 0;
+  background: rgba(4, 7, 14, 0.55);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s ease, visibility 0s linear 0.3s;
+  z-index: 40;
+  cursor: pointer;
+}
+.drawer-toggle:checked ~ .scrim {
+  opacity: 1;
+  visibility: visible;
+  transition: opacity 0.3s ease, visibility 0s linear 0s;
+}
+
+/* drawer: bounces in (overshoot ease), then pulses softly while open */
+.drawer {
+  position: fixed;
+  top: 50%;
+  right: 1rem;
+  transform: translate(100%, -50%);
+  width: min(22rem, 88vw);
+  max-height: 86vh;
+  display: flex;
+  flex-direction: column;
+  padding: 1.3rem;
+  border-radius: var(--radius);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  box-shadow: 0 30px 70px -30px rgba(0, 0, 0, 0.8);
+  opacity: 0;
+  visibility: hidden;
+  transition: transform var(--slide-duration) var(--bounce-ease),
+              opacity 0.25s ease,
+              visibility 0s linear var(--slide-duration);
+  z-index: 50;
+}
+.drawer-toggle:checked ~ .drawer {
+  transform: translate(0, -50%);
+  opacity: 1;
+  visibility: visible;
+  transition: transform var(--slide-duration) var(--bounce-ease),
+              opacity 0.25s ease,
+              visibility 0s linear 0s;
+  animation: bpd-pulse var(--pulse-duration) ease-in-out infinite;
+  animation-delay: var(--slide-duration);
+}
+
+/* gentle pulse: a subtle scale breathing of the drawer */
+@keyframes bpd-pulse {
+  0%, 100% { transform: translate(0, -50%) scale(1); }
+  50%      { transform: translate(0, -50%) scale(1.012); }
+}
+
+.drawer__head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0.8rem; }
+.drawer__title { margin: 0; font-size: 1.1rem; }
+.drawer__close {
+  font-size: 1.5rem; line-height: 1; color: var(--muted); cursor: pointer; user-select: none;
+  padding: 0.15rem 0.5rem; border-radius: 0.4rem; transition: color 0.18s ease, background 0.18s ease;
+}
+.drawer__close:hover, .drawer__close:focus-visible { color: var(--fg); background: rgba(255,255,255,0.08); outline: none; box-shadow: 0 0 0 2px rgba(110,168,255,0.6); }
+
+.drawer__body { overflow-y: auto; flex: 1; }
+.filter-group { border: 1px solid rgba(255,255,255,0.12); border-radius: 0.6rem; padding: 0.6rem 0.8rem; margin: 0 0 0.8rem; }
+.filter-group legend { font-size: 0.78rem; color: var(--muted); padding: 0 0.3rem; }
+.filter-group label { display: flex; align-items: center; gap: 0.5rem; font-size: 0.9rem; padding: 0.2rem 0; color: var(--fg); cursor: pointer; }
+
+.drawer__actions { display: flex; gap: 0.6rem; justify-content: flex-end; margin-top: 0.4rem; }
+.drawer__btn {
+  display: inline-flex; align-items: center; padding: 0.5rem 1rem; border-radius: 0.6rem;
+  font-weight: 600; font-size: 0.9rem; cursor: pointer; user-select: none;
+  transition: filter 0.18s ease, transform 0.18s ease, background 0.18s ease;
+}
+.drawer__btn--ghost { color: var(--fg); background: rgba(255,255,255,0.08); }
+.drawer__btn--ghost:hover, .drawer__btn--ghost:focus-visible { background: rgba(255,255,255,0.14); outline: none; box-shadow: 0 0 0 2px rgba(110,168,255,0.5); }
+.drawer__btn--primary { color: #06231a; background: linear-gradient(135deg, var(--accent), var(--accent2)); }
+.drawer__btn--primary:hover, .drawer__btn--primary:focus-visible { filter: brightness(1.08); transform: translateY(-1px); outline: none; box-shadow: 0 0 0 3px rgba(110,168,255,0.5); }
+
+@media (max-width: 480px) {
+  .drawer { right: 0; top: auto; bottom: 0; transform: translate(0, 100%); width: 100vw; max-height: 80vh; border-radius: var(--radius) var(--radius) 0 0; }
+  .drawer-toggle:checked ~ .drawer { transform: translate(0, 0); }
+  @keyframes bpd-pulse {
+    0%, 100% { transform: translate(0, 0) scale(1); }
+    50%      { transform: translate(0, 0) scale(1.012); }
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .drawer, .scrim { transition: none; }
+  .drawer-toggle:checked ~ .drawer { animation: none; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-bounce-pulse-drawer** from issue #62246 — a Bounce-Pulse Drawer component, following the submission pattern in the issue.

Closes #62246.

## Feature

A drawer that bounces in on open (overshoot easing `cubic-bezier(0.34, 1.56, 0.64, 1)` on `translate 100% → 0`) so it springs past rest and settles, then `@keyframes bpd-pulse` gently breathes its `scale` (`1 → 1.012 → 1`) while open (delayed until the slide finishes). A dimmed scrim fades in behind it. Pure CSS via a hidden checkbox.

## How it works

- Slide-in (`transform: translate`) with an overshoot easing for the bounce; `@keyframes bpd-pulse` breathes `scale` while open; scrim fades via `opacity` + `visibility` (deferred on close). All via `transform`/`opacity`.

## Accessibility

- `role="region"` + `aria-label`; trigger/close/actions are focusable labels with `:focus-visible` rings. Full `prefers-reduced-motion` support (drawer snaps; no pulse).

## Submission structure

```
submissions/examples/ease-bounce-pulse-drawer-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← glassmorphism drawer + bounce-in + pulse
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally