### PR TITLE
feat: Add CSS Synthwave Wireframe Terrain

### DIFF
--- a/submissions/examples/css-synthwave-wireframe-terrain/README.md
+++ b/submissions/examples/css-synthwave-wireframe-terrain/README.md
@@ -1,0 +1,20 @@
+# CSS Synthwave Wireframe Terrain
+
+An 80s retro-futuristic scrolling 3D wireframe terrain. Achieved by applying intense perspective to a custom CSS grid pattern, using `mask-image` to fade smoothly into the horizon.
+
+## What does this do?
+
+It provides a visually stunning retro-futuristic aesthetic featuring a glowing sun and a scrolling wireframe terrain.
+
+## How is it used?
+
+```html
+<div class="synthwave-container">
+  <div class="synthwave-sun"></div>
+  <div class="synthwave-terrain"></div>
+</div>
+```
+
+## Why is it useful?
+
+It provides a visually stunning retro-futuristic aesthetic without relying on WebGL or canvas, utilizing pure CSS for performant and lightweight 3D perspective animations perfect for modern and themed interfaces.

--- a/submissions/examples/css-synthwave-wireframe-terrain/demo.html
+++ b/submissions/examples/css-synthwave-wireframe-terrain/demo.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Synthwave Wireframe Terrain</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="synthwave-container">
+    <div class="synthwave-sun"></div>
+    <div class="synthwave-terrain"></div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/css-synthwave-wireframe-terrain/style.css
+++ b/submissions/examples/css-synthwave-wireframe-terrain/style.css
@@ -1,0 +1,59 @@
+body {
+  margin: 0;
+  padding: 0;
+  background-color: #0d0221;
+  overflow: hidden;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.synthwave-container {
+  position: relative;
+  width: 100vw;
+  height: 100vh;
+  perspective: 600px;
+  overflow: hidden;
+  background: linear-gradient(to bottom, #2b003e 0%, #0d0221 50%, #0d0221 100%);
+}
+
+.synthwave-sun {
+  position: absolute;
+  top: 10%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 200px;
+  height: 200px;
+  background: linear-gradient(to bottom, #ff007f 0%, #ff8c00 100%);
+  border-radius: 50%;
+  box-shadow: 0 0 50px #ff007f, 0 0 100px #ff8c00;
+  z-index: 1;
+}
+
+.synthwave-terrain {
+  position: absolute;
+  bottom: 0;
+  left: -50vw;
+  width: 200vw;
+  height: 150vh;
+  background-image: 
+    linear-gradient(#ff007f 2px, transparent 2px),
+    linear-gradient(90deg, #ff007f 2px, transparent 2px);
+  background-size: 50px 50px;
+  transform: rotateX(75deg);
+  transform-origin: bottom center;
+  animation: scroll-terrain 2s linear infinite;
+  mask-image: linear-gradient(to bottom, transparent 0%, black 40%);
+  -webkit-mask-image: linear-gradient(to bottom, transparent 0%, black 40%);
+  z-index: 2;
+}
+
+@keyframes scroll-terrain {
+  from {
+    background-position: 0 0;
+  }
+  to {
+    background-position: 0 50px;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an 80s retro-futuristic scrolling 3D wireframe terrain effect. The feature uses an intense CSS perspective rotation on a custom background grid pattern, layered with `mask-image` to fade smoothly into the horizon and create a stunning synthwave aesthetic without relying on WebGL or canvas.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

It provides a visually stunning retro-futuristic aesthetic featuring a glowing sun and a smoothly scrolling 3D wireframe terrain.

**How does a developer use it?**

```html
<div class="synthwave-container">
  <div class="synthwave-sun"></div>
  <div class="synthwave-terrain"></div>
</div>
