### PR TITLE
feat: add pure CSS Animated Favicon documentation component (#68069)

### DIFF
--- a/submissions/examples/css-animated-favicon/README.md
+++ b/submissions/examples/css-animated-favicon/README.md
@@ -1,0 +1,22 @@
+# CSS Animated Favicon
+
+A technique and demonstration of animating a website's browser tab favicon entirely via CSS `@keyframes`, eliminating the need for heavy JavaScript Canvas loops.
+
+## Features
+- Pure CSS and SVG (Zero JavaScript required for animation frames or DOM manipulation).
+- **Embedded CSS in SVG Technique**: 
+- Traditionally, animating a favicon required complex JavaScript to generate frames on a hidden HTML `<canvas>` element, encode them to Data URIs, and constantly swap the `href` of the `<link>` tag via `requestAnimationFrame`. This is heavy on the main thread and burns battery.
+- Modern browsers (Chrome, Edge, Firefox) now natively support SVG favicons. 
+- This component leverages this by embedding a standard HTML `<style>` block directly inside the `favicon.svg` file. The browser's native engine parses and executes these CSS `@keyframes` animations while rendering the icon in the tab bar.
+- **Native OS Theming Support**: 
+- Because the browser parses the SVG's CSS natively, CSS Media Queries like `@media (prefers-color-scheme: dark)` work *inside* the SVG favicon!
+- The favicon automatically adapts to the user's OS Dark/Light mode, changing its colors to ensure it remains visible against both dark browser tabs and light browser tabs.
+- Fully accessible with `prefers-reduced-motion` support. For motion-sensitive users, the `@keyframes` inside the SVG are disabled via media query, leaving a static, clean icon.
+
+## Usage
+Open `demo.html` in a modern browser (Chrome/Edge/Firefox). Look up at your browser's tab bar to see the favicon spinning and pulsing. Try toggling your operating system's Light/Dark mode and watch the favicon dynamically change its color palette to match.
+
+## Files
+- `favicon.svg`: The actual vector graphic containing the `<style>` block that powers the CSS `@keyframes` and media queries.
+- `demo.html`: The HTML wrapper demonstrating how to link the SVG (`<link rel="icon" type="image/svg+xml" href="favicon.svg">`) and providing documentation UI.
+- `style.css`: Basic styling for the demo page's info card.

--- a/submissions/examples/css-animated-favicon/demo.html
+++ b/submissions/examples/css-animated-favicon/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Animated Favicon!</title>
+    <link rel="stylesheet" href="style.css">
+    
+    <!-- 
+       [TECHNIQUE 4] Linking the SVG Favicon:
+       We simply link the .svg file as the icon. Modern browsers (Chrome, Edge, Firefox) 
+       natively parse and render the CSS animations embedded inside the SVG document.
+    -->
+    <link rel="icon" type="image/svg+xml" href="favicon.svg">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Look Up! ☝️</h1>
+            <p class="subtitle">Check your browser tab. The favicon is animating using pure CSS.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <div class="info-card">
+                <h2>How does this work?</h2>
+                <p>Traditionally, animating a favicon required complex JavaScript to generate frames on a hidden Canvas element and constantly swap the <code>href</code> of the link tag via `requestAnimationFrame`.</p>
+                <p>However, modern browsers now support SVG favicons. By embedding a <code>&lt;style&gt;</code> block directly inside the <code>favicon.svg</code> file, the browser natively executes the standard CSS <code>@keyframes</code> animations while rendering the icon.</p>
+                <p>Even better, CSS Media Queries like <code>@media (prefers-color-scheme: dark)</code> work inside the SVG! Try toggling your OS Light/Dark mode and watch the favicon seamlessly change colors to remain visible.</p>
+            </div>
+            
+        </div>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-animated-favicon/favicon.svg
+++ b/submissions/examples/css-animated-favicon/favicon.svg
@@ -1,0 +1,78 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <!-- 
+      [TECHNIQUE 1] Embedded CSS in SVG:
+      By placing a <style> block directly inside the SVG, modern browsers will parse 
+      and execute these CSS animations even when the SVG is used as a favicon.
+    -->
+    <style>
+        /* Base Colors (Light Mode) */
+        :root {
+            --ring-color: #3b82f6;
+            --core-color: #0f172a;
+        }
+
+        /* 
+          [TECHNIQUE 2] OS Theme Detection in Favicon:
+          Media queries work perfectly inside SVGs. This allows your favicon to 
+          automatically adapt to the user's OS Dark/Light mode!
+        */
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --ring-color: #60a5fa;
+                --core-color: #f8fafc;
+            }
+        }
+
+        .ring {
+            fill: none;
+            stroke: var(--ring-color);
+            stroke-width: 10;
+            stroke-dasharray: 200;
+            stroke-dashoffset: 200;
+            /* 
+              [TECHNIQUE 3] Pure CSS Animation:
+              Standard CSS keyframes dictate the animation.
+            */
+            animation: spin-ring 3s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+            transform-origin: 50px 50px;
+        }
+        
+        .core {
+            fill: var(--core-color);
+            animation: pulse-core 1.5s ease-in-out infinite alternate;
+            transform-origin: 50px 50px;
+        }
+
+        @keyframes spin-ring {
+            0% { 
+                stroke-dashoffset: 200; 
+                transform: rotate(0deg); 
+            }
+            50% { 
+                stroke-dashoffset: 0; 
+                transform: rotate(180deg); 
+            }
+            100% { 
+                stroke-dashoffset: -200; 
+                transform: rotate(360deg); 
+            }
+        }
+        
+        @keyframes pulse-core {
+            0% { transform: scale(0.8); opacity: 0.7; }
+            100% { transform: scale(1.1); opacity: 1; }
+        }
+        
+        /* Accessibility */
+        @media (prefers-reduced-motion: reduce) {
+            .ring, .core {
+                animation: none !important;
+                stroke-dashoffset: 0;
+            }
+        }
+    </style>
+    
+    <!-- The Vector Shapes -->
+    <circle class="ring" cx="50" cy="50" r="40" />
+    <circle class="core" cx="50" cy="50" r="15" />
+</svg>

