### PR TITLE
Add ease-skeleton-shimmer example submission

### DIFF
--- a/submissions/examples/ease-skeleton-shimmer-ag/README.md
+++ b/submissions/examples/ease-skeleton-shimmer-ag/README.md
@@ -1,13 +1,47 @@
-# Skeleton Loading Shimmer
+# ease-skeleton-shimmer
 
-A modern skeleton placeholder with a sweeping light shimmer effect, commonly used to indicate that content is loading.
+Animated skeleton placeholders that display a moving gradient highlight while actual content is loading. Pure CSS/HTML — no JavaScript required.
 
-## Preview
+## Why this is useful
 
-Open `demo.html` in your browser to see a mock user profile card displaying the shimmer loading state.
+Skeleton loaders improve perceived performance and give users a visual cue that content is on its way, instead of a blank screen or a spinner. This component provides reusable shimmer blocks for common UI patterns:
 
-## Implementation Details
+- **Text lines** — paragraph/heading placeholders
+- **Profile row** — avatar + text combo (e.g. comment, user card)
+- **Content card** — thumbnail image + text lines (e.g. feed/dashboard card)
+- **Simple skeleton** — minimal `<div class="skeleton"><i></i>...</div>` structure matching common skeleton markup conventions
 
-- **No Images/JavaScript:** The shimmer is created entirely mathematically using CSS gradients.
-- **The Gradient:** The base color of the skeleton elements is a solid light gray (`#e2e5e7`). On top of that, a `linear-gradient` is applied as a `background-image`. This gradient transitions from transparent, to semi-transparent white (the "shimmer"), back to transparent.
-- **Animation:** The gradient's `background-size` is stretched to `200%` width. The `@keyframes shimmer` animation then continuously sweeps the `background-position` from left (`-200%`) to right (`200%`), passing the white highlight over the gray elements repeatedly.
+## How it works
+
+Each skeleton element is a solid-colored block (`.skeleton` / `.skeleton-line` / etc.) with a `::after` pseudo-element containing a translucent gradient. The gradient is animated with `transform: translateX()` from `-100%` to `100%`, creating a left-to-right sweeping highlight over the base color.
+
+```css
+.skeleton::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.65) 50%, transparent 100%);
+  animation: shimmer-sweep 1.6s ease-in-out infinite;
+}
+```
+
+## Usage
+
+```html
+<div class="skeleton-card">
+  <div class="skeleton skeleton-line w-80"></div>
+  <div class="skeleton skeleton-line w-100"></div>
+  <div class="skeleton skeleton-line w-60"></div>
+</div>
+```
+
+Width utility classes (`w-40` through `w-100`) let you vary line lengths for a more natural, non-uniform placeholder look.
+
+## Accessibility
+
+Respects `prefers-reduced-motion: reduce` — the shimmer animation is disabled for users who have that preference set.
+
+## Browser support
+
+Uses standard CSS `linear-gradient`, `transform`, and `@keyframes` — supported in all modern browsers.

--- a/submissions/examples/ease-skeleton-shimmer-ag/demo.html
+++ b/submissions/examples/ease-skeleton-shimmer-ag/demo.html
@@ -1,19 +1,68 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Skeleton Loading Shimmer</title>
-    <link rel="stylesheet" href="style.css">
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ease-skeleton-shimmer</title>
+<link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <div class="card">
-        <div class="skeleton skeleton-avatar"></div>
-        <div class="skeleton-text-container">
-            <div class="skeleton skeleton-title"></div>
-            <div class="skeleton skeleton-text"></div>
-            <div class="skeleton skeleton-text"></div>
+
+  <main class="showcase">
+    <h1 class="showcase-title">ease-skeleton-shimmer</h1>
+    <p class="showcase-subtitle">Animated skeleton placeholders with a moving gradient highlight</p>
+
+    <section class="demo-grid">
+
+      <!-- 1. Text lines -->
+      <div class="demo-block">
+        <h2 class="demo-label">Text Lines</h2>
+        <div class="skeleton-card">
+          <div class="skeleton skeleton-line w-80"></div>
+          <div class="skeleton skeleton-line w-100"></div>
+          <div class="skeleton skeleton-line w-60"></div>
         </div>
-    </div>
+      </div>
+
+      <!-- 2. Avatar + text (profile row) -->
+      <div class="demo-block">
+        <h2 class="demo-label">Profile Row</h2>
+        <div class="skeleton-card">
+          <div class="skeleton-profile">
+            <div class="skeleton skeleton-avatar"></div>
+            <div class="skeleton-profile-lines">
+              <div class="skeleton skeleton-line w-70"></div>
+              <div class="skeleton skeleton-line w-40"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- 3. Card block (image + text) -->
+      <div class="demo-block">
+        <h2 class="demo-label">Content Card</h2>
+        <div class="skeleton-card">
+          <div class="skeleton skeleton-thumbnail"></div>
+          <div class="skeleton skeleton-line w-90"></div>
+          <div class="skeleton skeleton-line w-100"></div>
+          <div class="skeleton skeleton-line w-50"></div>
+        </div>
+      </div>
+
+      <!-- 4. Original issue snippet: div.skeleton with <i> lines -->
+      <div class="demo-block">
+        <h2 class="demo-label">Simple Skeleton</h2>
+        <div class="skeleton-card">
+          <div class="skeleton">
+            <i></i>
+            <i></i>
+            <i></i>
+          </div>
+        </div>
+      </div>
+
+    </section>
+  </main>
+
 </body>
 </html>

