### PR TITLE
feat: add pure css device mockups (#68992)

### DIFF
--- a/submissions/examples/device-mockups/README.md
+++ b/submissions/examples/device-mockups/README.md
@@ -1,0 +1,34 @@
+# Pure CSS 3D Perspective Device Mockups
+
+## Description
+This submission resolves Issue #68992 by providing pure CSS wrappers to simulate iPhone and MacBook devices. This eliminates the need to load heavy PNG mockups for framing screenshots, significantly improving load times and offering dynamic styling capabilities.
+
+## Features
+- **Pure CSS Construction**: Built completely with `border`, `border-radius`, and `box-shadow`.
+- **Dynamic Notch / Island**: Includes a `.ease-device-notch` positioned natively on the phone.
+- **3D Transforms**: Uses `rotateX` and `rotateY` alongside `preserve-3d` to present the devices in a modern, skewed "premium presentation" perspective.
+- **Responsive**: The laptop mockup resizes responsively on smaller screens.
+
+## Usage
+Wrap your content (images, iframes, or HTML) inside the `.ease-device-screen` container.
+
+```html
+<div class="ease-device-wrapper">
+  
+  <!-- Phone Layout -->
+  <div class="ease-device-phone">
+    <div class="ease-device-notch"></div>
+    <div class="ease-device-screen">
+      <img src="mobile-screenshot.jpg" alt="App Screen">
+    </div>
+  </div>
+
+  <!-- Laptop Layout -->
+  <div class="ease-device-laptop">
+    <div class="ease-device-screen">
+      <img src="desktop-screenshot.jpg" alt="Web Screen">
+    </div>
+  </div>
+
+</div>
+```

--- a/submissions/examples/device-mockups/demo.html
+++ b/submissions/examples/device-mockups/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pure CSS Device Mockups</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background-color: #f4f4f5;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      overflow-x: hidden;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="ease-device-wrapper">
+    
+    <!-- Phone Mockup -->
+    <div class="ease-device-phone">
+      <div class="ease-device-notch"></div>
+      <div class="ease-device-screen">
+        Mobile App View
+      </div>
+    </div>
+
+    <!-- Laptop Mockup -->
+    <div class="ease-device-laptop">
+      <div class="ease-device-screen">
+        Desktop Web View
+      </div>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/device-mockups/style.css
+++ b/submissions/examples/device-mockups/style.css
@@ -1,0 +1,121 @@
+/* 
+  Pure CSS 3D Perspective Device Mockups
+  Issue: #68992
+*/
+
+.ease-device-wrapper {
+  perspective: 1200px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 60px;
+  padding: 60px;
+  flex-wrap: wrap;
+}
+
+/* --- PHONE MOCKUP --- */
+.ease-device-phone {
+  position: relative;
+  width: 280px;
+  height: 580px;
+  background-color: #000;
+  border-radius: 40px;
+  border: 12px solid #1a1a1a;
+  box-shadow: 
+    inset 0 0 0 2px #333,
+    20px 30px 40px rgba(0, 0, 0, 0.4),
+    -10px 10px 20px rgba(0, 0, 0, 0.2);
+  transform: rotateY(-15deg) rotateX(10deg);
+  transform-style: preserve-3d;
+  box-sizing: border-box;
+}
+
+/* Phone Notch / Dynamic Island */
+.ease-device-notch {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100px;
+  height: 30px;
+  background-color: #000;
+  border-radius: 20px;
+  z-index: 10;
+  box-shadow: inset 0 -1px 2px rgba(255,255,255,0.1);
+}
+
+/* Phone Screen */
+.ease-device-phone .ease-device-screen {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(135deg, #FF6A88 0%, #FF99AC 100%);
+  border-radius: 28px;
+  overflow: hidden;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: white;
+  font-family: sans-serif;
+  font-weight: bold;
+}
+
+/* --- LAPTOP MOCKUP --- */
+.ease-device-laptop {
+  position: relative;
+  width: 600px;
+  height: 380px;
+  background-color: #1a1a1a;
+  border-radius: 16px 16px 0 0;
+  border: 12px solid #000;
+  border-bottom: 24px solid #111;
+  box-shadow: 
+    inset 0 0 0 2px #333,
+    30px 40px 50px rgba(0, 0, 0, 0.5),
+    -15px 15px 30px rgba(0, 0, 0, 0.2);
+  transform: rotateY(15deg) rotateX(5deg);
+  transform-style: preserve-3d;
+  box-sizing: border-box;
+}
+
+/* Laptop Base (Keyboard area simulation) */
+.ease-device-laptop::after {
+  content: '';
+  position: absolute;
+  bottom: -40px; /* extends below the screen */
+  left: -30px;
+  right: -30px;
+  height: 16px;
+  background: linear-gradient(to right, #333, #555, #333);
+  border-radius: 0 0 16px 16px;
+  box-shadow: 0 20px 30px rgba(0, 0, 0, 0.6);
+}
+
+/* Laptop Screen */
+.ease-device-laptop .ease-device-screen {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(135deg, #1e3c72 0%, #2a5298 100%);
+  border-radius: 4px;
+  overflow: hidden;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: white;
+  font-family: sans-serif;
+  font-size: 24px;
+  font-weight: bold;
+}
+
+/* Responsive adjustments */
+@media (max-width: 1000px) {
+  .ease-device-wrapper {
+    flex-direction: column;
+    gap: 80px;
+  }
+  .ease-device-laptop {
+    width: 90vw;
+    height: calc(90vw * 0.63);
+  }
+}


### PR DESCRIPTION
## Description
This PR resolves #68992 by providing pure CSS wrappers to simulate smartphone and laptop devices, eliminating the need to load heavy PNG mockups for framing screenshots.

### Features
- Pure CSS hardware simulation using heavy `border-radius`, borders, and `box-shadow`.
- Includes an `.ease-device-notch` positioned natively on the phone.
- Employs 3D perspective transforms (`rotateX`, `rotateY`, `preserve-3d`) to skew the devices for a premium presentation style.
- Fully compatible with the repository's `submissions/examples` directory requirements.

### Issue Fixed
Fixes #68992