### PR TITLE
feat: add pure CSS Layered Parallax Card component (#68164)

### DIFF
--- a/submissions/examples/css-layered-parallax-card-pure/README.md
+++ b/submissions/examples/css-layered-parallax-card-pure/README.md
@@ -1,0 +1,20 @@
+# CSS Layered Parallax Card
+
+A pure CSS card component that simulates interactive 3D mouse tracking to create a layered depth parallax effect, built entirely without JavaScript.
+
+## Features
+- Pure CSS and HTML (Zero JavaScript mouse coordinate math required).
+- **Theming & Dark Mode**: Utilizes CSS Custom Properties (`--card-bg`, `--content-bg`, etc.) for easy overriding. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`).
+- **3D Mouse Tracking Architecture (Documented in Code)**: 
+- To simulate JS mouse tracking (`mousemove`) purely in CSS, we use a 3x3 tracking grid.
+- We overlay 9 invisible `<div class="tracker">` squares precisely over the card's surface. 
+- Using the CSS general sibling selector (`~`), we map the `:hover` state of each specific tracking cell to a unique `transform: rotateX() rotateY()` coordinate on the underlying `.parallax-card`.
+- **True 3D Layers**: The main wrapper uses `perspective: 1000px;` and the card uses `transform-style: preserve-3d;`. The inner elements (background, graphic, and text content box) are absolute positioned with varying `translateZ()` values (e.g., `translateZ(80px)`). When the card tilts, these layers actually pop out of the screen, creating true 3D parallax depth.
+- Fully accessible with `prefers-reduced-motion` support. The hover rotations and 3D transforms are completely disabled for motion-sensitive users.
+
+## Usage
+Open `demo.html` in your browser. Move your mouse across the surface of the card to watch it dynamically tilt and reveal the true 3D depth between the background, the icon, and the glassmorphism content box.
+
+## Files
+- `demo.html`: The HTML structure containing the 9 tracking cells and the 3 distinct depth layers.
+- `style.css`: The styling, CSS Custom Property theming blocks, and heavily commented mechanics detailing the sibling-selector hover mapping trick.

--- a/submissions/examples/css-layered-parallax-card-pure/demo.html
+++ b/submissions/examples/css-layered-parallax-card-pure/demo.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Layered Parallax Card</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Layered Parallax Card</h1>
+            <p class="subtitle">A pure CSS 3D parallax effect on hover, achieved by mapping invisible tracking grids over the card using the sibling selector.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <!-- 
+              [TECHNIQUE] CSS Mouse Tracking Grid
+              We overlay an invisible 3x3 grid over the entire card area.
+              When a specific grid cell is hovered, we use the general sibling selector (~)
+              to rotate the underlying card in a specific 3D direction, simulating JavaScript mouse tracking.
+            -->
+            <div class="parallax-wrapper">
+                
+                <!-- Invisible Hover Trackers (3x3 grid) -->
+                <div class="tracker tr-1"></div>
+                <div class="tracker tr-2"></div>
+                <div class="tracker tr-3"></div>
+                <div class="tracker tr-4"></div>
+                <div class="tracker tr-5"></div>
+                <div class="tracker tr-6"></div>
+                <div class="tracker tr-7"></div>
+                <div class="tracker tr-8"></div>
+                <div class="tracker tr-9"></div>
+
+                <!-- The Actual Card -->
+                <div class="parallax-card">
+                    <!-- Layer 1: Background Base -->
+                    <div class="layer layer-bg"></div>
+                    
+                    <!-- Layer 2: Graphic/Image -->
+                    <div class="layer layer-graphic">
+                        <svg viewBox="0 0 24 24" width="64" height="64" stroke="currentColor" stroke-width="1.5" fill="none">
+                            <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"></path>
+                        </svg>
+                    </div>
+                    
+                    <!-- Layer 3: Text Content -->
+                    <div class="layer layer-content">
+                        <h3>Depth Effect</h3>
+                        <p>Move your mouse around this card to explore the layered 3D space entirely in CSS.</p>
+                    </div>
+                </div>
+                
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-layered-parallax-card-pure/style.css
+++ b/submissions/examples/css-layered-parallax-card-pure/style.css
@@ -1,0 +1,229 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    
+    --card-bg: linear-gradient(135deg, #e0e7ff 0%, #c7d2fe 100%);
+    --card-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+    
+    --graphic-color: #4f46e5;
+    --content-bg: rgba(255, 255, 255, 0.85);
+    --content-color: #1e1b4b;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a;
+        --text-primary: #f8fafc;
+        --text-secondary: #94a3b8;
+        
+        --card-bg: linear-gradient(135deg, #312e81 0%, #1e1b4b 100%);
+        --card-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.6);
+        
+        --graphic-color: #818cf8;
+        --content-bg: rgba(15, 23, 42, 0.85);
+        --content-color: #e0e7ff;
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    width: 100%;
+    padding: 60px 20px;
+    flex: 1;
+}
+
+.section-header {
+    margin-bottom: 80px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.5rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 500px;
+    perspective: 1000px; /* Establishes the 3D space */
+}
+
+
+/* =========================================
+   Parallax Architecture
+   ========================================= */
+
+.parallax-wrapper {
+    position: relative;
+    width: 320px;
+    height: 420px;
+    /* 
+      The wrapper houses both the grid trackers and the card.
+      It preserves the 3D transforms for its children.
+    */
+    transform-style: preserve-3d;
+}
+
+/* 
+  1. The Tracker Grid (3x3)
+  These invisible divs sit ON TOP of the card (z-index: 20) and capture mouse movements.
+*/
+.tracker {
+    position: absolute;
+    width: 33.333%;
+    height: 33.333%;
+    z-index: 20;
+    /* border: 1px solid red; Uncomment to see the grid */
+}
+
+/* Position the 9 tracker squares */
+.tr-1 { top: 0; left: 0; }
+.tr-2 { top: 0; left: 33.333%; }
+.tr-3 { top: 0; left: 66.666%; }
+.tr-4 { top: 33.333%; left: 0; }
+.tr-5 { top: 33.333%; left: 33.333%; } /* Center */
+.tr-6 { top: 33.333%; left: 66.666%; }
+.tr-7 { top: 66.666%; left: 0; }
+.tr-8 { top: 66.666%; left: 33.333%; }
+.tr-9 { top: 66.666%; left: 66.666%; }
+
+/* 
+  2. The Card Target
+  The actual visible card sitting beneath the trackers.
+*/
+.parallax-card {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border-radius: 20px;
+    transform-style: preserve-3d;
+    transition: transform 0.4s cubic-bezier(0.2, 0.8, 0.2, 1); /* Snappy return */
+    box-shadow: var(--card-shadow);
+}
+
+/* 
+  3. The Layers
+  Each layer is given a different translateZ value to create depth.
+*/
+.layer {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border-radius: 20px;
+    pointer-events: none; /* Let mouse pass through to trackers */
+}
+
+.layer-bg {
+    background: var(--card-bg);
+    transform: translateZ(0); /* Base level */
+}
+
+.layer-graphic {
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    padding-top: 60px;
+    color: var(--graphic-color);
+    /* Pop the graphic way out into 3D space */
+    transform: translateZ(80px);
+}
+
+.layer-content {
+    top: auto;
+    bottom: 24px;
+    left: 24px;
+    width: calc(100% - 48px);
+    height: auto;
+    padding: 24px;
+    background: var(--content-bg);
+    color: var(--content-color);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    border-radius: 16px;
+    
+    /* Pop the content slightly out into 3D space */
+    transform: translateZ(40px);
+}
+
+.layer-content h3 {
+    margin: 0 0 8px 0;
+    font-size: 1.5rem;
+    font-weight: 700;
+}
+
+.layer-content p {
+    margin: 0;
+    font-size: 0.95rem;
+    line-height: 1.5;
+    opacity: 0.9;
+}
+
+
+/* =========================================
+   The Mouse Tracking Logic
+   ========================================= */
+
+/* Top Row */
+.tr-1:hover ~ .parallax-card { transform: rotateX(15deg) rotateY(-15deg); }
+.tr-2:hover ~ .parallax-card { transform: rotateX(15deg) rotateY(0deg); }
+.tr-3:hover ~ .parallax-card { transform: rotateX(15deg) rotateY(15deg); }
+
+/* Middle Row */
+.tr-4:hover ~ .parallax-card { transform: rotateX(0deg) rotateY(-15deg); }
+.tr-5:hover ~ .parallax-card { transform: rotateX(0deg) rotateY(0deg); } /* Center rests flat */
+.tr-6:hover ~ .parallax-card { transform: rotateX(0deg) rotateY(15deg); }
+
+/* Bottom Row */
+.tr-7:hover ~ .parallax-card { transform: rotateX(-15deg) rotateY(-15deg); }
+.tr-8:hover ~ .parallax-card { transform: rotateX(-15deg) rotateY(0deg); }
+.tr-9:hover ~ .parallax-card { transform: rotateX(-15deg) rotateY(15deg); }
+
+/* Ensure card returns to flat smoothly when mouse leaves the wrapper entirely */
+.parallax-wrapper:hover .parallax-card {
+    transition: transform 0.15s linear; /* Fast track while moving */
+}
+
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .parallax-card,
+    .parallax-wrapper:hover .parallax-card {
+        transform: none !important;
+        transition: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a pure CSS card component that simulates interactive 3D mouse tracking to create a layered depth parallax effect, built entirely without JavaScript, resolving issue #68164.

### Changes Made:
- Added `submissions/examples/css-layered-parallax-card-pure/` directory.
- Created `demo.html` showcasing the HTML structure containing the 9 tracking cells and the 3 distinct depth layers.
- Created `style.css` featuring the UI mechanics:
  - **3D Mouse Tracking Architecture**: To simulate JS mouse tracking (`mousemove`) purely in CSS, we use a 3x3 tracking grid. We overlay 9 invisible `<div class="tracker">` squares precisely over the card's surface. Using the CSS general sibling selector (`~`), we map the `:hover` state of each specific tracking cell to a unique `transform: rotateX() rotateY()` coordinate on the underlying `.parallax-card`.
  - **True 3D Layers**: The main wrapper uses `perspective: 1000px;` and the card uses `transform-style: preserve-3d;`. The inner elements (background, graphic, and text content box) are absolute positioned with varying `translateZ()` values (e.g., `translateZ(80px)`). When the card tilts, these layers actually pop out of the screen, creating true 3D parallax depth.
  - **Theming & Dark Mode Supported**: Utilizes CSS Custom Properties. The stylesheet automatically respects the OS-level system theme (`prefers-color-scheme: dark`).
- Added `README.md` documenting usage and the technical mechanics of the sibling-selector hover mapping trick.
- Honors the `prefers-reduced-motion` accessibility standard. The hover rotations and 3D transforms are completely disabled for motion-sensitive users.

Closes #68164
