### PR TITLE
Add ease-sprint-burndown-chart component

### DIFF
--- a/submissions/examples/sprint-burndown-chart-ij/README.md
+++ b/submissions/examples/sprint-burndown-chart-ij/README.md
@@ -1,0 +1,11 @@
+# ease-sprint-burndown-chart
+
+A sprint burndown chart where the actual line draws, the point pulses, and the label blinks.
+
+## Run
+Open `demo.html` directly in a browser to watch the line draw.
+
+## Notes
+- The actual line draws across the grid.
+- The current point pulses on the line.
+- The header label blinks above.

--- a/submissions/examples/sprint-burndown-chart-ij/demo.html
+++ b/submissions/examples/sprint-burndown-chart-ij/demo.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-sprint-burndown-chart demo</title>
+</head>
+<body>
+<div class="sbd-card">
+  <div class="sbd-head">
+    <span class="sbd-title">SPRINT 24</span>
+    <span class="sbd-meta">ideal vs actual</span>
+  </div>
+  <svg class="sbd-svg" viewBox="0 0 320 180">
+    <g class="sbd-grid">
+      <line x1="40" y1="20" x2="40" y2="140"></line>
+      <line x1="40" y1="140" x2="300" y2="140"></line>
+      <line x1="40" y1="50" x2="300" y2="50" class="sbd-dash"></line>
+      <line x1="40" y1="95" x2="300" y2="95" class="sbd-dash"></line>
+    </g>
+    <path class="sbd-ideal" d="M40 40 L300 140"></path>
+    <path class="sbd-actual" d="M40 40 L120 62 L200 84 L260 100 L300 118"></path>
+    <circle class="sbd-point" cx="300" cy="118" r="5"></circle>
+  </svg>
+  <div class="sbd-legend">
+    <span class="sbd-key sbd-key1"></span>
+    <span class="sbd-kname">ideal</span>
+    <span class="sbd-key sbd-key2"></span>
+    <span class="sbd-kname">actual</span>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/sprint-burndown-chart-ij/style.css
+++ b/submissions/examples/sprint-burndown-chart-ij/style.css
@@ -1,0 +1,18 @@
+.sbd-card{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:372px;background:#0f1a2a;border:1px solid #1e3350;border-radius:14px;padding:20px}
+.sbd-head{display:flex;justify-content:space-between;align-items:baseline;margin-bottom:10px}
+.sbd-title{font-size:14px;font-weight:800;letter-spacing:2px;color:#e8f0f8}
+.sbd-meta{font-size:10px;color:#7e95ab;animation:sbd-label-blink-sprint-burndown-chart 2s ease-in-out infinite}
+.sbd-svg{width:100%;display:block}
+.sbd-grid line{stroke:#1b2b42;stroke-width:1}
+.sbd-dash{stroke:#22334c;stroke-width:1;stroke-dasharray:4 4}
+.sbd-ideal{stroke:#5a6b7e;stroke-width:2;stroke-dasharray:6 5;fill:none}
+.sbd-actual{stroke:#38bdf8;stroke-width:2.5;fill:none;stroke-dasharray:600;stroke-dashoffset:600;animation:sbd-line-draw-sprint-burndown-chart 3s ease-in-out infinite}
+.sbd-point{fill:#38bdf8;transform-box:fill-box;transform-origin:center;animation:sbd-point-pulse-sprint-burndown-chart 1.4s ease-in-out infinite}
+.sbd-legend{display:flex;align-items:center;gap:8px;margin-top:12px;font-size:10px;color:#7e95ab}
+.sbd-key{width:14px;height:4px;border-radius:2px}
+.sbd-key1{background:#5a6b7e}
+.sbd-key2{background:#38bdf8;animation:sbd-label-blink-sprint-burndown-chart 2s ease-in-out infinite}
+.sbd-kname{letter-spacing:1px}
+@keyframes sbd-line-draw-sprint-burndown-chart{0%{stroke-dashoffset:600}60%{stroke-dashoffset:0}100%{stroke-dashoffset:0}}
+@keyframes sbd-point-pulse-sprint-burndown-chart{0%{transform:scale(1)}50%{transform:scale(1.6)}100%{transform:scale(1)}}
+@keyframes sbd-label-blink-sprint-burndown-chart{0%{opacity:0.5}50%{opacity:1}100%{opacity:0.5}}


### PR DESCRIPTION
## Component: ease-sprint-burndown-chart — actual line draws, point pulses, and labels blink

**Closes #68997**

### What this adds
A sprint burndown chart: the actual line draws across the grid, the current point pulses on the end, and the header label blinks.

### Acceptance Criteria covered
- Actual line draws across the grid
- Current point pulses on the line
- Header label blinks above

### Files
- `submissions/examples/sprint-burndown-chart-ij/demo.html`
- `submissions/examples/sprint-burndown-chart-ij/style.css`
- `submissions/examples/sprint-burndown-chart-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the line draw.