### PR TITLE
feat: add ease-counter animated number counter/odometer (#62010)

### DIFF
--- a/submissions/examples/ease-counter-sbh/README.md
+++ b/submissions/examples/ease-counter-sbh/README.md
@@ -1,0 +1,38 @@
+# ease-counter
+
+A pure-CSS animated number counter / odometer that counts up from 0 to a target value on load — with thousands separators, optional decimals (0, 1, or 2 places), and a suffix. No JavaScript, no tweening library; the browser itself interpolates the integer via a registered `@property` custom property.
+
+## What does this do?
+
+Animates a number counting up by registering two `<integer>`-typed custom properties — `--int` (whole part) and `--frac` (fractional part) — with `@property`, then driving them from `0` to `--int-to` / `--frac-to` with a single `@keyframes` rule. The running integers are rendered with `counter-reset` + `content: counter()`, using custom `@counter-style` definitions for thousands separators (`group-separator`/`group-size`) and zero-padded fractional digits (`pad`). Each stat is staggered by index via `--i`.
+
+## How is it used?
+
+1. Link the stylesheet.
+2. Add a `.stat__value` span and set `--int-to` (and `--frac-to` for decimals), `data-decimals` (0/1/2), and `data-suffix` on it.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<span class="stat__value" data-decimals="0" data-suffix=""  style="--int-to: 48213;   --frac-to: 0"></span>
+<span class="stat__value" data-decimals="0" data-suffix="+" style="--int-to: 1900000; --frac-to: 0"></span>
+<span class="stat__value" data-decimals="2" data-suffix="%" style="--int-to: 99;      --frac-to: 98"></span>
+<span class="stat__value" data-decimals="1" data-suffix="/5" style="--int-to: 4;       --frac-to: 9"></span>
+```
+
+## Why is this useful?
+
+- **Animation-first** — the signature motion is the count-up: a registered `<integer>` custom property is interpolated by `@keyframes`, and `counter()` turns the running integer into visible digits. The browser handles every frame; there is no per-frame JS number-crunching.
+- **Grouped + padded** — a custom `@counter-style` (`ec-grouped`) inserts thousands separators; `ec-pad1`/`ec-pad2` zero-pad the fractional part so `99.9` shows as `99.90`.
+- **Accessible** — each stat card exposes the final value in its `aria-label` (so screen readers read "48,213" rather than counting), and full `prefers-reduced-motion` support renders the final value instantly with no animation.
+- **Reusable** — configurable via CSS custom properties (`--count-duration`, `--count-ease`, `--stagger`, accent colors, glass blur).
+
+## Files
+
+- `demo.html` — self-contained SaaS stats showcase (open directly in a browser; no server, CDNs, or frameworks). Reload to replay the count-up.
+- `style.css` — `@property` integer registration, count-up `@keyframes`, `counter()` rendering with custom `@counter-style` separators/padding, glassmorphism stat cards, reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-counter-sbh/demo.html
+++ b/submissions/examples/ease-counter-sbh/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-counter — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__intro">
+      <h1>ease-counter</h1>
+      <p>An animated number counter / odometer that counts up on load, using only CSS.</p>
+    </header>
+
+    <section class="stats" aria-label="Key metrics">
+      <article class="stat" tabindex="0" aria-label="Active users: 48213">
+        <span class="stat__value" data-decimals="0" data-suffix="" style="--int-to: 48213; --frac-to: 0"></span>
+        <span class="stat__label">Active users</span>
+      </article>
+      <article class="stat" tabindex="0" aria-label="API requests per day: 1900000">
+        <span class="stat__value" data-decimals="0" data-suffix="" style="--int-to: 1900000; --frac-to: 0"></span>
+        <span class="stat__label">API requests / day</span>
+      </article>
+      <article class="stat" tabindex="0" aria-label="Uptime percentage: 99.98">
+        <span class="stat__value" data-decimals="2" data-suffix="%" style="--int-to: 99; --frac-to: 98"></span>
+        <span class="stat__label">Uptime</span>
+      </article>
+      <article class="stat" tabindex="0" aria-label="Customer satisfaction score: 4.9 out of 5">
+        <span class="stat__value" data-decimals="1" data-suffix="/5" style="--int-to: 4; --frac-to: 9"></span>
+        <span class="stat__label">Satisfaction</span>
+      </article>
+    </section>
+
+    <p class="hint">Reload to replay the count-up animation.</p>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-counter-sbh/style.css
+++ b/submissions/examples/ease-counter-sbh/style.css
@@ -1,0 +1,166 @@
+/* ease-counter — pure-CSS animated number counter / odometer.
+   Registers two animatable <integer> custom properties (--int for the
+   whole part, --frac for the fractional part) via @property, animates
+   them from 0 to --int-to / --frac-to on load, and renders the value
+   with counter() — with thousands separators, optional decimals
+   (0/1/2), and a suffix. No JavaScript. */
+
+@property --int {
+  syntax: "<integer>";
+  inherits: false;
+  initial-value: 0;
+}
+@property --frac {
+  syntax: "<integer>";
+  inherits: false;
+  initial-value: 0;
+}
+
+:root {
+  --count-duration: 2s;
+  --count-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --stagger: 0.18s;
+  --fg: #e8edf5;
+  --muted: #8a94a6;
+  --accent: #6ea8ff;
+  --accent2: #b388ff;
+  --glass-bg: rgba(255, 255, 255, 0.07);
+  --glass-border: rgba(255, 255, 255, 0.14);
+  --glass-blur: 12px;
+  --radius: 1rem;
+}
+
+* { box-sizing: border-box; }
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.6rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at 50% 20%, #1c2440, #0a0d16 70%);
+  color: var(--fg);
+}
+
+.page__intro { text-align: center; max-width: 40rem; }
+.page__intro h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.5rem, 4vw, 2.2rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.page__intro p { margin: 0; opacity: 0.7; line-height: 1.6; }
+.hint { font-size: 0.82rem; color: var(--muted); }
+
+.stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+  gap: 1.2rem;
+  width: min(52rem, 100%);
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 0.3rem;
+  padding: 1.5rem 1rem;
+  border-radius: var(--radius);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  box-shadow: 0 18px 40px -24px rgba(0, 0, 0, 0.7);
+  transition: transform 0.22s ease, border-color 0.22s ease, box-shadow 0.22s ease;
+}
+.stat:hover, .stat:focus-visible {
+  outline: none;
+  transform: translateY(-4px);
+  border-color: rgba(110, 168, 255, 0.5);
+  box-shadow: 0 22px 48px -22px rgba(0, 0, 0, 0.75), 0 0 0 3px rgba(110, 168, 255, 0.35);
+}
+
+/* The animated value. --int and --frac are registered <integer>s so
+   they interpolate; --int-to / --frac-to set the end values per element. */
+.stat__value {
+  --int: 0;
+  --frac: 0;
+  --int-to: 1000;
+  --frac-to: 0;
+  font-size: clamp(1.6rem, 4.5vw, 2.4rem);
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: ec-count var(--count-duration) var(--count-ease) forwards;
+  animation-delay: calc(var(--stagger) * var(--i, 0));
+}
+.stat:nth-of-type(1) .stat__value { --i: 0; }
+.stat:nth-of-type(2) .stat__value { --i: 1; }
+.stat:nth-of-type(3) .stat__value { --i: 2; }
+.stat:nth-of-type(4) .stat__value { --i: 3; }
+
+@keyframes ec-count {
+  from { --int: 0; --frac: 0; }
+  to   { --int: var(--int-to); --frac: var(--frac-to); }
+}
+
+/* Render the animated integers with counter().
+   counter-reset reads the registered integer custom properties;
+   ::after prints them. A custom @counter-style adds thousands
+   separators (group-size:3) to the integer part. */
+
+@counter-style ec-grouped {
+  system: numeric;
+  symbols: "0" "1" "2" "3" "4" "5" "6" "7" "8" "9";
+  group-separator: ",";
+  group-size: 3;
+}
+@counter-style ec-pad1 { system: numeric; symbols: "0" "1" "2" "3" "4" "5" "6" "7" "8" "9"; pad: 2 "0"; }
+@counter-style ec-pad2 { system: numeric; symbols: "0" "1" "2" "3" "4" "5" "6" "7" "8" "9"; pad: 3 "0"; }
+
+.stat__value[data-decimals="0"] {
+  counter-reset: ec-int var(--int);
+}
+.stat__value[data-decimals="0"]::after {
+  content: counter(ec-int, ec-grouped) attr(data-suffix);
+}
+
+.stat__value[data-decimals="1"] {
+  counter-reset: ec-int var(--int) ec-frac var(--frac);
+}
+.stat__value[data-decimals="1"]::after {
+  content: counter(ec-int, ec-grouped) "." counter(ec-frac, ec-pad1) attr(data-suffix);
+}
+
+.stat__value[data-decimals="2"] {
+  counter-reset: ec-int var(--int) ec-frac var(--frac);
+}
+.stat__value[data-decimals="2"]::after {
+  content: counter(ec-int, ec-grouped) "." counter(ec-frac, ec-pad2) attr(data-suffix);
+}
+
+.stat__label {
+  font-size: 0.85rem;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+@media (max-width: 480px) {
+  .stat { padding: 1.2rem 0.8rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .stat__value { animation: none; --int: var(--int-to); --frac: var(--frac-to); }
+}


### PR DESCRIPTION
## Summary

Adds a pure-CSS **animated number counter / odometer** for SaaS showcase layouts, resolving #62010.

The number animates smoothly from 0 up to a target value on load with **no JavaScript and no tweening library** — the browser itself interpolates the integer via a registered `@property` custom property.

## How it works

- Registers two `<integer>`-typed custom properties — `--int` (whole part) and `--frac` (fractional part) — via `@property`.
- Drives them from `0` to `--int-to` / `--frac-to` with a single `@keyframes` rule.
- Renders the running integers with `counter-reset` + `content: counter()`.
- A custom `@counter-style` inserts thousands separators; `ec-pad1`/`ec-pad2` zero-pad fractional digits so `99.9` shows as `99.90`.
- Each stat is staggered by index via `--i`.

## Files

- `submissions/examples/ease-counter-sbh/demo.html` — self-contained SaaS stats showcase (open directly in a browser; no server, CDNs, or frameworks).
- `submissions/examples/ease-counter-sbh/style.css` — `@property` integer registration, count-up `@keyframes`, `counter()` rendering with custom `@counter-style` separators/padding, glassmorphism stat cards, reduced-motion rules.
- `submissions/examples/ease-counter-sbh/README.md` — documentation.

## Requirements met

- Pure CSS / HTML (no external JS frameworks)
- Smooth CSS transitions and keyframe animations
- Fully responsive (`clamp()` fluid type/spacing)
- Accessible: each stat exposes its final value in `aria-label`; full `prefers-reduced-motion` support (renders final value instantly)
- Uses the `@property` + `counter-reset`/`content: counter()` technique exactly as described in the issue

Closes #62010.