### PR TITLE
Add ease-battery-charge-level component

### DIFF
--- a/submissions/examples/battery-charge-level-ij/README.md
+++ b/submissions/examples/battery-charge-level-ij/README.md
@@ -1,0 +1,10 @@
+# ease-battery-charge-level
+
+A battery gauge where the fill rises, the bolt zaps, and the percent ticks.
+
+## Run
+Open `demo.html` directly in a browser to watch the fill rise.
+
+## Notes
+- The charge fill rises inside the shell.
+- The percent digits tick up beside the cell.

--- a/submissions/examples/battery-charge-level-ij/demo.html
+++ b/submissions/examples/battery-charge-level-ij/demo.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-battery-charge-level demo</title>
+</head>
+<body>
+<div class="bcl-panel">
+  <span class="bcl-title">POWER</span>
+  <div class="bcl-cell">
+    <span class="bcl-shell"><span class="bcl-fill"></span></span>
+    <span class="bcl-tip"></span>
+  </div>
+  <span class="bcl-percent">68%</span>
+  <span class="bcl-bolt">CHARGING</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/battery-charge-level-ij/style.css
+++ b/submissions/examples/battery-charge-level-ij/style.css
@@ -1,0 +1,13 @@
+:root{--bcl-lime:#a3e635;--bcl-night:#101a10;--bcl-soft:#b6c9a8}
+body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#1c2a16,#0d130a);font-family:'Tahoma',sans-serif}
+.bcl-panel{position:relative;width:260px;height:340px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#16231a,#0d130a);box-shadow:0 18px 36px rgba(0,0,0,0.6);padding:14px}
+.bcl-title{position:absolute;top:14px;left:0;right:0;text-align:center;font-size:11px;font-weight:700;letter-spacing:10px;color:#a3e635}
+.bcl-cell{position:absolute;top:76px;left:0;right:0;display:flex;align-items:center;justify-content:center}
+.bcl-shell{width:120px;height:64px;border-radius:8px;border:3px solid #3a5230;padding:4px;position:relative}
+.bcl-fill{position:absolute;bottom:4px;left:4px;right:4px;height:0;border-radius:4px;background:linear-gradient(180deg,#b6f36a,#6ea32a);animation:charge-fill-battery-charge-level 4s ease-in-out infinite}
+.bcl-tip{width:8px;height:26px;border-radius:0 4px 4px 0;background:#3a5230}
+.bcl-percent{position:absolute;top:174px;left:0;right:0;text-align:center;font-size:38px;font-weight:700;color:#d8ffa8;animation:percent-tick-battery-charge-level 1s steps(2) infinite}
+.bcl-bolt{position:absolute;bottom:16px;left:0;right:0;text-align:center;font-size:11px;font-weight:700;letter-spacing:6px;color:#a3e635;animation:bolt-zap-battery-charge-level 1.4s ease-in-out infinite}
+@keyframes charge-fill-battery-charge-level{0%{height:6%}50%{height:86%}100%{height:56%}}
+@keyframes percent-tick-battery-charge-level{0%,100%{opacity:1}50%{opacity:0.35}}
+@keyframes bolt-zap-battery-charge-level{0%,100%{opacity:0.3}50%{opacity:1}}


### PR DESCRIPTION
## Component: ease-battery-charge-level — fill rises, bolt zaps, and percent ticks

**Closes #68751**

### What this adds
A battery gauge: the charge fill rises inside the shell, the lightning bolt zaps on the label, and the percent digits tick up beside the cell.

### Acceptance Criteria covered
- Charge fill rises inside the shell
- Lightning bolt zaps on the label
- Percent digits tick up beside the cell

### Files
- `submissions/examples/battery-charge-level-ij/demo.html`
- `submissions/examples/battery-charge-level-ij/style.css`
- `submissions/examples/battery-charge-level-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the fill rise.