### PR TITLE
docs: utility class examples & live demos (Resolves #63965)

### DIFF
--- a/submissions/examples/utility-class-examples-sbh/README.md
+++ b/submissions/examples/utility-class-examples-sbh/README.md
@@ -1,0 +1,49 @@
+# utility-class-examples
+
+Practical, visual demonstrations of common animation utility classes — Fade In, Slide Up, Zoom In, Bounce — plus Delay (`.delay-1` … `.delay-4`) and Duration (`.dur-fast` / `.dur-slow`) utilities. Each demo card shows the utility name, a live preview box, and the exact class to use, with a Replay button to re-run every animation from the start.
+
+## What does this do?
+
+- **Fade In** — `.fade-in` animates `opacity` 0→1 (`@keyframes uc-fade-in`).
+- **Slide Up** — `.slide-up` fades in while translating up from `translateY(1.5rem)` (`@keyframes uc-slide-up`).
+- **Zoom In** — `.zoom-in` fades in while scaling from `scale(0.6)` (`@keyframes uc-zoom-in`).
+- **Bounce** — `.bounce` drops in and settles with a few diminishing bounces (`@keyframes uc-bounce`).
+- **Delay utilities** — `.delay-1` (0.2s) through `.delay-4` (0.8s) stagger entrance animations (shown with four `.fade-in` boxes).
+- **Duration utilities** — `.dur-fast` (0.3s) and `.dur-slow` (1.2s) override the default `--uc-dur` (0.6s).
+- **Replay** — a button re-triggers every animation by toggling classes off→reflow→on.
+- All entrance utilities use `both` fill mode so elements hold their start state until the animation runs (clean on-load reveals).
+
+## How is it used?
+
+1. Link the stylesheet.
+2. Add a utility class to any element. Utilities compose freely.
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<div class="box fade-in">Fade</div>
+<div class="box slide-up">Slide</div>
+<div class="box zoom-in">Zoom</div>
+<div class="box bounce">Bounce</div>
+
+<!-- compose: fade in, delayed, slow -->
+<div class="box fade-in delay-2 dur-slow">…</div>
+```
+
+## Why is this useful?
+
+- **Directly addresses the issue** — the issue asked for live demos of Fade In, Slide Up, Zoom In, Bounce, Delay, and Duration utilities with code snippets; this provides all six in a single self-contained page.
+- **Beginner-friendly** — each card pairs the visible animation with the exact class name and a copy-ready snippet.
+- **Composable** — entrance + delay + duration utilities stack cleanly (e.g. `.fade-in.delay-2.dur-slow`).
+- **Accessible** — `prefers-reduced-motion` disables all entrance animations (elements render in their final state); the Replay button is a real `<button>`.
+- **Reusable** — configurable via CSS custom properties (`--uc-dur`, `--uc-ease`, `--uc-accent`, `--uc-box-grad`, etc.).
+
+## Files
+
+- `demo.html` — self-contained showcase (open directly in a browser; no server, CDNs, or frameworks). Six demo cards (Fade In / Slide Up / Zoom In / Bounce / Delays / Durations) + the Replay script.
+- `style.css` — page + demo grid + animated box, the four entrance `@keyframes`, delay/duration utilities, reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions. Class names intentionally avoid the `ease-` prefix so the maintainer can standardize them during curation.

--- a/submissions/examples/utility-class-examples-sbh/demo.html
+++ b/submissions/examples/utility-class-examples-sbh/demo.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>utility-class-examples — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__head">
+      <p class="page__eyebrow">utility-class-examples</p>
+      <h1>Utility class examples &amp; live demos.</h1>
+      <p class="page__lede">
+        Practical, visual demonstrations of common animation utility classes
+        &mdash; Fade In, Slide Up, Zoom In, Bounce &mdash; plus Delay and Duration
+        utilities. Each card shows the utility name, a live preview box, and the
+        class name to use. Press <strong>Replay</strong> to re-run every
+        animation from the start.
+      </p>
+      <button class="replay" id="replay">↻ Replay all</button>
+    </header>
+
+    <section class="grid">
+
+      <!-- Fade In -->
+      <article class="demo" data-demo>
+        <div class="demo__head"><h2>Fade In</h2><code>.fade-in</code></div>
+        <div class="stage">
+          <div class="box fade-in">Fade</div>
+        </div>
+        <pre class="snippet"><code>&lt;div class="box fade-in"&gt;Fade&lt;/div&gt;</code></pre>
+      </article>
+
+      <!-- Slide Up -->
+      <article class="demo" data-demo>
+        <div class="demo__head"><h2>Slide Up</h2><code>.slide-up</code></div>
+        <div class="stage">
+          <div class="box slide-up">Slide</div>
+        </div>
+        <pre class="snippet"><code>&lt;div class="box slide-up"&gt;Slide&lt;/div&gt;</code></pre>
+      </article>
+
+      <!-- Zoom In -->
+      <article class="demo" data-demo>
+        <div class="demo__head"><h2>Zoom In</h2><code>.zoom-in</code></div>
+        <div class="stage">
+          <div class="box zoom-in">Zoom</div>
+        </div>
+        <pre class="snippet"><code>&lt;div class="box zoom-in"&gt;Zoom&lt;/div&gt;</code></pre>
+      </article>
+
+      <!-- Bounce -->
+      <article class="demo" data-demo>
+        <div class="demo__head"><h2>Bounce</h2><code>.bounce</code></div>
+        <div class="stage">
+          <div class="box bounce">Bounce</div>
+        </div>
+        <pre class="snippet"><code>&lt;div class="box bounce"&gt;Bounce&lt;/div&gt;</code></pre>
+      </article>
+
+      <!-- Delay utilities -->
+      <article class="demo" data-demo>
+        <div class="demo__head"><h2>Delay utilities</h2><code>.delay-1 … .delay-4</code></div>
+        <div class="stage stage--row">
+          <div class="box small fade-in delay-1">d1</div>
+          <div class="box small fade-in delay-2">d2</div>
+          <div class="box small fade-in delay-3">d3</div>
+          <div class="box small fade-in delay-4">d4</div>
+        </div>
+        <pre class="snippet"><code>&lt;div class="box fade-in delay-2"&gt;…&lt;/div&gt;</code></pre>
+      </article>
+
+      <!-- Duration utilities -->
+      <article class="demo" data-demo>
+        <div class="demo__head"><h2>Duration utilities</h2><code>.dur-fast / .dur-slow</code></div>
+        <div class="stage stage--row">
+          <div class="box small slide-up dur-fast">fast</div>
+          <div class="box small slide-up dur-slow">slow</div>
+        </div>
+        <pre class="snippet"><code>&lt;div class="box slide-up dur-slow"&gt;…&lt;/div&gt;</code></pre>
+      </article>
+
+    </section>
+
+    <p class="footnote">These utility classes are self-contained animation primitives. Combine them freely, e.g. <code>.fade-in.delay-2.dur-slow</code>.</p>
+
+    <script>
+      (function () {
+        var replay = document.getElementById('replay');
+        var demos = document.querySelectorAll('[data-demo]');
+        replay.addEventListener('click', function () {
+          demos.forEach(function (d) {
+            var boxes = d.querySelectorAll('.box');
+            boxes.forEach(function (b) {
+              // Restart CSS animations by cloning the class list off then on.
+              var cls = b.className;
+              b.className = 'box';          // strip animation classes momentarily
+              // force reflow so the browser registers the change
+              void b.offsetWidth;
+              b.className = cls;            // restore -> animations replay
+            });
+          });
+        });
+      })();
+    </script>
+  </main>
+</body>
+</html>

--- a/submissions/examples/utility-class-examples-sbh/style.css
+++ b/submissions/examples/utility-class-examples-sbh/style.css
@@ -1,0 +1,177 @@
+/* utility-class-examples — animation utility classes with live demos.
+   Defines small, composable utilities:
+     Entrance:  .fade-in | .slide-up | .zoom-in | .bounce
+     Timing:    .delay-1 (200ms) … .delay-4 (800ms) | .dur-fast (0.3s) | .dur-slow (1.2s)
+   Each entrance utility runs once on load (forwards fill). The demo's Replay
+   button re-triggers them by toggling classes. */
+
+:root {
+  --uc-bg: #ffffff;
+  --uc-ink: #0f172a;
+  --uc-muted: #64748b;
+  --uc-line: #e2e8f0;
+  --uc-accent: #4f46e5;
+  --uc-accent-2: #7c3aed;
+  --uc-accent-soft: rgba(79,70,229,0.12);
+  --uc-radius: 1rem;
+  --uc-box-grad: linear-gradient(135deg, var(--uc-accent), var(--uc-accent-2));
+  --uc-dur: 0.6s;
+  --uc-ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* ---------- Page (demo only) ---------- */
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  color: var(--uc-ink);
+  background:
+    radial-gradient(900px 520px at 85% -10%, #eef2ff, transparent 60%),
+    radial-gradient(700px 440px at 0% 0%, #faf5ff, transparent 55%),
+    #fff;
+  line-height: 1.6;
+}
+.page { max-width: 64rem; margin: 0 auto; padding: clamp(2rem, 6vw, 4rem) clamp(1rem, 4vw, 2rem); }
+.page__eyebrow {
+  margin: 0 0 0.5rem; text-transform: uppercase; letter-spacing: 0.18em;
+  font-size: 0.78rem; font-weight: 700; color: var(--uc-accent);
+}
+.page__head h1 { margin: 0 0 0.8rem; font-size: clamp(1.6rem, 4.5vw, 2.4rem); letter-spacing: -0.02em; }
+.page__lede { margin: 0 0 1.4rem; color: var(--uc-muted); max-width: 40rem; }
+.page__lede strong { color: var(--uc-ink); }
+.page__lede code { background: var(--uc-accent-soft); color: var(--uc-accent); padding: 0.12rem 0.4rem; border-radius: 0.4rem; font-size: 0.9em; }
+.footnote { color: var(--uc-muted); font-size: 0.85rem; margin: 1.5rem 0 0; }
+.footnote code { background: var(--uc-accent-soft); color: var(--uc-accent); padding: 0.1rem 0.35rem; border-radius: 0.35rem; font-size: 0.9em; }
+
+/* Replay button */
+.replay {
+  font: inherit; font-size: 0.9rem; font-weight: 700;
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--uc-line);
+  background: #fff;
+  color: var(--uc-ink);
+  cursor: pointer;
+  transition: transform 0.18s var(--uc-ease), box-shadow 0.18s var(--uc-ease), background-color 0.18s var(--uc-ease);
+}
+.replay:hover { transform: translateY(-0.1rem); box-shadow: 0 8px 18px -8px rgba(79,70,229,0.5); background: var(--uc-accent-soft); }
+
+/* ---------- Grid of demo cards ---------- */
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr));
+  gap: 1.2rem;
+}
+.demo {
+  background: rgba(255,255,255,0.7);
+  border: 1px solid var(--uc-line);
+  border-radius: var(--uc-radius);
+  padding: 1.2rem;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+.demo__head { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 0.9rem; gap: 0.5rem; }
+.demo__head h2 { margin: 0; font-size: 1rem; letter-spacing: -0.01em; }
+.demo__head code { font-size: 0.78rem; color: var(--uc-accent); background: var(--uc-accent-soft); padding: 0.12rem 0.4rem; border-radius: 0.4rem; }
+
+/* Stage: the live preview area */
+.stage {
+  display: grid;
+  place-items: center;
+  min-height: 5rem;
+  border-radius: 0.6rem;
+  background: repeating-linear-gradient(45deg, #f8fafc 0 0.8rem, #eef2f7 0.8rem 1.6rem);
+  border: 1px dashed var(--uc-line);
+  padding: 1rem;
+  margin-bottom: 0.8rem;
+}
+.stage--row { display: flex; gap: 0.5rem; flex-wrap: wrap; }
+
+/* The animated box */
+.box {
+  display: grid; place-items: center;
+  width: 4rem; height: 2.2rem;
+  color: #fff; font-weight: 700; font-size: 0.8rem;
+  background: var(--uc-box-grad);
+  border-radius: 0.5rem;
+  box-shadow: 0 8px 18px -8px rgba(79,70,229,0.6);
+}
+.box.small { width: 2.6rem; height: 2.2rem; font-size: 0.7rem; }
+
+/* Snippet */
+.snippet {
+  margin: 0;
+  padding: 0.6rem 0.7rem;
+  background: #0f172a;
+  color: #e2e8f0;
+  border-radius: 0.5rem;
+  overflow-x: auto;
+  font-size: 0.76rem;
+  line-height: 1.4;
+}
+.snippet code { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; }
+
+/* =========================================================
+   ENTRANCE UTILITY CLASSES  (run once on load, forwards fill)
+   ========================================================= */
+
+/* Fade In */
+.fade-in {
+  animation: uc-fade-in var(--uc-dur) var(--uc-ease) both;
+}
+@keyframes uc-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+/* Slide Up */
+.slide-up {
+  animation: uc-slide-up var(--uc-dur) var(--uc-ease) both;
+}
+@keyframes uc-slide-up {
+  from { opacity: 0; transform: translateY(1.5rem); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* Zoom In */
+.zoom-in {
+  animation: uc-zoom-in var(--uc-dur) var(--uc-ease) both;
+}
+@keyframes uc-zoom-in {
+  from { opacity: 0; transform: scale(0.6); }
+  to   { opacity: 1; transform: scale(1); }
+}
+
+/* Bounce */
+.bounce {
+  animation: uc-bounce var(--uc-dur) var(--uc-ease) both;
+}
+@keyframes uc-bounce {
+  0%   { opacity: 0; transform: translateY(-1.4rem); }
+  50%  { opacity: 1; transform: translateY(0.4rem); }
+  70%  { transform: translateY(-0.18rem); }
+  85%  { transform: translateY(0.06rem); }
+  100% { transform: translateY(0); }
+}
+
+/* =========================================================
+   TIMING UTILITY CLASSES
+   ========================================================= */
+
+/* Delay utilities (.delay-1 … .delay-4) */
+.delay-1 { animation-delay: 0.2s; }
+.delay-2 { animation-delay: 0.4s; }
+.delay-3 { animation-delay: 0.6s; }
+.delay-4 { animation-delay: 0.8s; }
+
+/* Duration utilities */
+.dur-fast { animation-duration: 0.3s; }
+.dur-slow { animation-duration: 1.2s; }
+
+/* =========================================================
+   Reduced motion: disable all entrance animations.
+   ========================================================= */
+@media (prefers-reduced-motion: reduce) {
+  .fade-in, .slide-up, .zoom-in, .bounce { animation: none !important; opacity: 1 !important; transform: none !important; }
+  .replay:hover { transform: none; }
+}


### PR DESCRIPTION
Resolves #63965.

## What
Adds a documentation example page with live demos and code snippets for common animation utility classes: Fade In, Slide Up, Zoom In, Bounce, Delay utilities, and Duration utilities.

## Files
- `submissions/examples/utility-class-examples-sbh/demo.html`
- `submissions/examples/utility-class-examples-sbh/style.css`
- `submissions/examples/utility-class-examples-sbh/README.md`

## How it works
- Six demo cards, each pairing a visible animation with the exact class name and a copy-ready snippet:
  - Fade In (`.fade-in`, `@keyframes uc-fade-in`)
  - Slide Up (`.slide-up`, `@keyframes uc-slide-up`)
  - Zoom In (`.zoom-in`, `@keyframes uc-zoom-in`)
  - Bounce (`.bounce`, `@keyframes uc-bounce`)
  - Delay utilities (`.delay-1` 0.2s ... `.delay-4` 0.8s)
  - Duration utilities (`.dur-fast` 0.3s / `.dur-slow` 1.2s)
- All entrance utilities use `both` fill mode so elements hold their start state until the animation runs (clean on-load reveals).
- Utilities compose freely (e.g. `.fade-in.delay-2.dur-slow`).
- A Replay button re-triggers every animation by toggling classes off -> reflow -> on.
- Full `prefers-reduced-motion` support (elements render in their final state).

Verified: each utility applies its keyframes with `fill=both`; the combo `.fade-in.delay-2.dur-slow` correctly overrides to `dur=1.2s, delay=0.4s`.

Self-contained: open `demo.html` directly in a browser; no server, CDNs, or frameworks. No core files changed.