### PR TITLE
feat: add ease-abacus-bead-slide (#67278)

### DIFF
--- a/submissions/examples/abacus-bead-slide-ns/README.md
+++ b/submissions/examples/abacus-bead-slide-ns/README.md
@@ -1,0 +1,16 @@
+# Abacus Bead Slide
+
+## What does this do?
+Renders a self-contained CSS-only `ease-abacus-bead-slide` demo: Wooden abacus beads sliding across rods during a count.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-abacus-bead-slide`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-abacus-bead-slide">
+  <div class="ease-abacus-bead-slide__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/abacus-bead-slide-ns/demo.html
+++ b/submissions/examples/abacus-bead-slide-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Abacus Bead Slide — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Abacus Bead Slide demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Abacus Bead Slide</h1>
+      <p class="lede">Wooden abacus beads sliding across rods during a count</p>
+    </header>
+
+    <section class="ease-abacus-bead-slide" data-demo="abacus-bead-slide" aria-live="polite">
+      <div class="ease-abacus-bead-slide__housing">
+        <div class="ease-abacus-bead-slide__bezel">
+          <div class="ease-abacus-bead-slide__face">
+            <div class="ease-abacus-bead-slide__readout">
+              <span class="ease-abacus-bead-slide__label">Abacus Bead Slide</span>
+              <span class="ease-abacus-bead-slide__value">LIVE</span>
+            </div>
+            <div class="ease-abacus-bead-slide__motion" aria-hidden="true">
+              <span class="ease-abacus-bead-slide__a"></span>
+              <span class="ease-abacus-bead-slide__b"></span>
+              <span class="ease-abacus-bead-slide__c"></span>
+              <span class="ease-abacus-bead-slide__d"></span>
+            </div>
+            <div class="ease-abacus-bead-slide__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-abacus-bead-slide__controls">
+          <button type="button" class="ease-abacus-bead-slide__btn primary">Engage</button>
+          <button type="button" class="ease-abacus-bead-slide__btn">Reset</button>
+          <label class="ease-abacus-bead-slide__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-abacus-bead-slide__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/abacus-bead-slide-ns/style.css
+++ b/submissions/examples/abacus-bead-slide-ns/style.css
@@ -1,0 +1,236 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #38bdf8 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #7dd3fc 18%, transparent), transparent 42%),
+    #0b1220;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-abacus-bead-slide {
+  --accent: #38bdf8;
+  --accent-2: #7dd3fc;
+  --panel: color-mix(in srgb, #e8eef6 7%, #0b1220);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #0b1220 75%, #000);
+}
+
+.ease-abacus-bead-slide__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-abacus-bead-slide__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #0b1220 90%, #38bdf8);
+}
+
+.ease-abacus-bead-slide__face {
+  position: relative;
+  min-height: 260px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 28% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #0b1220 85%, #000), color-mix(in srgb, #0b1220 65%, var(--accent-2)));
+}
+
+.ease-abacus-bead-slide__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-abacus-bead-slide__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-abacus-bead-slide__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-abacus-bead-slide__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-abacus-bead-slide__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-abacus-bead-slide__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-abacus-bead-slide__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: abacus_bead_slide_meter 1.7s ease-in-out infinite alternate;
+}
+
+.ease-abacus-bead-slide__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-abacus-bead-slide__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-abacus-bead-slide__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-abacus-bead-slide__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-abacus-bead-slide__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-abacus-bead-slide__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-abacus-bead-slide__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-abacus-bead-slide__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-abacus-bead-slide__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-abacus-bead-slide__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-abacus-bead-slide__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-abacus-bead-slide__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: abacus_bead_slide_status 1.8s ease-out infinite;
+}
+
+@keyframes abacus_bead_slide_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes abacus_bead_slide_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-abacus-bead-slide__a{position:absolute;left:18%;top:28%;width:54px;height:54px;border-radius:12px;border:3px solid color-mix(in srgb,var(--accent) 55%,#94a3b8);background:#0f172a;box-shadow:inset 0 0 0 6px #1e293b}
+.ease-abacus-bead-slide__b{position:absolute;left:42%;top:36%;width:110px;height:14px;border-radius:999px;background:linear-gradient(90deg,var(--accent-2),var(--accent));transform-origin:left center;animation:abacus_bead_slide_swing 2.8s ease-in-out infinite}
+.ease-abacus-bead-slide__c{position:absolute;left:30%;top:58%;width:10px;height:10px;border-radius:50%;background:var(--accent);animation:abacus_bead_slide_pulse 2.8s ease-out infinite}
+.ease-abacus-bead-slide__d{position:absolute;left:48%;top:56%;width:28%;height:6px;border-radius:999px;background:linear-gradient(90deg,transparent,var(--accent),transparent);opacity:.35;animation:abacus_bead_slide_flow 2.8s linear infinite}
+@keyframes abacus_bead_slide_swing{0%,100%{transform:rotate(-18deg)}50%{transform:rotate(16deg)}}
+@keyframes abacus_bead_slide_pulse{0%{transform:scale(.7);opacity:.4}40%{transform:scale(1.25);opacity:1}100%{transform:scale(.7);opacity:.35}}
+@keyframes abacus_bead_slide_flow{0%{transform:translateX(-12px);opacity:.15}50%{opacity:.9}100%{transform:translateX(18px);opacity:.15}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-abacus-bead-slide__a,
+  .ease-abacus-bead-slide__b,
+  .ease-abacus-bead-slide__c,
+  .ease-abacus-bead-slide__d,
+  .ease-abacus-bead-slide__meters i::after,
+  .ease-abacus-bead-slide__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-abacus-bead-slide` under `submissions/examples/abacus-bead-slide-ns/` — CSS-only Wooden abacus beads sliding across rods during a count.

Fixes #67278

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Wooden abacus beads sliding across rods during a count.

**How does a developer use it?**

```html
<section class="ease-abacus-bead-slide">
  <div class="ease-abacus-bead-slide__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `abacus_bead_slide_*` prefix. Reduced-motion disables animations.
