### PR TITLE
feat: add ease-bounce-pulse-carousel component (#62186)

### DIFF
--- a/submissions/examples/ease-bounce-pulse-carousel-sbh/README.md
+++ b/submissions/examples/ease-bounce-pulse-carousel-sbh/README.md
@@ -1,0 +1,51 @@
+# ease-bounce-pulse-carousel
+
+A carousel whose track bounces to the active slide (overshoot easing), and whose active slide bounces in (`scale` + `opacity`) then pulses a gentle scale breathing while active. Pure CSS — navigation is driven by hidden radio inputs, so no JavaScript is required for the animation.
+
+## What does this do?
+
+Adds a **bounce-pulse-carousel**: a glassmorphism carousel. When you select a slide (via dot navigation), the track translates to the active slide using an overshoot easing (`cubic-bezier(0.34, 1.56, 0.64, 1)`) so it springs past rest and settles; the active slide bounces in (`@keyframes bpc-bounce`: `scale(0.9 → 1)` + `opacity 0.4 → 1`) and then pulses a gentle scale (`@keyframes bpc-pulse`: `scale(1 → 1.015 → 1)`) while active.
+
+## How is it used?
+
+1. Place N hidden `<input type="radio" class="slide-toggle">` (sharing one `name`) before the viewport and nav.
+2. Each `.dot` is a `<label for="...">` pointing at its radio. The CSS `:checked ~` rules translate the track and apply the bounce/pulse to the active slide.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<input type="radio" name="bpc" id="bpc-1" class="slide-toggle" checked aria-hidden="true" />
+<input type="radio" name="bpc" id="bpc-2" class="slide-toggle" aria-hidden="true" />
+<input type="radio" name="bpc" id="bpc-3" class="slide-toggle" aria-hidden="true" />
+
+<div class="carousel__viewport" aria-live="polite">
+  <ul class="carousel__track">
+    <li class="slide" role="group" aria-roledescription="slide" aria-label="1 of 3">…</li>
+    <li class="slide" role="group" aria-roledescription="slide" aria-label="2 of 3">…</li>
+    <li class="slide" role="group" aria-roledescription="slide" aria-label="3 of 3">…</li>
+  </ul>
+</div>
+
+<div class="carousel__nav">
+  <label for="bpc-1" class="dot" tabindex="0" aria-label="Go to slide 1"></label>
+  <label for="bpc-2" class="dot" tabindex="0" aria-label="Go to slide 2"></label>
+  <label for="bpc-3" class="dot" tabindex="0" aria-label="Go to slide 3"></label>
+</div>
+```
+
+## Why is this useful?
+
+- **Animation-first** — the signature motion is the bounce + pulse: the track translates with an overshoot easing, then the active slide bounces in (`@keyframes bpc-bounce`: `transform: scale()` + `opacity`) and pulses (`@keyframes bpc-pulse`: `transform: scale()`), delayed until the slide has landed. All via `transform`/`opacity`.
+- **Glassmorphism aesthetic** — the viewport is a frosted panel via `backdrop-filter: blur()`; the pulse is a subtle scale breathing.
+- **Accessible** — carousel semantics (`aria-roledescription="carousel"` + `aria-label`), slides with `role="group"`/`aria-roledescription="slide"`/`aria-label="N of M"`, `aria-live="polite"` viewport. Dots are focusable labels with `aria-label`s and `:focus-visible` rings. Full `prefers-reduced-motion` support (track snaps; no bounce/pulse).
+- **Reusable** — configurable via CSS custom properties (`--slide-duration`, `--bounce-ease`, `--pulse-duration`, `--glass-blur`).
+
+## Files
+
+- `demo.html` — self-contained demo (open directly in a browser; no server, CDNs, or frameworks). Pure CSS navigation and animation, no JS.
+- `style.css` — glassmorphism carousel, track bounce + slide bounce/pulse via radio `:checked ~`, dot navigation with active state, focus-visible states, reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-bounce-pulse-carousel-sbh/demo.html
+++ b/submissions/examples/ease-bounce-pulse-carousel-sbh/demo.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-bounce-pulse-carousel — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-bounce-pulse-carousel</h1>
+      <p>A carousel whose active slide bounces in, then pulses softly while active.</p>
+    </header>
+
+    <section class="carousel" aria-roledescription="carousel" aria-label="Featured products">
+      <input type="radio" name="bpc" id="bpc-1" class="slide-toggle" checked aria-hidden="true" />
+      <input type="radio" name="bpc" id="bpc-2" class="slide-toggle" aria-hidden="true" />
+      <input type="radio" name="bpc" id="bpc-3" class="slide-toggle" aria-hidden="true" />
+
+      <div class="carousel__viewport" aria-live="polite">
+        <ul class="carousel__track">
+          <li class="slide" role="group" aria-roledescription="slide" aria-label="1 of 3">
+            <div class="slide__media"><span class="slide__emoji" aria-hidden="true">💡</span></div>
+            <div class="slide__body">
+              <h2 class="slide__title">Aurora Lamp</h2>
+              <p class="slide__desc">Tunable ambient lighting that adapts to your space.</p>
+              <span class="slide__price">$89</span>
+            </div>
+          </li>
+          <li class="slide" role="group" aria-roledescription="slide" aria-label="2 of 3">
+            <div class="slide__media"><span class="slide__emoji" aria-hidden="true">🎧</span></div>
+            <div class="slide__body">
+              <h2 class="slide__title">Pulse Headphones</h2>
+              <p class="slide__desc">Active noise cancellation with 30-hour battery.</p>
+              <span class="slide__price">$149</span>
+            </div>
+          </li>
+          <li class="slide" role="group" aria-roledescription="slide" aria-label="3 of 3">
+            <div class="slide__media"><span class="slide__emoji" aria-hidden="true">⌚</span></div>
+            <div class="slide__body">
+              <h2 class="slide__title">Tempo Watch</h2>
+              <p class="slide__desc">Health tracking with a 7-day battery life.</p>
+              <span class="slide__price">$199</span>
+            </div>
+          </li>
+        </ul>
+      </div>
+
+      <div class="carousel__nav">
+        <label for="bpc-1" class="dot" tabindex="0" aria-label="Go to slide 1"></label>
+        <label for="bpc-2" class="dot" tabindex="0" aria-label="Go to slide 2"></label>
+        <label for="bpc-3" class="dot" tabindex="0" aria-label="Go to slide 3"></label>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-bounce-pulse-carousel-sbh/style.css
+++ b/submissions/examples/ease-bounce-pulse-carousel-sbh/style.css
@@ -1,0 +1,128 @@
+:root {
+  --slide-duration: 0.55s;
+  --bounce-ease: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --pulse-duration: 2.4s;
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --glass-bg: rgba(255, 255, 255, 0.07);
+  --glass-border: rgba(255, 255, 255, 0.14);
+  --glass-blur: 14px;
+  --radius: 1.2rem;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 20%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+}
+
+.page__intro { text-align: center; max-width: 40rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+
+.slide-toggle { position: absolute; opacity: 0; pointer-events: none; }
+
+.carousel { width: min(34rem, 100%); }
+.carousel__viewport {
+  overflow: hidden;
+  border-radius: var(--radius);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+}
+.carousel__track {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  /* bounce-in on the track: overshoot ease translates it past rest and settles */
+  transition: transform var(--slide-duration) var(--bounce-ease);
+}
+.slide {
+  flex: 0 0 100%;
+  display: flex;
+  flex-direction: column;
+  /* the active slide pulses scale via an animation applied below */
+}
+.slide__media {
+  display: grid;
+  place-items: center;
+  height: 12rem;
+  background: linear-gradient(135deg, rgba(110,168,255,0.18), rgba(179,136,255,0.18));
+}
+.slide__emoji { font-size: 4rem; }
+.slide__body { padding: 1rem 1.3rem 1.3rem; }
+.slide__title { margin: 0 0 0.3rem; font-size: 1.15rem; }
+.slide__desc { margin: 0 0 0.5rem; color: var(--muted); line-height: 1.5; font-size: 0.9rem; }
+.slide__price { font-weight: 700; color: var(--accent); }
+
+#bpc-1:checked ~ .carousel__viewport .carousel__track { transform: translateX(0%); }
+#bpc-2:checked ~ .carousel__viewport .carousel__track { transform: translateX(-100%); }
+#bpc-3:checked ~ .carousel__viewport .carousel__track { transform: translateX(-200%); }
+
+/* the active slide bounces in then pulses softly */
+#bpc-1:checked ~ .carousel__viewport .slide:nth-child(1),
+#bpc-2:checked ~ .carousel__viewport .slide:nth-child(2),
+#bpc-3:checked ~ .carousel__viewport .slide:nth-child(3) {
+  animation: bpc-bounce var(--slide-duration) var(--bounce-ease),
+             bpc-pulse var(--pulse-duration) ease-in-out infinite;
+  animation-delay: 0s, var(--slide-duration);
+}
+
+@keyframes bpc-bounce {
+  0%   { transform: scale(0.9); opacity: 0.4; }
+  100% { transform: scale(1); opacity: 1; }
+}
+@keyframes bpc-pulse {
+  0%, 100% { transform: scale(1); }
+  50%      { transform: scale(1.015); }
+}
+
+.carousel__nav { display: flex; gap: 0.5rem; justify-content: center; margin-top: 0.9rem; }
+.dot {
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.25);
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+.dot:hover, .dot:focus-visible { background: rgba(255, 255, 255, 0.45); transform: scale(1.2); outline: none; box-shadow: 0 0 0 3px rgba(110,168,255,0.5); }
+#bpc-1:checked ~ .carousel__nav .dot:nth-child(1),
+#bpc-2:checked ~ .carousel__nav .dot:nth-child(2),
+#bpc-3:checked ~ .carousel__nav .dot:nth-child(3) {
+  background: linear-gradient(135deg, var(--accent), var(--accent2));
+  transform: scale(1.25);
+}
+
+@media (max-width: 480px) {
+  .slide__media { height: 9rem; }
+  .slide__emoji { font-size: 3rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .carousel__track { transition: none; }
+  #bpc-1:checked ~ .carousel__viewport .slide:nth-child(1),
+  #bpc-2:checked ~ .carousel__viewport .slide:nth-child(2),
+  #bpc-3:checked ~ .carousel__viewport .slide:nth-child(3) { animation: none; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-bounce-pulse-carousel** from issue #62186 — a Bounce-Pulse Carousel component, following the submission pattern in the issue.

Closes #62186.

## Feature

A carousel whose track bounces to the active slide (overshoot easing `cubic-bezier(0.34, 1.56, 0.64, 1)` on `translateX`) so it springs past rest and settles, and whose active slide bounces in (`@keyframes bpc-bounce`: `scale(0.9 → 1)` + `opacity 0.4 → 1`) then pulses a gentle scale (`@keyframes bpc-pulse`: `scale(1 → 1.015 → 1)`) while active, delayed until the slide has landed. Pure CSS via hidden radios; dots are labels.

## How it works

- Track translates with an overshoot easing; active slide bounces in (`transform: scale()` + `opacity`) then pulses (`transform: scale()`). All via `transform`/`opacity`.

## Accessibility

- Carousel semantics (`aria-roledescription="carousel"` + `aria-label`), slides `role="group"`/`aria-roledescription="slide"`/`aria-label="N of M"`, `aria-live="polite"` viewport. Dots are focusable labels with `aria-label`s and `:focus-visible` rings. Full `prefers-reduced-motion` support.

## Submission structure

```
submissions/examples/ease-bounce-pulse-carousel-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← glassmorphism carousel + track bounce + slide bounce/pulse
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally