### PR TITLE
feat: add CSS-only tooltip arrow

### DIFF
--- a/submissions/examples/css-tooltip-arrow/README.md
+++ b/submissions/examples/css-tooltip-arrow/README.md
@@ -1,0 +1,11 @@
+# CSS-only Tooltip Arrow
+
+A simple CSS-only tooltip component with directional arrows.
+
+## Features
+
+- Top, bottom, left, and right positions
+- Responsive layout
+- Keyboard focus support
+- ARIA accessibility attributes
+- No JavaScript required

--- a/submissions/examples/css-tooltip-arrow/demo.html
+++ b/submissions/examples/css-tooltip-arrow/demo.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS-only Tooltip Arrow</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+  <main class="demo">
+    <h1>CSS-only Tooltip Arrow</h1>
+    <p>Hover or focus a button to view its tooltip.</p>
+
+    <div class="tooltip-demo">
+      <div class="tooltip-container">
+        <button
+          class="tooltip-trigger top"
+          type="button"
+          aria-describedby="tooltip-top"
+        >
+          Top
+        </button>
+        <span id="tooltip-top" class="tooltip" role="tooltip">
+          Tooltip on top
+        </span>
+      </div>
+
+      <div class="tooltip-container">
+        <button
+          class="tooltip-trigger bottom"
+          type="button"
+          aria-describedby="tooltip-bottom"
+        >
+          Bottom
+        </button>
+        <span id="tooltip-bottom" class="tooltip" role="tooltip">
+          Tooltip on bottom
+        </span>
+      </div>
+
+      <div class="tooltip-container">
+        <button
+          class="tooltip-trigger left"
+          type="button"
+          aria-describedby="tooltip-left"
+        >
+          Left
+        </button>
+        <span id="tooltip-left" class="tooltip" role="tooltip">
+          Tooltip on left
+        </span>
+      </div>
+
+      <div class="tooltip-container">
+        <button
+          class="tooltip-trigger right"
+          type="button"
+          aria-describedby="tooltip-right"
+        >
+          Right
+        </button>
+        <span id="tooltip-right" class="tooltip" role="tooltip">
+          Tooltip on right
+        </span>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/css-tooltip-arrow/style.css
+++ b/submissions/examples/css-tooltip-arrow/style.css
@@ -1,0 +1,175 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Arial, sans-serif;
+  background: #f4f7fb;
+  color: #1f2937;
+}
+
+.demo {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  text-align: center;
+}
+
+.demo h1 {
+  margin: 0 0 0.5rem;
+  color: #4338ca;
+}
+
+.demo p {
+  margin: 0;
+  color: #64748b;
+}
+
+.tooltip-demo {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 5rem;
+  margin-top: 4rem;
+}
+
+.tooltip-container {
+  position: relative;
+}
+
+.tooltip-trigger {
+  padding: 0.7rem 1.3rem;
+  border: 0;
+  border-radius: 0.5rem;
+  color: #fff;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.tooltip-trigger:focus-visible {
+  outline: 3px solid #f59e0b;
+  outline-offset: 3px;
+}
+
+.tooltip {
+  --tooltip-color: #4338ca;
+
+  position: absolute;
+  z-index: 1;
+  width: max-content;
+  max-width: 180px;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.4rem;
+  background: var(--tooltip-color);
+  color: #fff;
+  font-size: 0.875rem;
+  line-height: 1.4;
+  text-align: center;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.tooltip::after {
+  content: "";
+  position: absolute;
+  border: 6px solid transparent;
+}
+
+.tooltip-trigger:hover + .tooltip,
+.tooltip-trigger:focus-visible + .tooltip {
+  opacity: 1;
+  visibility: visible;
+}
+
+/* Top */
+.tooltip-trigger.top {
+  background: #4338ca;
+}
+
+.tooltip-trigger.top + .tooltip {
+  bottom: calc(100% + 10px);
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.tooltip-trigger.top + .tooltip::after {
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-top-color: var(--tooltip-color);
+}
+
+/* Bottom */
+.tooltip-trigger.bottom {
+  background: #059669;
+}
+
+.tooltip-trigger.bottom + .tooltip {
+  top: calc(100% + 10px);
+  left: 50%;
+  transform: translateX(-50%);
+  --tooltip-color: #059669;
+}
+
+.tooltip-trigger.bottom + .tooltip::after {
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-bottom-color: var(--tooltip-color);
+}
+
+/* Left */
+.tooltip-trigger.left {
+  background: #ea580c;
+}
+
+.tooltip-trigger.left + .tooltip {
+  right: calc(100% + 10px);
+  top: 50%;
+  transform: translateY(-50%);
+  --tooltip-color: #ea580c;
+}
+
+.tooltip-trigger.left + .tooltip::after {
+  left: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  border-left-color: var(--tooltip-color);
+}
+
+/* Right */
+.tooltip-trigger.right {
+  background: #2563eb;
+}
+
+.tooltip-trigger.right + .tooltip {
+  left: calc(100% + 10px);
+  top: 50%;
+  transform: translateY(-50%);
+  --tooltip-color: #2563eb;
+}
+
+.tooltip-trigger.right + .tooltip::after {
+  right: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  border-right-color: var(--tooltip-color);
+}
+
+@media (max-width: 600px) {
+  .tooltip-demo {
+    gap: 4rem 2rem;
+  }
+
+  .tooltip {
+    max-width: 150px;
+    white-space: normal;
+  }
+}


### PR DESCRIPTION
## Description

Adds a CSS-only tooltip component with directional arrows.

## Features

- Top, bottom, left, and right tooltip positions
- Responsive layout
- Keyboard focus support
- ARIA accessibility attributes
- No JavaScript required

## Note

This implementation was developed while I was assigned to the original tooltip issue.