### PR TITLE
feat: add ease-map-pin-drop-sap

### DIFF
--- a/submissions/examples/ease-map-pin-drop-sap/README.md
+++ b/submissions/examples/ease-map-pin-drop-sap/README.md
@@ -1,0 +1,18 @@
+# ease-map-pin-drop-sap
+
+Click anywhere on the surface to drop an animated map pin that falls, bounces slightly on landing, and leaves a small shadow ring — pure CSS animation triggered by JS placement.
+
+## Usage
+1. Include `style.css`.
+2. Add markup: a positioned container (`.map-pin-sap`) to click within.
+3. Attach the click listener from `demo.html`, which creates a `.pin` element at the click coordinates.
+
+## Customization
+- `pin-drop-sap` keyframes: drop height/bounce intensity.
+- Pin color (`fill`) and size.
+- Background grid pattern — swap for a real map image/tile if desired.
+
+## Notes
+- Each click creates a new pin element positioned at click coordinates; the drop/bounce/ring-pop animations run automatically via CSS on element insertion (`both` fill-mode ensures the pin starts from its 0% state immediately).
+- Pins are not removed automatically — multiple clicks stack multiple pins, useful for multi-location marking demos.
+- Respects `prefers-reduced-motion`: pins appear directly in their landed position with no drop/bounce animation.

--- a/submissions/examples/ease-map-pin-drop-sap/demo.html
+++ b/submissions/examples/ease-map-pin-drop-sap/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-map-pin-drop-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      height: 100vh;
+      margin: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #f4f4f5;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="map-pin-sap" id="mapArea">
+    <span class="map-hint">Click anywhere to drop a pin</span>
+  </div>
+
+  <script>
+    const map = document.getElementById('mapArea');
+
+    map.addEventListener('click', (e) => {
+      const rect = map.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+
+      const pin = document.createElement('div');
+      pin.className = 'pin';
+      pin.style.left = x + 'px';
+      pin.style.top = y + 'px';
+      pin.innerHTML = `
+        <svg viewBox="0 0 24 24"><path d="M12 2C7.6 2 4 5.6 4 10c0 6 8 12 8 12s8-6 8-12c0-4.4-3.6-8-8-8zm0 11a3 3 0 1 1 0-6 3 3 0 0 1 0 6z"/></svg>
+        <div class="pin-ring"></div>
+      `;
+      map.appendChild(pin);
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-map-pin-drop-sap/style.css
+++ b/submissions/examples/ease-map-pin-drop-sap/style.css
@@ -1,0 +1,72 @@
+.map-pin-sap {
+  position: relative;
+  width: 380px;
+  height: 260px;
+  border-radius: 16px;
+  background:
+    linear-gradient(rgba(37,99,235,0.06) 1px, transparent 1px) 0 0/20px 20px,
+    linear-gradient(90deg, rgba(37,99,235,0.06) 1px, transparent 1px) 0 0/20px 20px,
+    #eef2f7;
+  overflow: hidden;
+  cursor: crosshair;
+}
+
+.map-pin-sap .pin {
+  position: absolute;
+  width: 32px;
+  height: 32px;
+  transform: translate(-50%, -100%);
+  animation: pin-drop-sap 0.55s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+  pointer-events: none;
+}
+
+.map-pin-sap .pin svg {
+  width: 100%;
+  height: 100%;
+  fill: #ef4444;
+  filter: drop-shadow(0 4px 6px rgba(0,0,0,0.25));
+}
+
+.map-pin-sap .pin .pin-ring {
+  position: absolute;
+  bottom: -4px;
+  left: 50%;
+  width: 14px;
+  height: 6px;
+  border-radius: 50%;
+  background: rgba(0,0,0,0.2);
+  transform: translateX(-50%) scale(0);
+  animation: ring-pop-sap 0.5s ease 0.15s both;
+}
+
+@keyframes pin-drop-sap {
+  0% { transform: translate(-50%, -240px); opacity: 0; }
+  70% { transform: translate(-50%, -100%); opacity: 1; }
+  85% { transform: translate(-50%, -108%); }
+  100% { transform: translate(-50%, -100%); }
+}
+
+@keyframes ring-pop-sap {
+  to { transform: translateX(-50%) scale(1); }
+}
+
+.map-pin-sap .map-hint {
+  position: absolute;
+  bottom: 12px;
+  left: 12px;
+  font-size: 12px;
+  font-family: system-ui, sans-serif;
+  color: #64748b;
+  background: rgba(255,255,255,0.85);
+  padding: 4px 10px;
+  border-radius: 8px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .map-pin-sap .pin,
+  .map-pin-sap .pin .pin-ring {
+    animation: none;
+    opacity: 1;
+    transform: translate(-50%, -100%);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-map-pin-drop-sap`, a click-to-drop animated map pin effect.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-map-pin-drop-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Pin drop/bounce/ring-pop are all pure CSS `@keyframes` with `both` fill-mode, so newly inserted pin elements animate immediately without a forced reflow trick in JS.
- Pins intentionally aren't auto-removed, supporting multi-pin demos from repeated clicks.
- `prefers-reduced-motion` disables all pin animations; pins appear instantly in their final landed position.

## Feature Description

Adds a reusable animated map-pin-drop interaction effect.

Level: Intermediate

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.