### PR TITLE
feat: add ease-shimmer-sweep-pricing-table component (#62117)

### DIFF
--- a/submissions/examples/ease-shimmer-sweep-pricing-table-sbh/README.md
+++ b/submissions/examples/ease-shimmer-sweep-pricing-table-sbh/README.md
@@ -1,0 +1,50 @@
+# ease-shimmer-sweep-pricing-table
+
+A SaaS pricing table whose selected plan gets a sweeping shimmer highlight band that travels diagonally across the card on a loop, plus an accent glow. Pure CSS — selection is driven by hidden radio inputs, so no JavaScript is required for the animation.
+
+## What does this do?
+
+Adds a **shimmer-sweep pricing table**: glassmorphism pricing cards. When a plan is selected (via click or keyboard focus on its `<label>`), a translucent diagonal highlight band sweeps across the card (`@keyframes ssp-shimmer`: `background-position` `180% → -80%` with an `opacity` fade-in/out) on an infinite loop, plus an accent-tinted background gradient and a colored `box-shadow` glow. Includes a "Recommended" badge on the Pro plan.
+
+## How is it used?
+
+1. Place N hidden `<input type="radio" class="plan-toggle">` (sharing one `name`) before the plan labels.
+2. Each `.plan` is a `<label for="...">` pointing at its radio, and contains a `.plan__shimmer` span (the band). The CSS `:checked ~ .plan:nth-of-type(N)` rules glow the selected plan and animate its shimmer band.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<input type="radio" name="ssp" id="ssp-1" class="plan-toggle" checked aria-hidden="true" />
+<input type="radio" name="ssp" id="ssp-2" class="plan-toggle" aria-hidden="true" />
+<input type="radio" name="ssp" id="ssp-3" class="plan-toggle" aria-hidden="true" />
+
+<label for="ssp-1" class="plan" tabindex="0" aria-label="Starter plan, $9 per month">
+  <span class="plan__shimmer" aria-hidden="true"></span>
+  <span class="plan__name">Starter</span>
+  <span class="plan__price"><span class="plan__cur">$</span>9<span class="plan__per">/mo</span></span>
+  <ul class="plan__features">…</ul>
+</label>
+<label for="ssp-2" class="plan" tabindex="0" aria-label="Pro plan, $29 per month, recommended">
+  <span class="plan__shimmer" aria-hidden="true"></span>
+  <span class="plan__badge">Recommended</span>
+  …
+</label>
+<label for="ssp-3" class="plan" tabindex="0" aria-label="Enterprise plan, custom pricing">…</label>
+```
+
+## Why is this useful?
+
+- **Animation-first** — the signature motion is the shimmer-sweep: `@keyframes ssp-shimmer` drives `background-position` (`180% → -80%`) of a translucent diagonal highlight band with an `opacity` fade-in/out, on the selected plan. All via `background-position`/`opacity`/`box-shadow`.
+- **Glassmorphism aesthetic** — plans are frosted panels via `backdrop-filter: blur()`; the selected plan's glow is an accent halo; the shimmer band is a translucent white sweep.
+- **Accessible** — plans are focusable labels (`tabindex="0"`) with descriptive `aria-label`s (including price and the "recommended" note); the shimmer band is `aria-hidden="true"`; `:focus-visible` shows a ring; selection works via click or keyboard. Full `prefers-reduced-motion` support (no shimmer; no glow transition).
+- **Reusable** — configurable via CSS custom properties (`--shimmer-duration`, `--shimmer-ease`, `--glass-blur`).
+
+## Files
+
+- `demo.html` — self-contained demo (open directly in a browser; no server, CDNs, or frameworks). Pure CSS selection and animation, no JS. SaaS-themed pricing content.
+- `style.css` — glassmorphism pricing cards, shimmer-sweep via radio `:checked ~`, "Recommended" badge, feature bullets, focus-visible states, responsive grid, reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-shimmer-sweep-pricing-table-sbh/demo.html
+++ b/submissions/examples/ease-shimmer-sweep-pricing-table-sbh/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-shimmer-sweep-pricing-table — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-shimmer-sweep-pricing-table</h1>
+      <p>Pricing cards whose selected plan gets a sweeping shimmer highlight band.</p>
+    </header>
+
+    <section class="pricing" aria-label="Pricing plans">
+      <input type="radio" name="ssp" id="ssp-1" class="plan-toggle" checked aria-hidden="true" />
+      <input type="radio" name="ssp" id="ssp-2" class="plan-toggle" aria-hidden="true" />
+      <input type="radio" name="ssp" id="ssp-3" class="plan-toggle" aria-hidden="true" />
+
+      <label for="ssp-1" class="plan" tabindex="0" aria-label="Starter plan, $9 per month">
+        <span class="plan__shimmer" aria-hidden="true"></span>
+        <span class="plan__name">Starter</span>
+        <span class="plan__price"><span class="plan__cur">$</span>9<span class="plan__per">/mo</span></span>
+        <ul class="plan__features">
+          <li>5 projects</li>
+          <li>2 GB storage</li>
+          <li>Community support</li>
+        </ul>
+      </label>
+
+      <label for="ssp-2" class="plan" tabindex="0" aria-label="Pro plan, $29 per month, recommended">
+        <span class="plan__shimmer" aria-hidden="true"></span>
+        <span class="plan__badge">Recommended</span>
+        <span class="plan__name">Pro</span>
+        <span class="plan__price"><span class="plan__cur">$</span>29<span class="plan__per">/mo</span></span>
+        <ul class="plan__features">
+          <li>Unlimited projects</li>
+          <li>50 GB storage</li>
+          <li>Priority support</li>
+        </ul>
+      </label>
+
+      <label for="ssp-3" class="plan" tabindex="0" aria-label="Enterprise plan, custom pricing">
+        <span class="plan__shimmer" aria-hidden="true"></span>
+        <span class="plan__name">Enterprise</span>
+        <span class="plan__price">Custom</span>
+        <ul class="plan__features">
+          <li>SSO &amp; SAML</li>
+          <li>Audit logs</li>
+          <li>Dedicated manager</li>
+        </ul>
+      </label>
+    </section>
+
+    <p class="hint">Click a card (or focus) to select; a shimmer sweeps across it.</p>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-shimmer-sweep-pricing-table-sbh/style.css
+++ b/submissions/examples/ease-shimmer-sweep-pricing-table-sbh/style.css
@@ -1,0 +1,175 @@
+:root {
+  --shimmer-duration: 2.4s;
+  --shimmer-ease: ease-in-out;
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --glass-bg: rgba(255, 255, 255, 0.07);
+  --glass-border: rgba(255, 255, 255, 0.14);
+  --glass-blur: 14px;
+  --radius: 1rem;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.6rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 20%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+}
+
+.page__intro { text-align: center; max-width: 40rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+.hint { font-size: 0.82rem; color: var(--muted); }
+
+.plan-toggle { position: absolute; opacity: 0; pointer-events: none; }
+
+.pricing {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+  gap: 1.2rem;
+  width: min(48rem, 100%);
+  align-items: stretch;
+}
+
+.plan {
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 0.6rem;
+  padding: 1.6rem 1.2rem;
+  border-radius: var(--radius);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  box-shadow: 0 16px 36px -24px rgba(0, 0, 0, 0.7);
+  cursor: pointer;
+  user-select: none;
+  transition: box-shadow 0.3s ease, border-color 0.3s ease, background 0.3s ease;
+}
+.plan:hover, .plan:focus-visible {
+  outline: none;
+  border-color: rgba(110, 168, 255, 0.5);
+  box-shadow: 0 16px 36px -24px rgba(0, 0, 0, 0.7), 0 0 0 3px rgba(110, 168, 255, 0.35);
+}
+
+/* the shimmer band sits above the card background but below content */
+.plan__shimmer {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  /* a translucent diagonal highlight band, swept via background-position */
+  background: linear-gradient(
+    115deg,
+    transparent 0%,
+    transparent 35%,
+    rgba(255, 255, 255, 0.28) 50%,
+    transparent 65%,
+    transparent 100%
+  );
+  background-size: 250% 100%;
+  background-position: 180% 0;
+  opacity: 0;
+}
+.plan__name, .plan__price, .plan__features, .plan__badge { position: relative; z-index: 1; }
+
+/* selected plan: accent glow + shimmer sweeps across on a loop */
+#ssp-1:checked ~ .plan:nth-of-type(1),
+#ssp-2:checked ~ .plan:nth-of-type(2),
+#ssp-3:checked ~ .plan:nth-of-type(3) {
+  border-color: transparent;
+  background: linear-gradient(160deg, rgba(110,168,255,0.22), rgba(179,136,255,0.18));
+  box-shadow: 0 24px 60px -20px rgba(110, 168, 255, 0.45),
+              0 0 0 1px rgba(110, 168, 255, 0.35);
+  z-index: 2;
+}
+#ssp-1:checked ~ .plan:nth-of-type(1) .plan__shimmer,
+#ssp-2:checked ~ .plan:nth-of-type(2) .plan__shimmer,
+#ssp-3:checked ~ .plan:nth-of-type(3) .plan__shimmer {
+  opacity: 1;
+  animation: ssp-shimmer var(--shimmer-duration) var(--shimmer-ease) infinite;
+}
+
+@keyframes ssp-shimmer {
+  0%   { background-position: 180% 0; opacity: 0; }
+  20%  { opacity: 1; }
+  80%  { opacity: 1; }
+  100% { background-position: -80% 0; opacity: 0; }
+}
+
+.plan__badge {
+  position: absolute;
+  top: -0.7rem;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  color: #06231a;
+  background: linear-gradient(135deg, var(--accent), var(--accent2));
+}
+.plan__name { font-size: 1rem; color: var(--muted); font-weight: 600; }
+.plan__price {
+  font-size: 2.2rem;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+.plan__cur { font-size: 1rem; vertical-align: top; opacity: 0.8; }
+.plan__per { font-size: 0.9rem; font-weight: 600; color: var(--muted); }
+
+.plan__features {
+  list-style: none;
+  margin: 0.4rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.86rem;
+  color: var(--muted);
+}
+.plan__features li { position: relative; padding-left: 1.1rem; }
+.plan__features li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.45em;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--accent), var(--accent2));
+}
+
+@media (max-width: 480px) {
+  .plan__price { font-size: 1.9rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .plan { transition: none; }
+  #ssp-1:checked ~ .plan:nth-of-type(1) .plan__shimmer,
+  #ssp-2:checked ~ .plan:nth-of-type(2) .plan__shimmer,
+  #ssp-3:checked ~ .plan:nth-of-type(3) .plan__shimmer { animation: none; opacity: 0; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-shimmer-sweep-pricing-table** from issue #62117 — a Shimmer-Sweep Pricing Table component, following the submission pattern in the issue.

Closes #62117.

## Feature

A SaaS pricing table whose selected plan gets a sweeping shimmer highlight band that travels diagonally across the card on a loop (`@keyframes ssp-shimmer`: `background-position` `180% → -80%` with an `opacity` fade-in/out), plus an accent-tinted background gradient and colored `box-shadow` glow. Pure CSS via hidden radios + `:checked ~ .plan:nth-of-type(N)` (no JS); plans are labels with a `.plan__shimmer` band. Includes a "Recommended" badge.

## How it works

- `@keyframes ssp-shimmer` drives `background-position` of a translucent diagonal band with `opacity` fade-in/out on the selected plan. All via `background-position`/`opacity`/`box-shadow`.

## Accessibility

- Plans are focusable labels (`tabindex="0"`) with descriptive `aria-label`s (price + recommended note); shimmer band `aria-hidden`; `:focus-visible` ring; selection via click or keyboard. Full `prefers-reduced-motion` support (no shimmer; no glow transition).

## Submission structure

```
submissions/examples/ease-shimmer-sweep-pricing-table-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← glassmorphism pricing cards + shimmer-sweep + glow
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally