### PR TITLE
Add ease-movie-ticket-seat component

### DIFF
--- a/submissions/examples/movie-ticket-seat-ij/README.md
+++ b/submissions/examples/movie-ticket-seat-ij/README.md
@@ -1,0 +1,11 @@
+# ease-movie-ticket-seat
+
+A cinema seat picker where the screen glows, the selected seats pop, and the hint blinks.
+
+## Run
+Open `demo.html` directly in a browser to watch the seat grid.
+
+## Notes
+- The screen glows at the front of the room.
+- Selected seats pop in the grid.
+- The seat count hint blinks below.

--- a/submissions/examples/movie-ticket-seat-ij/demo.html
+++ b/submissions/examples/movie-ticket-seat-ij/demo.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-movie-ticket-seat demo</title>
+</head>
+<body>
+<div class="mts-room">
+  <div class="mts-screen">SCREEN</div>
+  <div class="mts-block">
+    <div class="mts-row"><i class="mts-seat mts-sel"></i><i class="mts-seat mts-sel"></i><i class="mts-seat"></i><i class="mts-seat mts-taken"></i><i class="mts-seat"></i><i class="mts-seat mts-sel"></i><i class="mts-seat mts-taken"></i><i class="mts-seat"></i></div>
+    <div class="mts-row"><i class="mts-seat"></i><i class="mts-seat"></i><i class="mts-seat mts-sel"></i><i class="mts-seat"></i><i class="mts-seat"></i><i class="mts-seat"></i><i class="mts-seat"></i><i class="mts-seat mts-taken"></i></div>
+    <div class="mts-row"><i class="mts-seat mts-taken"></i><i class="mts-seat"></i><i class="mts-seat"></i><i class="mts-seat mts-sel"></i><i class="mts-seat mts-sel"></i><i class="mts-seat"></i><i class="mts-seat"></i><i class="mts-seat"></i></div>
+    <div class="mts-row"><i class="mts-seat"></i><i class="mts-seat mts-taken"></i><i class="mts-seat"></i><i class="mts-seat"></i><i class="mts-seat"></i><i class="mts-seat mts-sel"></i><i class="mts-seat"></i><i class="mts-seat"></i></div>
+  </div>
+  <span class="mts-hint">SELECTED 5 SEATS</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/movie-ticket-seat-ij/style.css
+++ b/submissions/examples/movie-ticket-seat-ij/style.css
@@ -1,0 +1,11 @@
+.mts-room{position:absolute;inset:0;background:#0d1624;display:flex;flex-direction:column;align-items:center;gap:26px;padding-top:34px}
+.mts-screen{width:330px;height:12px;background:#22314a;border-radius:0 0 26px 26px;display:grid;place-items:center;font-size:7px;letter-spacing:4px;color:#7e95ab;animation:mts-screen-glow-movie-ticket-seat 2.4s ease-in-out infinite}
+.mts-block{display:flex;flex-direction:column;gap:12px}
+.mts-row{display:flex;gap:10px}
+.mts-seat{width:22px;height:20px;border-radius:5px;background:#24344c}
+.mts-sel{background:#f59e0b;box-shadow:0 0 10px rgba(245,158,11,0.5);animation:mts-seat-pop-movie-ticket-seat 1.6s ease-in-out infinite}
+.mts-taken{background:#3f4b5e}
+.mts-hint{font-size:10px;letter-spacing:4px;font-weight:700;color:#f59e0b;animation:mts-hint-blink-movie-ticket-seat 1.4s ease-in-out infinite}
+@keyframes mts-screen-glow-movie-ticket-seat{0%{box-shadow:0 0 14px rgba(59,130,246,0.25)}50%{box-shadow:0 0 26px rgba(59,130,246,0.55)}100%{box-shadow:0 0 14px rgba(59,130,246,0.25)}}
+@keyframes mts-seat-pop-movie-ticket-seat{0%{transform:scale(1)}50%{transform:scale(1.18)}100%{transform:scale(1)}}
+@keyframes mts-hint-blink-movie-ticket-seat{0%{opacity:0.4}50%{opacity:1}100%{opacity:0.4}}


### PR DESCRIPTION
## Component: ease-movie-ticket-seat — screen glows, seats pop, and hint blinks

**Closes #68968**

### What this adds
A cinema seat picker: the screen glows at the front, the selected seats pop in the grid, and the seat count hint blinks below.

### Acceptance Criteria covered
- Screen glows at the front of the room
- Selected seats pop in the grid
- Seat count hint blinks below

### Files
- `submissions/examples/movie-ticket-seat-ij/demo.html`
- `submissions/examples/movie-ticket-seat-ij/style.css`
- `submissions/examples/movie-ticket-seat-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the seats pop.