### PR TITLE
feat: add ease-fade-in-tabs component (#62194)

### DIFF
--- a/submissions/examples/ease-fade-in-tabs-sbh/README.md
+++ b/submissions/examples/ease-fade-in-tabs-sbh/README.md
@@ -1,0 +1,45 @@
+# ease-fade-in-tabs
+
+Tabs whose content panels fade and lift into view when switched, paired with a gliding underline indicator.
+
+## What does this do?
+
+Adds **fade-in-tabs**: a glassmorphism tab bar. When you switch tabs, the active panel fades in with a gentle upward lift (`@keyframes fi-fade`: `opacity 0 → 1` + `translateY(10px → 0)`), while an underline indicator glides beneath the active tab. A tiny included script re-triggers the fade on each switch and implements the WAI-ARIA arrow-key pattern; the motion itself is pure CSS.
+
+## How is it used?
+
+1. Build a `.tabs__list` (a `role="tablist"`) of `.tabs__tab` buttons, each `role="tab"` with `aria-selected`, `aria-controls`, and an `id`.
+2. Pair each tab with a `.tabs__panel` (`role="tabpanel"`, `aria-labelledby`, `hidden` when inactive).
+3. The included script adds `is-entering` to the activated panel to (re)play the fade and implements arrow-key navigation.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<div class="tabs__list" role="tablist">
+  <button class="tabs__tab" role="tab" aria-selected="true" aria-controls="fi-panel-1" id="fi-tab-1" tabindex="0">Overview</button>
+  <button class="tabs__tab" role="tab" aria-selected="false" aria-controls="fi-panel-2" id="fi-tab-2" tabindex="0">Specs</button>
+  …
+</div>
+<div class="tabs__panels">
+  <div class="tabs__panel" role="tabpanel" id="fi-panel-1" aria-labelledby="fi-tab-1"><p>…</p></div>
+  <div class="tabs__panel tabs__panel--hidden" role="tabpanel" id="fi-panel-2" aria-labelledby="fi-tab-2" hidden><p>…</p></div>
+  …
+</div>
+```
+
+## Why is this useful?
+
+- **Animation-first** — the signature motion is `@keyframes fi-fade` driving `opacity` (`0 → 1`) and `transform: translateY()` (`10px → 0`) so the panel fades in with a gentle lift. The underline glides via `left`/`width` transitions to `--underline-left`/`--underline-width`. All via `opacity`/`transform`/`left`/`width`.
+- **Glassmorphism aesthetic** — the tab bar is a frosted panel via `backdrop-filter: blur()`; the underline is an accent gradient.
+- **Accessible** — full WAI-ARIA tabs pattern: `role="tablist"`/`tab`/`tabpanel`, `aria-selected`, `aria-controls`/`aria-labelledby`, roving `tabindex`, and arrow-key navigation (Left/Right). `:focus-visible` rings. Hidden panels use the `hidden` attribute. Full `prefers-reduced-motion` support (panel appears instantly; underline snaps).
+- **Reusable** — configurable via CSS custom properties (`--fade-duration`, `--fade-ease`, `--underline-duration`, `--underline-ease`).
+
+## Files
+
+- `demo.html` — self-contained demo (open directly in a browser; no server, CDNs, or frameworks). Includes a small script that re-triggers the fade on tab switch and implements the ARIA arrow-key pattern.
+- `style.css` — glassmorphism tabs, fade-in + lift keyframes, gliding underline, focus-visible states, responsive horizontal-scroll on narrow screens, reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation. The fade replay requires the small JS in `demo.html`; the maintainer may adapt this when curating into the framework.

--- a/submissions/examples/ease-fade-in-tabs-sbh/demo.html
+++ b/submissions/examples/ease-fade-in-tabs-sbh/demo.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-fade-in-tabs — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-fade-in-tabs</h1>
+      <p>Tabs whose content panels fade and lift into view when switched.</p>
+    </header>
+
+    <section class="tabs" aria-label="Product details">
+      <div class="tabs__list" role="tablist">
+        <button type="button" class="tabs__tab" role="tab" aria-selected="true" aria-controls="fi-panel-1" id="fi-tab-1" tabindex="0">Overview</button>
+        <button type="button" class="tabs__tab" role="tab" aria-selected="false" aria-controls="fi-panel-2" id="fi-tab-2" tabindex="0">Specs</button>
+        <button type="button" class="tabs__tab" role="tab" aria-selected="false" aria-controls="fi-panel-3" id="fi-tab-3" tabindex="0">Reviews</button>
+      </div>
+
+      <div class="tabs__panels">
+        <div class="tabs__panel" role="tabpanel" id="fi-panel-1" aria-labelledby="fi-tab-1">
+          <p>The Aurora Lamp panel fades in with a gentle lift when this tab is active.</p>
+        </div>
+        <div class="tabs__panel tabs__panel--hidden" role="tabpanel" id="fi-panel-2" aria-labelledby="fi-tab-2" hidden>
+          <p>12W LED, 2700–6500K, USB-C, 8-hour battery.</p>
+        </div>
+        <div class="tabs__panel tabs__panel--hidden" role="tabpanel" id="fi-panel-3" aria-labelledby="fi-tab-3" hidden>
+          <p>4.8★ from 1,204 reviews.</p>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    // Minimal interaction: selecting a tab re-triggers the fade-in on the panel.
+    // The motion itself is pure CSS (@keyframes).
+    var tabs = Array.prototype.slice.call(document.querySelectorAll('.tabs__tab'));
+    var panels = Array.prototype.slice.call(document.querySelectorAll('.tabs__panel'));
+
+    function selectTab(tab) {
+      tabs.forEach(function (t) {
+        var active = t === tab;
+        t.setAttribute('aria-selected', String(active));
+        t.tabIndex = active ? 0 : -1;
+      });
+      panels.forEach(function (p) {
+        var active = p.id === tab.getAttribute('aria-controls');
+        p.toggleAttribute('hidden', !active);
+        if (active) {
+          p.classList.remove('tabs__panel--hidden');
+          p.classList.remove('is-entering');
+          void p.offsetWidth;
+          p.classList.add('is-entering');
+        } else {
+          p.classList.add('tabs__panel--hidden');
+          p.classList.remove('is-entering');
+        }
+      });
+    }
+
+    tabs.forEach(function (t) { t.addEventListener('click', function () { selectTab(t); }); });
+    var list = document.querySelector('.tabs__list');
+    list.addEventListener('keydown', function (e) {
+      var i = tabs.indexOf(document.querySelector('.tabs__tab[aria-selected="true"]'));
+      if (e.key === 'ArrowRight') { selectTab(tabs[(i + 1) % tabs.length]); tabs[(i + 1) % tabs.length].focus(); }
+      if (e.key === 'ArrowLeft')  { selectTab(tabs[(i - 1 + tabs.length) % tabs.length]); tabs[(i - 1 + tabs.length) % tabs.length].focus(); }
+    });
+    window.addEventListener('load', function () { selectTab(tabs[0]); });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-fade-in-tabs-sbh/style.css
+++ b/submissions/examples/ease-fade-in-tabs-sbh/style.css
@@ -1,0 +1,118 @@
+:root {
+  --fade-duration: 0.34s;
+  --fade-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --underline-duration: 0.26s;
+  --underline-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --glass-bg: rgba(255, 255, 255, 0.06);
+  --glass-border: rgba(255, 255, 255, 0.12);
+  --glass-blur: 10px;
+  --radius: 0.8rem;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 20%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+}
+
+.page__intro { text-align: center; max-width: 36rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+
+.tabs {
+  width: min(40rem, 100%);
+  border-radius: var(--radius);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  overflow: hidden;
+}
+
+.tabs__list {
+  position: relative;
+  display: flex;
+  gap: 0.2rem;
+  padding: 0.4rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  --underline-left: 0.4rem;
+  --underline-width: 5rem;
+}
+.tabs__list::after {
+  content: "";
+  position: absolute;
+  bottom: -1px;
+  left: var(--underline-left);
+  width: var(--underline-width);
+  height: 3px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  transition: left var(--underline-duration) var(--underline-ease),
+              width var(--underline-duration) var(--underline-ease);
+  z-index: 2;
+}
+
+.tabs__tab {
+  position: relative;
+  z-index: 1;
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  font-size: 0.92rem;
+  font-weight: 600;
+  padding: 0.7rem 1rem;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color 0.2s ease;
+}
+.tabs__tab:hover { color: var(--fg); }
+.tabs__tab:focus-visible { outline: none; box-shadow: inset 0 0 0 2px rgba(110,168,255,0.6); border-radius: 0.4rem; }
+.tabs__tab[aria-selected="true"] { color: var(--fg); }
+
+.tabs__panels { padding: 1.4rem 1.2rem; position: relative; }
+.tabs__panel { color: var(--muted); line-height: 1.6; font-size: 0.92rem; }
+.tabs__panel p { margin: 0; }
+.tabs__panel--hidden { display: none; }
+
+/* fade-in + lift: panel enters by fading opacity and lifting up */
+.tabs__panel.is-entering {
+  animation: fi-fade var(--fade-duration) var(--fade-ease);
+}
+@keyframes fi-fade {
+  0%   { opacity: 0; transform: translateY(10px); }
+  100% { opacity: 1; transform: translateY(0); }
+}
+
+@media (max-width: 480px) {
+  .tabs__list { overflow-x: auto; scrollbar-width: none; }
+  .tabs__list::-webkit-scrollbar { display: none; }
+  .tabs__tab { padding: 0.6rem 0.8rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tabs__list::after { transition: none; }
+  .tabs__panel.is-entering { animation: none; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-fade-in-tabs** from issue #62194 — a Fade-In Tabs component, following the submission pattern in the issue.

Closes #62194.

## Feature

Tabs whose content panels fade and lift into view when switched: `@keyframes fi-fade` drives `opacity` (`0 → 1`) + `transform: translateY()` (`10px → 0`), paired with a gliding underline indicator beneath the active tab. A small included script re-triggers the fade on each switch and implements the WAI-ARIA arrow-key pattern; the motion itself is pure CSS.

## How it works

- `@keyframes fi-fade` drives `opacity` + `transform: translateY()` so the panel fades in with a gentle lift; underline glides via `left`/`width` transitions to `--underline-left`/`--underline-width`. All via `opacity`/`transform`/`left`/`width`.

## Accessibility

- Full WAI-ARIA tabs pattern (`role="tablist"`/`tab`/`tabpanel`, `aria-selected`, `aria-controls`/`aria-labelledby`, roving `tabindex`, Left/Right arrow-key nav). `:focus-visible` rings. Hidden panels use `hidden`. Full `prefers-reduced-motion` support.

## Submission structure

```
submissions/examples/ease-fade-in-tabs-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← glassmorphism tabs + fade-in + lift + gliding underline
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally