### PR TITLE
feat: add css split hero section submission

### DIFF
--- a/submissions/examples/css-split-hero-section-ag/README.md
+++ b/submissions/examples/css-split-hero-section-ag/README.md
@@ -1,0 +1,39 @@
+# CSS Split Hero Section
+
+A premium, highly responsive hero section featuring a dynamic diagonal split between typography and imagery, achieved purely through CSS.
+
+## Features
+- **Pure CSS / HTML**: Built entirely without JavaScript. Relies on the highly performant CSS `clip-path: polygon()` property to create the angled divide.
+- **Dynamic Interaction**: Hovering anywhere within the hero section triggers a smooth, orchestrated `cubic-bezier` transition that shifts the diagonal angle of the `clip-path` while simultaneously scaling the background image, creating a sophisticated parallax-like reveal effect.
+- **Responsive Layout**: On desktop screens, the split runs vertically with the image anchored to the right. On mobile devices (`max-width: 768px`), the layout elegantly restructures: the image fills the top portion, the `clip-path` transitions to a horizontal diagonal slice at the bottom of the image, and the text aligns centrally below it.
+- **Depth and Readability**: Utilizes a subtle CSS `linear-gradient` overlay on the image edge to ensure text remains highly legible even if window resizing forces overlap.
+- **Accessible**: Fully respects user preferences by gracefully disabling the `clip-path` shifting and image scaling animations via `@media (prefers-reduced-motion: reduce)`.
+
+## Usage
+
+Drop the HTML structure into the top of your landing page. Replace the `src` attribute of the `.hero-image` tag with your own high-resolution asset.
+
+```html
+<section class="split-hero">
+  <div class="hero-content">
+    <h1>Your Title</h1>
+    <p>Your description...</p>
+    <a href="#" class="hero-btn">Call to Action</a>
+  </div>
+  
+  <div class="hero-image-wrapper">
+    <img class="hero-image" src="your-image.jpg" alt="Hero background" />
+  </div>
+</section>
+```
+
+## CSS Custom Properties
+Easily customize the layout and angles using the root variables in `style.css`:
+- `--bg-color`: The primary background color (default: `#020617`)
+- `--accent-color`: Highlight color for subtitles and buttons (default: `#38bdf8`)
+- `--clip-desktop-default`: The initial `clip-path` polygon for desktop views.
+- `--clip-desktop-hover`: The expanded `clip-path` polygon triggered on hover.
+- `--clip-mobile-default`: The initial `clip-path` polygon for mobile views.
+
+## Browser Support
+Works in all modern browsers (Chrome, Firefox, Safari, Edge) that support `clip-path`.