--- a/submissions/examples/css-animated-favicon/style.css
+++ b/submissions/examples/css-animated-favicon/style.css
@@ -1,0 +1,106 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap');
+
+/* =========================================
+   Theming for Demo Page (Favicon themes itself in SVG)
+   ========================================= */
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    
+    --card-bg: #ffffff;
+    --card-border: #e2e8f0;
+    --accent: #3b82f6; 
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a;
+        --text-primary: #f8fafc;
+        --text-secondary: #94a3b8;
+        
+        --card-bg: #1e293b;
+        --card-border: #334155;
+        --accent: #60a5fa; 
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    -webkit-font-smoothing: antialiased;
+    transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.layout-container {
+    max-width: 800px;
+    width: 100%;
+    padding: 40px 20px;
+    text-align: center;
+}
+
+.section-header {
+    margin-bottom: 50px;
+}
+
+.title {
+    font-size: 3rem;
+    font-weight: 700;
+    margin: 0 0 12px 0;
+    letter-spacing: -1px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    margin: 0;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+}
+
+.info-card {
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 12px;
+    padding: 32px;
+    width: 100%;
+    max-width: 600px;
+    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+    text-align: left;
+}
+
+.info-card h2 {
+    margin: 0 0 16px 0;
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: var(--accent);
+}
+
+.info-card p {
+    margin: 0 0 16px 0;
+    line-height: 1.6;
+    color: var(--text-secondary);
+}
+
+.info-card p:last-child {
+    margin-bottom: 0;
+}
+
+code {
+    background-color: rgba(128, 128, 128, 0.15);
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-family: monospace;
+    font-size: 0.9em;
+    color: var(--text-primary);
+}


### PR DESCRIPTION
### Description
This PR introduces a demonstration and documentation of how to animate a website's browser tab favicon entirely via CSS `@keyframes`, eliminating the need for heavy JavaScript Canvas loops, resolving issue #68069. 

### Changes Made:
- Added `submissions/examples/css-animated-favicon/` directory.
- Created `favicon.svg`, which acts as the core of this technique.
  - Implemented the **Embedded CSS in SVG Technique** (with inline comments explaining the mechanics). Because modern browsers natively parse SVG favicons, this component embeds a standard HTML `<style>` block directly inside the `favicon.svg` file. The browser natively executes the standard CSS `@keyframes` animations while rendering the icon.
  - Implemented **Native OS Theming Support**. Because the browser parses the SVG's CSS natively, CSS Media Queries like `@media (prefers-color-scheme: dark)` work *inside* the SVG favicon! The favicon automatically adapts to the user's OS Dark/Light mode to remain visible.
- Created `demo.html` showcasing how to link the SVG and providing documentation.
- Created `style.css` featuring basic styling for the demo page's info card.
- Added `README.md` documenting usage and the technical mechanics of the embedded SVG CSS animations.
- Honors the `prefers-reduced-motion` accessibility standard. The animations inside the SVG are completely disabled for motion-sensitive users.

Closes #68069
