### PR TITLE
feat: add pure CSS Scroll-Linked Scale component (#68132)

### DIFF
--- a/submissions/examples/css-scroll-linked-scale-pure/README.md
+++ b/submissions/examples/css-scroll-linked-scale-pure/README.md
@@ -1,0 +1,20 @@
+# CSS Scroll-Linked Scale
+
+A pure CSS component featuring elements that scale dynamically from small to large as the page scrolls, built entirely without JavaScript using modern CSS APIs.
+
+## Features
+- Pure CSS and HTML (Zero JavaScript scroll event listeners or complex math calculations).
+- **Theming & Dark Mode**: Utilizes CSS Custom Properties (`--card-bg`, `--bg-base`, etc.) for easy overriding. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`).
+- **Scroll-Driven Timelines (Documented in Code)**: 
+- This component leverages two modern CSS timeline APIs:
+- `animation-timeline: scroll()`: Binds the scaling animation perfectly to the absolute scroll position of the entire page document.
+- `animation-timeline: view()`: Binds the scaling animation to the element's intersection with the viewport, which is perfect for elements placed far down the page.
+- Both animations scrub backwards smoothly if you scroll back up!
+- Fully accessible with `prefers-reduced-motion` support. The scaling animations are completely disabled for motion-sensitive users, rendering the elements at full scale by default.
+
+## Usage
+Open `demo.html` in your browser. Scroll down the page. You will notice the first card scaling up in direct proportion to your global scroll progress. Further down, you will see a second card scaling up as it enters the viewport.
+
+## Files
+- `demo.html`: The HTML structure detailing the layout and spacer blocks required to generate a scrollbar.
+- `style.css`: The styling, CSS Custom Property theming blocks, and heavily commented mechanics detailing the `scroll()` and `view()` timelines.

--- a/submissions/examples/css-scroll-linked-scale-pure/demo.html
+++ b/submissions/examples/css-scroll-linked-scale-pure/demo.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Scroll-Linked Scale</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Scroll-Linked Scale</h1>
+            <p class="subtitle">A pure CSS implementation of elements scaling dynamically as the page scrolls, utilizing `animation-timeline: scroll()`.</p>
+        </header>
+
+        <div class="scroll-instruction">
+            <span>Scroll down slowly</span>
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M12 5v14M19 12l-7 7-7-7"/>
+            </svg>
+        </div>
+
+        <!-- 
+           [TECHNIQUE] The Scroll Tracker 
+           This element scales based on the overall page scroll position.
+        -->
+        <div class="demo-area">
+            
+            <div class="scale-element global-scroll">
+                <h3>Global Scroll</h3>
+                <p>I scale from 0 to 1 based on your absolute scroll position in the document.</p>
+            </div>
+            
+        </div>
+
+        <div class="spacer">Keep scrolling...</div>
+
+        <!-- 
+           [TECHNIQUE] The View Tracker 
+           This element scales based on its own intersection with the viewport.
+        -->
+        <div class="demo-area">
+            
+            <div class="scale-element view-scroll">
+                <h3>Viewport Entry</h3>
+                <p>I scale up gracefully as I enter the viewport, regardless of how long the page is.</p>
+            </div>
+            
+        </div>
+        
+        <div class="spacer">End of page</div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-scroll-linked-scale-pure/style.css
+++ b/submissions/examples/css-scroll-linked-scale-pure/style.css
@@ -1,0 +1,177 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    
+    --card-bg: #ffffff;
+    --card-border: #e2e8f0;
+    --card-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a;
+        --text-primary: #f8fafc;
+        --text-secondary: #94a3b8;
+        
+        --card-bg: #1e293b;
+        --card-border: #334155;
+        --card-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.5), 0 10px 10px -5px rgba(0, 0, 0, 0.3);
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    width: 100%;
+    margin: 0 auto;
+    padding: 60px 20px;
+    text-align: center;
+}
+
+.section-header {
+    margin-bottom: 60px;
+}
+
+.title {
+    font-size: 2.5rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.scroll-instruction {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 80px;
+    color: var(--text-secondary);
+    font-weight: 500;
+    animation: bounce 2s infinite ease-in-out;
+}
+
+@keyframes bounce {
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(10px); }
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 300px;
+}
+
+.spacer {
+    height: 70vh; /* Adds scrollable space */
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-secondary);
+    font-style: italic;
+    font-size: 1.2rem;
+}
+
+
+/* =========================================
+   Scroll-Linked Scale Element
+   ========================================= */
+
+.scale-element {
+    background-color: var(--card-bg);
+    padding: 40px;
+    border-radius: 24px;
+    box-shadow: var(--card-shadow);
+    border: 1px solid var(--card-border);
+    max-width: 400px;
+    
+    /* Optimize scaling performance */
+    will-change: transform;
+}
+
+.scale-element h3 {
+    margin: 0 0 12px 0;
+    font-size: 1.75rem;
+    font-weight: 600;
+    background: linear-gradient(135deg, #3b82f6, #8b5cf6);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+.scale-element p {
+    margin: 0;
+    color: var(--text-secondary);
+    line-height: 1.6;
+    font-size: 1.1rem;
+}
+
+/* =========================================
+   Animation Timelines
+   ========================================= */
+
+/* 
+  [TECHNIQUE 1] Global Scroll Timeline 
+  Binds the scale animation to the absolute scroll position of the entire page document.
+  When you are at the top, it's 0% scaled. At the bottom, it's 100% scaled.
+*/
+.global-scroll {
+    animation: scale-up linear both;
+    animation-timeline: scroll();
+    /* No range needed, it maps perfectly 0-100% to the document height */
+}
+
+/* 
+  [TECHNIQUE 2] Viewport Entry Timeline 
+  Binds the scale animation to the element's intersection with the viewport.
+  This is useful if the element is way down the page and you only want it to scale when you see it.
+*/
+.view-scroll {
+    animation: scale-up linear both;
+    animation-timeline: view();
+    /* Animate from when it enters the viewport until it is fully visible (or centered) */
+    animation-range: entry 0% cover 50%;
+}
+
+
+@keyframes scale-up {
+    from {
+        transform: scale(0.2);
+        opacity: 0;
+    }
+    to {
+        transform: scale(1);
+        opacity: 1;
+    }
+}
+
+
+/* Accessibility - Disable scroll animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .scale-element {
+        animation: none !important;
+        opacity: 1 !important;
+        transform: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a pure CSS component featuring elements that scale dynamically from small to large as the page scrolls, built entirely without JavaScript using modern CSS APIs, resolving issue #68132.

### Changes Made:
- Added `submissions/examples/css-scroll-linked-scale-pure/` directory.
- Created `demo.html` showcasing the layout and spacer blocks required to generate a scrollbar.
- Created `style.css` featuring the UI mechanics:
  - **Scroll-Driven Timelines**: Leverages two modern CSS timeline APIs.
  - **`animation-timeline: scroll()`**: Binds the scaling animation perfectly to the absolute scroll position of the entire page document.
  - **`animation-timeline: view()`**: Binds the scaling animation to the element's intersection with the viewport, perfect for elements placed far down the page.
  - Both animations scrub backwards seamlessly if the user scrolls up.
  - **Theming & Dark Mode Supported**: Utilizes CSS Custom Properties. The stylesheet automatically respects the OS-level system theme (`prefers-color-scheme: dark`).
- Added `README.md` documenting usage and the technical mechanics of the `scroll()` and `view()` timelines.
- Honors the `prefers-reduced-motion` accessibility standard. The scroll-based scaling animations are completely disabled for motion-sensitive users, rendering elements fully scaled by default.

Closes #68132
