### PR TITLE
Feature/css logical properties demo

### DIFF
--- a/submissions/examples/css-logical-properties-demo-ag/README.md
+++ b/submissions/examples/css-logical-properties-demo-ag/README.md
@@ -1,0 +1,39 @@
+# CSS Logical Properties Demo
+
+A powerful demonstration of modern CSS Logical Properties (`margin-inline`, `padding-block`, `inset-inline`, etc.) allowing a component to seamlessly support both Left-to-Right (LTR) and Right-to-Left (RTL) languages without writing a single line of directional override CSS.
+
+## Features
+- **Pure CSS / HTML**: Built entirely without JavaScript. The LTR/RTL state toggle is handled purely via standard hidden `<input type="radio">` sibling selectors.
+- **Modern Logical Properties**: Replaces physical properties (`margin-left`, `border-right`, `top`, `bottom`) with their logical equivalents (`margin-inline-start`, `border-inline-end`, `inset-block-start`).
+- **Automatic Layout Flipping**: By simply changing the CSS `direction` from `ltr` to `rtl`, the browser automatically flips the layout, paddings, margins, absolute badge positioning (`inset`), and flexbox spacing—all perfectly mirrored.
+- **Accessible**: Semantic structure with accessible labels for the direction toggles.
+
+## Usage
+
+Drop the CSS into your project. To utilize logical properties, swap out physical directions for inline/block definitions:
+
+```css
+/* Old Physical Way */
+.card {
+  padding-top: 10px;
+  margin-left: 20px;
+  right: 0;
+  border-left: 2px solid blue;
+}
+
+/* New Logical Way */
+.card {
+  padding-block-start: 10px;
+  margin-inline-start: 20px;
+  inset-inline-end: 0;
+  border-inline-start: 2px solid blue;
+}
+```
+
+## CSS Custom Properties
+Easily customize the theme colors using the root variables in `style.css`:
+- `--card-bg`: Card background (default: `#ffffff`)
+- `--accent-color`: Base brand color for avatars and borders (default: `#3b82f6`)
+
+## Browser Support
+CSS Logical properties enjoy fantastic support across all modern browsers (Chrome, Firefox, Safari, Edge). They are highly recommended for multi-lingual internationalized applications.

