### PR TITLE
feat: add ease-slide-up-dropdown component (#62088)

### DIFF
--- a/submissions/examples/ease-slide-up-dropdown-sbh/README.md
+++ b/submissions/examples/ease-slide-up-dropdown-sbh/README.md
@@ -1,0 +1,46 @@
+# ease-slide-up-dropdown
+
+A SaaS showcase dropdown menu whose panel slides up into view from below the trigger when opened. Pure CSS — open state is driven by the native `<details>`/`<summary>` element, so no JavaScript is required for the animation.
+
+## What does this do?
+
+Adds a **slide-up dropdown**: a glassmorphism dropdown menu. When opened (via click or keyboard on the `<summary>` trigger), the panel slides up into view (`opacity 0 → 1` + `translateY(12px → 0)`) from below the trigger (anchored above it). The trigger chevron rotates 180° on open. Items include a styled "Leave workspace" danger item.
+
+## How is it used?
+
+1. Use a `<details class="dropdown">` with a `<summary class="dropdown__trigger">` and a `.dropdown__panel` (anchored above via `bottom: 100%`) containing `.dropdown__item` links.
+2. The CSS uses `[open]` to animate the panel's `opacity`/`transform`.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<details class="dropdown">
+  <summary class="dropdown__trigger" tabindex="0" aria-label="Open workspace menu">
+    <span>Workspace</span>
+    <span class="dropdown__chevron" aria-hidden="true"></span>
+  </summary>
+  <div class="dropdown__panel" role="menu">
+    <a class="dropdown__item" role="menuitem" href="#" tabindex="0">Projects</a>
+    <a class="dropdown__item" role="menuitem" href="#" tabindex="0">Members</a>
+    <a class="dropdown__item" role="menuitem" href="#" tabindex="0">Settings</a>
+    <a class="dropdown__item dropdown__item--danger" role="menuitem" href="#" tabindex="0">Leave workspace</a>
+  </div>
+</details>
+```
+
+## Why is this useful?
+
+- **Animation-first** — the signature motion is the slide-up: the panel transitions `opacity` (`0 → 1`) and `transform: translateY()` (`12px → 0`) from below the trigger; the chevron rotates on open. All via `opacity`/`transform`.
+- **Glassmorphism aesthetic** — the trigger and panel are frosted via `backdrop-filter: blur()`.
+- **Accessible** — uses native `<details>`/`<summary>` (keyboard-operable out of the box); the trigger and items are focusable with `:focus-visible` rings; the panel uses `role="menu"` and items `role="menuitem"`; the chevron is `aria-hidden`. Full `prefers-reduced-motion` support (panel appears instantly with no slide).
+- **Reusable** — configurable via CSS custom properties (`--open-duration`, `--open-ease`, `--travel`, `--glass-blur`).
+
+## Files
+
+- `demo.html` — self-contained demo (open directly in a browser; no server, CDNs, or frameworks). Pure CSS animation via native `<details>`, no JS. SaaS-themed workspace menu content.
+- `style.css` — glassmorphism dropdown, slide-up panel via `[open]`, rotating chevron, item hover/focus states, danger item, focus-visible states, reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-slide-up-dropdown-sbh/demo.html
+++ b/submissions/examples/ease-slide-up-dropdown-sbh/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-slide-up-dropdown — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-slide-up-dropdown</h1>
+      <p>A dropdown menu whose panel slides up into view from below the trigger.</p>
+    </header>
+
+    <section class="demo" aria-label="Dropdown demo">
+      <details class="dropdown">
+        <summary class="dropdown__trigger" tabindex="0" aria-label="Open workspace menu">
+          <span>Workspace</span>
+          <span class="dropdown__chevron" aria-hidden="true"></span>
+        </summary>
+        <div class="dropdown__panel" role="menu">
+          <a class="dropdown__item" role="menuitem" href="#" tabindex="0">Projects</a>
+          <a class="dropdown__item" role="menuitem" href="#" tabindex="0">Members</a>
+          <a class="dropdown__item" role="menuitem" href="#" tabindex="0">Settings</a>
+          <a class="dropdown__item dropdown__item--danger" role="menuitem" href="#" tabindex="0">Leave workspace</a>
+        </div>
+      </details>
+    </section>
+
+    <p class="hint">Click the trigger (or focus + Enter) to open; the panel slides up.</p>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-slide-up-dropdown-sbh/style.css
+++ b/submissions/examples/ease-slide-up-dropdown-sbh/style.css
@@ -1,0 +1,125 @@
+:root {
+  --open-duration: 0.3s;
+  --open-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --glass-bg: rgba(255, 255, 255, 0.07);
+  --glass-border: rgba(255, 255, 255, 0.14);
+  --glass-blur: 14px;
+  --radius: 0.8rem;
+  --travel: 12px;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.6rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 20%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+}
+
+.page__intro { text-align: center; max-width: 40rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+.hint { font-size: 0.82rem; color: var(--muted); }
+
+.demo { padding-top: 1rem; }
+
+.dropdown { position: relative; }
+.dropdown > summary { list-style: none; }
+.dropdown > summary::-webkit-details-marker { display: none; }
+
+.dropdown__trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1rem;
+  border-radius: var(--radius);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  cursor: pointer;
+  user-select: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+.dropdown__trigger:hover, .dropdown__trigger:focus-visible {
+  outline: none;
+  border-color: rgba(110, 168, 255, 0.5);
+  box-shadow: 0 0 0 3px rgba(110, 168, 255, 0.35);
+}
+
+.dropdown__chevron {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-right: 2px solid var(--muted);
+  border-bottom: 2px solid var(--muted);
+  transform: rotate(45deg) translate(-1px, -1px);
+  transition: transform var(--open-duration) var(--open-ease);
+}
+.dropdown[open] .dropdown__chevron { transform: rotate(225deg) translate(-1px, -1px); }
+
+/* panel slides UP into view from below the trigger */
+.dropdown__panel {
+  position: absolute;
+  bottom: calc(100% + 0.5rem);
+  left: 0;
+  min-width: 12rem;
+  display: flex;
+  flex-direction: column;
+  padding: 0.4rem;
+  border-radius: var(--radius);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  box-shadow: 0 18px 40px -24px rgba(0, 0, 0, 0.7);
+  opacity: 0;
+  transform: translateY(var(--travel));
+  pointer-events: none;
+  transition: opacity var(--open-duration) var(--open-ease),
+              transform var(--open-duration) var(--open-ease);
+}
+.dropdown[open] .dropdown__panel {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.dropdown__item {
+  display: block;
+  padding: 0.5rem 0.7rem;
+  border-radius: 0.5rem;
+  color: var(--fg);
+  text-decoration: none;
+  font-size: 0.9rem;
+  transition: background 0.18s ease, color 0.18s ease;
+}
+.dropdown__item:hover, .dropdown__item:focus-visible {
+  outline: none;
+  background: rgba(110, 168, 255, 0.16);
+}
+.dropdown__item--danger { color: #ff8b8b; }
+.dropdown__item--danger:hover, .dropdown__item--danger:focus-visible { background: rgba(255, 139, 139, 0.14); }
+
+@media (prefers-reduced-motion: reduce) {
+  .dropdown__panel { transition: none; }
+  .dropdown__chevron { transition: none; }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-slide-up-dropdown** from issue #62088 — a Slide-Up Dropdown component, following the submission pattern in the issue.

Closes #62088.

## Feature

A SaaS showcase dropdown menu whose panel slides up into view from below the trigger when opened (`opacity 0 → 1` + `translateY(12px → 0)`), anchored above via `bottom: 100%`. The trigger chevron rotates 180° on open. Pure CSS via native `<details>`/`<summary>` `[open]` (no JS). Includes a styled "Leave workspace" danger item.

## How it works

- Panel transitions `opacity`/`transform: translateY()` via `[open]`; chevron rotates. All via `opacity`/`transform`.

## Accessibility

- Uses native `<details>`/`<summary>` (keyboard-operable out of the box); trigger and items focusable with `:focus-visible` rings; panel `role="menu"`, items `role="menuitem"`; chevron `aria-hidden`. Full `prefers-reduced-motion` support (panel appears instantly with no slide).

## Submission structure

```
submissions/examples/ease-slide-up-dropdown-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← glassmorphism dropdown + slide-up panel + chevron
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally