### PR TITLE
feat: add ease-scale-hover-drawer component (#62242)

### DIFF
--- a/submissions/examples/ease-scale-hover-drawer-sbh/README.md
+++ b/submissions/examples/ease-scale-hover-drawer-sbh/README.md
@@ -1,0 +1,48 @@
+# ease-scale-hover-drawer
+
+A drawer that slides in from the side and, while open, scales up slightly on hover (or focus-within) for emphasis, with a deepened shadow. Pure CSS — open/close is driven by a hidden checkbox, so no JavaScript is required for the animation.
+
+## What does this do?
+
+Adds a **scale-hover-drawer**: a glassmorphism panel that slides in from the right (or up from the bottom on mobile). When open and hovered (or focused within), it scales up (`scale(1) → scale(1.03)`) and its shadow deepens, drawing attention. A dimmed scrim fades in behind it. The close button and action buttons are `<label for="drawer-toggle">`, so they close the drawer with no JS.
+
+## How is it used?
+
+1. Place a hidden `<input type="checkbox" class="drawer-toggle">`, an `.opener` label, a `.scrim` label, and the `.drawer` as siblings (the CSS uses the `~` sibling combinator).
+2. The close button and action buttons are also labels pointing at the checkbox.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<input type="checkbox" id="shd-toggle" class="drawer-toggle" aria-hidden="true" />
+<label for="shd-toggle" class="opener" tabindex="0">Filters</label>
+<label for="shd-toggle" class="scrim" aria-hidden="true"></label>
+<aside class="drawer" role="region" aria-label="Filters">
+  <div class="drawer__head">
+    <h2 class="drawer__title">Filters</h2>
+    <label for="shd-toggle" class="drawer__close" tabindex="0" aria-label="Close drawer">&times;</label>
+  </div>
+  <div class="drawer__body">…</div>
+  <div class="drawer__actions">
+    <label for="shd-toggle" class="drawer__btn drawer__btn--ghost" tabindex="0">Reset</label>
+    <label for="shd-toggle" class="drawer__btn drawer__btn--primary" tabindex="0">Apply</label>
+  </div>
+</aside>
+```
+
+## Why is this useful?
+
+- **Animation-first** — the signature motion is twofold: the drawer slides in (`transform: translate(100%, -50%) → translate(0, -50%)`) with an `opacity` fade, and while open it scales up on hover/focus (`scale(1) → scale(1.03)`) with a deepened `box-shadow`. The scrim fades via `opacity` + `visibility` (deferred on close). All via `transform`/`opacity`/`box-shadow`.
+- **Glassmorphism aesthetic** — the drawer is a frosted panel via `backdrop-filter: blur()`; the hover adds an accent-tinted ring.
+- **Accessible** — `role="region"` + `aria-label`; the trigger, close, and action buttons are focusable labels with `:focus-visible` rings. The `:focus-within` variant ensures keyboard focus within the drawer also triggers the scale. Full `prefers-reduced-motion` support (drawer snaps without transition).
+- **Reusable** — configurable via CSS custom properties (`--slide-duration`, `--slide-ease`, `--scale-duration`, `--scale-ease`, `--hover-scale`, `--glass-blur`).
+
+## Files
+
+- `demo.html` — self-contained demo (open directly in a browser; no server, CDNs, or frameworks). Pure CSS animation, no JS required for the animation. Includes filter controls for context.
+- `style.css` — glassmorphism drawer, slide-in + hover-scale via checkbox state, scrim, focus-visible states, mobile bottom-sheet variant, reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-scale-hover-drawer-sbh/demo.html
+++ b/submissions/examples/ease-scale-hover-drawer-sbh/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-scale-hover-drawer — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-scale-hover-drawer</h1>
+      <p>A drawer that slides in, then scales up slightly on hover for emphasis.</p>
+    </header>
+
+    <section class="stage" aria-label="Drawer demo">
+      <input type="checkbox" id="shd-toggle" class="drawer-toggle" aria-hidden="true" />
+      <label for="shd-toggle" class="opener" tabindex="0">Filters</label>
+
+      <label for="shd-toggle" class="scrim" aria-hidden="true"></label>
+
+      <aside class="drawer" role="region" aria-label="Filters">
+        <div class="drawer__head">
+          <h2 class="drawer__title">Filters</h2>
+          <label for="shd-toggle" class="drawer__close" tabindex="0" aria-label="Close drawer">&times;</label>
+        </div>
+        <div class="drawer__body">
+          <fieldset class="filter-group">
+            <legend>Category</legend>
+            <label><input type="radio" name="cat" checked /> All</label>
+            <label><input type="radio" name="cat" /> Lighting</label>
+            <label><input type="radio" name="cat" /> Audio</label>
+          </fieldset>
+          <fieldset class="filter-group">
+            <legend>Price</legend>
+            <label><input type="checkbox" checked /> Under $50</label>
+            <label><input type="checkbox" /> $50–$150</label>
+          </fieldset>
+        </div>
+        <div class="drawer__actions">
+          <label for="shd-toggle" class="drawer__btn drawer__btn--ghost" tabindex="0">Reset</label>
+          <label for="shd-toggle" class="drawer__btn drawer__btn--primary" tabindex="0">Apply</label>
+        </div>
+      </aside>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-scale-hover-drawer-sbh/style.css
+++ b/submissions/examples/ease-scale-hover-drawer-sbh/style.css
@@ -1,0 +1,153 @@
+:root {
+  --slide-duration: 0.4s;
+  --slide-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --scale-duration: 0.28s;
+  --scale-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --glass-bg: rgba(255, 255, 255, 0.07);
+  --glass-border: rgba(255, 255, 255, 0.14);
+  --glass-blur: 16px;
+  --radius: 1.2rem;
+  --hover-scale: 1.03;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 20%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+}
+
+.page__intro { text-align: center; max-width: 36rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+
+.drawer-toggle { position: absolute; opacity: 0; pointer-events: none; }
+
+.stage { position: relative; display: flex; flex-direction: column; align-items: center; }
+
+.opener {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.7rem 1.4rem;
+  border-radius: 0.7rem;
+  font-weight: 600;
+  color: #06231a;
+  background: linear-gradient(135deg, var(--accent), var(--accent2));
+  cursor: pointer;
+  user-select: none;
+  transition: filter 0.2s ease, transform 0.2s ease;
+}
+.opener:hover, .opener:focus-visible { filter: brightness(1.08); transform: translateY(-2px); outline: none; box-shadow: 0 0 0 3px rgba(110,168,255,0.5); }
+
+.scrim {
+  position: fixed;
+  inset: 0;
+  background: rgba(4, 7, 14, 0.55);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity var(--slide-duration) ease, visibility 0s linear var(--slide-duration);
+  z-index: 40;
+  cursor: pointer;
+}
+.drawer-toggle:checked ~ .scrim {
+  opacity: 1;
+  visibility: visible;
+  transition: opacity var(--slide-duration) ease, visibility 0s linear 0s;
+}
+
+/* drawer: slides in from the right; on hover (when open) scales up slightly */
+.drawer {
+  position: fixed;
+  top: 50%;
+  right: 1rem;
+  transform: translate(100%, -50%) scale(1);
+  width: min(22rem, 88vw);
+  max-height: 86vh;
+  display: flex;
+  flex-direction: column;
+  padding: 1.3rem;
+  border-radius: var(--radius);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  box-shadow: 0 30px 70px -30px rgba(0, 0, 0, 0.8);
+  opacity: 0;
+  visibility: hidden;
+  transition: transform var(--slide-duration) var(--slide-ease),
+              opacity var(--slide-duration) ease,
+              visibility 0s linear var(--slide-duration),
+              box-shadow var(--scale-duration) var(--scale-ease);
+  z-index: 50;
+}
+.drawer-toggle:checked ~ .drawer {
+  transform: translate(0, -50%) scale(1);
+  opacity: 1;
+  visibility: visible;
+  transition: transform var(--slide-duration) var(--slide-ease),
+              opacity var(--slide-duration) ease,
+              visibility 0s linear 0s,
+              box-shadow var(--scale-duration) var(--scale-ease);
+}
+/* scale on hover while open */
+.drawer-toggle:checked ~ .drawer:hover,
+.drawer-toggle:checked ~ .drawer:focus-within {
+  transform: translate(0, -50%) scale(var(--hover-scale));
+  box-shadow: 0 40px 90px -30px rgba(0, 0, 0, 0.85), 0 0 0 1px rgba(110, 168, 255, 0.25);
+  transition: transform var(--scale-duration) var(--scale-ease),
+              box-shadow var(--scale-duration) var(--scale-ease);
+}
+
+.drawer__head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0.8rem; }
+.drawer__title { margin: 0; font-size: 1.1rem; }
+.drawer__close {
+  font-size: 1.5rem; line-height: 1; color: var(--muted); cursor: pointer; user-select: none;
+  padding: 0.15rem 0.5rem; border-radius: 0.4rem; transition: color 0.18s ease, background 0.18s ease;
+}
+.drawer__close:hover, .drawer__close:focus-visible { color: var(--fg); background: rgba(255,255,255,0.08); outline: none; box-shadow: 0 0 0 2px rgba(110,168,255,0.6); }
+
+.drawer__body { overflow-y: auto; flex: 1; }
+.filter-group { border: 1px solid rgba(255,255,255,0.12); border-radius: 0.6rem; padding: 0.6rem 0.8rem; margin: 0 0 0.8rem; }
+.filter-group legend { font-size: 0.78rem; color: var(--muted); padding: 0 0.3rem; }
+.filter-group label { display: flex; align-items: center; gap: 0.5rem; font-size: 0.9rem; padding: 0.2rem 0; color: var(--fg); cursor: pointer; }
+
+.drawer__actions { display: flex; gap: 0.6rem; justify-content: flex-end; margin-top: 0.4rem; }
+.drawer__btn {
+  display: inline-flex; align-items: center; padding: 0.5rem 1rem; border-radius: 0.6rem;
+  font-weight: 600; font-size: 0.9rem; cursor: pointer; user-select: none;
+  transition: filter 0.18s ease, transform 0.18s ease, background 0.18s ease;
+}
+.drawer__btn--ghost { color: var(--fg); background: rgba(255,255,255,0.08); }
+.drawer__btn--ghost:hover, .drawer__btn--ghost:focus-visible { background: rgba(255,255,255,0.14); outline: none; box-shadow: 0 0 0 2px rgba(110,168,255,0.5); }
+.drawer__btn--primary { color: #06231a; background: linear-gradient(135deg, var(--accent), var(--accent2)); }
+.drawer__btn--primary:hover, .drawer__btn--primary:focus-visible { filter: brightness(1.08); transform: translateY(-1px); outline: none; box-shadow: 0 0 0 3px rgba(110,168,255,0.5); }
+
+@media (max-width: 480px) {
+  .drawer { right: 0; top: auto; bottom: 0; transform: translate(0, 100%) scale(1); width: 100vw; max-height: 80vh; border-radius: var(--radius) var(--radius) 0 0; }
+  .drawer-toggle:checked ~ .drawer { transform: translate(0, 0) scale(1); }
+  .drawer-toggle:checked ~ .drawer:hover, .drawer-toggle:checked ~ .drawer:focus-within { transform: translate(0, 0) scale(var(--hover-scale)); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .drawer, .scrim { transition: none; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-scale-hover-drawer** from issue #62242 — a Scale-Hover Drawer component, following the submission pattern in the issue.

Closes #62242.

## Feature

A drawer that slides in from the side and, while open, scales up slightly on hover (or focus-within) for emphasis (`scale(1) → scale(1.03)`), with a deepened shadow and an accent-tinted ring. A dimmed scrim fades in behind it. Pure CSS via a hidden checkbox.

## How it works

- Slide-in (`transform: translate`) + `opacity` fade; while open, hover/focus-within scales the drawer (`transform: scale`) and deepens `box-shadow`. Scrim fades via `opacity` + `visibility` (deferred on close). All via `transform`/`opacity`/`box-shadow`.

## Accessibility

- `role="region"` + `aria-label`; trigger/close/actions are focusable labels with `:focus-visible` rings. `:focus-within` also triggers the scale for keyboard focus. Full `prefers-reduced-motion` support (drawer snaps).

## Submission structure

```
submissions/examples/ease-scale-hover-drawer-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← glassmorphism drawer + slide-in + hover-scale
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally