### PR TITLE
feat: add ease-tesla-coil-arc (#65575)

### DIFF
--- a/submissions/examples/tesla-coil-arc-ns/README.md
+++ b/submissions/examples/tesla-coil-arc-ns/README.md
@@ -1,0 +1,16 @@
+# Tesla Coil Arc
+
+## What does this do?
+Renders a self-contained CSS-only `ease-tesla-coil-arc` demo: Tesla coil throwing intermittent electric arcs upward.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-tesla-coil-arc`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-tesla-coil-arc">
+  <div class="ease-tesla-coil-arc__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/tesla-coil-arc-ns/demo.html
+++ b/submissions/examples/tesla-coil-arc-ns/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tesla Coil Arc — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Tesla Coil Arc demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Tesla Coil Arc</h1>
+      <p class="lede">Tesla coil throwing intermittent electric arcs upward</p>
+    </header>
+
+    <section class="ease-tesla-coil-arc" data-demo="tesla-coil-arc" aria-live="polite">
+      <div class="ease-tesla-coil-arc__housing">
+        <div class="ease-tesla-coil-arc__bezel">
+          <div class="ease-tesla-coil-arc__face">
+            <div class="ease-tesla-coil-arc__readout">
+              <span class="ease-tesla-coil-arc__label">Tesla Coil Arc</span>
+              <span class="ease-tesla-coil-arc__value">HV LIVE</span>
+            </div>
+            <div class="ease-tesla-coil-arc__motion" aria-hidden="true">
+              <span class="ease-tesla-coil-arc__coil"></span>
+              <span class="ease-tesla-coil-arc__toroid"></span>
+              <span class="ease-tesla-coil-arc__arc a1"></span>
+              <span class="ease-tesla-coil-arc__arc a2"></span>
+              <span class="ease-tesla-coil-arc__arc a3"></span>
+              <span class="ease-tesla-coil-arc__spark"></span>
+            </div>
+            <div class="ease-tesla-coil-arc__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-tesla-coil-arc__controls">
+          <button type="button" class="ease-tesla-coil-arc__btn primary">Engage</button>
+          <button type="button" class="ease-tesla-coil-arc__btn">Reset</button>
+          <label class="ease-tesla-coil-arc__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-tesla-coil-arc__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/tesla-coil-arc-ns/style.css
+++ b/submissions/examples/tesla-coil-arc-ns/style.css
@@ -1,0 +1,236 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #38bdf8 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #94a3b8 18%, transparent), transparent 42%),
+    #0b1220;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-tesla-coil-arc {
+  --accent: #38bdf8;
+  --accent-2: #94a3b8;
+  --panel: color-mix(in srgb, #e8eef6 7%, #0b1220);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #0b1220 75%, #000);
+}
+
+.ease-tesla-coil-arc__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-tesla-coil-arc__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #0b1220 90%, #38bdf8);
+}
+
+.ease-tesla-coil-arc__face {
+  position: relative;
+  min-height: 260px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 28% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #0b1220 85%, #000), color-mix(in srgb, #0b1220 65%, var(--accent-2)));
+}
+
+.ease-tesla-coil-arc__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-tesla-coil-arc__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-tesla-coil-arc__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-tesla-coil-arc__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-tesla-coil-arc__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-tesla-coil-arc__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-tesla-coil-arc__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: tesla_coil_arc_meter 1.7s ease-in-out infinite alternate;
+}
+
+.ease-tesla-coil-arc__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-tesla-coil-arc__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-tesla-coil-arc__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-tesla-coil-arc__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-tesla-coil-arc__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-tesla-coil-arc__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-tesla-coil-arc__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-tesla-coil-arc__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-tesla-coil-arc__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-tesla-coil-arc__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-tesla-coil-arc__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-tesla-coil-arc__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: tesla_coil_arc_pulse 1.8s ease-out infinite;
+}
+
+@keyframes tesla_coil_arc_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes tesla_coil_arc_pulse {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+
+.ease-tesla-coil-arc__coil{position:absolute;left:46%;bottom:18%;width:18px;height:48%;background:linear-gradient(180deg,#94a3b8,#334155);border-radius:4px}
+.ease-tesla-coil-arc__toroid{position:absolute;left:38%;top:22%;width:24%;height:22%;border:10px solid #cbd5e1;border-radius:50%;box-shadow:0 0 18px color-mix(in srgb,var(--accent)40%,transparent)}
+.ease-tesla-coil-arc__arc{position:absolute;width:3px;background:linear-gradient(180deg,var(--accent),transparent);filter:blur(.5px);transform-origin:bottom center;animation:tesla_coil_arc_arc 1.1s ease-in-out infinite}
+.ease-tesla-coil-arc__arc.a1{left:48%;top:8%;height:18%;animation-delay:0s}
+.ease-tesla-coil-arc__arc.a2{left:56%;top:12%;height:14%;animation-delay:.2s;transform:rotate(18deg)}
+.ease-tesla-coil-arc__arc.a3{left:40%;top:10%;height:16%;animation-delay:.45s;transform:rotate(-22deg)}
+.ease-tesla-coil-arc__spark{position:absolute;left:50%;top:18%;width:8px;height:8px;border-radius:50%;background:var(--accent);box-shadow:0 0 16px var(--accent);animation:tesla_coil_arc_spark .9s ease-out infinite}
+@keyframes tesla_coil_arc_arc{0%,100%{opacity:.15;transform:scaleY(.4)}40%{opacity:1;transform:scaleY(1)}70%{opacity:.35}}
+@keyframes tesla_coil_arc_spark{0%{opacity:0;transform:scale(.4)}30%{opacity:1;transform:scale(1.3)}100%{opacity:0;transform:translateY(-18px) scale(.2)}}
+@media (prefers-reduced-motion:reduce){.ease-tesla-coil-arc__arc,.ease-tesla-coil-arc__spark{animation:none!important}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-tesla-coil-arc__meters i::after,
+  .ease-tesla-coil-arc__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-tesla-coil-arc` under `submissions/examples/tesla-coil-arc-ns/` — CSS-only Tesla coil throwing intermittent electric arcs upward.

Fixes #65575

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Tesla coil throwing intermittent electric arcs upward.

**How does a developer use it?**

```html
<section class="ease-tesla-coil-arc">
  <div class="ease-tesla-coil-arc__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `tesla_coil_arc_*` prefix. Reduced-motion disables animations.