### PR TITLE
feat: add CSS download button with progress

### DIFF
--- a/submissions/examples/css-download-button-progress/README.md
+++ b/submissions/examples/css-download-button-progress/README.md
@@ -1,0 +1,102 @@
+# CSS Download Button with Progress
+
+A responsive CSS-only download button that transforms into an animated progress bar and completed state when activated.
+
+## Features
+
+* Pure HTML and CSS
+* No JavaScript required
+* Animated download-to-progress transition
+* Animated progress indicator
+* Completed/downloaded state
+* Keyboard-accessible native checkbox control
+* Visible focus indicator
+* Responsive design
+* Reduced-motion support
+* No external dependencies
+
+## Files
+
+```text
+css-download-button-progress/
+├── demo.html
+├── style.css
+└── README.md
+```
+
+## How It Works
+
+The component uses a visually hidden native checkbox as the interaction state.
+
+When the checkbox is activated:
+
+1. The initial Download state fades out.
+2. The button changes into a progress state.
+3. The progress bar animates from 0% to 100%.
+4. The button changes to a completed state.
+5. A checkmark indicates that the simulated download has finished.
+
+CSS `:checked` selectors and `@keyframes` are used to control the entire visual transition.
+
+## Usage
+
+Open `demo.html` in a modern web browser.
+
+No build tools, JavaScript, external libraries, or dependencies are required.
+
+## Accessibility
+
+The component provides:
+
+* A native checkbox for keyboard interaction
+* An associated `<label>` for activation
+* Visible `:focus-visible` styling
+* Semantic button labeling
+* Responsive layout
+* `prefers-reduced-motion` support
+
+## Customization
+
+The main colors and sizing can be customized using CSS variables:
+
+```css
+:root {
+    --primary: #6366f1;
+    --primary-dark: #4f46e5;
+    --track: #e2e8f0;
+    --success: #16a34a;
+}
+```
+
+You can also customize:
+
+* Download duration
+* Button width
+* Progress-bar height
+* Border radius
+* Hover effects
+* Completion animation
+* Typography
+
+## Important Limitation
+
+This implementation provides a CSS-only **visual download progress simulation**.
+
+CSS cannot detect the actual progress of a file download. For a real download workflow with actual percentage updates, JavaScript and a download API would be required.
+
+## Technologies
+
+* HTML5
+* CSS3
+* CSS Animations
+* CSS Transitions
+* CSS Custom Properties
+* CSS Media Queries
+
+## Browser Support
+
+Designed for modern browsers supporting CSS custom properties, transitions, animations, pseudo-classes, and media queries.
+
+## License
+
+This example follows the EaseMotion CSS repository's contribution and licensing guidelines.

--- a/submissions/examples/css-download-button-progress/demo.html
+++ b/submissions/examples/css-download-button-progress/demo.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta
+        name="description"
+        content="CSS-only download button with animated progress state"
+    >
+    <title>CSS Download Button with Progress</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<main class="page">
+    <section class="demo-card" aria-labelledby="title">
+        <span class="badge">EaseMotion CSS</span>
+
+        <h1 id="title">Download Button</h1>
+
+        <p class="description">
+            A CSS-only download button that transforms into an animated
+            progress indicator when activated.
+        </p>
+
+        <div class="download-wrapper">
+            <input
+                type="checkbox"
+                id="download-toggle"
+                class="download-toggle"
+            >
+
+            <label
+                for="download-toggle"
+                class="download-button"
+                aria-label="Start download"
+            >
+                <span class="download-content">
+                    <svg
+                        class="download-icon"
+                        viewBox="0 0 24 24"
+                        aria-hidden="true"
+                    >
+                        <path
+                            d="M12 3v12m0 0 5-5m-5 5-5-5M5 21h14"
+                        />
+                    </svg>
+
+                    <span class="button-text">Download</span>
+                </span>
+
+                <span class="progress-content">
+                    <span class="progress-track">
+                        <span class="progress-fill"></span>
+                    </span>
+
+                    <span class="progress-text">Downloading...</span>
+                </span>
+
+                <span class="complete-content">
+                    <svg
+                        class="check-icon"
+                        viewBox="0 0 24 24"
+                        aria-hidden="true"
+                    >
+                        <path d="m5 12 4 4L19 6" />
+                    </svg>
+
+                    <span>Downloaded</span>
+                </span>
+            </label>
+        </div>
+
+        <p class="hint">
+            Click the button to preview the CSS animation.
+        </p>
+    </section>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/css-download-button-progress/style.css
+++ b/submissions/examples/css-download-button-progress/style.css
@@ -1,0 +1,333 @@
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+:root {
+    --background: #f4f7fb;
+    --surface: #ffffff;
+    --text: #172033;
+    --muted: #64748b;
+    --primary: #6366f1;
+    --primary-dark: #4f46e5;
+    --track: #e2e8f0;
+    --success: #16a34a;
+}
+
+body {
+    min-height: 100vh;
+    font-family:
+        Inter,
+        ui-sans-serif,
+        system-ui,
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        sans-serif;
+    background: var(--background);
+    color: var(--text);
+}
+
+.page {
+    min-height: 100vh;
+    display: grid;
+    place-items: center;
+    padding: 2rem 1rem;
+}
+
+.demo-card {
+    width: min(620px, 100%);
+    padding: clamp(1.5rem, 5vw, 3rem);
+    text-align: center;
+    background: var(--surface);
+    border: 1px solid #dbe3ee;
+    border-radius: 24px;
+    box-shadow: 0 20px 60px rgba(15, 23, 42, 0.08);
+}
+
+.badge {
+    display: inline-block;
+    margin-bottom: 1rem;
+    padding: 0.4rem 0.85rem;
+    border-radius: 999px;
+    background: #eef2ff;
+    color: var(--primary-dark);
+    font-size: 0.8rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+h1 {
+    margin-bottom: 0.75rem;
+    font-size: clamp(2rem, 5vw, 3rem);
+}
+
+.description {
+    max-width: 500px;
+    margin: 0 auto;
+    color: var(--muted);
+    line-height: 1.7;
+}
+
+.download-wrapper {
+    display: flex;
+    justify-content: center;
+    margin: 2.5rem 0 1.25rem;
+}
+
+.download-toggle {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    opacity: 0;
+}
+
+.download-button {
+    position: relative;
+    width: min(300px, 100%);
+    min-height: 58px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    padding: 0 1.5rem;
+    border-radius: 14px;
+    background: var(--primary);
+    color: #ffffff;
+    font-weight: 700;
+    cursor: pointer;
+    user-select: none;
+    box-shadow: 0 10px 24px rgba(99, 102, 241, 0.25);
+
+    transition:
+        background-color 250ms ease,
+        transform 200ms ease,
+        box-shadow 250ms ease;
+}
+
+.download-button:hover {
+    background: var(--primary-dark);
+    transform: translateY(-2px);
+}
+
+.download-button:active {
+    transform: translateY(0);
+}
+
+.download-toggle:focus-visible + .download-button {
+    outline: 3px solid #a5b4fc;
+    outline-offset: 4px;
+}
+
+/* Common content positioning */
+
+.download-content,
+.progress-content,
+.complete-content {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.6rem;
+}
+
+/* Initial state */
+
+.download-content {
+    opacity: 1;
+    transform: translateY(0);
+    transition:
+        opacity 200ms ease,
+        transform 250ms ease;
+}
+
+/* Download icon */
+
+.download-icon,
+.check-icon {
+    width: 22px;
+    height: 22px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}
+
+/* Progress state */
+
+.progress-content {
+    flex-direction: column;
+    gap: 0.35rem;
+    opacity: 0;
+    transform: translateY(12px);
+    pointer-events: none;
+    transition:
+        opacity 200ms ease,
+        transform 250ms ease;
+}
+
+.progress-track {
+    width: 72%;
+    height: 6px;
+    overflow: hidden;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.3);
+}
+
+.progress-fill {
+    display: block;
+    width: 0;
+    height: 100%;
+    border-radius: inherit;
+    background: #ffffff;
+}
+
+/* Complete state */
+
+.complete-content {
+    opacity: 0;
+    transform: scale(0.85);
+    pointer-events: none;
+    transition:
+        opacity 200ms ease,
+        transform 250ms ease;
+}
+
+/*
+ * Checkbox activates the progress animation.
+ */
+
+.download-toggle:checked + .download-button .download-content {
+    opacity: 0;
+    transform: translateY(-12px);
+}
+
+.download-toggle:checked + .download-button .progress-content {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.download-toggle:checked + .download-button .progress-fill {
+    animation: download-progress 3.5s linear forwards;
+}
+
+/*
+ * Once the progress animation finishes,
+ * the button transitions to the completed state.
+ */
+
+.download-toggle:checked + .download-button {
+    animation: button-success 3.5s linear forwards;
+}
+
+.download-toggle:checked + .download-button .complete-content {
+    animation: show-complete 3.5s linear forwards;
+}
+
+/* Progress animation */
+
+@keyframes download-progress {
+    0% {
+        width: 0;
+    }
+
+    15% {
+        width: 15%;
+    }
+
+    40% {
+        width: 42%;
+    }
+
+    70% {
+        width: 72%;
+    }
+
+    90% {
+        width: 92%;
+    }
+
+    100% {
+        width: 100%;
+    }
+}
+
+/* Completed button */
+
+@keyframes button-success {
+    0%,
+    85% {
+        background: var(--primary);
+    }
+
+    100% {
+        background: var(--success);
+    }
+}
+
+@keyframes show-complete {
+    0%,
+    82% {
+        opacity: 0;
+        transform: scale(0.85);
+    }
+
+    92%,
+    100% {
+        opacity: 1;
+        transform: scale(1);
+    }
+}
+
+.hint {
+    color: var(--muted);
+    font-size: 0.85rem;
+}
+
+/* Reduced motion */
+
+@media (prefers-reduced-motion: reduce) {
+    .download-button,
+    .download-content,
+    .progress-content,
+    .complete-content {
+        transition: none;
+    }
+
+    .download-toggle:checked + .download-button .progress-fill {
+        animation: none;
+        width: 100%;
+    }
+
+    .download-toggle:checked + .download-button {
+        animation: none;
+        background: var(--success);
+    }
+
+    .download-toggle:checked + .download-button .complete-content {
+        animation: none;
+        opacity: 1;
+        transform: scale(1);
+    }
+}
+
+/* Mobile */
+
+@media (max-width: 480px) {
+    .page {
+        padding: 1rem;
+    }
+
+    .demo-card {
+        padding: 1.5rem 1rem;
+        border-radius: 18px;
+    }
+
+    .download-button {
+        min-height: 54px;
+    }
+}


### PR DESCRIPTION
## Description

Implemented the CSS Download Button with Progress requested in #68541.

### Changes Made

* Added a CSS-only download button.
* Added animated transition from download state to progress state.
* Added animated progress indicator.
* Added completed/downloaded state with checkmark.
* Added keyboard-accessible interaction.
* Added visible focus styling.
* Added responsive mobile layout.
* Added `prefers-reduced-motion` support.
* Added README documentation.
* No external dependencies are required.

### Files Added

* `submissions/examples/css-download-button-progress/demo.html`
* `submissions/examples/css-download-button-progress/style.css`
* `submissions/examples/css-download-button-progress/README.md`

### Testing

* Tested the download interaction in the browser.
* Tested keyboard focus and activation.
* Tested progress animation.
* Tested completed state.
* Tested responsive layout.
* Tested reduced-motion behavior.

### Note

The progress indicator is a CSS animation for demonstration purposes. Actual file-download progress would require JavaScript.

### Related Issue

Closes #68541
