### PR TITLE
Add ease-toast-notification-slide component

### DIFF
--- a/submissions/examples/toast-notification-slide-ij/README.md
+++ b/submissions/examples/toast-notification-slide-ij/README.md
@@ -1,0 +1,10 @@
+# ease-toast-notification-slide
+
+A notification stack where the toasts slide in, the icons pop, and the bars drain.
+
+## Run
+Open `demo.html` directly in a browser to watch the toasts slide in.
+
+## Notes
+- The toasts slide in from the right one after another.
+- The time bars drain along each toast.

--- a/submissions/examples/toast-notification-slide-ij/demo.html
+++ b/submissions/examples/toast-notification-slide-ij/demo.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-toast-notification-slide demo</title>
+</head>
+<body>
+<div class="tns-stack">
+  <div class="tns-toast">
+    <span class="tns-icon">OK</span>
+    <div class="tns-body"><span class="tns-title">Saved</span><span class="tns-text">Changes are synced</span></div>
+    <span class="tns-bar"></span>
+  </div>
+  <div class="tns-toast tns-warn">
+    <span class="tns-icon">!</span>
+    <div class="tns-body"><span class="tns-title">Warning</span><span class="tns-text">Disk space is low</span></div>
+    <span class="tns-bar"></span>
+  </div>
+  <div class="tns-toast tns-err">
+    <span class="tns-icon">X</span>
+    <div class="tns-body"><span class="tns-title">Failed</span><span class="tns-text">Upload did not finish</span></div>
+    <span class="tns-bar"></span>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/toast-notification-slide-ij/style.css
+++ b/submissions/examples/toast-notification-slide-ij/style.css
@@ -1,0 +1,19 @@
+:root{--tns-ok:#45e08a;--tns-warn:#ffcf6e;--tns-err:#ff5d6e;--tns-night:#111a24}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#1a2634,#0d131c);font-family:'Trebuchet MS',sans-serif}
+.tns-stack{position:relative;width:320px;height:300px;border-radius:16px;overflow:hidden;background:linear-gradient(180deg,#16202c,#0e1520);box-shadow:0 16px 34px rgba(0,0,0,0.6);padding:14px}
+.tns-toast{position:absolute;left:14px;right:14px;height:64px;border-radius:10px;background:#1d2938;display:flex;align-items:center;gap:10px;padding:0 12px;transform:translateX(120%);animation:toast-slide-toast-notification-slide 7s ease-in-out infinite}
+.tns-toast:nth-child(1){top:22px}
+.tns-toast:nth-child(2){top:106px;animation-delay:2.2s}
+.tns-toast:nth-child(3){top:190px;animation-delay:4.4s}
+.tns-icon{width:30px;height:30px;border-radius:50%;background:#45e08a;color:#06211a;font-size:10px;font-weight:700;display:grid;place-items:center;animation:icon-pop-toast-notification-slide 7s ease-out infinite}
+.tns-warn .tns-icon{background:#ffcf6e;color:#2a1f06}
+.tns-err .tns-icon{background:#ff5d6e;color:#2a0609}
+.tns-body{display:flex;flex-direction:column;gap:2px}
+.tns-title{font-size:12px;font-weight:700;letter-spacing:2px;color:#eaf2f8}
+.tns-text{font-size:10px;color:#7f95a8}
+.tns-bar{position:absolute;bottom:0;left:0;height:4px;border-radius:2px;background:#45e08a;animation:bar-drain-toast-notification-slide 7s linear infinite}
+.tns-warn .tns-bar{background:#ffcf6e}
+.tns-err .tns-bar{background:#ff5d6e}
+@keyframes toast-slide-toast-notification-slide{0%{transform:translateX(120%)}10%{transform:translateX(0)}45%{transform:translateX(0)}55%{transform:translateX(120%)}100%{transform:translateX(120%)}}
+@keyframes icon-pop-toast-notification-slide{0%{transform:scale(0)}10%{transform:scale(1.2)}14%{transform:scale(1)}55%{transform:scale(1)}100%{transform:scale(0)}}
+@keyframes bar-drain-toast-notification-slide{0%{width:100%}55%{width:0}100%{width:0}}


### PR DESCRIPTION
## Component: ease-toast-notification-slide — toasts slide, icons pop, and bars drain

**Closes #68740**

### What this adds
A notification stack: the toasts slide in from the right one after another, the status icons pop on entry, and the time bars drain along each toast.

### Acceptance Criteria covered
- Toasts slide in from the right
- Status icons pop on entry
- Time bars drain on each toast

### Files
- `submissions/examples/toast-notification-slide-ij/demo.html`
- `submissions/examples/toast-notification-slide-ij/style.css`
- `submissions/examples/toast-notification-slide-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the toasts slide in.