### PR TITLE
Add ease-toggle-switch-flip component

### DIFF
--- a/submissions/examples/toggle-switch-flip-ij/README.md
+++ b/submissions/examples/toggle-switch-flip-ij/README.md
@@ -1,0 +1,10 @@
+# ease-toggle-switch-flip
+
+A settings panel where the knobs slide, the rails glow, and the names tap.
+
+## Run
+Open `demo.html` directly in a browser to watch the knobs slide.
+
+## Notes
+- Switch knobs slide across the rails.
+- Active rails glow in turn.

--- a/submissions/examples/toggle-switch-flip-ij/demo.html
+++ b/submissions/examples/toggle-switch-flip-ij/demo.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-toggle-switch-flip demo</title>
+</head>
+<body>
+<div class="tsf-panel">
+  <span class="tsf-title">SETTINGS</span>
+  <div class="tsf-row"><span class="tsf-name">Airplane Mode</span><span class="tsf-switch tsf-on"><span class="tsf-knob"></span></span></div>
+  <div class="tsf-row"><span class="tsf-name">Night Theme</span><span class="tsf-switch"><span class="tsf-knob"></span></span></div>
+  <div class="tsf-row"><span class="tsf-name">Auto Sync</span><span class="tsf-switch tsf-on"><span class="tsf-knob"></span></span></div>
+  <div class="tsf-row"><span class="tsf-name">Battery Saver</span><span class="tsf-switch"><span class="tsf-knob"></span></span></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/toggle-switch-flip-ij/style.css
+++ b/submissions/examples/toggle-switch-flip-ij/style.css
@@ -1,0 +1,22 @@
+:root{--tsf-mint:#2dd4bf;--tsf-night:#121a26;--tsf-soft:#8ba2b8}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(120deg,#1c2a38,#0e141c);font-family:'Arial Narrow',sans-serif}
+.tsf-panel{position:relative;width:320px;height:360px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#16202c,#0e141c);box-shadow:0 18px 36px rgba(0,0,0,0.6);padding:14px}
+.tsf-title{position:absolute;top:14px;left:0;right:0;text-align:center;font-size:12px;font-weight:700;letter-spacing:10px;color:#2dd4bf}
+.tsf-row{position:absolute;left:16px;right:16px;height:54px;border-radius:10px;background:#1a2734;display:flex;align-items:center;justify-content:space-between;padding:0 14px;animation:row-tap-toggle-switch-flip 4s ease-in-out infinite}
+.tsf-row:nth-of-type(1){top:54px}
+.tsf-row:nth-of-type(2){top:120px;animation-delay:1s}
+.tsf-row:nth-of-type(3){top:186px;animation-delay:2s}
+.tsf-row:nth-of-type(4){top:252px;animation-delay:3s}
+.tsf-name{font-size:12px;font-weight:700;letter-spacing:2px;color:#eaf2f8}
+.tsf-switch{width:44px;height:24px;border-radius:12px;background:#33424f;position:relative;animation:rail-glow-toggle-switch-flip 4s ease-in-out infinite}
+.tsf-row:nth-of-type(2) .tsf-switch{animation-delay:1s}
+.tsf-row:nth-of-type(3) .tsf-switch{animation-delay:2s}
+.tsf-row:nth-of-type(4) .tsf-switch{animation-delay:3s}
+.tsf-on{background:#2dd4bf}
+.tsf-knob{position:absolute;top:3px;left:3px;width:18px;height:18px;border-radius:50%;background:#ffffff;animation:knob-slide-toggle-switch-flip 4s ease-in-out infinite}
+.tsf-row:nth-of-type(2) .tsf-knob{animation-delay:1s}
+.tsf-row:nth-of-type(3) .tsf-knob{animation-delay:2s}
+.tsf-row:nth-of-type(4) .tsf-knob{animation-delay:3s}
+@keyframes knob-slide-toggle-switch-flip{0%,38%{transform:translateX(0)}50%,100%{transform:translateX(20px)}}
+@keyframes rail-glow-toggle-switch-flip{0%,38%{background:#33424f}50%,100%{background:#2dd4bf}}
+@keyframes row-tap-toggle-switch-flip{0%,38%{transform:translateX(0)}48%{transform:scale(0.97)}52%,100%{transform:translateX(0)}}


### PR DESCRIPTION
## Component: ease-toggle-switch-flip — knobs slide, rails glow, and names tap

**Closes #68746**

### What this adds
A settings panel: the switch knobs slide between rails, the active rails glow, and the setting names tap on their rows.

### Acceptance Criteria covered
- Switch knobs slide across the rails
- Active rails glow in turn
- Setting names tap on their rows

### Files
- `submissions/examples/toggle-switch-flip-ij/demo.html`
- `submissions/examples/toggle-switch-flip-ij/style.css`
- `submissions/examples/toggle-switch-flip-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the knobs slide.