### PR TITLE
feat: add CSS layered paper cutout component (#68051)

### DIFF
--- a/submissions/examples/css-layered-paper-cutout-eranmol/README.md
+++ b/submissions/examples/css-layered-paper-cutout-eranmol/README.md
@@ -1,0 +1,27 @@
+# CSS Layered Paper Cutout
+
+A layered paper cutout depth effect using stacked CSS elements with offset positioning, built entirely with pure CSS.
+
+## What does this do?
+
+It creates a visual depth illusion where multiple CSS layers are stacked with slight offsets, mimicking the look of cut paper sheets. On hover, the layers fan apart further to enhance the 3D effect. It works like stacked paper with shadows between each sheet.
+
+## How is it used?
+
+Drop `demo.html` and `style.css` into your project. Each cutout card uses three stacked layers:
+
+```html
+<article class="paper-cutout">
+  <div class="paper-cutout__layer paper-cutout__layer--3"></div>
+  <div class="paper-cutout__layer paper-cutout__layer--2"></div>
+  <div class="paper-cutout__layer paper-cutout__layer--1">
+    <span class="paper-cutout__label">Explore</span>
+  </div>
+</article>
+```
+
+Layer 3 sits at the bottom with the largest offset, layer 2 sits in the middle, and layer 1 is on top carrying the content. The CSS handles all the positioning, shadows, and hover animations.
+
+## Why is it useful?
+
+Paper cutout effects are a popular design trend for landing pages, feature cards, and product showcases. This component gives developers a ready-to-use, pure CSS solution that creates depth through simple offset layers and shadows, without needing any images, SVGs, or JavaScript. It includes CSS custom properties for easy theming, responsive sizing, and smooth hover transitions.

--- a/submissions/examples/css-layered-paper-cutout-eranmol/demo.html
+++ b/submissions/examples/css-layered-paper-cutout-eranmol/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Layered Paper Cutout</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="demo-container">
+
+    <h1 class="demo-title">Layered Paper Cutout</h1>
+    <p class="demo-subtitle">A depth effect built with stacked CSS elements</p>
+
+    <!-- Paper cutout card with three stacked layers -->
+    <article class="paper-cutout" role="img" aria-label="Layered paper cutout card with depth effect">
+
+      <!-- Bottom layer — darkest shadow -->
+      <div class="paper-cutout__layer paper-cutout__layer--3" aria-hidden="true"></div>
+
+      <!-- Middle layer -->
+      <div class="paper-cutout__layer paper-cutout__layer--2" aria-hidden="true"></div>
+
+      <!-- Top layer — the visible content -->
+      <div class="paper-cutout__layer paper-cutout__layer--1">
+        <span class="paper-cutout__label">Explore</span>
+      </div>
+
+    </article>
+
+    <!-- Variant: horizontal layout -->
+    <section class="paper-cutout-row" role="img" aria-label="Row of paper cutout cards">
+
+      <article class="paper-cutout paper-cutout--small" aria-label="Paper cutout card one">
+        <div class="paper-cutout__layer paper-cutout__layer--3" aria-hidden="true"></div>
+        <div class="paper-cutout__layer paper-cutout__layer--2" aria-hidden="true"></div>
+        <div class="paper-cutout__layer paper-cutout__layer--1">
+          <span class="paper-cutout__label">Design</span>
+        </div>
+      </article>
+
+      <article class="paper-cutout paper-cutout--small" aria-label="Paper cutout card two">
+        <div class="paper-cutout__layer paper-cutout__layer--3" aria-hidden="true"></div>
+        <div class="paper-cutout__layer paper-cutout__layer--2" aria-hidden="true"></div>
+        <div class="paper-cutout__layer paper-cutout__layer--1">
+          <span class="paper-cutout__label">Build</span>
+        </div>
+      </article>
+
+      <article class="paper-cutout paper-cutout--small" aria-label="Paper cutout card three">
+        <div class="paper-cutout__layer paper-cutout__layer--3" aria-hidden="true"></div>
+        <div class="paper-cutout__layer paper-cutout__layer--2" aria-hidden="true"></div>
+        <div class="paper-cutout__layer paper-cutout__layer--1">
+          <span class="paper-cutout__label">Ship</span>
+        </div>
+      </article>
+
+    </section>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/css-layered-paper-cutout-eranmol/style.css
+++ b/submissions/examples/css-layered-paper-cutout-eranmol/style.css
@@ -1,0 +1,280 @@
+/* ============================================================
+   CSS Layered Paper Cutout
+   Depth effect using stacked CSS elements with offset shadows.
+   Pure CSS — no JavaScript required.
+   ============================================================ */
+
+/* ---------- Reset ---------- */
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+/* ---------- CSS Custom Properties (Light Mode) ---------- */
+:root {
+  --cutout-bg: #ffffff;
+  --cutout-layer-1: #ffffff;
+  --cutout-layer-2: #e0e7ff;
+  --cutout-layer-3: #c7d2fe;
+  --cutout-shadow-color: rgba(99, 102, 241, 0.15);
+  --cutout-shadow-heavy: rgba(99, 102, 241, 0.25);
+  --cutout-text: #312e81;
+  --cutout-border: rgba(99, 102, 241, 0.2);
+  --cutout-hover-offset: 6px;
+  --page-bg: #f8fafc;
+  --page-text: #1e293b;
+  --page-text-muted: #64748b;
+
+  --card-width: 280px;
+  --card-height: 200px;
+  --layer-offset: 8px;
+  --card-radius: 12px;
+  --transition-speed: 0.35s;
+}
+
+/* ---------- Dark Mode ---------- */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --cutout-bg: #1e293b;
+    --cutout-layer-1: #1e293b;
+    --cutout-layer-2: #334155;
+    --cutout-layer-3: #475569;
+    --cutout-shadow-color: rgba(0, 0, 0, 0.35);
+    --cutout-shadow-heavy: rgba(0, 0, 0, 0.5);
+    --cutout-text: #e2e8f0;
+    --cutout-border: rgba(148, 163, 184, 0.2);
+    --cutout-hover-offset: 8px;
+    --page-bg: #0f172a;
+    --page-text: #f1f5f9;
+    --page-text-muted: #94a3b8;
+  }
+}
+
+/* ---------- Page Layout ---------- */
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  background: var(--page-bg);
+  color: var(--page-text);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  padding: 2rem 1rem;
+}
+
+.demo-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2.5rem;
+}
+
+.demo-title {
+  font-size: 1.75rem;
+  font-weight: 700;
+  text-align: center;
+}
+
+.demo-subtitle {
+  color: var(--page-text-muted);
+  text-align: center;
+  margin-top: -1rem;
+}
+
+/* ============================================================
+   Paper Cutout — Main Component
+   Three absolutely-positioned layers stacked with slight offsets
+   to simulate physical depth, like cut paper sheets.
+   ============================================================ */
+.paper-cutout {
+  position: relative;
+  width: var(--card-width);
+  height: var(--card-height);
+  cursor: default;
+
+  /* Hover lifts the top layer slightly further */
+  transition: transform var(--transition-speed) cubic-bezier(0.34, 1.2, 0.64, 1);
+}
+
+.paper-cutout:hover {
+  transform: translateY(-4px);
+}
+
+/* ---------- Individual Layers ---------- */
+/* Each layer is positioned absolutely inside the container.
+   The bottom layer (3) is offset the most to create the
+   shadow/depth illusion. Layers 2 and 1 progressively move
+   back toward the natural position. */
+.paper-cutout__layer {
+  position: absolute;
+  inset: 0;
+  border-radius: var(--card-radius);
+  transition:
+    transform var(--transition-speed) cubic-bezier(0.34, 1.2, 0.64, 1),
+    box-shadow var(--transition-speed) ease;
+}
+
+/* Layer 3 — bottom, most offset, darkest */
+.paper-cutout__layer--3 {
+  background: var(--cutout-layer-3);
+  transform: translate(var(--layer-offset), var(--layer-offset));
+  box-shadow:
+    0 2px 8px var(--cutout-shadow-color),
+    0 6px 20px var(--cutout-shadow-heavy);
+}
+
+/* Layer 2 — middle */
+.paper-cutout__layer--2 {
+  background: var(--cutout-layer-2);
+  transform: translate(
+    calc(var(--layer-offset) * 0.5),
+    calc(var(--layer-offset) * 0.5)
+  );
+  box-shadow:
+    0 2px 6px var(--cutout-shadow-color);
+}
+
+/* Layer 1 — top, natural position, content carrier */
+.paper-cutout__layer--1 {
+  background: var(--cutout-layer-1);
+  border: 1px solid var(--cutout-border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  /* Entrance animation: layers spread apart then settle */
+  animation: cutoutSpread 0.6s cubic-bezier(0.34, 1.2, 0.64, 1) both;
+}
+
+/* ---------- Hover: layers fan out slightly more ---------- */
+/* On hover, each layer moves further apart to enhance
+   the depth illusion — like lifting the top sheet. */
+.paper-cutout:hover .paper-cutout__layer--3 {
+  transform: translate(
+    calc(var(--layer-offset) + var(--cutout-hover-offset)),
+    calc(var(--layer-offset) + var(--cutout-hover-offset))
+  );
+  box-shadow:
+    0 4px 12px var(--cutout-shadow-color),
+    0 12px 32px var(--cutout-shadow-heavy);
+}
+
+.paper-cutout:hover .paper-cutout__layer--2 {
+  transform: translate(
+    calc(var(--layer-offset) * 0.5 + var(--cutout-hover-offset) * 0.5),
+    calc(var(--layer-offset) * 0.5 + var(--cutout-hover-offset) * 0.5)
+  );
+}
+
+/* ---------- Text Label ---------- */
+.paper-cutout__label {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--cutout-text);
+  letter-spacing: 0.02em;
+  user-select: none;
+}
+
+/* ============================================================
+   Small Variant (used in the row layout)
+   ============================================================ */
+.paper-cutout--small {
+  --card-width: 160px;
+  --card-height: 140px;
+  --layer-offset: 6px;
+}
+
+.paper-cutout--small .paper-cutout__label {
+  font-size: 0.9375rem;
+}
+
+/* ============================================================
+   Row Layout
+   Three small cutout cards in a horizontal row.
+   ============================================================ */
+.paper-cutout-row {
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+/* ============================================================
+   Entrance Animation
+   The layers start offset and stacked, then animate to their
+   resting positions. This simulates the paper being "placed"
+   onto the surface.
+   ============================================================ */
+@keyframes cutoutSpread {
+  from {
+    opacity: 0;
+    transform: translate(
+      calc(var(--layer-offset) * 2),
+      calc(var(--layer-offset) * 2)
+    ) scale(0.92);
+  }
+
+  to {
+    opacity: 1;
+    transform: translate(0, 0) scale(1);
+  }
+}
+
+/* Stagger the entrance for each layer */
+.paper-cutout__layer--3 {
+  animation-delay: 0s;
+}
+
+.paper-cutout__layer--2 {
+  animation: cutoutLayer2In 0.6s cubic-bezier(0.34, 1.2, 0.64, 0.15) both;
+}
+
+.paper-cutout__layer--1 {
+  animation-delay: 0.1s;
+}
+
+@keyframes cutoutLayer2In {
+  from {
+    opacity: 0;
+    transform: translate(
+      calc(var(--layer-offset) * 1.5),
+      calc(var(--layer-offset) * 1.5)
+    ) scale(0.95);
+  }
+
+  to {
+    opacity: 1;
+    transform: translate(0, 0) scale(1);
+  }
+}
+
+/* ============================================================
+   Responsive: Mobile
+   ============================================================ */
+@media (max-width: 560px) {
+  .paper-cutout-row {
+    gap: 1.5rem;
+  }
+
+  .paper-cutout--small {
+    --card-width: 130px;
+    --card-height: 120px;
+  }
+}
+
+/* ============================================================
+   Reduced Motion
+   ============================================================ */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a layered paper cutout depth effect using stacked CSS elements, addressing issue #68051.

---

## Type of Change

- [x] 🧩 New component

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/css-layered-paper-cutout-eranmol/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A layered paper cutout depth effect where three stacked CSS layers are offset from each other to simulate physical paper depth. On hover, the layers fan apart further to enhance the 3D illusion.

**How does a developer use it?**

```html
<article class="paper-cutout">
  <div class="paper-cutout__layer paper-cutout__layer--3"></div>
  <div class="paper-cutout__layer paper-cutout__layer--2"></div>
  <div class="paper-cutout__layer paper-cutout__layer--1">
    <span class="paper-cutout__label">Explore</span>
  </div>
</article>