### PR TITLE
feat: add adaptive jitter governor example

### DIFF
--- a/submissions/examples/adaptive-jitter-governor-kp/README.md
+++ b/submissions/examples/adaptive-jitter-governor-kp/README.md
@@ -1,0 +1,24 @@
+# Adaptive Jitter Governor
+
+An advanced EaseMotion dashboard for visualizing retry jitter control. It shows how a governor detects synchronized retry waves, spreads client cadence, protects capacity, and recovers once the retry storm cools.
+
+## Features
+
+- Interactive controls for retry sync, client pressure, capacity headroom, and jitter spread
+- Animated jitter radar, client lanes, governor playbook, and recovery metrics
+- Live state switching across calm, spreading, dampened, and recovered modes
+- Responsive operations layout with CSS variable driven motion
+- Advanced-tier contribution with more than 500 added lines
+
+## Files
+
+- `demo.html` - interactive dashboard and state logic
+- `style.css` - responsive styling and animation system
+
+## Validation
+
+```bash
+npx prettier --check submissions/examples/adaptive-jitter-governor-kp/README.md submissions/examples/adaptive-jitter-governor-kp/demo.html submissions/examples/adaptive-jitter-governor-kp/style.css
+npx stylelint submissions/examples/adaptive-jitter-governor-kp/style.css --allow-empty-input
+git diff --check
+```

