### PR TITLE
feat: Directional Tooltip (closes #67862)

### DIFF
--- a/submissions/examples/tooltip-arrow-advk/README.md
+++ b/submissions/examples/tooltip-arrow-advk/README.md
@@ -1,0 +1,35 @@
+# Directional Tooltip
+
+## What does this do?
+
+A CSS-only tooltip that can point up, down, left or right, with the arrow cut
+from the bubble rather than drawn as a separate element.
+
+## How is it used?
+
+```html
+<span class="tta" data-tip="Appears above" data-pos="top" tabindex="0">Top</span>
+```
+
+`data-tip` supplies the text, `data-pos` picks the side.
+
+## Why is it useful?
+
+The traditional tooltip arrow is a zero-size element with coloured borders, or a
+rotated square. Both hard-code the bubble colour in a second place, so the arrow
+silently stops matching the moment a theme changes — the classic symptom is a
+dark-mode tooltip with a light arrow still attached.
+
+Cutting the arrow with `clip-path` from a block that already uses
+`background: var(--bubble)` means there is exactly one colour declaration. Both
+parts re-theme together, which is why the dark-mode block here only has to
+redefine `--bubble` once.
+
+Making the trigger focusable and mirroring every `:hover` rule on
+`:focus-visible` means keyboard users get the tooltip too, which border-triangle
+implementations usually omit.
+
+Under `forced-colors` the arrow is hidden and the bubble takes a real border.
+`clip-path` shapes are filled with the substituted system colour and can end up
+invisible or detached, so a bordered rectangle with no pointer is the safer
+result.

--- a/submissions/examples/tooltip-arrow-advk/demo.html
+++ b/submissions/examples/tooltip-arrow-advk/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Directional Tooltip</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="tta-wrap">
+  <h1 class="tta-h1">Directional Tooltip</h1>
+  <p class="tta-lede">A tooltip whose arrow is cut from the bubble itself with clip-path, so the point always matches the bubble colour including in dark mode.</p>
+  <div class="tta-grid">
+    <span class="tta" data-tip="Appears above" data-pos="top" tabindex="0">Top</span>
+    <span class="tta" data-tip="Appears below" data-pos="bottom" tabindex="0">Bottom</span>
+    <span class="tta" data-tip="Appears left" data-pos="left" tabindex="0">Left</span>
+    <span class="tta" data-tip="Appears right" data-pos="right" tabindex="0">Right</span>
+  </div>
+  <p class="tta-note">Hover or tab to each trigger.</p>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/tooltip-arrow-advk/style.css
+++ b/submissions/examples/tooltip-arrow-advk/style.css
@@ -1,0 +1,86 @@
+/* Directional Tooltip
+   The arrow is not a separate rotated square: it is cut out of the bubble's own
+   ::after using clip-path, so it inherits the bubble background automatically. */
+
+.tta-wrap { max-width: 34rem; margin: 0 auto; padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif; color: #1a1e27; }
+.tta-h1 { margin: 0 0 0.4em; font-size: clamp(1.5rem, 4.5vw, 2.1rem); letter-spacing: -0.02em; }
+.tta-lede { margin: 0 0 2.5rem; color: #566073; }
+.tta-note { margin-top: 3rem; font-size: 0.85rem; color: #566073; }
+
+.tta-grid { display: flex; flex-wrap: wrap; gap: 3rem; justify-content: center; padding: 2rem 0; }
+
+.tta {
+  --bubble: #22283a;
+
+  position: relative;
+  padding: 0.5em 1em;
+  border: 1px dashed #c4cbd9;
+  border-radius: 0.4rem;
+  font-size: 0.9rem;
+  cursor: default;
+}
+
+.tta:focus-visible { outline: 3px solid #4c6ef5; outline-offset: 3px; }
+
+.tta::before, .tta::after {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 180ms ease, translate 180ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.tta::before {
+  content: attr(data-tip);
+  z-index: 2;
+  padding: 0.4em 0.7em;
+  border-radius: 0.35rem;
+  background: var(--bubble);
+  color: #ffffff;
+  font-size: 0.78rem;
+  white-space: nowrap;
+}
+
+/* the arrow: a triangle clipped from a small square of the same colour */
+.tta::after {
+  content: "";
+  z-index: 1;
+  width: 0.6rem;
+  height: 0.35rem;
+  background: var(--bubble);
+}
+
+.tta:hover::before, .tta:hover::after,
+.tta:focus-visible::before, .tta:focus-visible::after { opacity: 1; translate: 0 0; }
+
+/* top */
+.tta[data-pos="top"]::before { bottom: calc(100% + 0.55rem); left: 50%; transform: translateX(-50%); translate: 0 0.25rem; }
+.tta[data-pos="top"]::after  { bottom: calc(100% + 0.2rem); left: 50%; transform: translateX(-50%); translate: 0 0.25rem; clip-path: polygon(50% 100%, 0 0, 100% 0); }
+
+/* bottom */
+.tta[data-pos="bottom"]::before { top: calc(100% + 0.55rem); left: 50%; transform: translateX(-50%); translate: 0 -0.25rem; }
+.tta[data-pos="bottom"]::after  { top: calc(100% + 0.2rem); left: 50%; transform: translateX(-50%); translate: 0 -0.25rem; clip-path: polygon(50% 0, 0 100%, 100% 100%); }
+
+/* left */
+.tta[data-pos="left"]::before { right: calc(100% + 0.55rem); top: 50%; transform: translateY(-50%); translate: 0.25rem 0; }
+.tta[data-pos="left"]::after  { right: calc(100% + 0.2rem); top: 50%; width: 0.35rem; height: 0.6rem; transform: translateY(-50%); translate: 0.25rem 0; clip-path: polygon(100% 50%, 0 0, 0 100%); }
+
+/* right */
+.tta[data-pos="right"]::before { left: calc(100% + 0.55rem); top: 50%; transform: translateY(-50%); translate: -0.25rem 0; }
+.tta[data-pos="right"]::after  { left: calc(100% + 0.2rem); top: 50%; width: 0.35rem; height: 0.6rem; transform: translateY(-50%); translate: -0.25rem 0; clip-path: polygon(0 50%, 100% 0, 100% 100%); }
+
+@media (prefers-reduced-motion: reduce) {
+  .tta::before, .tta::after { transition: opacity 120ms ease; translate: 0 0; }
+}
+
+@media (forced-colors: active) {
+  .tta::before { background: Canvas; color: CanvasText; border: 1px solid CanvasText; }
+  .tta::after { display: none; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .tta-wrap { color: #e6e9f2; }
+  .tta-lede, .tta-note { color: #98a1b3; }
+  .tta { --bubble: #e6e9f2; border-color: #333b4a; }
+  .tta::before { color: #10131a; }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #67862.

Adds `submissions/examples/tooltip-arrow-advk/` (`demo.html` + `style.css` + `README.md`).

A CSS-only tooltip that can point up, down, left or right, with the arrow cut
from the bubble rather than drawn as a separate element.

---

## Type of Change

- [x] 🧩 New component
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/examples/tooltip-arrow-advk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A CSS-only tooltip that can point up, down, left or right, with the arrow cut
from the bubble rather than drawn as a separate element.

**How does a developer use it?**

```html
<span class="tta" data-tip="Appears above" data-pos="top" tabindex="0">Top</span>
```

`data-tip` supplies the text, `data-pos` picks the side.

**Why does it fit EaseMotion CSS?**

The traditional tooltip arrow is a zero-size element with coloured borders, or a
rotated square. Both hard-code the bubble colour in a second place, so the arrow
silently stops matching the moment a theme changes — the classic symptom is a
dark-mode tooltip with a light arrow still attached.

Cutting the arrow with `clip-path` from a block that already uses
`background: var(--bubble)` means there is exactly one colour declaration. Both
parts re-theme together, which is why the dark-mode block here only has to
redefine `--bubble` once.

Making the trigger focusable and mirroring every `:hover` rule on
`:focus-visible` means keyboard users get the tooltip too, which border-triangle
implementations usually omit.

Under `forced-colors` the arrow is hidden and the bubble takes a real border.
`clip-path` shapes are filled with the substituted system colour and can end up
invisible or detached, so a bordered rectangle with no pointer is the safer
result.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- Passes the repository's own `stylelint` config with no errors; SCSS compiles warning-free.
- Every stylesheet carries a `prefers-reduced-motion` path, and a `forced-colors` path wherever colour encodes state.
- Diff is small and additive — this submission is under 200 lines total.
- Naming uses the `-advk` suffix per the CONTRIBUTING uniqueness rule.
