### PR TITLE
feat: add CSS Blur-Entrance Accordion for Minimalist Tech Layouts (#64554)

### DIFF
--- a/submissions/examples/minimalist-tech-blur-entrance-accordion/README.md
+++ b/submissions/examples/minimalist-tech-blur-entrance-accordion/README.md
@@ -1,0 +1,24 @@
+# CSS Blur-Entrance Accordion (Minimalist Tech)
+
+A pure CSS accordion component designed for Minimalist Tech Layouts. It features entirely JavaScript-free state management and a cinematic "Blur-Entrance" animation that smoothly pulls the content into focus as the accordion expands.
+
+## Features
+- Pure CSS and HTML (Zero JavaScript required for state or animations).
+- **Minimalist Tech Aesthetic**: Clean panel layout, subtle focus states, distinct semantic icon background accents, and an animated Plus/Minus indicator.
+- **Pure CSS State Management**: 
+- Utilizes the "Radio Button Hack". Inside each `.accordion-item`, there is a hidden `<input type="radio">` that tracks the open/closed state, and an `<label>` acting as the header. 
+- Using `type="radio"` ensures that only one accordion item can be open at a time (exclusive expansion).
+- **CSS Grid Height Transition**: 
+- The `.accordion-body` uses modern CSS Grid techniques (`grid-template-rows: 0fr` transitioning to `1fr`) to smoothly animate the height from 0 to `auto`. This is the most performant, JS-free way to handle dynamic height transitions.
+- **The Blur-Entrance Animation System**: 
+- The inner `.body-content` starts with `opacity: 0`, a slight downward offset (`translateY(10px)`), and a heavy CSS filter (`filter: blur(10px)`).
+- When the parent radio button is checked, a CSS transition smoothly brings the content into focus (`blur(0px)`), fades it in, and slides it up to its baseline. 
+- We apply a `0.1s` transition delay to the content so that the grid has a moment to start opening *before* the content begins to fade and un-blur, creating a highly polished, cinematic reveal.
+- Fully accessible with `prefers-reduced-motion` support. For motion-sensitive users, the blur filter and spatial translations are completely disabled. The entrance safely falls back to a simple, immediate opacity fade.
+
+## Usage
+Open `demo.html` in your browser. You will see a mock "System Configuration FAQ". Click on any accordion header. Notice how the grid smoothly expands, the plus icon morphs into a minus, and the internal text cinematicly pulls into focus from a heavy blur.
+
+## Files
+- `demo.html`: The HTML structure for the accordion, detailing the crucial radio/label relationship for CSS state management, and the nested `body-content` structure required for the grid transition.
+- `style.css`: The styling, tech design tokens, the `grid-template-rows` trick for smooth height animation, and the `filter: blur()` transition logic.

--- a/submissions/examples/minimalist-tech-blur-entrance-accordion/demo.html
+++ b/submissions/examples/minimalist-tech-blur-entrance-accordion/demo.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Blur-Entrance Accordion - Minimalist Tech</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">System Configuration FAQ</h1>
+            <p class="subtitle">A minimalist tech accordion component featuring a smooth, cinematic blur-entrance animation when revealing content.</p>
+        </header>
+
+        <div class="dashboard-area">
+            
+            <div class="card">
+                
+                <div class="accordion-group">
+                    
+                    <!-- Accordion Item 1 -->
+                    <div class="accordion-item">
+                        <!-- Pure CSS State Management using radio buttons for exclusive accordion behavior -->
+                        <input type="radio" name="accordion-group" id="acc-1" class="accordion-input" checked>
+                        
+                        <label class="accordion-header" for="acc-1">
+                            <span class="header-content">
+                                <span class="header-icon-wrapper blue">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path></svg>
+                                </span>
+                                How do I configure cluster auto-scaling?
+                            </span>
+                            <span class="header-indicator">
+                                <svg class="plus-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>
+                                <svg class="minus-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="5" y1="12" x2="19" y2="12"></line></svg>
+                            </span>
+                        </label>
+                        
+                        <div class="accordion-body">
+                            <div class="body-content blur-entrance">
+                                <p>Auto-scaling can be configured via the node pool settings in your dashboard or declaratively via the Kubernetes Horizontal Pod Autoscaler (HPA) API. We recommend setting a minimum of 3 nodes to maintain high availability across availability zones during scale-down events.</p>
+                                <div class="code-block">
+                                    <code>kubectl autoscale deployment core-api --cpu-percent=80 --min=3 --max=10</code>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    
+                    <!-- Accordion Item 2 -->
+                    <div class="accordion-item">
+                        <input type="radio" name="accordion-group" id="acc-2" class="accordion-input">
+                        
+                        <label class="accordion-header" for="acc-2">
+                            <span class="header-content">
+                                <span class="header-icon-wrapper emerald">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect><path d="M7 11V7a5 5 0 0 1 10 0v4"></path></svg>
+                                </span>
+                                What encryption standards are used for data at rest?
+                            </span>
+                            <span class="header-indicator">
+                                <svg class="plus-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>
+                                <svg class="minus-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="5" y1="12" x2="19" y2="12"></line></svg>
+                            </span>
+                        </label>
+                        
+                        <div class="accordion-body">
+                            <div class="body-content blur-entrance">
+                                <p>All data at rest is encrypted using AES-256 block-level encryption. Encryption keys are managed automatically by the AWS Key Management Service (KMS). For enterprise-tier customers, we support Bring Your Own Key (BYOK) architecture via HashiCorp Vault integrations.</p>
+                            </div>
+                        </div>
+                    </div>
+                    
+                    <!-- Accordion Item 3 -->
+                    <div class="accordion-item">
+                        <input type="radio" name="accordion-group" id="acc-3" class="accordion-input">
+                        
+                        <label class="accordion-header" for="acc-3">
+                            <span class="header-content">
+                                <span class="header-icon-wrapper purple">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"></polyline></svg>
+                                </span>
+                                How do I handle WebSocket connection limits?
+                            </span>
+                            <span class="header-indicator">
+                                <svg class="plus-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>
+                                <svg class="minus-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="5" y1="12" x2="19" y2="12"></line></svg>
+                            </span>
+                        </label>
+                        
+                        <div class="accordion-body">
+                            <div class="body-content blur-entrance">
+                                <p>Standard instances support up to 10,000 concurrent WebSocket connections. If you require higher throughput, you must provision an API Gateway layer with dedicated load balancers configured for long-polling protocols.</p>
+                                <a href="#" class="action-link">View Architecture Guide &rarr;</a>
+                            </div>
+                        </div>
+                    </div>
+
+                </div>
+                
+            </div>
+            
+        </div>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/minimalist-tech-blur-entrance-accordion/style.css
+++ b/submissions/examples/minimalist-tech-blur-entrance-accordion/style.css
@@ -1,0 +1,286 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    --border-color: #e2e8f0;
+    
+    /* Tech Minimalist Accents */
+    --accent-blue: #0ea5e9;
+    --accent-emerald: #10b981;
+    --accent-purple: #8b5cf6;
+    
+    --surface-white: #ffffff;
+    --surface-hover: #f1f5f9;
+    --surface-active: #f8fafc;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    width: 100%;
+    padding: 40px 20px;
+}
+
+.section-header {
+    text-align: center;
+    margin-bottom: 50px;
+}
+
+.title {
+    font-size: 2rem;
+    font-weight: 600;
+    margin: 0 0 12px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    margin: 0;
+}
+
+
+/* =========================================
+   Card Styling (Environment)
+   ========================================= */
+
+.card {
+    background: var(--surface-white);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 40px; 
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+}
+
+
+/* =========================================
+   Accordion Structure
+   ========================================= */
+
+.accordion-group {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    width: 100%;
+}
+
+.accordion-item {
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    overflow: hidden;
+    background: var(--surface-white);
+    transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.accordion-item:focus-within {
+    border-color: var(--accent-blue);
+    box-shadow: 0 0 0 3px rgba(14, 165, 233, 0.1);
+}
+
+/* Hide the radio buttons used for state */
+.accordion-input {
+    display: none;
+}
+
+
+/* =========================================
+   Accordion Header (The Trigger)
+   ========================================= */
+
+.accordion-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 16px 20px;
+    cursor: pointer;
+    background: transparent;
+    transition: background-color 0.2s ease;
+    user-select: none;
+}
+
+.accordion-header:hover {
+    background-color: var(--surface-hover);
+}
+
+.header-content {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    font-size: 1rem;
+    font-weight: 500;
+    color: var(--text-primary);
+}
+
+.header-icon-wrapper {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border-radius: 6px;
+    flex-shrink: 0;
+}
+.header-icon-wrapper svg { width: 14px; height: 14px; }
+
+/* Icon Colors */
+.header-icon-wrapper.blue { background-color: rgba(14, 165, 233, 0.1); color: var(--accent-blue); }
+.header-icon-wrapper.emerald { background-color: rgba(16, 185, 129, 0.1); color: var(--accent-emerald); }
+.header-icon-wrapper.purple { background-color: rgba(139, 92, 246, 0.1); color: var(--accent-purple); }
+
+
+/* Plus / Minus Indicator Logic */
+.header-indicator {
+    position: relative;
+    width: 20px;
+    height: 20px;
+    color: var(--text-secondary);
+}
+
+.plus-icon, .minus-icon {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+/* Default state: Plus is visible, Minus is hidden */
+.plus-icon { opacity: 1; transform: rotate(0deg); }
+.minus-icon { opacity: 0; transform: rotate(-90deg); }
+
+/* Active state: Plus is hidden, Minus is visible */
+.accordion-input:checked ~ .accordion-header .plus-icon {
+    opacity: 0;
+    transform: rotate(90deg);
+}
+.accordion-input:checked ~ .accordion-header .minus-icon {
+    opacity: 1;
+    transform: rotate(0deg);
+}
+
+/* Active header background */
+.accordion-input:checked ~ .accordion-header {
+    background-color: var(--surface-active);
+    border-bottom: 1px solid var(--border-color);
+}
+
+
+/* =========================================
+   Accordion Body (Grid Track Expansion)
+   ========================================= */
+
+.accordion-body {
+    /* 
+       Use CSS Grid for smooth height transitions from 0 to auto.
+       This is the modern way to animate height without JS.
+    */
+    display: grid;
+    grid-template-rows: 0fr;
+    transition: grid-template-rows 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+    background-color: var(--surface-white);
+}
+
+.accordion-input:checked ~ .accordion-body {
+    grid-template-rows: 1fr;
+}
+
+
+/* =========================================
+   The Blur-Entrance Animation
+   ========================================= */
+
+.body-content {
+    /* Needs hidden overflow so it doesn't spill out when grid row is 0 */
+    overflow: hidden;
+    padding: 0 20px;
+    
+    /* 
+       Initial state for the blur entrance.
+       Start transparent, pushed down slightly, and heavily blurred.
+    */
+    opacity: 0;
+    filter: blur(10px);
+    transform: translateY(10px);
+    /* 
+       When closing, fade out quickly. 
+       Note: We don't transition the blur on close to keep the collapse snappy.
+    */
+    transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.accordion-input:checked ~ .accordion-body .blur-entrance {
+    /* 
+       When opening, smoothly bring into focus and position.
+       We delay this slightly (0.1s) so the grid has started opening before the content fades in.
+    */
+    opacity: 1;
+    filter: blur(0px);
+    transform: translateY(0);
+    transition: opacity 0.4s ease 0.1s, 
+                filter 0.5s cubic-bezier(0.16, 1, 0.3, 1) 0.1s,
+                transform 0.4s cubic-bezier(0.16, 1, 0.3, 1) 0.1s;
+}
+
+/* Internal content styling */
+.body-content p {
+    margin: 20px 0;
+    font-size: 0.95rem;
+    line-height: 1.6;
+    color: var(--text-secondary);
+}
+
+.code-block {
+    background: #1e293b;
+    border-radius: 6px;
+    padding: 12px 16px;
+    margin: 16px 0 20px 0;
+}
+.code-block code {
+    font-family: 'Courier New', Courier, monospace;
+    color: #e2e8f0;
+    font-size: 0.85rem;
+}
+
+.action-link {
+    display: inline-block;
+    margin-bottom: 20px;
+    font-size: 0.9rem;
+    font-weight: 500;
+    color: var(--accent-blue);
+    text-decoration: none;
+}
+.action-link:hover { text-decoration: underline; }
+
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    .accordion-body {
+        transition: grid-template-rows 0.1s ease;
+    }
+    
+    /* Disable the blur and transform, fallback to simple fade */
+    .body-content {
+        filter: none !important;
+        transform: none !important;
+        transition: opacity 0.2s ease !important;
+    }
+    
+    .accordion-input:checked ~ .accordion-body .blur-entrance {
+        transition: opacity 0.2s ease !important;
+    }
+}


### PR DESCRIPTION

### Description
This PR introduces the CSS Blur-Entrance Accordion designed for Minimalist Tech Layouts, resolving issue #64554. 

### Changes Made:
- Added `submissions/examples/minimalist-tech-blur-entrance-accordion/` directory.
- Created `demo.html` showcasing a mock "System Configuration FAQ". 
  - Implemented 100% JavaScript-free state management utilizing the "Radio Button Hack". Inside each `.accordion-item`, there is a hidden `<input type="radio">` that tracks the state. Using radios ensures exclusive expansion (only one item opens at a time).
- Created `style.css` featuring a clean aesthetic utilizing subtle focus states, distinct semantic icon background accents, and an animated Plus/Minus indicator.
  - Utilized modern CSS Grid (`grid-template-rows: 0fr` to `1fr`) to smoothly animate the accordion body height without JavaScript.
  - Implemented the Blur-Entrance Animation System. 
  - The inner `.body-content` starts with `opacity: 0`, a slight downward offset, and a heavy CSS filter (`filter: blur(10px)`).
  - When the accordion opens, a CSS transition smoothly brings the content into focus (`blur(0px)`), fades it in, and slides it up to its baseline. 
  - Engineered a precise `0.1s` transition delay to the content so that the grid has a moment to start opening *before* the text begins to fade and un-blur, creating a highly polished, cinematic reveal.
- Added `README.md` documenting usage and technical features.
- Honors the `prefers-reduced-motion` accessibility standard. The blur filter and spatial translations are completely disabled, safely falling back to a simple, immediate opacity fade for motion-sensitive users.

Closes #64554
