### PR TITLE
feat: add CSS chat widget component (#68054)

### DIFF
--- a/submissions/examples/css-chat-widget-eranmol/README.md
+++ b/submissions/examples/css-chat-widget-eranmol/README.md
@@ -1,0 +1,29 @@
+# CSS Chat Widget
+
+A floating customer support chat widget with a smooth open/close animation, built entirely with pure CSS.
+
+## What does this do?
+
+It provides a reusable, accessible chat widget component that sits in the bottom-right corner of any page. Users can toggle it open and closed with a single click. The open/close state is driven entirely by a hidden checkbox and the CSS `:checked` selector, so no JavaScript is required.
+
+## How is it used?
+
+Drop `demo.html` and `style.css` into your project. The widget is a self-contained block you can paste into any page:
+
+```html
+<div class="chat-widget" role="complementary" aria-label="Customer support chat">
+  <input type="checkbox" id="chat-toggle" class="chat-widget__toggle" aria-label="Open or close chat widget">
+  <label for="chat-toggle" class="chat-widget__trigger" tabindex="0" role="button">
+    <!-- chat and close SVG icons -->
+  </label>
+  <div class="chat-widget__panel" role="dialog" aria-label="Chat window">
+    <!-- header, messages, input area -->
+  </div>
+</div>
+```
+
+Toggle the panel by clicking the trigger label — the hidden checkbox handles the rest.
+
+## Why is it useful?
+
+Chat widgets are one of the most common UI elements on modern websites. This implementation gives developers a ready-to-use, pure CSS alternative to JavaScript-based chat widgets. It uses the checkbox hack for state management, CSS custom properties for easy theming, smooth slide-up animations, responsive design for mobile, and built-in dark mode support, all without a single line of JavaScript.

--- a/submissions/examples/css-chat-widget-eranmol/demo.html
+++ b/submissions/examples/css-chat-widget-eranmol/demo.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Chat Widget</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <!-- Simulated page content behind the widget -->
+  <main class="page-content">
+    <h1>My Website</h1>
+    <p>Scroll down or look at the bottom-right corner to find the chat widget.</p>
+  </main>
+
+  <!-- Chat Widget -->
+  <div class="chat-widget" role="complementary" aria-label="Customer support chat">
+
+    <!-- Hidden checkbox toggles open/close via CSS :checked — no JS needed -->
+    <input
+      type="checkbox"
+      id="chat-toggle"
+      class="chat-widget__toggle"
+      aria-label="Open or close chat widget"
+    >
+
+    <!-- Floating trigger button (visible when chat is closed) -->
+    <label for="chat-toggle" class="chat-widget__trigger" tabindex="0" role="button" aria-controls="chat-panel">
+      <!-- Chat bubble icon -->
+      <svg class="chat-widget__icon chat-widget__icon--open" xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
+      </svg>
+      <!-- Close (X) icon -->
+      <svg class="chat-widget__icon chat-widget__icon--close" xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <line x1="18" y1="6" x2="6" y2="18"></line>
+        <line x1="6" y1="6" x2="18" y2="18"></line>
+      </svg>
+      <span class="chat-widget__sr-text">Toggle chat</span>
+    </label>
+
+    <!-- Chat panel -->
+    <div class="chat-widget__panel" id="chat-panel" role="dialog" aria-label="Chat window">
+
+      <!-- Header -->
+      <div class="chat-widget__header">
+        <div class="chat-widget__header-info">
+          <div class="chat-widget__avatar" aria-hidden="true"></div>
+          <div>
+            <span class="chat-widget__name">Support Team</span>
+            <span class="chat-widget__status">Online</span>
+          </div>
+        </div>
+        <label for="chat-toggle" class="chat-widget__close-btn" tabindex="0" role="button" aria-label="Close chat">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <line x1="18" y1="6" x2="6" y2="18"></line>
+            <line x1="6" y1="6" x2="18" y2="18"></line>
+          </svg>
+        </label>
+      </div>
+
+      <!-- Messages area -->
+      <div class="chat-widget__messages" aria-live="polite">
+        <div class="chat-widget__message chat-widget__message--received">
+          <p>Hi there! How can we help you today?</p>
+          <span class="chat-widget__time">2:30 PM</span>
+        </div>
+        <div class="chat-widget__message chat-widget__message--received">
+          <p>Feel free to ask any questions about our product or services.</p>
+          <span class="chat-widget__time">2:30 PM</span>
+        </div>
+      </div>
+
+      <!-- Quick replies -->
+      <div class="chat-widget__quick-replies" role="group" aria-label="Quick reply suggestions">
+        <span class="chat-widget__quick-reply" tabindex="0" role="button">Pricing</span>
+        <span class="chat-widget__quick-reply" tabindex="0" role="button">Features</span>
+        <span class="chat-widget__quick-reply" tabindex="0" role="button">Support</span>
+      </div>
+
+      <!-- Input area -->
+      <div class="chat-widget__input-area">
+        <input
+          type="text"
+          class="chat-widget__input"
+          placeholder="Type a message..."
+          aria-label="Type a message"
+        >
+        <button class="chat-widget__send" type="button" aria-label="Send message">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <line x1="22" y1="2" x2="11" y2="13"></line>
+            <polygon points="22 2 15 22 11 13 2 9 22 2"></polygon>
+          </svg>
+        </button>
+      </div>
+
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/css-chat-widget-eranmol/style.css
+++ b/submissions/examples/css-chat-widget-eranmol/style.css
@@ -1,0 +1,627 @@
+/* ============================================================
+   CSS Chat Widget
+   Floating customer support chat widget with open/close animation.
+   Pure CSS — no JavaScript required.
+   Uses the :checked pseudo-class on a hidden checkbox to toggle
+   the chat panel open and closed.
+   ============================================================ */
+
+/* ---------- Reset ---------- */
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+/* ---------- CSS Custom Properties (Light Mode) ---------- */
+:root {
+  --chat-bg: #ffffff;
+  --chat-header-bg: #4f46e5;
+  --chat-header-text: #ffffff;
+  --chat-body-bg: #f8fafc;
+  --chat-text: #1e293b;
+  --chat-text-muted: #64748b;
+  --chat-border: #e2e8f0;
+  --chat-received-bg: #f1f5f9;
+  --chat-sent-bg: #4f46e5;
+  --chat-sent-text: #ffffff;
+  --chat-input-bg: #ffffff;
+  --chat-input-border: #e2e8f0;
+  --chat-trigger-bg: #4f46e5;
+  --chat-trigger-text: #ffffff;
+  --chat-trigger-hover: #4338ca;
+  --chat-quick-reply-bg: #ffffff;
+  --chat-quick-reply-border: #e2e8f0;
+  --chat-quick-reply-hover: #f0f0ff;
+  --chat-send-bg: #4f46e5;
+  --chat-send-hover: #4338ca;
+  --chat-online-dot: #22c55e;
+  --chat-shadow: 0 8px 32px rgba(0, 0, 0, 0.12), 0 2px 8px rgba(0, 0, 0, 0.06);
+  --chat-shadow-trigger: 0 4px 16px rgba(79, 70, 229, 0.3);
+  --chat-radius: 16px;
+  --chat-radius-sm: 12px;
+  --chat-radius-xs: 8px;
+  --transition-speed: 0.3s;
+}
+
+/* ---------- Dark Mode ---------- */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --chat-bg: #1e293b;
+    --chat-header-bg: #6366f1;
+    --chat-header-text: #ffffff;
+    --chat-body-bg: #0f172a;
+    --chat-text: #f1f5f9;
+    --chat-text-muted: #94a3b8;
+    --chat-border: #334155;
+    --chat-received-bg: #334155;
+    --chat-sent-bg: #6366f1;
+    --chat-sent-text: #ffffff;
+    --chat-input-bg: #1e293b;
+    --chat-input-border: #334155;
+    --chat-trigger-bg: #6366f1;
+    --chat-trigger-text: #ffffff;
+    --chat-trigger-hover: #818cf8;
+    --chat-quick-reply-bg: #1e293b;
+    --chat-quick-reply-border: #334155;
+    --chat-quick-reply-hover: #334155;
+    --chat-send-bg: #6366f1;
+    --chat-send-hover: #818cf8;
+    --chat-online-dot: #4ade80;
+    --chat-shadow: 0 8px 32px rgba(0, 0, 0, 0.4), 0 2px 8px rgba(0, 0, 0, 0.2);
+    --chat-shadow-trigger: 0 4px 16px rgba(99, 102, 241, 0.4);
+  }
+}
+
+/* ---------- Page Content (demo backdrop) ---------- */
+body {
+  min-height: 100vh;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background: var(--chat-body-bg);
+  color: var(--chat-text);
+}
+
+.page-content {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 4rem 1.5rem;
+  text-align: center;
+}
+
+.page-content h1 {
+  font-size: 2rem;
+  margin-bottom: 1rem;
+}
+
+.page-content p {
+  color: var(--chat-text-muted);
+}
+
+/* ============================================================
+   Chat Widget Container
+   Fixed to the bottom-right corner of the viewport.
+   ============================================================ */
+.chat-widget {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  z-index: 9999;
+  font-family: inherit;
+}
+
+/* ---------- Hidden Checkbox (toggle engine) ---------- */
+/* The checkbox is visually hidden but remains accessible.
+   Its :checked state drives the open/close animation of the
+   chat panel and the icon swap on the trigger button. */
+.chat-widget__toggle {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ---------- Floating Trigger Button ---------- */
+.chat-widget__trigger {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  width: 60px;
+  height: 60px;
+
+  background: var(--chat-trigger-bg);
+  color: var(--chat-trigger-text);
+
+  border-radius: 50%;
+  cursor: pointer;
+
+  box-shadow: var(--chat-shadow-trigger);
+
+  /* Entrance animation: scale in from zero */
+  animation: chatTriggerAppear 0.4s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+
+  /* Smooth transition for hover effects */
+  transition:
+    background var(--transition-speed) ease,
+    transform 0.2s ease;
+}
+
+/* Pulse ring effect around the trigger to draw attention */
+.chat-widget__trigger::before {
+  content: "";
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background: var(--chat-trigger-bg);
+  opacity: 0;
+  z-index: -1;
+
+  /* Continuous pulse animation */
+  animation: chatPulse 2s ease-in-out infinite;
+}
+
+.chat-widget__trigger:hover {
+  background: var(--chat-trigger-hover);
+  transform: scale(1.08);
+}
+
+.chat-widget__trigger:active {
+  transform: scale(0.95);
+}
+
+.chat-widget__trigger:focus-visible {
+  outline: 3px solid var(--chat-trigger-bg);
+  outline-offset: 3px;
+}
+
+/* ---------- Trigger Icons ---------- */
+/* Show/hide the open and close icons based on checkbox state */
+.chat-widget__icon {
+  position: absolute;
+  transition: transform var(--transition-speed) ease, opacity var(--transition-speed) ease;
+}
+
+.chat-widget__icon--open {
+  opacity: 1;
+  transform: rotate(0deg) scale(1);
+}
+
+.chat-widget__icon--close {
+  opacity: 0;
+  transform: rotate(-90deg) scale(0.5);
+}
+
+/* Screen-reader-only text */
+.chat-widget__sr-text {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+}
+
+/* ============================================================
+   Chat Panel
+   Slides up from the trigger button when opened.
+   Hidden by default (below the viewport + opacity 0).
+   ============================================================ */
+.chat-widget__panel {
+  position: absolute;
+  bottom: 76px;
+  right: 0;
+
+  width: 360px;
+  max-height: 520px;
+
+  display: flex;
+  flex-direction: column;
+
+  background: var(--chat-bg);
+  border: 1px solid var(--chat-border);
+  border-radius: var(--chat-radius);
+  box-shadow: var(--chat-shadow);
+
+  overflow: hidden;
+
+  /* Hidden by default */
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(20px) scale(0.95);
+  transform-origin: bottom right;
+
+  transition:
+    opacity var(--transition-speed) ease,
+    visibility var(--transition-speed) ease,
+    transform var(--transition-speed) cubic-bezier(0.34, 1.2, 0.64, 1);
+}
+
+/* ============================================================
+   OPEN STATE — checkbox :checked
+   When the hidden checkbox is :checked, the panel appears and
+   the trigger button switches its icon from chat bubble to X.
+   ============================================================ */
+
+/* Show panel */
+.chat-widget__toggle:checked ~ .chat-widget__panel {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0) scale(1);
+}
+
+/* Swap icons: hide chat bubble, show X */
+.chat-widget__toggle:checked ~ .chat-widget__trigger .chat-widget__icon--open {
+  opacity: 0;
+  transform: rotate(90deg) scale(0.5);
+}
+
+.chat-widget__toggle:checked ~ .chat-widget__trigger .chat-widget__icon--close {
+  opacity: 1;
+  transform: rotate(0deg) scale(1);
+}
+
+/* ============================================================
+   Panel Header
+   ============================================================ */
+.chat-widget__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  padding: 1rem;
+
+  background: var(--chat-header-bg);
+  color: var(--chat-header-text);
+}
+
+.chat-widget__header-info {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+/* Avatar circle */
+.chat-widget__avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.25);
+
+  /* Simple pulsing dot to indicate online status */
+  position: relative;
+}
+
+.chat-widget__avatar::after {
+  content: "";
+  position: absolute;
+  bottom: 1px;
+  right: 1px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--chat-online-dot);
+  border: 2px solid var(--chat-header-bg);
+
+  animation: chatDotPulse 2s ease-in-out infinite;
+}
+
+.chat-widget__name {
+  display: block;
+  font-size: 0.9375rem;
+  font-weight: 600;
+}
+
+.chat-widget__status {
+  display: block;
+  font-size: 0.75rem;
+  opacity: 0.85;
+}
+
+/* Close button inside header */
+.chat-widget__close-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  width: 32px;
+  height: 32px;
+
+  background: rgba(255, 255, 255, 0.15);
+  color: inherit;
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+
+  transition: background 0.2s ease;
+}
+
+.chat-widget__close-btn:hover {
+  background: rgba(255, 255, 255, 0.3);
+}
+
+.chat-widget__close-btn:focus-visible {
+  outline: 2px solid #ffffff;
+  outline-offset: 2px;
+}
+
+/* ============================================================
+   Messages Area
+   Scrollable region showing chat messages.
+   ============================================================ */
+.chat-widget__messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-height: 200px;
+  max-height: 300px;
+  background: var(--chat-body-bg);
+}
+
+/* Individual message bubble */
+.chat-widget__message {
+  max-width: 85%;
+  padding: 0.75rem 1rem;
+  border-radius: var(--chat-radius-sm);
+  font-size: 0.875rem;
+  line-height: 1.5;
+  position: relative;
+
+  /* Fade-in animation for messages */
+  animation: chatMessageIn 0.3s ease both;
+}
+
+/* Received messages (from support) — aligned left */
+.chat-widget__message--received {
+  align-self: flex-start;
+  background: var(--chat-received-bg);
+  color: var(--chat-text);
+  border-bottom-left-radius: 4px;
+}
+
+/* Sent messages (from user) — aligned right */
+.chat-widget__message--sent {
+  align-self: flex-end;
+  background: var(--chat-sent-bg);
+  color: var(--chat-sent-text);
+  border-bottom-right-radius: 4px;
+}
+
+.chat-widget__time {
+  display: block;
+  font-size: 0.6875rem;
+  color: var(--chat-text-muted);
+  margin-top: 0.25rem;
+  opacity: 0.7;
+}
+
+.chat-widget__message--sent .chat-widget__time {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+/* ============================================================
+   Quick Reply Chips
+   Horizontally scrollable row of suggestion buttons.
+   ============================================================ */
+.chat-widget__quick-replies {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  overflow-x: auto;
+  background: var(--chat-body-bg);
+  border-top: 1px solid var(--chat-border);
+
+  /* Hide scrollbar but keep functionality */
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.chat-widget__quick-replies::-webkit-scrollbar {
+  display: none;
+}
+
+.chat-widget__quick-reply {
+  flex-shrink: 0;
+  padding: 0.375rem 0.875rem;
+
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--chat-sent-bg);
+  background: var(--chat-quick-reply-bg);
+  border: 1px solid var(--chat-quick-reply-border);
+  border-radius: 20px;
+  cursor: pointer;
+  white-space: nowrap;
+
+  transition:
+    background 0.2s ease,
+    border-color 0.2s ease;
+}
+
+.chat-widget__quick-reply:hover {
+  background: var(--chat-quick-reply-hover);
+  border-color: var(--chat-sent-bg);
+}
+
+.chat-widget__quick-reply:focus-visible {
+  outline: 2px solid var(--chat-sent-bg);
+  outline-offset: 2px;
+}
+
+/* ============================================================
+   Input Area
+   Text input and send button at the bottom of the panel.
+   ============================================================ */
+.chat-widget__input-area {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border-top: 1px solid var(--chat-border);
+  background: var(--chat-bg);
+}
+
+.chat-widget__input {
+  flex: 1;
+  padding: 0.625rem 0.875rem;
+
+  font-size: 0.875rem;
+  font-family: inherit;
+  color: var(--chat-text);
+  background: var(--chat-input-bg);
+  border: 1px solid var(--chat-input-border);
+  border-radius: 24px;
+  outline: none;
+
+  transition: border-color 0.2s ease;
+}
+
+.chat-widget__input::placeholder {
+  color: var(--chat-text-muted);
+}
+
+.chat-widget__input:focus {
+  border-color: var(--chat-sent-bg);
+}
+
+/* Send button */
+.chat-widget__send {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  width: 40px;
+  height: 40px;
+  flex-shrink: 0;
+
+  background: var(--chat-send-bg);
+  color: #ffffff;
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+
+  transition: background 0.2s ease, transform 0.15s ease;
+}
+
+.chat-widget__send:hover {
+  background: var(--chat-send-hover);
+}
+
+.chat-widget__send:active {
+  transform: scale(0.92);
+}
+
+.chat-widget__send:focus-visible {
+  outline: 2px solid var(--chat-send-bg);
+  outline-offset: 2px;
+}
+
+/* ============================================================
+   Keyframe Animations
+   ============================================================ */
+
+/* Trigger button entrance — bouncy scale-in */
+@keyframes chatTriggerAppear {
+  from {
+    opacity: 0;
+    transform: scale(0);
+  }
+
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+/* Continuous pulse ring around the trigger */
+@keyframes chatPulse {
+  0% {
+    transform: scale(1);
+    opacity: 0.5;
+  }
+
+  70% {
+    transform: scale(1.6);
+    opacity: 0;
+  }
+
+  100% {
+    transform: scale(1.6);
+    opacity: 0;
+  }
+}
+
+/* Online status dot subtle pulse */
+@keyframes chatDotPulse {
+  0%, 100% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0.5;
+  }
+}
+
+/* Message bubble fade-in from below */
+@keyframes chatMessageIn {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* ============================================================
+   Responsive: Mobile — full-width panel
+   ============================================================ */
+@media (max-width: 480px) {
+  .chat-widget {
+    bottom: 1rem;
+    right: 1rem;
+  }
+
+  .chat-widget__panel {
+    position: fixed;
+    bottom: 0;
+    right: 0;
+    left: 0;
+    width: 100%;
+    max-height: 100vh;
+    border-radius: var(--chat-radius) var(--chat-radius) 0 0;
+  }
+
+  .chat-widget__trigger {
+    width: 54px;
+    height: 54px;
+  }
+
+  .chat-widget__messages {
+    max-height: calc(100vh - 260px);
+  }
+}
+
+/* ============================================================
+   Reduced Motion
+   Respect user preference for reduced motion.
+   ============================================================ */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a floating CSS-only customer support chat widget with open/close animation, addressing issue #68054.

---

## Type of Change

- [x] 🧩 New component

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/css-chat-widget-eranmol/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A floating customer support chat widget with a toggle button, slide-up panel, message bubbles, quick-reply chips, and an input area.

**How does a developer use it?**

```html
<div class="chat-widget" role="complementary" aria-label="Customer support chat">
  <input type="checkbox" id="chat-toggle" class="chat-widget__toggle" aria-label="Open or close chat widget">
  <label for="chat-toggle" class="chat-widget__trigger" role="button">
    <!-- SVG icons for chat bubble and close -->
  </label>
  <div class="chat-widget__panel" role="dialog" aria-label="Chat window">
    <!-- header, messages, quick replies, input area -->
  </div>
</div>