### PR TITLE
feat: add ease-foghorn-pulse (#65594)

### DIFF
--- a/submissions/examples/foghorn-pulse-ns/README.md
+++ b/submissions/examples/foghorn-pulse-ns/README.md
@@ -1,0 +1,16 @@
+# Foghorn Pulse
+
+## What does this do?
+Renders a self-contained CSS-only `ease-foghorn-pulse` demo: Foghorn housing pulsing concentric sound rings.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-foghorn-pulse`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-foghorn-pulse">
+  <div class="ease-foghorn-pulse__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/foghorn-pulse-ns/demo.html
+++ b/submissions/examples/foghorn-pulse-ns/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Foghorn Pulse — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Foghorn Pulse demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Foghorn Pulse</h1>
+      <p class="lede">Foghorn housing pulsing concentric sound rings</p>
+    </header>
+
+    <section class="ease-foghorn-pulse" data-demo="foghorn-pulse" aria-live="polite">
+      <div class="ease-foghorn-pulse__housing">
+        <div class="ease-foghorn-pulse__bezel">
+          <div class="ease-foghorn-pulse__face">
+            <div class="ease-foghorn-pulse__readout">
+              <span class="ease-foghorn-pulse__label">Foghorn Pulse</span>
+              <span class="ease-foghorn-pulse__value">BLAST</span>
+            </div>
+            <div class="ease-foghorn-pulse__motion" aria-hidden="true">
+              <span class="ease-foghorn-pulse__horn"></span>
+              <span class="ease-foghorn-pulse__ring r1"></span>
+              <span class="ease-foghorn-pulse__ring r2"></span>
+              <span class="ease-foghorn-pulse__ring r3"></span>
+              <span class="ease-foghorn-pulse__base"></span>
+            </div>
+            <div class="ease-foghorn-pulse__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-foghorn-pulse__controls">
+          <button type="button" class="ease-foghorn-pulse__btn primary">Engage</button>
+          <button type="button" class="ease-foghorn-pulse__btn">Reset</button>
+          <label class="ease-foghorn-pulse__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-foghorn-pulse__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/foghorn-pulse-ns/style.css
+++ b/submissions/examples/foghorn-pulse-ns/style.css
@@ -1,0 +1,234 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #f8fafc 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #94a3b8 18%, transparent), transparent 42%),
+    #0c1218;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-foghorn-pulse {
+  --accent: #f8fafc;
+  --accent-2: #94a3b8;
+  --panel: color-mix(in srgb, #e8eef6 7%, #0c1218);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #0c1218 75%, #000);
+}
+
+.ease-foghorn-pulse__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-foghorn-pulse__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #0c1218 90%, #f8fafc);
+}
+
+.ease-foghorn-pulse__face {
+  position: relative;
+  min-height: 260px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 28% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #0c1218 85%, #000), color-mix(in srgb, #0c1218 65%, var(--accent-2)));
+}
+
+.ease-foghorn-pulse__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-foghorn-pulse__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-foghorn-pulse__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-foghorn-pulse__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-foghorn-pulse__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-foghorn-pulse__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-foghorn-pulse__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: foghorn_pulse_meter 1.7s ease-in-out infinite alternate;
+}
+
+.ease-foghorn-pulse__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-foghorn-pulse__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-foghorn-pulse__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-foghorn-pulse__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-foghorn-pulse__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-foghorn-pulse__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-foghorn-pulse__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-foghorn-pulse__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-foghorn-pulse__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-foghorn-pulse__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-foghorn-pulse__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-foghorn-pulse__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: foghorn_pulse_pulse 1.8s ease-out infinite;
+}
+
+@keyframes foghorn_pulse_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes foghorn_pulse_pulse {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+
+.ease-foghorn-pulse__base{position:absolute;left:50%;bottom:16%;width:70px;height:18px;margin-left:-35px;background:#334155;border-radius:4px}
+.ease-foghorn-pulse__horn{position:absolute;left:42%;bottom:28%;width:70px;height:48px;background:linear-gradient(90deg,#64748b,#94a3b8);clip-path:polygon(0 35%,70% 0,100% 10%,100% 90%,70% 100%,0 65%);box-shadow:0 0 16px color-mix(in srgb,var(--accent)25%,transparent)}
+.ease-foghorn-pulse__ring{position:absolute;left:58%;top:40%;border:2px solid color-mix(in srgb,var(--accent)55%,transparent);border-radius:50%;animation:foghorn_pulse_pulse 2.4s ease-out infinite}
+.ease-foghorn-pulse__ring.r1{width:40px;height:40px;margin:-20px 0 0 0;animation-delay:0s}
+.ease-foghorn-pulse__ring.r2{width:70px;height:70px;margin:-35px 0 0 -10px;animation-delay:.4s}
+.ease-foghorn-pulse__ring.r3{width:110px;height:110px;margin:-55px 0 0 -25px;animation-delay:.8s}
+@keyframes foghorn_pulse_pulse{0%{transform:scale(.6);opacity:.85}100%{transform:scale(1.35);opacity:0}}
+@media (prefers-reduced-motion:reduce){.ease-foghorn-pulse__ring{animation:none!important}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-foghorn-pulse__meters i::after,
+  .ease-foghorn-pulse__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-foghorn-pulse` under `submissions/examples/foghorn-pulse-ns/` — CSS-only Foghorn housing pulsing concentric sound rings.

Fixes #65594

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Foghorn housing pulsing concentric sound rings.

**How does a developer use it?**

```html
<section class="ease-foghorn-pulse">
  <div class="ease-foghorn-pulse__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `foghorn_pulse_*` prefix. Reduced-motion disables animations.