### PR TITLE
Add ease-olympic-medal-count component

### DIFF
--- a/submissions/examples/olympic-medal-count-ij/README.md
+++ b/submissions/examples/olympic-medal-count-ij/README.md
@@ -1,0 +1,11 @@
+# ease-olympic-medal-count
+
+An Olympic medal count board where the medals pulse, the rows blink, and the totals tick.
+
+## Run
+Open `demo.html` directly in a browser to watch the medal board.
+
+## Notes
+- The gold, silver and bronze circles pulse in turn.
+- The country rows blink in turn.
+- The running totals tick below.

--- a/submissions/examples/olympic-medal-count-ij/demo.html
+++ b/submissions/examples/olympic-medal-count-ij/demo.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-olympic-medal-count demo</title>
+</head>
+<body>
+<div class="omc-board">
+  <div class="omc-title">OLYMPIC MEDALS</div>
+  <div class="omc-row omc-lead"><span>USA</span><i class="omc-gold"></i>40<i class="omc-silver"></i>44<i class="omc-bronze"></i>42<em>126</em></div>
+  <div class="omc-row"><span>CHN</span><i class="omc-gold"></i>40<i class="omc-silver"></i>27<i class="omc-bronze"></i>24<em>91</em></div>
+  <div class="omc-row"><span>JPN</span><i class="omc-gold"></i>20<i class="omc-silver"></i>12<i class="omc-bronze"></i>13<em>45</em></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/olympic-medal-count-ij/style.css
+++ b/submissions/examples/olympic-medal-count-ij/style.css
@@ -1,0 +1,15 @@
+.omc-board{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:400px;background:#0a1220;border:1px solid #1e3350;border-radius:14px;padding:20px;display:flex;flex-direction:column;gap:10px}
+.omc-title{text-align:center;font-size:13px;font-weight:800;letter-spacing:4px;color:#f4f0ff}
+.omc-row{display:flex;align-items:center;gap:8px;background:#0e1a2e;border-radius:8px;padding:10px 12px}
+.omc-row span{width:44px;font-size:12px;font-weight:800;color:#e8f0f8}
+.omc-row i{display:inline-block;width:14px;height:14px;border-radius:50%}
+.omc-row em{font-style:normal;margin-left:auto;font-size:14px;font-weight:800;color:#f5c542;font-family:"Courier New",monospace;animation:omc-total-tick-olympic-medal-count 1.6s ease-in-out infinite}
+.omc-gold{background:radial-gradient(circle at 35% 35%,#fff3c4,#d4a017);animation:omc-gold-pulse-olympic-medal-count 2s ease-in-out infinite}
+.omc-silver{background:radial-gradient(circle at 35% 35%,#ffffff,#8a8f98);animation:omc-silver-pulse-olympic-medal-count 2s ease-in-out 0.4s infinite}
+.omc-bronze{background:radial-gradient(circle at 35% 35%,#f0c89a,#9c6b2f);animation:omc-bronze-pulse-olympic-medal-count 2s ease-in-out 0.8s infinite}
+.omc-lead{border:1px solid #f5c542;box-shadow:0 0 10px rgba(245,197,66,0.2);animation:omc-lead-blink-olympic-medal-count 1.8s ease-in-out infinite}
+@keyframes omc-gold-pulse-olympic-medal-count{0%,100%{transform:scale(1)}50%{transform:scale(1.25)}}
+@keyframes omc-silver-pulse-olympic-medal-count{0%,100%{transform:scale(1)}50%{transform:scale(1.25)}}
+@keyframes omc-bronze-pulse-olympic-medal-count{0%,100%{transform:scale(1)}50%{transform:scale(1.25)}}
+@keyframes omc-total-tick-olympic-medal-count{0%,100%{transform:translateY(0)}50%{transform:translateY(-2px)}}
+@keyframes omc-lead-blink-olympic-medal-count{0%{opacity:0.7}50%{opacity:1}100%{opacity:0.7}}


### PR DESCRIPTION
## Component: ease-olympic-medal-count — medals pulse, rows blink, and totals tick

**Closes #69722**

### What this adds
An Olympic medal count board: the gold, silver and bronze circles pulse in turn, the country rows blink, and the running totals tick.

### Acceptance Criteria covered
- Gold, silver and bronze circles pulse
- Country rows blink in turn
- Running totals tick below

### Files
- `submissions/examples/olympic-medal-count-ij/demo.html`
- `submissions/examples/olympic-medal-count-ij/style.css`
- `submissions/examples/olympic-medal-count-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the medal board.