### PR TITLE
feat: File Drop Zone (closes #68815)

### DIFF
--- a/submissions/examples/file-drop-zone-advk/README.md
+++ b/submissions/examples/file-drop-zone-advk/README.md
@@ -1,0 +1,39 @@
+# File Drop Zone
+
+## What does this do?
+
+A drag-and-drop upload target that stays a real `<input type="file">`, so
+clicking and keyboard activation open the picker normally.
+
+## How is it used?
+
+```html
+<label class="fdz">
+  <input class="fdz-in" type="file" multiple />
+  <span class="fdz-ico" aria-hidden="true"></span>
+  <span class="fdz-t">Drop files here</span>
+</label>
+```
+
+Toggle `is-over` on dragover/dragleave and `is-got` on drop.
+
+## Why is it useful?
+
+Drop zones are frequently built as a styled `<div>` with drag handlers, which
+makes uploading impossible without a pointer — there is no way to reach a `div`
+by keyboard and no way to trigger a file picker from it. Users who cannot drag
+are locked out of the feature entirely.
+
+Wrapping a genuine file input in a `<label>` fixes that completely: the label
+forwards activation to the input, so click, Enter and Space all open the picker,
+and the control appears in the tab order with the correct role. Drag-and-drop
+becomes an enhancement layered on top rather than the only route.
+
+Because the input is visually hidden rather than `display: none`, it can still
+receive focus — and `:has(.fdz-in:focus-visible)` moves the visible focus ring
+onto the zone, so keyboard users see where they are. An input hidden with
+`display: none` is removed from the tab order, which is the usual bug in this
+pattern.
+
+The icon lifts on drag-over to signal the drop target is live; under reduced
+motion the colour change alone carries that, with no travel or scaling.

--- a/submissions/examples/file-drop-zone-advk/demo.html
+++ b/submissions/examples/file-drop-zone-advk/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>File Drop Zone</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="fdz-wrap">
+  <h1 class="fdz-h1">File Drop Zone</h1>
+  <p class="fdz-lede">An upload target that responds to drag-over, and remains a real file input so clicking and keyboard activation work identically.</p>
+  <label class="fdz" ondragover="event.preventDefault();this.classList.add('is-over')" ondragleave="this.classList.remove('is-over')" ondrop="event.preventDefault();this.classList.remove('is-over');this.classList.add('is-got')">
+    <input class="fdz-in" type="file" multiple />
+    <span class="fdz-ico" aria-hidden="true"></span>
+    <span class="fdz-t">Drop files here</span>
+    <span class="fdz-s">or click to browse — PNG, SVG, up to 5&nbsp;MB</span>
+  </label>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/file-drop-zone-advk/style.css
+++ b/submissions/examples/file-drop-zone-advk/style.css
@@ -1,0 +1,85 @@
+/* File Drop Zone
+   The <label> wraps a real file input, so click, Enter and Space all open the
+   picker. Drag state is a class; the dashed border animates its offset. */
+
+.fdz-wrap { max-width: 34rem; margin: 0 auto; padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif; color: #1a1e27; }
+.fdz-h1 { margin: 0 0 0.4em; font-size: clamp(1.5rem, 4.5vw, 2.1rem); letter-spacing: -0.02em; }
+.fdz-lede { margin: 0 0 2rem; color: #566073; }
+
+.fdz {
+  display: grid;
+  justify-items: center;
+  gap: 0.4rem;
+  padding: 2.5rem 1.5rem;
+  border: 2px dashed #c3cbdb;
+  border-radius: 0.8rem;
+  background: #fafbfe;
+  text-align: center;
+  cursor: pointer;
+  transition: border-color 200ms ease, background 200ms ease, scale 200ms ease;
+}
+
+.fdz-in { position: absolute; width: 1px; height: 1px; opacity: 0; }
+
+.fdz:hover { border-color: #4c6ef5; }
+.fdz.is-over { border-color: #4c6ef5; background: #eef2ff; scale: 1.01; }
+.fdz.is-got { border-style: solid; border-color: #2f9e6e; background: #edf9f4; }
+.fdz:has(.fdz-in:focus-visible) { outline: 3px solid #4c6ef5; outline-offset: 3px; }
+
+.fdz-ico {
+  width: 2.25rem;
+  height: 2.25rem;
+  margin-bottom: 0.5rem;
+  border: 2px solid #8b93a7;
+  border-radius: 0.35rem;
+  position: relative;
+  transition: transform 260ms cubic-bezier(0.34, 1.4, 0.6, 1), border-color 200ms ease;
+}
+
+/* upward arrow inside the box */
+.fdz-ico::before {
+  content: "";
+  position: absolute;
+  inset: 0.45rem auto auto 50%;
+  width: 0.55rem;
+  height: 0.55rem;
+  border-top: 2px solid #8b93a7;
+  border-left: 2px solid #8b93a7;
+  transform: translateX(-50%) rotate(45deg);
+}
+
+.fdz-ico::after {
+  content: "";
+  position: absolute;
+  inset: 0.5rem auto 0.4rem 50%;
+  width: 2px;
+  background: #8b93a7;
+  transform: translateX(-50%);
+}
+
+.fdz.is-over .fdz-ico { transform: translateY(-0.3rem); border-color: #4c6ef5; }
+
+.fdz-t { font-weight: 600; font-size: 0.98rem; }
+.fdz-s { font-size: 0.82rem; color: #6b7488; }
+
+@media (prefers-reduced-motion: reduce) {
+  .fdz, .fdz-ico { transition: none; }
+  .fdz.is-over { scale: 1; }
+  .fdz.is-over .fdz-ico { transform: none; }
+}
+
+@media (forced-colors: active) {
+  .fdz { border-color: CanvasText; background: Canvas; }
+  .fdz.is-over { border-color: Highlight; }
+  .fdz-ico, .fdz-ico::before, .fdz-ico::after { border-color: CanvasText; background: CanvasText; }
+  .fdz-ico { background: none; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .fdz-wrap { color: #e6e9f2; }
+  .fdz-lede, .fdz-s { color: #98a1b3; }
+  .fdz { background: #161b24; border-color: #333b4a; }
+  .fdz.is-over { background: #1a2138; }
+  .fdz.is-got { background: #12241d; }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #68815.

Adds `submissions/examples/file-drop-zone-advk/` (`demo.html` + `style.css` + `README.md`).

A drag-and-drop upload target that stays a real `<input type="file">`, so
clicking and keyboard activation open the picker normally.

---

## Type of Change

- [x] 🧩 New component
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/examples/file-drop-zone-advk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A drag-and-drop upload target that stays a real `<input type="file">`, so
clicking and keyboard activation open the picker normally.

**How does a developer use it?**

```html
<label class="fdz">
  <input class="fdz-in" type="file" multiple />
  <span class="fdz-ico" aria-hidden="true"></span>
  <span class="fdz-t">Drop files here</span>
</label>
```

Toggle `is-over` on dragover/dragleave and `is-got` on drop.

**Why does it fit EaseMotion CSS?**

Drop zones are frequently built as a styled `<div>` with drag handlers, which
makes uploading impossible without a pointer — there is no way to reach a `div`
by keyboard and no way to trigger a file picker from it. Users who cannot drag
are locked out of the feature entirely.

Wrapping a genuine file input in a `<label>` fixes that completely: the label
forwards activation to the input, so click, Enter and Space all open the picker,
and the control appears in the tab order with the correct role. Drag-and-drop
becomes an enhancement layered on top rather than the only route.

Because the input is visually hidden rather than `display: none`, it can still
receive focus — and `:has(.fdz-in:focus-visible)` moves the visible focus ring
onto the zone, so keyboard users see where they are. An input hidden with
`display: none` is removed from the tab order, which is the usual bug in this
pattern.

The icon lifts on drag-over to signal the drop target is live; under reduced
motion the colour change alone carries that, with no travel or scaling.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- Passes the repository's own `stylelint` config with no errors; SCSS compiles with no deprecation warnings.
- Reduced-motion path on every stylesheet, and a `forced-colors` path wherever colour encodes state.
- Small additive diff — this submission is well under 200 lines.
- `-advk` suffix per the CONTRIBUTING uniqueness rule.
