### PR TITLE
feat: add ease-sextant-arc (#65590)

### DIFF
--- a/submissions/examples/sextant-arc-ns/README.md
+++ b/submissions/examples/sextant-arc-ns/README.md
@@ -1,0 +1,16 @@
+# Sextant Arc
+
+## What does this do?
+Renders a self-contained CSS-only `ease-sextant-arc` demo: Nautical sextant arc index arm sweeping to measure angle.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-sextant-arc`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-sextant-arc">
+  <div class="ease-sextant-arc__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/sextant-arc-ns/demo.html
+++ b/submissions/examples/sextant-arc-ns/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sextant Arc — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Sextant Arc demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Sextant Arc</h1>
+      <p class="lede">Nautical sextant arc index arm sweeping to measure angle</p>
+    </header>
+
+    <section class="ease-sextant-arc" data-demo="sextant-arc" aria-live="polite">
+      <div class="ease-sextant-arc__housing">
+        <div class="ease-sextant-arc__bezel">
+          <div class="ease-sextant-arc__face">
+            <div class="ease-sextant-arc__readout">
+              <span class="ease-sextant-arc__label">Sextant Arc</span>
+              <span class="ease-sextant-arc__value">ALT 32°</span>
+            </div>
+            <div class="ease-sextant-arc__motion" aria-hidden="true">
+              <span class="ease-sextant-arc__frame"></span>
+              <span class="ease-sextant-arc__arc"></span>
+              <span class="ease-sextant-arc__index"></span>
+              <span class="ease-sextant-arc__mirror"></span>
+              <span class="ease-sextant-arc__horizon"></span>
+            </div>
+            <div class="ease-sextant-arc__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-sextant-arc__controls">
+          <button type="button" class="ease-sextant-arc__btn primary">Engage</button>
+          <button type="button" class="ease-sextant-arc__btn">Reset</button>
+          <label class="ease-sextant-arc__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-sextant-arc__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/sextant-arc-ns/style.css
+++ b/submissions/examples/sextant-arc-ns/style.css
@@ -1,0 +1,233 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #fbbf24 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #94a3b8 18%, transparent), transparent 42%),
+    #12100a;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-sextant-arc {
+  --accent: #fbbf24;
+  --accent-2: #94a3b8;
+  --panel: color-mix(in srgb, #e8eef6 7%, #12100a);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #12100a 75%, #000);
+}
+
+.ease-sextant-arc__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-sextant-arc__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #12100a 90%, #fbbf24);
+}
+
+.ease-sextant-arc__face {
+  position: relative;
+  min-height: 260px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 28% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #12100a 85%, #000), color-mix(in srgb, #12100a 65%, var(--accent-2)));
+}
+
+.ease-sextant-arc__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-sextant-arc__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-sextant-arc__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-sextant-arc__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-sextant-arc__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-sextant-arc__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-sextant-arc__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: sextant_arc_meter 1.7s ease-in-out infinite alternate;
+}
+
+.ease-sextant-arc__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-sextant-arc__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-sextant-arc__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-sextant-arc__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-sextant-arc__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-sextant-arc__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-sextant-arc__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-sextant-arc__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-sextant-arc__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-sextant-arc__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-sextant-arc__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-sextant-arc__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: sextant_arc_pulse 1.8s ease-out infinite;
+}
+
+@keyframes sextant_arc_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes sextant_arc_pulse {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+
+.ease-sextant-arc__frame{position:absolute;left:28%;top:28%;width:8px;height:48%;background:#64748b;border-radius:4px;transform:rotate(18deg)}
+.ease-sextant-arc__arc{position:absolute;left:22%;top:48%;width:56%;height:28%;border:8px solid #94a3b8;border-color:transparent transparent #94a3b8 transparent;border-radius:50%;}
+.ease-sextant-arc__index{position:absolute;left:48%;top:30%;width:4px;height:42%;background:var(--accent);transform-origin:50% 90%;border-radius:2px;animation:sextant_arc_sweep 3.4s ease-in-out infinite alternate}
+.ease-sextant-arc__mirror{position:absolute;left:44%;top:24%;width:24px;height:10px;background:#e2e8f0;border-radius:2px}
+.ease-sextant-arc__horizon{position:absolute;left:12%;right:12%;top:42%;height:2px;background:color-mix(in srgb,var(--accent-2)50%,transparent)}
+@keyframes sextant_arc_sweep{0%{transform:rotate(-28deg)}100%{transform:rotate(32deg)}}
+@media (prefers-reduced-motion:reduce){.ease-sextant-arc__index{animation:none!important}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-sextant-arc__meters i::after,
+  .ease-sextant-arc__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-sextant-arc` under `submissions/examples/sextant-arc-ns/` — CSS-only Nautical sextant arc index arm sweeping to measure angle.

Fixes #65590

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Nautical sextant arc index arm sweeping to measure angle.

**How does a developer use it?**

```html
<section class="ease-sextant-arc">
  <div class="ease-sextant-arc__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `sextant_arc_*` prefix. Reduced-motion disables animations.