### PR TITLE
feat: add animated notification bell with pulsing badge

### DIFF
--- a/submissions/examples/notification-bell-harrshita/README.md
+++ b/submissions/examples/notification-bell-harrshita/README.md
@@ -1,0 +1,44 @@
+# Notification Bell
+
+### 1. What does this do?
+A pure-CSS animated notification bell — swing animation on new alerts, a pulsing badge counter, and a dropdown notification panel — built for navbars and action bars.
+
+### 2. How is it used?
+Markup the bell inside a positioned wrapper, then toggle a couple of classes with a small amount of JS (shown in `demo.html`):
+
+```html
+<div class="ease-bell">
+  <button class="ease-bell__button" aria-label="Notifications" aria-haspopup="true" aria-expanded="false">
+    <span class="ease-bell__icon">
+      <!-- bell SVG here -->
+    </span>
+    <span class="ease-bell__badge ease-bell__badge--pulse">3</span>
+  </button>
+
+  <div class="ease-bell__dropdown">
+    <ul class="ease-bell__list">
+      <li class="ease-bell__item ease-bell__item--unread">…</li>
+      <li class="ease-bell__item">…</li>
+    </ul>
+  </div>
+</div>
+```
+
+- Add `.ease-bell__icon--ringing` to `.ease-bell__icon` to trigger the swing animation once (remove it on `animationend`, see `demo.html`).
+- Add `.ease-bell__dropdown--open` to `.ease-bell__dropdown` to reveal the panel; toggle `aria-expanded` on the button to match.
+- Remove `.ease-bell__badge--pulse` (or add `.ease-bell__badge--hidden`) once the count reaches 0 — the demo does this automatically as notifications are marked read.
+- Remove `.ease-bell__item--unread` from a row once it's read to drop its highlight and side dot.
+
+**Animation custom properties** (set on `:root`, override per-instance if needed):
+
+| Variable | Default | Controls |
+|---|---|---|
+| `--ease-bell-swing-duration` | `0.6s` | Length of the `ease-bell-swing` ring animation |
+| `--ease-bell-pulse-duration` | `1.6s` | Length of one `ease-badge-pulse` ring cycle |
+| `--ease-bell-badge-color` | `#ff5050` | Badge background and pulse ring color |
+| `--ease-bell-dropdown-width` | `300px` | Width of the notification panel |
+
+Dark mode follows `prefers-color-scheme: dark` automatically, or can be forced with a `.theme-dark` class on `<body>` (see the "Toggle dark mode" button in the demo). All animations are disabled under `prefers-reduced-motion: reduce`.
+
+### 3. Why is it useful?
+Notification indicators are one of the most common interactive UI patterns, and this component shows EaseMotion's animation-first approach applied to a real product need: attention-drawing motion (swing + pulse) that is triggered by state changes rather than looping forever, paired with a smooth CSS-transitioned dropdown. It's accessible by default (`aria-label`, `aria-haspopup`, `aria-expanded`, keyboard `Escape` to close) and respects `prefers-reduced-motion`, which fits EaseMotion's philosophy of motion that enhances usability instead of getting in the way.

