### PR TITLE
feat: add ease-audio-waveform-sap

### DIFF
--- a/submissions/examples/ease-audio-waveform-sap/README.md
+++ b/submissions/examples/ease-audio-waveform-sap/README.md
@@ -1,0 +1,18 @@
+# ease-audio-waveform-sap
+
+A play button paired with an animated bar-style waveform that bounces while audio is playing and stays still when paused.
+
+## Usage
+1. Include `style.css`.
+2. Add markup: play button + `.wave-bars` container + `<audio>` element.
+3. Attach the play/pause toggle and bar-generation logic from `demo.html`.
+
+## Customization
+- `heights` array (JS): static bar heights for the resting waveform shape.
+- `wave-bounce-sap` keyframes: bounce range/speed.
+- `animation-direction: reverse` on odd bars: creates visual variation instead of all bars moving in lockstep.
+
+## Notes
+- Bars only animate while `.playing` is present on the wrapper, toggled by actual `audio.play()`/`pause()` state — the animation is a stylized representation, not derived from real frequency data (that would require the Web Audio API's `AnalyserNode`).
+- Alternating `animation-direction: reverse` on odd-indexed bars avoids a robotic, perfectly-synchronized bounce.
+- Respects `prefers-reduced-motion`: bounce animation is disabled, bars settle at a fixed mid-height instead of oscillating.

--- a/submissions/examples/ease-audio-waveform-sap/demo.html
+++ b/submissions/examples/ease-audio-waveform-sap/demo.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-audio-waveform-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      height: 100vh;
+      margin: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #f4f4f5;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="audio-waveform-sap" id="waveformBox">
+    <button class="wave-play" id="playBtn" aria-label="Play audio">
+      <svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg>
+    </button>
+    <div class="wave-bars" id="waveBars"></div>
+    <audio id="audioEl" src="https://interactive-examples.mdn.mozilla.net/media/cc0-audio/t-rex-roar.mp3"></audio>
+  </div>
+
+  <script>
+    const box = document.getElementById('waveformBox');
+    const playBtn = document.getElementById('playBtn');
+    const barsWrap = document.getElementById('waveBars');
+    const audio = document.getElementById('audioEl');
+
+    const heights = [10, 22, 14, 30, 18, 26, 12, 24, 16, 28, 20, 14, 26, 18, 22, 12, 30, 16, 24, 10];
+    heights.forEach((h, i) => {
+      const bar = document.createElement('div');
+      bar.className = 'wave-bar';
+      bar.style.height = h + 'px';
+      bar.style.animationDelay = `${(i % 5) * 0.1}s`;
+      barsWrap.appendChild(bar);
+    });
+
+    playBtn.addEventListener('click', () => {
+      if (audio.paused) {
+        audio.play();
+        box.classList.add('playing');
+        playBtn.innerHTML = '<svg viewBox="0 0 24 24"><path d="M6 5h4v14H6zM14 5h4v14h-4z"/></svg>';
+      } else {
+        audio.pause();
+        box.classList.remove('playing');
+        playBtn.innerHTML = '<svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg>';
+      }
+    });
+
+    audio.addEventListener('ended', () => {
+      box.classList.remove('playing');
+      playBtn.innerHTML = '<svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg>';
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-audio-waveform-sap/style.css
+++ b/submissions/examples/ease-audio-waveform-sap/style.css
@@ -1,0 +1,72 @@
+.audio-waveform-sap {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  width: 360px;
+  padding: 16px 20px;
+  background: #111;
+  border-radius: 16px;
+  font-family: system-ui, sans-serif;
+}
+
+.audio-waveform-sap .wave-play {
+  width: 40px;
+  height: 40px;
+  border: none;
+  border-radius: 50%;
+  background: #2563eb;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 0.2s ease, transform 0.15s ease;
+}
+
+.audio-waveform-sap .wave-play:hover {
+  background: #3b82f6;
+  transform: scale(1.08);
+}
+
+.audio-waveform-sap .wave-play svg {
+  width: 14px;
+  height: 14px;
+  fill: #fff;
+}
+
+.audio-waveform-sap .wave-bars {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  height: 32px;
+  flex: 1;
+}
+
+.audio-waveform-sap .wave-bar {
+  width: 3px;
+  border-radius: 2px;
+  background: #52525b;
+  transition: background 0.2s ease;
+}
+
+.audio-waveform-sap.playing .wave-bar {
+  background: #2563eb;
+  animation: wave-bounce-sap 1s ease-in-out infinite;
+}
+
+.audio-waveform-sap.playing .wave-bar:nth-child(odd) {
+  animation-direction: reverse;
+}
+
+@keyframes wave-bounce-sap {
+  0%, 100% { transform: scaleY(0.4); }
+  50% { transform: scaleY(1); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .audio-waveform-sap.playing .wave-bar {
+    animation: none;
+    transform: scaleY(0.7);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-audio-waveform-sap`, a play button with an animated stylized audio waveform.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-audio-waveform-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Waveform bounce is a stylized CSS animation tied to actual play/pause state, not real frequency-analysis data — README notes the Web Audio API `AnalyserNode` as the path to true audio-reactive bars if needed later.
- Alternating `animation-direction: reverse` on odd bars avoids a mechanically synchronized bounce.
- `prefers-reduced-motion` disables the bounce animation, settling bars at a fixed height while playback state remains accurate.

## Feature Description

Adds a reusable animated audio waveform player component.

Level: Intermediate

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.