### PR TITLE
feat: add ease-hydraulic-press-ram (#67375)

### DIFF
--- a/submissions/examples/hydraulic-press-ram-ns/README.md
+++ b/submissions/examples/hydraulic-press-ram-ns/README.md
@@ -1,0 +1,16 @@
+# Hydraulic Press Ram
+
+## What does this do?
+Renders a self-contained CSS-only `ease-hydraulic-press-ram` demo: Hydraulic press ram descending onto a workpiece.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-hydraulic-press-ram`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-hydraulic-press-ram">
+  <div class="ease-hydraulic-press-ram__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/hydraulic-press-ram-ns/demo.html
+++ b/submissions/examples/hydraulic-press-ram-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Hydraulic Press Ram — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Hydraulic Press Ram demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Hydraulic Press Ram</h1>
+      <p class="lede">Hydraulic press ram descending onto a workpiece</p>
+    </header>
+
+    <section class="ease-hydraulic-press-ram" data-demo="hydraulic-press-ram" aria-live="polite">
+      <div class="ease-hydraulic-press-ram__housing">
+        <div class="ease-hydraulic-press-ram__bezel">
+          <div class="ease-hydraulic-press-ram__face">
+            <div class="ease-hydraulic-press-ram__readout">
+              <span class="ease-hydraulic-press-ram__label">Hydraulic Press Ram</span>
+              <span class="ease-hydraulic-press-ram__value">LIVE</span>
+            </div>
+            <div class="ease-hydraulic-press-ram__motion" aria-hidden="true">
+              <span class="ease-hydraulic-press-ram__a"></span>
+              <span class="ease-hydraulic-press-ram__b"></span>
+              <span class="ease-hydraulic-press-ram__c"></span>
+              <span class="ease-hydraulic-press-ram__d"></span>
+            </div>
+            <div class="ease-hydraulic-press-ram__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-hydraulic-press-ram__controls">
+          <button type="button" class="ease-hydraulic-press-ram__btn primary">Engage</button>
+          <button type="button" class="ease-hydraulic-press-ram__btn">Reset</button>
+          <label class="ease-hydraulic-press-ram__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-hydraulic-press-ram__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/hydraulic-press-ram-ns/style.css
+++ b/submissions/examples/hydraulic-press-ram-ns/style.css
@@ -1,0 +1,236 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #eab308 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #facc15 18%, transparent), transparent 42%),
+    #14100a;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-hydraulic-press-ram {
+  --accent: #eab308;
+  --accent-2: #facc15;
+  --panel: color-mix(in srgb, #e8eef6 7%, #14100a);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #14100a 75%, #000);
+}
+
+.ease-hydraulic-press-ram__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-hydraulic-press-ram__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #14100a 90%, #eab308);
+}
+
+.ease-hydraulic-press-ram__face {
+  position: relative;
+  min-height: 260px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 28% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #14100a 85%, #000), color-mix(in srgb, #14100a 65%, var(--accent-2)));
+}
+
+.ease-hydraulic-press-ram__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-hydraulic-press-ram__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-hydraulic-press-ram__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-hydraulic-press-ram__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-hydraulic-press-ram__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-hydraulic-press-ram__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-hydraulic-press-ram__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: hydraulic_press_ram_meter 1.7s ease-in-out infinite alternate;
+}
+
+.ease-hydraulic-press-ram__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-hydraulic-press-ram__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-hydraulic-press-ram__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-hydraulic-press-ram__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-hydraulic-press-ram__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-hydraulic-press-ram__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-hydraulic-press-ram__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-hydraulic-press-ram__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-hydraulic-press-ram__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-hydraulic-press-ram__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-hydraulic-press-ram__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-hydraulic-press-ram__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: hydraulic_press_ram_status 1.8s ease-out infinite;
+}
+
+@keyframes hydraulic_press_ram_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes hydraulic_press_ram_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-hydraulic-press-ram__a{position:absolute;left:18%;top:36%;width:64%;height:18px;border-radius:9px;background:#1e293b;box-shadow:inset 0 0 0 2px #334155;overflow:hidden}
+.ease-hydraulic-press-ram__b{position:absolute;left:18%;top:36%;width:28%;height:18px;border-radius:9px;background:linear-gradient(90deg,var(--accent-2),var(--accent));animation:hydraulic_press_ram_progress 3.2s ease-in-out infinite}
+.ease-hydraulic-press-ram__c{position:absolute;left:46%;top:28%;width:14px;height:34px;border-radius:4px;background:#94a3b8;animation:hydraulic_press_ram_press 3.2s ease-in-out infinite}
+.ease-hydraulic-press-ram__d{position:absolute;right:16%;top:34%;width:22px;height:22px;border-radius:50%;border:2px solid var(--accent);animation:hydraulic_press_ram_ring 3.2s ease-out infinite}
+@keyframes hydraulic_press_ram_progress{0%,15%{width:12%}55%,70%{width:72%}100%{width:12%}}
+@keyframes hydraulic_press_ram_press{0%,15%{transform:translateY(-6px)}55%,70%{transform:translateY(10px)}100%{transform:translateY(-6px)}}
+@keyframes hydraulic_press_ram_ring{0%,50%{box-shadow:0 0 0 0 color-mix(in srgb,var(--accent) 50%,transparent)}100%{box-shadow:0 0 0 14px transparent}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-hydraulic-press-ram__a,
+  .ease-hydraulic-press-ram__b,
+  .ease-hydraulic-press-ram__c,
+  .ease-hydraulic-press-ram__d,
+  .ease-hydraulic-press-ram__meters i::after,
+  .ease-hydraulic-press-ram__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-hydraulic-press-ram` under `submissions/examples/hydraulic-press-ram-ns/` — CSS-only Hydraulic press ram descending onto a workpiece.

Fixes #67375

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Hydraulic press ram descending onto a workpiece.

**How does a developer use it?**

```html
<section class="ease-hydraulic-press-ram">
  <div class="ease-hydraulic-press-ram__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `hydraulic_press_ram_*` prefix. Reduced-motion disables animations.
