### PR TITLE
feat: add pure CSS Holographic Foil Card component (#68162)

### DIFF
--- a/submissions/examples/css-holographic-foil-card-pure/README.md
+++ b/submissions/examples/css-holographic-foil-card-pure/README.md
@@ -1,0 +1,20 @@
+# CSS Holographic Foil Card
+
+A pure CSS card component that simulates a shimmering rainbow holographic foil effect, commonly seen on premium trading cards, built entirely without JavaScript.
+
+## Features
+- Pure CSS and HTML (Zero JavaScript or WebGL required).
+- **Theming & Dark Mode**: Utilizes CSS Custom Properties (`--card-base-bg`, `--holo-gradient`, etc.) for easy overriding. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), intensifying the neon foil colors in dark mode.
+- **Holographic Architecture (Documented in Code)**: 
+- To simulate the metallic rainbow sheen purely in CSS, we use a `::before` pseudo-element positioned absolutely over the entire card.
+- **The Gradient**: The pseudo-element contains a massive `linear-gradient` filled with rainbow colors (magenta, orange, yellow, green, blue, purple) with transparent buffers on the edges.
+- **The Animation**: We set `background-size: 300% 300%` so the gradient extends far beyond the bounds of the card. A `@keyframes` animation smoothly pans `background-position` back and forth, dragging the colors across the surface.
+- **The Blend Mode**: The crucial trick is `mix-blend-mode: color-dodge`. This forces the panned rainbow colors to interact with the underlying dark base of the card, blowing out the highlights and creating a metallic, over-exposed physical foil look.
+- Fully accessible with `prefers-reduced-motion` support. The shimmering animations and hover lifts are completely disabled for motion-sensitive users.
+
+## Usage
+Open `demo.html` in your browser. Watch the foil gradient continuously sweep across the card. Hover over the card to intensify the foil reflection opacity.
+
+## Files
+- `demo.html`: The HTML structure containing the base card layout and the content layer.
+- `style.css`: The styling, CSS Custom Property theming blocks, and heavily commented mechanics detailing the `mix-blend-mode` trick.

