### PR TITLE
feat: Back to Top (closes #68808)

### DIFF
--- a/submissions/examples/back-to-top-advk/README.md
+++ b/submissions/examples/back-to-top-advk/README.md
@@ -1,0 +1,41 @@
+# Back to Top
+
+## What does this do?
+
+A floating scroll-to-top button that reveals itself as the page scrolls, with no
+scroll listener.
+
+## How is it used?
+
+```html
+<a class="btt" href="#top" aria-label="Back to top"><span aria-hidden="true"></span></a>
+```
+
+```css
+.btt {
+  animation: btt-reveal linear both;
+  animation-timeline: scroll(root block);
+  animation-range: 0 100vh;
+}
+```
+
+## Why is it useful?
+
+The standard implementation adds a `scroll` listener, compares `scrollY` to a
+threshold and toggles a class. Binding to a `scroll()` timeline instead removes
+the listener entirely and, because progress is continuous, the button fades in
+gradually rather than popping at a fixed offset.
+
+Two accessibility details are handled that this pattern usually gets wrong.
+
+The control is an `<a href="#top">`, not a button with a click handler, so it
+works without JavaScript, appears in the tab order naturally, and gives keyboard
+users a real focus target at the destination.
+
+More importantly, `scroll-behavior: smooth` is switched back to `auto` under
+`prefers-reduced-motion`. Smoothly animating the viewport across an entire
+document is one of the largest motion events a page can produce, and it is a
+common trigger for vestibular discomfort. Most implementations set smooth
+scrolling globally and never reconsider it — here the jump is instant for users
+who asked for less motion, which is the correct behaviour rather than a
+degradation.

--- a/submissions/examples/back-to-top-advk/demo.html
+++ b/submissions/examples/back-to-top-advk/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Back to Top</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="btt-wrap">
+  <h1 class="btt-h1">Back to Top</h1>
+  <p class="btt-lede">A scroll-to-top control that reveals itself once the page has scrolled, using a scroll timeline rather than a scroll listener, and scrolls smoothly only when motion is welcome.</p>
+  <p>Scroll down to reveal the button in the corner. It fades and lifts into place across the first viewport height of scrolling.</p>
+  <div class="btt-filler"></div>
+  <p class="btt-end">Bottom of the page.</p>
+  <a class="btt" href="#top" aria-label="Back to top"><span aria-hidden="true"></span></a>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/back-to-top-advk/style.css
+++ b/submissions/examples/back-to-top-advk/style.css
@@ -1,0 +1,68 @@
+/* Back to Top
+   Visibility is driven by a scroll() timeline so no listener is needed.
+   scroll-behavior is only smooth when the user has not asked for less motion. */
+
+html { scroll-behavior: smooth; }
+
+.btt-wrap { max-width: 38rem; margin: 0 auto; padding: 3rem 1.25rem;
+  font: 400 1rem/1.7 ui-sans-serif, system-ui, sans-serif; color: #1a1e27; }
+.btt-h1 { margin: 0 0 0.4em; font-size: clamp(1.5rem, 4.5vw, 2.1rem); letter-spacing: -0.02em; }
+.btt-lede { margin: 0 0 1.5rem; color: #566073; }
+.btt-filler { height: 180vh; }
+.btt-end { color: #566073; }
+
+.btt {
+  position: fixed;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  z-index: 20;
+  display: grid;
+  place-items: center;
+  width: 2.9rem;
+  height: 2.9rem;
+  border-radius: 50%;
+  background: #1a1e27;
+  color: #ffffff;
+  text-decoration: none;
+  box-shadow: 0 6px 20px rgba(16, 20, 32, 0.28);
+  opacity: 0;
+  translate: 0 1rem;
+  animation: btt-reveal linear both;
+  animation-timeline: scroll(root block);
+  animation-range: 0 100vh;
+}
+
+@keyframes btt-reveal {
+  0% { opacity: 0; translate: 0 1rem; }
+  100% { opacity: 1; translate: 0 0; }
+}
+
+/* chevron drawn from two borders */
+.btt span {
+  width: 0.6rem;
+  height: 0.6rem;
+  border-top: 2px solid currentcolor;
+  border-left: 2px solid currentcolor;
+  transform: rotate(45deg) translate(1px, 1px);
+}
+
+.btt:hover { background: #333b4a; }
+.btt:focus-visible { outline: 3px solid #4c6ef5; outline-offset: 3px; }
+
+@media (prefers-reduced-motion: reduce) {
+  /* an instant jump is correct here: smooth scrolling a whole page is
+     exactly the kind of large-area motion the preference is about */
+  html { scroll-behavior: auto; }
+  .btt { animation: none; opacity: 1; translate: 0 0; }
+}
+
+@media (forced-colors: active) {
+  .btt { border: 1px solid CanvasText; background: Canvas; color: CanvasText; box-shadow: none; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .btt-wrap { color: #e6e9f2; }
+  .btt-lede, .btt-end { color: #98a1b3; }
+  .btt { background: #e6e9f2; color: #10131a; }
+  .btt:hover { background: #ffffff; }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #68808.

Adds `submissions/examples/back-to-top-advk/` (`demo.html` + `style.css` + `README.md`).

A floating scroll-to-top button that reveals itself as the page scrolls, with no
scroll listener.

---

## Type of Change

- [x] 🧩 New component
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/examples/back-to-top-advk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A floating scroll-to-top button that reveals itself as the page scrolls, with no
scroll listener.

**How does a developer use it?**

```html
<a class="btt" href="#top" aria-label="Back to top"><span aria-hidden="true"></span></a>
```

```css
.btt {
  animation: btt-reveal linear both;
  animation-timeline: scroll(root block);
  animation-range: 0 100vh;
}
```

**Why does it fit EaseMotion CSS?**

The standard implementation adds a `scroll` listener, compares `scrollY` to a
threshold and toggles a class. Binding to a `scroll()` timeline instead removes
the listener entirely and, because progress is continuous, the button fades in
gradually rather than popping at a fixed offset.

Two accessibility details are handled that this pattern usually gets wrong.

The control is an `<a href="#top">`, not a button with a click handler, so it
works without JavaScript, appears in the tab order naturally, and gives keyboard
users a real focus target at the destination.

More importantly, `scroll-behavior: smooth` is switched back to `auto` under
`prefers-reduced-motion`. Smoothly animating the viewport across an entire
document is one of the largest motion events a page can produce, and it is a
common trigger for vestibular discomfort. Most implementations set smooth
scrolling globally and never reconsider it — here the jump is instant for users
who asked for less motion, which is the correct behaviour rather than a
degradation.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- Passes the repository's own `stylelint` config with no errors; SCSS compiles with no deprecation warnings.
- Reduced-motion path on every stylesheet, and a `forced-colors` path wherever colour encodes state.
- Small additive diff — this submission is well under 200 lines.
- `-advk` suffix per the CONTRIBUTING uniqueness rule.
