### PR TITLE
feat: add hover-expanding flexbox image gallery (#68962)

### DIFF
--- a/submissions/examples/hover-flex-gallery/README.md
+++ b/submissions/examples/hover-flex-gallery/README.md
@@ -1,0 +1,24 @@
+# Hover-Expanding Flexbox Image Gallery
+
+## Description
+This submission resolves Issue #68962 by introducing a purely CSS-driven interactive image gallery. It displays a row of equal-width images, and when a user hovers over one, it expands to show more detail while smoothly compressing the others.
+
+## Features
+- Pure CSS implementation using Flexbox.
+- Seamless transitions driven by the `flex` property.
+- Prevents image distortion during expansion/compression by using `object-fit: cover`.
+- Highly responsive and easily configurable using CSS variables.
+
+## Usage
+Create an outer container with the `.ease-flex-gallery` class. Inside it, place your gallery items using the `.ease-gallery-item` class. Ensure that each item contains an `<img>` tag. The component handles the rest, automatically allocating space evenly until hovered.
+
+```html
+<div class="ease-flex-gallery">
+  <div class="ease-gallery-item">
+    <img src="..." alt="...">
+  </div>
+  <div class="ease-gallery-item">
+    <img src="..." alt="...">
+  </div>
+</div>
+```

--- a/submissions/examples/hover-flex-gallery/demo.html
+++ b/submissions/examples/hover-flex-gallery/demo.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Hover-Expanding Flexbox Image Gallery</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      margin: 0;
+      padding: 2rem;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      background-color: #1a1a1a;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      color: white;
+    }
+    
+    .container {
+      width: 100%;
+      max-width: 900px;
+    }
+
+    h2 {
+      margin-bottom: 2rem;
+      text-align: center;
+      font-weight: 300;
+      letter-spacing: 1px;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="container">
+    <h2>Hover over an image</h2>
+    
+    <div class="ease-flex-gallery">
+      <div class="ease-gallery-item">
+        <img src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80" alt="Mountain landscape">
+      </div>
+      <div class="ease-gallery-item">
+        <img src="https://images.unsplash.com/photo-1472214103451-9374bd1c798e?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80" alt="Nature path">
+      </div>
+      <div class="ease-gallery-item">
+        <img src="https://images.unsplash.com/photo-1493246507139-91e8fad9978e?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80" alt="Snowy peaks">
+      </div>
+      <div class="ease-gallery-item">
+        <img src="https://images.unsplash.com/photo-1511884642898-4c92249e20b6?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80" alt="Forest scene">
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/hover-flex-gallery/style.css
+++ b/submissions/examples/hover-flex-gallery/style.css
@@ -1,0 +1,43 @@
+/* 
+  Hover-Expanding Flexbox Image Gallery 
+  Issue: #68962
+*/
+
+.ease-flex-gallery {
+  /* Default custom easing variable if none is provided in the project */
+  --ease-out-expo: cubic-bezier(0.19, 1, 0.22, 1);
+  --gallery-gap: 10px;
+  --gallery-height: 400px;
+  --gallery-border-radius: 12px;
+  
+  display: flex;
+  gap: var(--gallery-gap);
+  height: var(--gallery-height);
+  width: 100%;
+}
+
+.ease-gallery-item {
+  /* Start with equal width */
+  flex: 1;
+  /* Smoothly transition the flex property */
+  transition: flex 0.5s var(--ease-out-expo);
+  border-radius: var(--gallery-border-radius);
+  overflow: hidden;
+  position: relative;
+  cursor: pointer;
+}
+
+/* Expand the hovered item while others compress (because they remain flex: 1) */
+.ease-gallery-item:hover {
+  flex: 3;
+}
+
+/* Ensure images fill the container without distorting */
+.ease-gallery-item img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  /* Optional: center the image subject */
+  object-position: center;
+}


### PR DESCRIPTION
## Description
This PR resolves #68962 by introducing a purely CSS-driven interactive image gallery. It displays a row of equal-width images, and when a user hovers over one, it expands to show more detail while smoothly compressing the others.

### Features
- Pure CSS implementation using Flexbox.
- Seamless transitions driven by the `flex` property.
- Prevents image distortion during expansion/compression by using `object-fit: cover`.
- Highly responsive and easily configurable using CSS variables.

### Issue Fixed
Fixes #68962