### PR TITLE
feat: add CSS Circular Skill Chart example

### DIFF
--- a/submissions/examples/css-circular-skill-chart-68220/README.md
+++ b/submissions/examples/css-circular-skill-chart-68220/README.md
@@ -1,0 +1,35 @@
+# CSS Circular Skill Chart
+
+## Description
+
+A pure CSS circular skill chart component that visually represents proficiency percentages using conic gradients.
+
+## Features
+
+- Pure CSS implementation
+- Circular percentage indicators
+- Smooth scale-in animation
+- Responsive layout
+- Multiple skill examples
+- No JavaScript required
+
+## File Structure
+
+css-circular-skill-chart-68220/
+├── demo.html
+├── style.css
+└── README.md
+
+## Usage
+
+Open `demo.html` directly in any modern browser.
+
+## Accessibility
+
+- Semantic content structure
+- Readable percentage labels
+- Responsive design
+
+## Author
+
+Created for EaseMotion CSS contribution #68220.

--- a/submissions/examples/css-circular-skill-chart-68220/demo.html
+++ b/submissions/examples/css-circular-skill-chart-68220/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>CSS Circular Skill Chart</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="skills-container">
+
+  <div class="skill-card">
+    <div class="circle skill-90">
+      <span>90%</span>
+    </div>
+    <h3>HTML</h3>
+  </div>
+
+  <div class="skill-card">
+    <div class="circle skill-80">
+      <span>80%</span>
+    </div>
+    <h3>CSS</h3>
+  </div>
+
+  <div class="skill-card">
+    <div class="circle skill-70">
+      <span>70%</span>
+    </div>
+    <h3>JavaScript</h3>
+  </div>
+
+</div>
+
+</body>
+</html>

--- a/submissions/examples/css-circular-skill-chart-68220/style.css
+++ b/submissions/examples/css-circular-skill-chart-68220/style.css
@@ -1,0 +1,86 @@
+*{
+  margin:0;
+  padding:0;
+  box-sizing:border-box;
+}
+
+body{
+  min-height:100vh;
+  display:flex;
+  justify-content:center;
+  align-items:center;
+  background:#f5f7fb;
+  font-family:Arial,sans-serif;
+  padding:2rem;
+}
+
+.skills-container{
+  display:flex;
+  gap:2rem;
+  flex-wrap:wrap;
+  justify-content:center;
+}
+
+.skill-card{
+  text-align:center;
+}
+
+.circle{
+  width:150px;
+  height:150px;
+  border-radius:50%;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  position:relative;
+  animation:grow 1.5s ease;
+}
+
+.circle::before{
+  content:"";
+  position:absolute;
+  width:115px;
+  height:115px;
+  background:white;
+  border-radius:50%;
+}
+
+.circle span{
+  position:relative;
+  z-index:2;
+  font-size:1.5rem;
+  font-weight:bold;
+  color:#111827;
+}
+
+.skill-90{
+  background:
+  conic-gradient(#6366f1 0deg 324deg,
+  #e5e7eb 324deg 360deg);
+}
+
+.skill-80{
+  background:
+  conic-gradient(#10b981 0deg 288deg,
+  #e5e7eb 288deg 360deg);
+}
+
+.skill-70{
+  background:
+  conic-gradient(#f59e0b 0deg 252deg,
+  #e5e7eb 252deg 360deg);
+}
+
+h3{
+  margin-top:1rem;
+  color:#374151;
+}
+
+@keyframes grow{
+  from{
+    transform:scale(0);
+  }
+  to{
+    transform:scale(1);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---
## closes #68220 

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

### What does this add?

A pure CSS circular skill chart that displays skill proficiency percentages using animated conic-gradient progress rings.

### How does a developer use it?

```html
<div class="skill-card">
  <div class="circle skill-90">
    <span>90%</span>
  </div>
  <h3>HTML</h3>
</div>