### PR TITLE
feat: add ease-harpsichord-jack-pluck (#67369)

### DIFF
--- a/submissions/examples/harpsichord-jack-pluck-ns/README.md
+++ b/submissions/examples/harpsichord-jack-pluck-ns/README.md
@@ -1,0 +1,16 @@
+# Harpsichord Jack Pluck
+
+## What does this do?
+Renders a self-contained CSS-only `ease-harpsichord-jack-pluck` demo: Harpsichord jack rising to pluck a string.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-harpsichord-jack-pluck`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-harpsichord-jack-pluck">
+  <div class="ease-harpsichord-jack-pluck__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/harpsichord-jack-pluck-ns/demo.html
+++ b/submissions/examples/harpsichord-jack-pluck-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Harpsichord Jack Pluck — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Harpsichord Jack Pluck demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Harpsichord Jack Pluck</h1>
+      <p class="lede">Harpsichord jack rising to pluck a string</p>
+    </header>
+
+    <section class="ease-harpsichord-jack-pluck" data-demo="harpsichord-jack-pluck" aria-live="polite">
+      <div class="ease-harpsichord-jack-pluck__housing">
+        <div class="ease-harpsichord-jack-pluck__bezel">
+          <div class="ease-harpsichord-jack-pluck__face">
+            <div class="ease-harpsichord-jack-pluck__readout">
+              <span class="ease-harpsichord-jack-pluck__label">Harpsichord Jack Pluck</span>
+              <span class="ease-harpsichord-jack-pluck__value">LIVE</span>
+            </div>
+            <div class="ease-harpsichord-jack-pluck__motion" aria-hidden="true">
+              <span class="ease-harpsichord-jack-pluck__a"></span>
+              <span class="ease-harpsichord-jack-pluck__b"></span>
+              <span class="ease-harpsichord-jack-pluck__c"></span>
+              <span class="ease-harpsichord-jack-pluck__d"></span>
+            </div>
+            <div class="ease-harpsichord-jack-pluck__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-harpsichord-jack-pluck__controls">
+          <button type="button" class="ease-harpsichord-jack-pluck__btn primary">Engage</button>
+          <button type="button" class="ease-harpsichord-jack-pluck__btn">Reset</button>
+          <label class="ease-harpsichord-jack-pluck__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-harpsichord-jack-pluck__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/harpsichord-jack-pluck-ns/style.css
+++ b/submissions/examples/harpsichord-jack-pluck-ns/style.css
@@ -1,0 +1,238 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #f59e0b 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #fbbf24 18%, transparent), transparent 42%),
+    #1a1208;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-harpsichord-jack-pluck {
+  --accent: #f59e0b;
+  --accent-2: #fbbf24;
+  --panel: color-mix(in srgb, #e8eef6 7%, #1a1208);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #1a1208 75%, #000);
+}
+
+.ease-harpsichord-jack-pluck__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-harpsichord-jack-pluck__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #1a1208 90%, #f59e0b);
+}
+
+.ease-harpsichord-jack-pluck__face {
+  position: relative;
+  min-height: 260px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 28% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #1a1208 85%, #000), color-mix(in srgb, #1a1208 65%, var(--accent-2)));
+}
+
+.ease-harpsichord-jack-pluck__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-harpsichord-jack-pluck__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-harpsichord-jack-pluck__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-harpsichord-jack-pluck__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-harpsichord-jack-pluck__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-harpsichord-jack-pluck__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-harpsichord-jack-pluck__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: harpsichord_jack_pluck_meter 1.7s ease-in-out infinite alternate;
+}
+
+.ease-harpsichord-jack-pluck__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-harpsichord-jack-pluck__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-harpsichord-jack-pluck__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-harpsichord-jack-pluck__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-harpsichord-jack-pluck__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-harpsichord-jack-pluck__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-harpsichord-jack-pluck__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-harpsichord-jack-pluck__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-harpsichord-jack-pluck__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-harpsichord-jack-pluck__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-harpsichord-jack-pluck__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-harpsichord-jack-pluck__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: harpsichord_jack_pluck_status 1.8s ease-out infinite;
+}
+
+@keyframes harpsichord_jack_pluck_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes harpsichord_jack_pluck_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-harpsichord-jack-pluck__a{position:absolute;left:22%;top:30%;width:70px;height:70px;border-radius:50%;border:4px solid #64748b;background:radial-gradient(circle at 35% 30%,#334155,#0f172a)}
+.ease-harpsichord-jack-pluck__b{position:absolute;left:33%;top:41%;width:36px;height:6px;background:var(--accent);transform-origin:left center;border-radius:2px;animation:harpsichord_jack_pluck_needle 3.4s ease-in-out infinite}
+.ease-harpsichord-jack-pluck__c{position:absolute;right:18%;top:34%;width:16px;height:72px;border-radius:8px;background:color-mix(in srgb,var(--accent) 25%,#0f172a);overflow:hidden}
+.ease-harpsichord-jack-pluck__c::after{content:"";position:absolute;left:0;right:0;bottom:0;height:55%;background:linear-gradient(180deg,var(--accent-2),var(--accent));animation:harpsichord_jack_pluck_fill 3.4s ease-in-out infinite}
+.ease-harpsichord-jack-pluck__d{position:absolute;left:20%;bottom:22%;width:60%;height:4px;background:color-mix(in srgb,#e8eef6 14%,transparent);border-radius:999px;overflow:hidden}
+.ease-harpsichord-jack-pluck__d::after{content:"";display:block;height:100%;width:40%;background:var(--accent);animation:harpsichord_jack_pluck_scan 3.4s linear infinite}
+@keyframes harpsichord_jack_pluck_needle{0%,100%{transform:rotate(-40deg)}50%{transform:rotate(48deg)}}
+@keyframes harpsichord_jack_pluck_fill{0%,100%{height:28%}50%{height:78%}}
+@keyframes harpsichord_jack_pluck_scan{0%{transform:translateX(-10%)}100%{transform:translateX(160%)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-harpsichord-jack-pluck__a,
+  .ease-harpsichord-jack-pluck__b,
+  .ease-harpsichord-jack-pluck__c,
+  .ease-harpsichord-jack-pluck__d,
+  .ease-harpsichord-jack-pluck__meters i::after,
+  .ease-harpsichord-jack-pluck__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-harpsichord-jack-pluck` under `submissions/examples/harpsichord-jack-pluck-ns/` — CSS-only Harpsichord jack rising to pluck a string.

Fixes #67369

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Harpsichord jack rising to pluck a string.

**How does a developer use it?**

```html
<section class="ease-harpsichord-jack-pluck">
  <div class="ease-harpsichord-jack-pluck__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `harpsichord_jack_pluck_*` prefix. Reduced-motion disables animations.
