### PR TITLE
Add ease-fitness-heart-rate-monitor component

### DIFF
--- a/submissions/examples/fitness-heart-rate-monitor-ij/README.md
+++ b/submissions/examples/fitness-heart-rate-monitor-ij/README.md
@@ -1,10 +1,11 @@
 # ease-fitness-heart-rate-monitor
 
-A fitness monitor whose EKG trace sweeps across the grid while the BPM readout pulses and the heart icon beats.
+A heart-rate monitor where the pulse pings, the BPM flashes, and the waveform draws across the card.
 
 ## Run
 Open `demo.html` directly in a browser to watch the pulse.
 
 ## Notes
-- The trace sweeps left to right.
-- The LIVE badge blinks while monitoring.
+- The pulse ring pings from the heart.
+- The BPM value flashes with each beat.
+- The ECG waveform draws across the card.

--- a/submissions/examples/fitness-heart-rate-monitor-ij/demo.html
+++ b/submissions/examples/fitness-heart-rate-monitor-ij/demo.html
@@ -6,23 +6,23 @@
 <title>ease-fitness-heart-rate-monitor demo</title>
 </head>
 <body>
-<div class="hm-app">
-  <span class="hm-model">PULSE PRO</span>
-  <div class="hm-screen">
-    <div class="hm-grid">
-      <span class="hm-grid-line"></span>
-      <span class="hm-grid-line"></span>
-      <span class="hm-grid-line"></span>
-    </div>
-    <svg class="hm-trace" viewBox="0 0 100 40" preserveAspectRatio="none">
-      <path d="M0 20 L14 20 L18 8 L22 32 L26 20 L40 20 L44 12 L48 28 L52 20 L66 20 L70 6 L74 34 L78 20 L100 20"></path>
-    </svg>
-    <span class="hm-bpm">128</span>
-    <span class="hm-unit">BPM</span>
-    <span class="hm-heart">&#10084;</span>
-    <span class="hm-badge">LIVE</span>
+<div class="hrw-card">
+  <div class="hrw-head">
+    <span class="hrw-tag">HEART RATE</span>
+    <span class="hrw-bpm">72 BPM</span>
   </div>
-  <span class="hm-caption">MONITORING</span>
+  <div class="hrw-pulse">
+    <span class="hrw-pulse-dot"></span>
+    <span class="hrw-pulse-ring"></span>
+  </div>
+  <svg class="hrw-wave" viewBox="0 0 360 90" aria-hidden="true">
+    <polyline class="hrw-line" points="0,62 60,62 76,38 92,74 110,26 128,82 146,30 164,72 182,42 200,58 220,54 240,60 300,60 360,60"></polyline>
+  </svg>
+  <div class="hrw-stats">
+    <span class="hrw-stat"><b>142</b><small>KCAL</small></span>
+    <span class="hrw-stat"><b>66</b><small>AVG</small></span>
+    <span class="hrw-stat"><b>Z2</b><small>ZONE</small></span>
+  </div>
 </div>
 </body>
 </html>

