### PR TITLE
feat: add token fairness arbiter example

### DIFF
--- a/submissions/examples/token-fairness-arbiter-kp/README.md
+++ b/submissions/examples/token-fairness-arbiter-kp/README.md
@@ -1,0 +1,24 @@
+# Token Fairness Arbiter
+
+An advanced EaseMotion dashboard for visualizing per-tenant token fairness. It shows how an arbiter detects noisy clients, protects reserved capacity, refills buckets, and restores balanced throughput after a fairness window cools.
+
+## Features
+
+- Interactive controls for token demand, noisy share, reserve depth, and refill speed
+- Animated fairness radar, tenant lanes, arbitration playbook, and recovery metrics
+- Live state switching across balanced, shaping, throttled, and refilling modes
+- Responsive operations layout using CSS variables and motion timing
+- Advanced-tier contribution with more than 500 added lines
+
+## Files
+
+- `demo.html` - interactive dashboard and state logic
+- `style.css` - responsive styling and animation system
+
+## Validation
+
+```bash
+npx prettier --check submissions/examples/token-fairness-arbiter-kp/README.md submissions/examples/token-fairness-arbiter-kp/demo.html submissions/examples/token-fairness-arbiter-kp/style.css
+npx stylelint submissions/examples/token-fairness-arbiter-kp/style.css --allow-empty-input
+git diff --check
+```

