### PR TITLE
Add ease-swing-ticket-stamp component

### DIFF
--- a/submissions/examples/swing-ticket-stamp-ij/README.md
+++ b/submissions/examples/swing-ticket-stamp-ij/README.md
@@ -1,0 +1,10 @@
+# ease-swing-ticket-stamp
+
+A ride ticket booth where the ticket slides on the counter, the stamp presses down, and the next queue tag blinks.
+
+## Run
+Open `demo.html` directly in a browser to watch the ticket slide.
+
+## Notes
+- The ticket slides on the counter.
+- The next queue tag blinks.

--- a/submissions/examples/swing-ticket-stamp-ij/demo.html
+++ b/submissions/examples/swing-ticket-stamp-ij/demo.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-swing-ticket-stamp demo</title>
+</head>
+<body>
+<div class="sts-booth">
+  <span class="sts-title">RIDE TICKETS</span>
+  <div class="sts-ticket">
+    <span class="sts-line">ADMIT ONE</span>
+    <span class="sts-zip">NO. 0042</span>
+  </div>
+  <div class="sts-arm">
+    <span class="sts-pad">STAMP</span>
+  </div>
+  <span class="sts-queue">NEXT</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/swing-ticket-stamp-ij/style.css
+++ b/submissions/examples/swing-ticket-stamp-ij/style.css
@@ -1,0 +1,13 @@
+:root{--sts-teal:#22c6b2;--sts-ink:#0a1414}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#0a1414,#050a0a);font-family:'Georgia',serif}
+.sts-booth{position:relative;width:340px;height:400px;border-radius:16px;overflow:hidden;background:linear-gradient(180deg,#10241f,#07120e);box-shadow:0 14px 32px rgba(0,0,0,0.6)}
+.sts-title{position:absolute;top:16px;left:0;right:0;text-align:center;font-size:12px;font-weight:700;letter-spacing:6px;color:#22c6b2}
+.sts-ticket{position:absolute;top:70px;left:50%;margin-left:-110px;width:220px;height:110px;border-radius:10px;background:#f4e6c2;box-shadow:inset 0 0 0 4px #d9bf94;animation:ticket-slide-swing-ticket-stamp 4s ease-in-out infinite}
+.sts-line{position:absolute;top:22px;left:0;right:0;text-align:center;font-size:18px;font-weight:700;letter-spacing:3px;color:#2a2620}
+.sts-zip{position:absolute;top:70px;left:0;right:0;text-align:center;font-size:11px;letter-spacing:4px;color:#7a6b52}
+.sts-arm{position:absolute;top:150px;left:50%;margin-left:-46px;width:92px;height:56px;border-radius:8px;background:#1c3530;box-shadow:0 0 0 3px #22c6b2;animation:stamp-press-swing-ticket-stamp 2s ease-in-out infinite}
+.sts-pad{position:absolute;top:0;right:0;bottom:0;left:0;display:grid;place-items:center;font-size:10px;font-weight:700;letter-spacing:3px;color:#22c6b2}
+.sts-queue{position:absolute;bottom:18px;left:0;right:0;text-align:center;font-size:14px;font-weight:700;letter-spacing:5px;color:#22c6b2;animation:queue-blink-swing-ticket-stamp 1s steps(1) infinite}
+@keyframes ticket-slide-swing-ticket-stamp{0%,100%{transform:translateX(-14px)}50%{transform:translateX(14px)}}
+@keyframes stamp-press-swing-ticket-stamp{0%,100%{transform:translateY(0)}45%{transform:translateY(52px)}55%{transform:translateY(52px)}}
+@keyframes queue-blink-swing-ticket-stamp{0%,49%{opacity:1}50%,100%{opacity:0.3}}


### PR DESCRIPTION
## Component: ease-swing-ticket-stamp — ticket slides, stamp presses, and queue blinks

**Closes #67646**

### What this adds
A ride ticket booth: the ticket slides on the counter, the stamp presses down, and the next queue tag blinks.

### Acceptance Criteria covered
- Ticket slides on the counter
- Stamp presses down
- Next queue tag blinks

### Files
- `submissions/examples/swing-ticket-stamp-ij/demo.html`
- `submissions/examples/swing-ticket-stamp-ij/style.css`
- `submissions/examples/swing-ticket-stamp-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the ticket slide.