### PR TITLE
feat: add ease-geiger-counter-click (#65580)

### DIFF
--- a/submissions/examples/geiger-counter-click-ns/README.md
+++ b/submissions/examples/geiger-counter-click-ns/README.md
@@ -1,0 +1,16 @@
+# Geiger Counter Click
+
+## What does this do?
+Renders a self-contained CSS-only `ease-geiger-counter-click` demo: Geiger counter needle ticks with radiation blip LEDs.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-geiger-counter-click`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-geiger-counter-click">
+  <div class="ease-geiger-counter-click__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/geiger-counter-click-ns/demo.html
+++ b/submissions/examples/geiger-counter-click-ns/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Geiger Counter Click — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Geiger Counter Click demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Geiger Counter Click</h1>
+      <p class="lede">Geiger counter needle ticks with radiation blip LEDs</p>
+    </header>
+
+    <section class="ease-geiger-counter-click" data-demo="geiger-counter-click" aria-live="polite">
+      <div class="ease-geiger-counter-click__housing">
+        <div class="ease-geiger-counter-click__bezel">
+          <div class="ease-geiger-counter-click__face">
+            <div class="ease-geiger-counter-click__readout">
+              <span class="ease-geiger-counter-click__label">Geiger Counter Click</span>
+              <span class="ease-geiger-counter-click__value">0.12 µSv</span>
+            </div>
+            <div class="ease-geiger-counter-click__motion" aria-hidden="true">
+              <span class="ease-geiger-counter-click__tube"></span>
+              <span class="ease-geiger-counter-click__needle"></span>
+              <span class="ease-geiger-counter-click__blip b1"></span>
+              <span class="ease-geiger-counter-click__blip b2"></span>
+              <span class="ease-geiger-counter-click__blip b3"></span>
+              <span class="ease-geiger-counter-click__scale"></span>
+            </div>
+            <div class="ease-geiger-counter-click__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-geiger-counter-click__controls">
+          <button type="button" class="ease-geiger-counter-click__btn primary">Engage</button>
+          <button type="button" class="ease-geiger-counter-click__btn">Reset</button>
+          <label class="ease-geiger-counter-click__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-geiger-counter-click__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/geiger-counter-click-ns/style.css
+++ b/submissions/examples/geiger-counter-click-ns/style.css
@@ -1,0 +1,236 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #4ade80 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #86efac 18%, transparent), transparent 42%),
+    #07140f;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-geiger-counter-click {
+  --accent: #4ade80;
+  --accent-2: #86efac;
+  --panel: color-mix(in srgb, #e8eef6 7%, #07140f);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #07140f 75%, #000);
+}
+
+.ease-geiger-counter-click__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-geiger-counter-click__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #07140f 90%, #4ade80);
+}
+
+.ease-geiger-counter-click__face {
+  position: relative;
+  min-height: 260px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 28% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #07140f 85%, #000), color-mix(in srgb, #07140f 65%, var(--accent-2)));
+}
+
+.ease-geiger-counter-click__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-geiger-counter-click__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-geiger-counter-click__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-geiger-counter-click__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-geiger-counter-click__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-geiger-counter-click__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-geiger-counter-click__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: geiger_counter_click_meter 1.7s ease-in-out infinite alternate;
+}
+
+.ease-geiger-counter-click__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-geiger-counter-click__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-geiger-counter-click__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-geiger-counter-click__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-geiger-counter-click__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-geiger-counter-click__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-geiger-counter-click__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-geiger-counter-click__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-geiger-counter-click__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-geiger-counter-click__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-geiger-counter-click__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-geiger-counter-click__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: geiger_counter_click_pulse 1.8s ease-out infinite;
+}
+
+@keyframes geiger_counter_click_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes geiger_counter_click_pulse {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+
+.ease-geiger-counter-click__tube{position:absolute;left:12%;top:34%;width:28%;height:28px;border-radius:999px;background:linear-gradient(180deg,#94a3b8,#475569);box-shadow:inset 0 0 0 2px #1e293b}
+.ease-geiger-counter-click__scale{position:absolute;right:12%;top:28%;width:42%;height:48px;border-radius:8px;border:1px solid var(--line);background:#0f172a}
+.ease-geiger-counter-click__needle{position:absolute;right:30%;top:34%;width:3px;height:36px;background:var(--accent);transform-origin:50% 90%;animation:geiger_counter_click_tick 2.4s steps(6,end) infinite}
+.ease-geiger-counter-click__blip{position:absolute;width:10px;height:10px;border-radius:50%;background:var(--accent);box-shadow:0 0 10px var(--accent);animation:geiger_counter_click_blip 2.4s ease-out infinite}
+.ease-geiger-counter-click__blip.b1{left:18%;bottom:30%;animation-delay:0s}
+.ease-geiger-counter-click__blip.b2{left:28%;bottom:30%;animation-delay:.4s}
+.ease-geiger-counter-click__blip.b3{left:38%;bottom:30%;animation-delay:.9s}
+@keyframes geiger_counter_click_tick{0%,100%{transform:rotate(-30deg)}50%{transform:rotate(35deg)}}
+@keyframes geiger_counter_click_blip{0%{opacity:0;transform:scale(.4)}15%{opacity:1;transform:scale(1.2)}40%,100%{opacity:.15;transform:scale(.8)}}
+@media (prefers-reduced-motion:reduce){.ease-geiger-counter-click__needle,.ease-geiger-counter-click__blip{animation:none!important}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-geiger-counter-click__meters i::after,
+  .ease-geiger-counter-click__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-geiger-counter-click` under `submissions/examples/geiger-counter-click-ns/` — CSS-only Geiger counter needle ticks with radiation blip LEDs.

Fixes #65580

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Geiger counter needle ticks with radiation blip LEDs.

**How does a developer use it?**

```html
<section class="ease-geiger-counter-click">
  <div class="ease-geiger-counter-click__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `geiger_counter_click_*` prefix. Reduced-motion disables animations.