### PR TITLE
feat(examples): add CSS-only tooltip component with multiple positions

### DIFF
--- a/submissions/examples/tooltip-harrshita/README.md
+++ b/submissions/examples/tooltip-harrshita/README.md
@@ -1,0 +1,46 @@
+# CSS-Only Tooltip
+
+Four-directional tooltip component using CSS pseudo-elements and transitions.
+No JavaScript required.
+
+## Usage
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<span class="ease-tooltip ease-tooltip--top" aria-label="Tooltip description">
+  <button>Hover me</button>
+  <span class="ease-tooltip__content">Tooltip text</span>
+</span>
+```
+
+## CSS Classes
+
+| Class | Description |
+|-------|-------------|
+| `.ease-tooltip` | Wrapper (inline-block) |
+| `.ease-tooltip__content` | Tooltip bubble |
+| `.ease-tooltip--top` | Appears above trigger |
+| `.ease-tooltip--bottom` | Appears below trigger |
+| `.ease-tooltip--left` | Appears to the left |
+| `.ease-tooltip--right` | Appears to the right |
+| `.ease-tooltip--dark` | Dark theme (default) |
+| `.ease-tooltip--light` | Light theme variant |
+
+## CSS Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `--ease-tt-bg` | `#2d2d44` | Tooltip background |
+| `--ease-tt-text` | `#ffffff` | Tooltip text color |
+| `--ease-tt-radius` | `7px` | Border radius |
+| `--ease-tt-gap` | `10px` | Distance from trigger |
+| `--ease-tt-transition` | `0.2s ease` | Show/hide speed |
+
+## Accessibility
+
+- Add `aria-label` on the wrapper for screen readers
+- Tooltip shows on `:focus-within` for keyboard navigation
+- Animation disabled via `prefers-reduced-motion`
+
+Closes #67721

--- a/submissions/examples/tooltip-harrshita/demo.html
+++ b/submissions/examples/tooltip-harrshita/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+  <title>CSS Tooltip | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css"/>
+</head>
+<body>
+  <header class="demo-header">
+    <h1>CSS-Only Tooltip</h1>
+    <p>Four directional tooltips with fade animation. No JavaScript required.</p>
+  </header>
+  <main class="demo-main">
+    <section class="demo-section">
+      <h2>Directional Variants</h2>
+      <div class="demo-grid">
+        <span class="ease-tooltip ease-tooltip--top" aria-label="Tooltip on top">
+          <button class="demo-btn">Hover (Top)</button>
+          <span class="ease-tooltip__content">Tooltip appears above</span>
+        </span>
+        <span class="ease-tooltip ease-tooltip--bottom" aria-label="Tooltip on bottom">
+          <button class="demo-btn">Hover (Bottom)</button>
+          <span class="ease-tooltip__content">Tooltip appears below</span>
+        </span>
+        <span class="ease-tooltip ease-tooltip--left" aria-label="Tooltip on left">
+          <button class="demo-btn">Hover (Left)</button>
+          <span class="ease-tooltip__content">Tooltip on left</span>
+        </span>
+        <span class="ease-tooltip ease-tooltip--right" aria-label="Tooltip on right">
+          <button class="demo-btn">Hover (Right)</button>
+          <span class="ease-tooltip__content">Tooltip on right</span>
+        </span>
+      </div>
+    </section>
+    <section class="demo-section">
+      <h2>Theme Variants</h2>
+      <div class="demo-grid">
+        <span class="ease-tooltip ease-tooltip--top ease-tooltip--dark" aria-label="Dark tooltip">
+          <button class="demo-btn">Dark Theme</button>
+          <span class="ease-tooltip__content">Dark tooltip</span>
+        </span>
+        <span class="ease-tooltip ease-tooltip--top ease-tooltip--light" aria-label="Light tooltip">
+          <button class="demo-btn demo-btn--dark">Light Theme</button>
+          <span class="ease-tooltip__content">Light tooltip</span>
+        </span>
+      </div>
+    </section>
+    <section class="demo-section">
+      <h2>Usage</h2>
+      <pre><code>&lt;span class="ease-tooltip ease-tooltip--top" aria-label="Description"&gt;
+  &lt;button&gt;Trigger&lt;/button&gt;
+  &lt;span class="ease-tooltip__content"&gt;Tooltip text&lt;/span&gt;
+&lt;/span&gt;</code></pre>
+    </section>
+  </main>
+  <footer class="demo-footer">EaseMotion CSS</footer>
+</body>
+</html>

