### PR TITLE
feat: add podcast episode card

### DIFF
--- a/submissions/examples/r-podcast-episode-card-68624/README.md
+++ b/submissions/examples/r-podcast-episode-card-68624/README.md
@@ -1,0 +1,24 @@
+# CSS Podcast Episode Card
+
+A responsive podcast episode card built with pure HTML and CSS.
+
+## Features
+
+- Pure HTML and CSS
+- No JavaScript required
+- Responsive card layout
+- Podcast artwork section
+- Animated audio-wave decoration
+- Episode title and description
+- Play button
+- Episode duration
+- Hover elevation effect
+- Keyboard-focusable button
+- Reduced-motion support
+
+## Usage
+
+Include the stylesheet:
+
+```html
+<link rel="stylesheet" href="style.css">

--- a/submissions/examples/r-podcast-episode-card-68624/demo.html
+++ b/submissions/examples/r-podcast-episode-card-68624/demo.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta
+    name="description"
+    content="Responsive CSS podcast episode card with play button, duration and description."
+  >
+  <title>CSS Podcast Episode Card</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="page">
+    <article class="podcast-card" aria-labelledby="episode-title">
+
+      <div class="cover">
+        <div class="cover-glow"></div>
+
+        <div class="podcast-logo" aria-hidden="true">
+          <span class="logo-wave"></span>
+          <span class="logo-wave"></span>
+          <span class="logo-wave"></span>
+        </div>
+
+        <span class="episode-label">EPISODE 42</span>
+      </div>
+
+      <div class="episode-content">
+
+        <div class="episode-meta">
+          <span>THE CREATIVE LAB</span>
+          <span class="dot" aria-hidden="true"></span>
+          <span>38 MIN</span>
+        </div>
+
+        <h1 id="episode-title">
+          Designing Interfaces That Feel Effortless
+        </h1>
+
+        <p class="description">
+          Explore the principles behind thoughtful interface design,
+          meaningful motion, and digital experiences that feel natural.
+        </p>
+
+        <div class="episode-footer">
+
+          <button
+            class="play-button"
+            type="button"
+            aria-label="Play episode"
+          >
+            <span class="play-icon" aria-hidden="true"></span>
+            <span>Play Episode</span>
+          </button>
+
+          <div class="duration" aria-label="Episode duration 38 minutes">
+            <span class="duration-icon" aria-hidden="true">◷</span>
+            <span>38:24</span>
+          </div>
+
+        </div>
+
+      </div>
+
+    </article>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/r-podcast-episode-card-68624/style.css
+++ b/submissions/examples/r-podcast-episode-card-68624/style.css
@@ -1,0 +1,431 @@
+:root {
+  --background: #eef2ff;
+  --card: #ffffff;
+  --text: #172033;
+  --muted: #697386;
+  --primary: #635bff;
+  --secondary: #8b5cf6;
+  --dark: #25233f;
+
+  --radius: 28px;
+  --ease: 360ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+
+  color: var(--text);
+
+  background:
+    radial-gradient(
+      circle at 15% 20%,
+      rgba(99, 91, 255, 0.16),
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at 85% 80%,
+      rgba(139, 92, 246, 0.14),
+      transparent 30%
+    ),
+    var(--background);
+}
+
+.page {
+  min-height: 100vh;
+
+  display: grid;
+  place-items: center;
+
+  padding: 2rem 1rem;
+}
+
+.podcast-card {
+  position: relative;
+
+  width: min(900px, 100%);
+
+  display: grid;
+  grid-template-columns: 310px 1fr;
+
+  overflow: hidden;
+
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: var(--radius);
+
+  background: var(--card);
+
+  box-shadow:
+    0 25px 70px rgba(15, 23, 42, 0.14);
+
+  transition:
+    transform var(--ease),
+    box-shadow var(--ease);
+}
+
+.podcast-card:hover {
+  transform: translateY(-6px);
+
+  box-shadow:
+    0 35px 90px rgba(15, 23, 42, 0.2);
+}
+
+.cover {
+  position: relative;
+
+  min-height: 360px;
+
+  display: grid;
+  place-items: center;
+
+  overflow: hidden;
+
+  background:
+    linear-gradient(
+      145deg,
+      #312e81,
+      #635bff 55%,
+      #a855f7
+    );
+}
+
+.cover::before,
+.cover::after {
+  position: absolute;
+
+  content: "";
+
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 50%;
+}
+
+.cover::before {
+  width: 310px;
+  height: 310px;
+}
+
+.cover::after {
+  width: 230px;
+  height: 230px;
+}
+
+.cover-glow {
+  position: absolute;
+
+  width: 180px;
+  height: 180px;
+
+  border-radius: 50%;
+
+  background: rgba(255, 255, 255, 0.2);
+
+  filter: blur(45px);
+
+  animation: glowPulse 3s ease-in-out infinite;
+}
+
+.podcast-logo {
+  position: relative;
+  z-index: 2;
+
+  width: 120px;
+  height: 120px;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+
+  border-radius: 34px;
+
+  background: rgba(255, 255, 255, 0.13);
+
+  border: 1px solid rgba(255, 255, 255, 0.25);
+
+  backdrop-filter: blur(12px);
+
+  box-shadow:
+    0 20px 50px rgba(0, 0, 0, 0.2);
+}
+
+.logo-wave {
+  width: 7px;
+
+  border-radius: 999px;
+
+  background: #ffffff;
+
+  animation: wave 1.3s ease-in-out infinite;
+}
+
+.logo-wave:nth-child(1) {
+  height: 32px;
+  animation-delay: -0.2s;
+}
+
+.logo-wave:nth-child(2) {
+  height: 58px;
+  animation-delay: -0.1s;
+}
+
+.logo-wave:nth-child(3) {
+  height: 40px;
+  animation-delay: 0s;
+}
+
+.episode-label {
+  position: absolute;
+  left: 1.4rem;
+  bottom: 1.3rem;
+
+  z-index: 3;
+
+  padding: 0.4rem 0.7rem;
+
+  border-radius: 999px;
+
+  color: #ffffff;
+
+  background: rgba(0, 0, 0, 0.22);
+
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+}
+
+.episode-content {
+  display: flex;
+  flex-direction: column;
+
+  justify-content: center;
+
+  padding: 3rem;
+}
+
+.episode-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+
+  margin-bottom: 1rem;
+
+  color: var(--primary);
+
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+}
+
+.dot {
+  width: 4px;
+  height: 4px;
+
+  border-radius: 50%;
+
+  background: currentColor;
+}
+
+.episode-content h1 {
+  max-width: 560px;
+
+  margin: 0 0 1rem;
+
+  font-size: clamp(2rem, 4vw, 3.2rem);
+  line-height: 1.05;
+  letter-spacing: -0.055em;
+}
+
+.description {
+  max-width: 570px;
+
+  margin: 0 0 2rem;
+
+  color: var(--muted);
+
+  font-size: 0.98rem;
+  line-height: 1.7;
+}
+
+.episode-footer {
+  display: flex;
+  align-items: center;
+  gap: 1.2rem;
+}
+
+.play-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+
+  min-height: 50px;
+
+  padding: 0.75rem 1.15rem;
+
+  border: 0;
+  border-radius: 999px;
+
+  color: #ffffff;
+
+  background:
+    linear-gradient(
+      135deg,
+      var(--primary),
+      var(--secondary)
+    );
+
+  font: inherit;
+  font-size: 0.85rem;
+  font-weight: 800;
+
+  cursor: pointer;
+
+  box-shadow:
+    0 10px 25px rgba(99, 91, 255, 0.25);
+
+  transition:
+    transform var(--ease),
+    box-shadow var(--ease);
+}
+
+.play-button:hover {
+  transform: translateY(-3px) scale(1.02);
+
+  box-shadow:
+    0 15px 35px rgba(99, 91, 255, 0.35);
+}
+
+.play-button:focus-visible {
+  outline: 3px solid rgba(99, 91, 255, 0.35);
+  outline-offset: 4px;
+}
+
+.play-icon {
+  width: 0;
+  height: 0;
+
+  border-top: 7px solid transparent;
+  border-bottom: 7px solid transparent;
+  border-left: 10px solid #ffffff;
+}
+
+.duration {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+
+  color: var(--muted);
+
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.duration-icon {
+  color: var(--primary);
+
+  font-size: 1.1rem;
+}
+
+@keyframes wave {
+  0%,
+  100% {
+    transform: scaleY(0.7);
+  }
+
+  50% {
+    transform: scaleY(1.15);
+  }
+}
+
+@keyframes glowPulse {
+  0%,
+  100% {
+    opacity: 0.55;
+    transform: scale(0.9);
+  }
+
+  50% {
+    opacity: 0.9;
+    transform: scale(1.15);
+  }
+}
+
+@media (max-width: 720px) {
+  .podcast-card {
+    grid-template-columns: 1fr;
+  }
+
+  .cover {
+    min-height: 280px;
+  }
+
+  .episode-content {
+    padding: 2rem;
+  }
+
+  .episode-content h1 {
+    font-size: 2.2rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .page {
+    padding: 1rem;
+  }
+
+  .podcast-card {
+    border-radius: 22px;
+  }
+
+  .cover {
+    min-height: 240px;
+  }
+
+  .podcast-logo {
+    width: 95px;
+    height: 95px;
+  }
+
+  .episode-content {
+    padding: 1.5rem;
+  }
+
+  .episode-footer {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .play-button {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .podcast-card,
+  .play-button {
+    transition: none;
+  }
+
+  .podcast-card:hover,
+  .play-button:hover {
+    transform: none;
+  }
+
+  .logo-wave,
+  .cover-glow {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds a responsive pure CSS Podcast Episode Card.

## Changes

- Added podcast artwork section
- Added animated audio-wave decoration
- Added episode metadata
- Added play button
- Added duration indicator
- Added responsive mobile layout
- Added hover interactions
- Added reduced-motion support
- Added README documentation

Closes #68624