### PR TITLE
feat: add fade-in toast for SaaS showcase layouts

### DIFF
--- a/submissions/examples/fade-in-toast-saas/README.md
+++ b/submissions/examples/fade-in-toast-saas/README.md
@@ -1,0 +1,74 @@
+Fade-In Toast
+
+A SaaS-style toast notification: click a trigger and it fades and slides in, holds for a few seconds, then fades itself back out — no JavaScript, no timers. A close button lets you dismiss it early. Four status variants included (success, error, warning, info).
+
+Files
+File	Purpose
+demo.html	Four trigger buttons + the toast viewport
+style.css	The lifecycle animation, tokens, and toast styling
+README.md	This file
+Markup
+html
+<input type="checkbox" id="toast-success-toggle" class="toast-toggle">
+<label for="toast-success-toggle" class="trigger-btn">Show success toast</label>
+
+<div class="toast-viewport">
+  <div class="toast toast-success">
+    <span class="toast-icon">&check;</span>
+    <div class="toast-body">
+      <p class="toast-title">Changes saved</p>
+      <p class="toast-text">Your workspace settings were updated.</p>
+    </div>
+    <label for="toast-success-toggle" class="toast-close">&times;</label>
+  </div>
+</div>
+
+Each toast has its own hidden checkbox. Two different labels point at the same checkbox: the trigger button (turns it on) and the toast's own close control (turns it back off). The checkbox and the toast don't need to be next to each other in the markup — the toast only needs to come after its checkbox somewhere in the document, so .toast-viewport can sit anywhere convenient (the demo puts it right before </body>).
+
+How the auto-dismissing lifecycle works
+
+The toast starts display: none. Checking its box does two things at once:
+
+css
+#toast-success-toggle:checked ~ .toast-viewport .toast-success {
+  display: flex;
+  animation: tn-lifecycle
+    calc(var(--tn-duration-in) + var(--tn-hold) + var(--tn-duration-out))
+    var(--tn-ease) forwards;
+}
+
+Switching display from none to flex is what restarts the CSS animation — that's the mechanism, not a JavaScript timer. The single tn-lifecycle keyframe animation handles the entire visible lifespan in one pass:
+
+css
+@keyframes tn-lifecycle {
+  0%   { opacity: 0; transform: translateY(16px) scale(0.96); }
+  9%   { opacity: 1; transform: translateY(0) scale(1); }      /* fully faded in */
+  88%  { opacity: 1; transform: translateY(0) scale(1); }      /* holds here */
+  100% { opacity: 0; transform: translateY(8px) scale(0.98); } /* auto fade-out */
+}
+
+The percentages are fixed proportions of the total animation duration, which is computed from three separate tokens (calc(--tn-duration-in + --tn-hold + --tn-duration-out)) — so changing any one of them retunes the whole lifecycle without needing to hand-recalculate the keyframe percentages yourself.
+
+Manual dismiss (clicking the &times;) simply unchecks the box, which snaps display straight back to none — instant, not animated. That's a deliberate trade-off for staying JS-free: animating a manual close differently from the automatic one would need a script to detect which kind of dismissal happened. In practice an instant manual close reads as responsive rather than abrupt.
+
+CSS custom properties
+Property	Default	Controls
+--tn-duration-in	380ms	Fade/slide-in length
+--tn-hold	3200ms	How long the toast stays fully visible
+--tn-duration-out	420ms	Auto fade-out length
+--tn-ease	cubic-bezier(0.16, 1, 0.3, 1)	Easing curve for the whole lifecycle
+Status variants
+
+.toast-success, .toast-error, .toast-warning, and .toast-info each set a left accent border and icon color from their own token (--tn-success, --tn-error, --tn-warning, --tn-info). Add a new variant by pairing a new modifier class with a new color token — no changes to the lifecycle animation needed.
+
+Accessibility
+Respects prefers-reduced-motion: reduce in a way that's more than cosmetic: the animation (and therefore the automatic timeout) is removed entirely, and the toast simply stays visible at full opacity until manually dismissed. Auto-expiring content is a real barrier for anyone who needs more time to read it (WCAG 2.2.1, Timing Adjustable), so reduced motion here also means "don't take this away from me before I'm done reading it," not just "don't animate it."
+The close control is a real, focusable <label for="...">, and the trigger buttons get a visible :focus-visible outline via the sibling checkbox's focus state.
+.toast-viewport carries role="region" with an aria-label, so assistive tech has a named landmark for where notifications appear.
+Responsive behavior
+
+Below 480px the viewport spans the full width (minus a small margin) instead of being a fixed 320px box pinned to the corner, and the trigger buttons stack vertically.
+
+Browser support
+
+Uses only display, transform, opacity, CSS custom properties, and standard keyframe animations — supported everywhere current, no fallback needed.

