### PR TITLE
feat: add ease-periscope-mirror (#65589)

### DIFF
--- a/submissions/examples/periscope-mirror-ns/README.md
+++ b/submissions/examples/periscope-mirror-ns/README.md
@@ -1,0 +1,16 @@
+# Periscope Mirror
+
+## What does this do?
+Renders a self-contained CSS-only `ease-periscope-mirror` demo: Periscope mirrors tilting to relay a sight line.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-periscope-mirror`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-periscope-mirror">
+  <div class="ease-periscope-mirror__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/periscope-mirror-ns/demo.html
+++ b/submissions/examples/periscope-mirror-ns/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Periscope Mirror — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Periscope Mirror demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Periscope Mirror</h1>
+      <p class="lede">Periscope mirrors tilting to relay a sight line</p>
+    </header>
+
+    <section class="ease-periscope-mirror" data-demo="periscope-mirror" aria-live="polite">
+      <div class="ease-periscope-mirror__housing">
+        <div class="ease-periscope-mirror__bezel">
+          <div class="ease-periscope-mirror__face">
+            <div class="ease-periscope-mirror__readout">
+              <span class="ease-periscope-mirror__label">Periscope Mirror</span>
+              <span class="ease-periscope-mirror__value">AZ 042</span>
+            </div>
+            <div class="ease-periscope-mirror__motion" aria-hidden="true">
+              <span class="ease-periscope-mirror__tube"></span>
+              <span class="ease-periscope-mirror__eyepiece"></span>
+              <span class="ease-periscope-mirror__mirror top"></span>
+              <span class="ease-periscope-mirror__mirror bot"></span>
+              <span class="ease-periscope-mirror__beam"></span>
+            </div>
+            <div class="ease-periscope-mirror__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-periscope-mirror__controls">
+          <button type="button" class="ease-periscope-mirror__btn primary">Engage</button>
+          <button type="button" class="ease-periscope-mirror__btn">Reset</button>
+          <label class="ease-periscope-mirror__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-periscope-mirror__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/periscope-mirror-ns/style.css
+++ b/submissions/examples/periscope-mirror-ns/style.css
@@ -1,0 +1,235 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #67e8f9 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #94a3b8 18%, transparent), transparent 42%),
+    #0a1418;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-periscope-mirror {
+  --accent: #67e8f9;
+  --accent-2: #94a3b8;
+  --panel: color-mix(in srgb, #e8eef6 7%, #0a1418);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #0a1418 75%, #000);
+}
+
+.ease-periscope-mirror__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-periscope-mirror__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #0a1418 90%, #67e8f9);
+}
+
+.ease-periscope-mirror__face {
+  position: relative;
+  min-height: 260px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 28% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #0a1418 85%, #000), color-mix(in srgb, #0a1418 65%, var(--accent-2)));
+}
+
+.ease-periscope-mirror__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-periscope-mirror__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-periscope-mirror__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-periscope-mirror__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-periscope-mirror__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-periscope-mirror__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-periscope-mirror__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: periscope_mirror_meter 1.7s ease-in-out infinite alternate;
+}
+
+.ease-periscope-mirror__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-periscope-mirror__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-periscope-mirror__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-periscope-mirror__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-periscope-mirror__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-periscope-mirror__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-periscope-mirror__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-periscope-mirror__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-periscope-mirror__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-periscope-mirror__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-periscope-mirror__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-periscope-mirror__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: periscope_mirror_pulse 1.8s ease-out infinite;
+}
+
+@keyframes periscope_mirror_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes periscope_mirror_pulse {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+
+.ease-periscope-mirror__tube{position:absolute;left:46%;top:18%;width:18px;height:64%;background:linear-gradient(180deg,#64748b,#334155);border-radius:4px}
+.ease-periscope-mirror__eyepiece{position:absolute;left:38%;bottom:16%;width:40px;height:18px;background:#94a3b8;border-radius:4px}
+.ease-periscope-mirror__mirror{position:absolute;width:28px;height:10px;background:linear-gradient(90deg,#e2e8f0,var(--accent));border-radius:2px;box-shadow:0 0 10px color-mix(in srgb,var(--accent)40%,transparent)}
+.ease-periscope-mirror__mirror.top{left:42%;top:16%;transform:rotate(-35deg);animation:periscope_mirror_tilt 3s ease-in-out infinite alternate}
+.ease-periscope-mirror__mirror.bot{left:42%;bottom:28%;transform:rotate(-35deg);animation:periscope_mirror_tilt 3s ease-in-out infinite alternate-reverse}
+.ease-periscope-mirror__beam{position:absolute;left:18%;top:20%;width:28%;height:3px;background:linear-gradient(90deg,transparent,var(--accent));opacity:.7;animation:periscope_mirror_beam 3s ease-in-out infinite}
+@keyframes periscope_mirror_tilt{0%{transform:rotate(-28deg)}100%{transform:rotate(-42deg)}}
+@keyframes periscope_mirror_beam{0%,100%{opacity:.35;transform:translateY(0)}50%{opacity:.9;transform:translateY(6px)}}
+@media (prefers-reduced-motion:reduce){.ease-periscope-mirror__mirror,.ease-periscope-mirror__beam{animation:none!important}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-periscope-mirror__meters i::after,
+  .ease-periscope-mirror__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-periscope-mirror` under `submissions/examples/periscope-mirror-ns/` — CSS-only Periscope mirrors tilting to relay a sight line.

Fixes #65589

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Periscope mirrors tilting to relay a sight line.

**How does a developer use it?**

```html
<section class="ease-periscope-mirror">
  <div class="ease-periscope-mirror__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `periscope_mirror_*` prefix. Reduced-motion disables animations.