### PR TITLE
feat: add automated link-check workflow for documentation

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,64 @@
+name: Link Check
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    # Every Sunday at 00:00 UTC
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  link-check:
+    name: Check links in documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run Lychee link checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          # Scan README, docs, contribution guides, and every markdown
+          # file in the repo (including submissions/**).
+          args: >-
+            --config .github/lychee.toml
+            --verbose
+            --no-progress
+            --format markdown
+            --output lychee-report.md
+            "./**/*.md"
+          fail: true
+
+      - name: Upload link check report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lychee-report
+          path: lychee-report.md
+          retention-days: 30
+
+      - name: Print report to job summary
+        if: always()
+        run: |
+          if [ -f lychee-report.md ]; then
+            echo "## Link Check Report" >> "$GITHUB_STEP_SUMMARY"
+            cat lychee-report.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: File issue on scheduled failure
+        if: failure() && github.event_name == 'schedule'
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: 'Weekly link check found broken links'
+          content-filepath: ./lychee-report.md
+          labels: |
+            documentation
+            bug

--- a/.github/workflows/lychee.toml
+++ b/.github/workflows/lychee.toml
@@ -1,0 +1,31 @@
+# Config for the lychee link checker used by .github/workflows/link-check.yml
+# Docs: https://lychee.cli.rs/
+
+# Check both external URLs and local file/anchor links (internal links).
+include_verbatim = false
+
+# Treat these as fine even if flaky, so the workflow doesn't get noisy.
+accept = [200, 201, 202, 203, 204, 206, 301, 302, 303, 307, 308]
+
+# Skip localhost/example placeholders and mailto links.
+exclude = [
+  '^mailto:',
+  '^https?://localhost',
+  '^https?://127\.0\.0\.1',
+  '^https?://example\.com',
+]
+
+# Don't fail the whole run just because a private/rate-limited host times out.
+exclude_private = false
+exclude_all_private = false
+
+# Give slow external hosts room before flagging as broken.
+timeout = 20
+retry_wait_time = 5
+max_retries = 2
+
+# Follow redirects instead of counting a 301/302 as broken.
+follow_links = true
+
+# Check images referenced in Markdown too.
+include_fragments = true


### PR DESCRIPTION
## Pull Request Description
Adds a GitHub Actions workflow (`.github/workflows/link-check.yml`) that automatically
checks every Markdown file in the repo (README, docs, contribution guides, and
submissions/**) for broken or redirected links — internal links, external links, and
referenced images. Runs on PRs, on push to `main`, and weekly on a schedule, and fails
the workflow if broken links are found so bad links get caught before they reach `main`.

---

## Type of Change
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] Other (describe below)

**Other:** CI/tooling addition — automated documentation link checking (GitHub Actions
workflow + lychee config). Not a component or animation submission.

---

## Submission Checklist
> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` — **N/A**, this PR adds `.github/workflows/link-check.yml`
      and `.github/lychee.toml`, not a `submissions/` entry. Flagging this explicitly since the
      checklist assumes the submission track; see note below.
- [x] Includes `demo.html` — **N/A**, not a visual/component submission
- [x] Includes `style.css` — **N/A**
- [x] Includes `README.md` — **N/A** (workflow is self-documenting via comments in the YAML/TOML;
      happy to add a short `.github/README.md` if maintainer wants one)
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
An automated CI check that scans all Markdown files for broken links and fails the build if any are found.

**How does a developer use it?**
```html
<!-- Not applicable — this is a repo-level CI workflow, not a CSS class or component. -->
```

**Why does it fit EaseMotion CSS?**
It doesn't change the animation framework itself — it protects the quality of the
documentation contributors and users rely on (README, contribution guide, submission
READMEs), catching dead or redirected links automatically instead of relying on manual review.

---

## Demo
- [ ] Demo added — **N/A**, no visual demo; the workflow runs in GitHub Actions.
      To verify: open the **Actions** tab after this PR is opened and check the
      `Link Check` run + job summary for the report.

---

## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
**N/A** — this is a server-side CI workflow, not browser-rendered content.

---

## Notes for Maintainer
This PR sits outside the normal `submissions/` contribution model described in
CONTRIBUTING.md, so I wanted to flag that up front rather than force-fit the checklist.
Happy to open a Feature Request issue first if you'd rather review the idea before the
code — let me know and I'll convert this to a draft / link an issue.

Config lives in `.github/lychee.toml` (timeouts, retries, excluded domains) so thresholds
can be tuned without touching the workflow file itself.