--- a/submissions/examples/fade-in-toast-saas/demo.html
+++ b/submissions/examples/fade-in-toast-saas/demo.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Fade-In Toast — EaseMotion CSS</title>
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@600;700&family=Inter:wght@400;500;600&family=IBM+Plex+Mono:wght@500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="noise" aria-hidden="true"></div>
+
+  <!-- Hidden checkboxes drive every toast's visibility (checkbox hack) -->
+  <input type="checkbox" id="toast-success-toggle" class="toast-toggle">
+  <input type="checkbox" id="toast-error-toggle" class="toast-toggle">
+  <input type="checkbox" id="toast-warning-toggle" class="toast-toggle">
+  <input type="checkbox" id="toast-info-toggle" class="toast-toggle">
+
+  <header class="hero">
+    <p class="eyebrow">EaseMotion CSS &middot; showcase</p>
+    <h1 class="hero-title">Fade-in toast</h1>
+    <p class="hero-sub">Click a button to fire a toast: it fades and slides in, holds, then fades itself out automatically &mdash; or dismiss it early with the &times;. Pure CSS, no JavaScript.</p>
+  </header>
+
+  <main class="showcase">
+
+    <section class="demo-card" aria-labelledby="trigger-title">
+      <h2 id="trigger-title" class="demo-card-title">Try it</h2>
+      <div class="trigger-row">
+        <label for="toast-success-toggle" class="trigger-btn trigger-btn-success">Show success toast</label>
+        <label for="toast-error-toggle" class="trigger-btn trigger-btn-error">Show error toast</label>
+        <label for="toast-warning-toggle" class="trigger-btn trigger-btn-warning">Show warning toast</label>
+        <label for="toast-info-toggle" class="trigger-btn trigger-btn-info">Show info toast</label>
+      </div>
+      <p class="demo-note">Fire more than one &mdash; they stack together in the corner.</p>
+    </section>
+
+  </main>
+
+  <!-- Toasts render here, stacked bottom-right, regardless of trigger position -->
+  <div class="toast-viewport" role="region" aria-label="Notifications">
+
+    <div class="toast toast-success">
+      <span class="toast-icon" aria-hidden="true">&check;</span>
+      <div class="toast-body">
+        <p class="toast-title">Changes saved</p>
+        <p class="toast-text">Your workspace settings were updated.</p>
+      </div>
+      <label for="toast-success-toggle" class="toast-close" aria-label="Dismiss">&times;</label>
+    </div>
+
+    <div class="toast toast-error">
+      <span class="toast-icon" aria-hidden="true">&times;</span>
+      <div class="toast-body">
+        <p class="toast-title">Upload failed</p>
+        <p class="toast-text">Check your connection and try again.</p>
+      </div>
+      <label for="toast-error-toggle" class="toast-close" aria-label="Dismiss">&times;</label>
+    </div>
+
+    <div class="toast toast-warning">
+      <span class="toast-icon" aria-hidden="true">!</span>
+      <div class="toast-body">
+        <p class="toast-title">Storage almost full</p>
+        <p class="toast-text">You're at 92% of your plan's limit.</p>
+      </div>
+      <label for="toast-warning-toggle" class="toast-close" aria-label="Dismiss">&times;</label>
+    </div>
+
+    <div class="toast toast-info">
+      <span class="toast-icon" aria-hidden="true">i</span>
+      <div class="toast-body">
+        <p class="toast-title">New teammate joined</p>
+        <p class="toast-text">Priya Sharma accepted your invite.</p>
+      </div>
+      <label for="toast-info-toggle" class="toast-close" aria-label="Dismiss">&times;</label>
+    </div>
+
+  </div>
+
+  <footer class="footer">
+    <p>EaseMotion CSS &middot; submissions/examples/fade-in-toast-saas</p>
+  </footer>
+
+</body>
+</html>

