### PR TITLE
Add ease-stock-ticker-scroll component

### DIFF
--- a/submissions/examples/stock-ticker-scroll-ij/README.md
+++ b/submissions/examples/stock-ticker-scroll-ij/README.md
@@ -1,0 +1,10 @@
+# ease-stock-ticker-scroll
+
+A stock ticker where the strips scroll, the prices tick, and the arrows blink.
+
+## Run
+Open `demo.html` directly in a browser to watch the ticker scroll.
+
+## Notes
+- The symbol strips scroll continuously.
+- The change arrows blink.

--- a/submissions/examples/stock-ticker-scroll-ij/demo.html
+++ b/submissions/examples/stock-ticker-scroll-ij/demo.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-stock-ticker-scroll demo</title>
+</head>
+<body>
+<div class="sts-board">
+  <div class="sts-strip">
+    <span class="sts-item"><span class="sts-sym">AAPL</span><span class="sts-price">214.32</span><span class="sts-arrow sts-up"></span><span class="sts-chg">+1.2</span></span>
+    <span class="sts-item"><span class="sts-sym">MSFT</span><span class="sts-price">432.10</span><span class="sts-arrow sts-dn"></span><span class="sts-chg sts-neg">-0.8</span></span>
+    <span class="sts-item"><span class="sts-sym">NVDA</span><span class="sts-price">128.44</span><span class="sts-arrow sts-up"></span><span class="sts-chg">+2.6</span></span>
+    <span class="sts-item"><span class="sts-sym">AMZN</span><span class="sts-price">188.05</span><span class="sts-arrow sts-dn"></span><span class="sts-chg sts-neg">-1.4</span></span>
+    <span class="sts-item"><span class="sts-sym">TSLA</span><span class="sts-price">242.77</span><span class="sts-arrow sts-up"></span><span class="sts-chg">+0.9</span></span>
+    <span class="sts-item"><span class="sts-sym">GOOG</span><span class="sts-price">174.60</span><span class="sts-arrow sts-dn"></span><span class="sts-chg sts-neg">-0.5</span></span>
+    <span class="sts-item"><span class="sts-sym">META</span><span class="sts-price">586.91</span><span class="sts-arrow sts-up"></span><span class="sts-chg">+3.1</span></span>
+    <span class="sts-item"><span class="sts-sym">NFLX</span><span class="sts-price">917.23</span><span class="sts-arrow sts-dn"></span><span class="sts-chg sts-neg">-2.2</span></span>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/stock-ticker-scroll-ij/style.css
+++ b/submissions/examples/stock-ticker-scroll-ij/style.css
@@ -1,0 +1,14 @@
+:root{--sts-up:#45e08a;--sts-dn:#ff5d6e;--sts-dark:#0a0f16}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#0e141c,#070a10);font-family:'Tahoma',sans-serif}
+.sts-board{position:relative;width:420px;height:140px;border-radius:14px;overflow:hidden;background:linear-gradient(180deg,#131b26,#0a0f16);box-shadow:0 16px 34px rgba(0,0,0,0.6)}
+.sts-strip{position:absolute;top:0;left:0;display:flex;width:max-content;height:100%;align-items:center;animation:ticker-scroll-stock-ticker-scroll 12s linear infinite}
+.sts-item{display:flex;align-items:center;gap:8px;padding:0 22px;border-right:1px solid #1f2a38;height:56px;animation:tick-glow-stock-ticker-scroll 2.6s ease-in-out infinite}
+.sts-sym{font-size:13px;font-weight:700;letter-spacing:1px;color:#e6ecf3}
+.sts-price{font-size:12px;font-weight:700;color:#aeb8c4}
+.sts-arrow{width:0;height:0;border-left:5px solid transparent;border-right:5px solid transparent}
+.sts-up{border-bottom:7px solid #45e08a}
+.sts-dn{border-top:7px solid #ff5d6e}
+.sts-chg{font-size:11px;font-weight:700;color:#45e08a}
+.sts-neg{color:#ff5d6e}
+@keyframes ticker-scroll-stock-ticker-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
+@keyframes tick-glow-stock-ticker-scroll{0%,100%{opacity:1}50%{opacity:0.5}}


### PR DESCRIPTION
## Component: ease-stock-ticker-scroll — strips scroll, prices tick, and arrows blink

**Closes #68256**

### What this adds
A stock ticker: the symbol strips scroll continuously across the bar, the prices tick, and the change arrows blink in place.

### Acceptance Criteria covered
- Symbol strips scroll across the bar
- Prices tick on each entry
- Change arrows blink

### Files
- `submissions/examples/stock-ticker-scroll-ij/demo.html`
- `submissions/examples/stock-ticker-scroll-ij/style.css`
- `submissions/examples/stock-ticker-scroll-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the ticker scroll.