### PR TITLE
feat: add pure CSS Comment Thread component (#68052)

### DIFF
--- a/submissions/examples/css-comment-thread/README.md
+++ b/submissions/examples/css-comment-thread/README.md
@@ -1,0 +1,23 @@
+# CSS Comment Thread
+
+A clean, indented comment system featuring deeply nested replies and a dynamic reply form toggle, built entirely without JavaScript.
+
+## Features
+- Pure CSS and HTML (Zero JavaScript required for UI state toggles or structural styling).
+- **Theming & Dark Mode**: Utilizes CSS Custom Properties (`--bg-card`, `--accent`, etc.) for easy overriding. Automatically respects the OS-level system theme (`prefers-color-scheme: light/dark`).
+- **Structural Nesting (Documented in Code)**: 
+- Deeply nested comment threads are achieved purely through HTML structure. 
+- By placing a reply `.comment-thread` *inside* its parent `.comment-thread` container and appending the `.nested` class, the child inherits a left margin (indentation) and a visual left border connecting line.
+- This creates an infinitely scalable threading system standard in platforms like Reddit or HackerNews.
+- **Dynamic CSS Reply Form (Checkbox Hack)**: 
+- When the user clicks the "Reply" button, a textarea form slides down smoothly. This complex UI state is handled 100% in CSS using the Checkbox Hack.
+- A hidden `<input type="checkbox">` is linked to a `<label>` styled perfectly as a button. 
+- Using the CSS general sibling selector (`~`), checking the box toggles the `max-height` and `opacity` of the reply form container, smoothly expanding it into view.
+- Fully accessible with `prefers-reduced-motion` support. The sliding animations on the reply form are disabled for motion-sensitive users.
+
+## Usage
+Open `demo.html` in your browser. You will see a 3-level deep comment thread. Notice the structural indentations and the subtle connecting lines on the left side (hover over them to see them highlight). Try clicking the "Reply" button on any comment to see the dynamic form slide into view, and click "Cancel" to slide it away—all without a single line of JavaScript.
+
+## Files
+- `demo.html`: The HTML structure detailing the nested containers and the hidden checkboxes required for the UI state.
+- `style.css`: The styling, CSS Custom Property theming blocks, and heavily commented mechanics detailing the `max-height` transition trick for the reply forms.

--- a/submissions/examples/css-comment-thread/demo.html
+++ b/submissions/examples/css-comment-thread/demo.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Comment Thread</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Nested Comment Thread</h1>
+            <p class="subtitle">A clean, indented comment system featuring CSS-only dynamic reply forms.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <div class="comment-section">
+                
+                <!-- 
+                   Top Level Comment 
+                -->
+                <div class="comment-thread">
+                    <div class="comment-block">
+                        <img src="https://i.pravatar.cc/150?img=11" alt="User Avatar" class="avatar">
+                        <div class="comment-content">
+                            <div class="comment-header">
+                                <span class="author">Alice Dev</span>
+                                <span class="time">2 hours ago</span>
+                            </div>
+                            <p class="comment-text">This pure CSS approach to component building is incredibly fast. How do you handle complex state without JS?</p>
+                            
+                            <!-- 
+                               [TECHNIQUE 1] Pure CSS Reply Form Toggle:
+                               We use a hidden checkbox to manage the UI state of the reply form.
+                               Clicking the label toggles the checkbox, which uses a sibling selector 
+                               in CSS to slide down the reply form.
+                            -->
+                            <input type="checkbox" id="reply-toggle-1" class="reply-toggle">
+                            <div class="comment-actions">
+                                <button class="action-btn">Like</button>
+                                <label for="reply-toggle-1" class="action-btn reply-btn">Reply</label>
+                            </div>
+                            
+                            <div class="reply-form-container">
+                                <textarea class="reply-input" rows="3" placeholder="Write a reply..."></textarea>
+                                <div class="reply-form-actions">
+                                    <label for="reply-toggle-1" class="cancel-btn">Cancel</label>
+                                    <button class="submit-btn">Post Reply</button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    
+                    <!-- 
+                       Nested Reply Level 1 
+                       [TECHNIQUE 2] Structural Nesting:
+                       Replies are placed inside the parent's `.comment-thread` container 
+                       to inherit the structural left border and indentation padding.
+                    -->
+                    <div class="comment-thread nested">
+                        <div class="comment-block">
+                            <img src="https://i.pravatar.cc/150?img=68" alt="User Avatar" class="avatar">
+                            <div class="comment-content">
+                                <div class="comment-header">
+                                    <span class="author author-op">Bob (Author)</span>
+                                    <span class="time">1 hour ago</span>
+                                </div>
+                                <p class="comment-text">For simple UI toggles (like opening this reply box), the Checkbox Hack is perfect! No JS framework needed.</p>
+                                
+                                <input type="checkbox" id="reply-toggle-2" class="reply-toggle">
+                                <div class="comment-actions">
+                                    <button class="action-btn">Like (2)</button>
+                                    <label for="reply-toggle-2" class="action-btn reply-btn">Reply</label>
+                                </div>
+                                
+                                <div class="reply-form-container">
+                                    <textarea class="reply-input" rows="3" placeholder="Write a reply..."></textarea>
+                                    <div class="reply-form-actions">
+                                        <label for="reply-toggle-2" class="cancel-btn">Cancel</label>
+                                        <button class="submit-btn">Post Reply</button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        
+                        <!-- Nested Reply Level 2 -->
+                        <div class="comment-thread nested">
+                            <div class="comment-block">
+                                <img src="https://i.pravatar.cc/150?img=47" alt="User Avatar" class="avatar">
+                                <div class="comment-content">
+                                    <div class="comment-header">
+                                        <span class="author">Charlie</span>
+                                        <span class="time">45 mins ago</span>
+                                    </div>
+                                    <p class="comment-text">Agreed! It keeps the DOM extremely light.</p>
+                                    
+                                    <input type="checkbox" id="reply-toggle-3" class="reply-toggle">
+                                    <div class="comment-actions">
+                                        <button class="action-btn">Like</button>
+                                        <label for="reply-toggle-3" class="action-btn reply-btn">Reply</label>
+                                    </div>
+                                    
+                                    <div class="reply-form-container">
+                                        <textarea class="reply-input" rows="3" placeholder="Write a reply..."></textarea>
+                                        <div class="reply-form-actions">
+                                            <label for="reply-toggle-3" class="cancel-btn">Cancel</label>
+                                            <button class="submit-btn">Post Reply</button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div> <!-- End Level 2 -->
+                        
+                    </div> <!-- End Level 1 -->
+                </div> <!-- End Top Level -->
+                
+            </div>
+            
+        </div>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-comment-thread/style.css
+++ b/submissions/examples/css-comment-thread/style.css
@@ -1,0 +1,309 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f8fafc;
+    --bg-card: #ffffff;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    --text-tertiary: #94a3b8;
+    
+    --border-color: #e2e8f0;
+    --border-hover: #cbd5e1;
+    
+    --accent: #3b82f6; /* Blue */
+    --accent-hover: #2563eb;
+    --accent-bg: #eff6ff;
+    
+    --op-tag-bg: #dbeafe;
+    --op-tag-text: #1e3a8a;
+    
+    --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a;
+        --bg-card: #1e293b;
+        --text-primary: #f8fafc;
+        --text-secondary: #94a3b8;
+        --text-tertiary: #64748b;
+        
+        --border-color: #334155;
+        --border-hover: #475569;
+        
+        --accent: #60a5fa; 
+        --accent-hover: #93c5fd;
+        --accent-bg: #0f172a;
+        
+        --op-tag-bg: #1e3a8a;
+        --op-tag-text: #bfdbfe;
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    -webkit-font-smoothing: antialiased;
+    transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.layout-container {
+    max-width: 800px;
+    width: 100%;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 50px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.25rem;
+    font-weight: 600;
+    margin: 0 0 12px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    margin: 0;
+}
+
+
+/* =========================================
+   Comment Thread Structure
+   ========================================= */
+
+.comment-section {
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 24px;
+    box-shadow: var(--shadow-sm);
+}
+
+.comment-thread {
+    position: relative;
+    margin-bottom: 24px;
+}
+
+.comment-thread:last-child {
+    margin-bottom: 0;
+}
+
+/* 
+  [TECHNIQUE 2] Structural Nesting & Connecting Lines:
+  Nested comments receive a left margin to indent them, and a subtle 
+  left border to visually connect them to the parent thread.
+*/
+.comment-thread.nested {
+    margin-top: 16px;
+    margin-bottom: 16px;
+    margin-left: 20px;
+    padding-left: 20px;
+    border-left: 2px solid var(--border-color);
+}
+
+.comment-thread.nested:hover {
+    border-left-color: var(--border-hover);
+}
+
+
+/* =========================================
+   Comment Block UI
+   ========================================= */
+
+.comment-block {
+    display: flex;
+    gap: 16px;
+}
+
+.avatar {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    object-fit: cover;
+    flex-shrink: 0;
+    background-color: var(--border-color);
+}
+
+.comment-content {
+    flex-grow: 1;
+    min-width: 0; /* Prevents flex blowout on long text */
+}
+
+.comment-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 6px;
+}
+
+.author {
+    font-weight: 600;
+    font-size: 0.95rem;
+}
+
+/* Original Poster Highlight */
+.author-op {
+    background-color: var(--op-tag-bg);
+    color: var(--op-tag-text);
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: 0.8rem;
+    letter-spacing: 0.2px;
+}
+
+.time {
+    color: var(--text-tertiary);
+    font-size: 0.85rem;
+}
+
+.comment-text {
+    margin: 0 0 12px 0;
+    line-height: 1.5;
+    font-size: 0.95rem;
+    color: var(--text-secondary);
+}
+
+.comment-actions {
+    display: flex;
+    gap: 16px;
+}
+
+.action-btn {
+    background: none;
+    border: none;
+    padding: 0;
+    color: var(--text-tertiary);
+    font-size: 0.85rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: color 0.2s ease;
+}
+
+.action-btn:hover {
+    color: var(--accent);
+}
+
+/* Make labels look and behave exactly like buttons */
+label.action-btn {
+    display: inline-block;
+    user-select: none;
+}
+
+
+/* =========================================
+   Pure CSS Reply Form Toggle
+   ========================================= */
+
+/* Hide the structural checkbox */
+.reply-toggle {
+    display: none;
+}
+
+/* Hide the form container by default using max-height for smooth transition */
+.reply-form-container {
+    max-height: 0;
+    opacity: 0;
+    overflow: hidden;
+    transition: max-height 0.3s ease, opacity 0.3s ease, margin-top 0.3s ease;
+}
+
+/* 
+  [TECHNIQUE 1] Checkbox Hack State Change:
+  When the user clicks the "Reply" label, it checks the hidden checkbox.
+  We use the `~` (general sibling) selector to target the form container 
+  and expand it into view.
+*/
+.reply-toggle:checked ~ .reply-form-container {
+    max-height: 200px; /* Arbitrary large height to contain the form */
+    opacity: 1;
+    margin-top: 16px;
+}
+
+/* Give the Reply button an active state when the form is open */
+.reply-toggle:checked ~ .comment-actions .reply-btn {
+    color: var(--accent);
+}
+
+
+/* =========================================
+   Reply Form UI
+   ========================================= */
+
+.reply-input {
+    width: 100%;
+    padding: 12px;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    background-color: var(--bg-base);
+    color: var(--text-primary);
+    font-family: inherit;
+    font-size: 0.9rem;
+    resize: vertical;
+    box-sizing: border-box;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.reply-input:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px var(--accent-bg);
+}
+
+.reply-form-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+    margin-top: 12px;
+}
+
+.cancel-btn {
+    padding: 8px 16px;
+    border-radius: 6px;
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+
+.cancel-btn:hover {
+    background-color: var(--border-color);
+}
+
+.submit-btn {
+    padding: 8px 16px;
+    border-radius: 6px;
+    border: none;
+    background-color: var(--accent);
+    color: #ffffff;
+    font-size: 0.85rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+
+.submit-btn:hover {
+    background-color: var(--accent-hover);
+}
+
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    .reply-form-container {
+        transition: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a clean, indented comment system featuring deeply nested replies and a dynamic reply form toggle, built entirely without JavaScript, resolving issue #68052. 

### Changes Made:
- Added `submissions/examples/css-comment-thread/` directory.
- Created `demo.html` showcasing a 3-level deep comment thread structure.
- Created `style.css` featuring UI tricks (with inline comments explaining the mechanics):
  - **Structural Nesting**: Deeply nested comment threads are achieved purely through HTML structure. By placing a reply `.comment-thread` *inside* its parent and appending the `.nested` class, the child inherits a left margin (indentation) and a visual left border connecting line. This creates an infinitely scalable threading system standard in platforms like Reddit.
  - **Dynamic CSS Reply Form (Checkbox Hack)**: When the user clicks the "Reply" button, a textarea form slides down smoothly. This complex UI state is handled 100% in CSS. A hidden `<input type="checkbox">` is linked to a `<label>` styled perfectly as a button. Using the CSS general sibling selector (`~`), checking the box toggles the `max-height` and `opacity` of the reply form container, smoothly expanding it into view.
  - **Theming & Dark Mode Supported**: Utilizes CSS Custom Properties. The stylesheet automatically respects the OS-level system theme (`prefers-color-scheme: dark`).
- Added `README.md` documenting usage and the technical mechanics of the `max-height` transition trick for the reply forms.
- Honors the `prefers-reduced-motion` accessibility standard. The sliding animations on the reply form are disabled for motion-sensitive users.

Closes #68052
