### PR TITLE
feat: add CSS OTP input fields

### DIFF
--- a/submissions/examples/css-otp-input-fields/README.md
+++ b/submissions/examples/css-otp-input-fields/README.md
@@ -1,0 +1,38 @@
+# CSS OTP Input Fields
+
+A responsive six-digit OTP input component with animated focus states, automatic focus advancement, keyboard navigation, and complete OTP paste support.
+
+## Features
+
+- Six separate OTP input fields
+- Automatic focus advancement
+- Backspace navigation
+- Left and right arrow navigation
+- Paste support for complete OTP codes
+- Numeric input optimization for mobile devices
+- Accessible labels and form structure
+- Responsive layout
+- Light and dark color-scheme support
+- CSS custom properties for easy customization
+- Reduced-motion support
+- No external dependencies
+
+## Files
+
+- `demo.html` — Standalone demo with OTP behavior
+- `style.css` — Component styling and responsive design
+- `README.md` — Documentation
+
+## Usage
+
+Add the OTP input structure to your page:
+
+```html
+<div class="otp-inputs" role="group" aria-label="One-time password">
+  <input class="otp-input" type="text" inputmode="numeric" maxlength="1" aria-label="Digit 1 of 6">
+  <input class="otp-input" type="text" inputmode="numeric" maxlength="1" aria-label="Digit 2 of 6">
+  <input class="otp-input" type="text" inputmode="numeric" maxlength="1" aria-label="Digit 3 of 6">
+  <input class="otp-input" type="text" inputmode="numeric" maxlength="1" aria-label="Digit 4 of 6">
+  <input class="otp-input" type="text" inputmode="numeric" maxlength="1" aria-label="Digit 5 of 6">
+  <input class="otp-input" type="text" inputmode="numeric" maxlength="1" aria-label="Digit 6 of 6">
+</div>

--- a/submissions/examples/css-otp-input-fields/demo.html
+++ b/submissions/examples/css-otp-input-fields/demo.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Accessible six-digit OTP input component with auto-advance and paste support.">
+  <title>CSS OTP Input Fields</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo">
+    <section class="otp-card" aria-labelledby="otp-title">
+      <div class="otp-icon" aria-hidden="true">✓</div>
+
+      <h1 id="otp-title">Verify your account</h1>
+      <p class="otp-description">
+        Enter the six-digit verification code sent to you.
+      </p>
+
+      <form class="otp-form" action="#" method="post">
+        <fieldset class="otp-group">
+          <legend class="sr-only">Six-digit verification code</legend>
+
+          <div class="otp-inputs" role="group" aria-label="One-time password">
+            <input
+              class="otp-input"
+              type="text"
+              inputmode="numeric"
+              autocomplete="one-time-code"
+              maxlength="1"
+              pattern="[0-9]"
+              aria-label="Digit 1 of 6"
+              required
+              autofocus
+            >
+            <input
+              class="otp-input"
+              type="text"
+              inputmode="numeric"
+              maxlength="1"
+              pattern="[0-9]"
+              aria-label="Digit 2 of 6"
+              required
+            >
+            <input
+              class="otp-input"
+              type="text"
+              inputmode="numeric"
+              maxlength="1"
+              pattern="[0-9]"
+              aria-label="Digit 3 of 6"
+              required
+            >
+            <input
+              class="otp-input"
+              type="text"
+              inputmode="numeric"
+              maxlength="1"
+              pattern="[0-9]"
+              aria-label="Digit 4 of 6"
+              required
+            >
+            <input
+              class="otp-input"
+              type="text"
+              inputmode="numeric"
+              maxlength="1"
+              pattern="[0-9]"
+              aria-label="Digit 5 of 6"
+              required
+            >
+            <input
+              class="otp-input"
+              type="text"
+              inputmode="numeric"
+              maxlength="1"
+              pattern="[0-9]"
+              aria-label="Digit 6 of 6"
+              required
+            >
+          </div>
+        </fieldset>
+
+        <button class="verify-button" type="submit">
+          Verify code
+        </button>
+      </form>
+
+      <p class="otp-hint">
+        You can also paste the complete six-digit code.
+      </p>
+    </section>
+  </main>
+
+  <script>
+    const inputs = [...document.querySelectorAll(".otp-input")];
+
+    const focusInput = (index) => {
+      if (index >= 0 && index < inputs.length) {
+        inputs[index].focus();
+        inputs[index].select();
+      }
+    };
+
+    inputs.forEach((input, index) => {
+      input.addEventListener("input", (event) => {
+        const value = event.target.value.replace(/\D/g, "");
+
+        event.target.value = value.slice(-1);
+
+        if (event.target.value && index < inputs.length - 1) {
+          focusInput(index + 1);
+        }
+      });
+
+      input.addEventListener("keydown", (event) => {
+        if (event.key === "Backspace" && !input.value && index > 0) {
+          event.preventDefault();
+          inputs[index - 1].value = "";
+          focusInput(index - 1);
+        }
+
+        if (event.key === "ArrowLeft" && index > 0) {
+          event.preventDefault();
+          focusInput(index - 1);
+        }
+
+        if (event.key === "ArrowRight" && index < inputs.length - 1) {
+          event.preventDefault();
+          focusInput(index + 1);
+        }
+      });
+
+      input.addEventListener("paste", (event) => {
+        event.preventDefault();
+
+        const pasted = event.clipboardData
+          .getData("text")
+          .replace(/\D/g, "")
+          .slice(0, inputs.length);
+
+        pasted.split("").forEach((digit, offset) => {
+          if (inputs[index + offset]) {
+            inputs[index + offset].value = digit;
+          }
+        });
+
+        const nextIndex = Math.min(
+          index + pasted.length,
+          inputs.length - 1
+        );
+
+        focusInput(nextIndex);
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/css-otp-input-fields/style.css
+++ b/submissions/examples/css-otp-input-fields/style.css
@@ -1,0 +1,246 @@
+:root {
+  --otp-bg: #0f172a;
+  --otp-card: #111827;
+  --otp-text: #f8fafc;
+  --otp-muted: #94a3b8;
+  --otp-border: #334155;
+  --otp-accent: #6366f1;
+  --otp-accent-soft: rgba(99, 102, 241, 0.18);
+  --otp-button: #6366f1;
+  --otp-button-hover: #4f46e5;
+  --otp-input-bg: #1e293b;
+  --otp-radius: 14px;
+  --otp-size: clamp(3rem, 10vw, 4.25rem);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  min-height: 100%;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background:
+    radial-gradient(circle at top, #1e293b 0, var(--otp-bg) 45%, #020617 100%);
+  color: var(--otp-text);
+}
+
+button,
+input {
+  font: inherit;
+}
+
+.demo {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1rem;
+}
+
+.otp-card {
+  width: min(100%, 30rem);
+  padding: clamp(1.75rem, 6vw, 3rem);
+  text-align: center;
+  background: color-mix(in srgb, var(--otp-card) 94%, transparent);
+  border: 1px solid var(--otp-border);
+  border-radius: 24px;
+  box-shadow:
+    0 24px 70px rgba(0, 0, 0, 0.35),
+    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.otp-icon {
+  width: 3.5rem;
+  height: 3.5rem;
+  display: grid;
+  place-items: center;
+  margin: 0 auto 1.25rem;
+  border-radius: 50%;
+  background: var(--otp-accent-soft);
+  color: #a5b4fc;
+  font-size: 1.4rem;
+  font-weight: 800;
+}
+
+.otp-card h1 {
+  margin: 0;
+  font-size: clamp(1.5rem, 5vw, 2rem);
+  line-height: 1.2;
+}
+
+.otp-description {
+  max-width: 24rem;
+  margin: 0.75rem auto 2rem;
+  color: var(--otp-muted);
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.otp-group {
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.otp-inputs {
+  display: flex;
+  justify-content: center;
+  gap: clamp(0.4rem, 2vw, 0.75rem);
+}
+
+.otp-input {
+  width: var(--otp-size);
+  height: var(--otp-size);
+  flex: 0 1 var(--otp-size);
+  border: 1px solid var(--otp-border);
+  border-radius: var(--otp-radius);
+  outline: none;
+  background: var(--otp-input-bg);
+  color: var(--otp-text);
+  text-align: center;
+  font-size: clamp(1.4rem, 5vw, 1.8rem);
+  font-weight: 700;
+  caret-color: var(--otp-accent);
+  transition:
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease,
+    background-color 180ms ease;
+}
+
+.otp-input:hover {
+  border-color: #475569;
+}
+
+.otp-input:focus {
+  border-color: var(--otp-accent);
+  background: #273449;
+  box-shadow:
+    0 0 0 4px var(--otp-accent-soft),
+    0 8px 20px rgba(0, 0, 0, 0.2);
+  transform: translateY(-2px);
+}
+
+.otp-input:valid:not(:placeholder-shown) {
+  border-color: #4f46e5;
+}
+
+.verify-button {
+  width: 100%;
+  margin-top: 1.75rem;
+  padding: 0.9rem 1.25rem;
+  border: 0;
+  border-radius: 12px;
+  background: var(--otp-button);
+  color: #fff;
+  cursor: pointer;
+  font-weight: 700;
+  transition:
+    background-color 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.verify-button:hover {
+  background: var(--otp-button-hover);
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(79, 70, 229, 0.25);
+}
+
+.verify-button:focus-visible {
+  outline: 3px solid #c7d2fe;
+  outline-offset: 3px;
+}
+
+.verify-button:active {
+  transform: translateY(0);
+}
+
+.otp-hint {
+  margin: 1.25rem 0 0;
+  color: var(--otp-muted);
+  font-size: 0.8rem;
+  line-height: 1.5;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --otp-bg: #eef2ff;
+    --otp-card: #ffffff;
+    --otp-text: #172033;
+    --otp-muted: #64748b;
+    --otp-border: #dbe2ea;
+    --otp-input-bg: #f8fafc;
+    --otp-accent-soft: rgba(99, 102, 241, 0.12);
+  }
+
+  body {
+    background:
+      radial-gradient(circle at top, #ffffff 0, #eef2ff 55%, #e0e7ff 100%);
+  }
+
+  .otp-card {
+    box-shadow:
+      0 24px 70px rgba(30, 41, 59, 0.12),
+      inset 0 1px 0 rgba(255, 255, 255, 0.8);
+  }
+
+  .otp-input:focus {
+    background: #ffffff;
+  }
+}
+
+@media (max-width: 420px) {
+  .demo {
+    padding: 1rem 0.75rem;
+  }
+
+  .otp-card {
+    padding: 1.5rem 1rem;
+    border-radius: 20px;
+  }
+
+  .otp-inputs {
+    gap: 0.35rem;
+  }
+
+  :root {
+    --otp-size: clamp(2.65rem, 13vw, 3.5rem);
+    --otp-radius: 10px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a responsive six-digit OTP input component with automatic focus advancement, keyboard navigation, paste support, accessible labels, and customizable styling.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to** **`core/`**
- [x] **No changes to** **`components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

