### PR TITLE
feat(examples): add morphing stepper process bar #69249

### DIFF
--- a/submissions/examples/ease-morphing-stepper/README.md
+++ b/submissions/examples/ease-morphing-stepper/README.md
@@ -1,0 +1,13 @@
+# Interactive Morphing Stepper Process Bar
+
+## 1. What does this do?
+This component provides a multi-step morphing progress bar built entirely with pure CSS. It features dynamic track filling, pulsing animations on the currently active step node, and checkmark state transitions for previously completed steps as users navigate through the process.
+
+## 2. How is it used?
+Hidden `<input type="radio">` element tags act as the pure HTML/CSS state engine. Clicking the `<label>` elements updates the selected radio button state. The CSS `:has()` relational pseudo-class parent selector inspects the checked radio state of `.ease-stepper-wrapper` to dynamically control styles across child elements:
+- Adjusts `.ease-track-fill` width based on the active step (0%, 33.33%, 66.66%, 100%).
+- Triggers active node styling and pulse keyframe animations (`@keyframes ease-node-pulse`).
+- Replaces step numbers on completed prior steps with `✓` checkmark pseudo-elements (`::after`).
+
+## 3. Why is it useful?
+It completely eliminates the need for JavaScript state arrays (`activeStep`), event listeners, or imperative DOM manipulation. By offloading state updates directly to the CSS engine and browser compositor, it delivers high performance, zero JS bundle overhead, and built-in accessibility through standard form controls and `prefers-reduced-motion` media queries.

--- a/submissions/examples/ease-morphing-stepper/demo.html
+++ b/submissions/examples/ease-morphing-stepper/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Interactive Morphing Stepper Process Bar</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="ease-stepper-wrapper">
+    <!-- State Management -->
+    <input type="radio" name="stepper" id="step-1" class="ease-step-radio" checked>
+    <input type="radio" name="stepper" id="step-2" class="ease-step-radio">
+    <input type="radio" name="stepper" id="step-3" class="ease-step-radio">
+    <input type="radio" name="stepper" id="step-4" class="ease-step-radio">
+    
+    <!-- Track & Nodes -->
+    <div class="ease-track-container">
+      <div class="ease-track-bg"></div>
+      <div class="ease-track-fill"></div>
+      
+      <label for="step-1" class="ease-step-node ease-node-1" tabindex="0">1<span class="ease-step-label">Account</span></label>
+      <label for="step-2" class="ease-step-node ease-node-2" tabindex="0">2<span class="ease-step-label">Profile</span></label>
+      <label for="step-3" class="ease-step-node ease-node-3" tabindex="0">3<span class="ease-step-label">Payment</span></label>
+      <label for="step-4" class="ease-step-node ease-node-4" tabindex="0">4<span class="ease-step-label">Complete</span></label>
+    </div>
+  </div>
+  <p style="position: absolute; bottom: 2rem; color: #475569; font-family: system-ui; font-size: 0.875rem;">Click the nodes to advance. Logic powered entirely by CSS :has() and Checkbox Hack.</p>
+</body>
+</html>

