### PR TITLE
docs: add broken link checker workflow template (#63447)

### DIFF
--- a/submissions/docs/broken-link-checker-sbh/README.md
+++ b/submissions/docs/broken-link-checker-sbh/README.md
@@ -1,0 +1,46 @@
+# Broken Link Checker — CI workflow template
+
+A drop-in GitHub Actions workflow that crawls the live docs site with
+[lychee](https://github.com/lycheeverse/lychee) and auto-opens a tracking
+issue when broken links are found. Resolves issue #63447.
+
+## Why
+
+The docs site links out to the Discord server, the GitHub repo, and internally
+between the Buttons/Cards/Animations/Layout sections — any of these can silently
+break as the site or Discord invite changes. A weekly automated check catches
+dead links before a visitor reports them.
+
+## Install
+
+Copy `broken-link-checker.yml` into your repo's `.github/workflows/` directory:
+
+```bash
+mkdir -p .github/workflows
+cp broken-link-checker.yml .github/workflows/
+```
+
+No other setup is required — the workflow uses public actions and the built-in
+`GITHUB_TOKEN`, so no secrets need to be configured.
+
+## What it does
+
+- **Triggers:** weekly schedule (Monday 06:00 UTC) + manual `workflow_dispatch`.
+- Runs `lycheeverse/lychee-action@v2` against `https://saptarshi-coder.github.io/EaseMotion-css/`.
+- Accepts `100..=399,401,402,403,429` (skip soft rate-limits / auth walls); excludes mailto: links.
+- Emits a Markdown report and uploads it as a workflow artifact (14-day retention).
+- **On broken links found:** opens (or reuses via title search) a tracking issue labelled `bug,documentation,ci` with the full lychee report — subsequent runs update the same issue instead of spamming.
+- **On clean run:** auto-closes the tracking issue with a link to the passing run.
+
+## Permissions
+
+Least-privilege: `contents: read`, `issues: write` (only to open/close the tracking issue).
+
+## Concurrency
+
+`broken-link-checker` group, `cancel-in-progress: false` so a long crawl isn't killed by a stray manual run.
+
+## Files
+
+- `broken-link-checker.yml` — the workflow template (copy to `.github/workflows/`).
+- `README.md` — this documentation.

--- a/submissions/docs/broken-link-checker-sbh/broken-link-checker.yml
+++ b/submissions/docs/broken-link-checker-sbh/broken-link-checker.yml
@@ -1,0 +1,107 @@
+name: Broken Link Checker
+
+# Catches dead links (renamed docs pages, deleted external references, expired
+# Discord invites) on the live docs site before visitors hit them. Runs weekly
+# and on manual dispatch, using lychee (fast Rust link checker). Opens a
+# tracking issue automatically when broken links are found.
+#
+# Install: copy this file to .github/workflows/broken-link-checker.yml
+
+on:
+  schedule:
+    # every Monday at 06:00 UTC
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: broken-link-checker
+  cancel-in-progress: false
+
+jobs:
+  check-links:
+    name: Check docs site links
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Link Checker (lychee)
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          # scan the live GitHub Pages docs site (HTML crawl)
+          args: >-
+            --no-progress
+            --max-concurrency 16
+            --accept 100..=399,401,402,403,429
+            --exclude-mail
+            'https://saptarshi-coder.github.io/EaseMotion-css/'
+          # fail the job when links are broken so the next step can react
+          fail: true
+          # produce a Markdown report we can paste into the issue body
+          format: markdown
+          output: broken-links-report.md
+
+      - name: Read report
+        if: always()
+        id: report
+        run: |
+          if [ -f broken-links-report.md ]; then
+            {
+              echo "body<<EOF"
+              cat broken-links-report.md
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open / update tracking issue for broken links
+        if: failure() && steps.report.outputs.exists == 'true'
+        uses: peter-evans/create-or-update-issue@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: 'docs: Broken links detected on the docs site 🚫'
+          labels: bug,documentation,ci
+          content: ${{ steps.report.outputs.body }}
+          # search key so subsequent runs reuse the same issue instead of spamming
+          search-existing-title: 'docs: Broken links detected on the docs site 🚫'
+          body: |
+            The weekly **Broken Link Checker** workflow found dead links on the docs site
+            (`https://saptarshi-coder.github.io/EaseMotion-css/`).
+
+            This issue was opened automatically by the
+            [Broken Link Checker workflow](https://github.com/${{ github.repository }}/actions/workflows/broken-link-checker.yml).
+
+            ## lychee report
+
+            ${{ steps.report.outputs.body }}
+
+            ---
+            _Re-run the workflow after fixing to verify. This issue stays open until a run passes clean._
+
+      - name: Close resolved tracking issue when links are clean
+        if: success()
+        uses: peter-evans/create-or-update-issue@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          state: closed
+          search-existing-title: 'docs: Broken links detected on the docs site 🚫'
+          body: |
+            ✅ The latest Broken Link Checker run found **no broken links** — this issue can be closed.
+
+            Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+      - name: Upload link report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: broken-links-report
+          path: broken-links-report.md
+          if-no-files-found: ignore
+          retention-days: 14


### PR DESCRIPTION
## What

Closes #63447 — a broken-link-checker CI workflow for the docs site, delivered as an installable workflow template under `submissions/docs/` (so it passes the repo's submission validator; copy the YAML into `.github/workflows/` to activate).

## Why a docs submission

The repo's submission validator auto-closes PRs that touch files outside `submissions/`. CI workflow files belong in `.github/workflows/`, so this PR ships the workflow as a **template + install guide** under `submissions/docs/broken-link-checker-sbh/` for a maintainer to install.

## Contents

`submissions/docs/broken-link-checker-sbh/`
- `broken-link-checker.yml` — the workflow (copy to `.github/workflows/`).
- `README.md` — what it does + install instructions.

## Workflow behavior

- **Triggers:** weekly (Monday 06:00 UTC) + manual `workflow_dispatch`.
- Runs `lycheeverse/lychee-action@v2` against `https://saptarshi-coder.github.io/EaseMotion-css/`.
- Accepts `100..=399,401,402,403,429`; excludes mailto:.
- Emits a Markdown report → uploaded as a workflow artifact (14-day retention).
- **Broken links found →** opens/reuses a tracking issue (labelled `bug,documentation,ci`) with the full report.
- **Clean run →** auto-closes the tracking issue.
- Permissions: `contents: read`, `issues: write`.
- Concurrency: `broken-link-checker`, `cancel-in-progress: false`.

## Install

```bash
mkdir -p .github/workflows
cp submissions/docs/broken-link-checker-sbh/broken-link-checker.yml .github/workflows/
```

## Verification

- YAML validated locally.
- Uses the issue's requested tool (lychee).