### PR TITLE
feat: add pure CSS Receipt Component (#68645)

### DIFF
--- a/submissions/examples/css-receipt-component-pure/README.md
+++ b/submissions/examples/css-receipt-component-pure/README.md
@@ -1,0 +1,19 @@
+# CSS Receipt Component
+
+A pure CSS digital receipt card component featuring classic POS (Point of Sale) thermal paper aesthetics, including a jagged torn-paper edge and semantic dotted separator lines, built entirely without JavaScript.
+
+## Features
+- Pure CSS and HTML.
+- **Theming & Dark Mode**: Utilizes CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), generating a modern, dark "terminal-style" receipt in dark mode contexts (while gracefully handling QR code color inversion).
+- **Component Architecture (Documented in Code)**: 
+  - **Grid Alignments**: The itemized list relies on a robust `display: grid; grid-template-columns: 1fr auto auto;` layout to perfectly align item names (left), quantities (center), and prices (right) regardless of content length.
+  - **The Jagged Torn Edge**: Achieved purely in CSS using the `::after` pseudo-element positioned at the bottom of the card. We use a repeating `radial-gradient` to draw transparent circles over the solid background color along the X-axis, creating a classic "torn paper" tooth effect without requiring external SVG assets.
+  - **Typography**: Inherits the `JetBrains Mono` (or system monospace) font to simulate the classic look of thermal receipt printers.
+- Fully accessible with semantic HTML `<hr>` elements for the dotted separators.
+
+## Usage
+Open `demo.html` in your browser to view the digital receipt card.
+
+## Files
+- `demo.html`: The HTML structure containing the receipt header, the grid-based itemized body, totals, and the QR code footer.
+- `style.css`: The styling, robust CSS Custom Property theming blocks, and the heavily commented `radial-gradient` torn-edge trick.

