### PR TITLE
Add ease-dartboard-target component

### DIFF
--- a/submissions/examples/dartboard-target-ij/README.md
+++ b/submissions/examples/dartboard-target-ij/README.md
@@ -1,0 +1,10 @@
+# ease-dartboard-target
+
+A dartboard where the target rings pulse, the dart aims across the board, and the score ticks.
+
+## Run
+Open `demo.html` directly in a browser to watch the rings pulse.
+
+## Notes
+- The target rings pulse in turn.
+- The score ticks beneath.

--- a/submissions/examples/dartboard-target-ij/demo.html
+++ b/submissions/examples/dartboard-target-ij/demo.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-dartboard-target demo</title>
+</head>
+<body>
+<div class="dbt-app">
+  <span class="dbt-title">DOUBLE 16</span>
+  <div class="dbt-board">
+    <div class="dbt-ring"></div>
+    <div class="dbt-ring"></div>
+    <div class="dbt-ring"></div>
+    <div class="dbt-bull"></div>
+    <div class="dbt-dart"></div>
+  </div>
+  <span class="dbt-score">501</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/dartboard-target-ij/style.css
+++ b/submissions/examples/dartboard-target-ij/style.css
@@ -1,0 +1,16 @@
+:root{--dbt-green:#4ae85a;--dbt-dark:#101810}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#101810,#060a06);font-family:'Haettenschweiler',sans-serif}
+.dbt-app{position:relative;width:376px;height:420px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#1a2418,#0a120a);box-shadow:0 16px 36px rgba(0,0,0,0.6)}
+.dbt-title{position:absolute;top:14px;left:0;right:0;text-align:center;font-size:11px;font-weight:700;letter-spacing:7px;color:#4ae85a}
+.dbt-board{position:absolute;top:56px;left:50%;margin-left:-142px;width:284px;height:284px;border-radius:50%;background:#1c2a1c;box-shadow:inset 0 0 0 8px #3a4a2a,0 0 0 8px #0c140c;overflow:hidden}
+.dbt-ring{position:absolute;border-radius:50%;animation:ring-hue-dartboard-target 4s ease-in-out infinite}
+.dbt-ring:nth-of-type(1){top:8px;left:8px;width:264px;height:264px;background:#e85a5a;box-shadow:inset 0 0 0 14px #f2e6d0}
+.dbt-ring:nth-of-type(2){top:44px;left:44px;width:192px;height:192px;background:#4ae85a;box-shadow:inset 0 0 0 10px #f2e6d0}
+.dbt-ring:nth-of-type(3){top:74px;left:74px;width:132px;height:132px;background:#e85a5a;box-shadow:inset 0 0 0 8px #f2e6d0}
+.dbt-bull{position:absolute;top:112px;left:112px;width:56px;height:56px;border-radius:50%;background:#e85a5a;box-shadow:inset 0 0 0 10px #4ae85a;animation:bull-pulse-dartboard-target 1s ease-in-out infinite}
+.dbt-dart{position:absolute;top:30px;left:50%;margin-left:-2px;width:4px;height:70px;border-radius:2px;background:#d8d8d8;transform-origin:50% 100%;animation:dart-aim-dartboard-target 3s ease-in-out infinite}
+.dbt-score{position:absolute;bottom:16px;left:0;right:0;text-align:center;font-size:16px;font-weight:700;color:#4ae85a;animation:score-tick-dartboard-target 1s steps(1) infinite}
+@keyframes ring-hue-dartboard-target{0%,100%{filter:brightness(1)}50%{filter:brightness(1.4)}}
+@keyframes bull-pulse-dartboard-target{0%,100%{transform:scale(1)}50%{transform:scale(1.08)}}
+@keyframes dart-aim-dartboard-target{0%,100%{transform:rotate(-24deg)}50%{transform:rotate(16deg)}}
+@keyframes score-tick-dartboard-target{0%,49%{opacity:1}50%,100%{opacity:0.3}}


### PR DESCRIPTION
## Component: ease-dartboard-target — rings pulse, dart aims, and score ticks

**Closes #67632**

### What this adds
A dartboard: the target rings pulse, the dart aims across the board, and the score ticks.

### Acceptance Criteria covered
- Target rings pulse in turn
- Dart aims across the board
- Score ticks beneath

### Files
- `submissions/examples/dartboard-target-ij/demo.html`
- `submissions/examples/dartboard-target-ij/style.css`
- `submissions/examples/dartboard-target-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the rings pulse.