### PR TITLE
feat: add ease-split-text-reveal-sap

### DIFF
--- a/submissions/examples/ease-split-text-reveal-sap/README.md
+++ b/submissions/examples/ease-split-text-reveal-sap/README.md
@@ -1,0 +1,18 @@
+# ease-split-text-reveal-sap
+
+A heading where each word rises up from below and fades in with a staggered delay — clipped so words appear to "slide into place" from a masked region.
+
+## Usage
+1. Include `style.css`.
+2. Add markup: any heading with `class="split-reveal-sap"` and plain text.
+3. Include the JS from `demo.html`, which wraps each word in a clipped outer span + animated inner span.
+
+## Customization
+- `i * 0.12s` stagger interval: delay between each word's reveal.
+- `translateY(110%)` starting offset and animation duration/easing.
+- Font size/weight for different heading levels.
+
+## Notes
+- Uses a two-span-per-word structure: the outer `.word` span has `overflow: hidden` to act as a mask, while the inner span is the one that actually translates upward — this is what creates the "sliding up from a hidden slot" look rather than a plain fade.
+- Splitting by word (not character) keeps the effect readable for longer headings without excessive animation count.
+- Respects `prefers-reduced-motion`: all words appear instantly in their final position and opacity, animation is fully disabled.

--- a/submissions/examples/ease-split-text-reveal-sap/demo.html
+++ b/submissions/examples/ease-split-text-reveal-sap/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-split-text-reveal-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      height: 100vh;
+      margin: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #fafafa;
+    }
+  </style>
+</head>
+<body>
+
+  <h1 class="split-reveal-sap" id="revealText">Build Beautiful Interfaces</h1>
+
+  <script>
+    const el = document.getElementById('revealText');
+    const words = el.textContent.trim().split(' ');
+    el.textContent = '';
+
+    words.forEach((word, i) => {
+      const wrap = document.createElement('span');
+      wrap.className = 'word';
+      const inner = document.createElement('span');
+      inner.textContent = word;
+      inner.style.animationDelay = `${i * 0.12}s`;
+      wrap.appendChild(inner);
+      el.appendChild(wrap);
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-split-text-reveal-sap/style.css
+++ b/submissions/examples/ease-split-text-reveal-sap/style.css
@@ -1,0 +1,36 @@
+.split-reveal-sap {
+  font-family: system-ui, sans-serif;
+  font-size: 40px;
+  font-weight: 800;
+  color: #111;
+  overflow: hidden;
+}
+
+.split-reveal-sap .word {
+  display: inline-block;
+  overflow: hidden;
+  vertical-align: top;
+  margin-right: 0.28em;
+}
+
+.split-reveal-sap .word span {
+  display: inline-block;
+  transform: translateY(110%);
+  opacity: 0;
+  animation: word-rise-sap 0.7s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+@keyframes word-rise-sap {
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .split-reveal-sap .word span {
+    animation: none;
+    transform: none;
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-split-text-reveal-sap`, a staggered word-by-word text reveal animation.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-split-text-reveal-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Two-span-per-word structure (outer masking span + inner translating span) produces a genuine "slide out of a hidden slot" reveal, not a simple opacity fade.
- Splitting by word rather than character keeps animation count reasonable for longer headings.
- `prefers-reduced-motion` disables the animation entirely, showing final text immediately.

## Feature Description

Adds a reusable staggered word-reveal heading animation.

Level: Intermediate

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.