--- a/submissions/examples/fitness-heart-rate-monitor-ij/style.css
+++ b/submissions/examples/fitness-heart-rate-monitor-ij/style.css
@@ -1,17 +1,18 @@
-:root{--hm-green:#33f57b;--hm-dark:#04150c}
-body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#0a1d12,#04100a);font-family:'Segoe UI',sans-serif}
-.hm-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#07230f,#04120a);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
-.hm-model{position:absolute;top:16px;left:0;right:0;text-align:center;font-size:12px;font-weight:800;letter-spacing:7px;color:#2fe06f}
-.hm-screen{position:absolute;top:52px;left:46px;width:276px;height:236px;border-radius:10px;background:#010e06;box-shadow:inset 0 0 0 3px #0f4423;overflow:hidden}
-.hm-grid{position:absolute;inset:0;background-image:linear-gradient(#0a2a16 1px,transparent 1px),linear-gradient(90deg,#0a2a16 1px,transparent 1px);background-size:24px 24px}
-.hm-grid-line{position:absolute;left:0;right:0;height:1px;background:#0a2a16}
-.hm-trace{position:absolute;inset:18px 14px 30px 14px;width:calc(100% - 28px);height:calc(100% - 48px);stroke:var(--hm-green);stroke-width:2;fill:none;stroke-linejoin:round;stroke-linecap:round;filter:drop-shadow(0 0 6px rgba(51,245,123,0.7));animation:ekg-sweep-fitness-heart-rate-monitor 2.4s linear infinite}
-.hm-bpm{position:absolute;left:20px;bottom:14px;font-size:26px;font-weight:900;color:var(--hm-green);text-shadow:0 0 12px rgba(51,245,123,0.7);animation:bpm-pulse-fitness-heart-rate-monitor 1.2s ease-in-out infinite}
-.hm-unit{position:absolute;left:76px;bottom:22px;font-size:11px;font-weight:800;color:#2fe06f;letter-spacing:2px}
-.hm-heart{position:absolute;right:20px;bottom:16px;font-size:20px;color:#ff4d5e;animation:heart-beat-fitness-heart-rate-monitor 1.2s ease-in-out infinite}
-.hm-badge{position:absolute;top:10px;right:12px;padding:3px 8px;border-radius:4px;background:#0f4423;color:#33f57b;font-size:10px;font-weight:800;letter-spacing:2px;animation:badge-blink-fitness-heart-rate-monitor 1.6s ease-in-out infinite}
-.hm-caption{position:absolute;bottom:16px;left:0;right:0;text-align:center;font-size:11px;font-weight:700;letter-spacing:5px;color:#1d7a3d}
-@keyframes ekg-sweep-fitness-heart-rate-monitor{0%{stroke-dashoffset:220;opacity:0.4}30%{opacity:1}100%{stroke-dashoffset:0;opacity:1}}
-@keyframes bpm-pulse-fitness-heart-rate-monitor{0%,100%{transform:scale(1)}50%{transform:scale(1.12)}}
-@keyframes heart-beat-fitness-heart-rate-monitor{0%,100%{transform:scale(1)}25%{transform:scale(1.25)}40%{transform:scale(1)}60%{transform:scale(1.18)}}
-@keyframes badge-blink-fitness-heart-rate-monitor{0%,100%{opacity:1}50%{opacity:0.35}}
+.hrw-card{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:372px;background:#0d1624;border:1px solid #1e3350;border-radius:16px;padding:22px;display:flex;flex-direction:column;gap:16px}
+.hrw-head{display:flex;align-items:center;justify-content:space-between}
+.hrw-tag{font-size:9px;font-weight:800;letter-spacing:3px;color:#7e95ab}
+.hrw-bpm{font-size:15px;font-weight:800;color:#f87171;animation:hrw-bpm-pulse-fitness-heart-rate-monitor 1.1s ease-in-out infinite}
+.hrw-pulse{position:relative;width:44px;height:44px;align-self:center;animation:hrw-heart-beat-fitness-heart-rate-monitor 1.1s ease-in-out infinite}
+.hrw-pulse-dot{position:absolute;inset:9px;border-radius:50%;background:#f87171}
+.hrw-pulse-ring{position:absolute;inset:0;border:2px solid #f87171;border-radius:50%;animation:hrw-ping-fitness-heart-rate-monitor 1.6s ease-out infinite}
+.hrw-wave{width:100%;display:block}
+.hrw-line{fill:none;stroke:#f87171;stroke-width:2.5;stroke-dasharray:520;stroke-dashoffset:520;animation:hrw-draw-fitness-heart-rate-monitor 2.8s linear infinite}
+.hrw-stats{display:flex;justify-content:space-between}
+.hrw-stat{display:flex;flex-direction:column;gap:2px;align-items:center}
+.hrw-stat b{font-size:14px;font-weight:800;color:#e8f0f8}
+.hrw-stat small{font-size:8px;letter-spacing:2px;color:#5d7690;animation:hrw-stat-blink-fitness-heart-rate-monitor 2s ease-in-out infinite}
+@keyframes hrw-heart-beat-fitness-heart-rate-monitor{0%{transform:scale(1)}25%{transform:scale(1.14)}50%{transform:scale(1)}100%{transform:scale(1)}}
+@keyframes hrw-bpm-pulse-fitness-heart-rate-monitor{0%{opacity:0.6}50%{opacity:1}100%{opacity:0.6}}
+@keyframes hrw-ping-fitness-heart-rate-monitor{0%{transform:scale(0.6);opacity:0.9}100%{transform:scale(1.4);opacity:0}}
+@keyframes hrw-draw-fitness-heart-rate-monitor{0%{stroke-dashoffset:520}100%{stroke-dashoffset:0}}
+@keyframes hrw-stat-blink-fitness-heart-rate-monitor{0%{opacity:0.5}50%{opacity:1}100%{opacity:0.5}}


### PR DESCRIPTION
## Component: ease-fitness-heart-rate-monitor — pulse pings, BPM flashes, and waveform draws

**Closes #69238**

### What this adds
A heart-rate monitor: the pulse ring pings, the BPM value flashes, and the ECG waveform draws across the card.

### Acceptance Criteria covered
- Pulse ring pings from the heart
- BPM value flashes with each beat
- ECG waveform draws across the card

### Files
- `submissions/examples/fitness-heart-rate-monitor-ij/demo.html`
- `submissions/examples/fitness-heart-rate-monitor-ij/style.css`
- `submissions/examples/fitness-heart-rate-monitor-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the pulse.