### PR TITLE
Add ease-airport-luggage-carousel component

### DIFF
--- a/submissions/examples/airport-luggage-carousel-ij/README.md
+++ b/submissions/examples/airport-luggage-carousel-ij/README.md
@@ -1,0 +1,11 @@
+# ease-airport-luggage-carousel
+
+An airport luggage carousel where the bags circle, the arrows flash, and the tags blink.
+
+## Run
+Open `demo.html` directly in a browser to watch the carousel.
+
+## Notes
+- The bags circle around the belt.
+- The direction arrows flash in turn.
+- The flight tag blinks above.

--- a/submissions/examples/airport-luggage-carousel-ij/demo.html
+++ b/submissions/examples/airport-luggage-carousel-ij/demo.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-airport-luggage-carousel demo</title>
+</head>
+<body>
+<div class="alc-carousel">
+  <div class="alc-tag">FLIGHT AI-204</div>
+  <div class="alc-belt">
+    <i class="alc-bag"></i>
+    <i class="alc-bag"></i>
+    <i class="alc-bag"></i>
+    <i class="alc-bag"></i>
+    <i class="alc-arrow"></i>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/airport-luggage-carousel-ij/style.css
+++ b/submissions/examples/airport-luggage-carousel-ij/style.css
@@ -1,0 +1,11 @@
+.alc-carousel{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:420px;background:#0d1624;border:1px solid #1e3350;border-radius:14px;padding:20px;display:flex;flex-direction:column;gap:14px}
+.alc-tag{text-align:center;font-size:11px;font-weight:800;letter-spacing:3px;color:#f5c542;border:1px solid #4a3c14;border-radius:20px;padding:4px 10px;align-self:center;animation:alc-tag-blink-airport-luggage-carousel 2s ease-in-out infinite}
+.alc-belt{position:relative;height:84px;background:#0a1520;border-radius:10px;border:1px solid #1e3350;overflow:hidden}
+.alc-bag{position:absolute;top:22px;width:34px;height:38px;border-radius:6px;background:linear-gradient(180deg,#4a5a72,#2c3a4e);left:-40px;animation:alc-bag-ride-airport-luggage-carousel 6s linear infinite}
+.alc-bag:nth-child(2){animation-delay:1.5s}
+.alc-bag:nth-child(3){animation-delay:3s}
+.alc-bag:nth-child(4){animation-delay:4.5s}
+.alc-arrow{position:absolute;top:12px;right:14px;width:0;height:0;border-top:6px solid transparent;border-bottom:6px solid transparent;border-left:10px solid #7cebb0;animation:alc-arrow-flash-airport-luggage-carousel 1.2s ease-in-out infinite}
+@keyframes alc-bag-ride-airport-luggage-carousel{0%{transform:translateX(0)}100%{transform:translateX(500px)}}
+@keyframes alc-arrow-flash-airport-luggage-carousel{0%{opacity:0.3}50%{opacity:1}100%{opacity:0.3}}
+@keyframes alc-tag-blink-airport-luggage-carousel{0%{opacity:0.6}50%{opacity:1}100%{opacity:0.6}}


### PR DESCRIPTION
## Component: ease-airport-luggage-carousel — bags circle, arrows flash, and tags blink

**Closes #69751**

### What this adds
An airport luggage carousel: the bags circle around the belt, the direction arrows flash, and the flight tag blinks.

### Acceptance Criteria covered
- Bags circle around the belt
- Direction arrows flash in turn
- Flight tag blinks above

### Files
- `submissions/examples/airport-luggage-carousel-ij/demo.html`
- `submissions/examples/airport-luggage-carousel-ij/style.css`
- `submissions/examples/airport-luggage-carousel-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the carousel.