### PR TITLE
feat: add CSS Glitch-Flicker Dropdown for Glassmorphism UI Layouts (#64327)

### DIFF
--- a/submissions/examples/glassmorphism-ui-glitch-flicker-dropdown/README.md
+++ b/submissions/examples/glassmorphism-ui-glitch-flicker-dropdown/README.md
@@ -1,0 +1,27 @@
+# CSS Glitch-Flicker Dropdown (Glassmorphism UI)
+
+A pure CSS dropdown component designed for Glassmorphism UI Layouts. It features entirely JavaScript-free state management and an unstable, chaotic "Glitch-Flicker" entrance animation that simulates a faulty holographic UI starting up.
+
+## Features
+- Pure CSS and HTML (Zero JavaScript required for state or animations).
+- **Glassmorphism Aesthetic**: 
+- A deep, dark background with three slowly floating animated "blobs" of cyan, purple, and pink to create a vibrant backdrop for the glass elements.
+- The main UI uses `backdrop-filter: blur(16px)` combined with a semi-transparent background color to create the signature frosted glass effect over the floating blobs.
+- The dropdown menu itself features an even heavier blur (`20px`), a clipped sci-fi angled corner (`clip-path`), and a cyan-tinted border to lean into the terminal/HUD aesthetic.
+- **Pure CSS State Management**: 
+- Utilizes the "Checkbox Hack". A hidden checkbox (`#dropdown-toggle`) controls the state.
+- The "Options" button is a `<label>` linked to this checkbox. Clicking it toggles the state.
+- When checked, CSS sibling selectors (`~`) update the chevron rotation, reveal an invisible full-screen overlay (to handle clicking outside to close), and trigger the dropdown visibility.
+- **The Glitch-Flicker Animation System**: 
+- We avoid `display: none` because it cannot be animated. Instead, the menu is managed with `opacity: 0`, `visibility: hidden`, and `pointer-events: none`.
+- When triggered, the `.dropdown-menu` container runs the `menu-glitch-flicker` animation.
+- This complex `@keyframes` sequence simulates a holographic malfunction by rapidly and erratically toggling opacity (`0`, `0.8`, `0.2`, `1`), skewing the container (`10deg`, `-15deg`, `5deg`), and flashing red/cyan `box-shadow` artifacts across several rapid keyframe steps.
+- As the container finishes its glitch sequence, the internal `.menu-item` elements stagger-slide into view (`item-slide-in`) using delayed utility classes, completing the startup sequence smoothly.
+- Fully accessible with `prefers-reduced-motion` support. For motion-sensitive users, the chaotic glitching, skewing, and staggered sliding are completely disabled. The menu safely falls back to a simple, immediate opacity fade.
+
+## Usage
+Open `demo.html` in your browser. You will see a "Command Interface" utilizing a rich frosted glass aesthetic. Click the "Options" button. The dropdown menu will erratically glitch and flicker into existence, mimicking a sci-fi HUD powering on. Click the invisible background overlay or the button again to dismiss the menu.
+
+## Files
+- `demo.html`: The HTML structure for the glassmorphism layout (including the background blobs), the checkbox hack setup for the dropdown trigger, the full-screen dismissal overlay, and the menu items.
+- `style.css`: The styling, glassmorphism design tokens (blurs, transparency), and the specific `@keyframes` driving the erratic, multi-step glitch entrance logic.

--- a/submissions/examples/glassmorphism-ui-glitch-flicker-dropdown/demo.html
+++ b/submissions/examples/glassmorphism-ui-glitch-flicker-dropdown/demo.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Glitch-Flicker Dropdown - Glassmorphism UI</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <!-- 
+       A colorful, abstract background is essential for Glassmorphism 
+       to demonstrate the frosted glass blur effect.
+    -->
+    <div class="glass-background">
+        <div class="blob blob-1"></div>
+        <div class="blob blob-2"></div>
+        <div class="blob blob-3"></div>
+    </div>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Command Interface</h1>
+            <p class="subtitle">A glassmorphism UI layout featuring an unstable glitch-flicker entrance animation for a dropdown menu.</p>
+        </header>
+
+        <div class="dashboard-area">
+            
+            <div class="glass-card">
+                
+                <div class="card-header">
+                    <h2>Active Connections</h2>
+                    
+                    <!-- 
+                       Pure CSS State Management for the Dropdown
+                       We use a checkbox to toggle the dropdown open/closed.
+                    -->
+                    <div class="dropdown-container">
+                        
+                        <input type="checkbox" id="dropdown-toggle" class="dropdown-input">
+                        
+                        <!-- The trigger button -->
+                        <label for="dropdown-toggle" class="btn-trigger">
+                            <span class="status-dot"></span>
+                            Options
+                            <svg class="chevron-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"></polyline></svg>
+                        </label>
+                        
+                        <!-- The Glitch-Flicker Dropdown Menu -->
+                        <div class="dropdown-menu glitch-flicker-group">
+                            <div class="menu-content">
+                                <a href="#" class="menu-item delay-1">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20h9"></path><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"></path></svg>
+                                    Edit Connection
+                                </a>
+                                <a href="#" class="menu-item delay-2">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path></svg>
+                                    Advanced Settings
+                                </a>
+                                <a href="#" class="menu-item delay-3">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path></svg>
+                                    View Logs
+                                </a>
+                                <div class="menu-divider"></div>
+                                <a href="#" class="menu-item danger delay-4">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 4H8l-7 8 7 8h13a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2z"></path><line x1="18" y1="9" x2="12" y2="15"></line><line x1="12" y1="9" x2="18" y2="15"></line></svg>
+                                    Terminate Session
+                                </a>
+                            </div>
+                        </div>
+                        
+                        <!-- Invisible overlay to close dropdown when clicking outside -->
+                        <label for="dropdown-toggle" class="dropdown-overlay"></label>
+                        
+                    </div>
+                </div>
+                
+                <div class="connection-list">
+                    <div class="connection-item">
+                        <div class="connection-info">
+                            <span class="conn-name">PROD-DB-01</span>
+                            <span class="conn-ip">10.0.4.152</span>
+                        </div>
+                        <span class="conn-status">Stable</span>
+                    </div>
+                    <div class="connection-item">
+                        <div class="connection-info">
+                            <span class="conn-name">CACHE-REDIS-M</span>
+                            <span class="conn-ip">10.0.5.11</span>
+                        </div>
+                        <span class="conn-status">Stable</span>
+                    </div>
+                </div>
+                
+            </div>
+            
+        </div>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/glassmorphism-ui-glitch-flicker-dropdown/style.css
+++ b/submissions/examples/glassmorphism-ui-glitch-flicker-dropdown/style.css
@@ -1,0 +1,417 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600&family=Space+Mono&display=swap');
+
+:root {
+    /* Glassmorphism Color Palette */
+    --bg-dark: #09090b; /* Very dark background to make colors pop */
+    --text-primary: #f8fafc;
+    --text-secondary: #94a3b8;
+    
+    /* Vibrant blob colors for background */
+    --blob-1: #06b6d4; /* Cyan */
+    --blob-2: #8b5cf6; /* Purple */
+    --blob-3: #ec4899; /* Pink */
+    
+    /* Dropdown UI Colors */
+    --accent-cyan: #06b6d4;
+    --accent-rose: #f43f5e;
+    
+    /* Glass Properties */
+    --glass-bg: rgba(15, 23, 42, 0.4);
+    --glass-border: rgba(255, 255, 255, 0.1);
+    --glass-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.4);
+    
+    /* Dropdown specific glass */
+    --menu-bg: rgba(9, 9, 11, 0.6);
+    --menu-border: rgba(6, 182, 212, 0.3); /* Cyan tinted border for tech feel */
+    --menu-hover: rgba(6, 182, 212, 0.15);
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-dark);
+    font-family: 'Outfit', sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    -webkit-font-smoothing: antialiased;
+    overflow-x: hidden;
+    position: relative;
+}
+
+/* =========================================
+   Abstract Background (For Glassmorphism Effect)
+   ========================================= */
+.glass-background {
+    position: fixed;
+    top: 0; left: 0; width: 100vw; height: 100vh;
+    z-index: -1;
+    overflow: hidden;
+}
+
+.blob {
+    position: absolute;
+    filter: blur(90px);
+    border-radius: 50%;
+    opacity: 0.5;
+    animation: float 25s infinite alternate ease-in-out;
+}
+
+.blob-1 {
+    top: 10%; left: 20%;
+    width: 400px; height: 400px;
+    background-color: var(--blob-1);
+    animation-delay: 0s;
+}
+
+.blob-2 {
+    bottom: 10%; right: 20%;
+    width: 500px; height: 500px;
+    background-color: var(--blob-2);
+    animation-delay: -5s;
+}
+
+.blob-3 {
+    top: 40%; left: 60%;
+    width: 350px; height: 350px;
+    background-color: var(--blob-3);
+    animation-delay: -10s;
+}
+
+@keyframes float {
+    0% { transform: translate(0, 0) scale(1); }
+    100% { transform: translate(150px, -50px) scale(1.1); }
+}
+
+
+/* =========================================
+   Layout & Container
+   ========================================= */
+
+.layout-container {
+    max-width: 600px;
+    width: 100%;
+    padding: 40px 20px;
+    position: relative;
+    z-index: 10;
+}
+
+.section-header {
+    text-align: center;
+    margin-bottom: 50px;
+}
+
+.title {
+    font-size: 2.25rem;
+    font-weight: 600;
+    margin: 0 0 12px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    margin: 0;
+    font-weight: 300;
+}
+
+
+/* =========================================
+   Glass Card Environment
+   ========================================= */
+
+.glass-card {
+    background: var(--glass-bg);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border: 1px solid var(--glass-border);
+    border-radius: 16px;
+    padding: 30px; 
+    box-shadow: var(--glass-shadow);
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding-bottom: 20px;
+    border-bottom: 1px solid rgba(255,255,255,0.05);
+}
+
+.card-header h2 {
+    font-size: 1.1rem;
+    font-weight: 500;
+    margin: 0;
+    color: var(--text-primary);
+}
+
+
+/* =========================================
+   Dropdown Structure & Trigger
+   ========================================= */
+
+.dropdown-container {
+    position: relative;
+    /* Important for absolute positioning of menu */
+}
+
+.dropdown-input {
+    display: none;
+}
+
+.btn-trigger {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 16px;
+    background: rgba(255, 255, 255, 0.05);
+    color: var(--text-primary);
+    border: 1px solid var(--glass-border);
+    border-radius: 8px;
+    font-size: 0.9rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    user-select: none;
+    backdrop-filter: blur(4px);
+}
+
+.btn-trigger:hover {
+    background: rgba(255, 255, 255, 0.1);
+    border-color: rgba(6, 182, 212, 0.5); /* Cyan hover hint */
+}
+
+.status-dot {
+    width: 8px;
+    height: 8px;
+    background-color: var(--accent-cyan);
+    border-radius: 50%;
+    box-shadow: 0 0 8px var(--accent-cyan);
+}
+
+.chevron-icon {
+    width: 16px;
+    height: 16px;
+    transition: transform 0.3s ease;
+}
+
+/* Rotate chevron when open */
+.dropdown-input:checked ~ .btn-trigger .chevron-icon {
+    transform: rotate(180deg);
+}
+
+/* Invisible overlay to close dropdown */
+.dropdown-overlay {
+    position: fixed;
+    top: 0; left: 0; right: 0; bottom: 0;
+    z-index: 90;
+    display: none;
+}
+
+.dropdown-input:checked ~ .dropdown-overlay {
+    display: block;
+}
+
+
+/* =========================================
+   Glitch-Flicker Menu Styling
+   ========================================= */
+
+.dropdown-menu {
+    position: absolute;
+    top: calc(100% + 8px);
+    right: 0;
+    min-width: 220px;
+    z-index: 100;
+    
+    /* Hide by default */
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+}
+
+.menu-content {
+    background: var(--menu-bg);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    border: 1px solid var(--menu-border);
+    border-radius: 8px;
+    padding: 8px;
+    box-shadow: 0 10px 40px rgba(0,0,0,0.6), 0 0 20px rgba(6, 182, 212, 0.15);
+    display: flex;
+    flex-direction: column;
+    
+    /* Clip path for a slight sci-fi angled corner */
+    clip-path: polygon(0 0, 100% 0, 100% calc(100% - 10px), calc(100% - 10px) 100%, 0 100%);
+}
+
+.menu-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 12px;
+    color: var(--text-primary);
+    text-decoration: none;
+    font-size: 0.9rem;
+    font-weight: 500;
+    border-radius: 4px;
+    transition: background-color 0.2s ease, color 0.2s ease;
+    
+    /* Setup for the staggered item animation */
+    opacity: 0;
+    transform: translateX(10px);
+}
+
+.menu-item svg {
+    width: 16px; height: 16px;
+    color: var(--accent-cyan);
+    transition: transform 0.2s ease;
+}
+
+.menu-item:hover {
+    background-color: var(--menu-hover);
+}
+.menu-item:hover svg {
+    transform: translateX(2px);
+}
+
+.menu-item.danger:hover {
+    background-color: rgba(244, 63, 94, 0.15);
+    color: var(--accent-rose);
+}
+.menu-item.danger svg { color: var(--accent-rose); }
+
+.menu-divider {
+    height: 1px;
+    background: linear-gradient(90deg, transparent, rgba(255,255,255,0.1), transparent);
+    margin: 6px 0;
+}
+
+
+/* =========================================
+   The Glitch-Flicker Animation System
+   ========================================= */
+
+/* State active triggers the animations */
+.dropdown-input:checked ~ .glitch-flicker-group {
+    visibility: visible;
+    pointer-events: auto;
+    
+    /* 1. Menu container flickers into existence */
+    animation: menu-glitch-flicker 0.4s ease forwards;
+}
+
+/* 2. Menu items stagger in slightly after the container */
+.dropdown-input:checked ~ .glitch-flicker-group .menu-item {
+    animation: item-slide-in 0.3s ease forwards;
+}
+
+/* 
+  Container Animation:
+  Simulates a faulty hologram starting up.
+  It rapidly toggles opacity, slight skewing, and blue/red dropshadows.
+*/
+@keyframes menu-glitch-flicker {
+    0% {
+        opacity: 0;
+        transform: translateY(-10px) skewX(10deg);
+        box-shadow: -5px 0 0 var(--accent-cyan), 5px 0 0 var(--accent-rose);
+    }
+    15% {
+        opacity: 0.8;
+        transform: translateY(2px) skewX(-15deg);
+        box-shadow: none;
+    }
+    30% {
+        opacity: 0.2;
+        transform: translateY(-2px) skewX(5deg);
+        box-shadow: 5px 0 0 var(--accent-cyan), -5px 0 0 var(--accent-rose);
+    }
+    45% { opacity: 0.9; transform: translateY(0) skewX(0); box-shadow: none; }
+    60% { opacity: 0.3; transform: scale(0.98); }
+    75% { opacity: 1; transform: scale(1.02); }
+    100% {
+        opacity: 1;
+        transform: translateY(0) scale(1) skewX(0);
+        box-shadow: 0 10px 40px rgba(0,0,0,0.6), 0 0 20px rgba(6, 182, 212, 0.15); /* Settle into normal state */
+    }
+}
+
+/* 
+  Item Animation:
+  Simple slide in to finish the effect smoothly after the chaotic container entrance.
+*/
+@keyframes item-slide-in {
+    0% { opacity: 0; transform: translateX(15px); }
+    100% { opacity: 1; transform: translateX(0); }
+}
+
+/* Stagger delays */
+.delay-1 { animation-delay: 0.15s !important; }
+.delay-2 { animation-delay: 0.2s !important; }
+.delay-3 { animation-delay: 0.25s !important; }
+.delay-4 { animation-delay: 0.3s !important; }
+
+
+/* =========================================
+   Mock List Content
+   ========================================= */
+
+.connection-list {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.connection-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 12px 16px;
+    background: rgba(255, 255, 255, 0.03);
+    border-radius: 8px;
+    border: 1px solid rgba(255,255,255,0.02);
+}
+
+.connection-info {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+.conn-name { font-size: 0.95rem; font-weight: 500; font-family: 'Space Mono', monospace; }
+.conn-ip { font-size: 0.8rem; color: var(--text-secondary); font-family: 'Space Mono', monospace;}
+
+.conn-status {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    color: var(--accent-cyan);
+    padding: 4px 8px;
+    background: rgba(6, 182, 212, 0.1);
+    border-radius: 4px;
+}
+
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    /* Disable all chaotic glitch effects */
+    .dropdown-input:checked ~ .glitch-flicker-group {
+        animation: simple-fade 0.2s ease forwards !important;
+        transform: none !important;
+    }
+    
+    .dropdown-input:checked ~ .glitch-flicker-group .menu-item {
+        animation: simple-fade 0.2s ease forwards !important;
+        transform: none !important;
+    }
+    
+    @keyframes simple-fade {
+        0% { opacity: 0; }
+        100% { opacity: 1; }
+    }
+}


