### PR TITLE
feat: add ease-hover-reveal-caption-sap

### DIFF
--- a/submissions/examples/ease-hover-reveal-caption-sap/README.md
+++ b/submissions/examples/ease-hover-reveal-caption-sap/README.md
@@ -1,0 +1,28 @@
+# ease-hover-reveal-caption-sap
+
+An image card where hovering slowly zooms the photo and reveals a gradient-backed caption sliding up from the bottom.
+
+## Usage
+1. Include `style.css`.
+2. Add markup:
+```html
+   <div class="reveal-caption-sap">
+     <img src="..." alt="...">
+     <div class="caption-overlay">
+       <div class="caption-text">
+         <h4>Title</h4>
+         <p>Subtitle</p>
+       </div>
+     </div>
+   </div>
+```
+
+## Customization
+- `scale(1.08)` on hover: zoom intensity.
+- Gradient overlay darkness/height.
+- Caption slide distance (`translateY(16px)`) and stagger delay relative to the overlay fade.
+
+## Notes
+- Overlay fade and caption slide use a slight delay offset (`0.05s`) on the text so the gradient appears fractionally before the text slides in, reading as one smooth reveal rather than simultaneous pop-in.
+- `overflow: hidden` on the card clips the zoomed image to the fixed card bounds.
+- Respects `prefers-reduced-motion`: image zoom and caption slide-up transforms are removed; only the overlay/caption opacity fade remains as the reveal mechanism.

--- a/submissions/examples/ease-hover-reveal-caption-sap/demo.html
+++ b/submissions/examples/ease-hover-reveal-caption-sap/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-hover-reveal-caption-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      height: 100vh;
+      margin: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #f4f4f5;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="reveal-caption-sap">
+    <img src="https://images.unsplash.com/photo-1470071459604-3b5ec3a7fe05?w=600" alt="Mountain lake">
+    <div class="caption-overlay">
+      <div class="caption-text">
+        <h4>Alpine Lake</h4>
+        <p>Switzerland · Summer 2024</p>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-hover-reveal-caption-sap/style.css
+++ b/submissions/examples/ease-hover-reveal-caption-sap/style.css
@@ -1,0 +1,73 @@
+.reveal-caption-sap {
+  position: relative;
+  width: 300px;
+  height: 220px;
+  border-radius: 16px;
+  overflow: hidden;
+  cursor: pointer;
+}
+
+.reveal-caption-sap img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: transform 0.4s ease;
+}
+
+.reveal-caption-sap:hover img {
+  transform: scale(1.08);
+}
+
+.reveal-caption-sap .caption-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to top, rgba(0,0,0,0.85), transparent 60%);
+  display: flex;
+  align-items: flex-end;
+  padding: 20px;
+  opacity: 0;
+  transition: opacity 0.35s ease;
+}
+
+.reveal-caption-sap:hover .caption-overlay {
+  opacity: 1;
+}
+
+.reveal-caption-sap .caption-text {
+  color: #fff;
+  transform: translateY(16px);
+  transition: transform 0.35s ease 0.05s;
+}
+
+.reveal-caption-sap:hover .caption-text {
+  transform: translateY(0);
+}
+
+.reveal-caption-sap .caption-text h4 {
+  margin: 0 0 4px;
+  font-size: 16px;
+  font-family: system-ui, sans-serif;
+}
+
+.reveal-caption-sap .caption-text p {
+  margin: 0;
+  font-size: 12px;
+  opacity: 0.85;
+  font-family: system-ui, sans-serif;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reveal-caption-sap img,
+  .reveal-caption-sap .caption-overlay,
+  .reveal-caption-sap .caption-text {
+    transition: opacity 0.2s ease;
+  }
+  .reveal-caption-sap:hover img {
+    transform: none;
+  }
+  .reveal-caption-sap .caption-text,
+  .reveal-caption-sap:hover .caption-text {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-hover-reveal-caption-sap`, a hover-triggered image zoom with sliding caption overlay.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-hover-reveal-caption-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Caption text has a slight transition delay (`0.05s`) relative to the overlay fade, so the gradient leads and text follows — reads as one continuous reveal rather than two separate pop-ins.
- `overflow: hidden` on the card clips the zoomed image cleanly to the fixed card bounds.
- `prefers-reduced-motion` removes the image zoom and caption slide transform, keeping only opacity fade as the reveal mechanism.

## Feature Description

Adds a reusable hover-reveal image caption component.

Level: Intermediate

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.