### PR TITLE
Add ease-mobile-pull-refresh-spinner component

### DIFF
--- a/submissions/examples/mobile-pull-refresh-spinner-ij/README.md
+++ b/submissions/examples/mobile-pull-refresh-spinner-ij/README.md
@@ -1,10 +1,11 @@
 # ease-mobile-pull-refresh-spinner
 
-A phone-style inbox whose circular spinner rotates with the pull distance.
+A mobile pull-to-refresh demo where the spinner rotates with the drag distance via `--pull-progress`.
 
 ## Run
-Open `demo.html` directly in a browser and drag down on the message list.
+Open `demo.html` directly in a browser.
 
 ## Notes
-- Drag distance maps to a CSS progress variable.
-- Releasing past the threshold spins out a refresh cycle.
+- Drag down on the list to rotate the spinner proportionally.
+- Release past the threshold to trigger the refresh spin.
+- The content translates down with the pull gesture.

--- a/submissions/examples/mobile-pull-refresh-spinner-ij/demo.html
+++ b/submissions/examples/mobile-pull-refresh-spinner-ij/demo.html
@@ -6,56 +6,29 @@
 <title>ease-mobile-pull-refresh-spinner demo</title>
 </head>
 <body>
-<div class="mpr-app">
-  <div class="mpr-bar"><span class="mpr-clock">9:41</span><span class="mpr-batt">100%</span></div>
-  <h1 class="mpr-head">MESSAGES</h1>
-  <div class="mpr-scroll" id="mprScroll">
-    <div class="mpr-pull">
-      <span class="mpr-spinner" aria-hidden="true"></span>
-      <span class="mpr-tip">pull to refresh</span>
+<div class="mprs-phone">
+  <span class="mprs-title">INBOX</span>
+  <div class="mprs-screen">
+    <div class="mprs-spinner"><span class="mprs-arc"></span></div>
+    <div class="mprs-list">
+      <div class="mprs-row"><span class="mprs-sender">Maya</span><span class="mprs-msg">Lunch tomorrow?</span></div>
+      <div class="mprs-row"><span class="mprs-sender">Dev Team</span><span class="mprs-msg">Sprint review at 3</span></div>
+      <div class="mprs-row"><span class="mprs-sender">Kai</span><span class="mprs-msg">Landed the patch</span></div>
+      <div class="mprs-row"><span class="mprs-sender">Nina</span><span class="mprs-msg">Docs updated</span></div>
+      <div class="mprs-row"><span class="mprs-sender">Arlo</span><span class="mprs-msg">Build passed</span></div>
     </div>
-    <ul class="mpr-list">
-      <li class="mpr-row"><strong>Ada</strong><span class="mpr-pre">Meeting moved to noon</span></li>
-      <li class="mpr-row"><strong>Ben</strong><span class="mpr-pre">See you at the gate</span></li>
-      <li class="mpr-row"><strong>Cleo</strong><span class="mpr-pre">Deploy looks good</span></li>
-      <li class="mpr-row"><strong>Dara</strong><span class="mpr-pre">Milk and bread, please</span></li>
-      <li class="mpr-row"><strong>Eli</strong><span class="mpr-pre">Photo is uploaded</span></li>
-    </ul>
   </div>
 </div>
 <script>
