### PR TITLE
fix: lock background scroll while mobile sidebar open (#60867)

### DIFF
--- a/submissions/examples/ease-sidebar-scroll-lock-sbh/README.md
+++ b/submissions/examples/ease-sidebar-scroll-lock-sbh/README.md
@@ -1,0 +1,49 @@
+# ease-sidebar-scroll-lock
+
+Mobile sidebar overlay that locks background body scroll while open. Fixes the bug where scrolling inside the sidebar leaked the scroll event to the background `<body>`, scrolling the page underneath.
+
+## What does this do?
+
+- **Background scroll lock** — when the sidebar opens, a `.ease-scroll-locked` class is added to **both** `<html>` and `<body>` (`overflow: hidden` + `height: 100%`, plus `scrollbar-gutter: stable` on `<html>` so the page doesn't shift when the scrollbar disappears). The background body can no longer scroll.
+- **Independent sidebar scroll** — `.ease-sidebar__nav` has `overflow-y: auto`, so the sidebar's own content scrolls normally without propagating to the body.
+- **Slide-in + backdrop** — the sidebar slides in from the left (`transform: translateX`); a semi-transparent backdrop fades in and closes on click.
+- **Keyboard + a11y** — Esc closes; the close button is focused on open and the trigger is refocused on close; `aria-hidden` toggles on the sidebar.
+
+## How is it used?
+
+```html
+<link rel="stylesheet" href="style.css" />
+<button id="open">☰ Open</button>
+<div class="ease-sidebar-backdrop" id="backdrop" hidden></div>
+<aside class="ease-sidebar" id="sidebar" aria-hidden="true">
+  <div class="ease-sidebar__head"><strong>Menu</strong>
+    <button class="ease-sidebar__close" id="close" aria-label="Close">&times;</button>
+  </div>
+  <nav class="ease-sidebar__nav">…links…</nav>
+</aside>
+
+<script>
+  const html = document.documentElement;
+  function show()  { html.classList.add('ease-scroll-locked'); /* + show sidebar */ }
+  function hide()  { html.classList.remove('ease-scroll-locked'); /* + hide sidebar */ }
+</script>
+```
+
+The CSS rule `html.ease-scroll-locked, html.ease-scroll-locked body { overflow: hidden; height: 100%; }` does the actual locking.
+
+## Why is this useful?
+
+- **Directly fixes the issue** — the root cause was that the body remained scrollable under the overlay; locking `<html>` **and** `<body>` overflow stops the leak at the source (locking only `<html>` can leave `<body>` as the viewport scroller).
+- **No layout jump** — `scrollbar-gutter: stable` reserves the scrollbar space so content doesn't shift horizontally when the lock engages.
+- **Sidebar still scrolls** — `overflow-y: auto` on the nav means long menus scroll independently.
+- **Accessible** — Esc to close, focus management, `aria-hidden` toggle, reduced-motion support.
+
+## Files
+
+- `demo.html` — self-contained showcase with a tall page + sidebar. No CDNs/frameworks.
+- `style.css` — scroll-lock rule, backdrop, sidebar slide-in, nav scroll, reduced-motion.
+- `README.md` — this documentation.
+
+## Notes for the maintainer
+
+The contributor used the `-sbh` suffix per the naming policy to avoid collisions.

--- a/submissions/examples/ease-sidebar-scroll-lock-sbh/demo.html
+++ b/submissions/examples/ease-sidebar-scroll-lock-sbh/demo.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ease-sidebar-scroll-lock — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <!-- Background page: tall so it scrolls -->
+  <main class="page">
+    <header class="page__head">
+      <p class="page__eyebrow">ease-sidebar-scroll-lock</p>
+      <h1>Mobile sidebar with background scroll lock.</h1>
+      <p class="page__lede">
+        Fixes the bug where scrolling inside the mobile sidebar overlay leaked
+        the scroll event to the background <code>&lt;body&gt;</code>, scrolling
+        the page underneath. This example locks body scroll while the sidebar is
+        open via a class on <code>&lt;html&gt;</code> (<code>overflow: hidden</code>
+        + a scrollbar-gap compensation), and the sidebar's own content scrolls
+        independently. Open the sidebar and scroll &mdash; the page behind stays put.
+      </p>
+      <button class="btn" id="open">☰ Open sidebar</button>
+    </header>
+
+    <section class="content">
+      <!-- filler so the page is tall enough to scroll -->
+      <p>Scroll the page. Then open the sidebar and scroll inside it &mdash; the background will not move.</p>
+      <p>Repeat. Repeat. Repeat. Repeat. Repeat. Repeat. Repeat. Repeat. Repeat. Repeat.</p>
+      <p>Filler. Filler. Filler. Filler. Filler. Filler. Filler. Filler. Filler. Filler.</p>
+      <p>Row. Row. Row. Row. Row. Row. Row. Row. Row. Row.</p>
+      <p>Line. Line. Line. Line. Line. Line. Line. Line. Line. Line.</p>
+      <p>Block. Block. Block. Block. Block. Block. Block. Block. Block. Block.</p>
+      <p>More. More. More. More. More. More. More. More. More. More.</p>
+      <p>Text. Text. Text. Text. Text. Text. Text. Text. Text. Text.</p>
+      <p>Body. Body. Body. Body. Body. Body. Body. Body. Body. Body.</p>
+      <p>End. End. End. End. End. End. End. End. End. End.</p>
+    </section>
+  </main>
+
+  <!-- Backdrop + sidebar -->
+  <div class="ease-sidebar-backdrop" id="backdrop" hidden></div>
+  <aside class="ease-sidebar" id="sidebar" aria-hidden="true" aria-label="Menu">
+    <div class="ease-sidebar__head">
+      <strong>Menu</strong>
+      <button class="ease-sidebar__close" id="close" type="button" aria-label="Close sidebar">&times;</button>
+    </div>
+    <nav class="ease-sidebar__nav">
+      <a href="#">Home</a><a href="#">Discover</a><a href="#">Library</a><a href="#">Playlists</a>
+      <a href="#">Stations</a><a href="#">Artists</a><a href="#">Albums</a><a href="#">Songs</a>
+      <a href="#">Genres</a><a href="#">Moods</a><a href="#">Search</a><a href="#">Settings</a>
+      <a href="#">Account</a><a href="#">Help</a><a href="#">About</a><a href="#">Logout</a>
+      <a href="#">Item A</a><a href="#">Item B</a><a href="#">Item C</a><a href="#">Item D</a>
+    </nav>
+  </aside>
+
+  <script>
+    (function () {
+      var open = document.getElementById('open');
+      var close = document.getElementById('close');
+      var backdrop = document.getElementById('backdrop');
+      var sidebar = document.getElementById('sidebar');
+      var html = document.documentElement;
+
+      function show() {
+        html.classList.add('ease-scroll-locked');  // lock background scroll
+        backdrop.hidden = false;
+        sidebar.classList.add('is-open');
+        sidebar.setAttribute('aria-hidden', 'false');
+        // focus the close button for keyboard users
+        close.focus();
+      }
+      function hide() {
+        html.classList.remove('ease-scroll-locked');
+        backdrop.hidden = true;
+        sidebar.classList.remove('is-open');
+        sidebar.setAttribute('aria-hidden', 'true');
+        open.focus();
+      }
+
+      open.addEventListener('click', show);
+      close.addEventListener('click', hide);
+      backdrop.addEventListener('click', hide);
+      document.addEventListener('keydown', function (e) { if (e.key === 'Escape') hide(); });
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-sidebar-scroll-lock-sbh/style.css
+++ b/submissions/examples/ease-sidebar-scroll-lock-sbh/style.css
@@ -1,0 +1,118 @@
+/* ease-sidebar-scroll-lock — lock background body scroll while sidebar open.
+   Bug: scrolling inside the mobile sidebar leaked to the background body.
+   Fix: add .ease-scroll-locked to <html> AND <body> (overflow:hidden
+   + scrollbar-gap compensation) when the sidebar opens; the
+   sidebar's own nav scrolls independently. */
+
+:root {
+  --ease-color-primary: #4f46e5;
+  --ease-sidebar-width: 18rem;
+  --ease-dur: 0.28s;
+  --ease-ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* ---------- THE FIX: lock background scroll on html AND body ----------
+   Locking only <html> can leave <body> as the viewport scroller in some
+   browsers; locking both guarantees the background cannot scroll. */
+html.ease-scroll-locked,
+html.ease-scroll-locked body {
+  overflow: hidden;
+  height: 100%;
+}
+html.ease-scroll-locked {
+  /* reserve the scrollbar gap so layout doesn't shift when the bar hides */
+  scrollbar-gutter: stable;
+}
+
+/* ---------- Page (demo only) ---------- */
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  color: #0f172a;
+  background:
+    radial-gradient(900px 520px at 85% -10%, #eef2ff, transparent 60%),
+    #fff;
+  line-height: 1.6;
+}
+.page { max-width: 48rem; margin: 0 auto; padding: clamp(2rem, 6vw, 4rem) clamp(1rem, 4vw, 2rem); }
+.page__eyebrow {
+  margin: 0 0 0.5rem; text-transform: uppercase; letter-spacing: 0.18em;
+  font-size: 0.78rem; font-weight: 700; color: var(--ease-color-primary);
+}
+.page__head h1 { margin: 0 0 0.8rem; font-size: clamp(1.6rem, 4.5vw, 2.2rem); letter-spacing: -0.02em; }
+.page__lede { margin: 0 0 1.4rem; color: #64748b; max-width: 42rem; }
+.page__lede code { background: rgba(79,70,229,0.12); color: var(--ease-color-primary); padding: 0.12rem 0.4rem; border-radius: 0.4rem; font-size: 0.9em; }
+.content p { margin: 0 0 1rem; color: #475569; }
+
+.btn {
+  font: inherit; font-size: 0.9rem; font-weight: 600;
+  padding: 0.55rem 1.1rem; border-radius: 0.5rem; cursor: pointer;
+  border: none; color: #fff; background: var(--ease-color-primary);
+  transition: transform 0.18s var(--ease-ease), box-shadow 0.18s var(--ease-ease);
+}
+.btn:hover { transform: translateY(-0.1rem); box-shadow: 0 8px 18px -8px rgba(79,70,229,0.6); }
+
+/* ---------- Backdrop ---------- */
+.ease-sidebar-backdrop {
+  position: fixed; inset: 0; z-index: 90;
+  background: rgba(15,23,42,0.5);
+  opacity: 0;
+  animation: ease-fade-in var(--ease-dur) var(--ease-ease) forwards;
+}
+.ease-sidebar-backdrop[hidden] { display: none; }
+@keyframes ease-fade-in { from { opacity: 0; } to { opacity: 1; } }
+
+/* ---------- Sidebar ---------- */
+.ease-sidebar {
+  position: fixed;
+  top: 0; left: 0; bottom: 0;
+  z-index: 100;
+  width: var(--ease-sidebar-width);
+  max-width: 86vw;
+  background: #fff;
+  border-right: 1px solid #e2e8f0;
+  box-shadow: 0 0 40px -10px rgba(15,23,42,0.4);
+  display: flex;
+  flex-direction: column;
+  transform: translateX(-100%);
+  transition: transform var(--ease-dur) var(--ease-ease);
+}
+.ease-sidebar.is-open { transform: translateX(0); }
+
+.ease-sidebar__head {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 1rem 1.2rem;
+  border-bottom: 1px solid #e2e8f0;
+}
+.ease-sidebar__close {
+  font: inherit; font-size: 1.3rem; line-height: 1;
+  width: 1.8rem; height: 1.8rem; border-radius: 0.4rem;
+  border: none; background: transparent; color: #64748b; cursor: pointer;
+  transition: background-color 0.15s, color 0.15s;
+}
+.ease-sidebar__close:hover { background: #f1f5f9; color: #0f172a; }
+
+/* The nav scrolls independently (overflow-y: auto) */
+.ease-sidebar__nav {
+  overflow-y: auto;           /* sidebar content scrolls here */
+  -webkit-overflow-scrolling: touch;
+  padding: 0.6rem;
+  flex: 1 1 auto;
+  display: flex; flex-direction: column;
+}
+.ease-sidebar__nav a {
+  display: block;
+  padding: 0.6rem 0.8rem;
+  border-radius: 0.4rem;
+  color: #0f172a; text-decoration: none; font-size: 0.9rem;
+  transition: background-color 0.15s, color 0.15s;
+}
+.ease-sidebar__nav a:hover { background: rgba(79,70,229,0.1); color: var(--ease-color-primary); }
+
+/* ---------- Reduced motion ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .ease-sidebar { transition: none; }
+  .ease-sidebar-backdrop { animation: none; opacity: 1; }
+  .btn:hover { transform: none; }
+}


### PR DESCRIPTION
## What

Fixes #60867 - scrolling inside the mobile sidebar overlay leaked the scroll event to the background `<body>`, scrolling the page underneath.

## Fix

When the sidebar opens, `.ease-scroll-locked` is added to **both** `<html>` and `<body>` (`overflow: hidden` + `height: 100%`, plus `scrollbar-gutter: stable` so the page doesn't shift when the scrollbar hides). The sidebar's own nav has `overflow-y: auto` and scrolls independently.

Verified: after opening, `html.overflow=hidden` and `body.overflow=hidden`; a programmatic `scrollTo(0,1500)` left `scrollY=0` (no leak); the nav's `scrollHeight` exceeds its `clientHeight` and `scrollTop` follows programmatic scroll (sidebar scrolls independently).

## Submission

Additive example under `submissions/examples/ease-sidebar-scroll-lock-sbh/` (`demo.html`, `style.css`, `README.md`) - no core files changed. `-sbh` suffix per CONTRIBUTING.md.