### PR TITLE
Add ease-train-schedule-board component

### DIFF
--- a/submissions/examples/train-schedule-board-ij/README.md
+++ b/submissions/examples/train-schedule-board-ij/README.md
@@ -1,0 +1,11 @@
+# ease-train-schedule-board
+
+A train schedule board where the rows flash, the platforms blink, and the times tick.
+
+## Run
+Open `demo.html` directly in a browser to watch the schedule.
+
+## Notes
+- The departure rows flash in turn.
+- The platform numbers blink on the rows.
+- The departure times tick on the left.

--- a/submissions/examples/train-schedule-board-ij/demo.html
+++ b/submissions/examples/train-schedule-board-ij/demo.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-train-schedule-board demo</title>
+</head>
+<body>
+<div class="tsb-board">
+  <div class="tsb-head">DEPARTURES</div>
+  <div class="tsb-row"><b>07:42</b><span>EXPRESS 221</span><em>PLAT 3</em></div>
+  <div class="tsb-row"><b>07:55</b><span>LOCAL 118</span><em>PLAT 1</em></div>
+  <div class="tsb-row"><b>08:10</b><span>RAPID 306</span><em>PLAT 5</em></div>
+  <div class="tsb-row"><b>08:27</b><span>EXPRESS 245</span><em>PLAT 2</em></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/train-schedule-board-ij/style.css
+++ b/submissions/examples/train-schedule-board-ij/style.css
@@ -1,0 +1,10 @@
+.tsb-board{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:400px;background:#0a1018;border:1px solid #1b2b42;border-radius:10px;padding:16px;font-family:"Courier New",monospace}
+.tsb-head{font-size:13px;font-weight:800;letter-spacing:4px;color:#ffd23f;text-align:center;margin-bottom:10px}
+.tsb-row{display:flex;align-items:center;gap:12px;padding:10px 12px;border-bottom:1px dashed #16263b;animation:tsb-row-flash-train-schedule-board 2s ease-in-out infinite}
+.tsb-row:nth-child(even){animation-delay:0.5s}
+.tsb-row b{width:52px;font-size:13px;color:#7cebb0;animation:tsb-time-tick-train-schedule-board 1.4s ease-in-out infinite}
+.tsb-row span{flex:1;font-size:12px;color:#e8f0f8}
+.tsb-row em{font-style:normal;font-size:12px;color:#f5c542;animation:tsb-plat-blink-train-schedule-board 1.8s ease-in-out infinite}
+@keyframes tsb-row-flash-train-schedule-board{0%,100%{background:#0a1018}50%{background:#13202e}}
+@keyframes tsb-time-tick-train-schedule-board{0%{opacity:0.6}50%{opacity:1}100%{opacity:0.6}}
+@keyframes tsb-plat-blink-train-schedule-board{0%{opacity:0.5}50%{opacity:1}100%{opacity:0.5}}


### PR DESCRIPTION
## Component: ease-train-schedule-board — rows flash, platforms blink, and times tick

**Closes #69734**

### What this adds
A train schedule board: the departure rows flash in turn, the platform numbers blink, and the departure times tick.

### Acceptance Criteria covered
- Departure rows flash in turn
- Platform numbers blink on the rows
- Departure times tick on the left

### Files
- `submissions/examples/train-schedule-board-ij/demo.html`
- `submissions/examples/train-schedule-board-ij/style.css`
- `submissions/examples/train-schedule-board-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the schedule.