### PR TITLE
feat: add stacked toast notifications (#68975)

### DIFF
--- a/submissions/examples/toast-stack/README.md
+++ b/submissions/examples/toast-stack/README.md
@@ -1,0 +1,24 @@
+# Stacked Toast Notifications Layout
+
+## Description
+This submission resolves Issue #68975 by implementing a modern, stacked toast notification layout natively in CSS. It automatically positions and styles incoming toasts so that the newest is displayed prominently on top, while older toasts visually recede backwards in the z-axis using CSS scale and translate transformations.
+
+## Features
+- Pure CSS 3D depth stack effect.
+- Uses structural pseudo-classes (`:nth-last-child()`) to automatically style elements based on their position in the DOM.
+- No JavaScript logic needed for the layout itself (JS is only used to append or remove elements in the demo).
+- Smooth transitions for `transform` and `opacity`.
+- Older notifications gracefully fade and shrink into the background before disappearing.
+
+## Usage
+Create a container element with the `.ease-toast-container` class, and append new notifications as `.ease-toast` elements at the end of the container. 
+
+```html
+<div class="ease-toast-container">
+  <div class="ease-toast">Notification 1 (Oldest)</div>
+  <div class="ease-toast">Notification 2</div>
+  <div class="ease-toast">Notification 3 (Newest)</div>
+</div>
+```
+
+The newest element (the last child) will automatically be styled to stay at the front.

--- a/submissions/examples/toast-stack/demo.html
+++ b/submissions/examples/toast-stack/demo.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Stacked Toast Notifications</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      background-color: #f0f2f5;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    }
+    
+    .btn {
+      padding: 12px 24px;
+      font-size: 16px;
+      border: none;
+      border-radius: 6px;
+      background-color: #4CAF50;
+      color: white;
+      cursor: pointer;
+      box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+      transition: background-color 0.2s, transform 0.1s;
+    }
+    
+    .btn:hover {
+      background-color: #45a049;
+    }
+    
+    .btn:active {
+      transform: scale(0.98);
+    }
+  </style>
+</head>
+<body>
+
+  <button class="btn" onclick="addToast()">Add Toast</button>
+
+  <div class="ease-toast-container" id="toastContainer">
+    <!-- Toasts will be injected here -->
+  </div>
+
+  <script>
+    let counter = 1;
+    function addToast() {
+      const container = document.getElementById('toastContainer');
+      
+      const toast = document.createElement('div');
+      toast.className = 'ease-toast';
+      toast.textContent = 'Notification #' + counter++;
+      
+      // Append newest toasts so they are the last-child natively
+      container.appendChild(toast);
+      
+      // Optional: Auto remove after a while to see the stack shift back
+      setTimeout(() => {
+        if (toast.parentNode) {
+          toast.remove();
+        }
+      }, 4000);
+    }
+    
+    // Add a couple initially to demonstrate
+    addToast();
+    setTimeout(addToast, 300);
+    setTimeout(addToast, 600);
+  </script>
+</body>
+</html>

--- a/submissions/examples/toast-stack/style.css
+++ b/submissions/examples/toast-stack/style.css
@@ -1,0 +1,62 @@
+/* 
+  Stacked Toast Notifications Layout
+  Issue: #68975
+*/
+
+.ease-toast-container {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  width: 320px;
+  /* Min height needed so absolute toasts don't collapse container completely */
+  height: 60px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  z-index: 9999;
+  pointer-events: none;
+}
+
+.ease-toast {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  background-color: #1e1e24;
+  color: #fff;
+  padding: 16px;
+  border-radius: 8px;
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.15);
+  transition: transform 0.4s cubic-bezier(0.2, 0.9, 0.3, 1.1), opacity 0.4s ease;
+  pointer-events: auto;
+  box-sizing: border-box;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+/* 1st toast (newest) */
+.ease-toast:nth-last-child(1) {
+  transform: translateY(0) scale(1);
+  opacity: 1;
+  z-index: 10;
+}
+
+/* 2nd toast */
+.ease-toast:nth-last-child(2) {
+  transform: translateY(-12px) scale(0.95);
+  opacity: 0.85;
+  z-index: 9;
+}
+
+/* 3rd toast */
+.ease-toast:nth-last-child(3) {
+  transform: translateY(-24px) scale(0.9);
+  opacity: 0.6;
+  z-index: 8;
+}
+
+/* 4th toast and older */
+.ease-toast:nth-last-child(n+4) {
+  transform: translateY(-36px) scale(0.85);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+}


### PR DESCRIPTION
## Description
This PR resolves #68975 by implementing a modern, stacked toast notification layout natively in CSS.

### Features
- Pure CSS 3D depth stack effect using `transform` (scale and translate).
- Utilizes structural pseudo-classes (`:nth-last-child()`) to automatically target older toasts.
- Newest toast appears prominently at the front, while older siblings gracefully recede and fade.
- Fully compatible with the repository's `submissions/examples` directory requirements.

### Issue Fixed
Fixes #68975