### PR TITLE
feat: add pure CSS Music Player Card component (#68542)

### DIFF
--- a/submissions/examples/css-music-player-card-pure/README.md
+++ b/submissions/examples/css-music-player-card-pure/README.md
@@ -1,0 +1,22 @@
+# CSS Music Player Card
+
+A pure CSS interactive music player component featuring a rotating vinyl album art, animated audio visualizer, and custom range slider styling, driven entirely by CSS state toggles without JavaScript.
+
+## Features
+- Pure CSS and HTML (Zero JavaScript).
+- **Theming & Dark Mode**: Utilizes CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), generating a sleek dark mode UI.
+- **Component Architecture (Documented in Code)**: 
+  - **The Checkbox Hack (State Toggle)**: We use a hidden `<input type="checkbox" id="play-toggle">` at the top of the card. The central Play/Pause button is actually a `<label for="play-toggle">`. When the user clicks the play button, it checks the hidden box.
+  - **Cascading State Changes**: Using the `~` general sibling selector, the checked state of the input controls the entire UI:
+    - `.play-state-input:checked ~ .player-controls` swaps the Play icon for a Pause icon.
+    - `.play-state-input:checked ~ .album-art-container` sets `animation-play-state: running` on the vinyl record to make it spin.
+    - `.play-state-input:checked ~ .visualizer` fades in the equalizer bars and starts their bounce animation.
+  - **Custom Range Slider**: Features deep custom styling for `<input type="range">`, overriding native browser UI (including specific `-moz` and `-webkit` pseudo-elements) to match the custom theme colors.
+- Fully accessible with `prefers-reduced-motion` support that disables the spinning record and bouncing equalizer for motion-sensitive users. Screen readers are instructed to ignore the hidden state checkbox via `aria-hidden="true"`, interacting directly with the styled `<label>` button.
+
+## Usage
+Open `demo.html` in your browser. Click the Play/Pause button in the center to toggle the component state and watch the vinyl record and visualizer react instantly.
+
+## Files
+- `demo.html`: The HTML structure containing the hidden state checkbox, SVG icons, and custom range slider.
+- `style.css`: The styling, CSS Custom Property theming blocks, and the heavily commented `:checked ~` state linkage techniques.

