### PR TITLE
feat: add corner bracket frame reveal card

### DIFF
--- a/submissions/docs/corner-bracket-frame-69025/README.md
+++ b/submissions/docs/corner-bracket-frame-69025/README.md
@@ -1,0 +1,59 @@
+# Corner Bracket Frame Reveal Card
+
+## Issue
+
+Closes #69025
+
+## Description
+
+This submission adds a pure-CSS hover interaction that reveals four animated corner brackets around a card.
+
+When the card is hovered, the corner brackets fade in and move outward toward the card boundaries, creating a clean futuristic frame-reveal effect.
+
+## Features
+
+* Four animated corner brackets
+* Fade and scale-out reveal effect
+* Smooth hover transition
+* Works with cards and other container elements
+* No JavaScript required
+* Includes reduced-motion handling
+
+## Usage
+
+Add the card structure to your HTML:
+
+```html
+<article class="corner-frame-card">
+  <span class="corner corner-top-left"></span>
+  <span class="corner corner-top-right"></span>
+  <span class="corner corner-bottom-left"></span>
+  <span class="corner corner-bottom-right"></span>
+
+  <div class="card-content">
+    <h2>Secure Server</h2>
+    <p>Hover to reveal the target framing brackets.</p>
+  </div>
+</article>
+```
+
+Then include the accompanying `style.css`.
+
+## Expected Behavior
+
+* Before hover: the corner brackets remain hidden.
+* On hover: all four brackets fade in and move into position.
+* When the pointer leaves: the brackets return to their initial state.
+* When reduced motion is preferred: animated transitions are disabled.
+
+## Demo
+
+Open `demo.html` directly in a browser to view the interaction.
+
+## Why It Fits EaseMotion CSS
+
+The effect is lightweight, reusable, and implemented entirely with CSS transitions and transforms. It provides a composable motion effect suitable for cards, buttons, dashboards, and other interactive UI elements.
+
+## Scope
+
+This contribution adds the example under `submissions/` only. It does not modify `core/` or `components/`.

--- a/submissions/docs/corner-bracket-frame-69025/demo.html
+++ b/submissions/docs/corner-bracket-frame-69025/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Corner Bracket Frame Reveal Card</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-container">
+    <h1>Corner Bracket Frame Reveal</h1>
+    <p class="intro">
+      Hover over the card to reveal the animated corner brackets.
+    </p>
+
+    <div class="card-grid">
+      <article class="corner-frame-card">
+        <span class="corner corner-top-left" aria-hidden="true"></span>
+        <span class="corner corner-top-right" aria-hidden="true"></span>
+        <span class="corner corner-bottom-left" aria-hidden="true"></span>
+        <span class="corner corner-bottom-right" aria-hidden="true"></span>
+
+        <div class="card-content">
+          <span class="card-label">ANIMATION</span>
+          <h2>Secure Server</h2>
+          <p>
+            Hover to reveal the target framing brackets around the card.
+          </p>
+          <button type="button">Explore</button>
+        </div>
+      </article>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/docs/corner-bracket-frame-69025/style.css
+++ b/submissions/docs/corner-bracket-frame-69025/style.css
@@ -1,0 +1,140 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  font-family: Arial, sans-serif;
+  background: #09090b;
+  color: #ffffff;
+}
+
+.demo-container {
+  width: min(900px, 100%);
+  text-align: center;
+}
+
+h1 {
+  margin-bottom: 10px;
+}
+
+.intro {
+  margin: 0 0 36px;
+  color: #a1a1aa;
+}
+
+.card-grid {
+  display: flex;
+  justify-content: center;
+}
+
+.corner-frame-card {
+  position: relative;
+  width: min(340px, 100%);
+  padding: 32px;
+  overflow: visible;
+  background: #111113;
+  border: 1px solid #27272a;
+  border-radius: 12px;
+  color: #ffffff;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    background-color 0.3s ease,
+    transform 0.3s ease;
+}
+
+.card-content {
+  position: relative;
+  z-index: 1;
+}
+
+.card-label {
+  font-size: 12px;
+  letter-spacing: 2px;
+  color: #a1a1aa;
+}
+
+.corner-frame-card h2 {
+  margin: 12px 0 10px;
+}
+
+.corner-frame-card p {
+  margin: 0 0 24px;
+  line-height: 1.6;
+  color: #a1a1aa;
+}
+
+.corner-frame-card button {
+  padding: 10px 18px;
+  border: 1px solid #3f3f46;
+  border-radius: 6px;
+  background: transparent;
+  color: #ffffff;
+  cursor: pointer;
+}
+
+.corner {
+  position: absolute;
+  width: 22px;
+  height: 22px;
+  border-color: #818cf8;
+  border-style: solid;
+  opacity: 0;
+  transition:
+    transform 0.4s cubic-bezier(0.25, 1, 0.5, 1),
+    opacity 0.4s ease;
+}
+
+.corner-top-left {
+  top: -1px;
+  left: -1px;
+  border-width: 2px 0 0 2px;
+  transform: translate(10px, 10px);
+}
+
+.corner-top-right {
+  top: -1px;
+  right: -1px;
+  border-width: 2px 2px 0 0;
+  transform: translate(-10px, 10px);
+}
+
+.corner-bottom-left {
+  bottom: -1px;
+  left: -1px;
+  border-width: 0 0 2px 2px;
+  transform: translate(10px, -10px);
+}
+
+.corner-bottom-right {
+  right: -1px;
+  bottom: -1px;
+  border-width: 0 2px 2px 0;
+  transform: translate(-10px, -10px);
+}
+
+.corner-frame-card:hover {
+  background-color: #16161a;
+  transform: translateY(-2px);
+}
+
+.corner-frame-card:hover .corner {
+  opacity: 1;
+  transform: translate(0, 0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .corner-frame-card,
+  .corner {
+    transition: none;
+  }
+
+  .corner-frame-card:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

### Related Issue

Closes #69025

---

## Type of Change

* [x] ✨ New animation / hover effect
* [x] 🧩 New component
* [ ] 📝 Documentation improvement
* [ ] 🐛 Bug fix in an existing submission
* [ ] Other (describe below)

---

## Submission Checklist

* [x] All changes are inside `submissions/`
* [x] Includes `demo.html` — self-contained, opens in browser with no server
* [x] Includes `style.css` — raw CSS for the proposed feature
* [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
* [x] **No changes to** **`core/`**
* [x] **No changes to** **`components/`
* [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds a pure-CSS **Corner Bracket Frame Reveal Card** hover effect. On hover, corner bracket elements fade in and animate outward to create a futuristic frame around the card.

**How does a developer use it?**

```html
<div class="corner-frame-card">
  <h3>Secure Server</h3>
  <p>Hover to reveal the target framing brackets.</p>
</div>
```

Add the provided `style.css` to the project and apply the `corner-frame-card` class to the desired card or container.

**Why does it fit EaseMotion CSS?**

This is a lightweight, reusable CSS hover interaction that creates a modern tech/futuristic visual effect using transitions, transforms, opacity, and pseudo-elements without requiring JavaScript.

---

## Demo

* [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

* [x] Chrome
* [x] Firefox
* [x] Edge
* [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The implementation is contained entirely within:

`submissions/docs/corner-bracket-frame-69025/`

No changes were made to `core/` or `components/`. The submission includes the required `demo.html`, `style.css`, and `README.md` files.
