### PR TITLE
feat: pricing comparison cards (Resolves #61778)

### DIFF
--- a/submissions/examples/pricing-comparison-cards-sbh/README.md
+++ b/submissions/examples/pricing-comparison-cards-sbh/README.md
@@ -1,0 +1,64 @@
+# pricing-comparison-cards
+
+A three-tier pricing card matrix with smooth pop-up scale transitions on hover and prominent glowing purchase buttons. The featured plan is pre-elevated above the rest; every card lifts and softens its shadow on hover. Pure CSS.
+
+## What does this do?
+
+- **Responsive grid** of pricing cards (`auto-fit, minmax(15rem, 1fr)`) that collapses gracefully on small screens.
+- **Featured plan pops up by default** — `translateY(-1rem) scale(1.05)` with a gradient border ring and elevated shadow, plus a floating "Most popular" badge.
+- **Hover pop-up transition** — every card `translateY` + `scale` up with a softer, accent-tinted shadow (`cubic-bezier(0.22, 1, 0.36, 1)`).
+- **Glowing primary CTA** — the Pro plan's button is a gradient with a layered `box-shadow` glow that intensifies (brighter, larger radius) on hover.
+- Checkmark feature bullets, price with currency/per-month superscripts.
+
+## How is it used?
+
+1. Link the stylesheet.
+2. Use the markup below. Add `card--featured` to the plan you want elevated; put `btn--primary` on its CTA for the glow.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<section class="pricing">
+  <article class="card">
+    <h2 class="card__name">Starter</h2>
+    <p class="card__blurb">For side projects.</p>
+    <div class="card__price"><span class="card__cur">$</span>0<span class="card__per">/mo</span></div>
+    <ul class="card__features"><li>1 project</li><li>Community support</li></ul>
+    <button class="btn">Get started</button>
+  </article>
+
+  <article class="card card--featured">
+    <span class="card__badge">Most popular</span>
+    <h2 class="card__name">Pro</h2>
+    <p class="card__blurb">For growing teams.</p>
+    <div class="card__price"><span class="card__cur">$</span>24<span class="card__per">/mo</span></div>
+    <ul class="card__features"><li>Unlimited projects</li><li>Priority support</li></ul>
+    <button class="btn btn--primary">Buy Pro</button>
+  </article>
+
+  <article class="card">
+    <h2 class="card__name">Enterprise</h2>
+    <p class="card__blurb">For organizations.</p>
+    <div class="card__price"><span class="card__cur">$</span>99<span class="card__per">/mo</span></div>
+    <ul class="card__features"><li>Everything in Pro</li><li>SSO &amp; SAML</li></ul>
+    <button class="btn">Contact sales</button>
+  </article>
+</section>
+```
+
+## Why is this useful?
+
+- **Universal SaaS pattern** — pricing matrices appear on nearly every product landing page; this is a ready, polished reference.
+- **Animation-first** — the pop-up scale + glowing CTA are exactly the "smooth transitions + glowing buttons" the issue requests, all in CSS (`transform`, `box-shadow`).
+- **Accessible** — real `<button>`s and `<ul>` semantics; full `prefers-reduced-motion` support disables the elevations and glow scaling.
+- **Reusable** — configurable via CSS custom properties (`--pc-accent`, `--pc-radius`, `--pc-shadow-up`, `--pc-dur`, etc.); `card--featured` and `btn--primary` modifiers opt into the elevated/glowing treatments.
+
+## Files
+
+- `demo.html` — self-contained showcase (open directly in a browser; no server, CDNs, or frameworks). Starter / Pro (featured) / Enterprise tiers.
+- `style.css` — responsive grid, card base + hover pop-up, featured elevation + gradient ring + badge, checkmark bullets, primary CTA glow, reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/pricing-comparison-cards-sbh/demo.html
+++ b/submissions/examples/pricing-comparison-cards-sbh/demo.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>pricing-comparison-cards — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__head">
+      <p class="page__eyebrow">pricing-comparison-cards</p>
+      <h1>Pricing comparison cards.</h1>
+      <p class="page__lede">
+        A three-tier pricing matrix with smooth pop-up scale transitions on
+        hover and prominent glowing purchase buttons. The featured plan lifts
+        above the rest; every card elevates and softens its shadow on hover.
+        Pure CSS.
+      </p>
+    </header>
+
+    <section class="pricing" aria-label="Pricing plans">
+      <article class="card">
+        <h2 class="card__name">Starter</h2>
+        <p class="card__blurb">For side projects &amp; tinkerers.</p>
+        <div class="card__price"><span class="card__cur">$</span>0<span class="card__per">/mo</span></div>
+        <ul class="card__features">
+          <li>1 project</li>
+          <li>Community support</li>
+          <li>Basic analytics</li>
+          <li>1&nbsp;GB storage</li>
+        </ul>
+        <button class="btn">Get started</button>
+      </article>
+
+      <article class="card card--featured">
+        <span class="card__badge">Most popular</span>
+        <h2 class="card__name">Pro</h2>
+        <p class="card__blurb">For growing teams that ship.</p>
+        <div class="card__price"><span class="card__cur">$</span>24<span class="card__per">/mo</span></div>
+        <ul class="card__features">
+          <li>Unlimited projects</li>
+          <li>Priority support</li>
+          <li>Advanced analytics</li>
+          <li>50&nbsp;GB storage</li>
+          <li>Custom domains</li>
+        </ul>
+        <button class="btn btn--primary">Buy Pro</button>
+      </article>
+
+      <article class="card">
+        <h2 class="card__name">Enterprise</h2>
+        <p class="card__blurb">For organizations at scale.</p>
+        <div class="card__price"><span class="card__cur">$</span>99<span class="card__per">/mo</span></div>
+        <ul class="card__features">
+          <li>Everything in Pro</li>
+          <li>Dedicated manager</li>
+          <li>SSO &amp; SAML</li>
+          <li>Unlimited storage</li>
+          <li>99.9% uptime SLA</li>
+        </ul>
+        <button class="btn">Contact sales</button>
+      </article>
+    </section>
+
+    <p class="footnote">Hover any card to see it pop up &amp; scale; the Pro plan stays elevated and glows.</p>
+  </main>
+</body>
+</html>

--- a/submissions/examples/pricing-comparison-cards-sbh/style.css
+++ b/submissions/examples/pricing-comparison-cards-sbh/style.css
@@ -1,0 +1,204 @@
+/* pricing-comparison-cards — three-tier pricing matrix.
+   - Cards sit in a responsive grid; the featured plan is pre-elevated
+     (translateY up + bigger shadow + accent ring) so it pops above the rest.
+   - On hover, every card scales up slightly and lifts further with a softer
+     shadow (pop-up transition).
+   - The primary CTA has a layered glow (box-shadow) that intensifies on hover. */
+
+:root {
+  --pc-bg: #ffffff;
+  --pc-surface: #ffffff;
+  --pc-ink: #0f172a;
+  --pc-muted: #64748b;
+  --pc-line: #e2e8f0;
+  --pc-accent: #4f46e5;
+  --pc-accent-2: #7c3aed;
+  --pc-accent-soft: rgba(79, 70, 229, 0.12);
+  --pc-radius: 1rem;
+  --pc-shadow: 0 1px 2px rgba(15,23,42,0.06), 0 12px 24px -12px rgba(15,23,42,0.18);
+  --pc-shadow-up: 0 1px 2px rgba(15,23,42,0.06), 0 30px 60px -20px rgba(79,70,229,0.35);
+  --pc-dur: 0.28s;
+  --pc-ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* ---------- Page (demo only) ---------- */
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  color: var(--pc-ink);
+  background:
+    radial-gradient(900px 520px at 85% -10%, #eef2ff, transparent 60%),
+    radial-gradient(700px 440px at 0% 0%, #faf5ff, transparent 55%),
+    #fff;
+  line-height: 1.6;
+}
+.page { max-width: 64rem; margin: 0 auto; padding: clamp(2rem, 6vw, 4rem) clamp(1rem, 4vw, 2rem); }
+.page__eyebrow {
+  margin: 0 0 0.5rem; text-transform: uppercase; letter-spacing: 0.18em;
+  font-size: 0.78rem; font-weight: 700; color: var(--pc-accent);
+}
+.page__head h1 { margin: 0 0 0.8rem; font-size: clamp(1.6rem, 4.5vw, 2.4rem); letter-spacing: -0.02em; }
+.page__lede { margin: 0 0 2.5rem; color: var(--pc-muted); max-width: 40rem; }
+.footnote { color: #94a3b8; font-size: 0.85rem; margin: 2rem 0 0; text-align: center; }
+
+/* ---------- Pricing grid ---------- */
+.pricing {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+  gap: 1.5rem;
+  align-items: center;       /* so the elevated featured card stays centered */
+}
+
+/* ---------- Card ---------- */
+.card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  background: var(--pc-surface);
+  border: 1px solid var(--pc-line);
+  border-radius: var(--pc-radius);
+  padding: clamp(1.5rem, 3vw, 2rem);
+  box-shadow: var(--pc-shadow);
+  transform: translateY(0) scale(1);
+  transition:
+    transform var(--pc-dur) var(--pc-ease),
+    box-shadow var(--pc-dur) var(--pc-ease),
+    border-color var(--pc-dur) var(--pc-ease);
+}
+.card:hover {
+  transform: translateY(-0.5rem) scale(1.03);
+  box-shadow: var(--pc-shadow-up);
+  border-color: rgba(79, 70, 229, 0.35);
+}
+
+/* Featured plan: pre-elevated, accent ring, gradient header accent */
+.card--featured {
+  transform: translateY(-1rem) scale(1.05);
+  border-color: transparent;
+  background:
+    linear-gradient(var(--pc-bg), var(--pc-bg)) padding-box,
+    linear-gradient(135deg, var(--pc-accent), var(--pc-accent-2)) border-box;
+  border: 2px solid transparent;
+  box-shadow: var(--pc-shadow-up), 0 0 0 1px rgba(124,58,237,0.15);
+  z-index: 1;
+}
+.card--featured:hover {
+  transform: translateY(-1.4rem) scale(1.08);
+}
+
+/* "Most popular" badge floating above the featured card */
+.card__badge {
+  position: absolute;
+  top: -0.8rem;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 0.25rem 0.8rem;
+  background: linear-gradient(135deg, var(--pc-accent), var(--pc-accent-2));
+  color: #fff;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  border-radius: 999px;
+  box-shadow: 0 6px 16px -4px rgba(79,70,229,0.6);
+  white-space: nowrap;
+}
+
+.card__name { margin: 0 0 0.2rem; font-size: 1.25rem; letter-spacing: -0.01em; }
+.card__blurb { margin: 0 0 1.2rem; color: var(--pc-muted); font-size: 0.9rem; }
+
+/* Price */
+.card__price {
+  display: flex;
+  align-items: baseline;
+  gap: 0.1rem;
+  margin: 0 0 1.4rem;
+  font-size: 2.6rem;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  color: var(--pc-ink);
+}
+.card__cur { font-size: 1.1rem; font-weight: 700; color: var(--pc-muted); transform: translateY(-0.6rem); }
+.card__per { font-size: 0.95rem; font-weight: 600; color: var(--pc-muted); }
+
+/* Feature list */
+.card__features {
+  list-style: none;
+  margin: 0 0 1.6rem;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  font-size: 0.92rem;
+  color: #334155;
+}
+.card__features li {
+  position: relative;
+  padding-left: 1.5rem;
+}
+.card__features li::before {
+  content: "";
+  position: absolute;
+  left: 0; top: 0.45rem;
+  width: 0.85rem; height: 0.85rem;
+  border-radius: 50%;
+  background: var(--pc-accent-soft);
+  box-shadow: inset 0 0 0 1px var(--pc-accent);
+}
+.card__features li::after {
+  content: "";
+  position: absolute;
+  left: 0.27rem; top: 0.72rem;
+  width: 0.3rem; height: 0.55rem;
+  border-right: 0.14rem solid var(--pc-accent);
+  border-bottom: 0.14rem solid var(--pc-accent);
+  transform: rotate(45deg);
+}
+
+/* ---------- Buttons ---------- */
+.btn {
+  margin-top: auto;
+  display: block;
+  width: 100%;
+  padding: 0.75rem 1rem;
+  font: inherit;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--pc-ink);
+  background: var(--pc-bg);
+  border: 1px solid var(--pc-line);
+  border-radius: 0.6rem;
+  cursor: pointer;
+  transition:
+    transform var(--pc-dur) var(--pc-ease),
+    box-shadow var(--pc-dur) var(--pc-ease),
+    background-color var(--pc-dur) var(--pc-ease),
+    color var(--pc-dur) var(--pc-ease);
+}
+.btn:hover { transform: translateY(-0.12rem); border-color: rgba(79,70,229,0.4); }
+
+/* Primary CTA — glowing gradient button */
+.btn--primary {
+  color: #fff;
+  background: linear-gradient(135deg, var(--pc-accent), var(--pc-accent-2));
+  border-color: transparent;
+  box-shadow:
+    0 8px 20px -6px rgba(79,70,229,0.55),
+    0 0 0 1px rgba(124,58,237,0.25);
+}
+.btn--primary:hover {
+  transform: translateY(-0.16rem) scale(1.02);
+  box-shadow:
+    0 14px 30px -8px rgba(79,70,229,0.7),
+    0 0 24px 2px rgba(124,58,237,0.45),
+    0 0 0 1px rgba(124,58,237,0.35);
+}
+
+/* ---------- Reduced motion ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .card, .card--featured, .card:hover, .card--featured:hover, .btn, .btn:hover {
+    transition: none;
+    transform: none;
+  }
+  .card--featured { box-shadow: var(--pc-shadow-up); }
+}


### PR DESCRIPTION
Resolves #61778.

## What
Adds a three-tier pricing comparison card matrix with smooth pop-up scale transitions on hover and prominent glowing purchase buttons.

## Files
- `submissions/examples/pricing-comparison-cards-sbh/demo.html`
- `submissions/examples/pricing-comparison-cards-sbh/style.css`
- `submissions/examples/pricing-comparison-cards-sbh/README.md`

## How it works
- Responsive `auto-fit` grid of pricing cards (Starter / Pro (featured) / Enterprise).
- The featured plan is pre-elevated (`translateY(-1rem) scale(1.05)`) with a gradient border ring, a floating "Most popular" badge, and an elevated shadow.
- On hover, every card pops up (`translateY + scale`) with a softer accent-tinted shadow (`cubic-bezier(0.22, 1, 0.36, 1)`).
- The primary CTA is a gradient button with a layered `box-shadow` glow that intensifies on hover.
- Checkmark feature bullets, price with currency/per-month superscripts.
- Full `prefers-reduced-motion` support (disables elevations + glow scaling).

Self-contained: open `demo.html` directly in a browser; no server, CDNs, or frameworks. No core files changed.