### PR TITLE
feat: add pure CSS Page Peel Corner component (#68644)

### DIFF
--- a/submissions/examples/css-page-peel-corner-pure/README.md
+++ b/submissions/examples/css-page-peel-corner-pure/README.md
@@ -1,0 +1,20 @@
+# CSS Page Peel Corner
+
+A pure CSS interactive component where the top-right corner of a card peels back smoothly on hover, revealing hidden content or imagery underneath, built entirely without JavaScript.
+
+## Features
+- Pure CSS and HTML (Zero JavaScript required).
+- **Theming & Dark Mode**: Utilizes CSS Custom Properties (`--reveal-bg`, `--fold-base`, etc.) for easy overriding. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), generating a high-contrast dark mode variant.
+- **Peel Architecture (Documented in Code)**: 
+  - The card utilizes three layered `div` elements managed by `z-index`.
+  - **The Reveal Layer**: Positioned at the absolute bottom (`z-index: 1`), holding the secret content.
+  - **The Main Layer**: Positioned in the middle (`z-index: 2`). We use `clip-path: polygon` to cut a small "dog-ear" off the top right corner by default. On `:hover`, CSS variables defining the polygon vertices are transitioned to expand the cut, exposing the reveal layer below.
+  - **The Fold Layer**: Positioned on top (`z-index: 3`). This piece simulates the physically curled paper. We use a complex `linear-gradient` to create the lighting and shadow effects of the paper bending back. On `:hover`, this element scales up perfectly in sync with the `clip-path` expansion beneath it.
+- Fully accessible with `prefers-reduced-motion` support. The peeling animation is disabled for motion-sensitive users, acting instead as a sudden state-swap. The `:focus-within` pseudo-class ensures keyboard navigators can trigger the reveal.
+
+## Usage
+Open `demo.html` in your browser. Hover your mouse (or tab focus) over the card to see the top-right corner smoothly peel backward and cast a realistic shadow over the hidden content.
+
+## Files
+- `demo.html`: The HTML structure containing the three required layers (reveal, main, fold).
+- `style.css`: The styling, CSS Custom Property theming blocks, and heavily commented mechanics detailing the `clip-path` polygon animation trick.

