### PR TITLE
feat: add CSS clip-path reveal on scroll

### DIFF
--- a/submissions/examples/css-clip-path-reveal/README.md
+++ b/submissions/examples/css-clip-path-reveal/README.md
@@ -1,0 +1,296 @@
+# CSS Clip-Path Reveal on Scroll
+
+A modern **CSS Clip-Path Reveal on Scroll** component that reveals content from left to right as it enters the viewport.
+
+The effect is built with pure HTML5 and CSS3 using `clip-path` and the modern CSS scroll-driven animation API. No JavaScript or external animation library is required.
+
+## ✨ Features
+
+* Pure HTML5 and CSS3
+* No JavaScript required
+* Left-to-right clip-path reveal
+* CSS scroll-driven animation
+* Uses `animation-timeline: view()`
+* Smooth reveal animation
+* Responsive desktop, tablet, and mobile layouts
+* Hover interactions
+* CSS Custom Properties
+* Reduced-motion support
+* Progressive enhancement with `@supports`
+* No external dependencies
+
+## 📂 Folder Structure
+
+```text id="c7d4km"
+css-clip-path-reveal/
+├── demo.html
+├── style.css
+└── README.md
+```
+
+## 🚀 Usage
+
+1. Open `demo.html` in a modern browser.
+2. Scroll down through the page.
+3. As the reveal cards enter the viewport, they animate from left to right.
+4. Customize the content and CSS variables in `style.css`.
+
+The component can be used for:
+
+* Landing pages
+* Portfolio sections
+* Product showcases
+* Feature sections
+* Case studies
+* Editorial layouts
+* Project presentations
+* Image and content galleries
+
+## 🔧 How It Works
+
+The reveal starts with the element clipped almost completely:
+
+```css id="1w5xat"
+.reveal-card {
+    clip-path: inset(0 100% 0 0);
+    opacity: 0;
+}
+```
+
+The animation gradually removes the clipping:
+
+```css id="c8z6z4"
+@keyframes clipReveal {
+    from {
+        clip-path: inset(0 100% 0 0);
+        opacity: 0;
+    }
+
+    to {
+        clip-path: inset(0 0 0 0);
+        opacity: 1;
+    }
+}
+```
+
+The animation is connected to the viewport using:
+
+```css id="g5m3g2"
+.reveal-card {
+    animation: clipReveal linear both;
+
+    animation-timeline: view();
+
+    animation-range:
+        entry 10% cover 35%;
+}
+```
+
+This allows the animation progress to be controlled by the element's position within the viewport.
+
+## 🧩 CSS Scroll-Driven Animation
+
+This component uses:
+
+```css id="bq7g0n"
+animation-timeline: view();
+```
+
+The `view()` timeline ties the animation to the visibility of an element as it moves through the viewport.
+
+The animation range:
+
+```css id="xw6q7p"
+animation-range: entry 10% cover 35%;
+```
+
+controls when the reveal begins and ends.
+
+## 🎨 CSS Custom Properties
+
+The component provides CSS variables for easy customization.
+
+| Variable          | Description            |
+| ----------------- | ---------------------- |
+| `--bg`            | Page background        |
+| `--surface`       | Card background        |
+| `--surface-soft`  | Secondary background   |
+| `--primary`       | Main accent color      |
+| `--primary-dark`  | Dark accent color      |
+| `--primary-soft`  | Soft accent background |
+| `--text`          | Primary text color     |
+| `--muted`         | Secondary text color   |
+| `--border`        | Border color           |
+| `--radius`        | Card border radius     |
+| `--transition`    | Transition duration    |
+| `--content-width` | Maximum content width  |
+| `--shadow`        | Card shadow            |
+
+### Example
+
+```css id="y9o3dw"
+:root {
+    --primary: #2563eb;
+    --primary-soft: #eff6ff;
+
+    --radius: 22px;
+
+    --content-width: 1100px;
+
+    --transition: 0.4s ease;
+}
+```
+
+## 📱 Responsive Design
+
+The component adapts to different viewport sizes.
+
+### Desktop
+
+Reveal cards use a two-column internal layout with a numbered indicator and content area.
+
+### Tablet
+
+Spacing and typography are reduced while maintaining the reveal effect.
+
+### Mobile
+
+Cards switch to a single-column layout:
+
+```css id="f84x9k"
+@media (max-width: 600px) {
+    .reveal-card {
+        grid-template-columns: 1fr;
+    }
+}
+```
+
+This keeps the content readable on narrow screens.
+
+## ✨ Hover Effects
+
+Cards include a subtle hover interaction:
+
+```css id="e2tq1n"
+.reveal-card:hover {
+    transform: translateY(-6px);
+}
+```
+
+The numbered indicator also receives a small rotation and scale effect:
+
+```css id="xj5f8c"
+.reveal-card:hover .reveal-number {
+    transform:
+        scale(1.08)
+        rotate(-4deg);
+}
+```
+
+These interactions provide additional visual feedback without JavaScript.
+
+## 🛡️ Progressive Enhancement
+
+The component checks whether the browser supports CSS scroll-driven animations:
+
+```css id="2e5g1r"
+@supports (animation-timeline: view()) {
+    .reveal-card {
+        animation: clipReveal linear both;
+        animation-timeline: view();
+    }
+}
+```
+
+For browsers without support, the content remains visible:
+
+```css id="3g2b8a"
+@supports not (animation-timeline: view()) {
+    .reveal-card {
+        clip-path: none;
+        opacity: 1;
+    }
+}
+```
+
+This ensures that unsupported browsers do not hide important content.
+
+## ♿ Accessibility
+
+Accessibility considerations include:
+
+* Semantic `<main>` and `<section>` elements
+* Proper heading hierarchy
+* Semantic `<article>` elements
+* Descriptive content
+* Decorative scroll hint
+* No JavaScript dependency
+* Content remains accessible when animation is unsupported
+* Reduced-motion support
+
+The animation is purely decorative and does not control access to the content.
+
+## 🌙 Reduced Motion
+
+Users who prefer reduced motion are supported through:
+
+```css id="f9z0ry"
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation: none !important;
+        transition: none !important;
+        scroll-behavior: auto;
+    }
+
+    .reveal-list .reveal-card,
+    .showcase-box {
+        clip-path: none;
+        opacity: 1;
+    }
+}
+```
+
+When reduced motion is enabled, all content is immediately visible without animation.
+
+## ⚡ Performance
+
+The component is lightweight because it uses native browser capabilities:
+
+* No JavaScript
+* No external libraries
+* No animation framework
+* CSS `clip-path`
+* CSS scroll-driven animations
+* CSS transitions
+* CSS Custom Properties
+
+## 🌐 Browser Support
+
+The basic layout works in modern browsers.
+
+The animated reveal specifically depends on support for:
+
+* CSS `clip-path`
+* CSS Animations
+* `animation-timeline`
+* `view()` timelines
+
+Browsers without scroll-driven animation support receive the static fallback, ensuring that the content remains visible.
+
+## 🧪 Testing Checklist
+
+* [x] Desktop layout tested
+* [x] Tablet layout tested
+* [x] Mobile layout tested
+* [x] Left-to-right reveal implemented
+* [x] Hover interaction implemented
+* [x] Reduced-motion support added
+* [x] Unsupported-browser fallback added
+* [x] No JavaScript required
+* [x] No external dependencies
+
+## 📄 License
+
+This example follows the same license as the EaseMotion CSS project.

