### PR TITLE
feat: add ease-signal-semaphore-arm (#65598)

### DIFF
--- a/submissions/examples/signal-semaphore-arm-ns/README.md
+++ b/submissions/examples/signal-semaphore-arm-ns/README.md
@@ -1,0 +1,16 @@
+# Signal Semaphore Arm
+
+## What does this do?
+Renders a self-contained CSS-only `ease-signal-semaphore-arm` demo: Railway semaphore signal arm dropping to clear.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-signal-semaphore-arm`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-signal-semaphore-arm">
+  <div class="ease-signal-semaphore-arm__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/signal-semaphore-arm-ns/demo.html
+++ b/submissions/examples/signal-semaphore-arm-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Signal Semaphore Arm — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Signal Semaphore Arm demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Signal Semaphore Arm</h1>
+      <p class="lede">Railway semaphore signal arm dropping to clear</p>
+    </header>
+
+    <section class="ease-signal-semaphore-arm" data-demo="signal-semaphore-arm" aria-live="polite">
+      <div class="ease-signal-semaphore-arm__housing">
+        <div class="ease-signal-semaphore-arm__bezel">
+          <div class="ease-signal-semaphore-arm__face">
+            <div class="ease-signal-semaphore-arm__readout">
+              <span class="ease-signal-semaphore-arm__label">Signal Semaphore Arm</span>
+              <span class="ease-signal-semaphore-arm__value">CLEAR</span>
+            </div>
+            <div class="ease-signal-semaphore-arm__motion" aria-hidden="true">
+              <span class="ease-signal-semaphore-arm__post"></span>
+              <span class="ease-signal-semaphore-arm__arm"></span>
+              <span class="ease-signal-semaphore-arm__lamp"></span>
+              <span class="ease-signal-semaphore-arm__ladder"></span>
+            </div>
+            <div class="ease-signal-semaphore-arm__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-signal-semaphore-arm__controls">
+          <button type="button" class="ease-signal-semaphore-arm__btn primary">Engage</button>
+          <button type="button" class="ease-signal-semaphore-arm__btn">Reset</button>
+          <label class="ease-signal-semaphore-arm__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-signal-semaphore-arm__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/signal-semaphore-arm-ns/style.css
+++ b/submissions/examples/signal-semaphore-arm-ns/style.css
@@ -1,0 +1,233 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #22c55e 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #ef4444 18%, transparent), transparent 42%),
+    #0c140e;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-signal-semaphore-arm {
+  --accent: #22c55e;
+  --accent-2: #ef4444;
+  --panel: color-mix(in srgb, #e8eef6 7%, #0c140e);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #0c140e 75%, #000);
+}
+
+.ease-signal-semaphore-arm__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-signal-semaphore-arm__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #0c140e 90%, #22c55e);
+}
+
+.ease-signal-semaphore-arm__face {
+  position: relative;
+  min-height: 260px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 28% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #0c140e 85%, #000), color-mix(in srgb, #0c140e 65%, var(--accent-2)));
+}
+
+.ease-signal-semaphore-arm__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-signal-semaphore-arm__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-signal-semaphore-arm__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-signal-semaphore-arm__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-signal-semaphore-arm__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-signal-semaphore-arm__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-signal-semaphore-arm__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: signal_semaphore_arm_meter 1.7s ease-in-out infinite alternate;
+}
+
+.ease-signal-semaphore-arm__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-signal-semaphore-arm__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-signal-semaphore-arm__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-signal-semaphore-arm__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-signal-semaphore-arm__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-signal-semaphore-arm__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-signal-semaphore-arm__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-signal-semaphore-arm__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-signal-semaphore-arm__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-signal-semaphore-arm__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-signal-semaphore-arm__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-signal-semaphore-arm__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: signal_semaphore_arm_pulse 1.8s ease-out infinite;
+}
+
+@keyframes signal_semaphore_arm_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes signal_semaphore_arm_pulse {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+
+.ease-signal-semaphore-arm__post{position:absolute;left:42%;top:16%;bottom:14%;width:14px;background:linear-gradient(180deg,#94a3b8,#334155);border-radius:3px}
+.ease-signal-semaphore-arm__ladder{position:absolute;left:36%;top:30%;width:10px;height:40%;background:repeating-linear-gradient(180deg,#64748b 0 3px,transparent 3px 10px)}
+.ease-signal-semaphore-arm__arm{position:absolute;left:42%;top:28%;width:90px;height:14px;background:linear-gradient(90deg,#ef4444,#fbbf24);border-radius:3px;transform-origin:8px 50%;animation:signal_semaphore_arm_drop 3.2s ease-in-out infinite;box-shadow:0 0 0 2px #0f172a}
+.ease-signal-semaphore-arm__lamp{position:absolute;left:40%;top:22%;width:18px;height:18px;border-radius:50%;background:var(--accent);box-shadow:0 0 14px var(--accent);animation:signal_semaphore_arm_lamp 3.2s ease-in-out infinite}
+@keyframes signal_semaphore_arm_drop{0%,25%{transform:rotate(-4deg)}50%,75%{transform:rotate(78deg)}100%{transform:rotate(-4deg)}}
+@keyframes signal_semaphore_arm_lamp{0%,25%{background:#ef4444;box-shadow:0 0 14px #ef4444}50%,75%{background:#22c55e;box-shadow:0 0 14px #22c55e}100%{background:#ef4444;box-shadow:0 0 14px #ef4444}}
+@media (prefers-reduced-motion:reduce){.ease-signal-semaphore-arm__arm,.ease-signal-semaphore-arm__lamp{animation:none!important}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-signal-semaphore-arm__meters i::after,
+  .ease-signal-semaphore-arm__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-signal-semaphore-arm` under `submissions/examples/signal-semaphore-arm-ns/` — CSS-only Railway semaphore signal arm dropping to clear.

Fixes #65598

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Railway semaphore signal arm dropping to clear.

**How does a developer use it?**

```html
<section class="ease-signal-semaphore-arm">
  <div class="ease-signal-semaphore-arm__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `signal_semaphore_arm_*` prefix. Reduced-motion disables animations.