### PR TITLE
feat: add ease-password-strength-sap

### DIFF
--- a/submissions/examples/ease-password-strength-sap/README.md
+++ b/submissions/examples/ease-password-strength-sap/README.md
@@ -1,0 +1,18 @@
+# ease-password-strength-sap
+
+A password input with a live 4-segment strength meter that fills and color-shifts (red → orange → yellow → green) as the password improves.
+
+## Usage
+1. Include `style.css`.
+2. Add markup: password `<input>` + 4 `.meter-bar` segments + a label element.
+3. Attach the `input` listener from `demo.html`, which scores the password and toggles `data-level` on the wrapper.
+
+## Customization
+- `scorePassword()` (JS): scoring criteria — length, case mix, digits, symbols. Adjust thresholds as needed.
+- `data-level` colors: edit the 4 color rules keyed by `[data-level="1"]` through `[data-level="4"]`.
+- `labels` array: strength text shown per level.
+
+## Notes
+- Strength color/fill state is driven entirely by a `data-level` attribute on the wrapper, so CSS handles all visual states — JS only computes the numeric score.
+- Active bars scale up slightly (`scaleY(1.3)`) to visually emphasize progress beyond just the color change.
+- Respects `prefers-reduced-motion`: bar scale animation is disabled, color change alone communicates strength level.

--- a/submissions/examples/ease-password-strength-sap/demo.html
+++ b/submissions/examples/ease-password-strength-sap/demo.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-password-strength-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      height: 100vh;
+      margin: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #f4f4f5;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="pw-strength-sap" id="pwStrength" data-level="0">
+    <input type="password" id="pwInput" placeholder="Enter password" aria-describedby="pwLabel">
+    <div class="meter-track">
+      <div class="meter-bar"></div>
+      <div class="meter-bar"></div>
+      <div class="meter-bar"></div>
+      <div class="meter-bar"></div>
+    </div>
+    <div class="strength-label" id="pwLabel">Enter a password</div>
+  </div>
+
+  <script>
+    const wrap = document.getElementById('pwStrength');
+    const input = document.getElementById('pwInput');
+    const bars = [...wrap.querySelectorAll('.meter-bar')];
+    const label = document.getElementById('pwLabel');
+    const labels = ['Enter a password', 'Weak', 'Fair', 'Good', 'Strong'];
+
+    function scorePassword(pw) {
+      let score = 0;
+      if (pw.length >= 8) score++;
+      if (/[A-Z]/.test(pw) && /[a-z]/.test(pw)) score++;
+      if (/[0-9]/.test(pw)) score++;
+      if (/[^A-Za-z0-9]/.test(pw)) score++;
+      return pw.length === 0 ? 0 : Math.max(1, score);
+    }
+
+    input.addEventListener('input', () => {
+      const level = scorePassword(input.value);
+      wrap.dataset.level = level;
+      bars.forEach((bar, i) => bar.classList.toggle('active', i < level));
+      label.textContent = labels[level];
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-password-strength-sap/style.css
+++ b/submissions/examples/ease-password-strength-sap/style.css
@@ -1,0 +1,62 @@
+.pw-strength-sap {
+  width: 300px;
+  font-family: system-ui, sans-serif;
+}
+
+.pw-strength-sap input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 12px 14px;
+  font-size: 14px;
+  border: 2px solid #e2e8f0;
+  border-radius: 10px;
+  outline: none;
+  transition: border-color 0.25s ease;
+}
+
+.pw-strength-sap input:focus {
+  border-color: #2563eb;
+}
+
+.pw-strength-sap .meter-track {
+  display: flex;
+  gap: 6px;
+  margin-top: 10px;
+}
+
+.pw-strength-sap .meter-bar {
+  flex: 1;
+  height: 6px;
+  border-radius: 4px;
+  background: #e2e8f0;
+  transition: background 0.35s ease, transform 0.35s ease;
+  transform: scaleY(1);
+  transform-origin: bottom;
+}
+
+.pw-strength-sap .meter-bar.active {
+  transform: scaleY(1.3);
+}
+
+.pw-strength-sap[data-level="1"] .meter-bar.active { background: #ef4444; }
+.pw-strength-sap[data-level="2"] .meter-bar.active { background: #f59e0b; }
+.pw-strength-sap[data-level="3"] .meter-bar.active { background: #eab308; }
+.pw-strength-sap[data-level="4"] .meter-bar.active { background: #22c55e; }
+
+.pw-strength-sap .strength-label {
+  margin-top: 8px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #64748b;
+  transition: color 0.25s ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pw-strength-sap .meter-bar,
+  .pw-strength-sap input {
+    transition: none;
+  }
+  .pw-strength-sap .meter-bar.active {
+    transform: scaleY(1);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-password-strength-sap`, a password input with an animated 4-segment strength meter.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-password-strength-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- All visual strength states are driven by a single `data-level` attribute on the wrapper — JS only computes the score, CSS handles color/fill per level via attribute selectors.
- Active bars get a subtle `scaleY` bump on top of the color change, reinforcing progress visually.
- `prefers-reduced-motion` disables the scale animation, relying on color alone.

## Feature Description

Adds a reusable animated password strength meter for signup/account forms.

Level: Intermediate

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.