### PR TITLE
feat: add ease-lock-canal-gate (#65595)

### DIFF
--- a/submissions/examples/lock-canal-gate-ns/README.md
+++ b/submissions/examples/lock-canal-gate-ns/README.md
@@ -1,0 +1,16 @@
+# Lock Canal Gate
+
+## What does this do?
+Renders a self-contained CSS-only `ease-lock-canal-gate` demo: Canal lock gate opening and water level changing.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-lock-canal-gate`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-lock-canal-gate">
+  <div class="ease-lock-canal-gate__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/lock-canal-gate-ns/demo.html
+++ b/submissions/examples/lock-canal-gate-ns/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Lock Canal Gate — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Lock Canal Gate demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Lock Canal Gate</h1>
+      <p class="lede">Canal lock gate opening and water level changing</p>
+    </header>
+
+    <section class="ease-lock-canal-gate" data-demo="lock-canal-gate" aria-live="polite">
+      <div class="ease-lock-canal-gate__housing">
+        <div class="ease-lock-canal-gate__bezel">
+          <div class="ease-lock-canal-gate__face">
+            <div class="ease-lock-canal-gate__readout">
+              <span class="ease-lock-canal-gate__label">Lock Canal Gate</span>
+              <span class="ease-lock-canal-gate__value">LEVEL</span>
+            </div>
+            <div class="ease-lock-canal-gate__motion" aria-hidden="true">
+              <span class="ease-lock-canal-gate__chamber"></span>
+              <span class="ease-lock-canal-gate__water"></span>
+              <span class="ease-lock-canal-gate__gate left"></span>
+              <span class="ease-lock-canal-gate__gate right"></span>
+              <span class="ease-lock-canal-gate__boat"></span>
+            </div>
+            <div class="ease-lock-canal-gate__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-lock-canal-gate__controls">
+          <button type="button" class="ease-lock-canal-gate__btn primary">Engage</button>
+          <button type="button" class="ease-lock-canal-gate__btn">Reset</button>
+          <label class="ease-lock-canal-gate__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-lock-canal-gate__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/lock-canal-gate-ns/style.css
+++ b/submissions/examples/lock-canal-gate-ns/style.css
@@ -1,0 +1,236 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #38bdf8 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #0ea5e9 18%, transparent), transparent 42%),
+    #0a141c;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-lock-canal-gate {
+  --accent: #38bdf8;
+  --accent-2: #0ea5e9;
+  --panel: color-mix(in srgb, #e8eef6 7%, #0a141c);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #0a141c 75%, #000);
+}
+
+.ease-lock-canal-gate__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-lock-canal-gate__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #0a141c 90%, #38bdf8);
+}
+
+.ease-lock-canal-gate__face {
+  position: relative;
+  min-height: 260px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 28% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #0a141c 85%, #000), color-mix(in srgb, #0a141c 65%, var(--accent-2)));
+}
+
+.ease-lock-canal-gate__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-lock-canal-gate__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-lock-canal-gate__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-lock-canal-gate__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-lock-canal-gate__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-lock-canal-gate__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-lock-canal-gate__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: lock_canal_gate_meter 1.7s ease-in-out infinite alternate;
+}
+
+.ease-lock-canal-gate__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-lock-canal-gate__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-lock-canal-gate__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-lock-canal-gate__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-lock-canal-gate__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-lock-canal-gate__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-lock-canal-gate__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-lock-canal-gate__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-lock-canal-gate__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-lock-canal-gate__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-lock-canal-gate__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-lock-canal-gate__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: lock_canal_gate_pulse 1.8s ease-out infinite;
+}
+
+@keyframes lock_canal_gate_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes lock_canal_gate_pulse {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+
+.ease-lock-canal-gate__chamber{position:absolute;left:16%;right:16%;top:22%;bottom:20%;border:3px solid #475569;border-radius:8px;background:#0f172a;overflow:hidden}
+.ease-lock-canal-gate__water{position:absolute;left:0;right:0;bottom:0;height:42%;background:linear-gradient(180deg,color-mix(in srgb,var(--accent)45%,transparent),#0ea5e9);animation:lock_canal_gate_level 5s ease-in-out infinite}
+.ease-lock-canal-gate__gate{position:absolute;top:8%;bottom:8%;width:18%;background:linear-gradient(180deg,#64748b,#334155);border:2px solid #94a3b8;transform-origin:top center}
+.ease-lock-canal-gate__gate.left{left:6%;animation:lock_canal_gate_gate 5s ease-in-out infinite}
+.ease-lock-canal-gate__gate.right{right:6%;animation:lock_canal_gate_gate 5s ease-in-out infinite reverse}
+.ease-lock-canal-gate__boat{position:absolute;left:42%;bottom:28%;width:36px;height:14px;background:var(--accent-2);border-radius:4px 10px 4px 4px;animation:lock_canal_gate_boat 5s ease-in-out infinite}
+@keyframes lock_canal_gate_level{0%,20%{height:28%}50%,70%{height:58%}100%{height:28%}}
+@keyframes lock_canal_gate_gate{0%,25%{transform:rotate(0)}45%,70%{transform:rotate(-55deg)}100%{transform:rotate(0)}}
+@keyframes lock_canal_gate_boat{0%,20%{transform:translateY(18px)}50%,70%{transform:translateY(-8px)}100%{transform:translateY(18px)}}
+@media (prefers-reduced-motion:reduce){.ease-lock-canal-gate__water,.ease-lock-canal-gate__gate,.ease-lock-canal-gate__boat{animation:none!important}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-lock-canal-gate__meters i::after,
+  .ease-lock-canal-gate__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-lock-canal-gate` under `submissions/examples/lock-canal-gate-ns/` — CSS-only Canal lock gate opening and water level changing.

Fixes #65595

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Canal lock gate opening and water level changing.

**How does a developer use it?**

```html
<section class="ease-lock-canal-gate">
  <div class="ease-lock-canal-gate__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `lock_canal_gate_*` prefix. Reduced-motion disables animations.