### PR TITLE
feat: add ease-scratch-to-reveal-sap

### DIFF
--- a/submissions/examples/ease-scratch-to-reveal-sap/README.md
+++ b/submissions/examples/ease-scratch-to-reveal-sap/README.md
@@ -1,0 +1,18 @@
+# ease-scratch-to-reveal-sap
+
+A scratch card where a canvas overlay is "erased" by dragging over it, revealing a prize/message underneath — classic scratch-off ticket UX.
+
+## Usage
+1. Include `style.css`.
+2. Add markup: content layer (`.scratch-prize`) + `<canvas>` overlay + hint text.
+3. Attach the canvas drawing logic from `demo.html`.
+
+## Customization
+- Scratch brush radius (`22` in `arc()`) for coarser/finer erasing.
+- Overlay texture pattern (currently random dot noise) — swap for a solid color or image.
+- Underlying prize content/styling.
+
+## Notes
+- Uses `ctx.globalCompositeOperation = 'destination-out'` to erase pixels where the user drags, rather than drawing over them — this makes the covered canvas transparent, revealing the content layer beneath it.
+- Canvas size is set from the card's actual rendered dimensions (`getBoundingClientRect()`), not hardcoded, so the scratch layer always matches the card exactly.
+- Respects `prefers-reduced-motion`: this is a direct-manipulation interaction (drawing follows the cursor/finger 1:1), not decorative animation, so it isn't gated behind the media query — a `transition: none` rule is included defensively in case future styling adds one.

--- a/submissions/examples/ease-scratch-to-reveal-sap/demo.html
+++ b/submissions/examples/ease-scratch-to-reveal-sap/demo.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-scratch-to-reveal-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      height: 100vh;
+      margin: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #f4f4f5;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="scratch-card-sap" id="card">
+    <div class="scratch-prize">
+      <h3>🎉 You Won!</h3>
+      <p>20% off your next order</p>
+    </div>
+    <canvas id="scratchCanvas"></canvas>
+    <span class="scratch-hint">Scratch here</span>
+  </div>
+
+  <script>
+    const canvas = document.getElementById('scratchCanvas');
+    const ctx = canvas.getContext('2d');
+    const card = document.getElementById('card');
+
+    function initCanvas() {
+      const rect = card.getBoundingClientRect();
+      canvas.width = rect.width;
+      canvas.height = rect.height;
+      ctx.fillStyle = '#b8bcc4';
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.fillStyle = 'rgba(255,255,255,0.15)';
+      for (let i = 0; i < 400; i++) {
+        ctx.fillRect(Math.random() * canvas.width, Math.random() * canvas.height, 2, 2);
+      }
+    }
+    initCanvas();
+
+    let scratching = false;
+
+    function scratch(x, y) {
+      ctx.globalCompositeOperation = 'destination-out';
+      ctx.beginPath();
+      ctx.arc(x, y, 22, 0, Math.PI * 2);
+      ctx.fill();
+    }
+
+    function getPos(e) {
+      const rect = canvas.getBoundingClientRect();
+      const point = e.touches ? e.touches[0] : e;
+      return { x: point.clientX - rect.left, y: point.clientY - rect.top };
+    }
+
+    canvas.addEventListener('mousedown', (e) => { scratching = true; const p = getPos(e); scratch(p.x, p.y); });
+    canvas.addEventListener('mousemove', (e) => { if (scratching) { const p = getPos(e); scratch(p.x, p.y); } });
+    canvas.addEventListener('mouseup', () => scratching = false);
+    canvas.addEventListener('mouseleave', () => scratching = false);
+
+    canvas.addEventListener('touchstart', (e) => { scratching = true; const p = getPos(e); scratch(p.x, p.y); }, { passive: true });
+    canvas.addEventListener('touchmove', (e) => { if (scratching) { const p = getPos(e); scratch(p.x, p.y); } }, { passive: true });
+    canvas.addEventListener('touchend', () => scratching = false);
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-scratch-to-reveal-sap/style.css
+++ b/submissions/examples/ease-scratch-to-reveal-sap/style.css
@@ -1,0 +1,54 @@
+.scratch-card-sap {
+  position: relative;
+  width: 300px;
+  height: 160px;
+  border-radius: 16px;
+  overflow: hidden;
+  font-family: system-ui, sans-serif;
+  user-select: none;
+}
+
+.scratch-card-sap .scratch-prize {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  background: linear-gradient(135deg, #22c55e, #0ea5e9);
+  color: #fff;
+}
+
+.scratch-card-sap .scratch-prize h3 {
+  margin: 0 0 4px;
+  font-size: 22px;
+}
+
+.scratch-card-sap .scratch-prize p {
+  margin: 0;
+  font-size: 13px;
+  opacity: 0.85;
+}
+
+.scratch-card-sap canvas {
+  position: absolute;
+  inset: 0;
+  cursor: pointer;
+  touch-action: none;
+}
+
+.scratch-card-sap .scratch-hint {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: #64748b;
+  font-size: 13px;
+  pointer-events: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .scratch-card-sap canvas {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-scratch-to-reveal-sap`, a canvas-based scratch-off reveal card.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-scratch-to-reveal-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Uses `globalCompositeOperation = 'destination-out'` to erase canvas pixels under the cursor/finger, revealing the content layer beneath rather than drawing a new layer on top.
- Canvas dimensions are read from the card's actual rendered size, keeping the scratch surface pixel-accurate to the card regardless of CSS sizing.
- README notes this is direct-manipulation input (not decorative motion), so it's intentionally not gated by `prefers-reduced-motion`, though a defensive `transition: none` is included.

## Feature Description

Adds a reusable canvas-based scratch-to-reveal card component.

Level: Advanced

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.