--- a/submissions/examples/token-fairness-arbiter-kp/demo.html
+++ b/submissions/examples/token-fairness-arbiter-kp/demo.html
@@ -1,0 +1,247 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Token Fairness Arbiter</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="arbiter" data-state="shaping">
+      <section class="hero" aria-labelledby="title">
+        <div>
+          <p class="eyebrow">EaseMotion fairness lab</p>
+          <h1 id="title">Token Fairness Arbiter</h1>
+          <p class="lede">
+            Tune demand and reserve signals to watch the arbiter slow noisy
+            tenants, preserve priority tokens, and refill capacity without
+            starving small clients.
+          </p>
+        </div>
+        <aside class="badge" aria-live="polite">
+          <span class="dot"></span>
+          <small>Fairness mode</small>
+          <strong id="modeLabel">Shaping tokens</strong>
+        </aside>
+      </section>
+
+      <section class="controls" aria-label="Fairness inputs">
+        <label
+          ><span>Token demand</span
+          ><input
+            id="demand"
+            type="range"
+            min="0"
+            max="100"
+            value="64"
+          /><output id="demandOut">64%</output></label
+        >
+        <label
+          ><span>Noisy share</span
+          ><input id="noise" type="range" min="0" max="100" value="55" /><output
+            id="noiseOut"
+            >55%</output
+          ></label
+        >
+        <label
+          ><span>Reserve depth</span
+          ><input
+            id="reserve"
+            type="range"
+            min="0"
+            max="100"
+            value="46"
+          /><output id="reserveOut">46%</output></label
+        >
+        <label
+          ><span>Refill speed</span
+          ><input
+            id="refill"
+            type="range"
+            min="0"
+            max="100"
+            value="58"
+          /><output id="refillOut">58%</output></label
+        >
+      </section>
+
+      <section class="grid" aria-label="Token fairness dashboard">
+        <article class="radar-panel">
+          <div class="panel-title">
+            <span>Fairness pressure</span><strong id="riskScore">55</strong>
+          </div>
+          <div class="radar" aria-hidden="true">
+            <span class="ring ring-a"></span><span class="ring ring-b"></span
+            ><span class="ring ring-c"></span>
+            <span class="sweep sweep-a"></span
+            ><span class="sweep sweep-b"></span
+            ><span class="sweep sweep-c"></span>
+            <span class="node node-a">A</span><span class="node node-b">B</span
+            ><span class="node node-c">C</span
+            ><span class="node node-d">D</span>
+            <span class="core"></span>
+          </div>
+          <div class="signal-strip">
+            <span></span><span></span><span></span><span></span><span></span
+            ><span></span><span></span><span></span><span></span>
+          </div>
+        </article>
+
+        <article class="lanes">
+          <div class="panel-title">
+            <span>Tenant buckets</span><strong id="laneLabel">Guarded</strong>
+          </div>
+          <div class="lane-list">
+            <div class="lane" style="--fill: 0.82">
+              <span>Checkout tenant</span><i></i><b>reserve</b>
+            </div>
+            <div class="lane" style="--fill: 0.66">
+              <span>Search tenant</span><i></i><b>shape</b>
+            </div>
+            <div class="lane" style="--fill: 0.48">
+              <span>Batch tenant</span><i></i><b>cap</b>
+            </div>
+            <div class="lane" style="--fill: 0.41">
+              <span>Export tenant</span><i></i><b>delay</b>
+            </div>
+            <div class="lane" style="--fill: 0.59">
+              <span>Notify tenant</span><i></i><b>refill</b>
+            </div>
+          </div>
+        </article>
+
+        <article class="playbook">
+          <div class="panel-title">
+            <span>Arbitration playbook</span
+            ><strong id="actionLabel">Shape</strong>
+          </div>
+          <ol>
+            <li>
+              <em>01</em>
+              <div>
+                <strong>Measure token slope</strong>
+                <p>
+                  Compare each tenant burst against its moving fairness window.
+                </p>
+              </div>
+            </li>
+            <li>
+              <em>02</em>
+              <div>
+                <strong>Reserve critical buckets</strong>
+                <p>
+                  Priority paths retain tokens even when noisy neighbors spike.
+                </p>
+              </div>
+            </li>
+            <li>
+              <em>03</em>
+              <div>
+                <strong>Throttle dominant clients</strong>
+                <p>
+                  Excess share gets jittered before smaller clients are starved.
+                </p>
+              </div>
+            </li>
+            <li>
+              <em>04</em>
+              <div>
+                <strong>Refill by cooling trend</strong>
+                <p>
+                  Token flow opens only after demand slope and reserve depth
+                  recover.
+                </p>
+              </div>
+            </li>
+          </ol>
+        </article>
+
+        <article class="metrics">
+          <div class="metric">
+            <span>Fairness debt</span><strong id="debtLabel">31%</strong>
+          </div>
+          <div class="metric">
+            <span>Reserve left</span><strong id="reserveLabel">46%</strong>
+          </div>
+          <div class="metric">
+            <span>Refill ETA</span><strong id="etaLabel">18s</strong>
+          </div>
+        </article>
+      </section>
+    </main>
+    <script>
+      const root = document.querySelector(".arbiter");
+      const input = {
+        demand: document.querySelector("#demand"),
+        noise: document.querySelector("#noise"),
+        reserve: document.querySelector("#reserve"),
+        refill: document.querySelector("#refill"),
+      };
+      const output = {
+        demand: document.querySelector("#demandOut"),
+        noise: document.querySelector("#noiseOut"),
+        reserve: document.querySelector("#reserveOut"),
+        refill: document.querySelector("#refillOut"),
+        mode: document.querySelector("#modeLabel"),
+        risk: document.querySelector("#riskScore"),
+        lane: document.querySelector("#laneLabel"),
+        action: document.querySelector("#actionLabel"),
+        debt: document.querySelector("#debtLabel"),
+        reserveLabel: document.querySelector("#reserveLabel"),
+        eta: document.querySelector("#etaLabel"),
+      };
+      function update() {
+        const demand = Number(input.demand.value);
+        const noise = Number(input.noise.value);
+        const reserve = Number(input.reserve.value);
+        const refill = Number(input.refill.value);
+        const risk = Math.round(
+          demand * 0.33 +
+            noise * 0.3 +
+            (100 - reserve) * 0.22 +
+            (100 - refill) * 0.15
+        );
+        let state = "balanced",
+          mode = "Balanced tokens",
+          lane = "Open",
+          action = "Observe";
+        if (risk > 76) {
+          state = "throttled";
+          mode = "Tenant throttled";
+          lane = "Capped";
+          action = "Throttle";
+        } else if (risk > 50) {
+          state = "shaping";
+          mode = "Shaping tokens";
+          lane = "Guarded";
+          action = "Shape";
+        } else if (risk < 32) {
+          state = "refilling";
+          mode = "Refilling buckets";
+          lane = "Cooling";
+          action = "Refill";
+        }
+        root.dataset.state = state;
+        root.style.setProperty("--risk", risk);
+        root.style.setProperty("--demand", demand);
+        root.style.setProperty("--noise", noise);
+        root.style.setProperty("--refill", refill);
+        output.demand.value = `${demand}%`;
+        output.noise.value = `${noise}%`;
+        output.reserve.value = `${reserve}%`;
+        output.refill.value = `${refill}%`;
+        output.risk.textContent = risk;
+        output.mode.textContent = mode;
+        output.lane.textContent = lane;
+        output.action.textContent = action;
+        output.debt.textContent = `${Math.max(0, risk - 24)}%`;
+        output.reserveLabel.textContent = `${reserve}%`;
+        output.eta.textContent = `${Math.max(6, Math.round((100 - refill + risk) / 5))}s`;
+      }
+      Object.values(input).forEach((item) =>
+        item.addEventListener("input", update)
+      );
+      update();
+    </script>
+  </body>
+</html>

