### PR TITLE
feat: add CSS puzzle piece loader

### DIFF
--- a/submissions/examples/css-puzzle-piece-loader/README.md
+++ b/submissions/examples/css-puzzle-piece-loader/README.md
@@ -1,0 +1,98 @@
+# CSS Puzzle Piece Loader
+
+A lightweight CSS-only loading animation where four puzzle pieces move together and assemble into a complete puzzle.
+
+## Features
+
+* Pure CSS implementation
+* No JavaScript required
+* Four animated puzzle pieces
+* Smooth assembly animation
+* Responsive design
+* Accessible loading status
+* Supports reduced-motion preferences
+* Easy to customize
+
+## Files
+
+```text
+css-puzzle-piece-loader/
+├── demo.html
+├── style.css
+└── README.md
+```
+
+## How It Works
+
+The loader is created using four HTML elements styled as puzzle pieces.
+
+CSS `@keyframes` animations move each piece from an offset position toward the center, creating the effect of the pieces assembling together.
+
+The animation repeats continuously to represent a loading state.
+
+## Usage
+
+Open `demo.html` in a modern browser.
+
+No build tools, JavaScript, or external dependencies are required.
+
+## Customization
+
+You can customize:
+
+* Puzzle piece size
+* Animation duration
+* Animation timing
+* Colors
+* Piece spacing
+* Rotation angle
+* Background
+* Border radius
+
+For example:
+
+```css
+.piece {
+    animation-duration: 2.4s;
+}
+```
+
+## Accessibility
+
+The loader uses:
+
+* `role="status"` to communicate the loading state
+* An accessible `aria-label`
+* Visually hidden loading text
+* `aria-hidden="true"` for decorative puzzle pieces
+* `prefers-reduced-motion` support
+
+## Reduced Motion
+
+For users who prefer reduced motion, the animation is disabled:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+    .piece {
+        animation: none;
+    }
+}
+```
+
+## Browser Support
+
+Designed for modern browsers supporting:
+
+* CSS Animations
+* CSS Transforms
+* CSS Pseudo-elements
+* CSS Media Queries
+
+## Technologies
+
+* HTML5
+* CSS3
+
+## License
+
+This example is contributed to the EaseMotion CSS project and follows the repository's contribution and licensing guidelines.

--- a/submissions/examples/css-puzzle-piece-loader/demo.html
+++ b/submissions/examples/css-puzzle-piece-loader/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta
+        name="description"
+        content="CSS puzzle pieces assembling together as a loading animation"
+    >
+    <title>CSS Puzzle Piece Loader</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <main class="loader-page">
+        <section class="loader-card" aria-labelledby="loader-title">
+
+            <span class="badge">EaseMotion CSS</span>
+
+            <h1 id="loader-title">Puzzle Piece Loader</h1>
+
+            <p class="description">
+                Puzzle pieces smoothly assemble together to create
+                a continuous CSS loading animation.
+            </p>
+
+            <div
+                class="puzzle-loader"
+                role="status"
+                aria-label="Loading"
+            >
+                <span class="sr-only">Loading...</span>
+
+                <div class="puzzle-grid" aria-hidden="true">
+                    <span class="piece piece-1"></span>
+                    <span class="piece piece-2"></span>
+                    <span class="piece piece-3"></span>
+                    <span class="piece piece-4"></span>
+                </div>
+            </div>
+
+            <div class="loader-info">
+                <span>Pure CSS</span>
+                <span>No JavaScript</span>
+                <span>Responsive</span>
+            </div>
+
+        </section>
+    </main>
+
+</body>
+</html>

--- a/submissions/examples/css-puzzle-piece-loader/style.css
+++ b/submissions/examples/css-puzzle-piece-loader/style.css
@@ -1,0 +1,287 @@
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+:root {
+    --background: #f4f7fb;
+    --surface: #ffffff;
+    --text: #172033;
+    --muted: #64748b;
+    --accent: #6366f1;
+    --accent-dark: #4f46e5;
+    --border: #e2e8f0;
+}
+
+body {
+    min-height: 100vh;
+    font-family:
+        Inter,
+        ui-sans-serif,
+        system-ui,
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        sans-serif;
+    background: var(--background);
+    color: var(--text);
+}
+
+.loader-page {
+    min-height: 100vh;
+    display: grid;
+    place-items: center;
+    padding: 2rem;
+}
+
+.loader-card {
+    width: min(700px, 100%);
+    padding: clamp(1.5rem, 5vw, 3rem);
+    text-align: center;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 24px;
+    box-shadow: 0 20px 60px rgba(15, 23, 42, 0.08);
+}
+
+.badge {
+    display: inline-block;
+    margin-bottom: 1rem;
+    padding: 0.4rem 0.85rem;
+    border-radius: 999px;
+    background: #eef2ff;
+    color: var(--accent-dark);
+    font-size: 0.8rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+h1 {
+    margin-bottom: 0.75rem;
+    font-size: clamp(2rem, 5vw, 3rem);
+    line-height: 1.1;
+}
+
+.description {
+    max-width: 520px;
+    margin: 0 auto;
+    color: var(--muted);
+    line-height: 1.7;
+}
+
+/* Loader area */
+
+.puzzle-loader {
+    min-height: 280px;
+    display: grid;
+    place-items: center;
+    margin: 2rem 0;
+    border-radius: 18px;
+    background: #f8fafc;
+    overflow: hidden;
+}
+
+/* Puzzle grid */
+
+.puzzle-grid {
+    position: relative;
+    width: 150px;
+    height: 150px;
+}
+
+/* Individual puzzle pieces */
+
+.piece {
+    position: absolute;
+    width: 72px;
+    height: 72px;
+    border-radius: 12px;
+
+    background:
+        linear-gradient(
+            135deg,
+            var(--accent),
+            var(--accent-dark)
+        );
+
+    box-shadow:
+        0 10px 25px rgba(79, 70, 229, 0.25);
+
+    animation-duration: 2.4s;
+    animation-timing-function: ease-in-out;
+    animation-iteration-count: infinite;
+}
+
+/* Puzzle tabs */
+
+.piece::before,
+.piece::after {
+    content: "";
+    position: absolute;
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    background: inherit;
+}
+
+/* Top tab */
+
+.piece::before {
+    top: -11px;
+    left: 25px;
+}
+
+/* Side tab */
+
+.piece::after {
+    right: -11px;
+    top: 25px;
+}
+
+/* Piece positions */
+
+.piece-1 {
+    top: 0;
+    left: 0;
+    animation-name: assemble-one;
+}
+
+.piece-2 {
+    top: 0;
+    right: 0;
+    animation-name: assemble-two;
+}
+
+.piece-3 {
+    bottom: 0;
+    left: 0;
+    animation-name: assemble-three;
+}
+
+.piece-4 {
+    bottom: 0;
+    right: 0;
+    animation-name: assemble-four;
+}
+
+/* Assembly animations */
+
+@keyframes assemble-one {
+    0%,
+    100% {
+        transform: translate(-35px, -35px) rotate(-12deg);
+        opacity: 0.55;
+    }
+
+    45%,
+    65% {
+        transform: translate(0, 0) rotate(0);
+        opacity: 1;
+    }
+}
+
+@keyframes assemble-two {
+    0%,
+    100% {
+        transform: translate(35px, -35px) rotate(12deg);
+        opacity: 0.55;
+    }
+
+    45%,
+    65% {
+        transform: translate(0, 0) rotate(0);
+        opacity: 1;
+    }
+}
+
+@keyframes assemble-three {
+    0%,
+    100% {
+        transform: translate(-35px, 35px) rotate(12deg);
+        opacity: 0.55;
+    }
+
+    45%,
+    65% {
+        transform: translate(0, 0) rotate(0);
+        opacity: 1;
+    }
+}
+
+@keyframes assemble-four {
+    0%,
+    100% {
+        transform: translate(35px, 35px) rotate(-12deg);
+        opacity: 0.55;
+    }
+
+    45%,
+    65% {
+        transform: translate(0, 0) rotate(0);
+        opacity: 1;
+    }
+}
+
+/* Accessibility */
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+/* Information badges */
+
+.loader-info {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.loader-info span {
+    padding: 0.5rem 0.85rem;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: #f8fafc;
+    color: var(--muted);
+    font-size: 0.85rem;
+    font-weight: 600;
+}
+
+/* Responsive */
+
+@media (max-width: 600px) {
+    .loader-page {
+        padding: 1rem;
+    }
+
+    .loader-card {
+        padding: 1.25rem;
+        border-radius: 18px;
+    }
+
+    .puzzle-loader {
+        min-height: 230px;
+    }
+
+    .puzzle-grid {
+        transform: scale(0.85);
+    }
+}
+
+/* Reduced motion */
+
+@media (prefers-reduced-motion: reduce) {
+    .piece {
+        animation: none;
+    }
+}


### PR DESCRIPTION
## Description

Implemented the CSS Puzzle Piece Loader requested in #68525.

### Changes Made

* Added a four-piece puzzle loading animation.
* Implemented smooth CSS-only assembly animations.
* Added responsive styling.
* Added accessible loading status.
* Added `prefers-reduced-motion` support.
* Added documentation in `README.md`.
* No JavaScript or external dependencies are required.

### Files Added

* `submissions/examples/css-puzzle-piece-loader/demo.html`
* `submissions/examples/css-puzzle-piece-loader/style.css`
* `submissions/examples/css-puzzle-piece-loader/README.md`

### Testing

* Tested the loader in a modern browser.
* Verified the puzzle pieces assemble correctly.
* Verified responsive behavior.
* Verified reduced-motion behavior.
* Verified that no JavaScript is required.

### Related Issue

Closes #68525
