### PR TITLE
feat(examples): add CSS-only animated skeleton loader screen

### DIFF
--- a/submissions/examples/skeleton-loader-harrshita/README.md
+++ b/submissions/examples/skeleton-loader-harrshita/README.md
@@ -1,0 +1,57 @@
+# CSS Skeleton Loader
+
+Pure CSS animated skeleton screen components for EaseMotion CSS.
+
+## Usage
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<!-- Card skeleton -->
+<div class="ease-skeleton ease-skeleton--card">
+  <div class="ease-skeleton__img ease-skeleton--shimmer"></div>
+  <div class="ease-skeleton__body">
+    <div class="ease-skeleton__text ease-skeleton--shimmer" style="width:70%"></div>
+    <div class="ease-skeleton__text ease-skeleton--shimmer" style="width:90%"></div>
+  </div>
+</div>
+
+<!-- Profile skeleton -->
+<div class="ease-skeleton ease-skeleton--profile">
+  <div class="ease-skeleton__circle ease-skeleton--shimmer"></div>
+  <div class="ease-skeleton__info">
+    <div class="ease-skeleton__text ease-skeleton--shimmer" style="width:50%"></div>
+  </div>
+</div>
+```
+
+## CSS Classes
+
+| Class | Description |
+|-------|-------------|
+| `.ease-skeleton` | Base wrapper |
+| `.ease-skeleton--shimmer` | Shimmer animation modifier |
+| `.ease-skeleton--card` | Card layout (image + body) |
+| `.ease-skeleton--profile` | Profile row (avatar + info) |
+| `.ease-skeleton--text-block` | Paragraph text block |
+| `.ease-skeleton__img` | Image placeholder |
+| `.ease-skeleton__circle` | Circle avatar placeholder |
+| `.ease-skeleton__text` | Text line placeholder |
+| `.ease-skeleton__body` | Card body wrapper |
+| `.ease-skeleton__info` | Profile info column |
+
+## CSS Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `--ease-sk-base` | `#e8e8f0` | Base background color |
+| `--ease-sk-shine` | `#f4f4ff` | Shimmer highlight color |
+| `--ease-sk-radius` | `8px` | Border radius |
+| `--ease-sk-speed` | `1.6s` | Animation duration |
+| `--ease-sk-shadow` | box-shadow | Card shadow |
+
+## Dark Mode
+
+Automatic via `prefers-color-scheme: dark`.
+
+Closes #67717

--- a/submissions/examples/skeleton-loader-harrshita/demo.html
+++ b/submissions/examples/skeleton-loader-harrshita/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+  <title>Skeleton Loader | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css"/>
+</head>
+<body>
+  <header class="demo-header">
+    <h1>CSS Skeleton Loader</h1>
+    <p>Pure CSS animated skeleton screens for loading states.</p>
+  </header>
+  <main class="demo-main">
+
+    <section class="demo-section">
+      <h2>Card Skeleton</h2>
+      <div class="ease-skeleton ease-skeleton--card">
+        <div class="ease-skeleton__img ease-skeleton--shimmer"></div>
+        <div class="ease-skeleton__body">
+          <div class="ease-skeleton__text ease-skeleton--shimmer" style="width:60%"></div>
+          <div class="ease-skeleton__text ease-skeleton--shimmer" style="width:90%"></div>
+          <div class="ease-skeleton__text ease-skeleton--shimmer" style="width:75%"></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="demo-section">
+      <h2>Profile Skeleton</h2>
+      <div class="ease-skeleton ease-skeleton--profile">
+        <div class="ease-skeleton__circle ease-skeleton--shimmer"></div>
+        <div class="ease-skeleton__info">
+          <div class="ease-skeleton__text ease-skeleton--shimmer" style="width:40%"></div>
+          <div class="ease-skeleton__text ease-skeleton--shimmer" style="width:65%"></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="demo-section">
+      <h2>Text Block Skeleton</h2>
+      <div class="ease-skeleton ease-skeleton--text-block">
+        <div class="ease-skeleton__text ease-skeleton--shimmer" style="width:80%"></div>
+        <div class="ease-skeleton__text ease-skeleton--shimmer" style="width:95%"></div>
+        <div class="ease-skeleton__text ease-skeleton--shimmer" style="width:70%"></div>
+        <div class="ease-skeleton__text ease-skeleton--shimmer" style="width:85%"></div>
+      </div>
+    </section>
+
+    <section class="demo-section">
+      <h2>Usage</h2>
+      <pre><code>&lt;div class="ease-skeleton ease-skeleton--card"&gt;
+  &lt;div class="ease-skeleton__img ease-skeleton--shimmer"&gt;&lt;/div&gt;
+  &lt;div class="ease-skeleton__body"&gt;
+    &lt;div class="ease-skeleton__text ease-skeleton--shimmer"&gt;&lt;/div&gt;
+  &lt;/div&gt;
+&lt;/div&gt;</code></pre>
+    </section>
+
+  </main>
+  <footer class="demo-footer">
+    <p>EaseMotion CSS &mdash; Motion without overhead.</p>
+  </footer>
+</body>
+</html>