--- a/submissions/examples/ease-skeleton-shimmer-ag/style.css
+++ b/submissions/examples/ease-skeleton-shimmer-ag/style.css
@@ -1,73 +1,156 @@
-body {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    height: 100vh;
-    margin: 0;
-    background-color: #f0f2f5;
+/* ===================================
+   ease-skeleton-shimmer
+   Animated skeleton placeholders with a moving gradient highlight,
+   used to indicate loading state for cards, dashboards, and feeds.
+   =================================== */
+
+.showcase {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 48px 24px;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #1a1a1a;
+  background: #f5f6fa;
 }
 
-.card {
-    background: #fff;
-    padding: 20px;
-    border-radius: 10px;
-    box-shadow: 0 4px 6px rgba(0,0,0,0.1);
-    display: flex;
-    align-items: center;
-    width: 350px;
-    gap: 15px;
+.showcase-title {
+  font-size: 2rem;
+  margin-bottom: 4px;
 }
 
+.showcase-subtitle {
+  color: #666;
+  margin-bottom: 32px;
+}
+
+.demo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 24px;
+}
+
+.demo-label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: #888;
+  margin-bottom: 12px;
+}
+
+.skeleton-card {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 20px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+}
+
+/* ---- Core shimmer block ---- */
 .skeleton {
-    background: #e2e5e7;
-    /* The linear gradient that creates the shimmer effect */
-    background-image: linear-gradient(
-        90deg, 
-        rgba(255, 255, 255, 0) 0, 
-        rgba(255, 255, 255, 0.5) 20%, 
-        rgba(255, 255, 255, 0) 40%,
-        rgba(255, 255, 255, 0) 100%
-    );
-    background-repeat: no-repeat;
-    background-size: 200% 100%;
-    animation: shimmer 1.5s infinite;
+  position: relative;
+  overflow: hidden;
+  background: #e4e6eb;
+  border-radius: 6px;
 }
 
+.skeleton::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0) 0%,
+    rgba(255, 255, 255, 0.65) 50%,
+    rgba(255, 255, 255, 0) 100%
+  );
+  animation: shimmer-sweep 1.6s ease-in-out infinite;
+}
+
+@keyframes shimmer-sweep {
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+/* ---- Text line variants ---- */
+.skeleton-line {
+  height: 12px;
+  margin-bottom: 10px;
+  border-radius: 6px;
+}
+.skeleton-line:last-child {
+  margin-bottom: 0;
+}
+
+.w-40  { width: 40%; }
+.w-50  { width: 50%; }
+.w-60  { width: 60%; }
+.w-70  { width: 70%; }
+.w-80  { width: 80%; }
+.w-90  { width: 90%; }
+.w-100 { width: 100%; }
+
+/* ---- Avatar ---- */
 .skeleton-avatar {
-    width: 60px;
-    height: 60px;
-    border-radius: 50%;
-    flex-shrink: 0;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  flex-shrink: 0;
 }
 
-.skeleton-text-container {
-    flex-grow: 1;
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
+.skeleton-profile {
+  display: flex;
+  align-items: center;
+  gap: 14px;
 }
 
-.skeleton-title {
-    width: 50%;
-    height: 20px;
-    border-radius: 4px;
+.skeleton-profile-lines {
+  flex: 1;
 }
 
-.skeleton-text {
-    width: 100%;
-    height: 12px;
-    border-radius: 4px;
+/* ---- Thumbnail / card image ---- */
+.skeleton-thumbnail {
+  width: 100%;
+  height: 120px;
+  border-radius: 8px;
+  margin-bottom: 14px;
 }
 
-.skeleton-text:last-child {
-    width: 80%;
+/* ---- Simple skeleton (matches the issue's HTML snippet: <div class="skeleton"><i></i>...) ---- */
+.skeleton > i {
+  display: block;
+  height: 12px;
+  margin-bottom: 10px;
+  border-radius: 6px;
+  background: #e4e6eb;
+  position: relative;
+  overflow: hidden;
+  font-style: normal;
 }
 
-@keyframes shimmer {
-    0% {
-        background-position: -200% 0;
-    }
-    100% {
-        background-position: 200% 0;
-    }
+.skeleton > i:nth-child(1) { width: 90%; }
+.skeleton > i:nth-child(2) { width: 100%; }
+.skeleton > i:nth-child(3) { width: 60%; margin-bottom: 0; }
+
+.skeleton > i::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0) 0%,
+    rgba(255, 255, 255, 0.65) 50%,
+    rgba(255, 255, 255, 0) 100%
+  );
+  animation: shimmer-sweep 1.6s ease-in-out infinite;
+}
+
+/* ---- Reduced motion support ---- */
+@media (prefers-reduced-motion: reduce) {
+  .skeleton::after,
+  .skeleton > i::after {
+    animation: none;
+  }
 }


### PR DESCRIPTION
closes #66727
## Pull Request Description
Adds a new pure CSS/HTML skeleton loading shimmer component with example variants for text lines, profile rows, and content cards.

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/ease-skeleton-shimmer-ag/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**
Animated skeleton placeholders with a moving gradient shimmer highlight, used to indicate a loading state for cards, dashboards, and feeds.

**How does a developer use it?**
```html
<div class="skeleton-card">
  <div class="skeleton skeleton-line w-80"></div>
  <div class="skeleton skeleton-line w-100"></div>
  <div class="skeleton skeleton-line w-60"></div>
</div>
```

**Why does it fit EaseMotion CSS?**
It's a pure CSS, class-based animation with human-readable naming (`skeleton`, `skeleton-line`, `skeleton-avatar`, `skeleton-thumbnail`) that requires no JavaScript and drops directly into existing markup — consistent with the library's animation-first, readable-class philosophy.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

---

## Notes for Maintainer
Also includes `prefers-reduced-motion` support to disable the shimmer animation for users with that preference set.