### PR TITLE
feat: add pure CSS iOS style segmented control (#68958)

### DIFF
--- a/submissions/examples/ios-segmented-control/README.md
+++ b/submissions/examples/ios-segmented-control/README.md
@@ -1,0 +1,14 @@
+# Pure CSS iOS-Style Segmented Control
+
+## Description
+This submission resolves Issue #68958 by introducing a pure CSS iOS-style segmented control (radio button group) with a sliding highlight pill. 
+
+## Features
+- Completely CSS-based, no JavaScript required.
+- Uses CSS Grid for perfect equal-width spacing of the segments.
+- Uses hidden `<input type="radio">` buttons to maintain native HTML form accessibility and state.
+- The highlighted pill utilizes the general sibling combinator (`~`) and `transform: translateX()` to slide smoothly into place based on which radio is `:checked`.
+- Dynamically scales based on the `--segment-count` CSS variable.
+
+## Usage
+Simply structure your HTML so that the radio inputs are defined first, followed by the labels, and ending with the `.ease-segmented-highlight` pill. Set the `--segment-count` variable on the wrapper to match the number of options you have. Click the labels to see the pill slide elegantly behind the text.

--- a/submissions/examples/ios-segmented-control/demo.html
+++ b/submissions/examples/ios-segmented-control/demo.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pure CSS iOS-Style Segmented Control</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      margin: 0;
+      background-color: #f5f5f7;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    }
+    .demo-wrapper {
+      background: white;
+      padding: 3rem;
+      border-radius: 16px;
+      box-shadow: 0 4px 20px rgba(0,0,0,0.05);
+      width: 100%;
+      max-width: 400px;
+    }
+    h2 {
+      text-align: center;
+      margin-top: 0;
+      margin-bottom: 2rem;
+      color: #1d1d1f;
+      font-size: 1.5rem;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="demo-wrapper">
+    <h2>Select Mode</h2>
+    
+    <!-- 
+      Ensure --segment-count matches the number of radio buttons/labels.
+      The structure must be:
+      1. All radio inputs
+      2. All labels corresponding to the inputs
+      3. The .ease-segmented-highlight div
+    -->
+    <div class="ease-segmented-control" style="--segment-count: 3;">
+      <!-- Hidden Radio Inputs -->
+      <input type="radio" name="mode" id="mode-day" checked>
+      <input type="radio" name="mode" id="mode-week">
+      <input type="radio" name="mode" id="mode-month">
+      
+      <!-- Labels acting as buttons -->
+      <label for="mode-day">Day</label>
+      <label for="mode-week">Week</label>
+      <label for="mode-month">Month</label>
+      
+      <!-- The sliding highlight pill -->
+      <div class="ease-segmented-highlight"></div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ios-segmented-control/style.css
+++ b/submissions/examples/ios-segmented-control/style.css
@@ -1,0 +1,84 @@
+/* 
+  Pure CSS iOS-Style Segmented Control
+  Issue: #68958
+*/
+
+.ease-segmented-control {
+  /* Configuration Variables */
+  --segment-count: 3;
+  --segment-bg: #e5e5ea;
+  --segment-pill: #ffffff;
+  --segment-text: #333333;
+  --segment-radius: 8px;
+  
+  display: grid;
+  grid-template-columns: repeat(var(--segment-count), 1fr);
+  position: relative;
+  background: var(--segment-bg);
+  border-radius: var(--segment-radius);
+  padding: 4px;
+  isolation: isolate;
+}
+
+/* Hide the radio inputs completely */
+.ease-segmented-control input[type="radio"] {
+  display: none;
+}
+
+/* Style the labels (which act as the clickable buttons) */
+.ease-segmented-control label {
+  text-align: center;
+  padding: 8px 16px;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--segment-text);
+  cursor: pointer;
+  border-radius: calc(var(--segment-radius) - 2px);
+  position: relative;
+  z-index: 2; /* Stay above the sliding pill */
+  transition: color 0.3s cubic-bezier(0.19, 1, 0.22, 1);
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* The sliding highlight pill */
+.ease-segmented-highlight {
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  bottom: 4px;
+  /* Width dynamically calculates based on segment count */
+  width: calc((100% - 8px) / var(--segment-count));
+  background: var(--segment-pill);
+  border-radius: calc(var(--segment-radius) - 2px);
+  box-shadow: 0 2px 5px rgba(0,0,0,0.1), 0 1px 2px rgba(0,0,0,0.05);
+  z-index: 1; /* Slide directly behind the labels */
+  /* Smooth easing transition */
+  transition: transform 0.4s cubic-bezier(0.19, 1, 0.22, 1);
+}
+
+/* 
+  Sliding Logic 
+  We use the general sibling combinator (~) to move the highlight
+  based on which radio button is currently checked.
+*/
+
+.ease-segmented-control input[type="radio"]:nth-of-type(1):checked ~ .ease-segmented-highlight {
+  transform: translateX(0);
+}
+
+.ease-segmented-control input[type="radio"]:nth-of-type(2):checked ~ .ease-segmented-highlight {
+  transform: translateX(100%);
+}
+
+.ease-segmented-control input[type="radio"]:nth-of-type(3):checked ~ .ease-segmented-highlight {
+  transform: translateX(200%);
+}
+
+.ease-segmented-control input[type="radio"]:nth-of-type(4):checked ~ .ease-segmented-highlight {
+  transform: translateX(300%);
+}
+
+.ease-segmented-control input[type="radio"]:nth-of-type(5):checked ~ .ease-segmented-highlight {
+  transform: translateX(400%);
+}


### PR DESCRIPTION
## Description
This PR resolves #68958 by introducing a pure CSS iOS-style segmented control (radio button group) with a sliding highlight pill. 

### Features
- Completely CSS-based, no JavaScript required.
- Uses CSS Grid for perfect equal-width spacing of the segments.
- Uses hidden `<input type="radio">` buttons to maintain native HTML form accessibility and state.
- The highlighted pill utilizes the general sibling combinator (`~`) and `transform: translateX()` to slide smoothly into place based on which radio is `:checked`.
- Dynamically scales based on the `--segment-count` CSS variable.

### Issue Fixed
Fixes #68958