### PR TITLE
feat: add ease-tooltip-label component

### DIFF
--- a/submissions/examples/ease-tooltip-label-vd/README.md
+++ b/submissions/examples/ease-tooltip-label-vd/README.md
@@ -1,0 +1,34 @@
+# Ease Tooltip Label
+
+## What does this do?
+
+A compact tooltip label that appears when the user hovers over an element.
+
+## How is it used?
+
+Open `demo.html` directly in any modern browser.
+
+Example:
+
+```html
+<button class="tooltip-trigger" aria-label="Information">
+    ?
+    <span class="tooltip-label">More information</span>
+</button>
+```
+
+## Features
+
+- Tooltip text
+- Hover interaction
+- Smooth fade-in animation
+- Smooth slide animation
+- Responsive positioning
+- Pure CSS
+- No JavaScript required
+
+## Why is it useful?
+
+Tooltip labels are useful for icons, buttons, controls, and compact UI elements where additional information needs to be displayed without taking up permanent space.
+
+This component follows the animation-first philosophy of EaseMotion CSS by providing lightweight CSS-only interaction feedback.

--- a/submissions/examples/ease-tooltip-label-vd/demo.html
+++ b/submissions/examples/ease-tooltip-label-vd/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ease Tooltip Label</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="tooltip-demo">
+
+    <button class="tooltip-trigger" aria-label="Information">
+        ?
+        <span class="tooltip-label">More information</span>
+    </button>
+
+    <button class="tooltip-trigger" aria-label="Settings">
+        ⚙
+        <span class="tooltip-label">Settings</span>
+    </button>
+
+    <button class="tooltip-trigger" aria-label="Help">
+        ?
+        <span class="tooltip-label">Help center</span>
+    </button>
+
+</div>
+
+</body>
+</html>

--- a/submissions/examples/ease-tooltip-label-vd/style.css
+++ b/submissions/examples/ease-tooltip-label-vd/style.css
@@ -1,0 +1,94 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 2rem;
+    background: #0f172a;
+    font-family: Arial, Helvetica, sans-serif;
+}
+
+.tooltip-demo {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 24px;
+}
+
+.tooltip-trigger {
+    position: relative;
+    width: 44px;
+    height: 44px;
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    border: 1px solid #334155;
+    border-radius: 50%;
+    background: #111827;
+    color: #f8fafc;
+    cursor: pointer;
+    font-size: 1rem;
+    font-weight: 700;
+}
+
+.tooltip-trigger:hover {
+    background: #1e293b;
+}
+
+.tooltip-label {
+    position: absolute;
+    bottom: calc(100% + 10px);
+    left: 50%;
+    transform: translateX(-50%) translateY(6px);
+    padding: 7px 11px;
+    border-radius: 7px;
+    background: #f8fafc;
+    color: #0f172a;
+    white-space: nowrap;
+    font-size: 0.75rem;
+    font-weight: 600;
+    pointer-events: none;
+    opacity: 0;
+    visibility: hidden;
+    transition:
+        opacity 0.2s ease,
+        transform 0.2s ease,
+        visibility 0.2s ease;
+}
+
+.tooltip-label::after {
+    content: "";
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border: 5px solid transparent;
+    border-top-color: #f8fafc;
+}
+
+.tooltip-trigger:hover .tooltip-label {
+    opacity: 1;
+    visibility: visible;
+    transform: translateX(-50%) translateY(0);
+}
+
+@media (max-width: 600px) {
+    .tooltip-demo {
+        gap: 18px;
+    }
+
+    .tooltip-trigger {
+        width: 40px;
+        height: 40px;
+    }
+
+    .tooltip-label {
+        font-size: 0.7rem;
+    }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #67204

This PR adds a new **Ease Tooltip Label** component under `submissions/examples/ease-tooltip-label-vd`.

The component provides a compact CSS-only tooltip that appears on hover with a smooth fade-in and slide animation.

---

## Type of Change

* [ ] ✨ New animation / hover effect
* [x] 🧩 New component
* [ ] 📝 Documentation improvement
* [ ] 🐛 Bug fix in an existing submission
* [ ] Other (describe below)

---

## Submission Checklist

* [x] All changes are inside `submissions/`
* [x] Includes `demo.html` — self-contained, opens in browser with no server
* [x] Includes `style.css` — raw CSS for the proposed feature
* [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
* [x] **No changes to** `core/`
* [x] **No changes to** `components/`
* [x] One feature per PR

---

## Feature Description

**What does this add?**

A reusable tooltip label that appears on hover with a smooth fade-in and slide animation.

**How does a developer use it?**

```html
<button class="tooltip-trigger" aria-label="Information">
    ?
    <span class="tooltip-label">More information</span>
</button>
```

**Why does it fit EaseMotion CSS?**

The component is lightweight, human-readable, reusable, and animation-first. It uses pure CSS to provide smooth visual feedback for compact UI elements without requiring JavaScript.

---

## Demo

* [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

* [x] Chrome
* [x] Firefox
* [x] Edge
* [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

This submission is fully self-contained inside `submissions/examples/ease-tooltip-label-vd` and follows the repository contribution guidelines.

Related issue: #67204
