### PR TITLE
docs: add global prefers-reduced-motion showcase (#64481)

### DIFF
--- a/submissions/docs/prefers-reduced-motion-ak/README.md
+++ b/submissions/docs/prefers-reduced-motion-ak/README.md
@@ -1,0 +1,27 @@
+# Global prefers-reduced-motion Support Showcase
+
+## What does this do?
+Documents and demonstrates the existing global `prefers-reduced-motion` support already present in `core/animations.css` and `core/base.css`, which addresses vestibular-safety concerns raised in issue #64481.
+
+## How is it used?
+No opt-in required — it's automatic. Any element using EaseMotion animation classes (e.g. `.ease-fade-in`, `.ease-bounce`, custom `em=""` engine animations) already respects the user's OS/browser-level reduced motion setting:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+```
+
+The included `demo.html` shows a set of heavy animations (3D flip, bounce, wobble) with a toggle that simulates `prefers-reduced-motion: reduce`, so reviewers can see the graceful degradation live.
+
+## Why is it useful?
+Issue #64481 requested a global, framework-wide fallback for `prefers-reduced-motion` to protect users with vestibular disorders from motion sickness caused by heavy animations (3D flips, bounces, wobbles). Investigation showed this already exists in `core/animations.css` (global override on `*, *::before, *::after`) and `core/base.css` (scroll-behavior). This submission:
+1. Provides a visual, interactive demo confirming the existing rule degrades complex 3D/bounce/wobble animations to near-instant, satisfying WCAG 2.1 SC 2.3.3 (Animation from Interactions) intent.
+2. Flags one gap for the maintainer to consider: the current rule reduces animation *duration* to near-zero but doesn't fully disable `transform`-based motion paths (e.g. a 3D flip still visually "snaps" to its end state extremely fast rather than being fully static) — an alternative approach using `animation: none !important;` and `transform: none !important;` inside the query could be considered for full compliance in a future core update.
+
+Relates to #64481.

--- a/submissions/docs/prefers-reduced-motion-ak/demo.html
+++ b/submissions/docs/prefers-reduced-motion-ak/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>EaseMotion CSS — Global prefers-reduced-motion Showcase</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>Global <code>prefers-reduced-motion</code> Support</h1>
+  <p class="subtitle">Demonstrates the existing global reduced-motion rule in <code>core/animations.css</code> — relates to issue #64481.</p>
+
+  <div class="controls">
+    <button id="toggle-btn">Simulate prefers-reduced-motion: reduce</button>
+    <span class="status" id="status-text">Currently: normal motion</span>
+  </div>
+
+  <div class="grid">
+    <div class="card flip">
+      <div class="box"></div>
+      <h3>3D Flip</h3>
+    </div>
+    <div class="card bounce">
+      <div class="box"></div>
+      <h3>Bounce</h3>
+    </div>
+    <div class="card wobble">
+      <div class="box"></div>
+      <h3>Wobble</h3>
+    </div>
+  </div>
+
+  <script>
+    const btn = document.getElementById("toggle-btn");
+    const statusText = document.getElementById("status-text");
+    const body = document.body;
+    let reduced = false;
+
+    btn.addEventListener("click", () => {
+      reduced = !reduced;
+      body.classList.toggle("reduced-motion-simulated", reduced);
+      statusText.textContent = reduced
+        ? "Currently: reduced motion (simulated) — animations near-instant"
+        : "Currently: normal motion";
+      btn.textContent = reduced
+        ? "Disable simulated reduced motion"
+        : "Simulate prefers-reduced-motion: reduce";
+    });
+
+    // Also respect the real OS-level setting on load, for users who
+    // actually have it enabled.
+    if (window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      reduced = true;
+      body.classList.add("reduced-motion-simulated");
+      statusText.textContent = "Currently: reduced motion (OS setting detected)";
+      btn.textContent = "Disable simulated reduced motion";
+    }
+  </script>
+</body>
+</html>

--- a/submissions/docs/prefers-reduced-motion-ak/style.css
+++ b/submissions/docs/prefers-reduced-motion-ak/style.css
@@ -1,0 +1,113 @@
+body {
+  font-family: system-ui, sans-serif;
+  max-width: 720px;
+  margin: 40px auto;
+  padding: 0 20px;
+  background: #0d1117;
+  color: #e6edf3;
+}
+
+h1 {
+  font-size: 1.4rem;
+  margin-bottom: 4px;
+}
+
+p.subtitle {
+  color: #8b949e;
+  margin-top: 0;
+  margin-bottom: 24px;
+}
+
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 24px;
+  padding: 12px 16px;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  background: #161b22;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+
+.card {
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  padding: 20px;
+  background: #161b22;
+  text-align: center;
+  perspective: 600px;
+}
+
+.card h3 {
+  font-size: 0.9rem;
+  margin: 12px 0 4px;
+}
+
+.box {
+  width: 60px;
+  height: 60px;
+  margin: 0 auto;
+  border-radius: 10px;
+  background: linear-gradient(135deg, #58a6ff, #a371f7);
+}
+
+/* Heavy animations — the kind the issue flags as motion-sickness risks */
+.flip .box {
+  animation: flip-anim 1.4s ease-in-out infinite;
+}
+@keyframes flip-anim {
+  0% { transform: rotateY(0deg); }
+  50% { transform: rotateY(180deg); }
+  100% { transform: rotateY(360deg); }
+}
+
+.bounce .box {
+  animation: bounce-anim 1s ease-in-out infinite;
+}
+@keyframes bounce-anim {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-30px); }
+}
+
+.wobble .box {
+  animation: wobble-anim 1.2s ease-in-out infinite;
+}
+@keyframes wobble-anim {
+  0%, 100% { transform: rotate(0deg); }
+  25% { transform: rotate(-8deg); }
+  75% { transform: rotate(8deg); }
+}
+
+/* This is the EXISTING global rule from core/animations.css,
+   duplicated here only so this standalone demo.html can show it
+   in isolation, without depending on the full bundled CSS. */
+.reduced-motion-simulated * {
+  animation-duration: 0.01ms !important;
+  animation-iteration-count: 1 !important;
+  transition-duration: 0.01ms !important;
+  scroll-behavior: auto !important;
+}
+
+button {
+  background: #238636;
+  color: #fff;
+  border: none;
+  padding: 8px 16px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+button:hover {
+  background: #2ea043;
+}
+
+.status {
+  font-size: 0.85rem;
+  color: #8b949e;
+}


### PR DESCRIPTION
## Pull Request Description
Adds an interactive showcase demonstrating the existing global `prefers-reduced-motion` support in `core/animations.css` 
Closes #64481.

## Type of Change
- [x] 📝 Documentation improvement

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/docs/prefers-reduced-motion-ak/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

## Feature Description
**What does this add?**
An interactive demo proving heavy animations (3D flip, bounce, wobble) already degrade gracefully to near-instant under `prefers-reduced-motion: reduce`, via the existing global rule in `core/animations.css`.

**How does a developer use it?**
```html
<!-- No opt-in needed — automatic via the existing core/animations.css rule -->
<div class="ease-bounce">...</div>
```

**Why does it fit EaseMotion CSS?**
Issue #64481 asked for a global `prefers-reduced-motion` fallback to protect users with vestibular disorders from motion sickness caused by heavy animations. Investigation showed this already exists as a global override on `*, *::before, *::after` in `core/animations.css` (plus a supplementary `scroll-behavior` rule in `core/base.css`). This submission documents and visually demonstrates that existing behavior with a live toggle, and flags one possible refinement for the maintainer: the current rule reduces animation duration to near-zero rather than fully disabling `transform`, so 3D/complex animations still "snap" very fast instead of staying fully static — worth considering `animation: none !important` for full WCAG 2.1 SC 2.3.3 compliance if the maintainer wants to fold that into `core/`.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome

## Notes for Maintainer
The current `core/animations.css` global rule (`@media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation-duration: 0.01ms !important; ... } }`) already addresses the crux of issue #64481. I couldn't identify a case where the framework fails to respect this preference. This PR documents/demos that existing coverage rather than adding a new fix, since I can't edit `core/` directly. Flagged a possible refinement (full `animation: none` vs. near-zero duration) in the README for your consideration.