### PR TITLE
feat: add ease-compare-slider image reveal (#60865)

### DIFF
--- a/submissions/examples/ease-compare-slider-sbh/README.md
+++ b/submissions/examples/ease-compare-slider-sbh/README.md
@@ -1,0 +1,52 @@
+# ease-compare-slider
+
+A draggable before/after image comparison slider that reveals a "before" image underneath an "after" image using `clip-path`, controlled by a native `<input type="range">` for full accessibility and zero custom drag logic.
+
+## What does this do?
+
+- Stacks two images: the "after" image is the base layer; the "before" image sits on top inside a wrapper clipped with `clip-path: inset()`.
+- A native `<input type="range">` covers the whole slider (so the entire surface is draggable) and drives the clip on `oninput`: `inset(0 (100-value)% 0 0)` — as the slider moves right, more of the "before" image is revealed.
+- The same `oninput` updates a `--cs-pos` custom property that positions a visible handle (a vertical line + circular grip with chevron arrows), so the handle tracks the slider with no extra drag logic.
+- Because it's a real range input, **keyboard** (arrow keys) and **touch** work natively — no custom pointer-event handling.
+
+## How is it used?
+
+1. Link the stylesheet.
+2. Use the markup below. Order matters: after-image → before-wrap → range input → handle line/grip. The `oninput` updates both the clip-path and `--cs-pos`.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<div class="compare-slider">
+  <img class="compare-slider-after" src="after.jpg" alt="After">
+  <div class="compare-slider-before-wrap">
+    <img class="compare-slider-before" src="before.jpg" alt="Before">
+  </div>
+  <input type="range" class="compare-slider-input" min="0" max="100" value="50"
+    aria-label="Reveal before image"
+    oninput="this.parentElement.style.setProperty('--cs-pos', this.value+'%');
+             this.previousElementSibling.style.clipPath='inset(0 '+(100-this.value)+'% 0 0)'">
+  <span class="compare-slider-handle-line" aria-hidden="true"></span>
+  <span class="compare-slider-handle-grip" aria-hidden="true"></span>
+</div>
+```
+
+Set the initial `--cs-pos` and `clip-path` to match the input's `value` (e.g. `value="35"` → `--cs-pos: 35%` + `clip-path: inset(0 65% 0 0)`).
+
+## Why is this useful?
+
+- **Accessible by default** — a native range input gives keyboard (arrow keys), touch, and screen-reader support for free; no custom drag logic or ARIA wiring to maintain.
+- **`clip-path` reveal** — the modern, GPU-friendly way to do image wipes; no overflow hacks or nested masks.
+- **Custom handle, native input** — the visible handle line + grip are siblings whose `left` reads `--cs-pos`, so they track the slider without a separate move handler.
+- **Self-contained demo** — images are inline SVG data URIs, so the demo runs with no external assets; swap in real `<img src>` for production.
+- **Reusable** — configurable via CSS custom properties (`--cs-radius`, `--cs-handle-w`, `--cs-grip-size`, `--cs-grip-bg`, `--cs-label-bg`, etc.).
+
+## Files
+
+- `demo.html` — self-contained showcase (open directly in a browser; no server, CDNs, or frameworks). Two sliders using inline-SVG before/after images.
+- `style.css` — stacked image layers, `clip-path` default, invisible range input, handle line + grip driven by `--cs-pos`, BEFORE/AFTER labels, focus/active states, reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/ease-compare-slider-sbh/demo.html
+++ b/submissions/examples/ease-compare-slider-sbh/demo.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-compare-slider — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__head">
+      <p class="page__eyebrow">ease-compare-slider</p>
+      <h1>A before/after image comparison slider.</h1>
+      <p class="page__lede">
+        A draggable slider that reveals a "before" image underneath an "after"
+        image using <code>clip-path</code>, controlled by a native
+        <code>&lt;input type="range"&gt;</code> for full accessibility and zero
+        custom drag logic. Keyboard-operable, touch-friendly, one line of JS.
+      </p>
+    </header>
+
+    <section class="panel">
+      <h2 class="panel__title">Day / Night</h2>
+
+      <div class="compare-slider" id="cmp1">
+        <img class="compare-slider-after" src="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='640' height='400' viewBox='0 0 640 400'><defs><linearGradient id='d' x1='0' y1='0' x2='0' y2='1'><stop offset='0' stop-color='%231e3a8a'/><stop offset='1' stop-color='%23763a8a'/></linearGradient></defs><rect width='640' height='400' fill='url(%23d)'/><circle cx='500' cy='90' r='42' fill='%23fde68a'/><g fill='%23ffffff' opacity='0.9'><circle cx='120' cy='70' r='2'/><circle cx='220' cy='40' r='1.5'/><circle cx='300' cy='110' r='2'/><circle cx='80' cy='150' r='1.5'/><circle cx='400' cy='60' r='1.5'/><circle cx='560' cy='200' r='2'/><circle cx='180' cy='220' r='1.5'/></g><rect y='320' width='640' height='80' fill='%230f172a'/><polygon points='0,320 120,240 240,320' fill='%231e293b'/><polygon points='180,320 320,200 460,320' fill='%231e293b'/></svg>" alt="Night cityscape" />
+        <div class="compare-slider-before-wrap">
+          <img class="compare-slider-before" src="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='640' height='400' viewBox='0 0 640 400'><defs><linearGradient id='y' x1='0' y1='0' x2='0' y2='1'><stop offset='0' stop-color='%2338bdf8'/><stop offset='1' stop-color='%23fbbf24'/></linearGradient></defs><rect width='640' height='400' fill='url(%23y)'/><circle cx='130' cy='80' r='36' fill='%23fffbeb'/><g fill='%23ffffff' opacity='0.8'><ellipse cx='430' cy='100' rx='60' ry='22'/><ellipse cx='520' cy='90' rx='50' ry='18'/></g><rect y='320' width='640' height='80' fill='%2316a34a'/><polygon points='0,320 120,240 240,320' fill='%234ade80'/><polygon points='180,320 320,200 460,320' fill='%234ade80'/></svg>" alt="Day cityscape" />
+        </div>
+        <input type="range" class="compare-slider-input" min="0" max="100" value="50"
+          aria-label="Reveal before image"
+          oninput="this.parentElement.style.setProperty('--cs-pos', this.value+'%'); this.previousElementSibling.style.clipPath='inset(0 '+(100-this.value)+'% 0 0)'" />
+        <span class="compare-slider-handle-line" aria-hidden="true"></span>
+        <span class="compare-slider-handle-grip" aria-hidden="true"></span>
+      </div>
+      <p class="panel__hint">Drag the handle, or tab to it and use the arrow keys.</p>
+    </section>
+
+    <section class="panel">
+      <h2 class="panel__title">Edited / Original</h2>
+
+      <div class="compare-slider" id="cmp2" style="--cs-pos: 35%">
+        <img class="compare-slider-after" src="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='640' height='400' viewBox='0 0 640 400'><rect width='640' height='400' fill='%23111827'/><g><circle cx='160' cy='200' r='70' fill='%23ef4444'/><circle cx='320' cy='200' r='70' fill='%2322d3ee'/><circle cx='480' cy='200' r='70' fill='%23a3e635'/></g></svg>" alt="Edited colored circles" />
+        <div class="compare-slider-before-wrap" style="clip-path: inset(0 65% 0 0)">
+          <img class="compare-slider-before" src="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='640' height='400' viewBox='0 0 640 400'><rect width='640' height='400' fill='%23f8fafc'/><g><circle cx='160' cy='200' r='70' fill='%23cbd5e1'/><circle cx='320' cy='200' r='70' fill='%23cbd5e1'/><circle cx='480' cy='200' r='70' fill='%23cbd5e1'/></g></svg>" alt="Original grayscale circles" />
+        </div>
+        <input type="range" class="compare-slider-input" min="0" max="100" value="35"
+          aria-label="Reveal original image"
+          oninput="this.parentElement.style.setProperty('--cs-pos', this.value+'%'); this.previousElementSibling.style.clipPath='inset(0 '+(100-this.value)+'% 0 0)'" />
+        <span class="compare-slider-handle-line" aria-hidden="true"></span>
+        <span class="compare-slider-handle-grip" aria-hidden="true"></span>
+      </div>
+    </section>
+
+    <p class="footnote">Both images use inline SVG data URIs so the demo runs with no external assets.</p>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-compare-slider-sbh/style.css
+++ b/submissions/examples/ease-compare-slider-sbh/style.css
@@ -1,0 +1,202 @@
+/* ease-compare-slider — before/after image reveal via clip-path.
+   The "after" image is the base layer; the "before" image sits on top
+   inside a wrapper that is clipped with inset(). A native <input type="range">
+   drives the clip: its oninput sets clipPath inset(0 (100-value)% 0 0),
+   revealing more of the before image as the slider moves right.
+   The range input also positions a visible handle line + grip via
+   a CSS counter / value-driven left%. The input is keyboard + touch native. */
+
+:root {
+  --cs-radius: 0.8rem;
+  --cs-handle-w: 0.25rem;
+  --cs-handle-color: #ffffff;
+  --cs-grip-size: 2.6rem;
+  --cs-grip-bg: rgba(255, 255, 255, 0.95);
+  --cs-grip-color: #0f172a;
+  --cs-grip-shadow: 0 6px 16px -4px rgba(15, 23, 42, 0.5);
+  --cs-label-bg: rgba(15, 23, 42, 0.6);
+  --cs-label-text: #ffffff;
+  --cs-accent: #4f46e5;
+  --cs-accent-soft: rgba(79, 70, 229, 0.25);
+  --cs-dur: 0.18s;
+  --cs-ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* ---------- Page (demo only) ---------- */
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  color: #0f172a;
+  background:
+    radial-gradient(1000px 560px at 85% -8%, #eef2ff, transparent 60%),
+    radial-gradient(760px 460px at 0% 0%, #faf5ff, transparent 55%),
+    #fff;
+  line-height: 1.6;
+}
+.page { max-width: 44rem; margin: 0 auto; padding: clamp(2rem, 6vw, 4rem) clamp(1rem, 4vw, 2rem); }
+.page__eyebrow {
+  margin: 0 0 0.5rem; text-transform: uppercase; letter-spacing: 0.18em;
+  font-size: 0.78rem; font-weight: 700; color: var(--cs-accent);
+}
+.page__head h1 { margin: 0 0 0.8rem; font-size: clamp(1.6rem, 4.5vw, 2.4rem); letter-spacing: -0.02em; }
+.page__lede { margin: 0 0 2rem; color: #64748b; max-width: 38rem; }
+.page__lede code { background: var(--cs-accent-soft); color: var(--cs-accent); padding: 0.12rem 0.4rem; border-radius: 0.4rem; font-size: 0.9em; }
+
+.panel {
+  background: rgba(255,255,255,0.7);
+  border: 1px solid rgba(15,23,42,0.06);
+  border-radius: 1rem;
+  padding: clamp(1.2rem, 3vw, 1.8rem);
+  margin-bottom: 1.4rem;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+.panel__title { margin: 0 0 1rem; font-size: 1.1rem; letter-spacing: -0.01em; }
+.panel__hint { margin: 1rem 0 0; color: #94a3b8; font-size: 0.85rem; }
+.footnote { color: #94a3b8; font-size: 0.85rem; margin: 0; }
+
+/* ---------- The compare-slider ---------- */
+.compare-slider {
+  position: relative;
+  display: block;
+  overflow: hidden;
+  border-radius: var(--cs-radius);
+  /* establish a sizing context: images fill this box */
+  aspect-ratio: 16 / 10;
+  background: #0f172a;
+  user-select: none;
+}
+
+/* Both images fill the slider, stacked. */
+.compare-slider img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  pointer-events: none;          /* let the range input receive pointer events */
+}
+
+/* The "after" image is the base layer. */
+.compare-slider-after { position: absolute; inset: 0; }
+
+/* The "before" image wrapper sits on top and is clipped.
+   Initial clip = 50% (matches the input value=50 default). The JS
+   oninput overrides this inline; we set a sane default here too. */
+.compare-slider-before-wrap {
+  position: absolute;
+  inset: 0;
+  clip-path: inset(0 50% 0 0);
+}
+.compare-slider-before { position: absolute; inset: 0; }
+
+/* Edge labels (Before / After) */
+.compare-slider::before,
+.compare-slider::after {
+  position: absolute;
+  top: 0.7rem;
+  z-index: 5;
+  padding: 0.2rem 0.55rem;
+  background: var(--cs-label-bg);
+  color: var(--cs-label-text);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  border-radius: 0.35rem;
+  pointer-events: none;
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+}
+.compare-slider::before { content: "BEFORE"; left: 0.7rem; }
+.compare-slider::after  { content: "AFTER";  right: 0.7rem; }
+
+/* ---------- The range input ---------- *
+ * The native <input type="range"> fills the whole slider so the entire
+ * surface is draggable. Its own thumb is made invisible (we draw a custom
+ * handle line + grip as siblings, moved by the same oninput that sets the
+ * clip-path). Keeping the real input means keyboard + touch come for free. */
+.compare-slider-input {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  background: transparent;
+  -webkit-appearance: none;
+  appearance: none;
+  cursor: ew-resize;
+  z-index: 10;
+}
+.compare-slider-input::-webkit-slider-runnable-track { background: transparent; border: 0; }
+.compare-slider-input::-webkit-slider-thumb {
+  -webkit-appearance: none; appearance: none;
+  /* an invisible hit area the size of the grip; the visible grip is a sibling */
+  width: var(--cs-grip-size); height: var(--cs-grip-size);
+  background: transparent;
+  cursor: ew-resize;
+}
+.compare-slider-input::-moz-range-track { background: transparent; border: 0; }
+.compare-slider-input::-moz-range-thumb {
+  width: var(--cs-grip-size); height: var(--cs-grip-size);
+  background: transparent; border: 0; border-radius: 50%;
+  cursor: ew-resize;
+}
+.compare-slider-input:focus-visible { outline: none; }
+.compare-slider-input:focus-visible ~ .compare-slider-handle-grip {
+  box-shadow: var(--cs-grip-shadow), 0 0 0 0.25rem var(--cs-accent-soft);
+}
+
+/* ---------- The visible handle (line + grip) ---------- *
+ * Sibling elements placed after the input in the DOM. Their horizontal
+ * position is driven by the same oninput that sets clip-path: it updates
+ * the --cs-pos custom property on the slider, and these read it for left. */
+.compare-slider-handle-line {
+  position: absolute;
+  top: 0; bottom: 0;
+  left: var(--cs-pos, 50%);
+  transform: translateX(-50%);
+  width: var(--cs-handle-w);
+  background: var(--cs-handle-color);
+  z-index: 8;
+  pointer-events: none;
+  box-shadow: 0 0 0 1px rgba(15,23,42,0.15);
+}
+.compare-slider-handle-grip {
+  position: absolute;
+  top: 50%;
+  left: var(--cs-pos, 50%);
+  transform: translate(-50%, -50%);
+  width: var(--cs-grip-size);
+  height: var(--cs-grip-size);
+  display: grid;
+  place-items: center;
+  background: var(--cs-grip-bg);
+  color: var(--cs-grip-color);
+  border-radius: 50%;
+  box-shadow: var(--cs-grip-shadow);
+  z-index: 9;
+  pointer-events: none;
+  transition: transform var(--cs-dur) var(--cs-ease);
+}
+/* Arrows inside the grip (a left/right chevron pair), pure CSS */
+.compare-slider-handle-grip::before,
+.compare-slider-handle-grip::after {
+  content: "";
+  width: 0.4rem; height: 0.4rem;
+  border-top: 0.14rem solid currentColor;
+  border-right: 0.14rem solid currentColor;
+}
+.compare-slider-handle-grip::before { transform: rotate(-135deg) translate(-0.05rem, 0.05rem); }  /* left arrow */
+.compare-slider-handle-grip::after  { transform: rotate(45deg) translate(0.05rem, -0.05rem); }     /* right arrow */
+
+/* Nudge the grip while dragging */
+.compare-slider-input:active ~ .compare-slider-handle-grip {
+  transform: translate(-50%, -50%) scale(1.08);
+}
+
+/* ---------- Reduced motion ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .compare-slider-handle-line,
+  .compare-slider-handle-grip { transition: none; }
+}


### PR DESCRIPTION
## Summary

Adds a **draggable before/after image comparison slider** that reveals a "before" image underneath an "after" image using `clip-path`, controlled by a native `<input type="range">` for full accessibility and zero custom drag logic, resolving #60865.

The "after" image is the base layer; the "before" image sits on top inside a wrapper clipped with `clip-path: inset()`. A native range input covers the whole slider (so the entire surface is draggable) and drives the clip on `oninput`: `inset(0 (100-value)% 0 0)` — as the slider moves right, more of the "before" image is revealed. The same `oninput` updates a `--cs-pos` custom property that positions a visible handle (vertical line + circular grip with chevron arrows). Because it's a real range input, **keyboard** (arrow keys) and **touch** work natively.

## Files

- `submissions/examples/ease-compare-slider-sbh/demo.html` — self-contained showcase (open directly in a browser; no server, CDNs, or frameworks). Two sliders using inline-SVG before/after images (no external assets).
- `submissions/examples/ease-compare-slider-sbh/style.css` — stacked image layers, `clip-path` default, invisible range input, handle line + grip driven by `--cs-pos`, BEFORE/AFTER labels, focus/active states, reduced-motion rules.
- `submissions/examples/ease-compare-slider-sbh/README.md` — documentation.

## Requirements met

- Before/after image reveal via `clip-path`
- Controlled by a native `<input type="range">` (keyboard + touch for free, no custom drag logic)
- Custom handle (line + grip) tracks the slider position via `--cs-pos`
- Self-contained demo with inline-SVG images (no external assets)
- Accessible: real range input with `aria-label`, visible focus ring, `prefers-reduced-motion` support
- Configurable via CSS custom properties

Verified in-browser via computed-style probe: setting the input to 20/50/80 produces `clip-path: inset(0 80%/50%/20% 0 0)` and `--cs-pos: 20%/50%/80%`, confirming the clip and handle both track the slider value.

Closes #60865.