### PR TITLE
Add ease-telescope-star-tracker component

### DIFF
--- a/submissions/examples/telescope-star-tracker-ij/README.md
+++ b/submissions/examples/telescope-star-tracker-ij/README.md
@@ -1,0 +1,11 @@
+# ease-telescope-star-tracker
+
+A telescope star tracker where the stars twinkle, the reticle drifts, and the readout blinks.
+
+## Run
+Open `demo.html` directly in a browser to watch the tracker.
+
+## Notes
+- The stars twinkle in the eyepiece.
+- The reticle drifts across the field.
+- The coordinate readout blinks below.

--- a/submissions/examples/telescope-star-tracker-ij/demo.html
+++ b/submissions/examples/telescope-star-tracker-ij/demo.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-telescope-star-tracker demo</title>
+</head>
+<body>
+<div class="tlp-eye">
+  <div class="tlp-field">
+    <i class="tlp-star"></i>
+    <i class="tlp-star"></i>
+    <i class="tlp-star"></i>
+    <i class="tlp-star"></i>
+    <i class="tlp-star"></i>
+    <i class="tlp-star"></i>
+    <span class="tlp-reticle-h"></span>
+    <span class="tlp-reticle-v"></span>
+    <span class="tlp-ring"></span>
+  </div>
+  <div class="tlp-read">RA 05h 34m DEC +22</div>
+</div>
+</body>
+</html>

--- a/submissions/examples/telescope-star-tracker-ij/style.css
+++ b/submissions/examples/telescope-star-tracker-ij/style.css
@@ -1,0 +1,16 @@
+.tlp-eye{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:340px;background:#0d1624;border:1px solid #1e3350;border-radius:14px;padding:18px;display:flex;flex-direction:column;align-items:center;gap:14px}
+.tlp-field{position:relative;width:240px;height:240px;border-radius:50%;background:radial-gradient(circle at 50% 50%,#0a1424,#050a12);border:3px solid #24385a;overflow:hidden}
+.tlp-star{position:absolute;width:4px;height:4px;border-radius:50%;background:#fff7cc;animation:tlp-star-twinkle-telescope-star-tracker 2s ease-in-out infinite}
+.tlp-star:nth-child(1){left:30px;top:54px;animation-delay:0s}
+.tlp-star:nth-child(2){left:96px;top:36px;animation-delay:0.4s}
+.tlp-star:nth-child(3){left:170px;top:88px;animation-delay:0.8s}
+.tlp-star:nth-child(4){left:52px;top:150px;animation-delay:1.2s}
+.tlp-star:nth-child(5){left:196px;top:170px;animation-delay:1.6s}
+.tlp-star:nth-child(6){left:128px;top:196px;animation-delay:0.6s}
+.tlp-reticle-h{position:absolute;left:0;right:0;top:50%;height:1px;background:rgba(56,189,248,0.6)}
+.tlp-reticle-v{position:absolute;top:0;bottom:0;left:50%;width:1px;background:rgba(56,189,248,0.6)}
+.tlp-ring{position:absolute;inset:0;border:1px dashed rgba(56,189,248,0.5);border-radius:50%;animation:tlp-ret-drift-telescope-star-tracker 4s ease-in-out infinite}
+.tlp-read{font-size:11px;letter-spacing:2px;color:#38bdf8;font-family:"Courier New",monospace;animation:tlp-read-blink-telescope-star-tracker 2.2s ease-in-out infinite}
+@keyframes tlp-star-twinkle-telescope-star-tracker{0%{opacity:0.3}50%{opacity:1}100%{opacity:0.3}}
+@keyframes tlp-ret-drift-telescope-star-tracker{0%{transform:scale(1)}50%{transform:scale(0.94)}100%{transform:scale(1)}}
+@keyframes tlp-read-blink-telescope-star-tracker{0%{opacity:0.5}50%{opacity:1}100%{opacity:0.5}}


### PR DESCRIPTION
## Component: ease-telescope-star-tracker — stars twinkle, reticle drifts, and readout blinks

**Closes #69577**

### What this adds
A telescope star tracker: the stars twinkle in the eyepiece, the reticle drifts, and the coordinate readout blinks.

### Acceptance Criteria covered
- Stars twinkle in the eyepiece
- Reticle drifts across the field
- Coordinate readout blinks below

### Files
- `submissions/examples/telescope-star-tracker-ij/demo.html`
- `submissions/examples/telescope-star-tracker-ij/style.css`
- `submissions/examples/telescope-star-tracker-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the tracker.