### PR TITLE
fix: update badge pulse glow to use color-mix for dynamic theme variable propagation

### DIFF
--- a/submissions/examples/bugfix-badge-pulse-theme/README.md
+++ b/submissions/examples/bugfix-badge-pulse-theme/README.md
@@ -1,0 +1,14 @@
+# Bugfix: Badge Pulse Theme Color
+
+This submission resolves **Issue 3: Pulse Ring Uses Static RGBA Colors Instead of Dynamic CSS Variables**.
+
+## 🐛 The Bug
+The `.ease-badge-pulse` glow effect was implemented using hardcoded `rgba()` values (e.g., `rgba(108, 99, 255, 0.7)`). While this achieved the correct 70% opacity for the glow, it entirely disconnected the pulse effect from the core theme variables (`--ease-color-primary`). Consequently, if a developer overrode the primary theme color dynamically, the badge's background color would update, but the pulsing outer ring would remain hardcoded to purple.
+
+## 🛠️ The Fix
+Without modifying the existing library files, this submission provides a `style.css` file that patches the `@layer easemotion-components` to use the modern CSS `color-mix()` function.
+
+By using `color-mix(in srgb, var(--ease-color-primary) 70%, transparent)`, we successfully combine the dynamic, unpredictable hex/hsl values provided by the CSS custom property with a fixed 70% opacity. This pattern is repeated for the danger and success variants to ensure full theme propagation.
+
+## 📋 Verification
+Open `demo.html` to see the fix in action. The page dynamically applies different theme overrides (`--ease-color-primary: #f97316` and `#ec4899`) to specific container blocks. You will see that the pulsing glow correctly adopts the dynamic theme color while retaining its intended translucency.

--- a/submissions/examples/bugfix-badge-pulse-theme/demo.html
+++ b/submissions/examples/bugfix-badge-pulse-theme/demo.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Bugfix: Badge Pulse Theme Color Override</title>
+  <!-- Import core EaseMotion CSS -->
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <!-- Import the bug fix styles -->
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      font-family: system-ui, sans-serif;
+      padding: 40px;
+      display: flex;
+      gap: 20px;
+      flex-direction: column;
+      align-items: flex-start;
+      background: #f8fafc;
+    }
+    .demo-group {
+      background: white;
+      padding: 24px;
+      border-radius: 8px;
+      border: 1px solid #e2e8f0;
+      margin-bottom: 16px;
+    }
+    .theme-override-orange {
+      --ease-color-primary: #f97316; /* Orange */
+    }
+    .theme-override-pink {
+      --ease-color-primary: #ec4899; /* Pink */
+    }
+  </style>
+</head>
+<body>
+
+  <h1>Bugfix Demo: Dynamic Pulse Theme Colors</h1>
+  <p>This demo verifies that overriding CSS theme variables (like <code>--ease-color-primary</code>) now correctly propagates to the badge's pulse glow ring using modern <code>color-mix()</code>.</p>
+
+  <div class="demo-group">
+    <h3>1. Default Theme Primary</h3>
+    <p>Using the default <code>--ease-color-primary</code>.</p>
+    <span class="ease-badge ease-badge-pulse">1</span>
+  </div>
+
+  <div class="demo-group theme-override-orange">
+    <h3>2. Dynamic Theme Override (Orange)</h3>
+    <p><code>--ease-color-primary: #f97316;</code> applied to container.</p>
+    <span class="ease-badge ease-badge-pulse">2</span>
+  </div>
+
+  <div class="demo-group theme-override-pink">
+    <h3>3. Dynamic Theme Override (Pink)</h3>
+    <p><code>--ease-color-primary: #ec4899;</code> applied to container.</p>
+    <span class="ease-badge ease-badge-pulse">3</span>
+  </div>
+
+  <div class="demo-group">
+    <h3>4. Danger Variant Theme Propagation</h3>
+    <p>The danger variant should also consume its own CSS variable (<code>--ease-color-danger</code>).</p>
+    <span class="ease-badge ease-badge-danger ease-badge-pulse">4</span>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/bugfix-badge-pulse-theme/style.css
+++ b/submissions/examples/bugfix-badge-pulse-theme/style.css
@@ -1,0 +1,32 @@
+/* ============================================================
+   Bugfix: Badge Pulse Theme Color
+   Replaces hardcoded RGBA pulse glow colors with dynamic CSS
+   variables using modern color-mix() for opacity.
+   ============================================================ */
+
+@layer easemotion-components {
+  
+  /* Override Default Primary Pulse */
+  .ease-badge-pulse::after,
+  .em-badge-pulse::after {
+    /* Uses color-mix to apply 70% opacity to the dynamic hex/hsl variable */
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--ease-color-primary) 70%, transparent);
+  }
+
+  /* Override Danger Pulse */
+  .ease-badge-danger.ease-badge-pulse::after,
+  .em-badge-danger.em-badge-pulse::after,
+  .ease-badge-danger.em-badge-pulse::after,
+  .em-badge-danger.ease-badge-pulse::after {
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--ease-color-danger) 70%, transparent);
+  }
+
+  /* Override Success Pulse */
+  .ease-badge-success.ease-badge-pulse::after,
+  .em-badge-success.em-badge-pulse::after,
+  .ease-badge-success.em-badge-pulse::after,
+  .em-badge-success.ease-badge-pulse::after {
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--ease-color-success) 70%, transparent);
+  }
+
+}


