### PR TITLE
feat: add ease-checkbox draw-in checkmark (#62001)

### DIFF
--- a/submissions/examples/ease-checkbox-sbh/README.md
+++ b/submissions/examples/ease-checkbox-sbh/README.md
@@ -1,0 +1,51 @@
+# ease-checkbox
+
+A custom-styled checkbox where, on check, an SVG checkmark path animates in via `stroke-dashoffset` (a "drawing" effect) instead of just appearing instantly, alongside a background color transition.
+
+## What does this do?
+
+- Visually hides the native `<input type="checkbox">` (sr-only pattern) but keeps it interactive and focusable — so keyboard support, form submission, and `:checked` all still work natively.
+- Renders a styled `.checkbox-box` that holds an inline SVG path.
+- On `:checked`, the box background transitions to the accent color **and** the path's `stroke-dashoffset` animates from its full length to `0`, so the checkmark appears to be *drawn* rather than popped in.
+- Uses the classic stroke-dash draw technique: `stroke-dasharray` equals the path length (~24 units for `M4 12l6 6L20 6`); `stroke-dashoffset` starts at that length (invisible) and animates to `0` (fully drawn) on check.
+
+## How is it used?
+
+1. Link the stylesheet.
+2. Use the markup below — the `<input>` must immediately precede the `.checkbox-box` (the `:checked + .checkbox-box` selector drives the visuals).
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<label class="checkbox">
+  <input type="checkbox">
+  <span class="checkbox-box">
+    <svg class="checkbox-check" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path class="checkbox-path" d="M4 12l6 6L20 6" fill="none" stroke="white"
+            stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    </svg>
+  </span>
+  Accept terms
+</label>
+
+<!-- sizes -->
+<label class="checkbox checkbox--sm"> … </label>
+<label class="checkbox checkbox--lg"> … </label>
+```
+
+## Why is this useful?
+
+- **Polished interaction** — native checkboxes can't be styled consistently across browsers, and most redesigns just fade a checkmark in. The stroke-draw technique is more delightful while still being just CSS + a static inline SVG (no JS drawing library).
+- **Native semantics preserved** — keyboard, focus, form submission, and `:disabled` all work because the real `<input>` stays in the DOM and focusable.
+- **Accessible** — the SVG is `aria-hidden`/`focusable="false"`; the label text is the accessible name; visible focus ring driven by `:focus-visible`; full `prefers-reduced-motion` support disables the draw animation.
+- **Reusable** — configurable via CSS custom properties (`--cb-accent`, `--cb-size`, `--cb-radius`, `--cb-dur`, `--cb-draw-dur`, etc.).
+
+## Files
+
+- `demo.html` — self-contained showcase (open directly in a browser; no server, CDNs, or frameworks). Shows basic, sized, and disabled states.
+- `style.css` — visually-hidden input, styled box, `stroke-dashoffset` draw animation, checked/disabled/focus states, size modifiers, reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-checkbox-sbh/demo.html
+++ b/submissions/examples/ease-checkbox-sbh/demo.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-checkbox — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__head">
+      <p class="page__eyebrow">ease-checkbox</p>
+      <h1>A checkbox that draws its checkmark.</h1>
+      <p class="page__lede">
+        A custom checkbox where, on check, an inline-SVG checkmark path animates
+        in via <code>stroke-dashoffset</code> — a "drawing" effect — alongside a
+        background color transition. Pure CSS + a static inline SVG, no JS.
+      </p>
+    </header>
+
+    <section class="panel">
+      <h2 class="panel__title">Basic</h2>
+      <div class="checks">
+        <label class="checkbox">
+          <input type="checkbox" checked />
+          <span class="checkbox-box">
+            <svg class="checkbox-check" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path class="checkbox-path" d="M4 12l6 6L20 6" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </span>
+          <span class="checkbox-label">Accept terms and conditions</span>
+        </label>
+
+        <label class="checkbox">
+          <input type="checkbox" />
+          <span class="checkbox-box">
+            <svg class="checkbox-check" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path class="checkbox-path" d="M4 12l6 6L20 6" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </span>
+          <span class="checkbox-label">Send me product updates</span>
+        </label>
+
+        <label class="checkbox">
+          <input type="checkbox" />
+          <span class="checkbox-box">
+            <svg class="checkbox-check" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path class="checkbox-path" d="M4 12l6 6L20 6" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </span>
+          <span class="checkbox-label">Enable two-factor authentication</span>
+        </label>
+      </div>
+    </section>
+
+    <section class="panel">
+      <h2 class="panel__title">Sizes</h2>
+      <div class="checks checks--sizes">
+        <label class="checkbox checkbox--sm">
+          <input type="checkbox" checked />
+          <span class="checkbox-box">
+            <svg class="checkbox-check" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path class="checkbox-path" d="M4 12l6 6L20 6" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </span>
+          <span class="checkbox-label">Small</span>
+        </label>
+        <label class="checkbox">
+          <input type="checkbox" checked />
+          <span class="checkbox-box">
+            <svg class="checkbox-check" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path class="checkbox-path" d="M4 12l6 6L20 6" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </span>
+          <span class="checkbox-label">Default</span>
+        </label>
+        <label class="checkbox checkbox--lg">
+          <input type="checkbox" checked />
+          <span class="checkbox-box">
+            <svg class="checkbox-check" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path class="checkbox-path" d="M4 12l6 6L20 6" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </span>
+          <span class="checkbox-label">Large</span>
+        </label>
+      </div>
+    </section>
+
+    <section class="panel">
+      <h2 class="panel__title">Disabled</h2>
+      <div class="checks">
+        <label class="checkbox">
+          <input type="checkbox" checked disabled />
+          <span class="checkbox-box">
+            <svg class="checkbox-check" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path class="checkbox-path" d="M4 12l6 6L20 6" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </span>
+          <span class="checkbox-label">Checked &amp; disabled</span>
+        </label>
+        <label class="checkbox">
+          <input type="checkbox" disabled />
+          <span class="checkbox-box">
+            <svg class="checkbox-check" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path class="checkbox-path" d="M4 12l6 6L20 6" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </span>
+          <span class="checkbox-label">Disabled</span>
+        </label>
+      </div>
+    </section>
+
+    <p class="footnote">Toggle any checkbox to see the checkmark draw in.</p>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-checkbox-sbh/style.css
+++ b/submissions/examples/ease-checkbox-sbh/style.css
@@ -1,0 +1,148 @@
+/* ease-checkbox — custom checkbox with a draw-in checkmark.
+   The native <input type="checkbox"> is visually hidden but kept focusable.
+   A styled .checkbox-box holds an inline SVG path; on :checked the path's
+   stroke-dashoffset animates from full length to 0 — a "drawing" effect —
+   while the box background transitions to the accent color. Pure CSS, no JS. */
+
+:root {
+  --cb-size: 1.4rem;
+  --cb-radius: 0.4rem;
+  --cb-border: 0.13rem;
+  --cb-border-color: #cbd5e1;
+  --cb-border-hover: #94a3b8;
+  --cb-accent: #4f46e5;
+  --cb-accent-soft: rgba(79, 70, 229, 0.12);
+  --cb-check: #ffffff;
+  --cb-dur: 0.32s;
+  --cb-ease: cubic-bezier(0.65, 0, 0.35, 1);
+  --cb-draw-dur: 0.4s;
+  --cb-draw-ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* ---------- Page (demo only) ---------- */
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  color: #0f172a;
+  background:
+    radial-gradient(1000px 560px at 85% -8%, #eef2ff, transparent 60%),
+    radial-gradient(760px 460px at 0% 0%, #faf5ff, transparent 55%),
+    #fff;
+  line-height: 1.6;
+}
+.page { max-width: 44rem; margin: 0 auto; padding: clamp(2rem, 6vw, 4rem) clamp(1rem, 4vw, 2rem); }
+.page__eyebrow {
+  margin: 0 0 0.5rem; text-transform: uppercase; letter-spacing: 0.18em;
+  font-size: 0.78rem; font-weight: 700; color: var(--cb-accent);
+}
+.page__head h1 { margin: 0 0 0.8rem; font-size: clamp(1.6rem, 4.5vw, 2.4rem); letter-spacing: -0.02em; }
+.page__lede { margin: 0 0 2rem; color: #64748b; max-width: 38rem; }
+.page__lede code { background: var(--cb-accent-soft); color: var(--cb-accent); padding: 0.12rem 0.4rem; border-radius: 0.4rem; font-size: 0.9em; }
+
+.panel {
+  background: rgba(255,255,255,0.7);
+  border: 1px solid rgba(15,23,42,0.06);
+  border-radius: 1rem;
+  padding: clamp(1.2rem, 3vw, 1.8rem);
+  margin-bottom: 1.4rem;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+.panel__title { margin: 0 0 1rem; font-size: 1.1rem; letter-spacing: -0.01em; }
+.checks { display: flex; flex-direction: column; gap: 0.9rem; }
+.checks--sizes { flex-direction: row; align-items: center; gap: 1.6rem; flex-wrap: wrap; }
+.footnote { color: #94a3b8; font-size: 0.85rem; margin: 0; }
+
+/* ---------- The checkbox ---------- */
+.checkbox {
+  display: inline-flex; align-items: center; gap: 0.7rem;
+  cursor: pointer;
+  user-select: none;
+}
+
+/* Visually hide the native input, keep it interactive + focusable.
+   sr-only pattern kept compact so keyboard focus still reaches it. */
+.checkbox input {
+  position: absolute;
+  width: 1px; height: 1px;
+  margin: 0; padding: 0;
+  overflow: hidden; clip: rect(0 0 0 0);
+  white-space: nowrap; border: 0;
+}
+
+/* The custom box */
+.checkbox-box {
+  position: relative;
+  display: inline-grid;
+  place-items: center;
+  width: var(--cb-size);
+  height: var(--cb-size);
+  flex: 0 0 auto;
+  border: var(--cb-border) solid var(--cb-border-color);
+  border-radius: var(--cb-radius);
+  background: #fff;
+  transition:
+    background-color var(--cb-dur) var(--cb-ease),
+    border-color var(--cb-dur) var(--cb-ease),
+    box-shadow var(--cb-dur) var(--cb-ease);
+}
+.checkbox:hover .checkbox-box { border-color: var(--cb-border-hover); }
+
+/* Focus ring driven by the real input */
+.checkbox input:focus-visible + .checkbox-box {
+  outline: none;
+  border-color: var(--cb-accent);
+  box-shadow: 0 0 0 0.25rem var(--cb-accent-soft);
+}
+
+/* The SVG fills the box and scales the path with it */
+.checkbox-check {
+  width: 75%;
+  height: 75%;
+  overflow: visible;
+}
+
+/* stroke-dash draw technique:
+   dash length = path length; offset starts at full length (invisible),
+   animates to 0 (fully drawn) when checked. The path length for
+   "M4 12l6 6L20 6" is ~22.6 units; we round up to 24 for safety. */
+.checkbox-path {
+  stroke: var(--cb-check);
+  stroke-dasharray: 24;
+  stroke-dashoffset: 24;
+  transition: stroke-dashoffset var(--cb-draw-dur) var(--cb-draw-ease);
+}
+
+/* Checked state: fill the box, draw the checkmark */
+.checkbox input:checked + .checkbox-box {
+  background: var(--cb-accent);
+  border-color: var(--cb-accent);
+}
+.checkbox input:checked + .checkbox-box .checkbox-path {
+  stroke-dashoffset: 0;
+}
+
+/* Disabled state */
+.checkbox input:disabled + .checkbox-box {
+  background: #f1f5f9;
+  border-color: #e2e8f0;
+  cursor: not-allowed;
+}
+.checkbox input:disabled:checked + .checkbox-box {
+  background: #cbd5e1;
+  border-color: #cbd5e1;
+}
+.checkbox input:disabled ~ .checkbox-label { color: #94a3b8; }
+
+.checkbox-label { font-weight: 500; }
+
+/* Size modifiers */
+.checkbox--sm { --cb-size: 1.1rem; --cb-radius: 0.32rem; }
+.checkbox--lg { --cb-size: 1.8rem; --cb-radius: 0.5rem; }
+
+/* ---------- Reduced motion ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .checkbox-box,
+  .checkbox-path { transition: none; }
+}


### PR DESCRIPTION
## Summary

Adds a **custom checkbox with a draw-in checkmark** that animates in via `stroke-dashoffset` (a drawing effect) instead of appearing instantly, alongside a background color transition, resolving #62001.

The native `<input type="checkbox">` is visually hidden (sr-only) but kept interactive and focusable, so keyboard support, form submission, and `:checked` all still work natively. A styled `.checkbox-box` holds an inline SVG path; on `:checked`, the box background transitions to the accent color and the path's `stroke-dashoffset` animates from its full length to `0`, so the checkmark appears to be drawn.

## Files

- `submissions/examples/ease-checkbox-sbh/demo.html` — self-contained showcase (open directly in a browser; no server, CDNs, or frameworks). Basic, sized, and disabled states.
- `submissions/examples/ease-checkbox-sbh/style.css` — visually-hidden input, styled box, `stroke-dashoffset` draw animation, checked/disabled/focus states, size modifiers, reduced-motion rules.
- `submissions/examples/ease-checkbox-sbh/README.md` — documentation.

## Requirements met

- Custom-styled checkbox with SVG checkmark path animating via `stroke-dashoffset` (draw-in effect)
- Background color transition on check
- Pure CSS + a static inline SVG (no JS drawing library)
- Native semantics preserved (keyboard, focus, form submission, `:disabled`)
- Accessible: SVG `aria-hidden`/`focusable="false"`, visible focus ring, full `prefers-reduced-motion` support
- Configurable via CSS custom properties

Closes #62001.