### PR TITLE
feat: add CSS morph-glow accordion for SaaS showcase layouts

### DIFF
--- a/submissions/examples/morph-glow-accordion-hgn/README.md
+++ b/submissions/examples/morph-glow-accordion-hgn/README.md
@@ -1,0 +1,79 @@
+Morph-Glow Accordion
+
+A FAQ-style accordion where opening an item does three things at once: its corners reshape (tight uniform radius → looser, asymmetric radius), it picks up a soft colored glow that breathes gently while open, and the panel expands with a real smooth height transition — no max-height guessing. Pure CSS, driven by the checkbox hack. No JavaScript.
+
+Files
+File	Purpose
+demo.html	A 4-item pricing/billing FAQ accordion
+style.css	The morph, glow, and height-expand mechanics
+README.md	This file
+Markup
+html
+<div class="accordion-item">
+  <input type="checkbox" id="acc-1" class="accordion-toggle">
+  <label for="acc-1" class="accordion-header">
+    <span class="accordion-title">Question text</span>
+    <span class="accordion-icon" aria-hidden="true"></span>
+  </label>
+  <div class="accordion-panel-wrapper">
+    <div class="accordion-panel">
+      <p>Answer text.</p>
+    </div>
+  </div>
+</div>
+
+Each item is independent — this is a "many can be open at once" accordion (every checkbox is separate, not grouped like radios), which is the more common pattern for FAQ content where answers are often read side by side. Mark any item checked in the markup to have it open by default.
+
+The three effects
+
+1. Smooth height expand, no fixed max-height. The panel wrapper is a CSS grid with a single row track that animates between 0fr and 1fr:
+
+css
+.accordion-panel-wrapper {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows var(--mg-duration) var(--mg-ease);
+}
+
+.accordion-toggle:checked ~ .accordion-panel-wrapper {
+  grid-template-rows: 1fr;
+}
+
+This is what lets answers of any length expand smoothly — the older max-height: 500px trick either clips long content or animates an awkward pause on short content. The direct child (.accordion-panel) needs overflow: hidden and no explicit height for the row track to actually control it.
+
+2. The corner morph. Closed corners are a small, uniform radius. Open, the top corners loosen to a larger radius while the bottom corners settle to something in between — an asymmetric reshape, not just "bigger rounding everywhere":
+
+css
+.accordion-item:has(.accordion-toggle:checked) {
+  border-radius: var(--mg-radius-open) var(--mg-radius-open) var(--mg-radius-closed) var(--mg-radius-closed);
+}
+
+3. The glow. The open item gets a soft, colored box-shadow halo that gently breathes (a slow, subtle @keyframes pulse between two glow intensities) for as long as it stays open — a quiet ambient cue for which item currently has your attention, distinct from the header's own icon change.
+
+Icon morph
+
+The +/× icon is two ::before/::after bars, no icon font or SVG. One bar is fixed (the horizontal stroke); the other rotates 90° and scales to zero, which reads as it folding into the fixed bar rather than two independent shapes crossing:
+
+css
+.accordion-toggle:checked ~ .accordion-header .accordion-icon::after {
+  transform: translate(-50%, -50%) rotate(90deg) scaleY(0);
+}
+CSS custom properties
+Property	Default	Controls
+--mg-duration	380ms	Length of the morph/expand transition
+--mg-ease	cubic-bezier(0.4, 0, 0.2, 1)	Easing curve
+--mg-radius-closed	12px	Corner radius at rest
+--mg-radius-open	22px	Corner radius (top corners) when open
+--mg-pulse-duration	2600ms	Length of one glow breathing cycle
+--mg-glow	soft mint, 35% alpha	The glow color itself
+Accessibility
+The checkbox is real and stays in the tab order (hidden with a clip-based technique, not display: none), so <kbd>Tab</kbd> + <kbd>Space</kbd> opens/closes each item exactly like a native checkbox.
+.accordion-toggle:focus-visible ~ .accordion-header draws a visible ring on the header when its checkbox has keyboard focus.
+Respects prefers-reduced-motion: reduce — but doesn't remove the glow outright, since it's a genuine "this one is open" signal, not just decoration. Instead the pulse animation stops and the glow holds at a fixed intensity, while all transitions collapse to 1ms.
+Responsive behavior
+
+Header padding and panel text padding tighten slightly below 480px; the morph/glow/expand mechanics themselves are viewport-independent and need no breakpoint-specific overrides.
+
+Browser support
+
+Uses grid-template-rows animation (broadly supported in current evergreen browsers) and :has() for the item-level glow/radius state. Where :has() is unsupported, the header's own border-radius and icon morph still work (they key off :checked ~ sibling selectors, not :has()) — only the outer item's glow and bottom-corner radius softening would be missed, a purely cosmetic degradation.

