### PR TITLE
feat: Range Slider Fill (closes #67855)

### DIFF
--- a/submissions/examples/range-slider-fill-advk/README.md
+++ b/submissions/examples/range-slider-fill-advk/README.md
@@ -1,0 +1,36 @@
+# Range Slider Fill
+
+## What does this do?
+
+A native `<input type="range">` whose track shows a coloured fill up to the
+thumb position.
+
+## How is it used?
+
+```html
+<input class="rsf" type="range" min="0" max="100" value="64" style="--v: 64%"
+       oninput="this.style.setProperty('--v', this.value + '%')" />
+```
+
+One line mirrors the value onto `--v`; the fill follows.
+
+## Why is it useful?
+
+A filled track is the single most requested range-input style and the one with
+the worst cross-browser story. `::-webkit-slider-runnable-track` has no Firefox
+counterpart, `::-moz-range-progress` has no WebKit counterpart, and the usual
+result is a stylesheet with two divergent implementations that drift apart.
+
+Putting a hard-stop `linear-gradient` on the input's own `background` sidesteps
+both. Every engine paints the element background, so one declaration produces the
+same fill everywhere, and only the thumb needs vendor-prefixed rules — which
+cannot be combined into one selector list anyway, since an unrecognised
+pseudo-element invalidates the whole rule.
+
+The control stays a real range input, so keyboard stepping, touch dragging and
+the announced value all work without intervention. `--v` is only a visual mirror
+of the value, never the source of truth, so the slider still functions correctly
+if the script never runs.
+
+`outline-offset: 6px` on focus keeps the ring clear of the thumb's shadow, which
+otherwise swallows it at small track heights.

--- a/submissions/examples/range-slider-fill-advk/demo.html
+++ b/submissions/examples/range-slider-fill-advk/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Range Slider Fill</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="rsf-wrap">
+  <h1 class="rsf-h1">Range Slider Fill</h1>
+  <p class="rsf-lede">A native range input whose track fills up to the thumb. The fill is a gradient sized from a custom property, so it works without pseudo-element hacks that differ per browser.</p>
+  <label class="rsf-f">Volume
+    <input class="rsf" type="range" min="0" max="100" value="64" style="--v: 64%"
+           oninput="this.style.setProperty('--v', this.value + '%')" />
+  </label>
+  <label class="rsf-f">Playback speed
+    <input class="rsf rsf--warm" type="range" min="50" max="200" value="120" style="--v: 46.7%"
+           oninput="this.style.setProperty('--v', (this.value - 50) / 1.5 + '%')" />
+  </label>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/range-slider-fill-advk/style.css
+++ b/submissions/examples/range-slider-fill-advk/style.css
@@ -1,0 +1,67 @@
+/* Range Slider Fill
+   The filled track is a hard-stop linear-gradient on the input background,
+   which both WebKit and Gecko honour -- unlike ::-webkit-slider-runnable-track,
+   which has no Firefox equivalent. */
+
+.rsf-wrap { max-width: 32rem; margin: 0 auto; padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif; color: #1a1e27; }
+.rsf-h1 { margin: 0 0 0.4em; font-size: clamp(1.5rem, 4.5vw, 2.1rem); letter-spacing: -0.02em; }
+.rsf-lede { margin: 0 0 2.25rem; color: #566073; }
+
+.rsf-f { display: grid; gap: 0.6rem; margin-bottom: 2rem; font-size: 0.9rem; font-weight: 600; }
+
+.rsf {
+  --accent: #4c6ef5;
+
+  width: 100%;
+  height: 0.4rem;
+  margin: 0;
+  border-radius: 999px;
+  appearance: none;
+  background: linear-gradient(90deg, var(--accent) 0 var(--v), #dfe3ec var(--v) 100%);
+  cursor: pointer;
+}
+
+.rsf--warm { --accent: #e8590c; }
+
+.rsf::-webkit-slider-thumb {
+  appearance: none;
+  width: 1.15rem;
+  height: 1.15rem;
+  border: 3px solid var(--accent);
+  border-radius: 50%;
+  background: #ffffff;
+  box-shadow: 0 1px 5px rgba(20, 25, 40, 0.24);
+  transition: transform 180ms cubic-bezier(0.34, 1.5, 0.6, 1);
+}
+
+.rsf::-moz-range-thumb {
+  width: 1.15rem;
+  height: 1.15rem;
+  border: 3px solid var(--accent);
+  border-radius: 50%;
+  background: #ffffff;
+  transition: transform 180ms cubic-bezier(0.34, 1.5, 0.6, 1);
+}
+
+.rsf:hover::-webkit-slider-thumb, .rsf:active::-webkit-slider-thumb { transform: scale(1.18); }
+.rsf:hover::-moz-range-thumb, .rsf:active::-moz-range-thumb { transform: scale(1.18); }
+.rsf:focus-visible { outline: 3px solid var(--accent); outline-offset: 6px; }
+
+@media (prefers-reduced-motion: reduce) {
+  .rsf::-webkit-slider-thumb, .rsf::-moz-range-thumb { transition: none; }
+}
+
+@media (forced-colors: active) {
+  .rsf { background: Canvas; border: 1px solid CanvasText; }
+  .rsf::-webkit-slider-thumb { background: Highlight; border-color: CanvasText; }
+  .rsf::-moz-range-thumb { background: Highlight; border-color: CanvasText; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .rsf-wrap { color: #e6e9f2; }
+  .rsf-lede { color: #98a1b3; }
+  .rsf { background: linear-gradient(90deg, var(--accent) 0 var(--v), #2a303c var(--v) 100%); }
+  .rsf::-webkit-slider-thumb { background: #10131a; }
+  .rsf::-moz-range-thumb { background: #10131a; }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #67855.

Adds `submissions/examples/range-slider-fill-advk/` (`demo.html` + `style.css` + `README.md`).

A native `<input type="range">` whose track shows a coloured fill up to the
thumb position.

---

## Type of Change

- [x] 🧩 New component
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/examples/range-slider-fill-advk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A native `<input type="range">` whose track shows a coloured fill up to the
thumb position.

**How does a developer use it?**

```html
<input class="rsf" type="range" min="0" max="100" value="64" style="--v: 64%"
       oninput="this.style.setProperty('--v', this.value + '%')" />
```

One line mirrors the value onto `--v`; the fill follows.

**Why does it fit EaseMotion CSS?**

A filled track is the single most requested range-input style and the one with
the worst cross-browser story. `::-webkit-slider-runnable-track` has no Firefox
counterpart, `::-moz-range-progress` has no WebKit counterpart, and the usual
result is a stylesheet with two divergent implementations that drift apart.

Putting a hard-stop `linear-gradient` on the input's own `background` sidesteps
both. Every engine paints the element background, so one declaration produces the
same fill everywhere, and only the thumb needs vendor-prefixed rules — which
cannot be combined into one selector list anyway, since an unrecognised
pseudo-element invalidates the whole rule.

The control stays a real range input, so keyboard stepping, touch dragging and
the announced value all work without intervention. `--v` is only a visual mirror
of the value, never the source of truth, so the slider still functions correctly
if the script never runs.

`outline-offset: 6px` on focus keeps the ring clear of the thumb's shadow, which
otherwise swallows it at small track heights.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- Passes the repository's own `stylelint` config with no errors; SCSS compiles warning-free.
- Every stylesheet carries a `prefers-reduced-motion` path, and a `forced-colors` path wherever colour encodes state.
- Diff is small and additive — this submission is under 200 lines total.
- Naming uses the `-advk` suffix per the CONTRIBUTING uniqueness rule.
