### PR TITLE
Add ease-arcade-high-score-table component

### DIFF
--- a/submissions/examples/arcade-high-score-table-ij/README.md
+++ b/submissions/examples/arcade-high-score-table-ij/README.md
@@ -1,0 +1,11 @@
+# ease-arcade-high-score-table
+
+An arcade high-score table where the ranks pulse, the initials blink, and the scores tick.
+
+## Run
+Open `demo.html` directly in a browser to watch the table.
+
+## Notes
+- The rank numbers pulse down the table.
+- The champion initials blink at the top.
+- The score values tick in turn.

--- a/submissions/examples/arcade-high-score-table-ij/demo.html
+++ b/submissions/examples/arcade-high-score-table-ij/demo.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-arcade-high-score-table demo</title>
+</head>
+<body>
+<div class="ahs-table">
+  <div class="ahs-title">HIGH SCORES <em>INSERT COIN</em></div>
+  <div class="ahs-row ahs-top"><b>1</b><span>AAA</span><em>98200</em></div>
+  <div class="ahs-row"><b>2</b><span>BMB</span><em>76400</em></div>
+  <div class="ahs-row"><b>3</b><span>CKC</span><em>65100</em></div>
+  <div class="ahs-row"><b>4</b><span>DLD</span><em>53200</em></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/arcade-high-score-table-ij/style.css
+++ b/submissions/examples/arcade-high-score-table-ij/style.css
@@ -1,0 +1,13 @@
+.ahs-table{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:360px;background:#0c0a1e;border:4px solid #ff3d5e;border-radius:12px;padding:18px;display:flex;flex-direction:column;gap:8px}
+.ahs-title{font-size:14px;font-weight:800;letter-spacing:3px;color:#ffd23f;text-align:center}
+.ahs-title em{font-style:normal;font-size:9px;letter-spacing:2px;color:#7cebb0;display:block;animation:ahs-coin-blink-arcade-high-score-table 2s ease-in-out infinite}
+.ahs-row{display:flex;align-items:center;gap:12px;background:#141233;border:1px solid #2c2a5c;border-radius:8px;padding:10px 12px}
+.ahs-row b{width:26px;text-align:center;font-size:12px;color:#ffd23f;animation:ahs-rank-pulse-arcade-high-score-table 1.8s ease-in-out infinite}
+.ahs-row span{flex:1;font-family:"Courier New",monospace;font-size:14px;font-weight:800;color:#f4f0ff;letter-spacing:2px}
+.ahs-row em{font-style:normal;font-family:"Courier New",monospace;font-size:13px;font-weight:800;color:#7cebb0;animation:ahs-score-tick-arcade-high-score-table 1.4s ease-in-out infinite}
+.ahs-top{border-color:#ffd23f;box-shadow:0 0 12px rgba(255,210,63,0.25)}
+.ahs-top span{color:#ffd23f;animation:ahs-init-blink-arcade-high-score-table 1.2s ease-in-out infinite}
+@keyframes ahs-rank-pulse-arcade-high-score-table{0%{opacity:0.5}50%{opacity:1}100%{opacity:0.5}}
+@keyframes ahs-init-blink-arcade-high-score-table{0%{text-shadow:0 0 0 transparent}50%{text-shadow:0 0 8px rgba(255,210,63,0.9)}100%{text-shadow:0 0 0 transparent}}
+@keyframes ahs-score-tick-arcade-high-score-table{0%{transform:translateY(0)}30%{transform:translateY(-3px)}100%{transform:translateY(0)}}
+@keyframes ahs-coin-blink-arcade-high-score-table{0%{opacity:0.4}50%{opacity:1}100%{opacity:0.4}}


### PR DESCRIPTION
## Component: ease-arcade-high-score-table — ranks pulse, initials blink, and scores tick

**Closes #69717**

### What this adds
An arcade high-score table: the rank numbers pulse down the rows, the champion initials blink, and the score values tick in turn.

### Acceptance Criteria covered
- Rank numbers pulse down the table
- Champion initials blink at the top
- Score values tick in turn

### Files
- `submissions/examples/arcade-high-score-table-ij/demo.html`
- `submissions/examples/arcade-high-score-table-ij/style.css`
- `submissions/examples/arcade-high-score-table-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the high-score table.