### PR TITLE
feat: add retro 8-bit pixelated utility (#68980)

### DIFF
--- a/submissions/examples/pixelated-utility/README.md
+++ b/submissions/examples/pixelated-utility/README.md
@@ -1,0 +1,20 @@
+# Retro 8-bit Pixelated Utility
+
+## Description
+This submission resolves Issue #68980 by providing a simple CSS utility class designed to enforce harsh, aliased scaling on images or canvas elements. It prevents the browser from automatically blurring scaled-up images (bilinear interpolation) and instead preserves sharp, blocky edges (nearest-neighbor interpolation), perfect for retro 8-bit aesthetics or pixel art.
+
+## Features
+- Pure CSS solution.
+- Uses `image-rendering: pixelated;` for modern browsers.
+- Includes fallbacks (`crisp-edges` and `-ms-interpolation-mode`) for maximum cross-browser compatibility.
+
+## Usage
+Simply apply the `.ease-pixelated` class to any `<img>`, `<canvas>`, or element with a `background-image` that you intend to scale up while retaining a sharp pixelated look.
+
+```html
+<!-- Scaling up a small 16x16 pixel art image to 200x200 -->
+<img src="small-pixel-art.png" class="ease-pixelated" style="width: 200px; height: 200px;" alt="Pixel Art">
+```
+
+### Why use this?
+When you have a small pixel art graphic (e.g., 16x16px or 32x32px) and you want it to appear large on the screen, setting a higher `width` and `height` in CSS usually causes the browser to smooth or blur the image to make it look "better". For pixel art, this destroys the aesthetic. Adding `.ease-pixelated` forces the browser to scale the image sharply, keeping every pixel crisp and distinct.

--- a/submissions/examples/pixelated-utility/demo.html
+++ b/submissions/examples/pixelated-utility/demo.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Retro 8-bit Pixelated Utility</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      margin: 0;
+      padding: 2rem;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      background-color: #f0f0f0;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+    }
+    
+    .demo-container {
+      display: flex;
+      gap: 4rem;
+      flex-wrap: wrap;
+      justify-content: center;
+      margin-top: 2rem;
+    }
+
+    .image-card {
+      background: white;
+      padding: 1rem;
+      border-radius: 8px;
+      box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+      text-align: center;
+      width: 300px;
+    }
+    
+    h2 {
+      margin-top: 0;
+      font-size: 1.2rem;
+    }
+    
+    p {
+      color: #666;
+      font-size: 0.9rem;
+    }
+    
+    /* 
+      We simulate a tiny pixel art image by generating a small 16x16 data URI, 
+      and then we scale it up to 200px width.
+      
+      Without .ease-pixelated, the browser blurs it.
+      With .ease-pixelated, it remains sharp.
+    */
+    .pixel-art {
+      width: 200px;
+      height: 200px;
+      /* This is a tiny 2x2 checkerboard pattern to simulate a very small image */
+      background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAFElEQVQIW2NkYGD4z8DAwMgAI0AMCKcAQZV110QAAAAASUVORK5CYII=');
+      background-size: 100% 100%;
+      margin: 0 auto;
+      border: 1px solid #ddd;
+    }
+    
+  </style>
+</head>
+<body>
+
+  <h1>Retro 8-bit Pixelated Utility</h1>
+
+  <div class="demo-container">
+    
+    <!-- Without Utility -->
+    <div class="image-card">
+      <h2>Default (Blurry)</h2>
+      <p>When you scale a tiny image up, browsers blur it by default using bilinear interpolation.</p>
+      <div class="pixel-art"></div>
+    </div>
+    
+    <!-- With Utility -->
+    <div class="image-card">
+      <h2>Pixelated (Sharp)</h2>
+      <p>Adding <code>.ease-pixelated</code> forces the browser to use nearest-neighbor scaling.</p>
+      <!-- We add the utility class here -->
+      <div class="pixel-art ease-pixelated"></div>
+    </div>
+    
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/pixelated-utility/style.css
+++ b/submissions/examples/pixelated-utility/style.css
@@ -1,0 +1,14 @@
+/* 
+  Retro 8-bit Pixelated Utility
+  Issue: #68980
+*/
+
+.ease-pixelated {
+  /* Standard property for modern browsers (Chrome, Safari, Firefox, Edge) */
+  image-rendering: pixelated;
+  
+  /* Fallback/alternative syntax for older Firefox and some other browsers */
+  -ms-interpolation-mode: nearest-neighbor;
+  image-rendering: -moz-crisp-edges;
+  image-rendering: crisp-edges;
+}


### PR DESCRIPTION
## Description
This PR resolves #68980 by providing a simple CSS utility class designed to enforce harsh, aliased scaling on images or canvas elements. It prevents the browser from automatically blurring scaled-up images (bilinear interpolation) and instead preserves sharp, blocky edges (nearest-neighbor interpolation), perfect for retro 8-bit aesthetics or pixel art.

### Features
- Pure CSS solution.
- Uses `image-rendering: pixelated;` for modern browsers.
- Includes fallbacks (`crisp-edges` and `-ms-interpolation-mode`) for maximum cross-browser compatibility.

### Issue Fixed
Fixes #68980