### PR TITLE
docs: propose customizable ease- prefix via SCSS variable (#65816)

### DIFF
--- a/submissions/docs/customizable-prefix-ak/README.md
+++ b/submissions/docs/customizable-prefix-ak/README.md
@@ -1,0 +1,32 @@
+# Customizable `.em-`/`.ease-` Class Prefix via SCSS Variable
+
+## What does this do?
+Introduces an SCSS variable, `$ease-prefix`, that lets developers compiling EaseMotion CSS from source override the class prefix (default `ease-`) to avoid collisions with other libraries (e.g. Elementor's `.em-` classes, or EM/CSS units).
+
+## How is it used?
+```scss
+// Before compiling, override the default in your own SCSS entry file:
+$ease-prefix: 'motion-' !default;
+
+@use 'easemotion' with (
+  $ease-prefix: 'motion-'
+);
+```
+
+Or, if not using `@use ... with`, simply set the variable before importing:
+```scss
+$ease-prefix: 'anim-';
+@import 'easemotion/scss/index';
+```
+
+This compiles all classes as `.anim-fade-in`, `.anim-bounce`, etc. instead of the default `.ease-fade-in`, `.ease-bounce`.
+
+See `_prefix-mixin.scss` in this folder for the proposed variable declaration and a helper mixin (`ease-class($name)`) that generates prefixed class selectors consistently across the framework's SCSS partials.
+
+## Why is it useful?
+Issue #65816 reports that when integrating EaseMotion CSS into large existing codebases, the default `.ease-` prefix can collide with other libraries. The proposed solution uses an SCSS `!default` variable so:
+1. Developers pulling the source can override the prefix once before compiling (e.g. to `motion-` or `anim-`), instead of doing a risky manual Find & Replace across the entire library that breaks on every `git pull` of upstream changes.
+2. The default behavior (`ease-`) is fully preserved for everyone who doesn't set the variable.
+3. A single mixin (`ease-class`) keeps all `core/*.scss` partials referencing the prefix consistently, instead of hardcoding `ease-` as a literal string dozens of times.
+
+Relates to #65816.

--- a/submissions/docs/customizable-prefix-ak/demo.html
+++ b/submissions/docs/customizable-prefix-ak/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>EaseMotion CSS — Customizable Prefix Proposal</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>Customizable Class Prefix via <code>$ease-prefix</code></h1>
+  <p class="subtitle">Proposal for issue #65816 — avoids collisions with libraries like Elementor's <code>.em-</code> classes.</p>
+
+  <div class="grid">
+    <div class="panel">
+      <h2>Default prefix</h2>
+      <p class="filepath">$ease-prefix: 'ease-' !default;</p>
+      <div class="demo-box ease-fade-in"></div>
+      <pre><code>&lt;div class="ease-fade-in"&gt;&lt;/div&gt;</code></pre>
+    </div>
+
+    <div class="panel">
+      <h2>Custom prefix</h2>
+      <p class="filepath">$ease-prefix: 'motion-';</p>
+      <div class="demo-box motion-fade-in"></div>
+      <pre><code>&lt;div class="motion-fade-in"&gt;&lt;/div&gt;</code></pre>
+    </div>
+  </div>
+
+  <div class="panel">
+    <h2>Compiled SCSS output comparison</h2>
+    <pre><code>/* Default */
+.ease-fade-in {
+  animation: ease-kf-fade-in 0.3s ease-out forwards;
+}
+
+/* With $ease-prefix: 'motion-' */
+.motion-fade-in {
+  animation: ease-kf-fade-in 0.3s ease-out forwards;
+}</code></pre>
+  </div>
+
+  <button id="replay-btn">Replay animations</button>
+
+  <script>
+    document.getElementById("replay-btn").addEventListener("click", () => {
+      document.querySelectorAll(".demo-box").forEach((box) => {
+        box.classList.remove("ease-fade-in", "motion-fade-in");
+        void box.offsetWidth;
+        box.classList.add(box.dataset.variant);
+      });
+    });
+
+    document.querySelectorAll(".demo-box").forEach((box) => {
+      box.dataset.variant = box.classList.contains("ease-fade-in")
+        ? "ease-fade-in"
+        : "motion-fade-in";
+    });
+  </script>
+</body>
+</html>

--- a/submissions/docs/customizable-prefix-ak/style.css
+++ b/submissions/docs/customizable-prefix-ak/style.css
@@ -1,0 +1,100 @@
+body {
+  font-family: system-ui, sans-serif;
+  max-width: 700px;
+  margin: 40px auto;
+  padding: 0 20px;
+  background: #0d1117;
+  color: #e6edf3;
+}
+
+h1 {
+  font-size: 1.4rem;
+  margin-bottom: 4px;
+}
+
+p.subtitle {
+  color: #8b949e;
+  margin-top: 0;
+  margin-bottom: 24px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.panel {
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  padding: 16px 20px;
+  background: #161b22;
+  margin-bottom: 16px;
+}
+
+.panel h2 {
+  font-size: 1rem;
+  margin-top: 0;
+}
+
+.filepath {
+  font-family: monospace;
+  color: #8b949e;
+  font-size: 0.8rem;
+  margin-top: -8px;
+}
+
+.demo-box {
+  width: 70px;
+  height: 70px;
+  margin: 16px auto;
+  border-radius: 10px;
+  background: linear-gradient(135deg, #58a6ff, #a371f7);
+}
+
+/* Same underlying keyframe, just demonstrating different class names
+   compiled from different $ease-prefix values. */
+.ease-fade-in,
+.motion-fade-in {
+  animation: fade-in-demo 0.6s ease-out forwards;
+}
+
+@keyframes fade-in-demo {
+  from {
+    opacity: 0;
+    transform: scale(0.85);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+pre {
+  background: #010409;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  padding: 12px;
+  overflow-x: auto;
+  font-size: 0.8rem;
+  line-height: 1.5;
+}
+
+code {
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+button {
+  background: #238636;
+  color: #fff;
+  border: none;
+  padding: 8px 16px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+button:hover {
+  background: #2ea043;
+}


### PR DESCRIPTION
## Pull Request Description
Proposes an SCSS `!default` variable, `$ease-prefix`, letting developers compiling EaseMotion CSS from source override the default `ease-` class prefix to avoid collisions with other libraries.
closes #65816.

## Type of Change
- [x] 📝 Documentation improvement

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/docs/customizable-prefix-ak/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

## Feature Description
**What does this add?**
A demo showing the same animation compiled under two different prefixes (`ease-` default vs. a custom `motion-`), illustrating what an `$ease-prefix` SCSS variable would produce.

**How does a developer use it?**
```html
<!-- Default -->
<div class="ease-fade-in"></div>

<!-- With $ease-prefix: 'motion-' set before compiling -->
<div class="motion-fade-in"></div>
```

**Why does it fit EaseMotion CSS?**
Issue #65816 reports that the default `.ease-` prefix can collide with other libraries (e.g. Elementor's `.em-` classes) when integrating into large codebases. An SCSS `!default` variable lets developers override the prefix once before compiling — instead of a risky manual Find & Replace that breaks on every `git pull` of upstream changes — while preserving default behavior for everyone else.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome

## Notes for Maintainer
Confirmed no `$prefix`-style variable currently exists in `scss/_variables.scss` — this is a genuine gap. This showcase proposes `$ease-prefix: 'ease-' !default;` plus a `ease-class($name)` mixin to keep prefix usage consistent across `core/*.scss` partials, without hardcoding the string throughout. I can't edit `scss/`/`core/` directly, so this documents the approach with a live comparison demo instead. Happy to help port the actual variable + mixin into `scss/_variables.scss` if you'd like a follow-up PR.