### PR TITLE
feat: add ease-pill-tab-switcher-sap

### DIFF
--- a/submissions/examples/ease-pill-tab-switcher-sap/README.md
+++ b/submissions/examples/ease-pill-tab-switcher-sap/README.md
@@ -1,0 +1,18 @@
+# ease-pill-tab-switcher-sap
+
+A simple pill-style tab group where each button gets its own scale-in dark background and a slight bounce when selected, independent of the other tabs.
+
+## Usage
+1. Include `style.css`.
+2. Add markup: `.pill-btn` elements (mark one `active` initially) inside `.pill-tabs-sap`.
+3. Attach the click toggle from `demo.html`.
+
+## Customization
+- Active pill background color.
+- Bounce keyframe intensity (`pill-select-sap`).
+- Number of tabs — each button independently manages its own `::before` fill, so any count works without layout math.
+
+## Notes
+- Unlike a sliding-indicator tab design, each button owns its own `::before` pill background that scales in/out independently — simpler to implement (no `offsetLeft` measurement needed) at the cost of not having a single indicator that visually travels between tabs.
+- The `.active` class re-triggers the `pill-select-sap` bounce animation each time a tab is clicked, since the class is freshly added (not just toggled on an already-active element).
+- Respects `prefers-reduced-motion`: the bounce animation and pill scale-in transition are both disabled; text color and background still switch correctly, just instantly.

--- a/submissions/examples/ease-pill-tab-switcher-sap/demo.html
+++ b/submissions/examples/ease-pill-tab-switcher-sap/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-pill-tab-switcher-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      height: 100vh;
+      margin: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #f4f4f5;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="pill-tabs-sap" id="pillTabs">
+    <button class="pill-btn active">Daily</button>
+    <button class="pill-btn">Weekly</button>
+    <button class="pill-btn">Monthly</button>
+  </div>
+
+  <script>
+    const wrap = document.getElementById('pillTabs');
+    wrap.querySelectorAll('.pill-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        wrap.querySelectorAll('.pill-btn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+      });
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-pill-tab-switcher-sap/style.css
+++ b/submissions/examples/ease-pill-tab-switcher-sap/style.css
@@ -1,0 +1,63 @@
+.pill-tabs-sap {
+  display: inline-flex;
+  background: #f1f5f9;
+  border-radius: 999px;
+  padding: 4px;
+  font-family: system-ui, sans-serif;
+}
+
+.pill-tabs-sap .pill-btn {
+  padding: 9px 20px;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  color: #64748b;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  position: relative;
+  z-index: 1;
+  transition: color 0.3s ease;
+}
+
+.pill-tabs-sap .pill-btn.active {
+  color: #fff;
+}
+
+.pill-tabs-sap .pill-btn.active {
+  animation: pill-select-sap 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.pill-tabs-sap .pill-btn::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 999px;
+  background: #111;
+  z-index: -1;
+  transform: scale(0);
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.pill-tabs-sap .pill-btn.active::before {
+  transform: scale(1);
+}
+
+@keyframes pill-select-sap {
+  0% { transform: scale(0.9); }
+  60% { transform: scale(1.05); }
+  100% { transform: scale(1); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pill-tabs-sap .pill-btn,
+  .pill-tabs-sap .pill-btn::before {
+    transition: color 0.2s ease;
+  }
+  .pill-tabs-sap .pill-btn::before {
+    transition: none;
+  }
+  .pill-tabs-sap .pill-btn.active {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-pill-tab-switcher-sap`, a bouncy pill-style tab switcher.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-pill-tab-switcher-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Each button owns its own `::before` pill fill rather than a single shared sliding indicator — simpler implementation with no `offsetLeft` measurement required, traded off against not having a visually traveling indicator between tabs.
- The bounce animation re-triggers on every click since `.active` is freshly applied to a previously-inactive element each time.
- `prefers-reduced-motion` disables the bounce animation and pill scale-in transition; tab switching remains instant and correct.

## Feature Description

Adds a reusable bouncy pill-style tab switcher component.

Level: Beginner

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.