### PR TITLE
feat(react): add EaseTooltip React component with position prop

### DIFF
--- a/submissions/react/react-tooltip-harrshita/EaseTooltip.jsx
+++ b/submissions/react/react-tooltip-harrshita/EaseTooltip.jsx
@@ -1,0 +1,72 @@
+import React, { useState, useRef, useEffect } from 'react';
+import './style.css';
+
+/**
+ * EaseTooltip component
+ *
+ * A lightweight tooltip wrapper that uses the EaseMotion CSS tooltip
+ * utility classes. Supports 4 positions, 2 themes, and keyboard focus.
+ *
+ * @param {object}  props
+ * @param {string}  props.content           - Tooltip text (required)
+ * @param {'top'|'bottom'|'left'|'right'} [props.position='top'] - Placement
+ * @param {'dark'|'light'} [props.theme='dark'] - Visual theme
+ * @param {number}  [props.delay=0]          - Show delay in ms
+ * @param {string}  [props.className]        - Extra class on wrapper
+ * @param {React.ReactNode} props.children   - Trigger element
+ */
+const EaseTooltip = ({
+  content,
+  position = 'top',
+  theme = 'dark',
+  delay = 0,
+  className = '',
+  children,
+}) => {
+  const [visible, setVisible] = useState(false);
+  const timerRef = useRef(null);
+
+  const show = () => {
+    clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setVisible(true), delay);
+  };
+
+  const hide = () => {
+    clearTimeout(timerRef.current);
+    setVisible(false);
+  };
+
+  useEffect(() => () => clearTimeout(timerRef.current), []);
+
+  const wrapperClass = [
+    'ease-tooltip',
+    `ease-tooltip--${position}`,
+    `ease-tooltip--${theme}`,
+    visible ? 'ease-tooltip--visible' : '',
+    className,
+  ].filter(Boolean).join(' ');
+
+  return (
+    <span
+      className={wrapperClass}
+      onMouseEnter={show}
+      onMouseLeave={hide}
+      onFocus={show}
+      onBlur={hide}
+      aria-label={content}
+    >
+      {children}
+      <span
+        className="ease-tooltip__content"
+        role="tooltip"
+        aria-hidden={!visible}
+      >
+        {content}
+      </span>
+    </span>
+  );
+};
+
+EaseTooltip.displayName = 'EaseTooltip';
+export { EaseTooltip };
+export default EaseTooltip;

--- a/submissions/react/react-tooltip-harrshita/README.md
+++ b/submissions/react/react-tooltip-harrshita/README.md
@@ -1,0 +1,49 @@
+# EaseTooltip React Component
+
+A lightweight React tooltip wrapper using EaseMotion CSS tooltip classes.
+Supports 4 positions, 2 themes, optional delay, and keyboard focus.
+
+## Usage
+
+```jsx
+import { EaseTooltip } from './EaseTooltip';
+import './style.css';
+
+function App() {
+  return (
+    <EaseTooltip content="This is a tooltip" position="top" theme="dark">
+      <button>Hover me</button>
+    </EaseTooltip>
+  );
+}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `content` | `string` | required | Tooltip text |
+| `position` | `top / bottom / left / right` | `top` | Tooltip placement |
+| `theme` | `dark / light` | `dark` | Visual theme |
+| `delay` | `number` | `0` | Show delay in milliseconds |
+| `className` | `string` | `''` | Extra classes on wrapper |
+| `children` | `ReactNode` | required | Trigger element |
+
+## CSS Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `--ease-tt-bg` | `#2d2d44` | Tooltip background |
+| `--ease-tt-text` | `#ffffff` | Tooltip text color |
+| `--ease-tt-radius` | `7px` | Border radius |
+| `--ease-tt-gap` | `10px` | Distance from trigger |
+| `--ease-tt-transition` | `0.2s ease` | Animation speed |
+
+## Accessibility
+
+- `aria-label` on the wrapper for screen reader context
+- `role="tooltip"` and `aria-hidden` on the content element
+- Keyboard focus triggers show/hide via `onFocus` and `onBlur`
+- Animation disabled via `prefers-reduced-motion`
+
+Closes #67722