--- a/submissions/examples/css-clip-path-reveal/demo.html
+++ b/submissions/examples/css-clip-path-reveal/demo.html
@@ -1,0 +1,265 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+
+    <meta
+        name="viewport"
+        content="width=device-width, initial-scale=1.0"
+    >
+
+    <meta
+        name="description"
+        content="CSS clip-path reveal on scroll animation"
+    >
+
+    <title>CSS Clip-Path Reveal on Scroll</title>
+
+    <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+<main>
+
+    <!-- Hero -->
+
+    <section
+        class="hero"
+        aria-labelledby="hero-title"
+    >
+
+        <span class="eyebrow">
+            EaseMotion CSS
+        </span>
+
+        <h1 id="hero-title">
+            Clip-Path Reveal
+        </h1>
+
+        <p>
+            Elements reveal from left to right as they enter
+            the viewport using CSS scroll-driven animation.
+        </p>
+
+        <span class="scroll-hint" aria-hidden="true">
+            ↓ Scroll to explore
+        </span>
+
+    </section>
+
+
+    <!-- Reveal Section -->
+
+    <section
+        class="reveal-section"
+        aria-labelledby="reveal-title"
+    >
+
+        <div class="section-heading">
+
+            <span>
+                01 / REVEAL
+            </span>
+
+            <h2 id="reveal-title">
+                Reveal Content on Scroll
+            </h2>
+
+            <p>
+                Scroll through the examples to see each element
+                smoothly reveal from left to right.
+            </p>
+
+        </div>
+
+
+        <div class="reveal-list">
+
+            <article class="reveal-card">
+
+                <div class="reveal-number">
+                    01
+                </div>
+
+                <div class="reveal-content">
+
+                    <span class="reveal-label">
+                        Animation
+                    </span>
+
+                    <h3>
+                        Smooth Entrance
+                    </h3>
+
+                    <p>
+                        The content begins hidden behind a clip-path
+                        and gradually becomes visible as it enters
+                        the viewport.
+                    </p>
+
+                </div>
+
+            </article>
+
+
+            <article class="reveal-card">
+
+                <div class="reveal-number">
+                    02
+                </div>
+
+                <div class="reveal-content">
+
+                    <span class="reveal-label">
+                        CSS Native
+                    </span>
+
+                    <h3>
+                        No JavaScript
+                    </h3>
+
+                    <p>
+                        The reveal effect uses CSS scroll-driven
+                        animation without requiring JavaScript or
+                        external animation libraries.
+                    </p>
+
+                </div>
+
+            </article>
+
+
+            <article class="reveal-card">
+
+                <div class="reveal-number">
+                    03
+                </div>
+
+                <div class="reveal-content">
+
+                    <span class="reveal-label">
+                        Performance
+                    </span>
+
+                    <h3>
+                        Lightweight Motion
+                    </h3>
+
+                    <p>
+                        The animation relies on performant CSS
+                        properties to provide a lightweight visual
+                        effect for modern interfaces.
+                    </p>
+
+                </div>
+
+            </article>
+
+
+            <article class="reveal-card">
+
+                <div class="reveal-number">
+                    04
+                </div>
+
+                <div class="reveal-content">
+
+                    <span class="reveal-label">
+                        Responsive
+                    </span>
+
+                    <h3>
+                        Works Everywhere
+                    </h3>
+
+                    <p>
+                        The component adapts to desktop, tablet,
+                        and mobile screen sizes while maintaining
+                        the reveal effect.
+                    </p>
+
+                </div>
+
+            </article>
+
+        </div>
+
+    </section>
+
+
+    <!-- Feature Showcase -->
+
+    <section
+        class="showcase"
+        aria-labelledby="showcase-title"
+    >
+
+        <div class="showcase-inner">
+
+            <div class="showcase-text">
+
+                <span class="eyebrow">
+                    02 / SHOWCASE
+                </span>
+
+                <h2 id="showcase-title">
+                    Built for Modern Interfaces
+                </h2>
+
+                <p>
+                    Use the clip-path reveal effect for landing
+                    pages, feature sections, portfolios, product
+                    showcases, and editorial layouts.
+                </p>
+
+            </div>
+
+
+            <div class="showcase-box reveal-card">
+
+                <span>
+                    CSS
+                </span>
+
+                <strong>
+                    Reveal
+                </strong>
+
+                <small>
+                    Scroll-driven motion
+                </small>
+
+            </div>
+
+        </div>
+
+    </section>
+
+
+    <!-- Footer Content -->
+
+    <section
+        class="ending"
+        aria-labelledby="ending-title"
+    >
+
+        <span class="eyebrow">
+            03 / FINISH
+        </span>
+
+        <h2 id="ending-title">
+            Continue Scrolling
+        </h2>
+
+        <p>
+            The page continues with normal vertical scrolling
+            after the reveal animation section.
+        </p>
+
+    </section>
+
+</main>
+
+</body>
+</html>