--- a/submissions/examples/css-logical-properties-demo-ag/demo.html
+++ b/submissions/examples/css-logical-properties-demo-ag/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Logical Properties Demo</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+
+  <!-- Pure CSS State for RTL/LTR -->
+  <input type="radio" name="dir" id="dir-ltr" checked>
+  <input type="radio" name="dir" id="dir-rtl">
+  
+  <div class="direction-controls" aria-label="Reading Direction Controls">
+    <label for="dir-ltr" tabindex="0">Left-to-Right (LTR)</label>
+    <label for="dir-rtl" tabindex="0">Right-to-Left (RTL)</label>
+  </div>
+
+  <div class="demo-container">
+    <div class="logical-card">
+      <div class="card-badge">Pro</div>
+      
+      <div class="card-avatar">JD</div>
+      
+      <div class="card-content">
+        <h3 class="card-title">John Doe</h3>
+        <p class="card-subtitle">Senior Developer</p>
+      </div>
+      
+      <div class="card-action">
+        <svg class="flip-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" width="24" height="24">
+          <!-- Chevron Right -->
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+        </svg>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/css-logical-properties-demo-ag/style.css
+++ b/submissions/examples/css-logical-properties-demo-ag/style.css
@@ -1,0 +1,166 @@
+:root {
+  --bg-color: #f1f5f9;
+  --card-bg: #ffffff;
+  --text-primary: #1e293b;
+  --text-secondary: #64748b;
+  --accent-color: #3b82f6;
+  --border-color: #e2e8f0;
+}
+
+body {
+  margin: 0;
+  padding: 40px 20px;
+  background-color: var(--bg-color);
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-height: 100vh;
+}
+
+/* 
+  Pure CSS RTL/LTR Toggle Logic
+*/
+input[type="radio"] {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.direction-controls {
+  display: flex;
+  gap: 16px;
+  margin-block-end: 40px; /* Logical margin-bottom */
+  background: var(--card-bg);
+  padding: 8px;
+  border-radius: 50px;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+}
+
+.direction-controls label {
+  padding: 8px 24px;
+  border-radius: 40px;
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--text-secondary);
+  transition: all 0.2s ease;
+  user-select: none;
+}
+
+/* Checked states */
+#dir-ltr:checked ~ .direction-controls label[for="dir-ltr"],
+#dir-rtl:checked ~ .direction-controls label[for="dir-rtl"] {
+  background-color: var(--accent-color);
+  color: #fff;
+}
+
+/* Sibling selector to apply RTL/LTR to the demo container */
+.demo-container {
+  width: 100%;
+  max-width: 450px;
+  /* Default is LTR */
+  direction: ltr; 
+  transition: direction 0.3s ease;
+}
+
+#dir-rtl:checked ~ .demo-container {
+  direction: rtl;
+}
+
+/* Flip the directional arrow icon when RTL is active */
+#dir-rtl:checked ~ .demo-container .flip-icon {
+  transform: scaleX(-1);
+}
+
+/* 
+  Logical Properties Card Styling
+*/
+.logical-card {
+  background-color: var(--card-bg);
+  border-radius: 16px;
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+  
+  /* Logical Padding (replaces padding-top/bottom/left/right) */
+  padding-block: 24px;
+  padding-inline: 32px;
+  
+  position: relative;
+  display: flex;
+  align-items: center;
+  
+  /* Logical Border (replaces border-left) */
+  border-inline-start: 6px solid var(--accent-color);
+  transition: transform 0.2s ease;
+}
+
+.logical-card:hover {
+  transform: translateY(-4px);
+}
+
+.card-avatar {
+  width: 70px;
+  height: 70px;
+  border-radius: 50%;
+  background-color: var(--accent-color);
+  color: white;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 1.5rem;
+  font-weight: 700;
+  flex-shrink: 0;
+  
+  /* Logical Margin (replaces margin-right) */
+  margin-inline-end: 24px;
+}
+
+.card-content {
+  display: flex;
+  flex-direction: column;
+}
+
+.card-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  /* Logical Margins */
+  margin-block-end: 6px;
+  margin-block-start: 0;
+}
+
+.card-subtitle {
+  font-size: 1rem;
+  color: var(--text-secondary);
+  margin-block: 0;
+}
+
+/* Badge using logical positioning */
+.card-badge {
+  position: absolute;
+  /* Logical Insets (replaces top and right) */
+  inset-block-start: -12px;
+  inset-inline-end: 24px;
+  background-color: #10b981;
+  color: white;
+  padding-block: 4px;
+  padding-inline: 12px;
+  border-radius: 20px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  box-shadow: 0 4px 6px rgba(16, 185, 129, 0.3);
+}
+
+/* Arrow Icon that logically aligns */
+.card-action {
+  /* Logical Auto Margin (replaces margin-left: auto) */
+  margin-inline-start: auto;
+  color: var(--text-secondary);
+  transition: color 0.2s ease;
+}
+
+.logical-card:hover .card-action {
+  color: var(--accent-color);
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #68666.

This PR adds the "CSS Logical Properties Demo" submission. It introduces a powerful demonstration of modern CSS Logical Properties (`margin-inline`, `padding-block`, `inset-inline`, etc.) allowing a component to seamlessly support both Left-to-Right (LTR) and Right-to-Left (RTL) languages without writing a single line of directional override CSS.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

It adds a responsive, JavaScript-free user profile card demo. The LTR/RTL state toggle is handled purely via standard hidden `<input type="radio">` sibling selectors. By simply changing the CSS `direction` from `ltr` to `rtl` on the container, the browser automatically flips the layout, paddings, margins, absolute badge positioning (`inset`), and flexbox spacing—all perfectly mirrored.

**How does a developer use it?**

Swap out physical directions for inline/block definitions:

```css
/* Old Physical Way */
.card {
  padding-top: 10px;
  margin-left: 20px;
  right: 0;
  border-left: 2px solid blue;
}

/* New Logical Way */
.card {
  padding-block-start: 10px;
  margin-inline-start: 20px;
  inset-inline-end: 0;
  border-inline-start: 2px solid blue;
}
