### PR TITLE
feat: add ease-bascule-bridge (#65596)

### DIFF
--- a/submissions/examples/bascule-bridge-ns/README.md
+++ b/submissions/examples/bascule-bridge-ns/README.md
@@ -1,0 +1,16 @@
+# Bascule Bridge
+
+## What does this do?
+Renders a self-contained CSS-only `ease-bascule-bridge` demo: Bascule bridge leaf raising for river traffic.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-bascule-bridge`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-bascule-bridge">
+  <div class="ease-bascule-bridge__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/bascule-bridge-ns/demo.html
+++ b/submissions/examples/bascule-bridge-ns/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Bascule Bridge — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Bascule Bridge demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Bascule Bridge</h1>
+      <p class="lede">Bascule bridge leaf raising for river traffic</p>
+    </header>
+
+    <section class="ease-bascule-bridge" data-demo="bascule-bridge" aria-live="polite">
+      <div class="ease-bascule-bridge__housing">
+        <div class="ease-bascule-bridge__bezel">
+          <div class="ease-bascule-bridge__face">
+            <div class="ease-bascule-bridge__readout">
+              <span class="ease-bascule-bridge__label">Bascule Bridge</span>
+              <span class="ease-bascule-bridge__value">OPEN</span>
+            </div>
+            <div class="ease-bascule-bridge__motion" aria-hidden="true">
+              <span class="ease-bascule-bridge__pier"></span>
+              <span class="ease-bascule-bridge__leaf"></span>
+              <span class="ease-bascule-bridge__counter"></span>
+              <span class="ease-bascule-bridge__water"></span>
+              <span class="ease-bascule-bridge__boat"></span>
+            </div>
+            <div class="ease-bascule-bridge__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-bascule-bridge__controls">
+          <button type="button" class="ease-bascule-bridge__btn primary">Engage</button>
+          <button type="button" class="ease-bascule-bridge__btn">Reset</button>
+          <label class="ease-bascule-bridge__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-bascule-bridge__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/bascule-bridge-ns/style.css
+++ b/submissions/examples/bascule-bridge-ns/style.css
@@ -1,0 +1,235 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #f59e0b 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #38bdf8 18%, transparent), transparent 42%),
+    #12100c;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-bascule-bridge {
+  --accent: #f59e0b;
+  --accent-2: #38bdf8;
+  --panel: color-mix(in srgb, #e8eef6 7%, #12100c);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #12100c 75%, #000);
+}
+
+.ease-bascule-bridge__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-bascule-bridge__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #12100c 90%, #f59e0b);
+}
+
+.ease-bascule-bridge__face {
+  position: relative;
+  min-height: 260px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 28% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #12100c 85%, #000), color-mix(in srgb, #12100c 65%, var(--accent-2)));
+}
+
+.ease-bascule-bridge__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-bascule-bridge__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-bascule-bridge__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-bascule-bridge__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-bascule-bridge__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-bascule-bridge__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-bascule-bridge__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: bascule_bridge_meter 1.7s ease-in-out infinite alternate;
+}
+
+.ease-bascule-bridge__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-bascule-bridge__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-bascule-bridge__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-bascule-bridge__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-bascule-bridge__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-bascule-bridge__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-bascule-bridge__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-bascule-bridge__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-bascule-bridge__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-bascule-bridge__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-bascule-bridge__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-bascule-bridge__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: bascule_bridge_pulse 1.8s ease-out infinite;
+}
+
+@keyframes bascule_bridge_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes bascule_bridge_pulse {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+
+.ease-bascule-bridge__water{position:absolute;left:8%;right:8%;bottom:16%;height:18%;background:linear-gradient(180deg,color-mix(in srgb,var(--accent)30%,transparent),#0369a1);border-radius:8px}
+.ease-bascule-bridge__pier{position:absolute;left:18%;bottom:28%;width:18px;height:36%;background:#475569;border-radius:3px}
+.ease-bascule-bridge__leaf{position:absolute;left:18%;bottom:58%;width:48%;height:14px;background:linear-gradient(90deg,#94a3b8,var(--accent-2));border-radius:3px;transform-origin:left center;animation:bascule_bridge_raise 4.5s ease-in-out infinite}
+.ease-bascule-bridge__counter{position:absolute;left:10%;bottom:58%;width:24px;height:12px;background:#334155;border-radius:2px;animation:bascule_bridge_counter 4.5s ease-in-out infinite}
+.ease-bascule-bridge__boat{position:absolute;left:55%;bottom:28%;width:40px;height:14px;background:var(--accent);border-radius:4px 12px 4px 4px;animation:bascule_bridge_pass 4.5s ease-in-out infinite}
+@keyframes bascule_bridge_raise{0%,20%{transform:rotate(0)}40%,65%{transform:rotate(-55deg)}85%,100%{transform:rotate(0)}}
+@keyframes bascule_bridge_counter{0%,20%{transform:translateY(0)}40%,65%{transform:translateY(18px)}85%,100%{transform:translateY(0)}}
+@keyframes bascule_bridge_pass{0%,35%{transform:translateX(-30px);opacity:0}45%{opacity:1}70%{transform:translateX(40px);opacity:1}80%,100%{opacity:0;transform:translateX(60px)}}
+@media (prefers-reduced-motion:reduce){.ease-bascule-bridge__leaf,.ease-bascule-bridge__counter,.ease-bascule-bridge__boat{animation:none!important}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-bascule-bridge__meters i::after,
+  .ease-bascule-bridge__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-bascule-bridge` under `submissions/examples/bascule-bridge-ns/` — CSS-only Bascule bridge leaf raising for river traffic.

Fixes #65596

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Bascule bridge leaf raising for river traffic.

**How does a developer use it?**

```html
<section class="ease-bascule-bridge">
  <div class="ease-bascule-bridge__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `bascule_bridge_*` prefix. Reduced-motion disables animations.