### PR TITLE
feat(examples): add CSS variable-powered dark mode toggle with smooth transition

### DIFF
--- a/submissions/examples/dark-mode-toggle-harrshita/README.md
+++ b/submissions/examples/dark-mode-toggle-harrshita/README.md
@@ -1,0 +1,72 @@
+# Dark Mode Toggle
+
+A CSS variable-powered dark mode toggle system with smooth transitions
+for EaseMotion CSS. Switching the toggle updates `data-theme` on `<html>`
+and all CSS variables transition simultaneously.
+
+## Usage
+
+```html
+<!-- 1. Add data-theme to html element -->
+<html data-theme="light">
+
+<!-- 2. Link stylesheet -->
+<link rel="stylesheet" href="style.css" />
+
+<!-- 3. Add toggle button -->
+<button class="ease-theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
+  <span class="ease-theme-toggle__track">
+    <span class="ease-theme-toggle__thumb">
+      <span class="ease-theme-toggle__sun">&#9728;</span>
+      <span class="ease-theme-toggle__moon">&#9790;</span>
+    </span>
+  </span>
+</button>
+
+<!-- 4. Add toggle script -->
+<script>
+  const btn  = document.getElementById('themeToggle');
+  const html = document.documentElement;
+  const saved = localStorage.getItem('ease-theme') ||
+    (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+  html.dataset.theme = saved;
+  btn.addEventListener('click', () => {
+    const next = html.dataset.theme === 'dark' ? 'light' : 'dark';
+    html.dataset.theme = next;
+    localStorage.setItem('ease-theme', next);
+  });
+</script>
+```
+
+## CSS Variables
+
+| Variable | Light | Dark | Description |
+|----------|-------|------|-------------|
+| `--ease-theme-bg` | `#f4f3ff` | `#0f0f1a` | Page background |
+| `--ease-theme-surface` | `#ffffff` | `#1a1a2e` | Card/panel background |
+| `--ease-theme-text` | `#2d2d44` | `#e0e0ff` | Primary text |
+| `--ease-theme-muted` | `#888` | `#9090aa` | Secondary text |
+| `--ease-theme-border` | `#ddd` | `#2e2e48` | Border color |
+| `--ease-theme-accent` | `#6c63ff` | `#9d97ff` | Accent/brand color |
+| `--ease-theme-accent2` | `#ede9ff` | `#1e1e38` | Light accent background |
+| `--ease-theme-input` | `#ffffff` | `#13131f` | Input background |
+
+## CSS Classes
+
+| Class | Description |
+|-------|-------------|
+| `.ease-theme-toggle` | Toggle button wrapper |
+| `.ease-theme-toggle__track` | Pill-shaped track |
+| `.ease-theme-toggle__thumb` | Moving circle thumb |
+| `.ease-theme-toggle__sun` | Sun icon (light mode) |
+| `.ease-theme-toggle__moon` | Moon icon (dark mode) |
+
+## Features
+
+- Smooth 350ms transitions on all color properties
+- LocalStorage persistence across page reloads
+- Respects system `prefers-color-scheme` as default
+- Accessible: `aria-label` and `aria-pressed` on button
+- Transitions disabled via `prefers-reduced-motion`
+
+Closes #67724

