### PR TITLE
feat: add ease-centrifuge-rotor (#65582)

### DIFF
--- a/submissions/examples/centrifuge-rotor-ns/README.md
+++ b/submissions/examples/centrifuge-rotor-ns/README.md
@@ -1,0 +1,16 @@
+# Centrifuge Rotor
+
+## What does this do?
+Renders a self-contained CSS-only `ease-centrifuge-rotor` demo: Lab centrifuge rotor spinning up with sample tubes.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-centrifuge-rotor`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-centrifuge-rotor">
+  <div class="ease-centrifuge-rotor__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/centrifuge-rotor-ns/demo.html
+++ b/submissions/examples/centrifuge-rotor-ns/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Centrifuge Rotor — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Centrifuge Rotor demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Centrifuge Rotor</h1>
+      <p class="lede">Lab centrifuge rotor spinning up with sample tubes</p>
+    </header>
+
+    <section class="ease-centrifuge-rotor" data-demo="centrifuge-rotor" aria-live="polite">
+      <div class="ease-centrifuge-rotor__housing">
+        <div class="ease-centrifuge-rotor__bezel">
+          <div class="ease-centrifuge-rotor__face">
+            <div class="ease-centrifuge-rotor__readout">
+              <span class="ease-centrifuge-rotor__label">Centrifuge Rotor</span>
+              <span class="ease-centrifuge-rotor__value">12k RPM</span>
+            </div>
+            <div class="ease-centrifuge-rotor__motion" aria-hidden="true">
+              <span class="ease-centrifuge-rotor__bowl"></span>
+              <span class="ease-centrifuge-rotor__rotor">
+                <i class="tube t1"></i><i class="tube t2"></i><i class="tube t3"></i><i class="tube t4"></i>
+              </span>
+              <span class="ease-centrifuge-rotor__lid"></span>
+            </div>
+            <div class="ease-centrifuge-rotor__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-centrifuge-rotor__controls">
+          <button type="button" class="ease-centrifuge-rotor__btn primary">Engage</button>
+          <button type="button" class="ease-centrifuge-rotor__btn">Reset</button>
+          <label class="ease-centrifuge-rotor__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-centrifuge-rotor__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/centrifuge-rotor-ns/style.css
+++ b/submissions/examples/centrifuge-rotor-ns/style.css
@@ -1,0 +1,235 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #fbbf24 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #f59e0b 18%, transparent), transparent 42%),
+    #16110a;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-centrifuge-rotor {
+  --accent: #fbbf24;
+  --accent-2: #f59e0b;
+  --panel: color-mix(in srgb, #e8eef6 7%, #16110a);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #16110a 75%, #000);
+}
+
+.ease-centrifuge-rotor__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-centrifuge-rotor__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #16110a 90%, #fbbf24);
+}
+
+.ease-centrifuge-rotor__face {
+  position: relative;
+  min-height: 260px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 28% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #16110a 85%, #000), color-mix(in srgb, #16110a 65%, var(--accent-2)));
+}
+
+.ease-centrifuge-rotor__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-centrifuge-rotor__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-centrifuge-rotor__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-centrifuge-rotor__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-centrifuge-rotor__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-centrifuge-rotor__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-centrifuge-rotor__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: centrifuge_rotor_meter 1.7s ease-in-out infinite alternate;
+}
+
+.ease-centrifuge-rotor__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-centrifuge-rotor__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-centrifuge-rotor__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-centrifuge-rotor__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-centrifuge-rotor__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-centrifuge-rotor__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-centrifuge-rotor__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-centrifuge-rotor__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-centrifuge-rotor__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-centrifuge-rotor__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-centrifuge-rotor__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-centrifuge-rotor__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: centrifuge_rotor_pulse 1.8s ease-out infinite;
+}
+
+@keyframes centrifuge_rotor_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes centrifuge_rotor_pulse {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+
+.ease-centrifuge-rotor__bowl{position:absolute;left:50%;top:46%;width:150px;height:150px;margin:-75px 0 0 -75px;border-radius:50%;border:10px solid #475569;background:#0f172a}
+.ease-centrifuge-rotor__rotor{position:absolute;left:50%;top:46%;width:120px;height:120px;margin:-60px 0 0 -60px;animation:centrifuge_rotor_spin 1.1s linear infinite}
+.ease-centrifuge-rotor__rotor .tube{position:absolute;width:14px;height:36px;border-radius:4px;background:linear-gradient(180deg,var(--accent),#334155);left:53px;top:8px;transform-origin:50% 52px}
+.ease-centrifuge-rotor__rotor .t2{transform:rotate(90deg)}
+.ease-centrifuge-rotor__rotor .t3{transform:rotate(180deg)}
+.ease-centrifuge-rotor__rotor .t4{transform:rotate(270deg)}
+.ease-centrifuge-rotor__lid{position:absolute;left:50%;top:46%;width:36px;height:36px;margin:-18px 0 0 -18px;border-radius:50%;background:#cbd5e1;box-shadow:0 0 0 4px #1e293b}
+@keyframes centrifuge_rotor_spin{to{transform:rotate(360deg)}}
+@media (prefers-reduced-motion:reduce){.ease-centrifuge-rotor__rotor{animation:none!important}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-centrifuge-rotor__meters i::after,
+  .ease-centrifuge-rotor__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-centrifuge-rotor` under `submissions/examples/centrifuge-rotor-ns/` — CSS-only Lab centrifuge rotor spinning up with sample tubes.

Fixes #65582

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Lab centrifuge rotor spinning up with sample tubes.

**How does a developer use it?**

```html
<section class="ease-centrifuge-rotor">
  <div class="ease-centrifuge-rotor__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `centrifuge_rotor_*` prefix. Reduced-motion disables animations.