### PR TITLE
feat: add ease-bolt-cutter-jaws (#67294)

### DIFF
--- a/submissions/examples/bolt-cutter-jaws-ns/README.md
+++ b/submissions/examples/bolt-cutter-jaws-ns/README.md
@@ -1,0 +1,16 @@
+# Bolt Cutter Jaws
+
+## What does this do?
+Renders a self-contained CSS-only `ease-bolt-cutter-jaws` demo: Heavy bolt-cutter jaws closing through a padlock shackle.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-bolt-cutter-jaws`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-bolt-cutter-jaws">
+  <div class="ease-bolt-cutter-jaws__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/bolt-cutter-jaws-ns/demo.html
+++ b/submissions/examples/bolt-cutter-jaws-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Bolt Cutter Jaws — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Bolt Cutter Jaws demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Bolt Cutter Jaws</h1>
+      <p class="lede">Heavy bolt-cutter jaws closing through a padlock shackle</p>
+    </header>
+
+    <section class="ease-bolt-cutter-jaws" data-demo="bolt-cutter-jaws" aria-live="polite">
+      <div class="ease-bolt-cutter-jaws__housing">
+        <div class="ease-bolt-cutter-jaws__bezel">
+          <div class="ease-bolt-cutter-jaws__face">
+            <div class="ease-bolt-cutter-jaws__readout">
+              <span class="ease-bolt-cutter-jaws__label">Bolt Cutter Jaws</span>
+              <span class="ease-bolt-cutter-jaws__value">LIVE</span>
+            </div>
+            <div class="ease-bolt-cutter-jaws__motion" aria-hidden="true">
+              <span class="ease-bolt-cutter-jaws__a"></span>
+              <span class="ease-bolt-cutter-jaws__b"></span>
+              <span class="ease-bolt-cutter-jaws__c"></span>
+              <span class="ease-bolt-cutter-jaws__d"></span>
+            </div>
+            <div class="ease-bolt-cutter-jaws__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-bolt-cutter-jaws__controls">
+          <button type="button" class="ease-bolt-cutter-jaws__btn primary">Engage</button>
+          <button type="button" class="ease-bolt-cutter-jaws__btn">Reset</button>
+          <label class="ease-bolt-cutter-jaws__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-bolt-cutter-jaws__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/bolt-cutter-jaws-ns/style.css
+++ b/submissions/examples/bolt-cutter-jaws-ns/style.css
@@ -1,0 +1,236 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #22d3ee 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #67e8f9 18%, transparent), transparent 42%),
+    #06141a;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-bolt-cutter-jaws {
+  --accent: #22d3ee;
+  --accent-2: #67e8f9;
+  --panel: color-mix(in srgb, #e8eef6 7%, #06141a);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #06141a 75%, #000);
+}
+
+.ease-bolt-cutter-jaws__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-bolt-cutter-jaws__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #06141a 90%, #22d3ee);
+}
+
+.ease-bolt-cutter-jaws__face {
+  position: relative;
+  min-height: 260px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 28% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #06141a 85%, #000), color-mix(in srgb, #06141a 65%, var(--accent-2)));
+}
+
+.ease-bolt-cutter-jaws__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-bolt-cutter-jaws__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-bolt-cutter-jaws__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-bolt-cutter-jaws__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-bolt-cutter-jaws__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-bolt-cutter-jaws__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-bolt-cutter-jaws__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: bolt_cutter_jaws_meter 1.7s ease-in-out infinite alternate;
+}
+
+.ease-bolt-cutter-jaws__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-bolt-cutter-jaws__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-bolt-cutter-jaws__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-bolt-cutter-jaws__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-bolt-cutter-jaws__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-bolt-cutter-jaws__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-bolt-cutter-jaws__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-bolt-cutter-jaws__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-bolt-cutter-jaws__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-bolt-cutter-jaws__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-bolt-cutter-jaws__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-bolt-cutter-jaws__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: bolt_cutter_jaws_status 1.8s ease-out infinite;
+}
+
+@keyframes bolt_cutter_jaws_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes bolt_cutter_jaws_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-bolt-cutter-jaws__a{position:absolute;left:36%;top:24%;width:28%;height:48%;border-radius:40% 40% 12px 12px;border:3px solid #64748b;background:color-mix(in srgb,var(--accent) 10%,#0f172a);overflow:hidden}
+.ease-bolt-cutter-jaws__a::after{content:"";position:absolute;left:-10%;right:-10%;bottom:0;height:55%;background:linear-gradient(180deg,color-mix(in srgb,var(--accent) 50%,transparent),var(--accent));animation:bolt_cutter_jaws_wave 2.8s ease-in-out infinite}
+.ease-bolt-cutter-jaws__b{position:absolute;left:30%;top:22%;width:12px;height:12px;border-radius:50%;background:var(--accent-2);animation:bolt_cutter_jaws_bubble 2.8s ease-in-out infinite}
+.ease-bolt-cutter-jaws__c{position:absolute;left:58%;top:30%;width:10px;height:10px;border-radius:50%;background:var(--accent);animation:bolt_cutter_jaws_bubble 2.8s ease-in-out infinite .4s}
+.ease-bolt-cutter-jaws__d{position:absolute;left:24%;bottom:20%;width:52%;height:8px;border-radius:999px;background:color-mix(in srgb,#e8eef6 14%,transparent)}
+@keyframes bolt_cutter_jaws_wave{0%,100%{transform:translateY(8px)}50%{transform:translateY(-6px)}}
+@keyframes bolt_cutter_jaws_bubble{0%,100%{transform:translateY(18px);opacity:0}40%{opacity:1}70%{transform:translateY(-28px);opacity:0}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-bolt-cutter-jaws__a,
+  .ease-bolt-cutter-jaws__b,
+  .ease-bolt-cutter-jaws__c,
+  .ease-bolt-cutter-jaws__d,
+  .ease-bolt-cutter-jaws__meters i::after,
+  .ease-bolt-cutter-jaws__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-bolt-cutter-jaws` under `submissions/examples/bolt-cutter-jaws-ns/` — CSS-only Heavy bolt-cutter jaws closing through a padlock shackle.

Fixes #67294

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Heavy bolt-cutter jaws closing through a padlock shackle.

**How does a developer use it?**

```html
<section class="ease-bolt-cutter-jaws">
  <div class="ease-bolt-cutter-jaws__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `bolt_cutter_jaws_*` prefix. Reduced-motion disables animations.
