### PR TITLE
feat: add ease-tooltip with CSS arrow (#61985)

### DIFF
--- a/submissions/examples/ease-tooltip-sbh/README.md
+++ b/submissions/examples/ease-tooltip-sbh/README.md
@@ -1,0 +1,43 @@
+# ease-tooltip
+
+A hover-triggered tooltip with a small CSS-triangle arrow pointing at its trigger element, fading and sliding in on hover. Positioned via a `data-tooltip` attribute — no extra wrapper markup for the text.
+
+## What does this do?
+
+- Reads the tooltip text from the `data-tooltip` attribute and renders it via `::before { content: attr(data-tooltip) }`, so the trigger element stays clean — no wrapper `<span>` for the label.
+- Draws the arrow with `::after` as a pure CSS triangle (zero-width element with colored borders), colored to match the bubble exactly so the join looks seamless.
+- Supports four placements — `--top`, `--bottom`, `--left`, `--right` — each sliding in from its own side.
+- Shows on `:hover` **and** `:focus-visible`, so keyboard users get the tooltip too.
+
+## How is it used?
+
+1. Link the stylesheet.
+2. Add the `tooltip` class, a `data-tooltip` attribute, and a placement modifier to any element.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<button class="tooltip tooltip--top" data-tooltip="Saves your changes">Save</button>
+
+<!-- works on inline links and icon buttons too -->
+<a class="tooltip tooltip--bottom" data-tooltip="Web Content Accessibility Guidelines" href="#">WCAG</a>
+```
+
+## Why is this useful?
+
+- **Attribute-driven, zero wrapper markup** — the label lives in `data-tooltip`; no extra `<span>` cluttering the DOM.
+- **Correct arrow** — the CSS-triangle arrow's color matches the bubble background, positioned precisely at the bubble's edge. This is the part that trips up most hand-rolled attempts.
+- **Keyboard accessible** — appears on `:focus-visible`, not just hover, so tab-only users see it.
+- **Four placements** — top/bottom/left/right via modifiers, each with a matching arrow direction and slide-in.
+- **Pure CSS, no JS** — `content: attr(...)` + pseudo-elements; nothing to initialize.
+- **Reusable** — configurable via CSS custom properties (`--tt-bg`, `--tt-text`, `--tt-radius`, `--tt-pad`, `--tt-arrow`, `--tt-gap`, `--tt-dur`, etc.).
+
+## Files
+
+- `demo.html` — self-contained showcase (open directly in a browser; no server, CDNs, or frameworks). Placements, icon-button toolbar, and inline-text triggers.
+- `style.css` — `::before` bubble + `::after` CSS-triangle arrow, four placements, hover/focus reveal, reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-tooltip-sbh/demo.html
+++ b/submissions/examples/ease-tooltip-sbh/demo.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-tooltip — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__head">
+      <p class="page__eyebrow">ease-tooltip</p>
+      <h1>Tooltips with arrows, attribute-driven.</h1>
+      <p class="page__lede">
+        A hover-triggered tooltip with a small CSS-triangle arrow pointing at its
+        trigger, fading and sliding in on hover. Positioned via a
+        <code>data-tooltip</code> attribute — no extra wrapper markup for the text.
+        Pure CSS, zero JS.
+      </p>
+    </header>
+
+    <section class="panel">
+      <h2 class="panel__title">Placements</h2>
+      <div class="stage stage--grid">
+        <button class="tooltip tooltip--top" data-tooltip="Appears above the trigger">Top</button>
+        <button class="tooltip tooltip--bottom" data-tooltip="Appears below the trigger">Bottom</button>
+        <button class="tooltip tooltip--left" data-tooltip="Appears to the left">Left</button>
+        <button class="tooltip tooltip--right" data-tooltip="Appears to the right">Right</button>
+      </div>
+      <p class="panel__hint">Hover (or keyboard-focus) each button.</p>
+    </section>
+
+    <section class="panel">
+      <h2 class="panel__title">In context</h2>
+      <div class="bar">
+        <button class="icon-btn tooltip tooltip--top" data-tooltip="Undo last edit" aria-label="Undo">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M9 14l-4-4 4-4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M5 10h9a5 5 0 0 1 0 10h-1" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </button>
+        <button class="icon-btn tooltip tooltip--top" data-tooltip="Redo" aria-label="Redo">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M15 14l4-4-4-4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M19 10h-9a5 5 0 0 0 0 10h1" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </button>
+        <button class="icon-btn tooltip tooltip--top" data-tooltip="Share read-only link" aria-label="Share">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 12v6a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M16 6l-4-4-4 4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M12 2v13" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </button>
+        <button class="icon-btn tooltip tooltip--top" data-tooltip="Delete permanently" aria-label="Delete">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </button>
+      </div>
+    </section>
+
+    <section class="panel">
+      <h2 class="panel__title">Inline text triggers</h2>
+      <p class="prose">
+        Use tooltips on inline text too — hover
+        <a class="tooltip tooltip--top" data-tooltip="API rate limits reset every minute" href="#">rate limit</a>
+        to see a definition, or
+        <a class="tooltip tooltip--bottom" data-tooltip="Web Content Accessibility Guidelines" href="#">WCAG</a>
+        for an acronym. They flow inline.
+      </p>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-tooltip-sbh/style.css
+++ b/submissions/examples/ease-tooltip-sbh/style.css
@@ -1,0 +1,218 @@
+/* ease-tooltip — hover/focus tooltip with a CSS-triangle arrow.
+   Text comes from the data-tooltip attribute (rendered via ::before content).
+   The arrow is ::after, a CSS triangle whose color matches the bubble.
+   Four placements via modifiers; fades + slides in. Pure CSS, zero JS. */
+
+:root {
+  --tt-bg: #0f172a;
+  --tt-text: #ffffff;
+  --tt-radius: 0.45rem;
+  --tt-pad: 0.4rem 0.65rem;
+  --tt-font: 0.78rem;
+  --tt-maxw: 16rem;
+  --tt-gap: 0.5rem;            /* distance from trigger to bubble */
+  --tt-arrow: 0.4rem;          /* arrow size */
+  --tt-dur: 0.16s;
+  --tt-ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* ---------- Page (demo only) ---------- */
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  color: #0f172a;
+  background:
+    radial-gradient(1000px 560px at 85% -8%, #eef2ff, transparent 60%),
+    radial-gradient(760px 460px at 0% 0%, #faf5ff, transparent 55%),
+    #fff;
+  line-height: 1.6;
+}
+.page { max-width: 46rem; margin: 0 auto; padding: clamp(2rem, 6vw, 4rem) clamp(1rem, 4vw, 2rem); }
+.page__eyebrow {
+  margin: 0 0 0.5rem; text-transform: uppercase; letter-spacing: 0.18em;
+  font-size: 0.78rem; font-weight: 700; color: #4f46e5;
+}
+.page__head h1 { margin: 0 0 0.8rem; font-size: clamp(1.6rem, 4.5vw, 2.4rem); letter-spacing: -0.02em; }
+.page__lede { margin: 0 0 2rem; color: #64748b; max-width: 40rem; }
+.page__lede code { background: rgba(79,70,229,0.12); color: #4f46e5; padding: 0.12rem 0.4rem; border-radius: 0.4rem; font-size: 0.9em; }
+
+.panel {
+  background: rgba(255,255,255,0.7);
+  border: 1px solid rgba(15,23,42,0.06);
+  border-radius: 1rem;
+  padding: clamp(1.2rem, 3vw, 1.8rem);
+  margin-bottom: 1.4rem;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+.panel__title { margin: 0 0 1rem; font-size: 1.1rem; letter-spacing: -0.01em; }
+.panel__hint { margin: 1rem 0 0; color: #94a3b8; font-size: 0.85rem; }
+
+.stage { display: flex; flex-wrap: wrap; gap: 1.4rem; align-items: center; }
+.stage--grid { justify-content: center; }
+
+.bar { display: flex; gap: 0.6rem; align-items: center; }
+.icon-btn {
+  display: inline-grid; place-items: center;
+  width: 2.3rem; height: 2.3rem;
+  border: 1px solid #e2e8f0; border-radius: 0.55rem;
+  background: #fff; color: #475569; cursor: pointer;
+  transition: background-color var(--tt-dur) var(--tt-ease), color var(--tt-dur) var(--tt-ease), border-color var(--tt-dur) var(--tt-ease);
+}
+.icon-btn svg { width: 1.2rem; height: 1.2rem; }
+.icon-btn:hover { background: #f8fafc; color: #0f172a; }
+.icon-btn:focus-visible { outline: none; border-color: #4f46e5; box-shadow: 0 0 0 0.2rem rgba(79,70,229,0.18); }
+
+.prose { color: #475569; max-width: 40rem; }
+.prose .tooltip { color: #4f46e5; text-decoration: underline dotted; }
+
+/* Generic demo button */
+.tooltip:not(.icon-btn):not(a) {
+  font: inherit; font-weight: 600;
+  padding: 0.55rem 1rem;
+  border: 1px solid #e2e8f0; border-radius: 0.55rem;
+  background: #fff; color: #0f172a; cursor: pointer;
+  transition: background-color var(--tt-dur) var(--tt-ease), border-color var(--tt-dur) var(--tt-ease);
+}
+.tooltip:not(.icon-btn):not(a):hover { background: #f8fafc; border-color: #cbd5e1; }
+.tooltip:not(.icon-btn):not(a):focus-visible { outline: none; border-color: #4f46e5; box-shadow: 0 0 0 0.2rem rgba(79,70,229,0.18); }
+
+/* ---------- The tooltip ---------- */
+/* Establish a positioning context + allow the bubble to overflow. */
+.tooltip {
+  position: relative;
+  display: inline-block;
+  text-decoration: none;
+}
+
+/* Bubble: text from data-tooltip. Hidden by default; we animate
+   opacity + a small translate. pointer-events:none so it never blocks hover. */
+.tooltip::before {
+  content: attr(data-tooltip);
+  position: absolute;
+  z-index: 20;
+  padding: var(--tt-pad);
+  background: var(--tt-bg);
+  color: var(--tt-text);
+  font-size: var(--tt-font);
+  font-weight: 500;
+  line-height: 1.4;
+  border-radius: var(--tt-radius);
+  max-width: var(--tt-maxw);
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity var(--tt-dur) var(--tt-ease), transform var(--tt-dur) var(--tt-ease);
+}
+
+/* Arrow: a CSS triangle whose color matches the bubble. */
+.tooltip::after {
+  content: "";
+  position: absolute;
+  z-index: 20;
+  width: 0; height: 0;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity var(--tt-dur) var(--tt-ease), transform var(--tt-dur) var(--tt-ease);
+}
+
+/* Show on hover or keyboard focus */
+.tooltip:hover::before,
+.tooltip:focus-visible::before,
+.tooltip:hover::after,
+.tooltip:focus-visible::after { opacity: 1; }
+
+/* ---------- Placement: TOP ---------- */
+.tooltip--top::before {
+  bottom: 100%;
+  left: 50%;
+  transform: translate(-50%, var(--tt-gap));           /* start nudged down */
+  margin-bottom: var(--tt-arrow);
+}
+.tooltip--top::after {
+  bottom: 100%;
+  left: 50%;
+  transform: translate(-50%, var(--tt-gap));
+  border-left: var(--tt-arrow) solid transparent;
+  border-right: var(--tt-arrow) solid transparent;
+  border-top: var(--tt-arrow) solid var(--tt-bg);
+}
+.tooltip--top:hover::before,
+.tooltip--top:focus-visible::before,
+.tooltip--top:hover::after,
+.tooltip--top:focus-visible::after {
+  transform: translate(-50%, 0);                        /* settle into place */
+}
+
+/* ---------- Placement: BOTTOM ---------- */
+.tooltip--bottom::before {
+  top: 100%;
+  left: 50%;
+  transform: translate(-50%, calc(-1 * var(--tt-gap)));
+  margin-top: var(--tt-arrow);
+}
+.tooltip--bottom::after {
+  top: 100%;
+  left: 50%;
+  transform: translate(-50%, calc(-1 * var(--tt-gap)));
+  border-left: var(--tt-arrow) solid transparent;
+  border-right: var(--tt-arrow) solid transparent;
+  border-bottom: var(--tt-arrow) solid var(--tt-bg);
+}
+.tooltip--bottom:hover::before,
+.tooltip--bottom:focus-visible::before,
+.tooltip--bottom:hover::after,
+.tooltip--bottom:focus-visible::after {
+  transform: translate(-50%, 0);
+}
+
+/* ---------- Placement: LEFT ---------- */
+.tooltip--left::before {
+  right: 100%;
+  top: 50%;
+  transform: translate(var(--tt-gap), -50%);
+  margin-right: var(--tt-arrow);
+}
+.tooltip--left::after {
+  right: 100%;
+  top: 50%;
+  transform: translate(var(--tt-gap), -50%);
+  border-top: var(--tt-arrow) solid transparent;
+  border-bottom: var(--tt-arrow) solid transparent;
+  border-left: var(--tt-arrow) solid var(--tt-bg);
+}
+.tooltip--left:hover::before,
+.tooltip--left:focus-visible::before,
+.tooltip--left:hover::after,
+.tooltip--left:focus-visible::after {
+  transform: translate(0, -50%);
+}
+
+/* ---------- Placement: RIGHT ---------- */
+.tooltip--right::before {
+  left: 100%;
+  top: 50%;
+  transform: translate(calc(-1 * var(--tt-gap)), -50%);
+  margin-left: var(--tt-arrow);
+}
+.tooltip--right::after {
+  left: 100%;
+  top: 50%;
+  transform: translate(calc(-1 * var(--tt-gap)), -50%);
+  border-top: var(--tt-arrow) solid transparent;
+  border-bottom: var(--tt-arrow) solid transparent;
+  border-right: var(--tt-arrow) solid var(--tt-bg);
+}
+.tooltip--right:hover::before,
+.tooltip--right:focus-visible::before,
+.tooltip--right:hover::after,
+.tooltip--right:focus-visible::after {
+  transform: translate(0, -50%);
+}
+
+/* ---------- Reduced motion ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .tooltip::before,
+  .tooltip::after { transition: none; }
+}


### PR DESCRIPTION
## Summary

Adds a **hover-triggered tooltip with a small CSS-triangle arrow** pointing at its trigger element, fading and sliding in on hover, resolving #61985.

Text comes from the `data-tooltip` attribute (rendered via `::before { content: attr(data-tooltip) }`), so the trigger element stays clean with no wrapper markup for the label. The arrow is `::after`, a pure CSS triangle (zero-width element with colored borders) colored to match the bubble exactly so the join looks seamless. Supports four placements (`--top`, `--bottom`, `--left`, `--right`), each sliding in from its own side. Shows on `:hover` and `:focus-visible`, so keyboard users get the tooltip too.

## Files

- `submissions/examples/ease-tooltip-sbh/demo.html` — self-contained showcase (open directly in a browser; no server, CDNs, or frameworks). Placements, icon-button toolbar, and inline-text triggers.
- `submissions/examples/ease-tooltip-sbh/style.css` — `::before` bubble + `::after` CSS-triangle arrow, four placements, hover/focus reveal, reduced-motion rules.
- `submissions/examples/ease-tooltip-sbh/README.md` — documentation.

## Requirements met

- Hover-triggered tooltip with CSS-triangle arrow pointing at trigger
- Positioned via `data-tooltip` attribute (no extra wrapper markup)
- Fades and slides in on hover
- Four placements (top/bottom/left/right) with matching arrow direction
- Pure CSS, zero JS (`content: attr(...)` + pseudo-elements)
- Accessible: shows on `:focus-visible` (keyboard), visible focus rings, full `prefers-reduced-motion` support
- Configurable via CSS custom properties

Closes #61985.