### PR TITLE
feat: add CSS Blur-Entrance Dropdown for Minimalist Tech Layouts (#64584)

### DIFF
--- a/submissions/examples/minimalist-tech-blur-entrance-dropdown/README.md
+++ b/submissions/examples/minimalist-tech-blur-entrance-dropdown/README.md
@@ -1,0 +1,27 @@
+# CSS Blur-Entrance Dropdown (Minimalist Tech)
+
+A pure CSS dropdown menu component designed for Minimalist Tech Layouts. It features entirely JavaScript-free state management and a sophisticated "Blur-Entrance" animation, perfect for user profile menus or complex dashboards.
+
+## Features
+- Pure CSS and HTML (Zero JavaScript required for state management or animations).
+- **Minimalist Tech Aesthetic**: Clean panel layouts, pill-shaped trigger buttons, semantic line-art iconography, and a dedicated header section for user data.
+- **Pure CSS State Management**: 
+- Utilizes the "Checkbox Hack". A hidden checkbox (`#profile-dropdown-trigger`) controls the open/closed state of the dropdown menu.
+- The main profile button (containing the avatar and username) acts as a `<label>` to toggle the checkbox.
+- Depending on the checkbox state, CSS sibling selectors (`~`) dynamically update:
+  1. The rotation of the chevron icon (`transform: rotate(180deg)`).
+  2. The border and focus ring of the trigger button.
+  3. The visibility and animation of the `.dropdown-menu` container.
+- **The Blur-Entrance Animation**: 
+- The `.dropdown-menu` is initially hidden (`opacity: 0`), slightly scaled down (`scale(0.95)`), and heavily blurred (`filter: blur(8px)`).
+- When triggered, it runs the `menu-blur-in` keyframes animation.
+- It transitions from `blur(8px)` to `blur(0px)` while simultaneously scaling up to `1` and fading in (`opacity: 1`).
+- This creates a highly sophisticated "materializing" effect commonly found in modern operating systems and premium web applications.
+- Fully accessible with `prefers-reduced-motion` support. For motion-sensitive users, the blurring effect and spatial scaling are completely disabled. The menu safely falls back to a fast, immediate opacity fade.
+
+## Usage
+Open `demo.html` in your browser. You will see a "User Profile" dashboard. Click the pill-shaped profile button. The dropdown menu will smoothly materialize from a blurred state into sharp focus, centered directly beneath the button. Click the button again to dismiss it. Hover over the menu items to see the distinct tech styling, including a dedicated "danger" state for the Sign Out action.
+
+## Files
+- `demo.html`: The HTML structure for the dropdown component, detailing the pure CSS checkbox hack setup, the pill button with a custom SVG avatar, and the nested menu list with a header section.
+- `style.css`: The styling, tech design tokens, hover variants, and the specific `@keyframes` driving the sophisticated CSS filter blur entrance logic.

--- a/submissions/examples/minimalist-tech-blur-entrance-dropdown/demo.html
+++ b/submissions/examples/minimalist-tech-blur-entrance-dropdown/demo.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Blur-Entrance Dropdown - Minimalist Tech</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">User Profile</h1>
+            <p class="subtitle">A minimalist tech layout featuring a sophisticated blur-entrance dropdown animation.</p>
+        </header>
+
+        <div class="dashboard-area">
+            
+            <div class="card">
+                
+                <p class="instruction-text">Click the profile button to toggle the menu.</p>
+                
+                <div class="dropdown-wrapper">
+                    
+                    <!-- 
+                       Pure CSS State Management
+                       Hidden checkbox controls the open/closed state.
+                    -->
+                    <input type="checkbox" id="profile-dropdown-trigger" class="dropdown-input">
+                    
+                    <label for="profile-dropdown-trigger" class="dropdown-btn">
+                        <div class="avatar">
+                            <!-- Simple SVG Avatar -->
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path><circle cx="12" cy="7" r="4"></circle></svg>
+                        </div>
+                        <span>Admin User</span>
+                        <svg class="chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"></polyline></svg>
+                    </label>
+                    
+                    <!-- 
+                       The Dropdown Menu 
+                       Using a Blur-Entrance animation.
+                    -->
+                    <div class="dropdown-menu blur-entrance-anim">
+                        
+                        <div class="menu-header">
+                            <span class="user-name">Administrator</span>
+                            <span class="user-email">admin@system.local</span>
+                        </div>
+                        
+                        <ul class="menu-list">
+                            <li>
+                                <a href="#" class="menu-item">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path><circle cx="12" cy="7" r="4"></circle></svg>
+                                    View Profile
+                                </a>
+                            </li>
+                            <li>
+                                <a href="#" class="menu-item">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path></svg>
+                                    Settings
+                                </a>
+                            </li>
+                            <li class="separator"></li>
+                            <li>
+                                <a href="#" class="menu-item danger">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"></path><polyline points="16 17 21 12 16 7"></polyline><line x1="21" y1="12" x2="9" y2="12"></line></svg>
+                                    Sign Out
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                    
+                </div>
+                
+            </div>
+            
+        </div>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/minimalist-tech-blur-entrance-dropdown/style.css
+++ b/submissions/examples/minimalist-tech-blur-entrance-dropdown/style.css
@@ -1,0 +1,303 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    --border-color: #e2e8f0;
+    
+    --surface-white: #ffffff;
+    --surface-hover: #f1f5f9;
+    
+    /* Tech Minimalist Accents */
+    --accent-blue: #0ea5e9;
+    --accent-danger: #ef4444;
+    --shadow-dropdown: 0 10px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 600px;
+    width: 100%;
+    padding: 40px 20px;
+}
+
+.section-header {
+    text-align: center;
+    margin-bottom: 50px;
+}
+
+.title {
+    font-size: 2.25rem;
+    font-weight: 600;
+    margin: 0 0 12px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    margin: 0;
+}
+
+
+/* =========================================
+   Dashboard Environment
+   ========================================= */
+
+.card {
+    background: var(--surface-white);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 60px 40px; 
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+    text-align: center;
+    /* Extra padding bottom so the dropdown has room to animate up */
+    padding-bottom: 300px; 
+}
+
+.instruction-text {
+    color: var(--text-secondary);
+    margin-bottom: 24px;
+    font-size: 0.95rem;
+}
+
+
+/* =========================================
+   Dropdown Structure & Trigger
+   ========================================= */
+
+.dropdown-wrapper {
+    position: relative;
+    display: inline-block;
+    text-align: left; /* Reset text align for the menu items */
+}
+
+.dropdown-input {
+    display: none;
+}
+
+.dropdown-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    padding: 8px 16px 8px 8px; /* Less padding on left to accommodate avatar */
+    background: var(--surface-white);
+    color: var(--text-primary);
+    border: 1px solid var(--border-color);
+    border-radius: 999px; /* Pill shape for profile */
+    font-size: 0.95rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    user-select: none;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+}
+
+.dropdown-btn:hover {
+    background: var(--surface-hover);
+    border-color: #cbd5e1;
+}
+
+.avatar {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background-color: var(--surface-hover);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: var(--text-secondary);
+    border: 1px solid var(--border-color);
+}
+
+.avatar svg {
+    width: 16px;
+    height: 16px;
+}
+
+.chevron {
+    width: 16px;
+    height: 16px;
+    color: var(--text-secondary);
+    transition: transform 0.3s ease;
+}
+
+
+/* =========================================
+   Dropdown Menu Core Styling
+   ========================================= */
+
+.dropdown-menu {
+    position: absolute;
+    /* Position it below the button */
+    top: calc(100% + 12px); 
+    /* Center it relative to the pill button */
+    left: 50%;
+    transform: translateX(-50%);
+    
+    width: 240px;
+    background: var(--surface-white);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    box-shadow: var(--shadow-dropdown);
+    padding: 8px 0;
+    
+    /* Hidden by default */
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    
+    /* 
+      Set initial blur state for the Blur-Entrance.
+    */
+    filter: blur(8px);
+}
+
+.menu-header {
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--border-color);
+    margin-bottom: 8px;
+    display: flex;
+    flex-direction: column;
+}
+
+.user-name {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.user-email {
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+}
+
+.menu-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+}
+
+.menu-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 16px;
+    color: var(--text-primary);
+    text-decoration: none;
+    font-size: 0.9rem;
+    font-weight: 500;
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.menu-item svg {
+    width: 16px;
+    height: 16px;
+    color: var(--text-secondary);
+    transition: color 0.2s ease;
+}
+
+.menu-item:hover {
+    background-color: var(--surface-hover);
+    color: var(--accent-blue);
+}
+
+.menu-item:hover svg {
+    color: var(--accent-blue);
+}
+
+/* Danger variant */
+.menu-item.danger {
+    color: var(--accent-danger);
+}
+.menu-item.danger svg {
+    color: var(--accent-danger);
+}
+.menu-item.danger:hover {
+    background-color: rgba(239, 68, 68, 0.05);
+}
+
+.separator {
+    height: 1px;
+    background-color: var(--border-color);
+    margin: 8px 0;
+}
+
+
+/* =========================================
+   State Management & Blur-Entrance Animation
+   ========================================= */
+
+/* 1. Rotate the chevron when checked */
+.dropdown-input:checked ~ .dropdown-btn .chevron {
+    transform: rotate(180deg);
+}
+
+/* 2. Highlight button when open */
+.dropdown-input:checked ~ .dropdown-btn {
+    border-color: var(--accent-blue);
+    box-shadow: 0 0 0 3px rgba(14, 165, 233, 0.1);
+}
+
+/* 3. Trigger the Blur-Entrance animation when checked */
+.dropdown-input:checked ~ .blur-entrance-anim {
+    visibility: visible;
+    pointer-events: auto;
+    
+    /* 
+      We use a smooth ease-out curve to clear the blur 
+      while simultaneously fading in.
+    */
+    animation: menu-blur-in 0.4s ease-out forwards;
+}
+
+@keyframes menu-blur-in {
+    0% {
+        opacity: 0;
+        filter: blur(8px);
+        /* Keep it centered horizontally during animation */
+        transform: translateX(-50%) scale(0.95);
+    }
+    100% {
+        opacity: 1;
+        filter: blur(0px);
+        transform: translateX(-50%) scale(1);
+    }
+}
+
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    /* Disable the blur and scale, fallback to simple fade */
+    .dropdown-input:checked ~ .blur-entrance-anim {
+        animation: simple-fade 0.2s ease forwards !important;
+        transform: translateX(-50%) !important;
+        filter: none !important;
+    }
+    
+    /* Reset the initial transform state (keep centering) */
+    .dropdown-menu {
+        transform: translateX(-50%) !important;
+        filter: none !important;
+    }
+    
+    @keyframes simple-fade {
+        0% { opacity: 0; }
+        100% { opacity: 1; }
+    }
+}


