### PR TITLE
feat: add CSS Shimmer-Sweep Accordion for Minimalist Tech Layouts (#64548)

### DIFF
--- a/submissions/examples/minimalist-tech-shimmer-sweep-accordion/README.md
+++ b/submissions/examples/minimalist-tech-shimmer-sweep-accordion/README.md
@@ -1,0 +1,28 @@
+# CSS Shimmer-Sweep Accordion (Minimalist Tech)
+
+A pure CSS accordion component designed for Minimalist Tech Layouts. It features entirely JavaScript-free state management and a dynamic, continuous "Shimmer-Sweep" border animation for the active item.
+
+## Features
+- Pure CSS and HTML (Zero JavaScript required for state management or animations).
+- **Minimalist Tech Aesthetic**: Clean panel layouts, precise borders, subtle structural icons, and a high-contrast active state.
+- **Pure CSS State Management**: 
+- Utilizes the "Radio Button Hack". A group of radio buttons (`name="tech-accordion"`) ensures that only one accordion panel can be open at a time.
+- The accordion headers are `<label>` elements linked to these hidden radio buttons. Clicking a header changes the active checked state.
+- Depending on which radio button is checked (`#acc-1:checked`, etc.), CSS sibling selectors (`~`) dynamically update:
+  1. The height of the `.accordion-content-wrapper` using a modern CSS Grid transition (`grid-template-rows: 0fr` to `1fr`).
+  2. The rotation of the chevron icon (`transform: rotate(180deg)`).
+  3. The text color of the active header.
+  4. The visibility and animation of the Shimmer-Sweep border layer.
+- **The Shimmer-Sweep Border Animation System**: 
+- This effect is created using a dedicated `.shimmer-border` element that sits absolutely positioned behind the header and content, but within the item container.
+- It utilizes a `conic-gradient` background to create a sweeping "beam" of light (`var(--accent-blue)`).
+- A `-webkit-mask` composite operation (often called the pseudo-element border trick) is used to cut out the center of this element, leaving only a 2px "border" visible around the edges.
+- When an item becomes active, the `.shimmer-border` becomes visible and triggers the `sweep-rotation` animation. This infinitely rotates the conic gradient 360 degrees, creating the illusion of a beam of light continuously sweeping around the perimeter of the active accordion panel.
+- Fully accessible with `prefers-reduced-motion` support. For motion-sensitive users, the continuous sweeping animation is disabled, gracefully falling back to a static, solid blue border for the active state. The panel expansion also snaps instantly without transitioning.
+
+## Usage
+Open `demo.html` in your browser. You will see a "System FAQ" list. Click the headers to expand the panels. Notice how the content drawer smoothly slides open, the chevron rotates, and a vibrant blue beam of light begins to sweep continuously around the border of the newly active item.
+
+## Files
+- `demo.html`: The HTML structure for the accordion, detailing the crucial radio button setup for CSS state management, the navigation headers, the content wrappers for grid animation, and the dedicated `.shimmer-border` layer.
+- `style.css`: The styling, tech design tokens, the complex state logic driven by `:checked ~` selectors, the CSS Grid height transition, and the specific `@keyframes` and conic-gradient logic driving the shimmer-sweep effect.

--- a/submissions/examples/minimalist-tech-shimmer-sweep-accordion/demo.html
+++ b/submissions/examples/minimalist-tech-shimmer-sweep-accordion/demo.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Shimmer-Sweep Accordion - Minimalist Tech</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">System FAQ</h1>
+            <p class="subtitle">A minimalist tech accordion featuring a continuous, dynamic shimmer-sweep border animation for the active item.</p>
+        </header>
+
+        <div class="dashboard-area">
+            
+            <div class="accordion-container">
+                
+                <!-- Accordion Item 1 -->
+                <div class="accordion-item">
+                    <!-- 
+                       Pure CSS State Management
+                       Radio buttons allow only one panel open at a time.
+                       Checkboxes would allow multiple.
+                    -->
+                    <input type="radio" name="tech-accordion" id="acc-1" class="accordion-input" checked>
+                    
+                    <label for="acc-1" class="accordion-header">
+                        <div class="header-content">
+                            <span class="header-icon">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"></path><line x1="12" y1="17" x2="12.01" y2="17"></line></svg>
+                            </span>
+                            How is data encrypted at rest?
+                        </div>
+                        <span class="chevron-icon">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"></polyline></svg>
+                        </span>
+                    </label>
+                    
+                    <div class="accordion-content-wrapper">
+                        <div class="accordion-content">
+                            <p>All data stored within the primary cluster is encrypted at rest using AES-256 block-level encryption. Encryption keys are managed automatically by the AWS Key Management Service (KMS), with keys rotated on a 90-day schedule.</p>
+                        </div>
+                    </div>
+                    
+                    <!-- The animated shimmer border layer -->
+                    <div class="shimmer-border"></div>
+                </div>
+                
+                <!-- Accordion Item 2 -->
+                <div class="accordion-item">
+                    <input type="radio" name="tech-accordion" id="acc-2" class="accordion-input">
+                    
+                    <label for="acc-2" class="accordion-header">
+                        <div class="header-content">
+                            <span class="header-icon">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect><line x1="8" y1="21" x2="16" y2="21"></line><line x1="12" y1="17" x2="12" y2="21"></line></svg>
+                            </span>
+                            What is the expected API latency?
+                        </div>
+                        <span class="chevron-icon">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"></polyline></svg>
+                        </span>
+                    </label>
+                    
+                    <div class="accordion-content-wrapper">
+                        <div class="accordion-content">
+                            <p>Under normal operational loads, our edge-routed API gateway maintains a p95 latency of less than 45ms for globally distributed requests. Complex analytical queries may take up to 200ms depending on the dataset size.</p>
+                        </div>
+                    </div>
+                    
+                    <div class="shimmer-border"></div>
+                </div>
+                
+                <!-- Accordion Item 3 -->
+                <div class="accordion-item">
+                    <input type="radio" name="tech-accordion" id="acc-3" class="accordion-input">
+                    
+                    <label for="acc-3" class="accordion-header">
+                        <div class="header-content">
+                            <span class="header-icon">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21.21 15.89A10 10 0 1 1 8 2.83"></path><path d="M22 12A10 10 0 0 0 12 2v10z"></path></svg>
+                            </span>
+                            How do I configure rate limiting?
+                        </div>
+                        <span class="chevron-icon">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"></polyline></svg>
+                        </span>
+                    </label>
+                    
+                    <div class="accordion-content-wrapper">
+                        <div class="accordion-content">
+                            <p>Rate limiting is enforced automatically at the gateway level based on your current subscription tier. To view or upgrade your limits, navigate to the Dashboard > Organization Settings > Plan Quotas. Custom enterprise limits require contacting support.</p>
+                        </div>
+                    </div>
+                    
+                    <div class="shimmer-border"></div>
+                </div>
+                
+            </div>
+            
+        </div>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/minimalist-tech-shimmer-sweep-accordion/style.css
+++ b/submissions/examples/minimalist-tech-shimmer-sweep-accordion/style.css
@@ -1,0 +1,275 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    --border-color: #e2e8f0;
+    
+    --surface-white: #ffffff;
+    --surface-hover: #f1f5f9;
+    
+    /* Tech Minimalist Accents */
+    --accent-blue: #0ea5e9;
+    --shimmer-glow: rgba(14, 165, 233, 0.4);
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    width: 100%;
+    padding: 40px 20px;
+}
+
+.section-header {
+    text-align: center;
+    margin-bottom: 50px;
+}
+
+.title {
+    font-size: 2.25rem;
+    font-weight: 600;
+    margin: 0 0 12px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    margin: 0;
+}
+
+
+/* =========================================
+   Accordion Container
+   ========================================= */
+
+.accordion-container {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    width: 100%;
+    max-width: 600px;
+    margin: 0 auto;
+}
+
+
+/* =========================================
+   Accordion Item Structure
+   ========================================= */
+
+.accordion-item {
+    background: var(--surface-white);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    position: relative;
+    overflow: hidden;
+    /* 
+      We use a subtle transition on the border color for the non-active state.
+      The active state uses the absolute positioned .shimmer-border.
+    */
+    transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.accordion-input {
+    display: none;
+}
+
+
+/* =========================================
+   Accordion Header (The Clickable Trigger)
+   ========================================= */
+
+.accordion-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 20px 24px;
+    cursor: pointer;
+    user-select: none;
+    position: relative;
+    z-index: 2; /* Keep above the shimmer layer */
+    background: var(--surface-white); /* Solid background to hide shimmer passing underneath */
+}
+
+.header-content {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    font-size: 1.05rem;
+    font-weight: 500;
+    color: var(--text-primary);
+    transition: color 0.3s ease;
+}
+
+.header-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-secondary);
+    transition: color 0.3s ease;
+}
+
+.header-icon svg {
+    width: 20px;
+    height: 20px;
+}
+
+.chevron-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-secondary);
+    transition: transform 0.3s ease, color 0.3s ease;
+}
+
+.chevron-icon svg {
+    width: 20px;
+    height: 20px;
+}
+
+
+/* =========================================
+   Accordion Content Area (Collapsible)
+   ========================================= */
+
+.accordion-content-wrapper {
+    /* 
+      Using CSS Grid to animate height from 0 to auto cleanly.
+      This requires a wrapper div around the actual content.
+    */
+    display: grid;
+    grid-template-rows: 0fr;
+    transition: grid-template-rows 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+    background: var(--surface-white);
+    position: relative;
+    z-index: 2; /* Keep above shimmer */
+}
+
+.accordion-content {
+    overflow: hidden;
+    /* Opacity starts low and scales up for a fading-in effect during expansion */
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.accordion-content p {
+    margin: 0;
+    padding: 0 24px 24px 24px; /* Padding bottom for spacing when open */
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+    line-height: 1.6;
+}
+
+
+/* =========================================
+   The Shimmer-Sweep Border Layer
+   ========================================= */
+
+/* 
+  We create a layer that sits behind the header and content,
+  but inside the .accordion-item. It is slightly larger than the item
+  to act as the "border".
+*/
+.shimmer-border {
+    position: absolute;
+    top: -2px; left: -2px; right: -2px; bottom: -2px;
+    background: conic-gradient(
+        from 0deg,
+        transparent 0%,
+        transparent 60%,
+        var(--accent-blue) 80%,
+        transparent 100%
+    );
+    z-index: 1; /* Below content, above item background */
+    opacity: 0; /* Hidden by default */
+    /* Use pseudo element trick to create the "hole" in the middle */
+    -webkit-mask: 
+        linear-gradient(#fff 0 0) content-box, 
+        linear-gradient(#fff 0 0);
+    -webkit-mask-composite: xor;
+    mask-composite: exclude;
+    padding: 2px; /* This padding determines the border width */
+    pointer-events: none;
+}
+
+
+/* =========================================
+   State Management & Animations (Active State)
+   ========================================= */
+
+/* 1. Open the content drawer */
+.accordion-input:checked ~ .accordion-content-wrapper {
+    grid-template-rows: 1fr;
+}
+.accordion-input:checked ~ .accordion-content-wrapper .accordion-content {
+    opacity: 1;
+    /* Delay opacity so it fades in after grid starts expanding */
+    transition: opacity 0.4s ease 0.1s; 
+}
+
+/* 2. Rotate the chevron */
+.accordion-input:checked ~ .accordion-header .chevron-icon {
+    transform: rotate(180deg);
+    color: var(--accent-blue);
+}
+
+/* 3. Highlight text and icons */
+.accordion-input:checked ~ .accordion-header .header-content {
+    color: var(--accent-blue);
+}
+.accordion-input:checked ~ .accordion-header .header-icon {
+    color: var(--accent-blue);
+}
+
+/* 4. Trigger the Shimmer-Sweep Animation on the active item */
+.accordion-input:checked ~ .shimmer-border {
+    opacity: 1;
+    animation: sweep-rotation 3s linear infinite;
+}
+
+/* Add a subtle glow to the active item box */
+.accordion-input:checked ~ .accordion-header,
+.accordion-input:checked ~ .accordion-content-wrapper {
+    box-shadow: inset 0 0 20px rgba(14, 165, 233, 0.05);
+}
+
+/* 
+  The sweeping rotation keyframes. 
+  It simply rotates the conic gradient 360 degrees infinitely.
+*/
+@keyframes sweep-rotation {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    /* Disable the continuous sweeping animation */
+    .shimmer-border {
+        animation: none !important;
+    }
+    
+    /* Just use a solid static border for active state instead */
+    .accordion-input:checked ~ .shimmer-border {
+        background: var(--accent-blue);
+    }
+    
+    /* Make drawer snap open/closed instantly */
+    .accordion-content-wrapper {
+        transition: none !important;
+    }
+}


### PR DESCRIPTION

### Description
This PR introduces the CSS Shimmer-Sweep Accordion designed for Minimalist Tech Layouts, resolving issue #64548. 

### Changes Made:
- Added `submissions/examples/minimalist-tech-shimmer-sweep-accordion/` directory.
- Created `demo.html` showcasing a mock "System FAQ" list. 
  - Implemented 100% JavaScript-free state management utilizing the "Radio Button Hack". A group of hidden radio buttons ensures that only one accordion panel can be open at a time. The accordion headers act as `<label>` elements linked to these inputs.
- Created `style.css` featuring a clean aesthetic utilizing precise borders, subtle structural icons, and a high-contrast active state.
  - Implemented the dynamic CSS state logic driven by `:checked ~` sibling selectors. Depending on the radio state, the height of the `.accordion-content-wrapper` smoothly expands using a modern CSS Grid transition (`grid-template-rows: 0fr` to `1fr`), the chevron icon rotates, and the active text highlights.
  - Implemented the Continuous Shimmer-Sweep Border Animation System. 
  - This effect is created using a dedicated `.shimmer-border` element that sits absolutely positioned behind the header and content, utilizing a `conic-gradient` background to create a sweeping "beam" of light.
  - A `-webkit-mask` composite operation (the pseudo-element border trick) is used to cut out the center of this element, leaving only a 2px "border" visible around the edges.
  - When an item becomes active, the `.shimmer-border` triggers the `sweep-rotation` animation, infinitely rotating the conic gradient 360 degrees to create the sweeping light effect.
- Added `README.md` documenting usage and technical features.
- Honors the `prefers-reduced-motion` accessibility standard. The continuous sweeping animation is disabled, gracefully falling back to a static, solid blue border for the active state. The panel expansion also snaps instantly without transitioning for motion-sensitive users.

Closes #64548
