### PR TITLE
feat: add ease-diagonal-wipe-transition-sap

### DIFF
--- a/submissions/examples/ease-diagonal-wipe-transition-sap/README.md
+++ b/submissions/examples/ease-diagonal-wipe-transition-sap/README.md
@@ -1,0 +1,23 @@
+# ease-diagonal-wipe-transition-sap
+
+A card where hovering triggers a diagonal wipe — a second layer sweeps in from one corner via an animated `clip-path` triangle, fully covering the base layer.
+
+## Usage
+1. Include `style.css`.
+2. Add markup: two stacked full-size layers, `.wipe-base` (bottom) and `.wipe-reveal` (top, clipped).
+```html
+   <div class="diagonal-wipe-sap">
+     <div class="wipe-base">Base content</div>
+     <div class="wipe-reveal">Revealed content</div>
+   </div>
+```
+
+## Customization
+- `clip-path` polygon points: change which corner the wipe originates from and its diagonal angle.
+- Transition duration/easing for wipe speed.
+- Colors/content of both layers.
+
+## Notes
+- The wipe animates a `clip-path: polygon()` from a collapsed triangle (all points at one corner) to a full-covering triangle, which CSS interpolates smoothly between matching point counts — this is what produces the diagonal sweep rather than a simple rectangular wipe.
+- Both layers are full-size and stacked; only the top layer's visible clipped area changes, so no actual layout shift occurs during the wipe.
+- Respects `prefers-reduced-motion`: `clip-path` animation is replaced with a simple opacity cross-fade between the two layers, avoiding the directional sweep motion.

--- a/submissions/examples/ease-diagonal-wipe-transition-sap/demo.html
+++ b/submissions/examples/ease-diagonal-wipe-transition-sap/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-diagonal-wipe-transition-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      height: 100vh;
+      margin: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #f4f4f5;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="diagonal-wipe-sap">
+    <div class="wipe-base">Hover Me</div>
+    <div class="wipe-reveal">Revealed!</div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-diagonal-wipe-transition-sap/style.css
+++ b/submissions/examples/ease-diagonal-wipe-transition-sap/style.css
@@ -1,0 +1,46 @@
+.diagonal-wipe-sap {
+  position: relative;
+  width: 320px;
+  height: 220px;
+  border-radius: 16px;
+  overflow: hidden;
+  cursor: pointer;
+}
+
+.diagonal-wipe-sap .wipe-base,
+.diagonal-wipe-sap .wipe-reveal {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: system-ui, sans-serif;
+  font-size: 20px;
+  font-weight: 700;
+  color: #fff;
+}
+
+.diagonal-wipe-sap .wipe-base {
+  background: linear-gradient(135deg, #1e293b, #0f172a);
+}
+
+.diagonal-wipe-sap .wipe-reveal {
+  background: linear-gradient(135deg, #2563eb, #7c3aed);
+  clip-path: polygon(0 100%, 0 100%, 0 100%, 0 100%);
+  transition: clip-path 0.5s cubic-bezier(0.65, 0, 0.35, 1);
+}
+
+.diagonal-wipe-sap:hover .wipe-reveal {
+  clip-path: polygon(0 100%, 100% 0, 100% 100%, 0 100%);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .diagonal-wipe-sap .wipe-reveal {
+    transition: opacity 0.25s ease;
+    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
+    opacity: 0;
+  }
+  .diagonal-wipe-sap:hover .wipe-reveal {
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-diagonal-wipe-transition-sap`, a hover-triggered diagonal clip-path wipe transition.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-diagonal-wipe-transition-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Diagonal sweep comes from animating `clip-path: polygon()` between two matching-point-count states (collapsed corner → full triangle), which CSS interpolates smoothly — no image mask or SVG needed.
- Both layers are full-size and stacked with no layout shift; only the visible clipped region of the top layer changes during the wipe.
- `prefers-reduced-motion` replaces the directional clip-path sweep with a simple opacity cross-fade between layers.

## Feature Description

Adds a reusable hover-triggered diagonal wipe transition component.

Level: Advanced

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.