### PR TITLE
feat: Scroll Snap Carousel (closes #68824)

### DIFF
--- a/submissions/examples/scroll-snap-carousel-advk/README.md
+++ b/submissions/examples/scroll-snap-carousel-advk/README.md
@@ -1,0 +1,40 @@
+# Scroll Snap Carousel
+
+## What does this do?
+
+A horizontal carousel using CSS scroll snapping, with anchor links as the paging
+controls.
+
+## How is it used?
+
+```html
+<div class="ssc" tabindex="0" role="region" aria-label="Featured components">
+  <article class="ssc-s" id="s1">...</article>
+  <article class="ssc-s" id="s2">...</article>
+</div>
+<nav class="ssc-dots" aria-label="Carousel navigation">
+  <a href="#s1" aria-label="Slide 1"></a>
+</nav>
+```
+
+## Why is it useful?
+
+Carousels are the single most over-engineered component on the web. A typical
+slider library reimplements touch physics, momentum and paging that the browser
+already does natively — and usually loses keyboard access and screen-reader
+navigation in the process, because the slides end up in transformed containers
+with the off-screen ones still focusable.
+
+`scroll-snap-type: x mandatory` gives real paging with the platform's own touch
+and trackpad handling. The slides remain normal document flow, so tab order is
+correct, find-in-page reaches them, and a screen reader can navigate the region
+linearly.
+
+Anchor links as controls mean the carousel pages with no JavaScript whatsoever,
+and each control has a genuine accessible name and focus behaviour.
+
+Making the track `tabindex="0"` is required rather than decorative: a scrollable
+region that cannot receive focus cannot be scrolled with the arrow keys, which is
+a WCAG keyboard-access failure that most native-scroll carousels overlook.
+`scroll-behavior` reverts to `auto` under reduced motion so paging jumps rather
+than glides.

--- a/submissions/examples/scroll-snap-carousel-advk/demo.html
+++ b/submissions/examples/scroll-snap-carousel-advk/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Scroll Snap Carousel</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="ssc-wrap">
+  <h1 class="ssc-h1">Scroll Snap Carousel</h1>
+  <p class="ssc-lede">A carousel built from CSS scroll snapping and anchor links. Native scrolling means touch, trackpad, keyboard and screen readers all work with no slider library.</p>
+  <div class="ssc" tabindex="0" role="region" aria-label="Featured components">
+    <article class="ssc-s" id="s1"><h2>Motion engine</h2><p>Compile animations from an attribute.</p></article>
+    <article class="ssc-s" id="s2"><h2>Utilities</h2><p>Readable class names, no shorthand to memorise.</p></article>
+    <article class="ssc-s" id="s3"><h2>Components</h2><p>Cards, modals, tabs and toasts.</p></article>
+    <article class="ssc-s" id="s4"><h2>SCSS tokens</h2><p>Curves and durations as named steps.</p></article>
+  </div>
+  <nav class="ssc-dots" aria-label="Carousel navigation">
+    <a href="#s1" aria-label="Slide 1"></a><a href="#s2" aria-label="Slide 2"></a><a href="#s3" aria-label="Slide 3"></a><a href="#s4" aria-label="Slide 4"></a>
+  </nav>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/scroll-snap-carousel-advk/style.css
+++ b/submissions/examples/scroll-snap-carousel-advk/style.css
@@ -1,0 +1,64 @@
+/* Scroll Snap Carousel
+   scroll-snap-type does the paging. Anchor links are the controls, so the
+   carousel works with scripting disabled and keeps a real focus order. */
+
+.ssc-wrap { max-width: 40rem; margin: 0 auto; padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif; color: #1a1e27; }
+.ssc-h1 { margin: 0 0 0.4em; font-size: clamp(1.5rem, 4.5vw, 2.1rem); letter-spacing: -0.02em; }
+.ssc-lede { margin: 0 0 1.75rem; color: #566073; }
+
+.ssc {
+  display: flex;
+  gap: 1rem;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scroll-behavior: smooth;
+  scrollbar-width: none;
+  padding-bottom: 0.5rem;
+}
+
+.ssc::-webkit-scrollbar { display: none; }
+.ssc:focus-visible { outline: 3px solid #4c6ef5; outline-offset: 4px; border-radius: 0.5rem; }
+
+.ssc-s {
+  flex: 0 0 min(20rem, 82%);
+  scroll-snap-align: center;
+  padding: 1.5rem;
+  border: 1px solid #e0e4ee;
+  border-radius: 0.7rem;
+  background: linear-gradient(150deg, #f5f7fc, #ffffff);
+}
+
+.ssc-s h2 { margin: 0 0 0.4rem; font-size: 1.05rem; }
+.ssc-s p { margin: 0; font-size: 0.9rem; color: #566073; }
+
+.ssc-dots { display: flex; justify-content: center; gap: 0.5rem; margin-top: 1rem; }
+
+.ssc-dots a {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 50%;
+  background: #ccd3e1;
+  transition: background 200ms ease, scale 200ms ease;
+}
+
+.ssc-dots a:hover { background: #4c6ef5; scale: 1.25; }
+.ssc-dots a:focus-visible { outline: 3px solid #4c6ef5; outline-offset: 3px; }
+
+@media (prefers-reduced-motion: reduce) {
+  .ssc { scroll-behavior: auto; }
+  .ssc-dots a { transition: none; }
+  .ssc-dots a:hover { scale: 1; }
+}
+
+@media (forced-colors: active) {
+  .ssc-s { border-color: CanvasText; background: Canvas; }
+  .ssc-dots a { background: CanvasText; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .ssc-wrap { color: #e6e9f2; }
+  .ssc-lede, .ssc-s p { color: #98a1b3; }
+  .ssc-s { background: #171b23; border-color: #2a303c; }
+  .ssc-dots a { background: #3a4356; }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #68824.

Adds `submissions/examples/scroll-snap-carousel-advk/` (`demo.html` + `style.css` + `README.md`).

A horizontal carousel using CSS scroll snapping, with anchor links as the paging
controls.

---

## Type of Change

- [x] 🧩 New component
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/examples/scroll-snap-carousel-advk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A horizontal carousel using CSS scroll snapping, with anchor links as the paging
controls.

**How does a developer use it?**

```html
<div class="ssc" tabindex="0" role="region" aria-label="Featured components">
  <article class="ssc-s" id="s1">...</article>
  <article class="ssc-s" id="s2">...</article>
</div>
<nav class="ssc-dots" aria-label="Carousel navigation">
  <a href="#s1" aria-label="Slide 1"></a>
</nav>
```

**Why does it fit EaseMotion CSS?**

Carousels are the single most over-engineered component on the web. A typical
slider library reimplements touch physics, momentum and paging that the browser
already does natively — and usually loses keyboard access and screen-reader
navigation in the process, because the slides end up in transformed containers
with the off-screen ones still focusable.

`scroll-snap-type: x mandatory` gives real paging with the platform's own touch
and trackpad handling. The slides remain normal document flow, so tab order is
correct, find-in-page reaches them, and a screen reader can navigate the region
linearly.

Anchor links as controls mean the carousel pages with no JavaScript whatsoever,
and each control has a genuine accessible name and focus behaviour.

Making the track `tabindex="0"` is required rather than decorative: a scrollable
region that cannot receive focus cannot be scrolled with the arrow keys, which is
a WCAG keyboard-access failure that most native-scroll carousels overlook.
`scroll-behavior` reverts to `auto` under reduced motion so paging jumps rather
than glides.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- Passes the repository's own `stylelint` config with no errors; SCSS compiles with no deprecation warnings.
- Reduced-motion path on every stylesheet, and a `forced-colors` path wherever colour encodes state.
- Small additive diff — this submission is well under 200 lines.
- `-advk` suffix per the CONTRIBUTING uniqueness rule.
