### PR TITLE
feat: add CSS meeting time slots #68616

### DIFF
--- a/submissions/examples/meeting-time-slots/README.md
+++ b/submissions/examples/meeting-time-slots/README.md
@@ -1,0 +1,28 @@
+# CSS Meeting Time Slots
+
+**Issue:** #68616
+
+A responsive and accessible meeting time-slot picker built using pure HTML and CSS.
+
+## ✨ Features
+
+- Pure HTML and CSS
+- No JavaScript required
+- Date selection using native radio controls
+- Morning, afternoon, and evening time groups
+- Available and booked states
+- Animated selected states
+- Responsive layout
+- Keyboard-friendly controls
+- Visible focus states
+- Accessible labels
+- `prefers-reduced-motion` support
+- Modern glass-style UI
+
+## 📁 Files
+
+```text
+meeting-time-slots/
+├── demo.html
+├── style.css
+└── README.md

--- a/submissions/examples/meeting-time-slots/demo.html
+++ b/submissions/examples/meeting-time-slots/demo.html
@@ -1,0 +1,350 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta
+    name="viewport"
+    content="width=device-width, initial-scale=1.0"
+  >
+  <meta
+    name="description"
+    content="Accessible CSS-only meeting time slot picker"
+  >
+  <title>CSS Meeting Time Slots</title>
+
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+  <main class="scheduler" aria-labelledby="scheduler-title">
+
+    <header class="scheduler__header">
+      <div>
+        <span class="scheduler__eyebrow">SCHEDULE A MEETING</span>
+        <h1 id="scheduler-title">Choose a time</h1>
+        <p>
+          Select a date and an available time slot that works for you.
+        </p>
+      </div>
+
+      <div class="timezone" aria-label="Current timezone">
+        <span aria-hidden="true">◷</span>
+        <span>IST · UTC+5:30</span>
+      </div>
+    </header>
+
+    <!-- Date selection -->
+    <section class="date-picker" aria-labelledby="date-heading">
+
+      <div class="section-heading">
+        <h2 id="date-heading">Select a date</h2>
+        <span>August 2026</span>
+      </div>
+
+      <div class="dates" role="radiogroup" aria-label="Available dates">
+
+        <div class="date-option">
+          <input
+            type="radio"
+            name="date"
+            id="date-10"
+            checked
+          >
+          <label for="date-10">
+            <span class="date-option__day">MON</span>
+            <strong>10</strong>
+            <span class="date-option__month">AUG</span>
+          </label>
+        </div>
+
+        <div class="date-option">
+          <input type="radio" name="date" id="date-11">
+          <label for="date-11">
+            <span class="date-option__day">TUE</span>
+            <strong>11</strong>
+            <span class="date-option__month">AUG</span>
+          </label>
+        </div>
+
+        <div class="date-option">
+          <input type="radio" name="date" id="date-12">
+          <label for="date-12">
+            <span class="date-option__day">WED</span>
+            <strong>12</strong>
+            <span class="date-option__month">AUG</span>
+          </label>
+        </div>
+
+        <div class="date-option">
+          <input type="radio" name="date" id="date-13">
+          <label for="date-13">
+            <span class="date-option__day">THU</span>
+            <strong>13</strong>
+            <span class="date-option__month">AUG</span>
+          </label>
+        </div>
+
+        <div class="date-option">
+          <input type="radio" name="date" id="date-14">
+          <label for="date-14">
+            <span class="date-option__day">FRI</span>
+            <strong>14</strong>
+            <span class="date-option__month">AUG</span>
+          </label>
+        </div>
+
+      </div>
+    </section>
+
+    <!-- Time slots -->
+    <section class="time-picker" aria-labelledby="time-heading">
+
+      <div class="section-heading">
+        <h2 id="time-heading">Available time slots</h2>
+        <span>30 min meeting</span>
+      </div>
+
+      <!-- Morning -->
+      <fieldset class="slot-group">
+        <legend>
+          <span aria-hidden="true">☀</span>
+          Morning
+        </legend>
+
+        <div class="slot-grid">
+
+          <div class="slot">
+            <input
+              type="radio"
+              name="time"
+              id="time-0900"
+            >
+            <label for="time-0900">
+              <span>09:00 AM</span>
+              <small>Available</small>
+            </label>
+          </div>
+
+          <div class="slot">
+            <input
+              type="radio"
+              name="time"
+              id="time-0930"
+            >
+            <label for="time-0930">
+              <span>09:30 AM</span>
+              <small>Available</small>
+            </label>
+          </div>
+
+          <div class="slot slot--disabled">
+            <input
+              type="radio"
+              name="time"
+              id="time-1000"
+              disabled
+            >
+            <label for="time-1000">
+              <span>10:00 AM</span>
+              <small>Booked</small>
+            </label>
+          </div>
+
+          <div class="slot">
+            <input
+              type="radio"
+              name="time"
+              id="time-1030"
+            >
+            <label for="time-1030">
+              <span>10:30 AM</span>
+              <small>Available</small>
+            </label>
+          </div>
+
+          <div class="slot">
+            <input
+              type="radio"
+              name="time"
+              id="time-1100"
+            >
+            <label for="time-1100">
+              <span>11:00 AM</span>
+              <small>Available</small>
+            </label>
+          </div>
+
+        </div>
+      </fieldset>
+
+      <!-- Afternoon -->
+      <fieldset class="slot-group">
+        <legend>
+          <span aria-hidden="true">◐</span>
+          Afternoon
+        </legend>
+
+        <div class="slot-grid">
+
+          <div class="slot">
+            <input
+              type="radio"
+              name="time"
+              id="time-1200"
+            >
+            <label for="time-1200">
+              <span>12:00 PM</span>
+              <small>Available</small>
+            </label>
+          </div>
+
+          <div class="slot">
+            <input
+              type="radio"
+              name="time"
+              id="time-1230"
+            >
+            <label for="time-1230">
+              <span>12:30 PM</span>
+              <small>Available</small>
+            </label>
+          </div>
+
+          <div class="slot slot--disabled">
+            <input
+              type="radio"
+              name="time"
+              id="time-0100"
+              disabled
+            >
+            <label for="time-0100">
+              <span>01:00 PM</span>
+              <small>Booked</small>
+            </label>
+          </div>
+
+          <div class="slot">
+            <input
+              type="radio"
+              name="time"
+              id="time-0130"
+            >
+            <label for="time-0130">
+              <span>01:30 PM</span>
+              <small>Available</small>
+            </label>
+          </div>
+
+          <div class="slot">
+            <input
+              type="radio"
+              name="time"
+              id="time-0200"
+            >
+            <label for="time-0200">
+              <span>02:00 PM</span>
+              <small>Available</small>
+            </label>
+          </div>
+
+          <div class="slot">
+            <input
+              type="radio"
+              name="time"
+              id="time-0230"
+            >
+            <label for="time-0230">
+              <span>02:30 PM</span>
+              <small>Available</small>
+            </label>
+          </div>
+
+        </div>
+      </fieldset>
+
+      <!-- Evening -->
+      <fieldset class="slot-group">
+        <legend>
+          <span aria-hidden="true">☾</span>
+          Evening
+        </legend>
+
+        <div class="slot-grid">
+
+          <div class="slot">
+            <input
+              type="radio"
+              name="time"
+              id="time-0500"
+            >
+            <label for="time-0500">
+              <span>05:00 PM</span>
+              <small>Available</small>
+            </label>
+          </div>
+
+          <div class="slot">
+            <input
+              type="radio"
+              name="time"
+              id="time-0530"
+            >
+            <label for="time-0530">
+              <span>05:30 PM</span>
+              <small>Available</small>
+            </label>
+          </div>
+
+          <div class="slot">
+            <input
+              type="radio"
+              name="time"
+              id="time-0600"
+            >
+            <label for="time-0600">
+              <span>06:00 PM</span>
+              <small>Available</small>
+            </label>
+          </div>
+
+          <div class="slot slot--disabled">
+            <input
+              type="radio"
+              name="time"
+              id="time-0630"
+              disabled
+            >
+            <label for="time-0630">
+              <span>06:30 PM</span>
+              <small>Booked</small>
+            </label>
+          </div>
+
+        </div>
+      </fieldset>
+
+    </section>
+
+    <!-- Summary -->
+    <aside class="booking-summary" aria-label="Booking summary">
+
+      <div class="summary-icon" aria-hidden="true">✓</div>
+
+      <div class="summary-content">
+        <span class="summary-label">SELECTED SLOT</span>
+        <strong>Monday, August 10 · 09:00 AM</strong>
+        <small>30 minutes · IST (UTC+5:30)</small>
+      </div>
+
+      <button type="button" class="confirm-button">
+        Confirm time
+        <span aria-hidden="true">→</span>
+      </button>
+
+    </aside>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/meeting-time-slots/style.css
+++ b/submissions/examples/meeting-time-slots/style.css
@@ -1,0 +1,674 @@
+/* =========================================================
+   CSS MEETING TIME SLOTS
+   Pure CSS · Responsive · Accessible
+   ========================================================= */
+
+   :root {
+    --bg: #07111f;
+    --surface: #0d1b2d;
+    --surface-light: #13243a;
+    --border: rgba(255, 255, 255, 0.10);
+    --border-hover: rgba(255, 255, 255, 0.22);
+  
+    --text: #f4f7fb;
+    --muted: #8fa1b7;
+  
+    --accent: #69e6c4;
+    --accent-dark: #123b34;
+  
+    --danger: #7f8b9c;
+  
+    --radius-lg: 24px;
+    --radius-md: 15px;
+    --radius-sm: 10px;
+  
+    --shadow:
+      0 24px 70px rgba(0, 0, 0, 0.35);
+  
+    --transition:
+      180ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  }
+  
+  /* =========================
+     RESET
+     ========================= */
+  
+  * {
+    box-sizing: border-box;
+  }
+  
+  html {
+    scroll-behavior: smooth;
+  }
+  
+  body {
+    min-height: 100vh;
+    margin: 0;
+  
+    display: grid;
+    place-items: center;
+  
+    padding: 32px 16px;
+  
+    font-family:
+      Inter,
+      ui-sans-serif,
+      system-ui,
+      -apple-system,
+      BlinkMacSystemFont,
+      "Segoe UI",
+      sans-serif;
+  
+    color: var(--text);
+  
+    background:
+      radial-gradient(
+        circle at 15% 10%,
+        rgba(105, 230, 196, 0.08),
+        transparent 28rem
+      ),
+      radial-gradient(
+        circle at 90% 90%,
+        rgba(100, 130, 255, 0.08),
+        transparent 28rem
+      ),
+      var(--bg);
+  }
+  
+  /* =========================
+     MAIN CONTAINER
+     ========================= */
+  
+  .scheduler {
+    width: min(100%, 960px);
+  
+    padding: clamp(22px, 4vw, 42px);
+  
+    background:
+      linear-gradient(
+        145deg,
+        rgba(255, 255, 255, 0.035),
+        rgba(255, 255, 255, 0.012)
+      ),
+      var(--surface);
+  
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+  
+    box-shadow: var(--shadow);
+  
+    animation: scheduler-enter 650ms ease both;
+  }
+  
+  @keyframes scheduler-enter {
+    from {
+      opacity: 0;
+      transform: translateY(20px) scale(0.985);
+    }
+  
+    to {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
+  }
+  
+  /* =========================
+     HEADER
+     ========================= */
+  
+  .scheduler__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+  
+    gap: 24px;
+  
+    padding-bottom: 32px;
+  
+    border-bottom: 1px solid var(--border);
+  }
+  
+  .scheduler__eyebrow {
+    display: inline-block;
+  
+    margin-bottom: 8px;
+  
+    color: var(--accent);
+  
+    font-size: 0.72rem;
+    font-weight: 800;
+  
+    letter-spacing: 0.16em;
+  }
+  
+  .scheduler h1 {
+    margin: 0;
+  
+    font-size: clamp(2rem, 5vw, 3rem);
+    line-height: 1.05;
+  
+    letter-spacing: -0.04em;
+  }
+  
+  .scheduler__header p {
+    max-width: 560px;
+  
+    margin: 12px 0 0;
+  
+    color: var(--muted);
+  
+    line-height: 1.6;
+  }
+  
+  .timezone {
+    flex-shrink: 0;
+  
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  
+    padding: 10px 13px;
+  
+    border: 1px solid var(--border);
+    border-radius: 999px;
+  
+    color: var(--muted);
+  
+    font-size: 0.78rem;
+  }
+  
+  /* =========================
+     SECTION HEADING
+     ========================= */
+  
+  .date-picker,
+  .time-picker {
+    padding-top: 32px;
+  }
+  
+  .section-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  
+    gap: 16px;
+  
+    margin-bottom: 18px;
+  }
+  
+  .section-heading h2 {
+    margin: 0;
+  
+    font-size: 1rem;
+    letter-spacing: -0.01em;
+  }
+  
+  .section-heading > span {
+    color: var(--muted);
+  
+    font-size: 0.8rem;
+  }
+  
+  /* =========================
+     DATE PICKER
+     ========================= */
+  
+  .dates {
+    display: grid;
+  
+    grid-template-columns:
+      repeat(5, minmax(0, 1fr));
+  
+    gap: 10px;
+  }
+  
+  .date-option {
+    position: relative;
+  }
+  
+  .date-option input {
+    position: absolute;
+  
+    width: 1px;
+    height: 1px;
+  
+    opacity: 0;
+  }
+  
+  .date-option label {
+    min-height: 112px;
+  
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+  
+    gap: 5px;
+  
+    padding: 14px;
+  
+    cursor: pointer;
+  
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+  
+    background: rgba(255, 255, 255, 0.015);
+  
+    transition:
+      transform var(--transition),
+      border-color var(--transition),
+      background var(--transition),
+      box-shadow var(--transition);
+  }
+  
+  .date-option label:hover {
+    transform: translateY(-3px);
+  
+    border-color: var(--border-hover);
+  
+    background: rgba(255, 255, 255, 0.04);
+  }
+  
+  .date-option__day,
+  .date-option__month {
+    color: var(--muted);
+  
+    font-size: 0.68rem;
+    font-weight: 800;
+  
+    letter-spacing: 0.12em;
+  }
+  
+  .date-option strong {
+    font-size: 1.65rem;
+  }
+  
+  /* Checked date */
+  
+  .date-option input:checked + label {
+    border-color: var(--accent);
+  
+    background:
+      linear-gradient(
+        145deg,
+        rgba(105, 230, 196, 0.16),
+        rgba(105, 230, 196, 0.04)
+      );
+  
+    box-shadow:
+      inset 0 0 0 1px rgba(105, 230, 196, 0.08),
+      0 10px 30px rgba(105, 230, 196, 0.06);
+  }
+  
+  .date-option input:checked + label strong {
+    color: var(--accent);
+  }
+  
+  /* Keyboard focus */
+  
+  .date-option input:focus-visible + label {
+    outline: 3px solid rgba(105, 230, 196, 0.35);
+    outline-offset: 3px;
+  }
+  
+  /* =========================
+     TIME GROUP
+     ========================= */
+  
+  .slot-group {
+    min-width: 0;
+  
+    margin: 0 0 26px;
+    padding: 0;
+  
+    border: 0;
+  }
+  
+  .slot-group legend {
+    display: flex;
+    align-items: center;
+  
+    gap: 8px;
+  
+    margin-bottom: 12px;
+  
+    color: var(--muted);
+  
+    font-size: 0.82rem;
+    font-weight: 700;
+  }
+  
+  /* =========================
+     TIME GRID
+     ========================= */
+  
+  .slot-grid {
+    display: grid;
+  
+    grid-template-columns:
+      repeat(4, minmax(0, 1fr));
+  
+    gap: 10px;
+  }
+  
+  .slot {
+    position: relative;
+  }
+  
+  .slot input {
+    position: absolute;
+  
+    width: 1px;
+    height: 1px;
+  
+    opacity: 0;
+  }
+  
+  .slot label {
+    min-height: 74px;
+  
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  
+    gap: 5px;
+  
+    padding: 14px;
+  
+    cursor: pointer;
+  
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+  
+    background: rgba(255, 255, 255, 0.015);
+  
+    transition:
+      transform var(--transition),
+      border-color var(--transition),
+      background var(--transition),
+      box-shadow var(--transition);
+  }
+  
+  .slot label span {
+    font-size: 0.9rem;
+    font-weight: 750;
+  }
+  
+  .slot label small {
+    color: var(--muted);
+  
+    font-size: 0.68rem;
+  }
+  
+  /* Hover */
+  
+  .slot:not(.slot--disabled) label:hover {
+    transform: translateY(-2px);
+  
+    border-color: var(--border-hover);
+  
+    background: rgba(255, 255, 255, 0.04);
+  }
+  
+  /* Checked */
+  
+  .slot input:checked + label {
+    border-color: var(--accent);
+  
+    background:
+      linear-gradient(
+        135deg,
+        rgba(105, 230, 196, 0.16),
+        rgba(105, 230, 196, 0.035)
+      );
+  
+    box-shadow:
+      0 0 0 1px rgba(105, 230, 196, 0.08),
+      0 12px 30px rgba(105, 230, 196, 0.07);
+  
+    animation: slot-selected 220ms ease both;
+  }
+  
+  .slot input:checked + label span {
+    color: var(--accent);
+  }
+  
+  @keyframes slot-selected {
+    from {
+      transform: scale(0.97);
+    }
+  
+    to {
+      transform: scale(1);
+    }
+  }
+  
+  /* Keyboard focus */
+  
+  .slot input:focus-visible + label {
+    outline: 3px solid rgba(105, 230, 196, 0.35);
+    outline-offset: 3px;
+  }
+  
+  /* Disabled */
+  
+  .slot--disabled label {
+    cursor: not-allowed;
+  
+    opacity: 0.38;
+  
+    background:
+      repeating-linear-gradient(
+        -45deg,
+        transparent,
+        transparent 6px,
+        rgba(255, 255, 255, 0.018) 6px,
+        rgba(255, 255, 255, 0.018) 12px
+      );
+  }
+  
+  .slot--disabled label small {
+    color: var(--danger);
+  }
+  
+  /* =========================
+     BOOKING SUMMARY
+     ========================= */
+  
+  .booking-summary {
+    display: flex;
+    align-items: center;
+  
+    gap: 16px;
+  
+    margin-top: 10px;
+    padding: 18px;
+  
+    border: 1px solid rgba(105, 230, 196, 0.18);
+    border-radius: var(--radius-md);
+  
+    background:
+      linear-gradient(
+        120deg,
+        rgba(105, 230, 196, 0.08),
+        rgba(105, 230, 196, 0.025)
+      );
+  }
+  
+  .summary-icon {
+    width: 42px;
+    height: 42px;
+  
+    flex-shrink: 0;
+  
+    display: grid;
+    place-items: center;
+  
+    border-radius: 50%;
+  
+    color: var(--accent);
+  
+    background: rgba(105, 230, 196, 0.12);
+  
+    font-weight: 900;
+  }
+  
+  .summary-content {
+    min-width: 0;
+  
+    display: flex;
+    flex-direction: column;
+  
+    gap: 4px;
+  
+    flex: 1;
+  }
+  
+  .summary-label {
+    color: var(--accent);
+  
+    font-size: 0.65rem;
+    font-weight: 900;
+  
+    letter-spacing: 0.14em;
+  }
+  
+  .summary-content strong {
+    font-size: 0.9rem;
+  }
+  
+  .summary-content small {
+    color: var(--muted);
+  }
+  
+  .confirm-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  
+    gap: 10px;
+  
+    min-height: 46px;
+  
+    padding: 0 18px;
+  
+    border: 0;
+    border-radius: 12px;
+  
+    cursor: pointer;
+  
+    color: #06120f;
+    background: var(--accent);
+  
+    font: inherit;
+    font-size: 0.85rem;
+    font-weight: 850;
+  
+    transition:
+      transform var(--transition),
+      box-shadow var(--transition);
+  }
+  
+  .confirm-button:hover {
+    transform: translateY(-2px);
+  
+    box-shadow:
+      0 10px 30px rgba(105, 230, 196, 0.2);
+  }
+  
+  .confirm-button:active {
+    transform: translateY(0);
+  }
+  
+  .confirm-button:focus-visible {
+    outline: 3px solid rgba(105, 230, 196, 0.4);
+    outline-offset: 3px;
+  }
+  
+  /* =========================
+     RESPONSIVE
+     ========================= */
+  
+  @media (max-width: 760px) {
+  
+    body {
+      padding: 14px;
+    }
+  
+    .scheduler {
+      padding: 22px 18px;
+    }
+  
+    .scheduler__header {
+      flex-direction: column;
+    }
+  
+    .timezone {
+      align-self: flex-start;
+    }
+  
+    .dates {
+      grid-template-columns:
+        repeat(5, minmax(72px, 1fr));
+  
+      overflow-x: auto;
+  
+      padding-bottom: 6px;
+    }
+  
+    .date-option label {
+      min-height: 96px;
+    }
+  
+    .slot-grid {
+      grid-template-columns:
+        repeat(2, minmax(0, 1fr));
+    }
+  
+    .booking-summary {
+      align-items: flex-start;
+      flex-wrap: wrap;
+    }
+  
+    .confirm-button {
+      width: 100%;
+    }
+  }
+  
+  @media (max-width: 430px) {
+  
+    .section-heading {
+      align-items: flex-start;
+      flex-direction: column;
+  
+      gap: 5px;
+    }
+  
+    .slot label {
+      min-height: 68px;
+  
+      padding: 11px;
+    }
+  
+    .booking-summary {
+      padding: 15px;
+    }
+  }
+  
+  /* =========================
+     REDUCED MOTION
+     ========================= */
+  
+  @media (prefers-reduced-motion: reduce) {
+  
+    *,
+    *::before,
+    *::after {
+      scroll-behavior: auto !important;
+  
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+  
+      transition-duration: 0.01ms !important;
+    }
+  }


### PR DESCRIPTION
## Description

Implemented the CSS Meeting Time Slots component for issue #68616.

### Changes

* Added responsive meeting time-slot picker
* Added date selection using native radio controls
* Added morning, afternoon, and evening time groups
* Added available and booked states
* Added selected-state animations
* Added keyboard focus states
* Added responsive mobile layout
* Added `prefers-reduced-motion` support
* Added accessible semantic HTML
* Added `README.md` documentation

### Files Added

* `submissions/examples/meeting-time-slots/demo.html`
* `submissions/examples/meeting-time-slots/style.css`
* `submissions/examples/meeting-time-slots/README.md`

### Technical Details

The component is implemented using pure HTML and CSS without JavaScript.

Native radio controls are used for date and time selection, while CSS
selectors such as `:checked` provide the interactive visual states.

### Testing

* Tested desktop responsive layout
* Tested mobile responsive layout
* Tested keyboard focus states
* Tested disabled time slots
* Tested reduced-motion preference
* Verified that no JavaScript is required

Closes #68616
