### PR TITLE
fix(a11y): WCAG AA-compliant badge contrast (#60886)

### DIFF
--- a/submissions/examples/ease-badge-contrast-wcag-sbh/README.md
+++ b/submissions/examples/ease-badge-contrast-wcag-sbh/README.md
@@ -1,0 +1,48 @@
+# ease-badge-contrast-wcag
+
+WCAG AA-compliant colored badges. Fixes the accessibility issue where white text on light colored badges (warning / info / success) failed the minimum 4.5:1 contrast ratio.
+
+## What does this do?
+
+- **Two AA-passing styles per semantic color** (primary / success / warning / danger / info):
+  - **Filled** — darkened background + white text (all ≥ 4.5:1).
+  - **Subtle** — soft tint + dark text (all ≥ 14:1).
+- **Verified ratios** — every color pair was checked with the WCAG relative-luminance formula. The demo includes a contrast-ratio table showing before (failing) vs after (passing).
+
+| Color | Before (white on tint) | After (filled) | After (subtle) |
+|---|---|---|---|
+| Primary | 6.29:1 (pass) | 7.90:1 | 14.49:1 |
+| Success | 2.54:1 (fail) | 5.48:1 | 15.74:1 |
+| Warning | 2.15:1 (fail) | 7.09:1 | 16.03:1 |
+| Danger  | 3.76:1 (fail) | 8.31:1 | 14.61:1 |
+| Info    | 2.77:1 (fail) | 5.93:1 | 15.56:1 |
+
+Threshold: WCAG AA normal text = 4.5:1.
+
+## How is it used?
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<!-- filled -->
+<span class="ease-badge ease-badge--warning">Warning</span>
+<!-- subtle -->
+<span class="ease-badge ease-badge--subtle ease-badge--warning-subtle">Warning</span>
+```
+
+## Why is this useful?
+
+- **Directly fixes the a11y issue** — warning/info/success badges now meet WCAG AA instead of failing at 2.15–2.77:1.
+- **Two styles** — filled (darkened bg + white text) for emphasis, subtle (tint + dark text) for calmer UIs; both pass.
+- **Additive** — ships under `submissions/examples/` without modifying core badge classes.
+- **Reusable** — colors are CSS custom properties (`--ease-badge-*`), so themes can override while keeping the darkened/tinted structure that guarantees contrast.
+
+## Files
+
+- `demo.html` — self-contained showcase (filled + subtle badge rows + contrast-ratio table). No server/CDN/frameworks.
+- `style.css` — badge base, filled (darkened) + subtle (tint) color variants, contrast table.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions.

--- a/submissions/examples/ease-badge-contrast-wcag-sbh/demo.html
+++ b/submissions/examples/ease-badge-contrast-wcag-sbh/demo.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-badge-contrast-wcag — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__head">
+      <p class="page__eyebrow">ease-badge-contrast-wcag</p>
+      <h1>WCAG&nbsp;AA-compliant colored badges.</h1>
+      <p class="page__lede">
+        Fixes the issue where white text on light colored badges (warning /
+        info / success) failed the minimum WCAG&nbsp;AA contrast ratio of
+        4.5:1. This example provides two AA-passing styles for every semantic
+        color: a <strong>filled</strong> badge (darkened background + white
+        text) and a <strong>subtle</strong> badge (soft tint + dark text). Every
+        pair is verified &ge;&nbsp;4.5:1.
+      </p>
+    </header>
+
+    <section class="panel">
+      <h2 class="panel__title">Filled &mdash; darkened background, white text</h2>
+      <div class="badge-row">
+        <span class="ease-badge ease-badge--primary">Primary</span>
+        <span class="ease-badge ease-badge--success">Success</span>
+        <span class="ease-badge ease-badge--warning">Warning</span>
+        <span class="ease-badge ease-badge--danger">Danger</span>
+        <span class="ease-badge ease-badge--info">Info</span>
+      </div>
+      <p class="panel__hint">Backgrounds darkened so white text clears 4.5:1 (e.g. warning <code>#92400e</code> &rarr; 7.09:1, was <code>#f59e0b</code> &rarr; 2.15:1).</p>
+    </section>
+
+    <section class="panel">
+      <h2 class="panel__title">Subtle &mdash; soft tint, dark text</h2>
+      <div class="badge-row">
+        <span class="ease-badge ease-badge--subtle ease-badge--primary-subtle">Primary</span>
+        <span class="ease-badge ease-badge--subtle ease-badge--success-subtle">Success</span>
+        <span class="ease-badge ease-badge--subtle ease-badge--warning-subtle">Warning</span>
+        <span class="ease-badge ease-badge--subtle ease-badge--danger-subtle">Danger</span>
+        <span class="ease-badge ease-badge--subtle ease-badge--info-subtle">Info</span>
+      </div>
+      <p class="panel__hint">Dark text on light tints &mdash; all &ge;&nbsp;14:1.</p>
+    </section>
+
+    <section class="panel panel--code">
+      <h2 class="panel__title">Verified contrast ratios</h2>
+      <table class="ratios">
+        <thead><tr><th>Color</th><th>Before (white on tint)</th><th>After (filled)</th><th>After (subtle)</th></tr></thead>
+        <tbody>
+          <tr><td>Primary</td><td class="fail">6.29:1*</td><td class="pass">7.90:1</td><td class="pass">14.49:1</td></tr>
+          <tr><td>Success</td><td class="fail">2.54:1</td><td class="pass">5.48:1</td><td class="pass">15.74:1</td></tr>
+          <tr><td>Warning</td><td class="fail">2.15:1</td><td class="pass">7.09:1</td><td class="pass">16.03:1</td></tr>
+          <tr><td>Danger</td><td class="fail">3.76:1</td><td class="pass">8.31:1</td><td class="pass">14.61:1</td></tr>
+          <tr><td>Info</td><td class="fail">2.77:1</td><td class="pass">5.93:1</td><td class="pass">15.56:1</td></tr>
+        </tbody>
+      </table>
+      <p class="panel__hint">*Primary already passed; others failed 4.5:1 and are fixed. Threshold: AA-normal = 4.5:1.</p>
+    </section>
+
+    <p class="footnote">Additive example under <code>submissions/examples/</code> &mdash; no core files changed.</p>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-badge-contrast-wcag-sbh/style.css
+++ b/submissions/examples/ease-badge-contrast-wcag-sbh/style.css
@@ -1,0 +1,100 @@
+/* ease-badge-contrast-wcag — WCAG AA-compliant colored badges.
+   Bug: white text on light colored badges (warning/info/success) failed 4.5:1.
+   Fix: two AA-passing styles per color:
+     - Filled:  darkened background + white text  (all >= 4.5:1)
+     - Subtle:  soft tint + dark text             (all >= 14:1)
+   Ratios verified with the WCAG relative-luminance formula. */
+
+:root {
+  /* filled (darkened) backgrounds — white text passes AA-normal */
+  --ease-badge-primary: #4338ca;   /* 7.90:1 */
+  --ease-badge-success: #047857;   /* 5.48:1 */
+  --ease-badge-warning: #92400e;   /* 7.09:1 */
+  --ease-badge-danger:  #991b1b;   /* 8.31:1 */
+  --ease-badge-info:    #0369a1;   /* 5.93:1 */
+
+  /* subtle tints — dark text passes AA-normal (>= 14:1) */
+  --ease-badge-primary-tint: #e0e7ff;
+  --ease-badge-success-tint: #d1fae5;
+  --ease-badge-warning-tint: #fef3c7;
+  --ease-badge-danger-tint:  #fee2e2;
+  --ease-badge-info-tint:    #e0f2fe;
+
+  --ease-badge-ink:   #0f172a;     /* slate-900, used as dark text */
+  --ease-badge-white: #ffffff;
+  --ease-radius: 999px;
+}
+
+/* ---------- Page (demo only) ---------- */
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  color: #0f172a;
+  background:
+    radial-gradient(900px 520px at 85% -10%, #eef2ff, transparent 60%),
+    radial-gradient(700px 440px at 0% 0%, #faf5ff, transparent 55%),
+    #fff;
+  line-height: 1.6;
+}
+.page { max-width: 48rem; margin: 0 auto; padding: clamp(2rem, 6vw, 4rem) clamp(1rem, 4vw, 2rem); }
+.page__eyebrow {
+  margin: 0 0 0.5rem; text-transform: uppercase; letter-spacing: 0.18em;
+  font-size: 0.78rem; font-weight: 700; color: var(--ease-badge-primary);
+}
+.page__head h1 { margin: 0 0 0.8rem; font-size: clamp(1.6rem, 4.5vw, 2.4rem); letter-spacing: -0.02em; }
+.page__lede { margin: 0 0 2rem; color: #64748b; max-width: 42rem; }
+.page__lede strong { color: #0f172a; }
+.page__lede code { background: rgba(79,70,229,0.12); color: var(--ease-badge-primary); padding: 0.12rem 0.4rem; border-radius: 0.4rem; font-size: 0.9em; }
+.footnote { color: #94a3b8; font-size: 0.85rem; margin: 1.5rem 0 0; }
+.footnote code { background: rgba(79,70,229,0.12); color: var(--ease-badge-primary); padding: 0.1rem 0.35rem; border-radius: 0.35rem; font-size: 0.9em; }
+
+.panel {
+  background: rgba(255,255,255,0.7);
+  border: 1px solid #e2e8f0;
+  border-radius: 1rem;
+  padding: clamp(1.2rem, 3vw, 1.8rem);
+  margin-bottom: 1.4rem;
+}
+.panel__title { margin: 0 0 1rem; font-size: 1.1rem; letter-spacing: -0.01em; }
+.panel__hint { margin: 0.8rem 0 0; color: #64748b; font-size: 0.85rem; }
+.panel__hint code { background: rgba(79,70,229,0.12); color: var(--ease-badge-primary); padding: 0.1rem 0.35rem; border-radius: 0.35rem; font-size: 0.9em; }
+.badge-row { display: flex; gap: 0.8rem; flex-wrap: wrap; align-items: center; }
+
+/* ---------- Badge base ---------- */
+.ease-badge {
+  display: inline-grid;
+  place-items: center;
+  min-width: 1.6rem;
+  height: 1.6rem;
+  padding: 0 0.6rem;
+  font-size: 0.8rem;
+  font-weight: 700;
+  line-height: 1;
+  white-space: nowrap;
+  border-radius: var(--ease-radius);
+  color: var(--ease-badge-white);
+  background: var(--ease-badge-primary);
+}
+
+/* Filled color variants (darkened bg + white text) */
+.ease-badge--primary { background: var(--ease-badge-primary); }
+.ease-badge--success { background: var(--ease-badge-success); }
+.ease-badge--warning { background: var(--ease-badge-warning); }
+.ease-badge--danger  { background: var(--ease-badge-danger); }
+.ease-badge--info    { background: var(--ease-badge-info); }
+
+/* Subtle style: dark text on soft tint */
+.ease-badge--subtle { color: var(--ease-badge-ink); }
+.ease-badge--primary-subtle { background: var(--ease-badge-primary-tint); }
+.ease-badge--success-subtle { background: var(--ease-badge-success-tint); }
+.ease-badge--warning-subtle { background: var(--ease-badge-warning-tint); }
+.ease-badge--danger-subtle  { background: var(--ease-badge-danger-tint); }
+.ease-badge--info-subtle    { background: var(--ease-badge-info-tint); }
+
+/* ---------- Contrast table ---------- */
+.ratios { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
+.ratios th, .ratios td { padding: 0.5rem 0.6rem; text-align: left; border-bottom: 1px solid #e2e8f0; }
+.ratios th { color: #64748b; font-weight: 600; }
+.ratios td.pass { color: #047857; font-weight: 700; }
+.ratios td.fail { color: #b91c1c; font-weight: 700; }


### PR DESCRIPTION
## What

Fixes #60886 - colored badge variants failed WCAG AA contrast (foreground/background ratios below 4.5:1).

## Fix

Re-tunes badge colors so all 10 variants pass WCAG AA (>=4.5:1) against their backgrounds:
- filled: primary #4338ca 7.90:1, success #047857 5.48:1, warning #92400e 7.09:1, danger #991b1b 8.31:1, info #0369a1 5.93:1
- subtle/tinted variants all >=14:1

Verified via live computed-style contrast measurement in a headless browser (all 10 PASS).

## Submission

Additive example under `submissions/examples/ease-badge-contrast-wcag-sbh/` (`demo.html`, `style.css`, `README.md`) - no core files changed. `-sbh` suffix per CONTRIBUTING.md.