### PR TITLE
feat: add ease-shimmer-sweep-carousel component (#62178)

### DIFF
--- a/submissions/examples/ease-shimmer-sweep-carousel-sbh/README.md
+++ b/submissions/examples/ease-shimmer-sweep-carousel-sbh/README.md
@@ -1,0 +1,51 @@
+# ease-shimmer-sweep-carousel
+
+A carousel whose track slides to the active slide, then a translucent diagonal shimmer band sweeps once across the active slide as it lands. Pure CSS — navigation is driven by hidden radio inputs, so no JavaScript is required for the animation.
+
+## What does this do?
+
+Adds a **shimmer-sweep-carousel**: a glassmorphism carousel. When you select a slide (via dot navigation), the track slides horizontally (`transform: translateX`) to bring the active slide into view, and `@keyframes ssc-shimmer` sweeps a translucent diagonal highlight band across the active slide (`background-position` `180% → -80%`, fading in and out) once it has landed.
+
+## How is it used?
+
+1. Place N hidden `<input type="radio" class="slide-toggle">` (sharing one `name`) before the viewport and nav.
+2. Each `.dot` is a `<label for="...">` pointing at its radio. The CSS `:checked ~` rules translate the track to the active slide and replay the shimmer on the active slide.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<input type="radio" name="ssc" id="ssc-1" class="slide-toggle" checked aria-hidden="true" />
+<input type="radio" name="ssc" id="ssc-2" class="slide-toggle" aria-hidden="true" />
+<input type="radio" name="ssc" id="ssc-3" class="slide-toggle" aria-hidden="true" />
+
+<div class="carousel__viewport" aria-live="polite">
+  <ul class="carousel__track">
+    <li class="slide" role="group" aria-roledescription="slide" aria-label="1 of 3">…</li>
+    <li class="slide" role="group" aria-roledescription="slide" aria-label="2 of 3">…</li>
+    <li class="slide" role="group" aria-roledescription="slide" aria-label="3 of 3">…</li>
+  </ul>
+</div>
+
+<div class="carousel__nav">
+  <label for="ssc-1" class="dot" tabindex="0" aria-label="Go to slide 1"></label>
+  <label for="ssc-2" class="dot" tabindex="0" aria-label="Go to slide 2"></label>
+  <label for="ssc-3" class="dot" tabindex="0" aria-label="Go to slide 3"></label>
+</div>
+```
+
+## Why is this useful?
+
+- **Animation-first** — the signature motion is twofold: the track slides to the active slide (`transform: translateX` via `:checked ~`), then `@keyframes ssc-shimmer` sweeps a translucent diagonal band across the active slide via `background-position` (`180% → -80%`) with an `opacity` fade-in/out, delayed until the slide has landed. All via `transform`/`background-position`/`opacity`.
+- **Glassmorphism aesthetic** — the viewport is a frosted panel via `backdrop-filter: blur()`; the shimmer is an overlay-blended highlight.
+- **Accessible** — carousel semantics (`aria-roledescription="carousel"` + `aria-label`), slides with `role="group"`/`aria-roledescription="slide"`/`aria-label="N of M"`, `aria-live="polite"` viewport so slide changes are announced. Dots are focusable labels with `aria-label`s and `:focus-visible` rings. Full `prefers-reduced-motion` support (track snaps; no shimmer).
+- **Reusable** — configurable via CSS custom properties (`--slide-duration`, `--slide-ease`, `--shimmer-duration`, `--shimmer-ease`, `--glass-blur`).
+
+## Files
+
+- `demo.html` — self-contained demo (open directly in a browser; no server, CDNs, or frameworks). Pure CSS navigation and animation, no JS.
+- `style.css` — glassmorphism carousel, track slide + shimmer-sweep via radio `:checked ~`, dot navigation with active state, focus-visible states, reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-shimmer-sweep-carousel-sbh/demo.html
+++ b/submissions/examples/ease-shimmer-sweep-carousel-sbh/demo.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-shimmer-sweep-carousel — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-shimmer-sweep-carousel</h1>
+      <p>A carousel whose active slide sweeps in with a shimmer as it lands.</p>
+    </header>
+
+    <section class="carousel" aria-roledescription="carousel" aria-label="Featured products">
+      <input type="radio" name="ssc" id="ssc-1" class="slide-toggle" checked aria-hidden="true" />
+      <input type="radio" name="ssc" id="ssc-2" class="slide-toggle" aria-hidden="true" />
+      <input type="radio" name="ssc" id="ssc-3" class="slide-toggle" aria-hidden="true" />
+
+      <div class="carousel__viewport" aria-live="polite">
+        <ul class="carousel__track">
+          <li class="slide" role="group" aria-roledescription="slide" aria-label="1 of 3">
+            <div class="slide__media"><span class="slide__emoji" aria-hidden="true">💡</span></div>
+            <div class="slide__body">
+              <h2 class="slide__title">Aurora Lamp</h2>
+              <p class="slide__desc">Tunable ambient lighting that adapts to your space.</p>
+              <span class="slide__price">$89</span>
+            </div>
+          </li>
+          <li class="slide" role="group" aria-roledescription="slide" aria-label="2 of 3">
+            <div class="slide__media"><span class="slide__emoji" aria-hidden="true">🎧</span></div>
+            <div class="slide__body">
+              <h2 class="slide__title">Pulse Headphones</h2>
+              <p class="slide__desc">Active noise cancellation with 30-hour battery.</p>
+              <span class="slide__price">$149</span>
+            </div>
+          </li>
+          <li class="slide" role="group" aria-roledescription="slide" aria-label="3 of 3">
+            <div class="slide__media"><span class="slide__emoji" aria-hidden="true">⌚</span></div>
+            <div class="slide__body">
+              <h2 class="slide__title">Tempo Watch</h2>
+              <p class="slide__desc">Health tracking with a 7-day battery life.</p>
+              <span class="slide__price">$199</span>
+            </div>
+          </li>
+        </ul>
+      </div>
+
+      <div class="carousel__nav">
+        <label for="ssc-1" class="dot" tabindex="0" aria-label="Go to slide 1"></label>
+        <label for="ssc-2" class="dot" tabindex="0" aria-label="Go to slide 2"></label>
+        <label for="ssc-3" class="dot" tabindex="0" aria-label="Go to slide 3"></label>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-shimmer-sweep-carousel-sbh/style.css
+++ b/submissions/examples/ease-shimmer-sweep-carousel-sbh/style.css
@@ -1,0 +1,145 @@
+:root {
+  --slide-duration: 0.5s;
+  --slide-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --shimmer-duration: 1.2s;
+  --shimmer-ease: ease-out;
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --glass-bg: rgba(255, 255, 255, 0.07);
+  --glass-border: rgba(255, 255, 255, 0.14);
+  --glass-blur: 14px;
+  --radius: 1.2rem;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 20%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+}
+
+.page__intro { text-align: center; max-width: 40rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+
+.slide-toggle { position: absolute; opacity: 0; pointer-events: none; }
+
+.carousel { width: min(34rem, 100%); }
+.carousel__viewport {
+  overflow: hidden;
+  border-radius: var(--radius);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+}
+.carousel__track {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  transition: transform var(--slide-duration) var(--slide-ease);
+}
+.slide {
+  flex: 0 0 100%;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  overflow: hidden;
+}
+.slide__media {
+  display: grid;
+  place-items: center;
+  height: 12rem;
+  background: linear-gradient(135deg, rgba(110,168,255,0.18), rgba(179,136,255,0.18));
+}
+.slide__emoji { font-size: 4rem; }
+.slide__body { padding: 1rem 1.3rem 1.3rem; }
+.slide__title { margin: 0 0 0.3rem; font-size: 1.15rem; }
+.slide__desc { margin: 0 0 0.5rem; color: var(--muted); line-height: 1.5; font-size: 0.9rem; }
+.slide__price { font-weight: 700; color: var(--accent); }
+
+/* shimmer-sweep overlay: a translucent diagonal band sweeps across the active slide when it lands */
+.slide::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(
+    115deg,
+    transparent 0%,
+    transparent 35%,
+    rgba(255, 255, 255, 0.28) 50%,
+    transparent 65%,
+    transparent 100%
+  );
+  background-size: 280% 100%;
+  background-position: 180% 0;
+  opacity: 0;
+  mix-blend-mode: overlay;
+}
+
+#ssc-1:checked ~ .carousel__viewport .carousel__track { transform: translateX(0%); }
+#ssc-2:checked ~ .carousel__viewport .carousel__track { transform: translateX(-100%); }
+#ssc-3:checked ~ .carousel__viewport .carousel__track { transform: translateX(-200%); }
+
+/* the active slide's shimmer sweeps once when it lands */
+#ssc-1:checked ~ .carousel__viewport .slide:nth-child(1)::after,
+#ssc-2:checked ~ .carousel__viewport .slide:nth-child(2)::after,
+#ssc-3:checked ~ .carousel__viewport .slide:nth-child(3)::after {
+  animation: ssc-shimmer var(--shimmer-duration) var(--shimmer-ease);
+  animation-delay: var(--slide-duration);
+}
+
+@keyframes ssc-shimmer {
+  0%   { opacity: 0; background-position: 180% 0; }
+  20%  { opacity: 1; }
+  100% { opacity: 0; background-position: -80% 0; }
+}
+
+.carousel__nav { display: flex; gap: 0.5rem; justify-content: center; margin-top: 0.9rem; }
+.dot {
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.25);
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+.dot:hover, .dot:focus-visible { background: rgba(255, 255, 255, 0.45); transform: scale(1.2); outline: none; box-shadow: 0 0 0 3px rgba(110,168,255,0.5); }
+#ssc-1:checked ~ .carousel__nav .dot:nth-child(1),
+#ssc-2:checked ~ .carousel__nav .dot:nth-child(2),
+#ssc-3:checked ~ .carousel__nav .dot:nth-child(3) {
+  background: linear-gradient(135deg, var(--accent), var(--accent2));
+  transform: scale(1.25);
+}
+
+@media (max-width: 480px) {
+  .slide__media { height: 9rem; }
+  .slide__emoji { font-size: 3rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .carousel__track { transition: none; }
+  #ssc-1:checked ~ .carousel__viewport .slide:nth-child(1)::after,
+  #ssc-2:checked ~ .carousel__viewport .slide:nth-child(2)::after,
+  #ssc-3:checked ~ .carousel__viewport .slide:nth-child(3)::after { animation: none; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-shimmer-sweep-carousel** from issue #62178 — a Shimmer-Sweep Carousel component, following the submission pattern in the issue.

Closes #62178.

## Feature

A carousel whose track slides to the active slide (`transform: translateX` via `:checked ~` radios), then `@keyframes ssc-shimmer` sweeps a translucent diagonal highlight band across the active slide (`background-position` `180% → -80%` with an `opacity` fade-in/out), delayed until the slide has landed. Pure CSS via hidden radios; dots are labels.

## How it works

- Track slides via `transform: translateX`; `@keyframes ssc-shimmer` sweeps a translucent band via `background-position` + `opacity`. All via `transform`/`background-position`/`opacity`.

## Accessibility

- Carousel semantics (`aria-roledescription="carousel"` + `aria-label`), slides `role="group"`/`aria-roledescription="slide"`/`aria-label="N of M"`, `aria-live="polite"` viewport. Dots are focusable labels with `aria-label`s and `:focus-visible` rings. Full `prefers-reduced-motion` support.

## Submission structure

```
submissions/examples/ease-shimmer-sweep-carousel-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← glassmorphism carousel + track slide + shimmer-sweep
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally