### PR TITLE
feat: add ease-bunsen-burner-flame (#65584)

### DIFF
--- a/submissions/examples/bunsen-burner-flame-ns/README.md
+++ b/submissions/examples/bunsen-burner-flame-ns/README.md
@@ -1,0 +1,16 @@
+# Bunsen Burner Flame
+
+## What does this do?
+Renders a self-contained CSS-only `ease-bunsen-burner-flame` demo: Bunsen burner flame flickering with heat shimmer.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-bunsen-burner-flame`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-bunsen-burner-flame">
+  <div class="ease-bunsen-burner-flame__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/bunsen-burner-flame-ns/demo.html
+++ b/submissions/examples/bunsen-burner-flame-ns/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Bunsen Burner Flame — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Bunsen Burner Flame demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Bunsen Burner Flame</h1>
+      <p class="lede">Bunsen burner flame flickering with heat shimmer</p>
+    </header>
+
+    <section class="ease-bunsen-burner-flame" data-demo="bunsen-burner-flame" aria-live="polite">
+      <div class="ease-bunsen-burner-flame__housing">
+        <div class="ease-bunsen-burner-flame__bezel">
+          <div class="ease-bunsen-burner-flame__face">
+            <div class="ease-bunsen-burner-flame__readout">
+              <span class="ease-bunsen-burner-flame__label">Bunsen Burner Flame</span>
+              <span class="ease-bunsen-burner-flame__value">SAFE</span>
+            </div>
+            <div class="ease-bunsen-burner-flame__motion" aria-hidden="true">
+              <span class="ease-bunsen-burner-flame__base"></span>
+              <span class="ease-bunsen-burner-flame__barrel"></span>
+              <span class="ease-bunsen-burner-flame__flame outer"></span>
+              <span class="ease-bunsen-burner-flame__flame inner"></span>
+              <span class="ease-bunsen-burner-flame__shimmer"></span>
+            </div>
+            <div class="ease-bunsen-burner-flame__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-bunsen-burner-flame__controls">
+          <button type="button" class="ease-bunsen-burner-flame__btn primary">Engage</button>
+          <button type="button" class="ease-bunsen-burner-flame__btn">Reset</button>
+          <label class="ease-bunsen-burner-flame__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-bunsen-burner-flame__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/bunsen-burner-flame-ns/style.css
+++ b/submissions/examples/bunsen-burner-flame-ns/style.css
@@ -1,0 +1,235 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #fb923c 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #38bdf8 18%, transparent), transparent 42%),
+    #140e0a;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-bunsen-burner-flame {
+  --accent: #fb923c;
+  --accent-2: #38bdf8;
+  --panel: color-mix(in srgb, #e8eef6 7%, #140e0a);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #140e0a 75%, #000);
+}
+
+.ease-bunsen-burner-flame__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-bunsen-burner-flame__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #140e0a 90%, #fb923c);
+}
+
+.ease-bunsen-burner-flame__face {
+  position: relative;
+  min-height: 260px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 28% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #140e0a 85%, #000), color-mix(in srgb, #140e0a 65%, var(--accent-2)));
+}
+
+.ease-bunsen-burner-flame__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-bunsen-burner-flame__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-bunsen-burner-flame__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-bunsen-burner-flame__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-bunsen-burner-flame__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-bunsen-burner-flame__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-bunsen-burner-flame__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: bunsen_burner_flame_meter 1.7s ease-in-out infinite alternate;
+}
+
+.ease-bunsen-burner-flame__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-bunsen-burner-flame__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-bunsen-burner-flame__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-bunsen-burner-flame__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-bunsen-burner-flame__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-bunsen-burner-flame__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-bunsen-burner-flame__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-bunsen-burner-flame__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-bunsen-burner-flame__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-bunsen-burner-flame__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-bunsen-burner-flame__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-bunsen-burner-flame__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: bunsen_burner_flame_pulse 1.8s ease-out infinite;
+}
+
+@keyframes bunsen_burner_flame_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes bunsen_burner_flame_pulse {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+
+.ease-bunsen-burner-flame__base{position:absolute;left:50%;bottom:14%;width:64px;height:16px;margin-left:-32px;border-radius:4px;background:#334155}
+.ease-bunsen-burner-flame__barrel{position:absolute;left:50%;bottom:28%;width:22px;height:34%;margin-left:-11px;background:linear-gradient(180deg,#94a3b8,#475569);border-radius:3px}
+.ease-bunsen-burner-flame__flame{position:absolute;left:50%;bottom:58%;margin-left:-18px;width:36px;height:54px;border-radius:50% 50% 50% 50%/60% 60% 40% 40%;transform-origin:50% 100%}
+.ease-bunsen-burner-flame__flame.outer{background:radial-gradient(ellipse at 50% 80%,#f97316,transparent 70%);animation:bunsen_burner_flame_flame .7s ease-in-out infinite alternate}
+.ease-bunsen-burner-flame__flame.inner{width:18px;height:34px;margin-left:-9px;bottom:62%;background:radial-gradient(ellipse at 50% 70%,#fef08a,#38bdf8 70%,transparent);animation:bunsen_burner_flame_flame .55s ease-in-out infinite alternate-reverse}
+.ease-bunsen-burner-flame__shimmer{position:absolute;left:42%;top:18%;width:16%;height:28%;background:linear-gradient(180deg,transparent,#fff2,transparent);filter:blur(3px);animation:bunsen_burner_flame_shimmer 1.2s ease-in-out infinite}
+@keyframes bunsen_burner_flame_flame{0%{transform:scaleX(.92) scaleY(.95) rotate(-2deg)}100%{transform:scaleX(1.08) scaleY(1.08) rotate(3deg)}}
+@keyframes bunsen_burner_flame_shimmer{0%,100%{opacity:.2;transform:translateX(0)}50%{opacity:.55;transform:translateX(8px)}}
+@media (prefers-reduced-motion:reduce){.ease-bunsen-burner-flame__flame,.ease-bunsen-burner-flame__shimmer{animation:none!important}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-bunsen-burner-flame__meters i::after,
+  .ease-bunsen-burner-flame__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-bunsen-burner-flame` under `submissions/examples/bunsen-burner-flame-ns/` — CSS-only Bunsen burner flame flickering with heat shimmer.

Fixes #65584

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Bunsen burner flame flickering with heat shimmer.

**How does a developer use it?**

```html
<section class="ease-bunsen-burner-flame">
  <div class="ease-bunsen-burner-flame__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `bunsen_burner_flame_*` prefix. Reduced-motion disables animations.