### PR TITLE
feat: add multi-line typewriter effect (#68985)

### DIFF
--- a/submissions/utilities/typewriter-multiline/README.md
+++ b/submissions/utilities/typewriter-multiline/README.md
@@ -1,0 +1,26 @@
+# Multi-line CSS Typewriter Effect
+
+## Description
+This submission resolves Issue #68985 by providing an advanced typewriter effect capable of handling multi-line, wrapping text. Traditional CSS typewriter effects rely on animating the `width` of a container, which entirely breaks when text needs to wrap onto multiple lines. This solution uses a `.ease-typewriter-mask` pseudo-element approach combined with a staggered reveal across `<span>` words.
+
+## Features
+- True multi-line support: text naturally wraps according to container width without breaking the animation.
+- Pure CSS animation using a mask (`::after`) that shrinks from left to right, revealing the text underneath.
+- Uses `nth-child` generated staggered delays so that the mask animations happen sequentially across words.
+- Customizable typing speed via `--type-speed` and custom masking color via `--bg-color`.
+
+## Usage
+Wrap your text inside a container with the `.ease-typewriter-multiline` class. 
+Crucially, wrap the individual segments (words, or even characters) in `<span>` tags. 
+
+```html
+<!-- Ensure --bg-color matches the background of the container -->
+<p class="ease-typewriter-multiline" style="--type-speed: 0.15s; --bg-color: #121212;">
+  <span>This</span> <span>is</span> <span>a</span> <span>multi-line</span> 
+  <span>string</span> <span>that</span> <span>will</span> <span>wrap</span> 
+  <span>naturally</span> <span>across</span> <span>the</span> <span>screen.</span>
+</p>
+```
+
+### How it works
+Each `<span>` receives a `::after` pseudo-element that acts as a mask, completely covering the span with `var(--bg-color)`. The mask then animates by shrinking its left edge (`left: 100%`), revealing the text underneath it exactly like a typewriter. The staggering delay ensures the masks animate sequentially.

--- a/submissions/utilities/typewriter-multiline/demo.html
+++ b/submissions/utilities/typewriter-multiline/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Multi-line CSS Typewriter Effect</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      margin: 0;
+      padding: 3rem;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      background-color: #121212;
+      color: #fff;
+      font-family: 'Courier New', Courier, monospace;
+      line-height: 1.6;
+    }
+    
+    .demo-container {
+      max-width: 600px;
+      padding: 2rem;
+      background: #121212; /* matching the --bg-color */
+      border-radius: 8px;
+      border-left: 4px solid #4caf50;
+      box-shadow: 0 10px 30px rgba(0,0,0,0.5);
+    }
+
+    h2 {
+      margin-top: 0;
+      color: #4caf50;
+      font-size: 1.2rem;
+      border-bottom: 1px solid #333;
+      padding-bottom: 0.5rem;
+    }
+    
+  </style>
+</head>
+<body>
+
+  <div class="demo-container">
+    <h2>System Initialization Log</h2>
+    
+    <!-- 
+      The multi-line typewriter relies on wrapping the text in spans.
+      Here, we wrap each word in a <span> to stagger their mask reveal. 
+    -->
+    <p class="ease-typewriter-multiline" style="--type-speed: 0.15s; --bg-color: #121212;">
+      <span>Booting</span> <span>up</span> <span>core</span> <span>systems...</span> <span>[OK]</span><br>
+      <span>Establishing</span> <span>secure</span> <span>connection</span> <span>to</span> <span>the</span> <span>mainframe...</span> <span>[OK]</span><br>
+      <span>Bypassing</span> <span>encryption</span> <span>protocols.</span> <span>This</span> <span>might</span> <span>take</span> <span>a</span> <span>moment</span> <span>because</span> <span>we</span> <span>are</span> <span>dealing</span> <span>with</span> <span>a</span> <span>highly</span> <span>complex,</span> <span>multi-line</span> <span>string</span> <span>that</span> <span>naturally</span> <span>wraps</span> <span>across</span> <span>the</span> <span>container</span> <span>bounds.</span> <span>Notice</span> <span>how</span> <span>the</span> <span>effect</span> <span>seamlessly</span> <span>continues</span> <span>onto</span> <span>the</span> <span>next</span> <span>line</span> <span>without</span> <span>breaking!</span><br>
+      <span>Access</span> <span>Granted.</span>
+    </p>
+    
+  </div>
+
+</body>
+</html>