--- a/submissions/examples/css-page-peel-corner-pure/demo.html
+++ b/submissions/examples/css-page-peel-corner-pure/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Page Peel Corner</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Page Peel Corner</h1>
+            <p class="subtitle">A pure CSS interactive component where the top-right corner peels back on hover, revealing hidden content or imagery underneath.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <!-- 
+              [TECHNIQUE] Page Peel
+              The .peel-card contains two layers: the base card (content) and the peeling corner element.
+              We use a linear-gradient trick and absolute positioning to simulate the curled paper.
+            -->
+            <div class="peel-card" tabindex="0">
+                
+                <!-- The content revealed UNDER the peel -->
+                <div class="peel-reveal-layer">
+                    <span class="reveal-badge">Secret Unlocked!</span>
+                    <p class="reveal-text">You found the hidden content. Use this pattern for easter eggs or premium upgrades.</p>
+                </div>
+                
+                <!-- The main content on TOP of the page -->
+                <div class="peel-main-layer">
+                    <div class="card-icon">
+                        <svg viewBox="0 0 24 24" width="48" height="48" stroke="currentColor" stroke-width="1.5" fill="none"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+                    </div>
+                    <h2>Hover Top Right</h2>
+                    <p>Move your mouse over the folded top-right corner to peel back the page and reveal what's underneath.</p>
+                </div>
+                
+                <!-- The corner element that animates the fold -->
+                <div class="peel-fold"></div>
+                
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-page-peel-corner-pure/style.css
+++ b/submissions/examples/css-page-peel-corner-pure/style.css
@@ -1,0 +1,238 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    
+    --card-bg: #ffffff;
+    --card-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
+    
+    --reveal-bg: #1e1b4b; /* Deep indigo for high contrast reveal */
+    --reveal-text: #ffffff;
+    
+    --fold-base: #e2e8f0;
+    --fold-shadow: rgba(0, 0, 0, 0.2);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a;
+        --text-primary: #f8fafc;
+        --text-secondary: #94a3b8;
+        
+        --card-bg: #1e293b;
+        --card-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.4), 0 8px 10px -6px rgba(0, 0, 0, 0.5);
+        
+        --reveal-bg: #09090b; /* Near black */
+        --reveal-text: #a78bfa; /* Vibrant purple accent text */
+        
+        --fold-base: #334155;
+        --fold-shadow: rgba(0, 0, 0, 0.6);
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 80px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.5rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 400px;
+}
+
+
+/* =========================================
+   Page Peel Architecture
+   ========================================= */
+
+.peel-card {
+    position: relative;
+    width: 320px;
+    height: 380px;
+    background-color: var(--reveal-bg);
+    box-shadow: var(--card-shadow);
+    cursor: pointer;
+    overflow: hidden; /* Prevent the peeling corner from overflowing the card */
+    border-radius: 8px; /* Optional: smooth corners on the base */
+}
+
+/* 
+  1. The Underneath (Reveal) Layer
+*/
+.peel-reveal-layer {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 100%;
+    height: 100%;
+    padding: 32px;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: flex-end; /* Align content to top right where peel happens */
+    text-align: right;
+    color: var(--reveal-text);
+    z-index: 1; /* Bottom layer */
+}
+
+.reveal-badge {
+    background-color: rgba(255, 255, 255, 0.1);
+    padding: 4px 12px;
+    border-radius: 16px;
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    margin-bottom: 16px;
+}
+
+.reveal-text {
+    margin: 0;
+    font-size: 0.9rem;
+    line-height: 1.6;
+    max-width: 80%;
+    opacity: 0.9;
+}
+
+
+/* 
+  2. The Top (Main) Layer
+  This layer needs its top-right corner clipped so it reveals the layer below.
+  We use `clip-path: polygon` to cut off the top right corner. 
+  The size of the cut is controlled by CSS variables that we animate on hover.
+*/
+.peel-main-layer {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: var(--card-bg);
+    padding: 40px 32px;
+    box-sizing: border-box;
+    z-index: 2; /* Middle layer */
+    
+    /* Default small dog-ear clip */
+    --peel-size-x: 90%; 
+    --peel-size-y: 10%;
+    clip-path: polygon(0 0, var(--peel-size-x) 0, 100% var(--peel-size-y), 100% 100%, 0 100%);
+    
+    transition: clip-path 0.5s cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+.card-icon {
+    color: var(--text-secondary);
+    margin-bottom: 24px;
+}
+
+.peel-main-layer h2 {
+    margin: 0 0 12px 0;
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--text-primary);
+}
+
+.peel-main-layer p {
+    margin: 0;
+    font-size: 0.95rem;
+    line-height: 1.6;
+    color: var(--text-secondary);
+}
+
+
+/* 
+  3. The Peeling Fold
+  This is the actual "curled paper" piece.
+  We position it at the top right, and apply a complex linear-gradient to simulate
+  lighting/shadows on the curled back paper.
+*/
+.peel-fold {
+    position: absolute;
+    top: 0;
+    right: 0;
+    z-index: 3; /* Top layer */
+    
+    /* Default small dog-ear size */
+    width: 32px;
+    height: 32px;
+    
+    /* Simulate the paper curl shadow and highlight */
+    background: linear-gradient(
+        225deg, 
+        transparent 50%, 
+        var(--fold-base) 50%, 
+        var(--card-bg) 70%, 
+        var(--fold-shadow) 100%
+    );
+    
+    box-shadow: -4px 4px 10px rgba(0, 0, 0, 0.1);
+    
+    transition: all 0.5s cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+
+/* 
+  Hover Interaction
+  Expand the clip-path of the main layer, and expand the size of the fold.
+*/
+.peel-card:hover .peel-main-layer,
+.peel-card:focus-within .peel-main-layer {
+    /* Expand the cut to reveal more */
+    --peel-size-x: 30%; 
+    --peel-size-y: 70%;
+}
+
+.peel-card:hover .peel-fold,
+.peel-card:focus-within .peel-fold {
+    /* Enlarge the curled paper piece to match the new cut */
+    width: 224px; /* 100% - 30% = 70% of 320px */
+    height: 266px; /* 70% of 380px */
+    box-shadow: -15px 15px 30px rgba(0, 0, 0, 0.3);
+}
+
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .peel-main-layer,
+    .peel-fold {
+        transition: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a pure CSS interactive component where the top-right corner of a card peels back smoothly on hover, revealing hidden content or imagery underneath, built entirely without JavaScript, resolving issue #68644.

### Changes Made:
- Added `submissions/examples/css-page-peel-corner-pure/` directory.
- Created `demo.html` showcasing the HTML structure containing the three required layers (reveal, main, fold).
- Created `style.css` featuring the UI mechanics:
  - **Peel Architecture**: The card utilizes three layered `div` elements managed by `z-index`.
  - **The Reveal Layer**: Positioned at the absolute bottom (`z-index: 1`), holding the secret content.
  - **The Main Layer**: Positioned in the middle (`z-index: 2`). We use `clip-path: polygon` to cut a small "dog-ear" off the top right corner by default. On `:hover`, CSS variables defining the polygon vertices are transitioned to smoothly expand the cut, exposing the reveal layer below.
  - **The Fold Layer**: Positioned on top (`z-index: 3`). This piece simulates the physically curled paper. We use a complex `linear-gradient` to create the lighting and shadow effects of the paper bending back. On `:hover`, this element scales up perfectly in sync with the `clip-path` expansion beneath it.
  - **Theming & Dark Mode Supported**: Utilizes CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), generating a high-contrast dark mode variant.
- Added `README.md` documenting usage and the technical mechanics of the `clip-path` polygon animation trick.
- Honors the `prefers-reduced-motion` accessibility standard. The peeling animation is disabled for motion-sensitive users, acting instead as a sudden state-swap. The `:focus-within` pseudo-class ensures keyboard navigators can trigger the reveal.

Closes #68644