--- a/submissions/examples/css-holographic-foil-card-pure/demo.html
+++ b/submissions/examples/css-holographic-foil-card-pure/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Holographic Foil Card</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Holographic Foil Card</h1>
+            <p class="subtitle">A pure CSS implementation of a shimmering rainbow holographic foil effect, utilizing animated background positions and modern blend modes.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <!-- 
+              [TECHNIQUE] Holographic Foil
+              The card wrapper handles the base styling and the dark background.
+              The ::before pseudo-element contains a massive, repeating linear-gradient 
+              of rainbow colors. It is animated to pan diagonally, and its blend mode
+              is set to color-dodge or overlay to create a metallic sheen.
+            -->
+            <div class="holo-card">
+                <div class="holo-content">
+                    <div class="card-logo">
+                        <svg viewBox="0 0 24 24" width="48" height="48" stroke="currentColor" stroke-width="1.5" fill="none">
+                            <polygon points="12 2 2 7 12 12 22 7 12 2"></polygon>
+                            <polyline points="2 17 12 22 22 17"></polyline>
+                            <polyline points="2 12 12 17 22 12"></polyline>
+                        </svg>
+                    </div>
+                    <h3>Premium Edition</h3>
+                    <p>001 / 999</p>
+                </div>
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-holographic-foil-card-pure/style.css
+++ b/submissions/examples/css-holographic-foil-card-pure/style.css
@@ -1,0 +1,228 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    
+    --card-base-bg: #1e1b4b; /* Dark indigo base for foil contrast */
+    --card-border: #4338ca;
+    --card-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+    
+    /* The Holographic Rainbow Gradient */
+    --holo-gradient: linear-gradient(
+        115deg,
+        transparent 20%,
+        rgba(255, 0, 128, 0.8) 30%,
+        rgba(255, 128, 0, 0.8) 40%,
+        rgba(255, 255, 0, 0.8) 50%,
+        rgba(0, 255, 128, 0.8) 60%,
+        rgba(0, 128, 255, 0.8) 70%,
+        rgba(128, 0, 255, 0.8) 80%,
+        transparent 90%
+    );
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a;
+        --text-primary: #f8fafc;
+        --text-secondary: #94a3b8;
+        
+        --card-base-bg: #09090b; /* Near black base */
+        --card-border: #27272a;
+        --card-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.6);
+        
+        /* Dark mode gets slightly more saturated neon foil */
+        --holo-gradient: linear-gradient(
+            115deg,
+            transparent 20%,
+            rgba(255, 0, 128, 1) 30%,
+            rgba(255, 128, 0, 1) 40%,
+            rgba(255, 255, 0, 1) 50%,
+            rgba(0, 255, 128, 1) 60%,
+            rgba(0, 128, 255, 1) 70%,
+            rgba(128, 0, 255, 1) 80%,
+            transparent 90%
+        );
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    width: 100%;
+    padding: 60px 20px;
+    flex: 1;
+}
+
+.section-header {
+    margin-bottom: 80px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.5rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 400px;
+}
+
+
+/* =========================================
+   Holographic Foil Card Architecture
+   ========================================= */
+
+.holo-card {
+    position: relative;
+    width: 280px;
+    height: 400px;
+    background-color: var(--card-base-bg);
+    border-radius: 16px;
+    overflow: hidden; /* Contains the overflowing gradient */
+    box-shadow: var(--card-shadow);
+    border: 1px solid var(--card-border);
+    transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    
+    /* 
+      We add a subtle texture grain to the base card 
+      to make the foil blend look more like a physical trading card.
+    */
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)' opacity='0.1'/%3E%3C/svg%3E");
+}
+
+.holo-card:hover {
+    transform: translateY(-8px) scale(1.02);
+}
+
+/* 
+  [TECHNIQUE] The Shimmering Foil Overlay
+  We use the ::before pseudo-element to render a massive background gradient.
+  We animate the background-position to make the rainbow colors sweep across the card.
+*/
+.holo-card::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    
+    /* Scale the background way up so we have room to pan it */
+    background-image: var(--holo-gradient);
+    background-size: 300% 300%;
+    
+    /* 
+      Blend mode is the magic key. 'color-dodge' creates that metallic, 
+      over-exposed sheen on top of the dark base background. 
+    */
+    mix-blend-mode: color-dodge;
+    opacity: 0.5; /* Subtle by default */
+    
+    transition: opacity 0.3s ease;
+    animation: shimmerFoil 6s linear infinite;
+    pointer-events: none; /* Let clicks pass through */
+    z-index: 10;
+}
+
+/* Intensify the foil reflection on hover */
+.holo-card:hover::before {
+    opacity: 0.85;
+}
+
+/* 
+  Animate the background-position diagonally across the massive 300% canvas.
+*/
+@keyframes shimmerFoil {
+    0% { background-position: 0% 50%; }
+    50% { background-position: 100% 50%; }
+    100% { background-position: 0% 50%; }
+}
+
+
+/* =========================================
+   Card Content Formatting
+   ========================================= */
+
+.holo-content {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    padding: 32px;
+    box-sizing: border-box;
+    color: #ffffff; /* Force white text to pop against dark base */
+    z-index: 20; /* Keep text above the foil blend */
+}
+
+.card-logo {
+    margin-bottom: 24px;
+    color: #ffffff;
+    opacity: 0.9;
+}
+
+.holo-content h3 {
+    margin: 0 0 8px 0;
+    font-size: 1.5rem;
+    font-weight: 700;
+    text-align: center;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+}
+
+.holo-content p {
+    margin: 0;
+    font-size: 0.85rem;
+    font-weight: 500;
+    opacity: 0.6;
+    letter-spacing: 1px;
+}
+
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .holo-card,
+    .holo-card::before {
+        transition: none !important;
+        transform: none !important;
+        animation: none !important;
+    }
+    
+    /* Set static position */
+    .holo-card::before {
+        background-position: 50% 50%;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a pure CSS card component that simulates a shimmering rainbow holographic foil effect, commonly seen on premium trading cards, built entirely without JavaScript, resolving issue #68162.

### Changes Made:
- Added `submissions/examples/css-holographic-foil-card-pure/` directory.
- Created `demo.html` showcasing the HTML structure containing the base card layout and the content layer.
- Created `style.css` featuring the UI mechanics:
  - **Holographic Architecture**: To simulate the metallic rainbow sheen purely in CSS, we use a `::before` pseudo-element positioned absolutely over the entire card.
  - **The Rainbow Gradient**: The pseudo-element contains a massive `linear-gradient` filled with rainbow colors with transparent buffers on the edges.
  - **Continuous Sweeping Animation**: We set `background-size: 300% 300%` so the gradient extends far beyond the bounds of the card. A `@keyframes` animation smoothly pans `background-position` back and forth, dragging the colors across the surface.
  - **Color-Dodge Blend Mode**: The crucial trick is `mix-blend-mode: color-dodge`. This forces the panned rainbow colors to interact with the underlying dark base of the card (complete with a noise texture filter), blowing out the highlights and creating a metallic, over-exposed physical foil look.
  - **Theming & Dark Mode Supported**: Utilizes CSS Custom Properties. The stylesheet automatically respects the OS-level system theme (`prefers-color-scheme: dark`), intensifying the neon foil colors in dark mode.
- Added `README.md` documenting usage and the technical mechanics of the `mix-blend-mode` trick.
- Honors the `prefers-reduced-motion` accessibility standard. The shimmering animations and hover lifts are completely disabled for motion-sensitive users.

Closes #68162
