### PR TITLE
feat: add CSS Filmstrip Gallery example

### DIFF
--- a/submissions/examples/css-filmstrip-gallery-68228/README.md
+++ b/submissions/examples/css-filmstrip-gallery-68228/README.md
@@ -1,0 +1,46 @@
+# CSS Filmstrip Gallery
+
+A responsive filmstrip-style image gallery built using pure HTML and CSS. The component mimics the appearance of a traditional movie film reel with decorative sprocket holes and smooth hover animations.
+
+## Features
+
+- Pure HTML & CSS
+- Responsive design
+- Horizontal scrollable gallery
+- Filmstrip appearance with sprocket-hole effect
+- Smooth hover animations
+- Accessible image alt text
+- No JavaScript required
+
+## File Structure
+
+```text
+css-filmstrip-gallery-68228/
+│
+├── demo.html
+├── style.css
+└── README.md
+```
+
+## Usage
+
+1. Open `demo.html` in a browser.
+2. Ensure `style.css` is in the same directory.
+3. Replace sample images with your own images if desired.
+
+## Customization
+
+- Adjust image sizes in `.film-frame img`
+- Change animation speed in the `float` keyframes
+- Modify filmstrip colors in `.film-frame`
+- Customize sprocket-hole spacing in the pseudo-elements
+
+## Accessibility
+
+- Uses descriptive `alt` text for images.
+- Gallery container includes ARIA labeling.
+- Keyboard focus is supported through the gallery container.
+
+## Author
+
+Created for EaseMotion CSS contribution #68228.

--- a/submissions/examples/css-filmstrip-gallery-68228/demo.html
+++ b/submissions/examples/css-filmstrip-gallery-68228/demo.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Filmstrip Gallery</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <section class="gallery-section">
+    <h1>CSS Filmstrip Gallery</h1>
+
+    <div
+      class="filmstrip-gallery"
+      role="region"
+      aria-label="Filmstrip image gallery"
+      tabindex="0"
+    >
+
+      <div class="film-frame">
+        <img
+          src="https://picsum.photos/id/1015/400/250"
+          alt="Mountain landscape"
+        />
+      </div>
+
+      <div class="film-frame">
+        <img
+          src="https://picsum.photos/id/1016/400/250"
+          alt="Forest scenery"
+        />
+      </div>
+
+      <div class="film-frame">
+        <img
+          src="https://picsum.photos/id/1025/400/250"
+          alt="Beautiful dog portrait"
+        />
+      </div>
+
+      <div class="film-frame">
+        <img
+          src="https://picsum.photos/id/1035/400/250"
+          alt="Ocean view"
+        />
+      </div>
+
+      <div class="film-frame">
+        <img
+          src="https://picsum.photos/id/1043/400/250"
+          alt="Nature trail"
+        />
+      </div>
+
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/css-filmstrip-gallery-68228/style.css
+++ b/submissions/examples/css-filmstrip-gallery-68228/style.css
@@ -1,0 +1,125 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  background: #f5f5f5;
+  font-family: Arial, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem;
+}
+
+.gallery-section {
+  width: 100%;
+  max-width: 1400px;
+}
+
+.gallery-section h1 {
+  text-align: center;
+  margin-bottom: 2rem;
+  color: #222;
+}
+
+.filmstrip-gallery {
+  display: flex;
+  gap: 1.5rem;
+  overflow-x: auto;
+  padding: 1rem;
+  scrollbar-width: thin;
+}
+
+.filmstrip-gallery::-webkit-scrollbar {
+  height: 8px;
+}
+
+.filmstrip-gallery::-webkit-scrollbar-thumb {
+  background: #666;
+  border-radius: 10px;
+}
+
+.film-frame {
+  position: relative;
+  background: #111;
+  padding: 20px 12px;
+  border-radius: 10px;
+  flex-shrink: 0;
+  animation: float 4s ease-in-out infinite;
+  transition: transform 0.3s ease;
+}
+
+.film-frame:hover {
+  transform: translateY(-8px);
+}
+
+.film-frame img {
+  width: 280px;
+  height: 180px;
+  object-fit: cover;
+  display: block;
+  border-radius: 4px;
+  transition: transform 0.4s ease;
+}
+
+.film-frame:hover img {
+  transform: scale(1.05);
+}
+
+/* Top sprocket holes */
+.film-frame::before {
+  content: "";
+  position: absolute;
+  top: 6px;
+  left: 10px;
+  right: 10px;
+  height: 8px;
+  background: repeating-linear-gradient(
+    to right,
+    #111 0 12px,
+    #fff 12px 22px
+  );
+}
+
+/* Bottom sprocket holes */
+.film-frame::after {
+  content: "";
+  position: absolute;
+  bottom: 6px;
+  left: 10px;
+  right: 10px;
+  height: 8px;
+  background: repeating-linear-gradient(
+    to right,
+    #111 0 12px,
+    #fff 12px 22px
+  );
+}
+
+@keyframes float {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+
+  50% {
+    transform: translateY(-6px);
+  }
+}
+
+@media (max-width: 768px) {
+  .film-frame img {
+    width: 220px;
+    height: 150px;
+  }
+}
+
+@media (max-width: 480px) {
+  .film-frame img {
+    width: 180px;
+    height: 120px;
+  }
+}


### PR DESCRIPTION
## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to** **`core/`**
- [x] **No changes to** **`components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## closes #68228 

## Feature Description

**What does this add?**

Adds a CSS Filmstrip Gallery component that presents images in a responsive horizontal filmstrip layout. The gallery uses pure CSS for layout, hover effects, focus states, and smooth visual transitions without requiring JavaScript.

**How does a developer use it?**

```html
<div class="filmstrip-gallery">
  <figure class="filmstrip-item">
    <img src="image-1.jpg" alt="Gallery image">
  </figure>

  <figure class="filmstrip-item">
    <img src="image-2.jpg" alt="Gallery image">
  </figure>

  <figure class="filmstrip-item">
    <img src="image-3.jpg" alt="Gallery image">
  </figure>
</div>