### PR TITLE
feat: Off-canvas Drawer (closes #67846)

### DIFF
--- a/submissions/examples/drawer-slide-advk/README.md
+++ b/submissions/examples/drawer-slide-advk/README.md
@@ -1,0 +1,41 @@
+# Off-canvas Drawer
+
+## What does this do?
+
+A slide-in filter panel opened with `:target`, where the panel, the backdrop and
+the list items each enter on their own timing.
+
+## How is it used?
+
+```html
+<a class="drw-open" href="#drawer">Open drawer</a>
+
+<div class="drw" id="drawer">
+  <a class="drw-scrim" href="#" aria-label="Close drawer"></a>
+  <aside class="drw-panel" role="dialog" aria-modal="true" aria-labelledby="drw-t">
+    <h2 id="drw-t">Filters</h2>
+    <ul class="drw-list"><li style="--i:0">Availability</li></ul>
+  </aside>
+</div>
+```
+
+## Why is it useful?
+
+Drawers are usually the first thing a project reaches for a JavaScript library
+to build, but the open/closed state is a single boolean that `:target` already
+expresses — and `:target` survives the back button, which hand-rolled state does
+not.
+
+The detail worth copying is the asymmetric timing. Giving the panel a
+decelerating curve while the scrim gets a plain fade with a 60ms delay on the way
+out makes the panel feel like the thing being moved and the scrim like a
+consequence of it. Running both on identical timing is what makes most drawers
+feel flat, and it costs nothing to fix.
+
+The list items stagger in behind the panel using the same `--i` custom-property
+pattern used elsewhere in these submissions, starting after the panel is mostly
+open so the content is not sliding while its container is still moving.
+
+`visibility: hidden` on the closed container rather than `display: none` keeps
+the panel out of the tab order while still allowing the transform transition to
+run — `display` changes are not transitionable and would make the panel jump.

--- a/submissions/examples/drawer-slide-advk/demo.html
+++ b/submissions/examples/drawer-slide-advk/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Off-canvas Drawer</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="drw-wrap">
+  <h1 class="drw-h1">Off-canvas Drawer</h1>
+  <p class="drw-lede">A slide-in panel driven by :target, with the backdrop and panel on separate curves so the panel leads and the scrim follows.</p>
+  <p><a class="drw-open" href="#drawer">Open drawer</a></p>
+
+  <div class="drw" id="drawer">
+    <a class="drw-scrim" href="#" aria-label="Close drawer"></a>
+    <aside class="drw-panel" role="dialog" aria-modal="true" aria-labelledby="drw-t">
+      <h2 class="drw-t" id="drw-t">Filters</h2>
+      <ul class="drw-list">
+        <li style="--i:0">Availability</li>
+        <li style="--i:1">Price range</li>
+        <li style="--i:2">Rating</li>
+        <li style="--i:3">Delivery speed</li>
+      </ul>
+      <a class="drw-close" href="#">Done</a>
+    </aside>
+  </div>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/drawer-slide-advk/style.css
+++ b/submissions/examples/drawer-slide-advk/style.css
@@ -1,0 +1,98 @@
+/* Off-canvas Drawer
+   :target drives the open state. The panel uses a decelerating curve and the
+   scrim a plain fade, so the panel appears to lead the transition. */
+
+.drw-wrap {
+  max-width: 34rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1a1e27;
+}
+
+.drw-h1 { margin: 0 0 0.4em; font-size: clamp(1.5rem, 4.5vw, 2.1rem); letter-spacing: -0.02em; }
+.drw-lede { margin: 0 0 1.5rem; color: #566073; }
+
+.drw-open, .drw-close {
+  display: inline-block;
+  padding: 0.6em 1.3em;
+  border-radius: 0.45rem;
+  background: #3b5bdb;
+  color: #ffffff;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.drw-open:focus-visible, .drw-close:focus-visible { outline: 3px solid #1a1e27; outline-offset: 3px; }
+
+.drw {
+  position: fixed;
+  inset: 0;
+  z-index: 20;
+  visibility: hidden;
+}
+
+.drw:target { visibility: visible; }
+
+.drw-scrim {
+  position: absolute;
+  inset: 0;
+  background: rgba(14, 17, 24, 0.5);
+  opacity: 0;
+  transition: opacity 380ms ease 60ms;
+}
+
+.drw:target .drw-scrim { opacity: 1; transition-delay: 0ms; }
+
+.drw-panel {
+  position: absolute;
+  inset-block: 0;
+  right: 0;
+  width: min(20rem, 82vw);
+  padding: 1.5rem;
+  background: #ffffff;
+  box-shadow: -12px 0 40px rgba(10, 14, 22, 0.22);
+  transform: translateX(100%);
+  transition: transform 400ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.drw:target .drw-panel { transform: translateX(0); }
+
+.drw-t { margin: 0 0 1rem; font-size: 1.1rem; }
+
+.drw-list { margin: 0 0 1.5rem; padding: 0; list-style: none; }
+
+.drw-list li {
+  padding: 0.65em 0;
+  border-bottom: 1px solid #e6e9f0;
+  font-size: 0.92rem;
+  opacity: 0;
+  transform: translateX(0.75rem);
+}
+
+.drw:target .drw-list li {
+  animation: drw-item 380ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation-delay: calc(180ms + var(--i) * 55ms);
+}
+
+@keyframes drw-item {
+  to { opacity: 1; transform: translateX(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .drw-scrim, .drw-panel { transition-duration: 1ms; }
+  .drw:target .drw-list li { animation: drw-fade 160ms ease both; animation-delay: 0ms; }
+}
+
+@keyframes drw-fade { to { opacity: 1; transform: none; } }
+
+@media (forced-colors: active) {
+  .drw-panel { border-left: 1px solid CanvasText; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .drw-wrap { color: #e6e9f2; }
+  .drw-lede { color: #98a1b3; }
+  .drw-panel { background: #171b23; }
+  .drw-list li { border-bottom-color: #2a303c; }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #67846.

Adds `submissions/examples/drawer-slide-advk/` (`demo.html` + `style.css` + `README.md`).

A slide-in filter panel opened with `:target`, where the panel, the backdrop and
the list items each enter on their own timing.

---

## Type of Change

- [x] 🧩 New component
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/examples/drawer-slide-advk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A slide-in filter panel opened with `:target`, where the panel, the backdrop and
the list items each enter on their own timing.

**How does a developer use it?**

```html
<a class="drw-open" href="#drawer">Open drawer</a>

<div class="drw" id="drawer">
  <a class="drw-scrim" href="#" aria-label="Close drawer"></a>
  <aside class="drw-panel" role="dialog" aria-modal="true" aria-labelledby="drw-t">
    <h2 id="drw-t">Filters</h2>
    <ul class="drw-list"><li style="--i:0">Availability</li></ul>
  </aside>
</div>
```

**Why does it fit EaseMotion CSS?**

Drawers are usually the first thing a project reaches for a JavaScript library
to build, but the open/closed state is a single boolean that `:target` already
expresses — and `:target` survives the back button, which hand-rolled state does
not.

The detail worth copying is the asymmetric timing. Giving the panel a
decelerating curve while the scrim gets a plain fade with a 60ms delay on the way
out makes the panel feel like the thing being moved and the scrim like a
consequence of it. Running both on identical timing is what makes most drawers
feel flat, and it costs nothing to fix.

The list items stagger in behind the panel using the same `--i` custom-property
pattern used elsewhere in these submissions, starting after the panel is mostly
open so the content is not sliding while its container is still moving.

`visibility: hidden` on the closed container rather than `display: none` keeps
the panel out of the tab order while still allowing the transform transition to
run — `display` changes are not transitionable and would make the panel jump.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- Passes the repository's own `stylelint` config with no errors; SCSS compiles warning-free.
- Every stylesheet carries a `prefers-reduced-motion` path, and a `forced-colors` path wherever colour encodes state.
- Diff is small and additive — this submission is under 200 lines total.
- Naming uses the `-advk` suffix per the CONTRIBUTING uniqueness rule.
