### PR TITLE
ci: add npm package validation workflow (#63661)

### DIFF
--- a/.github/workflows/package-validation.yml
+++ b/.github/workflows/package-validation.yml
@@ -1,0 +1,85 @@
+name: Package Validation
+
+# Validates the npm package before publishing by running `npm pack --dry-run`
+# and verifying that exactly the intended files (per package.json `files`)
+# are included — catching accidental inclusions (.github/, tests, screenshots)
+# or missing assets (compiled CSS, README, LICENSE). Runs on PRs, pushes to
+# main, and version tags, and uploads the packed tarball as an artifact.
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: package-validation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate-package:
+    name: Validate npm package contents
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci || npm install
+
+      - name: Build minified CSS (ensure assets exist)
+        run: npm run build
+
+      - name: Validate package manifest
+        run: npm run validate:manifest
+
+      - name: Dry-run pack and verify file allowlist
+        id: pack
+        run: |
+          set -o pipefail
+          npm pack --dry-run 2>&1 | tee pack-dryrun.txt
+          # the repo's own validator cross-checks packed files vs package.json `files`
+          npm run validate:pack
+
+      - name: Create real tarball for artifact
+        run: npm pack
+
+      - name: Upload package tarball + dry-run log
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-package-${{ github.sha }}
+          path: |
+            easemotion-css-*.tgz
+            pack-dryrun.txt
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "## npm package validation" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ job.status }}" = "success" ]; then
+            echo "✅ \`npm pack --dry-run\` succeeded and the packed file list matches \`package.json#files\`." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "❌ Package validation failed — see the dry-run log above." >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "<details><summary>Packed file list</summary>" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          cat pack-dryrun.txt 2>/dev/null >> "$GITHUB_STEP_SUMMARY" || echo "(no log)" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "</details>" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## What

Closes #63661 — adds a GitHub Actions workflow that validates the npm package by performing a dry-run publish before every release, catching packaging issues (accidental inclusions or missing assets) early.

## Workflow: `.github/workflows/package-validation.yml`

**Triggers** (per the issue's spec)
- Pull requests to `main`
- Pushes to `main`
- Version tags (`v*`)
- Manual `workflow_dispatch`

**What it does**
1. Checks out the repo, sets up Node 20 with npm caching (`cache: 'npm'`), installs deps.
2. **Builds the minified CSS** (`npm run build`) so `easemotion.min.css` exists — it's in the `files` allowlist and would otherwise be reported missing.
3. **Validates the manifest** (`npm run validate:manifest`) — runs the repo's existing `scripts/validate-package.mjs` manifest check.
4. **Dry-run pack** (`npm pack --dry-run`) — logs exactly which files would be published, then runs the repo's existing **`npm run validate:pack`** (`scripts/validate-pack.mjs`) which cross-checks the packed file list against `package.json#files`, failing if an unexpected file (e.g. `.github/`, tests, screenshots) sneaks in or a required asset is missing.
5. **Creates a real tarball** and uploads it (`easemotion-css-*.tgz` + the dry-run log) as a workflow artifact (14-day retention) for inspection.
6. Writes a **job summary** to `$GITHUB_STEP_SUMMARY` with pass/fail status and a collapsible list of packed files.

**Permissions** — least-privilege: `contents: read` only.

**Concurrency** — `package-validation-${{ github.ref }}`, cancels superseded runs.

## Why reuse the repo's existing tooling

The repo already ships `scripts/validate-pack.mjs` and a `validate:pack` npm script that enforce the `files` allowlist. The workflow wires these up rather than reinventing the check — so the source of truth stays in the repo and local `npm run validate:pack` matches CI exactly.

## Acceptance criteria (from the issue)

- ✅ Workflow at `.github/workflows/package-validation.yml`
- ✅ Triggers: PRs, pushes to main, version tags
- ✅ Sets up Node.js, installs deps
- ✅ Runs `npm pack --dry-run`
- ✅ Verifies the package is generated successfully
- ✅ Uploads generated package contents as a workflow artifact

## Verification

- YAML validated locally (parses cleanly; triggers, permissions, steps structurally correct).
- Confirmed the repo has `package.json#files`, `scripts/validate-pack.mjs`, and `validate:manifest`/`validate:pack` scripts — the workflow calls existing, tested tooling.
- No new runtime dependencies; no `package.json` changes.

## Notes

- Additive only — a single new workflow file.