### PR TITLE
Add ease-airline-seat-map component

### DIFF
--- a/submissions/examples/airline-seat-map-ij/README.md
+++ b/submissions/examples/airline-seat-map-ij/README.md
@@ -1,0 +1,10 @@
+# ease-airline-seat-map
+
+An airline seat map where the seats breathe, the pick pulses, and the exit blinks.
+
+## Run
+Open `demo.html` directly in a browser to watch the seat map.
+
+## Notes
+- The available seats breathe in the grid.
+- The selected seat pulses brighter.

--- a/submissions/examples/airline-seat-map-ij/demo.html
+++ b/submissions/examples/airline-seat-map-ij/demo.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-airline-seat-map demo</title>
+</head>
+<body>
+<div class="asm-cabin">
+  <span class="asm-title">CABIN A</span>
+  <div class="asm-legend">
+    <span class="asm-key asm-avail"></span>AVAILABLE
+    <span class="asm-key asm-taken"></span>TAKEN
+    <span class="asm-key asm-pick"></span>YOURS
+  </div>
+  <div class="asm-row"><span class="asm-seat">1A</span><span class="asm-seat">1B</span><span class="asm-aisle"></span><span class="asm-seat">1C</span><span class="asm-seat">1D</span></div>
+  <div class="asm-row"><span class="asm-seat asm-taken">2A</span><span class="asm-seat asm-taken">2B</span><span class="asm-aisle"></span><span class="asm-seat">2C</span><span class="asm-seat">2D</span></div>
+  <div class="asm-row"><span class="asm-seat">3A</span><span class="asm-seat asm-pick">3B</span><span class="asm-aisle"></span><span class="asm-seat asm-taken">3C</span><span class="asm-seat">3D</span></div>
+  <div class="asm-row"><span class="asm-seat">4A</span><span class="asm-seat">4B</span><span class="asm-aisle"></span><span class="asm-seat asm-taken">4C</span><span class="asm-seat">4D</span></div>
+  <div class="asm-row"><span class="asm-seat">5A</span><span class="asm-seat">5B</span><span class="asm-aisle"></span><span class="asm-seat">5C</span><span class="asm-seat asm-taken">5D</span></div>
+  <span class="asm-exit">EXIT</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/airline-seat-map-ij/style.css
+++ b/submissions/examples/airline-seat-map-ij/style.css
@@ -1,0 +1,23 @@
+:root{--asm-avail:#2c7a45;--asm-taken:#a84040;--asm-pick:#ffd166;--asm-dark:#0c1620}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#12212e,#0a141c);font-family:'Calibri',sans-serif}
+.asm-cabin{position:relative;width:400px;height:360px;border-radius:20px;overflow:hidden;background:linear-gradient(180deg,#132233,#0b1520);box-shadow:0 18px 38px rgba(0,0,0,0.6);padding:14px}
+.asm-title{position:absolute;top:14px;left:0;right:0;text-align:center;font-size:12px;font-weight:700;letter-spacing:12px;color:#9fc7e8}
+.asm-legend{position:absolute;top:44px;left:16px;right:16px;display:flex;align-items:center;justify-content:center;gap:6px;font-size:9px;letter-spacing:2px;color:#7f9fb8}
+.asm-key{width:10px;height:10px;border-radius:3px;margin-left:10px}
+.asm-avail{background:#2c7a45}
+.asm-taken{background:#a84040}
+.asm-pick{background:#ffd166}
+.asm-row{position:absolute;left:24px;right:24px;height:30px;display:flex;align-items:center;gap:6px}
+.asm-row:nth-of-type(1){top:76px}
+.asm-row:nth-of-type(2){top:116px}
+.asm-row:nth-of-type(3){top:156px}
+.asm-row:nth-of-type(4){top:196px}
+.asm-row:nth-of-type(5){top:236px}
+.asm-seat{flex:1;height:28px;border-radius:6px;background:#2c7a45;color:#d8ffe6;font-size:10px;font-weight:700;display:flex;align-items:center;justify-content:center;animation:seat-avail-breathe-airline-seat-map 3s ease-in-out infinite}
+.asm-seat.asm-taken{background:#a84040;color:#ffd9d9;animation:none}
+.asm-seat.asm-pick{background:#ffd166;color:#3a2c06;animation:pick-pulse-airline-seat-map 1.2s ease-in-out infinite}
+.asm-aisle{flex:0.5;height:28px}
+.asm-exit{position:absolute;bottom:16px;left:0;right:0;text-align:center;font-size:10px;font-weight:700;letter-spacing:8px;color:#ffb84d;animation:exit-blink-airline-seat-map 1.6s ease-in-out infinite}
+@keyframes seat-avail-breathe-airline-seat-map{0%,100%{background:#2c7a45}50%{background:#3fa35b}}
+@keyframes pick-pulse-airline-seat-map{0%,100%{transform:scale(1)}50%{transform:scale(1.2)}}
+@keyframes exit-blink-airline-seat-map{0%,100%{opacity:1}50%{opacity:0.28}}


### PR DESCRIPTION
## Component: ease-airline-seat-map — seats breathe, picks pulse, and exit blinks

**Closes #68353**

### What this adds
An airline seat map: the available seats breathe, the selected seat pulses, and the exit-row tag blinks on the cabin.

### Acceptance Criteria covered
- Available seats breathe in the grid
- Selected seat pulses brighter
- Exit-row tag blinks

### Files
- `submissions/examples/airline-seat-map-ij/demo.html`
- `submissions/examples/airline-seat-map-ij/style.css`
- `submissions/examples/airline-seat-map-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the seat map.