### PR TITLE
feat: add CSS full-page scroll snap example

### DIFF
--- a/submissions/examples/css-scroll-snap-full-page/README.md
+++ b/submissions/examples/css-scroll-snap-full-page/README.md
@@ -1,0 +1,22 @@
+# CSS Scroll Snap Full Page
+
+A responsive full-page scrolling component built using pure CSS.
+
+## Features
+
+- Full-page vertical scrolling
+- CSS `scroll-snap-type`
+- CSS `scroll-snap-align`
+- No JavaScript required
+- Responsive design
+- Smooth scrolling
+- Accessible section headings
+- Reduced-motion support
+- Lightweight and reusable
+
+## How It Works
+
+The main container uses:
+
+```css
+scroll-snap-type: y mandatory;

--- a/submissions/examples/css-scroll-snap-full-page/demo.html
+++ b/submissions/examples/css-scroll-snap-full-page/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta
+    name="description"
+    content="Pure CSS full-page scroll snap demonstration"
+  >
+  <title>CSS Scroll Snap Full Page</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="scroll-container" aria-label="Full page sections">
+
+    <section class="snap-section section-one" aria-labelledby="section-one-title">
+      <div class="content">
+        <span class="section-number">01</span>
+        <h1 id="section-one-title">Scroll Snap</h1>
+        <p>
+          A smooth full-page scrolling experience created using
+          pure CSS scroll-snap properties.
+        </p>
+        <span class="scroll-hint">Scroll to continue ↓</span>
+      </div>
+    </section>
+
+    <section class="snap-section section-two" aria-labelledby="section-two-title">
+      <div class="content">
+        <span class="section-number">02</span>
+        <h2 id="section-two-title">Pure CSS</h2>
+        <p>
+          No JavaScript is required. CSS controls the snapping behavior
+          between each full-screen section.
+        </p>
+      </div>
+    </section>
+
+    <section class="snap-section section-three" aria-labelledby="section-three-title">
+      <div class="content">
+        <span class="section-number">03</span>
+        <h2 id="section-three-title">Responsive</h2>
+        <p>
+          The layout adapts to different screen sizes while maintaining
+          a clean full-page scrolling experience.
+        </p>
+      </div>
+    </section>
+
+    <section class="snap-section section-four" aria-labelledby="section-four-title">
+      <div class="content">
+        <span class="section-number">04</span>
+        <h2 id="section-four-title">Done</h2>
+        <p>
+          A reusable full-page scroll snap component for modern interfaces.
+        </p>
+      </div>
+    </section>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/css-scroll-snap-full-page/style.css
+++ b/submissions/examples/css-scroll-snap-full-page/style.css
@@ -1,0 +1,133 @@
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+  }
+  
+  html {
+    scroll-behavior: smooth;
+  }
+  
+  body {
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+      sans-serif;
+    color: #ffffff;
+    background: #111827;
+  }
+  
+  /* Full-page scrolling container */
+  .scroll-container {
+    height: 100vh;
+    overflow-y: auto;
+    scroll-snap-type: y mandatory;
+    scroll-behavior: smooth;
+  }
+  
+  /* Individual snap sections */
+  .snap-section {
+    min-height: 100vh;
+    scroll-snap-align: start;
+    scroll-snap-stop: always;
+  
+    display: grid;
+    place-items: center;
+    padding: 2rem;
+  
+    text-align: center;
+  }
+  
+  /* Section content */
+  .content {
+    width: min(700px, 100%);
+    padding: 2rem;
+  }
+  
+  .section-number {
+    display: inline-block;
+    margin-bottom: 1rem;
+  
+    font-size: 0.9rem;
+    font-weight: 700;
+    letter-spacing: 0.15em;
+    opacity: 0.75;
+  }
+  
+  h1,
+  h2 {
+    margin-bottom: 1rem;
+    font-size: clamp(2.5rem, 7vw, 5rem);
+    line-height: 1.05;
+  }
+  
+  p {
+    max-width: 600px;
+    margin: 0 auto;
+  
+    font-size: clamp(1rem, 2vw, 1.25rem);
+    line-height: 1.7;
+    opacity: 0.9;
+  }
+  
+  .scroll-hint {
+    display: inline-block;
+    margin-top: 2rem;
+    font-size: 0.95rem;
+    opacity: 0.7;
+    animation: bounce 1.8s ease-in-out infinite;
+  }
+  
+  /* Section backgrounds */
+  .section-one {
+    background: #312e81;
+  }
+  
+  .section-two {
+    background: #0f766e;
+  }
+  
+  .section-three {
+    background: #9a3412;
+  }
+  
+  .section-four {
+    background: #374151;
+  }
+  
+  /* Small animation for the scroll hint */
+  @keyframes bounce {
+    0%,
+    100% {
+      transform: translateY(0);
+    }
+  
+    50% {
+      transform: translateY(8px);
+    }
+  }
+  
+  /* Mobile adjustments */
+  @media (max-width: 600px) {
+    .snap-section {
+      padding: 1rem;
+    }
+  
+    .content {
+      padding: 1rem;
+    }
+  
+    p {
+      line-height: 1.6;
+    }
+  }
+  
+  /* Respect reduced-motion preferences */
+  @media (prefers-reduced-motion: reduce) {
+    html,
+    .scroll-container {
+      scroll-behavior: auto;
+    }
+  
+    .scroll-hint {
+      animation: none;
+    }
+  }


### PR DESCRIPTION
## Description

Implemented the CSS Scroll Snap Full Page component for #68335.

## Changes

- Added a responsive full-page scroll snap demo
- Added pure CSS vertical snapping
- Added multiple full-screen sections
- Added smooth scrolling behavior
- Added responsive mobile styling
- Added reduced-motion support
- Added documentation in README.md

## Files Added

- `submissions/examples/css-scroll-snap-full-page/demo.html`
- `submissions/examples/css-scroll-snap-full-page/style.css`
- `submissions/examples/css-scroll-snap-full-page/README.md`

## Technical Details

The component uses:

- `scroll-snap-type`
- `scroll-snap-align`
- `scroll-snap-stop`
- CSS animations
- Responsive media queries
- `prefers-reduced-motion`

No JavaScript is required.

## Testing

- Tested the demo in a modern browser.
- Verified vertical section snapping.
- Verified responsive behavior.
- Verified reduced-motion support.

## Related Issue

Closes #68335