### PR TITLE
feat: add ease-ripple-wave-hero-section component (#62113)

### DIFF
--- a/submissions/examples/ease-ripple-wave-hero-section-sbh/README.md
+++ b/submissions/examples/ease-ripple-wave-hero-section-sbh/README.md
@@ -1,0 +1,50 @@
+# ease-ripple-wave-hero-section
+
+A SaaS showcase hero section with concentric ripple-wave rings expanding outward from the center on a loop, and content (eyebrow, title, subtitle, actions) that fades and lifts into view sequentially on load. Pure CSS — no JavaScript is required for the animation.
+
+## What does this do?
+
+Adds a **ripple-wave hero section**: a SaaS landing hero. Behind the content, three concentric ripple rings (`@keyframes rwh-ripple`: `scale(0.4 → 8)` + `opacity 0 → 0.8 → 0`, staggered by `animation-delay`) expand outward from the center on an infinite loop, evoking radiating waves. The content fades and lifts in sequentially (`@keyframes rwh-in`: `opacity 0 → 1` + `translateY`, staggered by index). Includes gradient buttons and a frosted ghost button.
+
+## How is it used?
+
+1. Build a `.hero` section with a `.hero__bg` backdrop, three `.hero__ripple` spans (the rings), and a `.hero__content` block.
+2. The CSS animates the rings on a loop and staggers the content fade-in.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<section class="hero" aria-label="Product hero">
+  <span class="hero__bg" aria-hidden="true"></span>
+  <span class="hero__ripple hero__ripple--1" aria-hidden="true"></span>
+  <span class="hero__ripple hero__ripple--2" aria-hidden="true"></span>
+  <span class="hero__ripple hero__ripple--3" aria-hidden="true"></span>
+
+  <div class="hero__content">
+    <span class="hero__eyebrow">Now in general availability</span>
+    <h1 class="hero__title">Ship reliable software, faster.</h1>
+    <p class="hero__subtitle">…</p>
+    <div class="hero__actions">
+      <a class="hero__btn hero__btn--primary" href="#" tabindex="0">Start free trial</a>
+      <a class="hero__btn hero__btn--ghost" href="#" tabindex="0">Book a demo</a>
+    </div>
+  </div>
+</section>
+```
+
+## Why is this useful?
+
+- **Animation-first** — the signature motion is the ripple-wave: `@keyframes rwh-ripple` drives `transform: scale()` (`0.4 → 8`) and `opacity` (`0 → 0.8 → 0`) on three rings staggered by `animation-delay` so waves radiate continuously. Content fades and lifts in via `@keyframes rwh-in` (`opacity` + `translateY`), staggered by index. All via `transform`/`opacity`.
+- **Glassmorphism aesthetic** — the ghost button is a frosted pill via `backdrop-filter: blur()`; the backdrop uses layered radial gradients; the title uses an accent gradient `background-clip: text`.
+- **Accessible** — the hero is a labelled `<section>` (`aria-label`); decorative rings and backdrop are `aria-hidden="true"`; buttons are real links with `:focus-visible` rings. Full `prefers-reduced-motion` support (no ripples; content appears instantly).
+- **Reusable** — configurable via CSS custom properties (`--ripple-duration`, `--ripple-ease`, `--content-duration`, `--content-ease`, `--stagger`, `--glass-blur`).
+
+## Files
+
+- `demo.html` — self-contained demo (open directly in a browser; no server, CDNs, or frameworks). Pure CSS animation, no JS. SaaS-themed hero content.
+- `style.css` — hero with gradient backdrop, concentric ripple-wave rings, staggered content fade-in, gradient + frosted buttons, focus-visible states, reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-ripple-wave-hero-section-sbh/demo.html
+++ b/submissions/examples/ease-ripple-wave-hero-section-sbh/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-ripple-wave-hero-section — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <section class="hero" aria-label="Product hero">
+      <span class="hero__bg" aria-hidden="true"></span>
+      <span class="hero__ripple hero__ripple--1" aria-hidden="true"></span>
+      <span class="hero__ripple hero__ripple--2" aria-hidden="true"></span>
+      <span class="hero__ripple hero__ripple--3" aria-hidden="true"></span>
+
+      <div class="hero__content">
+        <span class="hero__eyebrow">Now in general availability</span>
+        <h1 class="hero__title">Ship reliable software, faster.</h1>
+        <p class="hero__subtitle">Observability, incident response, and automation in one platform — built for teams that ship daily.</p>
+        <div class="hero__actions">
+          <a class="hero__btn hero__btn--primary" href="#" tabindex="0">Start free trial</a>
+          <a class="hero__btn hero__btn--ghost" href="#" tabindex="0">Book a demo</a>
+        </div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-ripple-wave-hero-section-sbh/style.css
+++ b/submissions/examples/ease-ripple-wave-hero-section-sbh/style.css
@@ -1,0 +1,164 @@
+:root {
+  --ripple-duration: 7s;
+  --ripple-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --content-duration: 0.7s;
+  --content-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --stagger: 0.12s;
+  --fg: #e8edf5;
+  --muted: #b6c0d4;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --glass-bg: rgba(255, 255, 255, 0.07);
+  --glass-border: rgba(255, 255, 255, 0.14);
+  --glass-blur: 6px;
+  --radius: 1rem;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 20%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+}
+
+.hero {
+  position: relative;
+  width: min(60rem, 100%);
+  min-height: 24rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 4rem 2rem;
+  border-radius: 1.6rem;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+/* base gradient backdrop */
+.hero__bg {
+  position: absolute;
+  inset: 0;
+  z-index: -3;
+  background: linear-gradient(135deg, #14224a 0%, #1b1140 100%);
+}
+.hero__bg::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 30% 30%, rgba(110,168,255,0.35), transparent 55%),
+              radial-gradient(circle at 75% 70%, rgba(179,136,255,0.32), transparent 55%);
+}
+
+/* concentric ripple rings expand outward from the center on a loop */
+.hero__ripple {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 6rem;
+  height: 6rem;
+  margin: -3rem 0 0 -3rem;
+  border-radius: 999px;
+  border: 2px solid rgba(110, 168, 255, 0.5);
+  opacity: 0;
+  z-index: -2;
+  animation: rwh-ripple var(--ripple-duration) var(--ripple-ease) infinite;
+}
+.hero__ripple--1 { animation-delay: 0s; }
+.hero__ripple--2 { animation-delay: calc(var(--ripple-duration) / 3); border-color: rgba(179, 136, 255, 0.5); }
+.hero__ripple--3 { animation-delay: calc(var(--ripple-duration) * 2 / 3); border-color: rgba(255, 255, 255, 0.25); }
+
+@keyframes rwh-ripple {
+  0%   { transform: scale(0.4); opacity: 0; }
+  15%  { opacity: 0.8; }
+  100% { transform: scale(8); opacity: 0; }
+}
+
+.hero__content { position: relative; z-index: 1; display: flex; flex-direction: column; align-items: center; gap: 0.8rem; max-width: 40rem; }
+.hero__eyebrow {
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+  padding: 0.3rem 0.8rem;
+  border-radius: 999px;
+  background: rgba(110, 168, 255, 0.12);
+  border: 1px solid rgba(110, 168, 255, 0.3);
+  /* fade-in stagger */
+  opacity: 0;
+  transform: translateY(12px);
+  animation: rwh-in var(--content-duration) var(--content-ease) forwards;
+  animation-delay: calc(var(--stagger) * 0);
+}
+.hero__title {
+  margin: 0;
+  font-size: clamp(1.8rem, 5vw, 3rem);
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, #ffffff, #cdd9ff 60%, var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  opacity: 0;
+  transform: translateY(14px);
+  animation: rwh-in var(--content-duration) var(--content-ease) forwards;
+  animation-delay: calc(var(--stagger) * 1);
+}
+.hero__subtitle {
+  margin: 0;
+  font-size: clamp(0.95rem, 2.5vw, 1.1rem);
+  line-height: 1.6;
+  color: var(--muted);
+  max-width: 34rem;
+  opacity: 0;
+  transform: translateY(14px);
+  animation: rwh-in var(--content-duration) var(--content-ease) forwards;
+  animation-delay: calc(var(--stagger) * 2);
+}
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+  justify-content: center;
+  margin-top: 0.4rem;
+  opacity: 0;
+  transform: translateY(14px);
+  animation: rwh-in var(--content-duration) var(--content-ease) forwards;
+  animation-delay: calc(var(--stagger) * 3);
+}
+
+@keyframes rwh-in {
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.hero__btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.75rem 1.4rem;
+  border-radius: 0.7rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  text-decoration: none;
+  cursor: pointer;
+  transition: filter 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+.hero__btn--primary { color: #06231a; background: linear-gradient(135deg, var(--accent), var(--accent2)); }
+.hero__btn--primary:hover, .hero__btn--primary:focus-visible { filter: brightness(1.08); transform: translateY(-2px); outline: none; box-shadow: 0 0 0 3px rgba(110,168,255,0.5); }
+.hero__btn--ghost { color: var(--fg); background: var(--glass-bg); border: 1px solid var(--glass-border); backdrop-filter: blur(var(--glass-blur)); -webkit-backdrop-filter: blur(var(--glass-blur)); }
+.hero__btn--ghost:hover, .hero__btn--ghost:focus-visible { background: rgba(255,255,255,0.14); transform: translateY(-2px); outline: none; box-shadow: 0 0 0 3px rgba(110,168,255,0.5); }
+
+@media (max-width: 480px) {
+  .hero { padding: 3rem 1.2rem; min-height: 20rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero__ripple { animation: none; opacity: 0; }
+  .hero__eyebrow, .hero__title, .hero__subtitle, .hero__actions { animation: none; opacity: 1; transform: none; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-ripple-wave-hero-section** from issue #62113 — a Ripple-Wave Hero Section component, following the submission pattern in the issue.

Closes #62113.

## Feature

A SaaS showcase hero section with concentric ripple-wave rings expanding outward from the center on a loop (`@keyframes rwh-ripple`: `scale(0.4 → 8)` + `opacity 0 → 0.8 → 0`, staggered by `animation-delay` across three rings) and content (eyebrow, title, subtitle, actions) that fades and lifts into view sequentially on load (`@keyframes rwh-in`: `opacity 0 → 1` + `translateY`, staggered by index). Pure CSS, no JS.

## How it works

- `@keyframes rwh-ripple` drives `transform: scale()` + `opacity` on three staggered rings; `@keyframes rwh-in` drives `opacity` + `translateY` for staggered content. All via `transform`/`opacity`.

## Accessibility

- Hero is a labelled `<section>` (`aria-label`); decorative rings and backdrop are `aria-hidden="true"`; buttons are real links with `:focus-visible` rings; ghost button uses `backdrop-filter`. Full `prefers-reduced-motion` support (no ripples; content appears instantly).

## Submission structure

```
submissions/examples/ease-ripple-wave-hero-section-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← hero + gradient backdrop + ripple rings + staggered content fade-in
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally