### PR TITLE
feat: add iOS bottom tab navigation

### DIFF
--- a/submissions/examples/r-bottom-tab-navigation-ios-68628/README.md
+++ b/submissions/examples/r-bottom-tab-navigation-ios-68628/README.md
@@ -1,0 +1,24 @@
+# CSS Bottom Tab Navigation iOS
+
+An iOS-inspired bottom tab navigation component built with
+pure HTML and CSS.
+
+## Features
+
+- Pure CSS implementation
+- No JavaScript required
+- iOS-style bottom navigation
+- Animated icon bounce on active tab
+- Responsive mobile layout
+- Safe-area support
+- Backdrop blur effect
+- Keyboard focus styles
+- Accessible navigation labels
+- Reduced-motion support
+
+## Usage
+
+Include the stylesheet:
+
+```html
+<link rel="stylesheet" href="style.css">

--- a/submissions/examples/r-bottom-tab-navigation-ios-68628/demo.html
+++ b/submissions/examples/r-bottom-tab-navigation-ios-68628/demo.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta
+    name="description"
+    content="CSS-only iOS style bottom tab navigation with animated icon bounce."
+  >
+  <title>CSS Bottom Tab Navigation iOS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="app-shell">
+    <section class="phone" aria-label="Mobile application preview">
+
+      <div class="phone-content">
+        <span class="badge">CSS ONLY</span>
+
+        <h1>Explore</h1>
+
+        <p>
+          A clean iOS-inspired bottom navigation bar built
+          entirely with HTML and CSS.
+        </p>
+
+        <div class="content-card">
+          <span class="content-icon" aria-hidden="true">✦</span>
+
+          <div>
+            <strong>Discover something new</strong>
+            <span>Tap a tab below to navigate.</span>
+          </div>
+        </div>
+      </div>
+
+      <nav class="bottom-tabs" aria-label="Primary navigation">
+
+        <a class="tab active" href="#home" aria-current="page">
+          <span class="tab-icon" aria-hidden="true">⌂</span>
+          <span class="tab-label">Home</span>
+        </a>
+
+        <a class="tab" href="#search">
+          <span class="tab-icon" aria-hidden="true">⌕</span>
+          <span class="tab-label">Search</span>
+        </a>
+
+        <a class="tab" href="#favorites">
+          <span class="tab-icon" aria-hidden="true">♡</span>
+          <span class="tab-label">Favorites</span>
+        </a>
+
+        <a class="tab" href="#profile">
+          <span class="tab-icon" aria-hidden="true">◉</span>
+          <span class="tab-label">Profile</span>
+        </a>
+
+      </nav>
+
+    </section>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/r-bottom-tab-navigation-ios-68628/style.css
+++ b/submissions/examples/r-bottom-tab-navigation-ios-68628/style.css
@@ -1,0 +1,367 @@
+:root {
+  --page-bg: #e9ecf5;
+  --phone-bg: #f8f9fd;
+
+  --nav-bg: rgba(255, 255, 255, 0.92);
+  --text: #171923;
+  --muted: #8a8f9f;
+
+  --accent: #635bff;
+  --accent-soft: #eceaff;
+
+  --border: rgba(20, 25, 45, 0.08);
+
+  --radius: 30px;
+  --ease: 300ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+
+  color: var(--text);
+
+  background:
+    radial-gradient(
+      circle at 20% 15%,
+      rgba(99, 91, 255, 0.18),
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at 80% 85%,
+      rgba(76, 201, 240, 0.15),
+      transparent 30%
+    ),
+    var(--page-bg);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.app-shell {
+  min-height: 100vh;
+
+  display: grid;
+  place-items: center;
+
+  padding: 2rem 1rem;
+}
+
+.phone {
+  position: relative;
+
+  width: min(390px, 100%);
+  min-height: 680px;
+
+  overflow: hidden;
+
+  border: 8px solid #181a22;
+  border-radius: 42px;
+
+  background: var(--phone-bg);
+
+  box-shadow:
+    0 30px 80px rgba(25, 30, 50, 0.25),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.5);
+}
+
+.phone::before {
+  content: "";
+
+  position: absolute;
+  top: 9px;
+  left: 50%;
+
+  width: 100px;
+  height: 24px;
+
+  z-index: 5;
+
+  transform: translateX(-50%);
+
+  border-radius: 0 0 16px 16px;
+
+  background: #181a22;
+}
+
+.phone-content {
+  min-height: 100%;
+
+  padding: 5.5rem 1.5rem 8rem;
+
+  background:
+    linear-gradient(
+      145deg,
+      rgba(99, 91, 255, 0.08),
+      transparent 45%
+    );
+}
+
+.badge {
+  display: inline-block;
+
+  margin-bottom: 1rem;
+  padding: 0.35rem 0.6rem;
+
+  border-radius: 999px;
+
+  color: var(--accent);
+
+  background: var(--accent-soft);
+
+  font-size: 0.62rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+}
+
+.phone-content h1 {
+  margin: 0;
+
+  font-size: clamp(2.2rem, 10vw, 3.2rem);
+  line-height: 1;
+  letter-spacing: -0.06em;
+}
+
+.phone-content > p {
+  max-width: 290px;
+
+  margin: 1rem 0 2rem;
+
+  color: var(--muted);
+
+  font-size: 0.95rem;
+  line-height: 1.65;
+}
+
+.content-card {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+
+  padding: 1.2rem;
+
+  border: 1px solid var(--border);
+  border-radius: 20px;
+
+  background: rgba(255, 255, 255, 0.75);
+
+  box-shadow: 0 15px 40px rgba(40, 45, 70, 0.07);
+}
+
+.content-icon {
+  width: 46px;
+  height: 46px;
+
+  display: grid;
+  place-items: center;
+
+  flex-shrink: 0;
+
+  border-radius: 14px;
+
+  color: white;
+  background: var(--accent);
+
+  font-size: 1.3rem;
+}
+
+.content-card strong,
+.content-card span {
+  display: block;
+}
+
+.content-card strong {
+  margin-bottom: 0.3rem;
+
+  font-size: 0.82rem;
+}
+
+.content-card div span {
+  color: var(--muted);
+
+  font-size: 0.7rem;
+  line-height: 1.4;
+}
+
+.bottom-tabs {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  align-items: end;
+
+  min-height: 82px;
+
+  padding:
+    0.65rem
+    0.45rem
+    calc(0.65rem + env(safe-area-inset-bottom));
+
+  border-top: 1px solid var(--border);
+
+  background: var(--nav-bg);
+
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+}
+
+.tab {
+  position: relative;
+
+  min-width: 0;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+
+  padding: 0.45rem 0.25rem;
+
+  border-radius: 16px;
+
+  color: var(--muted);
+
+  font-size: 0.65rem;
+  font-weight: 700;
+
+  transition:
+    color var(--ease),
+    background var(--ease);
+}
+
+.tab:hover {
+  color: var(--text);
+  background: rgba(99, 91, 255, 0.05);
+}
+
+.tab-icon {
+  width: 34px;
+  height: 34px;
+
+  display: grid;
+  place-items: center;
+
+  border-radius: 12px;
+
+  font-size: 1.45rem;
+  line-height: 1;
+
+  transition:
+    transform var(--ease),
+    color var(--ease),
+    background var(--ease),
+    box-shadow var(--ease);
+}
+
+.tab-label {
+  transition:
+    transform var(--ease),
+    opacity var(--ease);
+}
+
+.tab.active {
+  color: var(--accent);
+}
+
+.tab.active .tab-icon {
+  color: white;
+
+  background: var(--accent);
+
+  box-shadow:
+    0 8px 18px rgba(99, 91, 255, 0.3);
+
+  animation: iconBounce 700ms cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.tab.active .tab-label {
+  font-weight: 850;
+}
+
+.tab:focus-visible {
+  outline: 3px solid rgba(99, 91, 255, 0.3);
+  outline-offset: -2px;
+}
+
+@keyframes iconBounce {
+  0% {
+    transform: translateY(8px) scale(0.75);
+  }
+
+  45% {
+    transform: translateY(-6px) scale(1.08);
+  }
+
+  70% {
+    transform: translateY(2px) scale(0.96);
+  }
+
+  100% {
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media (max-width: 480px) {
+  .app-shell {
+    padding: 0;
+  }
+
+  .phone {
+    width: 100%;
+    min-height: 100vh;
+
+    border: 0;
+    border-radius: 0;
+  }
+
+  .phone::before {
+    top: 0;
+  }
+
+  .phone-content {
+    padding-top: 5rem;
+  }
+
+  .bottom-tabs {
+    border-radius: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  .tab,
+  .tab-icon,
+  .tab-label {
+    transition: none;
+  }
+
+  .tab.active .tab-icon {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds an iOS-inspired CSS-only bottom tab navigation component.

## Changes

- Added responsive bottom tab navigation
- Added animated active icon bounce
- Added iOS-style backdrop blur
- Added safe-area support
- Added keyboard focus styles
- Added accessible navigation markup
- Added reduced-motion support
- Added README documentation

Closes #68628