### PR TITLE
Add ease-cycling-cadence-meter component

### DIFF
--- a/submissions/examples/cycling-cadence-meter-ij/README.md
+++ b/submissions/examples/cycling-cadence-meter-ij/README.md
@@ -1,0 +1,11 @@
+# ease-cycling-cadence-meter
+
+A cycling cadence meter where the needle swings, the RPM ticks, and the stats blink.
+
+## Run
+Open `demo.html` directly in a browser to watch the meter.
+
+## Notes
+- The cadence needle swings on the dial.
+- The RPM value ticks in the center.
+- The ride stats blink below.

--- a/submissions/examples/cycling-cadence-meter-ij/demo.html
+++ b/submissions/examples/cycling-cadence-meter-ij/demo.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-cycling-cadence-meter demo</title>
+</head>
+<body>
+<div class="cyc-meter">
+  <div class="cyc-dial">
+    <i class="cyc-needle"></i>
+    <b class="cyc-rpm">92</b>
+    <small class="cyc-unit">RPM</small>
+  </div>
+  <div class="cyc-stats">
+    <span class="cyc-stat"><b>27</b><small>KM/H</small></span>
+    <span class="cyc-stat"><b>53</b><small>CAD</small></span>
+    <span class="cyc-stat"><b>168</b><small>HR</small></span>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/cycling-cadence-meter-ij/style.css
+++ b/submissions/examples/cycling-cadence-meter-ij/style.css
@@ -1,0 +1,12 @@
+.cyc-meter{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:372px;background:#0d1624;border:1px solid #1e3350;border-radius:16px;padding:22px;display:flex;flex-direction:column;gap:16px}
+.cyc-dial{position:relative;height:172px;background:radial-gradient(circle at 50% 100%,#142a44,#0d1624 60%);border-radius:172px 172px 14px 14px;display:flex;flex-direction:column;align-items:center;justify-content:flex-end;padding-bottom:22px}
+.cyc-needle{position:absolute;left:50%;top:16px;width:4px;height:112px;background:#f5c542;transform-origin:50% 100%;transform:translateX(-50%) rotate(-16deg);animation:cyc-needle-swing-cycling-cadence-meter 2.4s ease-in-out infinite}
+.cyc-rpm{font-size:36px;font-weight:800;color:#f5c542;animation:cyc-rpm-tick-cycling-cadence-meter 1.2s ease-in-out infinite}
+.cyc-unit{font-size:9px;letter-spacing:3px;color:#5d7690}
+.cyc-stats{display:flex;justify-content:space-around}
+.cyc-stat{display:flex;flex-direction:column;align-items:center;gap:2px}
+.cyc-stat b{font-size:16px;font-weight:800;color:#e8f0f8;animation:cyc-stat-blink-cycling-cadence-meter 2.2s ease-in-out infinite}
+.cyc-stat small{font-size:8px;letter-spacing:2px;color:#5d7690}
+@keyframes cyc-needle-swing-cycling-cadence-meter{0%{transform:translateX(-50%) rotate(-16deg)}50%{transform:translateX(-50%) rotate(34deg)}100%{transform:translateX(-50%) rotate(-16deg)}}
+@keyframes cyc-rpm-tick-cycling-cadence-meter{0%{opacity:0.7}50%{opacity:1}100%{opacity:0.7}}
+@keyframes cyc-stat-blink-cycling-cadence-meter{0%{opacity:0.5}50%{opacity:1}100%{opacity:0.5}}


### PR DESCRIPTION
## Component: ease-cycling-cadence-meter — needle swings, RPM ticks, and stats blink

**Closes #69535**

### What this adds
A cycling cadence meter: the cadence needle swings, the RPM value ticks, and the ride stats blink.

### Acceptance Criteria covered
- Cadence needle swings on the dial
- RPM value ticks in the center
- Ride stats blink below

### Files
- `submissions/examples/cycling-cadence-meter-ij/demo.html`
- `submissions/examples/cycling-cadence-meter-ij/style.css`
- `submissions/examples/cycling-cadence-meter-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the meter.