### PR TITLE
feat: add ease-ship-telegraph-engine (#65593)

### DIFF
--- a/submissions/examples/ship-telegraph-engine-ns/README.md
+++ b/submissions/examples/ship-telegraph-engine-ns/README.md
@@ -1,0 +1,16 @@
+# Ship Telegraph Engine
+
+## What does this do?
+Renders a self-contained CSS-only `ease-ship-telegraph-engine` demo: Engine order telegraph handle swinging between orders.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-ship-telegraph-engine`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-ship-telegraph-engine">
+  <div class="ease-ship-telegraph-engine__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/ship-telegraph-engine-ns/demo.html
+++ b/submissions/examples/ship-telegraph-engine-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ship Telegraph Engine — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Ship Telegraph Engine demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Ship Telegraph Engine</h1>
+      <p class="lede">Engine order telegraph handle swinging between orders</p>
+    </header>
+
+    <section class="ease-ship-telegraph-engine" data-demo="ship-telegraph-engine" aria-live="polite">
+      <div class="ease-ship-telegraph-engine__housing">
+        <div class="ease-ship-telegraph-engine__bezel">
+          <div class="ease-ship-telegraph-engine__face">
+            <div class="ease-ship-telegraph-engine__readout">
+              <span class="ease-ship-telegraph-engine__label">Ship Telegraph Engine</span>
+              <span class="ease-ship-telegraph-engine__value">AHEAD</span>
+            </div>
+            <div class="ease-ship-telegraph-engine__motion" aria-hidden="true">
+              <span class="ease-ship-telegraph-engine__dial"></span>
+              <span class="ease-ship-telegraph-engine__handle"></span>
+              <span class="ease-ship-telegraph-engine__pedestal"></span>
+              <span class="ease-ship-telegraph-engine__order"></span>
+            </div>
+            <div class="ease-ship-telegraph-engine__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-ship-telegraph-engine__controls">
+          <button type="button" class="ease-ship-telegraph-engine__btn primary">Engage</button>
+          <button type="button" class="ease-ship-telegraph-engine__btn">Reset</button>
+          <label class="ease-ship-telegraph-engine__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-ship-telegraph-engine__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ship-telegraph-engine-ns/style.css
+++ b/submissions/examples/ship-telegraph-engine-ns/style.css
@@ -1,0 +1,234 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #f87171 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #fbbf24 18%, transparent), transparent 42%),
+    #160c0c;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-ship-telegraph-engine {
+  --accent: #f87171;
+  --accent-2: #fbbf24;
+  --panel: color-mix(in srgb, #e8eef6 7%, #160c0c);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #160c0c 75%, #000);
+}
+
+.ease-ship-telegraph-engine__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-ship-telegraph-engine__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #160c0c 90%, #f87171);
+}
+
+.ease-ship-telegraph-engine__face {
+  position: relative;
+  min-height: 260px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 28% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #160c0c 85%, #000), color-mix(in srgb, #160c0c 65%, var(--accent-2)));
+}
+
+.ease-ship-telegraph-engine__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-ship-telegraph-engine__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-ship-telegraph-engine__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-ship-telegraph-engine__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-ship-telegraph-engine__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-ship-telegraph-engine__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-ship-telegraph-engine__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: ship_telegraph_engine_meter 1.7s ease-in-out infinite alternate;
+}
+
+.ease-ship-telegraph-engine__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-ship-telegraph-engine__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-ship-telegraph-engine__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-ship-telegraph-engine__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-ship-telegraph-engine__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-ship-telegraph-engine__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-ship-telegraph-engine__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-ship-telegraph-engine__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-ship-telegraph-engine__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-ship-telegraph-engine__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-ship-telegraph-engine__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-ship-telegraph-engine__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: ship_telegraph_engine_pulse 1.8s ease-out infinite;
+}
+
+@keyframes ship_telegraph_engine_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes ship_telegraph_engine_pulse {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+
+.ease-ship-telegraph-engine__dial{position:absolute;left:50%;top:48%;width:160px;height:160px;margin:-80px 0 0 -80px;border-radius:50%;border:10px solid #64748b;background:conic-gradient(from 210deg,#1e293b 0 40deg,color-mix(in srgb,var(--accent)25%,#1e293b)40deg 80deg,#1e293b 80deg 360deg)}
+.ease-ship-telegraph-engine__handle{position:absolute;left:50%;top:48%;width:10px;height:70px;margin:-60px 0 0 -5px;background:linear-gradient(180deg,#e2e8f0,var(--accent));border-radius:6px;transform-origin:50% 90%;animation:ship_telegraph_engine_swing 4s ease-in-out infinite;box-shadow:0 0 0 3px #0f172a}
+.ease-ship-telegraph-engine__pedestal{position:absolute;left:50%;bottom:12%;width:48px;height:18px;margin-left:-24px;background:#334155;border-radius:4px}
+.ease-ship-telegraph-engine__order{position:absolute;left:50%;top:18%;transform:translateX(-50%);font-size:.7rem;letter-spacing:.1em;text-transform:uppercase;color:var(--accent);animation:ship_telegraph_engine_label 4s steps(1,end) infinite}
+.ease-ship-telegraph-engine__order::after{content:"FULL AHEAD"}
+@keyframes ship_telegraph_engine_swing{0%,100%{transform:rotate(-48deg)}50%{transform:rotate(42deg)}}
+@keyframes ship_telegraph_engine_label{0%,24%{content:"FULL AHEAD"}25%,49%{content:"STOP"}50%,74%{content:"ASTERN"}75%,100%{content:"STANDBY"}}
+@media (prefers-reduced-motion:reduce){.ease-ship-telegraph-engine__handle,.ease-ship-telegraph-engine__order{animation:none!important}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-ship-telegraph-engine__meters i::after,
+  .ease-ship-telegraph-engine__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-ship-telegraph-engine` under `submissions/examples/ship-telegraph-engine-ns/` — CSS-only Engine order telegraph handle swinging between orders.

Fixes #65593

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Engine order telegraph handle swinging between orders.

**How does a developer use it?**

```html
<section class="ease-ship-telegraph-engine">
  <div class="ease-ship-telegraph-engine__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `ship_telegraph_engine_*` prefix. Reduced-motion disables animations.