### PR TITLE
Add ease-swimming-lap-counter component

### DIFF
--- a/submissions/examples/swimming-lap-counter-ij/README.md
+++ b/submissions/examples/swimming-lap-counter-ij/README.md
@@ -1,0 +1,10 @@
+# ease-swimming-lap-counter
+
+A swimming lap counter where the lap digits tick, the lane lines glide, and the split tag blinks.
+
+## Run
+Open `demo.html` directly in a browser to watch the laps tick.
+
+## Notes
+- The lap digits tick upward.
+- The split tag blinks beneath.

--- a/submissions/examples/swimming-lap-counter-ij/demo.html
+++ b/submissions/examples/swimming-lap-counter-ij/demo.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-swimming-lap-counter demo</title>
+</head>
+<body>
+<div class="swm-deck">
+  <span class="swm-title">LAP TRACKER</span>
+  <div class="swm-display">
+    <span class="swm-laps">12</span>
+  </div>
+  <div class="swm-pool">
+    <span class="swm-lane"></span>
+    <span class="swm-lane"></span>
+    <span class="swm-lane"></span>
+  </div>
+  <span class="swm-split">50.4</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/swimming-lap-counter-ij/style.css
+++ b/submissions/examples/swimming-lap-counter-ij/style.css
@@ -1,0 +1,15 @@
+:root{--swm-aqua:#3de6c6;--swm-dark:#0a1210}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#0a1210,#060b0a);font-family:'Arial Black',sans-serif}
+.swm-deck{position:relative;width:360px;height:400px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#12221e,#0a1412);box-shadow:0 16px 34px rgba(0,0,0,0.6)}
+.swm-title{position:absolute;top:18px;left:0;right:0;text-align:center;font-size:13px;font-weight:700;letter-spacing:8px;color:#3de6c6}
+.swm-display{position:absolute;top:74px;left:50%;margin-left:-92px;width:184px;height:104px;border-radius:16px;background:#0d1c18;box-shadow:inset 0 0 0 4px #1c3a30;display:grid;place-items:center}
+.swm-laps{font-size:48px;font-weight:700;color:#3de6c6;animation:lap-tick-swimming-lap-counter 2s steps(1) infinite}
+.swm-pool{position:absolute;top:220px;left:50%;margin-left:-120px;width:240px;height:72px;border-radius:10px;background:#0a1614;box-shadow:inset 0 0 0 3px #1c3a30;overflow:hidden}
+.swm-lane{position:absolute;top:0;bottom:0;width:40%;border-right:2px dashed #3de6c6;animation:lane-glide-swimming-lap-counter 2.4s linear infinite}
+.swm-lane:nth-child(1){left:0}
+.swm-lane:nth-child(2){left:55%;animation-delay:0.8s}
+.swm-lane:nth-child(3){left:110%;animation-delay:1.6s}
+.swm-split{position:absolute;bottom:18px;left:0;right:0;text-align:center;font-size:13px;font-weight:700;letter-spacing:5px;color:#3de6c6;animation:split-blink-swimming-lap-counter 1s steps(1) infinite}
+@keyframes lap-tick-swimming-lap-counter{0%,49%{opacity:1}50%,100%{opacity:0.3}}
+@keyframes lane-glide-swimming-lap-counter{0%{left:-40%}100%{left:110%}}
+@keyframes split-blink-swimming-lap-counter{0%,49%{opacity:1}50%,100%{opacity:0.3}}


### PR DESCRIPTION
## Component: ease-swimming-lap-counter — laps tick, lanes glide, and split blinks

**Closes #67920**

### What this adds
A swimming lap counter: the lap digits tick, the lane lines glide, and the split tag blinks.

### Acceptance Criteria covered
- Lap digits tick upward
- Lane lines glide across
- Split tag blinks beneath

### Files
- `submissions/examples/swimming-lap-counter-ij/demo.html`
- `submissions/examples/swimming-lap-counter-ij/style.css`
- `submissions/examples/swimming-lap-counter-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the laps tick.