### PR TITLE
Add ease-airport-departure-board component

### DIFF
--- a/submissions/examples/airport-departure-board-ij/README.md
+++ b/submissions/examples/airport-departure-board-ij/README.md
@@ -1,10 +1,11 @@
 # ease-airport-departure-board
 
-An airport departure board whose split-flap rows flip to new flight values while statuses pulse.
+An airport departure board where the flaps flip, the times tick, and the status labels blink.
 
 ## Run
-Open `demo.html` directly in a browser to watch the flaps roll over.
+Open `demo.html` directly in a browser to watch the flaps.
 
 ## Notes
-- Flight cells flip row by row.
-- Statuses pulse on the right side.
+- The split-flap rows flip in turn.
+- The departure times tick on the board.
+- The status labels blink beside the rows.

--- a/submissions/examples/airport-departure-board-ij/demo.html
+++ b/submissions/examples/airport-departure-board-ij/demo.html
@@ -6,37 +6,31 @@
 <title>ease-airport-departure-board demo</title>
 </head>
 <body>
-<div class="ab-app">
-  <span class="ab-title">DEPARTURES</span>
-  <div class="ab-board">
-    <div class="ab-row">
-      <span class="ab-cell ab-code">AA101</span>
-      <span class="ab-cell ab-dest">LONDON</span>
-      <span class="ab-cell ab-gate">B12</span>
-      <span class="ab-cell ab-time">10:45</span>
-      <span class="ab-cell ab-status">BOARD</span>
-    </div>
-    <div class="ab-row">
-      <span class="ab-cell ab-code">BA204</span>
-      <span class="ab-cell ab-dest">PARIS</span>
-      <span class="ab-cell ab-gate">C4</span>
-      <span class="ab-cell ab-time">11:20</span>
-      <span class="ab-cell ab-status">ON TIME</span>
-    </div>
-    <div class="ab-row">
-      <span class="ab-cell ab-code">LH317</span>
-      <span class="ab-cell ab-dest">BERLIN</span>
-      <span class="ab-cell ab-gate">A8</span>
-      <span class="ab-cell ab-time">12:05</span>
-      <span class="ab-cell ab-status">DELAYED</span>
-    </div>
-    <div class="ab-row">
-      <span class="ab-cell ab-code">AF502</span>
-      <span class="ab-cell ab-dest">ROME</span>
-      <span class="ab-cell ab-gate">D9</span>
-      <span class="ab-cell ab-time">13:15</span>
-      <span class="ab-cell ab-status">GATE OPEN</span>
-    </div>
+<div class="adb-board">
+  <div class="adb-top">DEPARTURES</div>
+  <div class="adb-row">
+    <b class="adb-flight">AI 402</b>
+    <span class="adb-dest">MUMBAI</span>
+    <span class="adb-time">09:40</span>
+    <i class="adb-status adb-on">ON TIME</i>
+  </div>
+  <div class="adb-row">
+    <b class="adb-flight">QF 128</b>
+    <span class="adb-dest">SYDNEY</span>
+    <span class="adb-time">10:15</span>
+    <i class="adb-status adb-on">ON TIME</i>
+  </div>
+  <div class="adb-row">
+    <b class="adb-flight">DL 77</b>
+    <span class="adb-dest">NEW YORK</span>
+    <span class="adb-time">11:05</span>
+    <i class="adb-status adb-late">DELAYED</i>
+  </div>
+  <div class="adb-row">
+    <b class="adb-flight">BA 66</b>
+    <span class="adb-dest">LONDON</span>
+    <span class="adb-time">12:30</span>
+    <i class="adb-status adb-on">ON TIME</i>
   </div>
 </div>
 </body>

