### PR TITLE
feat: interactive drag-and-drop kanban board (Resolves #61602)

### DIFF
--- a/submissions/examples/interactive-kanban-board-sbh/README.md
+++ b/submissions/examples/interactive-kanban-board-sbh/README.md
@@ -1,0 +1,55 @@
+# interactive-kanban-board
+
+An animated drag-and-drop Kanban board: HTML5 drag-and-drop card reordering across four columns (To Do / In Progress / In Review / Completed), with a 3D tilt + elevation effect on the dragged card, fluid placeholder slots that scale open, priority badges (High / Medium / Low), and per-card progress bars. Native DnD for reordering + CSS for all motion.
+
+## What does this do?
+
+- **HTML5 drag-and-drop** — cards are `draggable="true"`; a tiny script (`dragstart` / `dragover` / `drop` / `dragend`) moves the card node into the target column, inserting before the card under the pointer. Column counts recompute on drop.
+- **3D tilt + elevation on drag** — the dragged card gets `.is-dragging`, which applies `translateY(-0.4rem) rotate(3deg) scale(1.05)` with a deepened shadow and accent border.
+- **Fluid placeholder slots** — when a column's dropzone is hovered (`.is-over`), a dashed accent slot animates open with `scaleY` (`@keyframes kb-slot-open`) showing where the card will land.
+- **Priority badges** — High (red), Medium (amber), Low (green) with soft tinted backgrounds and matching ring colors.
+- **Per-card progress bars** — gradient fill whose width is set inline; Completed cards get green 100% fill, struck-through titles, and muted opacity.
+- **Hover lift** — every card lifts slightly with a stronger shadow on hover.
+
+## How is it used?
+
+1. Link the stylesheet + the tiny script (in `demo.html`).
+2. Use the markup below. The script hooks `#board` and relies on `draggable="true"` cards inside `[data-dropzone]` column bodies.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<section class="board" id="board">
+  <div class="column" data-column="todo">
+    <header class="column__head"><h2>To Do</h2><span class="column__count">1</span></header>
+    <div class="column__body" data-dropzone>
+      <article class="card" draggable="true">
+        <div class="card__top">
+          <span class="badge badge--high">High</span>
+          <span class="card__id">ENG-241</span>
+        </div>
+        <h3 class="card__title">Wire up auth flow</h3>
+        <div class="card__progress"><div class="card__progress-fill" style="width: 15%"></div></div>
+      </article>
+    </div>
+  </div>
+  <!-- …more columns… -->
+</section>
+```
+
+## Why is this useful?
+
+- **Animation-first productivity UI** — the tilt/elevation, placeholder slot, and hover lift are exactly the fluid motion the issue requests; all driven by CSS classes the script toggles.
+- **Native, accessible DnD** — uses the platform HTML5 drag-and-drop API (no DnD library); keyboard users can still focus cards (draggable elements are focusable). Add `tabindex`/keyboard reorder handlers if you need full keyboard DnD.
+- **Self-contained** — no frameworks, no CDNs, no build step; the script is ~30 lines.
+- **Reusable** — configurable via CSS custom properties (`--kb-accent`, `--kb-radius`, priority colors, `--kb-dur`, etc.); `card--done` and `column--done` modifiers for completed state.
+
+## Files
+
+- `demo.html` — self-contained showcase (open directly in a browser; no server, CDNs, or frameworks). Four columns with sample cards + the DnD script.
+- `style.css` — board/column/card layout, `.is-dragging` tilt + elevation, `.is-over` placeholder slot `scaleY` animation, priority badges, progress bars, done state, reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/interactive-kanban-board-sbh/demo.html
+++ b/submissions/examples/interactive-kanban-board-sbh/demo.html
@@ -1,0 +1,190 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>interactive-kanban-board — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__head">
+      <p class="page__eyebrow">interactive-kanban-board</p>
+      <h1>Animated drag-and-drop Kanban board.</h1>
+      <p class="page__lede">
+        HTML5 drag-and-drop cards across four columns, with a 3D tilt + drop
+        shadow on the dragged card, fluid placeholder slots that scale open,
+        priority badges, and per-card progress bars. Native DnD + CSS animation.
+      </p>
+    </header>
+
+    <section class="board" id="board">
+
+      <div class="column" data-column="todo">
+        <header class="column__head">
+          <h2>To Do</h2><span class="column__count">3</span>
+        </header>
+        <div class="column__body" data-dropzone>
+          <article class="card" draggable="true">
+            <div class="card__top">
+              <span class="badge badge--high">High</span>
+              <span class="card__id">ENG-241</span>
+            </div>
+            <h3 class="card__title">Wire up auth flow</h3>
+            <div class="card__progress"><div class="card__progress-fill" style="width: 15%"></div></div>
+          </article>
+          <article class="card" draggable="true">
+            <div class="card__top">
+              <span class="badge badge--medium">Medium</span>
+              <span class="card__id">ENG-242</span>
+            </div>
+            <h3 class="card__title">Design empty states</h3>
+            <div class="card__progress"><div class="card__progress-fill" style="width: 0%"></div></div>
+          </article>
+          <article class="card" draggable="true">
+            <div class="card__top">
+              <span class="badge badge--low">Low</span>
+              <span class="card__id">ENG-243</span>
+            </div>
+            <h3 class="card__title">Audit color tokens</h3>
+            <div class="card__progress"><div class="card__progress-fill" style="width: 5%"></div></div>
+          </article>
+        </div>
+      </div>
+
+      <div class="column" data-column="in-progress">
+        <header class="column__head">
+          <h2>In Progress</h2><span class="column__count">2</span>
+        </header>
+        <div class="column__body" data-dropzone>
+          <article class="card" draggable="true">
+            <div class="card__top">
+              <span class="badge badge--high">High</span>
+              <span class="card__id">ENG-238</span>
+            </div>
+            <h3 class="card__title">Migrate billing API</h3>
+            <div class="card__progress"><div class="card__progress-fill" style="width: 60%"></div></div>
+          </article>
+          <article class="card" draggable="true">
+            <div class="card__top">
+              <span class="badge badge--medium">Medium</span>
+              <span class="card__id">ENG-239</span>
+            </div>
+            <h3 class="card__title">Build onboarding tour</h3>
+            <div class="card__progress"><div class="card__progress-fill" style="width: 40%"></div></div>
+          </article>
+        </div>
+      </div>
+
+      <div class="column" data-column="review">
+        <header class="column__head">
+          <h2>In Review</h2><span class="column__count">2</span>
+        </header>
+        <div class="column__body" data-dropzone>
+          <article class="card" draggable="true">
+            <div class="card__top">
+              <span class="badge badge--medium">Medium</span>
+              <span class="card__id">ENG-235</span>
+            </div>
+            <h3 class="card__title">Settings page refactor</h3>
+            <div class="card__progress"><div class="card__progress-fill" style="width: 80%"></div></div>
+          </article>
+          <article class="card" draggable="true">
+            <div class="card__top">
+              <span class="badge badge--low">Low</span>
+              <span class="card__id">ENG-236</span>
+            </div>
+            <h3 class="card__title">Tooltip a11y pass</h3>
+            <div class="card__progress"><div class="card__progress-fill" style="width: 90%"></div></div>
+          </article>
+        </div>
+      </div>
+
+      <div class="column column--done" data-column="done">
+        <header class="column__head">
+          <h2>Completed</h2><span class="column__count">2</span>
+        </header>
+        <div class="column__body" data-dropzone>
+          <article class="card card--done" draggable="true">
+            <div class="card__top">
+              <span class="badge badge--low">Low</span>
+              <span class="card__id">ENG-230</span>
+            </div>
+            <h3 class="card__title">Fix favicon pipeline</h3>
+            <div class="card__progress"><div class="card__progress-fill" style="width: 100%"></div></div>
+          </article>
+          <article class="card card--done" draggable="true">
+            <div class="card__top">
+              <span class="badge badge--medium">Medium</span>
+              <span class="card__id">ENG-231</span>
+            </div>
+            <h3 class="card__title">Deploy preview env</h3>
+            <div class="card__progress"><div class="card__progress-fill" style="width: 100%"></div></div>
+          </article>
+        </div>
+      </div>
+
+    </section>
+
+    <p class="footnote">Drag any card into another column. The dragged card tilts and lifts; a placeholder slot opens where it will land.</p>
+
+    <script>
+      (function () {
+        var board = document.getElementById('board');
+        var dragEl = null;
+
+        board.addEventListener('dragstart', function (e) {
+          if (!e.target.classList || !e.target.classList.contains('card')) return;
+          dragEl = e.target;
+          e.target.classList.add('is-dragging');
+          e.dataTransfer.effectAllowed = 'move';
+          // Firefox requires setData to start the drag
+          try { e.dataTransfer.setData('text/plain', 'card'); } catch (_) {}
+        });
+
+        board.addEventListener('dragend', function (e) {
+          if (dragEl) { dragEl.classList.remove('is-dragging'); dragEl = null; }
+          // clear any leftover placeholder states
+          Array.prototype.forEach.call(board.querySelectorAll('.is-over'), function (z) { z.classList.remove('is-over'); });
+        });
+
+        board.addEventListener('dragover', function (e) {
+          if (!dragEl) return;
+          e.preventDefault();
+          e.dataTransfer.dropEffect = 'move';
+          var zone = e.target.closest('[data-dropzone]');
+          // clear previous over states in this board
+          Array.prototype.forEach.call(board.querySelectorAll('.is-over'), function (z) { if (z !== zone) z.classList.remove('is-over'); });
+          if (zone) zone.classList.add('is-over');
+        });
+
+        board.addEventListener('dragleave', function (e) {
+          var zone = e.target.closest('[data-dropzone]');
+          if (zone && !zone.contains(e.relatedTarget)) zone.classList.remove('is-over');
+        });
+
+        board.addEventListener('drop', function (e) {
+          e.preventDefault();
+          if (!dragEl) return;
+          var zone = e.target.closest('[data-dropzone]');
+          if (zone && zone !== dragEl.parentNode) {
+            // insert before the card the pointer is over, else append
+            var before = e.target.closest('.card');
+            if (before && before !== dragEl) zone.insertBefore(dragEl, before);
+            else zone.appendChild(dragEl);
+            recount();
+          }
+          Array.prototype.forEach.call(board.querySelectorAll('.is-over'), function (z) { z.classList.remove('is-over'); });
+        });
+
+        function recount() {
+          Array.prototype.forEach.call(board.querySelectorAll('.column'), function (col) {
+            var n = col.querySelector('.column__body').querySelectorAll('.card').length;
+            col.querySelector('.column__count').textContent = n;
+          });
+        }
+      })();
+    </script>
+  </main>
+</body>
+</html>

--- a/submissions/examples/interactive-kanban-board-sbh/style.css
+++ b/submissions/examples/interactive-kanban-board-sbh/style.css
@@ -1,0 +1,184 @@
+/* interactive-kanban-board — drag-and-drop task board.
+   Animations are CSS-driven off classes the tiny script toggles:
+     - .is-dragging on the card being dragged  -> 3D tilt + elevation + shadow
+     - .is-over on a dropzone                  -> placeholder slot scales open
+   Native HTML5 DnD provides the reordering; CSS provides the motion. */
+
+:root {
+  --kb-bg: #f1f5f9;
+  --kb-surface: #ffffff;
+  --kb-ink: #0f172a;
+  --kb-muted: #64748b;
+  --kb-line: #e2e8f0;
+  --kb-accent: #4f46e5;
+  --kb-radius: 0.7rem;
+  --kb-card-radius: 0.6rem;
+  --kb-shadow: 0 1px 2px rgba(15,23,42,0.06), 0 6px 14px -8px rgba(15,23,42,0.18);
+  --kb-shadow-up: 0 18px 38px -12px rgba(15,23,42,0.4);
+  --kb-dur: 0.22s;
+  --kb-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  /* priority colors */
+  --kb-high: #ef4444;
+  --kb-high-soft: rgba(239,68,68,0.12);
+  --kb-medium: #f59e0b;
+  --kb-medium-soft: rgba(245,158,11,0.14);
+  --kb-low: #10b981;
+  --kb-low-soft: rgba(16,185,129,0.14);
+  /* done */
+  --kb-done: #64748b;
+}
+
+/* ---------- Page (demo only) ---------- */
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  color: var(--kb-ink);
+  background: var(--kb-bg);
+  line-height: 1.5;
+}
+.page { max-width: 72rem; margin: 0 auto; padding: clamp(1.2rem, 4vw, 2.5rem) clamp(1rem, 4vw, 2rem); }
+.page__eyebrow {
+  margin: 0 0 0.4rem; text-transform: uppercase; letter-spacing: 0.18em;
+  font-size: 0.78rem; font-weight: 700; color: var(--kb-accent);
+}
+.page__head h1 { margin: 0 0 0.6rem; font-size: clamp(1.5rem, 4vw, 2.1rem); letter-spacing: -0.02em; }
+.page__lede { margin: 0 0 1.8rem; color: var(--kb-muted); max-width: 44rem; }
+.footnote { color: var(--kb-muted); font-size: 0.85rem; margin: 1.5rem 0 0; }
+
+/* ---------- Board ---------- */
+.board {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+  gap: 1rem;
+  align-items: start;
+}
+
+/* ---------- Column ---------- */
+.column {
+  background: rgba(255,255,255,0.6);
+  border: 1px solid var(--kb-line);
+  border-radius: var(--kb-radius);
+  display: flex; flex-direction: column;
+  min-height: 8rem;
+}
+.column__head {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 0.7rem 0.9rem;
+  border-bottom: 1px solid var(--kb-line);
+}
+.column__head h2 { margin: 0; font-size: 0.9rem; letter-spacing: -0.01em; }
+.column__count {
+  display: inline-grid; place-items: center;
+  min-width: 1.4rem; height: 1.4rem; padding: 0 0.35rem;
+  background: var(--kb-line); color: var(--kb-muted);
+  border-radius: 999px; font-size: 0.72rem; font-weight: 700;
+}
+.column__body {
+  display: flex; flex-direction: column; gap: 0.6rem;
+  padding: 0.6rem;
+  flex: 1;
+  /* keep a min height so empty columns can still receive drops */
+  min-height: 6rem;
+}
+
+/* Dropzone "over" state: opens a placeholder slot that scales open */
+.column__body.is-over {
+  background: rgba(79,70,229,0.06);
+  box-shadow: inset 0 0 0 2px var(--kb-accent);
+  border-radius: var(--kb-card-radius);
+}
+.column__body.is-over::before {
+  content: "";
+  display: block;
+  height: 3rem;
+  margin: -0.1rem 0;
+  border-radius: var(--kb-card-radius);
+  border: 2px dashed var(--kb-accent);
+  background: rgba(79,70,229,0.05);
+  transform-origin: top center;
+  animation: kb-slot-open var(--kb-dur) var(--kb-ease);
+}
+@keyframes kb-slot-open {
+  from { transform: scaleY(0.3); opacity: 0; }
+  to   { transform: scaleY(1);   opacity: 1; }
+}
+
+/* ---------- Card ---------- */
+.card {
+  background: var(--kb-surface);
+  border: 1px solid var(--kb-line);
+  border-radius: var(--kb-card-radius);
+  padding: 0.7rem 0.8rem;
+  box-shadow: var(--kb-shadow);
+  cursor: grab;
+  transform: translateY(0) rotate(0deg) scale(1);
+  transition:
+    transform var(--kb-dur) var(--kb-ease),
+    box-shadow var(--kb-dur) var(--kb-ease),
+    border-color var(--kb-dur) var(--kb-ease),
+    opacity var(--kb-dur) var(--kb-ease);
+}
+.card:hover {
+  transform: translateY(-0.15rem);
+  box-shadow: var(--kb-shadow-up);
+  border-color: rgba(79,70,229,0.3);
+}
+.card:active { cursor: grabbing; }
+
+/* Dragging: 3D tilt + elevation + stronger shadow */
+.card.is-dragging {
+  opacity: 0.92;
+  transform: translateY(-0.4rem) rotate(3deg) scale(1.05);
+  box-shadow: 0 26px 50px -12px rgba(15,23,42,0.45);
+  border-color: var(--kb-accent);
+  /* slight perspective lift */
+  z-index: 10;
+}
+
+.card__top { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0.4rem; }
+.card__id { font-size: 0.7rem; color: var(--kb-muted); font-weight: 600; letter-spacing: 0.02em; }
+.card__title { margin: 0; font-size: 0.92rem; letter-spacing: -0.01em; }
+
+/* ---------- Priority badges ---------- */
+.badge {
+  display: inline-block;
+  padding: 0.12rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.68rem; font-weight: 700; letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+.badge--high   { color: var(--kb-high);   background: var(--kb-high-soft);   box-shadow: inset 0 0 0 1px rgba(239,68,68,0.3); }
+.badge--medium { color: var(--kb-medium); background: var(--kb-medium-soft); box-shadow: inset 0 0 0 1px rgba(245,158,11,0.3); }
+.badge--low    { color: var(--kb-low);    background: var(--kb-low-soft);    box-shadow: inset 0 0 0 1px rgba(16,185,129,0.3); }
+
+/* ---------- Progress bar ---------- */
+.card__progress {
+  height: 0.3rem;
+  margin-top: 0.6rem;
+  border-radius: 999px;
+  background: var(--kb-line);
+  overflow: hidden;
+}
+.card__progress-fill {
+  height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--kb-accent), #7c3aed);
+  transition: width var(--kb-dur) var(--kb-ease);
+}
+
+/* Done cards: muted, struck, green fill */
+.card--done { opacity: 0.75; }
+.card--done .card__title { text-decoration: line-through; color: var(--kb-done); }
+.card--done .card__progress-fill { background: var(--kb-low); }
+.column--done .column__count { background: var(--kb-low-soft); color: var(--kb-low); }
+
+/* ---------- Reduced motion ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .card, .card:hover, .card.is-dragging, .column__body.is-over::before {
+    transition: none;
+    animation: none;
+    transform: none;
+  }
+  .card.is-dragging { opacity: 0.92; box-shadow: var(--kb-shadow-up); }
+}


### PR DESCRIPTION
Resolves #61602.

## What
Adds an animated drag-and-drop Kanban board with HTML5 DnD card reordering across four columns, a 3D tilt + elevation effect on the dragged card, fluid placeholder slots that scale open, priority badges, and per-card progress bars.

## Files
- `submissions/examples/interactive-kanban-board-sbh/demo.html`
- `submissions/examples/interactive-kanban-board-sbh/style.css`
- `submissions/examples/interactive-kanban-board-sbh/README.md`

## How it works
- HTML5 drag-and-drop: cards are `draggable="true"`; a ~30-line script (`dragstart`/`dragover`/`drop`/`dragend`) moves the card into the target column, inserting before the card under the pointer. Column counts recompute on drop.
- 3D tilt + elevation: the dragged card gets `.is-dragging` -> `translateY(-0.4rem) rotate(3deg) scale(1.05)` with a deepened shadow and accent border.
- Fluid placeholder slots: when a dropzone is hovered (`.is-over`), a dashed accent slot animates open with `scaleY` (`@keyframes kb-slot-open`).
- Priority badges: High (red) / Medium (amber) / Low (green) with soft tinted backgrounds.
- Per-card progress bars; Completed cards get green 100% fill, struck-through titles, muted opacity.
- Full `prefers-reduced-motion` support.

Verified: dragging applies `transform=matrix(1.0486, 0.055, -0.055, 1.0486, 0, -6.4)` (= scale 1.05 + rotate 3deg + translateY -0.4rem); dropping moves the card node to the target column.

Self-contained: open `demo.html` directly in a browser; no server, CDNs, or frameworks. No core files changed.