--- a/submissions/react/react-tooltip-harrshita/style.css
+++ b/submissions/react/react-tooltip-harrshita/style.css
@@ -1,0 +1,80 @@
+/* =====================================================
+   EaseMotion CSS: EaseTooltip React Component Styles
+   Issue: #67722
+   ===================================================== */
+:root {
+  --ease-tt-bg:         #2d2d44;
+  --ease-tt-text:       #ffffff;
+  --ease-tt-radius:     7px;
+  --ease-tt-padding:    .45rem .85rem;
+  --ease-tt-font-size:  .82rem;
+  --ease-tt-arrow-size: 7px;
+  --ease-tt-gap:        10px;
+  --ease-tt-transition: 0.2s ease;
+  --ease-tt-shadow:     0 4px 14px rgba(0,0,0,0.2);
+}
+
+.ease-tooltip { position:relative; display:inline-block; }
+
+.ease-tooltip__content {
+  position:absolute; z-index:1000;
+  background:var(--ease-tt-bg); color:var(--ease-tt-text);
+  padding:var(--ease-tt-padding); border-radius:var(--ease-tt-radius);
+  font-size:var(--ease-tt-font-size); white-space:nowrap;
+  box-shadow:var(--ease-tt-shadow); pointer-events:none;
+  opacity:0;
+  transition: opacity var(--ease-tt-transition), transform var(--ease-tt-transition);
+}
+.ease-tooltip__content::after {
+  content:""; position:absolute;
+  border:var(--ease-tt-arrow-size) solid transparent;
+}
+
+/* Visible state (controlled by React) */
+.ease-tooltip--visible .ease-tooltip__content { opacity:1; }
+
+/* Top */
+.ease-tooltip--top .ease-tooltip__content {
+  bottom:calc(100% + var(--ease-tt-gap)); left:50%;
+  transform:translateX(-50%) translateY(6px);
+}
+.ease-tooltip--top.ease-tooltip--visible .ease-tooltip__content { transform:translateX(-50%) translateY(0); }
+.ease-tooltip--top .ease-tooltip__content::after { top:100%; left:50%; transform:translateX(-50%); border-top-color:var(--ease-tt-bg); }
+
+/* Bottom */
+.ease-tooltip--bottom .ease-tooltip__content {
+  top:calc(100% + var(--ease-tt-gap)); left:50%;
+  transform:translateX(-50%) translateY(-6px);
+}
+.ease-tooltip--bottom.ease-tooltip--visible .ease-tooltip__content { transform:translateX(-50%) translateY(0); }
+.ease-tooltip--bottom .ease-tooltip__content::after { bottom:100%; left:50%; transform:translateX(-50%); border-bottom-color:var(--ease-tt-bg); }
+
+/* Left */
+.ease-tooltip--left .ease-tooltip__content {
+  right:calc(100% + var(--ease-tt-gap)); top:50%;
+  transform:translateY(-50%) translateX(6px);
+}
+.ease-tooltip--left.ease-tooltip--visible .ease-tooltip__content { transform:translateY(-50%) translateX(0); }
+.ease-tooltip--left .ease-tooltip__content::after { left:100%; top:50%; transform:translateY(-50%); border-left-color:var(--ease-tt-bg); }
+
+/* Right */
+.ease-tooltip--right .ease-tooltip__content {
+  left:calc(100% + var(--ease-tt-gap)); top:50%;
+  transform:translateY(-50%) translateX(-6px);
+}
+.ease-tooltip--right.ease-tooltip--visible .ease-tooltip__content { transform:translateY(-50%) translateX(0); }
+.ease-tooltip--right .ease-tooltip__content::after { right:100%; top:50%; transform:translateY(-50%); border-right-color:var(--ease-tt-bg); }
+
+/* Light theme */
+.ease-tooltip--light .ease-tooltip__content {
+  background:#f8f8ff; color:#2d2d44;
+  border:1px solid #ddd; box-shadow:0 4px 14px rgba(0,0,0,0.10);
+}
+.ease-tooltip--light.ease-tooltip--top .ease-tooltip__content::after { border-top-color:#f8f8ff; }
+.ease-tooltip--light.ease-tooltip--bottom .ease-tooltip__content::after { border-bottom-color:#f8f8ff; }
+.ease-tooltip--light.ease-tooltip--left .ease-tooltip__content::after { border-left-color:#f8f8ff; }
+.ease-tooltip--light.ease-tooltip--right .ease-tooltip__content::after { border-right-color:#f8f8ff; }
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-tooltip__content { transition:none; }
+}


### PR DESCRIPTION
## Summary
Adds EaseTooltip React component with position, theme, and delay props.

## Changes
- `EaseTooltip.jsx` - React component with useState delay, onFocus/onBlur, aria attributes
- `style.css` - Full tooltip CSS with 4 positions, dark/light themes, arrow pseudo-elements
- `README.md` - Props table, CSS variable reference, accessibility notes

## Checklist
- [x] Files under `submissions/react/react-tooltip-harrshita/`
- [x] React functional component with proper prop API
- [x] ARIA accessible (aria-label, role=tooltip, aria-hidden)
- [x] Keyboard accessible via onFocus/onBlur
- [x] Respects prefers-reduced-motion

Closes #67722
