### PR TITLE
feat: add CSS rotate-fade dropdown for product catalog layouts

### DIFF
--- a/submissions/examples/css-rotate-fade-dropdown-hg/README.md
+++ b/submissions/examples/css-rotate-fade-dropdown-hg/README.md
@@ -1,0 +1,74 @@
+Rotate-Fade Dropdown
+
+A dropdown for product catalog layouts that opens with a small rotation and scale alongside the fade — no perspective, no 3D hinge, just a quick, slightly playful settle into place with a gentle overshoot. Pure CSS, driven by the checkbox hack. No JavaScript.
+
+demo.html shows two uses: a toolbar "Sort" dropdown, and a per-product-card "quick actions" menu (Edit / Duplicate / Archive / Delete) anchored to each card's top-right corner.
+
+Files
+File	Purpose
+demo.html	Toolbar sort dropdown + 4 product cards with quick-action menus
+style.css	The rotate-fade mechanism, tokens, and catalog styling
+README.md	This file
+Markup
+html
+<div class="rf-dropdown">
+  <input type="checkbox" id="rf-sort" class="rf-dropdown__toggle">
+  <label for="rf-sort" class="rf-dropdown__close-overlay" aria-hidden="true"></label>
+  <label for="rf-sort" class="rf-dropdown__trigger">
+    Sort: <strong>Featured</strong>
+    <span class="rf-dropdown__chevron" aria-hidden="true"></span>
+  </label>
+  <div class="rf-dropdown__panel" role="menu">
+    <a href="#" class="rf-dropdown__item" role="menuitem">Featured</a>
+    …
+  </div>
+</div>
+
+Four pieces, in this order (order matters — the CSS relies on the general sibling combinator, which only looks forward through the DOM):
+
+The hidden checkbox — the actual open/closed state.
+A full-viewport <label for="..."> overlay — invisible and inert while closed, becomes a click target the instant the panel opens, so clicking anywhere outside closes it.
+The visible trigger <label for="..."> (text, or an icon-only .rf-dropdown__icon-trigger for the per-card menus).
+The panel.
+How the rotate-fade works
+css
+.rf-dropdown__panel {
+  transform-origin: top left;
+  transform: rotate(var(--rf-rotate)) scale(var(--rf-scale)); /* -6deg, 0.92 by default */
+  opacity: 0;
+}
+
+.rf-dropdown__toggle:checked ~ .rf-dropdown__panel {
+  transform: rotate(0deg) scale(1);
+  opacity: 1;
+}
+
+The easing does most of the personality work here: cubic-bezier(0.34, 1.56, 0.64, 1) overshoots slightly past its resting position before settling — the panel rotates a hair past flat and scales a hair past 100% before easing back, which is what makes this read as "quick and a little playful" rather than a plain linear fade. Because there's no perspective anywhere, the rotation stays flat and 2D — a deliberately lighter-weight effect than a 3D hinge-flip.
+
+visibility toggles alongside opacity — instant on the way in, delayed by the full transition duration on the way out — so a closing panel never intercepts clicks or keyboard focus while it's still animating out.
+
+CSS custom properties
+Property	Default	Controls
+--rf-duration	260ms	Length of the rotate-fade transition
+--rf-ease	cubic-bezier(0.34, 1.56, 0.64, 1)	The overshoot easing curve
+--rf-rotate	-6deg	Starting rotation before the panel opens
+--rf-scale	0.92	Starting scale before the panel opens
+Anchor variants
+.rf-dropdown-right — right-aligns the panel (transform-origin: top right) instead of left-aligning it, for triggers near a container's right edge.
+.rf-dropdown-corner — positions the whole .rf-dropdown absolutely in a card's top-right corner, used by the quick-actions menus so they don't take up card layout space.
+
+Both are combined on the per-card menus in the demo (class="rf-dropdown rf-dropdown-corner rf-dropdown-right").
+
+Accessibility
+The checkbox is real and stays in the tab order (hidden with a clip-based technique, not display: none), so <kbd>Tab</kbd> + <kbd>Space</kbd> opens/closes it exactly like a native checkbox.
+.rf-dropdown__toggle:focus-visible ~ .rf-dropdown__trigger (and the icon-trigger equivalent) draws a visible ring when the hidden checkbox has keyboard focus.
+Closes on outside click via the overlay label described above.
+Panels carry role="menu" with role="menuitem" links; icon-only triggers get a descriptive aria-label (e.g. "Quick actions for Mechanical Keyboard") rather than relying on the "⋮" glyph alone.
+Respects prefers-reduced-motion: reduce — the panel appears/disappears at its resting transform immediately, with transitions collapsed to 1ms.
+Responsive behavior
+
+The product grid drops from four columns to two at 640px and to one at 420px. Panel positioning (left/right anchor) is unaffected by viewport size — the panels themselves are compact enough not to need a mobile-specific layout change.
+
+Browser support
+
+Uses only transform, opacity, CSS custom properties, and standard transitions — supported everywhere current, no fallback needed.

