### PR TITLE
feat: add pure CSS Floating Dock Navigation component (#68186)

### DIFF
--- a/submissions/examples/css-floating-dock-navigation-pure/README.md
+++ b/submissions/examples/css-floating-dock-navigation-pure/README.md
@@ -1,0 +1,21 @@
+# CSS Floating Dock Navigation
+
+A pure CSS implementation of a macOS-style floating dock navigation bar featuring dynamic reactive scaling, built entirely without JavaScript.
+
+## Features
+- Pure CSS and HTML (Zero JavaScript coordinate tracking or math for the reactive scaling).
+- **Theming & Dark Mode**: Utilizes CSS Custom Properties (`--dock-bg`, `--bg-base`, etc.) for easy overriding. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`).
+- **Reactive Dock Scaling (Documented in Code)**: 
+- This component creates the iconic macOS dock wave effect utilizing the modern CSS `:has()` relational pseudo-class.
+- **Rule 1**: When an item is hovered, it scales up massively (`transform: scale(1.5)`).
+- **Rule 2**: We target the item *immediately preceding* the hovered item using `.dock-item:has(+ .dock-item:hover)` and scale it up slightly (`1.2`).
+- **Rule 3**: We target the item *immediately following* the hovered item using the adjacent sibling selector `.dock-item:hover + .dock-item` and scale it up slightly (`1.2`).
+- The combination of these three rules creates a seamless mathematical wave across the dock as your mouse moves.
+- Fully accessible with `prefers-reduced-motion` support. The scaling animations are completely disabled for motion-sensitive users.
+
+## Usage
+Open `demo.html` in your browser. Move your mouse rapidly across the dock items to see them scale reactively, creating a smooth, physics-like wave.
+
+## Files
+- `demo.html`: The HTML structure containing the list of dock buttons and SVG icons.
+- `style.css`: The styling, CSS Custom Property theming blocks, and heavily commented mechanics detailing the CSS `:has()` trick.

--- a/submissions/examples/css-floating-dock-navigation-pure/demo.html
+++ b/submissions/examples/css-floating-dock-navigation-pure/demo.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Floating Dock Navigation</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Floating Dock Navigation</h1>
+            <p class="subtitle">A pure CSS implementation of a macOS-style dock with reactive scaling utilizing the modern `:has()` selector.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <nav class="dock" aria-label="Main Navigation">
+                <ul class="dock-container">
+                    
+                    <li class="dock-item">
+                        <button class="dock-btn" aria-label="Finder">
+                            <svg viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" stroke-width="2" fill="none">
+                                <path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20"></path>
+                            </svg>
+                        </button>
+                        <span class="dock-tooltip">Finder</span>
+                    </li>
+                    
+                    <li class="dock-item">
+                        <button class="dock-btn" aria-label="Messages">
+                            <svg viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" stroke-width="2" fill="none">
+                                <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
+                            </svg>
+                        </button>
+                        <span class="dock-tooltip">Messages</span>
+                    </li>
+                    
+                    <li class="dock-item">
+                        <button class="dock-btn" aria-label="Mail">
+                            <svg viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" stroke-width="2" fill="none">
+                                <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"></path>
+                                <polyline points="22,6 12,13 2,6"></polyline>
+                            </svg>
+                        </button>
+                        <span class="dock-tooltip">Mail</span>
+                    </li>
+                    
+                    <li class="dock-item">
+                        <button class="dock-btn" aria-label="Photos">
+                            <svg viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" stroke-width="2" fill="none">
+                                <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
+                                <circle cx="8.5" cy="8.5" r="1.5"></circle>
+                                <polyline points="21 15 16 10 5 21"></polyline>
+                            </svg>
+                        </button>
+                        <span class="dock-tooltip">Photos</span>
+                    </li>
+                    
+                    <li class="dock-item">
+                        <button class="dock-btn" aria-label="Settings">
+                            <svg viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" stroke-width="2" fill="none">
+                                <circle cx="12" cy="12" r="3"></circle>
+                                <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
+                            </svg>
+                        </button>
+                        <span class="dock-tooltip">Settings</span>
+                    </li>
+                    
+                </ul>
+            </nav>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-floating-dock-navigation-pure/style.css
+++ b/submissions/examples/css-floating-dock-navigation-pure/style.css
@@ -1,0 +1,231 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    
+    --dock-bg: rgba(255, 255, 255, 0.7);
+    --dock-border: rgba(255, 255, 255, 0.4);
+    --dock-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    
+    --item-bg: #ffffff;
+    --item-color: #3b82f6;
+    --item-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+    
+    --tooltip-bg: rgba(15, 23, 42, 0.8);
+    --tooltip-text: #ffffff;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a;
+        --text-primary: #f8fafc;
+        --text-secondary: #94a3b8;
+        
+        --dock-bg: rgba(30, 41, 59, 0.7);
+        --dock-border: rgba(255, 255, 255, 0.1);
+        --dock-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.5), 0 10px 10px -5px rgba(0, 0, 0, 0.3);
+        
+        --item-bg: #334155;
+        --item-color: #60a5fa;
+        --item-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.3);
+        
+        --tooltip-bg: rgba(255, 255, 255, 0.9);
+        --tooltip-text: #0f172a;
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    width: 100%;
+    padding: 60px 20px;
+    flex: 1;
+}
+
+.section-header {
+    margin-bottom: 60px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.5rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.demo-area {
+    position: relative;
+    width: 100%;
+    height: 300px;
+    display: flex;
+    justify-content: center;
+    align-items: flex-end;
+    padding-bottom: 40px;
+}
+
+
+/* =========================================
+   Floating Dock Container
+   ========================================= */
+
+.dock {
+    padding: 12px;
+    background: var(--dock-bg);
+    border: 1px solid var(--dock-border);
+    border-radius: 24px;
+    /* Glassmorphism blur effect */
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    box-shadow: var(--dock-shadow);
+}
+
+.dock-container {
+    display: flex;
+    gap: 12px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    align-items: flex-end;
+    height: 48px; /* Base height for items */
+}
+
+
+/* =========================================
+   Dock Items & Reactive Scaling
+   ========================================= */
+
+.dock-item {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 48px;
+    height: 48px;
+    
+    /* Center transform origin for scaling */
+    transform-origin: bottom center;
+    transition: transform 0.2s cubic-bezier(0.25, 1, 0.5, 1), margin 0.2s cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+.dock-btn {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: var(--item-bg);
+    color: var(--item-color);
+    border: none;
+    border-radius: 12px;
+    box-shadow: var(--item-shadow);
+    cursor: pointer;
+    padding: 0;
+    /* The button fills the list item, so it inherits the LI scale */
+    transition: background-color 0.2s ease;
+}
+
+
+/* 
+  [TECHNIQUE] CSS Mac OS Dock Effect via :has()
+  We use the modern `:has()` selector to detect hover states of adjacent siblings.
+*/
+
+/* 1. Scale the directly hovered item massively */
+.dock-item:hover {
+    transform: scale(1.5) translateY(-4px);
+    margin: 0 12px; /* Push neighbors away slightly */
+    z-index: 10;
+}
+
+/* 2. Scale the item immediately PRECEDING the hovered item */
+.dock-item:has(+ .dock-item:hover) {
+    transform: scale(1.2) translateY(-2px);
+    margin-right: 6px;
+    z-index: 5;
+}
+
+/* 3. Scale the item immediately FOLLOWING the hovered item */
+.dock-item:hover + .dock-item {
+    transform: scale(1.2) translateY(-2px);
+    margin-left: 6px;
+    z-index: 5;
+}
+
+
+/* =========================================
+   Tooltips
+   ========================================= */
+
+.dock-tooltip {
+    position: absolute;
+    top: -45px;
+    padding: 6px 12px;
+    background-color: var(--tooltip-bg);
+    color: var(--tooltip-text);
+    font-size: 0.75rem;
+    font-weight: 500;
+    border-radius: 6px;
+    white-space: nowrap;
+    opacity: 0;
+    transform: scale(0.8);
+    transform-origin: bottom center;
+    pointer-events: none;
+    transition: all 0.2s cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+/* Show tooltip when parent is hovered */
+.dock-item:hover .dock-tooltip {
+    opacity: 1;
+    transform: scale(0.8) translateY(-4px); /* Scale down relative to the already scaled parent */
+}
+
+/* Small triangle pointer for tooltip */
+.dock-tooltip::after {
+    content: '';
+    position: absolute;
+    bottom: -4px;
+    left: 50%;
+    transform: translateX(-50%);
+    border-width: 4px 4px 0 4px;
+    border-style: solid;
+    border-color: var(--tooltip-bg) transparent transparent transparent;
+}
+
+
+/* Accessibility - Disable scaling animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .dock-item,
+    .dock-item:hover,
+    .dock-item:has(+ .dock-item:hover),
+    .dock-item:hover + .dock-item {
+        transform: none !important;
+        margin: 0 !important;
+        transition: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a pure CSS implementation of a macOS-style floating dock navigation bar featuring dynamic reactive scaling, built entirely without JavaScript, resolving issue #68186.

### Changes Made:
- Added `submissions/examples/css-floating-dock-navigation-pure/` directory.
- Created `demo.html` showcasing the HTML structure containing the list of dock buttons and SVG icons.
- Created `style.css` featuring the UI mechanics:
  - **Reactive Dock Scaling via `:has()`**: This component creates the iconic macOS dock wave effect utilizing the modern CSS `:has()` relational pseudo-class.
  - **Rule 1**: When an item is hovered, it scales up massively (`transform: scale(1.5)`).
  - **Rule 2**: We target the item *immediately preceding* the hovered item using `.dock-item:has(+ .dock-item:hover)` and scale it up slightly (`1.2`).
  - **Rule 3**: We target the item *immediately following* the hovered item using the adjacent sibling selector `.dock-item:hover + .dock-item` and scale it up slightly (`1.2`).
  - **Theming & Dark Mode Supported**: Utilizes CSS Custom Properties. The stylesheet automatically respects the OS-level system theme (`prefers-color-scheme: dark`).
- Added `README.md` documenting usage and the technical mechanics of the CSS `:has()` wave trick.
- Honors the `prefers-reduced-motion` accessibility standard. The scaling animations are completely disabled for motion-sensitive users.

Closes #68186
