### PR TITLE
feat: add ease-float-drift-feature-grid component (#62146)

### DIFF
--- a/submissions/examples/ease-float-drift-feature-grid-sbh/README.md
+++ b/submissions/examples/ease-float-drift-feature-grid-sbh/README.md
@@ -1,0 +1,42 @@
+# ease-float-drift-feature-grid
+
+A SaaS showcase feature grid whose cards float and drift gently while idle (a staggered vertical + rotational bob), settling flat and lifting on hover or focus. Pure CSS — no JavaScript is required for the animation.
+
+## What does this do?
+
+Adds a **float-drift feature grid**: glassmorphism feature cards. While idle, each card drifts on a loop (`@keyframes fdg-drift`: `translateY` + a slight `rotate`), staggered by its index (via negative `animation-delay`) so they bob out of sync. On hover or keyboard focus, the drift pauses and the card settles flat and lifts (`translateY(-6px) scale(1.03)`) with an accent ring.
+
+## How is it used?
+
+1. Build a `.grid` of `.card` articles (with `tabindex="0"` and an `aria-label`).
+2. The CSS applies the drift loop to every card and staggers them via `nth-child` delays.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<section class="grid" aria-label="Features">
+  <article class="card" tabindex="0" aria-label="Feature: Scalable infrastructure">
+    <span class="card__emoji" aria-hidden="true">🚀</span>
+    <h2 class="card__title">Scalable Infrastructure</h2>
+    <p class="card__desc">Auto-scales to millions of requests with zero downtime deploys.</p>
+  </article>
+  …
+</section>
+```
+
+## Why is this useful?
+
+- **Animation-first** — the signature motion is the float-drift: `@keyframes fdg-drift` drives `transform: translateY()` + `rotate()` on a loop, staggered by `nth-child` negative `animation-delay` so cards bob out of sync. On hover/focus, `animation-play-state: paused` halts the drift and a `transform`/`box-shadow` transition lifts and settles the card. All via `transform`/`box-shadow`.
+- **Glassmorphism aesthetic** — cards are frosted panels via `backdrop-filter: blur()`; the hover adds an accent-tinted ring.
+- **Accessible** — cards are focusable (`tabindex="0"`) with descriptive `aria-label`s; `:focus-visible` triggers the settle/lift and shows a ring; the emoji is `aria-hidden`. Full `prefers-reduced-motion` support (no drift; hover/focus does not transform).
+- **Reusable** — configurable via CSS custom properties (`--drift-duration`, `--drift-ease`, `--settle-duration`, `--settle-ease`, `--glass-blur`).
+
+## Files
+
+- `demo.html` — self-contained demo (open directly in a browser; no server, CDNs, or frameworks). Pure CSS animation, no JS. SaaS-themed feature content.
+- `style.css` — glassmorphism cards, staggered float-drift loop, hover/focus settle + lift, focus-visible states, responsive grid, reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-float-drift-feature-grid-sbh/demo.html
+++ b/submissions/examples/ease-float-drift-feature-grid-sbh/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-float-drift-feature-grid — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-float-drift-feature-grid</h1>
+      <p>Feature cards that float and drift gently while idle, settling on hover.</p>
+    </header>
+
+    <section class="grid" aria-label="Features">
+      <article class="card" tabindex="0" aria-label="Feature: Scalable infrastructure">
+        <span class="card__emoji" aria-hidden="true">🚀</span>
+        <h2 class="card__title">Scalable Infrastructure</h2>
+        <p class="card__desc">Auto-scales to millions of requests with zero downtime deploys.</p>
+      </article>
+
+      <article class="card" tabindex="0" aria-label="Feature: Unified API">
+        <span class="card__emoji" aria-hidden="true">🔌</span>
+        <h2 class="card__title">Unified API</h2>
+        <p class="card__desc">One REST + GraphQL endpoint for every integration you need.</p>
+      </article>
+
+      <article class="card" tabindex="0" aria-label="Feature: Compliance ready">
+        <span class="card__emoji" aria-hidden="true">🛡️</span>
+        <h2 class="card__title">Compliance Ready</h2>
+        <p class="card__desc">GDPR, HIPAA, and SOC 2 controls baked in for regulated teams.</p>
+      </article>
+
+      <article class="card" tabindex="0" aria-label="Feature: Smart insights">
+        <span class="card__emoji" aria-hidden="true">🧠</span>
+        <h2 class="card__title">Smart Insights</h2>
+        <p class="card__desc">ML-driven anomaly detection surfaces issues before users do.</p>
+      </article>
+    </section>
+
+    <p class="hint">Cards drift gently while idle; hover or focus to settle them.</p>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-float-drift-feature-grid-sbh/style.css
+++ b/submissions/examples/ease-float-drift-feature-grid-sbh/style.css
@@ -1,0 +1,103 @@
+:root {
+  --drift-duration: 6s;
+  --drift-ease: ease-in-out;
+  --settle-duration: 0.5s;
+  --settle-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --glass-bg: rgba(255, 255, 255, 0.07);
+  --glass-border: rgba(255, 255, 255, 0.14);
+  --glass-blur: 12px;
+  --radius: 1rem;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.6rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 20%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+}
+
+.page__intro { text-align: center; max-width: 40rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+.hint { font-size: 0.82rem; color: var(--muted); }
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
+  gap: 1.4rem;
+  width: min(48rem, 100%);
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 0.5rem;
+  padding: 1.6rem 1.2rem;
+  border-radius: var(--radius);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  box-shadow: 0 18px 40px -24px rgba(0, 0, 0, 0.7);
+  cursor: pointer;
+  /* float-drift: each card drifts on a loop, staggered by index via nth-child delays */
+  animation: fdg-drift var(--drift-duration) var(--drift-ease) infinite;
+  transition: transform var(--settle-duration) var(--settle-ease),
+              box-shadow var(--settle-duration) var(--settle-ease),
+              border-color var(--settle-duration) var(--settle-ease);
+}
+.card:nth-child(1) { animation-delay: 0s; }
+.card:nth-child(2) { animation-delay: -1.5s; }
+.card:nth-child(3) { animation-delay: -3s; }
+.card:nth-child(4) { animation-delay: -4.5s; }
+
+@keyframes fdg-drift {
+  0%, 100% { transform: translateY(0) rotate(0deg); }
+  25%      { transform: translateY(-8px) rotate(-0.6deg); }
+  50%      { transform: translateY(0) rotate(0deg); }
+  75%      { transform: translateY(6px) rotate(0.6deg); }
+}
+
+/* hover/focus settles the drift and lifts the card */
+.card:hover, .card:focus-visible {
+  outline: none;
+  animation-play-state: paused;
+  transform: translateY(-6px) scale(1.03);
+  border-color: rgba(110, 168, 255, 0.5);
+  box-shadow: 0 26px 50px -22px rgba(0, 0, 0, 0.75), 0 0 0 3px rgba(110, 168, 255, 0.35);
+}
+
+.card__emoji { font-size: 2.6rem; line-height: 1; }
+.card__title { margin: 0; font-size: 1.05rem; }
+.card__desc { margin: 0; font-size: 0.88rem; line-height: 1.5; color: var(--muted); }
+
+@media (max-width: 480px) {
+  .card__emoji { font-size: 2.2rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card { animation: none; }
+  .card:hover, .card:focus-visible { transform: none; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-float-drift-feature-grid** from issue #62146 — a Float-Drift Feature Grid component, following the submission pattern in the issue.

Closes #62146.

## Feature

A SaaS showcase feature grid whose cards float and drift gently while idle (`@keyframes fdg-drift`: `translateY` + a slight `rotate` on a loop), staggered by `nth-child` negative `animation-delay` so cards bob out of sync. On hover or keyboard focus, `animation-play-state: paused` halts the drift and the card settles flat and lifts (`translateY(-6px) scale(1.03)`) with an accent ring. Pure CSS, no JS.

## How it works

- `@keyframes fdg-drift` drives `transform: translateY()` + `rotate()` on a loop, staggered by `nth-child`; hover/focus pauses the drift and transitions `transform`/`box-shadow` to lift. All via `transform`/`box-shadow`.

## Accessibility

- Cards are focusable (`tabindex="0"`) with descriptive `aria-label`s; `:focus-visible` triggers the settle/lift and shows a ring; emoji `aria-hidden`. Full `prefers-reduced-motion` support (no drift; hover/focus does not transform).

## Submission structure

```
submissions/examples/ease-float-drift-feature-grid-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← glassmorphism cards + staggered float-drift + settle/lift
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally