### PR TITLE
feat: add pure css tooltip (#68988)

### DIFF
--- a/submissions/components/tooltip/README.md
+++ b/submissions/components/tooltip/README.md
@@ -1,0 +1,23 @@
+# Pure CSS Tooltip with Animated Directional Arrows
+
+## Description
+This submission resolves Issue #68988 by providing a robust, pure CSS tooltip solution that eliminates the need for external JS libraries like Popper.js for static positioning.
+
+## Features
+- Pure CSS tooltips using `::before` (text) and `::after` (arrow pointer).
+- Relies on `data-tooltip` attribute to define tooltip text dynamically.
+- Includes four directional variations: `.ease-tooltip-top` (default), `.ease-tooltip-bottom`, `.ease-tooltip-left`, and `.ease-tooltip-right`.
+- Smooth `:hover` animation combining `opacity` and a slight `transform: translate` offset to create a popping/sliding effect.
+
+## Usage
+Simply add the `.ease-tooltip` class and the `data-tooltip` attribute to any element. Add an optional directional class to override the default (top) placement.
+
+```html
+<!-- Top (Default) -->
+<div class="ease-tooltip" data-tooltip="Tooltip content here">Hover me</div>
+
+<!-- Specific Directions -->
+<div class="ease-tooltip ease-tooltip-bottom" data-tooltip="Below!">Hover me</div>
+<div class="ease-tooltip ease-tooltip-left" data-tooltip="Left!">Hover me</div>
+<div class="ease-tooltip ease-tooltip-right" data-tooltip="Right!">Hover me</div>
+```

--- a/submissions/components/tooltip/demo.html
+++ b/submissions/components/tooltip/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pure CSS Tooltip</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      background-color: #f5f5f5;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 40px;
+      padding: 60px;
+      background: white;
+      border-radius: 8px;
+      box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+    }
+    .btn {
+      padding: 10px 20px;
+      background-color: #4CAF50;
+      color: white;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 16px;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="grid">
+    <div class="ease-tooltip ease-tooltip-top" data-tooltip="I'm on top!">
+      <button class="btn">Hover Top</button>
+    </div>
+    
+    <div class="ease-tooltip ease-tooltip-bottom" data-tooltip="I'm on the bottom!">
+      <button class="btn">Hover Bottom</button>
+    </div>
+    
+    <div class="ease-tooltip ease-tooltip-left" data-tooltip="I'm on the left!">
+      <button class="btn">Hover Left</button>
+    </div>
+    
+    <div class="ease-tooltip ease-tooltip-right" data-tooltip="I'm on the right!">
+      <button class="btn">Hover Right</button>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/components/tooltip/style.css
+++ b/submissions/components/tooltip/style.css
@@ -1,0 +1,120 @@
+/* 
+  Pure CSS Tooltip with Animated Directional Arrows
+  Issue: #68988
+*/
+
+.ease-tooltip {
+  position: relative;
+  display: inline-block;
+  cursor: pointer;
+}
+
+.ease-tooltip::before,
+.ease-tooltip::after {
+  position: absolute;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s;
+  pointer-events: none;
+  z-index: 1000;
+}
+
+/* Tooltip Text */
+.ease-tooltip::before {
+  content: attr(data-tooltip);
+  background-color: #333;
+  color: #fff;
+  padding: 8px 12px;
+  border-radius: 4px;
+  font-size: 14px;
+  white-space: nowrap;
+}
+
+/* Tooltip Arrow */
+.ease-tooltip::after {
+  content: '';
+  border: 6px solid transparent;
+}
+
+/* Show on hover */
+.ease-tooltip:hover::before,
+.ease-tooltip:hover::after {
+  opacity: 1;
+  visibility: visible;
+}
+
+/* --- TOP (Default and Explicit) --- */
+.ease-tooltip:not(.ease-tooltip-bottom):not(.ease-tooltip-left):not(.ease-tooltip-right)::before,
+.ease-tooltip-top::before {
+  bottom: 100%;
+  left: 50%;
+  transform: translate(-50%, 10px);
+  margin-bottom: 12px;
+}
+.ease-tooltip:not(.ease-tooltip-bottom):not(.ease-tooltip-left):not(.ease-tooltip-right)::after,
+.ease-tooltip-top::after {
+  bottom: 100%;
+  left: 50%;
+  transform: translate(-50%, 10px);
+  border-top-color: #333;
+}
+.ease-tooltip:not(.ease-tooltip-bottom):not(.ease-tooltip-left):not(.ease-tooltip-right):hover::before,
+.ease-tooltip:not(.ease-tooltip-bottom):not(.ease-tooltip-left):not(.ease-tooltip-right):hover::after,
+.ease-tooltip-top:hover::before,
+.ease-tooltip-top:hover::after {
+  transform: translate(-50%, 0);
+}
+
+/* --- BOTTOM --- */
+.ease-tooltip-bottom::before {
+  top: 100%;
+  left: 50%;
+  transform: translate(-50%, -10px);
+  margin-top: 12px;
+}
+.ease-tooltip-bottom::after {
+  top: 100%;
+  left: 50%;
+  transform: translate(-50%, -10px);
+  border-bottom-color: #333;
+}
+.ease-tooltip-bottom:hover::before,
+.ease-tooltip-bottom:hover::after {
+  transform: translate(-50%, 0);
+}
+
+/* --- LEFT --- */
+.ease-tooltip-left::before {
+  top: 50%;
+  right: 100%;
+  transform: translate(10px, -50%);
+  margin-right: 12px;
+}
+.ease-tooltip-left::after {
+  top: 50%;
+  right: 100%;
+  transform: translate(10px, -50%);
+  border-left-color: #333;
+}
+.ease-tooltip-left:hover::before,
+.ease-tooltip-left:hover::after {
+  transform: translate(0, -50%);
+}
+
+/* --- RIGHT --- */
+.ease-tooltip-right::before {
+  top: 50%;
+  left: 100%;
+  transform: translate(-10px, -50%);
+  margin-left: 12px;
+}
+.ease-tooltip-right::after {
+  top: 50%;
+  left: 100%;
+  transform: translate(-10px, -50%);
+  border-right-color: #333;
+}
+.ease-tooltip-right:hover::before,
+.ease-tooltip-right:hover::after {
+  transform: translate(0, -50%);
+}


### PR DESCRIPTION
## Description
This PR resolves #68988 by providing a robust, pure CSS tooltip solution that eliminates the need for external JS libraries. 

### Features
- Pure CSS tooltips using `::before` for the text and `::after` for the arrow pointer (using CSS triangles).
- Uses `[data-tooltip]` attribute to define dynamic tooltip text.
- Supports directional classes `.ease-tooltip-top`, `.ease-tooltip-bottom`, `.ease-tooltip-left`, and `.ease-tooltip-right`.
- Animates opacity and applies a slight `translate` offset on `:hover`.

### Issue Fixed
Fixes #68988