### PR TITLE
[FEATURE] Add ease-cookie-banner Slide-Up Cookie Consent Component  #60392

### DIFF
--- a/submissions/examples/cookie-banner-dg/README.md
+++ b/submissions/examples/cookie-banner-dg/README.md
@@ -1,0 +1,53 @@
+# Cookie Consent Banner (Slide-Up)
+
+## What does this do?
+
+A bottom-fixed cookie consent banner that slides up into view on page load and
+slides back down when the user accepts or declines, remembering that choice in
+`localStorage` so it doesn't reappear on repeat visits.
+
+## How is it used?
+
+```html
+<div class="cookie-banner" id="cookieBanner">
+  <p>
+    We use cookies to improve your experience.
+    <a href="/privacy">Learn more</a>
+  </p>
+  <div class="cookie-banner-actions">
+    <button id="declineCookies" class="cookie-btn cookie-btn-secondary">Decline</button>
+    <button id="acceptCookies" class="cookie-btn cookie-btn-primary">Accept</button>
+  </div>
+</div>
+```
+
+Add the `is-visible` class (via JS, after a short delay on page load) to trigger
+the slide-up entrance. Add `is-hidden` on accept/decline to slide it back down.
+See `demo.html` for the full working example, including the small amount of
+persistence logic (~30 lines, framework-agnostic vanilla JS).
+
+## Why is this useful?
+
+Cookie/consent banners are a near-universal requirement for public-facing
+sites, and they're a natural fit for EaseMotion's animation-first philosophy —
+this combines a clean entrance/exit transition with a tiny bit of real-world
+state logic (remembering the user's choice), showing EaseMotion can power
+functional UI, not just decorative effects. It's self-contained, has no
+external dependencies, and degrades gracefully:
+
+- Respects `prefers-reduced-motion` (fades instead of sliding for users who
+  request reduced motion).
+- Falls back safely if `localStorage` is unavailable (e.g. private browsing) —
+  the banner just reappears on the next load instead of throwing.
+- Responsive: stacks vertically on narrow viewports.
+
+## Notes for maintainer
+
+- Demo includes a "Reset stored consent" button purely so reviewers can
+  re-trigger the banner without clearing devtools storage manually — happy to
+  remove it if you'd rather the demo only show the real component.
+- Open to adjusting the easing/duration, or swapping `cubic-bezier(0.16, 1, 0.3, 1)`
+  for whichever standard easing token EaseMotion settles on for entrance
+  animations.
+- Used the `-dg` suffix on the folder name per the naming rules in
+  CONTRIBUTING.md to avoid collisions with any similar submissions.

--- a/submissions/examples/cookie-banner-dg/demo.html
+++ b/submissions/examples/cookie-banner-dg/demo.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Cookie Consent Banner (Slide-Up) — EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="page">
+    <h1>Cookie Consent Banner Demo</h1>
+    <p>
+      Reload this page to see the banner slide up from the bottom.
+      Accept or dismiss it, then reload again — it won't reappear
+      until you reset your choice below.
+    </p>
+
+    <button id="resetConsent" class="reset-btn" type="button">
+      Reset stored consent
+    </button>
+  </main>
+
+  <div class="cookie-banner" id="cookieBanner" role="dialog" aria-live="polite" aria-label="Cookie consent">
+    <p>
+      We use cookies to improve your experience.
+      <a href="/privacy">Learn more</a>
+    </p>
+    <div class="cookie-banner-actions">
+      <button id="declineCookies" class="cookie-btn cookie-btn-secondary" type="button">
+        Decline
+      </button>
+      <button id="acceptCookies" class="cookie-btn cookie-btn-primary" type="button">
+        Accept
+      </button>
+    </div>
+  </div>
+
+  <script>
+    (function () {
+      var STORAGE_KEY = 'easemotion-cookie-consent';
+      var banner = document.getElementById('cookieBanner');
+      var acceptBtn = document.getElementById('acceptCookies');
+      var declineBtn = document.getElementById('declineCookies');
+      var resetBtn = document.getElementById('resetConsent');
+
+      function showBanner() {
+        // Small delay so the slide-up transition is visible on load
+        // rather than the banner just appearing already in place.
+        window.requestAnimationFrame(function () {
+          setTimeout(function () {
+            banner.classList.add('is-visible');
+          }, 150);
+        });
+      }
+
+      function hideBanner() {
+        banner.classList.remove('is-visible');
+        banner.classList.add('is-hidden');
+      }
+
+      function storeConsent(value) {
+        try {
+          localStorage.setItem(STORAGE_KEY, value);
+        } catch (e) {
+          // localStorage may be unavailable (private browsing, blocked
+          // storage, etc.) — fail silently, banner just reappears on reload.
+        }
+      }
+
+      function getStoredConsent() {
+        try {
+          return localStorage.getItem(STORAGE_KEY);
+        } catch (e) {
+          return null;
+        }
+      }
+
+      var existingConsent = getStoredConsent();
+      if (!existingConsent) {
+        showBanner();
+      }
+
+      acceptBtn.addEventListener('click', function () {
+        storeConsent('accepted');
+        hideBanner();
+      });
+
+      declineBtn.addEventListener('click', function () {
+        storeConsent('declined');
+        hideBanner();
+      });
+
+      // Demo-only control so reviewers can re-trigger the banner
+      // without manually clearing devtools storage.
+      resetBtn.addEventListener('click', function () {
+        try {
+          localStorage.removeItem(STORAGE_KEY);
+        } catch (e) {}
+        banner.classList.remove('is-hidden');
+        showBanner();
+      });
+    })();
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/cookie-banner-dg/style.css
+++ b/submissions/examples/cookie-banner-dg/style.css
@@ -1,0 +1,157 @@
+/* ---------------------------------------------------------
+   Cookie Consent Banner (Slide-Up)
+   Raw demo CSS — maintainer will rename classes to ease-*
+   and integrate tokens/keyframes as needed.
+--------------------------------------------------------- */
+
+/* Demo page styling — not part of the actual component */
+.page {
+  max-width: 640px;
+  margin: 4rem auto;
+  padding: 0 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #1a1a1a;
+  line-height: 1.6;
+}
+
+.reset-btn {
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  background: #fff;
+  cursor: pointer;
+}
+
+.reset-btn:hover {
+  background: #f2f2f2;
+}
+
+/* -----------------------------------------------------------
+   The actual component
+----------------------------------------------------------- */
+
+.cookie-banner {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1000;
+
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+
+  max-width: 100%;
+  padding: 1rem 1.5rem;
+  box-sizing: border-box;
+
+  background: #1a1a1a;
+  color: #f5f5f5;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  font-size: 0.9375rem;
+  box-shadow: 0 -2px 16px rgba(0, 0, 0, 0.15);
+
+  /* Start off-screen, below the viewport */
+  transform: translateY(100%);
+  opacity: 0;
+
+  transition:
+    transform 0.45s cubic-bezier(0.16, 1, 0.3, 1),
+    opacity 0.45s ease;
+
+  pointer-events: none;
+}
+
+.cookie-banner.is-visible {
+  transform: translateY(0);
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.cookie-banner.is-hidden {
+  transform: translateY(100%);
+  opacity: 0;
+  pointer-events: none;
+}
+
+.cookie-banner p {
+  margin: 0;
+  flex: 1 1 320px;
+}
+
+.cookie-banner a {
+  color: #8ecae6;
+  text-decoration: underline;
+}
+
+.cookie-banner a:hover {
+  color: #a8d8ea;
+}
+
+.cookie-banner-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-shrink: 0;
+}
+
+.cookie-btn {
+  padding: 0.5rem 1.25rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: background-color 0.2s ease, transform 0.15s ease;
+}
+
+.cookie-btn:active {
+  transform: scale(0.97);
+}
+
+.cookie-btn-primary {
+  background: #f5f5f5;
+  color: #1a1a1a;
+}
+
+.cookie-btn-primary:hover {
+  background: #ffffff;
+}
+
+.cookie-btn-secondary {
+  background: transparent;
+  color: #f5f5f5;
+  border-color: #555;
+}
+
+.cookie-btn-secondary:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+/* Respect users who prefer reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .cookie-banner {
+    transition: opacity 0.2s ease;
+    transform: none;
+  }
+
+  .cookie-banner.is-hidden {
+    transform: none;
+  }
+}
+
+/* Small screens: stack text and actions */
+@media (max-width: 520px) {
+  .cookie-banner {
+    flex-direction: column;
+    align-items: stretch;
+    text-align: center;
+  }
+
+  .cookie-banner-actions {
+    justify-content: center;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a bottom-fixed cookie consent banner that slides up into view on page load
and slides back down when dismissed, storing the user's choice in localStorage
so it doesn't reappear on repeat visits.

---

## Type of Change
- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (`submissions/examples/cookie-banner-dg/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A slide-up cookie consent banner that remembers the user's accept/decline choice via localStorage.

**How does a developer use it?**
```html
<div class="cookie-banner" id="cookieBanner">
  <p>
    We use cookies to improve your experience.
    <a href="/privacy">Learn more</a>
  </p>
  <div class="cookie-banner-actions">
    <button id="declineCookies" class="cookie-btn cookie-btn-secondary">Decline</button>
    <button id="acceptCookies" class="cookie-btn cookie-btn-primary">Accept</button>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
Cookie/consent banners are a near-universal real-world requirement for
public-facing sites, and combine an entrance/exit animation (EaseMotion's core
strength) with a small, genuinely useful bit of persistence logic. It's
self-contained, has no external dependencies, respects
`prefers-reduced-motion`, and degrades gracefully if `localStorage` is
unavailable.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Follow-up to Feature Request issue #<issue-number>. Included a "Reset stored
consent" button in the demo purely so reviewers can retrigger the banner
without clearing devtools storage — happy to remove it if you'd rather the
demo only show the real component in isolation. Open to adjusting the easing
curve/duration to match whatever entrance-animation token EaseMotion
standardizes on. Used the `-dg` suffix on the folder per the naming rules to
avoid collisions.