### PR TITLE
feat: add ease-flipbook-page-turn (#65587)

### DIFF
--- a/submissions/examples/flipbook-page-turn-ns/README.md
+++ b/submissions/examples/flipbook-page-turn-ns/README.md
@@ -1,0 +1,16 @@
+# Flipbook Page Turn
+
+## What does this do?
+Renders a self-contained CSS-only `ease-flipbook-page-turn` demo: Flipbook pages flipping rapidly to animate a figure.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-flipbook-page-turn`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-flipbook-page-turn">
+  <div class="ease-flipbook-page-turn__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/flipbook-page-turn-ns/demo.html
+++ b/submissions/examples/flipbook-page-turn-ns/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Flipbook Page Turn — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Flipbook Page Turn demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Flipbook Page Turn</h1>
+      <p class="lede">Flipbook pages flipping rapidly to animate a figure</p>
+    </header>
+
+    <section class="ease-flipbook-page-turn" data-demo="flipbook-page-turn" aria-live="polite">
+      <div class="ease-flipbook-page-turn__housing">
+        <div class="ease-flipbook-page-turn__bezel">
+          <div class="ease-flipbook-page-turn__face">
+            <div class="ease-flipbook-page-turn__readout">
+              <span class="ease-flipbook-page-turn__label">Flipbook Page Turn</span>
+              <span class="ease-flipbook-page-turn__value">PAGE</span>
+            </div>
+            <div class="ease-flipbook-page-turn__motion" aria-hidden="true">
+              <span class="ease-flipbook-page-turn__stack"></span>
+              <span class="ease-flipbook-page-turn__page p1"></span>
+              <span class="ease-flipbook-page-turn__page p2"></span>
+              <span class="ease-flipbook-page-turn__page p3"></span>
+              <span class="ease-flipbook-page-turn__figure"></span>
+            </div>
+            <div class="ease-flipbook-page-turn__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-flipbook-page-turn__controls">
+          <button type="button" class="ease-flipbook-page-turn__btn primary">Engage</button>
+          <button type="button" class="ease-flipbook-page-turn__btn">Reset</button>
+          <label class="ease-flipbook-page-turn__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-flipbook-page-turn__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/flipbook-page-turn-ns/style.css
+++ b/submissions/examples/flipbook-page-turn-ns/style.css
@@ -1,0 +1,235 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #f59e0b 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #fbbf24 18%, transparent), transparent 42%),
+    #16110a;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-flipbook-page-turn {
+  --accent: #f59e0b;
+  --accent-2: #fbbf24;
+  --panel: color-mix(in srgb, #e8eef6 7%, #16110a);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #16110a 75%, #000);
+}
+
+.ease-flipbook-page-turn__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-flipbook-page-turn__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #16110a 90%, #f59e0b);
+}
+
+.ease-flipbook-page-turn__face {
+  position: relative;
+  min-height: 260px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 28% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #16110a 85%, #000), color-mix(in srgb, #16110a 65%, var(--accent-2)));
+}
+
+.ease-flipbook-page-turn__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-flipbook-page-turn__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-flipbook-page-turn__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-flipbook-page-turn__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-flipbook-page-turn__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-flipbook-page-turn__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-flipbook-page-turn__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: flipbook_page_turn_meter 1.7s ease-in-out infinite alternate;
+}
+
+.ease-flipbook-page-turn__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-flipbook-page-turn__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-flipbook-page-turn__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-flipbook-page-turn__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-flipbook-page-turn__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-flipbook-page-turn__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-flipbook-page-turn__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-flipbook-page-turn__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-flipbook-page-turn__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-flipbook-page-turn__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-flipbook-page-turn__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-flipbook-page-turn__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: flipbook_page_turn_pulse 1.8s ease-out infinite;
+}
+
+@keyframes flipbook_page_turn_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes flipbook_page_turn_pulse {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+
+.ease-flipbook-page-turn__stack{position:absolute;left:22%;top:28%;width:56%;height:52%;background:#e2e8f0;border-radius:4px;box-shadow:0 8px 0 #94a3b8,0 16px 0 #64748b}
+.ease-flipbook-page-turn__page{position:absolute;left:22%;top:28%;width:56%;height:52%;background:#f8fafc;border-radius:4px;transform-origin:left center;box-shadow:2px 0 8px #0003}
+.ease-flipbook-page-turn__page.p1{animation:flipbook_page_turn_flip 1.2s ease-in-out infinite;z-index:3}
+.ease-flipbook-page-turn__page.p2{animation:flipbook_page_turn_flip 1.2s ease-in-out infinite .2s;z-index:2;background:#e2e8f0}
+.ease-flipbook-page-turn__page.p3{animation:flipbook_page_turn_flip 1.2s ease-in-out infinite .4s;z-index:1;background:#cbd5e1}
+.ease-flipbook-page-turn__figure{position:absolute;left:48%;top:42%;width:16px;height:24px;background:var(--accent);border-radius:3px;animation:flipbook_page_turn_pose .4s steps(2,end) infinite;z-index:4}
+@keyframes flipbook_page_turn_flip{0%{transform:perspective(400px) rotateY(0)}40%{transform:perspective(400px) rotateY(-160deg)}100%{transform:perspective(400px) rotateY(-180deg);opacity:.2}}
+@keyframes flipbook_page_turn_pose{0%{transform:translateY(0)}100%{transform:translateY(-6px)}}
+@media (prefers-reduced-motion:reduce){.ease-flipbook-page-turn__page,.ease-flipbook-page-turn__figure{animation:none!important}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-flipbook-page-turn__meters i::after,
+  .ease-flipbook-page-turn__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-flipbook-page-turn` under `submissions/examples/flipbook-page-turn-ns/` — CSS-only Flipbook pages flipping rapidly to animate a figure.

Fixes #65587

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Flipbook pages flipping rapidly to animate a figure.

**How does a developer use it?**

```html
<section class="ease-flipbook-page-turn">
  <div class="ease-flipbook-page-turn__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `flipbook_page_turn_*` prefix. Reduced-motion disables animations.