### PR TITLE
feat: add pure CSS Leaderboard Table component (#68540)

### DIFF
--- a/submissions/examples/css-leaderboard-table-pure/README.md
+++ b/submissions/examples/css-leaderboard-table-pure/README.md
@@ -1,0 +1,19 @@
+# CSS Leaderboard Table
+
+A pure CSS ranked leaderboard table utilizing advanced CSS pseudo-selectors to automatically apply Gold, Silver, and Bronze medal styling to the top rows, built without JavaScript.
+
+## Features
+- Pure CSS and HTML (Zero JavaScript logic required to calculate or style the top ranks).
+- **Theming & Dark Mode**: Utilizes CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), providing a sleek dark mode variant with glowing medal badges.
+- **Component Architecture (Documented in Code)**: 
+  - **Auto-Medal Styling**: We do not manually apply `.is-gold`, `.is-silver`, or `.is-bronze` classes to the HTML rows. Instead, we use the `tbody tr:nth-child(n)` selector in CSS.
+  - When the browser renders the table, CSS automatically detects the 1st, 2nd, and 3rd `<tr>` elements inside the `<tbody>` and dynamically overrides their `.rank-badge` variables with the appropriate gold, silver, or bronze theme colors, scale transforms, and box-shadow glows.
+  - The Gold row (`:nth-child(1)`) receives additional layout flair, including a subtle row background tint, colored score text, and an avatar border ring.
+- Fully accessible semantic `<table>` structure utilizing `<thead>`, `<tbody>`, `<th>`, and `<td>` elements with proper `scope` attributes for screen readers.
+
+## Usage
+Open `demo.html` in your browser. Notice how the top 3 rows are automatically styled as Gold, Silver, and Bronze without any specific HTML classes on those rows.
+
+## Files
+- `demo.html`: The HTML structure containing the semantic table and dummy player data.
+- `style.css`: The styling, CSS Custom Property theming blocks, and the heavily commented `:nth-child` auto-medal logic.

