### PR TITLE
Add ease-vintage-radio-tuner component

### DIFF
--- a/submissions/examples/vintage-radio-tuner-ij/README.md
+++ b/submissions/examples/vintage-radio-tuner-ij/README.md
@@ -1,0 +1,11 @@
+# ease-vintage-radio-tuner
+
+A vintage radio tuner where the needle sweeps, the power glows, and the knobs tick.
+
+## Run
+Open `demo.html` directly in a browser to watch the tuner.
+
+## Notes
+- The frequency needle sweeps the dial.
+- The power light glows at the top.
+- The tuner knobs tick in turn.

--- a/submissions/examples/vintage-radio-tuner-ij/demo.html
+++ b/submissions/examples/vintage-radio-tuner-ij/demo.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-vintage-radio-tuner demo</title>
+</head>
+<body>
+<div class="vrt-set">
+  <span class="vrt-power"></span>
+  <b class="vrt-brand">AEROWAVE 1958</b>
+  <div class="vrt-dial">
+    <span class="vrt-freq">88</span>
+    <span class="vrt-freq">96</span>
+    <span class="vrt-freq">104</span>
+    <span class="vrt-freq">108</span>
+    <i class="vrt-needle"></i>
+  </div>
+  <div class="vrt-knobs">
+    <i class="vrt-knob vrt-tune"></i>
+    <i class="vrt-knob vrt-vol"></i>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/vintage-radio-tuner-ij/style.css
+++ b/submissions/examples/vintage-radio-tuner-ij/style.css
@@ -1,0 +1,11 @@
+.vrt-set{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:420px;background:linear-gradient(180deg,#7a4a2b,#5a3418);border:8px solid #3a2008;border-radius:16px;padding:24px;display:flex;flex-direction:column;gap:16px}
+.vrt-power{width:14px;height:14px;border-radius:50%;background:#34d399;align-self:flex-end;animation:vrt-power-glow-vintage-radio-tuner 2s ease-in-out infinite}
+.vrt-brand{text-align:center;font-size:13px;letter-spacing:6px;color:#ffd9a0;font-weight:800}
+.vrt-dial{position:relative;height:64px;background:#f2d9a8;border:3px solid #2c1608;border-radius:8px;display:flex;align-items:flex-end;justify-content:space-between;padding:0 10px}
+.vrt-freq{font-size:10px;color:#4a2a10;font-weight:700;padding-bottom:6px}
+.vrt-needle{position:absolute;top:2px;left:50%;width:3px;height:56px;background:#c0392b;transform-origin:50% 100%;transform:translateX(-50%) rotate(-20deg);animation:vrt-needle-sweep-vintage-radio-tuner 3.6s ease-in-out infinite}
+.vrt-knobs{display:flex;justify-content:center;gap:40px}
+.vrt-knob{width:46px;height:46px;border-radius:50%;background:#3a2008;border:3px solid #1f1004;box-shadow:inset 0 0 0 4px #6b3f1d;animation:vrt-knob-tick-vintage-radio-tuner 3.6s ease-in-out infinite}
+@keyframes vrt-needle-sweep-vintage-radio-tuner{0%{transform:translateX(-50%) rotate(-20deg)}50%{transform:translateX(-50%) rotate(16deg)}100%{transform:translateX(-50%) rotate(-20deg)}}
+@keyframes vrt-power-glow-vintage-radio-tuner{0%{box-shadow:0 0 4px rgba(52,211,153,0.4)}50%{box-shadow:0 0 14px rgba(52,211,153,0.9)}100%{box-shadow:0 0 4px rgba(52,211,153,0.4)}}
+@keyframes vrt-knob-tick-vintage-radio-tuner{0%,24%{transform:rotate(0)}34%,48%{transform:rotate(20deg)}58%,100%{transform:rotate(0)}}


### PR DESCRIPTION
## Component: ease-vintage-radio-tuner — needle sweeps, power glows, and knobs tick

**Closes #69462**

### What this adds
A vintage radio tuner: the frequency needle sweeps across the dial, the power light glows, and the tuner knobs tick in turn.

### Acceptance Criteria covered
- Frequency needle sweeps the dial
- Power light glows at the top
- Tuner knobs tick in turn

### Files
- `submissions/examples/vintage-radio-tuner-ij/demo.html`
- `submissions/examples/vintage-radio-tuner-ij/style.css`
- `submissions/examples/vintage-radio-tuner-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the tuner.