--- a/submissions/examples/morph-glow-accordion-hgn/demo.html
+++ b/submissions/examples/morph-glow-accordion-hgn/demo.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Morph-Glow Accordion — EaseMotion CSS</title>
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@600;700&family=Inter:wght@400;500;600&family=IBM+Plex+Mono:wght@500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="noise" aria-hidden="true"></div>
+
+  <header class="hero">
+    <p class="eyebrow">EaseMotion CSS &middot; showcase</p>
+    <h1 class="hero-title">Morph-glow accordion</h1>
+    <p class="hero-sub">An accordion item reshapes its corners and picks up a soft colored glow the instant it opens, alongside a smooth height expand. Pure CSS, driven by the checkbox hack. No JavaScript.</p>
+  </header>
+
+  <main class="showcase">
+
+    <section class="accordion" aria-label="Frequently asked questions">
+
+      <div class="accordion-item">
+        <input type="checkbox" id="acc-1" class="accordion-toggle" checked>
+        <label for="acc-1" class="accordion-header">
+          <span class="accordion-title">What counts as a "seat" on the Team plan?</span>
+          <span class="accordion-icon" aria-hidden="true"></span>
+        </label>
+        <div class="accordion-panel-wrapper">
+          <div class="accordion-panel">
+            <p>Any teammate with an active login counts as one seat, whether they log in daily or once a month. Seats are billed monthly and you can add or remove them anytime from Workspace Settings &rarr; Billing.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="accordion-item">
+        <input type="checkbox" id="acc-2" class="accordion-toggle">
+        <label for="acc-2" class="accordion-header">
+          <span class="accordion-title">Can I switch plans mid-cycle?</span>
+          <span class="accordion-icon" aria-hidden="true"></span>
+        </label>
+        <div class="accordion-panel-wrapper">
+          <div class="accordion-panel">
+            <p>Yes. Upgrades apply immediately with a prorated charge for the rest of the billing period. Downgrades take effect at the start of your next cycle, so you keep full access to what you've already paid for.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="accordion-item">
+        <input type="checkbox" id="acc-3" class="accordion-toggle">
+        <label for="acc-3" class="accordion-header">
+          <span class="accordion-title">Is there a free trial?</span>
+          <span class="accordion-icon" aria-hidden="true"></span>
+        </label>
+        <div class="accordion-panel-wrapper">
+          <div class="accordion-panel">
+            <p>Every plan includes a 14-day trial with no card required. If you add a card during the trial, billing starts automatically the day it ends &mdash; we'll email you three days out as a reminder.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="accordion-item">
+        <input type="checkbox" id="acc-4" class="accordion-toggle">
+        <label for="acc-4" class="accordion-header">
+          <span class="accordion-title">What happens to my data if I cancel?</span>
+          <span class="accordion-icon" aria-hidden="true"></span>
+        </label>
+        <div class="accordion-panel-wrapper">
+          <div class="accordion-panel">
+            <p>Your workspace is kept, read-only, for 30 days after cancellation, so you can export anything you need or resubscribe without losing history. After 30 days it's permanently deleted.</p>
+          </div>
+        </div>
+      </div>
+
+    </section>
+
+  </main>
+
+  <footer class="footer">
+    <p>EaseMotion CSS &middot; submissions/examples/morph-glow-accordion</p>
+  </footer>
+
+</body>
+</html>

