### PR TITLE
Add ease-ssl-certificate-status component

### DIFF
--- a/submissions/examples/ssl-certificate-status-ij/README.md
+++ b/submissions/examples/ssl-certificate-status-ij/README.md
@@ -1,0 +1,11 @@
+# ease-ssl-certificate-status
+
+An SSL certificate card where the lock glows, the bar fills, and the expiry blinks.
+
+## Run
+Open `demo.html` directly in a browser to watch the card.
+
+## Notes
+- The padlock glows on the card.
+- The validity bar fills the meter.
+- The expiry text blinks below.

--- a/submissions/examples/ssl-certificate-status-ij/demo.html
+++ b/submissions/examples/ssl-certificate-status-ij/demo.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-ssl-certificate-status demo</title>
+</head>
+<body>
+<div class="ssl-card">
+  <div class="ssl-lock">
+    <span class="ssl-shackle"></span>
+    <span class="ssl-body"></span>
+  </div>
+  <div class="ssl-main">
+    <span class="ssl-name">east.example.com</span>
+    <span class="ssl-status">VALID</span>
+    <span class="ssl-expiry">expires in 86 days</span>
+  </div>
+  <div class="ssl-meter">
+    <span class="ssl-fill"></span>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/ssl-certificate-status-ij/style.css
+++ b/submissions/examples/ssl-certificate-status-ij/style.css
@@ -1,0 +1,13 @@
+.ssl-card{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:360px;background:#0f1a2a;border:1px solid #1e3350;border-radius:14px;padding:22px;display:flex;flex-direction:column;gap:18px}
+.ssl-lock{position:relative;width:56px;height:52px;align-self:center}
+.ssl-shackle{position:absolute;top:0;left:14px;right:14px;height:22px;border:5px solid #34d399;border-bottom:none;border-radius:14px 14px 0 0}
+.ssl-body{position:absolute;bottom:0;left:8px;right:8px;height:28px;background:#34d399;border-radius:7px;animation:ssl-lock-glow-ssl-certificate-status 2s ease-in-out infinite}
+.ssl-main{display:flex;flex-direction:column;align-items:center;gap:5px}
+.ssl-name{font-size:14px;font-weight:800;color:#e8f0f8}
+.ssl-status{font-size:10px;font-weight:800;letter-spacing:3px;color:#34d399;border:1px solid #1f5c43;padding:3px 10px;border-radius:20px}
+.ssl-expiry{font-size:11px;color:#7e95ab;animation:ssl-expiry-blink-ssl-certificate-status 2.4s ease-in-out infinite}
+.ssl-meter{height:8px;background:#1b2b42;border-radius:5px;overflow:hidden}
+.ssl-fill{display:block;height:100%;width:78%;background:linear-gradient(90deg,#34d399,#7cebb0);border-radius:5px;animation:ssl-bar-fill-ssl-certificate-status 3s ease-in-out infinite}
+@keyframes ssl-lock-glow-ssl-certificate-status{0%{box-shadow:0 0 0 0 rgba(52,211,153,0.5)}50%{box-shadow:0 0 16px 3px rgba(52,211,153,0.3)}100%{box-shadow:0 0 0 0 rgba(52,211,153,0.5)}}
+@keyframes ssl-bar-fill-ssl-certificate-status{0%{width:46%}50%{width:92%}100%{width:46%}}
+@keyframes ssl-expiry-blink-ssl-certificate-status{0%{opacity:0.5}50%{opacity:1}100%{opacity:0.5}}


### PR DESCRIPTION
## Component: ease-ssl-certificate-status — lock glows, bar fills, and expiry blinks

**Closes #69016**

### What this adds
An SSL certificate card: the padlock glows, the validity bar fills across the meter, and the expiry text blinks below.

### Acceptance Criteria covered
- Padlock glows on the card
- Validity bar fills the meter
- Expiry text blinks below

### Files
- `submissions/examples/ssl-certificate-status-ij/demo.html`
- `submissions/examples/ssl-certificate-status-ij/style.css`
- `submissions/examples/ssl-certificate-status-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the lock glow.