### PR TITLE
Add ease-train-departure-board component

### DIFF
--- a/submissions/examples/train-departure-board-ij/README.md
+++ b/submissions/examples/train-departure-board-ij/README.md
@@ -1,0 +1,10 @@
+# ease-train-departure-board
+
+A station board where the departure times tick, the destination names flip, and the boarding note blinks.
+
+## Run
+Open `demo.html` directly in a browser to watch the times tick.
+
+## Notes
+- The departure times tick in place.
+- The boarding note blinks beneath.

--- a/submissions/examples/train-departure-board-ij/demo.html
+++ b/submissions/examples/train-departure-board-ij/demo.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-train-departure-board demo</title>
+</head>
+<body>
+<div class="tdb-app">
+  <span class="tdb-title">DEPARTURES</span>
+  <div class="tdb-row"><span class="tdb-time">09:40</span><span class="tdb-dest">COAST CITY</span><span class="tdb-track">T3</span></div>
+  <div class="tdb-row"><span class="tdb-time">10:05</span><span class="tdb-dest">NORTH BAY</span><span class="tdb-track">T1</span></div>
+  <div class="tdb-row"><span class="tdb-time">10:22</span><span class="tdb-dest">WEST HILLS</span><span class="tdb-track">T2</span></div>
+  <span class="tdb-flip">NOW BOARDING</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/train-departure-board-ij/style.css
+++ b/submissions/examples/train-departure-board-ij/style.css
@@ -1,0 +1,15 @@
+:root{--tdb-amber:#ffb84d;--tdb-dark:#101418}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#101418,#05070a);font-family:'DIN',sans-serif}
+.tdb-app{position:relative;width:376px;height:420px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#1a2028,#0c0f14);box-shadow:0 16px 36px rgba(0,0,0,0.6)}
+.tdb-title{position:absolute;top:14px;left:0;right:0;text-align:center;font-size:12px;font-weight:700;letter-spacing:8px;color:#ffb84d}
+.tdb-row{position:absolute;left:20px;right:20px;height:56px;border-radius:8px;background:#0c0f14;box-shadow:inset 0 0 0 2px #2a3340}
+.tdb-row:nth-of-type(1){top:66px}
+.tdb-row:nth-of-type(2){top:132px}
+.tdb-row:nth-of-type(3){top:198px}
+.tdb-time{position:absolute;top:18px;left:16px;font-size:13px;font-weight:700;color:#ffb84d;animation:time-tick-train-departure-board 1s steps(1) infinite}
+.tdb-dest{position:absolute;top:18px;left:84px;font-size:12px;font-weight:700;letter-spacing:2px;color:#d8e0ea;animation:dest-flip-train-departure-board 3s ease-in-out infinite}
+.tdb-track{position:absolute;top:18px;right:14px;font-size:11px;font-weight:700;color:#ffb84d}
+.tdb-flip{position:absolute;bottom:16px;left:0;right:0;text-align:center;font-size:10px;letter-spacing:6px;color:#ffb84d;animation:note-blink-train-departure-board 1.6s steps(1) infinite}
+@keyframes time-tick-train-departure-board{0%,49%{opacity:1}50%,100%{opacity:0.3}}
+@keyframes dest-flip-train-departure-board{0%,100%{transform:translateY(0)}50%{transform:translateY(-3px)}}
+@keyframes note-blink-train-departure-board{0%,49%{opacity:1}50%,100%{opacity:0.25}}


### PR DESCRIPTION
## Component: ease-train-departure-board — times tick, names flip, and note blinks

**Closes #67612**

### What this adds
A station board: the departure times tick, the destination names flip, and the boarding note blinks.

### Acceptance Criteria covered
- Departure times tick in place
- Destination names flip on the rows
- Boarding note blinks beneath

### Files
- `submissions/examples/train-departure-board-ij/demo.html`
- `submissions/examples/train-departure-board-ij/style.css`
- `submissions/examples/train-departure-board-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the times tick.