### PR TITLE
feat: Color Swatch Picker (closes #68812)

### DIFF
--- a/submissions/examples/color-swatch-picker-advk/README.md
+++ b/submissions/examples/color-swatch-picker-advk/README.md
@@ -1,0 +1,41 @@
+# Color Swatch Picker
+
+## What does this do?
+
+A theme accent picker where each swatch is a radio, and the selected one is
+marked by a ring, a tick and a bolded name.
+
+## How is it used?
+
+```html
+<fieldset class="csp-set">
+  <legend class="csp-leg">Accent colour</legend>
+  <div class="csp">
+    <label class="csp-o" style="--c:#4c6ef5">
+      <input type="radio" name="c" checked />
+      <span aria-hidden="true"></span>
+      <span class="csp-n">Indigo</span>
+    </label>
+  </div>
+</fieldset>
+```
+
+## Why is it useful?
+
+A colour picker is the one control where colour genuinely is the content — which
+makes it the worst possible place to also use colour as the *selection* indicator.
+A user with colour vision deficiency may not be able to tell the swatches apart,
+so a picker that shows selection by tinting a border gives them nothing.
+
+Three redundant cues solve it: an offset ring in the swatch's own colour, a white
+tick inside the selected swatch, and a bolded text name below. Any one of them
+communicates the state independently, and the visible names mean the options are
+distinguishable even if the swatches are not.
+
+`forced-color-adjust: none` on the swatch is one of the rare correct uses of that
+property. High Contrast mode would otherwise replace every swatch with the same
+system colour, destroying the only information the control exists to convey — the
+selection ring switches to `Highlight` so the state remains visible.
+
+Radios rather than buttons give single-selection semantics, arrow-key navigation
+and form submission for free, and the `fieldset`/`legend` names the group.

--- a/submissions/examples/color-swatch-picker-advk/demo.html
+++ b/submissions/examples/color-swatch-picker-advk/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Color Swatch Picker</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="csp-wrap">
+  <h1 class="csp-h1">Color Swatch Picker</h1>
+  <p class="csp-lede">A theme colour picker built on radios. The selected swatch is marked with a tick and a ring, never colour alone, so the choice is readable without seeing hue.</p>
+  <fieldset class="csp-set">
+    <legend class="csp-leg">Accent colour</legend>
+    <div class="csp">
+      <label class="csp-o" style="--c:#4c6ef5"><input type="radio" name="c" checked /><span aria-hidden="true"></span><span class="csp-n">Indigo</span></label>
+      <label class="csp-o" style="--c:#2f9e6e"><input type="radio" name="c" /><span aria-hidden="true"></span><span class="csp-n">Green</span></label>
+      <label class="csp-o" style="--c:#d1453b"><input type="radio" name="c" /><span aria-hidden="true"></span><span class="csp-n">Red</span></label>
+      <label class="csp-o" style="--c:#d1971b"><input type="radio" name="c" /><span aria-hidden="true"></span><span class="csp-n">Amber</span></label>
+      <label class="csp-o" style="--c:#7048e8"><input type="radio" name="c" /><span aria-hidden="true"></span><span class="csp-n">Violet</span></label>
+    </div>
+  </fieldset>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/color-swatch-picker-advk/style.css
+++ b/submissions/examples/color-swatch-picker-advk/style.css
@@ -1,0 +1,60 @@
+/* Color Swatch Picker
+   Selection is shown three ways: an offset ring, a tick glyph and the visible
+   name -- so it never depends on distinguishing the swatch colours. */
+
+.csp-wrap { max-width: 34rem; margin: 0 auto; padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif; color: #1a1e27; }
+.csp-h1 { margin: 0 0 0.4em; font-size: clamp(1.5rem, 4.5vw, 2.1rem); letter-spacing: -0.02em; }
+.csp-lede { margin: 0 0 2rem; color: #566073; }
+
+.csp-set { margin: 0; padding: 0; border: 0; }
+.csp-leg { padding: 0 0 0.75rem; font-size: 0.85rem; font-weight: 600; color: #566073; }
+
+.csp { display: flex; flex-wrap: wrap; gap: 1.15rem; }
+.csp-o { display: grid; justify-items: center; gap: 0.4rem; cursor: pointer; }
+.csp-o input { position: absolute; opacity: 0; pointer-events: none; }
+
+.csp-o > span[aria-hidden] {
+  display: grid;
+  place-items: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 50%;
+  background: var(--c);
+  box-shadow: 0 0 0 0 var(--c);
+  transition: box-shadow 220ms cubic-bezier(0.34, 1.4, 0.6, 1);
+}
+
+/* tick, hidden until selected */
+.csp-o > span[aria-hidden]::before {
+  content: "\2713";
+  color: #ffffff;
+  font-size: 1rem;
+  font-weight: 700;
+  opacity: 0;
+  scale: 0.5;
+  transition: opacity 180ms ease, scale 220ms cubic-bezier(0.34, 1.6, 0.6, 1);
+}
+
+.csp-o input:checked + span[aria-hidden] { box-shadow: 0 0 0 3px #ffffff, 0 0 0 5px var(--c); }
+.csp-o input:checked + span[aria-hidden]::before { opacity: 1; scale: 1; }
+.csp-o input:focus-visible + span[aria-hidden] { outline: 3px solid #1a1e27; outline-offset: 5px; }
+
+.csp-n { font-size: 0.76rem; color: #6b7488; }
+.csp-o input:checked ~ .csp-n { color: #1a1e27; font-weight: 700; }
+
+@media (prefers-reduced-motion: reduce) {
+  .csp-o > span[aria-hidden], .csp-o > span[aria-hidden]::before { transition: none; }
+}
+
+@media (forced-colors: active) {
+  .csp-o > span[aria-hidden] { border: 1px solid CanvasText; forced-color-adjust: none; }
+  .csp-o input:checked + span[aria-hidden] { outline: 3px solid Highlight; outline-offset: 3px; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .csp-wrap { color: #e6e9f2; }
+  .csp-lede, .csp-leg, .csp-n { color: #98a1b3; }
+  .csp-o input:checked + span[aria-hidden] { box-shadow: 0 0 0 3px #10131a, 0 0 0 5px var(--c); }
+  .csp-o input:checked ~ .csp-n { color: #e6e9f2; }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #68812.

Adds `submissions/examples/color-swatch-picker-advk/` (`demo.html` + `style.css` + `README.md`).

A theme accent picker where each swatch is a radio, and the selected one is
marked by a ring, a tick and a bolded name.

---

## Type of Change

- [x] 🧩 New component
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/examples/color-swatch-picker-advk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A theme accent picker where each swatch is a radio, and the selected one is
marked by a ring, a tick and a bolded name.

**How does a developer use it?**

```html
<fieldset class="csp-set">
  <legend class="csp-leg">Accent colour</legend>
  <div class="csp">
    <label class="csp-o" style="--c:#4c6ef5">
      <input type="radio" name="c" checked />
      <span aria-hidden="true"></span>
      <span class="csp-n">Indigo</span>
    </label>
  </div>
</fieldset>
```

**Why does it fit EaseMotion CSS?**

A colour picker is the one control where colour genuinely is the content — which
makes it the worst possible place to also use colour as the *selection* indicator.
A user with colour vision deficiency may not be able to tell the swatches apart,
so a picker that shows selection by tinting a border gives them nothing.

Three redundant cues solve it: an offset ring in the swatch's own colour, a white
tick inside the selected swatch, and a bolded text name below. Any one of them
communicates the state independently, and the visible names mean the options are
distinguishable even if the swatches are not.

`forced-color-adjust: none` on the swatch is one of the rare correct uses of that
property. High Contrast mode would otherwise replace every swatch with the same
system colour, destroying the only information the control exists to convey — the
selection ring switches to `Highlight` so the state remains visible.

Radios rather than buttons give single-selection semantics, arrow-key navigation
and form submission for free, and the `fieldset`/`legend` names the group.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- Passes the repository's own `stylelint` config with no errors; SCSS compiles with no deprecation warnings.
- Reduced-motion path on every stylesheet, and a `forced-colors` path wherever colour encodes state.
- Small additive diff — this submission is well under 200 lines.
- `-advk` suffix per the CONTRIBUTING uniqueness rule.
