### PR TITLE
Add ease-stadium-scoreboard component

### DIFF
--- a/submissions/examples/stadium-scoreboard-ij/README.md
+++ b/submissions/examples/stadium-scoreboard-ij/README.md
@@ -1,0 +1,10 @@
+# ease-stadium-scoreboard
+
+A stadium board where the score digits flip, the game clock ticks, and the status tag blinks.
+
+## Run
+Open `demo.html` directly in a browser to watch the digits flip.
+
+## Notes
+- The score digits flip on the panels.
+- The status tag blinks beneath.

--- a/submissions/examples/stadium-scoreboard-ij/demo.html
+++ b/submissions/examples/stadium-scoreboard-ij/demo.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-stadium-scoreboard demo</title>
+</head>
+<body>
+<div class="ssb-app">
+  <span class="ssb-title">GAME 7</span>
+  <div class="ssb-home"><span class="ssb-name">HOME</span><span class="ssb-score">3</span></div>
+  <div class="ssb-away"><span class="ssb-name">AWAY</span><span class="ssb-score">2</span></div>
+  <div class="ssb-clock">4:22</div>
+  <span class="ssb-status">FINAL</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/stadium-scoreboard-ij/style.css
+++ b/submissions/examples/stadium-scoreboard-ij/style.css
@@ -1,0 +1,13 @@
+:root{--ssb-blue:#5aa0ff;--ssb-dark:#0e1420}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#0e1420,#050810);font-family:'Gill Sans MT Condensed',sans-serif}
+.ssb-app{position:relative;width:376px;height:400px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#182438,#0a101c);box-shadow:0 16px 36px rgba(0,0,0,0.6)}
+.ssb-title{position:absolute;top:14px;left:0;right:0;text-align:center;font-size:12px;font-weight:700;letter-spacing:8px;color:#5aa0ff}
+.ssb-home{position:absolute;top:70px;left:30px;width:150px;height:96px;border-radius:12px;background:#0a101c;box-shadow:inset 0 0 0 4px #2a3a5a}
+.ssb-away{position:absolute;top:70px;right:30px;width:150px;height:96px;border-radius:12px;background:#0a101c;box-shadow:inset 0 0 0 4px #2a3a5a}
+.ssb-name{position:absolute;top:14px;left:0;right:0;text-align:center;font-size:11px;letter-spacing:4px;color:#9aa8c8}
+.ssb-score{position:absolute;top:36px;left:0;right:0;text-align:center;font-size:32px;font-weight:700;color:#5aa0ff;animation:digit-flip-stadium-scoreboard 1s steps(1) infinite}
+.ssb-clock{position:absolute;top:196px;left:0;right:0;text-align:center;font-size:15px;font-weight:700;color:#5aa0ff;animation:clock-tick-stadium-scoreboard 1s steps(1) infinite}
+.ssb-status{position:absolute;bottom:16px;left:0;right:0;text-align:center;font-size:10px;letter-spacing:7px;color:#5aa0ff;animation:status-blink-stadium-scoreboard 1.6s steps(1) infinite}
+@keyframes digit-flip-stadium-scoreboard{0%,49%{opacity:1}50%,100%{opacity:0.3}}
+@keyframes clock-tick-stadium-scoreboard{0%,49%{opacity:1}50%,100%{opacity:0.3}}
+@keyframes status-blink-stadium-scoreboard{0%,49%{opacity:1}50%,100%{opacity:0.25}}


### PR DESCRIPTION
## Component: ease-stadium-scoreboard — digits flip, clock ticks, and status blinks

**Closes #67640**

### What this adds
A stadium board: the score digits flip, the game clock ticks, and the status tag blinks.

### Acceptance Criteria covered
- Score digits flip on the panels
- Game clock ticks between
- Status tag blinks beneath

### Files
- `submissions/examples/stadium-scoreboard-ij/demo.html`
- `submissions/examples/stadium-scoreboard-ij/style.css`
- `submissions/examples/stadium-scoreboard-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the digits flip.