--- a/submissions/examples/adaptive-jitter-governor-kp/demo.html
+++ b/submissions/examples/adaptive-jitter-governor-kp/demo.html
@@ -1,0 +1,271 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Adaptive Jitter Governor</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="governor" data-state="spread">
+      <section class="hero" aria-labelledby="title">
+        <div>
+          <p class="eyebrow">EaseMotion retry resilience</p>
+          <h1 id="title">Adaptive Jitter Governor</h1>
+          <p class="lede">
+            Tune retry signals and watch the governor scatter synchronized
+            clients, dampen storm waves, and reopen cadence after capacity
+            stabilizes.
+          </p>
+        </div>
+        <aside class="badge" aria-live="polite">
+          <span class="dot"></span>
+          <small>Governor mode</small>
+          <strong id="modeLabel">Spreading cadence</strong>
+        </aside>
+      </section>
+
+      <section class="controls" aria-label="Jitter inputs">
+        <label
+          ><span>Retry sync</span
+          ><input id="sync" type="range" min="0" max="100" value="66" /><output
+            id="syncOut"
+            >66%</output
+          ></label
+        >
+        <label
+          ><span>Client pressure</span
+          ><input
+            id="pressure"
+            type="range"
+            min="0"
+            max="100"
+            value="57"
+          /><output id="pressureOut">57%</output></label
+        >
+        <label
+          ><span>Headroom</span
+          ><input
+            id="headroom"
+            type="range"
+            min="0"
+            max="100"
+            value="44"
+          /><output id="headroomOut">44%</output></label
+        >
+        <label
+          ><span>Jitter spread</span
+          ><input
+            id="spread"
+            type="range"
+            min="0"
+            max="100"
+            value="53"
+          /><output id="spreadOut">53%</output></label
+        >
+      </section>
+
+      <section class="grid" aria-label="Jitter dashboard">
+        <article class="radar-panel">
+          <div class="panel-title">
+            <span>Storm pressure</span><strong id="riskScore">58</strong>
+          </div>
+          <div class="radar" aria-hidden="true">
+            <span class="ring ring-a"></span><span class="ring ring-b"></span
+            ><span class="ring ring-c"></span>
+            <span class="sweep sweep-a"></span
+            ><span class="sweep sweep-b"></span
+            ><span class="sweep sweep-c"></span>
+            <span class="node node-a">0ms</span
+            ><span class="node node-b">75ms</span
+            ><span class="node node-c">180ms</span
+            ><span class="node node-d">320ms</span>
+            <span class="core"></span>
+          </div>
+          <div class="signal-strip">
+            <span></span><span></span><span></span><span></span><span></span
+            ><span></span><span></span><span></span><span></span>
+          </div>
+        </article>
+
+        <article class="lanes">
+          <div class="panel-title">
+            <span>Client cadence</span><strong id="laneLabel">Staggered</strong>
+          </div>
+          <div class="lane-list">
+            <div class="lane" style="--fill: 0.8">
+              <span>Mobile clients</span><i></i><b>jitter</b>
+            </div>
+            <div class="lane" style="--fill: 0.64">
+              <span>Partner API</span><i></i><b>backoff</b>
+            </div>
+            <div class="lane" style="--fill: 0.5">
+              <span>Web checkout</span><i></i><b>shape</b>
+            </div>
+            <div class="lane" style="--fill: 0.43">
+              <span>Batch import</span><i></i><b>delay</b>
+            </div>
+            <div class="lane" style="--fill: 0.58">
+              <span>Webhook fanout</span><i></i><b>spread</b>
+            </div>
+          </div>
+        </article>
+
+        <article class="playbook">
+          <div class="panel-title">
+            <span>Governor playbook</span
+            ><strong id="actionLabel">Spread</strong>
+          </div>
+          <ol>
+            <li>
+              <em>01</em>
+              <div>
+                <strong>Detect retry alignment</strong>
+                <p>
+                  Compare client retry windows against synchronized arrival
+                  spikes.
+                </p>
+              </div>
+            </li>
+            <li>
+              <em>02</em>
+              <div>
+                <strong>Assign jitter bands</strong>
+                <p>
+                  Move cohorts into randomized delay bands before capacity
+                  collapses.
+                </p>
+              </div>
+            </li>
+            <li>
+              <em>03</em>
+              <div>
+                <strong>Dampen hot cohorts</strong>
+                <p>
+                  High-pressure clients receive slower backoff and capped
+                  retries.
+                </p>
+              </div>
+            </li>
+            <li>
+              <em>04</em>
+              <div>
+                <strong>Recover by headroom</strong>
+                <p>
+                  Cadence opens only after headroom and retry slope cool
+                  together.
+                </p>
+              </div>
+            </li>
+          </ol>
+        </article>
+
+        <article class="metrics">
+          <div class="metric">
+            <span>Wave risk</span><strong id="waveLabel">34%</strong>
+          </div>
+          <div class="metric">
+            <span>Spread width</span><strong id="spreadLabel">53%</strong>
+          </div>
+          <div class="metric">
+            <span>Recovery ETA</span><strong id="etaLabel">18s</strong>
+          </div>
+        </article>
+
+        <article class="cohort-panel">
+          <div class="panel-title">
+            <span>Cohort windows</span><strong>Adaptive</strong>
+          </div>
+          <div class="cohort-grid">
+            <div class="cohort" style="--delay: 0.1s; --shade: var(--cyan)">
+              <span>Band A</span><i></i><b>40-90ms</b>
+            </div>
+            <div class="cohort" style="--delay: 0.25s; --shade: var(--green)">
+              <span>Band B</span><i></i><b>120-210ms</b>
+            </div>
+            <div class="cohort" style="--delay: 0.4s; --shade: var(--amber)">
+              <span>Band C</span><i></i><b>240-390ms</b>
+            </div>
+            <div class="cohort" style="--delay: 0.55s; --shade: var(--violet)">
+              <span>Band D</span><i></i><b>420-610ms</b>
+            </div>
+          </div>
+        </article>
+      </section>
+    </main>
+    <script>
+      const root = document.querySelector(".governor");
+      const input = {
+        sync: document.querySelector("#sync"),
+        pressure: document.querySelector("#pressure"),
+        headroom: document.querySelector("#headroom"),
+        spread: document.querySelector("#spread"),
+      };
+      const output = {
+        sync: document.querySelector("#syncOut"),
+        pressure: document.querySelector("#pressureOut"),
+        headroom: document.querySelector("#headroomOut"),
+        spread: document.querySelector("#spreadOut"),
+        mode: document.querySelector("#modeLabel"),
+        risk: document.querySelector("#riskScore"),
+        lane: document.querySelector("#laneLabel"),
+        action: document.querySelector("#actionLabel"),
+        wave: document.querySelector("#waveLabel"),
+        spreadLabel: document.querySelector("#spreadLabel"),
+        eta: document.querySelector("#etaLabel"),
+      };
+      function update() {
+        const sync = Number(input.sync.value);
+        const pressure = Number(input.pressure.value);
+        const headroom = Number(input.headroom.value);
+        const spread = Number(input.spread.value);
+        const risk = Math.round(
+          sync * 0.34 +
+            pressure * 0.3 +
+            (100 - headroom) * 0.22 +
+            (100 - spread) * 0.14
+        );
+        let state = "calm",
+          mode = "Calm cadence",
+          lane = "Open",
+          action = "Observe";
+        if (risk > 76) {
+          state = "dampen";
+          mode = "Dampening storm";
+          lane = "Capped";
+          action = "Dampen";
+        } else if (risk > 50) {
+          state = "spread";
+          mode = "Spreading cadence";
+          lane = "Staggered";
+          action = "Spread";
+        } else if (risk < 32) {
+          state = "recover";
+          mode = "Recovered cadence";
+          lane = "Cooling";
+          action = "Recover";
+        }
+        root.dataset.state = state;
+        root.style.setProperty("--risk", risk);
+        root.style.setProperty("--sync", sync);
+        root.style.setProperty("--pressure", pressure);
+        root.style.setProperty("--spread", spread);
+        output.sync.value = `${sync}%`;
+        output.pressure.value = `${pressure}%`;
+        output.headroom.value = `${headroom}%`;
+        output.spread.value = `${spread}%`;
+        output.risk.textContent = risk;
+        output.mode.textContent = mode;
+        output.lane.textContent = lane;
+        output.action.textContent = action;
+        output.wave.textContent = `${Math.max(0, risk - 24)}%`;
+        output.spreadLabel.textContent = `${spread}%`;
+        output.eta.textContent = `${Math.max(6, Math.round((risk + 100 - headroom) / 6))}s`;
+      }
+      Object.values(input).forEach((item) =>
+        item.addEventListener("input", update)
+      );
+      update();
+    </script>
+  </body>
+</html>

