### PR TITLE
Add ease-tip-calculator-split component

### DIFF
--- a/submissions/examples/tip-calculator-split-ij/README.md
+++ b/submissions/examples/tip-calculator-split-ij/README.md
@@ -1,0 +1,11 @@
+# ease-tip-calculator-split
+
+A tip calculator where the tip buttons pop, the stepper pulses, and the total glows.
+
+## Run
+Open `demo.html` directly in a browser to watch the calculator.
+
+## Notes
+- The tip buttons pop on the row.
+- The split stepper pulses in turn.
+- The per-person total glows below.

--- a/submissions/examples/tip-calculator-split-ij/demo.html
+++ b/submissions/examples/tip-calculator-split-ij/demo.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-tip-calculator-split demo</title>
+</head>
+<body>
+<div class="tcs-app">
+  <div class="tcs-field">
+    <span class="tcs-lbl">BILL</span>
+    <span class="tcs-amount">$48.60</span>
+  </div>
+  <div class="tcs-field">
+    <span class="tcs-lbl">TIP</span>
+    <div class="tcs-tips">
+      <span class="tcs-tip tcs-on">15%</span>
+      <span class="tcs-tip">18%</span>
+      <span class="tcs-tip">20%</span>
+    </div>
+  </div>
+  <div class="tcs-field">
+    <span class="tcs-lbl">PEOPLE</span>
+    <div class="tcs-stepper">
+      <span class="tcs-step">&#8722;</span>
+      <span class="tcs-count">4</span>
+      <span class="tcs-step">+</span>
+    </div>
+  </div>
+  <div class="tcs-result">
+    <span class="tcs-per">PER PERSON</span>
+    <span class="tcs-total">$13.97</span>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/tip-calculator-split-ij/style.css
+++ b/submissions/examples/tip-calculator-split-ij/style.css
@@ -1,0 +1,16 @@
+.tcs-app{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:360px;background:#0f1a2a;border:1px solid #1e3350;border-radius:16px;padding:22px;display:flex;flex-direction:column;gap:18px}
+.tcs-field{display:flex;align-items:center;justify-content:space-between}
+.tcs-lbl{font-size:10px;font-weight:800;letter-spacing:3px;color:#5d7690}
+.tcs-amount{font-size:20px;font-weight:800;color:#e8f0f8}
+.tcs-tips{display:flex;gap:8px}
+.tcs-tip{font-size:11px;font-weight:700;padding:6px 14px;border-radius:8px;background:#16253a;color:#8aa1b8;animation:tcs-tip-pop-tip-calculator-split 2.4s ease-in-out infinite}
+.tcs-on{background:#38bdf8;color:#0a1a2a}
+.tcs-stepper{display:flex;align-items:center;gap:12px}
+.tcs-step{width:30px;height:30px;border-radius:8px;background:#16253a;color:#38bdf8;font-size:16px;font-weight:800;display:grid;place-items:center;animation:tcs-step-pulse-tip-calculator-split 1.6s ease-in-out infinite}
+.tcs-count{font-size:16px;font-weight:800;color:#e8f0f8}
+.tcs-result{display:flex;align-items:baseline;justify-content:space-between;background:#12382a;border-radius:10px;padding:14px 16px}
+.tcs-per{font-size:9px;letter-spacing:2px;font-weight:800;color:#7cebb0}
+.tcs-total{font-size:22px;font-weight:800;color:#34d399;animation:tcs-result-glow-tip-calculator-split 2s ease-in-out infinite}
+@keyframes tcs-tip-pop-tip-calculator-split{0%{transform:scale(1)}50%{transform:scale(1.1)}100%{transform:scale(1)}}
+@keyframes tcs-step-pulse-tip-calculator-split{0%{opacity:0.6}50%{opacity:1}100%{opacity:0.6}}
+@keyframes tcs-result-glow-tip-calculator-split{0%{text-shadow:0 0 0 rgba(52,211,153,0)}50%{text-shadow:0 0 12px rgba(52,211,153,0.6)}100%{text-shadow:0 0 0 rgba(52,211,153,0)}}


### PR DESCRIPTION
## Component: ease-tip-calculator-split — tips pop, steps pulse, and total glows

**Closes #69041**

### What this adds
A tip calculator: the tip buttons pop, the split stepper pulses, and the per-person total glows on the result row.

### Acceptance Criteria covered
- Tip buttons pop on the row
- Split stepper pulses in turn
- Per-person total glows below

### Files
- `submissions/examples/tip-calculator-split-ij/demo.html`
- `submissions/examples/tip-calculator-split-ij/style.css`
- `submissions/examples/tip-calculator-split-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the tips pop.