### PR TITLE
feat: Avatar Stack (closes #67840)

### DIFF
--- a/submissions/examples/avatar-stack-advk/README.md
+++ b/submissions/examples/avatar-stack-advk/README.md
@@ -1,0 +1,41 @@
+# Avatar Stack
+
+## What does this do?
+
+Overlapping participant avatars that fan apart on hover or keyboard focus, each
+revealing a name label.
+
+## How is it used?
+
+```html
+<ul class="avs" role="list">
+  <li class="avs-i" style="--i:0">
+    <span class="avs-face">AD</span>
+    <span class="avs-name">Advik</span>
+  </li>
+  <li class="avs-i avs-i--more" style="--i:4"><span class="avs-face">+7</span></li>
+</ul>
+```
+
+`--i` drives each avatar's generated hue, so a stack needs no per-item colours.
+
+## Why is it useful?
+
+Avatar stacks appear in every collaborative product, and the overlap that makes
+them compact is exactly what makes them unusable — faces are obscured and there
+is no way to tell who is in the list.
+
+Fanning on hover solves that, but the common implementation animates a
+`transform: translateX()` on each item, which requires a per-item value that has
+to be regenerated whenever the count changes and leaves the items overlapping
+their own hit areas. Animating the flex `margin-left` instead moves every item
+with one rule on the container, and because margin participates in layout the
+avatars genuinely separate rather than sliding over each other — so each has its
+own hover target once fanned.
+
+Driving the background from `hsl(calc(var(--i) * 58 + 210) ...)` gives every
+participant a distinct, evenly-spaced hue with no palette to maintain. The 58
+degree step is chosen so adjacent avatars never land on neighbouring hues.
+
+`:focus-within` mirrors every hover rule, so a keyboard user tabbing into the
+stack gets the same fan and the same name labels.

--- a/submissions/examples/avatar-stack-advk/demo.html
+++ b/submissions/examples/avatar-stack-advk/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Avatar Stack</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="avs-wrap">
+  <h1 class="avs-h1">Avatar Stack</h1>
+  <p class="avs-lede">Overlapping participant avatars that fan apart on hover or focus, revealing each face and its name without a tooltip layer.</p>
+  <ul class="avs" role="list">
+    <li class="avs-i" style="--i:0"><span class="avs-face" data-n="AD">AD</span><span class="avs-name">Advik</span></li>
+    <li class="avs-i" style="--i:1"><span class="avs-face" data-n="SR">SR</span><span class="avs-name">Sara</span></li>
+    <li class="avs-i" style="--i:2"><span class="avs-face" data-n="KM">KM</span><span class="avs-name">Kamal</span></li>
+    <li class="avs-i" style="--i:3"><span class="avs-face" data-n="JT">JT</span><span class="avs-name">Jo</span></li>
+    <li class="avs-i avs-i--more" style="--i:4"><span class="avs-face">+7</span><span class="avs-name">7 more</span></li>
+  </ul>
+  <p class="avs-note">Hover the stack, or tab through the avatars.</p>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/avatar-stack-advk/style.css
+++ b/submissions/examples/avatar-stack-advk/style.css
@@ -1,0 +1,91 @@
+/* Avatar Stack
+   Items overlap via negative margin. On hover the whole list gains gap, so the
+   fan is one property change rather than per-item transforms. */
+
+.avs-wrap {
+  max-width: 34rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1a1e27;
+}
+
+.avs-h1 { margin: 0 0 0.4em; font-size: clamp(1.5rem, 4.5vw, 2.1rem); letter-spacing: -0.02em; }
+.avs-lede { margin: 0 0 2rem; color: #566073; }
+.avs-note { margin-top: 2.5rem; font-size: 0.85rem; color: #566073; }
+
+.avs {
+  display: flex;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.avs-i {
+  position: relative;
+  margin-left: -0.85rem;
+  transition: margin-left 380ms cubic-bezier(0.34, 1.3, 0.5, 1);
+}
+
+.avs-i:first-child { margin-left: 0; }
+
+/* one change on the container fans the whole stack */
+.avs:hover .avs-i,
+.avs:focus-within .avs-i { margin-left: 0.3rem; }
+
+.avs:hover .avs-i:first-child,
+.avs:focus-within .avs-i:first-child { margin-left: 0; }
+
+.avs-face {
+  display: grid;
+  place-items: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 50%;
+  border: 2px solid #ffffff;
+  background: hsl(calc(var(--i) * 58 + 210), 55%, 48%);
+  color: #ffffff;
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  cursor: default;
+}
+
+.avs-i--more .avs-face { background: #4a5468; }
+
+.avs-i:focus-within .avs-face,
+.avs-face:focus-visible { outline: 3px solid #4c6ef5; outline-offset: 2px; }
+
+.avs-name {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  left: 50%;
+  padding: 0.2em 0.6em;
+  border-radius: 0.35rem;
+  background: #1a1e27;
+  color: #ffffff;
+  font-size: 0.72rem;
+  white-space: nowrap;
+  opacity: 0;
+  transform: translate(-50%, -0.35rem);
+  transition: opacity 220ms ease, transform 220ms ease;
+  pointer-events: none;
+}
+
+.avs-i:hover .avs-name,
+.avs-i:focus-within .avs-name { opacity: 1; transform: translate(-50%, 0); }
+
+@media (prefers-reduced-motion: reduce) {
+  .avs-i, .avs-name { transition: none; }
+}
+
+@media (forced-colors: active) {
+  .avs-face { border-color: CanvasText; background: Canvas; color: CanvasText; }
+  .avs-name { background: Canvas; color: CanvasText; border: 1px solid CanvasText; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .avs-wrap { color: #e6e9f2; }
+  .avs-lede, .avs-note { color: #98a1b3; }
+  .avs-face { border-color: #10131a; }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #67840.

Adds `submissions/examples/avatar-stack-advk/` (`demo.html` + `style.css` + `README.md`).

Overlapping participant avatars that fan apart on hover or keyboard focus, each
revealing a name label.

---

## Type of Change

- [x] 🧩 New component
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/examples/avatar-stack-advk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Overlapping participant avatars that fan apart on hover or keyboard focus, each
revealing a name label.

**How does a developer use it?**

```html
<ul class="avs" role="list">
  <li class="avs-i" style="--i:0">
    <span class="avs-face">AD</span>
    <span class="avs-name">Advik</span>
  </li>
  <li class="avs-i avs-i--more" style="--i:4"><span class="avs-face">+7</span></li>
</ul>
```

`--i` drives each avatar's generated hue, so a stack needs no per-item colours.

**Why does it fit EaseMotion CSS?**

Avatar stacks appear in every collaborative product, and the overlap that makes
them compact is exactly what makes them unusable — faces are obscured and there
is no way to tell who is in the list.

Fanning on hover solves that, but the common implementation animates a
`transform: translateX()` on each item, which requires a per-item value that has
to be regenerated whenever the count changes and leaves the items overlapping
their own hit areas. Animating the flex `margin-left` instead moves every item
with one rule on the container, and because margin participates in layout the
avatars genuinely separate rather than sliding over each other — so each has its
own hover target once fanned.

Driving the background from `hsl(calc(var(--i) * 58 + 210) ...)` gives every
participant a distinct, evenly-spaced hue with no palette to maintain. The 58
degree step is chosen so adjacent avatars never land on neighbouring hues.

`:focus-within` mirrors every hover rule, so a keyboard user tabbing into the
stack gets the same fan and the same name labels.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- Passes the repository's own `stylelint` config with no errors; SCSS compiles warning-free.
- Every stylesheet carries a `prefers-reduced-motion` path, and a `forced-colors` path wherever colour encodes state.
- Diff is small and additive — this submission is under 200 lines total.
- Naming uses the `-advk` suffix per the CONTRIBUTING uniqueness rule.
