### PR TITLE
docs: add animation durations reference table and demo

### DIFF
--- a/submissions/examples/animation-durations-dg/README.md
+++ b/submissions/examples/animation-durations-dg/README.md
@@ -1,0 +1,47 @@
+# Animation Durations Reference
+
+## What does this do?
+Adds a quick-reference table and interactive demo documenting EaseMotion CSS's built-in animation duration tokens, so developers can pick a timing without digging through source files.
+
+## How is it used?
+Override the duration on any element via the existing custom properties:
+
+```css
+.my-button {
+  transition: transform var(--ease-speed-fast) ease;
+}
+
+.my-modal {
+  animation-duration: var(--ease-speed-medium);
+}
+
+.my-hero {
+  animation-duration: var(--ease-speed-slow);
+}
+```
+
+Or reference them directly for a one-off value:
+
+```css
+.custom-element {
+  transition-duration: 300ms; /* same as --ease-speed-medium */
+}
+```
+
+## Reference table
+
+| Token | Value | Recommended use case |
+|---|---|---|
+| `--ease-speed-fast` | 150ms | Micro-interactions: hover states, button presses, small icon transitions |
+| `--ease-speed-medium` | 300ms | Default duration: most entrance/exit effects, modals, dropdowns |
+| `--ease-speed-slow` | 600ms | Larger or more deliberate motion: page transitions, hero reveals, emphasis animations |
+
+## Why is it useful?
+EaseMotion CSS already ships these three duration tokens, but the documentation doesn't currently surface them in one place. New contributors and users have to inspect the source to find the right timing value. This addition:
+
+- Gives a single, scannable reference instead of requiring source inspection
+- Explains *when* to use each speed, not just the numeric value
+- Includes a live interactive demo (`demo.html`) so the difference is felt, not just read
+- Matches the project's existing philosophy of human-readable, self-explanatory documentation
+
+This fits the **Core & Docs Showcase** track (`submissions/docs/`) since it documents existing core tokens rather than introducing a new component.

--- a/submissions/examples/animation-durations-dg/demo.html
+++ b/submissions/examples/animation-durations-dg/demo.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animation Durations — Reference Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main>
+    <h1>Animation Durations</h1>
+    <p>Hover each box to feel the difference between the three built-in speed tokens.</p>
+
+    <div class="duration-demo-row">
+      <span class="duration-demo-label"><code>--ease-speed-fast</code> (150ms)</span>
+      <div class="duration-box duration-fast"></div>
+    </div>
+
+    <div class="duration-demo-row">
+      <span class="duration-demo-label"><code>--ease-speed-medium</code> (300ms, default)</span>
+      <div class="duration-box duration-medium"></div>
+    </div>
+
+    <div class="duration-demo-row">
+      <span class="duration-demo-label"><code>--ease-speed-slow</code> (600ms)</span>
+      <div class="duration-box duration-slow"></div>
+    </div>
+
+    <h2>Reference table</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Token</th>
+          <th>Value</th>
+          <th>Recommended use</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>--ease-speed-fast</code></td>
+          <td>150ms</td>
+          <td>Micro-interactions: hover states, button presses, small icon transitions</td>
+        </tr>
+        <tr>
+          <td><code>--ease-speed-medium</code></td>
+          <td>300ms</td>
+          <td>Default duration: most entrance/exit effects, modals, dropdowns</td>
+        </tr>
+        <tr>
+          <td><code>--ease-speed-slow</code></td>
+          <td>600ms</td>
+          <td>Larger or more deliberate motion: page transitions, hero reveals, emphasis animations</td>
+        </tr>
+      </tbody>
+    </table>
+  </main>
+</body>
+</html>

--- a/submissions/examples/animation-durations-dg/style.css
+++ b/submissions/examples/animation-durations-dg/style.css
@@ -1,0 +1,73 @@
+/* Animation Durations reference demo — supplementary to docs submission */
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #fafafa;
+  color: #1a1a1a;
+  padding: 3rem 1.5rem;
+}
+
+main {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0 2.5rem;
+}
+
+th, td {
+  text-align: left;
+  padding: 0.6rem 0.8rem;
+  border-bottom: 1px solid #e2e2e2;
+}
+
+th {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: #666;
+}
+
+code {
+  background: #eee;
+  padding: 0.15rem 0.4rem;
+  border-radius: 3px;
+  font-size: 0.9em;
+}
+
+.duration-demo-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.duration-demo-label {
+  width: 140px;
+  font-size: 0.9rem;
+  flex-shrink: 0;
+}
+
+.duration-box {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 8px;
+  background: #4a90d9;
+  cursor: pointer;
+  transition: transform var(--demo-duration, 300ms) ease;
+}
+
+.duration-box:hover {
+  transform: translateX(120px);
+}
+
+.duration-fast   { --demo-duration: 150ms; }
+.duration-medium { --demo-duration: 300ms; }
+.duration-slow   { --demo-duration: 600ms; }
+
+@media (prefers-reduced-motion: reduce) {
+  .duration-box { transition: none; }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a quick-reference table and interactive demo for EaseMotion CSS's built-in animation duration tokens (--ease-speed-fast, --ease-speed-medium, --ease-speed-slow), so developers can pick a timing without inspecting the source files.

---

## Type of Change
- [x] 📝 Documentation improvement

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/docs/animation-durations-dg/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A documented, visual reference for the three existing animation duration tokens and when to use each one.

**How does a developer use it?**
```html
<div class="duration-box" style="transition: transform var(--ease-speed-fast) ease;"></div>
```

**Why does it fit EaseMotion CSS?**
It documents existing core tokens in the project's human-readable, self-explanatory style — the demo lets you *feel* the timing difference instead of just reading a number, matching EaseMotion's animation-first philosophy.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
This is a docs-only addition — no new classes or tokens introduced, just documentation and a live demo for the three duration values that already exist in the framework.