### PR TITLE
ci: add CodeQL security analysis workflow (#63648)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,56 @@
+name: CodeQL
+
+# Automated CodeQL static analysis for security vulnerabilities and code
+# quality issues. Runs on push to main, on pull requests, and on a weekly
+# schedule. Results are uploaded to GitHub Security → Code scanning alerts.
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    # every Monday at 02:00 UTC
+    - cron: '0 2 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  # required to upload CodeQL results to Security → Code scanning
+  security-events: write
+  # required by actions/upload-sarif
+  actions: read
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        # EaseMotion-css ships JS (build scripts, engine, benchmarks) + CSS.
+        # CodeQL analyses code; JavaScript is the analysable language here.
+        language: [ javascript ]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # run the security-and-quality query suite for richer findings
+          queries: security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
## What

Closes #63648 — adds a CodeQL static analysis workflow for automated security/code-quality scanning.

## Workflow: `.github/workflows/codeql.yml`

**Triggers** (per the issue's spec)
- Push to `main`
- Pull requests targeting `main`
- Weekly schedule (Monday 02:00 UTC)
- Manual `workflow_dispatch`

**What it does**
1. `github/codeql-action/init@v3` — initializes CodeQL for **JavaScript** (EaseMotion-css ships JS: build scripts, the motion engine, benchmarks) using the `security-and-quality` query suite for richer findings.
2. `github/codeql-action/autobuild@v3` — builds the analysis target automatically (no custom build step needed; the repo's JS is interpreted).
3. `github/codeql-action/analyze@v3` — runs the queries and uploads SARIF results to **GitHub Security → Code scanning**, categorized as `/language:javascript`.

**Permissions** — least-privilege, scoped exactly to what CodeQL needs:
- `contents: read` — checkout
- `security-events: write` — upload SARIF to Code scanning
- `actions: read` — required by the upload-sarif action

**Concurrency** — `codeql-${{ github.ref }}`, `cancel-in-progress: true` so superseded runs on the same branch are cancelled (saves Actions minutes).

**Timeout** — 30 min safety cap.

## Acceptance criteria (from the issue)

- ✅ New workflow at `.github/workflows/codeql.yml`
- ✅ Triggers: push to main, PRs, weekly schedule
- ✅ Uses GitHub's official CodeQL Action (`@v3`)
- ✅ Initializes the appropriate language (JavaScript)
- ✅ Performs analysis after the build step (autobuild)
- ✅ Uploads results to GitHub Security → Code scanning
- ✅ Configured workflow permissions (least-privilege)

## Verification

- YAML validated locally (parses cleanly; triggers, permissions, matrix, steps all structurally correct).
- No new runtime dependencies; no `package.json` or framework source changes.

## Duplicate issue note

#63649 is a byte-for-byte identical duplicate of this issue (same title and body). This PR resolves the underlying request; I'll close #63649 as a duplicate once this is reviewed.

## Notes

- Additive only — a single new workflow file.