### PR TITLE
feat: add ease-blur-entrance-stepper component (#62154)

### DIFF
--- a/submissions/examples/ease-blur-entrance-stepper-sbh/README.md
+++ b/submissions/examples/ease-blur-entrance-stepper-sbh/README.md
@@ -1,0 +1,45 @@
+# ease-blur-entrance-stepper
+
+A horizontal stepper whose steps blur into focus sequentially on load (staggered blur-in entrance), with a connector that also un-blurs. Pure CSS — no JavaScript required for the animation.
+
+## What does this do?
+
+Adds a **blur-entrance-stepper**: a glassmorphism horizontal stepper. On load, each step starts blurred, faded, and slightly lifted, then focuses in (`@keyframes bes-in`: `filter: blur(8px → 0)` + `opacity 0 → 1` + `translateY(8px → 0)`), staggered by its index (`--i`) so steps resolve one after another. The connector line also un-blurs (`@keyframes bes-line`). Completed steps show an emerald check; the current step is accent-filled with a glow ring.
+
+## How is it used?
+
+1. Build an `.stepper__list` of `.step` items, each carrying its index via `style="--i: N"` (0-based) to drive the stagger.
+2. Mark the current step with `aria-current="step"` on the node; mark completed steps with the `step--done` class.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<ol class="stepper__list" role="list">
+  <li class="step" style="--i: 0">
+    <span class="step__node" aria-current="step">1</span>
+    <span class="step__label">Cart</span>
+  </li>
+  <li class="step step--done" style="--i: 1">
+    <span class="step__node" aria-hidden="true">&#10003;</span>
+    <span class="step__label">Address</span>
+  </li>
+  …
+</ol>
+```
+
+## Why is this useful?
+
+- **Animation-first** — the signature motion is the staggered blur-in: `@keyframes bes-in` drives `filter: blur()` (`8px → 0`), `opacity` (`0 → 1`), and `transform: translateY()` (`8px → 0`), delayed by `calc(var(--stagger) * var(--i))` so each step resolves in sequence. The connector un-blurs via `@keyframes bes-line`. All via `filter`/`opacity`/`transform`.
+- **Glassmorphism aesthetic** — nodes are frosted pills via `backdrop-filter: blur()`; the entrance blur is a focus-pull effect.
+- **Accessible** — `role="list"`/`listitem` semantics; the current step uses `aria-current="step"`; completed-step checkmarks are `aria-hidden="true"` (the label text conveys meaning). Full `prefers-reduced-motion` support (steps appear instantly with no blur/stagger).
+- **Reusable** — configurable via CSS custom properties (`--blur-duration`, `--blur-ease`, `--stagger`, `--line-duration`, `--glass-blur-bg`).
+
+## Files
+
+- `demo.html` — self-contained demo (open directly in a browser; no server, CDNs, or frameworks). Pure CSS animation, no JS. Reload to replay the entrance.
+- `style.css` — glassmorphism stepper, staggered blur-in keyframes, connector un-blur, done/current node states, reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-blur-entrance-stepper-sbh/demo.html
+++ b/submissions/examples/ease-blur-entrance-stepper-sbh/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-blur-entrance-stepper — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-blur-entrance-stepper</h1>
+      <p>A horizontal stepper whose steps blur into focus sequentially on load.</p>
+    </header>
+
+    <section class="stepper" aria-label="Checkout progress">
+      <ol class="stepper__list" role="list">
+        <li class="step" style="--i: 0">
+          <span class="step__node" aria-current="step">1</span>
+          <span class="step__label">Cart</span>
+        </li>
+        <li class="step step--done" style="--i: 1">
+          <span class="step__node" aria-hidden="true">&#10003;</span>
+          <span class="step__label">Address</span>
+        </li>
+        <li class="step step--done" style="--i: 2">
+          <span class="step__node" aria-hidden="true">&#10003;</span>
+          <span class="step__label">Payment</span>
+        </li>
+        <li class="step" style="--i: 3">
+          <span class="step__node" aria-hidden="true">4</span>
+          <span class="step__label">Confirm</span>
+        </li>
+      </ol>
+    </section>
+
+    <p class="hint">Reload to replay the sequential blur-in entrance.</p>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-blur-entrance-stepper-sbh/style.css
+++ b/submissions/examples/ease-blur-entrance-stepper-sbh/style.css
@@ -1,0 +1,143 @@
+:root {
+  --blur-duration: 0.6s;
+  --blur-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --line-duration: 0.4s;
+  --line-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --stagger: 0.18s;
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --done: #34d399;
+  --glass-bg: rgba(255, 255, 255, 0.06);
+  --glass-border: rgba(255, 255, 255, 0.12);
+  --glass-blur-bg: 10px;
+  --radius: 0.7rem;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 20%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+}
+
+.page__intro { text-align: center; max-width: 40rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+
+.stepper { width: min(42rem, 100%); }
+.hint { font-size: 0.82rem; color: var(--muted); }
+
+.stepper__list {
+  list-style: none;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin: 0;
+  padding: 0;
+  position: relative;
+}
+.stepper__list::before {
+  content: "";
+  position: absolute;
+  top: 1.1rem;
+  left: 1.4rem;
+  right: 1.4rem;
+  height: 2px;
+  background: rgba(255, 255, 255, 0.14);
+  border-radius: 999px;
+  z-index: 0;
+  opacity: 0;
+  transform: scaleX(0.6);
+  filter: blur(6px);
+  animation: bes-line var(--line-duration) var(--line-ease) forwards;
+  animation-delay: calc(var(--stagger) * 3);
+}
+
+.step {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 1;
+  /* blur-entrance: each step starts blurred + faded + lifted, then focuses in, staggered */
+  opacity: 0;
+  transform: translateY(8px);
+  filter: blur(8px);
+  animation: bes-in var(--blur-duration) var(--blur-ease) forwards;
+  animation-delay: calc(var(--stagger) * var(--i));
+}
+
+@keyframes bes-in {
+  to { opacity: 1; transform: translateY(0); filter: blur(0); }
+}
+@keyframes bes-line {
+  to { opacity: 1; transform: scaleX(1); filter: blur(0); }
+}
+
+.step__node {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.2rem;
+  height: 2.2rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--muted);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur-bg));
+  -webkit-backdrop-filter: blur(var(--glass-blur-bg));
+}
+
+/* done steps: emerald fill */
+.step--done .step__node {
+  color: #06231a;
+  background: linear-gradient(135deg, var(--done), #6ee7b7);
+  border-color: transparent;
+}
+
+/* current step: accent fill + ring */
+.step[aria-current="step"] .step__node,
+.step:has([aria-current="step"]) .step__node {
+  color: #06231a;
+  background: linear-gradient(135deg, var(--accent), var(--accent2));
+  border-color: transparent;
+  box-shadow: 0 0 0 4px rgba(110, 168, 255, 0.25);
+}
+
+.step__label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+@media (max-width: 480px) {
+  .step__label { font-size: 0.7rem; }
+  .step__node { width: 1.9rem; height: 1.9rem; font-size: 0.78rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .step { animation: none; opacity: 1; transform: none; filter: none; }
+  .stepper__list::before { animation: none; opacity: 1; transform: none; filter: none; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-blur-entrance-stepper** from issue #62154 — a Blur-Entrance Stepper component, following the submission pattern in the issue.

Closes #62154.

## Feature

A horizontal stepper whose steps blur into focus sequentially on load: `@keyframes bes-in` drives `filter: blur()` (`8px → 0`) + `opacity` (`0 → 1`) + `transform: translateY()` (`8px → 0`), staggered by index via `calc(var(--stagger) * var(--i))` so each step resolves in sequence. The connector line also un-blurs (`@keyframes bes-line`). Completed steps show an emerald check; the current step is accent-filled with a glow ring. Pure CSS, no JS.

## How it works

- `@keyframes bes-in` drives `filter: blur()` + `opacity` + `transform: translateY()`, staggered by `--i`; `@keyframes bes-line` un-blurs the connector. All via `filter`/`opacity`/`transform`.

## Accessibility

- `role="list"`/`listitem` semantics; current step uses `aria-current="step"`; completed checkmarks `aria-hidden`. Full `prefers-reduced-motion` support (steps appear instantly with no blur/stagger).

## Submission structure

```
submissions/examples/ease-blur-entrance-stepper-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← glassmorphism stepper + staggered blur-in + connector un-blur
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally