### PR TITLE
Add ease-ci-pipeline-status component

### DIFF
--- a/submissions/examples/ci-pipeline-status-ij/README.md
+++ b/submissions/examples/ci-pipeline-status-ij/README.md
@@ -1,0 +1,11 @@
+# ease-ci-pipeline-status
+
+A CI pipeline where the running stage pulses, the icons pop, and the links fill.
+
+## Run
+Open `demo.html` directly in a browser to watch the pipeline.
+
+## Notes
+- The running stage pulses in the pipeline.
+- The finished stage icons pop.
+- The links between stages fill in turn.

--- a/submissions/examples/ci-pipeline-status-ij/demo.html
+++ b/submissions/examples/ci-pipeline-status-ij/demo.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-ci-pipeline-status demo</title>
+</head>
+<body>
+<div class="cip-panel">
+  <div class="cip-stage cip-ok">
+    <span class="cip-icon">&#10003;</span>
+    <span class="cip-label">BUILD</span>
+  </div>
+  <i class="cip-link"></i>
+  <div class="cip-stage cip-ok">
+    <span class="cip-icon">&#10003;</span>
+    <span class="cip-label">TEST</span>
+  </div>
+  <i class="cip-link"></i>
+  <div class="cip-stage cip-run">
+    <span class="cip-spin"></span>
+    <span class="cip-label">DEPLOY</span>
+  </div>
+  <i class="cip-link"></i>
+  <div class="cip-stage cip-wait">
+    <span class="cip-icon">&#183;</span>
+    <span class="cip-label">NOTIFY</span>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/ci-pipeline-status-ij/style.css
+++ b/submissions/examples/ci-pipeline-status-ij/style.css
@@ -1,0 +1,14 @@
+.cip-panel{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:460px;background:#0f1a2a;border:1px solid #1e3350;border-radius:14px;padding:30px 24px;display:flex;align-items:center;justify-content:space-between}
+.cip-stage{display:flex;flex-direction:column;align-items:center;gap:8px}
+.cip-icon{width:38px;height:38px;border-radius:50%;background:#12283a;color:#34d399;font-size:18px;font-weight:800;display:grid;place-items:center}
+.cip-ok .cip-icon{background:#123a2a;animation:cip-icon-pop-ci-pipeline-status 2.4s ease-in-out infinite}
+.cip-label{font-size:9px;letter-spacing:3px;font-weight:700;color:#8aa1b8}
+.cip-run .cip-label{color:#38bdf8;animation:cip-stage-pulse-ci-pipeline-status 1.2s ease-in-out infinite}
+.cip-spin{width:22px;height:22px;border:3px solid #1e3350;border-top-color:#38bdf8;border-radius:50%;animation:cip-spin-turn-ci-pipeline-status 0.9s linear infinite}
+.cip-wait .cip-icon{color:#64748b;background:#1b2836}
+.cip-link{width:46px;height:3px;background:#1e3350;position:relative;overflow:hidden}
+.cip-link::after{content:"";position:absolute;inset:0;background:#38bdf8;transform:translateX(-100%);animation:cip-line-fill-ci-pipeline-status 2.4s ease-in-out infinite}
+@keyframes cip-stage-pulse-ci-pipeline-status{0%{opacity:0.5}50%{opacity:1}100%{opacity:0.5}}
+@keyframes cip-icon-pop-ci-pipeline-status{0%{transform:scale(1)}50%{transform:scale(1.12)}100%{transform:scale(1)}}
+@keyframes cip-spin-turn-ci-pipeline-status{0%{transform:rotate(0)}100%{transform:rotate(360deg)}}
+@keyframes cip-line-fill-ci-pipeline-status{0%{transform:translateX(-100%)}50%{transform:translateX(0)}100%{transform:translateX(100%)}}


### PR DESCRIPTION
## Component: ease-ci-pipeline-status — stages pulse, icons pop, and links fill

**Closes #69006**

### What this adds
A CI pipeline: the running stage pulses, the finished icons pop, and the links between stages fill as the build moves on.

### Acceptance Criteria covered
- Running stage pulses in the pipeline
- Finished stage icons pop
- Links between stages fill in turn

### Files
- `submissions/examples/ci-pipeline-status-ij/demo.html`
- `submissions/examples/ci-pipeline-status-ij/style.css`
- `submissions/examples/ci-pipeline-status-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the pipeline.