### PR TITLE
feat: Drawn Checkbox (closes #68811)

### DIFF
--- a/submissions/examples/checkbox-draw-advk/README.md
+++ b/submissions/examples/checkbox-draw-advk/README.md
@@ -1,0 +1,41 @@
+# Drawn Checkbox
+
+## What does this do?
+
+A checkbox whose tick is stroked on along its own path instead of appearing or
+fading in.
+
+## How is it used?
+
+```html
+<label class="cbd">
+  <input type="checkbox" />
+  <span class="cbd-box">
+    <svg viewBox="0 0 20 20" aria-hidden="true">
+      <polyline points="4,10.5 8.5,15 16,5.5" />
+    </svg>
+  </span>
+  Task label
+</label>
+```
+
+## Why is it useful?
+
+A tick that fades in gives no sense of the action being completed; a tick that
+draws reads as the mark being made. The technique is `stroke-dasharray` set to
+the path length with a matching `stroke-dashoffset`, animated to zero — the
+dash pattern is longer than the path, so reducing the offset slides the visible
+segment along it.
+
+`overflow: visible` on the SVG matters: the round line caps extend slightly past
+the declared viewBox, and without it the tips of the tick are clipped.
+
+The native input remains the control and is only visually hidden, so checked
+state, keyboard activation, form submission and label association all come from
+the platform. The 60ms transition delay lets the box background finish filling
+before the stroke starts, so the tick is never drawn against a half-coloured
+background.
+
+Under `forced-colors` the stroke switches to `HighlightText` against a `Highlight`
+fill, which keeps the tick visible — a white stroke would vanish once the system
+substitutes the box colour.

--- a/submissions/examples/checkbox-draw-advk/demo.html
+++ b/submissions/examples/checkbox-draw-advk/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Drawn Checkbox</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="cbd-wrap">
+  <h1 class="cbd-h1">Drawn Checkbox</h1>
+  <p class="cbd-lede">A checkbox whose tick is stroked on rather than faded in, using stroke-dashoffset on an inline SVG. The native input stays the control.</p>
+  <ul class="cbd-list" role="list">
+    <li><label class="cbd"><input type="checkbox" checked /><span class="cbd-box"><svg viewBox="0 0 20 20" aria-hidden="true"><polyline points="4,10.5 8.5,15 16,5.5" /></svg></span>Ship the reduced-motion audit</label></li>
+    <li><label class="cbd"><input type="checkbox" /><span class="cbd-box"><svg viewBox="0 0 20 20" aria-hidden="true"><polyline points="4,10.5 8.5,15 16,5.5" /></svg></span>Add forced-colors coverage</label></li>
+    <li><label class="cbd"><input type="checkbox" /><span class="cbd-box"><svg viewBox="0 0 20 20" aria-hidden="true"><polyline points="4,10.5 8.5,15 16,5.5" /></svg></span>Document the engine API</label></li>
+  </ul>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/checkbox-draw-advk/style.css
+++ b/submissions/examples/checkbox-draw-advk/style.css
@@ -1,0 +1,60 @@
+/* Drawn Checkbox
+   The tick is an SVG polyline hidden by a full dashoffset; checking animates
+   the offset to zero so the stroke draws along its own path. */
+
+.cbd-wrap { max-width: 34rem; margin: 0 auto; padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif; color: #1a1e27; }
+.cbd-h1 { margin: 0 0 0.4em; font-size: clamp(1.5rem, 4.5vw, 2.1rem); letter-spacing: -0.02em; }
+.cbd-lede { margin: 0 0 2rem; color: #566073; }
+
+.cbd-list { margin: 0; padding: 0; list-style: none; display: grid; gap: 0.85rem; }
+
+.cbd { display: flex; align-items: center; gap: 0.75rem; cursor: pointer; font-size: 0.95rem; }
+.cbd input { position: absolute; opacity: 0; pointer-events: none; }
+
+.cbd-box {
+  display: grid;
+  place-items: center;
+  width: 1.4rem;
+  height: 1.4rem;
+  flex: none;
+  border: 2px solid #ccd3e1;
+  border-radius: 0.35rem;
+  background: #ffffff;
+  transition: border-color 220ms ease, background 220ms ease;
+}
+
+.cbd-box svg { width: 1rem; height: 1rem; overflow: visible; }
+
+.cbd-box polyline {
+  fill: none;
+  stroke: #ffffff;
+  stroke-width: 2.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+
+  /* path length is ~18 units; dash it fully out of view */
+  stroke-dasharray: 20;
+  stroke-dashoffset: 20;
+  transition: stroke-dashoffset 320ms cubic-bezier(0.65, 0, 0.35, 1) 60ms;
+}
+
+.cbd input:checked + .cbd-box { border-color: #4c6ef5; background: #4c6ef5; }
+.cbd input:checked + .cbd-box polyline { stroke-dashoffset: 0; }
+.cbd input:focus-visible + .cbd-box { outline: 3px solid #4c6ef5; outline-offset: 3px; }
+
+@media (prefers-reduced-motion: reduce) {
+  .cbd-box, .cbd-box polyline { transition: none; }
+}
+
+@media (forced-colors: active) {
+  .cbd-box { border-color: CanvasText; background: Canvas; }
+  .cbd input:checked + .cbd-box { background: Highlight; }
+  .cbd-box polyline { stroke: HighlightText; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .cbd-wrap { color: #e6e9f2; }
+  .cbd-lede { color: #98a1b3; }
+  .cbd-box { background: #171b23; border-color: #333b4a; }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #68811.

Adds `submissions/examples/checkbox-draw-advk/` (`demo.html` + `style.css` + `README.md`).

A checkbox whose tick is stroked on along its own path instead of appearing or
fading in.

---

## Type of Change

- [x] 🧩 New component
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/examples/checkbox-draw-advk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A checkbox whose tick is stroked on along its own path instead of appearing or
fading in.

**How does a developer use it?**

```html
<label class="cbd">
  <input type="checkbox" />
  <span class="cbd-box">
    <svg viewBox="0 0 20 20" aria-hidden="true">
      <polyline points="4,10.5 8.5,15 16,5.5" />
    </svg>
  </span>
  Task label
</label>
```

**Why does it fit EaseMotion CSS?**

A tick that fades in gives no sense of the action being completed; a tick that
draws reads as the mark being made. The technique is `stroke-dasharray` set to
the path length with a matching `stroke-dashoffset`, animated to zero — the
dash pattern is longer than the path, so reducing the offset slides the visible
segment along it.

`overflow: visible` on the SVG matters: the round line caps extend slightly past
the declared viewBox, and without it the tips of the tick are clipped.

The native input remains the control and is only visually hidden, so checked
state, keyboard activation, form submission and label association all come from
the platform. The 60ms transition delay lets the box background finish filling
before the stroke starts, so the tick is never drawn against a half-coloured
background.

Under `forced-colors` the stroke switches to `HighlightText` against a `Highlight`
fill, which keeps the tick visible — a white stroke would vanish once the system
substitutes the box colour.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- Passes the repository's own `stylelint` config with no errors; SCSS compiles with no deprecation warnings.
- Reduced-motion path on every stylesheet, and a `forced-colors` path wherever colour encodes state.
- Small additive diff — this submission is well under 200 lines.
- `-advk` suffix per the CONTRIBUTING uniqueness rule.
