### PR TITLE
Add ease-piano-keys-hammer component

### DIFF
--- a/submissions/examples/piano-keys-hammer-ij/README.md
+++ b/submissions/examples/piano-keys-hammer-ij/README.md
@@ -1,0 +1,10 @@
+# ease-piano-keys-hammer
+
+A piano where the white keys press in turn, the hammer strikes the strings, and the note tags blip.
+
+## Run
+Open `demo.html` directly in a browser to watch the keys press.
+
+## Notes
+- The white keys press in turn.
+- The note tags blip above.

--- a/submissions/examples/piano-keys-hammer-ij/demo.html
+++ b/submissions/examples/piano-keys-hammer-ij/demo.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-piano-keys-hammer demo</title>
+</head>
+<body>
+<div class="pkh-case">
+  <span class="pkh-note pkh-note-a">DO</span>
+  <span class="pkh-note pkh-note-b">RE</span>
+  <div class="pkh-hammer"></div>
+  <div class="pkh-keys">
+    <span class="pkh-key"></span>
+    <span class="pkh-key"></span>
+    <span class="pkh-key"></span>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/piano-keys-hammer-ij/style.css
+++ b/submissions/examples/piano-keys-hammer-ij/style.css
@@ -1,0 +1,14 @@
+:root{--pkh-ivory:#f2ecd8;--pkh-black:#1a1a1a;--pkh-dark:#0e0e10}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#0e0e10,#08080a);font-family:'Georgia',serif}
+.pkh-case{position:relative;width:384px;height:300px;border-radius:16px;overflow:hidden;background:linear-gradient(180deg,#241d16,#14100c);box-shadow:0 14px 32px rgba(0,0,0,0.6)}
+.pkh-note{position:absolute;top:22px;font-size:12px;font-weight:700;letter-spacing:2px;color:#f2ecd8}
+.pkh-note-a{left:60px;animation:note-blip-piano-keys-hammer 1.6s steps(1) infinite}
+.pkh-note-b{right:60px;animation:note-blip-piano-keys-hammer 1.6s steps(1) infinite;animation-delay:0.8s}
+.pkh-hammer{position:absolute;top:64px;left:50%;margin-left:-9px;width:18px;height:74px;border-radius:6px;background:#8a6f4a;transform-origin:50% 100%;animation:hammer-strike-piano-keys-hammer 1.6s ease-in-out infinite}
+.pkh-keys{position:absolute;top:160px;left:50%;margin-left:-150px;width:300px;height:88px;border-radius:0 0 12px 12px;background:#f2ecd8;box-shadow:inset 0 -6px 0 #d8cfae;display:flex}
+.pkh-key{flex:1;border-right:2px solid #b9ae8c;animation:key-press-piano-keys-hammer 1.6s ease-in-out infinite}
+.pkh-key:nth-child(2){animation-delay:0.53s}
+.pkh-key:nth-child(3){animation-delay:1.06s}
+@keyframes key-press-piano-keys-hammer{0%,100%{transform:translateY(0)}12%{transform:translateY(10px)}18%{transform:translateY(0)}}
+@keyframes hammer-strike-piano-keys-hammer{0%,100%{transform:rotate(0deg)}10%{transform:rotate(14deg)}18%{transform:rotate(0deg)}}
+@keyframes note-blip-piano-keys-hammer{0%,49%{opacity:1}50%,100%{opacity:0.3}}


### PR DESCRIPTION
## Component: ease-piano-keys-hammer — keys press, hammer strikes, and notes blip

**Closes #67704**

### What this adds
A piano: the white keys press in turn, the hammer strikes the strings, and the note tags blip.

### Acceptance Criteria covered
- White keys press in turn
- Hammer strikes the strings
- Note tags blip above

### Files
- `submissions/examples/piano-keys-hammer-ij/demo.html`
- `submissions/examples/piano-keys-hammer-ij/style.css`
- `submissions/examples/piano-keys-hammer-ij/README.md`

### How to review
Open `demo.html` in a browser and watch the keys press.