### PR TITLE
feat: add ease-drag-to-delete-sap

### DIFF
--- a/submissions/examples/ease-drag-to-delete-sap/README.md
+++ b/submissions/examples/ease-drag-to-delete-sap/README.md
@@ -1,0 +1,19 @@
+# ease-drag-to-delete-sap
+
+A list where dragging an item horizontally past a threshold marks it for deletion (red tint) and releasing removes it with a slide-out animation.
+
+## Usage
+1. Include `style.css`.
+2. Add markup: `.drag-delete-sap` containing multiple `.drag-item` rows.
+3. Attach the drag handling from `demo.html` to each item.
+
+## Customization
+- `threshold` (JS): drag distance required to trigger deletion.
+- `.delete-zone` styling: visual warning state while dragging past threshold.
+- `.removed` slide-out distance/direction.
+
+## Notes
+- Works bidirectionally (drag left or right past threshold both delete), using `Math.abs(currentX)`.
+- `touch-action: pan-y` allows vertical page scroll to still work while horizontal drag is captured for the delete gesture.
+- Item removal is deferred via `setTimeout` matching the CSS transition duration, so the DOM node is removed only after the slide-out animation completes.
+- Respects `prefers-reduced-motion`: slide-out transform is removed, items fade out via opacity only instead of sliding away.

--- a/submissions/examples/ease-drag-to-delete-sap/demo.html
+++ b/submissions/examples/ease-drag-to-delete-sap/demo.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-drag-to-delete-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      height: 100vh;
+      margin: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #f4f4f5;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="drag-delete-sap" id="list">
+    <div class="drag-item">Buy groceries</div>
+    <div class="drag-item">Finish report</div>
+    <div class="drag-item">Call dentist</div>
+  </div>
+
+  <script>
+    const list = document.getElementById('list');
+    const threshold = 110;
+
+    function attachDrag(item) {
+      let startX = 0, currentX = 0, dragging = false;
+
+      const onDown = (clientX) => {
+        dragging = true;
+        startX = clientX;
+        item.classList.add('dragging');
+      };
+
+      const onMove = (clientX) => {
+        if (!dragging) return;
+        currentX = clientX - startX;
+        item.style.transform = `translateX(${currentX}px)`;
+        item.classList.toggle('delete-zone', Math.abs(currentX) > threshold);
+      };
+
+      const onUp = () => {
+        if (!dragging) return;
+        dragging = false;
+        item.classList.remove('dragging');
+
+        if (Math.abs(currentX) > threshold) {
+          item.classList.add('removed');
+          setTimeout(() => item.remove(), 300);
+        } else {
+          item.style.transform = '';
+          item.classList.remove('delete-zone');
+        }
+        currentX = 0;
+      };
+
+      item.addEventListener('mousedown', (e) => onDown(e.clientX));
+      window.addEventListener('mousemove', (e) => onMove(e.clientX));
+      window.addEventListener('mouseup', onUp);
+
+      item.addEventListener('touchstart', (e) => onDown(e.touches[0].clientX), { passive: true });
+      item.addEventListener('touchmove', (e) => onMove(e.touches[0].clientX), { passive: true });
+      item.addEventListener('touchend', onUp);
+    }
+
+    [...list.querySelectorAll('.drag-item')].forEach(attachDrag);
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-drag-to-delete-sap/style.css
+++ b/submissions/examples/ease-drag-to-delete-sap/style.css
@@ -1,0 +1,52 @@
+.drag-delete-sap {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 300px;
+  font-family: system-ui, sans-serif;
+}
+
+.drag-delete-sap .drag-item {
+  position: relative;
+  padding: 16px 18px;
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.1);
+  font-size: 14px;
+  color: #111;
+  cursor: grab;
+  transition: transform 0.3s ease, opacity 0.3s ease, background 0.15s ease;
+  touch-action: pan-y;
+  user-select: none;
+}
+
+.drag-delete-sap .drag-item.dragging {
+  transition: none;
+  cursor: grabbing;
+  box-shadow: 0 8px 20px rgba(0,0,0,0.15);
+}
+
+.drag-delete-sap .drag-item.delete-zone {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.drag-delete-sap .drag-item.removed {
+  transform: translateX(120%);
+  opacity: 0;
+}
+
+.drag-delete-sap .delete-hint {
+  font-size: 11px;
+  opacity: 0.7;
+  margin-top: 4px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .drag-delete-sap .drag-item {
+    transition: opacity 0.2s ease;
+  }
+  .drag-delete-sap .drag-item.removed {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-drag-to-delete-sap`, a draggable list with threshold-based swipe-to-delete.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-drag-to-delete-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Deletion works bidirectionally via `Math.abs(currentX)`, so users can drag either direction past the threshold.
- `touch-action: pan-y` preserves vertical page scroll while the horizontal gesture drives the delete interaction on touch devices.
- Node removal is deferred with `setTimeout` matched to the CSS transition duration, avoiding an abrupt DOM removal before the slide-out finishes.
- `prefers-reduced-motion` removes the slide-out transform, using opacity fade only.

## Feature Description

Adds a reusable drag-to-delete list item interaction.

Level: Advanced

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.