### PR TITLE
perf: GPU-friendly loaders (transform/opacity only) (#60871)

### DIFF
--- a/submissions/examples/ease-loader-gpu-sbh/README.md
+++ b/submissions/examples/ease-loader-gpu-sbh/README.md
@@ -1,0 +1,43 @@
+# ease-loader-gpu
+
+GPU-friendly loaders that animate only `transform` and `opacity`. Fixes the issue where nested loader animations animated layout properties (`width`/`height`/`top`/`left`), triggering layout reflows and heavy repaints.
+
+## What does this do?
+
+Four loaders, all compositor-only (no layout/paint on the main thread):
+
+- **Spinner** — `@keyframes ease-spin` animates `transform: rotate()` only.
+- **Dot bounce** — `@keyframes ease-dot-bounce` animates `transform: translateY()` only (staggered).
+- **Bar sweep** — `@keyframes ease-bar` animates `transform: scaleY()` only (`transform-origin: bottom`).
+- **Shimmer skeleton** — `@keyframes ease-shimmer` animates `transform: translateX()` only on a highlight band over a tinted block.
+
+Each animated element sets `will-change: transform` to hint the compositor to promote it to its own layer.
+
+## Why is this useful?
+
+- **Directly fixes the issue** — the root cause was animating layout properties; `transform`/`opacity` are the canonical GPU-friendly properties that skip layout and paint.
+- **No reflow** — layout-dependent properties (`width`, `height`, `top`, `left`, `margin`) are never animated, so siblings and ancestors don't reflow each frame.
+- **`will-change`** — hints the browser to prepare a compositor layer up front, avoiding jank on the first frames.
+- **Accessible** — each loader is `role="status"` with an `aria-label`; `prefers-reduced-motion` disables all animations.
+
+## How is it used?
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<div class="ease-loader ease-loader--spinner" role="status" aria-label="Loading"></div>
+
+<div class="ease-loader ease-loader--dots" role="status" aria-label="Loading">
+  <span></span><span></span><span></span>
+</div>
+```
+
+## Files
+
+- `demo.html` — self-contained showcase (4 loaders + the animated property for each). No CDNs/frameworks.
+- `style.css` — 4 loaders, all `transform`/`opacity` keyframes, `will-change`, reduced-motion rules.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions.

--- a/submissions/examples/ease-loader-gpu-sbh/demo.html
+++ b/submissions/examples/ease-loader-gpu-sbh/demo.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-loader-gpu — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="page__head">
+      <p class="page__eyebrow">ease-loader-gpu</p>
+      <h1>GPU-friendly loaders &mdash; transform &amp; opacity only.</h1>
+      <p class="page__lede">
+        Fixes the issue where nested loader animations triggered heavy layout
+        reflows (animating <code>width</code>/<code>height</code>/<code>top</code>/<code>left</code>).
+        These loaders animate <strong>only</strong> <code>transform</code> and
+        <code>opacity</code> &mdash; compositor-only properties that run on the
+        GPU without touching layout. Includes a spinner, a dot bounce, a bar
+        sweep, and a shimmer skeleton.
+      </p>
+    </header>
+
+    <section class="grid">
+      <article class="demo">
+        <h2 class="demo__title">Spinner</h2>
+        <div class="stage"><div class="ease-loader ease-loader--spinner" role="status" aria-label="Loading"></div></div>
+        <pre class="snippet"><code>transform: rotate(0deg) -> rotate(360deg)</code></pre>
+      </article>
+
+      <article class="demo">
+        <h2 class="demo__title">Dot bounce</h2>
+        <div class="stage">
+          <div class="ease-loader ease-loader--dots" role="status" aria-label="Loading">
+            <span></span><span></span><span></span>
+          </div>
+        </div>
+        <pre class="snippet"><code>transform: translateY(0) -> translateY(-0.4rem)</code></pre>
+      </article>
+
+      <article class="demo">
+        <h2 class="demo__title">Bar sweep</h2>
+        <div class="stage">
+          <div class="ease-loader ease-loader--bars" role="status" aria-label="Loading">
+            <span></span><span></span><span></span><span></span><span></span>
+          </div>
+        </div>
+        <pre class="snippet"><code>transform: scaleY(0.3) -> scaleY(1)</code></pre>
+      </article>
+
+      <article class="demo">
+        <h2 class="demo__title">Shimmer skeleton</h2>
+        <div class="stage stage--wide">
+          <div class="ease-loader ease-loader--shimmer" role="status" aria-label="Loading">
+            <div class="sk-line sk--1"></div>
+            <div class="sk-line sk--2"></div>
+            <div class="sk-line sk--3"></div>
+          </div>
+        </div>
+        <pre class="snippet"><code>transform: translateX(-100%) -> translateX(100%)</code></pre>
+      </article>
+    </section>
+
+    <p class="footnote">Additive example under <code>submissions/examples/</code> &mdash; no core files changed.</p>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-loader-gpu-sbh/style.css
+++ b/submissions/examples/ease-loader-gpu-sbh/style.css
@@ -1,0 +1,143 @@
+/* ease-loader-gpu — loaders that animate ONLY transform & opacity.
+   Bug: nested loader animations animated layout properties
+   (width/height/top/left), triggering layout reflows + repaints.
+   Fix: every animation here uses transform/opacity only, so the browser
+   promotes the element to its own compositor layer and skips layout/paint
+   on the main thread. will-change hints the compositor. */
+
+:root {
+  --ease-color-primary: #4f46e5;
+  --ease-color-primary-soft: rgba(79,70,229,0.18);
+  --ease-dur: 1s;
+  --ease-ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* ---------- Page (demo only) ---------- */
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  color: #0f172a;
+  background:
+    radial-gradient(900px 520px at 85% -10%, #eef2ff, transparent 60%),
+    radial-gradient(700px 440px at 0% 0%, #faf5ff, transparent 55%),
+    #fff;
+  line-height: 1.6;
+}
+.page { max-width: 52rem; margin: 0 auto; padding: clamp(2rem, 6vw, 4rem) clamp(1rem, 4vw, 2rem); }
+.page__eyebrow {
+  margin: 0 0 0.5rem; text-transform: uppercase; letter-spacing: 0.18em;
+  font-size: 0.78rem; font-weight: 700; color: var(--ease-color-primary);
+}
+.page__head h1 { margin: 0 0 0.8rem; font-size: clamp(1.6rem, 4.5vw, 2.4rem); letter-spacing: -0.02em; }
+.page__lede { margin: 0 0 2rem; color: #64748b; max-width: 44rem; }
+.page__lede strong { color: #0f172a; }
+.page__lede code { background: var(--ease-color-primary-soft); color: var(--ease-color-primary); padding: 0.12rem 0.4rem; border-radius: 0.4rem; font-size: 0.9em; }
+.footnote { color: #94a3b8; font-size: 0.85rem; margin: 1.5rem 0 0; }
+.footnote code { background: var(--ease-color-primary-soft); color: var(--ease-color-primary); padding: 0.1rem 0.35rem; border-radius: 0.35rem; font-size: 0.9em; }
+
+.grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr)); gap: 1.2rem; }
+.demo {
+  background: rgba(255,255,255,0.7);
+  border: 1px solid #e2e8f0;
+  border-radius: 1rem;
+  padding: 1.4rem;
+}
+.demo__title { margin: 0 0 1rem; font-size: 1rem; }
+.stage {
+  display: grid; place-items: center;
+  min-height: 5rem;
+  border-radius: 0.6rem;
+  background: repeating-linear-gradient(45deg, #f8fafc 0 0.8rem, #eef2f7 0.8rem 1.6rem);
+  border: 1px dashed #e2e8f0;
+  padding: 1rem;
+  margin-bottom: 0.8rem;
+}
+.stage--wide { place-items: stretch; }
+.snippet {
+  margin: 0; padding: 0.5rem 0.7rem;
+  background: #0f172a; color: #e2e8f0;
+  border-radius: 0.5rem; overflow-x: auto;
+  font-size: 0.74rem; line-height: 1.4;
+}
+.snippet code { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; }
+
+/* =========================================================
+   LOADERS — transform/opacity only
+   ========================================================= */
+
+/* Spinner: rotate only */
+.ease-loader--spinner {
+  width: 2.2rem; height: 2.2rem;
+  border-radius: 50%;
+  border: 0.28rem solid var(--ease-color-primary-soft);
+  border-top-color: var(--ease-color-primary);
+  will-change: transform;
+  animation: ease-spin 0.8s linear infinite;
+}
+@keyframes ease-spin { to { transform: rotate(360deg); } }
+
+/* Dots: translateY only */
+.ease-loader--dots { display: inline-flex; gap: 0.4rem; }
+.ease-loader--dots span {
+  width: 0.6rem; height: 0.6rem; border-radius: 50%;
+  background: var(--ease-color-primary);
+  will-change: transform;
+  animation: ease-dot-bounce 1s var(--ease-ease) infinite;
+}
+.ease-loader--dots span:nth-child(2) { animation-delay: 0.15s; }
+.ease-loader--dots span:nth-child(3) { animation-delay: 0.3s; }
+@keyframes ease-dot-bounce {
+  0%, 100% { transform: translateY(0); }
+  50%      { transform: translateY(-0.4rem); }
+}
+
+/* Bars: scaleY only (origin bottom) */
+.ease-loader--bars { display: inline-flex; gap: 0.3rem; align-items: flex-end; height: 2rem; }
+.ease-loader--bars span {
+  width: 0.3rem; height: 100%;
+  background: var(--ease-color-primary);
+  border-radius: 0.2rem;
+  transform-origin: bottom;
+  will-change: transform;
+  animation: ease-bar 1s var(--ease-ease) infinite;
+}
+.ease-loader--bars span:nth-child(2) { animation-delay: 0.1s; }
+.ease-loader--bars span:nth-child(3) { animation-delay: 0.2s; }
+.ease-loader--bars span:nth-child(4) { animation-delay: 0.3s; }
+.ease-loader--bars span:nth-child(5) { animation-delay: 0.4s; }
+@keyframes ease-bar {
+  0%, 100% { transform: scaleY(0.3); }
+  50%      { transform: scaleY(1); }
+}
+
+/* Shimmer: a highlight band translated across (translateX only) */
+.ease-loader--shimmer { display: flex; flex-direction: column; gap: 0.6rem; width: 100%; }
+.ease-loader--shimmer .sk-line {
+  position: relative;
+  height: 0.7rem;
+  border-radius: 0.35rem;
+  background: var(--ease-color-primary-soft);
+  overflow: hidden;
+}
+.ease-loader--shimmer .sk-line::after {
+  content: "";
+  position: absolute; inset: 0;
+  background: linear-gradient(90deg, transparent, rgba(255,255,255,0.65), transparent);
+  transform: translateX(-100%);
+  will-change: transform;
+  animation: ease-shimmer 1.4s infinite;
+}
+.ease-loader--shimmer .sk--2 { width: 80%; }
+.ease-loader--shimmer .sk--3 { width: 60%; }
+@keyframes ease-shimmer {
+  100% { transform: translateX(100%); }
+}
+
+/* ---------- Reduced motion ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .ease-loader--spinner,
+  .ease-loader--dots span,
+  .ease-loader--bars span,
+  .ease-loader--shimmer .sk-line::after { animation: none !important; }
+}


### PR DESCRIPTION
## What

Fixes #60871 - nested loader animations animated layout properties (`width`/`height`/`top`/`left`), triggering layout reflows and heavy repaints.

## Fix

Four loaders (spinner, dot bounce, bar sweep, shimmer skeleton) that animate **only** `transform` and `opacity` - compositor-only properties that skip layout/paint. Each animated element sets `will-change: transform`.

Verified by parsing all `@keyframes` in `style.css`: every keyframe animates only `transform` (zero layout properties), and live computed styles confirm the animations are running.

## Submission

Additive example under `submissions/examples/ease-loader-gpu-sbh/` (`demo.html`, `style.css`, `README.md`) - no core files changed. `-sbh` suffix per CONTRIBUTING.md.