### PR TITLE
Add ease-shopping-cart-badge component

### DIFF
--- a/submissions/examples/shopping-cart-badge-ij/README.md
+++ b/submissions/examples/shopping-cart-badge-ij/README.md
@@ -1,0 +1,11 @@
+# ease-shopping-cart-badge
+
+A shopping cart widget where the count badge pops, the cart bumps, and the note fades.
+
+## Run
+Open `demo.html` directly in a browser to watch the badge pop.
+
+## Notes
+- The item count badge pops on the cart.
+- The cart bumps as the item lands.
+- The added note fades in and out.

--- a/submissions/examples/shopping-cart-badge-ij/demo.html
+++ b/submissions/examples/shopping-cart-badge-ij/demo.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-shopping-cart-badge demo</title>
+</head>
+<body>
+<div class="scb-panel">
+  <div class="scb-cart">
+    <span class="scb-handle"></span>
+    <span class="scb-basket"></span>
+    <span class="scb-badge">3</span>
+  </div>
+  <span class="scb-note">ITEM ADDED</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/shopping-cart-badge-ij/style.css
+++ b/submissions/examples/shopping-cart-badge-ij/style.css
@@ -1,0 +1,10 @@
+.scb-panel{position:absolute;inset:0;background:#0f172a;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:30px}
+.scb-cart{position:relative;width:120px;height:110px}
+.scb-basket{position:absolute;left:14px;right:14px;bottom:6px;height:58px;background:#f59e0b;border-radius:4px 4px 14px 14px;animation:scb-cart-bump-shopping-cart-badge 2s ease-in-out infinite}
+.scb-basket::before{content:"";position:absolute;top:-16px;left:0;right:0;height:16px;background:#fbbf24;border-radius:14px 14px 0 0}
+.scb-handle{position:absolute;top:2px;left:36px;right:36px;height:22px;border:5px solid #fbbf24;border-bottom:none;border-radius:16px 16px 0 0;animation:scb-cart-bump-shopping-cart-badge 2s ease-in-out infinite}
+.scb-badge{position:absolute;top:-4px;right:-4px;width:30px;height:30px;border-radius:50%;background:#ef4444;color:#ffffff;font-size:13px;font-weight:800;display:grid;place-items:center;animation:scb-badge-pop-shopping-cart-badge 2s ease-in-out infinite}
+.scb-note{font-size:11px;font-weight:700;letter-spacing:6px;color:#34d399;animation:scb-note-in-shopping-cart-badge 2.4s ease-in-out infinite}
+@keyframes scb-badge-pop-shopping-cart-badge{0%{transform:scale(0.6)}35%{transform:scale(1.25)}70%{transform:scale(1)}100%{transform:scale(0.6)}}
+@keyframes scb-cart-bump-shopping-cart-badge{0%{transform:translateY(0)}30%{transform:translateY(-5px)}60%{transform:translateY(0)}100%{transform:translateY(0)}}
+@keyframes scb-note-in-shopping-cart-badge{0%{opacity:0;transform:translateY(8px)}25%{opacity:1;transform:translateY(0)}75%{opacity:1}100%{opacity:0;transform:translateY(-8px)}}


### PR DESCRIPTION
## Component: ease-shopping-cart-badge — badge pops, cart bumps, and note fades

**Closes #68898**

### What this adds
A shopping cart widget: the item-count badge pops when a product is added, the cart bumps down, and the added note fades in and out.

### Acceptance Criteria covered
- Item count badge pops on the cart
- Cart bumps as the item lands
- Added note fades in and out

### Files
- `submissions/examples/shopping-cart-badge-ij/demo.html`
- `submissions/examples/shopping-cart-badge-ij/style.css`
- `submissions/examples/shopping-cart-badge-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the badge pop.