--- a/submissions/examples/airport-departure-board-ij/style.css
+++ b/submissions/examples/airport-departure-board-ij/style.css
@@ -1,17 +1,16 @@
-:root{--ab-dark:#161a20;--ab-gold:#e8b84a;--ab-teal:#3ac8b8}
-body{margin:0;min-height:100vh;display:grid;place-items:center;background:linear-gradient(180deg,#4a5058,#242830);font-family:'Segoe UI',sans-serif}
-.ab-app{position:relative;width:372px;height:372px;border-radius:18px;overflow:hidden;background:linear-gradient(180deg,#2a2e34,#14161a);box-shadow:0 16px 36px rgba(0,0,0,0.55)}
-.ab-title{position:absolute;top:14px;left:0;right:0;text-align:center;font-size:14px;font-weight:800;letter-spacing:7px;color:var(--ab-gold)}
-.ab-board{position:absolute;top:54px;left:20px;width:332px;height:290px;border-radius:10px;background:var(--ab-dark);box-shadow:inset 0 0 0 6px #0e1012;display:flex;flex-direction:column;gap:8px;padding:10px}
-.ab-row{display:grid;grid-template-columns:1fr 1.2fr 0.7fr 0.8fr 1fr;gap:4px;height:60px}
-.ab-cell{border-radius:4px;background:#20242a;box-shadow:inset 0 0 0 2px #14161a;font-size:11px;font-weight:700;color:#e8e0d0;display:flex;align-items:center;justify-content:center}
-.ab-code{color:var(--ab-teal);animation:flip-flap-airport-departure-board 5s ease-in-out infinite}
-.ab-dest{animation:flip-flap-airport-departure-board 5s ease-in-out infinite;animation-delay:0.4s}
-.ab-gate{color:var(--ab-gold);animation:flip-flap-airport-departure-board 5s ease-in-out infinite;animation-delay:0.8s}
-.ab-time{animation:flip-flap-airport-departure-board 5s ease-in-out infinite;animation-delay:1.2s}
-.ab-status{animation:pulse-status-airport-departure-board 2s ease-in-out infinite}
-.ab-row:nth-child(2) .ab-cell{animation-delay:0.25s}
-.ab-row:nth-child(3) .ab-cell{animation-delay:0.5s}
-.ab-row:nth-child(4) .ab-cell{animation-delay:0.75s}
-@keyframes flip-flap-airport-departure-board{0%,82%{transform:rotateX(0)}88%{transform:rotateX(90deg)}92%{transform:rotateX(0)}100%{transform:rotateX(0)}}
-@keyframes pulse-status-airport-departure-board{0%,100%{color:#e8e0d0}50%{color:var(--ab-teal)}}
+.adb-board{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:420px;background:#050b12;border:1px solid #1b2b42;border-radius:12px;padding:16px;font-family:"Courier New",monospace}
+.adb-top{text-align:center;font-size:16px;font-weight:800;letter-spacing:8px;color:#f5c542;margin-bottom:12px;animation:adb-title-blink-airport-departure-board 2.4s ease-in-out infinite}
+.adb-row{display:flex;align-items:center;gap:12px;padding:11px 10px;background:#0c1520;border-bottom:1px solid #16263b;animation:adb-flap-airport-departure-board 0.6s ease-out both}
+.adb-row:nth-child(3){animation-delay:0.08s}
+.adb-row:nth-child(4){animation-delay:0.16s}
+.adb-row:nth-child(5){animation-delay:0.24s}
+.adb-flight{width:64px;color:#e8f0f8;font-size:13px}
+.adb-dest{flex:1;color:#dbe7f3;font-size:13px;letter-spacing:2px}
+.adb-time{color:#9fb6cb;font-size:13px;animation:adb-time-tick-airport-departure-board 2s ease-in-out infinite}
+.adb-status{font-style:normal;font-size:9px;font-weight:800;letter-spacing:2px;padding:3px 8px;border-radius:4px}
+.adb-on{color:#34d399;border:1px solid #1f5c43}
+.adb-late{color:#f5c542;border:1px solid #5c4a1f;animation:adb-late-blink-airport-departure-board 1.2s ease-in-out infinite}
+@keyframes adb-flap-airport-departure-board{0%{transform:rotateX(90deg);opacity:0}100%{transform:rotateX(0);opacity:1}}
+@keyframes adb-title-blink-airport-departure-board{0%{opacity:0.6}50%{opacity:1}100%{opacity:0.6}}
+@keyframes adb-time-tick-airport-departure-board{0%{opacity:0.5}50%{opacity:1}100%{opacity:0.5}}
+@keyframes adb-late-blink-airport-departure-board{0%{opacity:0.4}50%{opacity:1}100%{opacity:0.4}}


### PR DESCRIPTION
## Component: ease-airport-departure-board — flaps flip, times tick, and status blinks

**Closes #69301**

### What this adds
An airport departure board: the split-flap rows flip in, the departure times tick, and the status labels blink.

### Acceptance Criteria covered
- Split-flap rows flip in turn
- Departure times tick on the board
- Status labels blink beside rows

### Files
- `submissions/examples/airport-departure-board-ij/demo.html`
- `submissions/examples/airport-departure-board-ij/style.css`
- `submissions/examples/airport-departure-board-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the flaps.