### PR TITLE
Add ease-airport-arrivals-board component

### DIFF
--- a/submissions/examples/airport-arrivals-board-ij/README.md
+++ b/submissions/examples/airport-arrivals-board-ij/README.md
@@ -1,0 +1,10 @@
+# ease-airport-arrivals-board
+
+An arrivals board where the flight rows flip their destinations, the times tick, and the status tag blinks.
+
+## Run
+Open `demo.html` directly in a browser to watch the rows flip.
+
+## Notes
+- The flight rows flip destinations.
+- The status tag blinks on the board.

--- a/submissions/examples/airport-arrivals-board-ij/demo.html
+++ b/submissions/examples/airport-arrivals-board-ij/demo.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-airport-arrivals-board demo</title>
+</head>
+<body>
+<div class="aab-board">
+  <span class="aab-head">ARRIVALS</span>
+  <div class="aab-row"><span class="aab-code">AC 401</span><span class="aab-dest">TOKYO</span><span class="aab-time">14:20</span><span class="aab-status">ON TIME</span></div>
+  <div class="aab-row"><span class="aab-code">BA 220</span><span class="aab-dest">PARIS</span><span class="aab-time">14:45</span><span class="aab-status">BOARDING</span></div>
+  <div class="aab-row"><span class="aab-code">QF 118</span><span class="aab-dest">SYDNEY</span><span class="aab-time">15:10</span><span class="aab-status">DELAYED</span></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/airport-arrivals-board-ij/style.css
+++ b/submissions/examples/airport-arrivals-board-ij/style.css
@@ -1,0 +1,15 @@
+:root{--aab-amber:#ffb84d;--aab-dark:#0d0f12}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#0d0f12,#08090b);font-family:'Verdana',sans-serif}
+.aab-board{position:relative;width:384px;height:400px;border-radius:16px;overflow:hidden;background:linear-gradient(180deg,#14171c,#0b0d10);box-shadow:0 16px 34px rgba(0,0,0,0.6)}
+.aab-head{position:absolute;top:18px;left:0;right:0;text-align:center;font-size:14px;font-weight:700;letter-spacing:9px;color:#ffb84d}
+.aab-row{position:absolute;left:18px;right:18px;height:56px;border-radius:8px;background:#1a1e24;display:flex;align-items:center;gap:10px;padding:0 14px;animation:row-flip-airport-arrivals-board 4s ease-in-out infinite}
+.aab-row:nth-of-type(1){top:78px}
+.aab-row:nth-of-type(2){top:150px;animation-delay:0.8s}
+.aab-row:nth-of-type(3){top:222px;animation-delay:1.6s}
+.aab-code{font-size:13px;font-weight:700;color:#ffb84d}
+.aab-dest{flex:1;font-size:13px;font-weight:700;letter-spacing:1px;color:#f2f2ee;animation:time-tick-airport-arrivals-board 4s steps(1) infinite}
+.aab-time{font-size:12px;color:#c2c8cc}
+.aab-status{font-size:10px;font-weight:700;color:#ffb84d;animation:status-blink-airport-arrivals-board 1s steps(1) infinite}
+@keyframes row-flip-airport-arrivals-board{0%,100%{transform:scaleY(1)}45%{transform:scaleY(0.15)}55%{transform:scaleY(0.15)}}
+@keyframes time-tick-airport-arrivals-board{0%,49%{opacity:1}50%,100%{opacity:0.4}}
+@keyframes status-blink-airport-arrivals-board{0%,49%{opacity:1}50%,100%{opacity:0.3}}


### PR DESCRIPTION
## Component: ease-airport-arrivals-board — rows flip, times tick, and status blinks

**Closes #67758**

### What this adds
An arrivals board: the flight rows flip their destinations, the times tick, and the status tag blinks.

### Acceptance Criteria covered
- Flight rows flip destinations
- Times tick on each row
- Status tag blinks on the board

### Files
- `submissions/examples/airport-arrivals-board-ij/demo.html`
- `submissions/examples/airport-arrivals-board-ij/style.css`
- `submissions/examples/airport-arrivals-board-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the rows flip.