### PR TITLE
feat: add ease-signature-pad-sap

### DIFF
--- a/submissions/examples/ease-signature-pad-sap/README.md
+++ b/submissions/examples/ease-signature-pad-sap/README.md
@@ -1,0 +1,19 @@
+# ease-signature-pad-sap
+
+A canvas-based signature pad supporting mouse and touch drawing, with a fading placeholder and a clear button.
+
+## Usage
+1. Include `style.css`.
+2. Add markup: canvas wrapped in a dashed container + placeholder text + clear button.
+3. Attach the drawing logic from `demo.html`.
+
+## Customization
+- `ctx.strokeStyle`/`lineWidth`: stroke appearance.
+- Canvas `height` in CSS for pad size.
+- Placeholder text/styling.
+
+## Notes
+- Canvas is scaled by `devicePixelRatio` for crisp strokes on high-DPI screens.
+- `touch-action: none` on the canvas prevents the browser from scrolling the page while drawing on touch devices.
+- Border highlights (`.active` class) while actively drawing, giving a subtle focus cue without needing `:focus` (canvas isn't natively focusable in a meaningful way here).
+- Respects `prefers-reduced-motion`: border/placeholder/button transitions are disabled; drawing itself is unaffected since it's direct user input, not decorative motion.

--- a/submissions/examples/ease-signature-pad-sap/demo.html
+++ b/submissions/examples/ease-signature-pad-sap/demo.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-signature-pad-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      height: 100vh;
+      margin: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #f4f4f5;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="sig-pad-sap">
+    <div class="sig-canvas-wrap" id="canvasWrap">
+      <canvas id="sigCanvas"></canvas>
+      <span class="sig-placeholder" id="placeholder">Sign here</span>
+    </div>
+    <div class="sig-actions">
+      <button id="clearBtn">Clear</button>
+    </div>
+  </div>
+
+  <script>
+    const canvas = document.getElementById('sigCanvas');
+    const ctx = canvas.getContext('2d');
+    const wrap = document.getElementById('canvasWrap');
+    const placeholder = document.getElementById('placeholder');
+    const clearBtn = document.getElementById('clearBtn');
+
+    function resizeCanvas() {
+      const rect = canvas.getBoundingClientRect();
+      canvas.width = rect.width * devicePixelRatio;
+      canvas.height = rect.height * devicePixelRatio;
+      ctx.scale(devicePixelRatio, devicePixelRatio);
+      ctx.strokeStyle = '#111';
+      ctx.lineWidth = 2.2;
+      ctx.lineCap = 'round';
+      ctx.lineJoin = 'round';
+    }
+    resizeCanvas();
+
+    let drawing = false;
+    let hasDrawn = false;
+
+    function getPos(e) {
+      const rect = canvas.getBoundingClientRect();
+      const point = e.touches ? e.touches[0] : e;
+      return { x: point.clientX - rect.left, y: point.clientY - rect.top };
+    }
+
+    function start(e) {
+      drawing = true;
+      wrap.classList.add('active');
+      if (!hasDrawn) {
+        placeholder.classList.add('hidden');
+        hasDrawn = true;
+      }
+      const pos = getPos(e);
+      ctx.beginPath();
+      ctx.moveTo(pos.x, pos.y);
+    }
+
+    function move(e) {
+      if (!drawing) return;
+      e.preventDefault();
+      const pos = getPos(e);
+      ctx.lineTo(pos.x, pos.y);
+      ctx.stroke();
+    }
+
+    function end() {
+      drawing = false;
+      wrap.classList.remove('active');
+    }
+
+    canvas.addEventListener('mousedown', start);
+    canvas.addEventListener('mousemove', move);
+    canvas.addEventListener('mouseup', end);
+    canvas.addEventListener('mouseleave', end);
+    canvas.addEventListener('touchstart', start, { passive: true });
+    canvas.addEventListener('touchmove', move, { passive: false });
+    canvas.addEventListener('touchend', end);
+
+    clearBtn.addEventListener('click', () => {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      placeholder.classList.remove('hidden');
+      hasDrawn = false;
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-signature-pad-sap/style.css
+++ b/submissions/examples/ease-signature-pad-sap/style.css
@@ -1,0 +1,71 @@
+.sig-pad-sap {
+  width: 400px;
+  font-family: system-ui, sans-serif;
+}
+
+.sig-pad-sap .sig-canvas-wrap {
+  position: relative;
+  border: 2px dashed #cbd5e1;
+  border-radius: 14px;
+  background: #f8fafc;
+  transition: border-color 0.25s ease;
+}
+
+.sig-pad-sap .sig-canvas-wrap.active {
+  border-color: #2563eb;
+}
+
+.sig-pad-sap canvas {
+  display: block;
+  width: 100%;
+  height: 200px;
+  border-radius: 12px;
+  cursor: crosshair;
+  touch-action: none;
+}
+
+.sig-pad-sap .sig-placeholder {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: #94a3b8;
+  font-size: 14px;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+}
+
+.sig-pad-sap .sig-placeholder.hidden {
+  opacity: 0;
+}
+
+.sig-pad-sap .sig-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 12px;
+}
+
+.sig-pad-sap button {
+  padding: 9px 18px;
+  border: none;
+  border-radius: 8px;
+  background: #111;
+  color: #fff;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.15s ease;
+}
+
+.sig-pad-sap button:hover {
+  background: #ef4444;
+  transform: translateY(-2px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sig-pad-sap .sig-canvas-wrap,
+  .sig-pad-sap .sig-placeholder,
+  .sig-pad-sap button {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-signature-pad-sap`, a canvas-based signature pad with mouse/touch support.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-signature-pad-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Canvas is scaled to `devicePixelRatio` for crisp lines on retina/high-DPI displays.
- `touch-action: none` prevents page scroll from hijacking touch-drawing gestures on mobile.
- `prefers-reduced-motion` disables cosmetic transitions (border highlight, placeholder fade); the drawing interaction itself is untouched since it's direct input, not decorative animation.

## Feature Description

Adds a reusable canvas signature pad component with touch and mouse support.

Level: Advanced

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.