### PR TITLE
feat: add ease-rotate-fade-progress component (#62170)

### DIFF
--- a/submissions/examples/ease-rotate-fade-progress-sbh/README.md
+++ b/submissions/examples/ease-rotate-fade-progress-sbh/README.md
@@ -1,0 +1,45 @@
+# ease-rotate-fade-progress
+
+Circular progress rings whose dial rotates and fades in on load, then the stroke draws (rotates around the ring) and fades up to the target value. Pure CSS — no JavaScript required for the animation.
+
+## What does this do?
+
+Adds a **rotate-fade progress** ring: on load each dial rotates in from `-90deg` and fades (`@keyframes rfp-in`), then the colored stroke draws around the ring via `stroke-dashoffset` (`@keyframes rfp-draw`) while fading in (`@keyframes rfp-stroke-fade`), stopping at the target value. Includes color variants and a numeric readout in the center.
+
+## How is it used?
+
+1. Set the target value via the `--val` CSS custom property on `.ring__fill` (e.g. `style="--val: 55"`, a number 0–100).
+2. Set `aria-valuenow` on `.ring__dial` to match for screen readers.
+3. Use modifier classes for color variants: `ring__fill--violet`, `ring__fill--emerald`.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<figure class="ring">
+  <div class="ring__dial" role="progressbar" aria-valuenow="55" aria-valuemin="0" aria-valuemax="100" aria-label="Onboarding progress">
+    <svg class="ring__svg" viewBox="0 0 120 120" aria-hidden="true">
+      <circle class="ring__track" cx="60" cy="60" r="52"></circle>
+      <circle class="ring__fill" cx="60" cy="60" r="52" style="--val: 55"></circle>
+    </svg>
+    <span class="ring__val">55%</span>
+  </div>
+  <figcaption class="ring__caption">Onboarding</figcaption>
+</figure>
+```
+
+## Why is this useful?
+
+- **Animation-first** — the signature motion is twofold: the whole dial rotates in and fades (`@keyframes rfp-in`: `rotate(-90deg) → 0` + `opacity 0 → 1` + `scale`), then the stroke draws around the ring via `stroke-dashoffset` (`@keyframes rfp-draw`, from full circumference to `(1 - val/100) * circumference`) while fading (`@keyframes rfp-stroke-fade`). All via `transform`/`opacity`/`stroke-dashoffset`.
+- **Glassmorphism aesthetic** — the dial is a frosted disc via `backdrop-filter: blur()`; the stroke is an accent color.
+- **Accessible** — `role="progressbar"` + `aria-valuenow/min/max` + `aria-label` on the dial; the SVG is `aria-hidden="true"` (the numeric readout + ARIA convey the value). Full `prefers-reduced-motion` support (dial appears instantly; stroke jumps to final offset).
+- **Reusable** — configurable via CSS custom properties (`--rotate-duration`, `--rotate-ease`, `--fade-duration`, `--val-duration`, `--circumference`, color tokens).
+
+## Files
+
+- `demo.html` — self-contained demo (open directly in a browser; no server, CDNs, or frameworks). Pure CSS animation, no JS.
+- `style.css` — glassmorphism dial, rotate-in + draw + stroke-fade keyframes, color variants, reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation. The `--circumference` is `2πr` for `r=52`; if the maintainer changes the ring radius, update `--circumference` accordingly.

--- a/submissions/examples/ease-rotate-fade-progress-sbh/demo.html
+++ b/submissions/examples/ease-rotate-fade-progress-sbh/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-rotate-fade-progress — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-rotate-fade-progress</h1>
+      <p>Circular progress rings whose fill rotates in and fades up to the target value.</p>
+    </header>
+
+    <section class="rings" aria-label="Progress rings">
+      <figure class="ring">
+        <div class="ring__dial" role="progressbar" aria-valuenow="55" aria-valuemin="0" aria-valuemax="100" aria-label="Onboarding progress">
+          <svg class="ring__svg" viewBox="0 0 120 120" aria-hidden="true">
+            <circle class="ring__track" cx="60" cy="60" r="52"></circle>
+            <circle class="ring__fill" cx="60" cy="60" r="52" style="--val: 55"></circle>
+          </svg>
+          <span class="ring__val">55%</span>
+        </div>
+        <figcaption class="ring__caption">Onboarding</figcaption>
+      </figure>
+
+      <figure class="ring">
+        <div class="ring__dial" role="progressbar" aria-valuenow="82" aria-valuemin="0" aria-valuemax="100" aria-label="Storage used">
+          <svg class="ring__svg" viewBox="0 0 120 120" aria-hidden="true">
+            <circle class="ring__track" cx="60" cy="60" r="52"></circle>
+            <circle class="ring__fill ring__fill--violet" cx="60" cy="60" r="52" style="--val: 82"></circle>
+          </svg>
+          <span class="ring__val">82%</span>
+        </div>
+        <figcaption class="ring__caption">Storage</figcaption>
+      </figure>
+
+      <figure class="ring">
+        <div class="ring__dial" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" aria-label="Deploy complete">
+          <svg class="ring__svg" viewBox="0 0 120 120" aria-hidden="true">
+            <circle class="ring__track" cx="60" cy="60" r="52"></circle>
+            <circle class="ring__fill ring__fill--emerald" cx="60" cy="60" r="52" style="--val: 100"></circle>
+          </svg>
+          <span class="ring__val">100%</span>
+        </div>
+        <figcaption class="ring__caption">Deploy</figcaption>
+      </figure>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-rotate-fade-progress-sbh/style.css
+++ b/submissions/examples/ease-rotate-fade-progress-sbh/style.css
@@ -1,0 +1,120 @@
+:root {
+  --rotate-duration: 1.2s;
+  --rotate-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --fade-duration: 0.8s;
+  --fade-ease: ease-out;
+  --val-duration: 1.2s;
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --emerald: #34d399;
+  --glass-bg: rgba(255, 255, 255, 0.06);
+  --glass-border: rgba(255, 255, 255, 0.12);
+  --glass-blur: 12px;
+  --radius: 1.4rem;
+  --circumference: 326.726; /* 2 * pi * 52 */
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 20%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+}
+
+.page__intro { text-align: center; max-width: 40rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+
+.rings { display: flex; flex-wrap: wrap; gap: 1.6rem; justify-content: center; }
+
+.ring { margin: 0; display: flex; flex-direction: column; align-items: center; gap: 0.6rem; }
+.ring__dial {
+  position: relative;
+  width: 9rem;
+  height: 9rem;
+  display: grid;
+  place-items: center;
+  border-radius: 999px;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  box-shadow: 0 18px 40px -22px rgba(0, 0, 0, 0.7);
+  /* rotate-fade-in: the whole dial rotates and fades on load */
+  opacity: 0;
+  transform: rotate(-90deg) scale(0.9);
+  animation: rfp-in var(--rotate-duration) var(--rotate-ease) forwards;
+}
+.ring:nth-child(2) .ring__dial { animation-delay: 0.12s; }
+.ring:nth-child(3) .ring__dial { animation-delay: 0.24s; }
+
+@keyframes rfp-in {
+  0%   { opacity: 0; transform: rotate(-90deg) scale(0.9); }
+  100% { opacity: 1; transform: rotate(0deg) scale(1); }
+}
+
+.ring__svg { width: 100%; height: 100%; transform: rotate(-90deg); /* start fill at top */ }
+.ring__track {
+  fill: none;
+  stroke: rgba(255, 255, 255, 0.1);
+  stroke-width: 10;
+}
+.ring__fill {
+  fill: none;
+  stroke: var(--accent);
+  stroke-width: 10;
+  stroke-linecap: round;
+  /* dasharray = full circumference; dashoffset animates from full (empty) to (1 - val/100)*circumference */
+  stroke-dasharray: var(--circumference);
+  stroke-dashoffset: var(--circumference);
+  /* fade-in of the stroke as it draws */
+  opacity: 0;
+  animation: rfp-draw var(--val-duration) var(--rotate-ease) forwards,
+             rfp-stroke-fade var(--fade-duration) var(--fade-ease) forwards;
+  animation-delay: var(--rotate-duration), var(--rotate-duration);
+}
+.ring__fill--violet { stroke: var(--accent2); }
+.ring__fill--emerald { stroke: var(--emerald); }
+
+@keyframes rfp-draw {
+  to { stroke-dashoffset: calc(var(--circumference) * (1 - var(--val) / 100)); }
+}
+@keyframes rfp-stroke-fade {
+  to { opacity: 1; }
+}
+
+.ring__val {
+  position: absolute;
+  font-size: 1.4rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+.ring__caption { font-size: 0.85rem; color: var(--muted); }
+
+@media (max-width: 480px) {
+  .ring__dial { width: 7.5rem; height: 7.5rem; }
+  .ring__val { font-size: 1.1rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ring__dial { animation: none; opacity: 1; transform: rotate(0) scale(1); }
+  .ring__fill { animation: none; opacity: 1; stroke-dashoffset: calc(var(--circumference) * (1 - var(--val) / 100)); }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-rotate-fade-progress** from issue #62170 — a Rotate-Fade Progress Bar component, following the submission pattern in the issue.

Closes #62170.

## Feature

Circular progress rings whose dial rotates in and fades on load (`@keyframes rfp-in`: `rotate(-90deg) → 0` + `opacity 0 → 1` + `scale`), then the colored stroke draws around the ring via `stroke-dashoffset` (`@keyframes rfp-draw`, from full circumference to `(1 - val/100) * circumference`) while fading (`@keyframes rfp-stroke-fade`), stopping at the target value set via `--val`. Includes color variants and a numeric readout.

## How it works

- `@keyframes rfp-in` rotates + fades the dial; `@keyframes rfp-draw` animates `stroke-dashoffset` to draw the stroke; `@keyframes rfp-stroke-fade` fades the stroke in. All via `transform`/`opacity`/`stroke-dashoffset`.

## Accessibility

- `role="progressbar"` + `aria-valuenow/min/max` + `aria-label` on the dial; SVG `aria-hidden`; numeric readout conveys value. Full `prefers-reduced-motion` support (dial appears instantly; stroke jumps to final offset).

## Submission structure

```
submissions/examples/ease-rotate-fade-progress-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← glassmorphism dial + rotate-in + draw + stroke-fade
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally