### PR TITLE
feat: add ease-drag-handle sortable grip icon (#62003)

### DIFF
--- a/submissions/examples/ease-drag-handle-sbh/README.md
+++ b/submissions/examples/ease-drag-handle-sbh/README.md
@@ -1,0 +1,50 @@
+# ease-drag-handle
+
+A 6-dot sortable grip icon (2 columns × 3 rows) commonly used as a drag affordance in reorderable lists, with a subtle hover scale and a `grab`/`grabbing` cursor change signaling "this is draggable." Pure CSS dot grid via `box-shadow` — no icon asset needed.
+
+## What does this do?
+
+A single `<span>` renders all six dots: the element itself is the top-left dot, and a `box-shadow` stack stamps out the other five (the second column and the two lower rows). On hover the whole grip scales up (`--dh-scale`) and every dot recolors to the accent; the cursor becomes `grab`, and `grabbing` while active. All gap/dot sizes are `em`-based so the entire icon scales with `font-size`.
+
+## How is it used?
+
+1. Link the stylesheet.
+2. Drop a `.drag-handle` `<span>` (marked `aria-hidden`, since it is decorative — real reorder UX needs a separate accessible control) next to your list item content.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<ul class="sortlist">
+  <li class="list-item">
+    <span class="drag-handle" aria-hidden="true"></span>
+    <span>Task item text</span>
+  </li>
+  <li class="list-item">
+    <span class="drag-handle" aria-hidden="true"></span>
+    <span>Another task</span>
+  </li>
+</ul>
+
+<!-- standalone, with sizes -->
+<span class="drag-handle drag-handle--sm" aria-hidden="true"></span>
+<span class="drag-handle" aria-hidden="true"></span>
+<span class="drag-handle drag-handle--lg" aria-hidden="true"></span>
+```
+
+## Why is this useful?
+
+- **No icon asset** — six dots from one element + a `box-shadow` stack; crisp at any DPI, themeable via custom properties.
+- **Drag affordance** — hover scale + `grab`/`grabbing` cursor immediately communicate "this is movable," pairing naturally with any drag-and-drop library (native or JS-based). EaseMotion supplies purely the visual/hover polish.
+- **Scalar** — gaps and dot sizes are `em`-based, so `font-size` (or the `--sm`/`--lg` modifiers) resizes the whole grip uniformly.
+- **Accessible** — marked `aria-hidden` (decorative); focus-visible styling; full `prefers-reduced-motion` support disables the scale.
+- **Reusable** — configurable via CSS custom properties (`--dh-dot`, `--dh-dot-hover`, `--dh-gap`, `--dh-row-gap`, `--dh-size`, `--dh-scale`, `--dh-dur`, `--dh-ease`).
+
+## Files
+
+- `demo.html` — self-contained showcase (open directly in a browser; no server, CDNs, or frameworks). Shows the grip inside a sortable list and standalone at three sizes.
+- `style.css` — box-shadow dot grid, hover scale/recolor, cursor states, size modifiers, reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-drag-handle-sbh/demo.html
+++ b/submissions/examples/ease-drag-handle-sbh/demo.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-drag-handle — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__head">
+      <p class="page__eyebrow">ease-drag-handle</p>
+      <h1>A sortable grip icon, in pure CSS.</h1>
+      <p class="page__lede">
+        A 6-dot drag affordance (2 columns &times; 3 rows) built from a single
+        <code>&lt;span&gt;</code> and <code>box-shadow</code> — no icon asset. Hover
+        scales it up and flips the cursor to <code>grab</code>.
+      </p>
+    </header>
+
+    <section class="panel">
+      <h2 class="panel__title">Sortable list</h2>
+      <ul class="sortlist" role="list">
+        <li class="list-item">
+          <span class="drag-handle" aria-hidden="true" title="Drag to reorder"></span>
+          <span class="list-item__label">Design the onboarding flow</span>
+          <span class="list-item__meta">High</span>
+        </li>
+        <li class="list-item">
+          <span class="drag-handle" aria-hidden="true" title="Drag to reorder"></span>
+          <span class="list-item__label">Ship analytics dashboard v2</span>
+          <span class="list-item__meta">Medium</span>
+        </li>
+        <li class="list-item">
+          <span class="drag-handle" aria-hidden="true" title="Drag to reorder"></span>
+          <span class="list-item__label">Migrate auth to passkeys</span>
+          <span class="list-item__meta">High</span>
+        </li>
+        <li class="list-item">
+          <span class="drag-handle" aria-hidden="true" title="Drag to reorder"></span>
+          <span class="list-item__label">Write API rate-limit docs</span>
+          <span class="list-item__meta">Low</span>
+        </li>
+        <li class="list-item">
+          <span class="drag-handle" aria-hidden="true" title="Drag to reorder"></span>
+          <span class="list-item__label">Audit color contrast</span>
+          <span class="list-item__meta">Low</span>
+        </li>
+      </ul>
+    </section>
+
+    <section class="panel">
+      <h2 class="panel__title">Standalone handles</h2>
+      <div class="standalone">
+        <span class="drag-handle drag-handle--sm" aria-hidden="true"></span>
+        <span class="drag-handle" aria-hidden="true"></span>
+        <span class="drag-handle drag-handle--lg" aria-hidden="true"></span>
+      </div>
+      <p class="panel__hint">Hover each to see the scale + grab cursor.</p>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-drag-handle-sbh/style.css
+++ b/submissions/examples/ease-drag-handle-sbh/style.css
@@ -1,0 +1,120 @@
+/* ease-drag-handle — a 6-dot sortable grip icon (2 cols × 3 rows).
+   Single <span> + box-shadow draws all six dots; no icon asset.
+   Hover scales the grip and flips the cursor to grab. Pure CSS, no JS. */
+
+:root {
+  --dh-dot: #94a3b8;
+  --dh-dot-hover: #4f46e5;
+  --dh-gap: 0.42em;          /* gap between the two columns */
+  --dh-row-gap: 0.5em;       /* gap between the three rows */
+  --dh-size: 0.18em;         /* dot radius base */
+  --dh-scale: 1.18;          /* hover scale */
+  --dh-dur: 0.18s;
+  --dh-ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* ---------- Page (demo only) ---------- */
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  color: #0f172a;
+  background:
+    radial-gradient(1000px 560px at 85% -8%, #eef2ff, transparent 60%),
+    radial-gradient(760px 460px at 0% 0%, #faf5ff, transparent 55%),
+    #fff;
+  line-height: 1.6;
+}
+.page { max-width: 44rem; margin: 0 auto; padding: clamp(2rem, 6vw, 4rem) clamp(1rem, 4vw, 2rem); }
+.page__eyebrow {
+  margin: 0 0 0.5rem; text-transform: uppercase; letter-spacing: 0.18em;
+  font-size: 0.78rem; font-weight: 700; color: var(--dh-dot-hover);
+}
+.page__head h1 { margin: 0 0 0.8rem; font-size: clamp(1.6rem, 4.5vw, 2.4rem); letter-spacing: -0.02em; }
+.page__lede { margin: 0 0 2rem; color: #64748b; max-width: 38rem; }
+.page__lede code { background: rgba(79,70,229,0.12); color: var(--dh-dot-hover); padding: 0.12rem 0.4rem; border-radius: 0.4rem; font-size: 0.9em; }
+
+.panel {
+  background: rgba(255,255,255,0.7);
+  border: 1px solid rgba(15,23,42,0.06);
+  border-radius: 1rem;
+  padding: clamp(1.2rem, 3vw, 1.8rem);
+  margin-bottom: 1.4rem;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+.panel__title { margin: 0 0 1rem; font-size: 1.1rem; letter-spacing: -0.01em; }
+.panel__hint { margin: 1rem 0 0; color: #94a3b8; font-size: 0.85rem; }
+
+.sortlist { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.5rem; }
+.list-item {
+  display: flex; align-items: center; gap: 0.9rem;
+  padding: 0.75rem 1rem;
+  background: #fff;
+  border: 1px solid rgba(15,23,42,0.06);
+  border-radius: 0.7rem;
+  transition: box-shadow var(--dh-dur) var(--dh-ease), border-color var(--dh-dur) var(--dh-ease);
+}
+.list-item:hover { border-color: rgba(79,70,229,0.3); box-shadow: 0 8px 20px -14px rgba(15,23,42,0.25); }
+.list-item__label { flex: 1; font-weight: 600; }
+.list-item__meta {
+  font-size: 0.72rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em;
+  padding: 0.2rem 0.5rem; border-radius: 0.5rem; color: #64748b; background: #f1f5f9;
+}
+
+.standalone { display: flex; align-items: center; gap: 2rem; padding: 0.5rem 0; }
+.standalone .drag-handle { font-size: 2.5rem; }
+
+/* ---------- The drag handle ---------- */
+/* A single element whose box-shadow stamps out the other 5 dots.
+   Layout (relative to the element box, font-size driven):
+     col1: rows 1,2,3   col2: rows 1,2,3
+   The element itself is the top-left dot; box-shadow paints the rest. */
+.drag-handle {
+  position: relative;
+  display: inline-block;
+  width: var(--dh-size);
+  height: var(--dh-size);
+  font-size: 1rem;             /* scales all em-based gaps/sizes */
+  border-radius: 50%;
+  background: var(--dh-dot);
+  cursor: grab;
+  vertical-align: middle;
+  /* order: x-offset(col2), y-offset(row2 col1), row2 col2, row3 col1, row3 col2 */
+  box-shadow:
+    calc(var(--dh-gap)) 0 0 var(--dh-dot),                          /* row1 col2 */
+    0 calc(var(--dh-row-gap)) 0 var(--dh-dot),                      /* row2 col1 */
+    calc(var(--dh-gap)) calc(var(--dh-row-gap)) 0 var(--dh-dot),    /* row2 col2 */
+    0 calc(var(--dh-row-gap) * 2) 0 var(--dh-dot),                  /* row3 col1 */
+    calc(var(--dh-gap)) calc(var(--dh-row-gap) * 2) 0 var(--dh-dot);/* row3 col2 */
+  transform-origin: center;
+  transition: transform var(--dh-dur) var(--dh-ease), background-color var(--dh-dur) var(--dh-ease);
+}
+
+/* On hover, recolor every dot + scale up. box-shadow color must be
+   re-stated because shadows don't inherit color from the element. */
+.drag-handle:hover,
+.drag-handle:focus-visible {
+  outline: none;
+  background: var(--dh-dot-hover);
+  transform: scale(var(--dh-scale));
+  box-shadow:
+    calc(var(--dh-gap)) 0 0 var(--dh-dot-hover),
+    0 calc(var(--dh-row-gap)) 0 var(--dh-dot-hover),
+    calc(var(--dh-gap)) calc(var(--dh-row-gap)) 0 var(--dh-dot-hover),
+    0 calc(var(--dh-row-gap) * 2) 0 var(--dh-dot-hover),
+    calc(var(--dh-gap)) calc(var(--dh-row-gap) * 2) 0 var(--dh-dot-hover);
+}
+.drag-handle:active { cursor: grabbing; transform: scale(calc(var(--dh-scale) * 0.96)); }
+
+/* Size modifiers (font-size scales the whole grip) */
+.drag-handle--sm { font-size: 0.8rem; }
+.drag-handle--lg { font-size: 1.3rem; }
+
+/* ---------- Reduced motion ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .drag-handle,
+  .list-item { transition: none; }
+  .drag-handle:hover,
+  .drag-handle:active { transform: none; }
+}


### PR DESCRIPTION
## Summary

Adds a **6-dot sortable grip icon** (2 columns x 3 rows) commonly used as a drag affordance in reorderable lists, with a subtle hover scale and a `grab`/`grabbing` cursor change, resolving #62003.

A single `<span>` renders all six dots: the element itself is the top-left dot, and a `box-shadow` stack stamps out the other five (the second column and the two lower rows). On hover the whole grip scales up and every dot recolors to the accent; the cursor becomes `grab`, and `grabbing` while active. All gap/dot sizes are `em`-based so the entire icon scales with `font-size`.

## Files

- `submissions/examples/ease-drag-handle-sbh/demo.html` — self-contained showcase (open directly in a browser; no server, CDNs, or frameworks). Shows the grip inside a sortable list and standalone at three sizes.
- `submissions/examples/ease-drag-handle-sbh/style.css` — box-shadow dot grid, hover scale/recolor, cursor states, size modifiers, reduced-motion rules.
- `submissions/examples/ease-drag-handle-sbh/README.md` — documentation.

## Requirements met

- Pure CSS dot grid via `box-shadow` (no icon asset)
- Subtle hover scale + `grab`/`grabbing` cursor change signaling draggable
- Fully responsive (em-based sizes + `--sm`/`--lg` modifiers)
- Accessible: `aria-hidden` decorative grip, `focus-visible` styling, full `prefers-reduced-motion` support
- Configurable via CSS custom properties

Closes #62003.