### PR TITLE
Add ease-seismograph-earthquake-reader component

### DIFF
--- a/submissions/examples/seismograph-earthquake-reader-ij/README.md
+++ b/submissions/examples/seismograph-earthquake-reader-ij/README.md
@@ -1,0 +1,11 @@
+# ease-seismograph-earthquake-reader
+
+A seismograph reader where the trace draws, the magnitude blinks, and the cells flash.
+
+## Run
+Open `demo.html` directly in a browser to watch the trace.
+
+## Notes
+- The tremor trace draws across the plot.
+- The magnitude blinks at the top.
+- The data cells flash at the foot.

--- a/submissions/examples/seismograph-earthquake-reader-ij/demo.html
+++ b/submissions/examples/seismograph-earthquake-reader-ij/demo.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-seismograph-earthquake-reader demo</title>
+</head>
+<body>
+<div class="ssm-console">
+  <div class="ssm-head">
+    <b class="ssm-mag">M 5.8</b>
+    <span class="ssm-station">KAT-01</span>
+  </div>
+  <svg class="ssm-plot" viewBox="0 0 400 120" aria-hidden="true">
+    <path class="ssm-trace" d="M0 60 H140 L150 20 L162 100 L174 30 L186 96 L198 44 L214 60 L400 60"></path>
+  </svg>
+  <div class="ssm-data">
+    <span class="ssm-cell"><b>34km</b><small>DEPTH</small></span>
+    <span class="ssm-cell"><b>2.4</b><small>SEC</small></span>
+    <span class="ssm-cell"><b>VII</b><small>INTENSITY</small></span>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/seismograph-earthquake-reader-ij/style.css
+++ b/submissions/examples/seismograph-earthquake-reader-ij/style.css
@@ -1,0 +1,13 @@
+.ssm-console{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:420px;background:#0a1018;border:1px solid #1b2b42;border-radius:12px;padding:18px;font-family:"Courier New",monospace;display:flex;flex-direction:column;gap:12px}
+.ssm-head{display:flex;align-items:center;justify-content:space-between}
+.ssm-mag{font-size:16px;font-weight:800;color:#f5c542;animation:ssm-mag-blink-seismograph-earthquake-reader 1.8s ease-in-out infinite}
+.ssm-station{font-size:10px;letter-spacing:2px;color:#5d7690}
+.ssm-plot{width:100%;display:block;background:#0c1520;border:1px solid #16263b;border-radius:6px}
+.ssm-trace{fill:none;stroke:#34d399;stroke-width:2;stroke-dasharray:500;stroke-dashoffset:500;animation:ssm-trace-draw-seismograph-earthquake-reader 3s ease-in-out infinite}
+.ssm-data{display:flex;justify-content:space-between}
+.ssm-cell{display:flex;flex-direction:column;align-items:center;gap:2px}
+.ssm-cell b{font-size:13px;font-weight:800;color:#e8f0f8;animation:ssm-cell-flash-seismograph-earthquake-reader 2.2s ease-in-out infinite}
+.ssm-cell small{font-size:8px;letter-spacing:2px;color:#5d7690}
+@keyframes ssm-trace-draw-seismograph-earthquake-reader{0%{stroke-dashoffset:500}45%{stroke-dashoffset:0}100%{stroke-dashoffset:0}}
+@keyframes ssm-mag-blink-seismograph-earthquake-reader{0%{opacity:0.6}50%{opacity:1}100%{opacity:0.6}}
+@keyframes ssm-cell-flash-seismograph-earthquake-reader{0%{opacity:0.5}50%{opacity:1}100%{opacity:0.5}}


### PR DESCRIPTION
## Component: ease-seismograph-earthquake-reader — trace draws, magnitude blinks, and cells flash

**Closes #69546**

### What this adds
A seismograph reader: the tremor trace draws across the plot, the magnitude blinks, and the data cells flash.

### Acceptance Criteria covered
- Tremor trace draws across the plot
- Magnitude blinks at the top
- Data cells flash at the foot

### Files
- `submissions/examples/seismograph-earthquake-reader-ij/demo.html`
- `submissions/examples/seismograph-earthquake-reader-ij/style.css`
- `submissions/examples/seismograph-earthquake-reader-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the trace.