--- a/submissions/examples/dark-mode-toggle-harrshita/demo.html
+++ b/submissions/examples/dark-mode-toggle-harrshita/demo.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+  <title>Dark Mode Toggle | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css"/>
+</head>
+<body>
+  <nav class="ease-navbar">
+    <span class="ease-navbar__brand">EaseMotion CSS</span>
+    <button
+      class="ease-theme-toggle"
+      id="themeToggle"
+      aria-label="Toggle dark mode"
+      aria-pressed="false"
+    >
+      <span class="ease-theme-toggle__track">
+        <span class="ease-theme-toggle__thumb">
+          <span class="ease-theme-toggle__sun" aria-hidden="true">&#9728;</span>
+          <span class="ease-theme-toggle__moon" aria-hidden="true">&#9790;</span>
+        </span>
+      </span>
+      <span class="ease-theme-toggle__label">Dark Mode</span>
+    </button>
+  </nav>
+
+  <main class="demo-main">
+    <section class="demo-section">
+      <h2>CSS Variable Dark Mode Toggle</h2>
+      <p>All colors are driven by CSS custom properties. Flipping the toggle
+      updates <code>data-theme="dark"</code> on the html element, switching
+      every variable at once with a smooth transition.</p>
+    </section>
+
+    <section class="demo-section">
+      <h2>Sample Components</h2>
+      <div class="demo-grid">
+        <div class="ease-sample-card">
+          <div class="ease-sample-card__title">Analytics</div>
+          <div class="ease-sample-card__value">24,512</div>
+          <div class="ease-sample-card__sub">Monthly active users</div>
+        </div>
+        <div class="ease-sample-card">
+          <div class="ease-sample-card__title">Revenue</div>
+          <div class="ease-sample-card__value">$8,240</div>
+          <div class="ease-sample-card__sub">This month</div>
+        </div>
+      </div>
+    </section>
+
+    <section class="demo-section">
+      <h2>Sample Form</h2>
+      <div class="ease-form-group">
+        <label class="ease-form-label" for="demoInput">Name</label>
+        <input class="ease-form-input" id="demoInput" type="text" placeholder="Your name"/>
+      </div>
+      <div class="ease-form-group">
+        <label class="ease-form-label" for="demoSelect">Role</label>
+        <select class="ease-form-input" id="demoSelect">
+          <option>Developer</option>
+          <option>Designer</option>
+          <option>Manager</option>
+        </select>
+      </div>
+    </section>
+
+    <section class="demo-section">
+      <h2>Usage</h2>
+      <pre><code>&lt;html data-theme="light"&gt;
+...
+&lt;link rel="stylesheet" href="style.css"/&gt;
+&lt;button class="ease-theme-toggle" id="themeToggle"&gt;
+  &lt;span class="ease-theme-toggle__track"&gt;
+    &lt;span class="ease-theme-toggle__thumb"&gt;&lt;/span&gt;
+  &lt;/span&gt;
+&lt;/button&gt;
+&lt;script&gt;
+  const btn = document.getElementById('themeToggle');
+  const html = document.documentElement;
+  const saved = localStorage.getItem('ease-theme');
+  if (saved) html.dataset.theme = saved;
+  btn.addEventListener('click', () => {
+    const next = html.dataset.theme === 'dark' ? 'light' : 'dark';
+    html.dataset.theme = next;
+    localStorage.setItem('ease-theme', next);
+  });
+&lt;/script&gt;</code></pre>
+    </section>
+  </main>
+
+  <script>
+    const btn  = document.getElementById('themeToggle');
+    const html = document.documentElement;
+    const saved = localStorage.getItem('ease-theme') ||
+      (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+    html.dataset.theme = saved;
+    btn.setAttribute('aria-pressed', saved === 'dark');
+    btn.addEventListener('click', () => {
+      const next = html.dataset.theme === 'dark' ? 'light' : 'dark';
+      html.dataset.theme = next;
+      localStorage.setItem('ease-theme', next);
+      btn.setAttribute('aria-pressed', next === 'dark');
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/dark-mode-toggle-harrshita/style.css
+++ b/submissions/examples/dark-mode-toggle-harrshita/style.css
@@ -1,0 +1,137 @@
+/* =====================================================
+   EaseMotion CSS: Dark Mode Toggle System
+   Issue: #67724
+   ===================================================== */
+
+/* -- Token definitions -- */
+:root,
+[data-theme="light"] {
+  --ease-theme-bg:      #f4f3ff;
+  --ease-theme-surface: #ffffff;
+  --ease-theme-text:    #2d2d44;
+  --ease-theme-muted:   #888888;
+  --ease-theme-border:  #ddd;
+  --ease-theme-accent:  #6c63ff;
+  --ease-theme-accent2: #ede9ff;
+  --ease-theme-input:   #ffffff;
+}
+[data-theme="dark"] {
+  --ease-theme-bg:      #0f0f1a;
+  --ease-theme-surface: #1a1a2e;
+  --ease-theme-text:    #e0e0ff;
+  --ease-theme-muted:   #9090aa;
+  --ease-theme-border:  #2e2e48;
+  --ease-theme-accent:  #9d97ff;
+  --ease-theme-accent2: #1e1e38;
+  --ease-theme-input:   #13131f;
+}
+
+/* Global transitions */
+*, *::before, *::after {
+  box-sizing:border-box; margin:0; padding:0;
+  transition: background-color .35s ease, color .35s ease,
+              border-color .35s ease, box-shadow .35s ease;
+}
+body {
+  font-family:'Segoe UI',Tahoma,sans-serif;
+  background:var(--ease-theme-bg);
+  color:var(--ease-theme-text);
+  min-height:100vh;
+}
+
+/* Navbar */
+.ease-navbar {
+  display:flex; align-items:center; justify-content:space-between;
+  padding:.9rem 1.8rem;
+  background:var(--ease-theme-surface);
+  border-bottom:1px solid var(--ease-theme-border);
+  box-shadow:0 2px 10px rgba(0,0,0,.06);
+  position:sticky; top:0; z-index:100;
+}
+.ease-navbar__brand { font-size:1.1rem; font-weight:700; color:var(--ease-theme-accent); }
+
+/* Toggle button */
+.ease-theme-toggle {
+  display:flex; align-items:center; gap:.6rem;
+  background:none; border:none; cursor:pointer;
+  padding:.25rem; border-radius:8px;
+  color:var(--ease-theme-text);
+}
+.ease-theme-toggle:focus-visible { outline:3px solid var(--ease-theme-accent); outline-offset:2px; }
+.ease-theme-toggle__label { font-size:.85rem; font-weight:600; }
+
+/* Track */
+.ease-theme-toggle__track {
+  width:52px; height:28px; border-radius:99px;
+  background:var(--ease-theme-accent2);
+  border:2px solid var(--ease-theme-border);
+  position:relative;
+  transition: background .35s ease, border-color .35s ease;
+}
+[data-theme="dark"] .ease-theme-toggle__track {
+  background:var(--ease-theme-accent);
+  border-color:var(--ease-theme-accent);
+}
+
+/* Thumb */
+.ease-theme-toggle__thumb {
+  position:absolute; top:2px; left:2px;
+  width:20px; height:20px; border-radius:50%;
+  background:#fff; box-shadow:0 2px 6px rgba(0,0,0,.2);
+  display:flex; align-items:center; justify-content:center;
+  transition: transform .35s cubic-bezier(0.4,0,0.2,1);
+  overflow:hidden;
+}
+[data-theme="dark"] .ease-theme-toggle__thumb { transform:translateX(24px); }
+
+.ease-theme-toggle__sun, .ease-theme-toggle__moon {
+  font-size:.75rem; line-height:1;
+  position:absolute;
+  transition: opacity .3s ease, transform .3s ease;
+}
+.ease-theme-toggle__sun  { opacity:1; transform:scale(1); }
+.ease-theme-toggle__moon { opacity:0; transform:scale(0); }
+[data-theme="dark"] .ease-theme-toggle__sun  { opacity:0; transform:scale(0); }
+[data-theme="dark"] .ease-theme-toggle__moon { opacity:1; transform:scale(1); }
+
+/* Main */
+.demo-main { max-width:760px; margin:2rem auto; padding:0 1.5rem; }
+.demo-section {
+  background:var(--ease-theme-surface);
+  border:1px solid var(--ease-theme-border);
+  border-radius:12px; padding:1.8rem; margin-bottom:1.6rem;
+  box-shadow:0 2px 10px rgba(0,0,0,.05);
+}
+.demo-section h2 { font-size:1.1rem; color:var(--ease-theme-accent); margin-bottom:1rem; }
+.demo-section p  { color:var(--ease-theme-muted); line-height:1.65; font-size:.95rem; }
+.demo-section code { background:var(--ease-theme-accent2); padding:.1rem .4rem; border-radius:4px; font-size:.88rem; color:var(--ease-theme-accent); }
+
+/* Sample cards */
+.demo-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(180px,1fr)); gap:1.2rem; }
+.ease-sample-card {
+  background:var(--ease-theme-bg); border:1px solid var(--ease-theme-border);
+  border-radius:10px; padding:1.2rem; display:flex; flex-direction:column; gap:.3rem;
+}
+.ease-sample-card__title { font-size:.8rem; text-transform:uppercase; letter-spacing:.06em; color:var(--ease-theme-muted); }
+.ease-sample-card__value { font-size:1.8rem; font-weight:800; color:var(--ease-theme-accent); }
+.ease-sample-card__sub { font-size:.82rem; color:var(--ease-theme-muted); }
+
+/* Form */
+.ease-form-group { display:flex; flex-direction:column; gap:.4rem; margin-bottom:1rem; }
+.ease-form-label { font-size:.88rem; font-weight:600; color:var(--ease-theme-text); }
+.ease-form-input {
+  padding:.55rem .9rem; border:1.5px solid var(--ease-theme-border);
+  border-radius:8px; font-size:.95rem; outline:none;
+  background:var(--ease-theme-input); color:var(--ease-theme-text);
+}
+.ease-form-input:focus { border-color:var(--ease-theme-accent); }
+
+pre {
+  background:#1e1e2e; color:#cdd6f4;
+  padding:1rem 1.2rem; border-radius:8px; font-size:.8rem;
+  overflow-x:auto; line-height:1.7;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { transition:none !important; }
+}


### PR DESCRIPTION
## Summary
Adds a complete CSS variable-powered dark mode toggle with smooth transitions.

## Changes
- `demo.html` - Full-page demo: navbar, stat cards, form, usage code, toggle button
- `style.css` - 8 CSS variables per theme, global color transitions, toggle pill animation
- `README.md` - Variable table (light/dark), usage guide, feature list

## Checklist
- [x] Files under `submissions/examples/dark-mode-toggle-harrshita/`
- [x] demo.html has DOCTYPE, html, head, body tags
- [x] localStorage persistence and prefers-color-scheme default
- [x] Accessible: aria-label, aria-pressed on toggle
- [x] prefers-reduced-motion disables all transitions

Closes #67724
