### PR TITLE
Add ease-leaderboard-ranks component

### DIFF
--- a/submissions/examples/leaderboard-ranks-ij/README.md
+++ b/submissions/examples/leaderboard-ranks-ij/README.md
@@ -1,0 +1,11 @@
+# ease-leaderboard-ranks
+
+A leaderboard where the medal badges shine, the rows slide in, and the scores tick.
+
+## Run
+Open `demo.html` directly in a browser to watch the ranks.
+
+## Notes
+- The top three medal badges shine.
+- The rows slide in one by one.
+- The scores tick beside the names.

--- a/submissions/examples/leaderboard-ranks-ij/demo.html
+++ b/submissions/examples/leaderboard-ranks-ij/demo.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-leaderboard-ranks demo</title>
+</head>
+<body>
+<div class="lbr-board">
+  <div class="lbr-row lbr-gold">
+    <span class="lbr-rank">1</span>
+    <span class="lbr-name">Nova Streams</span>
+    <span class="lbr-score">9,420</span>
+  </div>
+  <div class="lbr-row lbr-silver">
+    <span class="lbr-rank">2</span>
+    <span class="lbr-name">Pixel Forge</span>
+    <span class="lbr-score">8,105</span>
+  </div>
+  <div class="lbr-row lbr-bronze">
+    <span class="lbr-rank">3</span>
+    <span class="lbr-name">Code Harbor</span>
+    <span class="lbr-score">6,880</span>
+  </div>
+  <div class="lbr-row">
+    <span class="lbr-rank">4</span>
+    <span class="lbr-name">Byte Cabin</span>
+    <span class="lbr-score">5,240</span>
+  </div>
+  <div class="lbr-row">
+    <span class="lbr-rank">5</span>
+    <span class="lbr-name">Grid Works</span>
+    <span class="lbr-score">4,115</span>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/leaderboard-ranks-ij/style.css
+++ b/submissions/examples/leaderboard-ranks-ij/style.css
@@ -1,0 +1,15 @@
+.lbr-board{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:372px;background:#0f1a2a;border:1px solid #1e3350;border-radius:14px;padding:18px;display:flex;flex-direction:column;gap:10px}
+.lbr-row{display:flex;align-items:center;gap:14px;background:#16253a;border-radius:10px;padding:12px 14px;animation:lbr-row-in-leaderboard-ranks 0.5s ease-out both}
+.lbr-row:nth-child(2){animation-delay:0.1s}
+.lbr-row:nth-child(3){animation-delay:0.2s}
+.lbr-row:nth-child(4){animation-delay:0.3s}
+.lbr-row:nth-child(5){animation-delay:0.4s}
+.lbr-rank{width:30px;height:30px;border-radius:8px;background:#22334c;color:#dbe7f3;font-size:13px;font-weight:800;display:grid;place-items:center}
+.lbr-gold .lbr-rank{background:#f5c542;color:#3a2a05;animation:lbr-shine-leaderboard-ranks 1.8s ease-in-out infinite}
+.lbr-silver .lbr-rank{background:#c8d2e0;color:#27313d;animation:lbr-shine-leaderboard-ranks 1.8s ease-in-out 0.3s infinite}
+.lbr-bronze .lbr-rank{background:#e08a5a;color:#3a1d0a;animation:lbr-shine-leaderboard-ranks 1.8s ease-in-out 0.6s infinite}
+.lbr-name{flex:1;font-size:13px;font-weight:700;color:#e8f0f8}
+.lbr-score{font-size:13px;font-weight:800;color:#38bdf8;animation:lbr-score-tick-leaderboard-ranks 2s ease-in-out infinite}
+@keyframes lbr-shine-leaderboard-ranks{0%{box-shadow:0 0 0 rgba(245,197,66,0)}50%{box-shadow:0 0 14px rgba(245,197,66,0.6)}100%{box-shadow:0 0 0 rgba(245,197,66,0)}}
+@keyframes lbr-row-in-leaderboard-ranks{0%{opacity:0;transform:translateY(12px)}100%{opacity:1;transform:translateY(0)}}
+@keyframes lbr-score-tick-leaderboard-ranks{0%{transform:scale(1)}50%{transform:scale(1.1)}100%{transform:scale(1)}}


### PR DESCRIPTION
## Component: ease-leaderboard-ranks — medals shine, rows slide, and scores tick

**Closes #68984**

### What this adds
A leaderboard: the top three medal badges shine, the rows slide in one by one, and the scores tick beside the names.

### Acceptance Criteria covered
- Top three medal badges shine
- Rows slide in one by one
- Scores tick beside the names

### Files
- `submissions/examples/leaderboard-ranks-ij/demo.html`
- `submissions/examples/leaderboard-ranks-ij/style.css`
- `submissions/examples/leaderboard-ranks-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the ranks shine.