### PR TITLE
feat: add rounded tag badge demo

### DIFF
--- a/submissions/examples/rounded-tag-badge-kk/README.md
+++ b/submissions/examples/rounded-tag-badge-kk/README.md
@@ -1,0 +1,31 @@
+# Rounded Tag Badge
+
+## What it does
+
+This submission creates a simple CSS-only rounded tag badge utility for small labels such as Featured, New, Draft, Beta, or Pro.
+
+## How to use it
+
+Apply the badge class directly to an inline element:
+
+```html
+<span class="rounded-tag-badge">Featured</span>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful across many interfaces. It works well in cards, headers, pricing sections, badges, and lightweight status displays.
+
+## Included features
+
+- Pill-shaped badge utility
+- Soft, warm, and outline variations in the demo
+- Example card usage layout
+- Responsive demo layout
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained demo that opens directly in a browser
+- `style.css` - raw CSS for the badge utility
+- `README.md` - usage and contribution context

--- a/submissions/examples/rounded-tag-badge-kk/demo.html
+++ b/submissions/examples/rounded-tag-badge-kk/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Rounded Tag Badge</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <p class="eyebrow">Rounded Tag Badge</p>
+        <h1>Small pill-shaped labels for cards, headers, and UI status tags.</h1>
+        <p class="intro">
+          This demo shows a simple CSS-only badge utility for labels like
+          Featured, New, Draft, Beta, and Pro. It is lightweight, reusable, and
+          easy to apply across many interfaces.
+        </p>
+
+        <div class="badge-row">
+          <span class="rounded-tag-badge">Featured</span>
+          <span class="rounded-tag-badge soft">Beta</span>
+          <span class="rounded-tag-badge warm">New</span>
+          <span class="rounded-tag-badge outline">Pro</span>
+        </div>
+
+        <div class="example-card">
+          <div class="card-top">
+            <span class="rounded-tag-badge">Draft</span>
+            <span class="rounded-tag-badge soft">Internal</span>
+          </div>
+          <h2>Product Update Notes</h2>
+          <p>
+            Rounded tag badges can be used to quickly communicate lightweight
+            status information inside cards and section headers.
+          </p>
+        </div>
+
+        <div class="usage-panel">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;span class="rounded-tag-badge"&gt;Featured&lt;/span&gt;</code></pre>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/rounded-tag-badge-kk/style.css
+++ b/submissions/examples/rounded-tag-badge-kk/style.css
@@ -1,0 +1,140 @@
+:root {
+  color-scheme: dark;
+  --bg: #09111f;
+  --panel: rgba(13, 20, 36, 0.92);
+  --border: rgba(255, 255, 255, 0.09);
+  --text: #eef3ff;
+  --muted: #a2b1ce;
+  --soft: rgba(255, 255, 255, 0.08);
+  --accent: #8fa7ff;
+  --accent-soft: rgba(143, 167, 255, 0.18);
+  --warm: #ffbf7a;
+  --warm-soft: rgba(255, 191, 122, 0.16);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at top, rgba(143, 167, 255, 0.16), transparent 28%),
+    linear-gradient(180deg, #09111f 0%, #03060c 100%);
+  color: var(--text);
+}
+
+.demo-shell {
+  width: min(100%, 840px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border-radius: 28px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.38);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.76rem;
+  color: var(--muted);
+}
+
+h1 {
+  margin: 0.5rem 0 0.9rem;
+  font-size: clamp(2rem, 4vw, 2.9rem);
+  line-height: 1.08;
+  max-width: 14ch;
+}
+
+.intro,
+.example-card p {
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.badge-row,
+.card-top {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.badge-row {
+  margin: 1.8rem 0;
+}
+
+.rounded-tag-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.38rem 0.85rem;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 0.85rem;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.rounded-tag-badge.soft {
+  background: var(--soft);
+  color: var(--text);
+}
+
+.rounded-tag-badge.warm {
+  background: var(--warm-soft);
+  color: var(--warm);
+}
+
+.rounded-tag-badge.outline {
+  background: transparent;
+  color: var(--text);
+  border: 1px solid var(--border);
+}
+
+.example-card {
+  padding: 1.25rem;
+  border-radius: 22px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.example-card h2 {
+  margin: 0.9rem 0 0.4rem;
+  font-size: 1.2rem;
+}
+
+.usage-panel {
+  margin-top: 1.6rem;
+  padding: 1.1rem 1.2rem;
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #d7e2ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 640px) {
+  .demo-card {
+    padding: 1.4rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Rounded Tag Badge demo inside `submissions/examples/rounded-tag-badge-kk/`. This submission introduces a simple CSS-only pill-shaped badge utility for labels such as Featured, New, Draft, Beta, or Pro.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A CSS-only rounded badge utility for small labels that can be reused in cards, headers, pricing sections, and lightweight status displays.

**How does a developer use it?**

```html
<span class="rounded-tag-badge">Featured</span>