### PR TITLE
Add ease-weather-forecast-widget component

### DIFF
--- a/submissions/examples/weather-forecast-widget-ij/README.md
+++ b/submissions/examples/weather-forecast-widget-ij/README.md
@@ -1,0 +1,10 @@
+# ease-weather-forecast-widget
+
+A weather forecast widget where the day cards glow, the icons pulse, and the gauges flicker.
+
+## Run
+Open `demo.html` directly in a browser to watch the forecast.
+
+## Notes
+- The sun icon glows on the today card.
+- The footer gauges flicker in turn.

--- a/submissions/examples/weather-forecast-widget-ij/demo.html
+++ b/submissions/examples/weather-forecast-widget-ij/demo.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-weather-forecast-widget demo</title>
+</head>
+<body>
+<div class="wfw-frame">
+  <span class="wfw-title">FORECAST</span>
+  <div class="wfw-row">
+    <div class="wfw-day">
+      <span class="wfw-name">TODAY</span>
+      <span class="wfw-icon wfw-sun">SUN</span>
+      <span class="wfw-temp">27</span>
+      <span class="wfw-note">FEELS 29</span>
+    </div>
+    <div class="wfw-day">
+      <span class="wfw-name">SAT</span>
+      <span class="wfw-icon wfw-cloud">CLOUD</span>
+      <span class="wfw-temp">22</span>
+      <span class="wfw-note">FEELS 21</span>
+    </div>
+    <div class="wfw-day">
+      <span class="wfw-name">SUN</span>
+      <span class="wfw-icon wfw-rain">RAIN</span>
+      <span class="wfw-temp">18</span>
+      <span class="wfw-note">FEELS 16</span>
+    </div>
+  </div>
+  <div class="wfw-far">
+    <span class="wfw-gauge">WIND 14</span>
+    <span class="wfw-gauge">HUM 62</span>
+    <span class="wfw-gauge">UV 5</span>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/weather-forecast-widget-ij/style.css
+++ b/submissions/examples/weather-forecast-widget-ij/style.css
@@ -1,0 +1,21 @@
+:root{--wfw-sky:#7ec8ff;--wfw-panel:#0e2333;--wfw-amber:#ffcf6e}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(135deg,#16324a,#0a1a2a);font-family:'Trebuchet MS',sans-serif}
+.wfw-frame{position:relative;width:340px;height:440px;border-radius:24px;overflow:hidden;background:linear-gradient(180deg,#12293d,#0a1826);box-shadow:0 18px 36px rgba(0,0,0,0.55);padding:14px}
+.wfw-title{position:absolute;top:14px;left:0;right:0;text-align:center;font-size:12px;font-weight:700;letter-spacing:10px;color:#7ec8ff;animation:title-glint-weather-forecast-widget 2.4s ease-in-out infinite}
+.wfw-row{position:absolute;top:56px;left:14px;right:14px;display:flex;justify-content:space-between}
+.wfw-day{width:94px;height:238px;border-radius:16px;background:#16364e;display:flex;flex-direction:column;align-items:center;padding-top:12px;gap:10px}
+.wfw-name{font-size:11px;font-weight:700;letter-spacing:3px;color:#9fd4ff}
+.wfw-icon{font-size:11px;font-weight:700;letter-spacing:2px;border-radius:50%;width:44px;height:44px;display:grid;place-items:center}
+.wfw-sun{color:#ffe9b8;background:radial-gradient(circle at 30% 30%,#ffdf8f,#e8a33c);animation:sun-glow-weather-forecast-widget 2s ease-in-out infinite}
+.wfw-cloud{color:#eaf6ff;background:radial-gradient(circle at 30% 30%,#9fc7e8,#5d84a8);animation:cloud-drift-weather-forecast-widget 3.2s ease-in-out infinite}
+.wfw-rain{color:#d6f2ff;background:radial-gradient(circle at 30% 30%,#6ab2d8,#3c7096);animation:rain-drip-weather-forecast-widget 1.2s linear infinite}
+.wfw-temp{font-size:34px;font-weight:700;color:#ffffff;line-height:1;animation:temp-breathe-weather-forecast-widget 2.8s ease-in-out infinite}
+.wfw-note{font-size:9px;letter-spacing:2px;color:#7f9fb8}
+.wfw-far{position:absolute;bottom:14px;left:14px;right:14px;display:flex;justify-content:space-around;background:#123449;border-radius:12px;padding:8px 4px}
+.wfw-gauge{font-size:10px;letter-spacing:2px;color:#9fd4ff;animation:gauge-flicker-weather-forecast-widget 1.6s steps(2) infinite}
+@keyframes title-glint-weather-forecast-widget{0%,100%{opacity:1}50%{opacity:0.35}}
+@keyframes sun-glow-weather-forecast-widget{0%,100%{transform:scale(1);box-shadow:0 0 0 rgba(255,223,143,0)}50%{transform:scale(1.16);box-shadow:0 0 22px rgba(255,223,143,0.7)}}
+@keyframes cloud-drift-weather-forecast-widget{0%,100%{transform:translateX(0)}50%{transform:translateX(8px)}}
+@keyframes rain-drip-weather-forecast-widget{0%{transform:translateY(0);opacity:1}70%{opacity:0.4}100%{transform:translateY(16px);opacity:0.1}}
+@keyframes temp-breathe-weather-forecast-widget{0%,100%{transform:scale(1)}50%{transform:scale(1.08)}}
+@keyframes gauge-flicker-weather-forecast-widget{0%,100%{opacity:1}50%{opacity:0.3}}


### PR DESCRIPTION
## Component: ease-weather-forecast-widget — sun glows, temps breathe, and gauges flicker

**Closes #67990**

### What this adds
A weather forecast widget: three day cards show icons and temperatures, the sun icon glows, the temps breathe, and the gauges flicker along the footer.

### Acceptance Criteria covered
- Sun icon glows on the today card
- Temperatures breathe on each card
- Footer gauges flicker in turn

### Files
- `submissions/examples/weather-forecast-widget-ij/demo.html`
- `submissions/examples/weather-forecast-widget-ij/style.css`
- `submissions/examples/weather-forecast-widget-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the sun glow on the forecast.