### PR TITLE
Add ease-cinema-marquee-sign component

### DIFF
--- a/submissions/examples/cinema-marquee-sign-ij/README.md
+++ b/submissions/examples/cinema-marquee-sign-ij/README.md
@@ -1,0 +1,11 @@
+# ease-cinema-marquee-sign
+
+A cinema marquee sign where the bulbs chase, the reels spin, and the showtimes blink.
+
+## Run
+Open `demo.html` directly in a browser to watch the marquee.
+
+## Notes
+- The light bulbs chase around the frame.
+- The film reels spin on the sign.
+- The showtimes blink in the marquee.

--- a/submissions/examples/cinema-marquee-sign-ij/demo.html
+++ b/submissions/examples/cinema-marquee-sign-ij/demo.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-cinema-marquee-sign demo</title>
+</head>
+<body>
+<div class="cmq-sign">
+  <div class="cmq-bulbs">
+    <i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i>
+  </div>
+  <div class="cmq-title">GRAND CINEMA</div>
+  <div class="cmq-reels">
+    <i class="cmq-reel"></i>
+    <i class="cmq-reel"></i>
+  </div>
+  <div class="cmq-shows">
+    <span class="cmq-show">REBEL MOON 7:30</span>
+    <span class="cmq-show">SOLO DRIVE 9:15</span>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/cinema-marquee-sign-ij/style.css
+++ b/submissions/examples/cinema-marquee-sign-ij/style.css
@@ -1,0 +1,13 @@
+.cmq-sign{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:400px;background:#120a26;border:4px solid #ff3d5e;border-radius:14px;padding:18px;display:flex;flex-direction:column;gap:14px}
+.cmq-bulbs{display:flex;justify-content:space-between;gap:6px}
+.cmq-bulbs i{width:10px;height:10px;border-radius:50%;background:#fff7cc;animation:cmq-chase-cinema-marquee-sign 1.2s ease-in-out infinite}
+.cmq-bulbs i:nth-child(2n){animation-delay:0.15s}
+.cmq-bulbs i:nth-child(3n){animation-delay:0.3s}
+.cmq-title{text-align:center;font-size:22px;font-weight:800;letter-spacing:5px;color:#ff3d5e;text-shadow:0 0 14px rgba(255,61,94,0.8)}
+.cmq-reels{display:flex;justify-content:center;gap:24px}
+.cmq-reel{width:44px;height:44px;border-radius:50%;background:radial-gradient(circle,#1c1038 30%,#ff3d5e 32%,#120a26 40%);animation:cmq-reel-spin-cinema-marquee-sign 2.4s linear infinite}
+.cmq-shows{display:flex;flex-direction:column;gap:6px}
+.cmq-show{background:#1c1038;border-radius:6px;padding:8px 12px;text-align:center;font-size:12px;letter-spacing:2px;color:#e8f0f8;animation:cmq-show-blink-cinema-marquee-sign 2s ease-in-out infinite}
+@keyframes cmq-chase-cinema-marquee-sign{0%,100%{opacity:0.2}50%{opacity:1}}
+@keyframes cmq-reel-spin-cinema-marquee-sign{0%{transform:rotate(0)}100%{transform:rotate(360deg)}}
+@keyframes cmq-show-blink-cinema-marquee-sign{0%{opacity:0.6}50%{opacity:1}100%{opacity:0.6}}


### PR DESCRIPTION
## Component: ease-cinema-marquee-sign — bulbs chase, reels spin, and showtimes blink

**Closes #69742**

### What this adds
A cinema marquee sign: the light bulbs chase around the frame, the film reels spin, and the showtimes blink.

### Acceptance Criteria covered
- Light bulbs chase around the frame
- Film reels spin on the sign
- Showtimes blink in the marquee

### Files
- `submissions/examples/cinema-marquee-sign-ij/demo.html`
- `submissions/examples/cinema-marquee-sign-ij/style.css`
- `submissions/examples/cinema-marquee-sign-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the marquee.