### PR TITLE
feat: add ease-code-copy-btn-sap

### DIFF
--- a/submissions/examples/ease-code-copy-btn-sap/README.md
+++ b/submissions/examples/ease-code-copy-btn-sap/README.md
@@ -1,0 +1,18 @@
+# ease-code-copy-btn-sap
+
+A code block with a copy button that swaps its icon to a checkmark and turns green momentarily after a successful copy.
+
+## Usage
+1. Include `style.css`.
+2. Add markup: `<pre>` code block + button containing two SVG icons (copy + check).
+3. Attach the `navigator.clipboard.writeText()` click handler from `demo.html`.
+
+## Customization
+- `setTimeout(..., 1600)`: how long the "copied" state stays visible before reverting.
+- Icon swap via `.copy-icon`/`.check-icon` display toggling.
+- Code block background/font for theming.
+
+## Notes
+- Uses the native `navigator.clipboard` API (async, promise-based) rather than the deprecated `document.execCommand('copy')`.
+- Both icons exist in the DOM simultaneously; only `display` is toggled via the `.copied` class, avoiding any icon-swap flash or reflow.
+- Respects `prefers-reduced-motion`: the button's scale-up on copy is removed, leaving only the background color change and icon swap as feedback.

--- a/submissions/examples/ease-code-copy-btn-sap/demo.html
+++ b/submissions/examples/ease-code-copy-btn-sap/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-code-copy-btn-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      height: 100vh;
+      margin: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #f4f4f5;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="code-copy-sap">
+    <pre id="codeBlock">npm install ease-motion-css</pre>
+    <button class="copy-btn" id="copyBtn" aria-label="Copy code">
+      <svg class="copy-icon" viewBox="0 0 24 24">
+        <rect x="9" y="9" width="12" height="12" rx="2"/>
+        <path d="M5 15V5a2 2 0 0 1 2-2h10"/>
+      </svg>
+      <svg class="check-icon" viewBox="0 0 24 24">
+        <path d="M20 6L9 17l-5-5"/>
+      </svg>
+    </button>
+  </div>
+
+  <script>
+    const btn = document.getElementById('copyBtn');
+    const code = document.getElementById('codeBlock');
+
+    btn.addEventListener('click', async () => {
+      try {
+        await navigator.clipboard.writeText(code.textContent);
+        btn.classList.add('copied');
+        setTimeout(() => btn.classList.remove('copied'), 1600);
+      } catch (err) {
+        console.error('Copy failed', err);
+      }
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-code-copy-btn-sap/style.css
+++ b/submissions/examples/ease-code-copy-btn-sap/style.css
@@ -1,0 +1,75 @@
+.code-copy-sap {
+  position: relative;
+  width: 420px;
+  background: #1e1e2e;
+  border-radius: 14px;
+  overflow: hidden;
+  font-family: 'Courier New', monospace;
+}
+
+.code-copy-sap pre {
+  margin: 0;
+  padding: 20px 60px 20px 20px;
+  color: #e2e8f0;
+  font-size: 13px;
+  line-height: 1.7;
+  overflow-x: auto;
+}
+
+.code-copy-sap .copy-btn {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  width: 34px;
+  height: 34px;
+  border: none;
+  border-radius: 8px;
+  background: rgba(255,255,255,0.08);
+  color: #cbd5e1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.15s ease;
+}
+
+.code-copy-sap .copy-btn:hover {
+  background: rgba(255,255,255,0.16);
+}
+
+.code-copy-sap .copy-btn svg {
+  width: 16px;
+  height: 16px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.code-copy-sap .copy-btn.copied {
+  background: #22c55e;
+  color: #fff;
+  transform: scale(1.1);
+}
+
+.code-copy-sap .copy-btn .check-icon {
+  display: none;
+}
+
+.code-copy-sap .copy-btn.copied .copy-icon {
+  display: none;
+}
+
+.code-copy-sap .copy-btn.copied .check-icon {
+  display: block;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .code-copy-sap .copy-btn {
+    transition: background 0.2s ease;
+  }
+  .code-copy-sap .copy-btn.copied {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-code-copy-btn-sap`, a copy-to-clipboard button with animated success feedback.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-code-copy-btn-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Uses the modern async `navigator.clipboard.writeText()` API instead of the deprecated `execCommand('copy')`.
- Both copy/check icons are always present in the DOM with only `display` toggled, avoiding layout shift or reflow during the swap.
- `prefers-reduced-motion` removes the button's scale-up on success, keeping color/icon feedback only.

## Feature Description

Adds a reusable animated copy-to-clipboard button for code blocks.

Level: Beginner

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.