### PR TITLE
fix: prevent badge text wrapping and layout distortion in high line-height contexts by resetting line-height and setting white-space to nowrap

### DIFF
--- a/submissions/examples/bugfix-badge-text-alignment/README.md
+++ b/submissions/examples/bugfix-badge-text-alignment/README.md
@@ -1,0 +1,15 @@
+# Bugfix: Badge Text Alignment
+
+This submission resolves **Issue 4: Text Wrapping and Alignment Glitches for Multi-Character Labels**.
+
+## 🐛 The Bug
+The `.ease-badge` and `.em-badge` core components lacked explicit layout guards for typography. When a badge contained multiple characters (e.g., `99+ Messages`) and was placed inside a parent container with an elevated `line-height` (e.g., `line-height: 2.5`), the text inside the badge inherited that line height. This destroyed the vertical centering provided by flexbox, pushing the text down. Furthermore, if placed in a narrow container, the text could awkwardly wrap onto multiple lines, breaking the fixed 20px badge height.
+
+## 🛠️ The Fix
+Without modifying the existing library files, this submission provides a `style.css` file that patches the `@layer easemotion-components` to add two critical properties to the base badge classes:
+
+1. `white-space: nowrap;`: This explicitly prevents the text from wrapping onto a second line, forcing the flex container to expand its width horizontally as intended.
+2. `line-height: 1;`: This resets the inherited line height. By forcing the text's line height to exactly match its font size, we guarantee that the `align-items: center` flex property can perfectly center the text vertically within the fixed 20px height of the badge container, regardless of the surrounding typography context.
+
+## 📋 Verification
+Open `demo.html` to see the fix in action. The page demonstrates a multi-character badge placed inside a container with `line-height: 2.5;`. You will observe that the badge maintains its tight 20px height and the text remains perfectly centered vertically. Another example demonstrates that a badge with extremely long text placed in a narrow container will not wrap.

--- a/submissions/examples/bugfix-badge-text-alignment/demo.html
+++ b/submissions/examples/bugfix-badge-text-alignment/demo.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Bugfix: Badge Text Alignment</title>
+  <!-- Import core EaseMotion CSS -->
+  <link rel="stylesheet" href="../../../easemotion.css">
+  <!-- Import the bug fix styles -->
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      font-family: system-ui, sans-serif;
+      padding: 40px;
+      display: flex;
+      gap: 20px;
+      flex-direction: column;
+      align-items: flex-start;
+      background: #f8fafc;
+    }
+    .demo-group {
+      background: white;
+      padding: 24px;
+      border-radius: 8px;
+      border: 1px solid #e2e8f0;
+      margin-bottom: 16px;
+      width: 100%;
+      max-width: 600px;
+    }
+    /* Elevated line-height context */
+    .high-line-height {
+      line-height: 2.5;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>Bugfix Demo: Badge Text Alignment</h1>
+  <p>This demo verifies that multi-character text does not wrap and remains vertically centered even in parent containers with elevated <code>line-height</code> values.</p>
+
+  <div class="demo-group high-line-height">
+    <h3>1. Multi-character badge in high line-height context</h3>
+    <p>The container has <code>line-height: 2.5;</code>. The badge should maintain its fixed height and vertically center the text.</p>
+    <span class="ease-badge">99+ Messages</span>
+  </div>
+
+  <div class="demo-group" style="width: 250px;">
+    <h3>2. Constrained container width</h3>
+    <p>Even if the parent container is narrow, the badge text should not wrap onto multiple lines.</p>
+    <span class="ease-badge">Extremely Long Badge Text Content</span>
+  </div>
+
+  <div class="demo-group">
+    <h3>3. Legacy Badge Class</h3>
+    <p>Ensuring backward compatibility for the legacy class.</p>
+    <span class="em-badge">Legacy Class Fixed</span>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/bugfix-badge-text-alignment/style.css
+++ b/submissions/examples/bugfix-badge-text-alignment/style.css
@@ -1,0 +1,20 @@
+/* ============================================================
+   Bugfix: Badge Text Alignment
+   Fixes the issue where multi-character badges distort or wrap
+   in high line-height contexts or constrained widths.
+   ============================================================ */
+
+@layer easemotion-components {
+  
+  .ease-badge,
+  .em-badge {
+    /* Prevent text from wrapping onto multiple lines */
+    white-space: nowrap;
+    
+    /* Reset line-height to 1 to ensure vertical centering 
+       is dictated purely by flexbox and the fixed container height,
+       ignoring the parent's line-height context. */
+    line-height: 1;
+  }
+
+}


### PR DESCRIPTION
## Pull Request Description

Closes #61758
---

## Type of Change

* [ ] ✨ New animation / hover effect
* [ ] 🧩 New component
* [ ] 📝 Documentation improvement
* [x] 🐛 Bug fix in an existing submission
* [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

* [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
* [x] Includes `demo.html` — self-contained, opens in browser with no server
* [x] Includes `style.css` — raw CSS for the proposed feature
* [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
* [x] **No changes to** **`core/`**
* [x] **No changes to** **`components/`**
* [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Fixes text wrapping and vertical alignment issues for multi-character `.ease-badge` and legacy `.em-badge` elements.

The fix adds two CSS properties to the base badge classes:

* `white-space: nowrap` — prevents multi-character labels from wrapping onto multiple lines and allows the badge to expand horizontally.
* `line-height: 1` — prevents inherited parent line-height values from distorting the badge's fixed height and vertical alignment.

This ensures labels such as `99+ Messages` remain on a single line and stay vertically centered even when placed inside a parent with an unusually large line-height.

**How does a developer use it?**

No API changes are required. Existing badge markup continues to work:

```html id="83917"
<div style="line-height: 2.5;">
  <span class="ease-badge">99+ Messages</span>
</div>
```

The same alignment improvements also apply to legacy badges:

```html id="p1f4v2"
<span class="em-badge">99+ Messages</span>
```

**Why does it fit EaseMotion CSS?**

This is a focused CSS-only compatibility and layout fix that improves the reliability of the existing badge component.

The changes are lightweight, preserve the existing badge API, and ensure badge typography remains predictable regardless of inherited line-height or multi-character content.

---

## Demo

* [x] Demo added (`demo.html` works by opening directly in a browser)

The demo reproduces the original issue using:

* A `99+ Messages` multi-character badge
* A parent with `line-height: 2.5`
* A constrained-width environment

It demonstrates that the badge remains single-line and vertically centered after the fix.

---

## Browser Testing

* [x] Chrome
* [x] Firefox
* [x] Edge
* [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Implementation is contained entirely within:

`submissions/examples/bugfix-badge-text-alignment/`

The submission includes:

* `demo.html`
* `style.css`
* `README.md`

No existing core library files were modified.

The CSS patch is placed in the `easemotion-components` cascade layer and applies the alignment fixes to both modern `.ease-badge` and legacy `.em-badge` classes.

Branch: `fix/badge-text-alignment`

---

> **Reminder:** Only the repository maintainer may merge pull requests.
> Do not self-merge, even if you have write access.
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
>
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [[Discord Server](https://discord.gg/hWSdGrccBU)](https://discord.gg/hWSdGrccBU)!