### PR TITLE
feat: add ease-wind-tunnel-smoke (#65574)

### DIFF
--- a/submissions/examples/wind-tunnel-smoke-ns/README.md
+++ b/submissions/examples/wind-tunnel-smoke-ns/README.md
@@ -1,0 +1,16 @@
+# Wind Tunnel Smoke
+
+## What does this do?
+Renders a self-contained CSS-only `ease-wind-tunnel-smoke` demo: wind-tunnel smoke streamlines flowing over an airfoil.
+
+## How is it used?
+Open `demo.html` in a browser. The animated face uses classes like `ease-wind-tunnel-smoke`, `ease-wind-tunnel-smoke__strand`, and `ease-wind-tunnel-smoke__airfoil`. No build step or JavaScript is required for the motion.
+
+```html
+<section class="ease-wind-tunnel-smoke">
+  <div class="ease-wind-tunnel-smoke__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable aerodynamics motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/wind-tunnel-smoke-ns/demo.html
+++ b/submissions/examples/wind-tunnel-smoke-ns/demo.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Wind Tunnel Smoke — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Wind Tunnel Smoke demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Wind Tunnel Smoke</h1>
+      <p class="lede">Wind-tunnel smoke streamlines flowing over an airfoil</p>
+    </header>
+
+    <section class="ease-wind-tunnel-smoke" data-demo="wind-tunnel-smoke" aria-live="polite">
+      <div class="ease-wind-tunnel-smoke__housing">
+        <div class="ease-wind-tunnel-smoke__bezel">
+          <div class="ease-wind-tunnel-smoke__face">
+            <div class="ease-wind-tunnel-smoke__readout">
+              <span class="ease-wind-tunnel-smoke__label">Section A — Smoke Viz</span>
+              <span class="ease-wind-tunnel-smoke__value">42 m/s</span>
+            </div>
+
+            <div class="ease-wind-tunnel-smoke__tunnel" aria-hidden="true">
+              <span class="ease-wind-tunnel-smoke__grille"></span>
+              <span class="ease-wind-tunnel-smoke__strand s1"></span>
+              <span class="ease-wind-tunnel-smoke__strand s2"></span>
+              <span class="ease-wind-tunnel-smoke__strand s3"></span>
+              <span class="ease-wind-tunnel-smoke__strand s4"></span>
+              <span class="ease-wind-tunnel-smoke__strand s5"></span>
+              <span class="ease-wind-tunnel-smoke__strand s6"></span>
+              <span class="ease-wind-tunnel-smoke__airfoil"></span>
+              <span class="ease-wind-tunnel-smoke__wake"></span>
+            </div>
+
+            <div class="ease-wind-tunnel-smoke__dials">
+              <div class="ease-wind-tunnel-smoke__dial">
+                <span class="ease-wind-tunnel-smoke__dial-face">
+                  <i class="needle"></i>
+                </span>
+                <span class="cap">AoA</span>
+              </div>
+              <div class="ease-wind-tunnel-smoke__dial">
+                <span class="ease-wind-tunnel-smoke__dial-face secondary">
+                  <i class="needle"></i>
+                </span>
+                <span class="cap">Q</span>
+              </div>
+              <div class="ease-wind-tunnel-smoke__meters" aria-hidden="true">
+                <i></i><i></i><i></i><i></i><i></i><i></i>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="ease-wind-tunnel-smoke__controls">
+          <button type="button" class="ease-wind-tunnel-smoke__btn primary">Run tunnel</button>
+          <button type="button" class="ease-wind-tunnel-smoke__btn">Purge</button>
+          <label class="ease-wind-tunnel-smoke__switch">
+            <input type="checkbox" checked>
+            <span>Smoke on</span>
+          </label>
+        </div>
+      </div>
+
+      <footer class="ease-wind-tunnel-smoke__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/wind-tunnel-smoke-ns/style.css
+++ b/submissions/examples/wind-tunnel-smoke-ns/style.css
@@ -1,0 +1,481 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 20% 0%, #1a3348 0%, transparent 50%),
+    radial-gradient(ellipse at 90% 100%, #243018 0%, transparent 45%),
+    #0c1218;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-wind-tunnel-smoke {
+  --accent: #7dd3fc;
+  --accent-2: #94a3b8;
+  --panel: color-mix(in srgb, #e8eef6 7%, #0c1218);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #0c1218 75%, #000);
+}
+
+.ease-wind-tunnel-smoke__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-wind-tunnel-smoke__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #0c1218 90%, #1e3a4c);
+}
+
+.ease-wind-tunnel-smoke__face {
+  position: relative;
+  min-height: 260px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    linear-gradient(90deg, #0a1016 0%, #15202b 18%, #15202b 82%, #0a1016 100%),
+    repeating-linear-gradient(
+      90deg,
+      transparent,
+      transparent 11px,
+      color-mix(in srgb, #e8eef6 4%, transparent) 12px
+    );
+}
+
+.ease-wind-tunnel-smoke__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-wind-tunnel-smoke__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-wind-tunnel-smoke__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-wind-tunnel-smoke__tunnel {
+  position: absolute;
+  inset: 18% 6% 28%;
+  z-index: 1;
+}
+
+.ease-wind-tunnel-smoke__grille {
+  position: absolute;
+  left: 0;
+  top: 8%;
+  bottom: 8%;
+  width: 10px;
+  border-radius: 2px;
+  background:
+    repeating-linear-gradient(
+      180deg,
+      #334155 0 3px,
+      #0f172a 3px 7px
+    );
+  box-shadow: 2px 0 12px color-mix(in srgb, var(--accent) 25%, transparent);
+}
+
+.ease-wind-tunnel-smoke__strand {
+  position: absolute;
+  left: 4%;
+  height: 2px;
+  width: 72%;
+  border-radius: 999px;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    color-mix(in srgb, #f8fafc 55%, transparent) 18%,
+    color-mix(in srgb, var(--accent) 45%, transparent) 55%,
+    transparent 100%
+  );
+  filter: blur(0.6px);
+  opacity: 0.55;
+  transform-origin: left center;
+  animation: wind_tunnel_smoke_motion 2.8s linear infinite;
+}
+
+.ease-wind-tunnel-smoke__strand.s1 {
+  top: 18%;
+  width: 68%;
+  animation-duration: 2.4s;
+}
+
+.ease-wind-tunnel-smoke__strand.s2 {
+  top: 30%;
+  width: 74%;
+  animation-duration: 2.7s;
+  animation-delay: -0.35s;
+  transform: rotate(2deg);
+}
+
+.ease-wind-tunnel-smoke__strand.s3 {
+  top: 42%;
+  width: 78%;
+  animation-duration: 3s;
+  animation-delay: -0.7s;
+  transform: rotate(4deg);
+}
+
+.ease-wind-tunnel-smoke__strand.s4 {
+  top: 54%;
+  width: 76%;
+  animation-duration: 2.6s;
+  animation-delay: -1.1s;
+  transform: rotate(-3deg);
+}
+
+.ease-wind-tunnel-smoke__strand.s5 {
+  top: 66%;
+  width: 70%;
+  animation-duration: 2.9s;
+  animation-delay: -0.55s;
+  transform: rotate(-5deg);
+}
+
+.ease-wind-tunnel-smoke__strand.s6 {
+  top: 78%;
+  width: 64%;
+  animation-duration: 3.2s;
+  animation-delay: -1.4s;
+  opacity: 0.4;
+}
+
+.ease-wind-tunnel-smoke__airfoil {
+  position: absolute;
+  left: 38%;
+  top: 34%;
+  width: 150px;
+  height: 42px;
+  z-index: 2;
+  border-radius: 55% 8% 35% 45% / 70% 20% 80% 30%;
+  background:
+    linear-gradient(180deg, #cbd5e1 0%, #64748b 42%, #334155 100%);
+  box-shadow:
+    inset 0 2px 0 color-mix(in srgb, #fff 35%, transparent),
+    0 6px 14px color-mix(in srgb, #000 45%, transparent);
+  transform: rotate(-8deg);
+}
+
+.ease-wind-tunnel-smoke__wake {
+  position: absolute;
+  left: 58%;
+  top: 40%;
+  width: 34%;
+  height: 28%;
+  z-index: 1;
+  border-radius: 40%;
+  background: radial-gradient(
+    ellipse at left center,
+    color-mix(in srgb, #f8fafc 28%, transparent),
+    transparent 70%
+  );
+  filter: blur(4px);
+  opacity: 0.55;
+  animation: wind_tunnel_smoke_wake 2.4s ease-in-out infinite alternate;
+}
+
+.ease-wind-tunnel-smoke__dials {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.7rem;
+  display: flex;
+  align-items: flex-end;
+  gap: 0.75rem;
+  z-index: 3;
+}
+
+.ease-wind-tunnel-smoke__dial {
+  display: grid;
+  justify-items: center;
+  gap: 0.25rem;
+}
+
+.ease-wind-tunnel-smoke__dial-face {
+  position: relative;
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  border: 1px solid var(--line);
+  background:
+    conic-gradient(from 220deg, var(--accent) 0 95deg, #1e293b 95deg 360deg),
+    #0f172a;
+  box-shadow: inset 0 0 0 4px #0f172a;
+}
+
+.ease-wind-tunnel-smoke__dial-face.secondary {
+  background:
+    conic-gradient(from 220deg, var(--accent-2) 0 140deg, #1e293b 140deg 360deg),
+    #0f172a;
+}
+
+.ease-wind-tunnel-smoke__dial-face .needle {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 2px;
+  height: 14px;
+  margin-left: -1px;
+  margin-top: -14px;
+  border-radius: 999px;
+  background: #f8fafc;
+  transform-origin: bottom center;
+  animation: wind_tunnel_smoke_needle 3.4s ease-in-out infinite alternate;
+}
+
+.ease-wind-tunnel-smoke__dial-face.secondary .needle {
+  animation-duration: 2.6s;
+  animation-delay: -0.8s;
+}
+
+.ease-wind-tunnel-smoke__dial .cap {
+  font-size: 0.65rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  opacity: 0.7;
+}
+
+.ease-wind-tunnel-smoke__meters {
+  flex: 1;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  align-self: center;
+  margin-left: 0.4rem;
+}
+
+.ease-wind-tunnel-smoke__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-wind-tunnel-smoke__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: wind_tunnel_smoke_meter 1.7s ease-in-out infinite alternate;
+}
+
+.ease-wind-tunnel-smoke__meters i:nth-child(2)::after {
+  animation-delay: 0.1s;
+  width: 58%;
+}
+
+.ease-wind-tunnel-smoke__meters i:nth-child(3)::after {
+  animation-delay: 0.2s;
+  width: 72%;
+}
+
+.ease-wind-tunnel-smoke__meters i:nth-child(4)::after {
+  animation-delay: 0.3s;
+  width: 50%;
+}
+
+.ease-wind-tunnel-smoke__meters i:nth-child(5)::after {
+  animation-delay: 0.4s;
+  width: 84%;
+}
+
+.ease-wind-tunnel-smoke__meters i:nth-child(6)::after {
+  animation-delay: 0.5s;
+  width: 63%;
+}
+
+.ease-wind-tunnel-smoke__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-wind-tunnel-smoke__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-wind-tunnel-smoke__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-wind-tunnel-smoke__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-wind-tunnel-smoke__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-wind-tunnel-smoke__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-wind-tunnel-smoke__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 50%, transparent);
+  animation: wind_tunnel_smoke_pulse 1.8s ease-out infinite;
+}
+
+@keyframes wind_tunnel_smoke_motion {
+  0% {
+    transform: translateX(-12%) scaleX(0.92);
+    opacity: 0.15;
+  }
+
+  35% {
+    opacity: 0.7;
+  }
+
+  70% {
+    transform: translateX(8%) scaleX(1.05);
+    opacity: 0.45;
+  }
+
+  100% {
+    transform: translateX(18%) scaleX(1.1);
+    opacity: 0.1;
+  }
+}
+
+@keyframes wind_tunnel_smoke_wake {
+  0% {
+    transform: translateX(0) scaleX(0.9);
+    opacity: 0.3;
+  }
+
+  100% {
+    transform: translateX(10px) scaleX(1.15);
+    opacity: 0.65;
+  }
+}
+
+@keyframes wind_tunnel_smoke_needle {
+  0% {
+    transform: rotate(-28deg);
+  }
+
+  100% {
+    transform: rotate(22deg);
+  }
+}
+
+@keyframes wind_tunnel_smoke_meter {
+  0% {
+    transform: translateX(0);
+    opacity: 0.55;
+  }
+
+  100% {
+    transform: translateX(40%);
+    opacity: 1;
+  }
+}
+
+@keyframes wind_tunnel_smoke_pulse {
+  0% {
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent);
+  }
+
+  100% {
+    box-shadow: 0 0 0 12px transparent;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-wind-tunnel-smoke__strand,
+  .ease-wind-tunnel-smoke__wake,
+  .ease-wind-tunnel-smoke__dial-face .needle,
+  .ease-wind-tunnel-smoke__meters i::after,
+  .ease-wind-tunnel-smoke__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-wind-tunnel-smoke` under `submissions/examples/wind-tunnel-smoke-ns/` — CSS-only smoke streamlines over an airfoil with tunnel housing, AoA/Q dials, and meter bars.

Fixes #65574

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Wind-tunnel smoke viz: streamlines translate across an airfoil with wake blur and instrument dials.

**How does a developer use it?**

```html
<section class="ease-wind-tunnel-smoke">
  <div class="ease-wind-tunnel-smoke__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS — same curated demo model as other examples.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion lives in `wind_tunnel_smoke_motion` / wake / needle keyframes. Reduced-motion disables animations.


Made with [Cursor](https://cursor.com)