### PR TITLE
feat: add css-only scratch-off card reveal (#68972)

### DIFF
--- a/submissions/examples/css-scratch-card/README.md
+++ b/submissions/examples/css-scratch-card/README.md
@@ -1,0 +1,35 @@
+# CSS-Only Scratch-Off Card Reveal
+
+## Description
+This submission resolves Issue #68972 by creating a fun, interactive "scratch card" effect using CSS Grid and `:hover` states. It simulates the process of scratching off a top layer to reveal a prize or text hidden underneath without relying on JavaScript event listeners for the logic.
+
+## Features
+- Pure CSS logic for the "scratching" effect.
+- Uses a CSS Grid overlay (`.ease-scratch-card-mask`) filled with small blocks (`.ease-scratch-card-block`).
+- As the user hovers over each block, its `opacity` drops to `0` instantly.
+- Utilizes an extreme `transition-delay: 9999s` on mouseout so that once a block is "scratched", it essentially never returns, keeping the content underneath revealed.
+- Customizable metallic scratch-off texture using `repeating-linear-gradient`.
+
+## Usage
+Wrap your hidden content inside `.ease-scratch-card` and `.ease-scratch-card-content`. Above the content, place the mask `.ease-scratch-card-mask` containing a grid of `.ease-scratch-card-block` elements. 
+
+```html
+<div class="ease-scratch-card">
+  
+  <!-- Content to Reveal -->
+  <div class="ease-scratch-card-content">
+    You Won $1,000!
+  </div>
+  
+  <!-- Mask Grid (e.g. 10x10) -->
+  <div class="ease-scratch-card-mask">
+    <!-- Generate 100 blocks here -->
+    <div class="ease-scratch-card-block"></div>
+    <div class="ease-scratch-card-block"></div>
+    <!-- ... -->
+  </div>
+  
+</div>
+```
+
+The grid is defined in CSS to auto-fit the container dimensions. Adjust the number of blocks and `grid-template-columns`/`rows` in `style.css` for finer or coarser "scratch" granularity.

--- a/submissions/examples/css-scratch-card/demo.html
+++ b/submissions/examples/css-scratch-card/demo.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS-Only Scratch-Off Card Reveal</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      margin: 0;
+      padding: 2rem;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      background-color: #2c3e50;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      color: white;
+    }
+    
+    h2 {
+      margin: 0;
+      font-weight: 300;
+      text-align: center;
+    }
+    
+    p {
+      color: #aaa;
+      text-align: center;
+      margin-bottom: 2rem;
+    }
+    
+    .prize-title {
+      font-size: 1.5rem;
+      font-weight: bold;
+      margin-bottom: 0.5rem;
+      color: #fff;
+      text-shadow: 1px 1px 2px rgba(0,0,0,0.3);
+    }
+    
+    .prize-amount {
+      font-size: 3rem;
+      font-weight: 900;
+      color: #fff;
+      text-shadow: 2px 2px 4px rgba(0,0,0,0.3);
+    }
+  </style>
+</head>
+<body>
+
+  <h2>CSS-Only Scratch Card</h2>
+  <p>Hover your mouse over the card to "scratch" off the metallic layer!</p>
+
+  <div class="ease-scratch-card">
+    
+    <!-- The content underneath -->
+    <div class="ease-scratch-card-content">
+      <div class="prize-title">You Won!</div>
+      <div class="prize-amount">$1,000</div>
+    </div>
+    
+    <!-- The mask layer composed of 100 small blocks (10x10 grid) -->
+    <div class="ease-scratch-card-mask">
+      <!-- 
+        In a real application, you might use JS or a templating language to generate these.
+        For this pure HTML/CSS demo, we manually write them out.
+        We need 100 of these divs.
+      -->
+      <script>
+        for(let i=0; i<100; i++) {
+          document.write('<div class="ease-scratch-card-block"></div>');
+        }
+      </script>
+      <!-- We use a tiny inline script just to save space in the HTML file, 
+           the actual scratch effect is 100% CSS driven. If JS is completely forbidden 
+           in the HTML, you would copy/paste <div class="ease-scratch-card-block"></div> 100 times. -->
+    </div>
+    
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/css-scratch-card/style.css
+++ b/submissions/examples/css-scratch-card/style.css
@@ -1,0 +1,77 @@
+/* 
+  CSS-Only Scratch-Off Card Reveal
+  Issue: #68972
+*/
+
+.ease-scratch-card {
+  position: relative;
+  width: 300px;
+  height: 200px;
+  border-radius: 12px;
+  overflow: hidden;
+  background-color: #fff;
+  box-shadow: 0 10px 20px rgba(0,0,0,0.15);
+  user-select: none;
+}
+
+/* The hidden content (Prize) underneath */
+.ease-scratch-card-content {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  background: linear-gradient(135deg, #f6d365 0%, #fda085 100%);
+  color: white;
+  font-family: -apple-system, sans-serif;
+  z-index: 1;
+}
+
+/* The grid container that holds the scratchable blocks */
+.ease-scratch-card-mask {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: grid;
+  /* e.g., 10 columns and 10 rows of small blocks */
+  grid-template-columns: repeat(10, 1fr);
+  grid-template-rows: repeat(10, 1fr);
+  z-index: 2;
+  /* To ensure hover works immediately, no pointer-events on the mask itself, 
+     but allow it on children */
+  pointer-events: none;
+}
+
+/* The individual blocks that act as the scratch-off layer */
+.ease-scratch-card-block {
+  background-color: #bdc3c7;
+  /* Add a metallic/scratch-off texture via background image if desired, 
+     here we use a linear gradient for a shiny effect */
+  background-image: repeating-linear-gradient(
+    45deg,
+    transparent,
+    transparent 10px,
+    rgba(255,255,255,0.1) 10px,
+    rgba(255,255,255,0.1) 20px
+  );
+  opacity: 1;
+  pointer-events: auto; /* Re-enable pointer events for the blocks */
+  
+  /* When hovering off, delay the transition back to opacity:1 by a huge amount
+     so it stays "scratched off" essentially forever */
+  transition: opacity 0s ease 9999s;
+}
+
+/* When hovering over a block, immediately hide it */
+.ease-scratch-card-block:hover {
+  opacity: 0;
+  /* No delay on hover, happens instantly */
+  transition: opacity 0.1s ease 0s;
+}


### PR DESCRIPTION
## Description
This PR resolves #68972 by creating a fun, interactive "scratch card" effect using CSS Grid and `:hover` states. It simulates the process of scratching off a top layer to reveal a prize or text hidden underneath without relying on JavaScript event listeners for the logic.

### Features
- Pure CSS logic for the "scratching" effect.
- Uses a CSS Grid overlay (`.ease-scratch-card-mask`) filled with small blocks (`.ease-scratch-card-block`).
- As the user hovers over each block, its `opacity` drops to `0` instantly.
- Utilizes an extreme `transition-delay: 9999s` on mouseout so that once a block is "scratched", it essentially never returns, keeping the content underneath revealed.
- Customizable metallic scratch-off texture using `repeating-linear-gradient`.

### Issue Fixed
Fixes #68972