### PR TITLE
feat: add notification badge with radar-ping pulse animation

### DIFF
--- a/submissions/examples/notification-badge-pulse/README.md
+++ b/submissions/examples/notification-badge-pulse/README.md
@@ -1,0 +1,44 @@
+# Notification Badge (Pulse Dot)
+
+### 1. What does this do?
+A small corner badge — a plain dot or a number — that sits on top of an icon or avatar and can loop a radar-ping pulse animation to draw attention to unread state.
+
+### 2. How is it used?
+Wrap the icon/avatar and the badge together in `.badge-wrap`, then add `.badge` plus whichever modifiers you need:
+
+```html
+<!-- plain pulsing dot -->
+<div class="badge-wrap">
+  🔔
+  <span class="badge badge-pulse"></span>
+</div>
+
+<!-- static count -->
+<div class="badge-wrap">
+  🔔
+  <span class="badge badge-count">3</span>
+</div>
+
+<!-- count that also pulses -->
+<div class="badge-wrap">
+  💬
+  <span class="badge badge-count badge-pulse">12</span>
+</div>
+
+<!-- online status dot -->
+<div class="badge-wrap">
+  <span class="avatar">JS</span>
+  <span class="badge badge-pulse badge-online"></span>
+</div>
+```
+
+- `.badge-wrap` — any positioned container (icon, avatar, nav item) the badge anchors to.
+- `.badge` — the dot itself, absolutely positioned to the top-right corner.
+- `.badge-pulse` — adds the looping radar-ping ring (disabled automatically under `prefers-reduced-motion`).
+- `.badge-count` — resizes the badge to fit a number/text instead of a plain dot.
+- `.badge-online` — color variant for presence indicators (swap `background` for other states).
+
+Always add an `aria-label` (e.g. `"3 unread notifications"`) on the badge itself, since its content is often just a number or nothing at all.
+
+### 3. Why is it useful?
+Notification badges show up on nearly every icon, nav item, and avatar that carries unread state, and the ping-style pulse is exactly the kind of small, high-impact motion detail EaseMotion CSS is built around — a single `@keyframes` animation, applied with one class, that instantly reads as "something needs your attention." It's a natural companion to larger components (like a notification bell) but is deliberately minimal enough to drop onto anything.

