### PR TITLE
feat: add ease-spinner multi-style loading utility (#62004)

### DIFF
--- a/submissions/examples/ease-spinner-sbh/README.md
+++ b/submissions/examples/ease-spinner-sbh/README.md
@@ -1,0 +1,55 @@
+# ease-spinner
+
+A multi-style loading spinner utility with three ready-made styles under one consistent class prefix — classic ring, dual-ring, and dot-pulse — built from `border` tricks and a `::before` pseudo-element, avoiding wrapper divs where possible. Pure CSS, no JavaScript.
+
+## What does this do?
+
+Provides three spinners sharing one prefix:
+
+- **`.spinner`** — the classic ring: a single element with a transparent border whose top edge is colored; `@keyframes sp-spin` rotates it 360°.
+- **`.spinner.spinner-dual`** — a dual ring: the *same* single element, with colored top + bottom edges and a `::before` pseudo-element carrying colored left + right edges that counter-rotates (`@keyframes sp-spin-rev`), so two rings visibly cross.
+- **`.spinner-dots`** — a dot pulse: one wrapper + three `<span>`s; each dot scales and fades via `@keyframes sp-dot`, staggered by a third of the duration.
+
+Each style accepts `--sm` / `--lg` size modifiers and is color-driven entirely by CSS custom properties.
+
+## How is it used?
+
+1. Link the stylesheet.
+2. Drop in the markup for the style you want. Add `role="status"` + `aria-label` so screen readers announce "Loading".
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<!-- classic ring -->
+<div class="spinner" role="status" aria-label="Loading"></div>
+
+<!-- dual ring (same element, extra class) -->
+<div class="spinner spinner-dual" role="status" aria-label="Loading"></div>
+
+<!-- dot pulse -->
+<div class="spinner-dots" role="status" aria-label="Loading">
+  <span></span><span></span><span></span>
+</div>
+
+<!-- sizes -->
+<div class="spinner spinner--sm" role="status" aria-label="Loading"></div>
+<div class="spinner spinner--lg" role="status" aria-label="Loading"></div>
+```
+
+## Why is this useful?
+
+- **Single prefix, three styles** — `spinner`, `spinner-dual`, `spinner-dots` cover the common loading cases so developers stop hunting CodePen for a decent one.
+- **Minimal markup** — the ring and dual-ring are each a single element (the second ring is a `::before`, not a wrapper div); only the dot-pulse needs three child spans.
+- **Border/box-shadow tricks** — rings are `border` + `border-radius: 50%` with one/two colored edges; no images, no SVG.
+- **Accessible** — each spinner is `role="status"` with an `aria-label`; full `prefers-reduced-motion` support freezes the spinners into a static, legible state instead of endless rotation.
+- **Reusable** — configurable via CSS custom properties (`--sp-color`, `--sp-track`, `--sp-size`, `--sp-thick`, `--sp-dur`, `--sp-ease`).
+
+## Files
+
+- `demo.html` — self-contained showcase (open directly in a browser; no server, CDNs, or frameworks). Shows all three styles at multiple sizes and in a realistic "loading row" context.
+- `style.css` — three spinner styles, size modifiers, keyframes, reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-spinner-sbh/demo.html
+++ b/submissions/examples/ease-spinner-sbh/demo.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-spinner — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__head">
+      <p class="page__eyebrow">ease-spinner</p>
+      <h1>Loading spinners, three styles, one prefix.</h1>
+      <p class="page__lede">
+        A single-element spinner utility with three ready-made styles — classic ring,
+        dual-ring, and dot-pulse — built from <code>border</code> tricks and
+        <code>box-shadow</code>. Pure CSS, no wrapper divs where avoidable.
+      </p>
+    </header>
+
+    <section class="card">
+      <h2 class="card__title">Classic ring</h2>
+      <p class="card__hint"><code>&lt;div class="spinner"&gt;&lt;/div&gt;</code></p>
+      <div class="card__stage">
+        <div class="spinner" role="status" aria-label="Loading"></div>
+      </div>
+      <div class="card__sizes">
+        <div class="spinner spinner--sm" role="status" aria-label="Loading"></div>
+        <div class="spinner" role="status" aria-label="Loading"></div>
+        <div class="spinner spinner--lg" role="status" aria-label="Loading"></div>
+      </div>
+    </section>
+
+    <section class="card">
+      <h2 class="card__title">Dual ring</h2>
+      <p class="card__hint"><code>&lt;div class="spinner spinner-dual"&gt;&lt;/div&gt;</code></p>
+      <div class="card__stage">
+        <div class="spinner spinner-dual" role="status" aria-label="Loading"></div>
+      </div>
+      <div class="card__sizes">
+        <div class="spinner spinner-dual spinner--sm" role="status" aria-label="Loading"></div>
+        <div class="spinner spinner-dual" role="status" aria-label="Loading"></div>
+        <div class="spinner spinner-dual spinner--lg" role="status" aria-label="Loading"></div>
+      </div>
+    </section>
+
+    <section class="card">
+      <h2 class="card__title">Dot pulse</h2>
+      <p class="card__hint"><code>&lt;div class="spinner-dots"&gt;&lt;span&gt;&lt;/span&gt;×3&lt;/div&gt;</code></p>
+      <div class="card__stage">
+        <div class="spinner-dots" role="status" aria-label="Loading">
+          <span></span><span></span><span></span>
+        </div>
+      </div>
+      <div class="card__sizes">
+        <div class="spinner-dots spinner-dots--sm" role="status" aria-label="Loading"><span></span><span></span><span></span></div>
+        <div class="spinner-dots" role="status" aria-label="Loading"><span></span><span></span><span></span></div>
+        <div class="spinner-dots spinner-dots--lg" role="status" aria-label="Loading"><span></span><span></span><span></span></div>
+      </div>
+    </section>
+
+    <section class="card card--variants">
+      <h2 class="card__title">In context</h2>
+      <div class="uselist">
+        <div class="userow">
+          <div class="spinner spinner--sm" role="status" aria-label="Fetching analytics"></div>
+          <span class="userow__label">Fetching analytics…</span>
+        </div>
+        <div class="userow">
+          <div class="spinner spinner-dual spinner--sm" role="status" aria-label="Syncing data"></div>
+          <span class="userow__label">Syncing data…</span>
+        </div>
+        <div class="userow">
+          <div class="spinner-dots spinner-dots--sm" role="status" aria-label="Saving"><span></span><span></span><span></span></div>
+          <span class="userow__label">Saving…</span>
+        </div>
+      </div>
+    </section>
+
+    <p class="sr-only" id="sr-note">Spinners indicate loading. They are decorative while content is pending.</p>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-spinner-sbh/style.css
+++ b/submissions/examples/ease-spinner-sbh/style.css
@@ -1,0 +1,150 @@
+/* ease-spinner — a multi-style loading spinner utility.
+   Three styles under one consistent prefix:
+     .spinner            classic ring (single element, border trick)
+     .spinner.spinner-dual   dual ring (single element, two borders via ::before)
+     .spinner-dots       dot pulse (one wrapper + 3 <span>s, box-shadow free)
+   Pure CSS, no JS. Sizes via modifiers; colors via custom properties. */
+
+:root {
+  --sp-color: #4f46e5;
+  --sp-track: rgba(79, 70, 229, 0.18);
+  --sp-dur: 0.8s;
+  --sp-ease: linear;
+  --sp-size: 2.5rem;
+  --sp-thick: 0.28em;
+}
+
+/* ---------- Page (demo only) ---------- */
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  color: #0f172a;
+  background:
+    radial-gradient(1100px 600px at 85% -8%, #eef2ff, transparent 60%),
+    radial-gradient(800px 480px at 0% 0%, #faf5ff, transparent 55%),
+    #fff;
+  line-height: 1.6;
+}
+.page { max-width: 60rem; margin: 0 auto; padding: clamp(2rem, 6vw, 4rem) clamp(1rem, 4vw, 2rem); }
+.page__eyebrow {
+  margin: 0 0 0.6rem; text-transform: uppercase; letter-spacing: 0.18em;
+  font-size: 0.78rem; font-weight: 700; color: var(--sp-color);
+}
+.page__head h1 { margin: 0 0 0.8rem; font-size: clamp(1.6rem, 4.5vw, 2.6rem); letter-spacing: -0.02em; }
+.page__lede { margin: 0 0 2rem; color: #64748b; max-width: 40rem; }
+.page__lede code { background: rgba(79,70,229,0.12); color: var(--sp-color); padding: 0.12rem 0.4rem; border-radius: 0.4rem; font-size: 0.9em; }
+
+.card {
+  background: rgba(255,255,255,0.7);
+  border: 1px solid rgba(15,23,42,0.06);
+  border-radius: 1rem;
+  padding: clamp(1.2rem, 3vw, 1.8rem);
+  margin-bottom: 1.4rem;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+.card__title { margin: 0 0 0.2rem; font-size: 1.15rem; letter-spacing: -0.01em; }
+.card__hint { margin: 0 0 1.2rem; color: #94a3b8; font-size: 0.85rem; }
+.card__hint code { font-size: 0.85rem; }
+.card__stage {
+  display: grid; place-items: center;
+  min-height: 6rem;
+  background: #f8fafc; border-radius: 0.7rem; margin-bottom: 1rem;
+}
+.card__sizes { display: flex; align-items: center; justify-content: center; gap: 1.6rem; }
+
+.uselist { display: flex; flex-direction: column; gap: 1rem; }
+.userow { display: flex; align-items: center; gap: 0.8rem; }
+.userow__label { color: #475569; font-weight: 600; font-size: 0.95rem; }
+
+.sr-only {
+  position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+  overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0;
+}
+
+/* ---------- 1. Classic ring ---------- */
+/* Single element. A transparent border with one colored edge rotates. */
+.spinner {
+  display: inline-block;
+  width: var(--sp-size);
+  height: var(--sp-size);
+  vertical-align: middle;
+  border: var(--sp-thick) solid var(--sp-track);
+  border-top-color: var(--sp-color);
+  border-radius: 50%;
+  animation: sp-spin var(--sp-dur) var(--sp-ease) infinite;
+}
+
+/* ---------- 2. Dual ring ---------- */
+/* Same single element; a ::before adds a counter-rotating second ring. */
+.spinner.spinner-dual {
+  border-top-color: var(--sp-color);
+  border-bottom-color: var(--sp-color);
+  position: relative;
+}
+.spinner.spinner-dual::before {
+  content: "";
+  position: absolute;
+  inset: calc(var(--sp-thick) * -1);   /* sit just outside the host ring */
+  border: var(--sp-thick) solid transparent;
+  border-left-color: var(--sp-color);
+  border-right-color: var(--sp-color);
+  border-radius: 50%;
+  opacity: 0.55;
+  animation: sp-spin-rev var(--sp-dur) var(--sp-ease) infinite;
+}
+
+/* ---------- 3. Dot pulse ---------- */
+/* One wrapper + three <span>s. Each dot scales/fades, staggered. */
+.spinner-dots {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5em;
+  font-size: var(--sp-size);
+  line-height: 0;
+}
+.spinner-dots span {
+  display: block;
+  width: 0.28em;
+  height: 0.28em;
+  border-radius: 50%;
+  background: var(--sp-color);
+  transform-origin: center;
+  animation: sp-dot var(--sp-dur) var(--sp-ease) infinite;
+}
+.spinner-dots span:nth-child(2) { animation-delay: calc(var(--sp-dur) / 3); }
+.spinner-dots span:nth-child(3) { animation-delay: calc(var(--sp-dur) / 3 * 2); }
+
+/* ---------- Size modifiers ---------- */
+.spinner--sm { --sp-size: 1.5rem; }
+.spinner--lg { --sp-size: 3.5rem; }
+.spinner-dots--sm { --sp-size: 1.5rem; }
+.spinner-dots--lg { --sp-size: 3.5rem; }
+
+/* ---------- Keyframes ---------- */
+@keyframes sp-spin {
+  to { transform: rotate(360deg); }
+}
+@keyframes sp-spin-rev {
+  to { transform: rotate(-360deg); }
+}
+@keyframes sp-dot {
+  0%, 100% { transform: scale(0.6); opacity: 0.4; }
+  50%      { transform: scale(1);   opacity: 1; }
+}
+
+/* ---------- Reduced motion ---------- */
+/* Keep a static, legible indicator instead of endless rotation. */
+@media (prefers-reduced-motion: reduce) {
+  .spinner,
+  .spinner.spinner-dual,
+  .spinner.spinner-dual::before,
+  .spinner-dots span {
+    animation: none;
+  }
+  .spinner { border-top-color: var(--sp-color); }
+  .spinner.spinner-dual::before { opacity: 0.4; }
+  .spinner-dots span { transform: scale(0.85); opacity: 0.8; }
+  .spinner-dots span:nth-child(2) { opacity: 1; }
+}


### PR DESCRIPTION
## Summary

Adds a **multi-style loading spinner utility** with three ready-made styles under one consistent class prefix, resolving #62004.

- **`.spinner`** — classic ring: a single element with a transparent border whose top edge is colored; `@keyframes sp-spin` rotates it 360 degrees.
- **`.spinner.spinner-dual`** — dual ring: the *same* single element, with colored top + bottom edges and a `::before` pseudo-element carrying colored left + right edges that counter-rotates (`@keyframes sp-spin-rev`), so two rings visibly cross.
- **`.spinner-dots`** — dot pulse: one wrapper + three `<span>`s; each dot scales and fades via `@keyframes sp-dot`, staggered by a third of the duration.

Built from `border` tricks and a `::before` pseudo-element, avoiding wrapper divs where possible (the ring and dual-ring are each a single element). Each style accepts `--sm` / `--lg` size modifiers and is color-driven entirely by CSS custom properties.

## Files

- `submissions/examples/ease-spinner-sbh/demo.html` — self-contained showcase (open directly in a browser; no server, CDNs, or frameworks). Shows all three styles at multiple sizes and in a realistic loading-row context.
- `submissions/examples/ease-spinner-sbh/style.css` — three spinner styles, size modifiers, keyframes, reduced-motion rules.
- `submissions/examples/ease-spinner-sbh/README.md` — documentation.

## Requirements met

- Pure CSS / HTML (no JS, no external frameworks)
- Three selectable styles under one prefix (`spinner`, `spinner-dual`, `spinner-dots`)
- Built from `border` tricks and `box-shadow`/pseudo-elements, avoiding multiple wrapper divs
- Fully responsive (size modifiers + `clamp()` page type)
- Accessible: each spinner is `role="status"` with `aria-label`; full `prefers-reduced-motion` support freezes spinners into a static, legible state

Closes #62004.