### PR TITLE
feat: add pure CSS Quick View Modal component (#68664)

### DIFF
--- a/submissions/examples/css-quick-view-modal-pure/README.md
+++ b/submissions/examples/css-quick-view-modal-pure/README.md
@@ -1,0 +1,21 @@
+# CSS Quick View Modal
+
+A pure CSS product card where an interactive quick-view action modal smoothly slides up from the bottom on hover, built entirely without JavaScript.
+
+## Features
+- Pure CSS and HTML (Zero JavaScript event listeners required).
+- **Theming & Dark Mode**: Utilizes CSS Custom Properties (`--card-bg`, `--btn-primary`, etc.) for easy overriding. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`).
+- **Sliding Modal Architecture (Documented in Code)**: 
+  - The outer `.product-card` is set to `position: relative` and `overflow: hidden`.
+  - The `.quick-view-modal` is set to `position: absolute; bottom: 0; left: 0; width: 100%;`.
+  - **Hidden State**: By default, the modal is pushed down exactly out of view using `transform: translateY(100%);` and `opacity: 0;`.
+  - **Reveal State**: When `.product-card:hover` or `.product-card:focus-within` is triggered, the modal slides up to `transform: translateY(0);` and `opacity: 1;`.
+  - A subtle `backdrop-filter: blur(8px)` gives the modal a modern, frosted glass look over the product image.
+- Fully accessible with `prefers-reduced-motion` support. The sliding animation is disabled, falling back to a simple opacity fade for motion-sensitive users. The `:focus-within` pseudo-class ensures keyboard navigators can access the buttons.
+
+## Usage
+Open `demo.html` in your browser. Hover over the product card to see the Quick View modal slide up from the bottom edge.
+
+## Files
+- `demo.html`: The HTML structure containing the card, product info, and the absolute-positioned modal overlay.
+- `style.css`: The styling, CSS Custom Property theming blocks, and heavily commented mechanics detailing the `transform: translateY` trick.

--- a/submissions/examples/css-quick-view-modal-pure/demo.html
+++ b/submissions/examples/css-quick-view-modal-pure/demo.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Quick View Modal</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Quick View Modal</h1>
+            <p class="subtitle">A pure CSS product card where a quick-view action modal smoothly slides up from the bottom on hover.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <!-- 
+              [TECHNIQUE] Quick View Hover Action
+              The .quick-view-modal is absolute positioned at the bottom of the card,
+              initially translated down out of view (translateY(100%)).
+              When the parent .product-card is hovered, it translates back to 0.
+            -->
+            <div class="product-card">
+                
+                <div class="product-image">
+                    <svg viewBox="0 0 24 24" width="64" height="64" stroke="currentColor" stroke-width="1.5" fill="none">
+                        <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
+                        <circle cx="8.5" cy="8.5" r="1.5"></circle>
+                        <polyline points="21 15 16 10 5 21"></polyline>
+                    </svg>
+                </div>
+                
+                <div class="product-info">
+                    <h3 class="product-title">Minimalist Watch</h3>
+                    <p class="product-price">$129.00</p>
+                </div>
+
+                <!-- The Hidden Quick View Modal -->
+                <div class="quick-view-modal">
+                    <button class="btn-icon" aria-label="Add to Wishlist">
+                        <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg>
+                    </button>
+                    
+                    <button class="btn-primary">
+                        Quick View
+                    </button>
+                    
+                    <button class="btn-icon" aria-label="Compare">
+                        <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none"><line x1="18" y1="20" x2="18" y2="10"></line><line x1="12" y1="20" x2="12" y2="4"></line><line x1="6" y1="20" x2="6" y2="14"></line></svg>
+                    </button>
+                </div>
+                
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-quick-view-modal-pure/style.css
+++ b/submissions/examples/css-quick-view-modal-pure/style.css
@@ -1,0 +1,235 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    
+    --card-bg: #ffffff;
+    --card-border: #e2e8f0;
+    --card-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.05);
+    --card-hover-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1);
+    
+    --img-bg: #f1f5f9;
+    --img-color: #94a3b8;
+    
+    --modal-bg: rgba(255, 255, 255, 0.9);
+    --btn-primary: #0f172a;
+    --btn-primary-text: #ffffff;
+    --btn-icon-bg: #f1f5f9;
+    --btn-icon-hover: #e2e8f0;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a;
+        --text-primary: #f8fafc;
+        --text-secondary: #94a3b8;
+        
+        --card-bg: #1e293b;
+        --card-border: #334155;
+        --card-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.4);
+        --card-hover-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.6);
+        
+        --img-bg: #0f172a;
+        --img-color: #475569;
+        
+        --modal-bg: rgba(30, 41, 59, 0.9);
+        --btn-primary: #f8fafc;
+        --btn-primary-text: #0f172a;
+        --btn-icon-bg: #334155;
+        --btn-icon-hover: #475569;
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 80px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.5rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 400px;
+}
+
+
+/* =========================================
+   Product Card
+   ========================================= */
+
+.product-card {
+    position: relative;
+    width: 280px;
+    background-color: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 16px;
+    overflow: hidden; /* CRITICAL: Clips the sliding modal */
+    box-shadow: var(--card-shadow);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    cursor: pointer;
+}
+
+.product-card:hover {
+    transform: translateY(-4px);
+    box-shadow: var(--card-hover-shadow);
+}
+
+.product-image {
+    width: 100%;
+    height: 240px;
+    background-color: var(--img-bg);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: var(--img-color);
+}
+
+.product-info {
+    padding: 20px;
+    text-align: center;
+}
+
+.product-title {
+    margin: 0 0 8px 0;
+    font-size: 1.15rem;
+    font-weight: 600;
+}
+
+.product-price {
+    margin: 0;
+    color: var(--text-secondary);
+    font-weight: 500;
+}
+
+
+/* =========================================
+   The Quick View Modal Layer
+   ========================================= */
+
+.quick-view-modal {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    padding: 16px;
+    box-sizing: border-box;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 8px;
+    
+    background-color: var(--modal-bg);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    border-top: 1px solid var(--card-border);
+    
+    /* 
+      [TECHNIQUE] Hidden State
+      Translate down 100% of its own height to hide it below the card edge.
+    */
+    transform: translateY(100%);
+    opacity: 0;
+    transition: transform 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.1), opacity 0.3s ease;
+}
+
+/* Slide Up on Hover */
+.product-card:hover .quick-view-modal,
+.product-card:focus-within .quick-view-modal {
+    transform: translateY(0);
+    opacity: 1;
+}
+
+
+/* =========================================
+   Modal Buttons
+   ========================================= */
+
+.btn-primary {
+    flex: 1;
+    padding: 10px 0;
+    background-color: var(--btn-primary);
+    color: var(--btn-primary-text);
+    border: none;
+    border-radius: 8px;
+    font-weight: 600;
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: opacity 0.2s ease;
+}
+
+.btn-primary:hover {
+    opacity: 0.85;
+}
+
+.btn-icon {
+    width: 40px;
+    height: 40px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: var(--btn-icon-bg);
+    color: var(--text-primary);
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+
+.btn-icon:hover {
+    background-color: var(--btn-icon-hover);
+}
+
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .product-card,
+    .quick-view-modal {
+        transition: none !important;
+        transform: none !important;
+    }
+    
+    /* Fallback to fade only if motion is reduced */
+    .quick-view-modal {
+        transform: translateY(0) !important;
+        opacity: 0;
+    }
+    
+    .product-card:hover .quick-view-modal {
+        opacity: 1;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a pure CSS product card where an interactive quick-view action modal smoothly slides up from the bottom on hover, built entirely without JavaScript, resolving issue #68664.

### Changes Made:
- Added `submissions/examples/css-quick-view-modal-pure/` directory.
- Created `demo.html` showcasing the HTML structure containing the card, product info, and the absolute-positioned modal overlay.
- Created `style.css` featuring the UI mechanics:
  - **Sliding Modal Architecture**: The outer `.product-card` is set to `position: relative` and `overflow: hidden`. The `.quick-view-modal` is set to `position: absolute; bottom: 0; left: 0; width: 100%;`.
  - **Hidden & Reveal States**: By default, the modal is pushed down exactly out of view using `transform: translateY(100%);` and `opacity: 0;`. When `.product-card:hover` or `.product-card:focus-within` is triggered, the modal smoothly slides up to `transform: translateY(0);` and `opacity: 1;`.
  - **Glassmorphism**: A subtle `backdrop-filter: blur(8px)` gives the modal a modern, frosted glass look over the product image.
  - **Theming & Dark Mode Supported**: Utilizes CSS Custom Properties. The stylesheet automatically respects the OS-level system theme (`prefers-color-scheme: dark`).
- Added `README.md` documenting usage and the technical mechanics of the `transform: translateY` trick.
- Honors the `prefers-reduced-motion` accessibility standard. The sliding animation is disabled, falling back to a simple opacity fade for motion-sensitive users. The `:focus-within` pseudo-class ensures keyboard navigators can access the buttons.

Closes #68664
