### PR TITLE
feat: add ease-dock-magnify-sap

### DIFF
--- a/submissions/examples/ease-dock-magnify-sap/README.md
+++ b/submissions/examples/ease-dock-magnify-sap/README.md
@@ -1,0 +1,17 @@
+# ease-dock-magnify-sap
+
+A macOS-style dock where the hovered icon scales up and lifts, with neighboring icons growing slightly too, using pure CSS sibling selectors — no JS.
+
+## Usage
+1. Include `style.css`.
+2. Add markup: `.dock-icon` elements inside `.dock-magnify-sap`, each with its own background/emoji.
+
+## Customization
+- `scale(1.6)` on the hovered icon vs `scale(1.25)` on neighbors: magnification intensity.
+- `backdrop-filter: blur(20px)` on the dock background for the glass effect.
+- Icon size/border-radius.
+
+## Notes
+- Neighbor magnification uses the `:has()` relational pseudo-class (`.dock-icon:has(+ .dock-icon:hover)`) to affect the icon *before* the hovered one, combined with the adjacent sibling combinator (`:hover + .dock-icon`) for the one *after* — both directions handled in pure CSS.
+- `:has()` has broad modern browser support (Chrome/Edge/Safari) but should be verified for the target browser matrix if older browser support is required — it degrades gracefully by simply not applying the "before" neighbor's magnification.
+- Respects `prefers-reduced-motion`: all scale/lift/margin transforms are removed, dock remains static regardless of hover.

--- a/submissions/examples/ease-dock-magnify-sap/demo.html
+++ b/submissions/examples/ease-dock-magnify-sap/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-dock-magnify-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      height: 100vh;
+      margin: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: linear-gradient(135deg, #667eea, #764ba2);
+    }
+  </style>
+</head>
+<body>
+
+  <div class="dock-magnify-sap">
+    <div class="dock-icon" style="background:#ef4444;">🎵</div>
+    <div class="dock-icon" style="background:#3b82f6;">📁</div>
+    <div class="dock-icon" style="background:#22c55e;">💬</div>
+    <div class="dock-icon" style="background:#f59e0b;">🎨</div>
+    <div class="dock-icon" style="background:#8b5cf6;">📷</div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-dock-magnify-sap/style.css
+++ b/submissions/examples/ease-dock-magnify-sap/style.css
@@ -1,0 +1,45 @@
+.dock-magnify-sap {
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
+  padding: 14px 20px;
+  background: rgba(255,255,255,0.5);
+  backdrop-filter: blur(20px);
+  border-radius: 20px;
+  box-shadow: 0 10px 30px rgba(0,0,0,0.12);
+}
+
+.dock-magnify-sap .dock-icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 22px;
+  cursor: pointer;
+  transition: transform 0.18s cubic-bezier(0.34, 1.56, 0.64, 1), margin 0.18s ease;
+  transform-origin: bottom center;
+}
+
+.dock-magnify-sap .dock-icon:hover {
+  transform: scale(1.6) translateY(-10px);
+  margin: 0 8px;
+}
+
+.dock-magnify-sap .dock-icon:hover + .dock-icon,
+.dock-magnify-sap .dock-icon:has(+ .dock-icon:hover) {
+  transform: scale(1.25) translateY(-4px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dock-magnify-sap .dock-icon {
+    transition: none;
+  }
+  .dock-magnify-sap .dock-icon:hover,
+  .dock-magnify-sap .dock-icon:hover + .dock-icon,
+  .dock-magnify-sap .dock-icon:has(+ .dock-icon:hover) {
+    transform: none;
+    margin: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-dock-magnify-sap`, a macOS-style dock hover-magnify effect using pure CSS.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-dock-magnify-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Achieves the neighbor-magnify effect with zero JS: `:hover + .dock-icon` handles the following sibling, `:has(+ .dock-icon:hover)` handles the preceding one.
- README flags `:has()` browser support as worth verifying for older-browser target matrices, with graceful degradation noted (only the "before" neighbor effect is lost, not the whole component).
- `prefers-reduced-motion` removes all magnify/lift transforms, keeping the dock static.

## Feature Description

Adds a reusable pure-CSS dock magnification hover effect.

Level: Advanced

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.