--- a/submissions/examples/morph-glow-accordion-hgn/style.css
+++ b/submissions/examples/morph-glow-accordion-hgn/style.css
@@ -1,0 +1,330 @@
+/* =========================================================================
+   Morph-Glow Accordion — EaseMotion CSS
+   An accordion item reshapes its corners and picks up a soft colored glow
+   the instant it opens, alongside a smooth height expand driven by the
+   grid-template-rows 0fr -> 1fr technique (no max-height guessing needed
+   for variable-length content). Driven by the checkbox hack. Pure
+   CSS/HTML, no JavaScript.
+   ========================================================================= */
+ 
+ 
+/* -------------------------------------------------------------------------
+   1. Design tokens
+   ------------------------------------------------------------------------- */
+ 
+:root {
+  --mg-bg: #0e1116;
+  --mg-surface: #151a21;
+  --mg-surface-2: #1c222b;
+  --mg-border: #262e39;
+  --mg-text: #edeff2;
+  --mg-text-muted: #98a2b3;
+ 
+  --mg-accent: #7de0c0;
+  --mg-accent-strong: #9beed4;
+  --mg-glow: rgba(125, 224, 192, 0.35);
+ 
+  --mg-font-display: "Space Grotesk", "Segoe UI", sans-serif;
+  --mg-font-body: "Inter", "Segoe UI", sans-serif;
+  --mg-font-mono: "IBM Plex Mono", "Courier New", monospace;
+ 
+  /* Morph-glow tuning — override per instance to retune */
+  --mg-duration: 380ms;
+  --mg-ease: cubic-bezier(0.4, 0, 0.2, 1);
+  --mg-radius-closed: 12px;
+  --mg-radius-open: 22px;
+  --mg-pulse-duration: 2600ms;
+}
+ 
+* {
+  box-sizing: border-box;
+}
+ 
+body {
+  margin: 0;
+  background: var(--mg-bg);
+  color: var(--mg-text);
+  font-family: var(--mg-font-body);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+ 
+.noise {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.035;
+  z-index: 0;
+  background-image: radial-gradient(circle at 1px 1px, #ffffff 1px, transparent 0);
+  background-size: 3px 3px;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   2. Hero
+   ------------------------------------------------------------------------- */
+ 
+.hero {
+  position: relative;
+  z-index: 1;
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 92px 24px 52px;
+  text-align: center;
+}
+ 
+.eyebrow {
+  font-family: var(--mg-font-mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--mg-accent);
+  margin: 0 0 20px;
+}
+ 
+.hero-title {
+  font-family: var(--mg-font-display);
+  font-weight: 600;
+  font-size: clamp(30px, 5.5vw, 48px);
+  line-height: 1.1;
+  letter-spacing: -0.01em;
+  margin: 0 0 16px;
+}
+ 
+.hero-sub {
+  font-size: 15px;
+  color: var(--mg-text-muted);
+  max-width: 480px;
+  margin: 0 auto;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   3. Layout
+   ------------------------------------------------------------------------- */
+ 
+.showcase {
+  position: relative;
+  z-index: 1;
+  max-width: 620px;
+  margin: 0 auto;
+  padding: 0 24px 90px;
+}
+ 
+.accordion {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   4. Accordion item — the morph + glow
+   ------------------------------------------------------------------------- */
+ 
+.accordion-item {
+  position: relative;
+  background: var(--mg-surface);
+  border: 1px solid var(--mg-border);
+  border-radius: var(--mg-radius-closed);
+  box-shadow: 0 0 0 0 transparent;
+  transition:
+    border-radius var(--mg-duration) var(--mg-ease),
+    border-color var(--mg-duration) var(--mg-ease),
+    box-shadow var(--mg-duration) var(--mg-ease);
+}
+ 
+/* Real, focusable checkbox — hidden visually, not with display:none */
+.accordion-toggle {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+ 
+/* The morph: closed corners are tight and uniform; open corners loosen
+   asymmetrically (top corners open wider than bottom), which combined
+   with the glow is what makes the item read as "waking up" rather than
+   just sliding open. Applied to the header and the whole item below. */
+.accordion-toggle:checked ~ .accordion-header {
+  border-radius: var(--mg-radius-open) var(--mg-radius-open) 6px 6px;
+}
+ 
+.accordion-item:has(.accordion-toggle:checked) {
+  border-color: rgba(125, 224, 192, 0.4);
+  border-radius: var(--mg-radius-open) var(--mg-radius-open) var(--mg-radius-closed) var(--mg-radius-closed);
+  box-shadow: 0 0 0 1px rgba(125, 224, 192, 0.15), 0 0 32px 4px var(--mg-glow);
+  animation: mg-pulse var(--mg-pulse-duration) ease-in-out infinite;
+}
+ 
+/* Gentle breathing glow while a panel stays open — subtle on purpose */
+@keyframes mg-pulse {
+  0%, 100% {
+    box-shadow: 0 0 0 1px rgba(125, 224, 192, 0.15), 0 0 28px 2px var(--mg-glow);
+  }
+  50% {
+    box-shadow: 0 0 0 1px rgba(125, 224, 192, 0.25), 0 0 40px 6px var(--mg-glow);
+  }
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   5. Header / trigger
+   ------------------------------------------------------------------------- */
+ 
+.accordion-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 17px 20px;
+  border-radius: var(--mg-radius-closed);
+  cursor: pointer;
+  user-select: none;
+  transition: border-radius var(--mg-duration) var(--mg-ease);
+}
+ 
+.accordion-title {
+  font-family: var(--mg-font-display);
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--mg-text);
+}
+ 
+.accordion-toggle:focus-visible ~ .accordion-header {
+  outline: 2px solid var(--mg-accent);
+  outline-offset: -2px;
+}
+ 
+/* Icon: a plus that morphs into a cross via two bars, one of which
+   rotates 90deg to disappear into the other. */
+.accordion-icon {
+  position: relative;
+  flex: 0 0 auto;
+  width: 16px;
+  height: 16px;
+}
+ 
+.accordion-icon::before,
+.accordion-icon::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  background: var(--mg-text-muted);
+  transition: transform var(--mg-duration) var(--mg-ease), background var(--mg-duration) var(--mg-ease);
+}
+ 
+.accordion-icon::before {
+  width: 16px;
+  height: 2px;
+  transform: translate(-50%, -50%);
+}
+ 
+.accordion-icon::after {
+  width: 2px;
+  height: 16px;
+  transform: translate(-50%, -50%);
+}
+ 
+.accordion-toggle:checked ~ .accordion-header .accordion-icon::before,
+.accordion-toggle:checked ~ .accordion-header .accordion-icon::after {
+  background: var(--mg-accent);
+}
+ 
+.accordion-toggle:checked ~ .accordion-header .accordion-icon::after {
+  transform: translate(-50%, -50%) rotate(90deg) scaleY(0);
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   6. Panel — smooth auto-height via grid-template-rows
+   ------------------------------------------------------------------------- */
+ 
+.accordion-panel-wrapper {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows var(--mg-duration) var(--mg-ease);
+}
+ 
+.accordion-toggle:checked ~ .accordion-panel-wrapper {
+  grid-template-rows: 1fr;
+}
+ 
+.accordion-panel {
+  overflow: hidden;
+  min-height: 0;
+}
+ 
+.accordion-panel p {
+  margin: 0;
+  padding: 0 20px 18px;
+  font-size: 13.5px;
+  color: var(--mg-text-muted);
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   7. Footer
+   ------------------------------------------------------------------------- */
+ 
+.footer {
+  position: relative;
+  z-index: 1;
+  text-align: center;
+  padding: 8px 24px 48px;
+  font-size: 12.5px;
+  color: var(--mg-text-muted);
+  font-family: var(--mg-font-mono);
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   8. Responsive
+   ------------------------------------------------------------------------- */
+ 
+@media (max-width: 480px) {
+  .hero {
+    padding: 68px 20px 40px;
+  }
+ 
+  .accordion-header {
+    padding: 15px 16px;
+  }
+ 
+  .accordion-title {
+    font-size: 14px;
+  }
+ 
+  .accordion-panel p {
+    padding: 0 16px 16px;
+  }
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   9. Reduced motion
+   ------------------------------------------------------------------------- */
+ 
+@media (prefers-reduced-motion: reduce) {
+  .accordion-item,
+  .accordion-header,
+  .accordion-panel-wrapper,
+  .accordion-icon::before,
+  .accordion-icon::after {
+    transition-duration: 1ms;
+  }
+ 
+  /* Keep the glow as a fixed, non-pulsing indicator rather than removing
+     it outright — it's still useful information about which item is
+     open, it just shouldn't breathe. */
+  .accordion-item:has(.accordion-toggle:checked) {
+    animation: none;
+    box-shadow: 0 0 0 1px rgba(125, 224, 192, 0.2), 0 0 28px 3px var(--mg-glow);
+  }
+}


### PR DESCRIPTION
Closes #62068

## Pull Request Description
Adds a pure CSS/HTML FAQ accordion where opening an item reshapes its corners asymmetrically, applies a soft breathing glow, and expands its panel with a real smooth height transition (no max-height guessing). No JavaScript.

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/morph-glow-accordion/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
An accordion item that morphs its border-radius asymmetrically, glows softly while open, and expands via `grid-template-rows: 0fr → 1fr` instead of a fixed `max-height`.

**How does a developer use it?**
```html
<div class="accordion-item">
  <input type="checkbox" id="acc-1" class="accordion-toggle">
  <label for="acc-1" class="accordion-header">
    <span class="accordion-title">Question</span>
    <span class="accordion-icon" aria-hidden="true"></span>
  </label>
  <div class="accordion-panel-wrapper">
    <div class="accordion-panel"><p>Answer</p></div>
  </div>
</div>
```
Retune `--mg-radius-open`, `--mg-glow`, `--mg-duration`, or `--mg-pulse-duration` per instance.

**Why does it fit EaseMotion CSS?**
The grid-template-rows expand technique solves the classic "accordion with unknown content height" problem without JS or a magic-number max-height, and the morph + glow are a distinct combined motion signature rather than a plain slide-down.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

## Notes for Maintainer
Item-level glow/radius uses `:has()`; where unsupported, the header's own radius and icon morph still work fine (they don't depend on `:has()`) — only the glow and bottom-corner softening degrade, purely cosmetic. Under `prefers-reduced-motion`, the glow is kept as a static indicator rather than removed outright, since it's real state information (which item is open), not just decoration — happy to change that call if the maintainer prefers full removal.