### PR TITLE
Add ease-typewriter-text-effect component

### DIFF
--- a/submissions/examples/typewriter-text-effect-ij/README.md
+++ b/submissions/examples/typewriter-text-effect-ij/README.md
@@ -1,0 +1,10 @@
+# ease-typewriter-text-effect
+
+A terminal typewriter where the lines type out, the prompts blink, and the caret taps.
+
+## Run
+Open `demo.html` directly in a browser to watch the lines type.
+
+## Notes
+- Command lines type out letter by letter.
+- The caret taps at the line end.

--- a/submissions/examples/typewriter-text-effect-ij/demo.html
+++ b/submissions/examples/typewriter-text-effect-ij/demo.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-typewriter-text-effect demo</title>
+</head>
+<body>
+<div class="twt-card">
+  <span class="twt-label">TERMINAL</span>
+  <div class="twt-line"><span class="twt-prompt">$</span><span class="twt-text">deploy --release v2.4</span><span class="twt-caret"></span></div>
+  <div class="twt-line"><span class="twt-prompt">$</span><span class="twt-text twt-t2">npm test --all green</span><span class="twt-caret twt-c2"></span></div>
+  <div class="twt-line"><span class="twt-prompt">$</span><span class="twt-text twt-t3">git push origin main</span><span class="twt-caret twt-c3"></span></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/typewriter-text-effect-ij/style.css
+++ b/submissions/examples/typewriter-text-effect-ij/style.css
@@ -1,0 +1,20 @@
+:root{--twt-green:#4ade80;--twt-night:#0a0f0c;--twt-dim:#7f9a8a}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#12241a,#07100b);font-family:'Consolas',monospace}
+.twt-card{position:relative;width:360px;height:220px;border-radius:14px;overflow:hidden;background:linear-gradient(180deg,#0e1c14,#08120c);box-shadow:0 16px 34px rgba(0,0,0,0.6);padding:14px}
+.twt-label{position:absolute;top:14px;left:0;right:0;text-align:center;font-size:10px;font-weight:700;letter-spacing:10px;color:#4ade80}
+.twt-line{position:absolute;left:20px;right:20px;height:22px;display:flex;align-items:center;gap:8px}
+.twt-line:nth-child(2){top:56px}
+.twt-line:nth-child(3){top:102px}
+.twt-line:nth-child(4){top:148px}
+.twt-prompt{font-size:14px;font-weight:700;color:#4ade80;animation:prompt-blink-typewriter-text-effect 1s steps(2) infinite}
+.twt-text{font-size:14px;color:#d8ffe8;white-space:nowrap;overflow:hidden;width:0;animation:type-out-typewriter-text-effect 2.4s steps(21) forwards}
+.twt-t2{animation:type-out-2-typewriter-text-effect 2.2s steps(20) forwards;animation-delay:2.4s}
+.twt-t3{animation:type-out-3-typewriter-text-effect 2.6s steps(20) forwards;animation-delay:4.8s}
+.twt-caret{width:8px;height:16px;background:#4ade80;animation:caret-tap-typewriter-text-effect 0.7s steps(2) infinite}
+.twt-c2{animation-delay:2.4s}
+.twt-c3{animation-delay:4.8s}
+@keyframes type-out-typewriter-text-effect{0%{width:0}100%{width:21ch}}
+@keyframes type-out-2-typewriter-text-effect{0%{width:0}100%{width:20ch}}
+@keyframes type-out-3-typewriter-text-effect{0%{width:0}100%{width:20ch}}
+@keyframes prompt-blink-typewriter-text-effect{0%,100%{opacity:1}50%{opacity:0.2}}
+@keyframes caret-tap-typewriter-text-effect{0%,100%{opacity:1}50%{opacity:0}}


### PR DESCRIPTION
## Component: ease-typewriter-text-effect — lines type, prompts blink, and caret taps

**Closes #68721**

### What this adds
A terminal-style typewriter: each command line types out letter by letter, the prompt marks blink, and the caret taps at the end of the line.

### Acceptance Criteria covered
- Command lines type out letter by letter
- Prompt marks blink in turn
- Caret taps at the line end

### Files
- `submissions/examples/typewriter-text-effect-ij/demo.html`
- `submissions/examples/typewriter-text-effect-ij/style.css`
- `submissions/examples/typewriter-text-effect-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the lines type.