### PR TITLE
Add ease-color-palette-swatches component

### DIFF
--- a/submissions/examples/color-palette-swatches-ij/README.md
+++ b/submissions/examples/color-palette-swatches-ij/README.md
@@ -1,0 +1,11 @@
+# ease-color-palette-swatches
+
+A color palette where the swatches lift, the hex labels flicker, and the tick pops.
+
+## Run
+Open `demo.html` directly in a browser to watch the palette.
+
+## Notes
+- The swatches lift in sequence.
+- The hex labels flicker on the chips.
+- The copy tick pops on the first swatch.

--- a/submissions/examples/color-palette-swatches-ij/demo.html
+++ b/submissions/examples/color-palette-swatches-ij/demo.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-color-palette-swatches demo</title>
+</head>
+<body>
+<div class="cpsw-palette">
+  <div class="cpsw-swatch cpsw-red">
+    <span class="cpsw-tick">&#10003;</span>
+    <span class="cpsw-name">ember</span>
+    <span class="cpsw-hex">#e5484d</span>
+  </div>
+  <div class="cpsw-swatch cpsw-blue">
+    <span class="cpsw-name">sky</span>
+    <span class="cpsw-hex">#3b82f6</span>
+  </div>
+  <div class="cpsw-swatch cpsw-green">
+    <span class="cpsw-name">mint</span>
+    <span class="cpsw-hex">#22c55e</span>
+  </div>
+  <div class="cpsw-swatch cpsw-gold">
+    <span class="cpsw-name">honey</span>
+    <span class="cpsw-hex">#f59e0b</span>
+  </div>
+  <div class="cpsw-swatch cpsw-violet">
+    <span class="cpsw-name">orchid</span>
+    <span class="cpsw-hex">#8b5cf6</span>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/color-palette-swatches-ij/style.css
+++ b/submissions/examples/color-palette-swatches-ij/style.css
@@ -1,0 +1,13 @@
+.cpsw-palette{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:420px;background:#0f1a2a;border:1px solid #1e3350;border-radius:14px;padding:18px;display:grid;grid-template-columns:repeat(3,1fr);gap:14px}
+.cpsw-swatch{position:relative;border-radius:10px;height:120px;display:flex;flex-direction:column;justify-content:flex-end;padding:12px;animation:cpsw-lift-color-palette-swatches 2.6s ease-in-out infinite}
+.cpsw-red{background:#e5484d}
+.cpsw-blue{background:#3b82f6;animation-delay:0.3s}
+.cpsw-green{background:#22c55e;animation-delay:0.6s}
+.cpsw-gold{background:#f59e0b;animation-delay:0.9s}
+.cpsw-violet{background:#8b5cf6;animation-delay:1.2s}
+.cpsw-name{font-size:12px;font-weight:800;color:#0d1624}
+.cpsw-hex{font-size:10px;color:rgba(13,22,36,0.75);animation:cpsw-hex-flicker-color-palette-swatches 2.6s ease-in-out infinite}
+.cpsw-tick{position:absolute;top:10px;right:10px;width:16px;height:16px;border-radius:50%;background:#0d1624;color:#7cebb0;font-size:10px;display:grid;place-items:center;animation:cpsw-tick-pop-color-palette-swatches 2.6s ease-in-out infinite}
+@keyframes cpsw-lift-color-palette-swatches{0%{transform:translateY(0)}50%{transform:translateY(-6px)}100%{transform:translateY(0)}}
+@keyframes cpsw-hex-flicker-color-palette-swatches{0%{opacity:0.6}50%{opacity:1}100%{opacity:0.6}}
+@keyframes cpsw-tick-pop-color-palette-swatches{0%{transform:scale(0)}30%{transform:scale(1.2)}55%{transform:scale(1)}70%{transform:scale(0.6)}100%{transform:scale(0)}}


### PR DESCRIPTION
## Component: ease-color-palette-swatches — swatches lift, hex flickers, and tick pops

**Closes #69036**

### What this adds
A color palette: the swatches lift in sequence, the hex labels flicker, and the copy tick pops on the first swatch.

### Acceptance Criteria covered
- Swatches lift in sequence
- Hex labels flicker on the chips
- Copy tick pops on the first swatch

### Files
- `submissions/examples/color-palette-swatches-ij/demo.html`
- `submissions/examples/color-palette-swatches-ij/style.css`
- `submissions/examples/color-palette-swatches-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the swatches lift.