### PR TITLE
feat: add ease-folio-page-turner (#67350)

### DIFF
--- a/submissions/examples/folio-page-turner-ns/README.md
+++ b/submissions/examples/folio-page-turner-ns/README.md
@@ -1,0 +1,16 @@
+# Folio Page Turner
+
+## What does this do?
+Renders a self-contained CSS-only `ease-folio-page-turner` demo: Rare-book folio page lifting and settling.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-folio-page-turner`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-folio-page-turner">
+  <div class="ease-folio-page-turner__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/folio-page-turner-ns/demo.html
+++ b/submissions/examples/folio-page-turner-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Folio Page Turner — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Folio Page Turner demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Folio Page Turner</h1>
+      <p class="lede">Rare-book folio page lifting and settling</p>
+    </header>
+
+    <section class="ease-folio-page-turner" data-demo="folio-page-turner" aria-live="polite">
+      <div class="ease-folio-page-turner__housing">
+        <div class="ease-folio-page-turner__bezel">
+          <div class="ease-folio-page-turner__face">
+            <div class="ease-folio-page-turner__readout">
+              <span class="ease-folio-page-turner__label">Folio Page Turner</span>
+              <span class="ease-folio-page-turner__value">LIVE</span>
+            </div>
+            <div class="ease-folio-page-turner__motion" aria-hidden="true">
+              <span class="ease-folio-page-turner__a"></span>
+              <span class="ease-folio-page-turner__b"></span>
+              <span class="ease-folio-page-turner__c"></span>
+              <span class="ease-folio-page-turner__d"></span>
+            </div>
+            <div class="ease-folio-page-turner__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-folio-page-turner__controls">
+          <button type="button" class="ease-folio-page-turner__btn primary">Engage</button>
+          <button type="button" class="ease-folio-page-turner__btn">Reset</button>
+          <label class="ease-folio-page-turner__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-folio-page-turner__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/folio-page-turner-ns/style.css
+++ b/submissions/examples/folio-page-turner-ns/style.css
@@ -1,0 +1,234 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #a78bfa 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #c4b5fd 18%, transparent), transparent 42%),
+    #120b1a;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-folio-page-turner {
+  --accent: #a78bfa;
+  --accent-2: #c4b5fd;
+  --panel: color-mix(in srgb, #e8eef6 7%, #120b1a);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #120b1a 75%, #000);
+}
+
+.ease-folio-page-turner__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-folio-page-turner__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #120b1a 90%, #a78bfa);
+}
+
+.ease-folio-page-turner__face {
+  position: relative;
+  min-height: 260px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 28% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #120b1a 85%, #000), color-mix(in srgb, #120b1a 65%, var(--accent-2)));
+}
+
+.ease-folio-page-turner__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-folio-page-turner__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-folio-page-turner__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-folio-page-turner__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-folio-page-turner__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-folio-page-turner__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-folio-page-turner__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: folio_page_turner_meter 1.7s ease-in-out infinite alternate;
+}
+
+.ease-folio-page-turner__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-folio-page-turner__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-folio-page-turner__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-folio-page-turner__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-folio-page-turner__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-folio-page-turner__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-folio-page-turner__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-folio-page-turner__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-folio-page-turner__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-folio-page-turner__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-folio-page-turner__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-folio-page-turner__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: folio_page_turner_status 1.8s ease-out infinite;
+}
+
+@keyframes folio_page_turner_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes folio_page_turner_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-folio-page-turner__a{position:absolute;left:16%;top:32%;width:120px;height:56px;border-radius:10px;border:2px solid #64748b;background:#0f172a}
+.ease-folio-page-turner__b{position:absolute;left:24%;top:40%;width:18px;height:40px;border-radius:4px;background:var(--accent);animation:folio_page_turner_bob 2.2s ease-in-out infinite}
+.ease-folio-page-turner__c{position:absolute;left:38%;top:40%;width:18px;height:40px;border-radius:4px;background:var(--accent-2);animation:folio_page_turner_bob 2.2s ease-in-out infinite .2s}
+.ease-folio-page-turner__d{position:absolute;left:52%;top:40%;width:18px;height:40px;border-radius:4px;background:var(--accent);animation:folio_page_turner_bob 2.2s ease-in-out infinite .4s}
+@keyframes folio_page_turner_bob{0%,100%{transform:translateY(8px);opacity:.55}50%{transform:translateY(-10px);opacity:1}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-folio-page-turner__a,
+  .ease-folio-page-turner__b,
+  .ease-folio-page-turner__c,
+  .ease-folio-page-turner__d,
+  .ease-folio-page-turner__meters i::after,
+  .ease-folio-page-turner__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-folio-page-turner` under `submissions/examples/folio-page-turner-ns/` — CSS-only Rare-book folio page lifting and settling.

Fixes #67350

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Rare-book folio page lifting and settling.

**How does a developer use it?**

```html
<section class="ease-folio-page-turner">
  <div class="ease-folio-page-turner__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `folio_page_turner_*` prefix. Reduced-motion disables animations.
