### PR TITLE
feat: add CSS gauge progress ring

### DIFF
--- a/submissions/examples/css-gauge-progress-ring/README.md
+++ b/submissions/examples/css-gauge-progress-ring/README.md
@@ -1,0 +1,108 @@
+# CSS Gauge Progress Ring
+
+A responsive, CSS-only half-circle gauge progress indicator built with HTML and CSS.
+
+## Features
+
+* Pure CSS implementation
+* No JavaScript required
+* Half-circle gauge design
+* Customizable progress percentage
+* Smooth reveal animation
+* Responsive on desktop, tablet, and mobile
+* Accessible `progressbar` attributes
+* Supports reduced-motion preferences
+* Easy to customize and reuse
+
+## Demo
+
+The example includes three gauge variations:
+
+* **75%** — Project Progress
+* **60%** — Performance
+* **90%** — Completion
+
+Open `demo.html` in a browser to view the component.
+
+## Usage
+
+The progress value can be changed using the `--progress` CSS custom property.
+
+```html
+<div
+    class="gauge"
+    style="--progress: 80%;"
+    role="progressbar"
+    aria-valuemin="0"
+    aria-valuemax="100"
+    aria-valuenow="80"
+    aria-label="Progress: 80 percent"
+>
+    <div class="gauge-track"></div>
+    <div class="gauge-fill"></div>
+
+    <div class="gauge-center">
+        <strong>80%</strong>
+        <span>Complete</span>
+    </div>
+</div>
+```
+
+## Customization
+
+Change the progress value:
+
+```css
+--progress: 80%;
+```
+
+You can also customize the gauge size using:
+
+```css
+.gauge {
+    --size: 240px;
+}
+```
+
+The component uses CSS custom properties for easy customization.
+
+## File Structure
+
+```text
+css-gauge-progress-ring/
+├── demo.html
+├── style.css
+└── README.md
+```
+
+## Accessibility
+
+The gauge uses the `progressbar` ARIA role with:
+
+* `aria-valuemin`
+* `aria-valuemax`
+* `aria-valuenow`
+* `aria-label`
+
+The component also respects:
+
+```css
+@media (prefers-reduced-motion: reduce)
+```
+
+so animations are disabled for users who prefer reduced motion.
+
+## Browser Support
+
+The component uses modern CSS features such as:
+
+* CSS custom properties
+* `conic-gradient()`
+* CSS animations
+* Responsive media queries
+
+Use a modern browser for the best experience.
+
+## License
+
+This example is contributed to the EaseMotion CSS project under the project's existing license.

--- a/submissions/examples/css-gauge-progress-ring/demo.html
+++ b/submissions/examples/css-gauge-progress-ring/demo.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <meta
+        name="description"
+        content="CSS-only half-circle gauge progress ring"
+    >
+
+    <title>CSS Gauge Progress Ring</title>
+
+    <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+<main class="page">
+
+    <header class="hero">
+        <span class="eyebrow">EASEMOTION CSS</span>
+
+        <h1>Gauge Progress Ring</h1>
+
+        <p>
+            A responsive half-circle progress indicator built
+            entirely with HTML and CSS.
+        </p>
+    </header>
+
+    <section
+        class="gauge-grid"
+        aria-label="Gauge progress examples"
+    >
+
+        <!-- 75% Gauge -->
+        <article class="gauge-card">
+
+            <h2>Project Progress</h2>
+
+            <div
+                class="gauge"
+                style="--progress: 75%;"
+                role="progressbar"
+                aria-valuemin="0"
+                aria-valuemax="100"
+                aria-valuenow="75"
+                aria-label="Project progress: 75 percent"
+            >
+                <div class="gauge-track"></div>
+
+                <div class="gauge-fill"></div>
+
+                <div class="gauge-center">
+                    <strong>75%</strong>
+                    <span>Complete</span>
+                </div>
+            </div>
+
+        </article>
+
+
+        <!-- 60% Gauge -->
+        <article class="gauge-card">
+
+            <h2>Performance</h2>
+
+            <div
+                class="gauge"
+                style="--progress: 60%;"
+                role="progressbar"
+                aria-valuemin="0"
+                aria-valuemax="100"
+                aria-valuenow="60"
+                aria-label="Performance: 60 percent"
+            >
+                <div class="gauge-track"></div>
+
+                <div class="gauge-fill"></div>
+
+                <div class="gauge-center">
+                    <strong>60%</strong>
+                    <span>Good</span>
+                </div>
+            </div>
+
+        </article>
+
+
+        <!-- 90% Gauge -->
+        <article class="gauge-card">
+
+            <h2>Completion</h2>
+
+            <div
+                class="gauge"
+                style="--progress: 90%;"
+                role="progressbar"
+                aria-valuemin="0"
+                aria-valuemax="100"
+                aria-valuenow="90"
+                aria-label="Completion: 90 percent"
+            >
+                <div class="gauge-track"></div>
+
+                <div class="gauge-fill"></div>
+
+                <div class="gauge-center">
+                    <strong>90%</strong>
+                    <span>Excellent</span>
+                </div>
+            </div>
+
+        </article>
+
+    </section>
+
+
+    <section class="usage">
+
+        <h2>CSS Usage</h2>
+
+        <p>
+            Change the <code>--progress</code> custom property
+            to control the gauge value.
+        </p>
+
+        <div class="code-example">
+            <code>
+                --progress: 80%;
+            </code>
+        </div>
+
+    </section>
+
+
+    <footer>
+        <p>Built with pure HTML &amp; CSS · EaseMotion CSS</p>
+    </footer>
+
+</main>
+
+</body>
+</html>

