### PR TITLE
feat: add ease-image-before-after-slider-sap

### DIFF
--- a/submissions/examples/ease-image-before-after-slider-sap/README.md
+++ b/submissions/examples/ease-image-before-after-slider-sap/README.md
@@ -1,0 +1,18 @@
+# ease-image-before-after-slider-sap
+
+A draggable before/after image comparison slider — drag the handle horizontally to reveal more or less of the "after" image over the "before" image.
+
+## Usage
+1. Include `style.css`.
+2. Add markup: base "before" `<img>` + `.after-wrap` (clipped container with the "after" `<img>` at full container width) + `.slider-handle`.
+3. Attach the drag logic from `demo.html`.
+
+## Customization
+- Initial split position — set `afterWrap` starting `width` (default 50%).
+- Handle icon/size/color.
+- Label text/position.
+
+## Notes
+- The "after" image sits inside a width-clipped `.after-wrap`, while the image itself is set to the *container's* full width (not the wrap's) — this is what keeps the after-image content correctly aligned as the wrap narrows/widens, rather than the image scaling/distorting with its clipped parent.
+- Drag position is computed from cursor X relative to the container's own bounding box, then clamped to 0–100%.
+- Respects `prefers-reduced-motion`: the only transition present (`after-wrap` width, only relevant if animated programmatically elsewhere) is disabled; drag-following remains 1:1 direct input, unaffected either way.

--- a/submissions/examples/ease-image-before-after-slider-sap/demo.html
+++ b/submissions/examples/ease-image-before-after-slider-sap/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-image-before-after-slider-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      height: 100vh;
+      margin: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #f4f4f5;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="before-after-sap" id="baSlider">
+    <img src="https://images.unsplash.com/photo-1441974231531-c6227db76b6e?w=700&sat=-100" alt="Before">
+    <div class="after-wrap" id="afterWrap">
+      <img src="https://images.unsplash.com/photo-1441974231531-c6227db76b6e?w=700" alt="After">
+    </div>
+    <div class="slider-handle" id="handle"></div>
+    <span class="label before">Before</span>
+    <span class="label after">After</span>
+  </div>
+
+  <script>
+    const container = document.getElementById('baSlider');
+    const afterWrap = document.getElementById('afterWrap');
+    const handle = document.getElementById('handle');
+    let dragging = false;
+
+    function setPosition(clientX) {
+      const rect = container.getBoundingClientRect();
+      let pct = ((clientX - rect.left) / rect.width) * 100;
+      pct = Math.max(0, Math.min(100, pct));
+      afterWrap.style.width = pct + '%';
+      handle.style.left = pct + '%';
+    }
+
+    container.addEventListener('mousedown', (e) => { dragging = true; setPosition(e.clientX); });
+    window.addEventListener('mousemove', (e) => { if (dragging) setPosition(e.clientX); });
+    window.addEventListener('mouseup', () => dragging = false);
+
+    container.addEventListener('touchstart', (e) => { dragging = true; setPosition(e.touches[0].clientX); }, { passive: true });
+    container.addEventListener('touchmove', (e) => { if (dragging) setPosition(e.touches[0].clientX); }, { passive: true });
+    container.addEventListener('touchend', () => dragging = false);
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-image-before-after-slider-sap/style.css
+++ b/submissions/examples/ease-image-before-after-slider-sap/style.css
@@ -1,0 +1,81 @@
+.before-after-sap {
+  position: relative;
+  width: 360px;
+  height: 240px;
+  border-radius: 16px;
+  overflow: hidden;
+  cursor: ew-resize;
+  user-select: none;
+}
+
+.before-after-sap img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  pointer-events: none;
+}
+
+.before-after-sap .after-wrap {
+  position: absolute;
+  inset: 0;
+  width: 50%;
+  overflow: hidden;
+}
+
+.before-after-sap .after-wrap img {
+  width: 360px;
+  max-width: none;
+}
+
+.before-after-sap .slider-handle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 3px;
+  background: #fff;
+  transform: translateX(-50%);
+  pointer-events: none;
+}
+
+.before-after-sap .slider-handle::after {
+  content: "⇔";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: #fff;
+  color: #111;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+}
+
+.before-after-sap .label {
+  position: absolute;
+  top: 12px;
+  padding: 4px 10px;
+  border-radius: 6px;
+  background: rgba(0,0,0,0.6);
+  color: #fff;
+  font-size: 11px;
+  font-family: system-ui, sans-serif;
+  pointer-events: none;
+}
+
+.before-after-sap .label.before { left: 12px; }
+.before-after-sap .label.after { right: 12px; }
+
+@media (prefers-reduced-motion: reduce) {
+  .before-after-sap .after-wrap {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-image-before-after-slider-sap`, a draggable before/after image comparison slider.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-image-before-after-slider-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- The "after" image is sized to the container's full width (not its clipped wrapper's width), preventing distortion as the wrap narrows/widens during drag.
- Drag position is computed from cursor X relative to the container's bounding box and clamped to a 0–100% range.
- `prefers-reduced-motion` disables any programmatic width transition; direct drag-following remains unaffected as it's live input, not decorative animation.

## Feature Description

Adds a reusable draggable before/after image comparison slider component.

Level: Advanced

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.