### PR TITLE
feat: add ease-taxi-meter-fare (#65601)

### DIFF
--- a/submissions/examples/taxi-meter-fare-ns/README.md
+++ b/submissions/examples/taxi-meter-fare-ns/README.md
@@ -1,0 +1,16 @@
+# Taxi Meter Fare
+
+## What does this do?
+Renders a self-contained CSS-only `ease-taxi-meter-fare` demo: Taxi meter fare digits rolling upward as trip runs.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-taxi-meter-fare`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-taxi-meter-fare">
+  <div class="ease-taxi-meter-fare__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/taxi-meter-fare-ns/demo.html
+++ b/submissions/examples/taxi-meter-fare-ns/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Taxi Meter Fare — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Taxi Meter Fare demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Taxi Meter Fare</h1>
+      <p class="lede">Taxi meter fare digits rolling upward as trip runs</p>
+    </header>
+
+    <section class="ease-taxi-meter-fare" data-demo="taxi-meter-fare" aria-live="polite">
+      <div class="ease-taxi-meter-fare__housing">
+        <div class="ease-taxi-meter-fare__bezel">
+          <div class="ease-taxi-meter-fare__face">
+            <div class="ease-taxi-meter-fare__readout">
+              <span class="ease-taxi-meter-fare__label">Taxi Meter Fare</span>
+              <span class="ease-taxi-meter-fare__value">$12.40</span>
+            </div>
+            <div class="ease-taxi-meter-fare__motion" aria-hidden="true">
+              <span class="ease-taxi-meter-fare__screen">
+                <b class="d">1</b><b class="d">2</b><b class="d">.</b><b class="d">4</b><b class="d">0</b>
+              </span>
+              <span class="ease-taxi-meter-fare__lamp"></span>
+              <span class="ease-taxi-meter-fare__rate"></span>
+            </div>
+            <div class="ease-taxi-meter-fare__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-taxi-meter-fare__controls">
+          <button type="button" class="ease-taxi-meter-fare__btn primary">Engage</button>
+          <button type="button" class="ease-taxi-meter-fare__btn">Reset</button>
+          <label class="ease-taxi-meter-fare__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-taxi-meter-fare__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/taxi-meter-fare-ns/style.css
+++ b/submissions/examples/taxi-meter-fare-ns/style.css
@@ -1,0 +1,238 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #4ade80 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #86efac 18%, transparent), transparent 42%),
+    #07140f;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-taxi-meter-fare {
+  --accent: #4ade80;
+  --accent-2: #86efac;
+  --panel: color-mix(in srgb, #e8eef6 7%, #07140f);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #07140f 75%, #000);
+}
+
+.ease-taxi-meter-fare__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-taxi-meter-fare__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #07140f 90%, #4ade80);
+}
+
+.ease-taxi-meter-fare__face {
+  position: relative;
+  min-height: 260px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 28% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #07140f 85%, #000), color-mix(in srgb, #07140f 65%, var(--accent-2)));
+}
+
+.ease-taxi-meter-fare__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-taxi-meter-fare__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-taxi-meter-fare__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-taxi-meter-fare__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-taxi-meter-fare__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-taxi-meter-fare__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-taxi-meter-fare__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: taxi_meter_fare_meter 1.7s ease-in-out infinite alternate;
+}
+
+.ease-taxi-meter-fare__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-taxi-meter-fare__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-taxi-meter-fare__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-taxi-meter-fare__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-taxi-meter-fare__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-taxi-meter-fare__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-taxi-meter-fare__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-taxi-meter-fare__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-taxi-meter-fare__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-taxi-meter-fare__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-taxi-meter-fare__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-taxi-meter-fare__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: taxi_meter_fare_pulse 1.8s ease-out infinite;
+}
+
+@keyframes taxi_meter_fare_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes taxi_meter_fare_pulse {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+
+.ease-taxi-meter-fare__screen{position:absolute;left:14%;right:14%;top:28%;height:40%;border-radius:8px;border:4px solid #475569;background:#052e16;display:flex;align-items:center;justify-content:center;gap:.15rem;overflow:hidden;font-variant-numeric:tabular-nums}
+.ease-taxi-meter-fare__screen .d{display:inline-block;font-size:2rem;font-weight:700;color:#4ade80;min-width:.7ch;text-align:center;animation:taxi_meter_fare_digit 1.2s steps(1,end) infinite}
+.ease-taxi-meter-fare__screen .d:nth-child(1){animation-delay:0s}
+.ease-taxi-meter-fare__screen .d:nth-child(2){animation-delay:.15s}
+.ease-taxi-meter-fare__screen .d:nth-child(4){animation-delay:.3s}
+.ease-taxi-meter-fare__screen .d:nth-child(5){animation-delay:.45s}
+.ease-taxi-meter-fare__lamp{position:absolute;left:50%;top:14%;width:28px;height:12px;margin-left:-14px;background:var(--accent);border-radius:3px;animation:taxi_meter_fare_lamp 1.6s ease-in-out infinite}
+.ease-taxi-meter-fare__rate{position:absolute;left:18%;bottom:24%;font-size:.72rem;letter-spacing:.08em;text-transform:uppercase;opacity:.7}
+.ease-taxi-meter-fare__rate::after{content:"RATE A  ·  HIRED"}
+@keyframes taxi_meter_fare_digit{0%,49%{transform:translateY(0);filter:brightness(1)}50%{transform:translateY(-4px);filter:brightness(1.3)}100%{transform:translateY(0)}}
+@keyframes taxi_meter_fare_lamp{0%,100%{opacity:.55}50%{opacity:1}}
+@media (prefers-reduced-motion:reduce){.ease-taxi-meter-fare__screen .d,.ease-taxi-meter-fare__lamp{animation:none!important}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-taxi-meter-fare__meters i::after,
+  .ease-taxi-meter-fare__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-taxi-meter-fare` under `submissions/examples/taxi-meter-fare-ns/` — CSS-only Taxi meter fare digits rolling upward as trip runs.

Fixes #65601

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Taxi meter fare digits rolling upward as trip runs.

**How does a developer use it?**

```html
<section class="ease-taxi-meter-fare">
  <div class="ease-taxi-meter-fare__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `taxi_meter_fare_*` prefix. Reduced-motion disables animations.