-(function () {
-  var app = document.querySelector('.mpr-app');
-  var scroll = document.querySelector('.mpr-scroll');
-  var pulling = false;
-  var startY = 0;
-  scroll.addEventListener('pointerdown', function (e) {
-    if (app.classList.contains('mpr-refreshing')) return;
-    pulling = true;
-    startY = e.clientY;
-    scroll.setPointerCapture(e.pointerId);
-  });
-  scroll.addEventListener('pointermove', function (e) {
-    if (!pulling) return;
-    var delta = e.clientY - startY;
-    if (delta < 0) delta = 0;
-    var progress = Math.min(delta / 72, 1.15);
-    app.style.setProperty('--pull-progress', progress.toFixed(2));
-  });
-  scroll.addEventListener('pointerup', function () {
-    if (!pulling) return;
-    pulling = false;
-    var progress = parseFloat(app.style.getPropertyValue('--pull-progress') || '0');
-    if (progress >= 1) {
-      app.classList.add('mpr-refreshing');
-      setTimeout(function () {
-        app.classList.remove('mpr-refreshing');
-        app.style.setProperty('--pull-progress', '0');
-      }, 1400);
-    } else {
-      app.style.setProperty('--pull-progress', '0');
-    }
-  });
+(function(){
+  var phone=document.querySelector('.mprs-phone');
+  var screen=document.querySelector('.mprs-screen');
+  var pulling=false,startY=0,dist=0,refresh=false;
+  phone.addEventListener('pointerdown',function(e){pulling=true;startY=e.clientY;dist=0;refresh=false;screen.classList.remove('mprs-refresh');});
+  window.addEventListener('pointermove',function(e){if(!pulling){return;}dist=Math.max(0,e.clientY-startY);var prog=Math.min(dist/130,1);screen.style.setProperty('--pull-progress',prog.toFixed(3));if(prog>=0.55){refresh=true;}});
+  function finish(e){if(!pulling){return;}pulling=false;if(refresh){screen.classList.add('mprs-refresh');setTimeout(function(){screen.classList.remove('mprs-refresh');screen.style.setProperty('--pull-progress','0');refresh=false;},2200);}else{screen.style.setProperty('--pull-progress','0');}}
+  window.addEventListener('pointerup',finish);
+  window.addEventListener('pointercancel',finish);
 })();
 </script>
 </body>

--- a/submissions/examples/mobile-pull-refresh-spinner-ij/style.css
+++ b/submissions/examples/mobile-pull-refresh-spinner-ij/style.css
@@ -1,17 +1,14 @@
-:root{--mpr-blue:#5a7bff;--mpr-ink:#2a2f3a;--mpr-paper:#f6f7fb;--mpr-line:#e2e6f0}
-body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#e8edfb,#bcc6ea);font-family:'Segoe UI',sans-serif}
-.mpr-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:var(--mpr-paper);box-shadow:0 16px 36px rgba(0,0,0,0.25)}
-.mpr-bar{display:flex;justify-content:space-between;align-items:center;height:26px;padding:0 14px;font-size:11px;font-weight:600;color:var(--mpr-ink);background:#eef1fb}
-.mpr-head{position:absolute;top:26px;left:0;right:0;margin:0;padding:10px 0 8px;text-align:center;font-size:16px;font-weight:800;letter-spacing:6px;color:var(--mpr-blue)}
-.mpr-scroll{position:absolute;top:62px;bottom:0;left:0;right:0;overflow:hidden;touch-action:none}
-.mpr-pull{position:absolute;top:-48px;left:0;right:0;height:48px;display:flex;align-items:center;justify-content:center;gap:8px;transform:translateY(calc(var(--pull-progress,0)*48px))}
-.mpr-spinner{width:22px;height:22px;border-radius:50%;border:3px solid #c9d2f5;border-top-color:var(--mpr-blue);transform:rotate(calc(var(--pull-progress,0)*360deg));opacity:calc(0.3 + var(--pull-progress,0)*0.7)}
-.mpr-tip{font-size:11px;font-weight:600;letter-spacing:1px;color:#8892b8;opacity:calc(var(--pull-progress,0))}
-.mpr-list{list-style:none;margin:0;padding:48px 0 0;transform:translateY(calc(var(--pull-progress,0)*46px));transition:transform 0.25s ease-out}
-.mpr-row{display:flex;align-items:baseline;gap:10px;padding:11px 16px;border-bottom:1px solid var(--mpr-line)}
-.mpr-row strong{font-size:13px;color:var(--mpr-ink)}
-.mpr-pre{font-size:12px;color:#7c86a6;overflow:hidden;white-space:nowrap;text-overflow:ellipsis}
-.mpr-app.mpr-refreshing .mpr-pull{transform:translateY(48px)}
-.mpr-app.mpr-refreshing .mpr-spinner{animation:spin-refresh-mobile-pull-refresh-spinner 0.8s linear infinite;opacity:1}
-.mpr-app.mpr-refreshing .mpr-list{transform:translateY(46px)}
-@keyframes spin-refresh-mobile-pull-refresh-spinner{from{transform:rotate(0deg)}to{transform:rotate(360deg)}}
+:root{--mprs-teal:#2dd4bf;--mprs-night:#101820;--mprs-frost:#d8e2ec}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#22303c,#10161d);font-family:'Segoe UI',sans-serif}
+.mprs-phone{position:relative;width:276px;height:416px;border-radius:22px;overflow:hidden;background:linear-gradient(180deg,#18232e,#0e141b);box-shadow:0 18px 36px rgba(0,0,0,0.6);padding:14px}
+.mprs-title{position:absolute;top:14px;left:0;right:0;text-align:center;font-size:12px;font-weight:700;letter-spacing:10px;color:#2dd4bf}
+.mprs-screen{position:absolute;top:46px;left:14px;right:14px;bottom:14px;border-radius:12px;background:#101820;overflow:hidden}
+.mprs-spinner{position:absolute;top:12px;left:0;right:0;display:flex;justify-content:center;z-index:1}
+.mprs-arc{width:30px;height:30px;border-radius:50%;border:3px solid rgba(45,212,191,0.25);border-top-color:#2dd4bf;transform:rotate(calc(var(--pull-progress,0) * 360deg));transition:transform 0.18s ease-out}
+.mprs-refresh .mprs-arc{animation:refresh-spin-mobile-pull-refresh-spinner 0.8s linear infinite;border-top-color:#2dd4bf}
+.mprs-list{position:absolute;top:0;left:0;right:0;bottom:0;padding:14px 10px;display:flex;flex-direction:column;gap:10px;overflow:hidden;background:#101820;transform:translateY(calc(var(--pull-progress,0) * 26px));transition:transform 0.18s ease-out}
+.mprs-refresh .mprs-list{transform:translateY(52px)}
+.mprs-row{background:#16222c;border-radius:10px;padding:10px 12px;display:flex;flex-direction:column;gap:2px}
+.mprs-sender{font-size:11px;font-weight:700;letter-spacing:2px;color:#d8e2ec}
+.mprs-msg{font-size:10px;color:#7f93a5}
+@keyframes refresh-spin-mobile-pull-refresh-spinner{to{transform:rotate(360deg)}}


### PR DESCRIPTION
## Component: ease-mobile-pull-refresh-spinner — circular spinner rotation tied to pull progress, CSS handles visuals

**Closes #68707**

### What this adds
A "pull to refresh" interaction. The circular spinner rotates proportionally to the pull distance via `--pull-progress` CSS variable. Past the threshold, releasing triggers a full rotation animation. Content translates down with the pull gesture.

### Acceptance Criteria covered
- Circular spinner with rotation tied to pull progress
- CSS handles visual rotation via `--pull-progress`
- JS sets progress variable from drag distance

### Files
- `submissions/examples/mobile-pull-refresh-spinner-ij/demo.html`
- `submissions/examples/mobile-pull-refresh-spinner-ij/style.css`
- `submissions/examples/mobile-pull-refresh-spinner-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Click and drag down on the list area; watch the spinner rotate proportionally; release past threshold to trigger refresh animation.