### PR TITLE
feat(examples): add animated CSS counter and number ticker component

### DIFF
--- a/submissions/examples/number-counter-harrshita/README.md
+++ b/submissions/examples/number-counter-harrshita/README.md
@@ -1,0 +1,64 @@
+# Animated Number Counter
+
+CSS-animated number counter that counts up when it enters the viewport, using
+Intersection Observer and CSS keyframes.
+
+## Usage
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<div class="ease-counter" data-target="10000" data-suffix="+">
+  <div class="ease-counter__icon">&#128101;</div>
+  <div class="ease-counter__value" aria-live="polite">0</div>
+  <div class="ease-counter__label">Users</div>
+</div>
+
+<script>
+  // Intersection Observer triggers animation when counter enters viewport
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach(e => {
+      if (e.isIntersecting && !e.target.dataset.animated) {
+        e.target.dataset.animated = "1";
+        animateCounter(e.target);
+      }
+    });
+  }, { threshold: 0.3 });
+  document.querySelectorAll(".ease-counter").forEach(el => observer.observe(el));
+</script>
+```
+
+## Data Attributes
+
+| Attribute | Description |
+|-----------|-------------|
+| `data-target` | Target number to count up to |
+| `data-suffix` | Optional suffix (e.g., `+`, `%`, `K`) |
+
+## CSS Classes
+
+| Class | Description |
+|-------|-------------|
+| `.ease-counter` | Counter card wrapper |
+| `.ease-counter__icon` | Emoji or SVG icon |
+| `.ease-counter__value` | The animating number |
+| `.ease-counter__label` | Descriptive label |
+| `.ease-counter--animated` | Added by JS to trigger CSS animation |
+| `.ease-counter-grid` | Grid layout wrapper for multiple counters |
+
+## CSS Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `--ease-ct-accent` | `#6c63ff` | Number color |
+| `--ease-ct-radius` | `14px` | Card border radius |
+| `--ease-ct-shadow` | box-shadow | Card shadow |
+| `--ease-ct-duration` | `2000` | Count-up duration in ms |
+
+## Accessibility
+
+- `aria-live="polite"` on the value element announces updates to screen readers
+- Static `0` shown without JS
+- Animation disabled via `prefers-reduced-motion`
+
+Closes #67720

--- a/submissions/examples/number-counter-harrshita/demo.html
+++ b/submissions/examples/number-counter-harrshita/demo.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+  <title>Animated Number Counter | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css"/>
+</head>
+<body>
+  <header class="demo-header">
+    <h1>Animated Number Counter</h1>
+    <p>CSS-animated counters that count up when they enter the viewport.</p>
+  </header>
+  <main class="demo-main">
+    <section class="demo-section">
+      <h2>Live Demo</h2>
+      <div class="ease-counter-grid">
+        <div class="ease-counter" data-target="12500" data-suffix="+">
+          <div class="ease-counter__icon">&#128101;</div>
+          <div class="ease-counter__value" aria-live="polite">0</div>
+          <div class="ease-counter__label">Active Users</div>
+        </div>
+        <div class="ease-counter" data-target="850" data-suffix="">
+          <div class="ease-counter__icon">&#11088;</div>
+          <div class="ease-counter__value" aria-live="polite">0</div>
+          <div class="ease-counter__label">GitHub Stars</div>
+        </div>
+        <div class="ease-counter" data-target="300" data-suffix="+">
+          <div class="ease-counter__icon">&#127381;</div>
+          <div class="ease-counter__value" aria-live="polite">0</div>
+          <div class="ease-counter__label">Components</div>
+        </div>
+        <div class="ease-counter" data-target="99" data-suffix="%">
+          <div class="ease-counter__icon">&#9989;</div>
+          <div class="ease-counter__value" aria-live="polite">0</div>
+          <div class="ease-counter__label">Uptime</div>
+        </div>
+      </div>
+    </section>
+
+    <section class="demo-section">
+      <h2>Usage</h2>
+      <pre><code>&lt;div class="ease-counter" data-target="1000" data-suffix="+"&gt;
+  &lt;div class="ease-counter__icon"&gt;&#128101;&lt;/div&gt;
+  &lt;div class="ease-counter__value"&gt;0&lt;/div&gt;
+  &lt;div class="ease-counter__label"&gt;Users&lt;/div&gt;
+&lt;/div&gt;
+&lt;link rel="stylesheet" href="style.css"/&gt;
+&lt;!-- Include the Intersection Observer script below --&gt;</code></pre>
+    </section>
+  </main>
+  <footer class="demo-footer">EaseMotion CSS</footer>
+
+  <script>
+    function formatNumber(n) {
+      return n.toLocaleString();
+    }
+    function animateCounter(el) {
+      const target   = parseInt(el.dataset.target, 10);
+      const suffix   = el.dataset.suffix || "";
+      const valueEl  = el.querySelector(".ease-counter__value");
+      const duration = parseInt(getComputedStyle(el).getPropertyValue("--ease-ct-duration")) || 2000;
+      const start    = performance.now();
+      el.classList.add("ease-counter--animated");
+      function step(now) {
+        const elapsed  = now - start;
+        const progress = Math.min(elapsed / duration, 1);
+        const eased    = 1 - Math.pow(1 - progress, 3);
+        const current  = Math.floor(eased * target);
+        valueEl.textContent = formatNumber(current) + suffix;
+        if (progress < 1) requestAnimationFrame(step);
+        else valueEl.textContent = formatNumber(target) + suffix;
+      }
+      requestAnimationFrame(step);
+    }
+    const observer = new IntersectionObserver(entries => {
+      entries.forEach(e => {
+        if (e.isIntersecting && !e.target.dataset.animated) {
+          e.target.dataset.animated = "1";
+          animateCounter(e.target);
+        }
+      });
+    }, { threshold: 0.3 });
+    document.querySelectorAll(".ease-counter").forEach(el => observer.observe(el));
+  </script>
+</body>
+</html>

