### PR TITLE
feat: Reading Progress Bar (closes #67852)

### DIFF
--- a/submissions/examples/page-scroll-indicator-advk/README.md
+++ b/submissions/examples/page-scroll-indicator-advk/README.md
@@ -1,0 +1,38 @@
+# Reading Progress Bar
+
+## What does this do?
+
+A top-edge reading progress bar plus a circular dial, both scrubbed by document
+scroll from the same `scroll()` timeline.
+
+## How is it used?
+
+```css
+.rpb {
+  animation: rpb-grow linear both;
+  animation-timeline: scroll(root block);
+}
+@keyframes rpb-grow { to { transform: scaleX(1); } }
+```
+
+## Why is it useful?
+
+Progress bars are the canonical `scroll` listener: read `scrollTop`, divide by
+`scrollHeight`, write a style, every event. That forces a layout read on each
+tick and runs during the interaction least tolerant of main-thread work.
+
+Binding both indicators to `scroll(root block)` moves the sampling to the
+compositor and, more usefully, guarantees they agree. Two independent listeners
+updating a bar and a dial will drift under load; two animations on one timeline
+cannot.
+
+The dial shows a technique worth knowing: a `conic-gradient` colour stop cannot be
+animated unless the value driving it is a registered custom property. Declaring
+`--rpb-p` with `@property { syntax: "<percentage>" }` makes it interpolatable, so
+the sweep is smooth rather than stepping.
+
+The reduced-motion decision here is deliberate and different from the other
+submissions. Scroll progress is entirely user-driven — it moves only when the user
+moves — so it is not the autonomous motion WCAG 2.3.3 targets, and the bar is kept.
+Only the dial is dropped, because its continuous conic repaint is the expensive,
+visually busy half of the pair.

--- a/submissions/examples/page-scroll-indicator-advk/demo.html
+++ b/submissions/examples/page-scroll-indicator-advk/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Reading Progress Bar</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="rpb-wrap">
+  <div class="rpb" role="presentation"></div>
+  <h1 class="rpb-h1">Reading Progress Bar</h1>
+  <p class="rpb-lede">A top-edge progress bar scrubbed by document scroll, and a matching circular indicator, both from the same scroll() timeline with no script.</p>
+  <p>The bar is fixed to the viewport top and scales on X. The dial uses the identical timeline driving a conic gradient stop through an <code>@property</code> registered percentage.</p>
+  <p>Because both read the same timeline, they can never drift apart the way two independent scroll listeners would.</p>
+  <div class="rpb-filler"></div>
+  <p class="rpb-end">You have reached the end.</p>
+  <div class="rpb-dial" aria-hidden="true"></div>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/page-scroll-indicator-advk/style.css
+++ b/submissions/examples/page-scroll-indicator-advk/style.css
@@ -1,0 +1,66 @@
+/* Reading Progress Bar
+   Both indicators bind to scroll(root block). The dial animates a registered
+   custom property so the conic gradient stop can interpolate. */
+
+@property --rpb-p {
+  syntax: "<percentage>";
+  initial-value: 0%;
+  inherits: false;
+}
+
+.rpb-wrap { max-width: 38rem; margin: 0 auto; padding: 3rem 1.25rem 4rem;
+  font: 400 1rem/1.7 ui-sans-serif, system-ui, sans-serif; color: #1a1e27; }
+.rpb-h1 { margin: 0 0 0.4em; font-size: clamp(1.5rem, 4.5vw, 2.1rem); letter-spacing: -0.02em; }
+.rpb-lede { margin: 0 0 1.5rem; color: #566073; }
+.rpb-wrap p { margin: 0 0 1.15rem; }
+.rpb-wrap code { padding: 0.1em 0.35em; border-radius: 0.25rem; background: #e8ecf4; font-family: ui-monospace, Menlo, monospace; font-size: 0.88em; }
+.rpb-filler { height: 140vh; }
+.rpb-end { color: #566073; }
+
+.rpb {
+  position: fixed;
+  inset: 0 0 auto 0;
+  z-index: 30;
+  height: 4px;
+  background: linear-gradient(90deg, #4c6ef5, #a855f7);
+  transform: scaleX(0);
+  transform-origin: left;
+  animation: rpb-grow linear both;
+  animation-timeline: scroll(root block);
+}
+
+@keyframes rpb-grow { to { transform: scaleX(1); } }
+
+.rpb-dial {
+  position: fixed;
+  right: 1.25rem;
+  bottom: 1.25rem;
+  z-index: 30;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  background: conic-gradient(#4c6ef5 var(--rpb-p), #dfe3ec var(--rpb-p));
+  mask: radial-gradient(farthest-side, transparent calc(100% - 6px), #000 calc(100% - 5px));
+  animation: rpb-dial linear both;
+  animation-timeline: scroll(root block);
+}
+
+@keyframes rpb-dial { to { --rpb-p: 100%; } }
+
+@media (prefers-reduced-motion: reduce) {
+  /* progress is user-driven, not autonomous, so it is kept -- but the dial's
+     continuous repaint is dropped in favour of the bar alone */
+  .rpb-dial { display: none; }
+}
+
+@media (forced-colors: active) {
+  .rpb { background: Highlight; }
+  .rpb-dial { display: none; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .rpb-wrap { color: #e6e9f2; }
+  .rpb-lede, .rpb-end { color: #98a1b3; }
+  .rpb-wrap code { background: #262c38; }
+  .rpb-dial { background: conic-gradient(#4c6ef5 var(--rpb-p), #2a303c var(--rpb-p)); }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #67852.

Adds `submissions/examples/page-scroll-indicator-advk/` (`demo.html` + `style.css` + `README.md`).

A top-edge reading progress bar plus a circular dial, both scrubbed by document
scroll from the same `scroll()` timeline.

---

## Type of Change

- [x] 🧩 New component
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/examples/page-scroll-indicator-advk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A top-edge reading progress bar plus a circular dial, both scrubbed by document
scroll from the same `scroll()` timeline.

**How does a developer use it?**

```css
.rpb {
  animation: rpb-grow linear both;
  animation-timeline: scroll(root block);
}
@keyframes rpb-grow { to { transform: scaleX(1); } }
```

**Why does it fit EaseMotion CSS?**

Progress bars are the canonical `scroll` listener: read `scrollTop`, divide by
`scrollHeight`, write a style, every event. That forces a layout read on each
tick and runs during the interaction least tolerant of main-thread work.

Binding both indicators to `scroll(root block)` moves the sampling to the
compositor and, more usefully, guarantees they agree. Two independent listeners
updating a bar and a dial will drift under load; two animations on one timeline
cannot.

The dial shows a technique worth knowing: a `conic-gradient` colour stop cannot be
animated unless the value driving it is a registered custom property. Declaring
`--rpb-p` with `@property { syntax: "<percentage>" }` makes it interpolatable, so
the sweep is smooth rather than stepping.

The reduced-motion decision here is deliberate and different from the other
submissions. Scroll progress is entirely user-driven — it moves only when the user
moves — so it is not the autonomous motion WCAG 2.3.3 targets, and the bar is kept.
Only the dial is dropped, because its continuous conic repaint is the expensive,
visually busy half of the pair.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- Passes the repository's own `stylelint` config with no errors; SCSS compiles warning-free.
- Every stylesheet carries a `prefers-reduced-motion` path, and a `forced-colors` path wherever colour encodes state.
- Diff is small and additive — this submission is under 200 lines total.
- Naming uses the `-advk` suffix per the CONTRIBUTING uniqueness rule.
