### PR TITLE
feat: add CSS particle field background

### DIFF
--- a/submissions/examples/gssoc-2026-css-particle-field/README.md
+++ b/submissions/examples/gssoc-2026-css-particle-field/README.md
@@ -1,0 +1,25 @@
+# CSS Particle Field Background
+
+## GSSoC 2026
+
+A pure CSS drifting particle field background animation for
+EaseMotion CSS.
+
+## Features
+
+- Pure CSS animation
+- No JavaScript required
+- Responsive design
+- Light and dark mode support
+- CSS custom properties for easy customization
+- Accessible decorative particles
+- Reduced-motion support
+- Lightweight implementation
+
+## Files
+
+```text
+gssoc-2026-css-particle-field/
+├── demo.html
+├── style.css
+└── README.md

--- a/submissions/examples/gssoc-2026-css-particle-field/demo.html
+++ b/submissions/examples/gssoc-2026-css-particle-field/demo.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="color-scheme" content="light dark">
+  <title>CSS Particle Field Background</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+  <main class="particle-scene">
+
+    <!-- CSS-only particle field -->
+    <div class="particles" aria-hidden="true">
+      <span class="particle p1"></span>
+      <span class="particle p2"></span>
+      <span class="particle p3"></span>
+      <span class="particle p4"></span>
+      <span class="particle p5"></span>
+      <span class="particle p6"></span>
+      <span class="particle p7"></span>
+      <span class="particle p8"></span>
+      <span class="particle p9"></span>
+      <span class="particle p10"></span>
+      <span class="particle p11"></span>
+      <span class="particle p12"></span>
+      <span class="particle p13"></span>
+      <span class="particle p14"></span>
+      <span class="particle p15"></span>
+      <span class="particle p16"></span>
+      <span class="particle p17"></span>
+      <span class="particle p18"></span>
+      <span class="particle p19"></span>
+      <span class="particle p20"></span>
+    </div>
+
+    <section class="content">
+      <span class="badge">GSSoC 2026 • CSS Component</span>
+
+      <h1>CSS Particle Field</h1>
+
+      <p>
+        A responsive drifting particle background created entirely
+        with HTML and CSS.
+      </p>
+
+      <div class="features">
+        <article>
+          <h2>Pure CSS</h2>
+          <p>No JavaScript animation required.</p>
+        </article>
+
+        <article>
+          <h2>Responsive</h2>
+          <p>Adapts to different screen sizes.</p>
+        </article>
+
+        <article>
+          <h2>Accessible</h2>
+          <p>Decorative particles are hidden from assistive technology.</p>
+        </article>
+      </div>
+    </section>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/gssoc-2026-css-particle-field/style.css
+++ b/submissions/examples/gssoc-2026-css-particle-field/style.css
@@ -1,0 +1,355 @@
+:root {
+  --background: #f4f7fb;
+  --surface: rgba(255, 255, 255, 0.82);
+  --text: #172033;
+  --muted: #667085;
+  --accent: #2563eb;
+  --accent-soft: rgba(37, 99, 235, 0.35);
+  --particle: #2563eb;
+  --border: rgba(15, 23, 42, 0.1);
+}
+
+/* Dark mode follows the user's system preference. */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: #070b14;
+    --surface: rgba(15, 23, 42, 0.82);
+    --text: #f8fafc;
+    --muted: #a8b1c2;
+    --accent: #60a5fa;
+    --accent-soft: rgba(96, 165, 250, 0.35);
+    --particle: #60a5fa;
+    --border: rgba(255, 255, 255, 0.12);
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+}
+
+body {
+  font-family:
+    Arial,
+    Helvetica,
+    sans-serif;
+  background: var(--background);
+  color: var(--text);
+}
+
+/* Main particle background container. */
+.particle-scene {
+  position: relative;
+  min-height: 100vh;
+  overflow: hidden;
+  display: grid;
+  place-items: center;
+  padding: 40px 20px;
+}
+
+/*
+ * Particle layer.
+ * pointer-events are disabled because the particles are decorative.
+ */
+.particles {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+/*
+ * Each particle uses the same animation.
+ * Individual classes below change size, position and timing.
+ */
+.particle {
+  position: absolute;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--particle);
+  opacity: 0.65;
+
+  box-shadow:
+    0 0 10px var(--accent-soft);
+
+  animation:
+    drift 12s ease-in-out infinite alternate;
+}
+
+/*
+ * CSS-only drifting animation.
+ * Particles move using transform, which keeps the animation lightweight.
+ */
+@keyframes drift {
+  0% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+
+  50% {
+    transform: translate3d(35px, -45px, 0) scale(1.25);
+  }
+
+  100% {
+    transform: translate3d(-30px, 35px, 0) scale(0.8);
+  }
+}
+
+/* Particle positions and individual animation timing. */
+
+.p1 {
+  top: 8%;
+  left: 10%;
+  animation-duration: 10s;
+}
+
+.p2 {
+  top: 15%;
+  left: 25%;
+  width: 4px;
+  height: 4px;
+  animation-duration: 14s;
+}
+
+.p3 {
+  top: 20%;
+  left: 42%;
+  width: 8px;
+  height: 8px;
+  animation-duration: 11s;
+}
+
+.p4 {
+  top: 12%;
+  left: 70%;
+  animation-duration: 16s;
+}
+
+.p5 {
+  top: 30%;
+  left: 85%;
+  width: 5px;
+  height: 5px;
+  animation-duration: 13s;
+}
+
+.p6 {
+  top: 42%;
+  left: 15%;
+  width: 7px;
+  height: 7px;
+  animation-duration: 15s;
+}
+
+.p7 {
+  top: 48%;
+  left: 35%;
+  width: 4px;
+  height: 4px;
+  animation-duration: 9s;
+}
+
+.p8 {
+  top: 38%;
+  left: 60%;
+  animation-duration: 12s;
+}
+
+.p9 {
+  top: 55%;
+  left: 78%;
+  width: 8px;
+  height: 8px;
+  animation-duration: 17s;
+}
+
+.p10 {
+  top: 65%;
+  left: 8%;
+  width: 5px;
+  height: 5px;
+  animation-duration: 11s;
+}
+
+.p11 {
+  top: 70%;
+  left: 28%;
+  animation-duration: 14s;
+}
+
+.p12 {
+  top: 75%;
+  left: 48%;
+  width: 7px;
+  height: 7px;
+  animation-duration: 10s;
+}
+
+.p13 {
+  top: 68%;
+  left: 68%;
+  width: 4px;
+  height: 4px;
+  animation-duration: 15s;
+}
+
+.p14 {
+  top: 82%;
+  left: 88%;
+  animation-duration: 12s;
+}
+
+.p15 {
+  top: 88%;
+  left: 18%;
+  width: 8px;
+  height: 8px;
+  animation-duration: 16s;
+}
+
+.p16 {
+  top: 92%;
+  left: 40%;
+  width: 5px;
+  height: 5px;
+  animation-duration: 13s;
+}
+
+.p17 {
+  top: 85%;
+  left: 58%;
+  animation-duration: 9s;
+}
+
+.p18 {
+  top: 78%;
+  left: 75%;
+  width: 7px;
+  height: 7px;
+  animation-duration: 14s;
+}
+
+.p19 {
+  top: 35%;
+  left: 5%;
+  width: 4px;
+  height: 4px;
+  animation-duration: 12s;
+}
+
+.p20 {
+  top: 25%;
+  left: 92%;
+  width: 6px;
+  height: 6px;
+  animation-duration: 15s;
+}
+
+/* Foreground content. */
+.content {
+  position: relative;
+  z-index: 2;
+  width: min(100%, 850px);
+  padding: 45px;
+  text-align: center;
+
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 24px;
+
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+}
+
+.badge {
+  display: inline-block;
+  padding: 7px 14px;
+  border-radius: 20px;
+
+  background: var(--accent);
+  color: white;
+
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+h1 {
+  margin: 20px 0 12px;
+  font-size: clamp(2.2rem, 6vw, 4rem);
+}
+
+.content > p {
+  max-width: 600px;
+  margin: 0 auto;
+  color: var(--muted);
+  font-size: 1.1rem;
+}
+
+.features {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+  margin-top: 35px;
+}
+
+.features article {
+  padding: 20px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: var(--surface);
+}
+
+.features h2 {
+  margin: 0 0 8px;
+  font-size: 1.1rem;
+}
+
+.features p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+/*
+ * Accessibility:
+ * Respect users who prefer reduced motion.
+ *
+ * The decorative particles remain visible,
+ * but their animation is disabled.
+ */
+@media (prefers-reduced-motion: reduce) {
+  .particle {
+    animation: none;
+  }
+}
+
+/* Responsive layout. */
+@media (max-width: 700px) {
+  .content {
+    padding: 30px 20px;
+  }
+
+  .features {
+    grid-template-columns: 1fr;
+  }
+
+  .particle {
+    opacity: 0.45;
+  }
+}
+
+@media (max-width: 450px) {
+  .particle {
+    width: 4px;
+    height: 4px;
+  }
+
+  .content {
+    border-radius: 18px;
+  }
+}


### PR DESCRIPTION
## Description

Added a responsive CSS-only particle field background component
for EaseMotion CSS.

## Features

- Pure CSS particle animation
- No JavaScript required
- Responsive design
- Light and dark mode support
- CSS custom properties
- Reduced-motion support
- Accessible decorative particles

## Files Added

- `demo.html`
- `style.css`
- `README.md`

## Accessibility

- Decorative particles use `aria-hidden="true"`
- Supports `prefers-reduced-motion`
- Animation is disabled for users who prefer reduced motion

## Issue

Closes #68061