### PR TITLE
Add ease-podcast-player-now-playing component

### DIFF
--- a/submissions/examples/podcast-player-now-playing-ij/README.md
+++ b/submissions/examples/podcast-player-now-playing-ij/README.md
@@ -1,0 +1,11 @@
+# ease-podcast-player-now-playing
+
+A podcast player where the equalizer bounces, the progress fills, and the play button pulses.
+
+## Run
+Open `demo.html` directly in a browser to watch the player.
+
+## Notes
+- Equalizer bars bounce on the artwork.
+- The progress bar fills along the timeline.
+- The play button pulses on the controls.

--- a/submissions/examples/podcast-player-now-playing-ij/demo.html
+++ b/submissions/examples/podcast-player-now-playing-ij/demo.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-podcast-player-now-playing demo</title>
+</head>
+<body>
+<div class="pcp-player">
+  <div class="pcp-art">
+    <span class="pcp-eq"><i></i><i></i><i></i><i></i><i></i></span>
+  </div>
+  <span class="pcp-title">The Daily Byte</span>
+  <span class="pcp-host">with Srijan Jaiswal</span>
+  <div class="pcp-timeline"><span class="pcp-fill"></span></div>
+  <span class="pcp-time"><span>12:04</span><span>38:10</span></span>
+  <div class="pcp-controls">
+    <span class="pcp-btn pcp-prev"></span>
+    <span class="pcp-btn pcp-play"></span>
+    <span class="pcp-btn pcp-next"></span>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/podcast-player-now-playing-ij/style.css
+++ b/submissions/examples/podcast-player-now-playing-ij/style.css
@@ -1,0 +1,27 @@
+.pcp-player{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:340px;background:#0f1a28;border:1px solid #1e3350;border-radius:18px;padding:26px;display:flex;flex-direction:column;align-items:center;gap:14px}
+.pcp-art{width:176px;height:176px;border-radius:14px;background:linear-gradient(145deg,#17324f,#0c1626);display:flex;align-items:center;justify-content:center;overflow:hidden}
+.pcp-eq{display:flex;align-items:flex-end;gap:5px;height:60px}
+.pcp-eq i{width:8px;background:#38bdf8;border-radius:3px;animation:pcp-eq-bounce-podcast-player-now-playing 0.9s ease-in-out infinite}
+.pcp-eq i:nth-child(1){height:26px;animation-delay:0s}
+.pcp-eq i:nth-child(2){height:52px;animation-delay:0.15s}
+.pcp-eq i:nth-child(3){height:36px;animation-delay:0.3s}
+.pcp-eq i:nth-child(4){height:44px;animation-delay:0.45s}
+.pcp-eq i:nth-child(5){height:24px;animation-delay:0.6s}
+.pcp-title{font-size:16px;font-weight:800;color:#f1f6fb}
+.pcp-host{font-size:11px;letter-spacing:2px;color:#7e95ab}
+.pcp-timeline{width:100%;height:5px;background:#1e3350;border-radius:4px;overflow:hidden}
+.pcp-fill{display:block;height:100%;width:38%;background:#38bdf8;border-radius:4px;animation:pcp-progress-podcast-player-now-playing 4s ease-in-out infinite}
+.pcp-time{font-size:10px;letter-spacing:1px;color:#64748b;width:100%;display:flex;justify-content:space-between}
+.pcp-controls{display:flex;align-items:center;gap:18px}
+.pcp-btn{width:44px;height:44px;border-radius:50%;display:flex;align-items:center;justify-content:center}
+.pcp-prev{background:#152338}
+.pcp-next{background:#152338}
+.pcp-play{width:56px;height:56px;background:#38bdf8;animation:pcp-play-pulse-podcast-player-now-playing 1.8s ease-in-out infinite}
+.pcp-play::before{content:"";width:0;height:0;border-top:8px solid transparent;border-bottom:8px solid transparent;border-left:13px solid #0a1118;margin-left:4px}
+.pcp-prev::before{content:"";width:0;height:0;border-top:6px solid transparent;border-bottom:6px solid transparent;border-right:9px solid #7e95ab}
+.pcp-prev::after{content:"";width:0;height:0;border-top:6px solid transparent;border-bottom:6px solid transparent;border-right:9px solid #7e95ab;margin-left:-2px}
+.pcp-next::before{content:"";width:0;height:0;border-top:6px solid transparent;border-bottom:6px solid transparent;border-left:9px solid #7e95ab}
+.pcp-next::after{content:"";width:0;height:0;border-top:6px solid transparent;border-bottom:6px solid transparent;border-left:9px solid #7e95ab;margin-left:2px}
+@keyframes pcp-eq-bounce-podcast-player-now-playing{0%{transform:scaleY(0.4)}50%{transform:scaleY(1)}100%{transform:scaleY(0.4)}}
+@keyframes pcp-progress-podcast-player-now-playing{0%{width:8%}50%{width:78%}100%{width:8%}}
+@keyframes pcp-play-pulse-podcast-player-now-playing{0%{box-shadow:0 0 0 0 rgba(56,189,248,0.55)}70%{box-shadow:0 0 0 14px rgba(56,189,248,0)}100%{box-shadow:0 0 0 0 rgba(56,189,248,0)}}


### PR DESCRIPTION
## Component: ease-podcast-player-now-playing — bars bounce, progress fills, and play pulses

**Closes #68940**

### What this adds
A podcast player: the equalizer bars bounce on the artwork, the progress bar fills along the timeline, and the play button pulses.

### Acceptance Criteria covered
- Equalizer bars bounce on the art
- Progress bar fills along the timeline
- Play button pulses on the controls

### Files
- `submissions/examples/podcast-player-now-playing-ij/demo.html`
- `submissions/examples/podcast-player-now-playing-ij/style.css`
- `submissions/examples/podcast-player-now-playing-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the bars bounce.