### PR TITLE
feat: add ease-hygrometer-hair-coil (#67376)

### DIFF
--- a/submissions/examples/hygrometer-hair-coil-ns/README.md
+++ b/submissions/examples/hygrometer-hair-coil-ns/README.md
@@ -1,0 +1,16 @@
+# Hygrometer Hair Coil
+
+## What does this do?
+Renders a self-contained CSS-only `ease-hygrometer-hair-coil` demo: Hair-tension hygrometer coil unwinding with humidity.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-hygrometer-hair-coil`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-hygrometer-hair-coil">
+  <div class="ease-hygrometer-hair-coil__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/hygrometer-hair-coil-ns/demo.html
+++ b/submissions/examples/hygrometer-hair-coil-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Hygrometer Hair Coil — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Hygrometer Hair Coil demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Hygrometer Hair Coil</h1>
+      <p class="lede">Hair-tension hygrometer coil unwinding with humidity</p>
+    </header>
+
+    <section class="ease-hygrometer-hair-coil" data-demo="hygrometer-hair-coil" aria-live="polite">
+      <div class="ease-hygrometer-hair-coil__housing">
+        <div class="ease-hygrometer-hair-coil__bezel">
+          <div class="ease-hygrometer-hair-coil__face">
+            <div class="ease-hygrometer-hair-coil__readout">
+              <span class="ease-hygrometer-hair-coil__label">Hygrometer Hair Coil</span>
+              <span class="ease-hygrometer-hair-coil__value">LIVE</span>
+            </div>
+            <div class="ease-hygrometer-hair-coil__motion" aria-hidden="true">
+              <span class="ease-hygrometer-hair-coil__a"></span>
+              <span class="ease-hygrometer-hair-coil__b"></span>
+              <span class="ease-hygrometer-hair-coil__c"></span>
+              <span class="ease-hygrometer-hair-coil__d"></span>
+            </div>
+            <div class="ease-hygrometer-hair-coil__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-hygrometer-hair-coil__controls">
+          <button type="button" class="ease-hygrometer-hair-coil__btn primary">Engage</button>
+          <button type="button" class="ease-hygrometer-hair-coil__btn">Reset</button>
+          <label class="ease-hygrometer-hair-coil__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-hygrometer-hair-coil__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/hygrometer-hair-coil-ns/style.css
+++ b/submissions/examples/hygrometer-hair-coil-ns/style.css
@@ -1,0 +1,236 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #60a5fa 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #93c5fd 18%, transparent), transparent 42%),
+    #0a1020;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-hygrometer-hair-coil {
+  --accent: #60a5fa;
+  --accent-2: #93c5fd;
+  --panel: color-mix(in srgb, #e8eef6 7%, #0a1020);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #0a1020 75%, #000);
+}
+
+.ease-hygrometer-hair-coil__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-hygrometer-hair-coil__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #0a1020 90%, #60a5fa);
+}
+
+.ease-hygrometer-hair-coil__face {
+  position: relative;
+  min-height: 260px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 28% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #0a1020 85%, #000), color-mix(in srgb, #0a1020 65%, var(--accent-2)));
+}
+
+.ease-hygrometer-hair-coil__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-hygrometer-hair-coil__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-hygrometer-hair-coil__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-hygrometer-hair-coil__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-hygrometer-hair-coil__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-hygrometer-hair-coil__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-hygrometer-hair-coil__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: hygrometer_hair_coil_meter 1.7s ease-in-out infinite alternate;
+}
+
+.ease-hygrometer-hair-coil__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-hygrometer-hair-coil__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-hygrometer-hair-coil__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-hygrometer-hair-coil__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-hygrometer-hair-coil__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-hygrometer-hair-coil__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-hygrometer-hair-coil__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-hygrometer-hair-coil__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-hygrometer-hair-coil__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-hygrometer-hair-coil__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-hygrometer-hair-coil__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-hygrometer-hair-coil__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: hygrometer_hair_coil_status 1.8s ease-out infinite;
+}
+
+@keyframes hygrometer_hair_coil_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes hygrometer_hair_coil_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-hygrometer-hair-coil__a{position:absolute;left:24%;top:30%;width:52%;height:42%;perspective:400px}
+.ease-hygrometer-hair-coil__b{position:absolute;inset:0;border:2px solid color-mix(in srgb,var(--accent) 60%,#64748b);border-radius:10px;background:color-mix(in srgb,var(--accent) 12%,#0f172a);transform-style:preserve-3d;animation:hygrometer_hair_coil_flip 4s ease-in-out infinite}
+.ease-hygrometer-hair-coil__c{position:absolute;left:20%;bottom:18%;width:18px;height:18px;border-radius:4px;background:var(--accent);animation:hygrometer_hair_coil_tick 1s steps(4) infinite}
+.ease-hygrometer-hair-coil__d{position:absolute;left:40%;bottom:20%;width:40%;height:6px;border-radius:999px;background:linear-gradient(90deg,var(--accent),transparent);opacity:.7;animation:hygrometer_hair_coil_trail 4s linear infinite}
+@keyframes hygrometer_hair_coil_flip{0%,20%{transform:rotateY(0)}50%,70%{transform:rotateY(180deg)}100%{transform:rotateY(360deg)}}
+@keyframes hygrometer_hair_coil_tick{to{transform:translateX(46px)}}
+@keyframes hygrometer_hair_coil_trail{0%{transform:scaleX(.2);opacity:.2}50%{transform:scaleX(1);opacity:.85}100%{transform:scaleX(.2);opacity:.2}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-hygrometer-hair-coil__a,
+  .ease-hygrometer-hair-coil__b,
+  .ease-hygrometer-hair-coil__c,
+  .ease-hygrometer-hair-coil__d,
+  .ease-hygrometer-hair-coil__meters i::after,
+  .ease-hygrometer-hair-coil__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-hygrometer-hair-coil` under `submissions/examples/hygrometer-hair-coil-ns/` — CSS-only Hair-tension hygrometer coil unwinding with humidity.

Fixes #67376

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Hair-tension hygrometer coil unwinding with humidity.

**How does a developer use it?**

```html
<section class="ease-hygrometer-hair-coil">
  <div class="ease-hygrometer-hair-coil__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `hygrometer_hair_coil_*` prefix. Reduced-motion disables animations.