--- a/submissions/examples/token-fairness-arbiter-kp/style.css
+++ b/submissions/examples/token-fairness-arbiter-kp/style.css
@@ -1,0 +1,636 @@
+:root {
+  color-scheme: dark;
+  --bg: #091016;
+  --panel: #121c26;
+  --text: #f4f8ff;
+  --muted: #9fabbc;
+  --cyan: #22d3ee;
+  --green: #86efac;
+  --amber: #fbbf24;
+  --red: #fb7185;
+  --violet: #a78bfa;
+  --risk: 55;
+  --demand: 64;
+  --noise: 55;
+  --refill: 58;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+* {
+  box-sizing: border-box;
+}
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--text);
+  background:
+    linear-gradient(135deg, rgba(9, 16, 22, 0.98), rgba(18, 28, 38, 0.94)),
+    radial-gradient(
+      circle at 18% 8%,
+      rgba(34, 211, 238, 0.16),
+      transparent 29%
+    ),
+    radial-gradient(
+      circle at 82% 18%,
+      rgba(167, 139, 250, 0.13),
+      transparent 31%
+    ),
+    #091016;
+}
+input,
+button {
+  font: inherit;
+}
+.arbiter {
+  width: min(1190px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 30px 0 44px;
+}
+.hero {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 230px;
+  gap: 24px;
+  align-items: end;
+  min-height: 220px;
+  padding: 34px;
+  overflow: hidden;
+  border: 1px solid rgba(159, 171, 188, 0.22);
+  border-radius: 8px;
+  background:
+    linear-gradient(110deg, rgba(18, 28, 38, 0.97), rgba(26, 39, 54, 0.75)),
+    repeating-linear-gradient(
+      90deg,
+      rgba(34, 211, 238, 0.07) 0 1px,
+      transparent 1px 46px
+    );
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.35);
+}
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: auto -12% -52px 34%;
+  height: 160px;
+  border-top: 1px solid rgba(34, 211, 238, 0.28);
+  border-bottom: 1px solid rgba(167, 139, 250, 0.2);
+  transform: skewX(-18deg);
+  animation: headerDrift 5.4s linear infinite;
+}
+.hero::after {
+  content: "";
+  position: absolute;
+  top: 18px;
+  right: 32px;
+  width: 190px;
+  height: 80px;
+  border: 1px solid rgba(251, 191, 36, 0.22);
+  transform: rotate(-9deg);
+  animation: headerPulse 2.8s ease-in-out infinite;
+}
+.eyebrow {
+  margin: 0 0 12px;
+  color: var(--cyan);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+h1 {
+  max-width: 780px;
+  margin: 0;
+  font-size: clamp(2.55rem, 7vw, 5.85rem);
+  line-height: 0.92;
+  letter-spacing: 0;
+}
+.lede {
+  max-width: 690px;
+  margin: 18px 0 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+.badge {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 7px;
+  padding: 18px;
+  border: 1px solid rgba(159, 171, 188, 0.2);
+  border-radius: 8px;
+  background: rgba(9, 16, 22, 0.78);
+}
+.dot {
+  width: 13px;
+  height: 13px;
+  border-radius: 50%;
+  background: var(--amber);
+  box-shadow: 0 0 0 7px rgba(251, 191, 36, 0.15);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+.badge small {
+  color: var(--muted);
+  font-weight: 800;
+  text-transform: uppercase;
+}
+.badge strong {
+  font-size: 1.18rem;
+}
+.arbiter[data-state="throttled"] .dot {
+  background: var(--red);
+  box-shadow: 0 0 0 7px rgba(251, 113, 133, 0.17);
+}
+.arbiter[data-state="refilling"] .dot {
+  background: var(--green);
+  box-shadow: 0 0 0 7px rgba(134, 239, 172, 0.16);
+}
+.controls {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+  margin: 18px 0;
+}
+.controls label {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 11px;
+  align-items: center;
+  padding: 16px;
+  border: 1px solid rgba(159, 171, 188, 0.18);
+  border-radius: 8px;
+  background: rgba(18, 28, 38, 0.84);
+}
+.controls span {
+  color: var(--muted);
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+.controls output {
+  font-weight: 900;
+}
+.controls input {
+  grid-column: 1 / -1;
+  width: 100%;
+  accent-color: var(--cyan);
+}
+.grid {
+  display: grid;
+  grid-template-columns: 1.08fr 0.92fr;
+  gap: 18px;
+}
+.grid article {
+  min-width: 0;
+  border: 1px solid rgba(159, 171, 188, 0.2);
+  border-radius: 8px;
+  background: linear-gradient(
+    180deg,
+    rgba(18, 28, 38, 0.96),
+    rgba(9, 16, 22, 0.92)
+  );
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.24);
+}
+.panel-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 20px 0;
+}
+.panel-title span {
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.panel-title strong {
+  font-size: 1.18rem;
+}
+.radar-panel {
+  grid-row: span 2;
+  padding-bottom: 20px;
+}
+.radar {
+  position: relative;
+  width: min(430px, 82vw);
+  aspect-ratio: 1;
+  margin: 26px auto 18px;
+  overflow: hidden;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle, rgba(34, 211, 238, 0.16) 0 2px, transparent 3px),
+    conic-gradient(
+      from 140deg,
+      rgba(34, 211, 238, 0.24),
+      rgba(167, 139, 250, 0.17),
+      rgba(251, 191, 36, 0.24),
+      rgba(251, 113, 133, 0.28),
+      rgba(34, 211, 238, 0.24)
+    );
+  box-shadow:
+    inset 0 0 0 1px rgba(159, 171, 188, 0.2),
+    inset 0 0 72px rgba(0, 0, 0, 0.46);
+}
+.radar::before,
+.radar::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 8%;
+  right: 8%;
+  height: 1px;
+  background: rgba(244, 248, 255, 0.18);
+}
+.radar::after {
+  transform: rotate(90deg);
+}
+.ring {
+  position: absolute;
+  border: 1px solid rgba(244, 248, 255, 0.16);
+  border-radius: 50%;
+  animation: ringBreathe 3s ease-in-out infinite;
+}
+.ring-a {
+  inset: 12%;
+}
+.ring-b {
+  inset: 27%;
+  animation-delay: 0.28s;
+}
+.ring-c {
+  inset: 42%;
+  animation-delay: 0.56s;
+}
+.sweep {
+  position: absolute;
+  inset: 4%;
+  border-radius: 50%;
+  background: conic-gradient(
+    from 0deg,
+    rgba(34, 211, 238, 0.64),
+    rgba(34, 211, 238, 0.08) 48deg,
+    transparent 78deg
+  );
+  mask: radial-gradient(circle, transparent 0 13%, #000 14% 100%);
+  animation: sweep 3.4s linear infinite;
+}
+.sweep-b {
+  animation-duration: 4.9s;
+  animation-direction: reverse;
+  opacity: 0.52;
+}
+.sweep-c {
+  animation-duration: 6.4s;
+  opacity: 0.34;
+}
+.core {
+  position: absolute;
+  inset: calc(50% - 38px);
+  border-radius: 50%;
+  background: color-mix(
+    in srgb,
+    var(--amber) calc(var(--risk) * 1%),
+    var(--cyan)
+  );
+  box-shadow: 0 0 36px rgba(34, 211, 238, 0.45);
+  animation: coreBeat 1.65s ease-in-out infinite;
+}
+.node {
+  position: absolute;
+  display: grid;
+  place-items: center;
+  width: 38px;
+  height: 38px;
+  border: 1px solid rgba(244, 248, 255, 0.24);
+  border-radius: 50%;
+  background: rgba(9, 16, 22, 0.78);
+  color: var(--text);
+  font-size: 0.78rem;
+  font-weight: 900;
+  box-shadow: 0 0 24px rgba(34, 211, 238, 0.22);
+  animation: nodePulse 2.2s ease-in-out infinite;
+}
+.node-a {
+  top: 16%;
+  left: 62%;
+}
+.node-b {
+  top: 42%;
+  left: 78%;
+  animation-delay: 0.35s;
+}
+.node-c {
+  top: 72%;
+  left: 34%;
+  animation-delay: 0.7s;
+}
+.node-d {
+  top: 30%;
+  left: 18%;
+  animation-delay: 1.05s;
+}
+.signal-strip {
+  display: grid;
+  grid-template-columns: repeat(9, 1fr);
+  gap: 7px;
+  padding: 0 20px;
+}
+.signal-strip span {
+  height: 48px;
+  border-radius: 6px;
+  background: linear-gradient(180deg, var(--cyan), transparent);
+  transform-origin: bottom;
+  animation: signal 1.55s ease-in-out infinite;
+}
+.signal-strip span:nth-child(2n) {
+  animation-delay: 0.12s;
+}
+.signal-strip span:nth-child(3n) {
+  animation-delay: 0.28s;
+}
+.signal-strip span:nth-child(4n) {
+  animation-delay: 0.44s;
+}
+.lanes,
+.playbook,
+.metrics {
+  padding-bottom: 18px;
+}
+.lane-list {
+  display: grid;
+  gap: 13px;
+  padding: 20px;
+}
+.lane {
+  display: grid;
+  grid-template-columns: 138px minmax(100px, 1fr) 64px;
+  gap: 13px;
+  align-items: center;
+}
+.lane span {
+  font-size: 0.92rem;
+  font-weight: 800;
+}
+.lane i {
+  position: relative;
+  height: 12px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(159, 171, 188, 0.16);
+}
+.lane i::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  width: calc(var(--fill) * 100%);
+  border-radius: inherit;
+  background: linear-gradient(
+    90deg,
+    var(--green),
+    var(--cyan),
+    var(--amber),
+    var(--red)
+  );
+  animation: laneFlow 1.9s ease-in-out infinite;
+}
+.lane b {
+  color: var(--muted);
+  font-size: 0.78rem;
+  text-align: right;
+  text-transform: uppercase;
+}
+.playbook ol {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 20px;
+  list-style: none;
+}
+.playbook li {
+  display: grid;
+  grid-template-columns: 38px 1fr;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid rgba(159, 171, 188, 0.16);
+  border-radius: 8px;
+  background: rgba(26, 39, 54, 0.55);
+  animation: cardLift 3s ease-in-out infinite;
+}
+.playbook li:nth-child(2) {
+  animation-delay: 0.18s;
+}
+.playbook li:nth-child(3) {
+  animation-delay: 0.36s;
+}
+.playbook li:nth-child(4) {
+  animation-delay: 0.54s;
+}
+.playbook em {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  background: rgba(34, 211, 238, 0.12);
+  color: var(--cyan);
+  font-style: normal;
+  font-weight: 900;
+}
+.playbook strong {
+  display: block;
+  margin-bottom: 4px;
+}
+.playbook p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  padding: 18px;
+}
+.metric {
+  min-height: 110px;
+  padding: 16px;
+  border: 1px solid rgba(159, 171, 188, 0.16);
+  border-radius: 8px;
+  background: rgba(9, 16, 22, 0.58);
+}
+.metric span {
+  display: block;
+  margin-bottom: 12px;
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.metric strong {
+  font-size: 1.9rem;
+}
+.arbiter[data-state="balanced"] .hero {
+  border-color: rgba(34, 211, 238, 0.3);
+}
+.arbiter[data-state="shaping"] .hero {
+  border-color: rgba(251, 191, 36, 0.34);
+}
+.arbiter[data-state="throttled"] .hero {
+  border-color: rgba(251, 113, 133, 0.44);
+}
+.arbiter[data-state="refilling"] .hero {
+  border-color: rgba(134, 239, 172, 0.34);
+}
+.arbiter[data-state="throttled"] .core {
+  background: var(--red);
+  box-shadow: 0 0 46px rgba(251, 113, 133, 0.58);
+}
+.arbiter[data-state="refilling"] .core {
+  background: var(--green);
+  box-shadow: 0 0 42px rgba(134, 239, 172, 0.48);
+}
+@keyframes headerDrift {
+  0% {
+    transform: translateX(-44%) skewX(-18deg);
+  }
+  100% {
+    transform: translateX(58%) skewX(-18deg);
+  }
+}
+@keyframes headerPulse {
+  0%,
+  100% {
+    opacity: 0.25;
+  }
+  50% {
+    opacity: 0.76;
+  }
+}
+@keyframes pulse {
+  0%,
+  100% {
+    transform: scale(0.92);
+  }
+  50% {
+    transform: scale(1.14);
+  }
+}
+@keyframes ringBreathe {
+  0%,
+  100% {
+    opacity: 0.36;
+    transform: scale(0.98);
+  }
+  50% {
+    opacity: 0.88;
+    transform: scale(1.02);
+  }
+}
+@keyframes sweep {
+  to {
+    transform: rotate(1turn);
+  }
+}
+@keyframes coreBeat {
+  0%,
+  100% {
+    transform: scale(0.94);
+  }
+  50% {
+    transform: scale(1.09);
+  }
+}
+@keyframes nodePulse {
+  0%,
+  100% {
+    opacity: 0.72;
+    transform: scale(0.94);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.12);
+  }
+}
+@keyframes signal {
+  0%,
+  100% {
+    opacity: 0.43;
+    transform: scaleY(0.28);
+  }
+  50% {
+    opacity: 0.96;
+    transform: scaleY(calc(0.42 + var(--risk) / 120));
+  }
+}
+@keyframes laneFlow {
+  0%,
+  100% {
+    filter: saturate(0.9);
+  }
+  50% {
+    filter: saturate(1.55);
+  }
+}
+@keyframes cardLift {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-3px);
+  }
+}
+@media (max-width: 880px) {
+  .arbiter {
+    width: min(100% - 20px, 700px);
+    padding-top: 16px;
+  }
+  .hero {
+    grid-template-columns: 1fr;
+    min-height: 260px;
+    padding: 26px;
+  }
+  .badge {
+    width: min(100%, 260px);
+  }
+  .controls,
+  .grid {
+    grid-template-columns: 1fr;
+  }
+  .radar-panel {
+    grid-row: auto;
+  }
+  .lane {
+    grid-template-columns: 1fr;
+    gap: 7px;
+  }
+  .lane b {
+    text-align: left;
+  }
+}
+@media (max-width: 560px) {
+  .arbiter {
+    width: min(100% - 14px, 440px);
+  }
+  .hero {
+    padding: 22px;
+  }
+  h1 {
+    font-size: clamp(2.05rem, 18vw, 3.75rem);
+  }
+  .controls label,
+  .metrics {
+    grid-template-columns: 1fr;
+  }
+  .panel-title {
+    align-items: start;
+  }
+  .playbook li {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add an advanced token fairness arbiter animation example
- include interactive controls for token demand, noisy share, reserve depth, and refill speed
- visualize balanced, shaping, throttled, and refilling states for tenant fairness

## Validation
- npx prettier --check submissions/examples/token-fairness-arbiter-kp/README.md submissions/examples/token-fairness-arbiter-kp/demo.html submissions/examples/token-fairness-arbiter-kp/style.css
- npx stylelint submissions/examples/token-fairness-arbiter-kp/style.css --allow-empty-input
- git diff --check