### PR TITLE
feat: add em-hover-intent utility to debounce rapid hover animations …

### DIFF
--- a/submissions/examples/hover-intent-delay/README.md
+++ b/submissions/examples/hover-intent-delay/README.md
@@ -1,0 +1,41 @@
+# Hover Intent Delay
+
+Closes #65821
+
+### 1. What does this do?
+A CSS-only utility, `.em-hover-intent`, that adds a short delay (default 80ms) before a hover animation triggers on entry, while reverting instantly on exit — preventing the flashing/chaotic effect when a user's mouse quickly passes over several animated elements.
+
+### 2. How is it used?
+Add `.em-hover-intent` alongside any element that already has its own hover transition (card lift, button color change, underline link, etc.). No JavaScript is required:
+
+```html
+<div class="demo-card em-hover-intent">Card A</div>
+
+<button class="demo-btn em-hover-intent" type="button">Hover me</button>
+
+<a class="demo-link em-hover-intent" href="#">Underline link</a>
+```
+
+The element still needs its own `transition: <property> <duration> <easing>;` declaration — `.em-hover-intent` only controls the *delay* portion:
+
+```css
+.demo-card {
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+```
+
+Two speed modifiers are included, both changing a single custom property so you can also override it inline:
+
+```html
+<div class="demo-card em-hover-intent em-hover-intent--fast">50ms</div>
+<div class="demo-card em-hover-intent">80ms (default)</div>
+<div class="demo-card em-hover-intent em-hover-intent--slow">100ms</div>
+
+<!-- or a fully custom delay -->
+<div class="demo-card em-hover-intent" style="--em-hover-delay: 120ms;">Custom</div>
+```
+
+**How it works:** CSS resolves `transition-delay` from the *after-change* rule. Moving into `:hover` uses the delay from the `:hover` rule (`var(--em-hover-delay)`), so the animation waits. Moving back out uses the delay from the base rule (`0s`), so it snaps back immediately — no lag when the user actually leaves. `prefers-reduced-motion: reduce` collapses the delay to `0s` in both directions.
+
+### 3. Why is it useful?
+Hover-triggered animations are one of EaseMotion's core building blocks, but on dense layouts (grids of cards, nav bars, toolbars) a fast mouse pass can fire dozens of transitions in a fraction of a second, reading as visual noise rather than polish. `.em-hover-intent` fixes this with a single class and zero JavaScript, keeping with EaseMotion's philosophy of small, composable, human-readable utilities that layer cleanly on top of existing hover effects instead of replacing them.

