### PR TITLE
Add ease-bowling-alley-scorer component

### DIFF
--- a/submissions/examples/bowling-alley-scorer-ij/README.md
+++ b/submissions/examples/bowling-alley-scorer-ij/README.md
@@ -1,0 +1,11 @@
+# ease-bowling-alley-scorer
+
+A bowling alley scorer where the balls pop, the spare blinks, and the frame flashes.
+
+## Run
+Open `demo.html` directly in a browser to watch the frames.
+
+## Notes
+- The ball results pop in the frames.
+- The spare symbol blinks in place.
+- The current frame flashes on the lane.

--- a/submissions/examples/bowling-alley-scorer-ij/demo.html
+++ b/submissions/examples/bowling-alley-scorer-ij/demo.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-bowling-alley-scorer demo</title>
+</head>
+<body>
+<div class="bwa-lane">
+  <div class="bwa-frame"><b>1</b><i class="bwa-ball">X</i><span class="bwa-total">30</span></div>
+  <div class="bwa-frame"><b>2</b><i class="bwa-ball">9</i><i class="bwa-ball bwa-spare">/</i><span class="bwa-total">49</span></div>
+  <div class="bwa-frame"><b>3</b><i class="bwa-ball">7</i><i class="bwa-ball">1</i><span class="bwa-total">57</span></div>
+  <div class="bwa-frame bwa-cur"><b>4</b><i class="bwa-ball">8</i><i class="bwa-ball"></i><span class="bwa-total">-</span></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/bowling-alley-scorer-ij/style.css
+++ b/submissions/examples/bowling-alley-scorer-ij/style.css
@@ -1,0 +1,10 @@
+.bwa-lane{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:440px;background:#0d1624;border:1px solid #1e3350;border-radius:12px;padding:18px;display:flex;gap:10px}
+.bwa-frame{flex:1;background:#16253a;border-radius:8px;padding:8px;display:grid;grid-template-columns:1fr 1fr;gap:4px}
+.bwa-frame b{grid-column:1/3;font-size:9px;color:#5d7690}
+.bwa-ball{height:34px;border-radius:6px;background:#24344c;display:grid;place-items:center;font-size:14px;font-weight:800;color:#e8f0f8;animation:bwa-ball-pop-bowling-alley-scorer 2s ease-in-out infinite}
+.bwa-spare{background:#1f5c3e;color:#7cebb0;animation:bwa-spare-blink-bowling-alley-scorer 1.6s ease-in-out infinite}
+.bwa-total{grid-column:1/3;font-size:12px;font-weight:800;color:#f5c542;text-align:center;padding-top:4px}
+.bwa-cur{border:2px solid #38bdf8;animation:bwa-frame-flash-bowling-alley-scorer 1.8s ease-in-out infinite}
+@keyframes bwa-ball-pop-bowling-alley-scorer{0%,70%{transform:scale(1)}80%{transform:scale(1.12)}100%{transform:scale(1)}}
+@keyframes bwa-spare-blink-bowling-alley-scorer{0%{opacity:0.5}50%{opacity:1}100%{opacity:0.5}}
+@keyframes bwa-frame-flash-bowling-alley-scorer{0%{box-shadow:0 0 2px rgba(56,189,248,0.3)}50%{box-shadow:0 0 10px rgba(56,189,248,0.5)}100%{box-shadow:0 0 2px rgba(56,189,248,0.3)}}


### PR DESCRIPTION
## Component: ease-bowling-alley-scorer — balls pop, spare blinks, and frame flashes

**Closes #69516**

### What this adds
A bowling alley scorer: the ball results pop, the spare flashes, and the current frame flashes on the lane.

### Acceptance Criteria covered
- Ball results pop in the frames
- Spare symbol blinks in place
- Current frame flashes on the lane

### Files
- `submissions/examples/bowling-alley-scorer-ij/demo.html`
- `submissions/examples/bowling-alley-scorer-ij/style.css`
- `submissions/examples/bowling-alley-scorer-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the frames.