### PR TITLE
feat: add ease-fresnel-lens-sweep (#67352)

### DIFF
--- a/submissions/examples/fresnel-lens-sweep-ns/README.md
+++ b/submissions/examples/fresnel-lens-sweep-ns/README.md
@@ -1,0 +1,16 @@
+# Fresnel Lens Sweep
+
+## What does this do?
+Renders a self-contained CSS-only `ease-fresnel-lens-sweep` demo: Lighthouse Fresnel lens panels sweeping a beam.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-fresnel-lens-sweep`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-fresnel-lens-sweep">
+  <div class="ease-fresnel-lens-sweep__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/fresnel-lens-sweep-ns/demo.html
+++ b/submissions/examples/fresnel-lens-sweep-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Fresnel Lens Sweep — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Fresnel Lens Sweep demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Fresnel Lens Sweep</h1>
+      <p class="lede">Lighthouse Fresnel lens panels sweeping a beam</p>
+    </header>
+
+    <section class="ease-fresnel-lens-sweep" data-demo="fresnel-lens-sweep" aria-live="polite">
+      <div class="ease-fresnel-lens-sweep__housing">
+        <div class="ease-fresnel-lens-sweep__bezel">
+          <div class="ease-fresnel-lens-sweep__face">
+            <div class="ease-fresnel-lens-sweep__readout">
+              <span class="ease-fresnel-lens-sweep__label">Fresnel Lens Sweep</span>
+              <span class="ease-fresnel-lens-sweep__value">LIVE</span>
+            </div>
+            <div class="ease-fresnel-lens-sweep__motion" aria-hidden="true">
+              <span class="ease-fresnel-lens-sweep__a"></span>
+              <span class="ease-fresnel-lens-sweep__b"></span>
+              <span class="ease-fresnel-lens-sweep__c"></span>
+              <span class="ease-fresnel-lens-sweep__d"></span>
+            </div>
+            <div class="ease-fresnel-lens-sweep__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-fresnel-lens-sweep__controls">
+          <button type="button" class="ease-fresnel-lens-sweep__btn primary">Engage</button>
+          <button type="button" class="ease-fresnel-lens-sweep__btn">Reset</button>
+          <label class="ease-fresnel-lens-sweep__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-fresnel-lens-sweep__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/fresnel-lens-sweep-ns/style.css
+++ b/submissions/examples/fresnel-lens-sweep-ns/style.css
@@ -1,0 +1,236 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #f472b6 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #f9a8d4 18%, transparent), transparent 42%),
+    #1a0b14;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-fresnel-lens-sweep {
+  --accent: #f472b6;
+  --accent-2: #f9a8d4;
+  --panel: color-mix(in srgb, #e8eef6 7%, #1a0b14);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #1a0b14 75%, #000);
+}
+
+.ease-fresnel-lens-sweep__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-fresnel-lens-sweep__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #1a0b14 90%, #f472b6);
+}
+
+.ease-fresnel-lens-sweep__face {
+  position: relative;
+  min-height: 260px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 28% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #1a0b14 85%, #000), color-mix(in srgb, #1a0b14 65%, var(--accent-2)));
+}
+
+.ease-fresnel-lens-sweep__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-fresnel-lens-sweep__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-fresnel-lens-sweep__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-fresnel-lens-sweep__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-fresnel-lens-sweep__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-fresnel-lens-sweep__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-fresnel-lens-sweep__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: fresnel_lens_sweep_meter 1.7s ease-in-out infinite alternate;
+}
+
+.ease-fresnel-lens-sweep__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-fresnel-lens-sweep__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-fresnel-lens-sweep__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-fresnel-lens-sweep__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-fresnel-lens-sweep__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-fresnel-lens-sweep__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-fresnel-lens-sweep__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-fresnel-lens-sweep__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-fresnel-lens-sweep__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-fresnel-lens-sweep__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-fresnel-lens-sweep__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-fresnel-lens-sweep__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: fresnel_lens_sweep_status 1.8s ease-out infinite;
+}
+
+@keyframes fresnel_lens_sweep_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes fresnel_lens_sweep_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-fresnel-lens-sweep__a{position:absolute;left:20%;top:50%;width:60%;height:4px;background:color-mix(in srgb,#e8eef6 18%,transparent);border-radius:999px}
+.ease-fresnel-lens-sweep__b{position:absolute;left:18%;top:34%;width:22px;height:56px;border-radius:6px;background:linear-gradient(180deg,#94a3b8,#475569);transform-origin:50% 100%;animation:fresnel_lens_sweep_hinge 3s ease-in-out infinite}
+.ease-fresnel-lens-sweep__c{position:absolute;left:48%;top:28%;width:36px;height:36px;border-radius:8px;border:2px solid var(--accent);background:color-mix(in srgb,var(--accent) 18%,transparent);animation:fresnel_lens_sweep_drop 3s ease-in-out infinite}
+.ease-fresnel-lens-sweep__d{position:absolute;right:18%;top:42%;width:48px;height:12px;border-radius:999px;background:var(--accent-2);animation:fresnel_lens_sweep_slide 3s ease-in-out infinite}
+@keyframes fresnel_lens_sweep_hinge{0%,100%{transform:rotate(-12deg)}50%{transform:rotate(28deg)}}
+@keyframes fresnel_lens_sweep_drop{0%,20%{transform:translateY(-8px)}45%,70%{transform:translateY(42px)}100%{transform:translateY(-8px)}}
+@keyframes fresnel_lens_sweep_slide{0%,100%{transform:translateX(0)}50%{transform:translateX(-22px)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-fresnel-lens-sweep__a,
+  .ease-fresnel-lens-sweep__b,
+  .ease-fresnel-lens-sweep__c,
+  .ease-fresnel-lens-sweep__d,
+  .ease-fresnel-lens-sweep__meters i::after,
+  .ease-fresnel-lens-sweep__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-fresnel-lens-sweep` under `submissions/examples/fresnel-lens-sweep-ns/` — CSS-only Lighthouse Fresnel lens panels sweeping a beam.

Fixes #67352

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Lighthouse Fresnel lens panels sweeping a beam.

**How does a developer use it?**

```html
<section class="ease-fresnel-lens-sweep">
  <div class="ease-fresnel-lens-sweep__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `fresnel_lens_sweep_*` prefix. Reduced-motion disables animations.
