### PR TITLE
feat: add ease-ballista-bolt-launch (#67287)

### DIFF
--- a/submissions/examples/ballista-bolt-launch-ns/README.md
+++ b/submissions/examples/ballista-bolt-launch-ns/README.md
@@ -1,0 +1,16 @@
+# Ballista Bolt Launch
+
+## What does this do?
+Renders a self-contained CSS-only `ease-ballista-bolt-launch` demo: Siege ballista arms flexing then launching a bolt.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-ballista-bolt-launch`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-ballista-bolt-launch">
+  <div class="ease-ballista-bolt-launch__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/ballista-bolt-launch-ns/demo.html
+++ b/submissions/examples/ballista-bolt-launch-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ballista Bolt Launch — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Ballista Bolt Launch demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Ballista Bolt Launch</h1>
+      <p class="lede">Siege ballista arms flexing then launching a bolt</p>
+    </header>
+
+    <section class="ease-ballista-bolt-launch" data-demo="ballista-bolt-launch" aria-live="polite">
+      <div class="ease-ballista-bolt-launch__housing">
+        <div class="ease-ballista-bolt-launch__bezel">
+          <div class="ease-ballista-bolt-launch__face">
+            <div class="ease-ballista-bolt-launch__readout">
+              <span class="ease-ballista-bolt-launch__label">Ballista Bolt Launch</span>
+              <span class="ease-ballista-bolt-launch__value">LIVE</span>
+            </div>
+            <div class="ease-ballista-bolt-launch__motion" aria-hidden="true">
+              <span class="ease-ballista-bolt-launch__a"></span>
+              <span class="ease-ballista-bolt-launch__b"></span>
+              <span class="ease-ballista-bolt-launch__c"></span>
+              <span class="ease-ballista-bolt-launch__d"></span>
+            </div>
+            <div class="ease-ballista-bolt-launch__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-ballista-bolt-launch__controls">
+          <button type="button" class="ease-ballista-bolt-launch__btn primary">Engage</button>
+          <button type="button" class="ease-ballista-bolt-launch__btn">Reset</button>
+          <label class="ease-ballista-bolt-launch__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-ballista-bolt-launch__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ballista-bolt-launch-ns/style.css
+++ b/submissions/examples/ballista-bolt-launch-ns/style.css
@@ -1,0 +1,238 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #c084fc 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #d8b4fe 18%, transparent), transparent 42%),
+    #140a1c;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-ballista-bolt-launch {
+  --accent: #c084fc;
+  --accent-2: #d8b4fe;
+  --panel: color-mix(in srgb, #e8eef6 7%, #140a1c);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #140a1c 75%, #000);
+}
+
+.ease-ballista-bolt-launch__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-ballista-bolt-launch__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #140a1c 90%, #c084fc);
+}
+
+.ease-ballista-bolt-launch__face {
+  position: relative;
+  min-height: 260px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 28% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #140a1c 85%, #000), color-mix(in srgb, #140a1c 65%, var(--accent-2)));
+}
+
+.ease-ballista-bolt-launch__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-ballista-bolt-launch__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-ballista-bolt-launch__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-ballista-bolt-launch__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-ballista-bolt-launch__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-ballista-bolt-launch__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-ballista-bolt-launch__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: ballista_bolt_launch_meter 1.7s ease-in-out infinite alternate;
+}
+
+.ease-ballista-bolt-launch__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-ballista-bolt-launch__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-ballista-bolt-launch__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-ballista-bolt-launch__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-ballista-bolt-launch__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-ballista-bolt-launch__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-ballista-bolt-launch__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-ballista-bolt-launch__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-ballista-bolt-launch__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-ballista-bolt-launch__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-ballista-bolt-launch__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-ballista-bolt-launch__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: ballista_bolt_launch_status 1.8s ease-out infinite;
+}
+
+@keyframes ballista_bolt_launch_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes ballista_bolt_launch_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-ballista-bolt-launch__a{position:absolute;left:30%;top:26%;width:40%;height:40%;border-radius:50%;border:3px solid #475569;background:conic-gradient(from 0deg,transparent 0 70%,color-mix(in srgb,var(--accent) 70%,transparent) 0 100%);animation:ballista_bolt_launch_radar 3.5s linear infinite}
+.ease-ballista-bolt-launch__b{position:absolute;left:46%;top:42%;width:10px;height:10px;border-radius:50%;background:var(--accent);box-shadow:0 0 16px var(--accent);animation:ballista_bolt_launch_blip 3.5s ease-in-out infinite}
+.ease-ballista-bolt-launch__c{position:absolute;left:22%;bottom:22%;width:56%;height:6px;border-radius:999px;background:color-mix(in srgb,#e8eef6 12%,transparent);overflow:hidden}
+.ease-ballista-bolt-launch__c::after{content:"";display:block;height:100%;width:30%;background:var(--accent-2);animation:ballista_bolt_launch_load 3.5s ease-in-out infinite}
+.ease-ballista-bolt-launch__d{position:absolute;right:14%;top:28%;width:8px;height:48px;border-radius:4px;background:linear-gradient(180deg,var(--accent),transparent);animation:ballista_bolt_launch_bar 3.5s ease-in-out infinite}
+@keyframes ballista_bolt_launch_radar{to{transform:rotate(360deg)}}
+@keyframes ballista_bolt_launch_blip{0%,70%{opacity:.2;transform:scale(.6)}78%,88%{opacity:1;transform:scale(1.2)}100%{opacity:.2;transform:scale(.6)}}
+@keyframes ballista_bolt_launch_load{0%,100%{transform:translateX(0);width:22%}50%{transform:translateX(120%);width:40%}}
+@keyframes ballista_bolt_launch_bar{0%,100%{transform:scaleY(.4);transform-origin:bottom}50%{transform:scaleY(1)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-ballista-bolt-launch__a,
+  .ease-ballista-bolt-launch__b,
+  .ease-ballista-bolt-launch__c,
+  .ease-ballista-bolt-launch__d,
+  .ease-ballista-bolt-launch__meters i::after,
+  .ease-ballista-bolt-launch__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-ballista-bolt-launch` under `submissions/examples/ballista-bolt-launch-ns/` — CSS-only Siege ballista arms flexing then launching a bolt.

Fixes #67287

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Siege ballista arms flexing then launching a bolt.

**How does a developer use it?**

```html
<section class="ease-ballista-bolt-launch">
  <div class="ease-ballista-bolt-launch__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `ballista_bolt_launch_*` prefix. Reduced-motion disables animations.
