### PR TITLE
feat: add CSS Zoom-In Progress Bar for Minimalist Tech Layouts (#64656)

### DIFF
--- a/submissions/examples/minimalist-tech-zoom-in-progress-bar/README.md
+++ b/submissions/examples/minimalist-tech-zoom-in-progress-bar/README.md
@@ -1,0 +1,22 @@
+# CSS Zoom-In Progress Bar (Minimalist Tech)
+
+A pure CSS progress bar list component designed for Minimalist Tech Layouts. It features a satisfying, staggered "Zoom-In" entrance animation perfect for illustrating a sequence of initialization or loading tasks.
+
+## Features
+- Pure CSS and HTML (Zero JavaScript required for the entrance animation).
+- **Minimalist Tech Aesthetic**: Clean layouts, thin progress tracks, and crisp monospace (`JetBrains Mono`) typography for technical task names.
+- **The Zoom-In Effect**: 
+- The entrance animation is applied to the `.progress-item` containers via the `item-zoom-in` keyframes.
+- The initial state of each item is transparent (`opacity: 0`), slightly scaled down (`transform: scale(0.9)`), and pushed down slightly (`translateY(10px)`).
+- When triggered, the animation scales the item up to `1` and translates it to `0` using a custom `cubic-bezier(0.175, 0.885, 0.32, 1.1)` timing function. The `1.1` value causes the item to slightly "overshoot" its final size before snapping back, giving the zoom a soft, physical "pop".
+- **Cascading Sequence**: To draw the user's eye down the list of tasks, we utilize distinct `animation-delay` utility classes (`.delay-1` through `.delay-4`). This causes the progress bars to pop into view one after another.
+- **Active State Pulsing**: The active task features an infinite `@keyframes` opacity pulse (`pulse-opacity`) on its progress fill bar, clearly indicating which task is currently processing.
+- **State Management (Demo)**: The demo uses a hidden checkbox hack (`<input type="checkbox">`) connected to a "Replay Sequence" button. This allows users to easily re-trigger the cascading entrance sequence without reloading the page.
+- Fully accessible with `prefers-reduced-motion` support. For motion-sensitive users, the spatial scaling/translating entrance and the infinite active pulse are completely disabled. The entrance safely falls back to a simple, staggered opacity fade.
+
+## Usage
+Open `demo.html` in your browser. You will see a "System Initialization" list containing multiple progress bars in various states (Done, In Progress, Waiting). Upon load, the list items will dynamically pop into view sequentially from top to bottom. Notice the subtle throbbing animation on the "In Progress" blue bar. You can click the "Replay Sequence" button to toggle the state and watch the sequence run again.
+
+## Files
+- `demo.html`: The HTML structure for the progress list, detailing the pure CSS checkbox hack setup for the replay button, and the application of the specific state variants and staggered delay classes.
+- `style.css`: The styling, tech-specific design tokens for the semantic states (indigo, emerald), and the specific `@keyframes` driving the zoom-in logic and the custom bouncy `cubic-bezier`.

--- a/submissions/examples/minimalist-tech-zoom-in-progress-bar/demo.html
+++ b/submissions/examples/minimalist-tech-zoom-in-progress-bar/demo.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Zoom-In Progress Bar - Minimalist Tech</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">System Initialization</h1>
+            <p class="subtitle">A minimalist tech layout featuring a dynamic zoom-in entrance animation for progress indicators.</p>
+        </header>
+
+        <div class="dashboard-area">
+            
+            <div class="card">
+                
+                <div class="controls">
+                    <p class="instruction-text">Trigger the initialization sequence to observe the cascading zoom-in effect.</p>
+                    
+                    <!-- 
+                       Pure CSS State Management for Demo
+                       We use a checkbox to toggle the animation state.
+                    -->
+                    <input type="checkbox" id="init-trigger" class="init-input" checked>
+                    
+                    <label for="init-trigger" class="btn-trigger">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="1 4 1 10 7 10"></polyline><polyline points="23 20 23 14 17 14"></polyline><path d="M20.49 9A9 9 0 0 0 5.64 5.64L1 10m22 4l-4.64 4.36A9 9 0 0 1 3.51 15"></path></svg>
+                        Replay Sequence
+                    </label>
+                    
+                    <div class="progress-list zoom-in-group">
+                        
+                        <!-- Progress Item 1 -->
+                        <div class="progress-item delay-1">
+                            <div class="progress-info">
+                                <span class="task-name">Booting Kernel</span>
+                                <span class="task-status">Done</span>
+                            </div>
+                            <div class="progress-track">
+                                <div class="progress-fill fill-100"></div>
+                            </div>
+                        </div>
+                        
+                        <!-- Progress Item 2 -->
+                        <div class="progress-item delay-2">
+                            <div class="progress-info">
+                                <span class="task-name">Mounting File Systems</span>
+                                <span class="task-status">Done</span>
+                            </div>
+                            <div class="progress-track">
+                                <div class="progress-fill fill-100"></div>
+                            </div>
+                        </div>
+                        
+                        <!-- Progress Item 3 -->
+                        <div class="progress-item delay-3">
+                            <div class="progress-info">
+                                <span class="task-name">Starting Network Interfaces</span>
+                                <span class="task-status active-text">In Progress</span>
+                            </div>
+                            <div class="progress-track">
+                                <div class="progress-fill fill-active active-pulse"></div>
+                            </div>
+                        </div>
+                        
+                        <!-- Progress Item 4 -->
+                        <div class="progress-item delay-4">
+                            <div class="progress-info">
+                                <span class="task-name">Loading User Space</span>
+                                <span class="task-status pending-text">Waiting</span>
+                            </div>
+                            <div class="progress-track">
+                                <div class="progress-fill fill-0"></div>
+                            </div>
+                        </div>
+
+                    </div>
+                </div>
+                
+            </div>
+            
+        </div>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/minimalist-tech-zoom-in-progress-bar/style.css
+++ b/submissions/examples/minimalist-tech-zoom-in-progress-bar/style.css
@@ -1,0 +1,253 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@500&display=swap');
+
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    --border-color: #e2e8f0;
+    
+    --surface-white: #ffffff;
+    --surface-hover: #f1f5f9;
+    
+    /* Tech Minimalist Accents */
+    --accent-indigo: #4f46e5;
+    --accent-emerald: #10b981;
+    --track-bg: #e2e8f0;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 700px;
+    width: 100%;
+    padding: 40px 20px;
+}
+
+.section-header {
+    text-align: center;
+    margin-bottom: 50px;
+}
+
+.title {
+    font-size: 2.25rem;
+    font-weight: 600;
+    margin: 0 0 12px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    margin: 0;
+}
+
+
+/* =========================================
+   Dashboard Environment
+   ========================================= */
+
+.card {
+    background: var(--surface-white);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 40px; 
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+}
+
+.instruction-text {
+    color: var(--text-secondary);
+    margin-bottom: 24px;
+    font-size: 0.95rem;
+    text-align: center;
+}
+
+
+/* =========================================
+   Demo Controls
+   ========================================= */
+
+.controls {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+}
+
+.init-input {
+    display: none;
+}
+
+.btn-trigger {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 20px;
+    background: var(--surface-white);
+    color: var(--text-primary);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    font-size: 0.95rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    user-select: none;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+    margin-bottom: 40px;
+}
+
+.btn-trigger:hover {
+    background: var(--surface-hover);
+    border-color: #cbd5e1;
+}
+
+.btn-trigger svg {
+    width: 18px;
+    height: 18px;
+    color: var(--accent-indigo);
+}
+
+
+/* =========================================
+   Progress List Structure
+   ========================================= */
+
+.progress-list {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.progress-item {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    
+    /* Setup initial state for the Zoom-In animation */
+    opacity: 0;
+    transform: scale(0.9) translateY(10px);
+}
+
+.progress-info {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.task-name {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: var(--text-primary);
+}
+
+.task-status {
+    font-size: 0.8rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--accent-emerald);
+}
+
+.active-text { color: var(--accent-indigo); }
+.pending-text { color: var(--text-secondary); }
+
+/* The Track */
+.progress-track {
+    width: 100%;
+    height: 6px;
+    background-color: var(--track-bg);
+    border-radius: 3px;
+    overflow: hidden;
+}
+
+/* The Fill */
+.progress-fill {
+    height: 100%;
+    border-radius: 3px;
+    background-color: var(--accent-emerald);
+}
+
+/* Hardcoded demo states */
+.fill-100 { width: 100%; }
+.fill-0 { width: 0%; background-color: transparent; }
+.fill-active {
+    width: 65%;
+    background-color: var(--accent-indigo);
+}
+
+/* Subtle pulsing animation for the active task */
+.active-pulse {
+    animation: pulse-opacity 2s infinite ease-in-out;
+}
+
+@keyframes pulse-opacity {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.6; }
+}
+
+
+/* =========================================
+   The Zoom-In Entrance Animation
+   ========================================= */
+
+/* 
+  Trigger the animation when the checkbox is checked.
+*/
+.init-input:checked ~ .zoom-in-group .progress-item {
+    /* 
+      We use a cubic-bezier curve that overshoots slightly (1.1) 
+      to give the zoom a soft, satisfying pop without being overly aggressive.
+    */
+    animation: item-zoom-in 0.6s cubic-bezier(0.175, 0.885, 0.32, 1.1) forwards;
+}
+
+@keyframes item-zoom-in {
+    0% {
+        opacity: 0;
+        transform: scale(0.9) translateY(10px);
+    }
+    100% {
+        opacity: 1;
+        transform: scale(1) translateY(0);
+    }
+}
+
+/* 
+  Staggered Delays for Cascading Effect 
+*/
+.delay-1 { animation-delay: 0.1s !important; }
+.delay-2 { animation-delay: 0.25s !important; }
+.delay-3 { animation-delay: 0.4s !important; }
+.delay-4 { animation-delay: 0.55s !important; }
+
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    /* Disable the spatial scaling/translating entrance */
+    .init-input:checked ~ .zoom-in-group .progress-item {
+        animation: simple-fade 0.3s ease forwards !important;
+        transform: none !important;
+    }
+    
+    /* Disable the active pulse */
+    .active-pulse {
+        animation: none !important;
+    }
+    
+    @keyframes simple-fade {
+        0% { opacity: 0; }
+        100% { opacity: 1; }
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces the CSS Zoom-In Progress Bar designed for Minimalist Tech Layouts, resolving issue #64656. 

### Changes Made:
- Added `submissions/examples/minimalist-tech-zoom-in-progress-bar/` directory.
- Created `demo.html` showcasing a mock "System Initialization" list containing multiple progress bars in various states (Done, In Progress, Waiting).
  - The layout utilizes a pure CSS checkbox hack (`<input type="checkbox">`) connected to a "Replay Sequence" button to allow users to easily re-trigger the cascading entrance sequence without reloading the page.
- Created `style.css` featuring a clean aesthetic utilizing thin progress tracks, crisp monospace (`JetBrains Mono`) typography, and semantic color-coding (indigo, emerald).
  - Implemented the Snappy Zoom-In Animation System. 
  - The initial state of each item container is transparent (`opacity: 0`), slightly scaled down (`transform: scale(0.9)`), and pushed down (`translateY(10px)`).
  - When triggered, the animation scales the container up to `1` and translates it to `0` using a custom bouncy `cubic-bezier(0.175, 0.885, 0.32, 1.1)` timing function. The `1.1` value causes the item to slightly "overshoot" its final size before snapping back, giving the zoom a satisfying, physical "pop".
  - Orchestrated a cascading sequence. Utilizing 4 distinct `animation-delay` utility classes, the progress items pop into view one after another, drawing the user's eye down the list.
  - Added an infinite `@keyframes` pulsing animation to the active task's progress fill bar to clearly indicate active processing.
- Added `README.md` documenting usage and technical features.
- Honors the `prefers-reduced-motion` accessibility standard. The snappy spatial scaling/translating entrance and the active pulse are completely disabled, safely falling back to a simple, staggered opacity fade for motion-sensitive users.

Closes #64656
