### PR TITLE
feat: add pure CSS Resizable Panel component (#68264)

### DIFF
--- a/submissions/examples/css-draggable-resizable-panel/README.md
+++ b/submissions/examples/css-draggable-resizable-panel/README.md
@@ -1,0 +1,26 @@
+# CSS Resizable Panel
+
+A floating UI panel component that utilizes the native CSS `resize` property, enhanced with custom-styled visual handles and responsive internal layouts, built entirely without JavaScript.
+
+## Features
+- Pure CSS and HTML (Zero JavaScript required for resizing logic or dimension calculations).
+- **Native CSS Resize Mechanics**: 
+- The `.resizable-panel` uses the native CSS `resize: both;` property.
+- To function, this property requires `overflow` to be set to something other than `visible` (we use `overflow: hidden;`).
+- CSS `min-width`, `min-height`, `max-width`, and `max-height` constraints are respected natively by the browser during resizing, ensuring the panel doesn't break the UI.
+- **Custom Visual Resize Handle Trick**: 
+- By default, browsers (Chrome/Safari) render an ugly, un-styleable diagonal line grabber in the bottom right corner for `resize: both`.
+- We hide this default UI using the WebKit scrollbar pseudo-element hack (`::-webkit-scrollbar-corner { background: transparent; }`).
+- We then position a custom SVG icon (`.custom-resize-handle`) absolutely in the bottom-right corner.
+- **Crucially**, we apply `pointer-events: none;` to our custom SVG handle. This allows the user's mouse clicks to pass straight through our beautiful icon and hit the invisible native browser resize zone sitting directly underneath it.
+- **Responsive Internal Layout**: The internal form fields use CSS Grid (`grid-template-columns: repeat(auto-fit, minmax(...))`) ensuring that as the user drags the panel to be wider or narrower, the internal content flawlessly reflows to fit the new dimensions.
+- **Focus States**: Includes a `:focus-within` styling upgrade. When the user interacts with the panel (clicks inside it or resizes it), the shadow and border color dynamically intensify.
+
+## Usage
+Open `demo.html` in your browser. You will see a "Configuration" panel floating in the center of the screen. Click and drag the bottom-right corner (marked by the blue arrow icon) to resize the panel freely. Notice how the internal inputs automatically reflow into a single column when the panel is made too narrow.
+
+*Note: True arbitrary 2D window "dragging" (moving the panel across the screen) requires JavaScript to persistently update `left/top` or `transform` coordinates based on pointer events. This component focuses purely on the CSS resizing mechanics requested.*
+
+## Files
+- `demo.html`: The HTML structure for the panel, including the mock internal UI and the custom `.custom-resize-handle` SVG.
+- `style.css`: The styling, the core `resize: both` logic, min/max dimensional constraints, and the `pointer-events: none` hack for custom handle styling.

--- a/submissions/examples/css-draggable-resizable-panel/demo.html
+++ b/submissions/examples/css-draggable-resizable-panel/demo.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Resizable Panel</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Pure CSS Resizable Panel</h1>
+            <p class="subtitle">A floating UI panel utilizing native CSS <code>resize</code> with custom-styled visual handles, zero JavaScript required.</p>
+        </header>
+
+        <div class="workspace-area">
+            
+            <!-- 
+               The Resizable Panel
+               Native CSS resize requires overflow to be something other than visible.
+            -->
+            <div class="resizable-panel" aria-label="Settings Panel" tabindex="0">
+                
+                <div class="panel-header">
+                    <div class="panel-icon">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path></svg>
+                    </div>
+                    <h3>Configuration</h3>
+                    <div class="panel-controls">
+                        <button class="control-btn minimize-btn" aria-label="Minimize"></button>
+                        <button class="control-btn maximize-btn" aria-label="Maximize"></button>
+                        <button class="control-btn close-btn" aria-label="Close"></button>
+                    </div>
+                </div>
+                
+                <div class="panel-body">
+                    <p class="panel-desc">Drag the bottom-right corner to resize this panel. The content will flex and adapt to the new dimensions automatically.</p>
+                    
+                    <div class="mock-ui-grid">
+                        <div class="mock-input">
+                            <label>API Endpoint</label>
+                            <input type="text" value="https://api.easemotion.dev/v1" readonly>
+                        </div>
+                        <div class="mock-input">
+                            <label>Timeout (ms)</label>
+                            <input type="text" value="5000" readonly>
+                        </div>
+                    </div>
+                    
+                    <div class="mock-toggle">
+                        <span>Enable Auto-scaling</span>
+                        <div class="toggle-switch active"></div>
+                    </div>
+                </div>
+
+                <!-- 
+                   Custom visual resize handle. 
+                   Since native resize handles are hard to style cross-browser, 
+                   we use a visual overlay that sits perfectly on top of the native invisible handle zone.
+                -->
+                <div class="custom-resize-handle">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="21 3 21 21 3 21"></polyline><line x1="21" y1="13" x2="13" y2="21"></line><line x1="21" y1="7" x2="7" y2="21"></line></svg>
+                </div>
+
+            </div>
+            
+        </div>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-draggable-resizable-panel/style.css
+++ b/submissions/examples/css-draggable-resizable-panel/style.css
@@ -1,0 +1,275 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    --border-color: #e2e8f0;
+    
+    --panel-bg: #ffffff;
+    --panel-header-bg: #f1f5f9;
+    --accent: #3b82f6;
+    
+    --shadow-heavy: 0 25px 50px -12px rgba(0, 0, 0, 0.25), 0 0 0 1px rgba(0,0,0,0.05);
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    /* Optional dot pattern background */
+    background-image: radial-gradient(#cbd5e1 1px, transparent 1px);
+    background-size: 20px 20px;
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 1000px;
+    width: 100%;
+    padding: 40px 20px;
+}
+
+.section-header {
+    text-align: center;
+    margin-bottom: 50px;
+}
+
+.title {
+    font-size: 2.25rem;
+    font-weight: 600;
+    margin: 0 0 12px 0;
+    letter-spacing: -0.5px;
+    background: var(--bg-base);
+    display: inline-block;
+    padding: 0 16px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    margin: 0;
+    background: var(--bg-base);
+    display: inline-block;
+    padding: 4px 16px;
+}
+
+.workspace-area {
+    position: relative;
+    width: 100%;
+    height: 600px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+
+/* =========================================
+   The Resizable Panel Core Logic
+   ========================================= */
+
+.resizable-panel {
+    position: relative;
+    
+    /* Core constraints */
+    min-width: 300px;
+    min-height: 200px;
+    max-width: 800px;
+    max-height: 500px;
+    
+    /* Default starting size */
+    width: 450px;
+    height: 350px;
+    
+    /* The Native CSS Resize Magic */
+    resize: both;
+    overflow: hidden; /* Required for resize: both to work */
+    
+    background: var(--panel-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    box-shadow: var(--shadow-heavy);
+    display: flex;
+    flex-direction: column;
+    
+    /* Focus state styling */
+    outline: none;
+    transition: box-shadow 0.2s ease;
+}
+
+.resizable-panel:focus-within {
+    box-shadow: 0 25px 50px -12px rgba(59, 130, 246, 0.25), 0 0 0 2px var(--accent);
+}
+
+
+/* =========================================
+   Panel UI Internals
+   ========================================= */
+
+.panel-header {
+    display: flex;
+    align-items: center;
+    padding: 12px 16px;
+    background: var(--panel-header-bg);
+    border-bottom: 1px solid var(--border-color);
+    cursor: default; /* Would be cursor: grab if JS drag was implemented */
+}
+
+.panel-icon {
+    width: 20px;
+    height: 20px;
+    color: var(--text-secondary);
+    margin-right: 12px;
+}
+.panel-icon svg { width: 100%; height: 100%; }
+
+.panel-header h3 {
+    margin: 0;
+    font-size: 0.95rem;
+    font-weight: 600;
+    flex: 1;
+}
+
+.panel-controls {
+    display: flex;
+    gap: 8px;
+}
+
+.control-btn {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    border: none;
+    cursor: pointer;
+}
+.minimize-btn { background: #facc15; }
+.maximize-btn { background: #4ade80; }
+.close-btn { background: #f87171; }
+
+.panel-body {
+    padding: 20px;
+    flex: 1;
+    overflow-y: auto; /* Allow content to scroll if panel is sized too small */
+}
+
+.panel-desc {
+    margin: 0 0 24px 0;
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    line-height: 1.5;
+}
+
+/* Mock Form UI that flexes nicely during resize */
+.mock-ui-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 16px;
+    margin-bottom: 24px;
+}
+
+.mock-input label {
+    display: block;
+    font-size: 0.8rem;
+    font-weight: 600;
+    margin-bottom: 6px;
+    color: var(--text-secondary);
+}
+
+.mock-input input {
+    width: 100%;
+    padding: 8px 12px;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    background: #f8fafc;
+    color: var(--text-primary);
+    box-sizing: border-box;
+    font-family: inherit;
+}
+
+.mock-toggle {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 12px 16px;
+    background: #f8fafc;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    font-size: 0.9rem;
+    font-weight: 500;
+}
+
+.toggle-switch {
+    width: 36px;
+    height: 20px;
+    background: var(--border-color);
+    border-radius: 20px;
+    position: relative;
+}
+
+.toggle-switch.active {
+    background: var(--accent);
+}
+
+.toggle-switch.active::after {
+    content: "";
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    width: 16px;
+    height: 16px;
+    background: white;
+    border-radius: 50%;
+}
+
+
+/* =========================================
+   Custom Visual Resize Handle
+   ========================================= */
+
+/* 
+  Browsers render a tiny, un-styleable grabber for `resize: both`.
+  We place a custom SVG icon perfectly over the bottom-right corner 
+  and set `pointer-events: none` so mouse clicks pass through it 
+  and hit the native invisible resizer underneath.
+*/
+.custom-resize-handle {
+    position: absolute;
+    bottom: 2px;
+    right: 2px;
+    width: 16px;
+    height: 16px;
+    color: var(--text-secondary);
+    pointer-events: none; /* Crucial: Let clicks pass through to native resizer */
+    z-index: 10;
+    opacity: 0.5;
+    transition: opacity 0.2s ease;
+}
+
+.resizable-panel:hover .custom-resize-handle,
+.resizable-panel:focus-within .custom-resize-handle {
+    opacity: 1;
+    color: var(--accent);
+}
+
+.custom-resize-handle svg {
+    width: 100%;
+    height: 100%;
+}
+
+/* 
+  Hack to hide the native Chrome/Safari grabber styling 
+  (the little diagonal lines).
+  WebKit allows styling the scrollbar corner, which hides the default resizer UI.
+*/
+.resizable-panel::-webkit-scrollbar {
+    width: 12px;
+    height: 12px;
+}
+.resizable-panel::-webkit-scrollbar-corner {
+    background: transparent;
+}


### PR DESCRIPTION
### Description
This PR introduces a pure CSS Resizable Panel with custom visual handles, resolving issue #68264. 
*(Note: True arbitrary 2D window dragging requires JS; this component strictly implements the pure CSS resizing mechanics requested).*

### Changes Made:
- Added `submissions/examples/css-draggable-resizable-panel/` directory.
- Created `demo.html` showcasing a floating "Configuration" UI panel. 
  - Included a responsive internal mock form utilizing CSS Grid `auto-fit` so that content smoothly reflows when the user dynamically resizes the panel.
- Created `style.css` featuring a clean, modern aesthetic with `:focus-within` styling upgrades.
  - Implemented **Native CSS Resize Mechanics**. The panel uses the native `resize: both;` property coupled with `overflow: hidden;`. It strictly honors `min-width/height` constraints natively during interaction.
  - Implemented a **Custom Visual Handle Trick**. Default browser resize grabbers (the diagonal lines) are hidden using the WebKit scrollbar pseudo-element hack. 
  - A custom SVG icon (`.custom-resize-handle`) is absolutely positioned over the bottom-right corner. By applying `pointer-events: none;` to this custom handle, user mouse clicks pass straight through it and interact with the invisible native browser resize zone underneath, allowing for beautiful custom styling of native functionality without JavaScript.
- Added `README.md` documenting usage and technical mechanics.

Closes #68264