### PR DESCRIPTION
## Pull Request Description

Closes #61757

---

## Type of Change

* [ ] ✨ New animation / hover effect
* [ ] 🧩 New component
* [ ] 📝 Documentation improvement
* [x] 🐛 Bug fix in an existing submission
* [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

* [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
* [x] Includes `demo.html` — self-contained, opens in browser with no server
* [x] Includes `style.css` — raw CSS for the proposed feature
* [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
* [x] **No changes to** **`core/`**
* [x] **No changes to** **`components/`**
* [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Fixes the `.ease-badge-pulse` glow effect so that its pulse ring dynamically follows the active `--ease-color-primary` theme variable instead of using a hardcoded RGBA color.

The fix uses modern CSS `color-mix()` to blend the active theme color with transparency:

```css
color-mix(in srgb, var(--ease-color-primary) 70%, transparent)
```

This keeps the pulse ring visually synchronized with the badge background when the theme color is overridden.

The patch also retains the cross-combination selectors from the previous badge pulse compatibility fix, ensuring modern and legacy badge/pulse classes continue to work together.

**How does a developer use it?**

No API changes are required. Developers can override the theme variable normally:

```html
<style>
  :root {
    --ease-color-primary: #ff5722;
  }
</style>

<span class="ease-badge ease-badge-pulse">1</span>
```

The badge background and animated pulse ring will automatically use the updated theme color.

Theme variables can also be scoped to a container:

```html
<div style="--ease-color-primary: #ff4081;">
  <span class="ease-badge ease-badge-pulse">1</span>
</div>
```

**Why does it fit EaseMotion CSS?**

This is a focused CSS-only bug fix that improves EaseMotion CSS's theme-token support. It removes static color dependencies and allows the pulse animation to respond dynamically to existing CSS custom properties.

The implementation remains lightweight and does not require JavaScript or changes to the core library codebase.

---

## Demo

* [x] Demo added (`demo.html` works by opening directly in a browser)

The demo includes multiple examples with dynamically overridden primary theme colors, including orange and pink, to verify that the pulse glow follows the active theme.

---

## Browser Testing

* [x] Chrome
* [x] Firefox
* [x] Edge
* [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Implementation is contained entirely within:

`submissions/examples/bugfix-badge-pulse-theme/`

The submission includes:

* `demo.html`
* `style.css`
* `README.md`

No existing library files were modified.

The CSS patch is placed in the `easemotion-components` cascade layer and replaces hardcoded RGBA pulse colors with a `color-mix()` expression based on `var(--ease-color-primary)`.

Branch: `fix/badge-pulse-theme-color`

---

> **Reminder:** Only the repository maintainer may merge pull requests.
> Do not self-merge, even if you have write access.
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
>
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [[Discord Server](https://discord.gg/hWSdGrccBU)](https://discord.gg/hWSdGrccBU)!