### PR TITLE
feat: add ease-petri-colony-grow (#65585)

### DIFF
--- a/submissions/examples/petri-colony-grow-ns/README.md
+++ b/submissions/examples/petri-colony-grow-ns/README.md
@@ -1,0 +1,16 @@
+# Petri Colony Grow
+
+## What does this do?
+Renders a self-contained CSS-only `ease-petri-colony-grow` demo: Petri dish colonies growing and spreading over time.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-petri-colony-grow`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-petri-colony-grow">
+  <div class="ease-petri-colony-grow__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/petri-colony-grow-ns/demo.html
+++ b/submissions/examples/petri-colony-grow-ns/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Petri Colony Grow — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Petri Colony Grow demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Petri Colony Grow</h1>
+      <p class="lede">Petri dish colonies growing and spreading over time</p>
+    </header>
+
+    <section class="ease-petri-colony-grow" data-demo="petri-colony-grow" aria-live="polite">
+      <div class="ease-petri-colony-grow__housing">
+        <div class="ease-petri-colony-grow__bezel">
+          <div class="ease-petri-colony-grow__face">
+            <div class="ease-petri-colony-grow__readout">
+              <span class="ease-petri-colony-grow__label">Petri Colony Grow</span>
+              <span class="ease-petri-colony-grow__value">T+18h</span>
+            </div>
+            <div class="ease-petri-colony-grow__motion" aria-hidden="true">
+              <span class="ease-petri-colony-grow__dish"></span>
+              <span class="ease-petri-colony-grow__agar"></span>
+              <span class="ease-petri-colony-grow__colony c1"></span>
+              <span class="ease-petri-colony-grow__colony c2"></span>
+              <span class="ease-petri-colony-grow__colony c3"></span>
+              <span class="ease-petri-colony-grow__colony c4"></span>
+            </div>
+            <div class="ease-petri-colony-grow__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-petri-colony-grow__controls">
+          <button type="button" class="ease-petri-colony-grow__btn primary">Engage</button>
+          <button type="button" class="ease-petri-colony-grow__btn">Reset</button>
+          <label class="ease-petri-colony-grow__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-petri-colony-grow__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/petri-colony-grow-ns/style.css
+++ b/submissions/examples/petri-colony-grow-ns/style.css
@@ -1,0 +1,235 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #84cc16 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #a3e635 18%, transparent), transparent 42%),
+    #10160a;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-petri-colony-grow {
+  --accent: #84cc16;
+  --accent-2: #a3e635;
+  --panel: color-mix(in srgb, #e8eef6 7%, #10160a);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #10160a 75%, #000);
+}
+
+.ease-petri-colony-grow__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-petri-colony-grow__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #10160a 90%, #84cc16);
+}
+
+.ease-petri-colony-grow__face {
+  position: relative;
+  min-height: 260px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 28% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #10160a 85%, #000), color-mix(in srgb, #10160a 65%, var(--accent-2)));
+}
+
+.ease-petri-colony-grow__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-petri-colony-grow__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-petri-colony-grow__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-petri-colony-grow__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-petri-colony-grow__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-petri-colony-grow__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-petri-colony-grow__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: petri_colony_grow_meter 1.7s ease-in-out infinite alternate;
+}
+
+.ease-petri-colony-grow__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-petri-colony-grow__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-petri-colony-grow__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-petri-colony-grow__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-petri-colony-grow__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-petri-colony-grow__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-petri-colony-grow__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-petri-colony-grow__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-petri-colony-grow__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-petri-colony-grow__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-petri-colony-grow__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-petri-colony-grow__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: petri_colony_grow_pulse 1.8s ease-out infinite;
+}
+
+@keyframes petri_colony_grow_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes petri_colony_grow_pulse {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+
+.ease-petri-colony-grow__dish{position:absolute;left:50%;top:48%;width:150px;height:150px;margin:-75px 0 0 -75px;border-radius:50%;border:8px solid #94a3b8;background:#0f172a;box-shadow:inset 0 0 0 3px #1e293b}
+.ease-petri-colony-grow__agar{position:absolute;left:50%;top:48%;width:126px;height:126px;margin:-63px 0 0 -63px;border-radius:50%;background:color-mix(in srgb,var(--accent-2)18%,#0f172a)}
+.ease-petri-colony-grow__colony{position:absolute;border-radius:50%;background:radial-gradient(circle at 40% 35%,#fff6,transparent 45%),var(--accent);animation:petri_colony_grow_grow 3.6s ease-out infinite}
+.ease-petri-colony-grow__colony.c1{left:42%;top:40%;width:10px;height:10px}
+.ease-petri-colony-grow__colony.c2{left:55%;top:48%;width:8px;height:8px;animation-delay:.4s}
+.ease-petri-colony-grow__colony.c3{left:46%;top:58%;width:12px;height:12px;animation-delay:.9s}
+.ease-petri-colony-grow__colony.c4{left:58%;top:38%;width:7px;height:7px;animation-delay:1.3s}
+@keyframes petri_colony_grow_grow{0%{transform:scale(.2);opacity:0}30%{opacity:1}70%{transform:scale(2.2);opacity:.9}100%{transform:scale(2.6);opacity:.55}}
+@media (prefers-reduced-motion:reduce){.ease-petri-colony-grow__colony{animation:none!important}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-petri-colony-grow__meters i::after,
+  .ease-petri-colony-grow__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-petri-colony-grow` under `submissions/examples/petri-colony-grow-ns/` — CSS-only Petri dish colonies growing and spreading over time.

Fixes #65585

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Petri dish colonies growing and spreading over time.

**How does a developer use it?**

```html
<section class="ease-petri-colony-grow">
  <div class="ease-petri-colony-grow__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `petri_colony_grow_*` prefix. Reduced-motion disables animations.