### PR TITLE
feat: add ease-neumorphic-card-sap

### DIFF
--- a/submissions/examples/ease-neumorphic-card-sap/README.md
+++ b/submissions/examples/ease-neumorphic-card-sap/README.md
@@ -1,0 +1,25 @@
+# ease-neumorphic-card-sap
+
+A soft-UI (neumorphic) card using dual-direction box-shadows to simulate a raised, embossed surface, with an inset-shadow icon well and a pressable button.
+
+## Usage
+1. Include `style.css`.
+2. Add markup:
+```html
+   <div class="neumorphic-card-sap">
+     <div class="nc-icon">🔔</div>
+     <h3>Title</h3>
+     <p>Description</p>
+     <button class="nc-btn">Action</button>
+   </div>
+```
+
+## Customization
+- Base background `#e0e5ec` — light/dark shadow colors must be recalculated (roughly ±20% lightness) if you change this base color for the effect to look correct.
+- Shadow blur/offset for a flatter or deeper emboss.
+- `.nc-btn:active` inset shadow for the "pressed" feedback.
+
+## Notes
+- Neumorphism relies on the shadow colors closely matching the background — a light shadow (highlight) on one side and a dark shadow on the other, both derived from the same base hue, is what sells the raised/carved illusion.
+- The icon well uses `inset` shadows (opposite direction from the card) so it reads as pressed *into* the surface rather than raised.
+- Respects `prefers-reduced-motion`: hover lift and shadow-depth transition are disabled; button press feedback (instant shadow swap) remains since it's a direct interaction response, not decorative motion.

--- a/submissions/examples/ease-neumorphic-card-sap/demo.html
+++ b/submissions/examples/ease-neumorphic-card-sap/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-neumorphic-card-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      height: 100vh;
+      margin: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #e0e5ec;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="neumorphic-card-sap">
+    <div class="nc-icon">🔔</div>
+    <h3>Notifications</h3>
+    <p>Soft-UI styled card using dual light/dark shadows to simulate an embossed surface.</p>
+    <button class="nc-btn">Enable</button>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-neumorphic-card-sap/style.css
+++ b/submissions/examples/ease-neumorphic-card-sap/style.css
@@ -1,0 +1,68 @@
+.neumorphic-card-sap {
+  width: 260px;
+  padding: 28px;
+  border-radius: 24px;
+  background: #e0e5ec;
+  box-shadow: 9px 9px 18px #b8bcc2, -9px -9px 18px #ffffff;
+  font-family: system-ui, sans-serif;
+  transition: box-shadow 0.3s ease, transform 0.3s ease;
+}
+
+.neumorphic-card-sap:hover {
+  box-shadow: 12px 12px 24px #b8bcc2, -12px -12px 24px #ffffff;
+  transform: translateY(-3px);
+}
+
+.neumorphic-card-sap .nc-icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 16px;
+  background: #e0e5ec;
+  box-shadow: inset 4px 4px 8px #b8bcc2, inset -4px -4px 8px #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 24px;
+  margin-bottom: 16px;
+}
+
+.neumorphic-card-sap h3 {
+  margin: 0 0 8px;
+  font-size: 17px;
+  color: #3a3f47;
+}
+
+.neumorphic-card-sap p {
+  margin: 0;
+  font-size: 13px;
+  color: #6b7280;
+  line-height: 1.6;
+}
+
+.neumorphic-card-sap .nc-btn {
+  margin-top: 18px;
+  padding: 10px 18px;
+  border: none;
+  border-radius: 12px;
+  background: #e0e5ec;
+  color: #3a3f47;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 5px 5px 10px #b8bcc2, -5px -5px 10px #ffffff;
+  transition: box-shadow 0.2s ease;
+}
+
+.neumorphic-card-sap .nc-btn:active {
+  box-shadow: inset 3px 3px 6px #b8bcc2, inset -3px -3px 6px #ffffff;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .neumorphic-card-sap,
+  .neumorphic-card-sap .nc-btn {
+    transition: none;
+  }
+  .neumorphic-card-sap:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-neumorphic-card-sap`, a soft-UI card component using dual-shadow neumorphism.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-neumorphic-card-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Shadow colors are derived from the base background hue (light/dark pair), which is what produces the embossed illusion — flagged in the README since changing the base color requires recalculating both shadow tones.
- Icon well uses `inset` shadows in the opposite direction of the card's own shadows, reading as pressed-in rather than raised.
- `prefers-reduced-motion` disables hover lift/shadow transition; button press feedback remains as direct interaction response.

## Feature Description

Adds a reusable neumorphic (soft-UI) card component.

Level: Intermediate

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.