### PR TITLE
feat: add ease-barometer-aneroid (#65577)

### DIFF
--- a/submissions/examples/barometer-aneroid-ns/README.md
+++ b/submissions/examples/barometer-aneroid-ns/README.md
@@ -1,0 +1,16 @@
+# Barometer Aneroid
+
+## What does this do?
+Renders a self-contained CSS-only `ease-barometer-aneroid` demo: Aneroid barometer needle responding to pressure change.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-barometer-aneroid`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-barometer-aneroid">
+  <div class="ease-barometer-aneroid__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/barometer-aneroid-ns/demo.html
+++ b/submissions/examples/barometer-aneroid-ns/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Barometer Aneroid — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Barometer Aneroid demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Barometer Aneroid</h1>
+      <p class="lede">Aneroid barometer needle responding to pressure change</p>
+    </header>
+
+    <section class="ease-barometer-aneroid" data-demo="barometer-aneroid" aria-live="polite">
+      <div class="ease-barometer-aneroid__housing">
+        <div class="ease-barometer-aneroid__bezel">
+          <div class="ease-barometer-aneroid__face">
+            <div class="ease-barometer-aneroid__readout">
+              <span class="ease-barometer-aneroid__label">Barometer Aneroid</span>
+              <span class="ease-barometer-aneroid__value">1013 hPa</span>
+            </div>
+            <div class="ease-barometer-aneroid__motion" aria-hidden="true">
+              <span class="ease-barometer-aneroid__gauge"></span>
+              <span class="ease-barometer-aneroid__ticks"></span>
+              <span class="ease-barometer-aneroid__needle"></span>
+              <span class="ease-barometer-aneroid__hub"></span>
+              <span class="ease-barometer-aneroid__capsule"></span>
+            </div>
+            <div class="ease-barometer-aneroid__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-barometer-aneroid__controls">
+          <button type="button" class="ease-barometer-aneroid__btn primary">Engage</button>
+          <button type="button" class="ease-barometer-aneroid__btn">Reset</button>
+          <label class="ease-barometer-aneroid__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-barometer-aneroid__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/barometer-aneroid-ns/style.css
+++ b/submissions/examples/barometer-aneroid-ns/style.css
@@ -1,0 +1,234 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #38bdf8 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #64748b 18%, transparent), transparent 42%),
+    #0f172a;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-barometer-aneroid {
+  --accent: #38bdf8;
+  --accent-2: #64748b;
+  --panel: color-mix(in srgb, #e8eef6 7%, #0f172a);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #0f172a 75%, #000);
+}
+
+.ease-barometer-aneroid__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-barometer-aneroid__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #0f172a 90%, #38bdf8);
+}
+
+.ease-barometer-aneroid__face {
+  position: relative;
+  min-height: 260px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 28% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #0f172a 85%, #000), color-mix(in srgb, #0f172a 65%, var(--accent-2)));
+}
+
+.ease-barometer-aneroid__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-barometer-aneroid__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-barometer-aneroid__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-barometer-aneroid__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-barometer-aneroid__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-barometer-aneroid__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-barometer-aneroid__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: barometer_aneroid_meter 1.7s ease-in-out infinite alternate;
+}
+
+.ease-barometer-aneroid__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-barometer-aneroid__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-barometer-aneroid__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-barometer-aneroid__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-barometer-aneroid__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-barometer-aneroid__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-barometer-aneroid__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-barometer-aneroid__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-barometer-aneroid__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-barometer-aneroid__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-barometer-aneroid__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-barometer-aneroid__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: barometer_aneroid_pulse 1.8s ease-out infinite;
+}
+
+@keyframes barometer_aneroid_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes barometer_aneroid_pulse {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+
+.ease-barometer-aneroid__gauge{position:absolute;left:50%;top:48%;width:150px;height:150px;margin:-75px 0 0 -75px;border-radius:50%;border:8px solid #475569;background:radial-gradient(circle at 50% 50%,#1e293b,#0f172a)}
+.ease-barometer-aneroid__ticks{position:absolute;left:50%;top:48%;width:130px;height:130px;margin:-65px 0 0 -65px;border-radius:50%;background:repeating-conic-gradient(#94a3b8 0 2deg,transparent 2deg 20deg)}
+.ease-barometer-aneroid__needle{position:absolute;left:50%;top:48%;width:4px;height:58px;margin:-50px 0 0 -2px;background:linear-gradient(180deg,var(--accent),#64748b);border-radius:2px;transform-origin:50% 86%;animation:barometer_aneroid_needle 4s ease-in-out infinite alternate}
+.ease-barometer-aneroid__hub{position:absolute;left:50%;top:48%;width:14px;height:14px;margin:-7px 0 0 -7px;border-radius:50%;background:#e2e8f0}
+.ease-barometer-aneroid__capsule{position:absolute;right:12%;bottom:28%;width:44px;height:22px;border-radius:999px;border:2px solid var(--line);background:color-mix(in srgb,var(--accent)20%,transparent);animation:barometer_aneroid_capsule 4s ease-in-out infinite alternate}
+@keyframes barometer_aneroid_needle{0%{transform:rotate(-42deg)}100%{transform:rotate(48deg)}}
+@keyframes barometer_aneroid_capsule{0%{transform:scale(.92);opacity:.55}100%{transform:scale(1.08);opacity:1}}
+@media (prefers-reduced-motion:reduce){.ease-barometer-aneroid__needle,.ease-barometer-aneroid__capsule{animation:none!important}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-barometer-aneroid__meters i::after,
+  .ease-barometer-aneroid__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-barometer-aneroid` under `submissions/examples/barometer-aneroid-ns/` — CSS-only Aneroid barometer needle responding to pressure change.

Fixes #65577

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Aneroid barometer needle responding to pressure change.

**How does a developer use it?**

```html
<section class="ease-barometer-aneroid">
  <div class="ease-barometer-aneroid__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `barometer_aneroid_*` prefix. Reduced-motion disables animations.