--- a/submissions/examples/skeleton-loader-harrshita/style.css
+++ b/submissions/examples/skeleton-loader-harrshita/style.css
@@ -1,0 +1,100 @@
+/* =====================================================
+   EaseMotion CSS: Skeleton Loader Component
+   Issue: #67717
+   ===================================================== */
+:root {
+  --ease-sk-base:    #e8e8f0;
+  --ease-sk-shine:   #f4f4ff;
+  --ease-sk-radius:  8px;
+  --ease-sk-speed:   1.6s;
+  --ease-sk-shadow:  0 2px 12px rgba(0,0,0,0.07);
+}
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+body {
+  font-family: 'Segoe UI', Tahoma, sans-serif;
+  background: #f4f3ff;
+  color: #2d2d44;
+  line-height: 1.6;
+}
+.demo-header {
+  background: #6c63ff; color: #fff;
+  padding: 2.5rem 2rem; text-align: center;
+}
+.demo-header h1 { font-size: 2rem; margin-bottom: .4rem; }
+.demo-main { max-width: 680px; margin: 2rem auto; padding: 0 1.5rem; }
+.demo-section {
+  background: #fff; border-radius: 12px;
+  box-shadow: var(--ease-sk-shadow);
+  padding: 1.8rem; margin-bottom: 1.8rem;
+}
+.demo-section h2 {
+  font-size: 1.1rem; color: #6c63ff;
+  border-bottom: 2px solid #ede9ff;
+  padding-bottom: .4rem; margin-bottom: 1.2rem;
+}
+pre {
+  background: #1e1e2e; color: #cdd6f4;
+  padding: 1rem 1.2rem; border-radius: 8px;
+  font-size: .85rem; overflow-x: auto;
+}
+.demo-footer {
+  text-align: center; color: #999;
+  padding: 1.5rem; font-size: .85rem;
+}
+
+/* -- Shimmer animation -- */
+@keyframes ease-shimmer {
+  0%   { background-position: -400px 0; }
+  100% { background-position:  400px 0; }
+}
+
+/* -- Base skeleton block -- */
+.ease-skeleton { width: 100%; }
+
+.ease-skeleton--shimmer {
+  background: linear-gradient(
+    90deg,
+    var(--ease-sk-base) 25%,
+    var(--ease-sk-shine) 50%,
+    var(--ease-sk-base) 75%
+  );
+  background-size: 800px 100%;
+  animation: ease-shimmer var(--ease-sk-speed) infinite linear;
+  border-radius: var(--ease-sk-radius);
+}
+
+/* -- Card layout -- */
+.ease-skeleton--card {
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: var(--ease-sk-shadow);
+}
+.ease-skeleton__img {
+  width: 100%; height: 180px;
+  border-radius: 0;
+}
+.ease-skeleton__body { padding: 1rem; display: flex; flex-direction: column; gap: .7rem; }
+
+/* -- Text lines -- */
+.ease-skeleton__text { height: 14px; border-radius: 6px; }
+
+/* -- Profile layout -- */
+.ease-skeleton--profile { display: flex; align-items: center; gap: 1rem; }
+.ease-skeleton__circle {
+  width: 56px; height: 56px;
+  border-radius: 50%; flex-shrink: 0;
+}
+.ease-skeleton__info { flex: 1; display: flex; flex-direction: column; gap: .65rem; }
+
+/* -- Text block -- */
+.ease-skeleton--text-block { display: flex; flex-direction: column; gap: .75rem; }
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ease-sk-base:  #2a2a40;
+    --ease-sk-shine: #34345a;
+  }
+  body { background: #13131f; color: #e0e0ff; }
+  .demo-section { background: #1a1a2e; }
+}


### PR DESCRIPTION
## Summary
Adds a pure CSS animated skeleton loader screen component.

## Changes
- `demo.html` - Card, profile, and text block skeleton demos
- `style.css` - Shimmer @keyframes, CSS variables, dark mode
- `README.md` - CSS class table and variable reference

## Checklist
- [x] Files under `submissions/examples/skeleton-loader-harrshita/`
- [x] demo.html has DOCTYPE, html, head, body tags
- [x] style.css contains original CSS (shimmer animation)
- [x] No .github/ or docs/ modifications
- [x] Dark mode support
- [x] More than 50 lines added

Closes #67717
