### PR TITLE
feat: Dual Range Slider (closes #68814)

### DIFF
--- a/submissions/examples/dual-range-slider-advk/README.md
+++ b/submissions/examples/dual-range-slider-advk/README.md
@@ -1,0 +1,37 @@
+# Dual Range Slider
+
+## What does this do?
+
+A two-thumb min/max filter built from two overlaid native range inputs.
+
+## How is it used?
+
+```html
+<div class="drs" style="--lo:20%; --hi:70%">
+  <span class="drs-track" aria-hidden="true"></span>
+  <span class="drs-fill" aria-hidden="true"></span>
+  <input class="drs-i drs-i--lo" type="range" min="0" max="100" value="20" aria-label="Minimum price" />
+  <input class="drs-i drs-i--hi" type="range" min="0" max="100" value="70" aria-label="Maximum price" />
+</div>
+```
+
+## Why is it useful?
+
+There is no native two-thumb range input, so this is almost always a JavaScript
+widget built from divs — which means no keyboard support, no announced values,
+and a custom drag implementation per project.
+
+Stacking two real inputs keeps both thumbs as genuine controls: each is
+independently focusable, steppable with arrow keys, and announced with its own
+label and current value. A screen reader user can set a price range, which the div
+version makes impossible.
+
+The technique that makes the overlay work is `pointer-events: none` on the input
+element with `pointer-events: auto` restored on the thumb pseudo-elements. Without
+it the upper input's invisible body covers the entire track and the lower thumb
+becomes ungrabbable across most of its range — the single most common bug in
+hand-rolled dual sliders.
+
+Each input clamps against the other on `input`, so the thumbs cannot cross and
+produce an inverted range. The fill between them is a separate element positioned
+from `--lo` and `--hi`, so it needs no gradient recalculation.

--- a/submissions/examples/dual-range-slider-advk/demo.html
+++ b/submissions/examples/dual-range-slider-advk/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Dual Range Slider</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="drs-wrap">
+  <h1 class="drs-h1">Dual Range Slider</h1>
+  <p class="drs-lede">A min/max price filter from two overlaid native range inputs. Both thumbs stay real controls, so each is independently focusable and announced.</p>
+  <div class="drs" style="--lo:20%; --hi:70%">
+    <span class="drs-track" aria-hidden="true"></span>
+    <span class="drs-fill" aria-hidden="true"></span>
+    <input class="drs-i drs-i--lo" type="range" min="0" max="100" value="20" aria-label="Minimum price"
+      oninput="var p=this.closest('.drs');if(+this.value> +p.querySelector('.drs-i--hi').value)this.value=p.querySelector('.drs-i--hi').value;p.style.setProperty('--lo',this.value+'%');p.querySelector('.drs-lo').textContent='$'+this.value" />
+    <input class="drs-i drs-i--hi" type="range" min="0" max="100" value="70" aria-label="Maximum price"
+      oninput="var p=this.closest('.drs');if(+this.value< +p.querySelector('.drs-i--lo').value)this.value=p.querySelector('.drs-i--lo').value;p.style.setProperty('--hi',this.value+'%');p.querySelector('.drs-hi').textContent='$'+this.value" />
+  </div>
+  <p class="drs-out"><output class="drs-lo">$20</output> &ndash; <output class="drs-hi">$70</output></p>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/dual-range-slider-advk/style.css
+++ b/submissions/examples/dual-range-slider-advk/style.css
@@ -1,0 +1,77 @@
+/* Dual Range Slider
+   Two inputs share one track. pointer-events is disabled on the input body and
+   re-enabled only on the thumbs, so the lower one is still grabbable where the
+   upper input overlaps it. */
+
+.drs-wrap { max-width: 32rem; margin: 0 auto; padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif; color: #1a1e27; }
+.drs-h1 { margin: 0 0 0.4em; font-size: clamp(1.5rem, 4.5vw, 2.1rem); letter-spacing: -0.02em; }
+.drs-lede { margin: 0 0 2.5rem; color: #566073; }
+
+.drs { position: relative; height: 1.5rem; }
+
+.drs-track, .drs-fill {
+  position: absolute;
+  top: 50%;
+  height: 0.35rem;
+  margin-top: -0.175rem;
+  border-radius: 999px;
+}
+
+.drs-track { inset-inline: 0; background: #dfe3ec; }
+.drs-fill { left: var(--lo); right: calc(100% - var(--hi)); background: #4c6ef5; }
+
+.drs-i {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  margin: 0;
+  appearance: none;
+  background: none;
+
+  /* let clicks fall through the input body to whichever thumb is beneath */
+  pointer-events: none;
+}
+
+.drs-i::-webkit-slider-thumb {
+  appearance: none;
+  pointer-events: auto;
+  width: 1.15rem;
+  height: 1.15rem;
+  border: 3px solid #4c6ef5;
+  border-radius: 50%;
+  background: #ffffff;
+  box-shadow: 0 1px 4px rgba(20, 25, 40, 0.25);
+  cursor: grab;
+}
+
+.drs-i::-moz-range-thumb {
+  pointer-events: auto;
+  width: 1.15rem;
+  height: 1.15rem;
+  border: 3px solid #4c6ef5;
+  border-radius: 50%;
+  background: #ffffff;
+  cursor: grab;
+}
+
+.drs-i:focus-visible { outline: none; }
+.drs-i:focus-visible::-webkit-slider-thumb { outline: 3px solid #1a1e27; outline-offset: 2px; }
+.drs-i:focus-visible::-moz-range-thumb { outline: 3px solid #1a1e27; outline-offset: 2px; }
+
+.drs-out { margin-top: 1.25rem; font-weight: 700; font-variant-numeric: tabular-nums; }
+
+@media (forced-colors: active) {
+  .drs-track { background: Canvas; border: 1px solid CanvasText; }
+  .drs-fill { background: Highlight; }
+  .drs-i::-webkit-slider-thumb { background: Canvas; border-color: CanvasText; }
+  .drs-i::-moz-range-thumb { background: Canvas; border-color: CanvasText; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .drs-wrap { color: #e6e9f2; }
+  .drs-lede { color: #98a1b3; }
+  .drs-track { background: #2a303c; }
+  .drs-i::-webkit-slider-thumb { background: #10131a; }
+  .drs-i::-moz-range-thumb { background: #10131a; }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #68814.

Adds `submissions/examples/dual-range-slider-advk/` (`demo.html` + `style.css` + `README.md`).

A two-thumb min/max filter built from two overlaid native range inputs.

---

## Type of Change

- [x] 🧩 New component
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/examples/dual-range-slider-advk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A two-thumb min/max filter built from two overlaid native range inputs.

**How does a developer use it?**

```html
<div class="drs" style="--lo:20%; --hi:70%">
  <span class="drs-track" aria-hidden="true"></span>
  <span class="drs-fill" aria-hidden="true"></span>
  <input class="drs-i drs-i--lo" type="range" min="0" max="100" value="20" aria-label="Minimum price" />
  <input class="drs-i drs-i--hi" type="range" min="0" max="100" value="70" aria-label="Maximum price" />
</div>
```

**Why does it fit EaseMotion CSS?**

There is no native two-thumb range input, so this is almost always a JavaScript
widget built from divs — which means no keyboard support, no announced values,
and a custom drag implementation per project.

Stacking two real inputs keeps both thumbs as genuine controls: each is
independently focusable, steppable with arrow keys, and announced with its own
label and current value. A screen reader user can set a price range, which the div
version makes impossible.

The technique that makes the overlay work is `pointer-events: none` on the input
element with `pointer-events: auto` restored on the thumb pseudo-elements. Without
it the upper input's invisible body covers the entire track and the lower thumb
becomes ungrabbable across most of its range — the single most common bug in
hand-rolled dual sliders.

Each input clamps against the other on `input`, so the thumbs cannot cross and
produce an inverted range. The fill between them is a separate element positioned
from `--lo` and `--hi`, so it needs no gradient recalculation.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- Passes the repository's own `stylelint` config with no errors; SCSS compiles with no deprecation warnings.
- Reduced-motion path on every stylesheet, and a `forced-colors` path wherever colour encodes state.
- Small additive diff — this submission is well under 200 lines.
- `-advk` suffix per the CONTRIBUTING uniqueness rule.