--- a/submissions/examples/css-music-player-card-pure/demo.html
+++ b/submissions/examples/css-music-player-card-pure/demo.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Music Player Card</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Music Player Card</h1>
+            <p class="subtitle">A pure CSS interactive music player component featuring a rotating vinyl album art, animated audio visualizer, and custom range slider styling.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <div class="player-card">
+                
+                <!-- 
+                  [TECHNIQUE] CSS State Toggle
+                  We use a hidden checkbox to act as the Play/Pause state controller.
+                  When checked, the vinyl spins, the visualizer animates, and the play icon swaps.
+                -->
+                <input type="checkbox" id="play-toggle" class="sr-only play-state-input" aria-hidden="true">
+                
+                <div class="player-header">
+                    <span class="badge-now-playing">Now Playing</span>
+                    <button class="btn-icon" aria-label="More options">
+                        <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none"><circle cx="12" cy="12" r="1"></circle><circle cx="12" cy="5" r="1"></circle><circle cx="12" cy="19" r="1"></circle></svg>
+                    </button>
+                </div>
+                
+                <div class="album-art-container">
+                    <div class="vinyl-record">
+                        <!-- Placeholder album art (gradient) -->
+                        <div class="album-cover">
+                            <div class="vinyl-hole"></div>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="track-info">
+                    <h2 class="track-title">Midnight Synthesizer</h2>
+                    <p class="track-artist">Neon Wave</p>
+                </div>
+                
+                <!-- Progress Bar (Range Slider) -->
+                <div class="progress-container">
+                    <div class="time-stamps">
+                        <span class="time-current">1:24</span>
+                        <span class="time-total">4:05</span>
+                    </div>
+                    <label for="track-progress" class="sr-only">Seek track</label>
+                    <input type="range" id="track-progress" class="progress-bar" min="0" max="100" value="35">
+                </div>
+                
+                <!-- Audio Visualizer (Hidden/Animated based on play state) -->
+                <div class="visualizer">
+                    <div class="bar bar-1"></div>
+                    <div class="bar bar-2"></div>
+                    <div class="bar bar-3"></div>
+                    <div class="bar bar-4"></div>
+                    <div class="bar bar-5"></div>
+                </div>
+                
+                <div class="player-controls">
+                    <button class="btn-control" aria-label="Previous track">
+                        <svg viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" stroke-width="2" fill="none"><polygon points="19 20 9 12 19 4 19 20"></polygon><line x1="5" y1="19" x2="5" y2="5"></line></svg>
+                    </button>
+                    
+                    <!-- Play/Pause Label linked to the hidden checkbox -->
+                    <label for="play-toggle" class="btn-play-pause" tabindex="0" role="button" aria-label="Play or Pause">
+                        <div class="icon-play">
+                            <svg viewBox="0 0 24 24" width="28" height="28" stroke="currentColor" stroke-width="2" fill="currentColor"><polygon points="5 3 19 12 5 21 5 3"></polygon></svg>
+                        </div>
+                        <div class="icon-pause">
+                            <svg viewBox="0 0 24 24" width="28" height="28" stroke="currentColor" stroke-width="2" fill="currentColor"><rect x="6" y="4" width="4" height="16"></rect><rect x="14" y="4" width="4" height="16"></rect></svg>
+                        </div>
+                    </label>
+                    
+                    <button class="btn-control" aria-label="Next track">
+                        <svg viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" stroke-width="2" fill="none"><polygon points="5 4 15 12 5 20 5 4"></polygon><line x1="19" y1="5" x2="19" y2="19"></line></svg>
+                    </button>
+                </div>
+                
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-music-player-card-pure/style.css
+++ b/submissions/examples/css-music-player-card-pure/style.css
@@ -1,0 +1,413 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #e2e8f0;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    
+    --card-bg: #ffffff;
+    --card-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.05);
+    
+    --accent-color: #ec4899; /* Vibrant pink */
+    --accent-hover: #db2777;
+    
+    --control-bg: #f1f5f9;
+    --control-hover: #e2e8f0;
+    
+    --progress-track: #e2e8f0;
+    --progress-fill: var(--accent-color);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a;
+        --text-primary: #f8fafc;
+        --text-secondary: #94a3b8;
+        
+        --card-bg: #1e293b;
+        --card-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+        
+        --accent-color: #f43f5e;
+        --accent-hover: #e11d48;
+        
+        --control-bg: #334155;
+        --control-hover: #475569;
+        
+        --progress-track: #475569;
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 60px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 500px;
+}
+
+/* Accessibility helper */
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border-width: 0;
+}
+
+
+/* =========================================
+   Player Card
+   ========================================= */
+
+.player-card {
+    width: 100%;
+    max-width: 320px;
+    background-color: var(--card-bg);
+    border-radius: 24px;
+    padding: 24px;
+    box-shadow: var(--card-shadow);
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.player-header {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 24px;
+}
+
+.badge-now-playing {
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--text-secondary);
+}
+
+.btn-icon {
+    background: none;
+    border: none;
+    color: var(--text-secondary);
+    cursor: pointer;
+    padding: 4px;
+    border-radius: 50%;
+    transition: color 0.2s ease, background-color 0.2s ease;
+}
+
+.btn-icon:hover {
+    color: var(--text-primary);
+    background-color: var(--control-bg);
+}
+
+
+/* =========================================
+   Vinyl Album Art (Animated)
+   ========================================= */
+
+.album-art-container {
+    margin-bottom: 24px;
+    position: relative;
+}
+
+.vinyl-record {
+    width: 200px;
+    height: 200px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #111, #333, #111);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    box-shadow: 0 10px 20px rgba(0,0,0,0.3);
+    /* Pause animation by default */
+    animation: spinVinyl 5s linear infinite;
+    animation-play-state: paused;
+}
+
+/* Grooves */
+.vinyl-record::before,
+.vinyl-record::after {
+    content: '';
+    position: absolute;
+    border-radius: 50%;
+    border: 1px solid rgba(255,255,255,0.1);
+}
+.vinyl-record::before { width: 180px; height: 180px; }
+.vinyl-record::after { width: 140px; height: 140px; }
+
+.album-cover {
+    width: 90px;
+    height: 90px;
+    border-radius: 50%;
+    /* Gradient acting as placeholder art */
+    background: linear-gradient(45deg, var(--accent-color), #8b5cf6);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: relative;
+    z-index: 2;
+}
+
+.vinyl-hole {
+    width: 16px;
+    height: 16px;
+    background-color: var(--card-bg);
+    border-radius: 50%;
+    box-shadow: inset 0 2px 4px rgba(0,0,0,0.5);
+}
+
+@keyframes spinVinyl {
+    100% { transform: rotate(360deg); }
+}
+
+
+/* =========================================
+   Track Info
+   ========================================= */
+
+.track-info {
+    text-align: center;
+    margin-bottom: 24px;
+    width: 100%;
+}
+
+.track-title {
+    margin: 0 0 4px 0;
+    font-size: 1.3rem;
+    font-weight: 700;
+    color: var(--text-primary);
+}
+
+.track-artist {
+    margin: 0;
+    font-size: 0.95rem;
+    color: var(--text-secondary);
+}
+
+
+/* =========================================
+   Progress Bar
+   ========================================= */
+
+.progress-container {
+    width: 100%;
+    margin-bottom: 24px;
+}
+
+.time-stamps {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+    font-weight: 500;
+    margin-bottom: 8px;
+}
+
+/* Custom Range Slider */
+.progress-bar {
+    -webkit-appearance: none;
+    width: 100%;
+    height: 6px;
+    background: var(--progress-track);
+    border-radius: 3px;
+    outline: none;
+    cursor: pointer;
+    /* Simulate fill using linear-gradient (value is hardcoded in demo to 35%) */
+    background-image: linear-gradient(var(--progress-fill), var(--progress-fill));
+    background-size: 35% 100%;
+    background-repeat: no-repeat;
+}
+
+.progress-bar::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: var(--progress-fill);
+    cursor: pointer;
+    box-shadow: 0 0 0 4px var(--card-bg); /* Cutout effect */
+    transition: transform 0.2s ease;
+}
+
+.progress-bar::-webkit-slider-thumb:hover {
+    transform: scale(1.3);
+}
+
+/* Firefox compatibility */
+.progress-bar::-moz-range-thumb {
+    width: 12px;
+    height: 12px;
+    border: none;
+    border-radius: 50%;
+    background: var(--progress-fill);
+    cursor: pointer;
+    box-shadow: 0 0 0 4px var(--card-bg);
+}
+
+
+/* =========================================
+   Audio Visualizer
+   ========================================= */
+
+.visualizer {
+    display: flex;
+    justify-content: center;
+    align-items: flex-end;
+    gap: 4px;
+    height: 20px;
+    margin-bottom: 24px;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.bar {
+    width: 4px;
+    background-color: var(--accent-color);
+    border-radius: 2px;
+    animation: eqBounce 1s ease-in-out infinite alternate;
+    animation-play-state: paused;
+}
+
+/* Stagger animation timing */
+.bar-1 { height: 10px; animation-delay: 0.1s; }
+.bar-2 { height: 16px; animation-delay: 0.3s; }
+.bar-3 { height: 20px; animation-delay: 0s; }
+.bar-4 { height: 14px; animation-delay: 0.4s; }
+.bar-5 { height: 12px; animation-delay: 0.2s; }
+
+@keyframes eqBounce {
+    0% { transform: scaleY(0.3); }
+    100% { transform: scaleY(1); }
+}
+
+
+/* =========================================
+   Controls & State Linkage
+   ========================================= */
+
+.player-controls {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 24px;
+    width: 100%;
+}
+
+.btn-control {
+    background: none;
+    border: none;
+    color: var(--text-secondary);
+    cursor: pointer;
+    padding: 8px;
+    border-radius: 50%;
+    transition: all 0.2s ease;
+}
+
+.btn-control:hover {
+    color: var(--text-primary);
+    transform: scale(1.1);
+}
+
+.btn-play-pause {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 60px;
+    height: 60px;
+    background-color: var(--accent-color);
+    color: #ffffff;
+    border-radius: 50%;
+    cursor: pointer;
+    box-shadow: 0 8px 16px rgba(236, 72, 153, 0.3);
+    transition: all 0.2s ease;
+}
+
+.btn-play-pause:hover {
+    background-color: var(--accent-hover);
+    transform: scale(1.05);
+}
+
+/* Initially hide pause icon */
+.icon-pause { display: none; }
+.icon-play { display: block; }
+
+
+/* 
+  [TECHNIQUE] The Magic State Toggle 
+  When the hidden checkbox (.play-state-input) is checked:
+*/
+.play-state-input:checked ~ .player-controls .btn-play-pause .icon-play { display: none; }
+.play-state-input:checked ~ .player-controls .btn-play-pause .icon-pause { display: block; }
+
+.play-state-input:checked ~ .album-art-container .vinyl-record {
+    animation-play-state: running;
+}
+
+.play-state-input:checked ~ .visualizer {
+    opacity: 1;
+}
+
+.play-state-input:checked ~ .visualizer .bar {
+    animation-play-state: running;
+}
+
+
+/* Accessibility */
+.btn-play-pause:focus {
+    outline: 2px solid var(--text-primary);
+    outline-offset: 4px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .vinyl-record,
+    .bar {
+        animation: none !important;
+    }
+    .btn-control {
+        transition: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a pure CSS interactive music player component featuring a rotating vinyl album art, animated audio visualizer, and custom range slider styling, driven entirely by CSS state toggles without JavaScript, resolving issue #68542.

### Changes Made:
- Added `submissions/examples/css-music-player-card-pure/` directory.
- Created `demo.html` showcasing the HTML structure containing the hidden state checkbox, SVG icons, and custom range slider.
- Created `style.css` featuring the UI mechanics:
  - **The Checkbox Hack (State Toggle)**: We use a hidden `<input type="checkbox" id="play-toggle">` at the top of the card. The central Play/Pause button is actually a `<label for="play-toggle">`. When the user clicks the play button, it checks the hidden box.
  - **Cascading State Changes**: Using the `~` general sibling selector, the checked state of the input controls the entire UI:
    - `.play-state-input:checked ~ .player-controls` swaps the Play icon for a Pause icon.
    - `.play-state-input:checked ~ .album-art-container` sets `animation-play-state: running` on the vinyl record to make it spin.
    - `.play-state-input:checked ~ .visualizer` fades in the equalizer bars and starts their bounce animation.
  - **Custom Range Slider**: Features deep custom styling for `<input type="range">`, overriding native browser UI (including specific `-moz` and `-webkit` pseudo-elements) to match the custom theme colors.
  - **Theming & Dark Mode Supported**: Utilizes CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), generating a sleek dark mode UI.
- Added `README.md` documenting usage and the technical mechanics of the `:checked ~` state linkage techniques.
- Honors the `prefers-reduced-motion` accessibility standard. The spinning record and bouncing equalizer are disabled for motion-sensitive users. Accessible with screen-reader instructions to ignore the hidden state checkbox via `aria-hidden="true"`, interacting directly with the styled `<label>` button.

Closes #68542
