### PR TITLE
feat: add ease-orrery-planetarium (#65591)

### DIFF
--- a/submissions/examples/orrery-planetarium-ns/README.md
+++ b/submissions/examples/orrery-planetarium-ns/README.md
@@ -1,0 +1,16 @@
+# Orrery Planetarium
+
+## What does this do?
+Renders a self-contained CSS-only `ease-orrery-planetarium` demo: Mechanical orrery with orbiting planet gears.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-orrery-planetarium`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-orrery-planetarium">
+  <div class="ease-orrery-planetarium__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/orrery-planetarium-ns/demo.html
+++ b/submissions/examples/orrery-planetarium-ns/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Orrery Planetarium — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Orrery Planetarium demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Orrery Planetarium</h1>
+      <p class="lede">Mechanical orrery with orbiting planet gears</p>
+    </header>
+
+    <section class="ease-orrery-planetarium" data-demo="orrery-planetarium" aria-live="polite">
+      <div class="ease-orrery-planetarium__housing">
+        <div class="ease-orrery-planetarium__bezel">
+          <div class="ease-orrery-planetarium__face">
+            <div class="ease-orrery-planetarium__readout">
+              <span class="ease-orrery-planetarium__label">Orrery Planetarium</span>
+              <span class="ease-orrery-planetarium__value">EPOCH</span>
+            </div>
+            <div class="ease-orrery-planetarium__motion" aria-hidden="true">
+              <span class="ease-orrery-planetarium__sun"></span>
+              <span class="ease-orrery-planetarium__orbit o1"><i class="planet"></i></span>
+              <span class="ease-orrery-planetarium__orbit o2"><i class="planet"></i></span>
+              <span class="ease-orrery-planetarium__orbit o3"><i class="planet"></i></span>
+              <span class="ease-orrery-planetarium__gear"></span>
+            </div>
+            <div class="ease-orrery-planetarium__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-orrery-planetarium__controls">
+          <button type="button" class="ease-orrery-planetarium__btn primary">Engage</button>
+          <button type="button" class="ease-orrery-planetarium__btn">Reset</button>
+          <label class="ease-orrery-planetarium__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-orrery-planetarium__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/orrery-planetarium-ns/style.css
+++ b/submissions/examples/orrery-planetarium-ns/style.css
@@ -1,0 +1,238 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #fbbf24 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #60a5fa 18%, transparent), transparent 42%),
+    #0c1018;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-orrery-planetarium {
+  --accent: #fbbf24;
+  --accent-2: #60a5fa;
+  --panel: color-mix(in srgb, #e8eef6 7%, #0c1018);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #0c1018 75%, #000);
+}
+
+.ease-orrery-planetarium__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-orrery-planetarium__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #0c1018 90%, #fbbf24);
+}
+
+.ease-orrery-planetarium__face {
+  position: relative;
+  min-height: 260px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 28% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #0c1018 85%, #000), color-mix(in srgb, #0c1018 65%, var(--accent-2)));
+}
+
+.ease-orrery-planetarium__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-orrery-planetarium__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-orrery-planetarium__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-orrery-planetarium__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-orrery-planetarium__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-orrery-planetarium__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-orrery-planetarium__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: orrery_planetarium_meter 1.7s ease-in-out infinite alternate;
+}
+
+.ease-orrery-planetarium__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-orrery-planetarium__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-orrery-planetarium__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-orrery-planetarium__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-orrery-planetarium__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-orrery-planetarium__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-orrery-planetarium__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-orrery-planetarium__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-orrery-planetarium__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-orrery-planetarium__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-orrery-planetarium__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-orrery-planetarium__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: orrery_planetarium_pulse 1.8s ease-out infinite;
+}
+
+@keyframes orrery_planetarium_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes orrery_planetarium_pulse {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+
+.ease-orrery-planetarium__sun{position:absolute;left:50%;top:46%;width:28px;height:28px;margin:-14px 0 0 -14px;border-radius:50%;background:radial-gradient(circle at 35% 30%,#fde68a,var(--accent));box-shadow:0 0 20px color-mix(in srgb,var(--accent)50%,transparent)}
+.ease-orrery-planetarium__orbit{position:absolute;left:50%;top:46%;border:1px dashed color-mix(in srgb,#e2e8f0 25%,transparent);border-radius:50%}
+.ease-orrery-planetarium__orbit .planet{position:absolute;top:-6px;left:50%;width:12px;height:12px;margin-left:-6px;border-radius:50%;background:var(--accent-2);box-shadow:0 0 8px #0005}
+.ease-orrery-planetarium__orbit.o1{width:70px;height:70px;margin:-35px 0 0 -35px;animation:orrery_planetarium_orbit 4s linear infinite}
+.ease-orrery-planetarium__orbit.o1 .planet{background:#60a5fa}
+.ease-orrery-planetarium__orbit.o2{width:110px;height:110px;margin:-55px 0 0 -55px;animation:orrery_planetarium_orbit 7s linear infinite reverse}
+.ease-orrery-planetarium__orbit.o2 .planet{background:#34d399;width:14px;height:14px}
+.ease-orrery-planetarium__orbit.o3{width:150px;height:150px;margin:-75px 0 0 -75px;animation:orrery_planetarium_orbit 11s linear infinite}
+.ease-orrery-planetarium__orbit.o3 .planet{background:#f472b6}
+.ease-orrery-planetarium__gear{position:absolute;right:12%;bottom:22%;width:28px;height:28px;border-radius:50%;border:3px dotted var(--accent);animation:orrery_planetarium_orbit 3s linear infinite}
+@keyframes orrery_planetarium_orbit{to{transform:rotate(360deg)}}
+@media (prefers-reduced-motion:reduce){.ease-orrery-planetarium__orbit,.ease-orrery-planetarium__gear{animation:none!important}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-orrery-planetarium__meters i::after,
+  .ease-orrery-planetarium__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-orrery-planetarium` under `submissions/examples/orrery-planetarium-ns/` — CSS-only Mechanical orrery with orbiting planet gears.

Fixes #65591

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Mechanical orrery with orbiting planet gears.

**How does a developer use it?**

```html
<section class="ease-orrery-planetarium">
  <div class="ease-orrery-planetarium__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `orrery_planetarium_*` prefix. Reduced-motion disables animations.