### PR TITLE
feat: add ease-sticky-header shrink-on-scroll (#62008)

### DIFF
--- a/submissions/examples/ease-sticky-header-sbh/README.md
+++ b/submissions/examples/ease-sticky-header-sbh/README.md
@@ -1,0 +1,60 @@
+# ease-sticky-header
+
+A page header pinned to the top with `position: sticky` that shrinks in height and gains a shadow once the user scrolls past a threshold — signaling "you've moved away from the top of the page." CSS handles the pinning, the shrink, and the shadow transition; a single scroll listener toggles one boolean class.
+
+## What does this do?
+
+Uses `position: sticky` (zero layout JS) to keep the header pinned at the top. A tiny scroll listener toggles a `.scrolled` class on the header once `window.scrollY > 40`. That class drives the entire visual change via CSS transitions: the header bar height shrinks (`--sh-height` → `--sh-height-scrolled`), the logo mark/text scale down, the call-to-action padding tightens, a bottom border fades in, and a soft drop-shadow appears. Everything is transitioned with a single easing for a cohesive feel.
+
+## How is it used?
+
+1. Link the stylesheet.
+2. Mark up a `.sticky-header` with a `.sticky-header__inner` row containing your logo, nav, and actions.
+3. Add the one-line scroll listener that toggles `.scrolled`.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<header class="sticky-header" id="siteHeader">
+  <div class="sticky-header__inner">
+    <a class="sticky-header__logo" href="#top">
+      <span class="sticky-header__logo-mark" aria-hidden="true">◢</span>
+      <span class="sticky-header__logo-text">Nimbus</span>
+    </a>
+    <nav class="sticky-header__nav" aria-label="Primary">
+      <a href="#features">Features</a>
+      <a href="#pricing">Pricing</a>
+    </nav>
+    <div class="sticky-header__actions">
+      <a class="sticky-header__link" href="#signin">Sign in</a>
+      <a class="sticky-header__cta" href="#start">Get started</a>
+    </div>
+  </div>
+</header>
+
+<script>
+  const header = document.getElementById('siteHeader');
+  window.addEventListener('scroll', () => {
+    header.classList.toggle('scrolled', window.scrollY > 40);
+  }, { passive: true });
+</script>
+```
+
+## Why is this useful?
+
+- **Sticky without JS layout** — `position: sticky` does the pinning natively; the only script is one `scroll` listener flipping a class, wrapped in `requestAnimationFrame` and `{ passive: true }` for smoothness.
+- **Cohesive shrink** — height, logo scale, CTA padding, border, and shadow all transition together with a single easing (`--sh-ease`) and duration (`--sh-dur`), so the header feels like one object compacting.
+- **Glassmorphism** — frosted `backdrop-filter: blur()` background that intensifies slightly on scroll for legibility over content.
+- **Accessible** — semantic `<header>`/`<nav>` with `aria-label`s, visible focus states, hover underlines; full `prefers-reduced-motion` support disables transitions and the bobbing scroll hint.
+- **Responsive** — nav collapses on small screens; fluid type and spacing via `clamp()`.
+- **Reusable** — configurable via CSS custom properties (heights, duration, easing, colors, blur, max width).
+
+## Files
+
+- `demo.html` — self-contained marketing-shell demo (open directly in a browser; no server, CDNs, or frameworks). Scroll to see the header shrink and shadow appear.
+- `style.css` — sticky header, `.scrolled` shrink/shadow transitions, glassmorphism, responsive + reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation. A minimal inline scroll listener is included per the issue's own HTML snippet (the one place EaseMotion accepts a single boolean JS toggle).

--- a/submissions/examples/ease-sticky-header-sbh/demo.html
+++ b/submissions/examples/ease-sticky-header-sbh/demo.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-sticky-header — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="sticky-header" id="siteHeader">
+    <div class="sticky-header__inner">
+      <a class="sticky-header__logo" href="#top" aria-label="Nimbus home">
+        <span class="sticky-header__logo-mark" aria-hidden="true">◢</span>
+        <span class="sticky-header__logo-text">Nimbus</span>
+      </a>
+      <nav class="sticky-header__nav" aria-label="Primary">
+        <a href="#features">Features</a>
+        <a href="#pricing">Pricing</a>
+        <a href="#docs">Docs</a>
+        <a href="#changelog">Changelog</a>
+      </nav>
+      <div class="sticky-header__actions">
+        <a class="sticky-header__link" href="#signin">Sign in</a>
+        <a class="sticky-header__cta" href="#start">Get started</a>
+      </div>
+    </div>
+  </header>
+
+  <main id="top">
+    <section class="hero">
+      <p class="hero__eyebrow">v1.2 — Motion engine</p>
+      <h1>Scroll down.<br />Watch the header react.</h1>
+      <p class="hero__lede">
+        A page header pinned with <code>position: sticky</code> that shrinks in height
+        and gains a shadow once you scroll past a threshold — a single boolean class
+        toggled by one scroll listener. CSS does the layout and the transition.
+      </p>
+      <p class="hero__scroll-hint" aria-hidden="true">↓ scroll</p>
+    </section>
+
+    <section class="filler" id="features">
+      <h2>Features</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+      <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    </section>
+
+    <section class="filler" id="pricing">
+      <h2>Pricing</h2>
+      <p>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.</p>
+      <p>Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.</p>
+    </section>
+
+    <section class="filler" id="docs">
+      <h2>Docs</h2>
+      <p>Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem.</p>
+      <p>Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur.</p>
+    </section>
+
+    <section class="filler" id="changelog">
+      <h2>Changelog</h2>
+      <p>Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur.</p>
+      <p>At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores.</p>
+    </section>
+  </main>
+
+  <script>
+    // The only JavaScript: toggle one boolean class on scroll.
+    // CSS handles the pinning, shrink, and shadow transition.
+    (function () {
+      var header = document.getElementById('siteHeader');
+      var threshold = 40;
+      var ticking = false;
+
+      function update() {
+        header.classList.toggle('scrolled', window.scrollY > threshold);
+        ticking = false;
+      }
+
+      window.addEventListener('scroll', function () {
+        if (!ticking) {
+          window.requestAnimationFrame(update);
+          ticking = true;
+        }
+      }, { passive: true });
+
+      update();
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-sticky-header-sbh/style.css
+++ b/submissions/examples/ease-sticky-header-sbh/style.css
@@ -1,0 +1,263 @@
+/* ease-sticky-header — a sticky page header that shrinks and gains a
+   shadow once the user scrolls past a threshold.
+   position: sticky handles the pinning with zero layout JS; a single
+   `.scrolled` class (toggled by one scroll listener in demo.html)
+   drives the height/logo/spacing/shadow transition. */
+
+:root {
+  --sh-bg: rgba(255, 255, 255, 0.82);
+  --sh-bg-scrolled: rgba(255, 255, 255, 0.92);
+  --sh-border: rgba(15, 23, 42, 0.06);
+  --sh-fg: #0f172a;
+  --sh-muted: #64748b;
+  --sh-accent: #4f46e5;
+  --sh-accent-soft: rgba(79, 70, 229, 0.12);
+  --sh-blur: 14px;
+  --sh-shadow-scrolled: 0 10px 30px -12px rgba(15, 23, 42, 0.22);
+  --sh-height: 4.5rem;
+  --sh-height-scrolled: 3.25rem;
+  --sh-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --sh-dur: 0.3s;
+  --sh-maxw: 72rem;
+  --sh-pad-x: clamp(1rem, 4vw, 2rem);
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  color: var(--sh-fg);
+  background:
+    radial-gradient(1200px 600px at 80% -10%, #eef2ff, transparent 60%),
+    radial-gradient(900px 500px at 0% 0%, #faf5ff, transparent 55%),
+    #ffffff;
+  line-height: 1.6;
+}
+
+/* The sticky header. position: sticky keeps it pinned to the top
+   without JS, and top: 0 / z-index keep it above page content. */
+.sticky-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: var(--sh-bg);
+  border-bottom: 1px solid transparent;
+  backdrop-filter: blur(var(--sh-blur));
+  -webkit-backdrop-filter: blur(var(--sh-blur));
+  transition:
+    background var(--sh-dur) var(--sh-ease),
+    border-color var(--sh-dur) var(--sh-ease),
+    box-shadow var(--sh-dur) var(--sh-ease);
+}
+
+.sticky-header__inner {
+  max-width: var(--sh-maxw);
+  margin: 0 auto;
+  padding: 0 var(--sh-pad-x);
+  height: var(--sh-height);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  transition: height var(--sh-dur) var(--sh-ease);
+}
+
+/* Shrunk state — toggled by the scroll listener. */
+.sticky-header.scrolled {
+  background: var(--sh-bg-scrolled);
+  border-bottom-color: var(--sh-border);
+  box-shadow: var(--sh-shadow-scrolled);
+}
+.sticky-header.scrolled .sticky-header__inner {
+  height: var(--sh-height-scrolled);
+}
+
+/* Logo */
+.sticky-header__logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  text-decoration: none;
+  color: var(--sh-fg);
+  font-weight: 800;
+  font-size: 1.15rem;
+  letter-spacing: -0.02em;
+}
+.sticky-header__logo-mark {
+  display: inline-grid;
+  place-items: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 0.6rem;
+  background: var(--sh-accent);
+  color: #fff;
+  font-size: 0.85rem;
+  transform-origin: center;
+  transition: transform var(--sh-dur) var(--sh-ease), width var(--sh-dur) var(--sh-ease), height var(--sh-dur) var(--sh-ease);
+}
+.sticky-header__logo-text {
+  transform-origin: left center;
+  transition: transform var(--sh-dur) var(--sh-ease);
+}
+.sticky-header.scrolled .sticky-header__logo-mark {
+  transform: scale(0.82);
+}
+.sticky-header.scrolled .sticky-header__logo-text {
+  transform: scale(0.94);
+}
+
+/* Nav */
+.sticky-header__nav {
+  display: flex;
+  align-items: center;
+  gap: clamp(0.6rem, 2vw, 1.4rem);
+}
+.sticky-header__nav a {
+  position: relative;
+  text-decoration: none;
+  color: var(--sh-muted);
+  font-weight: 600;
+  font-size: 0.95rem;
+  padding: 0.4rem 0.2rem;
+  transition: color var(--sh-dur) var(--sh-ease);
+}
+.sticky-header__nav a::after {
+  content: "";
+  position: absolute;
+  left: 0; right: 0; bottom: 0.1rem;
+  height: 2px;
+  background: var(--sh-accent);
+  border-radius: 2px;
+  transform: scaleX(0);
+  transform-origin: center;
+  transition: transform var(--sh-dur) var(--sh-ease);
+}
+.sticky-header__nav a:hover,
+.sticky-header__nav a:focus-visible {
+  color: var(--sh-fg);
+  outline: none;
+}
+.sticky-header__nav a:hover::after,
+.sticky-header__nav a:focus-visible::after {
+  transform: scaleX(1);
+}
+
+/* Actions */
+.sticky-header__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+.sticky-header__link {
+  text-decoration: none;
+  color: var(--sh-muted);
+  font-weight: 600;
+  font-size: 0.95rem;
+  transition: color var(--sh-dur) var(--sh-ease);
+}
+.sticky-header__link:hover { color: var(--sh-fg); }
+
+.sticky-header__cta {
+  text-decoration: none;
+  background: var(--sh-accent);
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.92rem;
+  padding: 0.6rem 1.1rem;
+  border-radius: 0.7rem;
+  box-shadow: 0 6px 18px -8px var(--sh-accent);
+  transition: transform var(--sh-dur) var(--sh-ease), box-shadow var(--sh-dur) var(--sh-ease), padding var(--sh-dur) var(--sh-ease);
+}
+.sticky-header__cta:hover,
+.sticky-header__cta:focus-visible {
+  outline: none;
+  transform: translateY(-2px);
+  box-shadow: 0 10px 22px -8px var(--sh-accent);
+}
+.sticky-header.scrolled .sticky-header__cta {
+  padding-block: 0.45rem;
+}
+
+/* Page content */
+main { display: block; }
+.hero {
+  max-width: var(--sh-maxw);
+  margin: 0 auto;
+  padding: clamp(4rem, 12vh, 9rem) var(--sh-pad-x) clamp(3rem, 8vh, 6rem);
+}
+.hero__eyebrow {
+  margin: 0 0 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: var(--sh-accent);
+}
+.hero h1 {
+  margin: 0 0 1.2rem;
+  font-size: clamp(2rem, 6vw, 3.6rem);
+  line-height: 1.05;
+  letter-spacing: -0.03em;
+}
+.hero__lede {
+  max-width: 42rem;
+  margin: 0 0 2rem;
+  font-size: clamp(1rem, 2.5vw, 1.2rem);
+  color: var(--sh-muted);
+}
+.hero__lede code {
+  background: var(--sh-accent-soft);
+  color: var(--sh-accent);
+  padding: 0.15rem 0.4rem;
+  border-radius: 0.4rem;
+  font-size: 0.9em;
+}
+.hero__scroll-hint {
+  color: var(--sh-accent);
+  font-weight: 700;
+  animation: sh-bob 1.8s var(--sh-ease) infinite;
+}
+@keyframes sh-bob {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(0.4rem); }
+}
+
+.filler {
+  max-width: var(--sh-maxw);
+  margin: 0 auto;
+  padding: clamp(2.5rem, 6vh, 4rem) var(--sh-pad-x);
+  border-top: 1px solid var(--sh-border);
+}
+.filler h2 {
+  font-size: clamp(1.4rem, 3.5vw, 2rem);
+  letter-spacing: -0.02em;
+  margin: 0 0 1rem;
+}
+.filler p {
+  margin: 0 0 1rem;
+  color: var(--sh-muted);
+  max-width: 48rem;
+}
+
+/* Responsive: collapse nav on small screens */
+@media (max-width: 640px) {
+  .sticky-header__nav { display: none; }
+  .sticky-header__inner { gap: 0.5rem; }
+  .hero h1 br { display: none; }
+}
+
+/* Reduced motion: keep the shrink/shadow but skip the bobbing hint. */
+@media (prefers-reduced-motion: reduce) {
+  .sticky-header,
+  .sticky-header__inner,
+  .sticky-header__logo-mark,
+  .sticky-header__logo-text,
+  .sticky-header__nav a,
+  .sticky-header__nav a::after,
+  .sticky-header__cta,
+  .hero__scroll-hint {
+    transition: none;
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a **sticky header that shrinks and gains a shadow on scroll** for SaaS/marketing showcase layouts, resolving #62008.

`position: sticky` pins the header to the top with zero layout JS. A single scroll listener toggles one boolean `.scrolled` class once `window.scrollY > 40`; CSS transitions handle the rest: the bar height shrinks, the logo mark/text scale down, the CTA padding tightens, a bottom border fades in, and a soft drop-shadow appears, all with one shared easing for a cohesive feel.

This matches the issue's stated philosophy: "CSS does layout, JS does one boolean." A minimal inline scroll listener is included per the issue's own HTML snippet (the one place EaseMotion accepts a single boolean toggle).

## Files

- `submissions/examples/ease-sticky-header-sbh/demo.html` — self-contained marketing-shell demo (open directly in a browser; no server, CDNs, or frameworks). Scroll to see the header shrink and shadow appear.
- `submissions/examples/ease-sticky-header-sbh/style.css` — sticky header, `.scrolled` shrink/shadow transitions, glassmorphism, responsive + reduced-motion rules.
- `submissions/examples/ease-sticky-header-sbh/README.md` — documentation.

## Requirements met

- Sticky via `position: sticky` (no layout JS)
- Single scroll listener wrapped in `requestAnimationFrame` + `{ passive: true }`
- Shrink-in-height + shadow on scroll past threshold
- Smooth CSS transitions with shared easing
- Fully responsive (`clamp()` fluid type/spacing; nav collapses on small screens)
- Accessible: semantic `<header>`/`<nav>` with `aria-label`s, visible focus states; full `prefers-reduced-motion` support

Closes #62008.