--- a/submissions/examples/notification-badge-pulse/demo.html
+++ b/submissions/examples/notification-badge-pulse/demo.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Notification Badge (Pulse Dot) — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="demo-page">
+    <header class="demo-page__header">
+      <h1>🔴 Notification Badge</h1>
+      <p>A corner badge with a looping radar-ping pulse, for icons, nav items, and avatars.</p>
+    </header>
+
+    <section class="demo-page__grid">
+
+      <div class="demo-card">
+        <h2>Icon with pulse dot</h2>
+        <div class="badge-wrap">
+          <span class="demo-icon" aria-hidden="true">🔔</span>
+          <span class="badge badge-pulse" aria-label="Unread notifications"></span>
+        </div>
+      </div>
+
+      <div class="demo-card">
+        <h2>Icon with count</h2>
+        <div class="badge-wrap">
+          <span class="demo-icon" aria-hidden="true">🔔</span>
+          <span class="badge badge-count" aria-label="3 unread notifications">3</span>
+        </div>
+      </div>
+
+      <div class="demo-card">
+        <h2>Count + pulse</h2>
+        <div class="badge-wrap">
+          <span class="demo-icon" aria-hidden="true">💬</span>
+          <span class="badge badge-count badge-pulse" aria-label="12 unread messages">12</span>
+        </div>
+      </div>
+
+      <div class="demo-card">
+        <h2>On an avatar</h2>
+        <div class="badge-wrap">
+          <span class="demo-avatar" aria-hidden="true">JS</span>
+          <span class="badge badge-pulse badge-online" aria-label="Online"></span>
+        </div>
+      </div>
+
+      <div class="demo-card">
+        <h2>On a nav item</h2>
+        <div class="demo-nav-item">
+          <div class="badge-wrap">
+            <span class="demo-icon demo-icon--outline" aria-hidden="true">📥</span>
+            <span class="badge badge-count badge-pulse" aria-label="99+ unread items">99+</span>
+          </div>
+          <span>Inbox</span>
+        </div>
+      </div>
+
+    </section>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/notification-badge-pulse/style.css
+++ b/submissions/examples/notification-badge-pulse/style.css
@@ -1,0 +1,170 @@
+/* -------------------- keyframes -------------------- */
+
+@keyframes badge-ping {
+  0% {
+    transform: scale(1);
+    opacity: 0.7;
+  }
+  70% {
+    transform: scale(2.4);
+    opacity: 0;
+  }
+  100% {
+    transform: scale(2.4);
+    opacity: 0;
+  }
+}
+
+/* -------------------- badge component -------------------- */
+
+.badge-wrap {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.badge {
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  min-width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: #ff4d4f;
+  border: 2px solid #fff;
+  box-sizing: content-box;
+}
+
+.badge::before {
+  content: "";
+  position: absolute;
+  inset: -2px;
+  border-radius: inherit;
+  background: inherit;
+  opacity: 0;
+}
+
+.badge-pulse::before {
+  animation: badge-ping 1.6s cubic-bezier(0.2, 0.7, 0.4, 1) infinite;
+}
+
+.badge-count {
+  top: -8px;
+  right: -10px;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.68rem;
+  font-weight: 700;
+  line-height: 1;
+  color: #fff;
+}
+
+.badge-online {
+  background: #22c55e;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .badge-pulse::before {
+    animation: none;
+  }
+}
+
+/* -------------------- demo page chrome (not part of the component) -------------------- */
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+  background: #f3f4f6;
+  color: #1f2430;
+  padding: 40px 20px 80px;
+}
+
+.demo-page {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.demo-page__header {
+  text-align: center;
+  margin-bottom: 32px;
+}
+
+.demo-page__header h1 {
+  margin: 0 0 6px;
+}
+
+.demo-page__header p {
+  margin: 0;
+  opacity: 0.75;
+}
+
+.demo-page__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 16px;
+}
+
+.demo-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 18px;
+  padding: 24px 12px;
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  border-radius: 14px;
+  text-align: center;
+}
+
+.demo-card h2 {
+  margin: 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #4b5563;
+}
+
+.demo-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  background: #eef1f6;
+  font-size: 1.4rem;
+}
+
+.demo-icon--outline {
+  background: transparent;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.demo-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: #6366f1;
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.85rem;
+}
+
+.demo-nav-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.8rem;
+  color: #4b5563;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a small, reusable notification badge — a corner dot or count anchored to an icon/avatar — with a looping "radar ping" pulse animation to draw attention to unread state. Solves the common need for a lightweight, drop-anywhere unread indicator that doesn't require a full component.

---

## Type of Change
- [x] ✨ New animation / hover effect

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/notification-badge-pulse/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A corner badge (plain dot or number) with an optional looping radar-ping pulse, for icons, nav items, and avatars.

**How does a developer use it?**
```html
<!-- plain pulsing dot -->
<div class="badge-wrap">
  🔔
  <span class="badge badge-pulse"></span>
</div>

<!-- static count -->
<div class="badge-wrap">
  🔔
  <span class="badge badge-count">3</span>
</div>

<!-- count that also pulses -->
<div class="badge-wrap">
  💬
  <span class="badge badge-count badge-pulse">12</span>
</div>
```

**Why does it fit EaseMotion CSS?**
Notification badges appear on nearly every icon, nav item, and avatar with unread state, and the ping-style pulse is exactly the kind of small, high-impact motion detail EaseMotion is built around — a single `@keyframes` animation applied with one class that instantly reads as "something needs attention." It's minimal enough to drop onto anything, and pairs naturally with larger components like a notification bell.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

- I used `.badge-wrap`, `.badge`, `.badge-pulse`, and `.badge-count` as given in the feature request, plus one extra modifier, `.badge-online`, for presence-dot use cases (green dot on an avatar) — drop it if it's out of scope.
- The pulse animation lives on a `::before` pseudo-element rather than the badge itself, so the dot stays crisp while only the ring expands/fades — happy to adjust the timing/easing (`badge-ping`, 1.6s, `cubic-bezier(0.2, 0.7, 0.4, 1)`) if you have a house standard for pulse effects already.
- Per the naming-conflict guidance in CONTRIBUTING, I don't have a fixed contributor identifier to append to the folder name yet — let me know if you'd like it renamed before merge, or if you'll handle that during standardization.