### PR TITLE
feat: add CSS country selector dropdown

### DIFF
--- a/submissions/examples/country-selector-dropdown/README.md
+++ b/submissions/examples/country-selector-dropdown/README.md
@@ -1,0 +1,21 @@
+# CSS Country Selector Dropdown
+
+A lightweight, responsive country selector dropdown built using pure HTML and CSS.
+
+## Features
+
+- 🌍 Country selector with flag emojis
+- 🎨 CSS custom properties for easy theming
+- 📱 Responsive on desktop, tablet, and mobile
+- ♿ Accessible native `<select>` element
+- ⌨️ Keyboard accessible
+- 🌙 Automatic light/dark mode support
+- ⚡ No JavaScript required
+- ♿ Supports `prefers-reduced-motion`
+
+## Usage
+
+Include the stylesheet:
+
+```html
+<link rel="stylesheet" href="style.css">

--- a/submissions/examples/country-selector-dropdown/demo.html
+++ b/submissions/examples/country-selector-dropdown/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS Country Selector Dropdown">
+  <title>CSS Country Selector Dropdown</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="demo-page">
+    <section class="country-demo" aria-labelledby="country-title">
+      <h1 id="country-title">Country Selector</h1>
+      <p class="description">
+        Select your preferred country or locale.
+      </p>
+
+      <label for="country-select">Country</label>
+
+      <div class="country-select-wrapper">
+        <span class="select-icon" aria-hidden="true">🌍</span>
+
+        <select id="country-select" class="country-select" name="country">
+          <option value="in">🇮🇳 India</option>
+          <option value="us">🇺🇸 United States</option>
+          <option value="gb">🇬🇧 United Kingdom</option>
+          <option value="ca">🇨🇦 Canada</option>
+          <option value="au">🇦🇺 Australia</option>
+          <option value="de">🇩🇪 Germany</option>
+          <option value="fr">🇫🇷 France</option>
+          <option value="jp">🇯🇵 Japan</option>
+        </select>
+      </div>
+    </section>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/country-selector-dropdown/style.css
+++ b/submissions/examples/country-selector-dropdown/style.css
@@ -1,0 +1,133 @@
+:root {
+    --country-bg: #ffffff;
+    --country-text: #1f2937;
+    --country-border: #d1d5db;
+    --country-border-hover: #6366f1;
+    --country-focus: rgba(99, 102, 241, 0.2);
+    --country-surface: #f8fafc;
+    --country-radius: 12px;
+    --country-transition: 180ms ease;
+  }
+  
+  * {
+    box-sizing: border-box;
+  }
+  
+  body {
+    margin: 0;
+    min-height: 100vh;
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    background: var(--country-surface);
+    color: var(--country-text);
+  }
+  
+  .demo-page {
+    min-height: 100vh;
+    display: grid;
+    place-items: center;
+    padding: 24px;
+  }
+  
+  .country-demo {
+    width: min(100%, 420px);
+    padding: 32px;
+    background: var(--country-bg);
+    border: 1px solid var(--country-border);
+    border-radius: 18px;
+    box-shadow: 0 12px 35px rgba(0, 0, 0, 0.08);
+  }
+  
+  .country-demo h1 {
+    margin: 0 0 8px;
+    font-size: clamp(1.5rem, 4vw, 2rem);
+  }
+  
+  .description {
+    margin: 0 0 24px;
+    color: #6b7280;
+    line-height: 1.6;
+  }
+  
+  .country-demo label {
+    display: block;
+    margin-bottom: 8px;
+    font-weight: 600;
+  }
+  
+  .country-select-wrapper {
+    position: relative;
+  }
+  
+  .select-icon {
+    position: absolute;
+    left: 14px;
+    top: 50%;
+    transform: translateY(-50%);
+    pointer-events: none;
+    font-size: 1.15rem;
+  }
+  
+  .country-select {
+    width: 100%;
+    min-height: 48px;
+    padding: 10px 42px 10px 44px;
+    border: 2px solid var(--country-border);
+    border-radius: var(--country-radius);
+    background: var(--country-bg);
+    color: var(--country-text);
+    font: inherit;
+    cursor: pointer;
+    appearance: auto;
+    transition:
+      border-color var(--country-transition),
+      box-shadow var(--country-transition),
+      transform var(--country-transition);
+  }
+  
+  .country-select:hover {
+    border-color: var(--country-border-hover);
+  }
+  
+  .country-select:focus-visible {
+    outline: none;
+    border-color: var(--country-border-hover);
+    box-shadow: 0 0 0 4px var(--country-focus);
+  }
+  
+  .country-select:active {
+    transform: scale(0.99);
+  }
+  
+  @media (max-width: 480px) {
+    .demo-page {
+      padding: 16px;
+    }
+  
+    .country-demo {
+      padding: 24px 20px;
+    }
+  }
+  
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --country-bg: #111827;
+      --country-text: #f9fafb;
+      --country-border: #374151;
+      --country-surface: #030712;
+      --country-focus: rgba(129, 140, 248, 0.25);
+    }
+  
+    .description {
+      color: #9ca3af;
+    }
+  
+    .country-select {
+      color-scheme: dark;
+    }
+  }
+  
+  @media (prefers-reduced-motion: reduce) {
+    .country-select {
+      transition: none;
+    }
+  }


### PR DESCRIPTION
## Pull Request Description

### Type of Change

* [ ] ✨ New animation / hover effect
* [x] 🧩 New component
* [ ] 📝 Documentation improvement
* [ ] 🐛 Bug fix in an existing submission
* [ ] Other

---

## Submission Checklist

* [x] All changes are inside `submissions/`
* [x] Includes `demo.html` — self-contained and works by opening directly in a browser
* [x] Includes `style.css` — raw CSS for the proposed feature
* [x] Includes `README.md` — documentation and usage instructions
* [x] No changes to `core/`
* [x] No changes to `components/`
* [x] One feature per PR

---

## Feature Description

### What does this add?

Adds a responsive CSS Country Selector Dropdown with country flags and country names.

The component uses a native HTML `<select>` element with custom CSS styling, focus states, responsive behavior, dark-mode support, and reduced-motion support.

### How does a developer use it?

```html
<label for="country-select">Country</label>

<select id="country-select" class="country-select" name="country">
  <option value="in">🇮🇳 India</option>
  <option value="us">🇺🇸 United States</option>
  <option value="gb">🇬🇧 United Kingdom</option>
</select>
```

### Why does it fit EaseMotion CSS?

It provides a lightweight, reusable UI component using only HTML and CSS. It includes smooth CSS transitions, responsive styling, keyboard accessibility, dark-mode support, and `prefers-reduced-motion` handling without requiring JavaScript or external dependencies.

---

## Demo

* [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

* [x] Chrome
* [x] Firefox
* [x] Edge
* [x] Safari

---

## Notes for Maintainer

Implemented as a standalone submission under:

`submissions/examples/country-selector-dropdown/`

No changes were made to `core/` or `components/`.

**Issue:** Closes #68639