--- a/submissions/examples/css-split-hero-section-ag/demo.html
+++ b/submissions/examples/css-split-hero-section-ag/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Split Hero Section</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+
+  <section class="split-hero" aria-label="Hero Section">
+    
+    <div class="hero-content">
+      <span class="hero-subtitle">New Frontiers</span>
+      <h1 class="hero-title">Redefining<br/>Digital Space.</h1>
+      <p class="hero-desc">Experience a fluid, diagonally split layout powered entirely by native CSS clip-paths. No JavaScript overhead, just pure performant design.</p>
+      
+      <a href="#" class="hero-btn">
+        Discover the Future
+        <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" width="20" height="20">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"></path>
+        </svg>
+      </a>
+    </div>
+
+    <div class="hero-image-wrapper">
+      <!-- High quality abstract/landscape image for demonstration -->
+      <img class="hero-image" src="https://images.unsplash.com/photo-1618005182384-a83a8bd57fbe?ixlib=rb-4.0.3&auto=format&fit=crop&w=2000&q=80" alt="Abstract fluid artistic rendering" />
+    </div>
+    
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/css-split-hero-section-ag/style.css
+++ b/submissions/examples/css-split-hero-section-ag/style.css
@@ -1,0 +1,177 @@
+:root {
+  --bg-color: #020617; /* Very dark slate */
+  --text-primary: #f8fafc;
+  --text-secondary: #94a3b8;
+  --accent-color: #38bdf8; /* Bright blue */
+  --btn-hover: #0ea5e9;
+  
+  --clip-desktop-default: polygon(20% 0, 100% 0, 100% 100%, 0% 100%);
+  --clip-desktop-hover: polygon(15% 0, 100% 0, 100% 100%, 5% 100%);
+  
+  --clip-mobile-default: polygon(0 0, 100% 0, 100% 80%, 0 100%);
+  --clip-mobile-hover: polygon(0 0, 100% 0, 100% 75%, 0 95%);
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background-color: var(--bg-color);
+  color: var(--text-primary);
+}
+
+.split-hero {
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+}
+
+/* Text Content Section */
+.hero-content {
+  position: relative;
+  z-index: 10;
+  width: 55%;
+  padding: 4rem 4rem 4rem 8vw;
+  box-sizing: border-box;
+}
+
+.hero-subtitle {
+  display: block;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--accent-color);
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  margin-bottom: 1rem;
+}
+
+.hero-title {
+  font-size: clamp(3rem, 5vw, 5rem);
+  font-weight: 800;
+  line-height: 1.1;
+  margin: 0 0 1.5rem 0;
+  letter-spacing: -1px;
+}
+
+.hero-desc {
+  font-size: 1.25rem;
+  line-height: 1.6;
+  color: var(--text-secondary);
+  max-width: 500px;
+  margin: 0 0 2.5rem 0;
+}
+
+/* Call to Action Button */
+.hero-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 32px;
+  background-color: var(--accent-color);
+  color: #fff;
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 1.1rem;
+  border-radius: 50px;
+  transition: all 0.3s ease;
+  box-shadow: 0 10px 20px -5px rgba(56, 189, 248, 0.4);
+}
+
+.hero-btn:hover,
+.hero-btn:focus-visible {
+  background-color: var(--btn-hover);
+  transform: translateY(-3px);
+  box-shadow: 0 15px 25px -5px rgba(56, 189, 248, 0.5);
+  outline: none;
+}
+
+/* Image Section */
+.hero-image-wrapper {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 60%;
+  height: 100%;
+  z-index: 5;
+  clip-path: var(--clip-desktop-default);
+  transition: clip-path 0.7s cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+/* Subtle overlay gradient to ensure text readability if it ever overlaps, 
+   and to add depth to the image */
+.hero-image-wrapper::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to right, rgba(2, 6, 23, 0.8) 0%, rgba(2, 6, 23, 0) 40%);
+  pointer-events: none;
+}
+
+.hero-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+  transition: transform 1.5s cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+/* Interactive Hover States on the whole section */
+.split-hero:hover .hero-image-wrapper {
+  clip-path: var(--clip-desktop-hover);
+}
+
+.split-hero:hover .hero-image {
+  transform: scale(1.03);
+}
+
+/* Mobile Responsive Adjustments */
+@media (max-width: 992px) {
+  .hero-content {
+    width: 65%;
+  }
+}
+
+@media (max-width: 768px) {
+  .split-hero {
+    flex-direction: column;
+    justify-content: flex-end;
+  }
+  
+  .hero-image-wrapper {
+    width: 100%;
+    height: 65%;
+    top: 0;
+    right: auto;
+    clip-path: var(--clip-mobile-default);
+  }
+  
+  .hero-image-wrapper::after {
+    background: linear-gradient(to bottom, rgba(2, 6, 23, 0.8) 0%, rgba(2, 6, 23, 0) 50%);
+  }
+  
+  .split-hero:hover .hero-image-wrapper {
+    clip-path: var(--clip-mobile-hover);
+  }
+  
+  .hero-content {
+    width: 100%;
+    padding: 3rem 2rem;
+    text-align: center;
+    /* Pushes content up slightly to overlap the diagonal */
+    margin-top: -10vh; 
+  }
+  
+  .hero-desc {
+    margin: 0 auto 2.5rem auto;
+  }
+}
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+  .hero-image-wrapper,
+  .hero-image {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #68297.

This PR adds the "CSS Split Hero Section" submission. It introduces a premium, highly responsive hero section featuring a dynamic diagonal split between typography and imagery, achieved purely through CSS clip-paths.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

It adds a responsive, JavaScript-free hero component. It relies on the highly performant CSS `clip-path: polygon()` property to create an angled divide. Hovering anywhere within the hero section triggers a smooth, orchestrated `cubic-bezier` transition that shifts the diagonal angle of the `clip-path` while simultaneously scaling the background image, creating a sophisticated parallax-like reveal effect.

**How does a developer use it?**

```html
<section class="split-hero">
  <div class="hero-content">
    <h1>Your Title</h1>
    <p>Your description...</p>
    <a href="#" class="hero-btn">Call to Action</a>
  </div>
  
  <div class="hero-image-wrapper">
    <img class="hero-image" src="your-image.jpg" alt="Hero background" />
  </div>
</section>