--- a/submissions/examples/tooltip-harrshita/style.css
+++ b/submissions/examples/tooltip-harrshita/style.css
@@ -1,0 +1,142 @@
+/* =====================================================
+   EaseMotion CSS: CSS-Only Tooltip Component
+   Issue: #67721
+   ===================================================== */
+:root {
+  --ease-tt-bg:         #2d2d44;
+  --ease-tt-text:       #ffffff;
+  --ease-tt-radius:     7px;
+  --ease-tt-padding:    .45rem .85rem;
+  --ease-tt-font-size:  .82rem;
+  --ease-tt-arrow-size: 7px;
+  --ease-tt-gap:        10px;
+  --ease-tt-transition: 0.2s ease;
+  --ease-tt-shadow:     0 4px 14px rgba(0,0,0,0.2);
+  --ease-tt-light-bg:   #f8f8ff;
+  --ease-tt-light-text: #2d2d44;
+  --ease-tt-light-border: #ddd;
+}
+*, *::before, *::after { box-sizing:border-box; margin:0; padding:0; }
+body { font-family:'Segoe UI',Tahoma,sans-serif; background:#f4f3ff; color:#2d2d44; }
+.demo-header { background:#6c63ff; color:#fff; padding:2.5rem 2rem; text-align:center; }
+.demo-header h1 { font-size:2rem; margin-bottom:.4rem; }
+.demo-main { max-width:720px; margin:2rem auto; padding:0 1.5rem; }
+.demo-section { background:#fff; border-radius:12px; box-shadow:0 2px 12px rgba(0,0,0,.07); padding:2rem; margin-bottom:1.8rem; }
+.demo-section h2 { font-size:1.1rem; color:#6c63ff; border-bottom:2px solid #ede9ff; padding-bottom:.4rem; margin-bottom:1.4rem; }
+.demo-grid { display:flex; flex-wrap:wrap; gap:1.5rem 2rem; align-items:center; justify-content:center; padding:1rem 0; }
+pre { background:#1e1e2e; color:#cdd6f4; padding:1rem; border-radius:8px; font-size:.83rem; overflow-x:auto; }
+.demo-btn { padding:.55rem 1.2rem; border:none; border-radius:8px; background:#6c63ff; color:#fff; cursor:pointer; font-size:.92rem; font-weight:600; }
+.demo-btn--dark { background:#2d2d44; }
+.demo-footer { text-align:center; color:#999; padding:1.5rem; font-size:.85rem; }
+
+/* Base tooltip wrapper */
+.ease-tooltip {
+  position:relative;
+  display:inline-block;
+}
+
+/* Tooltip bubble */
+.ease-tooltip__content {
+  position:absolute;
+  z-index:1000;
+  background:var(--ease-tt-bg);
+  color:var(--ease-tt-text);
+  padding:var(--ease-tt-padding);
+  border-radius:var(--ease-tt-radius);
+  font-size:var(--ease-tt-font-size);
+  white-space:nowrap;
+  box-shadow:var(--ease-tt-shadow);
+  pointer-events:none;
+  opacity:0;
+  transition: opacity var(--ease-tt-transition), transform var(--ease-tt-transition);
+}
+
+/* Arrow shared */
+.ease-tooltip__content::after {
+  content:"";
+  position:absolute;
+  border:var(--ease-tt-arrow-size) solid transparent;
+}
+
+/* Show on hover and focus-within */
+.ease-tooltip:hover .ease-tooltip__content,
+.ease-tooltip:focus-within .ease-tooltip__content {
+  opacity:1;
+  transform:translateY(0) translateX(0) !important;
+}
+
+/* -- Top -- */
+.ease-tooltip--top .ease-tooltip__content {
+  bottom:calc(100% + var(--ease-tt-gap));
+  left:50%;
+  transform:translateX(-50%) translateY(6px);
+}
+.ease-tooltip:hover.ease-tooltip--top .ease-tooltip__content,
+.ease-tooltip:focus-within.ease-tooltip--top .ease-tooltip__content {
+  transform:translateX(-50%) translateY(0);
+}
+.ease-tooltip--top .ease-tooltip__content::after {
+  top:100%; left:50%; transform:translateX(-50%);
+  border-top-color:var(--ease-tt-bg);
+}
+
+/* -- Bottom -- */
+.ease-tooltip--bottom .ease-tooltip__content {
+  top:calc(100% + var(--ease-tt-gap));
+  left:50%;
+  transform:translateX(-50%) translateY(-6px);
+}
+.ease-tooltip:hover.ease-tooltip--bottom .ease-tooltip__content,
+.ease-tooltip:focus-within.ease-tooltip--bottom .ease-tooltip__content {
+  transform:translateX(-50%) translateY(0);
+}
+.ease-tooltip--bottom .ease-tooltip__content::after {
+  bottom:100%; left:50%; transform:translateX(-50%);
+  border-bottom-color:var(--ease-tt-bg);
+}
+
+/* -- Left -- */
+.ease-tooltip--left .ease-tooltip__content {
+  right:calc(100% + var(--ease-tt-gap));
+  top:50%;
+  transform:translateY(-50%) translateX(6px);
+}
+.ease-tooltip:hover.ease-tooltip--left .ease-tooltip__content,
+.ease-tooltip:focus-within.ease-tooltip--left .ease-tooltip__content {
+  transform:translateY(-50%) translateX(0);
+}
+.ease-tooltip--left .ease-tooltip__content::after {
+  left:100%; top:50%; transform:translateY(-50%);
+  border-left-color:var(--ease-tt-bg);
+}
+
+/* -- Right -- */
+.ease-tooltip--right .ease-tooltip__content {
+  left:calc(100% + var(--ease-tt-gap));
+  top:50%;
+  transform:translateY(-50%) translateX(-6px);
+}
+.ease-tooltip:hover.ease-tooltip--right .ease-tooltip__content,
+.ease-tooltip:focus-within.ease-tooltip--right .ease-tooltip__content {
+  transform:translateY(-50%) translateX(0);
+}
+.ease-tooltip--right .ease-tooltip__content::after {
+  right:100%; top:50%; transform:translateY(-50%);
+  border-right-color:var(--ease-tt-bg);
+}
+
+/* -- Light theme -- */
+.ease-tooltip--light .ease-tooltip__content {
+  background:var(--ease-tt-light-bg);
+  color:var(--ease-tt-light-text);
+  border:1px solid var(--ease-tt-light-border);
+  box-shadow:0 4px 14px rgba(0,0,0,0.10);
+}
+.ease-tooltip--light.ease-tooltip--top .ease-tooltip__content::after { border-top-color:var(--ease-tt-light-bg); }
+.ease-tooltip--light.ease-tooltip--bottom .ease-tooltip__content::after { border-bottom-color:var(--ease-tt-light-bg); }
+.ease-tooltip--light.ease-tooltip--left .ease-tooltip__content::after { border-left-color:var(--ease-tt-light-bg); }
+.ease-tooltip--light.ease-tooltip--right .ease-tooltip__content::after { border-right-color:var(--ease-tt-light-bg); }
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-tooltip__content { transition:none; }
+}


### PR DESCRIPTION
## Summary
Adds a CSS-only tooltip component with 4 directional positions and 2 themes.

## Changes
- `demo.html` - All 4 positions (top, bottom, left, right) plus dark/light themes
- `style.css` - Pseudo-element arrows, fade+slide animation, focus-within support
- `README.md` - Class reference, CSS variables, accessibility notes

## Checklist
- [x] Files under `submissions/examples/tooltip-harrshita/`
- [x] demo.html has DOCTYPE, html, head, body tags
- [x] No JavaScript required
- [x] Keyboard accessible via :focus-within
- [x] Respects prefers-reduced-motion

Closes #67721
