### PR TITLE
feat: add ease-blueprint-ink-roll (#67293)

### DIFF
--- a/submissions/examples/blueprint-ink-roll-ns/README.md
+++ b/submissions/examples/blueprint-ink-roll-ns/README.md
@@ -1,0 +1,16 @@
+# Blueprint Ink Roll
+
+## What does this do?
+Renders a self-contained CSS-only `ease-blueprint-ink-roll` demo: Diazo blueprint roller spreading cyan ink across paper.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-blueprint-ink-roll`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-blueprint-ink-roll">
+  <div class="ease-blueprint-ink-roll__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/blueprint-ink-roll-ns/demo.html
+++ b/submissions/examples/blueprint-ink-roll-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Blueprint Ink Roll — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Blueprint Ink Roll demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Blueprint Ink Roll</h1>
+      <p class="lede">Diazo blueprint roller spreading cyan ink across paper</p>
+    </header>
+
+    <section class="ease-blueprint-ink-roll" data-demo="blueprint-ink-roll" aria-live="polite">
+      <div class="ease-blueprint-ink-roll__housing">
+        <div class="ease-blueprint-ink-roll__bezel">
+          <div class="ease-blueprint-ink-roll__face">
+            <div class="ease-blueprint-ink-roll__readout">
+              <span class="ease-blueprint-ink-roll__label">Blueprint Ink Roll</span>
+              <span class="ease-blueprint-ink-roll__value">LIVE</span>
+            </div>
+            <div class="ease-blueprint-ink-roll__motion" aria-hidden="true">
+              <span class="ease-blueprint-ink-roll__a"></span>
+              <span class="ease-blueprint-ink-roll__b"></span>
+              <span class="ease-blueprint-ink-roll__c"></span>
+              <span class="ease-blueprint-ink-roll__d"></span>
+            </div>
+            <div class="ease-blueprint-ink-roll__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-blueprint-ink-roll__controls">
+          <button type="button" class="ease-blueprint-ink-roll__btn primary">Engage</button>
+          <button type="button" class="ease-blueprint-ink-roll__btn">Reset</button>
+          <label class="ease-blueprint-ink-roll__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-blueprint-ink-roll__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/blueprint-ink-roll-ns/style.css
+++ b/submissions/examples/blueprint-ink-roll-ns/style.css
@@ -1,0 +1,234 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #fb7185 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #fda4af 18%, transparent), transparent 42%),
+    #1a0b0e;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-blueprint-ink-roll {
+  --accent: #fb7185;
+  --accent-2: #fda4af;
+  --panel: color-mix(in srgb, #e8eef6 7%, #1a0b0e);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #1a0b0e 75%, #000);
+}
+
+.ease-blueprint-ink-roll__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-blueprint-ink-roll__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #1a0b0e 90%, #fb7185);
+}
+
+.ease-blueprint-ink-roll__face {
+  position: relative;
+  min-height: 260px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 28% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #1a0b0e 85%, #000), color-mix(in srgb, #1a0b0e 65%, var(--accent-2)));
+}
+
+.ease-blueprint-ink-roll__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-blueprint-ink-roll__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-blueprint-ink-roll__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-blueprint-ink-roll__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-blueprint-ink-roll__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-blueprint-ink-roll__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-blueprint-ink-roll__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: blueprint_ink_roll_meter 1.7s ease-in-out infinite alternate;
+}
+
+.ease-blueprint-ink-roll__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-blueprint-ink-roll__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-blueprint-ink-roll__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-blueprint-ink-roll__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-blueprint-ink-roll__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-blueprint-ink-roll__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-blueprint-ink-roll__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-blueprint-ink-roll__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-blueprint-ink-roll__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-blueprint-ink-roll__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-blueprint-ink-roll__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-blueprint-ink-roll__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: blueprint_ink_roll_status 1.8s ease-out infinite;
+}
+
+@keyframes blueprint_ink_roll_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes blueprint_ink_roll_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-blueprint-ink-roll__a{position:absolute;inset:24% 18% 30%;border-radius:12px;border:2px solid #475569;background:linear-gradient(180deg,#0f172a,#111827);overflow:hidden}
+.ease-blueprint-ink-roll__b{position:absolute;left:10%;top:20%;width:18%;height:60%;background:color-mix(in srgb,var(--accent) 55%,transparent);animation:blueprint_ink_roll_rise 2.4s ease-in-out infinite}
+.ease-blueprint-ink-roll__c{position:absolute;left:40%;top:20%;width:18%;height:60%;background:color-mix(in srgb,var(--accent-2) 55%,transparent);animation:blueprint_ink_roll_rise 2.4s ease-in-out infinite .15s}
+.ease-blueprint-ink-roll__d{position:absolute;left:70%;top:20%;width:18%;height:60%;background:color-mix(in srgb,var(--accent) 40%,transparent);animation:blueprint_ink_roll_rise 2.4s ease-in-out infinite .3s}
+@keyframes blueprint_ink_roll_rise{0%,100%{transform:scaleY(.35);transform-origin:bottom;opacity:.5}50%{transform:scaleY(1);opacity:1}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-blueprint-ink-roll__a,
+  .ease-blueprint-ink-roll__b,
+  .ease-blueprint-ink-roll__c,
+  .ease-blueprint-ink-roll__d,
+  .ease-blueprint-ink-roll__meters i::after,
+  .ease-blueprint-ink-roll__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-blueprint-ink-roll` under `submissions/examples/blueprint-ink-roll-ns/` — CSS-only Diazo blueprint roller spreading cyan ink across paper.

Fixes #67293

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Diazo blueprint roller spreading cyan ink across paper.

**How does a developer use it?**

```html
<section class="ease-blueprint-ink-roll">
  <div class="ease-blueprint-ink-roll__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `blueprint_ink_roll_*` prefix. Reduced-motion disables animations.