--- a/submissions/examples/number-counter-harrshita/style.css
+++ b/submissions/examples/number-counter-harrshita/style.css
@@ -1,0 +1,89 @@
+/* =====================================================
+   EaseMotion CSS: Animated Number Counter
+   Issue: #67720
+   ===================================================== */
+:root {
+  --ease-ct-accent:     #6c63ff;
+  --ease-ct-accent-lt:  #ede9ff;
+  --ease-ct-bg:         #ffffff;
+  --ease-ct-text:       #2d2d44;
+  --ease-ct-radius:     14px;
+  --ease-ct-shadow:     0 4px 18px rgba(108,99,255,0.12);
+  --ease-ct-duration:   2000;
+}
+*, *::before, *::after { box-sizing:border-box; margin:0; padding:0; }
+body { font-family:'Segoe UI',Tahoma,sans-serif; background:#f4f3ff; color:var(--ease-ct-text); }
+.demo-header { background:var(--ease-ct-accent); color:#fff; padding:2.5rem 2rem; text-align:center; }
+.demo-header h1 { font-size:2rem; margin-bottom:.4rem; }
+.demo-main { max-width:800px; margin:2rem auto; padding:0 1.5rem; }
+.demo-section { background:#fff; border-radius:12px; box-shadow:0 2px 12px rgba(0,0,0,.07); padding:2rem; margin-bottom:1.8rem; }
+.demo-section h2 { font-size:1.1rem; color:var(--ease-ct-accent); border-bottom:2px solid var(--ease-ct-accent-lt); padding-bottom:.4rem; margin-bottom:1.4rem; }
+pre { background:#1e1e2e; color:#cdd6f4; padding:1rem; border-radius:8px; font-size:.83rem; overflow-x:auto; }
+.demo-footer { text-align:center; color:#999; padding:1.5rem; font-size:.85rem; }
+
+/* Counter grid */
+.ease-counter-grid {
+  display:grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap:1.5rem;
+}
+
+/* Counter card */
+.ease-counter {
+  background:var(--ease-ct-bg);
+  border-radius:var(--ease-ct-radius);
+  box-shadow:var(--ease-ct-shadow);
+  padding:1.8rem 1.2rem;
+  text-align:center;
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  gap:.6rem;
+  transition: transform .25s ease, box-shadow .25s ease;
+}
+.ease-counter:hover {
+  transform:translateY(-4px);
+  box-shadow:0 8px 28px rgba(108,99,255,.2);
+}
+
+/* Icon */
+.ease-counter__icon { font-size:2.2rem; line-height:1; }
+
+/* Animated value */
+.ease-counter__value {
+  font-size:2.4rem;
+  font-weight:800;
+  color:var(--ease-ct-accent);
+  line-height:1;
+  font-variant-numeric:tabular-nums;
+  transition: transform .15s ease;
+}
+.ease-counter--animated .ease-counter__value {
+  animation: ease-ct-pop .4s ease forwards;
+}
+@keyframes ease-ct-pop {
+  0%   { transform:scale(0.85); opacity:.5; }
+  60%  { transform:scale(1.08); }
+  100% { transform:scale(1); opacity:1; }
+}
+
+/* Label */
+.ease-counter__label {
+  font-size:.88rem;
+  color:#888;
+  font-weight:600;
+  text-transform:uppercase;
+  letter-spacing:.05em;
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+  body { background:#13131f; color:#e0e0ff; }
+  .ease-counter { background:#1a1a2e; }
+  .demo-section { background:#1a1a2e; }
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .ease-counter--animated .ease-counter__value { animation:none; }
+}


### PR DESCRIPTION
## Summary
Adds an animated number counter component that counts up when it enters the viewport.

## Changes
- `demo.html` - 4 counters (Users, Stars, Components, Uptime) with Intersection Observer
- `style.css` - Counter card styles, CSS pop animation, dark mode, reduced-motion support
- `README.md` - Data attributes, class reference, CSS variables, accessibility notes

## Checklist
- [x] Files under `submissions/examples/number-counter-harrshita/`
- [x] demo.html has DOCTYPE, html, head, body tags
- [x] Original CSS with @keyframes pop animation
- [x] Accessible: aria-live on value element
- [x] Respects prefers-reduced-motion
- [x] Dark mode support

Closes #67720
