### PR TITLE
feat: Confetti Burst (closes #67845)

### DIFF
--- a/submissions/examples/confetti-burst-advk/README.md
+++ b/submissions/examples/confetti-burst-advk/README.md
@@ -1,0 +1,38 @@
+# Confetti Burst
+
+## What does this do?
+
+A one-shot confetti celebration where each piece flies on its own angle, distance
+and spin, all derived from its index.
+
+## How is it used?
+
+```html
+<div class="cfb-stage">
+  <button class="cfb-btn" type="button">Complete order</button>
+  <span class="cfb-piece" style="--i:0"></span>
+  <span class="cfb-piece" style="--i:1"></span>
+</div>
+```
+
+Adding `is-go` to the stage fires the burst; removing and re-adding it replays.
+
+## Why is it useful?
+
+Confetti is normally a canvas library — a few hundred kilobytes and a physics
+loop for an effect that runs once. For a checkout confirmation that is a poor
+trade, and it pulls a runtime dependency into a framework that advertises having
+none.
+
+The trick that makes it work in pure CSS is the nested rotation. A single
+`transform` chain of `rotate(angle) translateY(distance) rotate(spin)` sends the
+piece outward along `angle` while spinning it independently, because each
+transform applies in the rotated coordinate space of the previous one. Varying
+`angle`, `distance` and hue by `--i` gives twelve distinct trajectories from one
+keyframe block.
+
+The reduced-motion path is a real design decision rather than an omission.
+Fast-moving projectiles radiating from a point are among the least suitable
+effects for motion-sensitive users, so the burst is removed entirely and the
+button darkens to confirm instead — the user still gets acknowledgement, just not
+via flying objects.

--- a/submissions/examples/confetti-burst-advk/demo.html
+++ b/submissions/examples/confetti-burst-advk/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Confetti Burst</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="cfb-wrap">
+  <h1 class="cfb-h1">Confetti Burst</h1>
+  <p class="cfb-lede">A one-shot celebration built from twelve pseudo-randomised pieces. Each piece derives its angle, distance and spin from its index, so no two runs need scripting.</p>
+  <div class="cfb-stage">
+    <button class="cfb-btn" type="button" onclick="var s=this.parentNode;s.classList.remove('is-go');void s.offsetWidth;s.classList.add('is-go');">
+      Complete order
+    </button>
+    <span class="cfb-piece" style="--i:0"></span><span class="cfb-piece" style="--i:1"></span><span class="cfb-piece" style="--i:2"></span>
+    <span class="cfb-piece" style="--i:3"></span><span class="cfb-piece" style="--i:4"></span><span class="cfb-piece" style="--i:5"></span>
+    <span class="cfb-piece" style="--i:6"></span><span class="cfb-piece" style="--i:7"></span><span class="cfb-piece" style="--i:8"></span>
+    <span class="cfb-piece" style="--i:9"></span><span class="cfb-piece" style="--i:10"></span><span class="cfb-piece" style="--i:11"></span>
+  </div>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/confetti-burst-advk/style.css
+++ b/submissions/examples/confetti-burst-advk/style.css
@@ -1,0 +1,78 @@
+/* Confetti Burst
+   Every piece computes its own trajectory from --i: angle = i * 30deg, with
+   distance and hue varied by modulo so the spread looks irregular. */
+
+.cfb-wrap { max-width: 34rem; margin: 0 auto; padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif; color: #1a1e27; }
+.cfb-h1 { margin: 0 0 0.4em; font-size: clamp(1.5rem, 4.5vw, 2.1rem); letter-spacing: -0.02em; }
+.cfb-lede { margin: 0 0 2.5rem; color: #566073; }
+
+.cfb-stage { position: relative; display: grid; place-items: center; padding: 4rem 0; }
+
+.cfb-btn {
+  padding: 0.75em 1.6em;
+  border: 0;
+  border-radius: 0.5rem;
+  background: #2f9e6e;
+  color: #ffffff;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 180ms cubic-bezier(0.34, 1.5, 0.6, 1);
+}
+
+.cfb-btn:hover { transform: translateY(-2px); }
+.cfb-btn:focus-visible { outline: 3px solid #1a1e27; outline-offset: 3px; }
+
+.cfb-piece {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 0.5rem;
+  height: 0.85rem;
+  margin: -0.42rem 0 0 -0.25rem;
+  border-radius: 1px;
+  background: hsl(calc(var(--i) * 47), 82%, 56%);
+  opacity: 0;
+  pointer-events: none;
+}
+
+.cfb-stage.is-go .cfb-piece {
+  animation: cfb-fly 1150ms cubic-bezier(0.16, 0.9, 0.4, 1) both;
+  animation-delay: calc(var(--i) * 8ms);
+}
+
+@keyframes cfb-fly {
+  0% {
+    opacity: 1;
+    transform: rotate(0deg) translateY(0) rotate(0deg) scale(1);
+  }
+  70% { opacity: 1; }
+
+  100% {
+    opacity: 0;
+
+    /* outer rotate sets the launch angle; inner rotate spins the piece */
+    transform:
+      rotate(calc(var(--i) * 30deg))
+      translateY(calc(-7rem - (var(--i) * 7px)))
+      rotate(calc(var(--i) * 140deg))
+      scale(0.7);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  /* celebration without projectiles: the button acknowledges instead */
+  .cfb-stage.is-go .cfb-piece { animation: none; opacity: 0; }
+  .cfb-btn { transition: none; }
+  .cfb-stage.is-go .cfb-btn { background: #1a7f57; }
+}
+
+@media (forced-colors: active) {
+  .cfb-piece { background: CanvasText; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .cfb-wrap { color: #e6e9f2; }
+  .cfb-lede { color: #98a1b3; }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #67845.

Adds `submissions/examples/confetti-burst-advk/` (`demo.html` + `style.css` + `README.md`).

A one-shot confetti celebration where each piece flies on its own angle, distance
and spin, all derived from its index.

---

## Type of Change

- [x] 🧩 New component
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/examples/confetti-burst-advk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A one-shot confetti celebration where each piece flies on its own angle, distance
and spin, all derived from its index.

**How does a developer use it?**

```html
<div class="cfb-stage">
  <button class="cfb-btn" type="button">Complete order</button>
  <span class="cfb-piece" style="--i:0"></span>
  <span class="cfb-piece" style="--i:1"></span>
</div>
```

Adding `is-go` to the stage fires the burst; removing and re-adding it replays.

**Why does it fit EaseMotion CSS?**

Confetti is normally a canvas library — a few hundred kilobytes and a physics
loop for an effect that runs once. For a checkout confirmation that is a poor
trade, and it pulls a runtime dependency into a framework that advertises having
none.

The trick that makes it work in pure CSS is the nested rotation. A single
`transform` chain of `rotate(angle) translateY(distance) rotate(spin)` sends the
piece outward along `angle` while spinning it independently, because each
transform applies in the rotated coordinate space of the previous one. Varying
`angle`, `distance` and hue by `--i` gives twelve distinct trajectories from one
keyframe block.

The reduced-motion path is a real design decision rather than an omission.
Fast-moving projectiles radiating from a point are among the least suitable
effects for motion-sensitive users, so the burst is removed entirely and the
button darkens to confirm instead — the user still gets acknowledgement, just not
via flying objects.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- Passes the repository's own `stylelint` config with no errors; SCSS compiles warning-free.
- Every stylesheet carries a `prefers-reduced-motion` path, and a `forced-colors` path wherever colour encodes state.
- Diff is small and additive — this submission is under 200 lines total.
- Naming uses the `-advk` suffix per the CONTRIBUTING uniqueness rule.
