### PR TITLE
fix(a11y): add keyboard arrow key navigation to tabs pattern

### DIFF
--- a/submissions/examples/accessible-keyboard-tabs/README.md
+++ b/submissions/examples/accessible-keyboard-tabs/README.md
@@ -1,0 +1,65 @@
+Accessible Keyboard Tabs
+
+A tabs widget that matches the WAI-ARIA APG Tabs pattern: click a tab, or focus one and use <kbd>←</kbd> <kbd>→</kbd> (or <kbd>Home</kbd>/<kbd>End</kbd>) to move between them, with a sliding indicator that follows smoothly. Fixes #60880 — "Tab components lack keyboard arrow keys navigation support."
+
+Why this one isn't pure CSS
+
+Every other submission in this batch has been CSS/HTML only. This one can't be — intercepting arrow-key presses is not something CSS can do. There's no CSS selector or pseudo-class that fires on ArrowLeft; that's squarely JavaScript's job, and it's the literal bug this issue reports. A "CSS-only" version of this fix would just not fix the bug. So tabs.js contains a small, real keydown handler — nothing else in this submission needed one, and it stays out of everything that CSS can own (colors, spacing, the sliding indicator's transition, the panel fade).
+
+Files
+File	Purpose
+demo.html	A 4-tab settings widget
+style.css	All visual styling, including the indicator's transition
+tabs.js	The keyboard/selection logic — see below
+README.md	This file
+Markup
+html
+<div class="ease-tabs">
+  <div class="ease-tabs__list" role="tablist" aria-label="Workspace settings">
+    <button class="ease-tabs__tab" role="tab" id="tab-general"
+      aria-controls="panel-general" aria-selected="true" tabindex="0">
+      General
+    </button>
+    <button class="ease-tabs__tab" role="tab" id="tab-members"
+      aria-controls="panel-members" aria-selected="false" tabindex="-1">
+      Members
+    </button>
+    <span class="ease-tabs__indicator" aria-hidden="true"></span>
+  </div>
+
+  <div class="ease-tabs__panel" role="tabpanel" id="panel-general"
+    aria-labelledby="tab-general" tabindex="0">
+    General settings…
+  </div>
+  <div class="ease-tabs__panel" role="tabpanel" id="panel-members"
+    aria-labelledby="tab-members" tabindex="0" hidden>
+    Member settings…
+  </div>
+</div>
+
+Include tabs.js once per page; it initializes every .ease-tabs block it finds, so multiple independent tab groups on one page work with no extra wiring.
+
+What tabs.js actually does
+
+Implements the APG pattern's automatic activation model and roving tabindex:
+
+Arrow keys (ArrowRight/ArrowDown next, ArrowLeft/ArrowUp previous, wrapping at either end) move focus and selection together — moving focus to a tab activates it immediately, which is the "automatic" variant of the pattern (the alternative, "manual activation," would require pressing Enter/Space to actually switch; automatic is the more common expectation for tabs).
+Home / End jump to the first / last tab.
+Click selects a tab directly, same as always.
+Roving tabindex: only the selected tab has tabindex="0" — every other tab is tabindex="-1". This is what lets a user Tab into the widget once, arrow around freely inside it, then Tab back out to the rest of the page in one more press, instead of tabbing through every individual tab.
+The sliding indicator's position and width are set in pixels by reading the newly-selected tab's real offsetLeft/offsetWidth — that measurement is also not something CSS can do on its own, since it depends on actual rendered geometry, which can change (window resize, font load, wrapping to two rows on narrow screens). The script re-measures on resize for exactly that reason.
+
+Everything the script touches is limited to aria-selected, tabindex, the hidden attribute, and the indicator's inline transform/width — it never sets colors, fonts, or spacing; that's style.css's job entirely, and the transition itself (the smooth slide, not the target position) is a CSS transition, not a JS animation loop.
+
+Accessibility
+Matches the WAI-ARIA APG Tabs pattern structurally: role="tablist" / role="tab" / role="tabpanel", aria-controls, aria-labelledby, and aria-selected are all wired correctly, not just visually implied.
+This is the accessibility fix — arrow-key navigation, Home/End, and roving tabindex are the actual acceptance criteria from #60880, not an extra.
+:focus-visible outlines exist independently of the indicator, so keyboard focus is visible even in the (very unlikely) case tabs.js fails to load — the tabs remain click-usable and each panel is still independently focusable and readable.
+Respects prefers-reduced-motion: reduce for the indicator's slide and the panel's fade-in; none of the actual interaction logic changes.
+Responsive behavior
+
+Below 480px the tab list wraps to two rows of two; tabs.js's resize listener keeps the indicator aligned to the (possibly now two-row) layout automatically.
+
+Browser support
+
+The CSS uses only transform, opacity, and standard transitions. The JS uses plain addEventListener, querySelectorAll, and Array.prototype methods — no build step, no dependencies, works in any current browser.

