### PR TITLE
feat: add ease-3d-flip-toast component (#62076)

### DIFF
--- a/submissions/examples/ease-3d-flip-toast-sbh/README.md
+++ b/submissions/examples/ease-3d-flip-toast-sbh/README.md
@@ -1,0 +1,48 @@
+# ease-3d-flip-toast
+
+SaaS showcase toast notifications that flip into view in 3D (rotating on the X axis from `-90deg` to `0deg`) and flip out (`0deg` to `90deg`) after a hold, staggered by index. Pure CSS — no JavaScript is required for the animation.
+
+## What does this do?
+
+Adds a **3D-flip toast**: glassmorphism toast notifications. Each toast flips in (`@keyframes tft-in`: `opacity 0 → 1` + `transform: rotateX(-90deg → 0deg)`) within a 3D perspective context, holds, then flips out (`@keyframes tft-out`: `opacity 1 → 0` + `transform: rotateX(0 → 90deg)`), staggered by its index. Uses `perspective`, `transform-style: preserve-3d`, and `backface-visibility: hidden`. Includes info/success/warn variants with colored icons.
+
+## How is it used?
+
+1. Build a `.toaststack` region (fixed bottom-right, with `perspective`) containing `.toast` elements, each with a `.toast__icon` and `.toast__msg`.
+2. The CSS applies the 3D-flip-in/hold/flip-out animation, staggered by `--i`.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<div class="toaststack" role="region" aria-label="Notifications" aria-live="polite">
+  <div class="toast toast--info" role="status">
+    <span class="toast__icon" aria-hidden="true">ⓘ</span>
+    <span class="toast__msg">Invite sent to 3 members.</span>
+  </div>
+  <div class="toast toast--success" role="status">
+    <span class="toast__icon" aria-hidden="true">✓</span>
+    <span class="toast__msg">Build passed in 42s.</span>
+  </div>
+  <div class="toast toast--warn" role="status">
+    <span class="toast__icon" aria-hidden="true">!</span>
+    <span class="toast__msg">API rate limit nearing.</span>
+  </div>
+</div>
+```
+
+## Why is this useful?
+
+- **Animation-first** — the signature motion is the 3D flip: `@keyframes tft-in`/`tft-out` drive `opacity` and `transform: rotateX()` (`-90deg → 0deg → 90deg`) within a `perspective` context, staggered by `--i`. All via `opacity`/`transform`.
+- **Glassmorphism aesthetic** — toasts are frosted panels via `backdrop-filter: blur()`; variants use accent-tinted icon chips.
+- **Accessible** — the stack is an `aria-live="polite"` region labelled "Notifications"; each toast is `role="status"` so screen readers announce it; the icon is `aria-hidden`. Full `prefers-reduced-motion` support (toasts appear instantly with no flip).
+- **Reusable** — configurable via CSS custom properties (`--in-duration`, `--out-duration`, `--hold-duration`, `--stagger`, `--perspective`, `--glass-blur`).
+
+## Files
+
+- `demo.html` — self-contained demo (open directly in a browser; no server, CDNs, or frameworks). Pure CSS animation, no JS. Reload to replay the entrance; each toast auto-dismisses after the loop. SaaS-themed notification content.
+- `style.css` — glassmorphism toasts, 3D-flip-in/flip-out keyframes staggered by `--i`, perspective context, info/success/warn variants, fixed toast stack, reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-3d-flip-toast-sbh/demo.html
+++ b/submissions/examples/ease-3d-flip-toast-sbh/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-3d-flip-toast — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-3d-flip-toast</h1>
+      <p>Toast notifications that flip into view in 3D and flip out after a hold.</p>
+    </header>
+
+    <section class="demo" aria-label="Toast demo">
+      <p class="demo__note">Reload to replay the 3D flip entrance. Each toast auto-dismisses after the loop.</p>
+
+      <div class="toaststack" role="region" aria-label="Notifications" aria-live="polite">
+        <div class="toast toast--info" role="status">
+          <span class="toast__icon" aria-hidden="true">ⓘ</span>
+          <span class="toast__msg">Invite sent to 3 members.</span>
+        </div>
+        <div class="toast toast--success" role="status">
+          <span class="toast__icon" aria-hidden="true">✓</span>
+          <span class="toast__msg">Build passed in 42s.</span>
+        </div>
+        <div class="toast toast--warn" role="status">
+          <span class="toast__icon" aria-hidden="true">!</span>
+          <span class="toast__msg">API rate limit nearing.</span>
+        </div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-3d-flip-toast-sbh/style.css
+++ b/submissions/examples/ease-3d-flip-toast-sbh/style.css
@@ -1,0 +1,122 @@
+:root {
+  --in-duration: 0.6s;
+  --out-duration: 0.5s;
+  --hold-duration: 3.2s;
+  --in-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --out-ease: cubic-bezier(0.55, 0, 0.65, 0.25);
+  --stagger: 0.18s;
+  --perspective: 600px;
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --glass-bg: rgba(255, 255, 255, 0.08);
+  --glass-border: rgba(255, 255, 255, 0.14);
+  --glass-blur: 14px;
+  --radius: 0.8rem;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.6rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 20%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+}
+
+.page__intro { text-align: center; max-width: 40rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+
+.demo { display: flex; flex-direction: column; align-items: center; gap: 1rem; }
+.demo__note { font-size: 0.82rem; color: var(--muted); margin: 0; }
+
+.toaststack {
+  position: fixed;
+  right: 1.2rem;
+  bottom: 1.2rem;
+  display: flex;
+  flex-direction: column-reverse;
+  gap: 0.6rem;
+  width: min(20rem, calc(100vw - 2.4rem));
+  z-index: 50;
+  perspective: var(--perspective);
+}
+
+.toast {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.7rem 0.9rem;
+  border-radius: var(--radius);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  box-shadow: 0 18px 40px -24px rgba(0, 0, 0, 0.7);
+  font-size: 0.88rem;
+  transform-style: preserve-3d;
+  backface-visibility: hidden;
+  /* flip in (rotateX), hold, flip out (rotateX) */
+  opacity: 0;
+  transform: rotateX(-90deg);
+  animation:
+    tft-in var(--in-duration) var(--in-ease) forwards,
+    tft-out var(--out-duration) var(--out-ease) forwards;
+  animation-delay:
+    calc(var(--stagger) * var(--i, 0)),
+    calc(var(--in-duration) + var(--hold-duration) + (var(--stagger) * var(--i, 0)));
+}
+.toast:nth-child(1) { --i: 0; }
+.toast:nth-child(2) { --i: 1; }
+.toast:nth-child(3) { --i: 2; }
+
+@keyframes tft-in {
+  to { opacity: 1; transform: rotateX(0deg); }
+}
+@keyframes tft-out {
+  to { opacity: 0; transform: rotateX(90deg); }
+}
+
+.toast__icon {
+  display: grid;
+  place-items: center;
+  width: 1.3rem;
+  height: 1.3rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  flex: 0 0 auto;
+}
+.toast--info .toast__icon    { color: var(--accent);  background: rgba(110,168,255,0.18); }
+.toast--success .toast__icon { color: #6ef0a8;        background: rgba(110,240,168,0.16); }
+.toast--warn .toast__icon    { color: #ffd27a;        background: rgba(255,210,122,0.16); }
+.toast__msg { line-height: 1.4; }
+
+@media (max-width: 480px) {
+  .toaststack { right: 0.8rem; bottom: 0.8rem; }
+  .toast { font-size: 0.82rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .toast {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## What this PR does

Implements **ease-3d-flip-toast** from issue #62076 — a 3D-Flip Toast component, following the submission pattern in the issue.

Closes #62076.

## Feature

SaaS showcase toast notifications that flip into view in 3D (rotating on the X axis from `-90deg` to `0deg`) and flip out (`0deg` to `90deg`) after a hold, staggered by index. Pure CSS, no JS. Uses `perspective`, `transform-style: preserve-3d`, `backface-visibility: hidden`. `@keyframes tft-in` (`opacity 0 → 1` + `rotateX(-90deg → 0)`) then `@keyframes tft-out` (`opacity 1 → 0` + `rotateX(0 → 90deg)`), staggered by `--i`. Includes info/success/warn variants.

## How it works

- `@keyframes tft-in`/`tft-out` drive `opacity` + `transform: rotateX()` within a `perspective` context, staggered by `--i`. All via `opacity`/`transform`.

## Accessibility

- Stack is an `aria-live="polite"` region labelled "Notifications"; toasts `role="status"` so screen readers announce them; icon `aria-hidden`. Full `prefers-reduced-motion` support (toasts appear instantly with no flip).

## Submission structure

```
submissions/examples/ease-3d-flip-toast-sbh/
├── demo.html      ← self-contained demo (DOCTYPE + html + head + body)
├── style.css      ← glassmorphism toasts + 3D flip-in/flip-out + perspective
└── README.md      ← what / how / why documentation
```

## Checklist

- [x] Submission is inside `submissions/examples/your-feature-name/`
- [x] `demo.html`, `style.css`, and `README.md` all present and non-empty
- [x] `demo.html` contains `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`
- [x] Demo is self-contained — no server / CDN / external framework
- [x] No existing files in `core/`, `components/`, `docs/`, or root modified
- [x] No code deletions — only new files added
- [x] Single squashed commit with a Conventional Commit message
- [x] Feature does not duplicate an existing EaseMotion CSS class
- [x] Tested locally