### PR TITLE
feat: add ease-range-slider-sap

### DIFF
--- a/submissions/examples/ease-range-slider-sap/README.md
+++ b/submissions/examples/ease-range-slider-sap/README.md
@@ -1,0 +1,27 @@
+# ease-range-slider-sap
+
+A styled native range slider with a live-filling track, animated thumb hover/active states, and a synced value readout.
+
+## Usage
+1. Include `style.css`.
+2. Add markup:
+```html
+   <div class="range-slider-sap">
+     <div class="range-label">
+       <span>Volume</span>
+       <span class="range-value" id="rangeValue">50</span>
+     </div>
+     <input type="range" min="0" max="100" value="50" id="rangeInput" style="--fill: 50%;">
+   </div>
+```
+3. Attach the `input` listener from `demo.html` to update `--fill` and the value label live.
+
+## Customization
+- `--fill` custom property: drives the filled-vs-unfilled track split; must be updated in JS to match the current value's percentage.
+- Thumb size/border/hover scale in `::-webkit-slider-thumb` / `::-moz-range-thumb`.
+- Track colors in the `linear-gradient()` background.
+
+## Notes
+- The filled-track effect uses a `linear-gradient` background with a `--fill` custom property as the color-stop percentage — this needs to be recalculated in JS on every `input` event since native range inputs don't expose fill percentage via CSS alone.
+- Thumb styling is duplicated across `-webkit-` and `-moz-` prefixes since range thumb pseudo-elements aren't standardized across browsers.
+- Respects `prefers-reduced-motion`: thumb hover/active scale transitions are disabled.

--- a/submissions/examples/ease-range-slider-sap/demo.html
+++ b/submissions/examples/ease-range-slider-sap/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-range-slider-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      height: 100vh;
+      margin: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #f4f4f5;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="range-slider-sap">
+    <div class="range-label">
+      <span>Volume</span>
+      <span class="range-value" id="rangeValue">50</span>
+    </div>
+    <input type="range" min="0" max="100" value="50" id="rangeInput" style="--fill: 50%;">
+  </div>
+
+  <script>
+    const input = document.getElementById('rangeInput');
+    const value = document.getElementById('rangeValue');
+
+    input.addEventListener('input', () => {
+      input.style.setProperty('--fill', input.value + '%');
+      value.textContent = input.value;
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-range-slider-sap/style.css
+++ b/submissions/examples/ease-range-slider-sap/style.css
@@ -1,0 +1,70 @@
+.range-slider-sap {
+  width: 300px;
+  font-family: system-ui, sans-serif;
+}
+
+.range-slider-sap .range-label {
+  display: flex;
+  justify-content: space-between;
+  font-size: 14px;
+  font-weight: 600;
+  color: #111;
+  margin-bottom: 10px;
+}
+
+.range-slider-sap .range-value {
+  color: #2563eb;
+  background: #eff6ff;
+  padding: 2px 10px;
+  border-radius: 8px;
+  transition: transform 0.15s ease;
+}
+
+.range-slider-sap input[type="range"] {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 6px;
+  border-radius: 3px;
+  background: linear-gradient(to right, #2563eb 0%, #2563eb var(--fill, 50%), #e2e8f0 var(--fill, 50%), #e2e8f0 100%);
+  outline: none;
+  cursor: pointer;
+}
+
+.range-slider-sap input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #fff;
+  border: 3px solid #2563eb;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.range-slider-sap input[type="range"]:hover::-webkit-slider-thumb {
+  transform: scale(1.15);
+}
+
+.range-slider-sap input[type="range"]:active::-webkit-slider-thumb {
+  transform: scale(1.25);
+  box-shadow: 0 0 0 8px rgba(37, 99, 235, 0.15);
+}
+
+.range-slider-sap input[type="range"]::-moz-range-thumb {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #fff;
+  border: 3px solid #2563eb;
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .range-slider-sap input[type="range"]::-webkit-slider-thumb,
+  .range-slider-sap .range-value {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-range-slider-sap`, a styled native range slider with live fill and animated thumb states.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-range-slider-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Track fill uses a `--fill` CSS custom property driving a `linear-gradient` color-stop, recalculated on every `input` event since native ranges don't expose their own fill percentage.
- Thumb styles are duplicated for `-webkit-` and `-moz-` prefixes for cross-browser consistency.
- `prefers-reduced-motion` disables thumb hover/active scale transitions only; the slider remains fully functional.

## Feature Description

Adds a reusable styled range slider with animated thumb interaction and live value display.

Level: Intermediate

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.