### PR TITLE
feat: add pure CSS 3D Flip Clock component (#68247)

### DIFF
--- a/submissions/examples/css-flip-clock/README.md
+++ b/submissions/examples/css-flip-clock/README.md
@@ -1,0 +1,21 @@
+# CSS Flip Clock
+
+A pure CSS implementation of a classic mechanical flip clock using advanced 3D CSS transforms and animations.
+
+## Features
+- Pure CSS and HTML (Zero JavaScript required for the 3D flipping animation).
+- **Retro Aesthetic**: Utilizes the `Oswald` condensed font, a dark modern palette (`#2a2a31`), and a distinct center split line to emulate the physical split-flap displays found in retro train stations and alarm clocks.
+- **True 3D Transforms**: 
+- The container uses CSS `perspective: 1000px` to establish a 3D rendering context.
+- Each number card is split into a static top half, a static bottom half, and an animated "flipping" half.
+- The flipping mechanism utilizes `transform-origin: bottom;` to ensure the top card hinges downward exactly at the center split line.
+- The animation rotates the card along the X-axis (`transform: rotateX(-180deg)`) simulating physical gravity.
+- **Realistic Lighting**: CSS pseudo-elements (`::after`) are used to overlay linear gradients that fade in and out during the rotation keyframes (`shadow-top`, `shadow-back`). This fakes the effect of dynamic ambient lighting casting shadows as the physical card changes its angle relative to a light source.
+- Fully accessible with `prefers-reduced-motion` support. For motion-sensitive users, the 3D rotation animations and the blinking colon divider are completely disabled.
+
+## Usage
+Open `demo.html` in your browser. You will see a large digital clock interface. The "Seconds" unit on the far right will continuously loop through a realistic 3D flipping animation, while the Hours and Minutes units will demonstrate a staggered, one-off time change (e.g., flipping from 09:24 to 10:25) shortly after the page loads.
+
+## Files
+- `demo.html`: The HTML structure for the clock, detailing the complex nesting required for 3D flip cards (separate divs for the top, bottom, and the back-face of the flipping card).
+- `style.css`: The styling, font configuration, 3D `perspective` setup, and the highly specific `@keyframes` managing the `rotateX` transforms and dynamic lighting shadows.

--- a/submissions/examples/css-flip-clock/demo.html
+++ b/submissions/examples/css-flip-clock/demo.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Flip Clock</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Pure CSS Flip Clock</h1>
+            <p class="subtitle">A classic retro flip-clock animation built entirely with CSS 3D transforms.</p>
+        </header>
+
+        <div class="clock-area">
+            
+            <!-- 
+               The Flip Clock Container 
+               We mock a time transition (e.g., from 09 to 10)
+            -->
+            <div class="flip-clock" aria-label="Clock showing 10">
+                
+                <!-- Hours -->
+                <div class="flip-unit">
+                    <div class="flip-card flip-anim-1">
+                        <div class="flip-card-top">10</div>
+                        <div class="flip-card-bottom">09</div>
+                        <div class="flip-card-back">
+                            <div class="flip-card-back-bottom">10</div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="flip-divider">:</div>
+
+                <!-- Minutes -->
+                <div class="flip-unit">
+                    <div class="flip-card flip-anim-2">
+                        <div class="flip-card-top">25</div>
+                        <div class="flip-card-bottom">24</div>
+                        <div class="flip-card-back">
+                            <div class="flip-card-back-bottom">25</div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="flip-divider">:</div>
+
+                <!-- Seconds -->
+                <div class="flip-unit">
+                    <!-- For the seconds, we will loop an infinite flip animation -->
+                    <div class="flip-card flip-anim-infinite">
+                        <div class="flip-card-top">59</div>
+                        <div class="flip-card-bottom">58</div>
+                        <div class="flip-card-back">
+                            <!-- In a real JS implementation, these numbers would dynamically update.
+                                 Here we just simulate the visual flip effect. -->
+                            <div class="flip-card-back-bottom">59</div>
+                        </div>
+                    </div>
+                </div>
+                
+            </div>
+            
+            <p class="instruction-text">Notice the 3D rotation and realistic lighting gradients during the flip.</p>
+            
+        </div>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-flip-clock/style.css
+++ b/submissions/examples/css-flip-clock/style.css
@@ -1,0 +1,256 @@
+@import url('https://fonts.googleapis.com/css2?family=Oswald:wght@500;700&display=swap');
+
+:root {
+    --bg-base: #1e1e24; /* Dark modern background */
+    --text-primary: #ffffff;
+    --text-secondary: #8c8c94;
+    
+    /* Clock Specifics */
+    --clock-bg: #2a2a31;
+    --clock-text: #f8fafc;
+    --clock-line: rgba(0, 0, 0, 0.4);
+    --clock-shadow: 0 10px 20px rgba(0, 0, 0, 0.3), inset 0 2px 0 rgba(255, 255, 255, 0.05);
+    --clock-border-radius: 12px;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', -apple-system, sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    width: 100%;
+    padding: 40px 20px;
+    text-align: center;
+}
+
+.section-header {
+    margin-bottom: 60px;
+}
+
+.title {
+    font-size: 2.5rem;
+    font-weight: 700;
+    margin: 0 0 12px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    margin: 0;
+}
+
+.instruction-text {
+    margin-top: 40px;
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+}
+
+
+/* =========================================
+   Flip Clock Layout
+   ========================================= */
+
+.clock-area {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.flip-clock {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.flip-divider {
+    font-family: 'Oswald', sans-serif;
+    font-size: 4rem;
+    font-weight: 700;
+    color: var(--clock-text);
+    margin: 0 8px;
+    padding-bottom: 8px; /* Optical alignment */
+    animation: blink 1s ease-in-out infinite alternate;
+}
+
+@keyframes blink {
+    0% { opacity: 1; }
+    100% { opacity: 0.3; }
+}
+
+
+/* =========================================
+   Flip Unit Mechanics (3D Setup)
+   ========================================= */
+
+.flip-unit {
+    position: relative;
+    width: 120px;
+    height: 140px;
+    perspective: 1000px; /* Enable 3D space */
+    border-radius: var(--clock-border-radius);
+    box-shadow: var(--clock-shadow);
+    background-color: #1a1a1f; /* Underneath layer color */
+}
+
+/* 
+  The core structure.
+  We divide the number card into top and bottom halves.
+*/
+.flip-card-top,
+.flip-card-bottom,
+.flip-card-back-bottom {
+    position: absolute;
+    width: 100%;
+    height: 50%;
+    background-color: var(--clock-bg);
+    color: var(--clock-text);
+    font-family: 'Oswald', sans-serif;
+    font-size: 6rem;
+    font-weight: 700;
+    line-height: 140px; /* Match total height for vertical centering */
+    text-align: center;
+    overflow: hidden; /* Hide the overflow from the half height */
+    box-shadow: inset 0 0 15px rgba(0,0,0,0.2);
+}
+
+.flip-card-top {
+    top: 0;
+    transform-origin: bottom; /* Crucial: hinge at the bottom */
+    border-radius: var(--clock-border-radius) var(--clock-border-radius) 0 0;
+    border-bottom: 1px solid var(--clock-line); /* The center line split */
+    z-index: 2;
+}
+
+.flip-card-bottom {
+    bottom: 0;
+    /* Adjust line-height alignment for bottom half */
+    line-height: 0; 
+    border-radius: 0 0 var(--clock-border-radius) var(--clock-border-radius);
+    z-index: 1;
+}
+
+/* 
+  The "Back" side of the top card that flips down.
+  It's actually the *new* bottom number.
+*/
+.flip-card-back {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 50%;
+    transform-origin: bottom;
+    transform: rotateX(180deg); /* Start flipped up/backwards */
+    backface-visibility: hidden; /* Hide until rotated into view */
+    z-index: 3; 
+}
+
+.flip-card-back-bottom {
+    /* Identical styling to the bottom half, but lives inside the flipping container */
+    bottom: 0;
+    top: auto; /* Reset top inherited from .flip-card-top grouping */
+    line-height: 0;
+    border-radius: 0 0 var(--clock-border-radius) var(--clock-border-radius);
+    /* Reverse the rotation so text reads correctly when flipped down */
+    transform: rotateX(180deg);
+}
+
+/* Add realistic shadows during flip */
+.flip-card-top::after,
+.flip-card-back-bottom::after {
+    content: "";
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background: linear-gradient(to bottom, rgba(0,0,0,0.6) 0%, rgba(0,0,0,0) 100%);
+    opacity: 0;
+    transition: opacity 0.5s ease;
+}
+
+
+/* =========================================
+   Flip Animations
+   ========================================= */
+
+/* Top half falls down */
+@keyframes flip-top {
+    0% { transform: rotateX(0deg); }
+    100% { transform: rotateX(-180deg); } /* Folds forward/down */
+}
+
+/* Back face (new bottom) becomes visible */
+@keyframes flip-back {
+    0% { transform: rotateX(180deg); } /* Started tucked behind */
+    100% { transform: rotateX(0deg); } /* Folds down into final place */
+}
+
+/* Shadow fading for realism */
+@keyframes shadow-top {
+    0% { opacity: 0; }
+    50% { opacity: 1; }
+    100% { opacity: 1; }
+}
+
+@keyframes shadow-back {
+    0% { opacity: 1; }
+    50% { opacity: 0; }
+    100% { opacity: 0; }
+}
+
+
+/* Apply animations to demo elements */
+
+/* Infinite looping seconds */
+.flip-anim-infinite .flip-card-top {
+    animation: flip-top 1s cubic-bezier(0.37, 0, 0.63, 1) infinite;
+}
+.flip-anim-infinite .flip-card-top::after {
+    animation: shadow-top 1s cubic-bezier(0.37, 0, 0.63, 1) infinite;
+}
+.flip-anim-infinite .flip-card-back {
+    animation: flip-back 1s cubic-bezier(0.37, 0, 0.63, 1) infinite;
+}
+.flip-anim-infinite .flip-card-back-bottom::after {
+    animation: shadow-back 1s cubic-bezier(0.37, 0, 0.63, 1) infinite;
+}
+
+/* Staggered one-off animations for hours/mins to simulate a specific time change */
+.flip-anim-1 .flip-card-top,
+.flip-anim-2 .flip-card-top {
+    animation: flip-top 0.8s cubic-bezier(0.37, 0, 0.63, 1) forwards;
+    animation-delay: 2s;
+}
+.flip-anim-1 .flip-card-back,
+.flip-anim-2 .flip-card-back {
+    animation: flip-back 0.8s cubic-bezier(0.37, 0, 0.63, 1) forwards;
+    animation-delay: 2s;
+}
+.flip-anim-2 .flip-card-top,
+.flip-anim-2 .flip-card-back {
+    animation-delay: 2.2s; /* Minutes flip slightly after hours */
+}
+
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    /* Disable 3D transforms */
+    .flip-card-top, .flip-card-back {
+        animation: none !important;
+        transform: none !important;
+    }
+    
+    /* Disable blinking divider */
+    .flip-divider {
+        animation: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a classic mechanical CSS Flip Clock component, resolving issue #68247. 

### Changes Made:
- Added `submissions/examples/css-flip-clock/` directory.
- Created `demo.html` showcasing a large digital clock interface. 
  - The structure handles the complex nesting required for 3D flip cards (separate divs for the top half, bottom half, and the back-face of the flipping card) without relying on any JavaScript.
- Created `style.css` featuring a dark retro aesthetic utilizing the `Oswald` condensed font and a distinct center split line.
  - Implemented True 3D Transforms. The container uses CSS `perspective: 1000px` to establish a 3D rendering context.
  - The flipping mechanism utilizes `transform-origin: bottom;` to ensure the top card hinges downward exactly at the center split line, rotating along the X-axis (`transform: rotateX(-180deg)`) to simulate physical gravity.
  - Added Realistic Lighting. CSS pseudo-elements (`::after`) are used to overlay linear gradients that fade in and out during the rotation keyframes (`shadow-top`, `shadow-back`). This fakes the effect of dynamic ambient lighting casting shadows as the physical card changes its angle.
- Added `README.md` documenting usage and technical features.
- Honors the `prefers-reduced-motion` accessibility standard. The 3D rotation animations and the blinking colon divider are completely disabled for motion-sensitive users.

Closes #68247
