### PR TITLE
feat: add ease-book-press-screw (#67295)

### DIFF
--- a/submissions/examples/book-press-screw-ns/README.md
+++ b/submissions/examples/book-press-screw-ns/README.md
@@ -1,0 +1,16 @@
+# Book Press Screw
+
+## What does this do?
+Renders a self-contained CSS-only `ease-book-press-screw` demo: Antique book press screw descending onto stacked pages.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-book-press-screw`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-book-press-screw">
+  <div class="ease-book-press-screw__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/book-press-screw-ns/demo.html
+++ b/submissions/examples/book-press-screw-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Book Press Screw — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Book Press Screw demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Book Press Screw</h1>
+      <p class="lede">Antique book press screw descending onto stacked pages</p>
+    </header>
+
+    <section class="ease-book-press-screw" data-demo="book-press-screw" aria-live="polite">
+      <div class="ease-book-press-screw__housing">
+        <div class="ease-book-press-screw__bezel">
+          <div class="ease-book-press-screw__face">
+            <div class="ease-book-press-screw__readout">
+              <span class="ease-book-press-screw__label">Book Press Screw</span>
+              <span class="ease-book-press-screw__value">LIVE</span>
+            </div>
+            <div class="ease-book-press-screw__motion" aria-hidden="true">
+              <span class="ease-book-press-screw__a"></span>
+              <span class="ease-book-press-screw__b"></span>
+              <span class="ease-book-press-screw__c"></span>
+              <span class="ease-book-press-screw__d"></span>
+            </div>
+            <div class="ease-book-press-screw__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-book-press-screw__controls">
+          <button type="button" class="ease-book-press-screw__btn primary">Engage</button>
+          <button type="button" class="ease-book-press-screw__btn">Reset</button>
+          <label class="ease-book-press-screw__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-book-press-screw__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/book-press-screw-ns/style.css
+++ b/submissions/examples/book-press-screw-ns/style.css
@@ -1,0 +1,236 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #eab308 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #facc15 18%, transparent), transparent 42%),
+    #14100a;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-book-press-screw {
+  --accent: #eab308;
+  --accent-2: #facc15;
+  --panel: color-mix(in srgb, #e8eef6 7%, #14100a);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #14100a 75%, #000);
+}
+
+.ease-book-press-screw__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-book-press-screw__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #14100a 90%, #eab308);
+}
+
+.ease-book-press-screw__face {
+  position: relative;
+  min-height: 260px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 28% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #14100a 85%, #000), color-mix(in srgb, #14100a 65%, var(--accent-2)));
+}
+
+.ease-book-press-screw__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-book-press-screw__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-book-press-screw__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-book-press-screw__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-book-press-screw__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-book-press-screw__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-book-press-screw__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: book_press_screw_meter 1.7s ease-in-out infinite alternate;
+}
+
+.ease-book-press-screw__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-book-press-screw__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-book-press-screw__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-book-press-screw__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-book-press-screw__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-book-press-screw__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-book-press-screw__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-book-press-screw__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-book-press-screw__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-book-press-screw__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-book-press-screw__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-book-press-screw__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: book_press_screw_status 1.8s ease-out infinite;
+}
+
+@keyframes book_press_screw_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes book_press_screw_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-book-press-screw__a{position:absolute;left:18%;top:36%;width:64%;height:18px;border-radius:9px;background:#1e293b;box-shadow:inset 0 0 0 2px #334155;overflow:hidden}
+.ease-book-press-screw__b{position:absolute;left:18%;top:36%;width:28%;height:18px;border-radius:9px;background:linear-gradient(90deg,var(--accent-2),var(--accent));animation:book_press_screw_progress 3.2s ease-in-out infinite}
+.ease-book-press-screw__c{position:absolute;left:46%;top:28%;width:14px;height:34px;border-radius:4px;background:#94a3b8;animation:book_press_screw_press 3.2s ease-in-out infinite}
+.ease-book-press-screw__d{position:absolute;right:16%;top:34%;width:22px;height:22px;border-radius:50%;border:2px solid var(--accent);animation:book_press_screw_ring 3.2s ease-out infinite}
+@keyframes book_press_screw_progress{0%,15%{width:12%}55%,70%{width:72%}100%{width:12%}}
+@keyframes book_press_screw_press{0%,15%{transform:translateY(-6px)}55%,70%{transform:translateY(10px)}100%{transform:translateY(-6px)}}
+@keyframes book_press_screw_ring{0%,50%{box-shadow:0 0 0 0 color-mix(in srgb,var(--accent) 50%,transparent)}100%{box-shadow:0 0 0 14px transparent}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-book-press-screw__a,
+  .ease-book-press-screw__b,
+  .ease-book-press-screw__c,
+  .ease-book-press-screw__d,
+  .ease-book-press-screw__meters i::after,
+  .ease-book-press-screw__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-book-press-screw` under `submissions/examples/book-press-screw-ns/` — CSS-only Antique book press screw descending onto stacked pages.

Fixes #67295

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Antique book press screw descending onto stacked pages.

**How does a developer use it?**

```html
<section class="ease-book-press-screw">
  <div class="ease-book-press-screw__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `book_press_screw_*` prefix. Reduced-motion disables animations.
