### PR TITLE
feat: add css-only dark mode switch

### DIFF
--- a/submissions/examples/r-css-dark-mode-switch-68420/README.md
+++ b/submissions/examples/r-css-dark-mode-switch-68420/README.md
@@ -1,0 +1,22 @@
+# CSS-only Dark Mode Switch
+
+A pure CSS dark mode switch using CSS custom properties and the `:checked` state.
+
+## Features
+
+- Pure HTML and CSS
+- No JavaScript required
+- CSS custom property based themes
+- Animated light/dark transition
+- Sun and moon switch states
+- Responsive layout
+- Keyboard focus support
+- `prefers-reduced-motion` support
+- Accessible switch label
+
+## Usage
+
+Include the stylesheet:
+
+```html
+<link rel="stylesheet" href="style.css">

--- a/submissions/examples/r-css-dark-mode-switch-68420/demo.html
+++ b/submissions/examples/r-css-dark-mode-switch-68420/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Pure CSS dark mode switch">
+  <title>CSS-only Dark Mode Switch</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <input
+    type="checkbox"
+    id="theme-toggle"
+    class="theme-toggle"
+    aria-label="Toggle dark mode"
+  >
+
+  <main class="page">
+    <section class="theme-card">
+      <div class="content">
+        <span class="eyebrow">EaseMotion CSS</span>
+        <h1>CSS-only Dark Mode</h1>
+        <p>
+          Toggle the switch to smoothly transition between light and dark
+          themes using only CSS custom properties and the :checked state.
+        </p>
+
+        <div class="theme-status">
+          <span class="status-dot"></span>
+          <span class="light-label">Light mode</span>
+          <span class="dark-label">Dark mode</span>
+        </div>
+      </div>
+
+      <label class="switch" for="theme-toggle">
+        <span class="switch-track">
+          <span class="switch-thumb">
+            <span class="sun">☀</span>
+            <span class="moon">☾</span>
+          </span>
+        </span>
+        <span class="switch-text">Toggle theme</span>
+      </label>
+    </section>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/r-css-dark-mode-switch-68420/style.css
+++ b/submissions/examples/r-css-dark-mode-switch-68420/style.css
@@ -1,0 +1,568 @@
+:root {
+  --bg: #f3f6fb;
+  --surface: rgba(255, 255, 255, 0.82);
+  --surface-solid: #ffffff;
+  --text: #182033;
+  --muted: #68738a;
+  --border: rgba(24, 32, 51, 0.1);
+  --accent: #6d5dfc;
+  --accent-soft: rgba(109, 93, 252, 0.12);
+  --shadow: 0 30px 70px rgba(40, 50, 80, 0.14);
+  --track: #dce2ed;
+  --thumb: #ffffff;
+  --duration: 420ms;
+  --ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  min-height: 100%;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  transition:
+    background var(--duration) var(--ease),
+    color var(--duration) var(--ease);
+}
+
+.theme-toggle {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.page {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.theme-card {
+  width: min(720px, 100%);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 3rem;
+  padding: clamp(2rem, 6vw, 4rem);
+  border: 1px solid var(--border);
+  border-radius: 2rem;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  transition:
+    background var(--duration) var(--ease),
+    border-color var(--duration) var(--ease),
+    box-shadow var(--duration) var(--ease);
+}
+
+.content {
+  flex: 1;
+}
+
+.eyebrow {
+  display: inline-block;
+  margin-bottom: 1rem;
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 3.6rem);
+  line-height: 1.05;
+  letter-spacing: -0.045em;
+}
+
+.content p {
+  max-width: 520px;
+  margin: 1.25rem 0 0;
+  color: var(--muted);
+  font-size: 1rem;
+  line-height: 1.7;
+  transition: color var(--duration) var(--ease);
+}
+
+.theme-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  margin-top: 1.5rem;
+  padding: 0.55rem 0.85rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 700;
+  transition:
+    background var(--duration) var(--ease),
+    color var(--duration) var(--ease);
+}
+
+.status-dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: #f59e0b;
+  box-shadow: 0 0 12px rgba(245, 158, 11, 0.45);
+}
+
+.dark-label {
+  display: none;
+}
+
+.switch {
+  flex: 0 0 auto;
+  display: grid;
+  gap: 0.7rem;
+  justify-items: center;
+  cursor: pointer;
+  user-select: none;
+}
+
+.switch-track {
+  position: relative;
+  display: block;
+  width: 82px;
+  height: 44px;
+  padding: 4px;
+  border-radius: 999px;
+  background: var(--track);
+  box-shadow:
+    inset 0 2px 5px rgba(0, 0, 0, 0.08),
+    0 8px 20px rgba(40, 50, 80, 0.08);
+  transition:
+    background var(--duration) var(--ease),
+    box-shadow var(--duration) var(--ease);
+}
+
+.switch-thumb {
+  position: relative;
+  display: grid;
+  width: 36px;
+  height: 36px;
+  place-items: center;
+  border-radius: 50%;
+  background: var(--thumb);
+  color: #f59e0b;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.16);
+  transform: translateX(0);
+  transition:
+    transform var(--duration) var(--ease),
+    background var(--duration) var(--ease),
+    color var(--duration) var(--ease);
+}
+
+.sun,
+.moon {
+  position: absolute;
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.moon {
+  opacity: 0;
+  transform: rotate(-90deg) scale(0.5);
+  transition:
+    opacity var(--duration) var(--ease),
+    transform var(--duration) var(--ease);
+}
+
+.sun {
+  opacity: 1;
+  transform: rotate(0) scale(1);
+  transition:
+    opacity var(--duration) var(--ease),
+    transform var(--duration) var(--ease);
+}
+
+.switch-text {
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+  transition: color var(--duration) var(--ease);
+}
+
+.theme-toggle:focus-visible + .page .switch-track {
+  outline: 3px solid var(--accent);
+  outline-offset: 4px;
+}
+
+.theme-toggle:checked ~ .page {
+  --bg: #080c17;
+  --surface: rgba(20, 27, 45, 0.86);
+  --surface-solid: #141b2d;
+  --text: #f5f7ff;
+  --muted: #a7b0c5;
+  --border: rgba(255, 255, 255, 0.1);
+  --accent: #a78bfa;
+  --accent-soft: rgba(167, 139, 250, 0.12);
+  --shadow: 0 30px 80px rgba(0, 0, 0, 0.4);
+  --track: #272e43;
+  --thumb: #161d31;
+}
+
+.theme-toggle:checked ~ .page .switch-thumb {
+  transform: translateX(38px);
+  color: #a78bfa;
+}
+
+.theme-toggle:checked ~ .page .sun {
+  opacity: 0;
+  transform: rotate(90deg) scale(0.5);
+}
+
+.theme-toggle:checked ~ .page .moon {
+  opacity: 1;
+  transform: rotate(0) scale(1);
+}
+
+.theme-toggle:checked ~ .page .dark-label {
+  display: inline;
+}
+
+.theme-toggle:checked ~ .page .light-label {
+  display: none;
+}
+
+.theme-toggle:checked ~ .page .status-dot {
+  background: #8b5cf6;
+  box-shadow: 0 0 14px rgba(139, 92, 246, 0.7);
+}
+
+@media (max-width: 640px) {
+  .page {
+    padding: 1rem;
+  }
+
+  .theme-card {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2rem;
+    border-radius: 1.5rem;
+  }
+
+  .switch {
+    align-self: center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body,
+  .theme-card,
+  .content p,
+  .theme-status,
+  .switch-track,
+  .switch-thumb,
+  .sun,
+  .moon,
+  .switch-text {
+    transition: none;
+  }
+}
+:root {
+  --bg: #f3f6fb;
+  --surface: rgba(255, 255, 255, 0.82);
+  --surface-solid: #ffffff;
+  --text: #182033;
+  --muted: #68738a;
+  --border: rgba(24, 32, 51, 0.1);
+  --accent: #6d5dfc;
+  --accent-soft: rgba(109, 93, 252, 0.12);
+  --shadow: 0 30px 70px rgba(40, 50, 80, 0.14);
+  --track: #dce2ed;
+  --thumb: #ffffff;
+  --duration: 420ms;
+  --ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  min-height: 100%;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  transition:
+    background var(--duration) var(--ease),
+    color var(--duration) var(--ease);
+}
+
+.theme-toggle {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.page {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.theme-card {
+  width: min(720px, 100%);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 3rem;
+  padding: clamp(2rem, 6vw, 4rem);
+  border: 1px solid var(--border);
+  border-radius: 2rem;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  transition:
+    background var(--duration) var(--ease),
+    border-color var(--duration) var(--ease),
+    box-shadow var(--duration) var(--ease);
+}
+
+.content {
+  flex: 1;
+}
+
+.eyebrow {
+  display: inline-block;
+  margin-bottom: 1rem;
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 3.6rem);
+  line-height: 1.05;
+  letter-spacing: -0.045em;
+}
+
+.content p {
+  max-width: 520px;
+  margin: 1.25rem 0 0;
+  color: var(--muted);
+  font-size: 1rem;
+  line-height: 1.7;
+  transition: color var(--duration) var(--ease);
+}
+
+.theme-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  margin-top: 1.5rem;
+  padding: 0.55rem 0.85rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 700;
+  transition:
+    background var(--duration) var(--ease),
+    color var(--duration) var(--ease);
+}
+
+.status-dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: #f59e0b;
+  box-shadow: 0 0 12px rgba(245, 158, 11, 0.45);
+}
+
+.dark-label {
+  display: none;
+}
+
+.switch {
+  flex: 0 0 auto;
+  display: grid;
+  gap: 0.7rem;
+  justify-items: center;
+  cursor: pointer;
+  user-select: none;
+}
+
+.switch-track {
+  position: relative;
+  display: block;
+  width: 82px;
+  height: 44px;
+  padding: 4px;
+  border-radius: 999px;
+  background: var(--track);
+  box-shadow:
+    inset 0 2px 5px rgba(0, 0, 0, 0.08),
+    0 8px 20px rgba(40, 50, 80, 0.08);
+  transition:
+    background var(--duration) var(--ease),
+    box-shadow var(--duration) var(--ease);
+}
+
+.switch-thumb {
+  position: relative;
+  display: grid;
+  width: 36px;
+  height: 36px;
+  place-items: center;
+  border-radius: 50%;
+  background: var(--thumb);
+  color: #f59e0b;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.16);
+  transform: translateX(0);
+  transition:
+    transform var(--duration) var(--ease),
+    background var(--duration) var(--ease),
+    color var(--duration) var(--ease);
+}
+
+.sun,
+.moon {
+  position: absolute;
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.moon {
+  opacity: 0;
+  transform: rotate(-90deg) scale(0.5);
+  transition:
+    opacity var(--duration) var(--ease),
+    transform var(--duration) var(--ease);
+}
+
+.sun {
+  opacity: 1;
+  transform: rotate(0) scale(1);
+  transition:
+    opacity var(--duration) var(--ease),
+    transform var(--duration) var(--ease);
+}
+
+.switch-text {
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+  transition: color var(--duration) var(--ease);
+}
+
+.theme-toggle:focus-visible + .page .switch-track {
+  outline: 3px solid var(--accent);
+  outline-offset: 4px;
+}
+
+.theme-toggle:checked ~ .page {
+  --bg: #080c17;
+  --surface: rgba(20, 27, 45, 0.86);
+  --surface-solid: #141b2d;
+  --text: #f5f7ff;
+  --muted: #a7b0c5;
+  --border: rgba(255, 255, 255, 0.1);
+  --accent: #a78bfa;
+  --accent-soft: rgba(167, 139, 250, 0.12);
+  --shadow: 0 30px 80px rgba(0, 0, 0, 0.4);
+  --track: #272e43;
+  --thumb: #161d31;
+}
+
+.theme-toggle:checked ~ .page .switch-thumb {
+  transform: translateX(38px);
+  color: #a78bfa;
+}
+
+.theme-toggle:checked ~ .page .sun {
+  opacity: 0;
+  transform: rotate(90deg) scale(0.5);
+}
+
+.theme-toggle:checked ~ .page .moon {
+  opacity: 1;
+  transform: rotate(0) scale(1);
+}
+
+.theme-toggle:checked ~ .page .dark-label {
+  display: inline;
+}
+
+.theme-toggle:checked ~ .page .light-label {
+  display: none;
+}
+
+.theme-toggle:checked ~ .page .status-dot {
+  background: #8b5cf6;
+  box-shadow: 0 0 14px rgba(139, 92, 246, 0.7);
+}
+
+@media (max-width: 640px) {
+  .page {
+    padding: 1rem;
+  }
+
+  .theme-card {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2rem;
+    border-radius: 1.5rem;
+  }
+
+  .switch {
+    align-self: center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body,
+  .theme-card,
+  .content p,
+  .theme-status,
+  .switch-track,
+  .switch-thumb,
+  .sun,
+  .moon,
+  .switch-text {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds a pure CSS-only Dark Mode Switch component for EaseMotion CSS.

## Changes

- Added CSS custom property based light and dark themes
- Added animated theme switch
- Added sun and moon states
- Added responsive layout
- Added keyboard focus support
- Added prefers-reduced-motion support
- Added documentation

## Issue

Closes #68420