--- a/submissions/examples/notification-bell-harrshita/demo.html
+++ b/submissions/examples/notification-bell-harrshita/demo.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Notification Bell — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="demo-page">
+    <header class="demo-page__header">
+      <h1>🔔 Notification Bell</h1>
+      <p>A CSS-driven bell with a pulsing badge and dropdown panel.</p>
+
+      <div class="demo-page__actions">
+        <button id="addNotifBtn" class="demo-page__btn" type="button">Simulate new notification</button>
+        <button id="themeToggle" class="demo-page__btn demo-page__btn--ghost" type="button">Toggle dark mode</button>
+      </div>
+    </header>
+
+    <div class="demo-page__stage">
+      <nav class="demo-navbar">
+        <span class="demo-navbar__brand">EaseMotion App</span>
+
+        <div class="ease-bell">
+          <button
+            id="bellButton"
+            class="ease-bell__button"
+            type="button"
+            aria-label="Notifications"
+            aria-haspopup="true"
+            aria-expanded="false"
+          >
+            <span id="bellIcon" class="ease-bell__icon">
+              <svg viewBox="0 0 24 24" width="26" height="26" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path
+                  d="M12 3c-3.3 0-6 2.7-6 6v3.6c0 .6-.2 1.2-.6 1.7L4 16.5c-.6.8 0 2 1 2h14c1 0 1.6-1.2 1-2l-1.4-2.2c-.4-.5-.6-1.1-.6-1.7V9c0-3.3-2.7-6-6-6Z"
+                  stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"
+                />
+                <path d="M9.5 20a2.5 2.5 0 0 0 5 0" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
+              </svg>
+            </span>
+            <span id="bellBadge" class="ease-bell__badge ease-bell__badge--pulse">3</span>
+          </button>
+
+          <div id="bellDropdown" class="ease-bell__dropdown" role="menu" aria-label="Notification list">
+            <div class="ease-bell__dropdown-header">
+              <span>Notifications</span>
+              <button id="markAllBtn" class="ease-bell__mark-all" type="button">Mark all read</button>
+            </div>
+
+            <ul id="bellList" class="ease-bell__list">
+              <li class="ease-bell__item ease-bell__item--unread" role="menuitem" tabindex="0">
+                <span class="ease-bell__item-dot" aria-hidden="true"></span>
+                <div class="ease-bell__item-text">
+                  <strong>New comment</strong>
+                  <span>Priya replied to your post</span>
+                </div>
+                <time>2m</time>
+              </li>
+              <li class="ease-bell__item ease-bell__item--unread" role="menuitem" tabindex="0">
+                <span class="ease-bell__item-dot" aria-hidden="true"></span>
+                <div class="ease-bell__item-text">
+                  <strong>Task assigned</strong>
+                  <span>You were added to "Launch checklist"</span>
+                </div>
+                <time>1h</time>
+              </li>
+              <li class="ease-bell__item ease-bell__item--unread" role="menuitem" tabindex="0">
+                <span class="ease-bell__item-dot" aria-hidden="true"></span>
+                <div class="ease-bell__item-text">
+                  <strong>Build passed</strong>
+                  <span>main branch deployed successfully</span>
+                </div>
+                <time>3h</time>
+              </li>
+              <li class="ease-bell__item" role="menuitem" tabindex="0">
+                <span class="ease-bell__item-dot" aria-hidden="true"></span>
+                <div class="ease-bell__item-text">
+                  <strong>Welcome!</strong>
+                  <span>Thanks for trying EaseMotion CSS</span>
+                </div>
+                <time>1d</time>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </nav>
+    </div>
+  </main>
+
+<script>
+  (function () {
+    "use strict";
+
+    const bellButton = document.getElementById("bellButton");
+    const bellIcon = document.getElementById("bellIcon");
+    const bellBadge = document.getElementById("bellBadge");
+    const bellDropdown = document.getElementById("bellDropdown");
+    const bellList = document.getElementById("bellList");
+    const addNotifBtn = document.getElementById("addNotifBtn");
+    const markAllBtn = document.getElementById("markAllBtn");
+    const themeToggle = document.getElementById("themeToggle");
+
+    let unreadCount = bellList.querySelectorAll(".ease-bell__item--unread").length;
+
+    function updateBadge() {
+      if (unreadCount > 0) {
+        bellBadge.textContent = unreadCount > 99 ? "99+" : String(unreadCount);
+        bellBadge.classList.remove("ease-bell__badge--hidden");
+        bellBadge.classList.add("ease-bell__badge--pulse");
+      } else {
+        bellBadge.classList.add("ease-bell__badge--hidden");
+        bellBadge.classList.remove("ease-bell__badge--pulse");
+      }
+    }
+
+    function ringBell() {
+      bellIcon.classList.remove("ease-bell__icon--ringing");
+      // restart the animation even if it's already mid-swing
+      void bellIcon.offsetWidth;
+      bellIcon.classList.add("ease-bell__icon--ringing");
+    }
+
+    bellIcon.addEventListener("animationend", () => {
+      bellIcon.classList.remove("ease-bell__icon--ringing");
+    });
+
+    function toggleDropdown(forceState) {
+      const isOpen = bellDropdown.classList.contains("ease-bell__dropdown--open");
+      const nextOpen = typeof forceState === "boolean" ? forceState : !isOpen;
+      bellDropdown.classList.toggle("ease-bell__dropdown--open", nextOpen);
+      bellButton.setAttribute("aria-expanded", String(nextOpen));
+    }
+
+    bellButton.addEventListener("click", () => {
+      toggleDropdown();
+    });
+
+    document.addEventListener("click", (e) => {
+      if (!e.target.closest(".ease-bell")) {
+        toggleDropdown(false);
+      }
+    });
+
+    document.addEventListener("keydown", (e) => {
+      if (e.key === "Escape") {
+        toggleDropdown(false);
+        bellButton.focus();
+      }
+    });
+
+    bellList.addEventListener("click", (e) => {
+      const item = e.target.closest(".ease-bell__item");
+      if (!item || !item.classList.contains("ease-bell__item--unread")) return;
+      item.classList.remove("ease-bell__item--unread");
+      unreadCount = Math.max(0, unreadCount - 1);
+      updateBadge();
+    });
+
+    markAllBtn.addEventListener("click", () => {
+      bellList.querySelectorAll(".ease-bell__item--unread").forEach((item) => {
+        item.classList.remove("ease-bell__item--unread");
+      });
+      unreadCount = 0;
+      updateBadge();
+    });
+
+    addNotifBtn.addEventListener("click", () => {
+      const item = document.createElement("li");
+      item.className = "ease-bell__item ease-bell__item--unread";
+      item.setAttribute("role", "menuitem");
+      item.setAttribute("tabindex", "0");
+      item.innerHTML =
+        '<span class="ease-bell__item-dot" aria-hidden="true"></span>' +
+        '<div class="ease-bell__item-text"><strong>New notification</strong>' +
+        "<span>Something just happened</span></div><time>now</time>";
+      bellList.insertBefore(item, bellList.firstChild);
+
+      unreadCount += 1;
+      updateBadge();
+      ringBell();
+    });
+
+    themeToggle.addEventListener("click", () => {
+      document.body.classList.toggle("theme-dark");
+    });
+
+    updateBadge();
+  })();
+</script>
+</body>
+</html>

