### PR TITLE
feat: add ease-cookie-banner-sap

### DIFF
--- a/submissions/examples/ease-cookie-banner-sap/README.md
+++ b/submissions/examples/ease-cookie-banner-sap/README.md
@@ -1,0 +1,18 @@
+# ease-cookie-banner-sap
+
+A cookie-consent banner that slides up from off-screen after a short delay, with accept/decline actions that dismiss it back down.
+
+## Usage
+1. Include `style.css`.
+2. Add markup: banner container with message + accept/decline buttons.
+3. Attach the delayed-show and dismiss handlers from `demo.html`.
+
+## Customization
+- `setTimeout(..., 600)`: delay before the banner appears.
+- Banner width/position (`bottom`, `left: 50%`) for corner vs centered placement.
+- Button colors/labels for accept vs decline styling.
+
+## Notes
+- Off-screen resting position uses `transform: translate(-50%, 140%)` (below viewport) rather than `display: none`, so the slide-up transition has something to animate from.
+- Both buttons call the same `dismiss()` function — in a real integration, `acceptBtn` and `declineBtn` would additionally set a cookie/localStorage flag before dismissing.
+- Respects `prefers-reduced-motion`: banner transform transition is removed (banner still needs a visibility mechanism, so in a stricter build this would toggle instantly via opacity or `display` instead); button hover lift is unaffected as it's a minor interaction cue, only bg-color transition remains.

--- a/submissions/examples/ease-cookie-banner-sap/demo.html
+++ b/submissions/examples/ease-cookie-banner-sap/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-cookie-banner-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      height: 100vh;
+      margin: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #f4f4f5;
+      font-family: system-ui, sans-serif;
+    }
+  </style>
+</head>
+<body>
+
+  <p style="color:#555;">The cookie banner slides up from the bottom after a short delay.</p>
+
+  <div class="cookie-banner-sap" id="cookieBanner">
+    <p>We use cookies to improve your experience on this site. By continuing to browse, you agree to our use of cookies.</p>
+    <div class="banner-actions">
+      <button class="decline-btn" id="declineBtn">Decline</button>
+      <button class="accept-btn" id="acceptBtn">Accept All</button>
+    </div>
+  </div>
+
+  <script>
+    const banner = document.getElementById('cookieBanner');
+    const acceptBtn = document.getElementById('acceptBtn');
+    const declineBtn = document.getElementById('declineBtn');
+
+    setTimeout(() => banner.classList.add('visible'), 600);
+
+    function dismiss() {
+      banner.classList.remove('visible');
+    }
+
+    acceptBtn.addEventListener('click', dismiss);
+    declineBtn.addEventListener('click', dismiss);
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-cookie-banner-sap/style.css
+++ b/submissions/examples/ease-cookie-banner-sap/style.css
@@ -1,0 +1,71 @@
+.cookie-banner-sap {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  width: min(480px, calc(100% - 48px));
+  transform: translate(-50%, 140%);
+  background: #111;
+  color: #fff;
+  border-radius: 16px;
+  padding: 22px 24px;
+  box-shadow: 0 20px 50px rgba(0,0,0,0.3);
+  font-family: system-ui, sans-serif;
+  transition: transform 0.5s cubic-bezier(0.2, 0.8, 0.3, 1);
+  z-index: 1000;
+}
+
+.cookie-banner-sap.visible {
+  transform: translate(-50%, 0);
+}
+
+.cookie-banner-sap p {
+  margin: 0 0 16px;
+  font-size: 14px;
+  line-height: 1.6;
+  color: #d4d4d8;
+}
+
+.cookie-banner-sap .banner-actions {
+  display: flex;
+  gap: 10px;
+}
+
+.cookie-banner-sap button {
+  flex: 1;
+  padding: 10px 16px;
+  border: none;
+  border-radius: 10px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, background 0.2s ease;
+}
+
+.cookie-banner-sap .accept-btn {
+  background: #2563eb;
+  color: #fff;
+}
+
+.cookie-banner-sap .accept-btn:hover {
+  background: #3b82f6;
+  transform: translateY(-2px);
+}
+
+.cookie-banner-sap .decline-btn {
+  background: transparent;
+  color: #d4d4d8;
+  border: 1px solid #3f3f46;
+}
+
+.cookie-banner-sap .decline-btn:hover {
+  background: #1f1f23;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cookie-banner-sap {
+    transition: none;
+  }
+  .cookie-banner-sap button {
+    transition: background 0.2s ease;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-cookie-banner-sap`, a slide-up cookie consent banner with accept/decline actions.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-cookie-banner-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Off-screen state uses a `transform` offset (not `display: none`), giving the slide-in transition an actual starting position to animate from.
- Accept/decline both call a shared `dismiss()` — flagged in the README as the integration point for actual consent-storage logic.
- `prefers-reduced-motion` removes the slide transition; button hover retains only background-color feedback.

## Feature Description

Adds a reusable animated cookie consent banner component.

Level: Intermediate

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.