--- a/submissions/examples/css-leaderboard-table-pure/demo.html
+++ b/submissions/examples/css-leaderboard-table-pure/demo.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Leaderboard Table</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Leaderboard Table</h1>
+            <p class="subtitle">A pure CSS ranked leaderboard utilizing the <code>:nth-child()</code> selector to automatically style Gold, Silver, and Bronze medalists.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <div class="leaderboard-card">
+                
+                <div class="card-header">
+                    <h2>Global Rankings</h2>
+                    <p>Season 4 • Top Players</p>
+                </div>
+                
+                <div class="table-wrapper">
+                    <table class="leaderboard-table" aria-label="Global Player Rankings">
+                        
+                        <thead>
+                            <tr>
+                                <th scope="col" class="col-rank">Rank</th>
+                                <th scope="col" class="col-player">Player</th>
+                                <th scope="col" class="col-score">Score</th>
+                            </tr>
+                        </thead>
+                        
+                        <!-- 
+                          [TECHNIQUE] Auto-Medal Styling
+                          We don't manually apply classes to the top 3 rows.
+                          Instead, we use pure CSS :nth-child(1), (2), and (3) on the <tr> elements.
+                        -->
+                        <tbody>
+                            
+                            <!-- Gold -->
+                            <tr>
+                                <td class="col-rank">
+                                    <div class="rank-badge">1</div>
+                                </td>
+                                <td class="col-player">
+                                    <div class="player-info">
+                                        <img src="https://i.pravatar.cc/150?img=11" alt="Avatar" class="player-avatar">
+                                        <span class="player-name">AlexHunter_99</span>
+                                    </div>
+                                </td>
+                                <td class="col-score">9,450</td>
+                            </tr>
+                            
+                            <!-- Silver -->
+                            <tr>
+                                <td class="col-rank">
+                                    <div class="rank-badge">2</div>
+                                </td>
+                                <td class="col-player">
+                                    <div class="player-info">
+                                        <img src="https://i.pravatar.cc/150?img=32" alt="Avatar" class="player-avatar">
+                                        <span class="player-name">SarahSnipe</span>
+                                    </div>
+                                </td>
+                                <td class="col-score">8,920</td>
+                            </tr>
+                            
+                            <!-- Bronze -->
+                            <tr>
+                                <td class="col-rank">
+                                    <div class="rank-badge">3</div>
+                                </td>
+                                <td class="col-player">
+                                    <div class="player-info">
+                                        <img src="https://i.pravatar.cc/150?img=12" alt="Avatar" class="player-avatar">
+                                        <span class="player-name">RetroGamerX</span>
+                                    </div>
+                                </td>
+                                <td class="col-score">8,750</td>
+                            </tr>
+                            
+                            <!-- Standard rows below top 3 -->
+                            <tr>
+                                <td class="col-rank">
+                                    <div class="rank-badge">4</div>
+                                </td>
+                                <td class="col-player">
+                                    <div class="player-info">
+                                        <img src="https://i.pravatar.cc/150?img=5" alt="Avatar" class="player-avatar">
+                                        <span class="player-name">NinjaCat</span>
+                                    </div>
+                                </td>
+                                <td class="col-score">7,100</td>
+                            </tr>
+                            
+                            <tr>
+                                <td class="col-rank">
+                                    <div class="rank-badge">5</div>
+                                </td>
+                                <td class="col-player">
+                                    <div class="player-info">
+                                        <img src="https://i.pravatar.cc/150?img=8" alt="Avatar" class="player-avatar">
+                                        <span class="player-name">CosmicRay</span>
+                                    </div>
+                                </td>
+                                <td class="col-score">6,840</td>
+                            </tr>
+                            
+                        </tbody>
+                        
+                    </table>
+                </div>
+                
+                <div class="card-footer">
+                    <button class="btn-load">Load More</button>
+                </div>
+                
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-leaderboard-table-pure/style.css
+++ b/submissions/examples/css-leaderboard-table-pure/style.css
@@ -1,0 +1,314 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    
+    --card-bg: #ffffff;
+    --card-border: #e2e8f0;
+    --card-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.05), 0 4px 6px -2px rgba(0, 0, 0, 0.025);
+    
+    --table-header: #f1f5f9;
+    --table-border: #f1f5f9;
+    --table-hover: #f8fafc;
+    
+    /* Base Rank Badge (Standard) */
+    --badge-bg: #f1f5f9;
+    --badge-text: #64748b;
+    --badge-border: #cbd5e1;
+    
+    /* Medals */
+    --gold-bg: #fef3c7;
+    --gold-text: #b45309;
+    --gold-border: #f59e0b;
+    
+    --silver-bg: #f1f5f9;
+    --silver-text: #475569;
+    --silver-border: #94a3b8;
+    
+    --bronze-bg: #ffedd5;
+    --bronze-text: #9a3412;
+    --bronze-border: #ea580c;
+    
+    --btn-color: #3b82f6;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a;
+        --text-primary: #f8fafc;
+        --text-secondary: #94a3b8;
+        
+        --card-bg: #1e293b;
+        --card-border: #334155;
+        --card-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.4), 0 4px 6px -2px rgba(0, 0, 0, 0.2);
+        
+        --table-header: #0f172a;
+        --table-border: #334155;
+        --table-hover: #0f172a;
+        
+        /* Base Rank Badge (Standard) */
+        --badge-bg: #334155;
+        --badge-text: #94a3b8;
+        --badge-border: #475569;
+        
+        /* Medals */
+        --gold-bg: rgba(245, 158, 11, 0.15);
+        --gold-text: #fcd34d;
+        --gold-border: #f59e0b;
+        
+        --silver-bg: rgba(148, 163, 184, 0.15);
+        --silver-text: #e2e8f0;
+        --silver-border: #94a3b8;
+        
+        --bronze-bg: rgba(234, 88, 12, 0.15);
+        --bronze-text: #fdba74;
+        --bronze-border: #ea580c;
+        
+        --btn-color: #60a5fa;
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 60px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 800;
+    margin: 0 0 16px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 400px;
+}
+
+
+/* =========================================
+   Leaderboard Card
+   ========================================= */
+
+.leaderboard-card {
+    width: 100%;
+    max-width: 480px;
+    background-color: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 16px;
+    box-shadow: var(--card-shadow);
+    overflow: hidden; /* Contains the table radius */
+}
+
+.card-header {
+    padding: 24px 24px 16px 24px;
+    border-bottom: 1px solid var(--table-border);
+}
+
+.card-header h2 {
+    margin: 0 0 4px 0;
+    font-size: 1.25rem;
+    font-weight: 700;
+}
+
+.card-header p {
+    margin: 0;
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+}
+
+
+/* =========================================
+   Table Styling
+   ========================================= */
+
+.table-wrapper {
+    width: 100%;
+    overflow-x: auto;
+}
+
+.leaderboard-table {
+    width: 100%;
+    border-collapse: collapse;
+    text-align: left;
+}
+
+.leaderboard-table th {
+    background-color: var(--table-header);
+    color: var(--text-secondary);
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    padding: 12px 24px;
+    border-bottom: 1px solid var(--table-border);
+}
+
+.leaderboard-table td {
+    padding: 16px 24px;
+    border-bottom: 1px solid var(--table-border);
+    transition: background-color 0.2s ease;
+}
+
+/* Column Widths */
+.col-rank { width: 60px; text-align: center; }
+.col-player { min-width: 180px; }
+.col-score { text-align: right; font-weight: 700; font-variant-numeric: tabular-nums; }
+
+/* Interactive rows */
+.leaderboard-table tbody tr {
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.leaderboard-table tbody tr:hover td {
+    background-color: var(--table-hover);
+}
+
+.leaderboard-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+
+/* =========================================
+   Player Info & Avatar
+   ========================================= */
+
+.player-info {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.player-avatar {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    object-fit: cover;
+    background-color: var(--badge-bg);
+}
+
+.player-name {
+    font-weight: 600;
+}
+
+
+/* =========================================
+   [TECHNIQUE] Auto-Medal System using :nth-child
+   ========================================= */
+
+.rank-badge {
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    font-size: 0.85rem;
+    font-weight: 700;
+    
+    /* Default Styling (Rank 4+) */
+    background-color: var(--badge-bg);
+    color: var(--badge-text);
+    border: 1px solid var(--badge-border);
+}
+
+/* 1st Place - Gold */
+.leaderboard-table tbody tr:nth-child(1) {
+    background-color: rgba(245, 158, 11, 0.03); /* Slight tint to the whole row */
+}
+.leaderboard-table tbody tr:nth-child(1) .rank-badge {
+    background-color: var(--gold-bg);
+    color: var(--gold-text);
+    border-color: var(--gold-border);
+    box-shadow: 0 0 10px rgba(245, 158, 11, 0.3);
+    transform: scale(1.15); /* Slightly larger */
+}
+.leaderboard-table tbody tr:nth-child(1) .col-score { color: var(--gold-border); }
+.leaderboard-table tbody tr:nth-child(1) .player-avatar { border: 2px solid var(--gold-border); padding: 2px; }
+
+/* 2nd Place - Silver */
+.leaderboard-table tbody tr:nth-child(2) .rank-badge {
+    background-color: var(--silver-bg);
+    color: var(--silver-text);
+    border-color: var(--silver-border);
+    box-shadow: 0 0 8px rgba(148, 163, 184, 0.3);
+    transform: scale(1.05);
+}
+
+/* 3rd Place - Bronze */
+.leaderboard-table tbody tr:nth-child(3) .rank-badge {
+    background-color: var(--bronze-bg);
+    color: var(--bronze-text);
+    border-color: var(--bronze-border);
+    box-shadow: 0 0 8px rgba(234, 88, 12, 0.3);
+    transform: scale(1.05);
+}
+
+
+/* =========================================
+   Footer Button
+   ========================================= */
+
+.card-footer {
+    padding: 16px;
+    text-align: center;
+    border-top: 1px solid var(--table-border);
+    background-color: var(--card-bg);
+}
+
+.btn-load {
+    background: none;
+    border: none;
+    color: var(--btn-color);
+    font-family: inherit;
+    font-size: 0.9rem;
+    font-weight: 600;
+    cursor: pointer;
+    padding: 8px 16px;
+    border-radius: 6px;
+    transition: background-color 0.2s ease;
+}
+
+.btn-load:hover {
+    background-color: rgba(59, 130, 246, 0.1);
+}
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    .leaderboard-table tbody tr,
+    .leaderboard-table tbody tr td,
+    .btn-load {
+        transition: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a pure CSS ranked leaderboard table utilizing advanced CSS pseudo-selectors to automatically apply Gold, Silver, and Bronze medal styling to the top rows, built without JavaScript, resolving issue #68540.

### Changes Made:
- Added `submissions/examples/css-leaderboard-table-pure/` directory.
- Created `demo.html` showcasing the HTML structure containing the semantic table and dummy player data.
- Created `style.css` featuring the UI mechanics:
  - **Auto-Medal Styling**: We do not manually apply `.is-gold`, `.is-silver`, or `.is-bronze` classes to the HTML rows. Instead, we use the `tbody tr:nth-child(n)` selector in CSS.
  - When the browser renders the table, CSS automatically detects the 1st, 2nd, and 3rd `<tr>` elements inside the `<tbody>` and dynamically overrides their `.rank-badge` variables with the appropriate gold, silver, or bronze theme colors, scale transforms, and box-shadow glows.
  - The Gold row (`:nth-child(1)`) receives additional layout flair, including a subtle row background tint, colored score text, and an avatar border ring.
  - **Theming & Dark Mode Supported**: Utilizes CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), providing a sleek dark mode variant with glowing medal badges.
- Added `README.md` documenting usage and the technical mechanics of the `:nth-child` auto-medal logic.
- Fully accessible semantic `<table>` structure utilizing `<thead>`, `<tbody>`, `<th>`, and `<td>` elements with proper `scope` attributes for screen readers. Honors the `prefers-reduced-motion` accessibility standard.

Closes #68540