--- a/submissions/examples/notification-bell-harrshita/style.css
+++ b/submissions/examples/notification-bell-harrshita/style.css
@@ -1,0 +1,348 @@
+:root {
+  --ease-bell-color: #2b2f38;
+  --ease-bell-hover-bg: rgba(43, 47, 56, 0.08);
+  --ease-bell-badge-color: #ff5050;
+  --ease-bell-badge-text: #ffffff;
+  --ease-bell-swing-duration: 0.6s;
+  --ease-bell-pulse-duration: 1.6s;
+  --ease-bell-dropdown-bg: #ffffff;
+  --ease-bell-dropdown-border: rgba(0, 0, 0, 0.08);
+  --ease-bell-dropdown-width: 300px;
+  --ease-bell-unread-bg: rgba(59, 130, 246, 0.08);
+  --ease-bell-text: #1f2430;
+  --ease-bell-text-muted: #6b7280;
+}
+
+.theme-dark {
+  --ease-bell-color: #f4f5f7;
+  --ease-bell-hover-bg: rgba(255, 255, 255, 0.1);
+  --ease-bell-dropdown-bg: #1e222b;
+  --ease-bell-dropdown-border: rgba(255, 255, 255, 0.1);
+  --ease-bell-unread-bg: rgba(96, 165, 250, 0.12);
+  --ease-bell-text: #f2f3f5;
+  --ease-bell-text-muted: #9aa1ad;
+}
+
+@media (prefers-color-scheme: dark) {
+  body:not(.theme-light) {
+    --ease-bell-color: #f4f5f7;
+    --ease-bell-hover-bg: rgba(255, 255, 255, 0.1);
+    --ease-bell-dropdown-bg: #1e222b;
+    --ease-bell-dropdown-border: rgba(255, 255, 255, 0.1);
+    --ease-bell-unread-bg: rgba(96, 165, 250, 0.12);
+    --ease-bell-text: #f2f3f5;
+    --ease-bell-text-muted: #9aa1ad;
+  }
+}
+
+/* -------------------- keyframes -------------------- */
+
+@keyframes ease-bell-swing {
+  0%, 100% { transform: rotate(0deg); }
+  20%      { transform: rotate(15deg); }
+  40%      { transform: rotate(-12deg); }
+  60%      { transform: rotate(8deg); }
+  80%      { transform: rotate(-5deg); }
+}
+
+@keyframes ease-badge-pulse {
+  0%   { box-shadow: 0 0 0 0 rgba(255, 80, 80, 0.5); }
+  70%  { box-shadow: 0 0 0 8px rgba(255, 80, 80, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(255, 80, 80, 0); }
+}
+
+@keyframes ease-bell-dropdown-in {
+  from {
+    opacity: 0;
+    transform: translateY(-8px) scale(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+/* -------------------- bell wrapper -------------------- */
+
+.ease-bell {
+  position: relative;
+  display: inline-block;
+}
+
+.ease-bell__button {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--ease-bell-color);
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.ease-bell__button:hover,
+.ease-bell__button:focus-visible {
+  background: var(--ease-bell-hover-bg);
+}
+
+.ease-bell__button:focus-visible {
+  outline: 2px solid #3b82f6;
+  outline-offset: 2px;
+}
+
+.ease-bell__icon {
+  display: inline-flex;
+  transform-origin: top center;
+}
+
+.ease-bell__icon--ringing {
+  animation: ease-bell-swing var(--ease-bell-swing-duration) ease-in-out;
+}
+
+/* -------------------- badge -------------------- */
+
+.ease-bell__badge {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  background: var(--ease-bell-badge-color);
+  color: var(--ease-bell-badge-text);
+  font-size: 0.68rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.ease-bell__badge--pulse {
+  animation: ease-badge-pulse var(--ease-bell-pulse-duration) ease-out infinite;
+}
+
+.ease-bell__badge--hidden {
+  display: none;
+}
+
+/* -------------------- dropdown -------------------- */
+
+.ease-bell__dropdown {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  width: var(--ease-bell-dropdown-width);
+  max-width: calc(100vw - 32px);
+  background: var(--ease-bell-dropdown-bg);
+  border: 1px solid var(--ease-bell-dropdown-border);
+  border-radius: 14px;
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.18);
+  overflow: hidden;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-8px) scale(0.97);
+  transform-origin: top right;
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s;
+  z-index: 20;
+}
+
+.ease-bell__dropdown--open {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0) scale(1);
+  animation: ease-bell-dropdown-in 0.22s ease;
+}
+
+.ease-bell__dropdown-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--ease-bell-dropdown-border);
+  color: var(--ease-bell-text);
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.ease-bell__mark-all {
+  border: none;
+  background: none;
+  color: #3b82f6;
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.ease-bell__mark-all:hover {
+  text-decoration: underline;
+}
+
+.ease-bell__list {
+  list-style: none;
+  margin: 0;
+  padding: 4px;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.ease-bell__item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px 10px;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.ease-bell__item:hover,
+.ease-bell__item:focus-visible {
+  background: var(--ease-bell-hover-bg);
+}
+
+.ease-bell__item--unread {
+  background: var(--ease-bell-unread-bg);
+}
+
+.ease-bell__item-dot {
+  margin-top: 6px;
+  width: 8px;
+  height: 8px;
+  flex: 0 0 8px;
+  border-radius: 50%;
+  background: transparent;
+}
+
+.ease-bell__item--unread .ease-bell__item-dot {
+  background: var(--ease-bell-badge-color);
+}
+
+.ease-bell__item-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+  color: var(--ease-bell-text);
+  font-size: 0.85rem;
+}
+
+.ease-bell__item-text span {
+  color: var(--ease-bell-text-muted);
+  font-size: 0.8rem;
+}
+
+.ease-bell__item time {
+  flex: 0 0 auto;
+  color: var(--ease-bell-text-muted);
+  font-size: 0.72rem;
+}
+
+/* -------------------- reduced motion -------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-bell__icon--ringing,
+  .ease-bell__badge--pulse,
+  .ease-bell__dropdown--open {
+    animation: none !important;
+  }
+
+  .ease-bell__dropdown,
+  .ease-bell__item,
+  .ease-bell__button {
+    transition: none !important;
+  }
+}
+
+/* -------------------- demo page chrome (not part of the component) -------------------- */
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+  background: #f3f4f6;
+  color: var(--ease-bell-text, #1f2430);
+  transition: background 0.25s ease, color 0.25s ease;
+}
+
+body.theme-dark {
+  background: #12151b;
+}
+
+.demo-page {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 40px 20px 80px;
+}
+
+.demo-page__header {
+  text-align: center;
+  margin-bottom: 32px;
+}
+
+.demo-page__header h1 {
+  margin: 0 0 6px;
+}
+
+.demo-page__header p {
+  margin: 0 0 18px;
+  opacity: 0.75;
+}
+
+.demo-page__actions {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.demo-page__btn {
+  padding: 9px 16px;
+  border-radius: 10px;
+  border: none;
+  background: #3b82f6;
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.demo-page__btn--ghost {
+  background: rgba(59, 130, 246, 0.12);
+  color: #3b82f6;
+}
+
+.demo-page__stage {
+  border-radius: 16px;
+  overflow: visible;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+}
+
+.demo-navbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 20px;
+  border-radius: 16px;
+  background: var(--ease-bell-dropdown-bg);
+  border: 1px solid var(--ease-bell-dropdown-border);
+}
+
+.demo-navbar__brand {
+  font-weight: 700;
+  color: var(--ease-bell-text);
+}
+
+@media (max-width: 480px) {
+  .ease-bell__dropdown {
+    right: -60px;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained, pure-CSS animated notification bell component — swing animation, pulsing badge counter, and a dropdown notification panel — for use in navbars and action bars. Implements Issue's requested class API (`.ease-bell`, `.ease-bell__icon--ringing`, `.ease-bell__badge--pulse`, `.ease-bell__dropdown--open`, `.ease-bell__item--unread`) with dark mode and reduced-motion support.

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/notification-bell-harrshita/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A pure-CSS animated notification bell with a pulsing badge counter and dropdown panel.

**How does a developer use it?**
```html
<div class="ease-bell">
  <button class="ease-bell__button" aria-label="Notifications" aria-haspopup="true" aria-expanded="false">
    <span class="ease-bell__icon"><!-- bell SVG here --></span>
    <span class="ease-bell__badge ease-bell__badge--pulse">3</span>
  </button>

  <div class="ease-bell__dropdown">
    <ul class="ease-bell__list">
      <li class="ease-bell__item ease-bell__item--unread">…</li>
      <li class="ease-bell__item">…</li>
    </ul>
  </div>
</div>
```
Toggle `.ease-bell__icon--ringing` to trigger the swing, `.ease-bell__dropdown--open` to reveal the panel, and remove `.ease-bell__item--unread` as items are read (see `demo.html` for the small JS that drives these class toggles).

**Why does it fit EaseMotion CSS?**
It demonstrates state-driven, attention-drawing motion (swing + pulse triggered by events rather than looping indefinitely) plus a smoothly CSS-transitioned dropdown, using human-readable `ease-*` class names throughout. It's accessible (`aria-label`, `aria-haspopup`, `aria-expanded`, `Escape`-to-close) and respects `prefers-reduced-motion`, matching the framework's animation-first-but-usable philosophy.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

*(I validated the inline JS syntax and CSS brace balance programmatically and traced the interaction logic by hand; I only had a Chromium-based environment available to manually click through the demo, so Firefox/Edge/Safari are unchecked — happy to have those confirmed in review.)*

---

## Notes for Maintainer

- The three required custom properties for the animation timing (`--ease-bell-swing-duration`, `--ease-bell-pulse-duration`) and badge color (`--ease-bell-badge-color`) are documented in the README table — feel free to fold these into your token system if there's an existing convention.
- `.ease-bell__dropdown` positioning is `right: 0` relative to `.ease-bell`; on very narrow viewports (<480px) I nudged it with a media query rather than a JS-based clamp — flagging in case you'd prefer a different approach for consistency with other EaseMotion dropdown patterns.
- No external dependencies, fonts, or icon libraries — the bell is a two-path inline SVG.