--- a/submissions/examples/hover-intent-delay/demo.html
+++ b/submissions/examples/hover-intent-delay/demo.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Hover Intent Delay — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="demo-page">
+    <header class="demo-page__header">
+      <h1>🖱️ Hover Intent Delay</h1>
+      <p>
+        Swipe your mouse quickly across each row. The top row fires instantly on every
+        pass-through; the bottom row waits briefly to confirm you meant to hover,
+        then reverts immediately when you leave.
+      </p>
+    </header>
+
+    <section class="demo-page__section">
+      <h2>Without hover intent <span class="demo-page__tag demo-page__tag--bad">flashes on every pass</span></h2>
+      <div class="demo-row">
+        <div class="demo-card">Card A</div>
+        <div class="demo-card">Card B</div>
+        <div class="demo-card">Card C</div>
+        <div class="demo-card">Card D</div>
+      </div>
+    </section>
+
+    <section class="demo-page__section">
+      <h2>With <code>.em-hover-intent</code> <span class="demo-page__tag demo-page__tag--good">waits ~80ms</span></h2>
+      <div class="demo-row">
+        <div class="demo-card em-hover-intent">Card A</div>
+        <div class="demo-card em-hover-intent">Card B</div>
+        <div class="demo-card em-hover-intent">Card C</div>
+        <div class="demo-card em-hover-intent">Card D</div>
+      </div>
+    </section>
+
+    <section class="demo-page__section">
+      <h2>Delay modifiers</h2>
+      <div class="demo-row">
+        <div class="demo-card em-hover-intent em-hover-intent--fast">Fast · 50ms</div>
+        <div class="demo-card em-hover-intent">Default · 80ms</div>
+        <div class="demo-card em-hover-intent em-hover-intent--slow">Slow · 100ms</div>
+      </div>
+    </section>
+
+    <section class="demo-page__section">
+      <h2>Works on buttons and nav links too</h2>
+      <div class="demo-row demo-row--mixed">
+        <button class="demo-btn em-hover-intent" type="button">Hover me</button>
+        <a class="demo-link em-hover-intent" href="#">Underline link</a>
+      </div>
+    </section>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/hover-intent-delay/style.css
+++ b/submissions/examples/hover-intent-delay/style.css
@@ -1,0 +1,160 @@
+/* -------------------- em-hover-intent utility -------------------- */
+/*
+  The trick: transition-delay is read from the *after-change* rule.
+  - Entering :hover -> the used delay comes from the :hover rule (var(--em-hover-delay)).
+  - Leaving :hover  -> the used delay comes from the base rule (0s), so it snaps back instantly.
+
+  This class only controls the *delay*. The element still needs its own
+  `transition: <property> <duration> <easing>;` declaration for anything to animate.
+*/
+
+.em-hover-intent {
+  --em-hover-delay: 80ms;
+  transition-delay: 0s;
+}
+
+.em-hover-intent:hover,
+.em-hover-intent:focus-visible {
+  transition-delay: var(--em-hover-delay);
+}
+
+.em-hover-intent--fast {
+  --em-hover-delay: 50ms;
+}
+
+.em-hover-intent--slow {
+  --em-hover-delay: 100ms;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .em-hover-intent,
+  .em-hover-intent:hover,
+  .em-hover-intent:focus-visible {
+    transition-delay: 0s;
+  }
+}
+
+/* -------------------- demo page chrome (not part of the feature) -------------------- */
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+  background: #f3f4f6;
+  color: #1f2430;
+  padding: 40px 20px 80px;
+}
+
+.demo-page {
+  max-width: 760px;
+  margin: 0 auto;
+}
+
+.demo-page__header {
+  text-align: center;
+  margin-bottom: 36px;
+}
+
+.demo-page__header h1 {
+  margin: 0 0 10px;
+}
+
+.demo-page__header p {
+  margin: 0 auto;
+  max-width: 520px;
+  opacity: 0.75;
+  line-height: 1.5;
+}
+
+.demo-page__section {
+  margin-bottom: 32px;
+}
+
+.demo-page__section h2 {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 1rem;
+  margin-bottom: 14px;
+}
+
+.demo-page__tag {
+  font-size: 0.72rem;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 999px;
+}
+
+.demo-page__tag--bad {
+  background: rgba(239, 68, 68, 0.12);
+  color: #dc2626;
+}
+
+.demo-page__tag--good {
+  background: rgba(34, 197, 94, 0.12);
+  color: #16a34a;
+}
+
+.demo-row {
+  display: flex;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.demo-row--mixed {
+  align-items: center;
+}
+
+.demo-card {
+  flex: 1 1 140px;
+  padding: 22px 16px;
+  text-align: center;
+  font-weight: 600;
+  border-radius: 14px;
+  background: #ffffff;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.04);
+  cursor: pointer;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
+}
+
+.demo-card:hover {
+  transform: translateY(-6px) scale(1.02);
+  background: #eef2ff;
+  box-shadow: 0 14px 28px rgba(79, 70, 229, 0.22);
+}
+
+.demo-btn {
+  padding: 12px 22px;
+  border: none;
+  border-radius: 10px;
+  background: #4f46e5;
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background 0.25s ease, transform 0.25s ease;
+}
+
+.demo-btn:hover {
+  background: #4338ca;
+  transform: translateY(-2px);
+}
+
+.demo-link {
+  color: #4f46e5;
+  font-weight: 600;
+  text-decoration: none;
+  background-image: linear-gradient(#4f46e5, #4f46e5);
+  background-size: 0% 2px;
+  background-position: left bottom;
+  background-repeat: no-repeat;
+  transition: background-size 0.25s ease;
+  padding-bottom: 2px;
+}
+
+.demo-link:hover {
+  background-size: 100% 2px;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a CSS-only `.em-hover-intent` utility that delays hover animations by a short debounce (default 80ms) on entry while reverting instantly on exit. Solves the flashing/chaotic UI reported in #65821, where a fast mouse pass across a grid of hover-animated elements fires every transition in rapid succession.

Closes #65821

---

## Type of Change
- [x] ✨ New animation / hover effect

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/hover-intent-delay/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A `.em-hover-intent` class that delays hover-triggered transitions on entry but not on exit, preventing rapid-mouse-pass flashing.

**How does a developer use it?**
```html
<div class="demo-card em-hover-intent">Card A</div>

<button class="demo-btn em-hover-intent" type="button">Hover me</button>

<a class="demo-link em-hover-intent" href="#">Underline link</a>

<!-- speed modifiers -->
<div class="demo-card em-hover-intent em-hover-intent--fast">50ms</div>
<div class="demo-card em-hover-intent em-hover-intent--slow">100ms</div>
```
The element keeps its own `transition: <property> <duration> <easing>;` declaration as usual — `.em-hover-intent` only overrides the delay.

**Why does it fit EaseMotion CSS?**
Hover animations are one of EaseMotion's core building blocks, but on dense layouts a fast mouse pass can fire dozens of transitions in a fraction of a second, reading as noise instead of polish. This fixes that with a single class and zero JavaScript, in keeping with EaseMotion's philosophy of small, composable, human-readable utilities that layer on top of existing hover effects rather than replacing them.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

- The core trick: `transition-delay` is resolved from the *after-change* rule, so entering `:hover` picks up the delay declared on `.em-hover-intent:hover` while leaving picks up `0s` from the base rule — no JS timers involved. Worth a quick sanity-check on a couple of browsers since this relies on standard-but-slightly-subtle transition resolution behavior.
- I also applied the delay on `:focus-visible`, not just `:hover`, so keyboard users get the same debounce — happy to drop that if it's out of scope for this issue.
- `prefers-reduced-motion: reduce` collapses the delay to `0s` in both directions, since a delay without motion can just feel like lag.
- Same as the last couple of submissions — I don't have a fixed contributor identifier to append to the folder name per the naming-conflict convention in CONTRIBUTING; let me know if you'd like it renamed before merge.