### PR TITLE
feat: add ease-destination-blind-roll (#65600)

### DIFF
--- a/submissions/examples/destination-blind-roll-ns/README.md
+++ b/submissions/examples/destination-blind-roll-ns/README.md
@@ -1,23 +1,16 @@
-# Ease Destination Blind Roll
+# Destination Blind Roll
 
-A CSS-only animated bus destination blind component for the EaseMotion CSS library.
+## What does this do?
+Renders a self-contained CSS-only `ease-destination-blind-roll` demo: Bus destination blind rolling to a new city name.
 
-## Features
-
-- Pure HTML and CSS
-- No JavaScript required
-- Real-world bus destination blind visual metaphor
-- Vertical destination rolling animation
-- Motion blur during transitions
-- Animated physical control dial
-- Status indicators
-- Responsive layout
-- `prefers-reduced-motion` support
-- Easy to customize with CSS variables
-
-## Usage
-
-Include the component stylesheet:
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-destination-blind-roll`. No build step or JavaScript is required for the effect.
 
 ```html
-<link rel="stylesheet" href="style.css">
+<section class="ease-destination-blind-roll">
+  <div class="ease-destination-blind-roll__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/destination-blind-roll-ns/demo.html
+++ b/submissions/examples/destination-blind-roll-ns/demo.html
@@ -3,74 +3,51 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta
-    name="description"
-    content="CSS-only animated bus destination blind roll component"
-  >
-  <title>Ease Destination Blind Roll</title>
-  <link rel="stylesheet" href="style.css">
+  <title>Destination Blind Roll — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
 </head>
-
 <body>
-  <main class="showcase">
-    <p class="eyebrow">EASEMOTION CSS</p>
-    <h1>Destination Blind Roll</h1>
-    <p class="intro">
-      A CSS-only bus destination display that rolls between destinations.
-    </p>
+  <main class="stage" aria-label="Destination Blind Roll demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Destination Blind Roll</h1>
+      <p class="lede">Bus destination blind rolling to a new city name</p>
+    </header>
 
-    <section
-      class="ease-destination-blind-roll"
-      aria-label="Bus destination display"
-    >
-      <div class="blind-housing">
-        <div class="housing-top">
-          <span class="operator-label">CITY TRANSIT</span>
-          <span class="route-label">ROUTE 42</span>
-        </div>
-
-        <div class="destination-frame">
-          <span class="display-label">DESTINATION</span>
-
-          <div class="destination-window">
-            <div class="destination-roll" aria-hidden="true">
-              <span>NEW DELHI</span>
-              <span>NOIDA</span>
-              <span>GHAZIABAD</span>
-              <span>GURUGRAM</span>
-              <span>NEW DELHI</span>
+    <section class="ease-destination-blind-roll" data-demo="destination-blind-roll" aria-live="polite">
+      <div class="ease-destination-blind-roll__housing">
+        <div class="ease-destination-blind-roll__bezel">
+          <div class="ease-destination-blind-roll__face">
+            <div class="ease-destination-blind-roll__readout">
+              <span class="ease-destination-blind-roll__label">Destination Blind Roll</span>
+              <span class="ease-destination-blind-roll__value">ROUTE</span>
+            </div>
+            <div class="ease-destination-blind-roll__motion" aria-hidden="true">
+              <span class="ease-destination-blind-roll__frame"></span>
+              <span class="ease-destination-blind-roll__blind">
+                <i>CITY CENTER</i><i>RIVERSIDE</i><i>AIRPORT</i><i>UNIVERSITY</i>
+              </span>
+              <span class="ease-destination-blind-roll__roller"></span>
+            </div>
+            <div class="ease-destination-blind-roll__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
             </div>
           </div>
         </div>
-
-        <div class="control-panel">
-          <div class="indicator">
-            <span class="indicator-light"></span>
-            <span>ROLLING</span>
-          </div>
-
-          <div class="dial" aria-hidden="true">
-            <span class="dial-mark mark-top"></span>
-            <span class="dial-mark mark-right"></span>
-            <span class="dial-mark mark-bottom"></span>
-            <span class="dial-mark mark-left"></span>
-            <span class="dial-center"></span>
-          </div>
-
-          <div class="indicator ready">
-            <span class="indicator-light"></span>
-            <span>READY</span>
-          </div>
-        </div>
-
-        <div class="housing-bottom">
-          <span>DESTINATION BLIND</span>
-          <span>CSS MOTION CONTROL</span>
+        <div class="ease-destination-blind-roll__controls">
+          <button type="button" class="ease-destination-blind-roll__btn primary">Engage</button>
+          <button type="button" class="ease-destination-blind-roll__btn">Reset</button>
+          <label class="ease-destination-blind-roll__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
         </div>
       </div>
+      <footer class="ease-destination-blind-roll__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
     </section>
-
-    <p class="hint">CSS animation • No JavaScript</p>
   </main>
 </body>
 </html>

--- a/submissions/examples/destination-blind-roll-ns/style.css
+++ b/submissions/examples/destination-blind-roll-ns/style.css
@@ -1,489 +1,232 @@
-:root {
-  --ease-color-bg: #111827;
-  --ease-color-surface: #1f2937;
-  --ease-color-surface-dark: #111827;
-  --ease-color-white: #ffffff;
-  --ease-color-text: #e5e7eb;
-  --ease-color-muted: #9ca3af;
-  --ease-color-accent: #f59e0b;
-  --ease-color-accent-dark: #b45309;
-  --ease-color-success: #22c55e;
-  --ease-color-border: #374151;
-  --ease-color-display: #0b0f0d;
-}
-
-* {
+*,
+*::before,
+*::after {
   box-sizing: border-box;
 }
 
 body {
   margin: 0;
   min-height: 100vh;
-  font-family:
-    Inter, ui-sans-serif, system-ui, -apple-system,
-    BlinkMacSystemFont, "Segoe UI", sans-serif;
-  color: var(--ease-color-text);
-  background:
-    radial-gradient(
-      circle at top,
-      #273449 0,
-      var(--ease-color-bg) 55%
-    );
-}
-
-.showcase {
-  width: min(900px, 92%);
-  margin: 0 auto;
-  padding: 64px 0;
-  text-align: center;
-}
-
-.eyebrow {
-  margin: 0 0 8px;
-  color: var(--ease-color-accent);
-  font-size: 0.75rem;
-  font-weight: 800;
-  letter-spacing: 0.18em;
-}
-
-h1 {
-  margin: 0;
-  color: var(--ease-color-white);
-  font-size: clamp(2rem, 5vw, 3.5rem);
-}
-
-.intro {
-  max-width: 560px;
-  margin: 14px auto 44px;
-  color: var(--ease-color-muted);
-  line-height: 1.7;
-}
-
-/* Component shell */
-
-.ease-destination-blind-roll {
-  width: min(760px, 100%);
-  margin: auto;
-}
-
-.blind-housing {
-  position: relative;
-  overflow: hidden;
-  padding: 26px;
-  border: 3px solid var(--ease-color-border);
-  border-radius: 18px;
-  background:
-    linear-gradient(
-      145deg,
-      var(--ease-color-surface),
-      var(--ease-color-surface-dark)
-    );
-  box-shadow:
-    0 24px 60px rgb(0 0 0 / 35%),
-    inset 0 1px 0 rgb(255 255 255 / 8%);
-}
-
-/* Top labels */
-
-.housing-top,
-.housing-bottom {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-}
-
-.housing-top {
-  margin-bottom: 18px;
-}
-
-.housing-bottom {
-  margin-top: 18px;
-  color: var(--ease-color-muted);
-  font-size: 0.65rem;
-  font-weight: 700;
-  letter-spacing: 0.12em;
-}
-
-.operator-label {
-  color: var(--ease-color-white);
-  font-size: 0.8rem;
-  font-weight: 800;
-  letter-spacing: 0.12em;
-}
-
-.route-label {
-  padding: 5px 10px;
-  border: 1px solid var(--ease-color-border);
-  border-radius: 4px;
-  color: var(--ease-color-accent);
-  font-size: 0.75rem;
-  font-weight: 800;
-  letter-spacing: 0.1em;
-}
-
-/* Destination display */
-
-.destination-frame {
-  padding: 18px;
-  border: 2px solid var(--ease-color-border);
-  border-radius: 10px;
-  background: #0d1110;
-}
-
-.display-label {
-  display: block;
-  margin-bottom: 10px;
-  color: var(--ease-color-muted);
-  font-size: 0.65rem;
-  font-weight: 800;
-  letter-spacing: 0.18em;
-  text-align: left;
-}
-
-.destination-window {
-  position: relative;
-  height: 125px;
-  overflow: hidden;
-  border: 4px solid #374151;
-  border-radius: 5px;
-  background: var(--ease-color-display);
-  box-shadow:
-    inset 0 8px 16px rgb(0 0 0 / 45%),
-    inset 0 -8px 16px rgb(0 0 0 / 45%);
-}
-
-/* Subtle horizontal divider lines */
-
-.destination-window::before,
-.destination-window::after {
-  position: absolute;
-  z-index: 2;
-  left: 0;
-  width: 100%;
-  height: 1px;
-  background: rgb(255 255 255 / 8%);
-  content: "";
-}
-
-.destination-window::before {
-  top: 50%;
-}
-
-.destination-window::after {
-  top: 50%;
-  transform: translateY(-31px);
-}
-
-/* Rolling destination */
-
-.destination-roll {
   display: flex;
   flex-direction: column;
   align-items: center;
-  animation: destination_blind_roll_motion 8s
-    cubic-bezier(0.65, 0, 0.35, 1) infinite;
-}
-
-.destination-roll span {
-  display: flex;
-  align-items: center;
   justify-content: center;
-  flex: 0 0 125px;
-  width: 100%;
-  color: var(--ease-color-accent);
-  font-family: "Courier New", monospace;
-  font-size: clamp(1.5rem, 5vw, 2.8rem);
-  font-weight: 900;
-  letter-spacing: 0.12em;
-  text-shadow:
-    0 0 5px var(--ease-color-accent),
-    0 0 16px rgb(245 158 11 / 30%);
-}
-
-/*
- * Destination blind rolling motion.
- * The vertical translation creates the physical blind-roll effect.
- */
-@keyframes destination_blind_roll_motion {
-  0% {
-    transform: translateY(0);
-    filter: blur(0);
-  }
-
-  12% {
-    transform: translateY(0);
-    filter: blur(0);
-  }
-
-  18% {
-    transform: translateY(-125px);
-    filter: blur(2px);
-  }
-
-  30% {
-    transform: translateY(-125px);
-    filter: blur(0);
-  }
-
-  38% {
-    transform: translateY(-250px);
-    filter: blur(2px);
-  }
-
-  50% {
-    transform: translateY(-250px);
-    filter: blur(0);
-  }
-
-  58% {
-    transform: translateY(-375px);
-    filter: blur(2px);
-  }
-
-  70% {
-    transform: translateY(-375px);
-    filter: blur(0);
-  }
-
-  78% {
-    transform: translateY(-500px);
-    filter: blur(2px);
-  }
-
-  90% {
-    transform: translateY(-500px);
-    filter: blur(0);
-  }
-
-  100% {
-    transform: translateY(-500px);
-    filter: blur(0);
-  }
-}
-
-/* Control panel */
-
-.control-panel {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-top: 22px;
-}
-
-.indicator {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  color: var(--ease-color-accent);
-  font-size: 0.65rem;
-  font-weight: 800;
-  letter-spacing: 0.1em;
-}
-
-.indicator.ready {
-  color: var(--ease-color-success);
-}
-
-.indicator-light {
-  width: 9px;
-  height: 9px;
-  border-radius: 50%;
-  background: currentColor;
-  box-shadow: 0 0 10px currentColor;
-  animation: indicator_pulse 1.5s ease-in-out infinite;
-}
-
-@keyframes indicator_pulse {
-  0%,
-  100% {
-    opacity: 0.45;
-  }
-
-  50% {
-    opacity: 1;
-  }
-}
-
-/* Physical control dial */
-
-.dial {
-  position: relative;
-  width: 58px;
-  height: 58px;
-  border: 4px solid #4b5563;
-  border-radius: 50%;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
   background:
-    radial-gradient(
-      circle,
-      #6b7280 0,
-      #374151 42%,
-      #1f2937 44%,
-      #111827 100%
-    );
-  box-shadow:
-    inset 0 2px 3px rgb(255 255 255 / 15%),
-    0 4px 8px rgb(0 0 0 / 35%);
-  animation: dial_turn 8s ease-in-out infinite;
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #fbbf24 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #e2e8f0 18%, transparent), transparent 42%),
+    #111111;
 }
 
-@keyframes dial_turn {
-  0%,
-  12% {
-    transform: rotate(0deg);
-  }
-
-  18%,
-  30% {
-    transform: rotate(45deg);
-  }
-
-  38%,
-  50% {
-    transform: rotate(90deg);
-  }
-
-  58%,
-  70% {
-    transform: rotate(135deg);
-  }
-
-  78%,
-  90% {
-    transform: rotate(180deg);
-  }
-
-  100% {
-    transform: rotate(180deg);
-  }
+.stage {
+  width: min(680px, 100%);
 }
 
-.dial-center {
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-destination-blind-roll {
+  --accent: #fbbf24;
+  --accent-2: #e2e8f0;
+  --panel: color-mix(in srgb, #e8eef6 7%, #111111);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #111111 75%, #000);
+}
+
+.ease-destination-blind-roll__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-destination-blind-roll__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #111111 90%, #fbbf24);
+}
+
+.ease-destination-blind-roll__face {
+  position: relative;
+  min-height: 260px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 28% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #111111 85%, #000), color-mix(in srgb, #111111 65%, var(--accent-2)));
+}
+
+.ease-destination-blind-roll__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-destination-blind-roll__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-destination-blind-roll__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-destination-blind-roll__motion {
   position: absolute;
-  top: 50%;
-  left: 50%;
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  background: var(--ease-color-accent);
-  transform: translate(-50%, -50%);
+  inset: 16% 6% 24%;
+  z-index: 1;
 }
 
-.dial-mark {
+.ease-destination-blind-roll__meters {
   position: absolute;
-  width: 5px;
-  height: 5px;
-  border-radius: 50%;
-  background: #d1d5db;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
 }
 
-.mark-top {
-  top: 4px;
-  left: 50%;
-  transform: translateX(-50%);
+.ease-destination-blind-roll__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
 }
 
-.mark-right {
-  top: 50%;
-  right: 4px;
-  transform: translateY(-50%);
+.ease-destination-blind-roll__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: destination_blind_roll_meter 1.7s ease-in-out infinite alternate;
 }
 
-.mark-bottom {
-  bottom: 4px;
-  left: 50%;
-  transform: translateX(-50%);
+.ease-destination-blind-roll__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-destination-blind-roll__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-destination-blind-roll__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-destination-blind-roll__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-destination-blind-roll__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-destination-blind-roll__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
 }
 
-.mark-left {
-  top: 50%;
-  left: 4px;
-  transform: translateY(-50%);
+.ease-destination-blind-roll__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
 }
 
-.hint {
-  margin-top: 28px;
-  color: var(--ease-color-muted);
-  font-family: "Courier New", monospace;
+.ease-destination-blind-roll__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-destination-blind-roll__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-destination-blind-roll__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-destination-blind-roll__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
   font-size: 0.8rem;
+  opacity: 0.75;
 }
 
-/* Responsive */
-
-@media (max-width: 600px) {
-  .showcase {
-    padding: 40px 0;
-  }
-
-  .blind-housing {
-    padding: 16px;
-    border-radius: 12px;
-  }
-
-  .destination-window {
-    height: 95px;
-  }
-
-  .destination-roll span {
-    flex-basis: 95px;
-  }
-
-  .destination-roll {
-    animation-name: destination_blind_roll_mobile;
-  }
-
-  .control-panel {
-    gap: 12px;
-  }
-
-  .housing-bottom {
-    font-size: 0.55rem;
-  }
+.ease-destination-blind-roll__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: destination_blind_roll_pulse 1.8s ease-out infinite;
 }
 
-@keyframes destination_blind_roll_mobile {
-  0%,
-  12% {
-    transform: translateY(0);
-    filter: blur(0);
-  }
-
-  18%,
-  30% {
-    transform: translateY(-95px);
-    filter: blur(0);
-  }
-
-  38%,
-  50% {
-    transform: translateY(-190px);
-    filter: blur(0);
-  }
-
-  58%,
-  70% {
-    transform: translateY(-285px);
-    filter: blur(0);
-  }
-
-  78%,
-  90%,
-  100% {
-    transform: translateY(-380px);
-    filter: blur(0);
-  }
+@keyframes destination_blind_roll_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
 }
 
-/* Accessibility */
+@keyframes destination_blind_roll_pulse {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+
+.ease-destination-blind-roll__frame{position:absolute;left:12%;right:12%;top:28%;height:44%;border:6px solid #475569;border-radius:8px;background:#0f172a;overflow:hidden}
+.ease-destination-blind-roll__blind{position:absolute;left:0;right:0;top:0;display:grid;animation:destination_blind_roll_roll 4.5s cubic-bezier(.45,.05,.2,1) infinite}
+.ease-destination-blind-roll__blind i{display:flex;align-items:center;justify-content:center;height:88px;font-style:normal;font-weight:700;letter-spacing:.12em;font-size:1.05rem;color:var(--accent);border-bottom:1px solid #1e293b}
+.ease-destination-blind-roll__roller{position:absolute;left:10%;right:10%;top:24%;height:8px;border-radius:999px;background:#64748b}
+@keyframes destination_blind_roll_roll{0%,15%{transform:translateY(0)}25%,40%{transform:translateY(-88px)}50%,65%{transform:translateY(-176px)}75%,90%{transform:translateY(-264px)}100%{transform:translateY(0)}}
+@media (prefers-reduced-motion:reduce){.ease-destination-blind-roll__blind{animation:none!important}}
 
 @media (prefers-reduced-motion: reduce) {
-  .destination-roll,
-  .dial,
-  .indicator-light {
-    animation: none;
-  }
-
-  .destination-roll {
-    transform: translateY(0);
+  .ease-destination-blind-roll__meters i::after,
+  .ease-destination-blind-roll__status .dot {
+    animation: none !important;
   }
 }


### PR DESCRIPTION
## Pull Request Description

Adds `ease-destination-blind-roll` under `submissions/examples/destination-blind-roll-ns/` — CSS-only Bus destination blind rolling to a new city name.

Fixes #65600

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Bus destination blind rolling to a new city name.

**How does a developer use it?**

```html
<section class="ease-destination-blind-roll">
  <div class="ease-destination-blind-roll__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `destination_blind_roll_*` prefix. Reduced-motion disables animations.