### PR TITLE
feat: add css animated svg path drawing submission

### DIFF
--- a/submissions/examples/css-animated-svg-path-drawing-ag/README.md
+++ b/submissions/examples/css-animated-svg-path-drawing-ag/README.md
@@ -1,0 +1,28 @@
+# CSS Animated SVG Path Drawing
+
+A stunning, purely CSS-driven SVG path drawing animation. It utilizes the classic `stroke-dasharray` offset trick, heavily modernized with the HTML `pathLength` attribute.
+
+## Features
+- **Pure CSS / HTML**: Built entirely without JavaScript. Utilizes CSS `@keyframes` to animate the `stroke-dashoffset` property.
+- **Normalized Path Lengths**: Eliminates the fragile and tedious process of calculating exact SVG pixel path lengths in JavaScript. By applying the modern `pathLength="100"` attribute directly to the SVG `<path>`, CSS can reliably animate `stroke-dashoffset` from 100 to 0 on any complex vector shape perfectly.
+- **Sequential Animations**: Leverages `animation-delay` to queue a subtle color `fill` fade-in exactly as the line drawing sequence completes.
+- **Accessible**: Fully respects user preferences by gracefully disabling the drawing sequence and instantly rendering the completed, filled vector graphic via `@media (prefers-reduced-motion: reduce)`.
+
+## Usage
+
+Drop the HTML structure into your layout. You can replace the inner `<path>` with any vector you like—just ensure you leave `pathLength="100"` attached to the new path so the CSS animation timing remains perfectly calibrated.
+
+```html
+<svg class="animated-svg" viewBox="0 0 100 100">
+  <path pathLength="100" d="..." />
+</svg>
+```
+
+## CSS Custom Properties
+Easily customize the visual styling using the root variables in `style.css`:
+- `--stroke-color`: Color of the drawn line (default: `#38bdf8`)
+- `--fill-color`: Color of the faded-in interior fill (default: `rgba(56, 189, 248, 0.15)`)
+- `--animation-duration`: Total duration of the line drawing sequence (default: `3s`)
+
+## Browser Support
+Works beautifully in all modern browsers (Chrome, Firefox, Safari, Edge). The `pathLength` attribute is fully supported across all major rendering engines.

--- a/submissions/examples/css-animated-svg-path-drawing-ag/demo.html
+++ b/submissions/examples/css-animated-svg-path-drawing-ag/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Animated SVG Path Drawing</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+
+  <div class="drawing-container">
+    
+    <!-- SVG with pathLength="100" to normalize the stroke-dasharray animation -->
+    <svg class="animated-svg" viewBox="0 0 100 100" aria-label="Animated geometric logo">
+      <path pathLength="100" d="M 50,5 
+               L 95,25 
+               L 95,75 
+               L 50,95 
+               L 5,75 
+               L 5,25 
+               Z 
+               M 50,5 
+               L 50,45 
+               M 5,25 
+               L 50,45 
+               L 95,25 
+               M 5,75 
+               L 50,45 
+               L 95,75" />
+    </svg>
+
+    <h2 class="title">Geometry in Motion</h2>
+    <p class="desc">A purely CSS-driven path drawing animation. Reload to see it again.</p>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/css-animated-svg-path-drawing-ag/style.css
+++ b/submissions/examples/css-animated-svg-path-drawing-ag/style.css
@@ -1,0 +1,112 @@
+:root {
+  --bg-color: #0f172a;
+  --stroke-color: #38bdf8;
+  --fill-color: rgba(56, 189, 248, 0.15);
+  --text-color: #f8fafc;
+  --text-muted: #94a3b8;
+  /* Since we use pathLength="100" in the SVG, we normalize the length to 100 */
+  --path-length: 100; 
+  --animation-duration: 3s;
+}
+
+body {
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  margin: 0;
+  padding: 20px;
+}
+
+.drawing-container {
+  width: 100%;
+  max-width: 400px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+/* 
+  The SVG Path Animation Logic
+*/
+.animated-svg {
+  width: 250px;
+  height: 250px;
+  margin-bottom: 2rem;
+  /* Add a subtle drop shadow to the SVG itself */
+  filter: drop-shadow(0 10px 15px rgba(56, 189, 248, 0.2));
+}
+
+.animated-svg path {
+  fill: transparent;
+  stroke: var(--stroke-color);
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  
+  /* 
+    The magic: dasharray sets the dash length to be exactly the normalized path length.
+    dashoffset hides the dash entirely off-screen.
+  */
+  stroke-dasharray: var(--path-length);
+  stroke-dashoffset: var(--path-length);
+  
+  /* 
+    We animate the offset back to 0, which "draws" the line.
+    Then we animate the fill color fading in.
+  */
+  animation: 
+    draw-line var(--animation-duration) cubic-bezier(0.4, 0, 0.2, 1) forwards,
+    fill-in 1s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+  
+  /* Delay the fill-in animation until the drawing is nearly complete */
+  animation-delay: 0s, calc(var(--animation-duration) - 0.5s);
+}
+
+@keyframes draw-line {
+  0% {
+    stroke-dashoffset: var(--path-length);
+  }
+  100% {
+    stroke-dashoffset: 0;
+  }
+}
+
+@keyframes fill-in {
+  0% {
+    fill: transparent;
+  }
+  100% {
+    fill: var(--fill-color);
+  }
+}
+
+/* Text styles */
+.title {
+  font-size: 2rem;
+  font-weight: 700;
+  margin: 0 0 10px 0;
+  letter-spacing: -0.5px;
+}
+
+.desc {
+  font-size: 1.1rem;
+  line-height: 1.6;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+  .animated-svg path {
+    /* Instantly draw and fill */
+    animation: none;
+    stroke-dashoffset: 0;
+    fill: var(--fill-color);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #68287.

This PR adds the "CSS Animated SVG Path Drawing" submission. It introduces a stunning, purely CSS-driven SVG path drawing animation utilizing the classic `stroke-dasharray` offset trick, heavily modernized with the HTML `pathLength` attribute.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

It adds a JavaScript-free SVG line drawing animation. It leverages `animation-delay` to queue a subtle color `fill` fade-in exactly as the line drawing sequence completes. Crucially, it eliminates the fragile and tedious process of calculating exact SVG pixel path lengths in JavaScript. By applying the modern `pathLength="100"` attribute directly to the SVG `<path>`, CSS can reliably animate `stroke-dashoffset` from 100 to 0 on any complex vector shape perfectly.

**How does a developer use it?**

```html
<svg class="animated-svg" viewBox="0 0 100 100">
  <path pathLength="100" d="..." />
</svg>
