### PR TITLE
feat: add pure CSS image comparison slider (#68954)

### DIFF
--- a/submissions/examples/css-only-image-slider/README.md
+++ b/submissions/examples/css-only-image-slider/README.md
@@ -1,0 +1,18 @@
+# CSS-Only Before/After Image Comparison Slider
+
+## Description
+This submission resolves Issue #68954 by introducing a pure CSS before-and-after image comparison slider. The slider utilizes the CSS `resize` property on a wrapper element to allow dragging and resizing without any JavaScript event listeners.
+
+## Features
+- Pure CSS implementation, no JavaScript required.
+- Uses `resize: horizontal` coupled with `overflow: hidden` to reveal or hide the before image.
+- Both "before" and "after" images are perfectly aligned by locking the `background-size` across layers.
+- Custom pseudo-element acts as a visual drag indicator in the bottom-right corner.
+
+## Usage
+Simply hover over the center of the image and drag the handle left and right. The images will flawlessly slide over one another.
+
+### Configuration
+Pass the image URLs using CSS variables directly on the `.ease-image-compare` wrapper:
+- `--ease-compare-before`: The "Before" image URL
+- `--ease-compare-after`: The "After" image URL

--- a/submissions/examples/css-only-image-slider/demo.html
+++ b/submissions/examples/css-only-image-slider/demo.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS-Only Image Comparison Slider</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      margin: 0;
+      background-color: #f8f9fa;
+      font-family: system-ui, -apple-system, sans-serif;
+    }
+    .demo-wrapper {
+      padding: 2rem;
+      background: white;
+      border-radius: 12px;
+      box-shadow: 0 10px 30px rgba(0,0,0,0.05);
+    }
+    h2 {
+      margin-top: 0;
+      color: #333;
+      text-align: center;
+      margin-bottom: 2rem;
+    }
+    p.instruction {
+      text-align: center;
+      color: #666;
+      font-size: 0.9rem;
+      margin-top: 1rem;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="demo-wrapper">
+    <h2>Before & After</h2>
+    
+    <!-- Using inline styles for CSS variables to easily pass image URLs -->
+    <div class="ease-image-compare" style="
+      --ease-compare-before: url('https://images.unsplash.com/photo-1542385151-efd9000785a0?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80');
+      --ease-compare-after: url('https://images.unsplash.com/photo-1542385151-efd9000785a0?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80&sat=-100');
+    ">
+      <div class="ease-image-compare-before"></div>
+    </div>
+    
+    <p class="instruction">Drag the slider handle in the center to compare images.</p>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/css-only-image-slider/style.css
+++ b/submissions/examples/css-only-image-slider/style.css
@@ -1,0 +1,75 @@
+/* 
+  Pure CSS Before/After Image Comparison Slider
+  Issue: #68954
+*/
+
+.ease-image-compare {
+  position: relative;
+  /* Adjust width and height as needed */
+  width: 800px;
+  max-width: 100%;
+  height: 450px;
+  
+  /* The "after" image is the background of the wrapper */
+  background-image: var(--ease-compare-after);
+  background-size: 800px 450px; /* Force size to match exactly so images align */
+  background-position: left top;
+  background-repeat: no-repeat;
+  
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.15);
+}
+
+.ease-image-compare-before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  
+  /* Initial position (50% split) */
+  width: 50%;
+  min-width: 0;
+  max-width: 100%;
+  
+  /* The magic happens here: CSS native resize capability */
+  resize: horizontal;
+  overflow: hidden;
+  
+  /* The "before" image */
+  background-image: var(--ease-compare-before);
+  background-size: 800px 450px; /* Same size as parent to ensure perfect alignment */
+  background-position: left top;
+  background-repeat: no-repeat;
+  
+  /* The separator line */
+  border-right: 4px solid #fff;
+  box-shadow: 2px 0 15px rgba(0,0,0,0.4);
+}
+
+/* Custom Resize Handle indicator in the bottom right corner */
+.ease-image-compare-before::after {
+  content: '◂ ▸'; /* Simple arrows to indicate draggability */
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  width: 44px;
+  height: 40px;
+  background-color: rgba(255, 255, 255, 0.95);
+  color: #333;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  font-weight: 700;
+  border-top-left-radius: 8px;
+  box-shadow: -2px -2px 10px rgba(0,0,0,0.1);
+  
+  /* CRITICAL: Let clicks pass through so the native resize handle underneath still works */
+  pointer-events: none; 
+}
+
+/* For better aesthetics on WebKit browsers, hide the native dotted resize handle lines */
+.ease-image-compare-before::-webkit-resizer {
+  background-color: transparent;
+}


### PR DESCRIPTION
## Description
This PR resolves #68954 by introducing a pure CSS before-and-after image comparison slider. The slider utilizes the CSS `resize` property on a wrapper element to allow dragging and resizing without any JavaScript event listeners.

### Features
- Pure CSS implementation, no JavaScript required.
- Uses `resize: horizontal` coupled with `overflow: hidden` to reveal or hide the before image.
- Both "before" and "after" images are perfectly aligned by locking the `background-size` across layers.
- Custom pseudo-element acts as a visual drag indicator in the bottom-right corner.

### Issue Fixed
Fixes #68954