### PR TITLE
docs: propose broken link checker CI workflow (#63447)

### DIFF
--- a/submissions/docs/broken-link-checker-ak/README.md
+++ b/submissions/docs/broken-link-checker-ak/README.md
@@ -1,0 +1,40 @@
+# Broken Link Checker CI Workflow — Proposal
+
+## What does this do?
+Proposes a scheduled GitHub Actions workflow that crawls the live docs site (`https://saptarshi-coder.github.io/EaseMotion-css/`) using [lychee](https://github.com/lycheeverse/lychee), a fast Rust-based link checker, and automatically opens a GitHub Issue if any internal or external link returns a broken status.
+
+## How is it used?
+This is not a runtime HTML/CSS feature — it's CI infrastructure, so there's no class usage. Instead, `demo.html` in this folder documents the proposed workflow YAML and what the auto-filed issue would look like, since actual `.github/workflows/*.yml` files are outside the `submissions/` contribution model and need direct maintainer setup (workflow files can access repo secrets, so they're typically restricted to maintainers for security reasons).
+
+Proposed workflow (`.github/workflows/broken-link-checker.yml`):
+```yaml
+name: Broken Link Checker
+on:
+  schedule:
+    - cron: "0 6 * * 1"  # weekly, Monday 6am UTC
+  workflow_dispatch:
+
+jobs:
+  lychee:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v1
+        with:
+          args: --verbose --no-progress 'https://saptarshi-coder.github.io/EaseMotion-css/'
+          fail: false
+      - name: Create Issue on broken links
+        if: steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: "🔗 Broken links found in docs site"
+          content-filepath: ./lychee/out.md
+          labels: bug, documentation, automated
+```
+
+## Why is it useful?
+The docs site links out to the Discord server, the GitHub repo, and internally between the Buttons/Cards/Animations/Layout sections seen on the demo page — any of these can silently break as the site or Discord invite changes. A weekly automated check catches this proactively instead of relying on a user reporting it. This satisfies issue #63447's acceptance criteria: a scheduled crawl using lychee, and automatic issue creation on broken-link detection.
+
+Relates to #63447.

--- a/submissions/docs/broken-link-checker-ak/demo.html
+++ b/submissions/docs/broken-link-checker-ak/demo.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>EaseMotion CSS — Broken Link Checker CI Workflow Proposal</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>Broken Link Checker CI Workflow</h1>
+  <p class="subtitle">Proposal for issue #63447 — not a runtime HTML/CSS feature, no end-user markup involved.</p>
+
+  <div class="panel">
+    <h2>What it does</h2>
+    <p>A scheduled GitHub Actions workflow crawls <code>https://saptarshi-coder.github.io/EaseMotion-css/</code> weekly using <strong>lychee</strong>, a fast Rust-based link checker, and opens a GitHub Issue automatically if any link is broken.</p>
+  </div>
+
+  <div class="panel">
+    <h2>Proposed workflow file</h2>
+    <p class="filepath">.github/workflows/broken-link-checker.yml</p>
+    <pre><code>name: Broken Link Checker
+on:
+  schedule:
+    - cron: "0 6 * * 1"  # weekly, Monday 6am UTC
+  workflow_dispatch:
+
+jobs:
+  lychee:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v1
+        with:
+          args: --verbose --no-progress 'https://saptarshi-coder.github.io/EaseMotion-css/'
+          fail: false
+      - name: Create Issue on broken links
+        if: steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: "🔗 Broken links found in docs site"
+          content-filepath: ./lychee/out.md
+          labels: bug, documentation, automated</code></pre>
+  </div>
+
+  <div class="panel">
+    <h2>Mockup: auto-filed issue</h2>
+    <div class="issue-mock">
+      <div class="issue-title">🔗 Broken links found in docs site <span class="badge">automated</span></div>
+      <div class="issue-body">
+        <p>lychee found the following broken links during the scheduled crawl:</p>
+        <ul>
+          <li><code>https://saptarshi-coder.github.io/EaseMotion-css/animations</code> → <span class="status-code">404</span></li>
+          <li><code>https://discord.gg/oldinvite</code> → <span class="status-code">410 Gone</span></li>
+        </ul>
+        <p class="issue-footer">Filed automatically by the Broken Link Checker workflow.</p>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel">
+    <h2>Why this matters</h2>
+    <p>The docs site links to the Discord server, the GitHub repo, and internally between the Buttons/Cards/Animations/Layout sections. Any of these can silently break as the site or Discord invite changes — a weekly automated check catches this before a visitor does.</p>
+  </div>
+</body>
+</html>

--- a/submissions/docs/broken-link-checker-ak/style.css
+++ b/submissions/docs/broken-link-checker-ak/style.css
@@ -1,0 +1,98 @@
+body {
+  font-family: system-ui, sans-serif;
+  max-width: 700px;
+  margin: 40px auto;
+  padding: 0 20px;
+  background: #0d1117;
+  color: #e6edf3;
+}
+
+h1 {
+  font-size: 1.4rem;
+  margin-bottom: 4px;
+}
+
+p.subtitle {
+  color: #8b949e;
+  margin-top: 0;
+  margin-bottom: 24px;
+}
+
+.panel {
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  padding: 16px 20px;
+  margin-bottom: 16px;
+  background: #161b22;
+}
+
+.panel h2 {
+  font-size: 1rem;
+  margin-top: 0;
+}
+
+.filepath {
+  font-family: monospace;
+  color: #8b949e;
+  font-size: 0.85rem;
+  margin-top: -8px;
+}
+
+pre {
+  background: #010409;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  padding: 12px;
+  overflow-x: auto;
+  font-size: 0.8rem;
+  line-height: 1.5;
+}
+
+code {
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+.issue-mock {
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.issue-title {
+  background: #21262d;
+  padding: 10px 14px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.badge {
+  background: #58a6ff;
+  color: #0d1117;
+  font-size: 0.7rem;
+  font-weight: 700;
+  padding: 2px 8px;
+  border-radius: 999px;
+}
+
+.issue-body {
+  padding: 14px;
+}
+
+.issue-body ul {
+  margin: 8px 0;
+  padding-left: 20px;
+}
+
+.status-code {
+  color: #f85149;
+  font-family: monospace;
+  font-weight: 600;
+}
+
+.issue-footer {
+  color: #8b949e;
+  font-size: 0.85rem;
+  margin-top: 10px;
+}


### PR DESCRIPTION
closes #63447
## Pull Request Description
Proposes a scheduled GitHub Actions workflow using lychee to crawl the live docs site and auto-file an issue on broken links, addressing feature request #63447. Since workflow files aren't part of the submission model, this documents the proposed YAML and behavior rather than adding a live `.github/workflows/` file.

## Type of Change
- [x] 📝 Documentation improvement

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/docs/broken-link-checker-ak/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

## Feature Description
**What does this add?**
A documentation page proposing `.github/workflows/broken-link-checker.yml`: a weekly scheduled crawl of the live docs site using lychee, which auto-opens a GitHub Issue if any link is broken.

**How does a developer use it?**
```html
<!-- Not a runtime HTML/CSS feature — this is CI infrastructure.
     No end-user markup is involved; demo.html documents the proposed workflow. -->
```

**Why does it fit EaseMotion CSS?**
Issue #63447 notes the docs site links out to Discord, GitHub, and internal Buttons/Cards/Animations/Layout sections — any of which can silently break as the site or invite changes. A weekly automated lychee crawl catches this proactively rather than relying on a user report, satisfying the issue's acceptance criteria (scheduled crawl + automatic issue creation on broken links).

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome

## Notes for Maintainer
This issue asks for a `.github/workflows/*.yml` file, which falls outside the four `submissions/` tracks and outside contributor-writable paths (workflow files can access repo secrets, so it makes sense they're maintainer-only). I've documented the proposed workflow YAML, trigger schedule, and a mockup of the auto-filed issue in `demo.html`/`README.md` instead. If this looks right, happy to have you drop the actual `.yml` in directly, or let me know if you'd rather I open a separate PR with the real workflow file if contributor access to `.github/workflows/` is fine for this case.