### PR TITLE
Add ease-crosswalk-signal-box component

### DIFF
--- a/submissions/examples/crosswalk-signal-box-ij/README.md
+++ b/submissions/examples/crosswalk-signal-box-ij/README.md
@@ -1,0 +1,10 @@
+# ease-crosswalk-signal-box
+
+A crosswalk signal where the walk figure steps, the walk sign flips to the wait sign, and the request button presses.
+
+## Run
+Open `demo.html` directly in a browser to watch the figure step.
+
+## Notes
+- The walk figure steps in the window.
+- The request button presses in place.

--- a/submissions/examples/crosswalk-signal-box-ij/demo.html
+++ b/submissions/examples/crosswalk-signal-box-ij/demo.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-crosswalk-signal-box demo</title>
+</head>
+<body>
+<div class="csb-app">
+  <span class="csb-title">CROSSWALK</span>
+  <div class="csb-head">
+    <span class="csb-walk">WALK</span>
+    <span class="csb-dont">DONT WALK</span>
+    <div class="csb-fig"></div>
+  </div>
+  <div class="csb-pole"></div>
+  <div class="csb-btn"></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/crosswalk-signal-box-ij/style.css
+++ b/submissions/examples/crosswalk-signal-box-ij/style.css
@@ -1,0 +1,14 @@
+:root{--csb-lime:#b8e84a;--csb-dark:#141a10}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#141a10,#070a05);font-family:'Futura',sans-serif}
+.csb-app{position:relative;width:320px;height:440px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#20281a,#0e140a);box-shadow:0 16px 36px rgba(0,0,0,0.6)}
+.csb-title{position:absolute;top:14px;left:0;right:0;text-align:center;font-size:11px;font-weight:700;letter-spacing:7px;color:#b8e84a}
+.csb-head{position:absolute;top:56px;left:50%;margin-left:-70px;width:140px;height:220px;border-radius:16px;background:#0e140a;box-shadow:inset 0 0 0 5px #2c3a1c;overflow:hidden}
+.csb-walk{position:absolute;top:20px;left:0;right:0;text-align:center;font-size:13px;font-weight:700;color:#b8e84a;animation:walk-visible-crosswalk-signal-box 3s steps(1) infinite}
+.csb-dont{position:absolute;top:20px;left:0;right:0;text-align:center;font-size:12px;font-weight:700;color:#e85a5a;animation:dont-visible-crosswalk-signal-box 3s steps(1) infinite}
+.csb-fig{position:absolute;top:64px;left:50%;margin-left:-26px;width:52px;height:96px;border-radius:6px;background:#b8e84a;box-shadow:inset 0 0 0 4px #4a7a1c;animation:figure-step-crosswalk-signal-box 1.2s ease-in-out infinite}
+.csb-pole{position:absolute;top:276px;left:50%;margin-left:-7px;width:14px;height:130px;background:#2c3a1c;box-shadow:inset 0 0 0 3px #0e140a}
+.csb-btn{position:absolute;top:300px;left:50%;margin-left:-18px;width:36px;height:36px;border-radius:50%;background:#5a4a1c;box-shadow:inset 0 0 0 4px #b8e84a;animation:btn-press-crosswalk-signal-box 3s ease-in-out infinite}
+@keyframes walk-visible-crosswalk-signal-box{0%,49%{opacity:1}50%,100%{opacity:0.15}}
+@keyframes dont-visible-crosswalk-signal-box{0%,49%{opacity:0.15}50%,100%{opacity:1}}
+@keyframes figure-step-crosswalk-signal-box{0%,100%{transform:translateX(0)}50%{transform:translateX(8px)}}
+@keyframes btn-press-crosswalk-signal-box{0%,100%{transform:scale(1)}50%{transform:scale(0.8)}}


### PR DESCRIPTION
## Component: ease-crosswalk-signal-box — figure steps, sign flips, and button presses

**Closes #67614**

### What this adds
A crosswalk signal: the walk figure steps, the walk sign flips to the wait sign, and the request button presses.

### Acceptance Criteria covered
- Walk figure steps in the window
- Walk sign flips to the wait sign
- Request button presses in place

### Files
- `submissions/examples/crosswalk-signal-box-ij/demo.html`
- `submissions/examples/crosswalk-signal-box-ij/style.css`
- `submissions/examples/crosswalk-signal-box-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the figure step.