### PR TITLE
feat: add ease-zoom-in-hero-section component (#62105)

### DIFF
--- a/submissions/examples/ease-zoom-in-hero-section-sbh/README.md
+++ b/submissions/examples/ease-zoom-in-hero-section-sbh/README.md
@@ -1,0 +1,46 @@
+# ease-zoom-in-hero-section
+
+A SaaS showcase hero section whose content (eyebrow, title, subtitle, actions) zooms in — fading in while scaling up from `0.8` to `1` — sequentially on load. Pure CSS — no JavaScript is required for the animation.
+
+## What does this do?
+
+Adds a **zoom-in hero section** for SaaS showcase layouts: a SaaS landing hero. On load, each content element fades in while scaling up (`@keyframes zih-in`: `opacity 0 → 1` + `transform: scale(0.8 → 1)`), staggered by index. Includes a gradient backdrop, an accent eyebrow pill, a gradient-clipped title, and gradient + frosted buttons.
+
+## How is it used?
+
+1. Build a `.hero` section with a `.hero__bg` backdrop and a `.hero__content` block.
+2. The CSS applies the zoom-in entrance to the eyebrow, title, subtitle, and actions, staggered by `animation-delay`.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<section class="hero" aria-label="Product hero">
+  <span class="hero__bg" aria-hidden="true"></span>
+  <div class="hero__content">
+    <span class="hero__eyebrow">New · v3.0</span>
+    <h1 class="hero__title">Data that moves at the speed of your team.</h1>
+    <p class="hero__subtitle">…</p>
+    <div class="hero__actions">
+      <a class="hero__btn hero__btn--primary" href="#" tabindex="0">Start free trial</a>
+      <a class="hero__btn hero__btn--ghost" href="#" tabindex="0">Watch demo</a>
+    </div>
+  </div>
+</section>
+```
+
+## Why is this useful?
+
+- **Animation-first** — the signature motion is the zoom-in entrance: `@keyframes zih-in` drives `opacity` (`0 → 1`) and `transform: scale()` (`0.8 → 1`), staggered by `animation-delay` so each element resolves in sequence. All via `opacity`/`transform`.
+- **Glassmorphism aesthetic** — the ghost button is a frosted pill via `backdrop-filter: blur()`; the backdrop uses layered radial gradients; the title uses an accent gradient `background-clip: text`.
+- **Accessible** — the hero is a labelled `<section>` (`aria-label`); the backdrop is `aria-hidden="true"`; buttons are real links with `:focus-visible` rings. Full `prefers-reduced-motion` support (content appears instantly with no zoom).
+- **Reusable** — configurable via CSS custom properties (`--in-duration`, `--in-ease`, `--stagger`, `--glass-blur`).
+
+## Files
+
+- `demo.html` — self-contained demo (open directly in a browser; no server, CDNs, or frameworks). Pure CSS animation, no JS. Reload to replay the entrance. SaaS-themed hero content.
+- `style.css` — hero with gradient backdrop, staggered zoom-in content entrance, gradient + frosted buttons, focus-visible states, reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-zoom-in-hero-section-sbh/demo.html
+++ b/submissions/examples/ease-zoom-in-hero-section-sbh/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-zoom-in-hero-section — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <section class="hero" aria-label="Product hero">
+      <span class="hero__bg" aria-hidden="true"></span>
+
+      <div class="hero__content">
+        <span class="hero__eyebrow">New · v3.0</span>
+        <h1 class="hero__title">Data that moves at the speed of your team.</h1>
+        <p class="hero__subtitle">Real-time analytics, automated insights, and collaborative dashboards — all in one workspace.</p>
+        <div class="hero__actions">
+          <a class="hero__btn hero__btn--primary" href="#" tabindex="0">Start free trial</a>
+          <a class="hero__btn hero__btn--ghost" href="#" tabindex="0">Watch demo</a>
+        </div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-zoom-in-hero-section-sbh/style.css
+++ b/submissions/examples/ease-zoom-in-hero-section-sbh/style.css
@@ -1,0 +1,133 @@
+:root {
+  --in-duration: 0.7s;
+  --in-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --stagger: 0.16s;
+  --fg: #e8edf5;
+  --muted: #b6c0d4;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --glass-bg: rgba(255, 255, 255, 0.07);
+  --glass-border: rgba(255, 255, 255, 0.14);
+  --glass-blur: 6px;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 20%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+}
+
+.hero {
+  position: relative;
+  width: min(60rem, 100%);
+  min-height: 24rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 4rem 2rem;
+  border-radius: 1.6rem;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.hero__bg {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  background: linear-gradient(135deg, #14224a 0%, #1b1140 100%);
+}
+.hero__bg::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 30% 30%, rgba(110,168,255,0.35), transparent 55%),
+              radial-gradient(circle at 75% 70%, rgba(179,136,255,0.32), transparent 55%);
+}
+
+.hero__content { position: relative; z-index: 1; display: flex; flex-direction: column; align-items: center; gap: 0.8rem; max-width: 40rem; }
+
+/* zoom-in entrance: each element fades in while scaling up from 0.8 to 1, staggered */
+.hero__eyebrow,
+.hero__title,
+.hero__subtitle,
+.hero__actions {
+  opacity: 0;
+  transform: scale(0.8);
+  animation: zih-in var(--in-duration) var(--in-ease) forwards;
+}
+.hero__eyebrow  { animation-delay: calc(var(--stagger) * 0); }
+.hero__title    { animation-delay: calc(var(--stagger) * 1); }
+.hero__subtitle { animation-delay: calc(var(--stagger) * 2); }
+.hero__actions  { animation-delay: calc(var(--stagger) * 3); }
+
+@keyframes zih-in {
+  to { opacity: 1; transform: scale(1); }
+}
+
+.hero__eyebrow {
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+  padding: 0.3rem 0.8rem;
+  border-radius: 999px;
+  background: rgba(110, 168, 255, 0.12);
+  border: 1px solid rgba(110, 168, 255, 0.3);
+}
+.hero__title {
+  margin: 0;
+  font-size: clamp(1.8rem, 5vw, 3rem);
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, #ffffff, #cdd9ff 60%, var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.hero__subtitle {
+  margin: 0;
+  font-size: clamp(0.95rem, 2.5vw, 1.1rem);
+  line-height: 1.6;
+  color: var(--muted);
+  max-width: 34rem;
+}
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+  justify-content: center;
+  margin-top: 0.4rem;
+}
+
+.hero__btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.75rem 1.4rem;
+  border-radius: 0.7rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  text-decoration: none;
+  cursor: pointer;
+  transition: filter 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+.hero__btn--primary { color: #06231a; background: linear-gradient(135deg, var(--accent), var(--accent2)); }
+.hero__btn--primary:hover, .hero__btn--primary:focus-visible { filter: brightness(1.08); transform: translateY(-2px); outline: none; box-shadow: 0 0 0 3px rgba(110,168,255,0.5); }
+.hero__btn--ghost { color: var(--fg); background: var(--glass-bg); border: 1px solid var(--glass-border); backdrop-filter: blur(var(--glass-blur)); -webkit-backdrop-filter: blur(var(--glass-blur)); }
+.hero__btn--ghost:hover, .hero__btn--ghost:focus-visible { background: rgba(255,255,255,0.14); transform: translateY(-2px); outline: none; box-shadow: 0 0 0 3px rgba(110,168,255,0.5); }
+
+@media (max-width: 480px) {
+  .hero { padding: 3rem 1.2rem; min-height: 20rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero__eyebrow, .hero__title, .hero__subtitle, .hero__actions { animation: none; opacity: 1; transform: none; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-zoom-in-hero-section** from issue #62105 — a Zoom-In Hero Section component, following the submission pattern in the issue.

Closes #62105.

## Feature

A SaaS showcase hero section whose content (eyebrow, title, subtitle, actions) zooms in — fading in while scaling up (`scale 0.8 → 1`) — sequentially on load (`@keyframes zih-in`), staggered by `animation-delay`. Pure CSS, no JS. Includes a gradient backdrop, accent eyebrow pill, gradient-clipped title, and gradient + frosted buttons.

## How it works

- `@keyframes zih-in` drives `opacity` + `transform: scale()`, staggered by `animation-delay`. All via `opacity`/`transform`.

## Accessibility

- Hero is a labelled `<section>` (`aria-label`); backdrop `aria-hidden`; buttons are real links with `:focus-visible` rings; ghost button uses `backdrop-filter`. Full `prefers-reduced-motion` support (content appears instantly with no zoom).

## Submission structure

```
submissions/examples/ease-zoom-in-hero-section-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← hero + staggered zoom-in entrance + gradient buttons
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally