### PR TITLE
feat: add pure CSS Swipe-to-Delete Card component (#68139)

### DIFF
--- a/submissions/examples/css-swipe-to-delete-card-pure/README.md
+++ b/submissions/examples/css-swipe-to-delete-card-pure/README.md
@@ -1,0 +1,20 @@
+# CSS Swipe-to-Delete Card
+
+A pure CSS card component that can be natively swiped left on touch devices (or horizontally scrolled) to reveal a hidden delete action, built entirely without JavaScript.
+
+## Features
+- Pure CSS and HTML (Zero JavaScript touch event listeners, calculation math, or drag physics).
+- **Theming & Dark Mode**: Utilizes CSS Custom Properties (`--card-bg`, `--delete-bg`, etc.) for easy overriding. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`).
+- **Native Scroll Snapping (Documented in Code)**: 
+- This component creates the "swipe" effect utilizing the native CSS scroll physics engine. 
+- `overflow-x: auto` is combined with `scrollbar-width: none` to create a hidden horizontal scroll plane.
+- `scroll-snap-type: x mandatory` enforces strict snapping behavior so the card perfectly rests in either the "closed" or "open" state when the user releases their finger.
+- The main card is set to `flex: 0 0 100%;` forcing it to take up the full view width, pushing the action button off-screen.
+- Because it uses the browser's native scroll engine, the swipe physics are hardware-accelerated, buttery smooth, and feel entirely native on iOS and Android touch screens.
+
+## Usage
+Open `demo.html` in your browser. On a trackpad or touch screen, simply swipe left on the card to reveal the delete button. If using a mouse without horizontal scroll capability, you can hold shift and scroll down, or simulate touch in Chrome DevTools.
+
+## Files
+- `demo.html`: The HTML structure containing the swipe wrapper, the main card flex items, and the action button.
+- `style.css`: The styling, CSS Custom Property theming blocks, and heavily commented mechanics detailing the CSS `scroll-snap` architecture.

--- a/submissions/examples/css-swipe-to-delete-card-pure/demo.html
+++ b/submissions/examples/css-swipe-to-delete-card-pure/demo.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Swipe-to-Delete Card</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Swipe-to-Delete Card</h1>
+            <p class="subtitle">A pure CSS implementation utilizing native `scroll-snap-type` to create a smooth, touch-friendly swipe gesture without JavaScript.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <div class="swipe-list">
+                
+                <!-- Card 1 -->
+                <div class="swipe-container">
+                    <div class="swipe-scroll-area">
+                        
+                        <!-- The main content that the user sees initially -->
+                        <div class="swipe-card">
+                            <div class="card-avatar" style="background-image: url('https://i.pravatar.cc/150?img=68');"></div>
+                            <div class="card-info">
+                                <h3>Sarah Jenkins</h3>
+                                <p>Can we reschedule our meeting to 3 PM?</p>
+                            </div>
+                            <span class="card-time">10:42 AM</span>
+                            
+                            <!-- A subtle hint that the card is swipeable -->
+                            <div class="swipe-hint">
+                                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <polyline points="15 18 9 12 15 6"></polyline>
+                                </svg>
+                            </div>
+                        </div>
+                        
+                        <!-- The action button revealed on swipe -->
+                        <div class="swipe-action delete-action">
+                            <button aria-label="Delete message">
+                                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <polyline points="3 6 5 6 21 6"></polyline>
+                                    <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+                                    <line x1="10" y1="11" x2="10" y2="17"></line>
+                                    <line x1="14" y1="11" x2="14" y2="17"></line>
+                                </svg>
+                                <span>Delete</span>
+                            </button>
+                        </div>
+                        
+                    </div>
+                </div>
+                
+                <!-- Card 2 -->
+                <div class="swipe-container">
+                    <div class="swipe-scroll-area">
+                        <div class="swipe-card">
+                            <div class="card-avatar" style="background-image: url('https://i.pravatar.cc/150?img=11');"></div>
+                            <div class="card-info">
+                                <h3>Design System Team</h3>
+                                <p>New components have been pushed to main.</p>
+                            </div>
+                            <span class="card-time">Yesterday</span>
+                            <div class="swipe-hint">
+                                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"></polyline></svg>
+                            </div>
+                        </div>
+                        <div class="swipe-action delete-action">
+                            <button aria-label="Delete message">
+                                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <polyline points="3 6 5 6 21 6"></polyline>
+                                    <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+                                    <line x1="10" y1="11" x2="10" y2="17"></line>
+                                    <line x1="14" y1="11" x2="14" y2="17"></line>
+                                </svg>
+                                <span>Delete</span>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-swipe-to-delete-card-pure/style.css
+++ b/submissions/examples/css-swipe-to-delete-card-pure/style.css
@@ -1,0 +1,246 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    
+    --card-bg: #ffffff;
+    --card-border: #e2e8f0;
+    --card-hover: #f1f5f9;
+    
+    --delete-bg: #ef4444;
+    --delete-color: #ffffff;
+    --delete-hover: #dc2626;
+    
+    --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a;
+        --text-primary: #f8fafc;
+        --text-secondary: #94a3b8;
+        
+        --card-bg: #1e293b;
+        --card-border: #334155;
+        --card-hover: #0f172a;
+        
+        --delete-bg: #f87171;
+        --delete-color: #7f1d1d;
+        --delete-hover: #ef4444;
+        
+        --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.5);
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 600px;
+    width: 100%;
+    padding: 60px 20px;
+    flex: 1;
+}
+
+.section-header {
+    margin-bottom: 60px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2rem;
+    font-weight: 700;
+    margin: 0 0 12px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    margin: 0 auto;
+    line-height: 1.6;
+}
+
+/* =========================================
+   Swipe-to-Delete Architecture
+   ========================================= */
+
+.swipe-list {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    width: 100%;
+}
+
+/* 
+  1. The Outer Container
+  This establishes the bounded box and hides the scrollbar globally.
+*/
+.swipe-container {
+    position: relative;
+    width: 100%;
+    border-radius: 12px;
+    overflow: hidden; /* Hides the action buttons initially */
+    box-shadow: var(--shadow-sm);
+    background-color: var(--card-bg);
+}
+
+/* 
+  2. The Scroll Area (The Native Swipe Engine)
+  This is where the magic happens. We use native CSS horizontal scrolling
+  combined with scroll snapping to create the swipe gesture.
+*/
+.swipe-scroll-area {
+    display: flex;
+    width: 100%;
+    overflow-x: auto;
+    
+    /* Hide the native scrollbar so it looks like a clean UI component */
+    scrollbar-width: none; /* Firefox */
+    -ms-overflow-style: none; /* IE/Edge */
+    
+    /* Native CSS scroll snapping */
+    scroll-snap-type: x mandatory;
+    scroll-behavior: smooth;
+}
+.swipe-scroll-area::-webkit-scrollbar {
+    display: none; /* Chrome/Safari/Webkit */
+}
+
+/* 
+  3. The Main Card Content
+  Forces the card to be exactly 100% of the container width.
+*/
+.swipe-card {
+    position: relative;
+    flex: 0 0 100%; /* Take up the entire visible width */
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    padding: 20px;
+    background-color: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 12px;
+    box-sizing: border-box;
+    scroll-snap-align: start; /* Snap point 1: The closed state */
+    z-index: 2;
+    transition: background-color 0.2s ease;
+}
+
+.swipe-card:hover {
+    background-color: var(--card-hover);
+}
+
+/* 
+  4. The Hidden Action Button
+  Sits immediately to the right of the main card inside the flex layout.
+  The user scrolls/swipes horizontally to reveal it.
+*/
+.swipe-action {
+    flex: 0 0 100px; /* Fixed width for the action button */
+    display: flex;
+    scroll-snap-align: end; /* Snap point 2: The open state */
+}
+
+.swipe-action button {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 6px;
+    border: none;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.85rem;
+    font-weight: 600;
+    transition: background-color 0.2s ease;
+}
+
+.delete-action button {
+    background-color: var(--delete-bg);
+    color: var(--delete-color);
+}
+.delete-action button:hover,
+.delete-action button:focus {
+    background-color: var(--delete-hover);
+    outline: none;
+}
+
+
+/* =========================================
+   Card UI Detailing
+   ========================================= */
+
+.card-avatar {
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    background-size: cover;
+    background-position: center;
+    background-color: var(--card-border);
+}
+
+.card-info {
+    flex: 1;
+    min-width: 0; /* Prevents flex children from pushing bounds */
+}
+
+.card-info h3 {
+    margin: 0 0 4px 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.card-info p {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.card-time {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    white-space: nowrap;
+    align-self: flex-start;
+    padding-top: 4px;
+}
+
+/* Hint chevron to show it's swipeable */
+.swipe-hint {
+    position: absolute;
+    right: 12px;
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--text-secondary);
+    opacity: 0.5;
+    animation: hintPulse 2s infinite ease-in-out;
+}
+
+@keyframes hintPulse {
+    0%, 100% { transform: translate(0, -50%); opacity: 0.3; }
+    50% { transform: translate(-4px, -50%); opacity: 0.8; }
+}


### PR DESCRIPTION
### Description
This PR introduces a pure CSS card component that can be natively swiped left on touch devices (or horizontally scrolled) to reveal a hidden delete action, built entirely without JavaScript, resolving issue #68139.

### Changes Made:
- Added `submissions/examples/css-swipe-to-delete-card-pure/` directory.
- Created `demo.html` showcasing the HTML structure containing the swipe wrapper, the main card flex items, and the action button.
- Created `style.css` featuring the UI mechanics:
  - **Native Scroll Snapping**: This component creates the "swipe" effect utilizing the native CSS scroll physics engine. `overflow-x: auto` is combined with `scrollbar-width: none` to create a hidden horizontal scroll plane.
  - **Snapping Physics**: `scroll-snap-type: x mandatory` enforces strict snapping behavior so the card perfectly rests in either the "closed" or "open" state when the user releases their finger.
  - **Native Hardware Acceleration**: Because it uses the browser's native scroll engine rather than JavaScript touch physics, the swipe physics are hardware-accelerated, buttery smooth, and feel entirely native on iOS and Android touch screens.
  - **Theming & Dark Mode Supported**: Utilizes CSS Custom Properties. The stylesheet automatically respects the OS-level system theme (`prefers-color-scheme: dark`).
- Added `README.md` documenting usage and the technical mechanics of the CSS `scroll-snap` architecture.

Closes #68139