--- a/submissions/examples/css-clip-path-reveal/style.css
+++ b/submissions/examples/css-clip-path-reveal/style.css
@@ -1,0 +1,719 @@
+/* ==========================================
+   CSS CLIP-PATH REVEAL ON SCROLL
+========================================== */
+
+:root {
+    --bg: #f8fafc;
+    --surface: #ffffff;
+    --surface-soft: #f1f5f9;
+
+    --primary: #2563eb;
+    --primary-dark: #1d4ed8;
+    --primary-soft: #eff6ff;
+
+    --text: #0f172a;
+    --muted: #64748b;
+
+    --border: #dbe3ea;
+
+    --radius: 22px;
+
+    --transition: 0.4s ease;
+
+    --content-width: 1100px;
+
+    --shadow:
+        0 18px 45px
+        rgba(15, 23, 42, 0.08);
+}
+
+/* ==========================================
+   RESET
+========================================== */
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+
+    margin: 0;
+    padding: 0;
+}
+
+html {
+    scroll-behavior: smooth;
+}
+
+body {
+    min-height: 100vh;
+
+    overflow-x: hidden;
+
+    font-family:
+        Inter,
+        ui-sans-serif,
+        system-ui,
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        sans-serif;
+
+    color: var(--text);
+
+    background:
+        radial-gradient(
+            circle at top,
+            #dbeafe,
+            var(--bg) 48%
+        );
+}
+
+/* ==========================================
+   COMMON
+========================================== */
+
+.eyebrow {
+    display: inline-block;
+
+    margin-bottom: 1rem;
+
+    padding: 0.4rem 0.85rem;
+
+    border: 1px solid
+        rgba(37, 99, 235, 0.25);
+
+    border-radius: 999px;
+
+    background: var(--primary-soft);
+
+    color: var(--primary);
+
+    font-size: 0.75rem;
+
+    font-weight: 800;
+
+    letter-spacing: 0.12em;
+}
+
+/* ==========================================
+   HERO
+========================================== */
+
+.hero {
+    width: min(900px, 100%);
+
+    min-height: 90vh;
+
+    margin: 0 auto;
+
+    display: flex;
+
+    flex-direction: column;
+
+    align-items: center;
+
+    justify-content: center;
+
+    padding: 4rem 1.25rem;
+
+    text-align: center;
+}
+
+.hero h1 {
+    margin-bottom: 1.25rem;
+
+    font-size:
+        clamp(2.8rem, 8vw, 6rem);
+
+    line-height: 0.95;
+
+    letter-spacing: -0.05em;
+}
+
+.hero p {
+    max-width: 680px;
+
+    color: var(--muted);
+
+    line-height: 1.8;
+}
+
+.scroll-hint {
+    margin-top: 3rem;
+
+    color: var(--primary);
+
+    font-size: 0.85rem;
+
+    font-weight: 700;
+
+    animation:
+        hintFloat 2s ease-in-out infinite;
+}
+
+/* ==========================================
+   REVEAL SECTION
+========================================== */
+
+.reveal-section {
+    width: min(
+        var(--content-width),
+        100%
+    );
+
+    margin: 0 auto;
+
+    padding:
+        6rem 1.25rem;
+}
+
+.section-heading {
+    max-width: 700px;
+
+    margin-bottom: 4rem;
+}
+
+.section-heading > span {
+    display: block;
+
+    margin-bottom: 0.75rem;
+
+    color: var(--primary);
+
+    font-size: 0.75rem;
+
+    font-weight: 800;
+
+    letter-spacing: 0.12em;
+}
+
+.section-heading h2 {
+    margin-bottom: 1rem;
+
+    font-size:
+        clamp(2rem, 5vw, 3.5rem);
+
+    line-height: 1.1;
+}
+
+.section-heading p {
+    color: var(--muted);
+
+    line-height: 1.8;
+}
+
+/* ==========================================
+   REVEAL LIST
+========================================== */
+
+.reveal-list {
+    display: grid;
+
+    gap: 2rem;
+}
+
+/* ==========================================
+   REVEAL CARD
+========================================== */
+
+.reveal-card {
+    position: relative;
+
+    display: grid;
+
+    grid-template-columns:
+        80px 1fr;
+
+    gap: 2rem;
+
+    min-height: 240px;
+
+    padding: 2rem;
+
+    border: 1px solid var(--border);
+
+    border-radius: var(--radius);
+
+    background: var(--surface);
+
+    box-shadow: var(--shadow);
+
+    overflow: hidden;
+}
+
+/*
+   Default state.
+
+   The card is fully clipped on the
+   left side until the animation begins.
+*/
+
+.reveal-list .reveal-card {
+    clip-path:
+        inset(
+            0 100% 0 0
+        );
+
+    opacity: 0;
+}
+
+/* ==========================================
+   CSS SCROLL-DRIVEN ANIMATION
+========================================== */
+
+@supports (
+    animation-timeline: view()
+) {
+    .reveal-list .reveal-card {
+        animation:
+            clipReveal linear both;
+
+        animation-timeline: view();
+
+        animation-range:
+            entry 10% cover 35%;
+    }
+}
+
+/* ==========================================
+   FALLBACK
+========================================== */
+
+/*
+   Browsers without scroll-driven animation
+   support still show the content.
+*/
+
+@supports not (
+    animation-timeline: view()
+) {
+    .reveal-list .reveal-card {
+        clip-path: none;
+
+        opacity: 1;
+    }
+}
+
+/* ==========================================
+   REVEAL NUMBER
+========================================== */
+
+.reveal-number {
+    width: 54px;
+    height: 54px;
+
+    display: flex;
+
+    align-items: center;
+    justify-content: center;
+
+    border-radius: 15px;
+
+    background: var(--primary-soft);
+
+    color: var(--primary);
+
+    font-size: 0.85rem;
+
+    font-weight: 800;
+}
+
+/* ==========================================
+   REVEAL CONTENT
+========================================== */
+
+.reveal-content {
+    display: flex;
+
+    flex-direction: column;
+
+    justify-content: center;
+}
+
+.reveal-label {
+    margin-bottom: 0.7rem;
+
+    color: var(--primary);
+
+    font-size: 0.75rem;
+
+    font-weight: 800;
+
+    letter-spacing: 0.1em;
+
+    text-transform: uppercase;
+}
+
+.reveal-content h3 {
+    margin-bottom: 0.75rem;
+
+    font-size:
+        clamp(1.4rem, 3vw, 2rem);
+}
+
+.reveal-content p {
+    max-width: 650px;
+
+    color: var(--muted);
+
+    line-height: 1.75;
+}
+
+/* ==========================================
+   HOVER
+========================================== */
+
+.reveal-card {
+    transition:
+        transform var(--transition),
+        border-color var(--transition),
+        box-shadow var(--transition);
+}
+
+.reveal-card:hover {
+    transform:
+        translateY(-6px);
+
+    border-color:
+        rgba(37, 99, 235, 0.35);
+
+    box-shadow:
+        0 25px 55px
+        rgba(15, 23, 42, 0.12);
+}
+
+.reveal-number {
+    transition:
+        transform var(--transition);
+}
+
+.reveal-card:hover .reveal-number {
+    transform:
+        scale(1.08)
+        rotate(-4deg);
+}
+
+/* ==========================================
+   SHOWCASE
+========================================== */
+
+.showcase {
+    padding:
+        7rem 1.25rem;
+
+    background:
+        var(--surface-soft);
+}
+
+.showcase-inner {
+    width: min(
+        var(--content-width),
+        100%
+    );
+
+    margin: 0 auto;
+
+    display: grid;
+
+    grid-template-columns:
+        1.2fr 0.8fr;
+
+    gap: 4rem;
+
+    align-items: center;
+}
+
+.showcase-text h2 {
+    margin-bottom: 1rem;
+
+    font-size:
+        clamp(2rem, 5vw, 3.5rem);
+
+    line-height: 1.1;
+}
+
+.showcase-text p {
+    max-width: 600px;
+
+    color: var(--muted);
+
+    line-height: 1.8;
+}
+
+/* ==========================================
+   SHOWCASE BOX
+========================================== */
+
+.showcase-box {
+    min-height: 330px;
+
+    display: flex;
+
+    flex-direction: column;
+
+    align-items: center;
+
+    justify-content: center;
+
+    text-align: center;
+
+    background:
+        linear-gradient(
+            135deg,
+            var(--primary-soft),
+            var(--surface)
+        );
+}
+
+.showcase-box span {
+    margin-bottom: 0.5rem;
+
+    color: var(--primary);
+
+    font-size: 0.8rem;
+
+    font-weight: 800;
+
+    letter-spacing: 0.15em;
+}
+
+.showcase-box strong {
+    font-size:
+        clamp(2rem, 6vw, 4rem);
+
+    line-height: 1;
+}
+
+.showcase-box small {
+    margin-top: 1rem;
+
+    color: var(--muted);
+}
+
+/* ==========================================
+   SHOWCASE REVEAL
+========================================== */
+
+@supports (
+    animation-timeline: view()
+) {
+    .showcase-box {
+        clip-path:
+            inset(
+                0 100% 0 0
+            );
+
+        animation:
+            clipReveal linear both;
+
+        animation-timeline: view();
+
+        animation-range:
+            entry 10% cover 40%;
+    }
+}
+
+/* ==========================================
+   ENDING
+========================================== */
+
+.ending {
+    width: min(850px, 100%);
+
+    min-height: 70vh;
+
+    margin: 0 auto;
+
+    display: flex;
+
+    flex-direction: column;
+
+    justify-content: center;
+
+    padding: 5rem 1.25rem;
+}
+
+.ending h2 {
+    margin-bottom: 1rem;
+
+    font-size:
+        clamp(2rem, 5vw, 3.5rem);
+
+    line-height: 1.1;
+}
+
+.ending p {
+    max-width: 650px;
+
+    color: var(--muted);
+
+    line-height: 1.8;
+}
+
+/* ==========================================
+   CLIP-PATH KEYFRAMES
+========================================== */
+
+@keyframes clipReveal {
+    from {
+        clip-path:
+            inset(
+                0 100% 0 0
+            );
+
+        opacity: 0;
+    }
+
+    to {
+        clip-path:
+            inset(
+                0 0 0 0
+            );
+
+        opacity: 1;
+    }
+}
+
+/* ==========================================
+   HINT ANIMATION
+========================================== */
+
+@keyframes hintFloat {
+    0%,
+    100% {
+        transform:
+            translateY(0);
+    }
+
+    50% {
+        transform:
+            translateY(7px);
+    }
+}
+
+/* ==========================================
+   TABLET
+========================================== */
+
+@media (max-width: 800px) {
+    .reveal-card {
+        grid-template-columns:
+            60px 1fr;
+
+        gap: 1.5rem;
+
+        padding: 1.5rem;
+    }
+
+    .showcase-inner {
+        grid-template-columns: 1fr;
+
+        gap: 2.5rem;
+    }
+
+    .showcase-box {
+        min-height: 280px;
+    }
+}
+
+/* ==========================================
+   MOBILE
+========================================== */
+
+@media (max-width: 600px) {
+    .hero {
+        min-height: 80vh;
+
+        padding:
+            3rem 1rem;
+    }
+
+    .reveal-section {
+        padding:
+            4rem 1rem;
+    }
+
+    .section-heading {
+        margin-bottom: 2.5rem;
+    }
+
+    .reveal-card {
+        grid-template-columns: 1fr;
+
+        gap: 1.25rem;
+
+        min-height: auto;
+
+        padding: 1.5rem;
+    }
+
+    .reveal-number {
+        width: 48px;
+        height: 48px;
+    }
+
+    .showcase {
+        padding:
+            4rem 1rem;
+    }
+
+    .showcase-box {
+        min-height: 240px;
+    }
+
+    .ending {
+        min-height: 60vh;
+
+        padding:
+            4rem 1rem;
+    }
+}
+
+/* ==========================================
+   SMALL MOBILE
+========================================== */
+
+@media (max-width: 380px) {
+    .reveal-card {
+        padding: 1.25rem;
+    }
+
+    .showcase-box {
+        min-height: 210px;
+    }
+}
+
+/* ==========================================
+   REDUCED MOTION
+========================================== */
+
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation: none !important;
+
+        transition: none !important;
+
+        scroll-behavior: auto;
+    }
+
+    .reveal-list .reveal-card,
+    .showcase-box {
+        clip-path: none;
+
+        opacity: 1;
+    }
+
+    .reveal-card:hover {
+        transform: none;
+    }
+
+    .reveal-card:hover .reveal-number {
+        transform: none;
+    }
+
+    .scroll-hint {
+        animation: none;
+    }
+}


### PR DESCRIPTION
## Description

This PR adds a **CSS Clip-Path Reveal on Scroll** example to EaseMotion CSS.

The component reveals content from left to right as it enters the viewport using modern CSS scroll-driven animations and `clip-path`, without requiring JavaScript.

### ✨ Features

* Pure HTML5 and CSS3
* No JavaScript required
* Left-to-right `clip-path` reveal
* CSS `animation-timeline: view()` support
* Scroll-driven animation
* Progressive enhancement with `@supports`
* Responsive desktop, tablet, and mobile layouts
* Smooth hover interactions
* CSS Custom Properties
* `prefers-reduced-motion` support
* Accessible semantic HTML
* No external dependencies

### 📁 Files Added

* `submissions/examples/css-clip-path-reveal/demo.html`
* `submissions/examples/css-clip-path-reveal/style.css`
* `submissions/examples/css-clip-path-reveal/README.md`

### 🧪 Testing

* Tested the reveal animation while scrolling
* Tested desktop, tablet, and mobile layouts
* Verified the left-to-right clip-path transition
* Tested hover interactions
* Verified reduced-motion behavior
* Verified fallback for unsupported scroll-driven animation
* Confirmed no JavaScript dependencies

Fixes #68368
