### PR TITLE
feat: add ease-zoetrope-drum (#65586)

### DIFF
--- a/submissions/examples/zoetrope-drum-ns/README.md
+++ b/submissions/examples/zoetrope-drum-ns/README.md
@@ -1,0 +1,16 @@
+# Zoetrope Drum
+
+## What does this do?
+Renders a self-contained CSS-only `ease-zoetrope-drum` demo: Zoetrope drum rotating with frame slots blurring to motion.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-zoetrope-drum`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-zoetrope-drum">
+  <div class="ease-zoetrope-drum__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/zoetrope-drum-ns/demo.html
+++ b/submissions/examples/zoetrope-drum-ns/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Zoetrope Drum — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Zoetrope Drum demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Zoetrope Drum</h1>
+      <p class="lede">Zoetrope drum rotating with frame slots blurring to motion</p>
+    </header>
+
+    <section class="ease-zoetrope-drum" data-demo="zoetrope-drum" aria-live="polite">
+      <div class="ease-zoetrope-drum__housing">
+        <div class="ease-zoetrope-drum__bezel">
+          <div class="ease-zoetrope-drum__face">
+            <div class="ease-zoetrope-drum__readout">
+              <span class="ease-zoetrope-drum__label">Zoetrope Drum</span>
+              <span class="ease-zoetrope-drum__value">24 FPS</span>
+            </div>
+            <div class="ease-zoetrope-drum__motion" aria-hidden="true">
+              <span class="ease-zoetrope-drum__drum">
+                <i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i>
+              </span>
+              <span class="ease-zoetrope-drum__axle"></span>
+              <span class="ease-zoetrope-drum__figure"></span>
+            </div>
+            <div class="ease-zoetrope-drum__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-zoetrope-drum__controls">
+          <button type="button" class="ease-zoetrope-drum__btn primary">Engage</button>
+          <button type="button" class="ease-zoetrope-drum__btn">Reset</button>
+          <label class="ease-zoetrope-drum__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-zoetrope-drum__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/zoetrope-drum-ns/style.css
+++ b/submissions/examples/zoetrope-drum-ns/style.css
@@ -1,0 +1,233 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #f472b6 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #c084fc 18%, transparent), transparent 42%),
+    #140a16;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-zoetrope-drum {
+  --accent: #f472b6;
+  --accent-2: #c084fc;
+  --panel: color-mix(in srgb, #e8eef6 7%, #140a16);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #140a16 75%, #000);
+}
+
+.ease-zoetrope-drum__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-zoetrope-drum__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #140a16 90%, #f472b6);
+}
+
+.ease-zoetrope-drum__face {
+  position: relative;
+  min-height: 260px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 28% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #140a16 85%, #000), color-mix(in srgb, #140a16 65%, var(--accent-2)));
+}
+
+.ease-zoetrope-drum__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-zoetrope-drum__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-zoetrope-drum__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-zoetrope-drum__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-zoetrope-drum__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-zoetrope-drum__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-zoetrope-drum__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: zoetrope_drum_meter 1.7s ease-in-out infinite alternate;
+}
+
+.ease-zoetrope-drum__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-zoetrope-drum__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-zoetrope-drum__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-zoetrope-drum__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-zoetrope-drum__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-zoetrope-drum__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-zoetrope-drum__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-zoetrope-drum__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-zoetrope-drum__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-zoetrope-drum__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-zoetrope-drum__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-zoetrope-drum__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: zoetrope_drum_pulse 1.8s ease-out infinite;
+}
+
+@keyframes zoetrope_drum_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes zoetrope_drum_pulse {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+
+.ease-zoetrope-drum__drum{position:absolute;left:50%;top:46%;width:160px;height:90px;margin:-45px 0 0 -80px;border-radius:12px;background:repeating-linear-gradient(90deg,#1e293b 0 14px,#334155 14px 18px);border:4px solid #64748b;animation:zoetrope_drum_spin 2s linear infinite;transform-style:preserve-3d}
+.ease-zoetrope-drum__drum i{display:none}
+.ease-zoetrope-drum__axle{position:absolute;left:50%;top:70%;width:10px;height:18%;margin-left:-5px;background:#94a3b8;border-radius:4px}
+.ease-zoetrope-drum__figure{position:absolute;left:50%;top:40%;width:18px;height:28px;margin:-14px 0 0 -9px;background:var(--accent);border-radius:4px;animation:zoetrope_drum_figure .25s steps(2,end) infinite}
+@keyframes zoetrope_drum_spin{to{transform:rotateY(360deg)}}
+@keyframes zoetrope_drum_figure{0%{transform:translateX(-4px) rotate(-6deg)}100%{transform:translateX(4px) rotate(6deg)}}
+@media (prefers-reduced-motion:reduce){.ease-zoetrope-drum__drum,.ease-zoetrope-drum__figure{animation:none!important}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-zoetrope-drum__meters i::after,
+  .ease-zoetrope-drum__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-zoetrope-drum` under `submissions/examples/zoetrope-drum-ns/` — CSS-only Zoetrope drum rotating with frame slots blurring to motion.

Fixes #65586

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Zoetrope drum rotating with frame slots blurring to motion.

**How does a developer use it?**

```html
<section class="ease-zoetrope-drum">
  <div class="ease-zoetrope-drum__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `zoetrope_drum_*` prefix. Reduced-motion disables animations.