### PR TITLE
feat: add ease-skeleton loading shimmer (#61978)

### DIFF
--- a/submissions/examples/ease-skeleton-sbh/README.md
+++ b/submissions/examples/ease-skeleton-sbh/README.md
@@ -1,0 +1,47 @@
+# ease-skeleton
+
+Placeholder blocks (text lines, avatars, images) with an animated diagonal shimmer sweep across a gray base, signaling "content loading." Pure CSS `@keyframes` gradient animation — no JS required until real content swaps in.
+
+## What does this do?
+
+- Each `.skeleton` block is a gray base with a brighter linear-gradient "sheen" band laid on top.
+- `@keyframes skeleton-sweep` animates `background-position` from `-200%` to `+200%`, so the bright band travels fully across the block and off the right edge, then loops — an infinite shimmer.
+- The gradient is `200%` wide (twice the block) with the bright band in the middle (`transparent 20% → white 50% → transparent 80%`), so the sweep looks like a single diagonal sheen passing through.
+- Presets for the common shapes: `.skeleton-line` (text), `.skeleton-avatar` (round), `.skeleton-image` (rectangle), plus size modifiers.
+
+## How is it used?
+
+1. Link the stylesheet.
+2. Drop in `.skeleton` blocks with the right preset class. Set `width` inline to vary line lengths (mimicking real text).
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<!-- text lines -->
+<div class="skeleton skeleton-line" style="width: 80%"></div>
+<div class="skeleton skeleton-line" style="width: 60%"></div>
+
+<!-- avatar -->
+<div class="skeleton skeleton-avatar"></div>
+
+<!-- image / media -->
+<div class="skeleton skeleton-image"></div>
+```
+
+## Why is this useful?
+
+- **Foundational loading pattern** — skeleton screens are now the default loading affordance (replacing spinners) across modern apps, and they pair with almost every other component (cards, avatars, lists).
+- **Single keyframe, fully CSS** — one `background-position` animation drives the whole effect; no JS, no assets, no libraries.
+- **Composable shapes** — line/avatar/image presets cover the vast majority of loading layouts; width is set inline so lines look like real prose.
+- **Accessible** — the blocks are decorative; reduced-motion users get a static gray block (the sweep is disabled via `prefers-reduced-motion`), which is the correct behavior since a shimmer is purely decorative.
+- **Reusable** — configurable via CSS custom properties (`--sk-base`, `--sk-sheen`, `--sk-dur`, `--sk-radius`, `--sk-line-h`, `--sk-avatar-size`, `--sk-image-h`, etc.).
+
+## Files
+
+- `demo.html` — self-contained showcase (open directly in a browser; no server, CDNs, or frameworks). Text lines, avatar+card, image, and a combined "loading post" composition.
+- `style.css` — `.skeleton` base + shimmer `@keyframes`, line/avatar/image presets + size modifiers, demo layouts, reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-skeleton-sbh/demo.html
+++ b/submissions/examples/ease-skeleton-sbh/demo.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-skeleton — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__head">
+      <p class="page__eyebrow">ease-skeleton</p>
+      <h1>Skeleton loading shimmer, pure CSS.</h1>
+      <p class="page__lede">
+        Placeholder blocks for text lines, avatars, and images with an animated
+        diagonal shimmer sweep across a gray base &mdash; signaling "content loading."
+        Built with a single <code>@keyframes</code> gradient animation, no JS.
+      </p>
+    </header>
+
+    <section class="panel">
+      <h2 class="panel__title">Text lines</h2>
+      <div class="skeleton-group">
+        <div class="skeleton skeleton-line skeleton-line--lg" style="width: 60%"></div>
+        <div class="skeleton skeleton-line" style="width: 90%"></div>
+        <div class="skeleton skeleton-line" style="width: 75%"></div>
+        <div class="skeleton skeleton-line" style="width: 85%"></div>
+        <div class="skeleton skeleton-line" style="width: 40%"></div>
+      </div>
+    </section>
+
+    <section class="panel">
+      <h2 class="panel__title">Avatar + card</h2>
+      <div class="skeleton-card">
+        <div class="skeleton skeleton-avatar"></div>
+        <div class="skeleton-card-body">
+          <div class="skeleton skeleton-line" style="width: 50%"></div>
+          <div class="skeleton skeleton-line skeleton-line--sm" style="width: 30%"></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="panel">
+      <h2 class="panel__title">Image / media</h2>
+      <div class="skeleton skeleton-image"></div>
+    </section>
+
+    <section class="panel">
+      <h2 class="panel__title">Combined: loading post</h2>
+      <article class="skeleton-post">
+        <div class="skeleton skeleton-image skeleton-image--banner"></div>
+        <div class="skeleton-group skeleton-post-body">
+          <div class="skeleton skeleton-line skeleton-line--lg" style="width: 70%"></div>
+          <div class="skeleton skeleton-line" style="width: 95%"></div>
+          <div class="skeleton skeleton-line" style="width: 88%"></div>
+          <div class="skeleton skeleton-line" style="width: 60%"></div>
+        </div>
+        <div class="skeleton-card">
+          <div class="skeleton skeleton-avatar skeleton-avatar--sm"></div>
+          <div class="skeleton-card-body">
+            <div class="skeleton skeleton-line skeleton-line--sm" style="width: 60%"></div>
+            <div class="skeleton skeleton-line skeleton-line--sm" style="width: 40%"></div>
+          </div>
+        </div>
+      </article>
+    </section>
+
+    <p class="footnote">The shimmer sweeps diagonally across every block on an infinite loop until real content swaps in.</p>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-skeleton-sbh/style.css
+++ b/submissions/examples/ease-skeleton-sbh/style.css
@@ -1,0 +1,114 @@
+/* ease-skeleton — placeholder blocks with an animated diagonal shimmer.
+   Each block is a gray base with a lighter gradient "sheen" that sweeps
+   diagonally across it on an infinite loop via @keyframes background-position.
+   The gradient is ~200% wide and translates from -200% to +200% (left exit),
+   so the bright band travels fully across and off. No JS. */
+
+:root {
+  --sk-base: #e2e8f0;                       /* gray base */
+  --sk-sheen: #ffffff;                      /* bright sweep band */
+  --sk-sheen-opacity: 0.65;
+  --sk-radius: 0.4rem;
+  --sk-dur: 1.5s;
+  --sk-ease: linear;
+  /* block presets */
+  --sk-line-h: 0.9rem;
+  --sk-line-gap: 0.6rem;
+  --sk-avatar-size: 2.6rem;
+  --sk-image-h: 10rem;
+}
+
+/* ---------- Page (demo only) ---------- */
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  color: #0f172a;
+  background:
+    radial-gradient(1000px 560px at 85% -8%, #eef2ff, transparent 60%),
+    radial-gradient(760px 460px at 0% 0%, #faf5ff, transparent 55%),
+    #fff;
+  line-height: 1.6;
+}
+.page { max-width: 42rem; margin: 0 auto; padding: clamp(2rem, 6vw, 4rem) clamp(1rem, 4vw, 2rem); }
+.page__eyebrow {
+  margin: 0 0 0.5rem; text-transform: uppercase; letter-spacing: 0.18em;
+  font-size: 0.78rem; font-weight: 700; color: #4f46e5;
+}
+.page__head h1 { margin: 0 0 0.8rem; font-size: clamp(1.6rem, 4.5vw, 2.4rem); letter-spacing: -0.02em; }
+.page__lede { margin: 0 0 2rem; color: #64748b; max-width: 38rem; }
+.page__lede code { background: rgba(79,70,229,0.12); color: #4f46e5; padding: 0.12rem 0.4rem; border-radius: 0.4rem; font-size: 0.9em; }
+
+.panel {
+  background: rgba(255,255,255,0.7);
+  border: 1px solid rgba(15,23,42,0.06);
+  border-radius: 1rem;
+  padding: clamp(1.2rem, 3vw, 1.8rem);
+  margin-bottom: 1.4rem;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+.panel__title { margin: 0 0 1rem; font-size: 1.1rem; letter-spacing: -0.01em; }
+.footnote { color: #94a3b8; font-size: 0.85rem; margin: 0; }
+.skeleton-group { display: flex; flex-direction: column; gap: var(--sk-line-gap); }
+
+/* ---------- The skeleton block ---------- */
+.skeleton {
+  display: block;
+  position: relative;
+  overflow: hidden;
+  border-radius: var(--sk-radius);
+  background-color: var(--sk-base);
+  /* The sheen: a wide linear-gradient with a bright band in the middle,
+     laid on top of the base color. We animate background-position so the
+     band sweeps from left to right. */
+  background-image: linear-gradient(
+    100deg,
+    transparent 20%,
+    rgba(255, 255, 255, var(--sk-sheen-opacity)) 50%,
+    transparent 80%
+  );
+  background-repeat: no-repeat;
+  background-size: 200% 100%;            /* gradient is 2x the block width */
+  background-position: -200% 0;           /* start fully off to the left */
+  animation: skeleton-sweep var(--sk-dur) var(--sk-ease) infinite;
+}
+
+@keyframes skeleton-sweep {
+  from { background-position: -200% 0; }  /* sheen off the left edge */
+  to   { background-position:  200% 0; }  /* sheen off the right edge */
+}
+
+/* ---------- Block presets ---------- */
+.skeleton-line {
+  width: 100%;
+  height: var(--sk-line-h);
+}
+.skeleton-line--sm { height: calc(var(--sk-line-h) * 0.75); }
+.skeleton-line--lg { height: calc(var(--sk-line-h) * 1.5); border-radius: 0.5rem; }
+
+.skeleton-avatar {
+  width: var(--sk-avatar-size);
+  height: var(--sk-avatar-size);
+  border-radius: 50%;
+  flex: 0 0 auto;
+}
+.skeleton-avatar--sm { width: calc(var(--sk-avatar-size) * 0.6); height: calc(var(--sk-avatar-size) * 0.6); }
+
+.skeleton-image {
+  width: 100%;
+  height: var(--sk-image-h);
+  border-radius: 0.6rem;
+}
+.skeleton-image--banner { height: 9rem; }
+
+/* ---------- Composed demo layouts ---------- */
+.skeleton-card { display: flex; align-items: center; gap: 0.9rem; }
+.skeleton-card-body { flex: 1; display: flex; flex-direction: column; gap: 0.5rem; }
+.skeleton-post { display: flex; flex-direction: column; gap: 1.1rem; }
+.skeleton-post-body { margin-bottom: 0; }
+
+/* ---------- Reduced motion: stop the sweep ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .skeleton { animation: none; background-position: 0 0; }
+}


### PR DESCRIPTION
## Summary

Adds **placeholder blocks (text lines, avatars, images) with an animated diagonal shimmer sweep** across a gray base, signaling "content loading," resolving #61978.

Each `.skeleton` block is a gray base with a brighter linear-gradient "sheen" band laid on top. `@keyframes skeleton-sweep` animates `background-position` from `-200%` to `+200%`, so the bright band travels fully across the block and off the right edge, then loops — an infinite shimmer. The gradient is `200%` wide with the bright band in the middle (`transparent 20% -> white 50% -> transparent 80%`).

## Files

- `submissions/examples/ease-skeleton-sbh/demo.html` — self-contained showcase (open directly in a browser; no server, CDNs, or frameworks). Text lines, avatar+card, image, and a combined "loading post" composition.
- `submissions/examples/ease-skeleton-sbh/style.css` — `.skeleton` base + shimmer `@keyframes`, line/avatar/image presets + size modifiers, demo layouts, reduced-motion rules.
- `submissions/examples/ease-skeleton-sbh/README.md` — documentation.

## Requirements met

- Placeholder blocks for text lines, avatars, and images
- Animated diagonal shimmer sweep via `@keyframes` gradient animation (pure CSS, no JS)
- Single keyframe drives the whole effect; composable shape presets
- Accessible: decorative blocks; reduced-motion users get a static gray block (sweep disabled via `prefers-reduced-motion`)
- Configurable via CSS custom properties

Verified in-browser via computed-style probe: `background-position` advances `-200% -> -71% -> +89%` over time with `animation: skeleton-sweep 1.5s infinite`, confirming the shimmer is actively running.

Closes #61978.