### PR TITLE
Add ease-concert-stage-lights component

### DIFF
--- a/submissions/examples/concert-stage-lights-ij/README.md
+++ b/submissions/examples/concert-stage-lights-ij/README.md
@@ -1,0 +1,11 @@
+# ease-concert-stage-lights
+
+A concert stage light rig where the beams sweep, the spots pulse, and the bars bounce.
+
+## Run
+Open `demo.html` directly in a browser to watch the stage.
+
+## Notes
+- The color beams sweep across the stage.
+- The spotlight dots pulse in turn.
+- The crowd bars bounce at the base.

--- a/submissions/examples/concert-stage-lights-ij/demo.html
+++ b/submissions/examples/concert-stage-lights-ij/demo.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-concert-stage-lights demo</title>
+</head>
+<body>
+<div class="csl-stage">
+  <div class="csl-beams">
+    <i class="csl-beam csl-red"></i>
+    <i class="csl-beam csl-blue"></i>
+    <i class="csl-beam csl-gold"></i>
+  </div>
+  <div class="csl-spots">
+    <i class="csl-spot"></i>
+    <i class="csl-spot"></i>
+    <i class="csl-spot"></i>
+  </div>
+  <div class="csl-crowd">
+    <i class="csl-bar"></i>
+    <i class="csl-bar"></i>
+    <i class="csl-bar"></i>
+    <i class="csl-bar"></i>
+    <i class="csl-bar"></i>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/concert-stage-lights-ij/style.css
+++ b/submissions/examples/concert-stage-lights-ij/style.css
@@ -1,0 +1,20 @@
+.csl-stage{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:400px;height:300px;background:linear-gradient(180deg,#0d0718,#1a0b30);border:1px solid #2c1a52;border-radius:14px;overflow:hidden}
+.csl-beams{position:absolute;left:0;right:0;top:0;height:120px}
+.csl-beam{position:absolute;top:0;width:120px;height:120px;transform-origin:top center}
+.csl-red{left:30px;background:linear-gradient(180deg,rgba(255,61,94,0.75),transparent);animation:csl-beam-red-concert-stage-lights 3s ease-in-out infinite}
+.csl-blue{left:150px;background:linear-gradient(180deg,rgba(56,189,248,0.75),transparent);animation:csl-beam-blue-concert-stage-lights 3s ease-in-out 0.5s infinite}
+.csl-gold{left:270px;background:linear-gradient(180deg,rgba(245,197,66,0.75),transparent);animation:csl-beam-gold-concert-stage-lights 3s ease-in-out 1s infinite}
+.csl-spots{position:absolute;left:0;right:0;top:120px;display:flex;justify-content:space-around}
+.csl-spot{width:16px;height:16px;border-radius:50%;background:#fff7cc;box-shadow:0 0 14px rgba(255,247,204,0.9);animation:csl-spot-pulse-concert-stage-lights 1.6s ease-in-out infinite}
+.csl-crowd{position:absolute;left:0;right:0;bottom:0;height:70px;display:flex;align-items:flex-end;gap:6px;padding:0 14px}
+.csl-bar{flex:1;background:#2c1a52;border-radius:6px 6px 0 0;animation:csl-bar-bounce-concert-stage-lights 0.8s ease-in-out infinite}
+.csl-bar:nth-child(1){height:44px}
+.csl-bar:nth-child(2){height:50px;animation-delay:0.1s}
+.csl-bar:nth-child(3){height:74px;animation-delay:0.2s}
+.csl-bar:nth-child(4){height:58px;animation-delay:0.3s}
+.csl-bar:nth-child(5){height:66px;animation-delay:0.4s}
+@keyframes csl-beam-red-concert-stage-lights{0%,100%{transform:scaleX(0.4)}50%{transform:scaleX(1.1)}}
+@keyframes csl-beam-blue-concert-stage-lights{0%,100%{transform:scaleX(0.4)}50%{transform:scaleX(1.1)}}
+@keyframes csl-beam-gold-concert-stage-lights{0%,100%{transform:scaleX(0.4)}50%{transform:scaleX(1.1)}}
+@keyframes csl-spot-pulse-concert-stage-lights{0%,100%{opacity:0.5}50%{opacity:1}}
+@keyframes csl-bar-bounce-concert-stage-lights{0%,100%{transform:scaleY(0.85)}50%{transform:scaleY(1.15)}}


### PR DESCRIPTION
## Component: ease-concert-stage-lights — beams sweep, spots pulse, and bars bounce

**Closes #69754**

### What this adds
A concert stage light rig: the color beams sweep across the stage, the spotlight dots pulse, and the crowd bars bounce.

### Acceptance Criteria covered
- Color beams sweep the stage
- Spotlight dots pulse in turn
- Crowd bars bounce at the base

### Files
- `submissions/examples/concert-stage-lights-ij/demo.html`
- `submissions/examples/concert-stage-lights-ij/style.css`
- `submissions/examples/concert-stage-lights-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the stage.