### PR TITLE
feat: add ease-spectroscope-prism (#65581)

### DIFF
--- a/submissions/examples/spectroscope-prism-ns/README.md
+++ b/submissions/examples/spectroscope-prism-ns/README.md
@@ -1,0 +1,16 @@
+# Spectroscope Prism
+
+## What does this do?
+Renders a self-contained CSS-only `ease-spectroscope-prism` demo: Light beam splitting through a prism into spectrum bands.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-spectroscope-prism`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-spectroscope-prism">
+  <div class="ease-spectroscope-prism__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/spectroscope-prism-ns/demo.html
+++ b/submissions/examples/spectroscope-prism-ns/demo.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Spectroscope Prism — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Spectroscope Prism demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Spectroscope Prism</h1>
+      <p class="lede">Light beam splitting through a prism into spectrum bands</p>
+    </header>
+
+    <section class="ease-spectroscope-prism" data-demo="spectroscope-prism" aria-live="polite">
+      <div class="ease-spectroscope-prism__housing">
+        <div class="ease-spectroscope-prism__bezel">
+          <div class="ease-spectroscope-prism__face">
+            <div class="ease-spectroscope-prism__readout">
+              <span class="ease-spectroscope-prism__label">Spectroscope Prism</span>
+              <span class="ease-spectroscope-prism__value">λ SCAN</span>
+            </div>
+            <div class="ease-spectroscope-prism__motion" aria-hidden="true">
+              <span class="ease-spectroscope-prism__beam"></span>
+              <span class="ease-spectroscope-prism__prism"></span>
+              <span class="ease-spectroscope-prism__band r"></span>
+              <span class="ease-spectroscope-prism__band o"></span>
+              <span class="ease-spectroscope-prism__band y"></span>
+              <span class="ease-spectroscope-prism__band g"></span>
+              <span class="ease-spectroscope-prism__band b"></span>
+              <span class="ease-spectroscope-prism__band v"></span>
+            </div>
+            <div class="ease-spectroscope-prism__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-spectroscope-prism__controls">
+          <button type="button" class="ease-spectroscope-prism__btn primary">Engage</button>
+          <button type="button" class="ease-spectroscope-prism__btn">Reset</button>
+          <label class="ease-spectroscope-prism__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-spectroscope-prism__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/spectroscope-prism-ns/style.css
+++ b/submissions/examples/spectroscope-prism-ns/style.css
@@ -1,0 +1,238 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #a78bfa 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #f472b6 18%, transparent), transparent 42%),
+    #12081c;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-spectroscope-prism {
+  --accent: #a78bfa;
+  --accent-2: #f472b6;
+  --panel: color-mix(in srgb, #e8eef6 7%, #12081c);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #12081c 75%, #000);
+}
+
+.ease-spectroscope-prism__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-spectroscope-prism__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #12081c 90%, #a78bfa);
+}
+
+.ease-spectroscope-prism__face {
+  position: relative;
+  min-height: 260px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 28% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #12081c 85%, #000), color-mix(in srgb, #12081c 65%, var(--accent-2)));
+}
+
+.ease-spectroscope-prism__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-spectroscope-prism__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-spectroscope-prism__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-spectroscope-prism__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-spectroscope-prism__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-spectroscope-prism__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-spectroscope-prism__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: spectroscope_prism_meter 1.7s ease-in-out infinite alternate;
+}
+
+.ease-spectroscope-prism__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-spectroscope-prism__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-spectroscope-prism__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-spectroscope-prism__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-spectroscope-prism__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-spectroscope-prism__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-spectroscope-prism__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-spectroscope-prism__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-spectroscope-prism__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-spectroscope-prism__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-spectroscope-prism__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-spectroscope-prism__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: spectroscope_prism_pulse 1.8s ease-out infinite;
+}
+
+@keyframes spectroscope_prism_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes spectroscope_prism_pulse {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+
+.ease-spectroscope-prism__beam{position:absolute;left:8%;top:48%;width:28%;height:4px;background:linear-gradient(90deg,transparent,#f8fafc);animation:spectroscope_prism_beam 2.8s ease-in-out infinite}
+.ease-spectroscope-prism__prism{position:absolute;left:36%;top:36%;width:0;height:0;border-left:28px solid transparent;border-right:28px solid transparent;border-bottom:48px solid color-mix(in srgb,var(--accent)55%,#94a3b8);filter:drop-shadow(0 0 8px #fff3)}
+.ease-spectroscope-prism__band{position:absolute;left:52%;height:5px;width:34%;border-radius:999px;opacity:.85;transform-origin:left center;animation:spectroscope_prism_spread 2.8s ease-in-out infinite}
+.ease-spectroscope-prism__band.r{top:34%;background:#ef4444;transform:rotate(-16deg)}
+.ease-spectroscope-prism__band.o{top:40%;background:#f97316;transform:rotate(-10deg);animation-delay:.05s}
+.ease-spectroscope-prism__band.y{top:46%;background:#eab308;transform:rotate(-4deg);animation-delay:.1s}
+.ease-spectroscope-prism__band.g{top:52%;background:#22c55e;transform:rotate(2deg);animation-delay:.15s}
+.ease-spectroscope-prism__band.b{top:58%;background:#3b82f6;transform:rotate(8deg);animation-delay:.2s}
+.ease-spectroscope-prism__band.v{top:64%;background:#8b5cf6;transform:rotate(14deg);animation-delay:.25s}
+@keyframes spectroscope_prism_beam{0%,100%{opacity:.35;transform:scaleX(.85)}50%{opacity:1;transform:scaleX(1)}}
+@keyframes spectroscope_prism_spread{0%,100%{opacity:.35;transform:scaleX(.7)}50%{opacity:1;transform:scaleX(1)}}
+@media (prefers-reduced-motion:reduce){.ease-spectroscope-prism__beam,.ease-spectroscope-prism__band{animation:none!important}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-spectroscope-prism__meters i::after,
+  .ease-spectroscope-prism__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-spectroscope-prism` under `submissions/examples/spectroscope-prism-ns/` — CSS-only Light beam splitting through a prism into spectrum bands.

Fixes #65581

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Light beam splitting through a prism into spectrum bands.

**How does a developer use it?**

```html
<section class="ease-spectroscope-prism">
  <div class="ease-spectroscope-prism__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `spectroscope_prism_*` prefix. Reduced-motion disables animations.