### PR TITLE
Add ease-telescope-tripod component

### DIFF
--- a/submissions/examples/telescope-tripod-ij/README.md
+++ b/submissions/examples/telescope-tripod-ij/README.md
@@ -1,0 +1,10 @@
+# ease-telescope-tripod
+
+A telescope where the lens glints at the eyepiece, the tripod legs spread, and a star blinks overhead.
+
+## Run
+Open `demo.html` directly in a browser to watch the lens glint.
+
+## Notes
+- The lens glints at the eyepiece.
+- The star blinks overhead.

--- a/submissions/examples/telescope-tripod-ij/demo.html
+++ b/submissions/examples/telescope-tripod-ij/demo.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-telescope-tripod demo</title>
+</head>
+<body>
+<div class="tsc-dome">
+  <span class="tsc-star"></span>
+  <div class="tsc-tube">
+    <span class="tsc-eyepiece"></span>
+  </div>
+  <div class="tsc-leg tsc-leg-a"></div>
+  <div class="tsc-leg tsc-leg-b"></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/telescope-tripod-ij/style.css
+++ b/submissions/examples/telescope-tripod-ij/style.css
@@ -1,0 +1,12 @@
+:root{--tsc-gold:#e8c04a;--tsc-mid:#1a1410}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#0e1220,#080a14);font-family:'Georgia',serif}
+.tsc-dome{position:relative;width:330px;height:400px;border-radius:16px;overflow:hidden;background:linear-gradient(180deg,#161c30,#0a0e1c);box-shadow:0 14px 32px rgba(0,0,0,0.6)}
+.tsc-star{position:absolute;top:30px;right:64px;width:10px;height:10px;border-radius:50%;background:#e8c04a;box-shadow:0 0 12px #e8c04a;animation:star-blink-telescope-tripod 1.4s ease-in-out infinite}
+.tsc-tube{position:absolute;top:120px;left:50%;margin-left:-34px;width:68px;height:150px;border-radius:12px;background:#2a2418;box-shadow:0 0 0 3px #4a4028}
+.tsc-eyepiece{position:absolute;top:-14px;left:50%;margin-left:-16px;width:32px;height:22px;border-radius:6px;background:#e8c04a;animation:lens-glint-telescope-tripod 2s ease-in-out infinite}
+.tsc-leg{position:absolute;top:270px;width:14px;height:104px;border-radius:6px;background:#241e14;transform-origin:50% 0;animation:leg-spread-telescope-tripod 2.6s ease-in-out infinite}
+.tsc-leg-a{left:50%;margin-left:-7px}
+.tsc-leg-b{left:24px}
+@keyframes lens-glint-telescope-tripod{0%,100%{opacity:0.6}50%{opacity:1}}
+@keyframes star-blink-telescope-tripod{0%,100%{opacity:0.3}50%{opacity:1}}
+@keyframes leg-spread-telescope-tripod{0%,100%{transform:rotate(-10deg)}50%{transform:rotate(-20deg)}}


### PR DESCRIPTION
## Component: ease-telescope-tripod — lens glints, tripod spreads, and star blinks

**Closes #67684**

### What this adds
A telescope: the lens glints at the eyepiece, the tripod legs spread, and a star blinks overhead.

### Acceptance Criteria covered
- Lens glints at the eyepiece
- Tripod legs spread out
- Star blinks overhead

### Files
- `submissions/examples/telescope-tripod-ij/demo.html`
- `submissions/examples/telescope-tripod-ij/style.css`
- `submissions/examples/telescope-tripod-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the lens glint.