### PR TITLE
feat: add CSS Glitch Text Effect example

### DIFF
--- a/submissions/examples/css-glitch-text-effect-68230/README.md
+++ b/submissions/examples/css-glitch-text-effect-68230/README.md
@@ -1,0 +1,29 @@
+# CSS Glitch Text Effect
+
+## Description
+
+A pure CSS RGB split glitch animation that creates a digital distortion effect on heading text using pseudo-elements and keyframe animations.
+
+## Features
+
+- Pure CSS implementation
+- RGB split glitch effect
+- Animated pseudo-elements
+- Responsive typography
+- No JavaScript required
+
+## File Structure
+
+css-glitch-text-effect-68230/
+├── demo.html
+├── style.css
+└── README.md
+
+## Usage
+
+Link the stylesheet and apply the `.glitch` class.
+
+```html
+<h1 class="glitch" data-text="GLITCH EFFECT">
+  GLITCH EFFECT
+</h1>

--- a/submissions/examples/css-glitch-text-effect-68230/demo.html
+++ b/submissions/examples/css-glitch-text-effect-68230/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Glitch Text Effect</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <section class="hero">
+    <h1 class="glitch" data-text="GLITCH EFFECT">
+      GLITCH EFFECT
+    </h1>
+
+    <p>
+      Pure CSS RGB split glitch animation using pseudo-elements.
+    </p>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/css-glitch-text-effect-68230/style.css
+++ b/submissions/examples/css-glitch-text-effect-68230/style.css
@@ -1,0 +1,91 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #090909;
+  color: white;
+  font-family: Arial, sans-serif;
+}
+
+.hero {
+  text-align: center;
+}
+
+.glitch {
+  position: relative;
+  font-size: clamp(3rem, 10vw, 7rem);
+  font-weight: 800;
+  letter-spacing: 4px;
+  text-transform: uppercase;
+  color: #fff;
+  animation: glitch-main 2s infinite;
+}
+
+.glitch::before,
+.glitch::after {
+  content: attr(data-text);
+  position: absolute;
+  inset: 0;
+}
+
+.glitch::before {
+  color: #ff0055;
+  transform: translate(-3px, 0);
+  clip-path: inset(0 0 50% 0);
+  animation: glitch-top 1s infinite linear alternate;
+}
+
+.glitch::after {
+  color: #00e5ff;
+  transform: translate(3px, 0);
+  clip-path: inset(50% 0 0 0);
+  animation: glitch-bottom 1.2s infinite linear alternate;
+}
+
+@keyframes glitch-main {
+  0%,100% {
+    transform: translate(0);
+  }
+  20% {
+    transform: translate(-2px,2px);
+  }
+  40% {
+    transform: translate(2px,-2px);
+  }
+  60% {
+    transform: translate(-1px,1px);
+  }
+  80% {
+    transform: translate(1px,-1px);
+  }
+}
+
+@keyframes glitch-top {
+  0% {
+    transform: translate(-3px,0);
+  }
+  50% {
+    transform: translate(4px,-2px);
+  }
+  100% {
+    transform: translate(-4px,2px);
+  }
+}
+
+@keyframes glitch-bottom {
+  0% {
+    transform: translate(3px,0);
+  }
+  50% {
+    transform: translate(-4px,2px);
+  }
+  100% {
+    transform: translate(4px,-2px);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---
## closes #68230 

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

### What does this add?

Adds a pure CSS RGB-split Glitch Text Effect using pseudo-elements and keyframe animations to create a digital distortion appearance on headings.

### How does a developer use it?

```html
<h1 class="glitch" data-text="GLITCH EFFECT">
  GLITCH EFFECT
</h1>
