### PR TITLE
feat: Vertical Timeline (closes #67861)

### DIFF
--- a/submissions/examples/timeline-vertical-advk/README.md
+++ b/submissions/examples/timeline-vertical-advk/README.md
@@ -1,0 +1,38 @@
+# Vertical Timeline
+
+## What does this do?
+
+A changelog rail where each entry fades and rises into place as it enters the
+viewport, using a per-element `view()` scroll timeline.
+
+## How is it used?
+
+```css
+.tml-e {
+  animation: tml-in linear both;
+  animation-timeline: view();
+  animation-range: entry 8% cover 30%;
+}
+```
+
+## Why is it useful?
+
+Reveal-on-scroll is normally an `IntersectionObserver` that toggles a class. That
+works, but it is binary: the element is either revealed or not, so the animation
+plays at a fixed rate regardless of how fast the user is scrolling, and a fast
+flick can leave entries animating after they have already passed.
+
+`animation-timeline: view()` binds progress to the element's own travel through
+the viewport, so the reveal is scrubbed by scroll position. Scroll slowly and it
+eases in slowly; scroll back up and it reverses. `animation-range: entry 8% cover
+30%` states exactly which part of that travel drives it, which is far more legible
+than a threshold buried in observer options.
+
+The distinction from the `scroll()` timeline used in the scroll-spy submission is
+worth noting: `scroll()` tracks the scroll container's overall position, while
+`view()` tracks *this element* relative to the viewport — which is what per-item
+reveals actually want.
+
+Browsers without scroll-driven animation support ignore `animation-timeline` and
+the `both` fill leaves entries at their final state, so the timeline renders fully
+visible rather than blank.

--- a/submissions/examples/timeline-vertical-advk/demo.html
+++ b/submissions/examples/timeline-vertical-advk/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Vertical Timeline</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="tml-wrap">
+  <h1 class="tml-h1">Vertical Timeline</h1>
+  <p class="tml-lede">A changelog rail where each entry reveals as it scrolls into view, using a view() timeline so the reveal tracks the element rather than a global scroll position.</p>
+  <ol class="tml">
+    <li class="tml-e"><time class="tml-d">1.2.0</time><h2 class="tml-t">Motion engine</h2><p class="tml-p">Parser, compiler and runtime for the em attribute DSL.</p></li>
+    <li class="tml-e"><time class="tml-d">1.1.4</time><h2 class="tml-t">SCSS entry point</h2><p class="tml-p">Token maps exposed as Sass variables.</p></li>
+    <li class="tml-e"><time class="tml-d">1.1.0</time><h2 class="tml-t">Component layer</h2><p class="tml-p">Cards, modals, tabs and toasts.</p></li>
+    <li class="tml-e"><time class="tml-d">1.0.0</time><h2 class="tml-t">First release</h2><p class="tml-p">Core animation utilities.</p></li>
+  </ol>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/timeline-vertical-advk/style.css
+++ b/submissions/examples/timeline-vertical-advk/style.css
@@ -1,0 +1,55 @@
+/* Vertical Timeline
+   Entries animate on a view() timeline, so each reveal is driven by that
+   element's own progress through the viewport, not by document scroll. */
+
+.tml-wrap { max-width: 36rem; margin: 0 auto; padding: 3rem 1.25rem 60vh;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif; color: #1a1e27; }
+.tml-h1 { margin: 0 0 0.4em; font-size: clamp(1.5rem, 4.5vw, 2.1rem); letter-spacing: -0.02em; }
+.tml-lede { margin: 0 0 2.5rem; color: #566073; }
+
+.tml { margin: 0; padding: 0 0 0 1.75rem; list-style: none; border-left: 2px solid #e2e6ef; }
+
+.tml-e {
+  position: relative;
+  padding-bottom: 2.75rem;
+  animation: tml-in linear both;
+  animation-timeline: view();
+  animation-range: entry 8% cover 30%;
+}
+
+.tml-e::before {
+  content: "";
+  position: absolute;
+  top: 0.35rem;
+  left: calc(-1.75rem - 7px);
+  width: 12px;
+  height: 12px;
+  border: 2px solid #4c6ef5;
+  border-radius: 50%;
+  background: #ffffff;
+}
+
+.tml-d { font-family: ui-monospace, Menlo, monospace; font-size: 0.78rem; color: #4c6ef5; font-weight: 700; }
+.tml-t { margin: 0.2rem 0 0.35rem; font-size: 1.05rem; }
+.tml-p { margin: 0; font-size: 0.9rem; color: #566073; }
+
+@keyframes tml-in {
+  from { opacity: 0; transform: translateY(1.25rem); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tml-e { animation: none; opacity: 1; transform: none; }
+}
+
+@media (forced-colors: active) {
+  .tml { border-left-color: CanvasText; }
+  .tml-e::before { border-color: CanvasText; background: Canvas; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .tml-wrap { color: #e6e9f2; }
+  .tml-lede, .tml-p { color: #98a1b3; }
+  .tml { border-left-color: #2a303c; }
+  .tml-e::before { background: #10131a; }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #67861.

Adds `submissions/examples/timeline-vertical-advk/` (`demo.html` + `style.css` + `README.md`).

A changelog rail where each entry fades and rises into place as it enters the
viewport, using a per-element `view()` scroll timeline.

---

## Type of Change

- [x] 🧩 New component
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/examples/timeline-vertical-advk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A changelog rail where each entry fades and rises into place as it enters the
viewport, using a per-element `view()` scroll timeline.

**How does a developer use it?**

```css
.tml-e {
  animation: tml-in linear both;
  animation-timeline: view();
  animation-range: entry 8% cover 30%;
}
```

**Why does it fit EaseMotion CSS?**

Reveal-on-scroll is normally an `IntersectionObserver` that toggles a class. That
works, but it is binary: the element is either revealed or not, so the animation
plays at a fixed rate regardless of how fast the user is scrolling, and a fast
flick can leave entries animating after they have already passed.

`animation-timeline: view()` binds progress to the element's own travel through
the viewport, so the reveal is scrubbed by scroll position. Scroll slowly and it
eases in slowly; scroll back up and it reverses. `animation-range: entry 8% cover
30%` states exactly which part of that travel drives it, which is far more legible
than a threshold buried in observer options.

The distinction from the `scroll()` timeline used in the scroll-spy submission is
worth noting: `scroll()` tracks the scroll container's overall position, while
`view()` tracks *this element* relative to the viewport — which is what per-item
reveals actually want.

Browsers without scroll-driven animation support ignore `animation-timeline` and
the `both` fill leaves entries at their final state, so the timeline renders fully
visible rather than blank.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- Passes the repository's own `stylelint` config with no errors; SCSS compiles warning-free.
- Every stylesheet carries a `prefers-reduced-motion` path, and a `forced-colors` path wherever colour encodes state.
- Diff is small and additive — this submission is under 200 lines total.
- Naming uses the `-advk` suffix per the CONTRIBUTING uniqueness rule.