--- a/submissions/examples/css-rotate-fade-dropdown-hg/demo.html
+++ b/submissions/examples/css-rotate-fade-dropdown-hg/demo.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Rotate-Fade Dropdown — EaseMotion CSS</title>
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@600;700&family=Inter:wght@400;500;600&family=IBM+Plex+Mono:wght@500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="noise" aria-hidden="true"></div>
+
+  <header class="hero">
+    <p class="eyebrow">EaseMotion CSS &middot; showcase</p>
+    <h1 class="hero-title">Rotate-fade dropdown</h1>
+    <p class="hero-sub">A dropdown that opens with a small rotation and scale alongside the fade &mdash; not a 3D flip, just a quick, slightly playful settle into place. Pure CSS, checkbox-driven. No JavaScript.</p>
+  </header>
+
+  <main class="catalog-page">
+
+    <!-- ================= Toolbar sort dropdown ================= -->
+    <div class="catalog-toolbar">
+      <p class="toolbar-label">4 products</p>
+
+      <div class="rf-dropdown">
+        <input type="checkbox" id="rf-sort" class="rf-dropdown__toggle">
+        <label for="rf-sort" class="rf-dropdown__close-overlay" aria-hidden="true"></label>
+        <label for="rf-sort" class="rf-dropdown__trigger">
+          Sort: <strong>Featured</strong>
+          <span class="rf-dropdown__chevron" aria-hidden="true"></span>
+        </label>
+        <div class="rf-dropdown__panel" role="menu" aria-label="Sort products">
+          <a href="#" class="rf-dropdown__item" role="menuitem">Featured</a>
+          <a href="#" class="rf-dropdown__item" role="menuitem">Price: low to high</a>
+          <a href="#" class="rf-dropdown__item" role="menuitem">Price: high to low</a>
+          <a href="#" class="rf-dropdown__item" role="menuitem">Newest</a>
+        </div>
+      </div>
+    </div>
+
+    <!-- ================= Product grid, each with its own quick-actions dropdown ================= -->
+    <div class="product-grid">
+
+      <article class="product-card">
+        <div class="product-thumb product-thumb-1" aria-hidden="true"></div>
+
+        <div class="rf-dropdown rf-dropdown-corner rf-dropdown-right">
+          <input type="checkbox" id="rf-actions-1" class="rf-dropdown__toggle">
+          <label for="rf-actions-1" class="rf-dropdown__close-overlay" aria-hidden="true"></label>
+          <label for="rf-actions-1" class="rf-dropdown__icon-trigger" aria-label="Quick actions for Mechanical Keyboard">&#8942;</label>
+          <div class="rf-dropdown__panel rf-dropdown__panel-narrow" role="menu" aria-label="Quick actions">
+            <a href="#" class="rf-dropdown__item" role="menuitem">Edit</a>
+            <a href="#" class="rf-dropdown__item" role="menuitem">Duplicate</a>
+            <a href="#" class="rf-dropdown__item" role="menuitem">Archive</a>
+            <a href="#" class="rf-dropdown__item rf-dropdown__item-danger" role="menuitem">Delete</a>
+          </div>
+        </div>
+
+        <p class="product-name">Mechanical Keyboard, 65%</p>
+        <p class="product-price">$89.00</p>
+      </article>
+
+      <article class="product-card">
+        <div class="product-thumb product-thumb-2" aria-hidden="true"></div>
+
+        <div class="rf-dropdown rf-dropdown-corner rf-dropdown-right">
+          <input type="checkbox" id="rf-actions-2" class="rf-dropdown__toggle">
+          <label for="rf-actions-2" class="rf-dropdown__close-overlay" aria-hidden="true"></label>
+          <label for="rf-actions-2" class="rf-dropdown__icon-trigger" aria-label="Quick actions for Studio Headphones">&#8942;</label>
+          <div class="rf-dropdown__panel rf-dropdown__panel-narrow" role="menu" aria-label="Quick actions">
+            <a href="#" class="rf-dropdown__item" role="menuitem">Edit</a>
+            <a href="#" class="rf-dropdown__item" role="menuitem">Duplicate</a>
+            <a href="#" class="rf-dropdown__item" role="menuitem">Archive</a>
+            <a href="#" class="rf-dropdown__item rf-dropdown__item-danger" role="menuitem">Delete</a>
+          </div>
+        </div>
+
+        <p class="product-name">Studio Headphones</p>
+        <p class="product-price">$129.00</p>
+      </article>
+
+      <article class="product-card">
+        <div class="product-thumb product-thumb-3" aria-hidden="true"></div>
+
+        <div class="rf-dropdown rf-dropdown-corner rf-dropdown-right">
+          <input type="checkbox" id="rf-actions-3" class="rf-dropdown__toggle">
+          <label for="rf-actions-3" class="rf-dropdown__close-overlay" aria-hidden="true"></label>
+          <label for="rf-actions-3" class="rf-dropdown__icon-trigger" aria-label="Quick actions for Desk Lamp">&#8942;</label>
+          <div class="rf-dropdown__panel rf-dropdown__panel-narrow" role="menu" aria-label="Quick actions">
+            <a href="#" class="rf-dropdown__item" role="menuitem">Edit</a>
+            <a href="#" class="rf-dropdown__item" role="menuitem">Duplicate</a>
+            <a href="#" class="rf-dropdown__item" role="menuitem">Archive</a>
+            <a href="#" class="rf-dropdown__item rf-dropdown__item-danger" role="menuitem">Delete</a>
+          </div>
+        </div>
+
+        <p class="product-name">Desk Lamp, Warm LED</p>
+        <p class="product-price">$42.00</p>
+      </article>
+
+      <article class="product-card">
+        <div class="product-thumb product-thumb-4" aria-hidden="true"></div>
+
+        <div class="rf-dropdown rf-dropdown-corner rf-dropdown-right">
+          <input type="checkbox" id="rf-actions-4" class="rf-dropdown__toggle">
+          <label for="rf-actions-4" class="rf-dropdown__close-overlay" aria-hidden="true"></label>
+          <label for="rf-actions-4" class="rf-dropdown__icon-trigger" aria-label="Quick actions for Cable Organizer Tray">&#8942;</label>
+          <div class="rf-dropdown__panel rf-dropdown__panel-narrow" role="menu" aria-label="Quick actions">
+            <a href="#" class="rf-dropdown__item" role="menuitem">Edit</a>
+            <a href="#" class="rf-dropdown__item" role="menuitem">Duplicate</a>
+            <a href="#" class="rf-dropdown__item" role="menuitem">Archive</a>
+            <a href="#" class="rf-dropdown__item rf-dropdown__item-danger" role="menuitem">Delete</a>
+          </div>
+        </div>
+
+        <p class="product-name">Cable Organizer Tray</p>
+        <p class="product-price">$18.00</p>
+      </article>
+
+    </div>
+
+  </main>
+
+  <footer class="footer">
+    <p>EaseMotion CSS &middot; submissions/examples/css-rotate-fade-dropdown</p>
+  </footer>
+
+</body>
+</html>