### PR DESCRIPTION

### Description
This PR introduces the CSS Blur-Entrance Dropdown designed for Minimalist Tech Layouts, resolving issue #64584. 

### Changes Made:
- Added `submissions/examples/minimalist-tech-blur-entrance-dropdown/` directory.
- Created `demo.html` showcasing a mock "User Profile" dashboard. 
  - Implemented 100% JavaScript-free state management utilizing the "Checkbox Hack". A hidden checkbox (`#profile-dropdown-trigger`) controls the open/closed state of the dropdown menu. The main pill-shaped profile button (containing the avatar and username) acts as a `<label>` to toggle the checkbox.
- Created `style.css` featuring a clean aesthetic utilizing precise borders, semantic line-art iconography, and distinct hover states (including a dedicated danger state for sign out).
  - Implemented the Blur-Entrance Animation System. 
  - The `.dropdown-menu` is initially hidden (`opacity: 0`), slightly scaled down (`scale(0.95)`), and heavily blurred (`filter: blur(8px)`).
  - When triggered, it runs the `menu-blur-in` keyframes animation, transitioning from `blur(8px)` to `blur(0px)` while simultaneously scaling up to `1` and fading in (`opacity: 1`).
  - This creates a highly sophisticated "materializing" effect commonly found in modern operating systems and premium web applications.
- Added `README.md` documenting usage and technical features.
- Honors the `prefers-reduced-motion` accessibility standard. The blurring effect and spatial scaling are completely disabled. The menu safely falls back to a fast, immediate opacity fade for motion-sensitive users.

Closes #64584
