### PR TITLE
feat: add CSS Zoom-In Dropdown for Minimalist Tech Layouts (#64581)

### DIFF
--- a/submissions/examples/minimalist-tech-zoom-in-dropdown/README.md
+++ b/submissions/examples/minimalist-tech-zoom-in-dropdown/README.md
@@ -1,0 +1,23 @@
+# CSS Zoom-In Dropdown (Minimalist Tech)
+
+A pure CSS dropdown component designed for Minimalist Tech Layouts. It features entirely JavaScript-free state management and a sharp, scaling "Zoom-In" entrance animation, perfect for dense configuration menus.
+
+## Features
+- Pure CSS and HTML (Zero JavaScript required for state or animations).
+- **Minimalist Tech Aesthetic**: Clean, data-dense menu layout, distinct semantic status indicators (Active, Warning, Offline), structured `.menu-group` dividers, and prominent inline action links.
+- **Pure CSS State Management**: 
+- Utilizes the "Checkbox Hack". The entire dropdown is wrapped in `.dropdown-wrapper`. A hidden `<input type="checkbox">` tracks the open/closed state, while the trigger button acts as its `<label>`.
+- Clicking anywhere on the trigger toggles the hidden checkbox, which in turn drives the visibility of the adjacent `.dropdown-menu` via the general sibling combinator (`~`).
+- **The Zoom-In Animation System**: 
+- We avoid `display: none` because it cannot be animated. Instead, the closed menu is managed with `opacity: 0`, `visibility: hidden`, and `pointer-events: none` (to prevent clicking invisible items).
+- The initial state of the menu is scaled down (`transform: scale(0.9)`) and slightly offset upwards (`translateY(-10px)`). 
+- We define `transform-origin: top center`, which ensures the scaling effect appears to "bloom" directly outwards from the trigger button above it.
+- When the checkbox is active, the menu transitions to `scale(1)` and `translateY(0)`. We apply a bouncy `cubic-bezier(0.175, 0.885, 0.32, 1.275)` timing function. The slight overshoot of this curve gives the zoom a snappy, physical "pop" that feels highly responsive.
+- Fully accessible with `prefers-reduced-motion` support. For motion-sensitive users, the scaling transform is completely disabled. The menu safely falls back to a simple, immediate opacity fade.
+
+## Usage
+Open `demo.html` in your browser. You will see a mock "Deploy Configuration" dropdown trigger. Click the trigger to expand the menu. Notice how the menu sharply zooms into view, snapping into full scale with a subtle bounce, while the chevron arrow smoothly rotates 180 degrees.
+
+## Files
+- `demo.html`: The HTML structure for the dropdown, detailing the crucial checkbox/label relationship for CSS state management, and the complex internal structure for the grouped menu items.
+- `style.css`: The styling, minimalist tech design tokens, the `visibility`/`opacity` toggling logic, and the precise `cubic-bezier` transform rules driving the zoom-in scaling effect.

--- a/submissions/examples/minimalist-tech-zoom-in-dropdown/demo.html
+++ b/submissions/examples/minimalist-tech-zoom-in-dropdown/demo.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Zoom-In Dropdown - Minimalist Tech</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Deploy Configuration</h1>
+            <p class="subtitle">A minimalist tech dropdown component featuring a sharp, scaling zoom-in entrance.</p>
+        </header>
+
+        <div class="dashboard-area">
+            
+            <div class="card">
+                
+                <!-- 
+                   Pure CSS State Management for Dropdown
+                   Using a hidden checkbox to toggle the dropdown state without JS.
+                   We place the dropdown inside a relative container.
+                -->
+                <div class="dropdown-wrapper">
+                    <input type="checkbox" id="dropdown-toggle" class="dropdown-input">
+                    
+                    <label for="dropdown-toggle" class="dropdown-trigger">
+                        <span class="trigger-text">
+                            <svg class="trigger-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect><line x1="8" y1="21" x2="16" y2="21"></line><line x1="12" y1="17" x2="12" y2="21"></line></svg>
+                            Select Target Environment
+                        </span>
+                        <svg class="chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"></polyline></svg>
+                    </label>
+                    
+                    <!-- The Dropdown Menu Menu -->
+                    <div class="dropdown-menu zoom-in-menu">
+                        <div class="menu-group">
+                            <span class="group-label">Primary Clusters</span>
+                            
+                            <label class="menu-item" for="dropdown-toggle">
+                                <span class="status-indicator active"></span>
+                                <div class="item-content">
+                                    <span class="item-title">US-East-1 (Production)</span>
+                                    <span class="item-desc">High availability, full replication</span>
+                                </div>
+                            </label>
+                            
+                            <label class="menu-item" for="dropdown-toggle">
+                                <span class="status-indicator active"></span>
+                                <div class="item-content">
+                                    <span class="item-title">EU-Central-1 (Production)</span>
+                                    <span class="item-desc">GDPR compliant zone</span>
+                                </div>
+                            </label>
+                        </div>
+                        
+                        <div class="menu-divider"></div>
+                        
+                        <div class="menu-group">
+                            <span class="group-label">Testing & Staging</span>
+                            
+                            <label class="menu-item" for="dropdown-toggle">
+                                <span class="status-indicator warning"></span>
+                                <div class="item-content">
+                                    <span class="item-title">Staging-Alpha</span>
+                                    <span class="item-desc">Pre-release candidate environment</span>
+                                </div>
+                            </label>
+                            
+                            <label class="menu-item disabled" for="dropdown-toggle">
+                                <span class="status-indicator inactive"></span>
+                                <div class="item-content">
+                                    <span class="item-title">Dev-Sandbox (Offline)</span>
+                                    <span class="item-desc">Scheduled maintenance in progress</span>
+                                </div>
+                            </label>
+                        </div>
+                        
+                        <div class="menu-divider"></div>
+                        
+                        <a href="#" class="menu-action">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="16"></line><line x1="8" y1="12" x2="16" y2="12"></line></svg>
+                            Provision New Environment
+                        </a>
+                    </div>
+                </div>
+                
+            </div>
+            
+        </div>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/minimalist-tech-zoom-in-dropdown/style.css
+++ b/submissions/examples/minimalist-tech-zoom-in-dropdown/style.css
@@ -1,0 +1,300 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    --border-color: #e2e8f0;
+    
+    /* Tech Minimalist Accents */
+    --accent-blue: #0ea5e9;
+    --accent-emerald: #10b981;
+    --accent-orange: #f59e0b;
+    --accent-gray: #94a3b8;
+    
+    --surface-white: #ffffff;
+    --surface-hover: #f1f5f9;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: flex-start; /* Align top so dropdown has room to open downwards */
+    padding-top: 100px;
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    width: 100%;
+    padding: 0 20px;
+}
+
+.section-header {
+    text-align: center;
+    margin-bottom: 50px;
+}
+
+.title {
+    font-size: 2rem;
+    font-weight: 600;
+    margin: 0 0 12px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    margin: 0;
+}
+
+
+/* =========================================
+   Card Styling (Environment)
+   ========================================= */
+
+.card {
+    background: var(--surface-white);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 60px 40px; 
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+    display: flex;
+    justify-content: center;
+}
+
+
+/* =========================================
+   Dropdown Structure & Trigger
+   ========================================= */
+
+.dropdown-wrapper {
+    position: relative;
+    width: 100%;
+    max-width: 320px;
+}
+
+.dropdown-input {
+    display: none;
+}
+
+.dropdown-trigger {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 12px 16px;
+    background: var(--surface-white);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    cursor: pointer;
+    user-select: none;
+    transition: all 0.2s ease;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.02);
+}
+
+.dropdown-trigger:hover {
+    border-color: #cbd5e1;
+    background: var(--surface-hover);
+}
+
+/* Active state styling for the trigger when dropdown is open */
+.dropdown-input:checked ~ .dropdown-trigger {
+    border-color: var(--accent-blue);
+    box-shadow: 0 0 0 3px rgba(14, 165, 233, 0.1);
+}
+
+.trigger-text {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.95rem;
+    font-weight: 500;
+    color: var(--text-primary);
+}
+
+.trigger-icon {
+    width: 18px;
+    height: 18px;
+    color: var(--text-secondary);
+}
+
+.chevron {
+    width: 18px;
+    height: 18px;
+    color: var(--text-secondary);
+    transition: transform 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+/* Rotate chevron when open */
+.dropdown-input:checked ~ .dropdown-trigger .chevron {
+    transform: rotate(180deg);
+}
+
+
+/* =========================================
+   Dropdown Menu Styling
+   ========================================= */
+
+.dropdown-menu {
+    position: absolute;
+    top: calc(100% + 8px);
+    left: 0;
+    width: 100%;
+    background: var(--surface-white);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    padding: 8px 0;
+    z-index: 100;
+    
+    /* 
+       Visibility Management:
+       We use opacity and visibility rather than display:none to allow transitions.
+       Pointer-events prevents interacting with invisible menus.
+    */
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+}
+
+
+/* Menu Structure */
+.menu-group {
+    padding: 4px 0;
+}
+
+.group-label {
+    display: block;
+    padding: 4px 16px 8px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.menu-item {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 10px 16px;
+    cursor: pointer;
+    transition: background-color 0.15s ease;
+}
+
+.menu-item:hover:not(.disabled) {
+    background-color: var(--surface-hover);
+}
+
+.menu-item.disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+}
+
+/* Content inside menu items */
+.item-content {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.item-title {
+    font-size: 0.9rem;
+    font-weight: 500;
+    color: var(--text-primary);
+}
+
+.item-desc {
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+}
+
+.menu-divider {
+    height: 1px;
+    background-color: var(--border-color);
+    margin: 4px 0;
+}
+
+.menu-action {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 16px;
+    font-size: 0.9rem;
+    font-weight: 500;
+    color: var(--accent-blue);
+    text-decoration: none;
+    transition: background-color 0.15s ease;
+}
+.menu-action:hover {
+    background-color: rgba(14, 165, 233, 0.05);
+}
+.menu-action svg { width: 16px; height: 16px; }
+
+
+/* Status Indicators */
+.status-indicator {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    margin-top: 6px; /* Align with title */
+    flex-shrink: 0;
+}
+.status-indicator.active { background-color: var(--accent-emerald); box-shadow: 0 0 6px rgba(16, 185, 129, 0.4); }
+.status-indicator.warning { background-color: var(--accent-orange); }
+.status-indicator.inactive { background-color: var(--accent-gray); }
+
+
+/* =========================================
+   The Zoom-In Animation Logic
+   ========================================= */
+
+/* Set initial transform state for the closed menu */
+.zoom-in-menu {
+    /* 
+      Start scaled down significantly and slightly pushed down.
+      Transform origin at the top center makes it feel like it's blooming from the trigger.
+    */
+    transform-origin: top center;
+    transform: scale(0.9) translateY(-10px);
+    transition: opacity 0.2s ease, visibility 0.2s ease, transform 0.2s ease;
+}
+
+/* When the checkbox is checked (Dropdown is open) */
+.dropdown-input:checked ~ .zoom-in-menu {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+    
+    /* 
+       Zoom into full scale and standard position.
+       We use a bouncy cubic-bezier to give the zoom a snappy, physical pop.
+    */
+    transform: scale(1) translateY(0);
+    transition: opacity 0.3s ease, visibility 0.3s ease, transform 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    .dropdown-input:checked ~ .dropdown-trigger .chevron {
+        transition: none !important;
+    }
+    
+    /* Disable the scaling transform, fallback to simple fade */
+    .zoom-in-menu {
+        transform: none !important;
+        transition: opacity 0.2s ease, visibility 0.2s ease !important;
+    }
+    
+    .dropdown-input:checked ~ .zoom-in-menu {
+        transform: none !important;
+        transition: opacity 0.2s ease, visibility 0.2s ease !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces the CSS Zoom-In Dropdown designed for Minimalist Tech Layouts, resolving issue #64581. 

### Changes Made:
- Added `submissions/examples/minimalist-tech-zoom-in-dropdown/` directory.
- Created `demo.html` showcasing a mock "Deploy Configuration" menu. 
  - Implemented 100% JavaScript-free state management utilizing the "Checkbox Hack". The entire dropdown is wrapped in `.dropdown-wrapper`. A hidden `<input type="checkbox">` tracks the open/closed state, while the trigger button acts as its `<label>`. Clicking the trigger drives the visibility of the adjacent `.dropdown-menu` via the general sibling combinator.
- Created `style.css` featuring a data-dense aesthetic utilizing distinct semantic status indicators (Active, Warning, Offline), structured `.menu-group` dividers, and inline action links.
  - Implemented the Zoom-In Animation System. 
  - To ensure the menu is animatable without JS, we avoid `display: none` and instead manage the closed state using `opacity: 0`, `visibility: hidden`, and `pointer-events: none`.
  - The initial state is scaled down (`transform: scale(0.9)`) and slightly offset upwards. We set `transform-origin: top center` so the scaling effect appears to "bloom" directly outwards from the trigger button.
  - When opened, the menu transitions to `scale(1)` using a bouncy `cubic-bezier` timing function. The slight overshoot of this curve gives the zoom a snappy, physical "pop" that feels highly responsive.
- Added `README.md` documenting usage and technical features.
- Honors the `prefers-reduced-motion` accessibility standard. The scaling transform is completely disabled, safely falling back to a simple, immediate opacity fade for motion-sensitive users.

Closes #64581
