### PR TITLE
feat: add CSS-only modal

### DIFF
--- a/submissions/examples/css-only-modal/README.md
+++ b/submissions/examples/css-only-modal/README.md
@@ -1,0 +1,28 @@
+# CSS-Only Modal Hack
+
+A responsive modal component built entirely with HTML and CSS.
+
+The modal uses the CSS `:target` selector to control its visibility,
+so no JavaScript is required.
+
+## ✨ Features
+
+- Pure HTML and CSS
+- No JavaScript
+- Uses the `:target` selector
+- Smooth open and close animation
+- Backdrop overlay
+- Close button
+- Responsive design
+- Keyboard-focusable links
+- Visible focus states
+- Reduced-motion support
+- No external dependencies
+
+## 📁 Files
+
+```text
+css-only-modal/
+├── demo.html
+├── style.css
+└── README.md

--- a/submissions/examples/css-only-modal/demo.html
+++ b/submissions/examples/css-only-modal/demo.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <meta
+    name="description"
+    content="CSS-only modal using the :target selector without JavaScript."
+  >
+
+  <title>CSS-Only Modal Hack</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+  <main class="page">
+    <section class="hero">
+      <p class="eyebrow">EaseMotion CSS</p>
+
+      <h1>CSS-Only Modal</h1>
+
+      <p class="intro">
+        A responsive modal built entirely with HTML and CSS using the
+        <code>:target</code> selector.
+      </p>
+
+      <a
+        class="open-button"
+        href="#demo-modal"
+        aria-label="Open example modal"
+      >
+        Open Modal
+      </a>
+    </section>
+  </main>
+
+  <!-- Modal -->
+  <div
+    class="modal"
+    id="demo-modal"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="modal-title"
+  >
+    <a
+      class="modal-backdrop"
+      href="#"
+      aria-label="Close modal"
+    ></a>
+
+    <div class="modal-content">
+      <a
+        class="close-button"
+        href="#"
+        aria-label="Close modal"
+      >
+        &times;
+      </a>
+
+      <span class="modal-badge">CSS Only</span>
+
+      <h2 id="modal-title">Welcome!</h2>
+
+      <p>
+        This modal uses the CSS <code>:target</code> selector to control
+        visibility. No JavaScript is required.
+      </p>
+
+      <div class="modal-actions">
+        <a class="secondary-button" href="#">
+          Close
+        </a>
+
+        <a class="primary-button" href="#demo-modal">
+          Keep Open
+        </a>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/css-only-modal/style.css
+++ b/submissions/examples/css-only-modal/style.css
@@ -1,0 +1,320 @@
+:root {
+    --background: #0f172a;
+    --surface: #ffffff;
+    --text: #0f172a;
+    --muted: #64748b;
+    --primary: #6366f1;
+    --primary-dark: #4f46e5;
+    --overlay: rgba(15, 23, 42, 0.75);
+    --border: #e2e8f0;
+    --radius: 20px;
+    --transition: 300ms ease;
+  }
+  
+  * {
+    box-sizing: border-box;
+  }
+  
+  html {
+    scroll-behavior: smooth;
+  }
+  
+  body {
+    margin: 0;
+    min-height: 100vh;
+    font-family:
+      Inter,
+      ui-sans-serif,
+      system-ui,
+      -apple-system,
+      BlinkMacSystemFont,
+      "Segoe UI",
+      sans-serif;
+    background:
+      radial-gradient(circle at top, #1e293b, var(--background) 55%);
+    color: #ffffff;
+  }
+  
+  .page {
+    width: min(1000px, 92%);
+    min-height: 100vh;
+    margin: 0 auto;
+    display: grid;
+    place-items: center;
+    padding: 40px 0;
+  }
+  
+  .hero {
+    max-width: 650px;
+    text-align: center;
+  }
+  
+  .eyebrow {
+    margin: 0 0 12px;
+    color: #a5b4fc;
+    font-size: 0.85rem;
+    font-weight: 700;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+  }
+  
+  .hero h1 {
+    margin: 0;
+    font-size: clamp(2.5rem, 7vw, 5rem);
+    line-height: 1;
+  }
+  
+  .intro {
+    margin: 24px 0 32px;
+    color: #cbd5e1;
+    font-size: 1.05rem;
+    line-height: 1.7;
+  }
+  
+  code {
+    padding: 2px 6px;
+    border-radius: 5px;
+    background: rgba(255, 255, 255, 0.1);
+    font-family: monospace;
+  }
+  
+  /* Open button */
+  
+  .open-button,
+  .primary-button,
+  .secondary-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 46px;
+    padding: 12px 22px;
+    border-radius: 999px;
+    text-decoration: none;
+    font-weight: 700;
+    transition:
+      transform var(--transition),
+      background var(--transition),
+      box-shadow var(--transition);
+  }
+  
+  .open-button,
+  .primary-button {
+    background: var(--primary);
+    color: #ffffff;
+  }
+  
+  .open-button:hover,
+  .primary-button:hover {
+    background: var(--primary-dark);
+    transform: translateY(-2px);
+    box-shadow: 0 10px 25px rgba(99, 102, 241, 0.3);
+  }
+  
+  .open-button:focus-visible,
+  .primary-button:focus-visible,
+  .secondary-button:focus-visible,
+  .close-button:focus-visible {
+    outline: 3px solid #c7d2fe;
+    outline-offset: 4px;
+  }
+  
+  /* Modal container */
+  
+  .modal {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+  
+    display: grid;
+    place-items: center;
+  
+    padding: 24px;
+  
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+  
+    transition:
+      opacity var(--transition),
+      visibility var(--transition);
+  }
+  
+  /*
+   * :target makes the modal visible when
+   * the URL hash becomes #demo-modal.
+   */
+  .modal:target {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+  }
+  
+  /* Background overlay */
+  
+  .modal-backdrop {
+    position: absolute;
+    inset: 0;
+    background: var(--overlay);
+    backdrop-filter: blur(6px);
+  
+    opacity: 0;
+    transition: opacity var(--transition);
+  }
+  
+  .modal:target .modal-backdrop {
+    opacity: 1;
+  }
+  
+  /* Modal box */
+  
+  .modal-content {
+    position: relative;
+    z-index: 2;
+  
+    width: min(500px, 100%);
+    padding: 36px;
+  
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+  
+    background: var(--surface);
+    color: var(--text);
+  
+    box-shadow: 0 30px 80px rgba(0, 0, 0, 0.35);
+  
+    transform: translateY(30px) scale(0.95);
+    opacity: 0;
+  
+    transition:
+      transform var(--transition),
+      opacity var(--transition);
+  }
+  
+  .modal:target .modal-content {
+    transform: translateY(0) scale(1);
+    opacity: 1;
+  }
+  
+  /* Close button */
+  
+  .close-button {
+    position: absolute;
+    top: 16px;
+    right: 18px;
+  
+    display: grid;
+    place-items: center;
+  
+    width: 40px;
+    height: 40px;
+  
+    border-radius: 50%;
+  
+    color: var(--muted);
+    text-decoration: none;
+  
+    font-size: 1.8rem;
+    line-height: 1;
+  
+    transition:
+      background var(--transition),
+      color var(--transition);
+  }
+  
+  .close-button:hover {
+    background: #f1f5f9;
+    color: var(--text);
+  }
+  
+  /* Modal content */
+  
+  .modal-badge {
+    display: inline-block;
+    margin-bottom: 14px;
+    padding: 6px 10px;
+  
+    border-radius: 999px;
+    background: #eef2ff;
+    color: var(--primary-dark);
+  
+    font-size: 0.75rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+  
+  .modal-content h2 {
+    margin: 0 0 14px;
+    font-size: 2rem;
+  }
+  
+  .modal-content p {
+    margin: 0;
+    color: var(--muted);
+    line-height: 1.7;
+  }
+  
+  .modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+    margin-top: 28px;
+  }
+  
+  .secondary-button {
+    border: 1px solid var(--border);
+    background: #f8fafc;
+    color: var(--text);
+  }
+  
+  .secondary-button:hover {
+    background: #e2e8f0;
+    transform: translateY(-2px);
+  }
+  
+  /* Mobile */
+  
+  @media (max-width: 600px) {
+    .page {
+      padding: 24px 0;
+    }
+  
+    .modal {
+      padding: 16px;
+    }
+  
+    .modal-content {
+      padding: 30px 24px;
+    }
+  
+    .modal-content h2 {
+      font-size: 1.7rem;
+    }
+  
+    .modal-actions {
+      flex-direction: column-reverse;
+    }
+  
+    .primary-button,
+    .secondary-button {
+      width: 100%;
+    }
+  }
+  
+  /* Reduced motion */
+  
+  @media (prefers-reduced-motion: reduce) {
+    html {
+      scroll-behavior: auto;
+    }
+  
+    .modal,
+    .modal-backdrop,
+    .modal-content,
+    .open-button,
+    .primary-button,
+    .secondary-button,
+    .close-button {
+      transition: none;
+    }
+  }


### PR DESCRIPTION
## Description

Implemented the CSS-only Modal Hack for issue #68336.

### Changes

* Added a pure CSS modal using the `:target` selector.
* Added smooth modal entrance and exit animations.
* Added a backdrop overlay with blur effect.
* Added close controls.
* Added responsive behavior for mobile devices.
* Added keyboard focus styles.
* Added semantic dialog attributes.
* Added `prefers-reduced-motion` support.
* Added documentation in `README.md`.

### Files Added

* `submissions/examples/css-only-modal/demo.html`
* `submissions/examples/css-only-modal/style.css`
* `submissions/examples/css-only-modal/README.md`

### Testing

* Tested the modal opening through the URL hash.
* Tested the close buttons.
* Tested the backdrop close interaction.
* Tested keyboard focus.
* Tested responsive behavior.
* Tested reduced-motion support.
* Confirmed that no JavaScript is required.

### Issue

Closes #68336
