### PR TITLE
fix: add CSS overrides to support cross-compatibility between legacy and modern badge pulse color variants

### DIFF
--- a/submissions/examples/bugfix-pulse-glow-override/README.md
+++ b/submissions/examples/bugfix-pulse-glow-override/README.md
@@ -1,0 +1,18 @@
+# Bugfix: Badge Pulse Glow Override
+
+This submission resolves **Issue 2: Compound Class Color Overrides Fail When Mixing Legacy and New Classes**.
+
+## 🐛 The Bug
+When combining modern badge classes with legacy pulse classes (e.g., `.ease-badge-danger` with `.em-badge-pulse`), the pulse ring color failed to update to the variant color (danger/success). This caused the ring to fall back to the default primary color because the core CSS only provided selectors for strict pairings (`.ease-badge-danger.ease-badge-pulse` or `.em-badge-danger.em-badge-pulse`), but not cross-combinations.
+
+## 🛠️ The Fix
+Without modifying the existing `easemotion.css` or `badges.css` files, this submission provides a `style.css` file that injects the missing CSS selectors into the `@layer easemotion-components`. 
+
+The injected selectors explicitly cover the cross-combinations:
+- `.ease-badge-danger.em-badge-pulse`
+- `.em-badge-danger.ease-badge-pulse`
+- `.ease-badge-success.em-badge-pulse`
+- `.em-badge-success.ease-badge-pulse`
+
+## 📋 Verification
+Open `demo.html` to see the fix in action. It provides examples of all four mixed-class combinations, verifying that the pulse glow colors accurately reflect their respective variants (red for danger, green for success) regardless of whether the legacy or modern prefix was used for the pulse class.

--- a/submissions/examples/bugfix-pulse-glow-override/demo.html
+++ b/submissions/examples/bugfix-pulse-glow-override/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Bugfix: Badge Pulse Glow Override</title>
+  <!-- Import core EaseMotion CSS -->
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <!-- Import the bug fix styles -->
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      font-family: system-ui, sans-serif;
+      padding: 40px;
+      display: flex;
+      gap: 20px;
+      flex-direction: column;
+      align-items: flex-start;
+      background: #f8fafc;
+    }
+    .demo-group {
+      background: white;
+      padding: 24px;
+      border-radius: 8px;
+      border: 1px solid #e2e8f0;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>Bugfix Demo: Badge Pulse Glow Overrides</h1>
+  <p>This demo verifies that mixing modern (<code>.ease-*</code>) and legacy (<code>.em-*</code>) classes now correctly updates the pulse glow color.</p>
+
+  <div class="demo-group">
+    <h3>1. Modern Danger + Legacy Pulse</h3>
+    <p><code>class="ease-badge ease-badge-danger em-badge-pulse"</code></p>
+    <span class="ease-badge ease-badge-danger em-badge-pulse">1</span>
+  </div>
+
+  <div class="demo-group">
+    <h3>2. Legacy Danger + Modern Pulse</h3>
+    <p><code>class="em-badge em-badge-danger ease-badge-pulse"</code></p>
+    <span class="em-badge em-badge-danger ease-badge-pulse">2</span>
+  </div>
+
+  <div class="demo-group">
+    <h3>3. Modern Success + Legacy Pulse</h3>
+    <p><code>class="ease-badge ease-badge-success em-badge-pulse"</code></p>
+    <span class="ease-badge ease-badge-success em-badge-pulse">3</span>
+  </div>
+
+  <div class="demo-group">
+    <h3>4. Legacy Success + Modern Pulse</h3>
+    <p><code>class="em-badge em-badge-success ease-badge-pulse"</code></p>
+    <span class="em-badge em-badge-success ease-badge-pulse">4</span>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/bugfix-pulse-glow-override/style.css
+++ b/submissions/examples/bugfix-pulse-glow-override/style.css
@@ -1,0 +1,21 @@
+/* ============================================================
+   Bugfix: Badge Pulse Glow Override
+   Fixes the issue where mixing legacy (.em-) and modern (.ease-)
+   classes fails to apply the correct pulse glow color.
+   ============================================================ */
+
+@layer easemotion-components {
+  
+  /* Fix Danger Variant Combinations */
+  .ease-badge-danger.em-badge-pulse::after,
+  .em-badge-danger.ease-badge-pulse::after {
+    box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.7);
+  }
+
+  /* Fix Success Variant Combinations */
+  .ease-badge-success.em-badge-pulse::after,
+  .em-badge-success.ease-badge-pulse::after {
+    box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.7);
+  }
+
+}


### PR DESCRIPTION
## Pull Request Description

Closes #61756

---

## Type of Change

* [ ] ✨ New animation / hover effect
* [ ] 🧩 New component
* [ ] 📝 Documentation improvement
* [x] 🐛 Bug fix in an existing submission
* [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

* [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
* [x] Includes `demo.html` — self-contained, opens in browser with no server
* [x] Includes `style.css` — raw CSS for the proposed feature
* [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
* [x] **No changes to** **`core/`**
* [x] **No changes to** **`components/`**
* [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Fixes the pulse glow color override when modern `.ease-badge-*` classes are combined with legacy `.em-badge-*` pulse classes.

The existing selectors were too tightly coupled to specific class prefixes, causing combinations such as `.ease-badge-danger.em-badge-pulse` to fall back to the default primary pulse color instead of using the danger variant color.

The fix adds explicit compound selectors covering cross-combinations of modern and legacy badge/pulse classes. The `::after` pseudo-element now receives the correct variant-specific `box-shadow` color.

The fix covers both danger and success variants and supports both modern/legacy prefix combinations.

**How does a developer use it?**

The fix supports mixed modern and legacy classes without requiring a different markup pattern:

```html
<span class="ease-badge ease-badge-danger em-badge-pulse">1</span>

<span class="em-badge em-badge-danger ease-badge-pulse">2</span>

<span class="ease-badge ease-badge-success em-badge-pulse">3</span>

<span class="em-badge em-badge-success ease-badge-pulse">4</span>
```

The appropriate pulse glow color is automatically applied based on the badge variant.

**Why does it fit EaseMotion CSS?**

This is a focused compatibility fix that improves interoperability between EaseMotion CSS's modern class naming conventions and its legacy `.em-*` classes.

The patch remains pure CSS, uses the existing `easemotion-components` cascade layer, and does not require JavaScript or changes to the core library implementation.

---

## Demo

* [x] Demo added (`demo.html` works by opening directly in a browser)

The demo provides an isolated reproduction containing four badges covering the modern/legacy combinations for danger and success variants.

---

## Browser Testing

* [x] Chrome
* [x] Firefox
* [x] Edge
* [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Implementation is contained entirely within:

`submissions/examples/bugfix-pulse-glow-override/`

The submission includes:

* `demo.html`
* `style.css`
* `README.md`

No existing library files were modified. The CSS patch is isolated within the `easemotion-components` cascade layer.

The demo verifies that mixed modern/legacy badge and pulse classes correctly override the default primary pulse glow color.

Branch: `fix/badge-pulse-color-overrides`

---

> **Reminder:** Only the repository maintainer may merge pull requests.
> Do not self-merge, even if you have write access.
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
>
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [[Discord Server](https://discord.gg/hWSdGrccBU)](https://discord.gg/hWSdGrccBU)!