### PR TITLE
feat: add ease-morph-icon-set-sap

### DIFF
--- a/submissions/examples/ease-morph-icon-set-sap/README.md
+++ b/submissions/examples/ease-morph-icon-set-sap/README.md
@@ -1,0 +1,18 @@
+# ease-morph-icon-set-sap
+
+A like/heart icon toggle where the outline stroke changes color and a filled heart pops in underneath with a bouncy scale-up on activation.
+
+## Usage
+1. Include `style.css`.
+2. Add markup: button containing a two-layer SVG (fill path + outline path sharing the same `d`).
+3. Attach the click toggle from `demo.html`, syncing `.active` class with `aria-pressed`.
+
+## Customization
+- Swap the heart path `d` for any other icon shape (star, bookmark, etc) — keep both `.heart-fill` and `.icon-path` using the same `d` value.
+- Colors for active/inactive states.
+- Scale-up easing on `.heart-fill` for a snappier/softer pop.
+
+## Notes
+- Two stacked `<path>` elements share identical `d` coordinates: one is always-visible outline, one is a fill that scales in only when active — this avoids needing true SVG shape morphing (animating the `d` attribute itself), which has poor cross-browser support without a JS library.
+- `aria-pressed` is kept in sync with the visual state since this is a toggle control, not a static icon.
+- Respects `prefers-reduced-motion`: the bouncy scale-in becomes a simple state change (fill still appears/disappears via opacity, just without the elastic scale).

--- a/submissions/examples/ease-morph-icon-set-sap/demo.html
+++ b/submissions/examples/ease-morph-icon-set-sap/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-morph-icon-set-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      height: 100vh;
+      margin: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #f4f4f5;
+    }
+  </style>
+</head>
+<body>
+
+  <button class="morph-icon-sap" id="heartBtn" aria-label="Like" aria-pressed="false">
+    <svg viewBox="0 0 24 24">
+      <path class="heart-fill" d="M12 21s-7.5-4.6-10-9.2C.6 8.4 2.4 5 6 5c2 0 3.5 1.1 4.3 2.4C11.1 6.1 12.6 5 14.6 5c3.6 0 5.4 3.4 4 6.8C19.5 16.4 12 21 12 21z"/>
+      <path class="icon-path" d="M12 21s-7.5-4.6-10-9.2C.6 8.4 2.4 5 6 5c2 0 3.5 1.1 4.3 2.4C11.1 6.1 12.6 5 14.6 5c3.6 0 5.4 3.4 4 6.8C19.5 16.4 12 21 12 21z"/>
+    </svg>
+  </button>
+
+  <script>
+    const btn = document.getElementById('heartBtn');
+    btn.addEventListener('click', () => {
+      const active = btn.classList.toggle('active');
+      btn.setAttribute('aria-pressed', active);
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-morph-icon-set-sap/style.css
+++ b/submissions/examples/ease-morph-icon-set-sap/style.css
@@ -1,0 +1,58 @@
+.morph-icon-sap {
+  width: 52px;
+  height: 52px;
+  border: none;
+  border-radius: 50%;
+  background: #f1f5f9;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.morph-icon-sap:hover {
+  background: #e2e8f0;
+}
+
+.morph-icon-sap svg {
+  width: 24px;
+  height: 24px;
+  overflow: visible;
+}
+
+.morph-icon-sap .icon-path {
+  fill: none;
+  stroke: #111;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  transition: d 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.morph-icon-sap.active .icon-path {
+  stroke: #ef4444;
+}
+
+.morph-icon-sap .heart-fill {
+  fill: #ef4444;
+  opacity: 0;
+  transform: scale(0);
+  transform-origin: center;
+  transition: opacity 0.3s ease, transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.morph-icon-sap.active .heart-fill {
+  opacity: 1;
+  transform: scale(1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .morph-icon-sap .icon-path,
+  .morph-icon-sap .heart-fill {
+    transition: opacity 0.2s ease;
+  }
+  .morph-icon-sap .heart-fill {
+    transform: scale(1);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-morph-icon-set-sap`, an animated icon toggle (heart/like) with a bouncy fill-in effect.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-morph-icon-set-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Two stacked paths sharing identical coordinates (outline + fill) avoid needing true `d`-attribute shape morphing, which lacks reliable cross-browser CSS support without a JS animation library.
- `aria-pressed` is toggled alongside the `.active` class since this is a functional toggle control, not decorative.
- `prefers-reduced-motion` removes the elastic scale-in, keeping only an opacity-based fill appearance.

## Feature Description

Adds a reusable animated icon toggle component (heart/like pattern).

Level: Intermediate

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.