### PR TITLE
feat: add pure CSS gooey filter button effect (#68953)

### DIFF
--- a/components/gooey-btn.css
+++ b/components/gooey-btn.css
@@ -1,0 +1,77 @@
+/* 
+  Pure CSS Gooey Filter Button Effect
+  Issue: #68953
+*/
+
+.ease-gooey-container {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  /* The contrast filter is key to the gooey effect. 
+     Note: It requires a solid background to contrast against the blurred elements. */
+  background-color: var(--ease-gooey-bg, #ffffff);
+  filter: contrast(20);
+  padding: 2.5rem; /* Extra padding to allow drops to animate outwards without clipping */
+  overflow: hidden;
+}
+
+.ease-btn-gooey {
+  position: relative;
+  z-index: 2;
+  color: var(--ease-gooey-text, #ffffff);
+  background: transparent;
+  border: none;
+  padding: 1rem 2.5rem;
+  font-size: 1.125rem;
+  font-weight: 600;
+  cursor: pointer;
+  outline: none;
+  border-radius: 50px;
+}
+
+/* This is the main body of the button that merges with the drops */
+.ease-btn-gooey::before {
+  content: '';
+  position: absolute;
+  top: 0; 
+  left: 0; 
+  right: 0; 
+  bottom: 0;
+  background-color: var(--ease-gooey-color, #000000);
+  border-radius: 50px;
+  z-index: -1;
+  filter: blur(10px);
+}
+
+.ease-gooey-drop {
+  position: absolute;
+  z-index: 1;
+  background-color: var(--ease-gooey-color, #000000);
+  border-radius: 50%;
+  width: 25px;
+  height: 25px;
+  filter: blur(10px);
+  transition: transform 0.6s var(--ease-out-expo, cubic-bezier(0.19, 1, 0.22, 1));
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+}
+
+/* Animation states for drops on hover */
+.ease-gooey-container:hover .ease-gooey-drop:nth-of-type(1) {
+  transform: translate(-140%, -200%) scale(1.3);
+}
+
+.ease-gooey-container:hover .ease-gooey-drop:nth-of-type(2) {
+  transform: translate(50%, -220%) scale(0.9);
+}
+
+.ease-gooey-container:hover .ease-gooey-drop:nth-of-type(3) {
+  transform: translate(110%, 120%) scale(1.4);
+}
+
+.ease-gooey-container:hover .ease-gooey-drop:nth-of-type(4) {
+  transform: translate(-120%, 110%) scale(1.1);
+}

--- a/easemotion.css
+++ b/easemotion.css
@@ -61,6 +61,7 @@
 @import "./components/toast.css";
 @import "./components/view-transitions.css";
 @import "./components/forms.css";
+@import "./components/gooey-btn.css";
 
 
 /* Accessibility: Respect user's reduced motion preference */


### PR DESCRIPTION
## Description
This PR resolves #68953 by introducing a pure CSS gooey button effect. The effect is achieved completely natively in CSS without any JavaScript or SVG blobs, utilizing `filter: contrast()` paired with `filter: blur()`.

### Changes Made:
- Added `components/gooey-btn.css` with the implementation of the `.ease-gooey-container`, `.ease-btn-gooey` and `.ease-gooey-drop` classes.
- Used CSS Grid/Flexbox along with `transition: transform` for the fluid expanding hover animations.
- Imported the new component into the main `easemotion.css` index.

### Issue Fixed
Fixes #68953

### Screenshots / Demo
_The button uses a crisp contrast wrapper with blurred inner drops to create a melting/liquid separation effect natively on hover._