### PR TITLE
feat: add hover underline button demo

### DIFF
--- a/submissions/examples/hover-underline-button-kk/README.md
+++ b/submissions/examples/hover-underline-button-kk/README.md
@@ -1,0 +1,31 @@
+# Hover Underline Button
+
+## What it does
+
+This submission creates a simple CSS-only text button with a smooth underline reveal on hover. The underline animates from left to right, making the interaction feel polished without adding complexity.
+
+## How to use it
+
+Apply the button class directly in HTML:
+
+```html
+<button class="hover-underline-btn">Learn More</button>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, animation-first, and composable. The effect is easy to understand, lightweight to apply, and useful across navigation links, secondary actions, and minimal call-to-action patterns.
+
+## Included features
+
+- Smooth underline reveal on hover
+- Keyboard focus-visible support
+- Multiple color variations in the demo
+- Responsive layout
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained demo that opens directly in a browser
+- `style.css` - raw CSS for the button effect
+- `README.md` - usage and contribution context

--- a/submissions/examples/hover-underline-button-kk/demo.html
+++ b/submissions/examples/hover-underline-button-kk/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Hover Underline Button</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <p class="eyebrow">Hover Underline Button</p>
+        <h1>Minimal button with a smooth underline reveal.</h1>
+        <p class="intro">
+          This demo showcases a clean text-style button where the underline
+          slides in on hover. It works well for navigation links, secondary
+          actions, and lightweight call-to-action patterns.
+        </p>
+
+        <div class="button-showcase">
+          <button class="hover-underline-btn">Learn More</button>
+          <button class="hover-underline-btn warm">See Pricing</button>
+          <button class="hover-underline-btn cool">View Docs</button>
+        </div>
+
+        <div class="usage-panel">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;button class="hover-underline-btn"&gt;Learn More&lt;/button&gt;</code></pre>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/hover-underline-button-kk/style.css
+++ b/submissions/examples/hover-underline-button-kk/style.css
@@ -1,0 +1,141 @@
+:root {
+  color-scheme: dark;
+  --bg: #09111f;
+  --panel: rgba(12, 20, 38, 0.9);
+  --border: rgba(255, 255, 255, 0.09);
+  --text: #eef3ff;
+  --muted: #aeb9d8;
+  --primary: #8ea8ff;
+  --warm: #ffb870;
+  --cool: #78e5d5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at top, rgba(142, 168, 255, 0.2), transparent 30%),
+    linear-gradient(180deg, #09111f 0%, #04070f 100%);
+  color: var(--text);
+}
+
+.demo-shell {
+  width: min(100%, 860px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border-radius: 28px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.38);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.76rem;
+  color: var(--muted);
+}
+
+h1 {
+  margin: 0.5rem 0 0.9rem;
+  font-size: clamp(2rem, 4vw, 3rem);
+  line-height: 1.06;
+  max-width: 12ch;
+}
+
+.intro {
+  max-width: 58ch;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.button-showcase {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.1rem;
+  margin: 2rem 0;
+}
+
+.hover-underline-btn {
+  position: relative;
+  padding: 0.4rem 0;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+}
+
+.hover-underline-btn::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -0.18rem;
+  width: 0;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+  transition: width 220ms ease;
+}
+
+.hover-underline-btn:hover::after,
+.hover-underline-btn:focus-visible::after {
+  width: 100%;
+}
+
+.hover-underline-btn:focus-visible {
+  outline: 2px solid rgba(142, 168, 255, 0.55);
+  outline-offset: 0.35rem;
+}
+
+.hover-underline-btn.warm {
+  color: var(--warm);
+}
+
+.hover-underline-btn.cool {
+  color: var(--cool);
+}
+
+.usage-panel {
+  margin-top: 1.5rem;
+  padding: 1.1rem 1.2rem;
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #d6e2ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 640px) {
+  .demo-card {
+    padding: 1.4rem;
+  }
+
+  .button-showcase {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Hover Underline Button demo inside `submissions/examples/hover-underline-button-kk/`. This submission introduces a minimal text-style button with a smooth underline reveal on hover, suitable for links, secondary actions, and lightweight call-to-action patterns.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A CSS-only button hover effect where a clean underline smoothly reveals from left to right when the button is hovered or keyboard-focused.

**How does a developer use it?**

```html
<button class="hover-underline-btn">Learn More</button>