--- a/submissions/examples/css-rotate-fade-dropdown-hg/style.css
+++ b/submissions/examples/css-rotate-fade-dropdown-hg/style.css
@@ -1,0 +1,418 @@
+/* =========================================================================
+   Rotate-Fade Dropdown — EaseMotion CSS
+   A dropdown panel that opens with a small 2D rotation and scale
+   alongside the fade — transform-origin pinned near the trigger, a slight
+   negative rotate() and a scale-down at rest, settling to rotate(0)
+   scale(1) opacity 1 with a gentle overshoot easing. No perspective, no
+   3D — a quicker, lighter-weight sibling to a full 3D-flip dropdown.
+   Driven by the checkbox hack. Pure CSS/HTML, no JavaScript.
+   ========================================================================= */
+
+
+/* -------------------------------------------------------------------------
+   1. Design tokens
+   ------------------------------------------------------------------------- */
+
+:root {
+  --rf-bg: #0e1116;
+  --rf-surface: #151a21;
+  --rf-surface-2: #1c222b;
+  --rf-border: #262e39;
+  --rf-text: #edeff2;
+  --rf-text-muted: #98a2b3;
+
+  --rf-accent: #7de0c0;
+  --rf-accent-strong: #9beed4;
+  --rf-danger: #fb7185;
+  --rf-danger-soft: rgba(251, 113, 133, 0.12);
+
+  --rf-font-display: "Space Grotesk", "Segoe UI", sans-serif;
+  --rf-font-body: "Inter", "Segoe UI", sans-serif;
+  --rf-font-mono: "IBM Plex Mono", "Courier New", monospace;
+
+  /* Rotate-fade mechanics — override per instance to retune */
+  --rf-duration: 260ms;
+  --rf-ease: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --rf-rotate: -6deg;
+  --rf-scale: 0.92;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--rf-bg);
+  color: var(--rf-text);
+  font-family: var(--rf-font-body);
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+.noise {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.035;
+  z-index: 0;
+  background-image: radial-gradient(circle at 1px 1px, #ffffff 1px, transparent 0);
+  background-size: 3px 3px;
+}
+
+
+/* -------------------------------------------------------------------------
+   2. Hero
+   ------------------------------------------------------------------------- */
+
+.hero {
+  position: relative;
+  z-index: 1;
+  max-width: 660px;
+  margin: 0 auto;
+  padding: 88px 24px 52px;
+  text-align: center;
+}
+
+.eyebrow {
+  font-family: var(--rf-font-mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--rf-accent);
+  margin: 0 0 20px;
+}
+
+.hero-title {
+  font-family: var(--rf-font-display);
+  font-weight: 600;
+  font-size: clamp(30px, 5.5vw, 48px);
+  line-height: 1.1;
+  letter-spacing: -0.01em;
+  margin: 0 0 16px;
+}
+
+.hero-sub {
+  font-size: 15px;
+  color: var(--rf-text-muted);
+  max-width: 500px;
+  margin: 0 auto;
+}
+
+
+/* -------------------------------------------------------------------------
+   3. Catalog page shell
+   ------------------------------------------------------------------------- */
+
+.catalog-page {
+  position: relative;
+  z-index: 1;
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 0 24px 90px;
+}
+
+.catalog-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 22px;
+}
+
+.toolbar-label {
+  font-size: 13px;
+  color: var(--rf-text-muted);
+  margin: 0;
+}
+
+
+/* -------------------------------------------------------------------------
+   4. Rotate-fade dropdown core
+   ------------------------------------------------------------------------- */
+
+.rf-dropdown {
+  position: relative;
+}
+
+/* Real, focusable checkbox — hidden visually, not with display:none */
+.rf-dropdown__toggle {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.rf-dropdown__trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 15px;
+  border-radius: 10px;
+  background: var(--rf-surface);
+  border: 1px solid var(--rf-border);
+  color: var(--rf-text-muted);
+  font-size: 13.5px;
+  cursor: pointer;
+  user-select: none;
+  transition: border-color 160ms ease, background 160ms ease;
+}
+
+.rf-dropdown__trigger strong {
+  color: var(--rf-text);
+  font-weight: 600;
+}
+
+.rf-dropdown__trigger:hover {
+  border-color: rgba(125, 224, 192, 0.35);
+}
+
+.rf-dropdown__chevron {
+  width: 7px;
+  height: 7px;
+  border-right: 1.5px solid var(--rf-text-muted);
+  border-bottom: 1.5px solid var(--rf-text-muted);
+  transform: rotate(45deg) translateY(-2px);
+  transition: transform var(--rf-duration) var(--rf-ease);
+}
+
+.rf-dropdown__toggle:checked ~ .rf-dropdown__trigger .rf-dropdown__chevron {
+  transform: rotate(225deg) translateY(-1px);
+}
+
+.rf-dropdown__toggle:focus-visible ~ .rf-dropdown__trigger,
+.rf-dropdown__toggle:focus-visible ~ .rf-dropdown__icon-trigger {
+  outline: 2px solid var(--rf-accent);
+  outline-offset: 2px;
+}
+
+/* Icon-only trigger, used for the per-card quick-actions menu */
+.rf-dropdown__icon-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  background: rgba(14, 17, 22, 0.6);
+  border: 1px solid var(--rf-border);
+  color: var(--rf-text);
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 160ms ease, border-color 160ms ease;
+}
+
+.rf-dropdown__icon-trigger:hover {
+  background: var(--rf-surface-2);
+  border-color: rgba(125, 224, 192, 0.35);
+}
+
+
+/* -------------------------------------------------------------------------
+   5. The rotate-fade panel itself
+   ------------------------------------------------------------------------- */
+
+.rf-dropdown__panel {
+  position: absolute;
+  z-index: 20;
+  top: calc(100% + 8px);
+  left: 0;
+  min-width: 200px;
+  padding: 7px;
+  border-radius: 12px;
+  background: var(--rf-surface);
+  border: 1px solid var(--rf-border);
+  box-shadow: 0 20px 44px -16px rgba(0, 0, 0, 0.55);
+
+  transform-origin: top left;
+  transform: rotate(var(--rf-rotate)) scale(var(--rf-scale));
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+
+  transition:
+    transform var(--rf-duration) var(--rf-ease),
+    opacity calc(var(--rf-duration) * 0.7) linear,
+    visibility 0s linear var(--rf-duration);
+}
+
+.rf-dropdown__toggle:checked ~ .rf-dropdown__panel {
+  transform: rotate(0deg) scale(1);
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition:
+    transform var(--rf-duration) var(--rf-ease),
+    opacity calc(var(--rf-duration) * 0.5) linear,
+    visibility 0s linear 0s;
+}
+
+/* Corner variant: panel anchors to the trigger's own right edge instead
+   of the left, so a menu opening near a card's right corner never
+   overflows past it. */
+.rf-dropdown-right .rf-dropdown__panel {
+  left: auto;
+  right: 0;
+  transform-origin: top right;
+}
+
+.rf-dropdown__panel-narrow {
+  min-width: 150px;
+}
+
+/* Positions the icon trigger + its panel in a card's top-right corner */
+.rf-dropdown-corner {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 5;
+}
+
+
+/* -------------------------------------------------------------------------
+   6. Panel contents
+   ------------------------------------------------------------------------- */
+
+.rf-dropdown__item {
+  display: block;
+  padding: 8px 10px;
+  border-radius: 7px;
+  font-size: 13px;
+  color: var(--rf-text);
+  text-decoration: none;
+  transition: background 120ms ease;
+}
+
+.rf-dropdown__item:hover {
+  background: var(--rf-surface-2);
+}
+
+.rf-dropdown__item-danger {
+  color: var(--rf-danger);
+}
+
+.rf-dropdown__item-danger:hover {
+  background: var(--rf-danger-soft);
+}
+
+
+/* -------------------------------------------------------------------------
+   7. Outside-click close overlay
+   ------------------------------------------------------------------------- */
+
+.rf-dropdown__close-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 15;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.rf-dropdown__toggle:checked ~ .rf-dropdown__close-overlay {
+  pointer-events: auto;
+}
+
+
+/* -------------------------------------------------------------------------
+   8. Product grid (demo context, not part of the component)
+   ------------------------------------------------------------------------- */
+
+.product-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 14px;
+}
+
+.product-card {
+  position: relative;
+  background: var(--rf-surface);
+  border: 1px solid var(--rf-border);
+  border-radius: 14px;
+  padding: 14px;
+}
+
+.product-thumb {
+  height: 84px;
+  border-radius: 10px;
+  margin-bottom: 12px;
+  background: linear-gradient(135deg, var(--rf-surface-2), var(--rf-border));
+}
+
+.product-thumb-1 { background: linear-gradient(135deg, #2b3340, #1c222b); }
+.product-thumb-2 { background: linear-gradient(135deg, #33313f, #1c222b); }
+.product-thumb-3 { background: linear-gradient(135deg, #3a2f2b, #1c222b); }
+.product-thumb-4 { background: linear-gradient(135deg, #2a3a3a, #1c222b); }
+
+.product-name {
+  font-size: 12.5px;
+  color: var(--rf-text);
+  margin: 0 0 4px;
+}
+
+.product-price {
+  font-family: var(--rf-font-mono);
+  font-size: 12px;
+  color: var(--rf-accent);
+  margin: 0;
+}
+
+
+/* -------------------------------------------------------------------------
+   9. Footer
+   ------------------------------------------------------------------------- */
+
+.footer {
+  position: relative;
+  z-index: 1;
+  text-align: center;
+  padding: 8px 24px 48px;
+  font-size: 12.5px;
+  color: var(--rf-text-muted);
+  font-family: var(--rf-font-mono);
+}
+
+
+/* -------------------------------------------------------------------------
+   10. Responsive
+   ------------------------------------------------------------------------- */
+
+@media (max-width: 640px) {
+  .hero {
+    padding: 68px 20px 44px;
+  }
+
+  .product-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 420px) {
+  .product-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+
+/* -------------------------------------------------------------------------
+   11. Reduced motion
+   ------------------------------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .rf-dropdown__panel {
+    transform: none;
+    transition-duration: 1ms;
+  }
+
+  .rf-dropdown__toggle:checked ~ .rf-dropdown__panel {
+    transform: none;
+  }
+
+  .rf-dropdown__chevron {
+    transition-duration: 1ms;
+  }
+}


### PR DESCRIPTION
Closes #62353

## Pull Request Description
Adds a pure CSS/HTML dropdown for product catalog layouts that opens with a 2D rotate + scale + fade (not a 3D flip), used for a toolbar sort control and per-card quick-actions menus. No JavaScript.

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/css-rotate-fade-dropdown/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A `.rf-dropdown` component whose panel opens with a small `rotate()` + `scale()` + fade and a slight overshoot easing, rather than a plain fade/slide or a 3D hinge-flip.

**How does a developer use it?**
```html
<div class="rf-dropdown">
  <input type="checkbox" id="rf-1" class="rf-dropdown__toggle">
  <label for="rf-1" class="rf-dropdown__close-overlay" aria-hidden="true"></label>
  <label for="rf-1" class="rf-dropdown__trigger">Sort</label>
  <div class="rf-dropdown__panel">…</div>
</div>
```
Add `.rf-dropdown-right` to right-align the panel, `.rf-dropdown-corner` to position the whole trigger absolutely (used for the per-card quick-actions menus). Retune `--rf-rotate`, `--rf-scale`, `--rf-duration`, or `--rf-ease` per instance.

**Why does it fit EaseMotion CSS?**
Distinct, named motion signature (2D rotate+scale+fade with an overshoot ease, deliberately lighter-weight than a 3D flip) fully exposed as custom properties, shown in two real usage contexts — a toolbar control and per-item quick-action menus — rather than one isolated example.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

## Notes for Maintainer
Reuses the same checkbox-hack + outside-click-overlay pattern as other recent dropdown/popover submissions in this repo for consistency. `--rf-ease` intentionally overshoots slightly (`cubic-bezier(0.34, 1.56, 0.64, 1)`) — happy to flatten that to a standard ease if it reads as too playful for the library's overall tone.