### PR TITLE
feat: add ease-tide-clock-lunar (#65592)

### DIFF
--- a/submissions/examples/tide-clock-lunar-ns/README.md
+++ b/submissions/examples/tide-clock-lunar-ns/README.md
@@ -1,0 +1,16 @@
+# Tide Clock Lunar
+
+## What does this do?
+Renders a self-contained CSS-only `ease-tide-clock-lunar` demo: Tide clock with lunar dial and high/low tide markers.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-tide-clock-lunar`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-tide-clock-lunar">
+  <div class="ease-tide-clock-lunar__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/tide-clock-lunar-ns/demo.html
+++ b/submissions/examples/tide-clock-lunar-ns/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tide Clock Lunar — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Tide Clock Lunar demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Tide Clock Lunar</h1>
+      <p class="lede">Tide clock with lunar dial and high/low tide markers</p>
+    </header>
+
+    <section class="ease-tide-clock-lunar" data-demo="tide-clock-lunar" aria-live="polite">
+      <div class="ease-tide-clock-lunar__housing">
+        <div class="ease-tide-clock-lunar__bezel">
+          <div class="ease-tide-clock-lunar__face">
+            <div class="ease-tide-clock-lunar__readout">
+              <span class="ease-tide-clock-lunar__label">Tide Clock Lunar</span>
+              <span class="ease-tide-clock-lunar__value">FLOOD</span>
+            </div>
+            <div class="ease-tide-clock-lunar__motion" aria-hidden="true">
+              <span class="ease-tide-clock-lunar__face"></span>
+              <span class="ease-tide-clock-lunar__moon"></span>
+              <span class="ease-tide-clock-lunar__hand"></span>
+              <span class="ease-tide-clock-lunar__mark hi"></span>
+              <span class="ease-tide-clock-lunar__mark lo"></span>
+              <span class="ease-tide-clock-lunar__wave"></span>
+            </div>
+            <div class="ease-tide-clock-lunar__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-tide-clock-lunar__controls">
+          <button type="button" class="ease-tide-clock-lunar__btn primary">Engage</button>
+          <button type="button" class="ease-tide-clock-lunar__btn">Reset</button>
+          <label class="ease-tide-clock-lunar__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-tide-clock-lunar__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/tide-clock-lunar-ns/style.css
+++ b/submissions/examples/tide-clock-lunar-ns/style.css
@@ -1,0 +1,239 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #38bdf8 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #94a3b8 18%, transparent), transparent 42%),
+    #0a1218;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-tide-clock-lunar {
+  --accent: #38bdf8;
+  --accent-2: #94a3b8;
+  --panel: color-mix(in srgb, #e8eef6 7%, #0a1218);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #0a1218 75%, #000);
+}
+
+.ease-tide-clock-lunar__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-tide-clock-lunar__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #0a1218 90%, #38bdf8);
+}
+
+.ease-tide-clock-lunar__face {
+  position: relative;
+  min-height: 260px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 28% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #0a1218 85%, #000), color-mix(in srgb, #0a1218 65%, var(--accent-2)));
+}
+
+.ease-tide-clock-lunar__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-tide-clock-lunar__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-tide-clock-lunar__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-tide-clock-lunar__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-tide-clock-lunar__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-tide-clock-lunar__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-tide-clock-lunar__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: tide_clock_lunar_meter 1.7s ease-in-out infinite alternate;
+}
+
+.ease-tide-clock-lunar__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-tide-clock-lunar__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-tide-clock-lunar__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-tide-clock-lunar__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-tide-clock-lunar__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-tide-clock-lunar__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-tide-clock-lunar__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-tide-clock-lunar__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-tide-clock-lunar__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-tide-clock-lunar__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-tide-clock-lunar__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-tide-clock-lunar__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: tide_clock_lunar_pulse 1.8s ease-out infinite;
+}
+
+@keyframes tide_clock_lunar_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes tide_clock_lunar_pulse {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+
+.ease-tide-clock-lunar__face{position:absolute;left:50%;top:46%;width:150px;height:150px;margin:-75px 0 0 -75px;border-radius:50%;border:8px solid #475569;background:radial-gradient(circle at 50% 50%,#1e293b,#0f172a)}
+.ease-tide-clock-lunar__moon{position:absolute;left:50%;top:28%;width:28px;height:28px;margin-left:-14px;border-radius:50%;background:radial-gradient(circle at 35% 30%,#f8fafc,#94a3b8);animation:tide_clock_lunar_moon 8s linear infinite;transform-origin:50% 70px}
+.ease-tide-clock-lunar__hand{position:absolute;left:50%;top:46%;width:4px;height:52px;margin:-44px 0 0 -2px;background:var(--accent);transform-origin:50% 85%;border-radius:2px;animation:tide_clock_lunar_hand 8s ease-in-out infinite}
+.ease-tide-clock-lunar__mark{position:absolute;font-size:.65rem;letter-spacing:.08em;text-transform:uppercase;opacity:.7}
+.ease-tide-clock-lunar__mark.hi{left:50%;top:18%;transform:translateX(-50%)}
+.ease-tide-clock-lunar__mark.lo{left:50%;bottom:18%;transform:translateX(-50%)}
+.ease-tide-clock-lunar__mark.hi::after{content:"HIGH"}
+.ease-tide-clock-lunar__mark.lo::after{content:"LOW"}
+.ease-tide-clock-lunar__wave{position:absolute;left:20%;right:20%;bottom:14%;height:16px;border-radius:50%;background:color-mix(in srgb,var(--accent)30%,transparent);animation:tide_clock_lunar_wave 8s ease-in-out infinite}
+@keyframes tide_clock_lunar_moon{to{transform:rotate(360deg)}}
+@keyframes tide_clock_lunar_hand{0%,100%{transform:rotate(-20deg)}50%{transform:rotate(160deg)}}
+@keyframes tide_clock_lunar_wave{0%,100%{transform:scaleX(.8);opacity:.4}50%{transform:scaleX(1.2);opacity:.85}}
+@media (prefers-reduced-motion:reduce){.ease-tide-clock-lunar__moon,.ease-tide-clock-lunar__hand,.ease-tide-clock-lunar__wave{animation:none!important}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-tide-clock-lunar__meters i::after,
+  .ease-tide-clock-lunar__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-tide-clock-lunar` under `submissions/examples/tide-clock-lunar-ns/` — CSS-only Tide clock with lunar dial and high/low tide markers.

Fixes #65592

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Tide clock with lunar dial and high/low tide markers.

**How does a developer use it?**

```html
<section class="ease-tide-clock-lunar">
  <div class="ease-tide-clock-lunar__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `tide_clock_lunar_*` prefix. Reduced-motion disables animations.