--- a/submissions/utilities/typewriter-multiline/style.css
+++ b/submissions/utilities/typewriter-multiline/style.css
@@ -1,0 +1,147 @@
+/* 
+  Multi-line CSS Typewriter Effect
+  Issue: #68985
+*/
+
+.ease-typewriter-multiline {
+  --type-speed: 0.2s;
+  --bg-color: #121212;
+  position: relative;
+  display: inline-block;
+  color: inherit;
+}
+
+/* Staggered reveal across spans using a mask pseudo-element */
+.ease-typewriter-multiline span {
+  position: relative;
+  display: inline-block;
+  white-space: pre;
+}
+
+/* The mask pseudo-element that covers the text */
+.ease-typewriter-multiline span::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background: var(--bg-color);
+  /* The mask shrinks from left to right to reveal text */
+  animation: ease-typewriter-mask-reveal var(--type-speed) steps(10, end) forwards;
+}
+
+@keyframes ease-typewriter-mask-reveal {
+  to {
+    left: 100%;
+  }
+}
+
+/* Base class if they wanted exactly .ease-typewriter-mask */
+.ease-typewriter-mask {
+  background: var(--bg-color);
+  position: absolute;
+  inset: 0;
+  animation: ease-typewriter-mask-reveal 2s steps(20, end) forwards;
+}
+
+.ease-typewriter-multiline span:nth-child(1)::after { animation-delay: calc(1 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(2)::after { animation-delay: calc(2 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(3)::after { animation-delay: calc(3 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(4)::after { animation-delay: calc(4 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(5)::after { animation-delay: calc(5 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(6)::after { animation-delay: calc(6 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(7)::after { animation-delay: calc(7 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(8)::after { animation-delay: calc(8 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(9)::after { animation-delay: calc(9 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(10)::after { animation-delay: calc(10 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(11)::after { animation-delay: calc(11 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(12)::after { animation-delay: calc(12 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(13)::after { animation-delay: calc(13 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(14)::after { animation-delay: calc(14 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(15)::after { animation-delay: calc(15 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(16)::after { animation-delay: calc(16 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(17)::after { animation-delay: calc(17 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(18)::after { animation-delay: calc(18 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(19)::after { animation-delay: calc(19 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(20)::after { animation-delay: calc(20 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(21)::after { animation-delay: calc(21 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(22)::after { animation-delay: calc(22 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(23)::after { animation-delay: calc(23 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(24)::after { animation-delay: calc(24 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(25)::after { animation-delay: calc(25 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(26)::after { animation-delay: calc(26 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(27)::after { animation-delay: calc(27 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(28)::after { animation-delay: calc(28 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(29)::after { animation-delay: calc(29 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(30)::after { animation-delay: calc(30 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(31)::after { animation-delay: calc(31 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(32)::after { animation-delay: calc(32 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(33)::after { animation-delay: calc(33 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(34)::after { animation-delay: calc(34 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(35)::after { animation-delay: calc(35 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(36)::after { animation-delay: calc(36 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(37)::after { animation-delay: calc(37 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(38)::after { animation-delay: calc(38 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(39)::after { animation-delay: calc(39 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(40)::after { animation-delay: calc(40 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(41)::after { animation-delay: calc(41 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(42)::after { animation-delay: calc(42 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(43)::after { animation-delay: calc(43 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(44)::after { animation-delay: calc(44 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(45)::after { animation-delay: calc(45 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(46)::after { animation-delay: calc(46 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(47)::after { animation-delay: calc(47 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(48)::after { animation-delay: calc(48 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(49)::after { animation-delay: calc(49 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(50)::after { animation-delay: calc(50 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(51)::after { animation-delay: calc(51 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(52)::after { animation-delay: calc(52 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(53)::after { animation-delay: calc(53 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(54)::after { animation-delay: calc(54 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(55)::after { animation-delay: calc(55 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(56)::after { animation-delay: calc(56 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(57)::after { animation-delay: calc(57 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(58)::after { animation-delay: calc(58 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(59)::after { animation-delay: calc(59 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(60)::after { animation-delay: calc(60 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(61)::after { animation-delay: calc(61 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(62)::after { animation-delay: calc(62 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(63)::after { animation-delay: calc(63 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(64)::after { animation-delay: calc(64 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(65)::after { animation-delay: calc(65 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(66)::after { animation-delay: calc(66 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(67)::after { animation-delay: calc(67 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(68)::after { animation-delay: calc(68 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(69)::after { animation-delay: calc(69 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(70)::after { animation-delay: calc(70 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(71)::after { animation-delay: calc(71 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(72)::after { animation-delay: calc(72 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(73)::after { animation-delay: calc(73 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(74)::after { animation-delay: calc(74 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(75)::after { animation-delay: calc(75 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(76)::after { animation-delay: calc(76 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(77)::after { animation-delay: calc(77 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(78)::after { animation-delay: calc(78 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(79)::after { animation-delay: calc(79 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(80)::after { animation-delay: calc(80 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(81)::after { animation-delay: calc(81 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(82)::after { animation-delay: calc(82 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(83)::after { animation-delay: calc(83 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(84)::after { animation-delay: calc(84 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(85)::after { animation-delay: calc(85 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(86)::after { animation-delay: calc(86 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(87)::after { animation-delay: calc(87 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(88)::after { animation-delay: calc(88 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(89)::after { animation-delay: calc(89 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(90)::after { animation-delay: calc(90 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(91)::after { animation-delay: calc(91 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(92)::after { animation-delay: calc(92 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(93)::after { animation-delay: calc(93 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(94)::after { animation-delay: calc(94 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(95)::after { animation-delay: calc(95 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(96)::after { animation-delay: calc(96 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(97)::after { animation-delay: calc(97 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(98)::after { animation-delay: calc(98 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(99)::after { animation-delay: calc(99 * var(--type-speed)); }
+.ease-typewriter-multiline span:nth-child(100)::after { animation-delay: calc(100 * var(--type-speed)); }


### PR DESCRIPTION
## Description
This PR resolves #68985 by providing an advanced typewriter effect capable of handling multi-line, wrapping text. Traditional CSS typewriter effects rely on animating the `width` of a container, which entirely breaks when text needs to wrap onto multiple lines. This solution uses a staggered reveal approach on individual words/characters.

### Features
- True multi-line support: text naturally wraps according to container width without breaking the animation.
- Pure CSS animation using `opacity` and `nth-child` generated staggered delays.
- Supports up to 100 words/elements by default.
- Customizable typing speed via the `--type-speed` CSS variable.

### Issue Fixed
Fixes #68985