### PR TITLE
feat: add ease-otp-input-sap

### DIFF
--- a/submissions/examples/ease-otp-input-sap/README.md
+++ b/submissions/examples/ease-otp-input-sap/README.md
@@ -1,0 +1,19 @@
+# ease-otp-input-sap
+
+An animated OTP/PIN entry field group — auto-advances between boxes, supports paste-to-fill, backspace-to-go-back, and success/error animation states.
+
+## Usage
+1. Include `style.css`.
+2. Add markup: a row of single-character `<input>` boxes inside `.otp-input-sap`.
+3. Attach the input/keydown/paste listeners from `demo.html`.
+
+## Customization
+- Number of inputs: add/remove `<input>` elements — JS logic works with any count.
+- `.filled`/`.error` classes: trigger success pop or error shake animation states.
+- Box size/border/focus ring colors.
+
+## Notes
+- Auto-advance on digit entry and auto-back on backspace are handled via array indexing over the input group, not hardcoded per-box.
+- Paste support splits clipboard text into individual digits and distributes them across boxes starting from index 0.
+- `inputmode="numeric"` brings up the numeric keyboard on mobile without restricting the underlying input type.
+- Respects `prefers-reduced-motion`: pop and shake animations are disabled entirely; focus/fill state still communicated via border color change.

--- a/submissions/examples/ease-otp-input-sap/demo.html
+++ b/submissions/examples/ease-otp-input-sap/demo.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-otp-input-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      height: 100vh;
+      margin: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #f4f4f5;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="otp-input-sap" id="otpGroup">
+    <input type="text" inputmode="numeric" maxlength="1" aria-label="Digit 1">
+    <input type="text" inputmode="numeric" maxlength="1" aria-label="Digit 2">
+    <input type="text" inputmode="numeric" maxlength="1" aria-label="Digit 3">
+    <input type="text" inputmode="numeric" maxlength="1" aria-label="Digit 4">
+  </div>
+
+  <script>
+    const group = document.getElementById('otpGroup');
+    const inputs = [...group.querySelectorAll('input')];
+
+    inputs.forEach((input, i) => {
+      input.addEventListener('input', () => {
+        input.value = input.value.replace(/[^0-9]/g, '');
+        if (input.value) {
+          input.classList.add('filled');
+          if (inputs[i + 1]) inputs[i + 1].focus();
+        } else {
+          input.classList.remove('filled');
+        }
+      });
+
+      input.addEventListener('keydown', (e) => {
+        if (e.key === 'Backspace' && !input.value && inputs[i - 1]) {
+          inputs[i - 1].focus();
+        }
+      });
+
+      input.addEventListener('paste', (e) => {
+        e.preventDefault();
+        const digits = (e.clipboardData.getData('text') || '').replace(/[^0-9]/g, '').split('');
+        digits.forEach((d, idx) => {
+          if (inputs[idx]) {
+            inputs[idx].value = d;
+            inputs[idx].classList.add('filled');
+          }
+        });
+        const next = inputs[Math.min(digits.length, inputs.length - 1)];
+        if (next) next.focus();
+      });
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-otp-input-sap/style.css
+++ b/submissions/examples/ease-otp-input-sap/style.css
@@ -1,0 +1,53 @@
+.otp-input-sap {
+  display: flex;
+  gap: 12px;
+  font-family: system-ui, sans-serif;
+}
+
+.otp-input-sap input {
+  width: 48px;
+  height: 56px;
+  text-align: center;
+  font-size: 22px;
+  font-weight: 700;
+  color: #111;
+  border: 2px solid #e2e8f0;
+  border-radius: 12px;
+  outline: none;
+  transition: border-color 0.25s ease, transform 0.2s ease, box-shadow 0.25s ease;
+}
+
+.otp-input-sap input:focus {
+  border-color: #2563eb;
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.15);
+  transform: translateY(-2px);
+}
+
+.otp-input-sap input.filled {
+  border-color: #22c55e;
+  animation: otp-pop-sap 0.25s ease;
+}
+
+.otp-input-sap input.error {
+  border-color: #ef4444;
+  animation: otp-shake-sap 0.4s ease;
+}
+
+@keyframes otp-pop-sap {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.12); }
+  100% { transform: scale(1); }
+}
+
+@keyframes otp-shake-sap {
+  0%, 100% { transform: translateX(0); }
+  25% { transform: translateX(-6px); }
+  75% { transform: translateX(6px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .otp-input-sap input {
+    transition: none;
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-otp-input-sap`, an animated multi-box OTP/PIN input with auto-advance, paste support, and success/error states.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-otp-input-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Auto-advance/auto-back logic indexes over the input array generically, so the component works with any number of boxes without code changes.
- Paste handler intercepts the default paste, strips non-digit characters, and distributes them across boxes starting at index 0.
- `prefers-reduced-motion` disables pop/shake animations entirely (`!important` override), keeping only border-color feedback.

## Feature Description

Adds a reusable animated OTP/PIN entry component with auto-advance and paste support.

Level: Advanced

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.