### PR TITLE
feat: add CSS gradient text reveal

### DIFF
--- a/submissions/examples/gradient-text-reveal/README.md
+++ b/submissions/examples/gradient-text-reveal/README.md
@@ -1,0 +1,37 @@
+# CSS Gradient Text Reveal
+
+A CSS-only text reveal effect where a gradient sweeps from left to right across the text.
+
+## Features
+
+- Pure CSS implementation
+- No JavaScript required
+- Smooth gradient reveal animation
+- Responsive typography
+- Keyboard accessible link
+- Respects `prefers-reduced-motion`
+- Works across modern browsers
+
+## Files
+
+- `demo.html` - Demonstration page
+- `style.css` - Animation and styling
+
+## How It Works
+
+The effect uses:
+
+- `background: linear-gradient()` to create the gradient
+- `background-size` to extend the gradient
+- `background-position` to control the reveal direction
+- `background-clip: text` to display the gradient inside the text
+- CSS `@keyframes` to animate the gradient from right to left
+
+No JavaScript is required.
+
+## Usage
+
+Link the stylesheet:
+
+```html
+<link rel="stylesheet" href="style.css">

--- a/submissions/examples/gradient-text-reveal/demo.html
+++ b/submissions/examples/gradient-text-reveal/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta
+    name="description"
+    content="CSS-only gradient text reveal animation"
+  >
+  <title>Gradient Text Reveal</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+  <main class="demo">
+    <section class="hero" aria-labelledby="gradient-title">
+      <p class="eyebrow">EaseMotion CSS</p>
+
+      <h1 id="gradient-title" class="gradient-text">
+        Gradient Text Reveal
+      </h1>
+
+      <p class="description">
+        A smooth left-to-right gradient reveal created entirely with CSS.
+        No JavaScript required.
+      </p>
+
+      <a class="demo-button" href="#gradient-title">
+        Replay Animation
+      </a>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/gradient-text-reveal/style.css
+++ b/submissions/examples/gradient-text-reveal/style.css
@@ -1,0 +1,110 @@
+* {
+    box-sizing: border-box;
+  }
+  
+  html {
+    scroll-behavior: smooth;
+  }
+  
+  body {
+    margin: 0;
+    min-height: 100vh;
+    font-family: Arial, sans-serif;
+    background: #0f172a;
+    color: #f8fafc;
+  }
+  
+  .demo {
+    min-height: 100vh;
+    display: grid;
+    place-items: center;
+    padding: 2rem;
+  }
+  
+  .hero {
+    width: min(900px, 100%);
+    padding: clamp(2rem, 6vw, 5rem);
+    text-align: center;
+    border-radius: 24px;
+    background: #1e293b;
+    box-shadow: 0 20px 60px rgb(0 0 0 / 25%);
+  }
+  
+  .eyebrow {
+    margin: 0 0 1rem;
+    font-size: 0.85rem;
+    font-weight: 700;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+  }
+  
+  .gradient-text {
+    margin: 0;
+    font-size: clamp(2.5rem, 8vw, 6rem);
+    line-height: 1;
+    font-weight: 800;
+  
+    background: linear-gradient(
+      90deg,
+      #38bdf8 0%,
+      #818cf8 50%,
+      #e879f9 100%
+    );
+  
+    background-size: 200% 100%;
+    background-position: 100% 0;
+  
+    color: transparent;
+    background-clip: text;
+    -webkit-background-clip: text;
+  
+    animation: gradient-reveal 1.8s ease-out forwards;
+  }
+  
+  .description {
+    max-width: 650px;
+    margin: 1.5rem auto 2rem;
+    line-height: 1.7;
+    color: #cbd5e1;
+  }
+  
+  .demo-button {
+    display: inline-block;
+    padding: 0.8rem 1.4rem;
+    border-radius: 999px;
+    background: #f8fafc;
+    color: #0f172a;
+    text-decoration: none;
+    font-weight: 700;
+    transition: transform 0.2s ease;
+  }
+  
+  .demo-button:hover,
+  .demo-button:focus-visible {
+    transform: translateY(-2px);
+  }
+  
+  @keyframes gradient-reveal {
+    from {
+      background-position: 100% 0;
+    }
+  
+    to {
+      background-position: 0 0;
+    }
+  }
+  
+  @media (prefers-reduced-motion: reduce) {
+    .gradient-text {
+      animation: none;
+      background-position: 0 0;
+    }
+  
+    html {
+      scroll-behavior: auto;
+    }
+  
+    .demo-button {
+      transition: none;
+    }
+  }


### PR DESCRIPTION
## Related Issue

Closes #68298

## What does this PR add?

- Added a CSS-only gradient text reveal animation
- Added responsive demo page
- Added accessibility support
- Added reduced-motion support
- Added documentation

## Implementation

The animation uses CSS gradients, background clipping, and keyframes.
No JavaScript is required.

## Testing

- Tested the demo in a modern browser
- Verified responsive layout
- Verified keyboard navigation
- Verified `prefers-reduced-motion`