### PR TITLE
feat: add CSS Size Guide Tooltip example

### DIFF
--- a/submissions/examples/css-size-guide-tooltip-68515/README.md
+++ b/submissions/examples/css-size-guide-tooltip-68515/README.md
@@ -1,0 +1,41 @@
+# CSS Size Guide Tooltip
+
+## Overview
+
+A pure CSS size guide tooltip that displays a sizing chart beside product size selectors. The tooltip appears on hover or keyboard focus and provides quick access to sizing information without requiring JavaScript.
+
+## Features
+
+- Pure HTML and CSS
+- Hover and keyboard-focus support
+- Smooth fade and slide animation
+- Responsive design
+- Accessible interaction states
+- Lightweight and customizable
+
+## Usage
+
+Include the HTML structure and stylesheet.
+
+```html
+<button class="size-guide-trigger">
+  Size Guide
+</button>
+```
+
+## Accessibility
+
+- Keyboard accessible using focus states
+- Visible focus indicators
+- Semantic table structure for size data
+
+## Browser Support
+
+- Chrome
+- Firefox
+- Edge
+- Safari
+
+## Author
+
+Created for EaseMotion CSS contribution #68515.

--- a/submissions/examples/css-size-guide-tooltip-68515/demo.html
+++ b/submissions/examples/css-size-guide-tooltip-68515/demo.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Size Guide Tooltip</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <div class="product-card">
+    <h2>Classic Cotton T-Shirt</h2>
+    <p class="subtitle">Choose your size</p>
+
+    <div class="size-selector">
+      <button>XS</button>
+      <button>S</button>
+      <button class="active">M</button>
+      <button>L</button>
+      <button>XL</button>
+
+      <div class="tooltip-wrapper">
+        <button
+          class="size-guide-trigger"
+          aria-label="Open size guide"
+        >
+          Size Guide
+        </button>
+
+        <div class="size-tooltip">
+          <h3>Size Chart</h3>
+
+          <table>
+            <thead>
+              <tr>
+                <th>Size</th>
+                <th>Chest</th>
+                <th>Waist</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>XS</td>
+                <td>34"</td>
+                <td>28"</td>
+              </tr>
+              <tr>
+                <td>S</td>
+                <td>36"</td>
+                <td>30"</td>
+              </tr>
+              <tr>
+                <td>M</td>
+                <td>38"</td>
+                <td>32"</td>
+              </tr>
+              <tr>
+                <td>L</td>
+                <td>42"</td>
+                <td>36"</td>
+              </tr>
+              <tr>
+                <td>XL</td>
+                <td>46"</td>
+                <td>40"</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/css-size-guide-tooltip-68515/style.css
+++ b/submissions/examples/css-size-guide-tooltip-68515/style.css
@@ -1,0 +1,142 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #f4f6f8;
+  font-family: Inter, Arial, sans-serif;
+  padding: 2rem;
+}
+
+.product-card {
+  background: #fff;
+  padding: 2rem;
+  border-radius: 18px;
+  box-shadow: 0 12px 35px rgba(0, 0, 0, 0.08);
+  max-width: 600px;
+  width: 100%;
+}
+
+h2 {
+  margin-bottom: 0.5rem;
+  color: #222;
+}
+
+.subtitle {
+  color: #666;
+  margin-bottom: 1.5rem;
+}
+
+.size-selector {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.size-selector button {
+  border: 1px solid #d9d9d9;
+  background: white;
+  padding: 0.75rem 1rem;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: 0.3s ease;
+}
+
+.size-selector button:hover {
+  border-color: #111;
+}
+
+.active {
+  background: #111 !important;
+  color: white;
+}
+
+.tooltip-wrapper {
+  position: relative;
+}
+
+.size-guide-trigger {
+  border: none;
+  background: transparent;
+  color: #2563eb;
+  font-weight: 600;
+  text-decoration: underline;
+}
+
+.size-tooltip {
+  position: absolute;
+  top: 120%;
+  right: 0;
+
+  width: 320px;
+  background: white;
+  border-radius: 14px;
+  padding: 1rem;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.15);
+
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(12px);
+
+  transition:
+    opacity 0.3s ease,
+    transform 0.3s ease,
+    visibility 0.3s ease;
+
+  z-index: 10;
+}
+
+.tooltip-wrapper:hover .size-tooltip,
+.tooltip-wrapper:focus-within .size-tooltip {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+.size-tooltip h3 {
+  margin-bottom: 0.8rem;
+  color: #111;
+  font-size: 1rem;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  padding: 0.6rem;
+  text-align: center;
+}
+
+th {
+  background: #f3f4f6;
+}
+
+tr:not(:last-child) td {
+  border-bottom: 1px solid #eee;
+}
+
+.size-guide-trigger:focus-visible,
+.size-selector button:focus-visible {
+  outline: 3px solid #2563eb;
+  outline-offset: 2px;
+}
+
+@media (max-width: 600px) {
+  .size-tooltip {
+    width: 280px;
+    right: -40px;
+  }
+
+  .size-selector {
+    gap: 0.5rem;
+  }
+}


### PR DESCRIPTION
## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to** **`core/`**
- [x] **No changes to** **`components/`**
- [x] One feature per PR (no bundled unrelated changes)

---
## closes #68515 

## Feature Description

**What does this add?**

Adds a pure CSS Size Guide Tooltip component that displays a sizing chart beside product size selectors. The tooltip appears on hover and keyboard focus, providing quick access to sizing information without requiring JavaScript.

**How does a developer use it?**

```html
<div class="tooltip-wrapper">
  <button class="size-guide-trigger">
    Size Guide
  </button>

  <div class="size-tooltip">
    <!-- Size chart content -->
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**

This component provides a practical e-commerce UI pattern using only HTML and CSS. It combines accessibility, responsive design, and smooth micro-interactions, making it a useful addition to the EaseMotion CSS component library.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---
