### PR TITLE
Add ease-command-palette-search component

### DIFF
--- a/submissions/examples/command-palette-search-ij/README.md
+++ b/submissions/examples/command-palette-search-ij/README.md
@@ -1,0 +1,11 @@
+# ease-command-palette-search
+
+A command palette where the caret blinks, the hit row sweeps, and the keys tap.
+
+## Run
+Open `demo.html` directly in a browser to watch the palette.
+
+## Notes
+- The caret blinks in the search field.
+- The highlighted row sweeps on the left edge.
+- The shortcut keys tap in turn.

--- a/submissions/examples/command-palette-search-ij/demo.html
+++ b/submissions/examples/command-palette-search-ij/demo.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-command-palette-search demo</title>
+</head>
+<body>
+<div class="cps-palette">
+  <div class="cps-inputrow">
+    <span class="cps-prompt">&gt;</span>
+    <input class="cps-input" value="open settings" readonly>
+    <span class="cps-caret"></span>
+  </div>
+  <div class="cps-results">
+    <div class="cps-row cps-hit"><span>Open settings</span><kbd class="cps-key">G,S</kbd></div>
+    <div class="cps-row"><span>New file</span><kbd class="cps-key">N</kbd></div>
+    <div class="cps-row"><span>Toggle theme</span><kbd class="cps-key">T</kbd></div>
+    <div class="cps-row"><span>Run tests</span><kbd class="cps-key">R</kbd></div>
+  </div>
+  <span class="cps-foot">Type to filter commands</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/command-palette-search-ij/style.css
+++ b/submissions/examples/command-palette-search-ij/style.css
@@ -1,0 +1,13 @@
+.cps-palette{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:420px;background:#101b2c;border:1px solid #24364d;border-radius:12px;overflow:hidden}
+.cps-inputrow{display:flex;align-items:center;gap:10px;padding:14px 16px;border-bottom:1px solid #24364d}
+.cps-prompt{font-size:14px;font-weight:800;color:#3b82f6}
+.cps-input{flex:1;background:none;border:none;outline:none;color:#e8f0f8;font-size:14px;font-family:inherit}
+.cps-caret{width:2px;height:16px;background:#3b82f6;animation:cps-caret-blink-command-palette-search 1s steps(2) infinite}
+.cps-results{display:flex;flex-direction:column;padding:8px}
+.cps-row{display:flex;align-items:center;justify-content:space-between;padding:10px 12px;border-radius:8px;font-size:13px;color:#c3d3e3}
+.cps-hit{background:#16263b;color:#ffffff;animation:cps-row-sweep-command-palette-search 2s ease-in-out infinite}
+.cps-key{font-size:10px;font-weight:700;color:#8aa1b8;border:1px solid #2a3c52;border-radius:5px;padding:2px 7px;animation:cps-key-tap-command-palette-search 2.4s ease-in-out infinite}
+.cps-foot{padding:9px 16px;font-size:10px;color:#5d7690;border-top:1px solid #24364d;letter-spacing:1px}
+@keyframes cps-caret-blink-command-palette-search{0%{opacity:1}50%{opacity:0}100%{opacity:1}}
+@keyframes cps-row-sweep-command-palette-search{0%{box-shadow:inset 0 0 0 rgba(59,130,246,0)}40%{box-shadow:inset 3px 0 0 #3b82f6}100%{box-shadow:inset 0 0 0 rgba(59,130,246,0)}}
+@keyframes cps-key-tap-command-palette-search{0%{transform:translateY(0)}30%{transform:translateY(-2px)}60%{transform:translateY(0)}100%{transform:translateY(0)}}


### PR DESCRIPTION
## Component: ease-command-palette-search — caret blinks, row highlights, and keys tap

**Closes #68912**

### What this adds
A command palette: the caret blinks in the search field, the top result row highlights with a sweep, and the shortcut keys tap in turn.

### Acceptance Criteria covered
- Caret blinks in the search field
- Highlighted result row sweeps
- Shortcut keys tap in turn

### Files
- `submissions/examples/command-palette-search-ij/demo.html`
- `submissions/examples/command-palette-search-ij/style.css`
- `submissions/examples/command-palette-search-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the caret blink.