### PR TITLE
Add ease-pinball-scoreboard component

### DIFF
--- a/submissions/examples/pinball-scoreboard-ij/README.md
+++ b/submissions/examples/pinball-scoreboard-ij/README.md
@@ -1,0 +1,11 @@
+# ease-pinball-scoreboard
+
+A pinball scoreboard where the digits roll, the values flash, and the bonus blinks.
+
+## Run
+Open `demo.html` directly in a browser to watch the board.
+
+## Notes
+- The score digits roll in turn.
+- The bonus values flash on the row.
+- The multiplier blinks below.

--- a/submissions/examples/pinball-scoreboard-ij/demo.html
+++ b/submissions/examples/pinball-scoreboard-ij/demo.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-pinball-scoreboard demo</title>
+</head>
+<body>
+<div class="pnb-board">
+  <div class="pnb-total">
+    <i class="pnb-digit">1</i>
+    <i class="pnb-digit">4</i>
+    <i class="pnb-digit">2</i>
+    <i class="pnb-digit">0</i>
+    <i class="pnb-digit">0</i>
+  </div>
+  <div class="pnb-row">
+    <span class="pnb-label">BONUS</span>
+    <span class="pnb-value">25K</span>
+    <span class="pnb-label">BALL</span>
+    <span class="pnb-value">2</span>
+  </div>
+  <div class="pnb-mult">3X MULTIPLIER</div>
+</div>
+</body>
+</html>

--- a/submissions/examples/pinball-scoreboard-ij/style.css
+++ b/submissions/examples/pinball-scoreboard-ij/style.css
@@ -1,0 +1,14 @@
+.pnb-board{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:400px;background:#150a2e;border:4px solid #f5c542;border-radius:12px;padding:20px;display:flex;flex-direction:column;gap:16px}
+.pnb-total{display:flex;gap:8px;justify-content:center;background:#0a0520;border:2px solid #2a1a5e;border-radius:10px;padding:14px}
+.pnb-digit{width:46px;height:62px;background:#170e38;border-radius:6px;display:grid;place-items:center;font-size:34px;font-weight:800;color:#f5c542;animation:pnb-digit-roll-pinball-scoreboard 1.2s ease-in-out infinite}
+.pnb-digit:nth-child(2){animation-delay:0.12s}
+.pnb-digit:nth-child(3){animation-delay:0.24s}
+.pnb-digit:nth-child(4){animation-delay:0.36s}
+.pnb-digit:nth-child(5){animation-delay:0.48s}
+.pnb-row{display:flex;align-items:center;gap:10px;justify-content:center}
+.pnb-label{font-size:10px;letter-spacing:3px;color:#a97ab8}
+.pnb-value{font-size:16px;font-weight:800;color:#7cebb0;animation:pnb-value-flash-pinball-scoreboard 1.8s ease-in-out infinite}
+.pnb-mult{text-align:center;font-size:11px;font-weight:800;letter-spacing:3px;color:#f87171;animation:pnb-mult-blink-pinball-scoreboard 1.4s ease-in-out infinite}
+@keyframes pnb-digit-roll-pinball-scoreboard{0%{transform:translateY(0)}25%{transform:translateY(-6px)}50%{transform:translateY(0)}75%{transform:translateY(3px)}100%{transform:translateY(0)}}
+@keyframes pnb-value-flash-pinball-scoreboard{0%{opacity:0.6}50%{opacity:1}100%{opacity:0.6}}
+@keyframes pnb-mult-blink-pinball-scoreboard{0%{opacity:0.5}50%{opacity:1}100%{opacity:0.5}}


### PR DESCRIPTION
## Component: ease-pinball-scoreboard — digits roll, values flash, and bonus blinks

**Closes #69494**

### What this adds
A pinball scoreboard: the score digits roll in turn, the bonus values flash, and the multiplier blinks.

### Acceptance Criteria covered
- Score digits roll in turn
- Bonus values flash on the row
- Multiplier blinks below

### Files
- `submissions/examples/pinball-scoreboard-ij/demo.html`
- `submissions/examples/pinball-scoreboard-ij/style.css`
- `submissions/examples/pinball-scoreboard-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the board.