### PR TITLE
feat: add ease-kaleidoscope-prism (#65588)

### DIFF
--- a/submissions/examples/kaleidoscope-prism-ns/README.md
+++ b/submissions/examples/kaleidoscope-prism-ns/README.md
@@ -1,0 +1,16 @@
+# Kaleidoscope Prism
+
+## What does this do?
+Renders a self-contained CSS-only `ease-kaleidoscope-prism` demo: Kaleidoscope shards rotating into mirrored patterns.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-kaleidoscope-prism`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-kaleidoscope-prism">
+  <div class="ease-kaleidoscope-prism__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/kaleidoscope-prism-ns/demo.html
+++ b/submissions/examples/kaleidoscope-prism-ns/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Kaleidoscope Prism — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Kaleidoscope Prism demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Kaleidoscope Prism</h1>
+      <p class="lede">Kaleidoscope shards rotating into mirrored patterns</p>
+    </header>
+
+    <section class="ease-kaleidoscope-prism" data-demo="kaleidoscope-prism" aria-live="polite">
+      <div class="ease-kaleidoscope-prism__housing">
+        <div class="ease-kaleidoscope-prism__bezel">
+          <div class="ease-kaleidoscope-prism__face">
+            <div class="ease-kaleidoscope-prism__readout">
+              <span class="ease-kaleidoscope-prism__label">Kaleidoscope Prism</span>
+              <span class="ease-kaleidoscope-prism__value">SPIN</span>
+            </div>
+            <div class="ease-kaleidoscope-prism__motion" aria-hidden="true">
+              <span class="ease-kaleidoscope-prism__scope">
+                <i class="shard s1"></i><i class="shard s2"></i><i class="shard s3"></i>
+                <i class="shard s4"></i><i class="shard s5"></i><i class="shard s6"></i>
+              </span>
+              <span class="ease-kaleidoscope-prism__ring"></span>
+            </div>
+            <div class="ease-kaleidoscope-prism__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-kaleidoscope-prism__controls">
+          <button type="button" class="ease-kaleidoscope-prism__btn primary">Engage</button>
+          <button type="button" class="ease-kaleidoscope-prism__btn">Reset</button>
+          <label class="ease-kaleidoscope-prism__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-kaleidoscope-prism__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/kaleidoscope-prism-ns/style.css
+++ b/submissions/examples/kaleidoscope-prism-ns/style.css
@@ -1,0 +1,237 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #ec4899 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #8b5cf6 18%, transparent), transparent 42%),
+    #160a14;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-kaleidoscope-prism {
+  --accent: #ec4899;
+  --accent-2: #8b5cf6;
+  --panel: color-mix(in srgb, #e8eef6 7%, #160a14);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #160a14 75%, #000);
+}
+
+.ease-kaleidoscope-prism__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-kaleidoscope-prism__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #160a14 90%, #ec4899);
+}
+
+.ease-kaleidoscope-prism__face {
+  position: relative;
+  min-height: 260px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 28% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #160a14 85%, #000), color-mix(in srgb, #160a14 65%, var(--accent-2)));
+}
+
+.ease-kaleidoscope-prism__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-kaleidoscope-prism__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-kaleidoscope-prism__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-kaleidoscope-prism__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-kaleidoscope-prism__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-kaleidoscope-prism__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-kaleidoscope-prism__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: kaleidoscope_prism_meter 1.7s ease-in-out infinite alternate;
+}
+
+.ease-kaleidoscope-prism__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-kaleidoscope-prism__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-kaleidoscope-prism__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-kaleidoscope-prism__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-kaleidoscope-prism__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-kaleidoscope-prism__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-kaleidoscope-prism__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-kaleidoscope-prism__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-kaleidoscope-prism__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-kaleidoscope-prism__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-kaleidoscope-prism__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-kaleidoscope-prism__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: kaleidoscope_prism_pulse 1.8s ease-out infinite;
+}
+
+@keyframes kaleidoscope_prism_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes kaleidoscope_prism_pulse {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+
+.ease-kaleidoscope-prism__scope{position:absolute;left:50%;top:46%;width:140px;height:140px;margin:-70px 0 0 -70px;border-radius:50%;overflow:hidden;border:6px solid #475569;animation:kaleidoscope_prism_spin 6s linear infinite;background:#0f172a}
+.ease-kaleidoscope-prism__scope .shard{position:absolute;width:50%;height:50%;left:25%;top:0;transform-origin:50% 100%;clip-path:polygon(50% 0,100% 100%,0 100%)}
+.ease-kaleidoscope-prism__scope .s1{background:#ef4444;transform:rotate(0deg)}
+.ease-kaleidoscope-prism__scope .s2{background:#f59e0b;transform:rotate(60deg)}
+.ease-kaleidoscope-prism__scope .s3{background:#22c55e;transform:rotate(120deg)}
+.ease-kaleidoscope-prism__scope .s4{background:#3b82f6;transform:rotate(180deg)}
+.ease-kaleidoscope-prism__scope .s5{background:#a855f7;transform:rotate(240deg)}
+.ease-kaleidoscope-prism__scope .s6{background:#ec4899;transform:rotate(300deg)}
+.ease-kaleidoscope-prism__ring{position:absolute;left:50%;top:46%;width:160px;height:160px;margin:-80px 0 0 -80px;border-radius:50%;border:2px dashed color-mix(in srgb,var(--accent)50%,transparent);animation:kaleidoscope_prism_spin 10s linear infinite reverse}
+@keyframes kaleidoscope_prism_spin{to{transform:rotate(360deg)}}
+@media (prefers-reduced-motion:reduce){.ease-kaleidoscope-prism__scope,.ease-kaleidoscope-prism__ring{animation:none!important}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-kaleidoscope-prism__meters i::after,
+  .ease-kaleidoscope-prism__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-kaleidoscope-prism` under `submissions/examples/kaleidoscope-prism-ns/` — CSS-only Kaleidoscope shards rotating into mirrored patterns.

Fixes #65588

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Kaleidoscope shards rotating into mirrored patterns.

**How does a developer use it?**

```html
<section class="ease-kaleidoscope-prism">
  <div class="ease-kaleidoscope-prism__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `kaleidoscope_prism_*` prefix. Reduced-motion disables animations.