--- a/submissions/examples/adaptive-jitter-governor-kp/style.css
+++ b/submissions/examples/adaptive-jitter-governor-kp/style.css
@@ -1,0 +1,826 @@
+:root {
+  color-scheme: dark;
+  --bg: #091118;
+  --panel: #121d28;
+  --text: #f4f8ff;
+  --muted: #9fabbc;
+  --cyan: #22d3ee;
+  --green: #86efac;
+  --amber: #fbbf24;
+  --red: #fb7185;
+  --violet: #a78bfa;
+  --risk: 58;
+  --sync: 66;
+  --pressure: 57;
+  --spread: 53;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+* {
+  box-sizing: border-box;
+}
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--text);
+  background:
+    linear-gradient(135deg, rgba(9, 17, 24, 0.98), rgba(18, 29, 40, 0.94)),
+    radial-gradient(
+      circle at 18% 8%,
+      rgba(34, 211, 238, 0.16),
+      transparent 29%
+    ),
+    radial-gradient(
+      circle at 82% 18%,
+      rgba(167, 139, 250, 0.13),
+      transparent 31%
+    ),
+    #091118;
+}
+input,
+button {
+  font: inherit;
+}
+.governor {
+  width: min(1190px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 30px 0 44px;
+}
+.hero {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 230px;
+  gap: 24px;
+  align-items: end;
+  min-height: 220px;
+  padding: 34px;
+  overflow: hidden;
+  border: 1px solid rgba(159, 171, 188, 0.22);
+  border-radius: 8px;
+  background:
+    linear-gradient(110deg, rgba(18, 29, 40, 0.97), rgba(26, 40, 56, 0.75)),
+    repeating-linear-gradient(
+      90deg,
+      rgba(34, 211, 238, 0.07) 0 1px,
+      transparent 1px 46px
+    );
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.35);
+}
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: auto -12% -52px 34%;
+  height: 160px;
+  border-top: 1px solid rgba(34, 211, 238, 0.28);
+  border-bottom: 1px solid rgba(167, 139, 250, 0.2);
+  transform: skewX(-18deg);
+  animation: headerDrift 5.4s linear infinite;
+}
+.hero::after {
+  content: "";
+  position: absolute;
+  top: 18px;
+  right: 32px;
+  width: 190px;
+  height: 80px;
+  border: 1px solid rgba(251, 191, 36, 0.22);
+  transform: rotate(-9deg);
+  animation: headerPulse 2.8s ease-in-out infinite;
+}
+.eyebrow {
+  margin: 0 0 12px;
+  color: var(--cyan);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+h1 {
+  max-width: 780px;
+  margin: 0;
+  font-size: clamp(2.55rem, 7vw, 5.85rem);
+  line-height: 0.92;
+  letter-spacing: 0;
+}
+.lede {
+  max-width: 690px;
+  margin: 18px 0 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+.badge {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 7px;
+  padding: 18px;
+  border: 1px solid rgba(159, 171, 188, 0.2);
+  border-radius: 8px;
+  background: rgba(9, 17, 24, 0.78);
+}
+.dot {
+  width: 13px;
+  height: 13px;
+  border-radius: 50%;
+  background: var(--amber);
+  box-shadow: 0 0 0 7px rgba(251, 191, 36, 0.15);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+.badge small {
+  color: var(--muted);
+  font-weight: 800;
+  text-transform: uppercase;
+}
+.badge strong {
+  font-size: 1.18rem;
+}
+.governor[data-state="dampen"] .dot {
+  background: var(--red);
+  box-shadow: 0 0 0 7px rgba(251, 113, 133, 0.17);
+}
+.governor[data-state="recover"] .dot {
+  background: var(--green);
+  box-shadow: 0 0 0 7px rgba(134, 239, 172, 0.16);
+}
+.controls {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+  margin: 18px 0;
+}
+.controls label {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 11px;
+  align-items: center;
+  padding: 16px;
+  border: 1px solid rgba(159, 171, 188, 0.18);
+  border-radius: 8px;
+  background: rgba(18, 29, 40, 0.84);
+}
+.controls span {
+  color: var(--muted);
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+.controls output {
+  font-weight: 900;
+}
+.controls input {
+  grid-column: 1 / -1;
+  width: 100%;
+  accent-color: var(--cyan);
+}
+.grid {
+  display: grid;
+  grid-template-columns: 1.08fr 0.92fr;
+  gap: 18px;
+}
+.grid article {
+  min-width: 0;
+  border: 1px solid rgba(159, 171, 188, 0.2);
+  border-radius: 8px;
+  background: linear-gradient(
+    180deg,
+    rgba(18, 29, 40, 0.96),
+    rgba(9, 17, 24, 0.92)
+  );
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.24);
+}
+.panel-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 20px 0;
+}
+.panel-title span {
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.panel-title strong {
+  font-size: 1.18rem;
+}
+.radar-panel {
+  grid-row: span 2;
+  padding-bottom: 20px;
+}
+.radar {
+  position: relative;
+  width: min(430px, 82vw);
+  aspect-ratio: 1;
+  margin: 26px auto 18px;
+  overflow: hidden;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle, rgba(34, 211, 238, 0.16) 0 2px, transparent 3px),
+    conic-gradient(
+      from 140deg,
+      rgba(34, 211, 238, 0.24),
+      rgba(167, 139, 250, 0.17),
+      rgba(251, 191, 36, 0.24),
+      rgba(251, 113, 133, 0.28),
+      rgba(34, 211, 238, 0.24)
+    );
+  box-shadow:
+    inset 0 0 0 1px rgba(159, 171, 188, 0.2),
+    inset 0 0 72px rgba(0, 0, 0, 0.46);
+}
+.radar::before,
+.radar::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 8%;
+  right: 8%;
+  height: 1px;
+  background: rgba(244, 248, 255, 0.18);
+}
+.radar::after {
+  transform: rotate(90deg);
+}
+.ring {
+  position: absolute;
+  border: 1px solid rgba(244, 248, 255, 0.16);
+  border-radius: 50%;
+  animation: ringBreathe 3s ease-in-out infinite;
+}
+.ring-a {
+  inset: 12%;
+}
+.ring-b {
+  inset: 27%;
+  animation-delay: 0.28s;
+}
+.ring-c {
+  inset: 42%;
+  animation-delay: 0.56s;
+}
+.sweep {
+  position: absolute;
+  inset: 4%;
+  border-radius: 50%;
+  background: conic-gradient(
+    from 0deg,
+    rgba(34, 211, 238, 0.64),
+    rgba(34, 211, 238, 0.08) 48deg,
+    transparent 78deg
+  );
+  mask: radial-gradient(circle, transparent 0 13%, #000 14% 100%);
+  animation: sweep 3.4s linear infinite;
+}
+.sweep-b {
+  animation-duration: 4.9s;
+  animation-direction: reverse;
+  opacity: 0.52;
+}
+.sweep-c {
+  animation-duration: 6.4s;
+  opacity: 0.34;
+}
+.core {
+  position: absolute;
+  inset: calc(50% - 38px);
+  border-radius: 50%;
+  background: color-mix(
+    in srgb,
+    var(--amber) calc(var(--risk) * 1%),
+    var(--cyan)
+  );
+  box-shadow: 0 0 36px rgba(34, 211, 238, 0.45);
+  animation: coreBeat 1.65s ease-in-out infinite;
+}
+.node {
+  position: absolute;
+  display: grid;
+  place-items: center;
+  width: 46px;
+  height: 38px;
+  border: 1px solid rgba(244, 248, 255, 0.24);
+  border-radius: 999px;
+  background: rgba(9, 17, 24, 0.78);
+  color: var(--text);
+  font-size: 0.72rem;
+  font-weight: 900;
+  box-shadow: 0 0 24px rgba(34, 211, 238, 0.22);
+  animation: nodePulse 2.2s ease-in-out infinite;
+}
+.node-a {
+  top: 16%;
+  left: 60%;
+}
+.node-b {
+  top: 42%;
+  left: 75%;
+  animation-delay: 0.35s;
+}
+.node-c {
+  top: 72%;
+  left: 32%;
+  animation-delay: 0.7s;
+}
+.node-d {
+  top: 30%;
+  left: 16%;
+  animation-delay: 1.05s;
+}
+.signal-strip {
+  display: grid;
+  grid-template-columns: repeat(9, 1fr);
+  gap: 7px;
+  padding: 0 20px;
+}
+.signal-strip span {
+  height: 48px;
+  border-radius: 6px;
+  background: linear-gradient(180deg, var(--cyan), transparent);
+  transform-origin: bottom;
+  animation: signal 1.55s ease-in-out infinite;
+}
+.signal-strip span:nth-child(2n) {
+  animation-delay: 0.12s;
+}
+.signal-strip span:nth-child(3n) {
+  animation-delay: 0.28s;
+}
+.signal-strip span:nth-child(4n) {
+  animation-delay: 0.44s;
+}
+.lanes,
+.playbook,
+.metrics {
+  padding-bottom: 18px;
+}
+.lane-list {
+  display: grid;
+  gap: 13px;
+  padding: 20px;
+}
+.lane {
+  display: grid;
+  grid-template-columns: 138px minmax(100px, 1fr) 64px;
+  gap: 13px;
+  align-items: center;
+}
+.lane span {
+  font-size: 0.92rem;
+  font-weight: 800;
+}
+.lane i {
+  position: relative;
+  height: 12px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(159, 171, 188, 0.16);
+}
+.lane i::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  width: calc(var(--fill) * 100%);
+  border-radius: inherit;
+  background: linear-gradient(
+    90deg,
+    var(--green),
+    var(--cyan),
+    var(--amber),
+    var(--red)
+  );
+  animation: laneFlow 1.9s ease-in-out infinite;
+}
+.lane b {
+  color: var(--muted);
+  font-size: 0.78rem;
+  text-align: right;
+  text-transform: uppercase;
+}
+.playbook ol {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 20px;
+  list-style: none;
+}
+.playbook li {
+  display: grid;
+  grid-template-columns: 38px 1fr;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid rgba(159, 171, 188, 0.16);
+  border-radius: 8px;
+  background: rgba(26, 40, 56, 0.55);
+  animation: cardLift 3s ease-in-out infinite;
+}
+.playbook li:nth-child(2) {
+  animation-delay: 0.18s;
+}
+.playbook li:nth-child(3) {
+  animation-delay: 0.36s;
+}
+.playbook li:nth-child(4) {
+  animation-delay: 0.54s;
+}
+.playbook em {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  background: rgba(34, 211, 238, 0.12);
+  color: var(--cyan);
+  font-style: normal;
+  font-weight: 900;
+}
+.playbook strong {
+  display: block;
+  margin-bottom: 4px;
+}
+.playbook p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  padding: 18px;
+}
+.metric {
+  min-height: 110px;
+  padding: 16px;
+  border: 1px solid rgba(159, 171, 188, 0.16);
+  border-radius: 8px;
+  background: rgba(9, 17, 24, 0.58);
+}
+.metric span {
+  display: block;
+  margin-bottom: 12px;
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.metric strong {
+  font-size: 1.9rem;
+}
+.governor[data-state="calm"] .hero {
+  border-color: rgba(34, 211, 238, 0.3);
+}
+.governor[data-state="spread"] .hero {
+  border-color: rgba(251, 191, 36, 0.34);
+}
+.governor[data-state="dampen"] .hero {
+  border-color: rgba(251, 113, 133, 0.44);
+}
+.governor[data-state="recover"] .hero {
+  border-color: rgba(134, 239, 172, 0.34);
+}
+.governor[data-state="dampen"] .core {
+  background: var(--red);
+  box-shadow: 0 0 46px rgba(251, 113, 133, 0.58);
+}
+.governor[data-state="recover"] .core {
+  background: var(--green);
+  box-shadow: 0 0 42px rgba(134, 239, 172, 0.48);
+}
+@keyframes headerDrift {
+  0% {
+    transform: translateX(-44%) skewX(-18deg);
+  }
+  100% {
+    transform: translateX(58%) skewX(-18deg);
+  }
+}
+@keyframes headerPulse {
+  0%,
+  100% {
+    opacity: 0.25;
+  }
+  50% {
+    opacity: 0.76;
+  }
+}
+@keyframes pulse {
+  0%,
+  100% {
+    transform: scale(0.92);
+  }
+  50% {
+    transform: scale(1.14);
+  }
+}
+@keyframes ringBreathe {
+  0%,
+  100% {
+    opacity: 0.36;
+    transform: scale(0.98);
+  }
+  50% {
+    opacity: 0.88;
+    transform: scale(1.02);
+  }
+}
+@keyframes sweep {
+  to {
+    transform: rotate(1turn);
+  }
+}
+@keyframes coreBeat {
+  0%,
+  100% {
+    transform: scale(0.94);
+  }
+  50% {
+    transform: scale(1.09);
+  }
+}
+@keyframes nodePulse {
+  0%,
+  100% {
+    opacity: 0.72;
+    transform: scale(0.94);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.12);
+  }
+}
+@keyframes signal {
+  0%,
+  100% {
+    opacity: 0.43;
+    transform: scaleY(0.28);
+  }
+  50% {
+    opacity: 0.96;
+    transform: scaleY(calc(0.42 + var(--risk) / 120));
+  }
+}
+@keyframes laneFlow {
+  0%,
+  100% {
+    filter: saturate(0.9);
+  }
+  50% {
+    filter: saturate(1.55);
+  }
+}
+@keyframes cardLift {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-3px);
+  }
+}
+
+.cohort-panel {
+  grid-column: 1 / -1;
+  padding-bottom: 18px;
+}
+
+.cohort-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  padding: 20px;
+}
+
+.cohort {
+  position: relative;
+  min-height: 138px;
+  overflow: hidden;
+  padding: 16px;
+  border: 1px solid rgba(159, 171, 188, 0.16);
+  border-radius: 8px;
+  background:
+    linear-gradient(180deg, rgba(26, 40, 56, 0.78), rgba(9, 17, 24, 0.76)),
+    repeating-linear-gradient(
+      0deg,
+      rgba(244, 248, 255, 0.04) 0 1px,
+      transparent 1px 18px
+    );
+  animation: cohortFloat 3s ease-in-out infinite;
+  animation-delay: var(--delay);
+}
+
+.cohort::before {
+  content: "";
+  position: absolute;
+  inset: auto 16px 18px;
+  height: 3px;
+  border-radius: 999px;
+  background: var(--shade);
+  box-shadow: 0 0 18px color-mix(in srgb, var(--shade), transparent 35%);
+  animation: cohortScan 1.8s ease-in-out infinite;
+  animation-delay: var(--delay);
+}
+
+.cohort::after {
+  content: "";
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  width: 42px;
+  height: 42px;
+  border: 1px solid color-mix(in srgb, var(--shade), transparent 45%);
+  border-radius: 50%;
+  animation: cohortDial 2.4s linear infinite;
+}
+
+.cohort span {
+  display: block;
+  margin-bottom: 12px;
+  color: var(--shade);
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.cohort i {
+  display: block;
+  width: 54px;
+  height: 54px;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle, var(--shade) 0 5px, transparent 6px),
+    conic-gradient(var(--shade), transparent, var(--shade));
+  opacity: 0.82;
+  animation: jitterDisc 2.2s ease-in-out infinite;
+  animation-delay: var(--delay);
+}
+
+.cohort b {
+  position: absolute;
+  right: 16px;
+  bottom: 32px;
+  color: var(--text);
+  font-size: 1.05rem;
+}
+
+.cohort:nth-child(2) i {
+  transform-origin: 46% 54%;
+}
+
+.cohort:nth-child(3) i {
+  transform-origin: 54% 48%;
+}
+
+.cohort:nth-child(4) i {
+  transform-origin: 49% 52%;
+}
+
+.governor[data-state="dampen"] .cohort {
+  border-color: rgba(251, 113, 133, 0.28);
+}
+
+.governor[data-state="recover"] .cohort {
+  border-color: rgba(134, 239, 172, 0.24);
+}
+
+.governor[data-state="dampen"] .cohort i {
+  filter: saturate(1.45);
+}
+
+.governor[data-state="recover"] .cohort i {
+  filter: hue-rotate(35deg);
+}
+
+.cohort:hover {
+  transform: translateY(-3px);
+  border-color: color-mix(in srgb, var(--shade), transparent 38%);
+}
+
+.cohort:hover i {
+  animation-duration: 1.2s;
+}
+
+.cohort:hover::after {
+  border-color: var(--shade);
+}
+
+.cohort-grid .cohort:nth-child(1)::before {
+  width: 42%;
+}
+
+.cohort-grid .cohort:nth-child(2)::before {
+  width: 56%;
+}
+
+.cohort-grid .cohort:nth-child(3)::before {
+  width: 68%;
+}
+
+.cohort-grid .cohort:nth-child(4)::before {
+  width: 78%;
+}
+
+.cohort-panel .panel-title strong {
+  color: var(--cyan);
+}
+
+@keyframes cohortFloat {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+
+  50% {
+    transform: translateY(-4px);
+  }
+}
+
+@keyframes cohortScan {
+  0%,
+  100% {
+    opacity: 0.48;
+    transform: scaleX(0.72);
+  }
+
+  50% {
+    opacity: 1;
+    transform: scaleX(1);
+  }
+}
+
+@keyframes cohortDial {
+  to {
+    transform: rotate(1turn);
+  }
+}
+
+@keyframes jitterDisc {
+  0%,
+  100% {
+    transform: translateX(0) rotate(0deg);
+  }
+
+  33% {
+    transform: translateX(4px) rotate(12deg);
+  }
+
+  66% {
+    transform: translateX(-3px) rotate(-10deg);
+  }
+}
+@media (max-width: 880px) {
+  .governor {
+    width: min(100% - 20px, 700px);
+    padding-top: 16px;
+  }
+  .hero {
+    grid-template-columns: 1fr;
+    min-height: 260px;
+    padding: 26px;
+  }
+  .badge {
+    width: min(100%, 260px);
+  }
+  .controls,
+  .grid {
+    grid-template-columns: 1fr;
+  }
+  .radar-panel {
+    grid-row: auto;
+  }
+  .lane {
+    grid-template-columns: 1fr;
+    gap: 7px;
+  }
+  .lane b {
+    text-align: left;
+  }
+}
+@media (max-width: 560px) {
+  .governor {
+    width: min(100% - 14px, 440px);
+  }
+  .hero {
+    padding: 22px;
+  }
+  h1 {
+    font-size: clamp(2.05rem, 18vw, 3.75rem);
+  }
+  .controls label,
+  .metrics {
+    grid-template-columns: 1fr;
+  }
+  .panel-title {
+    align-items: start;
+  }
+  .playbook li {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add an advanced adaptive jitter governor animation example
- include interactive controls for retry sync, client pressure, headroom, and jitter spread
- visualize calm, spread, dampen, and recover states for retry storm control

## Validation
- npx prettier --check submissions/examples/adaptive-jitter-governor-kp/README.md submissions/examples/adaptive-jitter-governor-kp/demo.html submissions/examples/adaptive-jitter-governor-kp/style.css
- npx stylelint submissions/examples/adaptive-jitter-governor-kp/style.css --allow-empty-input
- git diff --check