This PR adds a six-box OTP input component designed for entering one-time verification codes. It includes responsive styling, animated focus states, numeric input support, keyboard navigation, automatic focus advancement, and complete OTP paste handling.

**How does a developer use it?**

Add the OTP input fields using the provided `otp-input` classes:

```html
<div class="otp-inputs" role="group" aria-label="One-time password">
  <input class="otp-input" type="text" inputmode="numeric"
         maxlength="1" aria-label="Digit 1 of 6">

  <input class="otp-input" type="text" inputmode="numeric"
         maxlength="1" aria-label="Digit 2 of 6">

  <input class="otp-input" type="text" inputmode="numeric"
         maxlength="1" aria-label="Digit 3 of 6">

  <input class="otp-input" type="text" inputmode="numeric"
         maxlength="1" aria-label="Digit 4 of 6">

  <input class="otp-input" type="text" inputmode="numeric"
         maxlength="1" aria-label="Digit 5 of 6">

  <input class="otp-input" type="text" inputmode="numeric"
         maxlength="1" aria-label="Digit 6 of 6">
</div>

**Why does it fit EaseMotion CSS?**

The component provides a reusable and polished authentication UI pattern with CSS-driven visual states and transitions. It is responsive, customizable through CSS custom properties, accessible, and requires no external libraries.

---

## Demo

- [ ] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [*] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Added under submissions/examples/css-otp-input-fields/
Includes demo.html, style.css, and README.md
Supports six-digit OTP entry, auto-advance, backspace navigation, arrow-key navigation, and OTP paste.
Includes responsive styling and light/dark color-scheme support.
Includes accessibility labels and reduced-motion support.
No changes were made to core/ or components/.

Closes #68196

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
