### PR TITLE
feat: add ease-sticky-note-peel-sap

### DIFF
--- a/submissions/examples/ease-sticky-note-peel-sap/README.md
+++ b/submissions/examples/ease-sticky-note-peel-sap/README.md
@@ -1,0 +1,20 @@
+# ease-sticky-note-peel-sap
+
+A sticky-note styled card with a corner that peels up on hover, revealing a shadowed underside triangle — pure CSS, no images.
+
+## Usage
+1. Include `style.css`.
+2. Add markup:
+```html
+   <div class="sticky-note-sap">Your note text here</div>
+```
+
+## Customization
+- Note `background` color and slight `rotate()` for a "stuck on a wall" tilt.
+- `::after` gradient stops: peel corner size/shadow depth.
+- Peel size on hover (`width`/`height` in `:hover::after`).
+
+## Notes
+- The peel effect is a `::after` pseudo-element sized at `0` by default and grown on hover, using a diagonal gradient split (paper-white to note-yellow) to simulate the underside of curling paper.
+- `overflow: hidden` on the note keeps the growing peel corner clipped to the note's own boundary.
+- Respects `prefers-reduced-motion`: peel corner and shadow both apply instantly on hover instead of easing in.

--- a/submissions/examples/ease-sticky-note-peel-sap/demo.html
+++ b/submissions/examples/ease-sticky-note-peel-sap/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-sticky-note-peel-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      height: 100vh;
+      margin: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #f4f4f5;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="sticky-note-sap">
+    Remember to review PR #67091 before end of day!
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-sticky-note-peel-sap/style.css
+++ b/submissions/examples/ease-sticky-note-peel-sap/style.css
@@ -1,0 +1,43 @@
+.sticky-note-sap {
+  position: relative;
+  width: 200px;
+  height: 200px;
+  background: #fde047;
+  padding: 20px;
+  box-sizing: border-box;
+  font-family: 'Courier New', monospace;
+  font-size: 14px;
+  color: #422006;
+  box-shadow: 2px 4px 10px rgba(0,0,0,0.15);
+  transform: rotate(-2deg);
+  overflow: hidden;
+  transition: box-shadow 0.3s ease;
+}
+
+.sticky-note-sap::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 0;
+  height: 0;
+  background: linear-gradient(135deg, transparent 50%, #fff 50%, #fde68a 52%, #fbbf24 100%);
+  box-shadow: -2px -2px 6px rgba(0,0,0,0.15);
+  transition: width 0.35s ease, height 0.35s ease;
+}
+
+.sticky-note-sap:hover {
+  box-shadow: 4px 10px 20px rgba(0,0,0,0.25);
+}
+
+.sticky-note-sap:hover::after {
+  width: 60px;
+  height: 60px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sticky-note-sap,
+  .sticky-note-sap::after {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-sticky-note-peel-sap`, a hover-triggered curling-corner sticky note effect.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-sticky-note-peel-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Peel corner is a diagonal-gradient `::after`, grown from `0` on hover — no image asset or SVG needed to fake the paper-underside look.
- `overflow: hidden` on the note itself clips the peel corner cleanly to its bounds as it grows.
- `prefers-reduced-motion` disables the peel/shadow transitions; hover state still applies, just instantly.

## Feature Description

Adds a reusable pure-CSS sticky note with a hover peel-corner effect.

Level: Intermediate

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.