### PR TITLE
feat(scss): add SCSS mixin library for responsive breakpoints

### DIFF
--- a/submissions/scss/responsive-breakpoints-harrshita/README.md
+++ b/submissions/scss/responsive-breakpoints-harrshita/README.md
@@ -1,0 +1,97 @@
+# SCSS Responsive Breakpoint Mixins
+
+A SCSS mixin library providing clean, named responsive breakpoint mixins
+for mobile-first development, compatible with EaseMotion CSS.
+
+## Installation
+
+Import the partial in your SCSS file:
+
+```scss
+@use 'responsive-breakpoints' as *;
+// or
+@import 'responsive-breakpoints';
+```
+
+## Breakpoints
+
+| Name | Min Width | Typical Device |
+|------|-----------|----------------|
+| `xs` | 0px | Extra small (default/mobile) |
+| `sm` | 576px | Small phones |
+| `md` | 768px | Tablets |
+| `lg` | 992px | Small laptops |
+| `xl` | 1200px | Desktops |
+| `xxl` | 1400px | Wide screens |
+
+## Mixins
+
+### `ease-respond-up($bp)` — Mobile-first (min-width)
+
+```scss
+.ease-container {
+  padding: 1rem;
+
+  @include ease-respond-up(md) { padding: 2rem; }
+  @include ease-respond-up(xl) { padding: 3rem; max-width: 1200px; }
+}
+```
+
+### `ease-respond-down($bp)` — Max-width
+
+```scss
+.ease-sidebar {
+  display: block;
+
+  @include ease-respond-down(md) { display: none; }
+}
+```
+
+### `ease-respond-only($bp)` — Exact breakpoint range
+
+```scss
+.ease-badge {
+  @include ease-respond-only(sm) { font-size: 0.8rem; }
+  @include ease-respond-only(lg) { font-size: 1rem; }
+}
+```
+
+### `ease-respond-between($lower, $upper)` — Between two breakpoints
+
+```scss
+.ease-grid {
+  @include ease-respond-between(sm, lg) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+```
+
+## Custom Breakpoints
+
+Override the `$ease-breakpoints` map before importing:
+
+```scss
+$ease-breakpoints: (
+  "mobile":  0px,
+  "tablet":  600px,
+  "desktop": 1024px,
+);
+
+@import 'responsive-breakpoints';
+```
+
+## Error Handling
+
+Passing an unknown breakpoint name triggers a Sass `@error`:
+
+```
+Error: ease-respond: unknown breakpoint `xxs`.
+       Valid values: xs, sm, md, lg, xl, xxl
+```
+
+## Requirements
+
+- Dart Sass 1.x or later
+- No dependencies
+
+Closes #67725

--- a/submissions/scss/responsive-breakpoints-harrshita/_responsive-breakpoints.scss
+++ b/submissions/scss/responsive-breakpoints-harrshita/_responsive-breakpoints.scss
@@ -1,0 +1,116 @@
+// =====================================================
+// EaseMotion CSS: SCSS Responsive Breakpoint Mixins
+// Issue: #67725
+// =====================================================
+
+/// Breakpoint map — override this map before importing to customize.
+/// Keys must match the names used in mixin arguments.
+$ease-breakpoints: (
+  "xs":  0px,
+  "sm":  576px,
+  "md":  768px,
+  "lg":  992px,
+  "xl":  1200px,
+  "xxl": 1400px,
+) !default;
+
+// ─── Internal helpers ──────────────────────────────────
+
+/// Returns the min-width for a given breakpoint name.
+/// @param {string} $name - Breakpoint key (xs, sm, md, lg, xl, xxl)
+/// @return {number} Width in px
+@function ease-bp-min($name) {
+  @if not map-has-key($ease-breakpoints, $name) {
+    @error "ease-respond: unknown breakpoint `#{$name}`. " +
+           "Valid values: #{map-keys($ease-breakpoints)}.";
+  }
+  @return map-get($ease-breakpoints, $name);
+}
+
+/// Returns the sorted list of breakpoint names for range queries.
+@function ease-bp-next($name) {
+  $keys: map-keys($ease-breakpoints);
+  $idx: index($keys, $name);
+  @if $idx == null {
+    @error "ease-respond: unknown breakpoint `#{$name}`.";
+  }
+  @if $idx < length($keys) {
+    @return nth($keys, $idx + 1);
+  }
+  @return null;
+}
+
+// ─── Public mixins ─────────────────────────────────────
+
+/// Apply styles from the given breakpoint and wider (mobile-first).
+/// @param {string} $bp - Breakpoint name
+/// @example scss
+///   .ease-container {
+///     @include ease-respond-up(md) { max-width: 720px; }
+///   }
+@mixin ease-respond-up($bp) {
+  $min: ease-bp-min($bp);
+  @if $min == 0px {
+    @content;
+  } @else {
+    @media (min-width: $min) {
+      @content;
+    }
+  }
+}
+
+/// Apply styles below the given breakpoint (desktop-first / max-width).
+/// @param {string} $bp - Breakpoint name
+/// @example scss
+///   .ease-sidebar {
+///     @include ease-respond-down(md) { display: none; }
+///   }
+@mixin ease-respond-down($bp) {
+  $next: ease-bp-next($bp);
+  @if $next == null {
+    @content;
+  } @else {
+    $max: ease-bp-min($next) - 0.02px;
+    @media (max-width: $max) {
+      @content;
+    }
+  }
+}
+
+/// Apply styles only at the given breakpoint (between its min and the next breakpoint).
+/// @param {string} $bp - Breakpoint name
+/// @example scss
+///   .ease-badge {
+///     @include ease-respond-only(sm) { font-size: 0.8rem; }
+///   }
+@mixin ease-respond-only($bp) {
+  $min: ease-bp-min($bp);
+  $next: ease-bp-next($bp);
+  @if $next == null {
+    @include ease-respond-up($bp) { @content; }
+  } @else {
+    $max: ease-bp-min($next) - 0.02px;
+    @if $min == 0px {
+      @media (max-width: $max) { @content; }
+    } @else {
+      @media (min-width: $min) and (max-width: $max) { @content; }
+    }
+  }
+}
+
+/// Apply styles between two breakpoints (inclusive lower, exclusive upper).
+/// @param {string} $lower - Lower breakpoint name
+/// @param {string} $upper - Upper breakpoint name
+/// @example scss
+///   .ease-grid {
+///     @include ease-respond-between(sm, lg) { grid-template-columns: repeat(2, 1fr); }
+///   }
+@mixin ease-respond-between($lower, $upper) {
+  $min: ease-bp-min($lower);
+  $max: ease-bp-min($upper) - 0.02px;
+  @if $min == 0px {
+    @media (max-width: $max) { @content; }
+  } @else {
+    @media (min-width: $min) and (max-width: $max) { @content; }
+  }
+}


### PR DESCRIPTION
## Summary
Adds a SCSS mixin library with 4 responsive breakpoint mixins and 6 named breakpoints.

## Changes
- `_responsive-breakpoints.scss` - ease-respond-up, down, only, between mixins with @error validation
- `README.md` - Breakpoint table, usage examples for all 4 mixins, custom override guide

## Checklist
- [x] Files under `submissions/scss/responsive-breakpoints-harrshita/`
- [x] All 4 mixin types implemented
- [x] @error for invalid breakpoint names
- [x] Breakpoints configurable via SCSS map variable
- [x] Compatible with Dart Sass 1.x
- [x] README has full usage examples

Closes #67725
