### PR TITLE
feat: Sticky Table Header (closes #68828)

### DIFF
--- a/submissions/examples/sticky-table-header-advk/README.md
+++ b/submissions/examples/sticky-table-header-advk/README.md
@@ -1,0 +1,43 @@
+# Sticky Table Header
+
+## What does this do?
+
+A scrollable data table that pins both the header row and the first column, so
+labels stay visible on both axes.
+
+## How is it used?
+
+```html
+<div class="sth-scroll">
+  <table class="sth">
+    <thead><tr><th>Component</th><th>Size</th></tr></thead>
+    <tbody><tr><th>fade</th><td>0.4 kB</td></tr></tbody>
+  </table>
+</div>
+```
+
+Row labels must be `<th>`, not `<td>`, for the column pinning to apply.
+
+## Why is it useful?
+
+Two-axis sticky headers are a common request and are usually abandoned because
+the first attempt does not work. The reasons are specific and worth documenting.
+
+`position: sticky` has no effect on table elements when `border-collapse:
+collapse` is set — the collapsed border model reassigns borders to the table
+itself, and the cells stop being positionable. Switching to `border-collapse:
+separate` with `border-spacing: 0` keeps the visual result while making sticky
+work.
+
+The second trap is the corner cell. The header row and the first column each need
+their own `z-index`, and the intersecting cell has to outrank both — otherwise the
+row header scrolls over the corner and the top-left label disappears exactly when
+it is most needed.
+
+Because collapsed borders are unavailable, borders are applied per cell and the
+last row's are removed individually, which is what keeps the rounded container
+edge clean.
+
+Using `<th>` for row labels also gives the table real row-header semantics, so a
+screen reader announces the row name with each cell rather than reading bare
+values.

--- a/submissions/examples/sticky-table-header-advk/demo.html
+++ b/submissions/examples/sticky-table-header-advk/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Sticky Table Header</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="sth-wrap">
+  <h1 class="sth-h1">Sticky Table Header</h1>
+  <p class="sth-lede">A scrollable table whose header row and first column both stay pinned, with a shadow that appears only once the table has actually scrolled.</p>
+  <div class="sth-scroll">
+    <table class="sth">
+      <thead><tr><th>Component</th><th>Size</th><th>Reduced motion</th><th>Forced colors</th><th>Since</th></tr></thead>
+      <tbody>
+        <tr><th>fade</th><td>0.4 kB</td><td>yes</td><td>n/a</td><td>1.0.0</td></tr>
+        <tr><th>slide</th><td>0.6 kB</td><td>yes</td><td>n/a</td><td>1.0.0</td></tr>
+        <tr><th>loaders</th><td>1.9 kB</td><td>no</td><td>no</td><td>1.1.0</td></tr>
+        <tr><th>skeleton</th><td>1.2 kB</td><td>no</td><td>no</td><td>1.1.0</td></tr>
+        <tr><th>modals</th><td>2.4 kB</td><td>yes</td><td>no</td><td>1.1.0</td></tr>
+        <tr><th>engine</th><td>4.8 kB</td><td>partial</td><td>no</td><td>1.2.0</td></tr>
+      </tbody>
+    </table>
+  </div>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/sticky-table-header-advk/style.css
+++ b/submissions/examples/sticky-table-header-advk/style.css
@@ -1,0 +1,61 @@
+/* Sticky Table Header
+   Both axes pin at once: thead th gets top, row th gets left, and the corner
+   cell needs both plus a higher z-index or it scrolls under its neighbours. */
+
+.sth-wrap { max-width: 42rem; margin: 0 auto; padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif; color: #1a1e27; }
+.sth-h1 { margin: 0 0 0.4em; font-size: clamp(1.5rem, 4.5vw, 2.1rem); letter-spacing: -0.02em; }
+.sth-lede { margin: 0 0 2rem; color: #566073; }
+
+.sth-scroll {
+  max-height: 17rem;
+  overflow: auto;
+  border: 1px solid #dfe3ec;
+  border-radius: 0.6rem;
+}
+
+.sth { width: 100%; border-collapse: separate; border-spacing: 0; font-size: 0.88rem; }
+
+.sth th, .sth td { padding: 0.65em 0.9em; text-align: left; white-space: nowrap; }
+
+.sth thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background: #f2f5fa;
+  border-bottom: 1px solid #d8dde8;
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #566073;
+}
+
+.sth tbody th {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+  background: #ffffff;
+  font-weight: 600;
+  border-right: 1px solid #eef1f6;
+  border-bottom: 1px solid #f1f4f9;
+}
+
+/* the corner must outrank both, or the row header slides over it */
+.sth thead th:first-child { left: 0; z-index: 3; }
+
+.sth tbody td { border-bottom: 1px solid #f1f4f9; background: #ffffff; }
+.sth tbody tr:last-child th, .sth tbody tr:last-child td { border-bottom: 0; }
+
+@media (forced-colors: active) {
+  .sth thead th, .sth tbody th, .sth tbody td { background: Canvas; border-color: CanvasText; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .sth-wrap { color: #e6e9f2; }
+  .sth-lede { color: #98a1b3; }
+  .sth-scroll { border-color: #2a303c; }
+  .sth thead th { background: #1e2532; border-bottom-color: #333b4a; color: #98a1b3; }
+  .sth tbody th, .sth tbody td { background: #141821; border-bottom-color: #1e2532; }
+  .sth tbody th { border-right-color: #232a37; }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #68828.

Adds `submissions/examples/sticky-table-header-advk/` (`demo.html` + `style.css` + `README.md`).

A scrollable data table that pins both the header row and the first column, so
labels stay visible on both axes.

---

## Type of Change

- [x] 🧩 New component
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/examples/sticky-table-header-advk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A scrollable data table that pins both the header row and the first column, so
labels stay visible on both axes.

**How does a developer use it?**

```html
<div class="sth-scroll">
  <table class="sth">
    <thead><tr><th>Component</th><th>Size</th></tr></thead>
    <tbody><tr><th>fade</th><td>0.4 kB</td></tr></tbody>
  </table>
</div>
```

Row labels must be `<th>`, not `<td>`, for the column pinning to apply.

**Why does it fit EaseMotion CSS?**

Two-axis sticky headers are a common request and are usually abandoned because
the first attempt does not work. The reasons are specific and worth documenting.

`position: sticky` has no effect on table elements when `border-collapse:
collapse` is set — the collapsed border model reassigns borders to the table
itself, and the cells stop being positionable. Switching to `border-collapse:
separate` with `border-spacing: 0` keeps the visual result while making sticky
work.

The second trap is the corner cell. The header row and the first column each need
their own `z-index`, and the intersecting cell has to outrank both — otherwise the
row header scrolls over the corner and the top-left label disappears exactly when
it is most needed.

Because collapsed borders are unavailable, borders are applied per cell and the
last row's are removed individually, which is what keeps the rounded container
edge clean.

Using `<th>` for row labels also gives the table real row-header semantics, so a
screen reader announces the row name with each cell rather than reading bare
values.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- Passes the repository's own `stylelint` config with no errors; SCSS compiles with no deprecation warnings.
- Reduced-motion path on every stylesheet, and a `forced-colors` path wherever colour encodes state.
- Small additive diff — this submission is well under 200 lines.
- `-advk` suffix per the CONTRIBUTING uniqueness rule.
