### PR TITLE
feat: add sticky comparison bar component

### DIFF
--- a/submissions/examples/sticky-comparison-bar/README.md
+++ b/submissions/examples/sticky-comparison-bar/README.md
@@ -1,0 +1,36 @@
+# Sticky Comparison Bar
+
+A CSS sticky comparison bar that sticks to the bottom of the viewport for comparing products.
+
+## Features
+
+- Fixed position bar with slide-up entrance animation
+- Clean, minimal design with product labels and prices
+- Responsive across all screen sizes
+- CSS custom properties for easy theming
+- Accessible with `prefers-reduced-motion` support
+- Pure CSS — no JavaScript required
+
+## Customization
+
+```css
+:root {
+  --scb-white: #ffffff;
+  --scb-bg: #f8f9fa;
+  --scb-text: #212529;
+  --scb-muted: #6c757d;
+  --scb-indigo: #4f46e5;
+  --scb-green: #10b981;
+}
+```
+
+## Usage
+
+```html
+<link rel="stylesheet" href="style.css">
+```
+
+## Files
+
+- `demo.html` — Demo page with pricing sections and sticky bar
+- `style.css` — All styles, sticky positioning, and animations

--- a/submissions/examples/sticky-comparison-bar/demo.html
+++ b/submissions/examples/sticky-comparison-bar/demo.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS sticky comparison bar for comparing two selected products">
+  <title>Sticky Comparison Bar — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <nav class="scb-nav">
+    <span class="scb-nav__brand">EaseMotion</span>
+    <span class="scb-nav__gap"></span>
+    <span class="scb-nav__item">Products</span>
+  </nav>
+
+  <header class="scb-header">
+    <h1 class="scb-header__title">Sticky Comparison Bar</h1>
+    <p class="scb-header__sub">Scroll down — the bar sticks to the bottom of the viewport.</p>
+  </header>
+
+  <main class="scb-content">
+
+    <section class="scb-section">
+      <h2 class="scb-section__h">Starter Plan</h2>
+      <ul class="scb-section__list">
+        <li>1 GB storage</li>
+        <li>10k requests / mo</li>
+        <li>Community support</li>
+        <li>Basic analytics</li>
+      </ul>
+      <p class="scb-section__price">$9 / mo</p>
+    </section>
+
+    <section class="scb-section">
+      <h2 class="scb-section__h">Pro Plan</h2>
+      <ul class="scb-section__list">
+        <li>50 GB storage</li>
+        <li>Unlimited requests</li>
+        <li>Priority support</li>
+        <li>Advanced analytics</li>
+      </ul>
+      <p class="scb-section__price">$29 / mo</p>
+    </section>
+
+    <section class="scb-section">
+      <h2 class="scb-section__h">Enterprise Plan</h2>
+      <ul class="scb-section__list">
+        <li>500 GB storage</li>
+        <li>Unlimited requests</li>
+        <li>Dedicated support</li>
+        <li>Custom integrations</li>
+      </ul>
+      <p class="scb-section__price">$99 / mo</p>
+    </section>
+
+    <section class="scb-section">
+      <h2 class="scb-section__h">Add-on: Extra Storage</h2>
+      <ul class="scb-section__list">
+        <li>+25 GB block storage</li>
+        <li>Auto-scaling</li>
+        <li>Encryption at rest</li>
+      </ul>
+      <p class="scb-section__price">$5 / mo</p>
+    </section>
+
+    <section class="scb-section">
+      <h2 class="scb-section__h">Add-on: Custom Domain</h2>
+      <ul class="scb-section__list">
+        <li>Bring your own domain</li>
+        <li>Free SSL certificate</li>
+        <li>DNS management</li>
+      </ul>
+      <p class="scb-section__price">$3 / mo</p>
+    </section>
+
+  </main>
+
+  <div class="scb-bar" role="complementary" aria-label="Product comparison">
+    <div class="scb-bar__item">
+      <span class="scb-bar__label">Starter</span>
+      <span class="scb-bar__val">$9</span>
+    </div>
+    <span class="scb-bar__vs">vs</span>
+    <div class="scb-bar__item">
+      <span class="scb-bar__label">Pro</span>
+      <span class="scb-bar__val">$29</span>
+    </div>
+    <button class="scb-bar__btn">Compare Now</button>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/sticky-comparison-bar/style.css
+++ b/submissions/examples/sticky-comparison-bar/style.css
@@ -1,0 +1,208 @@
+:root {
+  --scb-white: #ffffff;
+  --scb-bg: #f8f9fa;
+  --scb-text: #212529;
+  --scb-muted: #6c757d;
+  --scb-border: #dee2e6;
+  --scb-indigo: #4f46e5;
+  --scb-green: #10b981;
+  --scb-radius: 10px;
+}
+
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  background: var(--scb-bg);
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--scb-text);
+  line-height: 1.55;
+  padding-bottom: 72px;
+}
+
+/* ── nav ────────────────────────────────────────── */
+
+.scb-nav {
+  display: flex;
+  align-items: center;
+  height: 48px;
+  padding: 0 24px;
+  background: var(--scb-white);
+  border-bottom: 1px solid var(--scb-border);
+}
+
+.scb-nav__brand {
+  font-size: 0.8rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+
+.scb-nav__gap {
+  flex: 1;
+}
+
+.scb-nav__item {
+  font-size: 0.7rem;
+  color: var(--scb-muted);
+  cursor: pointer;
+}
+
+.scb-nav__item:hover {
+  color: var(--scb-text);
+}
+
+/* ── header ─────────────────────────────────────── */
+
+.scb-header {
+  text-align: center;
+  padding: 44px 24px 8px;
+}
+
+.scb-header__title {
+  font-size: clamp(1.2rem, 3.5vw, 1.6rem);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+}
+
+.scb-header__sub {
+  font-size: 0.72rem;
+  color: var(--scb-muted);
+  margin-top: 6px;
+}
+
+/* ── content ────────────────────────────────────── */
+
+.scb-content {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 28px 24px;
+}
+
+.scb-section {
+  background: var(--scb-white);
+  border: 1px solid var(--scb-border);
+  border-radius: var(--scb-radius);
+  padding: 20px;
+  margin-bottom: 14px;
+}
+
+.scb-section__h {
+  font-size: 0.82rem;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.scb-section__list {
+  list-style: none;
+  margin-bottom: 10px;
+}
+
+.scb-section__list li {
+  font-size: 0.68rem;
+  color: var(--scb-muted);
+  padding: 3px 0;
+}
+
+.scb-section__list li::before {
+  content: "\2713 ";
+  color: var(--scb-green);
+  font-weight: 700;
+  margin-right: 4px;
+}
+
+.scb-section__price {
+  font-size: 0.92rem;
+  font-weight: 800;
+  color: var(--scb-indigo);
+}
+
+/* ── sticky bar ─────────────────────────────────── */
+
+.scb-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  background: var(--scb-white);
+  border-top: 1px solid var(--scb-border);
+  box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.06);
+  z-index: 100;
+  padding: 0 20px;
+  transform: translateY(100%);
+  animation: scb-slide-up 0.5s 0.3s ease forwards;
+}
+
+@keyframes scb-slide-up {
+  to {
+    transform: translateY(0);
+  }
+}
+
+.scb-bar__item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1px;
+}
+
+.scb-bar__label {
+  font-size: 0.6rem;
+  font-weight: 600;
+  color: var(--scb-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.scb-bar__val {
+  font-size: 0.88rem;
+  font-weight: 800;
+  color: var(--scb-text);
+}
+
+.scb-bar__vs {
+  font-size: 0.64rem;
+  color: var(--scb-muted);
+  font-weight: 600;
+}
+
+.scb-bar__btn {
+  font-family: inherit;
+  font-size: 0.68rem;
+  font-weight: 700;
+  padding: 7px 18px;
+  border: none;
+  border-radius: 6px;
+  background: var(--scb-indigo);
+  color: var(--scb-white);
+  cursor: pointer;
+  transition: background 0.2s;
+  margin-left: 8px;
+}
+
+.scb-bar__btn:hover {
+  background: #4338ca;
+}
+
+/* ── reduced motion ─────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .scb-bar {
+    animation: none;
+    transform: translateY(0);
+  }
+
+  .scb-bar__btn {
+    transition: none;
+  }
+}


### PR DESCRIPTION
**Summary**
Adds a CSS sticky comparison bar component that sticks to the bottom of the viewport for comparing two selected products. Pure CSS implementation with no JavaScript.

**Changes**
- `submissions/examples/sticky-comparison-bar/demo.html` — Demo page with 5 pricing sections and a sticky bottom bar
- `submissions/examples/sticky-comparison-bar/style.css` — Fixed-position bar with slide-up animation, product labels, prices, and compare button
- `submissions/examples/sticky-comparison-bar/README.md` — Documentation with usage and customization

**Resolves** #68078

**Labels:** GSSoC-26, animation, component, contribution, enhancement, good first issue, type:feature