### PR DESCRIPTION

### Description
This PR introduces the CSS Glitch-Flicker Dropdown designed for Glassmorphism UI Layouts, resolving issue #64327. 

### Changes Made:
- Added `submissions/examples/glassmorphism-ui-glitch-flicker-dropdown/` directory.
- Created `demo.html` showcasing a "Command Interface" dashboard. 
  - Implemented 100% JavaScript-free state management utilizing the "Checkbox Hack". A hidden checkbox acts as the state controller. The "Options" button and an invisible full-screen dismissal overlay act as `<label>` elements linked to this input, handling open and close interactions effortlessly.
- Created `style.css` featuring an immersive frosted glass aesthetic.
  - Implemented a deep background with three animated, floating "blobs" to create a vibrant backdrop.
  - The main UI uses `backdrop-filter: blur(16px)` to create the signature glass effect. The dropdown menu itself uses a heavier blur (`20px`), a clipped sci-fi angled corner (`clip-path`), and a cyan-tinted border to lean into a terminal/HUD aesthetic.
  - Implemented the Glitch-Flicker Animation System. 
  - We avoid `display: none` and instead manage the inactive menu with `opacity: 0`, `visibility: hidden`, and `pointer-events: none`.
  - When triggered, the `.dropdown-menu` container runs the `menu-glitch-flicker` animation. This complex `@keyframes` sequence simulates a holographic malfunction by rapidly and erratically toggling opacity (`0`, `0.8`, `0.2`, `1`), skewing the container, and flashing red/cyan `box-shadow` artifacts across several rapid keyframe steps.
  - As the container finishes its glitch sequence, the internal `.menu-item` elements stagger-slide into view (`item-slide-in`) using delayed utility classes, completing the startup sequence smoothly.
- Added `README.md` documenting usage and technical features.
- Honors the `prefers-reduced-motion` accessibility standard. The chaotic glitching, skewing, and staggered sliding are completely disabled, safely falling back to a simple, immediate opacity fade for motion-sensitive users.

Closes #64327
