### PR TITLE
feat: add ease-fog-machine-plume (#67349)

### DIFF
--- a/submissions/examples/fog-machine-plume-ns/README.md
+++ b/submissions/examples/fog-machine-plume-ns/README.md
@@ -1,0 +1,16 @@
+# Fog Machine Plume
+
+## What does this do?
+Renders a self-contained CSS-only `ease-fog-machine-plume` demo: Stage fog machine puffing a rolling plume.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-fog-machine-plume`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-fog-machine-plume">
+  <div class="ease-fog-machine-plume__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/fog-machine-plume-ns/demo.html
+++ b/submissions/examples/fog-machine-plume-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Fog Machine Plume — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Fog Machine Plume demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Fog Machine Plume</h1>
+      <p class="lede">Stage fog machine puffing a rolling plume</p>
+    </header>
+
+    <section class="ease-fog-machine-plume" data-demo="fog-machine-plume" aria-live="polite">
+      <div class="ease-fog-machine-plume__housing">
+        <div class="ease-fog-machine-plume__bezel">
+          <div class="ease-fog-machine-plume__face">
+            <div class="ease-fog-machine-plume__readout">
+              <span class="ease-fog-machine-plume__label">Fog Machine Plume</span>
+              <span class="ease-fog-machine-plume__value">LIVE</span>
+            </div>
+            <div class="ease-fog-machine-plume__motion" aria-hidden="true">
+              <span class="ease-fog-machine-plume__a"></span>
+              <span class="ease-fog-machine-plume__b"></span>
+              <span class="ease-fog-machine-plume__c"></span>
+              <span class="ease-fog-machine-plume__d"></span>
+            </div>
+            <div class="ease-fog-machine-plume__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-fog-machine-plume__controls">
+          <button type="button" class="ease-fog-machine-plume__btn primary">Engage</button>
+          <button type="button" class="ease-fog-machine-plume__btn">Reset</button>
+          <label class="ease-fog-machine-plume__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-fog-machine-plume__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/fog-machine-plume-ns/style.css
+++ b/submissions/examples/fog-machine-plume-ns/style.css
@@ -1,0 +1,238 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #f59e0b 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #fbbf24 18%, transparent), transparent 42%),
+    #1a1208;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-fog-machine-plume {
+  --accent: #f59e0b;
+  --accent-2: #fbbf24;
+  --panel: color-mix(in srgb, #e8eef6 7%, #1a1208);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #1a1208 75%, #000);
+}
+
+.ease-fog-machine-plume__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-fog-machine-plume__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #1a1208 90%, #f59e0b);
+}
+
+.ease-fog-machine-plume__face {
+  position: relative;
+  min-height: 260px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 28% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #1a1208 85%, #000), color-mix(in srgb, #1a1208 65%, var(--accent-2)));
+}
+
+.ease-fog-machine-plume__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-fog-machine-plume__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-fog-machine-plume__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-fog-machine-plume__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-fog-machine-plume__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-fog-machine-plume__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-fog-machine-plume__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: fog_machine_plume_meter 1.7s ease-in-out infinite alternate;
+}
+
+.ease-fog-machine-plume__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-fog-machine-plume__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-fog-machine-plume__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-fog-machine-plume__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-fog-machine-plume__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-fog-machine-plume__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-fog-machine-plume__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-fog-machine-plume__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-fog-machine-plume__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-fog-machine-plume__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-fog-machine-plume__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-fog-machine-plume__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: fog_machine_plume_status 1.8s ease-out infinite;
+}
+
+@keyframes fog_machine_plume_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes fog_machine_plume_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-fog-machine-plume__a{position:absolute;left:22%;top:30%;width:70px;height:70px;border-radius:50%;border:4px solid #64748b;background:radial-gradient(circle at 35% 30%,#334155,#0f172a)}
+.ease-fog-machine-plume__b{position:absolute;left:33%;top:41%;width:36px;height:6px;background:var(--accent);transform-origin:left center;border-radius:2px;animation:fog_machine_plume_needle 3.4s ease-in-out infinite}
+.ease-fog-machine-plume__c{position:absolute;right:18%;top:34%;width:16px;height:72px;border-radius:8px;background:color-mix(in srgb,var(--accent) 25%,#0f172a);overflow:hidden}
+.ease-fog-machine-plume__c::after{content:"";position:absolute;left:0;right:0;bottom:0;height:55%;background:linear-gradient(180deg,var(--accent-2),var(--accent));animation:fog_machine_plume_fill 3.4s ease-in-out infinite}
+.ease-fog-machine-plume__d{position:absolute;left:20%;bottom:22%;width:60%;height:4px;background:color-mix(in srgb,#e8eef6 14%,transparent);border-radius:999px;overflow:hidden}
+.ease-fog-machine-plume__d::after{content:"";display:block;height:100%;width:40%;background:var(--accent);animation:fog_machine_plume_scan 3.4s linear infinite}
+@keyframes fog_machine_plume_needle{0%,100%{transform:rotate(-40deg)}50%{transform:rotate(48deg)}}
+@keyframes fog_machine_plume_fill{0%,100%{height:28%}50%{height:78%}}
+@keyframes fog_machine_plume_scan{0%{transform:translateX(-10%)}100%{transform:translateX(160%)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-fog-machine-plume__a,
+  .ease-fog-machine-plume__b,
+  .ease-fog-machine-plume__c,
+  .ease-fog-machine-plume__d,
+  .ease-fog-machine-plume__meters i::after,
+  .ease-fog-machine-plume__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-fog-machine-plume` under `submissions/examples/fog-machine-plume-ns/` — CSS-only Stage fog machine puffing a rolling plume.

Fixes #67349

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Stage fog machine puffing a rolling plume.

**How does a developer use it?**

```html
<section class="ease-fog-machine-plume">
  <div class="ease-fog-machine-plume__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `fog_machine_plume_*` prefix. Reduced-motion disables animations.
