### PR TITLE
feat: add ease-accordion collapse panel (#61994)

### DIFF
--- a/submissions/examples/ease-accordion-sbh/README.md
+++ b/submissions/examples/ease-accordion-sbh/README.md
@@ -1,0 +1,50 @@
+# ease-accordion
+
+An expandable/collapsible content panel built on the native `<details>`/`<summary>` HTML elements, enhanced with a smooth height animation (via the CSS `grid-template-rows: 0fr → 1fr` trick) and a rotating chevron icon — since `<details>` alone snaps open/closed with no animation.
+
+## What does this do?
+
+- Uses native `<details>`/`<summary>`, so toggle logic, keyboard support (Enter/Space to toggle, Tab to traverse), and screen-reader expanded/collapsed announcements come for free — **no JavaScript**.
+- Removes the default disclosure triangle (`::-webkit-details-marker` + `list-style`) and replaces it with a CSS-drawn chevron (two borders forming a rotated corner) that rotates 90° on open.
+- Animates the panel height smoothly using the modern `grid-template-rows: 0fr → 1fr` technique: the content wrapper is a single-row grid whose track interpolates, so the panel slides open to its **natural auto height** — something `height: auto` can't animate directly.
+
+## How is it used?
+
+1. Link the stylesheet.
+2. Use the markup below. The structure matters: `.accordion__panel` (the grid row) must wrap `.accordion__inner` (the content), so the `0fr→1fr` track can collapse/expand.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<details class="accordion__item" open>
+  <summary class="accordion__trigger">
+    <span class="accordion__title">What is EaseMotion CSS?</span>
+    <span class="accordion__icon" aria-hidden="true"></span>
+  </summary>
+  <div class="accordion__panel">
+    <div class="accordion__inner">
+      <p>A lightweight, animation-first CSS component library.</p>
+    </div>
+  </div>
+</details>
+```
+
+Multiple `.accordion__item` elements inside a `.accordion` wrapper get spacing and grouping. Nest `.accordion.accordion--nested` inside `.accordion__inner` for sub-panels.
+
+## Why is this useful?
+
+- **Accessible by default** — `<details>`/`<summary>` are semantic and keyboard-operable; the chevron is `aria-hidden` (decorative). No ARIA wiring or JS toggle to forget.
+- **Real auto-height animation** — the `grid-template-rows: 0fr → 1fr` trick solves the classic "can't animate to `height: auto`" problem elegantly, with a single transition.
+- **No JS at all** — independent `<details>` each manage their own state, so any number of panels can be open at once.
+- **Reusable** — configurable via CSS custom properties (`--ac-radius`, `--ac-pad`, `--ac-accent`, `--ac-dur`, `--ac-icon-size`, etc.).
+- **Reduced motion** — full `prefers-reduced-motion` support disables the slide/rotation.
+
+## Files
+
+- `demo.html` — self-contained showcase (open directly in a browser; no server, CDNs, or frameworks). An FAQ group plus a nested accordion.
+- `style.css` — `<details>`/`<summary>` reset, CSS chevron, `grid-template-rows` height animation, hover/focus/open states, nested styling, reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-accordion-sbh/demo.html
+++ b/submissions/examples/ease-accordion-sbh/demo.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-accordion — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__head">
+      <p class="page__eyebrow">ease-accordion</p>
+      <h1>An accordion that animates to auto height.</h1>
+      <p class="page__lede">
+        Expandable panels on native <code>&lt;details&gt;</code>/<code>&lt;summary&gt;</code>,
+        enhanced with a smooth height animation via the CSS
+        <code>grid-template-rows: 0fr &rarr; 1fr</code> trick and a rotating chevron —
+        since <code>&lt;details&gt;</code> alone snaps open/closed. No JS.
+      </p>
+    </header>
+
+    <section class="panel">
+      <h2 class="panel__title">FAQ</h2>
+      <div class="accordion" role="list">
+        <details class="accordion__item" open>
+          <summary class="accordion__trigger">
+            <span class="accordion__title">What is EaseMotion CSS?</span>
+            <span class="accordion__icon" aria-hidden="true"></span>
+          </summary>
+          <div class="accordion__panel">
+            <div class="accordion__inner">
+              <p>A lightweight, animation-first CSS component library. It ships small, composable utility classes for the interactions designers rebuild on every project — spinners, sticky headers, accordions, and more — without pulling in a full framework.</p>
+            </div>
+          </div>
+        </details>
+
+        <details class="accordion__item">
+          <summary class="accordion__trigger">
+            <span class="accordion__title">Do I need JavaScript?</span>
+            <span class="accordion__icon" aria-hidden="true"></span>
+          </summary>
+          <div class="accordion__panel">
+            <div class="accordion__inner">
+              <p>No. This accordion leans on the native <code>&lt;details&gt;</code> element for open/close state, so toggle logic, keyboard support, and screen-reader semantics come for free. The only JavaScript anywhere in EaseMotion is the occasional single-boolean scroll listener.</p>
+            </div>
+          </div>
+        </details>
+
+        <details class="accordion__item">
+          <summary class="accordion__trigger">
+            <span class="accordion__title">How does the height animation work?</span>
+            <span class="accordion__icon" aria-hidden="true"></span>
+          </summary>
+          <div class="accordion__panel">
+            <div class="accordion__inner">
+              <p>CSS can't animate <code>height: auto</code> directly. The classic workaround is to wrap the content in a grid container and animate <code>grid-template-rows</code> from <code>0fr</code> to <code>1fr</code>. The browser interpolates the row track, so the panel slides open smoothly to whatever its natural height is.</p>
+            </div>
+          </div>
+        </details>
+
+        <details class="accordion__item">
+          <summary class="accordion__trigger">
+            <span class="accordion__title">Is it accessible?</span>
+            <span class="accordion__icon" aria-hidden="true"></span>
+          </summary>
+          <div class="accordion__panel">
+            <div class="accordion__inner">
+              <p>Yes. Because it's built on <code>&lt;details&gt;</code>/<code>&lt;summary&gt;</code>, the panel is operable with the keyboard (Enter/Space to toggle, Tab to move), and assistive tech announces the expanded/collapsed state automatically. The chevron is decorative and hidden from screen readers.</p>
+            </div>
+          </div>
+        </details>
+
+        <details class="accordion__item">
+          <summary class="accordion__trigger">
+            <span class="accordion__title">Can multiple panels stay open at once?</span>
+            <span class="accordion__icon" aria-hidden="true"></span>
+          </summary>
+          <div class="accordion__panel">
+            <div class="accordion__inner">
+              <p>Yes. Unlike a classic accordion built with JS, independent <code>&lt;details&gt;</code> elements each manage their own state, so any number can be open simultaneously. If you want single-open behavior, that's the one place you'd add a tiny script — or leave it out and let users compare answers.</p>
+            </div>
+          </div>
+        </details>
+      </div>
+    </section>
+
+    <section class="panel">
+      <h2 class="panel__title">Nested</h2>
+      <div class="accordion" role="list">
+        <details class="accordion__item">
+          <summary class="accordion__trigger">
+            <span class="accordion__title">Account &amp; billing</span>
+            <span class="accordion__icon" aria-hidden="true"></span>
+          </summary>
+          <div class="accordion__panel">
+            <div class="accordion__inner">
+              <div class="accordion accordion--nested" role="list">
+                <details class="accordion__item">
+                  <summary class="accordion__trigger">
+                    <span class="accordion__title">How do I change my plan?</span>
+                    <span class="accordion__icon" aria-hidden="true"></span>
+                  </summary>
+                  <div class="accordion__panel">
+                    <div class="accordion__inner">
+                      <p>Open Settings &rarr; Billing &rarr; Plan and pick a new tier. Changes prorate immediately.</p>
+                    </div>
+                  </div>
+                </details>
+                <details class="accordion__item">
+                  <summary class="accordion__trigger">
+                    <span class="accordion__title">Where are my invoices?</span>
+                    <span class="accordion__icon" aria-hidden="true"></span>
+                  </summary>
+                  <div class="accordion__panel">
+                    <div class="accordion__inner">
+                      <p>Invoices are emailed monthly and archived under Billing &rarr; Invoices.</p>
+                    </div>
+                  </div>
+                </details>
+              </div>
+            </div>
+          </div>
+        </details>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-accordion-sbh/style.css
+++ b/submissions/examples/ease-accordion-sbh/style.css
@@ -1,0 +1,144 @@
+/* ease-accordion — expandable panels on native <details>/<summary>.
+   <details> alone snaps open/closed. We animate height via the
+   grid-template-rows 0fr -> 1fr trick and rotate a chevron on open.
+   No JS: toggle/keyboard/semantics all come from <details>. */
+
+:root {
+  --ac-radius: 0.7rem;
+  --ac-gap: 0.5rem;
+  --ac-pad: 1rem 1.15rem;
+  --ac-trigger-pad: 0.95rem 1.15rem;
+  --ac-bg: #ffffff;
+  --ac-bg-hover: #f8fafc;
+  --ac-border: rgba(15, 23, 42, 0.08);
+  --ac-text: #0f172a;
+  --ac-muted: #64748b;
+  --ac-accent: #4f46e5;
+  --ac-accent-soft: rgba(79, 70, 229, 0.1);
+  --ac-dur: 0.32s;
+  --ac-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --ac-icon-size: 0.9rem;
+  --ac-icon-thick: 0.14rem;
+}
+
+/* ---------- Page (demo only) ---------- */
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  color: var(--ac-text);
+  background:
+    radial-gradient(1000px 560px at 85% -8%, #eef2ff, transparent 60%),
+    radial-gradient(760px 460px at 0% 0%, #faf5ff, transparent 55%),
+    #fff;
+  line-height: 1.6;
+}
+.page { max-width: 46rem; margin: 0 auto; padding: clamp(2rem, 6vw, 4rem) clamp(1rem, 4vw, 2rem); }
+.page__eyebrow {
+  margin: 0 0 0.5rem; text-transform: uppercase; letter-spacing: 0.18em;
+  font-size: 0.78rem; font-weight: 700; color: var(--ac-accent);
+}
+.page__head h1 { margin: 0 0 0.8rem; font-size: clamp(1.6rem, 4.5vw, 2.4rem); letter-spacing: -0.02em; }
+.page__lede { margin: 0 0 2rem; color: var(--ac-muted); max-width: 40rem; }
+.page__lede code { background: var(--ac-accent-soft); color: var(--ac-accent); padding: 0.12rem 0.4rem; border-radius: 0.4rem; font-size: 0.9em; }
+
+.panel {
+  background: rgba(255,255,255,0.7);
+  border: 1px solid rgba(15,23,42,0.06);
+  border-radius: 1rem;
+  padding: clamp(1.2rem, 3vw, 1.8rem);
+  margin-bottom: 1.4rem;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+.panel__title { margin: 0 0 1rem; font-size: 1.1rem; letter-spacing: -0.01em; }
+
+/* ---------- The accordion ---------- */
+.accordion { display: flex; flex-direction: column; gap: var(--ac-gap); }
+
+.accordion__item {
+  background: var(--ac-bg);
+  border: 1px solid var(--ac-border);
+  border-radius: var(--ac-radius);
+  overflow: hidden;            /* clip the sliding panel + rotating icon */
+  transition: border-color var(--ac-dur) var(--ac-ease), box-shadow var(--ac-dur) var(--ac-ease);
+}
+.accordion__item[open] {
+  border-color: rgba(79, 70, 229, 0.25);
+  box-shadow: 0 10px 24px -18px rgba(15,23,42,0.3);
+}
+
+/* Reset the default disclosure marker so our chevron is the only one */
+.accordion__trigger {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 1rem;
+  padding: var(--ac-trigger-pad);
+  cursor: pointer;
+  list-style: none;                 /* remove the default triangle (some browsers) */
+  user-select: none;
+  transition: background-color var(--ac-dur) var(--ac-ease);
+}
+.accordion__trigger::-webkit-details-marker { display: none; } /* remove the default triangle (WebKit) */
+.accordion__trigger:hover { background: var(--ac-bg-hover); }
+.accordion__trigger:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 0.15rem var(--ac-accent);
+}
+
+.accordion__title { font-weight: 600; font-size: 0.98rem; }
+
+/* Chevron drawn from two borders (a rotated square corner), no icon asset.
+   Rotates 90deg when the item is open. */
+.accordion__icon {
+  position: relative;
+  flex: 0 0 auto;
+  width: var(--ac-icon-size);
+  height: var(--ac-icon-size);
+  border-right: var(--ac-icon-thick) solid var(--ac-muted);
+  border-bottom: var(--ac-icon-thick) solid var(--ac-muted);
+  transform: rotate(45deg) translate(-0.12em, 0.12em);   /* point down-right (chevron down) */
+  transform-origin: center;
+  transition: transform var(--ac-dur) var(--ac-ease), border-color var(--ac-dur) var(--ac-ease);
+}
+.accordion__item[open] .accordion__icon {
+  transform: rotate(-135deg) translate(-0.12em, 0.12em);   /* point up-right (chevron up) */
+  border-color: var(--ac-accent);
+}
+
+/* The height-animation trick:
+   .accordion__panel is a 1-row grid whose track animates 0fr -> 1fr.
+   Its child .accordion__inner holds the actual content (min-height: 0
+   lets the row shrink). overflow hidden clips content while collapsed. */
+.accordion__panel {
+  display: grid;
+  grid-template-rows: 0fr;          /* collapsed by default */
+  transition: grid-template-rows var(--ac-dur) var(--ac-ease);
+}
+.accordion__item[open] .accordion__panel {
+  grid-template-rows: 1fr;          /* expand to content's natural height */
+}
+.accordion__inner {
+  overflow: hidden;
+  min-height: 0;                    /* permit the row to collapse below content */
+}
+.accordion__inner > :first-child { padding-top: 0; }
+.accordion__inner > :last-child { padding-bottom: 0; }
+.accordion__panel .accordion__inner {
+  padding: var(--ac-pad);
+  color: var(--ac-muted);
+}
+.accordion__panel .accordion__inner p { margin: 0 0 0.6rem; }
+.accordion__panel .accordion__inner p:last-child { margin-bottom: 0; }
+.accordion__panel .accordion__inner code { background: var(--ac-accent-soft); color: var(--ac-accent); padding: 0.1rem 0.35rem; border-radius: 0.35rem; font-size: 0.9em; }
+
+/* Nested accordions sit inside .accordion__inner without double padding */
+.accordion--nested { margin: 0; }
+.accordion--nested .accordion__item { background: #f8fafc; border-color: rgba(15,23,42,0.06); }
+
+/* ---------- Reduced motion ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .accordion__item,
+  .accordion__trigger,
+  .accordion__icon,
+  .accordion__panel { transition: none; }
+}


### PR DESCRIPTION
## Summary

Adds an **expandable/collapsible content panel built on native `<details>`/`<summary>`**, enhanced with a smooth height animation via the CSS `grid-template-rows: 0fr -> 1fr` trick and a rotating chevron icon, resolving #61994.

Since `<details>` alone snaps open/closed with no animation, the content wrapper is a single-row grid whose track interpolates from `0fr` to `1fr`, so the panel slides open to its natural auto height. The default disclosure triangle is removed and replaced with a CSS-drawn chevron (two borders forming a rotated corner) that rotates 90deg on open.

## Files

- `submissions/examples/ease-accordion-sbh/demo.html` — self-contained showcase (open directly in a browser; no server, CDNs, or frameworks). An FAQ group plus a nested accordion.
- `submissions/examples/ease-accordion-sbh/style.css` — `<details>`/`<summary>` reset, CSS chevron, `grid-template-rows` height animation, hover/focus/open states, nested styling, reduced-motion rules.
- `submissions/examples/ease-accordion-sbh/README.md` — documentation.

## Requirements met

- Built on native `<details>`/`<summary>` (toggle, keyboard, screen-reader semantics for free, no JS)
- Smooth height animation via `grid-template-rows: 0fr -> 1fr` (animates to auto height)
- Rotating chevron icon (CSS-drawn, no icon asset)
- Accessible: native semantics, decorative `aria-hidden` chevron, visible focus, full `prefers-reduced-motion` support
- Configurable via CSS custom properties

Closes #61994.