### PR TITLE
Add ease-kanban-board-columns component

### DIFF
--- a/submissions/examples/kanban-board-columns-ij/README.md
+++ b/submissions/examples/kanban-board-columns-ij/README.md
@@ -1,0 +1,11 @@
+# ease-kanban-board-columns
+
+A kanban board where the cards drop in, the header underlines sweep, and the done cards blink.
+
+## Run
+Open `demo.html` directly in a browser to watch the board.
+
+## Notes
+- Cards drop into their columns.
+- Header underlines sweep across.
+- Done cards blink softly.

--- a/submissions/examples/kanban-board-columns-ij/demo.html
+++ b/submissions/examples/kanban-board-columns-ij/demo.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-kanban-board-columns demo</title>
+</head>
+<body>
+<div class="kbb-board">
+  <div class="kbb-col">
+    <span class="kbb-head">TO DO</span>
+    <div class="kbb-card">Wireframe checkout</div>
+    <div class="kbb-card">Write API docs</div>
+    <div class="kbb-card">Design empty state</div>
+  </div>
+  <div class="kbb-col">
+    <span class="kbb-head">IN PROGRESS</span>
+    <div class="kbb-card kbb-live">Payment flow</div>
+    <div class="kbb-card kbb-live">Auth tokens</div>
+  </div>
+  <div class="kbb-col">
+    <span class="kbb-head">DONE</span>
+    <div class="kbb-card kbb-done">Logo refresh</div>
+    <div class="kbb-card kbb-done">Landing page</div>
+    <div class="kbb-card kbb-done">Color tokens</div>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/kanban-board-columns-ij/style.css
+++ b/submissions/examples/kanban-board-columns-ij/style.css
@@ -1,0 +1,10 @@
+.kbb-board{position:absolute;inset:0;background:#0f172a;display:grid;grid-template-columns:repeat(3,1fr);gap:16px;padding:20px}
+.kbb-col{background:#16233a;border-radius:12px;padding:14px;display:flex;flex-direction:column;gap:10px}
+.kbb-head{font-size:11px;font-weight:800;letter-spacing:2px;color:#94a8bd;padding-bottom:10px;border-bottom:2px solid #22344c;position:relative}
+.kbb-head::after{content:"";position:absolute;left:0;bottom:-2px;width:38px;height:2px;background:#38bdf8;animation:kbb-head-line-kanban-board-columns 2.2s ease-in-out infinite}
+.kbb-card{background:#1e3048;border-radius:8px;padding:12px 14px;font-size:12px;color:#dbe7f3;animation:kbb-card-in-kanban-board-columns 0.6s ease-out both}
+.kbb-live{border-left:3px solid #38bdf8}
+.kbb-done{color:#7ecfa5;animation:kbb-done-blink-kanban-board-columns 2s ease-in-out infinite}
+@keyframes kbb-card-in-kanban-board-columns{0%{opacity:0;transform:translateY(-10px)}100%{opacity:1;transform:translateY(0)}}
+@keyframes kbb-head-line-kanban-board-columns{0%{transform:translateX(0);opacity:0.4}50%{transform:translateX(96px);opacity:1}100%{transform:translateX(0);opacity:0.4}}
+@keyframes kbb-done-blink-kanban-board-columns{0%{opacity:1}50%{opacity:0.45}100%{opacity:1}}


### PR DESCRIPTION
## Component: ease-kanban-board-columns — cards drop in, headers underline, and done blinks

**Closes #68918**

### What this adds
A kanban board: cards drop into their columns, each header underline sweeps across, and the done cards blink softly.

### Acceptance Criteria covered
- Cards drop into their columns
- Header underlines sweep across
- Done cards blink softly

### Files
- `submissions/examples/kanban-board-columns-ij/demo.html`
- `submissions/examples/kanban-board-columns-ij/style.css`
- `submissions/examples/kanban-board-columns-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the cards drop.