--- a/submissions/examples/fade-in-toast-saas/style.css
+++ b/submissions/examples/fade-in-toast-saas/style.css
@@ -1,0 +1,355 @@
+/* -------------------------------------------------------------------------
+   1. Design tokens
+   ------------------------------------------------------------------------- */
+ 
+:root {
+  --tn-bg: #0e1116;
+  --tn-surface: #151a21;
+  --tn-surface-2: #1c222b;
+  --tn-border: #262e39;
+  --tn-text: #edeff2;
+  --tn-text-muted: #98a2b3;
+ 
+  --tn-accent: #7de0c0;
+  --tn-success: #7de0c0;
+  --tn-error: #fb7185;
+  --tn-warning: #fcd34d;
+  --tn-info: #7dd3fc;
+ 
+  --tn-font-display: "Space Grotesk", "Segoe UI", sans-serif;
+  --tn-font-body: "Inter", "Segoe UI", sans-serif;
+  --tn-font-mono: "IBM Plex Mono", "Courier New", monospace;
+ 
+  /* Lifecycle tuning — override per instance to retune timing */
+  --tn-duration-in: 380ms;
+  --tn-hold: 3200ms;
+  --tn-duration-out: 420ms;
+  --tn-ease: cubic-bezier(0.16, 1, 0.3, 1);
+}
+ 
+* {
+  box-sizing: border-box;
+}
+ 
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--tn-bg);
+  color: var(--tn-text);
+  font-family: var(--tn-font-body);
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+ 
+.noise {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.035;
+  z-index: 0;
+  background-image: radial-gradient(circle at 1px 1px, #ffffff 1px, transparent 0);
+  background-size: 3px 3px;
+}
+ 
+/* Real, focusable checkboxes — hidden visually, not with display:none */
+.toast-toggle {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   2. Hero
+   ------------------------------------------------------------------------- */
+ 
+.hero {
+  position: relative;
+  z-index: 1;
+  max-width: 620px;
+  margin: 0 auto;
+  padding: 92px 24px 48px;
+  text-align: center;
+}
+ 
+.eyebrow {
+  font-family: var(--tn-font-mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--tn-accent);
+  margin: 0 0 20px;
+}
+ 
+.hero-title {
+  font-family: var(--tn-font-display);
+  font-weight: 600;
+  font-size: clamp(32px, 5.5vw, 50px);
+  line-height: 1.1;
+  letter-spacing: -0.01em;
+  margin: 0 0 16px;
+}
+ 
+.hero-sub {
+  font-size: 15px;
+  color: var(--tn-text-muted);
+  max-width: 480px;
+  margin: 0 auto;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   3. Trigger card
+   ------------------------------------------------------------------------- */
+ 
+.showcase {
+  position: relative;
+  z-index: 1;
+  max-width: 560px;
+  margin: 0 auto;
+  padding: 0 24px 90px;
+}
+ 
+.demo-card {
+  background: var(--tn-surface);
+  border: 1px solid var(--tn-border);
+  border-radius: 16px;
+  padding: 26px 24px 24px;
+  text-align: center;
+}
+ 
+.demo-card-title {
+  font-family: var(--tn-font-display);
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0 0 18px;
+}
+ 
+.trigger-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px;
+}
+ 
+.trigger-btn {
+  padding: 10px 16px;
+  border-radius: 9px;
+  border: 1px solid var(--tn-border);
+  background: var(--tn-surface-2);
+  color: var(--tn-text);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  user-select: none;
+  transition: border-color 160ms ease, background 160ms ease;
+}
+ 
+.trigger-btn:hover {
+  background: #232a34;
+}
+ 
+.toast-toggle:focus-visible + .trigger-btn {
+  outline: 2px solid var(--tn-accent);
+  outline-offset: 2px;
+}
+ 
+.trigger-btn-success:hover { border-color: var(--tn-success); }
+.trigger-btn-error:hover { border-color: var(--tn-error); }
+.trigger-btn-warning:hover { border-color: var(--tn-warning); }
+.trigger-btn-info:hover { border-color: var(--tn-info); }
+ 
+.demo-note {
+  font-size: 12px;
+  color: var(--tn-text-muted);
+  margin: 16px 0 0;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   4. Toast viewport
+   ------------------------------------------------------------------------- */
+ 
+.toast-viewport {
+  position: fixed;
+  z-index: 50;
+  bottom: 20px;
+  right: 20px;
+  width: min(320px, calc(100vw - 40px));
+  display: flex;
+  flex-direction: column-reverse;
+  gap: 10px;
+  pointer-events: none;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   5. Toast card
+   ------------------------------------------------------------------------- */
+ 
+.toast {
+  display: none;
+  align-items: flex-start;
+  gap: 11px;
+  padding: 14px 14px 14px 15px;
+  border-radius: 12px;
+  background: var(--tn-surface);
+  border: 1px solid var(--tn-border);
+  border-left: 3px solid var(--tn-accent);
+  box-shadow: 0 20px 40px -16px rgba(0, 0, 0, 0.55);
+  pointer-events: auto;
+}
+ 
+.toast-success { border-left-color: var(--tn-success); }
+.toast-error { border-left-color: var(--tn-error); }
+.toast-warning { border-left-color: var(--tn-warning); }
+.toast-info { border-left-color: var(--tn-info); }
+ 
+/* Showing a toast (display: none -> flex) restarts its CSS animation,
+   which is what produces the fade-in / hold / fade-out lifecycle with no
+   JavaScript or timer involved. */
+#toast-success-toggle:checked ~ .toast-viewport .toast-success,
+#toast-error-toggle:checked   ~ .toast-viewport .toast-error,
+#toast-warning-toggle:checked ~ .toast-viewport .toast-warning,
+#toast-info-toggle:checked    ~ .toast-viewport .toast-info {
+  display: flex;
+  animation: tn-lifecycle
+    calc(var(--tn-duration-in) + var(--tn-hold) + var(--tn-duration-out))
+    var(--tn-ease) forwards;
+}
+ 
+@keyframes tn-lifecycle {
+  0% {
+    opacity: 0;
+    transform: translateY(16px) scale(0.96);
+  }
+  /* Fraction of the total duration spent animating in — see README for
+     how these percentages relate to the three duration tokens. */
+  9% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  88% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(8px) scale(0.98);
+  }
+}
+ 
+.toast-icon {
+  flex: 0 0 auto;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 700;
+  background: var(--tn-surface-2);
+  color: var(--tn-accent);
+}
+ 
+.toast-success .toast-icon { color: var(--tn-success); }
+.toast-error .toast-icon { color: var(--tn-error); }
+.toast-warning .toast-icon { color: var(--tn-warning); }
+.toast-info .toast-icon { color: var(--tn-info); }
+ 
+.toast-body {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+ 
+.toast-title {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--tn-text);
+  margin: 1px 0 2px;
+}
+ 
+.toast-text {
+  font-size: 12.5px;
+  color: var(--tn-text-muted);
+  margin: 0;
+}
+ 
+.toast-close {
+  flex: 0 0 auto;
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  color: var(--tn-text-muted);
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+}
+ 
+.toast-close:hover {
+  background: var(--tn-surface-2);
+  color: var(--tn-text);
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   6. Footer
+   ------------------------------------------------------------------------- */
+ 
+.footer {
+  position: relative;
+  z-index: 1;
+  text-align: center;
+  padding: 8px 24px 48px;
+  font-size: 12.5px;
+  color: var(--tn-text-muted);
+  font-family: var(--tn-font-mono);
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   7. Responsive
+   ------------------------------------------------------------------------- */
+ 
+@media (max-width: 480px) {
+  .hero {
+    padding: 68px 20px 40px;
+  }
+ 
+  .toast-viewport {
+    left: 16px;
+    right: 16px;
+    bottom: 16px;
+    width: auto;
+  }
+ 
+  .trigger-row {
+    flex-direction: column;
+  }
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   8. Reduced motion
+   ------------------------------------------------------------------------- */
+ 
+@media (prefers-reduced-motion: reduce) {
+  #toast-success-toggle:checked ~ .toast-viewport .toast-success,
+  #toast-error-toggle:checked   ~ .toast-viewport .toast-error,
+  #toast-warning-toggle:checked ~ .toast-viewport .toast-warning,
+  #toast-info-toggle:checked    ~ .toast-viewport .toast-info {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}


### PR DESCRIPTION
Closes #62072

## Pull Request Description
Adds a pure CSS/HTML toast notification that fades and slides in, holds, then auto-dismisses via a single keyframe animation — no JavaScript, no timers. Includes success/error/warning/info variants and a manual close control.

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/fade-in-toast-saas/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A toast notification whose entire show → hold → auto-dismiss lifecycle runs off one CSS keyframe animation triggered by the checkbox hack, with an optional early manual dismiss.

**How does a developer use it?**
```html
<input type="checkbox" id="toast-1-toggle" class="toast-toggle">
<label for="toast-1-toggle" class="trigger-btn">Show toast</label>

<div class="toast-viewport">
  <div class="toast toast-success">
    …
    <label for="toast-1-toggle" class="toast-close">&times;</label>
  </div>
</div>
```
Retune `--tn-duration-in`, `--tn-hold`, and `--tn-duration-out` per instance to change pacing.

**Why does it fit EaseMotion CSS?**
Auto-dismissing toasts are usually the first thing people reach for JS for; this shows the whole lifecycle — timed entrance, hold, timed exit — expressed purely as one animation with proportional keyframe stops, computed from three separate duration tokens via `calc()`.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

## Notes for Maintainer
Worth calling out: under `prefers-reduced-motion: reduce`, the toast doesn't just skip the animation — it removes the auto-dismiss entirely and stays visible until manually closed, since auto-expiring content is a real timing barrier (WCAG 2.2.1) independent of the motion question. Manual close via the × is instant rather than animated, a deliberate JS-free trade-off explained in the README.