--- a/submissions/examples/css-receipt-component-pure/demo.html
+++ b/submissions/examples/css-receipt-component-pure/demo.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Receipt Component</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Receipt Component</h1>
+            <p class="subtitle">A pure CSS digital receipt card featuring classic jagged edges (via radial gradients) and perfectly dotted semantic separator lines.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <!-- 
+              [TECHNIQUE] The Receipt Shape
+              The jagged bottom edge is achieved using a repeating radial-gradient 
+              in the CSS mask-image or background property of the ::after pseudo-element.
+            -->
+            <div class="receipt-card" aria-label="Digital Receipt">
+                
+                <div class="receipt-header">
+                    <div class="store-logo">
+                        <svg viewBox="0 0 24 24" width="32" height="32" stroke="currentColor" stroke-width="2" fill="none"><circle cx="12" cy="12" r="10"></circle><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"></path><path d="M2 12h20"></path></svg>
+                    </div>
+                    <h2>Globe Store Inc.</h2>
+                    <p class="receipt-address">123 Commerce Blvd, Tech City, TC 90210</p>
+                    <p class="receipt-date">Oct 24, 2026 • 14:32 PM</p>
+                </div>
+                
+                <!-- Dotted separator -->
+                <hr class="receipt-separator">
+                
+                <div class="receipt-body">
+                    
+                    <div class="receipt-row receipt-col-header">
+                        <span>Item</span>
+                        <span>Qty</span>
+                        <span>Price</span>
+                    </div>
+                    
+                    <div class="receipt-row">
+                        <span class="item-name">Wireless Keyboard</span>
+                        <span class="item-qty">1</span>
+                        <span class="item-price">$129.99</span>
+                    </div>
+                    
+                    <div class="receipt-row">
+                        <span class="item-name">USB-C Hub</span>
+                        <span class="item-qty">2</span>
+                        <span class="item-price">$49.98</span>
+                    </div>
+                    
+                    <div class="receipt-row">
+                        <span class="item-name">Ergonomic Mouse</span>
+                        <span class="item-qty">1</span>
+                        <span class="item-price">$89.50</span>
+                    </div>
+                    
+                </div>
+                
+                <!-- Dotted separator -->
+                <hr class="receipt-separator">
+                
+                <div class="receipt-totals">
+                    <div class="receipt-row">
+                        <span>Subtotal</span>
+                        <span>$269.47</span>
+                    </div>
+                    <div class="receipt-row">
+                        <span>Tax (8.5%)</span>
+                        <span>$22.90</span>
+                    </div>
+                    
+                    <!-- Dotted separator -->
+                    <hr class="receipt-separator">
+                    
+                    <div class="receipt-row total-row">
+                        <span>Total</span>
+                        <span>$292.37</span>
+                    </div>
+                </div>
+                
+                <div class="receipt-footer">
+                    <img src="https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=https://example.com/receipt/12345&color=0f172a&bgcolor=ffffff" alt="Receipt QR Code" class="qr-code">
+                    <p>Thank you for shopping with us!</p>
+                </div>
+                
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-receipt-component-pure/style.css
+++ b/submissions/examples/css-receipt-component-pure/style.css
@@ -1,0 +1,249 @@
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f1f5f9;
+    
+    /* 
+      Receipts typically simulate thermal paper, 
+      so they are usually light even in dark mode contexts, 
+      but we provide theme variables for flexibility.
+    */
+    --receipt-bg: #ffffff;
+    --receipt-text: #0f172a;
+    --receipt-text-muted: #64748b;
+    --receipt-border: #cbd5e1;
+    --receipt-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
+    
+    /* Variables for the jagged edge size */
+    --tooth-size: 8px;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a;
+        
+        /* Simulating a "dark mode" receipt (like a modern terminal output) */
+        --receipt-bg: #1e293b;
+        --receipt-text: #f8fafc;
+        --receipt-text-muted: #94a3b8;
+        --receipt-border: #475569;
+        --receipt-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.4), 0 8px 10px -6px rgba(0, 0, 0, 0.5);
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    /* Monospace font gives it that classic POS printer feel */
+    font-family: 'JetBrains Mono', monospace; 
+    color: var(--receipt-text);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 60px;
+    text-align: center;
+    /* Use a standard font for the page header, keep monospace for the receipt */
+    font-family: system-ui, -apple-system, sans-serif;
+    color: var(--receipt-text);
+}
+@media (prefers-color-scheme: dark) {
+    .section-header { color: #f8fafc; }
+}
+
+.title {
+    font-size: 2.5rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--receipt-text-muted);
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+}
+
+
+/* =========================================
+   Receipt Architecture
+   ========================================= */
+
+.receipt-card {
+    position: relative;
+    width: 100%;
+    max-width: 340px;
+    background-color: var(--receipt-bg);
+    padding: 32px 24px;
+    /* Padding bottom to account for the jagged edge */
+    padding-bottom: 48px;
+    box-shadow: var(--receipt-shadow);
+    color: var(--receipt-text);
+    /* Smooth entrance animation */
+    animation: slideUp 0.6s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+@keyframes slideUp {
+    from { opacity: 0; transform: translateY(20px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+/* 
+  [TECHNIQUE] The Jagged Edge 
+  We use the ::after pseudo-element positioned at the bottom.
+  We use a repeating radial-gradient to draw transparent circles over a solid background,
+  creating a classic "torn paper" look.
+*/
+.receipt-card::after {
+    content: '';
+    position: absolute;
+    bottom: -var(--tooth-size);
+    left: 0;
+    width: 100%;
+    height: calc(var(--tooth-size) * 2);
+    /* 
+      The magic radial gradient:
+      It creates transparent circles (radial holes) cutting into the background color.
+    */
+    background: radial-gradient(circle at 50% 100%, transparent var(--tooth-size), var(--receipt-bg) calc(var(--tooth-size) + 0.5px));
+    background-size: calc(var(--tooth-size) * 2) 100%;
+    background-repeat: repeat-x;
+    background-position: bottom;
+}
+
+
+/* =========================================
+   Receipt Sections
+   ========================================= */
+
+.receipt-header {
+    text-align: center;
+    margin-bottom: 24px;
+}
+
+.store-logo {
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    margin-bottom: 12px;
+}
+
+.receipt-header h2 {
+    margin: 0 0 8px 0;
+    font-size: 1.25rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.receipt-address,
+.receipt-date {
+    margin: 0 0 4px 0;
+    font-size: 0.8rem;
+    color: var(--receipt-text-muted);
+}
+
+/* Dotted Separators */
+hr.receipt-separator {
+    border: none;
+    border-top: 1.5px dashed var(--receipt-border);
+    margin: 16px 0;
+}
+
+/* Grid Layout for Rows */
+.receipt-row {
+    display: grid;
+    grid-template-columns: 1fr auto auto;
+    gap: 16px;
+    margin-bottom: 12px;
+    font-size: 0.9rem;
+}
+
+/* Specific column alignments */
+.receipt-row span:nth-child(1) { text-align: left; }
+.receipt-row span:nth-child(2) { text-align: center; width: 30px; }
+.receipt-row span:nth-child(3) { text-align: right; width: 70px; }
+
+.receipt-col-header {
+    font-weight: 700;
+    color: var(--receipt-text-muted);
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    letter-spacing: 1px;
+}
+
+.item-name { font-weight: 500; }
+.item-qty { color: var(--receipt-text-muted); }
+.item-price { font-weight: 500; }
+
+
+/* Totals Section */
+.receipt-totals {
+    margin-top: 16px;
+}
+
+.receipt-totals .receipt-row {
+    grid-template-columns: 1fr auto;
+}
+
+.receipt-totals .receipt-row span:nth-child(1) { text-align: right; color: var(--receipt-text-muted); }
+.receipt-totals .receipt-row span:nth-child(2) { text-align: right; width: 70px; font-weight: 500; }
+
+.total-row {
+    font-size: 1.15rem;
+    margin-top: 8px;
+}
+.receipt-totals .total-row span:nth-child(1) { color: var(--receipt-text); font-weight: 700; text-transform: uppercase; }
+.receipt-totals .total-row span:nth-child(2) { font-weight: 700; }
+
+
+/* Footer */
+.receipt-footer {
+    text-align: center;
+    margin-top: 32px;
+}
+
+.qr-code {
+    width: 80px;
+    height: 80px;
+    margin-bottom: 16px;
+    /* Invert colors in dark mode if needed, though QR APIs can handle it natively usually */
+}
+
+@media (prefers-color-scheme: dark) {
+    /* Optional: invert a standard black-on-white QR image in CSS if not using an API */
+    .qr-code { filter: invert(1) hue-rotate(180deg); }
+}
+
+.receipt-footer p {
+    margin: 0;
+    font-size: 0.8rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .receipt-card {
+        animation: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a pure CSS digital receipt card component featuring classic POS (Point of Sale) thermal paper aesthetics, including a jagged torn-paper edge and semantic dotted separator lines, built entirely without JavaScript, resolving issue #68645.

### Changes Made:
- Added `submissions/examples/css-receipt-component-pure/` directory.
- Created `demo.html` showcasing the HTML structure containing the receipt header, the grid-based itemized body, totals, and the QR code footer.
- Created `style.css` featuring the UI mechanics:
  - **Grid Alignments**: The itemized list relies on a robust `display: grid; grid-template-columns: 1fr auto auto;` layout to perfectly align item names (left), quantities (center), and prices (right) regardless of content length.
  - **The Jagged Torn Edge**: Achieved purely in CSS using the `::after` pseudo-element positioned at the bottom of the card. We use a repeating `radial-gradient` to draw transparent circles over the solid background color along the X-axis, creating a classic "torn paper" tooth effect without requiring external SVG assets.
  - **Typography**: Inherits the `JetBrains Mono` (or system monospace) font to simulate the classic look of thermal receipt printers.
  - **Theming & Dark Mode Supported**: Utilizes CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), generating a modern, dark "terminal-style" receipt in dark mode contexts (while gracefully handling QR code color inversion via CSS filters).
- Added `README.md` documenting usage and the technical mechanics of the `radial-gradient` torn-edge trick.
- Fully accessible with semantic HTML `<hr>` elements for the dotted separators.

Closes #68645
