### PR TITLE
fix: concurrent toasts stack without overlap (#60873)

### DIFF
--- a/submissions/examples/ease-toast-stack-sbh/README.md
+++ b/submissions/examples/ease-toast-stack-sbh/README.md
@@ -1,0 +1,45 @@
+# ease-toast-stack
+
+Concurrent toast notifications that stack without overlapping. Fixes the bug where multiple toasts triggered at the same time rendered at identical coordinates, hiding earlier toasts.
+
+## What does this do?
+
+- **Flex-column viewport with a gap** — `.ease-toast-viewport` is `display: flex; flex-direction: column; gap`. Each toast is a flex child that occupies its own vertical slot, so concurrent toasts never collide (the original bug used absolute positioning at one fixed coordinate).
+- **Entrance/exit animations** — slide-in-from-right + fade on appear; slide-out + fade on dismiss. Uses only `transform`/`opacity` (GPU-friendly, no layout reflow).
+- **Auto-dismiss + manual close** — each toast auto-dismisses after 4.5s; the × button dismisses immediately.
+- **Four types** — info / success / warning / danger, each with a colored left border + icon.
+- **Accessible** — the viewport is an `aria-live="polite"` region; each toast is `role="status"`; the close button has an `aria-label`.
+- **Reduced-motion** — animations disabled.
+
+## How is it used?
+
+```html
+<link rel="stylesheet" href="style.css" />
+<div class="ease-toast-viewport" role="region" aria-live="polite" aria-label="Notifications"></div>
+
+<script>
+  const vp = document.querySelector('.ease-toast-viewport');
+  const t = document.createElement('div');
+  t.className = 'ease-toast ease-toast--success';
+  t.innerHTML = '<span class="ease-toast__icon"></span><div class="ease-toast__body"><strong class="ease-toast__title">Done</strong><p class="ease-toast__msg">Saved.</p></div><button class="ease-toast__close" aria-label="Dismiss">&times;</button>';
+  vp.appendChild(t);   // flex column places it below any existing toast
+</script>
+```
+
+The demo's "Burst 5" button spawns five toasts 250ms apart to prove they stack progressively.
+
+## Why is this useful?
+
+- **Directly fixes the issue** — the root cause was shared coordinates; a flex column with a gap guarantees distinct slots.
+- **GPU-friendly** — only `transform`/`opacity` animate (also addresses the spirit of reflow-related issues).
+- **Additive** — ships under `submissions/examples/` without modifying core toast classes.
+
+## Files
+
+- `demo.html` — self-contained showcase with trigger buttons (4 types + a 5-toast burst). No CDNs/frameworks.
+- `style.css` — viewport (flex column + gap), toast styles, entrance/exit keyframes, reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions.

--- a/submissions/examples/ease-toast-stack-sbh/demo.html
+++ b/submissions/examples/ease-toast-stack-sbh/demo.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-toast-stack — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__head">
+      <p class="page__eyebrow">ease-toast-stack</p>
+      <h1>Concurrent toasts stack without overlapping.</h1>
+      <p class="page__lede">
+        Fixes the bug where multiple concurrent toast notifications stacked at
+        the exact same coordinates, rendering earlier ones unreadable. This
+        example uses a flex column container with a gap and a per-toast
+        entrance/exit animation, so toasts always occupy distinct vertical
+        slots. Trigger several toasts quickly to see them stack progressively.
+      </p>
+      <div class="controls">
+        <button class="btn" data-type="info">Show info</button>
+        <button class="btn" data-type="success">Show success</button>
+        <button class="btn" data-type="warning">Show warning</button>
+        <button class="btn" data-type="danger">Show danger</button>
+        <button class="btn btn--ghost" id="burst">Burst 5</button>
+      </div>
+    </header>
+
+    <!-- The toast viewport: a flex column. Each toast gets its own slot. -->
+    <div class="ease-toast-viewport" id="viewport" role="region" aria-live="polite" aria-label="Notifications"></div>
+
+    <p class="footnote">Additive example under <code>submissions/examples/</code> &mdash; no core files changed.</p>
+  </main>
+
+  <template id="toast-tpl">
+    <div class="ease-toast" role="status">
+      <span class="ease-toast__icon" aria-hidden="true"></span>
+      <div class="ease-toast__body">
+        <strong class="ease-toast__title"></strong>
+        <p class="ease-toast__msg"></p>
+      </div>
+      <button class="ease-toast__close" type="button" aria-label="Dismiss">&times;</button>
+    </div>
+  </template>
+
+  <script>
+    (function () {
+      var vp = document.getElementById('viewport');
+      var tpl = document.getElementById('toast-tpl');
+      var seq = 0;
+      var titles = { info: 'Heads up', success: 'Done', warning: 'Careful', danger: 'Error' };
+      var msgs = {
+        info: 'Auto-save is on.', success: 'Changes saved.', warning: 'Storage almost full.', danger: 'Could not reach server.'
+      };
+
+      function spawn(type) {
+        var node = tpl.content.firstElementChild.cloneNode(true);
+        node.classList.add('ease-toast--' + type);
+        seq += 1;
+        node.querySelector('.ease-toast__title').textContent = titles[type] + ' #' + seq;
+        node.querySelector('.ease-toast__msg').textContent = msgs[type];
+        node.querySelector('.ease-toast__close').addEventListener('click', function () { dismiss(node); });
+        vp.appendChild(node);           // flex column places it below the previous toast
+        // auto-dismiss
+        setTimeout(function () { dismiss(node); }, 4500);
+      }
+
+      function dismiss(node) {
+        if (!node || node.classList.contains('is-leaving')) return;
+        node.classList.add('is-leaving');
+        node.addEventListener('animationend', function () { if (node.parentNode) node.parentNode.removeChild(node); });
+      }
+
+      document.querySelectorAll('[data-type]').forEach(function (b) {
+        b.addEventListener('click', function () { spawn(b.getAttribute('data-type')); });
+      });
+      document.getElementById('burst').addEventListener('click', function () {
+        var types = ['info', 'success', 'warning', 'danger', 'info'];
+        types.forEach(function (t, i) { setTimeout(function () { spawn(t); }, i * 250); });
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-toast-stack-sbh/style.css
+++ b/submissions/examples/ease-toast-stack-sbh/style.css
@@ -1,0 +1,123 @@
+/* ease-toast-stack — concurrent toasts stack without overlapping.
+   Bug: toasts used absolute positioning at the same coordinates and overlapped.
+   Fix: the viewport is a flex COLUMN with a gap; each toast is a flex child
+   that occupies its own vertical slot, so they never collide. Entrance/exit
+   use transform/opacity only (GPU-friendly, no layout reflow). */
+
+:root {
+  --ease-color-primary: #4338ca;
+  --ease-color-success: #047857;
+  --ease-color-warning: #92400e;
+  --ease-color-danger:  #991b1b;
+  --ease-toast-gap: 0.6rem;
+  --ease-toast-max: 22rem;
+  --ease-dur: 0.32s;
+  --ease-ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* ---------- Page (demo only) ---------- */
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  color: #0f172a;
+  background:
+    radial-gradient(900px 520px at 85% -10%, #eef2ff, transparent 60%),
+    radial-gradient(700px 440px at 0% 0%, #faf5ff, transparent 55%),
+    #fff;
+  line-height: 1.6;
+}
+.page { max-width: 48rem; margin: 0 auto; padding: clamp(2rem, 6vw, 4rem) clamp(1rem, 4vw, 2rem); }
+.page__eyebrow {
+  margin: 0 0 0.5rem; text-transform: uppercase; letter-spacing: 0.18em;
+  font-size: 0.78rem; font-weight: 700; color: var(--ease-color-primary);
+}
+.page__head h1 { margin: 0 0 0.8rem; font-size: clamp(1.6rem, 4.5vw, 2.4rem); letter-spacing: -0.02em; }
+.page__lede { margin: 0 0 1.4rem; color: #64748b; max-width: 42rem; }
+.footnote { color: #94a3b8; font-size: 0.85rem; margin: 2rem 0 0; }
+.footnote code { background: rgba(79,70,229,0.12); color: var(--ease-color-primary); padding: 0.1rem 0.35rem; border-radius: 0.35rem; font-size: 0.9em; }
+
+.controls { display: flex; gap: 0.6rem; flex-wrap: wrap; }
+.btn {
+  font: inherit; font-size: 0.9rem; font-weight: 600;
+  padding: 0.5rem 1rem; border-radius: 0.5rem; cursor: pointer;
+  border: 1px solid transparent; color: #fff;
+  background: var(--ease-color-primary);
+  transition: transform 0.18s var(--ease-ease), box-shadow 0.18s var(--ease-ease);
+}
+.btn:hover { transform: translateY(-0.1rem); box-shadow: 0 8px 18px -8px rgba(67,56,202,0.6); }
+.btn--ghost { background: #fff; color: #0f172a; border-color: #cbd5e1; }
+
+/* ---------- Toast viewport: THE FIX (flex column + gap) ---------- */
+.ease-toast-viewport {
+  position: fixed;
+  right: clamp(1rem, 4vw, 1.6rem);
+  bottom: clamp(1rem, 4vw, 1.6rem);
+  z-index: 1000;
+  display: flex;              /* column stack — each toast owns its slot */
+  flex-direction: column;
+  gap: var(--ease-toast-gap); /* guaranteed spacing between toasts */
+  width: min(var(--ease-toast-max), 90vw);
+  pointer-events: none;       /* let clicks pass through empty viewport space */
+}
+
+/* ---------- Toast ---------- */
+.ease-toast {
+  pointer-events: auto;
+  display: grid;
+  grid-template-columns: 1.4rem 1fr auto;
+  gap: 0.7rem;
+  align-items: start;
+  padding: 0.75rem 0.8rem;
+  background: #fff;
+  color: #0f172a;
+  border-radius: 0.6rem;
+  border: 1px solid #e2e8f0;
+  border-left: 4px solid var(--ease-color-primary);
+  box-shadow: 0 10px 24px -12px rgba(15,23,42,0.35);
+  /* entrance: slide in from the right + fade (transform/opacity only) */
+  animation: ease-toast-in var(--ease-dur) var(--ease-ease) both;
+}
+.ease-toast--success { border-left-color: var(--ease-color-success); }
+.ease-toast--warning { border-left-color: var(--ease-color-warning); }
+.ease-toast--danger  { border-left-color: var(--ease-color-danger); }
+.ease-toast--info    { border-left-color: var(--ease-color-primary); }
+
+.ease-toast__icon {
+  width: 1.4rem; height: 1.4rem; border-radius: 999px;
+  background: var(--ease-color-primary);
+  color: #fff; display: grid; place-items: center; font-size: 0.8rem; font-weight: 700;
+}
+.ease-toast--success .ease-toast__icon { background: var(--ease-color-success); }
+.ease-toast--warning .ease-toast__icon { background: var(--ease-color-warning); }
+.ease-toast--danger  .ease-toast__icon { background: var(--ease-color-danger); }
+
+.ease-toast__body { min-width: 0; }
+.ease-toast__title { font-size: 0.85rem; }
+.ease-toast__msg { margin: 0.1rem 0 0; font-size: 0.8rem; color: #475569; }
+
+.ease-toast__close {
+  font: inherit; font-size: 1.1rem; line-height: 1;
+  width: 1.4rem; height: 1.4rem; border-radius: 0.35rem;
+  border: none; background: transparent; color: #94a3b8; cursor: pointer;
+  transition: background-color 0.15s, color 0.15s;
+}
+.ease-toast__close:hover { background: #f1f5f9; color: #0f172a; }
+
+/* exit */
+.ease-toast.is-leaving { animation: ease-toast-out var(--ease-dur) var(--ease-ease) both; }
+
+@keyframes ease-toast-in {
+  from { opacity: 0; transform: translateX(1.2rem); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+@keyframes ease-toast-out {
+  from { opacity: 1; transform: translateX(0); }
+  to   { opacity: 0; transform: translateX(1.2rem); }
+}
+
+/* ---------- Reduced motion ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .ease-toast, .ease-toast.is-leaving { animation: none !important; opacity: 1 !important; transform: none !important; }
+  .btn:hover { transform: none; }
+}


### PR DESCRIPTION
## What

Fixes #60873 - concurrent toast notifications rendered at identical coordinates, hiding earlier toasts.

## Fix

The toast viewport is a `display: flex; flex-direction: column; gap` container, so each toast occupies its own vertical slot and they never collide (the original bug used absolute positioning at one fixed coordinate). Entrance/exit use `transform`/`opacity` only (GPU-friendly, no reflow).

Verified with a 5-toast burst: all toasts have distinct, non-overlapping vertical rects (`NO VERTICAL OVERLAPS`), viewport computed style `display=flex flexDir=column gap=9.6px`.

## Submission

Additive example under `submissions/examples/ease-toast-stack-sbh/` (`demo.html`, `style.css`, `README.md`) - no core files changed. `-sbh` suffix per CONTRIBUTING.md.