### PR TITLE
Add ease-tag-cloud component

### DIFF
--- a/submissions/examples/tag-cloud-ij/README.md
+++ b/submissions/examples/tag-cloud-ij/README.md
@@ -1,0 +1,10 @@
+# ease-tag-cloud
+
+A tag cloud where many topic tags float at varying sizes, each bobs gently, and the hovered tag swells.
+
+## Run
+Open `demo.html` directly in a browser to watch the tags bob.
+
+## Notes
+- Topic tags bob in place.
+- The hovered tag swells larger.

--- a/submissions/examples/tag-cloud-ij/demo.html
+++ b/submissions/examples/tag-cloud-ij/demo.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-tag-cloud demo</title>
+</head>
+<body>
+<div class="tgc-frame">
+  <span class="tgc-title">TOPIC CLOUD</span>
+  <div class="tgc-tags">
+    <span class="tgc-tag tgc-tag-xl">Design</span>
+    <span class="tgc-tag tgc-tag-m">Motion</span>
+    <span class="tgc-tag tgc-tag-s">CSS</span>
+    <span class="tgc-tag tgc-tag-l">Animation</span>
+    <span class="tgc-tag tgc-tag-s">Grid</span>
+    <span class="tgc-tag tgc-tag-m">Flexbox</span>
+    <span class="tgc-tag tgc-tag-l">Keyframes</span>
+    <span class="tgc-tag tgc-tag-s">Hover</span>
+    <span class="tgc-tag tgc-tag-m">Layout</span>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/tag-cloud-ij/style.css
+++ b/submissions/examples/tag-cloud-ij/style.css
@@ -1,0 +1,13 @@
+:root{--tgc-purple:#9b6cff;--tgc-navy:#0e0a18}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#0e0a18,#08060f);font-family:'Trebuchet MS',sans-serif}
+.tgc-frame{position:relative;width:360px;height:400px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#171130,#0f0b20);box-shadow:0 16px 34px rgba(0,0,0,0.6)}
+.tgc-title{position:absolute;top:18px;left:0;right:0;text-align:center;font-size:13px;font-weight:700;letter-spacing:7px;color:#9b6cff}
+.tgc-tags{position:absolute;top:64px;left:0;right:0;display:flex;flex-wrap:wrap;gap:12px;padding:0 22px}
+.tgc-tag{display:inline-block;padding:7px 11px;border-radius:12px;background:#1d1640;color:#b48dff;animation:bob-tag-cloud 3s ease-in-out infinite}
+.tgc-tag-s{font-size:11px}
+.tgc-tag-m{font-size:15px}
+.tgc-tag-l{font-size:19px}
+.tgc-tag-xl{font-size:24px;color:#d9beff}
+.tgc-tag:hover{animation:swell-tag-cloud 0.6s ease-in-out infinite}
+@keyframes bob-tag-cloud{0%,100%{transform:translateY(0)}50%{transform:translateY(-6px)}}
+@keyframes swell-tag-cloud{0%,100%{transform:scale(1)}50%{transform:scale(1.18)}}


### PR DESCRIPTION
## Component: ease-tag-cloud — tags bob, sizes vary, and hover swells

**Closes #67734**

### What this adds
A tag cloud: many topic tags float at varying sizes, each bobs gently, and the hovered tag swells.

### Acceptance Criteria covered
- Topic tags bob in place
- Tag sizes vary across rows
- Hovered tag swells larger

### Files
- `submissions/examples/tag-cloud-ij/demo.html`
- `submissions/examples/tag-cloud-ij/style.css`
- `submissions/examples/tag-cloud-ij/README.md`

### How to review
Open `demo.html` directly in a browser and hover the tags.