### PR TITLE
feat: add ease-anemometer-cups (#65578)

### DIFF
--- a/submissions/examples/anemometer-cups-ns/README.md
+++ b/submissions/examples/anemometer-cups-ns/README.md
@@ -1,0 +1,16 @@
+# Anemometer Cups
+
+## What does this do?
+Renders a self-contained CSS-only `ease-anemometer-cups` demo: Cup anemometer spinning with wind-speed readout.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-anemometer-cups`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-anemometer-cups">
+  <div class="ease-anemometer-cups__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/anemometer-cups-ns/demo.html
+++ b/submissions/examples/anemometer-cups-ns/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Anemometer Cups — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Anemometer Cups demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Anemometer Cups</h1>
+      <p class="lede">Cup anemometer spinning with wind-speed readout</p>
+    </header>
+
+    <section class="ease-anemometer-cups" data-demo="anemometer-cups" aria-live="polite">
+      <div class="ease-anemometer-cups__housing">
+        <div class="ease-anemometer-cups__bezel">
+          <div class="ease-anemometer-cups__face">
+            <div class="ease-anemometer-cups__readout">
+              <span class="ease-anemometer-cups__label">Anemometer Cups</span>
+              <span class="ease-anemometer-cups__value">18 kt</span>
+            </div>
+            <div class="ease-anemometer-cups__motion" aria-hidden="true">
+              <span class="ease-anemometer-cups__mast"></span>
+              <span class="ease-anemometer-cups__rotor">
+                <i class="cup c1"></i><i class="cup c2"></i><i class="cup c3"></i>
+              </span>
+              <span class="ease-anemometer-cups__wind"></span>
+            </div>
+            <div class="ease-anemometer-cups__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-anemometer-cups__controls">
+          <button type="button" class="ease-anemometer-cups__btn primary">Engage</button>
+          <button type="button" class="ease-anemometer-cups__btn">Reset</button>
+          <label class="ease-anemometer-cups__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-anemometer-cups__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/anemometer-cups-ns/style.css
+++ b/submissions/examples/anemometer-cups-ns/style.css
@@ -1,0 +1,236 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #7dd3fc 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #94a3b8 18%, transparent), transparent 42%),
+    #0c1520;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-anemometer-cups {
+  --accent: #7dd3fc;
+  --accent-2: #94a3b8;
+  --panel: color-mix(in srgb, #e8eef6 7%, #0c1520);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #0c1520 75%, #000);
+}
+
+.ease-anemometer-cups__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-anemometer-cups__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #0c1520 90%, #7dd3fc);
+}
+
+.ease-anemometer-cups__face {
+  position: relative;
+  min-height: 260px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 28% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #0c1520 85%, #000), color-mix(in srgb, #0c1520 65%, var(--accent-2)));
+}
+
+.ease-anemometer-cups__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-anemometer-cups__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-anemometer-cups__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-anemometer-cups__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-anemometer-cups__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-anemometer-cups__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-anemometer-cups__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: anemometer_cups_meter 1.7s ease-in-out infinite alternate;
+}
+
+.ease-anemometer-cups__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-anemometer-cups__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-anemometer-cups__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-anemometer-cups__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-anemometer-cups__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-anemometer-cups__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-anemometer-cups__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-anemometer-cups__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-anemometer-cups__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-anemometer-cups__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-anemometer-cups__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-anemometer-cups__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: anemometer_cups_pulse 1.8s ease-out infinite;
+}
+
+@keyframes anemometer_cups_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes anemometer_cups_pulse {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+
+.ease-anemometer-cups__mast{position:absolute;left:50%;bottom:16%;width:8px;height:42%;margin-left:-4px;background:linear-gradient(180deg,#94a3b8,#334155);border-radius:4px}
+.ease-anemometer-cups__rotor{position:absolute;left:50%;top:34%;width:120px;height:120px;margin:-60px 0 0 -60px;animation:anemometer_cups_spin 1.4s linear infinite}
+.ease-anemometer-cups__rotor .cup{position:absolute;width:34px;height:34px;border-radius:50% 50% 50% 8%;background:radial-gradient(circle at 30% 30%,#fff6,transparent 45%),var(--accent);box-shadow:0 2px 8px #0005}
+.ease-anemometer-cups__rotor .c1{left:43px;top:0}
+.ease-anemometer-cups__rotor .c2{right:0;bottom:18px;transform:rotate(120deg)}
+.ease-anemometer-cups__rotor .c3{left:0;bottom:18px;transform:rotate(-120deg)}
+.ease-anemometer-cups__wind{position:absolute;left:8%;top:40%;width:28%;height:2px;background:linear-gradient(90deg,transparent,var(--accent-2));animation:anemometer_cups_wind 1.2s linear infinite}
+@keyframes anemometer_cups_spin{to{transform:rotate(360deg)}}
+@keyframes anemometer_cups_wind{0%{transform:translateX(0);opacity:0}40%{opacity:.8}100%{transform:translateX(40px);opacity:0}}
+@media (prefers-reduced-motion:reduce){.ease-anemometer-cups__rotor,.ease-anemometer-cups__wind{animation:none!important}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-anemometer-cups__meters i::after,
+  .ease-anemometer-cups__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-anemometer-cups` under `submissions/examples/anemometer-cups-ns/` — CSS-only Cup anemometer spinning with wind-speed readout.

Fixes #65578

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Cup anemometer spinning with wind-speed readout.

**How does a developer use it?**

```html
<section class="ease-anemometer-cups">
  <div class="ease-anemometer-cups__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `anemometer_cups_*` prefix. Reduced-motion disables animations.