### PR TITLE
feat(examples): add CSS glassmorphism card component

### DIFF
--- a/submissions/examples/glass-card-harrshita/README.md
+++ b/submissions/examples/glass-card-harrshita/README.md
@@ -1,0 +1,50 @@
+# CSS Glassmorphism Card
+
+Frosted glass card component using `backdrop-filter` and CSS variables for EaseMotion CSS.
+
+## Usage
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<!-- Place cards over a colorful background for full effect -->
+<div style="background: linear-gradient(135deg, #6c63ff, #f5576c); padding: 2rem;">
+  <div class="ease-glass">
+    <div class="ease-glass__icon">&#127776;</div>
+    <div class="ease-glass__title">Card Title</div>
+    <div class="ease-glass__body">Card body content goes here.</div>
+    <div class="ease-glass__footer"><span class="ease-glass__tag">Tag</span></div>
+  </div>
+</div>
+```
+
+## CSS Classes
+
+| Class | Description |
+|-------|-------------|
+| `.ease-glass` | Standard glass card |
+| `.ease-glass--dark` | Dark frosted variant |
+| `.ease-glass--sm` | Compact small variant |
+| `.ease-glass__icon` | Emoji or SVG icon |
+| `.ease-glass__title` | Card heading |
+| `.ease-glass__body` | Card content text |
+| `.ease-glass__footer` | Card footer row |
+| `.ease-glass__tag` | Small badge tag |
+
+## CSS Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `--ease-gl-blur` | `14px` | Blur intensity |
+| `--ease-gl-bg` | `rgba(255,255,255,0.18)` | Card background |
+| `--ease-gl-border` | `rgba(255,255,255,0.30)` | Card border |
+| `--ease-gl-radius` | `18px` | Border radius |
+| `--ease-gl-shadow` | box-shadow | Card shadow |
+| `--ease-gl-transition` | `0.3s ease` | Hover animation speed |
+
+## Browser Compatibility
+
+`backdrop-filter` is supported in all modern browsers.
+A graceful fallback uses `rgba(255,255,255,0.75)` for unsupported browsers via `@supports`.
+
+Closes #67719

--- a/submissions/examples/glass-card-harrshita/demo.html
+++ b/submissions/examples/glass-card-harrshita/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+  <title>Glassmorphism Card | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css"/>
+</head>
+<body>
+  <div class="demo-bg">
+    <header class="demo-header">
+      <h1>CSS Glassmorphism Card</h1>
+      <p>Frosted glass cards using backdrop-filter and CSS variables.</p>
+    </header>
+
+    <main class="demo-main">
+      <section class="demo-section">
+        <h2>Standard Variants</h2>
+        <div class="demo-grid">
+          <div class="ease-glass">
+            <div class="ease-glass__icon">&#127776;</div>
+            <div class="ease-glass__title">Sunrise Mode</div>
+            <div class="ease-glass__body">Start your day with a gentle gradient and frosted panels.</div>
+            <div class="ease-glass__footer"><span class="ease-glass__tag">Light</span></div>
+          </div>
+          <div class="ease-glass ease-glass--dark">
+            <div class="ease-glass__icon">&#127768;</div>
+            <div class="ease-glass__title">Night Mode</div>
+            <div class="ease-glass__body">Dark frosted glass panel for low-light environments.</div>
+            <div class="ease-glass__footer"><span class="ease-glass__tag">Dark</span></div>
+          </div>
+          <div class="ease-glass ease-glass--sm">
+            <div class="ease-glass__title">Compact</div>
+            <div class="ease-glass__body">A smaller glass card for tight layouts.</div>
+          </div>
+        </div>
+      </section>
+
+      <section class="demo-section demo-section--plain">
+        <h2>Usage</h2>
+        <pre><code>&lt;div class="ease-glass"&gt;
+  &lt;div class="ease-glass__icon"&gt;...&lt;/div&gt;
+  &lt;div class="ease-glass__title"&gt;Title&lt;/div&gt;
+  &lt;div class="ease-glass__body"&gt;Content&lt;/div&gt;
+  &lt;div class="ease-glass__footer"&gt;...&lt;/div&gt;
+&lt;/div&gt;</code></pre>
+      </section>
+    </main>
+  </div>
+</body>
+</html>

--- a/submissions/examples/glass-card-harrshita/style.css
+++ b/submissions/examples/glass-card-harrshita/style.css
@@ -1,0 +1,73 @@
+/* =====================================================
+   EaseMotion CSS: Glassmorphism Card
+   Issue: #67719
+   ===================================================== */
+:root {
+  --ease-gl-blur:       14px;
+  --ease-gl-bg:         rgba(255,255,255,0.18);
+  --ease-gl-border:     rgba(255,255,255,0.30);
+  --ease-gl-shadow:     0 8px 32px rgba(31,38,135,0.22);
+  --ease-gl-radius:     18px;
+  --ease-gl-text:       #1a1a2e;
+  --ease-gl-transition: 0.3s ease;
+  --ease-gl-dark-bg:    rgba(10,10,30,0.45);
+  --ease-gl-dark-border:rgba(255,255,255,0.12);
+}
+*, *::before, *::after { box-sizing:border-box; margin:0; padding:0; }
+body { font-family:'Segoe UI',Tahoma,sans-serif; min-height:100vh; }
+.demo-bg {
+  min-height:100vh;
+  background: linear-gradient(135deg, #6c63ff 0%, #f093fb 40%, #f5576c 70%, #fda085 100%);
+}
+.demo-header { padding:3rem 2rem; text-align:center; color:#fff; }
+.demo-header h1 { font-size:2.2rem; font-weight:700; margin-bottom:.5rem; text-shadow:0 2px 8px rgba(0,0,0,.2); }
+.demo-header p { opacity:.9; font-size:1.05rem; }
+.demo-main { max-width:900px; margin:0 auto; padding:1rem 1.5rem 3rem; }
+.demo-section { margin-bottom:2rem; }
+.demo-section h2 { color:#fff; font-size:1.1rem; margin-bottom:1.2rem; }
+.demo-section--plain h2 { color:#fff; }
+.demo-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:1.5rem; }
+pre { background:rgba(0,0,0,.4); color:#f8f8f2; padding:1rem 1.2rem; border-radius:10px; font-size:.85rem; overflow-x:auto; }
+
+/* Base glass card */
+.ease-glass {
+  padding:1.8rem 1.5rem;
+  background:var(--ease-gl-bg);
+  border:1px solid var(--ease-gl-border);
+  border-radius:var(--ease-gl-radius);
+  box-shadow:var(--ease-gl-shadow);
+  color:var(--ease-gl-text);
+  backdrop-filter:blur(var(--ease-gl-blur));
+  -webkit-backdrop-filter:blur(var(--ease-gl-blur));
+  transition: transform var(--ease-gl-transition), box-shadow var(--ease-gl-transition);
+  display:flex; flex-direction:column; gap:.8rem;
+}
+@supports not (backdrop-filter:blur(1px)) {
+  .ease-glass { background:rgba(255,255,255,0.75); }
+}
+.ease-glass:hover {
+  transform:translateY(-6px);
+  box-shadow:0 16px 40px rgba(31,38,135,0.3);
+}
+
+/* Dark variant */
+.ease-glass--dark {
+  background:var(--ease-gl-dark-bg);
+  border-color:var(--ease-gl-dark-border);
+  color:#e0e0ff;
+}
+
+/* Small variant */
+.ease-glass--sm { padding:1.1rem 1.1rem; border-radius:12px; }
+
+/* Inner elements */
+.ease-glass__icon { font-size:2rem; line-height:1; }
+.ease-glass__title { font-size:1.1rem; font-weight:700; }
+.ease-glass__body { font-size:.93rem; opacity:.85; line-height:1.55; }
+.ease-glass__footer { margin-top:.3rem; }
+.ease-glass__tag {
+  display:inline-block; font-size:.72rem; font-weight:700;
+  padding:.2rem .65rem; border-radius:20px;
+  background:rgba(255,255,255,0.25); border:1px solid rgba(255,255,255,0.35);
+  letter-spacing:.04em;
+}


### PR DESCRIPTION
## Summary
Adds a glassmorphism card component using backdrop-filter and CSS variables.

## Changes
- `demo.html` - Cards over gradient background showing light, dark, and compact variants
- `style.css` - backdrop-filter blur, CSS variables, hover lift, @supports fallback
- `README.md` - Class and variable reference, browser compatibility notes

## Checklist
- [x] Files under `submissions/examples/glass-card-harrshita/`
- [x] demo.html has DOCTYPE, html, head, body tags
- [x] Original CSS with backdrop-filter and @supports fallback
- [x] No protected directory modifications
- [x] 3 variants: standard, dark, compact

Closes #67719