--- a/submissions/examples/accessible-keyboard-tabs/demo.html
+++ b/submissions/examples/accessible-keyboard-tabs/demo.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Accessible Keyboard Tabs — EaseMotion CSS</title>
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@600;700&family=Inter:wght@400;500;600&family=IBM+Plex+Mono:wght@500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="noise" aria-hidden="true"></div>
+
+  <header class="hero">
+    <p class="eyebrow">EaseMotion CSS &middot; a11y fix showcase</p>
+    <h1 class="hero-title">Accessible keyboard tabs</h1>
+    <p class="hero-sub">A tab widget matching the WAI-ARIA APG Tabs pattern: click a tab or focus one and use &larr; &rarr; (or Home/End) to move between them &mdash; focus and selection move together, and the sliding indicator follows smoothly.</p>
+    <p class="hero-note">Arrow-key interception is outside what CSS can do on its own, so this one includes a small, real keydown handler &mdash; documented in full in the README rather than pretending a CSS-only trick covers it.</p>
+  </header>
+
+  <main class="showcase">
+
+    <div class="ease-tabs" data-orientation="horizontal">
+
+      <div class="ease-tabs__list" role="tablist" aria-label="Workspace settings">
+        <button
+          class="ease-tabs__tab"
+          role="tab"
+          id="tab-general"
+          aria-controls="panel-general"
+          aria-selected="true"
+          tabindex="0">
+          General
+        </button>
+        <button
+          class="ease-tabs__tab"
+          role="tab"
+          id="tab-members"
+          aria-controls="panel-members"
+          aria-selected="false"
+          tabindex="-1">
+          Members
+        </button>
+        <button
+          class="ease-tabs__tab"
+          role="tab"
+          id="tab-billing"
+          aria-controls="panel-billing"
+          aria-selected="false"
+          tabindex="-1">
+          Billing
+        </button>
+        <button
+          class="ease-tabs__tab"
+          role="tab"
+          id="tab-integrations"
+          aria-controls="panel-integrations"
+          aria-selected="false"
+          tabindex="-1">
+          Integrations
+        </button>
+        <span class="ease-tabs__indicator" aria-hidden="true"></span>
+      </div>
+
+      <div
+        class="ease-tabs__panel"
+        role="tabpanel"
+        id="panel-general"
+        aria-labelledby="tab-general"
+        tabindex="0">
+        <h2 class="panel-title">General</h2>
+        <p class="panel-text">Workspace name, timezone, and default language live here. Changes save automatically.</p>
+      </div>
+
+      <div
+        class="ease-tabs__panel"
+        role="tabpanel"
+        id="panel-members"
+        aria-labelledby="tab-members"
+        tabindex="0"
+        hidden>
+        <h2 class="panel-title">Members</h2>
+        <p class="panel-text">Invite teammates, assign roles, and manage pending invitations from this panel.</p>
+      </div>
+
+      <div
+        class="ease-tabs__panel"
+        role="tabpanel"
+        id="panel-billing"
+        aria-labelledby="tab-billing"
+        tabindex="0"
+        hidden>
+        <h2 class="panel-title">Billing</h2>
+        <p class="panel-text">Current plan, payment method, and invoice history. Downgrades apply next cycle.</p>
+      </div>
+
+      <div
+        class="ease-tabs__panel"
+        role="tabpanel"
+        id="panel-integrations"
+        aria-labelledby="tab-integrations"
+        tabindex="0"
+        hidden>
+        <h2 class="panel-title">Integrations</h2>
+        <p class="panel-text">Connect Slack, GitHub, and webhooks. Each integration can be scoped per-project.</p>
+      </div>
+
+    </div>
+
+  </main>
+
+  <footer class="footer">
+    <p>EaseMotion CSS &middot; submissions/examples/accessible-keyboard-tabs</p>
+  </footer>
+
+<script src="tabs.js"></script>
+</body>
+</html>

