### PR TITLE
Add ease-bowling-scorer component

### DIFF
--- a/submissions/examples/bowling-scorer-ij/README.md
+++ b/submissions/examples/bowling-scorer-ij/README.md
@@ -1,0 +1,10 @@
+# ease-bowling-scorer
+
+A bowling scorer where the pins reset in the lane, the ball rolls toward them, and the frame scores tick.
+
+## Run
+Open `demo.html` directly in a browser to watch the pins set.
+
+## Notes
+- The pins reset in the lane.
+- The frame scores tick on the sheet.

--- a/submissions/examples/bowling-scorer-ij/demo.html
+++ b/submissions/examples/bowling-scorer-ij/demo.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-bowling-scorer demo</title>
+</head>
+<body>
+<div class="blw-lane">
+  <span class="blw-title">LANE 7</span>
+  <div class="blw-pins">
+    <span class="blw-pin"></span>
+    <span class="blw-pin"></span>
+    <span class="blw-pin"></span>
+    <span class="blw-pin"></span>
+    <span class="blw-pin"></span>
+  </div>
+  <div class="blw-ball"></div>
+  <div class="blw-sheet">
+    <span class="blw-frame">X</span>
+    <span class="blw-frame">7</span>
+    <span class="blw-frame">9</span>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/bowling-scorer-ij/style.css
+++ b/submissions/examples/bowling-scorer-ij/style.css
@@ -1,0 +1,12 @@
+:root{--blw-orange:#ff8a3d;--blw-dark:#120d08}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#120d08,#0a0805);font-family:'Arial Black',sans-serif}
+.blw-lane{position:relative;width:360px;height:420px;border-radius:16px;overflow:hidden;background:linear-gradient(180deg,#241a10,#140e08);box-shadow:0 16px 34px rgba(0,0,0,0.6)}
+.blw-title{position:absolute;top:16px;left:0;right:0;text-align:center;font-size:13px;font-weight:700;letter-spacing:8px;color:#ff8a3d}
+.blw-pins{position:absolute;top:66px;left:50%;margin-left:-92px;width:184px;height:52px;display:flex;justify-content:center;gap:10px;animation:pin-set-bowling-scorer 3.4s ease-in-out infinite}
+.blw-pin{width:22px;height:46px;border-radius:6px;background:#f2f0ea;box-shadow:0 4px 0 #c2beb2}
+.blw-ball{position:absolute;top:150px;left:50%;margin-left:-16px;width:32px;height:32px;border-radius:50%;background:#e8483d;box-shadow:0 0 14px #e8483d;animation:ball-roll-bowling-scorer 3.4s ease-in-out infinite}
+.blw-sheet{position:absolute;bottom:20px;left:50%;margin-left:-116px;width:232px;height:64px;border-radius:10px;background:#1e160e;display:flex;gap:8px;align-items:center;padding:0 12px;box-shadow:inset 0 0 0 3px #3a2a18}
+.blw-frame{flex:1;display:grid;place-items:center;height:38px;border-radius:6px;background:#3a2a18;color:#ff8a3d;font-size:16px;font-weight:700;animation:score-tick-bowling-scorer 1s steps(1) infinite}
+@keyframes pin-set-bowling-scorer{0%,100%{opacity:1}30%{opacity:0.15}45%{opacity:0.15}}
+@keyframes ball-roll-bowling-scorer{0%,100%{transform:translateY(0)}40%{transform:translateY(58px)}55%{transform:translateY(58px)}}
+@keyframes score-tick-bowling-scorer{0%,49%{opacity:1}50%,100%{opacity:0.35}}


### PR DESCRIPTION
## Component: ease-bowling-scorer — pins set, ball rolls, and scores tick

**Closes #67772**

### What this adds
A bowling scorer: the pins reset in the lane, the ball rolls toward them, and the frame scores tick.

### Acceptance Criteria covered
- Pins reset in the lane
- Ball rolls down the lane
- Frame scores tick on the sheet

### Files
- `submissions/examples/bowling-scorer-ij/demo.html`
- `submissions/examples/bowling-scorer-ij/style.css`
- `submissions/examples/bowling-scorer-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the pins set.