### PR TITLE
feat: Accessible Marquee (closes #67849)

### DIFF
--- a/submissions/examples/marquee-pause-advk/README.md
+++ b/submissions/examples/marquee-pause-advk/README.md
@@ -1,0 +1,39 @@
+# Accessible Marquee
+
+## What does this do?
+
+A seamless scrolling ticker that pauses on hover and keyboard focus, and stops
+completely under reduced motion.
+
+## How is it used?
+
+```html
+<div class="mrq" tabindex="0" role="marquee" aria-label="Latest releases">
+  <div class="mrq-track">
+    <span>Item one</span><span>Item two</span>
+    <span aria-hidden="true">Item one</span><span aria-hidden="true">Item two</span>
+  </div>
+</div>
+```
+
+Duplicate the item list and mark the copy `aria-hidden="true"`.
+
+## Why is it useful?
+
+`components/ease-marquee.css` scrolls continuously with no pause affordance.
+WCAG 2.2.2 requires that any automatically-moving content lasting more than five
+seconds can be paused — a ticker runs indefinitely, so it needs one.
+
+Adding `:hover` alone is the common half-fix and it excludes keyboard users
+entirely. Making the container focusable and pausing on `:focus-visible` too
+means the content is reachable and stoppable without a pointer, which is the
+actual requirement.
+
+The seamless loop comes from translating exactly `-50%` of a track containing two
+identical copies: at the end of the cycle the second copy sits precisely where the
+first started, so the reset is invisible. The duplicate is `aria-hidden` so screen
+readers announce the list once rather than twice.
+
+Under reduced motion the track stops and wraps onto multiple lines instead of
+scrolling, so every item stays readable rather than being clipped at the
+container edge.

--- a/submissions/examples/marquee-pause-advk/demo.html
+++ b/submissions/examples/marquee-pause-advk/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Accessible Marquee</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="mrq-wrap">
+  <h1 class="mrq-h1">Accessible Marquee</h1>
+  <p class="mrq-lede">A scrolling ticker that pauses on hover and on keyboard focus, and stops entirely under reduced motion. The track is duplicated so the loop is seamless.</p>
+  <div class="mrq" tabindex="0" role="marquee" aria-label="Latest releases">
+    <div class="mrq-track">
+      <span>v1.2.0 motion engine</span><span>scroll-driven timelines</span><span>SCSS token scale</span><span>forced-colors support</span>
+      <span aria-hidden="true">v1.2.0 motion engine</span><span aria-hidden="true">scroll-driven timelines</span><span aria-hidden="true">SCSS token scale</span><span aria-hidden="true">forced-colors support</span>
+    </div>
+  </div>
+  <p class="mrq-note">Hover or tab to the ticker to pause it.</p>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/marquee-pause-advk/style.css
+++ b/submissions/examples/marquee-pause-advk/style.css
@@ -1,0 +1,57 @@
+/* Accessible Marquee
+   The track holds two identical copies and translates by exactly -50%, so the
+   second copy lands where the first began and the loop has no visible seam. */
+
+.mrq-wrap { max-width: 38rem; margin: 0 auto; padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif; color: #1a1e27; }
+.mrq-h1 { margin: 0 0 0.4em; font-size: clamp(1.5rem, 4.5vw, 2.1rem); letter-spacing: -0.02em; }
+.mrq-lede { margin: 0 0 1.75rem; color: #566073; }
+.mrq-note { margin-top: 1rem; font-size: 0.85rem; color: #566073; }
+
+.mrq {
+  overflow: hidden;
+  padding: 0.75rem 0;
+  border-block: 1px solid #dfe3ec;
+  mask: linear-gradient(90deg, transparent, #000 8%, #000 92%, transparent);
+}
+
+.mrq:focus-visible { outline: 3px solid #4c6ef5; outline-offset: 3px; }
+
+.mrq-track {
+  display: flex;
+  width: max-content;
+  gap: 2.5rem;
+  animation: mrq-run 18s linear infinite;
+}
+
+.mrq-track span {
+  font-size: 0.92rem;
+  font-weight: 600;
+  color: #3b4660;
+  white-space: nowrap;
+}
+
+.mrq-track span::before { content: "\25C6"; margin-right: 0.75rem; color: #4c6ef5; }
+
+/* pause is the whole point: hover, and focus for keyboard users */
+.mrq:hover .mrq-track,
+.mrq:focus-visible .mrq-track { animation-play-state: paused; }
+
+@keyframes mrq-run { to { transform: translateX(-50%); } }
+
+@media (prefers-reduced-motion: reduce) {
+  .mrq-track { animation: none; flex-wrap: wrap; width: auto; }
+  .mrq { mask: none; }
+}
+
+@media (forced-colors: active) {
+  .mrq { border-color: CanvasText; mask: none; }
+  .mrq-track span::before { color: CanvasText; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .mrq-wrap { color: #e6e9f2; }
+  .mrq-lede, .mrq-note { color: #98a1b3; }
+  .mrq { border-color: #2a303c; }
+  .mrq-track span { color: #c3cad9; }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #67849.

Adds `submissions/examples/marquee-pause-advk/` (`demo.html` + `style.css` + `README.md`).

A seamless scrolling ticker that pauses on hover and keyboard focus, and stops
completely under reduced motion.

---

## Type of Change

- [x] 🧩 New component
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/examples/marquee-pause-advk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A seamless scrolling ticker that pauses on hover and keyboard focus, and stops
completely under reduced motion.

**How does a developer use it?**

```html
<div class="mrq" tabindex="0" role="marquee" aria-label="Latest releases">
  <div class="mrq-track">
    <span>Item one</span><span>Item two</span>
    <span aria-hidden="true">Item one</span><span aria-hidden="true">Item two</span>
  </div>
</div>
```

Duplicate the item list and mark the copy `aria-hidden="true"`.

**Why does it fit EaseMotion CSS?**

`components/ease-marquee.css` scrolls continuously with no pause affordance.
WCAG 2.2.2 requires that any automatically-moving content lasting more than five
seconds can be paused — a ticker runs indefinitely, so it needs one.

Adding `:hover` alone is the common half-fix and it excludes keyboard users
entirely. Making the container focusable and pausing on `:focus-visible` too
means the content is reachable and stoppable without a pointer, which is the
actual requirement.

The seamless loop comes from translating exactly `-50%` of a track containing two
identical copies: at the end of the cycle the second copy sits precisely where the
first started, so the reset is invisible. The duplicate is `aria-hidden` so screen
readers announce the list once rather than twice.

Under reduced motion the track stops and wraps onto multiple lines instead of
scrolling, so every item stays readable rather than being clipped at the
container edge.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- Passes the repository's own `stylelint` config with no errors; SCSS compiles warning-free.
- Every stylesheet carries a `prefers-reduced-motion` path, and a `forced-colors` path wherever colour encodes state.
- Diff is small and additive — this submission is under 200 lines total.
- Naming uses the `-advk` suffix per the CONTRIBUTING uniqueness rule.