--- a/submissions/examples/accessible-keyboard-tabs/style.css
+++ b/submissions/examples/accessible-keyboard-tabs/style.css
@@ -1,0 +1,279 @@
+/* =========================================================================
+   Accessible Keyboard Tabs — EaseMotion CSS
+   Visual styling for a WAI-ARIA APG-compliant tabs widget. The sliding
+   indicator's position/width are set inline by tabs.js (it needs to know
+   the focused tab's actual pixel geometry, which isn't something CSS can
+   compute on its own) — this file owns every other visual detail:
+   colors, spacing, the indicator's transition, panel fade, and
+   prefers-reduced-motion handling.
+   ========================================================================= */
+ 
+ 
+/* -------------------------------------------------------------------------
+   1. Design tokens
+   ------------------------------------------------------------------------- */
+ 
+:root {
+  --et-bg: #0e1116;
+  --et-surface: #151a21;
+  --et-surface-2: #1c222b;
+  --et-border: #262e39;
+  --et-text: #edeff2;
+  --et-text-muted: #98a2b3;
+ 
+  --et-accent: #7de0c0;
+  --et-accent-strong: #9beed4;
+ 
+  --et-font-display: "Space Grotesk", "Segoe UI", sans-serif;
+  --et-font-body: "Inter", "Segoe UI", sans-serif;
+  --et-font-mono: "IBM Plex Mono", "Courier New", monospace;
+ 
+  --et-duration: 260ms;
+  --et-ease: cubic-bezier(0.4, 0, 0.2, 1);
+}
+ 
+* {
+  box-sizing: border-box;
+}
+ 
+body {
+  margin: 0;
+  background: var(--et-bg);
+  color: var(--et-text);
+  font-family: var(--et-font-body);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+ 
+.noise {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.035;
+  z-index: 0;
+  background-image: radial-gradient(circle at 1px 1px, #ffffff 1px, transparent 0);
+  background-size: 3px 3px;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   2. Hero
+   ------------------------------------------------------------------------- */
+ 
+.hero {
+  position: relative;
+  z-index: 1;
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 92px 24px 40px;
+  text-align: center;
+}
+ 
+.eyebrow {
+  font-family: var(--et-font-mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--et-accent);
+  margin: 0 0 20px;
+}
+ 
+.hero-title {
+  font-family: var(--et-font-display);
+  font-weight: 600;
+  font-size: clamp(30px, 5.5vw, 48px);
+  line-height: 1.1;
+  letter-spacing: -0.01em;
+  margin: 0 0 16px;
+}
+ 
+.hero-sub {
+  font-size: 15px;
+  color: var(--et-text-muted);
+  max-width: 520px;
+  margin: 0 auto 14px;
+}
+ 
+.hero-note {
+  font-size: 12.5px;
+  color: var(--et-text-muted);
+  max-width: 480px;
+  margin: 0 auto;
+  padding: 10px 16px;
+  border: 1px dashed var(--et-border);
+  border-radius: 10px;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   3. Layout
+   ------------------------------------------------------------------------- */
+ 
+.showcase {
+  position: relative;
+  z-index: 1;
+  max-width: 560px;
+  margin: 0 auto;
+  padding: 0 24px 90px;
+}
+ 
+.ease-tabs {
+  background: var(--et-surface);
+  border: 1px solid var(--et-border);
+  border-radius: 16px;
+  overflow: hidden;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   4. Tab list + sliding indicator
+   ------------------------------------------------------------------------- */
+ 
+.ease-tabs__list {
+  position: relative;
+  display: flex;
+  gap: 2px;
+  padding: 6px;
+  border-bottom: 1px solid var(--et-border);
+}
+ 
+.ease-tabs__tab {
+  position: relative;
+  z-index: 1;
+  flex: 1 1 auto;
+  padding: 10px 14px;
+  border: none;
+  background: transparent;
+  color: var(--et-text-muted);
+  font-family: var(--et-font-body);
+  font-size: 13.5px;
+  font-weight: 500;
+  border-radius: 9px;
+  cursor: pointer;
+  transition: color var(--et-duration) var(--et-ease);
+}
+ 
+.ease-tabs__tab[aria-selected="true"] {
+  color: var(--et-bg);
+}
+ 
+.ease-tabs__tab:hover {
+  color: var(--et-text);
+}
+ 
+.ease-tabs__tab[aria-selected="true"]:hover {
+  color: var(--et-bg);
+}
+ 
+/* Real focus indicator, independent of the sliding background — visible
+   even for the one edge case where a browser doesn't run tabs.js. */
+.ease-tabs__tab:focus-visible {
+  outline: 2px solid var(--et-accent);
+  outline-offset: 2px;
+}
+ 
+/* Positioned and sized by tabs.js (transform + width, in pixels, based
+   on the actual selected tab's measured geometry). Only the appearance
+   and the transition are CSS's job. */
+.ease-tabs__indicator {
+  position: absolute;
+  z-index: 0;
+  top: 6px;
+  left: 0;
+  height: calc(100% - 12px);
+  border-radius: 9px;
+  background: var(--et-accent);
+  transition: transform var(--et-duration) var(--et-ease), width var(--et-duration) var(--et-ease);
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   5. Panels
+   ------------------------------------------------------------------------- */
+ 
+.ease-tabs__panel {
+  padding: 22px 22px 24px;
+  animation: et-panel-fade var(--et-duration) var(--et-ease);
+}
+ 
+.ease-tabs__panel:focus-visible {
+  outline: 2px solid var(--et-accent);
+  outline-offset: -2px;
+}
+ 
+@keyframes et-panel-fade {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+ 
+.panel-title {
+  font-family: var(--et-font-display);
+  font-size: 15px;
+  font-weight: 600;
+  margin: 0 0 8px;
+}
+ 
+.panel-text {
+  font-size: 13.5px;
+  color: var(--et-text-muted);
+  margin: 0;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   6. Footer
+   ------------------------------------------------------------------------- */
+ 
+.footer {
+  position: relative;
+  z-index: 1;
+  text-align: center;
+  padding: 8px 24px 48px;
+  font-size: 12.5px;
+  color: var(--et-text-muted);
+  font-family: var(--et-font-mono);
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   7. Responsive
+   ------------------------------------------------------------------------- */
+ 
+@media (max-width: 480px) {
+  .hero {
+    padding: 68px 20px 36px;
+  }
+ 
+  .ease-tabs__list {
+    flex-wrap: wrap;
+  }
+ 
+  .ease-tabs__tab {
+    flex: 1 1 calc(50% - 2px);
+  }
+ 
+  .ease-tabs__panel {
+    padding: 18px 18px 20px;
+  }
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   8. Reduced motion
+   ------------------------------------------------------------------------- */
+ 
+@media (prefers-reduced-motion: reduce) {
+  .ease-tabs__indicator {
+    transition-duration: 1ms;
+  }
+ 
+  .ease-tabs__panel {
+    animation: none;
+  }
+}  

--- a/submissions/examples/accessible-keyboard-tabs/tab.js
+++ b/submissions/examples/accessible-keyboard-tabs/tab.js
@@ -1,0 +1,122 @@
+/**
+ * Accessible Keyboard Tabs — EaseMotion CSS
+ *
+ * This is the one piece of this submission that genuinely can't be done
+ * in CSS: intercepting arrow-key presses and moving focus between tabs.
+ * That's the actual bug this issue reports (#60880 — "Tab components
+ * lack keyboard arrow key navigation support"), so faking a CSS-only fix
+ * wouldn't actually fix it. Everything else — colors, spacing, the
+ * sliding indicator's transition, the panel fade — stays in style.css;
+ * this file only ever touches `aria-*`, `tabindex`, `hidden`, and the
+ * indicator's transform/width.
+ *
+ * Implements the WAI-ARIA Authoring Practices Guide "Tabs" pattern with
+ * automatic activation:
+ * https://www.w3.org/WAI/ARIA/apg/patterns/tabs/
+ *
+ *   ArrowRight / ArrowDown  → move to + select the next tab (wraps)
+ *   ArrowLeft  / ArrowUp    → move to + select the previous tab (wraps)
+ *   Home                    → move to + select the first tab
+ *   End                     → move to + select the last tab
+ *   Click                   → select that tab directly
+ *
+ * Roving tabindex: only the selected tab is in the Tab order
+ * (tabindex="0"); every other tab is tabindex="-1" and reached with the
+ * arrow keys instead, per the APG pattern — this is what lets a user
+ * Tab into the widget once, then arrow around it, then Tab back out.
+ *
+ * Works on every `.ease-tabs` block on the page independently, so a
+ * consumer can drop in more than one tab group without conflicts.
+ */
+ 
+(function () {
+  function initTabs(root) {
+    var tabs = Array.prototype.slice.call(
+      root.querySelectorAll('[role="tab"]')
+    );
+    var indicator = root.querySelector(".ease-tabs__indicator");
+ 
+    if (!tabs.length) return;
+ 
+    function panelFor(tab) {
+      return document.getElementById(tab.getAttribute("aria-controls"));
+    }
+ 
+    function moveIndicatorTo(tab) {
+      if (!indicator) return;
+      indicator.style.transform = "translateX(" + tab.offsetLeft + "px)";
+      indicator.style.width = tab.offsetWidth + "px";
+    }
+ 
+    function selectTab(tab, options) {
+      var focusToo = !options || options.focus !== false;
+ 
+      tabs.forEach(function (t) {
+        var selected = t === tab;
+        t.setAttribute("aria-selected", selected ? "true" : "false");
+        t.tabIndex = selected ? 0 : -1;
+ 
+        var panel = panelFor(t);
+        if (panel) panel.hidden = !selected;
+      });
+ 
+      moveIndicatorTo(tab);
+      if (focusToo) tab.focus();
+    }
+ 
+    function handleKeydown(event) {
+      var currentIndex = tabs.indexOf(document.activeElement);
+      if (currentIndex === -1) return;
+ 
+      var targetIndex = null;
+ 
+      switch (event.key) {
+        case "ArrowRight":
+        case "ArrowDown":
+          targetIndex = (currentIndex + 1) % tabs.length;
+          break;
+        case "ArrowLeft":
+        case "ArrowUp":
+          targetIndex = (currentIndex - 1 + tabs.length) % tabs.length;
+          break;
+        case "Home":
+          targetIndex = 0;
+          break;
+        case "End":
+          targetIndex = tabs.length - 1;
+          break;
+        default:
+          return; // not a key this widget cares about — let it bubble
+      }
+ 
+      event.preventDefault();
+      selectTab(tabs[targetIndex]);
+    }
+ 
+    tabs.forEach(function (tab) {
+      tab.addEventListener("click", function () {
+        selectTab(tab, { focus: false });
+      });
+    });
+ 
+    root.addEventListener("keydown", handleKeydown);
+ 
+    // Keep the indicator aligned if the layout reflows (font load,
+    // window resize, wrapping to two rows on narrow viewports).
+    window.addEventListener("resize", function () {
+      var current = tabs.find(function (t) {
+        return t.getAttribute("aria-selected") === "true";
+      });
+      if (current) moveIndicatorTo(current);
+    });
+ 
+    var initial =
+      tabs.find(function (t) {
+        return t.getAttribute("aria-selected") === "true";
+      }) || tabs[0];
+    moveIndicatorTo(initial);
+  }
+ 
+  document.querySelectorAll(".ease-tabs").forEach(initTabs);
+})();
+ 


### PR DESCRIPTION
Accessible Keyboard Tabs

A tabs widget that matches the [WAI-ARIA APG Tabs pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/): click a tab, or focus one and use <kbd>←</kbd> <kbd>→</kbd> (or <kbd>Home</kbd>/<kbd>End</kbd>) to move between them, with a sliding indicator that follows smoothly. Fixes #60880 — "Tab components lack keyboard arrow keys navigation support."

Why this one isn't pure CSS

Every other submission in this batch has been CSS/HTML only. This one can't be — intercepting arrow-key presses is not something CSS can do. There's no CSS selector or pseudo-class that fires on ArrowLeft; that's squarely JavaScript's job, and it's the literal bug this issue reports. A "CSS-only" version of this fix would just not fix the bug. So tabs.js contains a small, real keydown handler — nothing else in this submission needed one, and it stays out of everything that CSS can own (colors, spacing, the sliding indicator's transition, the panel fade).