--- a/submissions/examples/css-gauge-progress-ring/style.css
+++ b/submissions/examples/css-gauge-progress-ring/style.css
@@ -1,0 +1,491 @@
+/* =========================================
+   CSS GAUGE PROGRESS RING
+   EaseMotion CSS
+========================================= */
+
+:root {
+    --background: #f5f7fb;
+    --surface: #ffffff;
+    --text: #111827;
+    --muted: #6b7280;
+
+    --accent: #6366f1;
+    --accent-light: #8b5cf6;
+
+    --track: #e5e7eb;
+
+    --radius: 24px;
+
+    --transition: 0.4s ease;
+}
+
+
+/* =========================================
+   RESET
+========================================= */
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+html {
+    scroll-behavior: smooth;
+}
+
+body {
+    margin: 0;
+
+    min-height: 100vh;
+
+    font-family:
+        Inter,
+        ui-sans-serif,
+        system-ui,
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        sans-serif;
+
+    color: var(--text);
+
+    background:
+        radial-gradient(
+            circle at top left,
+            rgba(99, 102, 241, 0.12),
+            transparent 35%
+        ),
+        var(--background);
+}
+
+
+/* =========================================
+   PAGE
+========================================= */
+
+.page {
+    width: min(1100px, 92%);
+
+    margin: 0 auto;
+
+    padding: 70px 0 40px;
+}
+
+
+/* =========================================
+   HERO
+========================================= */
+
+.hero {
+    max-width: 700px;
+
+    margin-bottom: 50px;
+}
+
+.eyebrow {
+    display: inline-block;
+
+    margin-bottom: 15px;
+
+    color: var(--accent);
+
+    font-size: 0.75rem;
+
+    font-weight: 800;
+
+    letter-spacing: 0.18em;
+}
+
+.hero h1 {
+    margin: 0;
+
+    font-size:
+        clamp(2.5rem, 6vw, 5rem);
+
+    line-height: 1;
+
+    letter-spacing: -0.06em;
+}
+
+.hero p {
+    max-width: 600px;
+
+    margin-top: 22px;
+
+    color: var(--muted);
+
+    font-size: 1.05rem;
+
+    line-height: 1.7;
+}
+
+
+/* =========================================
+   GAUGE GRID
+========================================= */
+
+.gauge-grid {
+    display: grid;
+
+    grid-template-columns:
+        repeat(3, 1fr);
+
+    gap: 20px;
+}
+
+
+/* =========================================
+   CARD
+========================================= */
+
+.gauge-card {
+    padding: 30px;
+
+    overflow: hidden;
+
+    border:
+        1px solid
+        rgba(17, 24, 39, 0.08);
+
+    border-radius: var(--radius);
+
+    background: var(--surface);
+
+    box-shadow:
+        0 15px 40px
+        rgba(0, 0, 0, 0.06);
+
+    transition:
+        transform var(--transition),
+        box-shadow var(--transition);
+}
+
+.gauge-card:hover {
+    transform:
+        translateY(-6px);
+
+    box-shadow:
+        0 25px 55px
+        rgba(0, 0, 0, 0.11);
+}
+
+.gauge-card h2 {
+    margin:
+        0 0 30px;
+
+    text-align: center;
+
+    font-size: 1.2rem;
+
+    letter-spacing: -0.02em;
+}
+
+
+/* =========================================
+   GAUGE
+========================================= */
+
+.gauge {
+    --size: 240px;
+
+    position: relative;
+
+    width: var(--size);
+
+    height:
+        calc(var(--size) / 2);
+
+    margin:
+        0 auto 15px;
+
+    overflow: hidden;
+}
+
+
+/* =========================================
+   GAUGE TRACK
+========================================= */
+
+.gauge-track,
+.gauge-fill {
+    position: absolute;
+
+    left: 0;
+    top: 0;
+
+    width: var(--size);
+
+    height: var(--size);
+
+    border-radius: 50%;
+
+    transform:
+        rotate(-45deg);
+}
+
+
+/*
+    The bottom part is hidden by the
+    gauge container, leaving a half-circle.
+*/
+
+.gauge-track {
+    background:
+        conic-gradient(
+            from -45deg,
+            var(--track) 0deg 270deg,
+            transparent 270deg 360deg
+        );
+}
+
+
+/* =========================================
+   GAUGE FILL
+========================================= */
+
+.gauge-fill {
+    background:
+        conic-gradient(
+            from -45deg,
+            var(--accent) 0deg,
+            var(--accent-light) calc(var(--progress) * 2.7),
+            transparent calc(var(--progress) * 2.7),
+            transparent 270deg
+        );
+
+    animation:
+        gauge-reveal 1.2s ease-out both;
+}
+
+
+/* =========================================
+   INNER CUTOUT
+========================================= */
+
+.gauge::after {
+    content: "";
+
+    position: absolute;
+
+    left: 12%;
+
+    top: 24%;
+
+    width: 76%;
+
+    aspect-ratio: 1;
+
+    border-radius: 50%;
+
+    background: var(--surface);
+
+    z-index: 2;
+}
+
+
+/* =========================================
+   CENTER CONTENT
+========================================= */
+
+.gauge-center {
+    position: absolute;
+
+    z-index: 3;
+
+    left: 0;
+    right: 0;
+
+    bottom: 8px;
+
+    display: flex;
+
+    flex-direction: column;
+
+    align-items: center;
+
+    justify-content: center;
+}
+
+.gauge-center strong {
+    font-size: 2.3rem;
+
+    line-height: 1;
+
+    letter-spacing: -0.06em;
+}
+
+.gauge-center span {
+    margin-top: 8px;
+
+    color: var(--muted);
+
+    font-size: 0.8rem;
+
+    font-weight: 600;
+
+    text-transform: uppercase;
+
+    letter-spacing: 0.08em;
+}
+
+
+/* =========================================
+   ANIMATION
+========================================= */
+
+@keyframes gauge-reveal {
+
+    from {
+        opacity: 0;
+
+        transform:
+            rotate(-45deg)
+            scale(0.7);
+    }
+
+    to {
+        opacity: 1;
+
+        transform:
+            rotate(-45deg)
+            scale(1);
+    }
+}
+
+
+/* =========================================
+   USAGE SECTION
+========================================= */
+
+.usage {
+    margin-top: 45px;
+
+    padding: 30px;
+
+    border-radius: var(--radius);
+
+    background: var(--surface);
+}
+
+.usage h2 {
+    margin-top: 0;
+
+    font-size: 1.4rem;
+}
+
+.usage p {
+    color: var(--muted);
+
+    line-height: 1.6;
+}
+
+.usage code {
+    padding:
+        3px 7px;
+
+    border-radius: 6px;
+
+    background: #eef0ff;
+
+    color: var(--accent);
+
+    font-family:
+        "SFMono-Regular",
+        Consolas,
+        monospace;
+}
+
+.code-example {
+    display: inline-block;
+
+    margin-top: 10px;
+
+    padding:
+        12px 18px;
+
+    border-radius: 10px;
+
+    background: #111827;
+
+    color: #ffffff;
+
+    font-family:
+        "SFMono-Regular",
+        Consolas,
+        monospace;
+}
+
+
+/* =========================================
+   FOOTER
+========================================= */
+
+footer {
+    padding-top: 35px;
+
+    text-align: center;
+
+    color: var(--muted);
+
+    font-size: 0.8rem;
+}
+
+
+/* =========================================
+   TABLET
+========================================= */
+
+@media (max-width: 900px) {
+
+    .gauge-grid {
+        grid-template-columns:
+            repeat(2, 1fr);
+    }
+}
+
+
+/* =========================================
+   MOBILE
+========================================= */
+
+@media (max-width: 620px) {
+
+    .page {
+        width: 92%;
+
+        padding-top: 45px;
+    }
+
+    .gauge-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .gauge-card {
+        padding: 25px;
+    }
+
+    .gauge {
+        --size: 250px;
+    }
+}
+
+
+/* =========================================
+   REDUCED MOTION
+========================================= */
+
+@media (prefers-reduced-motion: reduce) {
+
+    html {
+        scroll-behavior: auto;
+    }
+
+    *,
+    *::before,
+    *::after {
+        animation: none !important;
+
+        transition: none !important;
+    }
+}


### PR DESCRIPTION
## Description

Implemented a responsive CSS-only gauge progress ring for issue #68388.

### Features
- Half-circle gauge progress indicator
- Pure HTML and CSS implementation
- Multiple progress examples
- Responsive layout
- Accessible progressbar attributes
- Smooth CSS animation
- Reduced-motion support
- Demo included under submissions/examples/

Fixes #68388