### PR TITLE
feat: add ease-rain-gauge-tipping (#65579)

### DIFF
--- a/submissions/examples/rain-gauge-tipping-ns/README.md
+++ b/submissions/examples/rain-gauge-tipping-ns/README.md
@@ -1,0 +1,16 @@
+# Rain Gauge Tipping
+
+## What does this do?
+Renders a self-contained CSS-only `ease-rain-gauge-tipping` demo: Tipping-bucket rain gauge emptying and resetting.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-rain-gauge-tipping`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-rain-gauge-tipping">
+  <div class="ease-rain-gauge-tipping__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/rain-gauge-tipping-ns/demo.html
+++ b/submissions/examples/rain-gauge-tipping-ns/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Rain Gauge Tipping — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Rain Gauge Tipping demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Rain Gauge Tipping</h1>
+      <p class="lede">Tipping-bucket rain gauge emptying and resetting</p>
+    </header>
+
+    <section class="ease-rain-gauge-tipping" data-demo="rain-gauge-tipping" aria-live="polite">
+      <div class="ease-rain-gauge-tipping__housing">
+        <div class="ease-rain-gauge-tipping__bezel">
+          <div class="ease-rain-gauge-tipping__face">
+            <div class="ease-rain-gauge-tipping__readout">
+              <span class="ease-rain-gauge-tipping__label">Rain Gauge Tipping</span>
+              <span class="ease-rain-gauge-tipping__value">2.4 mm</span>
+            </div>
+            <div class="ease-rain-gauge-tipping__motion" aria-hidden="true">
+              <span class="ease-rain-gauge-tipping__funnel"></span>
+              <span class="ease-rain-gauge-tipping__drop d1"></span>
+              <span class="ease-rain-gauge-tipping__drop d2"></span>
+              <span class="ease-rain-gauge-tipping__bucket"></span>
+              <span class="ease-rain-gauge-tipping__pool"></span>
+            </div>
+            <div class="ease-rain-gauge-tipping__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-rain-gauge-tipping__controls">
+          <button type="button" class="ease-rain-gauge-tipping__btn primary">Engage</button>
+          <button type="button" class="ease-rain-gauge-tipping__btn">Reset</button>
+          <label class="ease-rain-gauge-tipping__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-rain-gauge-tipping__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/rain-gauge-tipping-ns/style.css
+++ b/submissions/examples/rain-gauge-tipping-ns/style.css
@@ -1,0 +1,236 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #38bdf8 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #0ea5e9 18%, transparent), transparent 42%),
+    #0b1620;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-rain-gauge-tipping {
+  --accent: #38bdf8;
+  --accent-2: #0ea5e9;
+  --panel: color-mix(in srgb, #e8eef6 7%, #0b1620);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #0b1620 75%, #000);
+}
+
+.ease-rain-gauge-tipping__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-rain-gauge-tipping__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #0b1620 90%, #38bdf8);
+}
+
+.ease-rain-gauge-tipping__face {
+  position: relative;
+  min-height: 260px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 28% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #0b1620 85%, #000), color-mix(in srgb, #0b1620 65%, var(--accent-2)));
+}
+
+.ease-rain-gauge-tipping__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-rain-gauge-tipping__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-rain-gauge-tipping__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-rain-gauge-tipping__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-rain-gauge-tipping__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-rain-gauge-tipping__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-rain-gauge-tipping__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: rain_gauge_tipping_meter 1.7s ease-in-out infinite alternate;
+}
+
+.ease-rain-gauge-tipping__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-rain-gauge-tipping__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-rain-gauge-tipping__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-rain-gauge-tipping__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-rain-gauge-tipping__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-rain-gauge-tipping__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-rain-gauge-tipping__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-rain-gauge-tipping__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-rain-gauge-tipping__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-rain-gauge-tipping__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-rain-gauge-tipping__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-rain-gauge-tipping__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: rain_gauge_tipping_pulse 1.8s ease-out infinite;
+}
+
+@keyframes rain_gauge_tipping_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes rain_gauge_tipping_pulse {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+
+.ease-rain-gauge-tipping__funnel{position:absolute;left:50%;top:14%;width:56px;height:36px;margin-left:-28px;background:linear-gradient(180deg,#64748b,#334155);clip-path:polygon(10% 0,90% 0,70% 100%,30% 100%)}
+.ease-rain-gauge-tipping__drop{position:absolute;left:50%;width:8px;height:12px;margin-left:-4px;border-radius:50% 50% 50% 50%/60% 60% 40% 40%;background:var(--accent);animation:rain_gauge_tipping_drop 1.8s ease-in infinite}
+.ease-rain-gauge-tipping__drop.d1{top:40%;animation-delay:0s}
+.ease-rain-gauge-tipping__drop.d2{top:40%;animation-delay:.9s;opacity:.7}
+.ease-rain-gauge-tipping__bucket{position:absolute;left:50%;top:52%;width:54px;height:28px;margin-left:-27px;background:#475569;border-radius:0 0 8px 8px;transform-origin:50% 0;animation:rain_gauge_tipping_tip 1.8s ease-in-out infinite}
+.ease-rain-gauge-tipping__pool{position:absolute;left:30%;right:30%;bottom:18%;height:10px;border-radius:999px;background:color-mix(in srgb,var(--accent)35%,transparent);animation:rain_gauge_tipping_pool 1.8s ease-in-out infinite}
+@keyframes rain_gauge_tipping_drop{0%{transform:translateY(0);opacity:0}20%{opacity:1}70%{transform:translateY(36px);opacity:1}100%{transform:translateY(48px);opacity:0}}
+@keyframes rain_gauge_tipping_tip{0%,55%{transform:rotate(0)}70%{transform:rotate(48deg)}85%,100%{transform:rotate(0)}}
+@keyframes rain_gauge_tipping_pool{0%,60%{transform:scaleX(.7);opacity:.4}80%{transform:scaleX(1.15);opacity:.85}100%{transform:scaleX(.85);opacity:.5}}
+@media (prefers-reduced-motion:reduce){.ease-rain-gauge-tipping__drop,.ease-rain-gauge-tipping__bucket,.ease-rain-gauge-tipping__pool{animation:none!important}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-rain-gauge-tipping__meters i::after,
+  .ease-rain-gauge-tipping__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-rain-gauge-tipping` under `submissions/examples/rain-gauge-tipping-ns/` — CSS-only Tipping-bucket rain gauge emptying and resetting.

Fixes #65579

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Tipping-bucket rain gauge emptying and resetting.

**How does a developer use it?**

```html
<section class="ease-rain-gauge-tipping">
  <div class="ease-rain-gauge-tipping__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `rain_gauge_tipping_*` prefix. Reduced-motion disables animations.