--- a/submissions/examples/ease-morphing-stepper/style.css
+++ b/submissions/examples/ease-morphing-stepper/style.css
@@ -1,0 +1,163 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #0f172a;
+  font-family: system-ui, sans-serif;
+  color: #f8fafc;
+}
+
+.ease-step-radio {
+  display: none;
+}
+
+.ease-stepper-wrapper {
+  position: relative;
+  width: 600px;
+  max-width: 90vw;
+  padding: 2rem;
+  background: #1e293b;
+  border-radius: 16px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
+}
+
+.ease-track-container {
+  position: relative;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2rem;
+}
+
+.ease-track-bg {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  height: 4px;
+  background: #334155;
+  transform: translateY(-50%);
+  z-index: 1;
+  border-radius: 2px;
+}
+
+.ease-track-fill {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  height: 4px;
+  background: #3b82f6;
+  transform: translateY(-50%);
+  z-index: 2;
+  border-radius: 2px;
+  transition: width 0.6s cubic-bezier(0.34, 1.56, 0.64, 1);
+  width: 0%;
+}
+
+.ease-step-node {
+  position: relative;
+  z-index: 3;
+  width: 40px;
+  height: 40px;
+  background: #1e293b;
+  border: 3px solid #334155;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-weight: bold;
+  cursor: pointer;
+  transition: all 0.4s ease;
+  box-sizing: border-box;
+}
+
+.ease-step-label {
+  position: absolute;
+  top: 50px;
+  white-space: nowrap;
+  font-size: 0.875rem;
+  color: #64748b;
+  font-weight: 600;
+  transition: color 0.4s ease;
+}
+
+/* Liquid Fill Widths */
+.ease-stepper-wrapper:has(#step-1:checked) .ease-track-fill {
+  width: 0%;
+}
+
+.ease-stepper-wrapper:has(#step-2:checked) .ease-track-fill {
+  width: 33.33%;
+}
+
+.ease-stepper-wrapper:has(#step-3:checked) .ease-track-fill {
+  width: 66.66%;
+}
+
+.ease-stepper-wrapper:has(#step-4:checked) .ease-track-fill {
+  width: 100%;
+}
+
+/* Active Node Pulse State */
+.ease-stepper-wrapper:has(#step-1:checked) .ease-node-1,
+.ease-stepper-wrapper:has(#step-2:checked) .ease-node-2,
+.ease-stepper-wrapper:has(#step-3:checked) .ease-node-3,
+.ease-stepper-wrapper:has(#step-4:checked) .ease-node-4 {
+  border-color: #3b82f6;
+  background: #3b82f6;
+  color: white;
+  animation: ease-node-pulse 2s infinite;
+}
+
+.ease-stepper-wrapper:has(#step-1:checked) .ease-node-1 .ease-step-label,
+.ease-stepper-wrapper:has(#step-2:checked) .ease-node-2 .ease-step-label,
+.ease-stepper-wrapper:has(#step-3:checked) .ease-node-3 .ease-step-label,
+.ease-stepper-wrapper:has(#step-4:checked) .ease-node-4 .ease-step-label {
+  color: #3b82f6;
+}
+
+/* Completed Node Checkmark State (Previous steps) */
+.ease-stepper-wrapper:has(#step-2:checked) .ease-node-1,
+.ease-stepper-wrapper:has(#step-3:checked) .ease-node-1,
+.ease-stepper-wrapper:has(#step-3:checked) .ease-node-2,
+.ease-stepper-wrapper:has(#step-4:checked) .ease-node-1,
+.ease-stepper-wrapper:has(#step-4:checked) .ease-node-2,
+.ease-stepper-wrapper:has(#step-4:checked) .ease-node-3 {
+  background: #10b981;
+  border-color: #10b981;
+  color: transparent;
+}
+
+.ease-stepper-wrapper:has(#step-2:checked) .ease-node-1::after,
+.ease-stepper-wrapper:has(#step-3:checked) .ease-node-1::after,
+.ease-stepper-wrapper:has(#step-3:checked) .ease-node-2::after,
+.ease-stepper-wrapper:has(#step-4:checked) .ease-node-1::after,
+.ease-stepper-wrapper:has(#step-4:checked) .ease-node-2::after,
+.ease-stepper-wrapper:has(#step-4:checked) .ease-node-3::after {
+  content: "✓";
+  position: absolute;
+  color: white;
+  font-size: 1.2rem;
+}
+
+@keyframes ease-node-pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.6);
+  }
+  70% {
+    box-shadow: 0 0 0 15px rgba(59, 130, 246, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(59, 130, 246, 0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-step-node {
+    animation: none !important;
+    transition: none !important;
+  }
+  .ease-track-fill {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds an interactive, multi-step morphing progress bar component to resolve Issue #69249. It utilizes pure CSS (the radio button hack combined with the modern `:has()` relational selector) to manage active node pulses, liquid track fill transitions, and previous-step checkmarks entirely without JavaScript.

Fixes #69249

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

An interactive, multi-step morphing progress bar with animated node pulses, completed state checkmarks, and liquid fill track transitions—powered entirely by pure CSS state logic.

**How does a developer use it?**

```html
<div class="ease-stepper-wrapper">
  <!-- CSS State Engine -->
  <input type="radio" name="stepper" id="step-1" class="ease-step-radio" checked>
  <input type="radio" name="stepper" id="step-2" class="ease-step-radio">
  <input type="radio" name="stepper" id="step-3" class="ease-step-radio">
  <input type="radio" name="stepper" id="step-4" class="ease-step-radio">
  
  <!-- Visual Track & Nodes -->
  <div class="ease-track-container">
    <div class="ease-track-bg"></div>
    <div class="ease-track-fill"></div>
    
    <label for="step-1" class="ease-step-node ease-node-1" tabindex="0">1<span class="ease-step-label">Account</span></label>
    <label for="step-2" class="ease-step-node ease-node-2" tabindex="0">2<span class="ease-step-label">Profile</span></label>
    <label for="step-3" class="ease-step-node ease-node-3" tabindex="0">3<span class="ease-step-label">Payment</span></label>
    <label for="step-4" class="ease-step-node ease-node-4" tabindex="0">4<span class="ease-step-label">Complete</span></label>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**

It replaces what is traditionally a heavy JavaScript state array (activeStep) with native, GPU-accelerated CSS compositor logic, perfectly aligning with EaseMotion's zero-JS, lightweight philosophy.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Directory Name Adjustment: The original issue requested placing this in gssoc-2026-interactive-morphing-stepper-bb/. However, that directory already existed in upstream main (likely an accidental push from the issue author). To prevent a Git tree collision and overriding existing files, I placed this pristine implementation in submissions/examples/ease-morphing-stepper/.

Technical Note: This component heavily leverages the :has() selector to traverse the DOM from the hidden radio inputs to determine track width percentages and node checkmark states natively.
---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
