### PR TITLE
feat: add CSS Fade-In Carousel for Cyberpunk Neon Layouts (#64669)

### DIFF
--- a/submissions/examples/cyberpunk-neon-fade-in-carousel/README.md
+++ b/submissions/examples/cyberpunk-neon-fade-in-carousel/README.md
@@ -1,0 +1,23 @@
+# CSS Fade-In Carousel (Cyberpunk Neon)
+
+A pure CSS carousel component designed for Cyberpunk Neon Layouts. It features entirely JavaScript-free state management and a smooth, scaling "Fade-In" entrance animation that perfectly matches a retro-futuristic data terminal aesthetic.
+
+## Features
+- Pure CSS and HTML (Zero JavaScript required for state management or animations).
+- **Cyberpunk Neon Aesthetic**: Deep void backgrounds, vibrant neon accents (Cyan, Magenta, Yellow), sharp structural borders, glowing text/shadows, and `Share Tech Mono` typography.
+- **Pure CSS State Management**: 
+- Utilizes the "Radio Button Hack". A group of radio buttons (`name="cyber-carousel"`) controls which slide is currently active.
+- The navigation dots at the bottom are `<label>` elements linked to these hidden radio buttons. Clicking a dot changes the checked radio button.
+- Depending on which radio button is checked (`#slide-1:checked`, etc.), CSS sibling selectors (`~`) dynamically update the visibility of the corresponding slide and the active state of the navigation dots.
+- **The Fade-In Animation System**: 
+- We avoid `display: none` because it cannot be animated. Instead, inactive slides are managed with `opacity: 0`, `visibility: hidden`, and `pointer-events: none`.
+- When a slide becomes active, it triggers the `cyber-fade-in` animation.
+- This `@keyframes` animation scales the content slightly from `0.95` to `1` while simultaneously manipulating CSS filters (`brightness(0.5)` to `1`). This creates a cinematic "powering up" or "establishing connection" effect that fits the cyberpunk theme perfectly.
+- Fully accessible with `prefers-reduced-motion` support. For motion-sensitive users, the scaling transform and filter transitions are completely disabled. The slide transition safely falls back to a simple, immediate opacity fade.
+
+## Usage
+Open `demo.html` in your browser. You will see a mock "NEURAL_NET.CAROUSEL" terminal interface. Click the rectangular navigation dots at the bottom to transition between the data slides. Notice how the content fades in smoothly with a subtle scale and brightness shift, mimicking a digital display powering on.
+
+## Files
+- `demo.html`: The HTML structure for the carousel, detailing the crucial radio button setup for CSS state management, the slides container, and the navigation labels.
+- `style.css`: The styling, cyberpunk design tokens (neon glows, grid backgrounds, monospace fonts), the complex state logic driven by `:checked ~` selectors, and the specific `@keyframes` driving the fade-in logic.

--- a/submissions/examples/cyberpunk-neon-fade-in-carousel/demo.html
+++ b/submissions/examples/cyberpunk-neon-fade-in-carousel/demo.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Fade-In Carousel - Cyberpunk Neon</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">NEURAL_NET.CAROUSEL</h1>
+            <p class="subtitle">// ACCESSING DISTRIBUTED DATABANKS // ESTABLISHING LINK // FADE INITIATED</p>
+        </header>
+
+        <div class="dashboard-area">
+            
+            <div class="card">
+                
+                <!-- 
+                   Pure CSS State Management for Carousel
+                   We use radio buttons to handle the active slide state without JS.
+                -->
+                <div class="carousel-container">
+                    
+                    <input type="radio" name="cyber-carousel" id="slide-1" checked class="carousel-input">
+                    <input type="radio" name="cyber-carousel" id="slide-2" class="carousel-input">
+                    <input type="radio" name="cyber-carousel" id="slide-3" class="carousel-input">
+                    
+                    <!-- The Slides Wrapper -->
+                    <div class="carousel-slides fade-in-group">
+                        
+                        <!-- Slide 1 -->
+                        <div class="carousel-slide slide-1">
+                            <div class="slide-content">
+                                <span class="sys-badge cyan">[SYS.CORE.1]</span>
+                                <h2 class="slide-title">CYBER_ARCHIVE_01</h2>
+                                <p class="slide-desc">Primary memory core accessed. Data stream stable. Initiating decrypt sequence for sector 7G. Neon matrix active.</p>
+                                <a href="#" class="action-btn">ACCESS DATA</a>
+                            </div>
+                        </div>
+                        
+                        <!-- Slide 2 -->
+                        <div class="carousel-slide slide-2">
+                            <div class="slide-content">
+                                <span class="sys-badge magenta">[SYS.CORE.2]</span>
+                                <h2 class="slide-title">NEURAL_LINK_BETA</h2>
+                                <p class="slide-desc">Biometric sync established. Sync rate 98.4%. Overriding firewall protocols. Uploading payload to mainframe.</p>
+                                <a href="#" class="action-btn">INITIATE UPLOAD</a>
+                            </div>
+                        </div>
+                        
+                        <!-- Slide 3 -->
+                        <div class="carousel-slide slide-3">
+                            <div class="slide-content">
+                                <span class="sys-badge yellow">[SYS.CORE.3]</span>
+                                <h2 class="slide-title">GRID_OVERRIDE</h2>
+                                <p class="slide-desc">Warning: Unauthorized access detected in sector 4. Rerouting power to defense grids. Engaging lockdown protocols.</p>
+                                <a href="#" class="action-btn">ENGAGE LOCKDOWN</a>
+                            </div>
+                        </div>
+                        
+                    </div>
+                    
+                    <!-- Carousel Navigation -->
+                    <div class="carousel-nav">
+                        <label for="slide-1" class="nav-dot" aria-label="Go to slide 1"></label>
+                        <label for="slide-2" class="nav-dot" aria-label="Go to slide 2"></label>
+                        <label for="slide-3" class="nav-dot" aria-label="Go to slide 3"></label>
+                    </div>
+                    
+                </div>
+                
+            </div>
+            
+        </div>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/cyberpunk-neon-fade-in-carousel/style.css
+++ b/submissions/examples/cyberpunk-neon-fade-in-carousel/style.css
@@ -1,0 +1,292 @@
+@import url('https://fonts.googleapis.com/css2?family=Share+Tech+Mono&family=Rajdhani:wght@500;600;700&display=swap');
+
+:root {
+    /* Cyberpunk Core Backgrounds */
+    --bg-void: #09090b;      /* Deepest black/grey */
+    --bg-surface: #121214;   /* Slightly lighter surface */
+    --bg-card: #18181b;      /* Card background */
+    
+    /* Neon Accents */
+    --neon-cyan: #0ff;
+    --neon-magenta: #f0f;
+    --neon-yellow: #ff0;
+    
+    /* Text */
+    --text-primary: #fff;
+    --text-secondary: #a1a1aa;
+    
+    /* Borders & Grids */
+    --border-dark: #27272a;
+    --border-glow-cyan: rgba(0, 255, 255, 0.3);
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-void);
+    font-family: 'Rajdhani', sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    -webkit-font-smoothing: antialiased;
+    
+    /* Cyberpunk Grid Background */
+    background-image: 
+        linear-gradient(rgba(0, 255, 255, 0.03) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(0, 255, 255, 0.03) 1px, transparent 1px);
+    background-size: 30px 30px;
+}
+
+.layout-container {
+    max-width: 900px;
+    width: 100%;
+    padding: 40px 20px;
+}
+
+.section-header {
+    text-align: center;
+    margin-bottom: 50px;
+}
+
+.title {
+    font-family: 'Share Tech Mono', monospace;
+    font-size: 2.5rem;
+    color: var(--neon-cyan);
+    margin: 0 0 12px 0;
+    text-shadow: 0 0 10px var(--border-glow-cyan);
+    letter-spacing: 2px;
+}
+
+.subtitle {
+    font-family: 'Share Tech Mono', monospace;
+    color: var(--neon-magenta);
+    font-size: 1rem;
+    margin: 0;
+    opacity: 0.8;
+}
+
+
+/* =========================================
+   Card Styling (Environment)
+   ========================================= */
+
+.card {
+    background: var(--bg-card);
+    border: 1px solid var(--border-dark);
+    border-radius: 4px; /* Sharp corners for cyberpunk */
+    padding: 40px; 
+    box-shadow: 0 0 20px rgba(0,0,0,0.8), inset 0 0 0 1px rgba(0, 255, 255, 0.1);
+    position: relative;
+    overflow: hidden;
+}
+
+/* Decorative corner accents */
+.card::before, .card::after {
+    content: '';
+    position: absolute;
+    width: 20px;
+    height: 20px;
+    border: 2px solid var(--neon-cyan);
+    opacity: 0.5;
+}
+.card::before { top: 0; left: 0; border-right: none; border-bottom: none; }
+.card::after { bottom: 0; right: 0; border-left: none; border-top: none; }
+
+
+/* =========================================
+   Carousel Structure
+   ========================================= */
+
+.carousel-container {
+    position: relative;
+    width: 100%;
+    height: 350px; /* Fixed height for absolute positioning of slides */
+}
+
+.carousel-input {
+    display: none;
+}
+
+.carousel-slides {
+    position: relative;
+    width: 100%;
+    height: 100%;
+}
+
+.carousel-slide {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    
+    /* 
+      Visibility Management
+      We manage states using opacity, visibility, and pointer-events.
+    */
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    
+    /* Base setup for the fade transition */
+    transition: opacity 0.5s ease, visibility 0.5s ease;
+}
+
+
+/* =========================================
+   Slide Content Styling
+   ========================================= */
+
+.slide-content {
+    background: var(--bg-surface);
+    border: 1px solid var(--border-dark);
+    padding: 40px;
+    width: 80%;
+    max-width: 500px;
+    text-align: center;
+    position: relative;
+    
+    /* Cyberpunk visual flair */
+    box-shadow: 0 10px 30px rgba(0,0,0,0.5);
+}
+
+.sys-badge {
+    font-family: 'Share Tech Mono', monospace;
+    font-size: 0.8rem;
+    display: inline-block;
+    margin-bottom: 16px;
+    letter-spacing: 1px;
+}
+.sys-badge.cyan { color: var(--neon-cyan); }
+.sys-badge.magenta { color: var(--neon-magenta); }
+.sys-badge.yellow { color: var(--neon-yellow); }
+
+.slide-title {
+    font-family: 'Share Tech Mono', monospace;
+    font-size: 1.8rem;
+    margin: 0 0 16px 0;
+    color: var(--text-primary);
+    text-transform: uppercase;
+    letter-spacing: 2px;
+}
+
+.slide-desc {
+    font-size: 1.1rem;
+    color: var(--text-secondary);
+    line-height: 1.6;
+    margin: 0 0 32px 0;
+}
+
+/* Cyberpunk Button */
+.action-btn {
+    display: inline-block;
+    font-family: 'Share Tech Mono', monospace;
+    padding: 12px 24px;
+    background: transparent;
+    color: var(--neon-cyan);
+    border: 1px solid var(--neon-cyan);
+    text-decoration: none;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    font-size: 0.9rem;
+    transition: all 0.3s ease;
+    position: relative;
+    overflow: hidden;
+}
+
+.action-btn:hover {
+    background: var(--neon-cyan);
+    color: var(--bg-void);
+    box-shadow: 0 0 15px var(--border-glow-cyan);
+}
+
+
+/* =========================================
+   Carousel Navigation (Dots)
+   ========================================= */
+
+.carousel-nav {
+    position: absolute;
+    bottom: -20px;
+    left: 0;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    gap: 16px;
+    z-index: 10;
+}
+
+.nav-dot {
+    width: 30px;
+    height: 4px;
+    background: var(--border-dark);
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.nav-dot:hover {
+    background: #52525b;
+}
+
+/* State Management for Navigation Dots */
+#slide-1:checked ~ .carousel-nav .nav-dot[for="slide-1"],
+#slide-2:checked ~ .carousel-nav .nav-dot[for="slide-2"],
+#slide-3:checked ~ .carousel-nav .nav-dot[for="slide-3"] {
+    background: var(--neon-cyan);
+    box-shadow: 0 0 8px var(--border-glow-cyan);
+}
+
+
+/* =========================================
+   The Fade-In Animation Logic
+   ========================================= */
+
+/* 
+  When the corresponding radio button is checked, 
+  make the slide visible and animate the fade.
+*/
+#slide-1:checked ~ .carousel-slides .slide-1,
+#slide-2:checked ~ .carousel-slides .slide-2,
+#slide-3:checked ~ .carousel-slides .slide-3 {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+    
+    /* Apply a smooth fade-in and slight scale up for the content */
+    animation: cyber-fade-in 0.6s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+@keyframes cyber-fade-in {
+    0% {
+        opacity: 0;
+        transform: scale(0.95);
+        filter: brightness(0.5) contrast(1.2);
+    }
+    100% {
+        opacity: 1;
+        transform: scale(1);
+        filter: brightness(1) contrast(1);
+    }
+}
+
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    #slide-1:checked ~ .carousel-slides .slide-1,
+    #slide-2:checked ~ .carousel-slides .slide-2,
+    #slide-3:checked ~ .carousel-slides .slide-3 {
+        /* Fallback to simple, immediate opacity fade without scaling or filters */
+        animation: simple-fade 0.3s ease forwards !important;
+    }
+    
+    @keyframes simple-fade {
+        0% { opacity: 0; }
+        100% { opacity: 1; }
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces the CSS Fade-In Carousel designed for Cyberpunk Neon Layouts, resolving issue #64669. 

### Changes Made:
- Added `submissions/examples/cyberpunk-neon-fade-in-carousel/` directory.
- Created `demo.html` showcasing a mock "NEURAL_NET.CAROUSEL" data terminal interface. 
  - Implemented 100% JavaScript-free state management utilizing the "Radio Button Hack". A group of hidden radio buttons controls which slide is currently active. The navigation dots act as `<label>` elements linked to these inputs.
- Created `style.css` featuring an immersive cyberpunk aesthetic utilizing deep void backgrounds, vibrant neon accents (Cyan, Magenta, Yellow), sharp structural borders, glowing text/shadows, and `Share Tech Mono` typography.
  - Implemented the dynamic CSS state logic driven by `:checked ~` sibling selectors. Depending on the radio state, the visibility of the corresponding slide is updated.
  - Implemented the Fade-In Animation System. We avoid `display: none` and instead manage inactive slides with `opacity: 0`, `visibility: hidden`, and `pointer-events: none`.
  - When a slide becomes active, it triggers the `cyber-fade-in` animation. This animation scales the content slightly from `0.95` to `1` while simultaneously manipulating CSS filters (`brightness(0.5)` to `1`). This creates a cinematic "powering up" or "establishing connection" effect that fits the cyberpunk theme perfectly.
- Added `README.md` documenting usage and technical features.
- Honors the `prefers-reduced-motion` accessibility standard. The scaling transform and filter transitions are completely disabled, safely falling back to a simple, immediate opacity fade for motion-sensitive users.

Closes #64669
