### PR TITLE
feat: add ease-newton-cradle-click (#65576)

### DIFF
--- a/submissions/examples/newton-cradle-click-ns/README.md
+++ b/submissions/examples/newton-cradle-click-ns/README.md
@@ -1,0 +1,16 @@
+# Newton Cradle Click
+
+## What does this do?
+Renders a self-contained CSS-only `ease-newton-cradle-click` demo: Newton cradle end spheres transferring momentum.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-newton-cradle-click`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-newton-cradle-click">
+  <div class="ease-newton-cradle-click__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/newton-cradle-click-ns/demo.html
+++ b/submissions/examples/newton-cradle-click-ns/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Newton Cradle Click — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Newton Cradle Click demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Newton Cradle Click</h1>
+      <p class="lede">Newton cradle end spheres transferring momentum</p>
+    </header>
+
+    <section class="ease-newton-cradle-click" data-demo="newton-cradle-click" aria-live="polite">
+      <div class="ease-newton-cradle-click__housing">
+        <div class="ease-newton-cradle-click__bezel">
+          <div class="ease-newton-cradle-click__face">
+            <div class="ease-newton-cradle-click__readout">
+              <span class="ease-newton-cradle-click__label">Newton Cradle Click</span>
+              <span class="ease-newton-cradle-click__value">CLICK</span>
+            </div>
+            <div class="ease-newton-cradle-click__motion" aria-hidden="true">
+              <span class="ease-newton-cradle-click__rail"></span>
+              <span class="ease-newton-cradle-click__ball b1"></span>
+              <span class="ease-newton-cradle-click__ball b2"></span>
+              <span class="ease-newton-cradle-click__ball b3"></span>
+              <span class="ease-newton-cradle-click__ball b4"></span>
+              <span class="ease-newton-cradle-click__ball b5"></span>
+            </div>
+            <div class="ease-newton-cradle-click__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-newton-cradle-click__controls">
+          <button type="button" class="ease-newton-cradle-click__btn primary">Engage</button>
+          <button type="button" class="ease-newton-cradle-click__btn">Reset</button>
+          <label class="ease-newton-cradle-click__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-newton-cradle-click__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/newton-cradle-click-ns/style.css
+++ b/submissions/examples/newton-cradle-click-ns/style.css
@@ -1,0 +1,237 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #e2e8f0 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #64748b 18%, transparent), transparent 42%),
+    #111827;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-newton-cradle-click {
+  --accent: #e2e8f0;
+  --accent-2: #64748b;
+  --panel: color-mix(in srgb, #e8eef6 7%, #111827);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #111827 75%, #000);
+}
+
+.ease-newton-cradle-click__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-newton-cradle-click__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #111827 90%, #e2e8f0);
+}
+
+.ease-newton-cradle-click__face {
+  position: relative;
+  min-height: 260px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 28% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #111827 85%, #000), color-mix(in srgb, #111827 65%, var(--accent-2)));
+}
+
+.ease-newton-cradle-click__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-newton-cradle-click__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-newton-cradle-click__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-newton-cradle-click__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-newton-cradle-click__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-newton-cradle-click__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-newton-cradle-click__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: newton_cradle_click_meter 1.7s ease-in-out infinite alternate;
+}
+
+.ease-newton-cradle-click__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-newton-cradle-click__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-newton-cradle-click__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-newton-cradle-click__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-newton-cradle-click__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-newton-cradle-click__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-newton-cradle-click__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-newton-cradle-click__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-newton-cradle-click__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-newton-cradle-click__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-newton-cradle-click__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-newton-cradle-click__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: newton_cradle_click_pulse 1.8s ease-out infinite;
+}
+
+@keyframes newton_cradle_click_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes newton_cradle_click_pulse {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+
+.ease-newton-cradle-click__rail{position:absolute;left:12%;right:12%;top:18%;height:6px;background:#64748b;border-radius:3px}
+.ease-newton-cradle-click__ball{position:absolute;top:18%;width:28px;height:28px;margin-left:-14px;border-radius:50%;background:radial-gradient(circle at 35% 30%,#fff8,transparent 40%),radial-gradient(circle at 50% 50%,#cbd5e1,#475569);box-shadow:0 4px 10px #0006;transform-origin:50% -54px}
+.ease-newton-cradle-click__ball::before{content:"";position:absolute;left:50%;top:-54px;width:2px;height:54px;background:#94a3b8;transform:translateX(-50%)}
+.ease-newton-cradle-click__ball.b1{left:22%;animation:newton_cradle_click_left 1.6s ease-in-out infinite}
+.ease-newton-cradle-click__ball.b2{left:36%}
+.ease-newton-cradle-click__ball.b3{left:50%}
+.ease-newton-cradle-click__ball.b4{left:64%}
+.ease-newton-cradle-click__ball.b5{left:78%;animation:newton_cradle_click_right 1.6s ease-in-out infinite}
+@keyframes newton_cradle_click_left{0%,100%{transform:rotate(0)}20%{transform:rotate(28deg)}40%,100%{transform:rotate(0)}}
+@keyframes newton_cradle_click_right{0%,40%{transform:rotate(0)}60%{transform:rotate(-28deg)}80%,100%{transform:rotate(0)}}
+@media (prefers-reduced-motion:reduce){.ease-newton-cradle-click__ball{animation:none!important}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-newton-cradle-click__meters i::after,
+  .ease-newton-cradle-click__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-newton-cradle-click` under `submissions/examples/newton-cradle-click-ns/` — CSS-only Newton cradle end spheres transferring momentum.

Fixes #65576

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Newton cradle end spheres transferring momentum.

**How does a developer use it?**

```html
<section class="ease-newton-cradle-click">
  <div class="ease-newton-cradle-click__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `newton_cradle_click_*` prefix. Reduced-motion disables animations.