### PR TITLE
feat: add zoom card gallery with sibling blur effect

### DIFF
--- a/submissions/examples/zoom-card-gallery/README.md
+++ b/submissions/examples/zoom-card-gallery/README.md
@@ -1,0 +1,36 @@
+# Zoom Card Gallery
+
+A CSS zoom card gallery where hovering one card zooms it in while blurring and fading sibling cards.
+
+## Features
+
+- Hover zoom with sibling blur effect — pure CSS, no JavaScript
+- Keyboard accessible via `tabindex` and `:focus-visible`
+- Responsive grid layout
+- Staggered entrance animation
+- Accessible with `prefers-reduced-motion` support
+- CSS custom properties for easy theming
+
+## Customization
+
+```css
+:root {
+  --zcg-white: #ffffff;
+  --zcg-bg: #f3f4f6;
+  --zcg-text: #1f2937;
+  --zcg-muted: #6b7280;
+  --zcg-border: #e5e7eb;
+  --zcg-radius: 10px;
+}
+```
+
+## Usage
+
+```html
+<link rel="stylesheet" href="style.css">
+```
+
+## Files
+
+- `demo.html` — Demo page with 6 gallery cards
+- `style.css` — All styles, zoom/blur effects, and animations

--- a/submissions/examples/zoom-card-gallery/demo.html
+++ b/submissions/examples/zoom-card-gallery/demo.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS zoom card gallery where cards zoom and blur neighbors on hover">
+  <title>Zoom Card Gallery — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <nav class="zcg-nav">
+    <span class="zcg-nav__brand">EaseMotion</span>
+    <span class="zcg-nav__gap"></span>
+    <span class="zcg-nav__item">Gallery</span>
+  </nav>
+
+  <header class="zcg-header">
+    <h1 class="zcg-header__title">Zoom Card Gallery</h1>
+    <p class="zcg-header__sub">Hover any card — it zooms in while siblings fade and blur out.</p>
+  </header>
+
+  <main class="zcg-gallery" aria-label="Image gallery">
+
+    <div class="zcg-card" tabindex="0">
+      <div class="zcg-card__img" style="background:#c7d2fe"></div>
+      <div class="zcg-card__body">
+        <h3 class="zcg-card__h">Mountain Lake</h3>
+        <p class="zcg-card__p">Calm waters reflecting snow-capped peaks at dawn.</p>
+      </div>
+    </div>
+
+    <div class="zcg-card" tabindex="0">
+      <div class="zcg-card__img" style="background:#a5b4fc"></div>
+      <div class="zcg-card__body">
+        <h3 class="zcg-card__h">City Skyline</h3>
+        <p class="zcg-card__p">Glass towers catching the last golden hour light.</p>
+      </div>
+    </div>
+
+    <div class="zcg-card" tabindex="0">
+      <div class="zcg-card__img" style="background:#818cf8"></div>
+      <div class="zcg-card__body">
+        <h3 class="zcg-card__h">Forest Trail</h3>
+        <p class="zcg-card__p">A winding path through pine and fern under a canopy.</p>
+      </div>
+    </div>
+
+    <div class="zcg-card" tabindex="0">
+      <div class="zcg-card__img" style="background:#6366f1"></div>
+      <div class="zcg-card__body">
+        <h3 class="zcg-card__h">Ocean Coast</h3>
+        <p class="zcg-card__p">Waves crashing against red sandstone cliffs.</p>
+      </div>
+    </div>
+
+    <div class="zcg-card" tabindex="0">
+      <div class="zcg-card__img" style="background:#4f46e5"></div>
+      <div class="zcg-card__body">
+        <h3 class="zcg-card__h">Desert Dunes</h3>
+        <p class="zcg-card__p">Wind-sculpted ridges stretching to the horizon.</p>
+      </div>
+    </div>
+
+    <div class="zcg-card" tabindex="0">
+      <div class="zcg-card__img" style="background:#4338ca"></div>
+      <div class="zcg-card__body">
+        <h3 class="zcg-card__h">Autumn Field</h3>
+        <p class="zcg-card__p">Golden stalks swaying under a pale blue sky.</p>
+      </div>
+    </div>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/zoom-card-gallery/style.css
+++ b/submissions/examples/zoom-card-gallery/style.css
@@ -1,0 +1,182 @@
+:root {
+  --zcg-white: #ffffff;
+  --zcg-bg: #f3f4f6;
+  --zcg-text: #1f2937;
+  --zcg-muted: #6b7280;
+  --zcg-border: #e5e7eb;
+  --zcg-radius: 10px;
+}
+
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  background: var(--zcg-bg);
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--zcg-text);
+  line-height: 1.55;
+}
+
+/* ── nav ────────────────────────────────────────── */
+
+.zcg-nav {
+  display: flex;
+  align-items: center;
+  height: 48px;
+  padding: 0 24px;
+  background: var(--zcg-white);
+  border-bottom: 1px solid var(--zcg-border);
+}
+
+.zcg-nav__brand {
+  font-size: 0.8rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+
+.zcg-nav__gap {
+  flex: 1;
+}
+
+.zcg-nav__item {
+  font-size: 0.7rem;
+  color: var(--zcg-muted);
+  cursor: pointer;
+}
+
+.zcg-nav__item:hover {
+  color: var(--zcg-text);
+}
+
+/* ── header ─────────────────────────────────────── */
+
+.zcg-header {
+  text-align: center;
+  padding: 44px 24px 8px;
+}
+
+.zcg-header__title {
+  font-size: clamp(1.2rem, 3.5vw, 1.6rem);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+}
+
+.zcg-header__sub {
+  font-size: 0.72rem;
+  color: var(--zcg-muted);
+  margin-top: 6px;
+}
+
+/* ── gallery ────────────────────────────────────── */
+
+.zcg-gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 16px;
+  max-width: 660px;
+  margin: 0 auto;
+  padding: 28px 24px 64px;
+}
+
+/* ── card ───────────────────────────────────────── */
+
+.zcg-card {
+  background: var(--zcg-white);
+  border: 1px solid var(--zcg-border);
+  border-radius: var(--zcg-radius);
+  overflow: hidden;
+  outline: none;
+  cursor: pointer;
+  transition: transform 0.3s ease, filter 0.3s ease, box-shadow 0.3s ease;
+  transform-origin: center center;
+}
+
+.zcg-card:focus-visible {
+  box-shadow: 0 0 0 2px #6366f1;
+}
+
+.zcg-card__img {
+  height: 110px;
+  transition: height 0.3s ease;
+}
+
+.zcg-card__body {
+  padding: 12px 14px 14px;
+}
+
+.zcg-card__h {
+  font-size: 0.74rem;
+  font-weight: 700;
+  margin-bottom: 3px;
+}
+
+.zcg-card__p {
+  font-size: 0.64rem;
+  color: var(--zcg-muted);
+  line-height: 1.55;
+}
+
+/* ── hover: zoom this card, blur siblings ──────── */
+
+.zcg-gallery:hover .zcg-card {
+  filter: blur(3px) saturate(0.7);
+  transform: scale(0.96);
+}
+
+.zcg-gallery:hover .zcg-card:hover,
+.zcg-gallery:hover .zcg-card:focus-visible {
+  filter: none;
+  transform: scale(1.06);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.12);
+  z-index: 2;
+}
+
+/* ── entrance animation ─────────────────────────── */
+
+.zcg-card {
+  opacity: 0;
+  transform: translateY(14px);
+  animation: zcg-in 0.4s ease forwards;
+}
+
+.zcg-card:nth-child(1) { animation-delay: 0.00s; }
+.zcg-card:nth-child(2) { animation-delay: 0.06s; }
+.zcg-card:nth-child(3) { animation-delay: 0.12s; }
+.zcg-card:nth-child(4) { animation-delay: 0.18s; }
+.zcg-card:nth-child(5) { animation-delay: 0.24s; }
+.zcg-card:nth-child(6) { animation-delay: 0.30s; }
+
+@keyframes zcg-in {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* ── reduced motion ─────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .zcg-card {
+    animation: none;
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+
+  .zcg-gallery:hover .zcg-card {
+    filter: none;
+    transform: none;
+  }
+
+  .zcg-gallery:hover .zcg-card:hover,
+  .zcg-gallery:hover .zcg-card:focus-visible {
+    transform: none;
+    box-shadow: none;
+  }
+}


### PR DESCRIPTION
**Summary**
Adds a CSS zoom card gallery where hovering one card zooms it in while sibling cards blur and fade out. Pure CSS implementation with no JavaScript.

**Changes**
- `submissions/examples/zoom-card-gallery/demo.html` — Demo page with 6 gallery cards in a responsive grid
- `submissions/examples/zoom-card-gallery/style.css` — Zoom/blur hover effect using sibling selector, keyboard accessible via `:focus-visible`, staggered entrance animation, `prefers-reduced-motion` support
- `submissions/examples/zoom-card-gallery/README.md` — Documentation with usage and customization

**Resolves** #68083

**Labels:** GSSoC-26, animation, contribution, enhancement, good first issue, type:feature