### PR TITLE
feat: add CSS dark mode form component (#68085)

### DIFF
--- a/submissions/examples/css-dark-mode-form-eranmol/README.md
+++ b/submissions/examples/css-dark-mode-form-eranmol/README.md
@@ -1,0 +1,27 @@
+# CSS Dark Mode Form
+
+A complete dark mode form set with all HTML input types styled — text, email, password, select, textarea, checkboxes, radios, toggle switch, and range slider.
+
+## What does this do?
+
+It provides a fully styled form component where every standard HTML input type looks polished in both light and dark mode. The dark mode is activated automatically via the `prefers-color-scheme` media query, requiring no toggle or JavaScript.
+
+## How is it used?
+
+Drop `demo.html` and `style.css` into your project. The form uses standard semantic HTML with CSS classes:
+
+```html
+<form class="dark-form" action="#" method="post">
+  <div class="dark-form__group">
+    <label for="email" class="dark-form__label">Email</label>
+    <input type="email" id="email" name="email" class="dark-form__input" placeholder="jane@example.com">
+  </div>
+  <button type="submit" class="dark-form__button">Submit</button>
+</form>
+```
+
+Every input type has a corresponding class: `dark-form__input`, `dark-form__select`, `dark-form__textarea`, `dark-form__checkbox`, `dark-form__radio`, `dark-form__toggle`, and `dark-form__range`.
+
+## Why is it useful?
+
+Forms are one of the most common UI elements on any website, and styling them consistently across light and dark modes is tedious. This component gives developers a complete, ready-to-use form kit with custom-styled checkboxes, radios, toggle switches, and range sliders, all using CSS custom properties for easy theming and automatic dark mode support.

--- a/submissions/examples/css-dark-mode-form-eranmol/demo.html
+++ b/submissions/examples/css-dark-mode-form-eranmol/demo.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Dark Mode Form</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="form-page">
+
+    <div class="form-card">
+      <h1 class="form-card__title">Create Account</h1>
+      <p class="form-card__subtitle">Fill in the details below to get started</p>
+
+      <form class="dark-form" action="#" method="post" novalidate aria-label="Registration form">
+
+        <!-- Text input -->
+        <div class="dark-form__group">
+          <label for="full-name" class="dark-form__label">Full Name</label>
+          <input type="text" id="full-name" name="full-name" class="dark-form__input" placeholder="Jane Doe" autocomplete="name" required>
+          <span class="dark-form__hint">As it appears on your ID</span>
+        </div>
+
+        <!-- Email input -->
+        <div class="dark-form__group">
+          <label for="email" class="dark-form__label">Email Address</label>
+          <input type="email" id="email" name="email" class="dark-form__input" placeholder="jane@example.com" autocomplete="email" required>
+        </div>
+
+        <!-- Password input -->
+        <div class="dark-form__group">
+          <label for="password" class="dark-form__label">Password</label>
+          <input type="password" id="password" name="password" class="dark-form__input" placeholder="Min. 8 characters" autocomplete="new-password" required minlength="8">
+        </div>
+
+        <!-- Select dropdown -->
+        <div class="dark-form__group">
+          <label for="role" class="dark-form__label">Role</label>
+          <select id="role" name="role" class="dark-form__select" required>
+            <option value="" disabled selected>Choose a role</option>
+            <option value="developer">Developer</option>
+            <option value="designer">Designer</option>
+            <option value="manager">Project Manager</option>
+            <option value="other">Other</option>
+          </select>
+        </div>
+
+        <!-- Textarea -->
+        <div class="dark-form__group">
+          <label for="bio" class="dark-form__label">Short Bio</label>
+          <textarea id="bio" name="bio" class="dark-form__textarea" rows="3" placeholder="Tell us about yourself..."></textarea>
+        </div>
+
+        <!-- Checkbox group -->
+        <fieldset class="dark-form__fieldset">
+          <legend class="dark-form__legend">Interests</legend>
+          <div class="dark-form__checkbox-group">
+            <label class="dark-form__checkbox-label">
+              <input type="checkbox" name="interests" value="css" class="dark-form__checkbox">
+              <span class="dark-form__checkbox-custom" aria-hidden="true"></span>
+              CSS
+            </label>
+            <label class="dark-form__checkbox-label">
+              <input type="checkbox" name="interests" value="js" class="dark-form__checkbox">
+              <span class="dark-form__checkbox-custom" aria-hidden="true"></span>
+              JavaScript
+            </label>
+            <label class="dark-form__checkbox-label">
+              <input type="checkbox" name="interests" value="design" class="dark-form__checkbox">
+              <span class="dark-form__checkbox-custom" aria-hidden="true"></span>
+              UI Design
+            </label>
+          </div>
+        </fieldset>
+
+        <!-- Radio group -->
+        <fieldset class="dark-form__fieldset">
+          <legend class="dark-form__legend">Experience Level</legend>
+          <div class="dark-form__radio-group">
+            <label class="dark-form__radio-label">
+              <input type="radio" name="experience" value="junior" class="dark-form__radio">
+              <span class="dark-form__radio-custom" aria-hidden="true"></span>
+              Junior
+            </label>
+            <label class="dark-form__radio-label">
+              <input type="radio" name="experience" value="mid" class="dark-form__radio" checked>
+              <span class="dark-form__radio-custom" aria-hidden="true"></span>
+              Mid-level
+            </label>
+            <label class="dark-form__radio-label">
+              <input type="radio" name="experience" value="senior" class="dark-form__radio">
+              <span class="dark-form__radio-custom" aria-hidden="true"></span>
+              Senior
+            </label>
+          </div>
+        </fieldset>
+
+        <!-- Toggle switch -->
+        <div class="dark-form__group dark-form__group--row">
+          <label for="notifications" class="dark-form__label">Email Notifications</label>
+          <input type="checkbox" id="notifications" name="notifications" class="dark-form__toggle" checked>
+          <label for="notifications" class="dark-form__toggle-track" aria-label="Toggle email notifications">
+            <span class="dark-form__toggle-thumb"></span>
+          </label>
+        </div>
+
+        <!-- Range slider -->
+        <div class="dark-form__group">
+          <label for="volume" class="dark-form__label">Notification Volume: <output id="volume-output" for="volume">50</output>%</label>
+          <input type="range" id="volume" name="volume" class="dark-form__range" min="0" max="100" value="50" step="5">
+        </div>
+
+        <!-- Submit button -->
+        <button type="submit" class="dark-form__button">Create Account</button>
+
+      </form>
+    </div>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/css-dark-mode-form-eranmol/style.css
+++ b/submissions/examples/css-dark-mode-form-eranmol/style.css
@@ -1,0 +1,521 @@
+/* ============================================================
+   CSS Dark Mode Form
+   Complete form set with all input types styled for dark mode.
+   Pure CSS — no JavaScript required.
+   ============================================================ */
+
+/* ---------- Reset ---------- */
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+/* ---------- CSS Custom Properties (Light Mode) ---------- */
+:root {
+  --form-bg: #ffffff;
+  --form-card-bg: #ffffff;
+  --form-card-shadow: 0 1px 3px rgba(0, 0, 0, 0.06), 0 8px 24px rgba(0, 0, 0, 0.04);
+  --form-text: #1e293b;
+  --form-text-muted: #64748b;
+  --form-label: #334155;
+  --form-input-bg: #f8fafc;
+  --form-input-border: #cbd5e1;
+  --form-input-focus: #6366f1;
+  --form-input-focus-ring: rgba(99, 102, 241, 0.25);
+  --form-placeholder: #94a3b8;
+  --form-button-bg: #4f46e5;
+  --form-button-text: #ffffff;
+  --form-button-hover: #4338ca;
+  --form-accent: #4f46e5;
+  --form-accent-light: #e0e7ff;
+  --form-border: #e2e8f0;
+  --form-toggle-bg: #cbd5e1;
+  --form-toggle-active: #4f46e5;
+  --form-toggle-thumb: #ffffff;
+  --form-range-track: #e2e8f0;
+  --form-range-fill: #4f46e5;
+  --form-error: #ef4444;
+  --form-success: #22c55e;
+  --page-bg: #f1f5f9;
+
+  --input-radius: 8px;
+  --transition-speed: 0.25s;
+}
+
+/* ---------- Dark Mode ---------- */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --form-bg: #0f172a;
+    --form-card-bg: #1e293b;
+    --form-card-shadow: 0 1px 3px rgba(0, 0, 0, 0.3), 0 8px 24px rgba(0, 0, 0, 0.2);
+    --form-text: #f1f5f9;
+    --form-text-muted: #94a3b8;
+    --form-label: #e2e8f0;
+    --form-input-bg: #0f172a;
+    --form-input-border: #334155;
+    --form-input-focus: #818cf8;
+    --form-input-focus-ring: rgba(129, 140, 248, 0.3);
+    --form-placeholder: #475569;
+    --form-button-bg: #6366f1;
+    --form-button-text: #ffffff;
+    --form-button-hover: #818cf8;
+    --form-accent: #818cf8;
+    --form-accent-light: rgba(99, 102, 241, 0.15);
+    --form-border: #334155;
+    --form-toggle-bg: #475569;
+    --form-toggle-active: #818cf8;
+    --form-toggle-thumb: #ffffff;
+    --form-range-track: #334155;
+    --form-range-fill: #818cf8;
+    --form-error: #f87171;
+    --form-success: #4ade80;
+    --page-bg: #0f172a;
+  }
+}
+
+/* ---------- Page Layout ---------- */
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--page-bg);
+  color: var(--form-text);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  line-height: 1.6;
+  padding: 2rem 1rem;
+}
+
+.form-page {
+  width: 100%;
+  max-width: 480px;
+}
+
+/* ---------- Card Container ---------- */
+.form-card {
+  background: var(--form-card-bg);
+  border: 1px solid var(--form-border);
+  border-radius: 16px;
+  box-shadow: var(--form-card-shadow);
+  padding: 2rem 1.75rem;
+  animation: cardFadeIn 0.4s ease both;
+}
+
+.form-card__title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 0.25rem;
+}
+
+.form-card__subtitle {
+  font-size: 0.9375rem;
+  color: var(--form-text-muted);
+  margin-bottom: 1.75rem;
+}
+
+/* ============================================================
+   Form Groups & Labels
+   ============================================================ */
+.dark-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.dark-form__group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+/* Row layout for inline items like toggle switch */
+.dark-form__group--row {
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.dark-form__label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--form-label);
+}
+
+.dark-form__hint {
+  font-size: 0.75rem;
+  color: var(--form-text-muted);
+}
+
+/* ============================================================
+   Text Input, Email, Password
+   ============================================================ */
+.dark-form__input,
+.dark-form__select,
+.dark-form__textarea {
+  width: 100%;
+  padding: 0.7rem 0.875rem;
+
+  font-size: 0.9375rem;
+  font-family: inherit;
+  color: var(--form-text);
+  background: var(--form-input-bg);
+  border: 1px solid var(--form-input-border);
+  border-radius: var(--input-radius);
+  outline: none;
+  transition:
+    border-color var(--transition-speed) ease,
+    box-shadow var(--transition-speed) ease;
+}
+
+.dark-form__input::placeholder,
+.dark-form__textarea::placeholder {
+  color: var(--form-placeholder);
+}
+
+.dark-form__input:focus,
+.dark-form__select:focus,
+.dark-form__textarea:focus {
+  border-color: var(--form-input-focus);
+  box-shadow: 0 0 0 3px var(--form-input-focus-ring);
+}
+
+/* Valid state via :valid pseudo-class */
+.dark-form__input:valid:not(:placeholder-shown) {
+  border-color: var(--form-success);
+}
+
+/* ============================================================
+   Select Dropdown
+   ============================================================ */
+.dark-form__select {
+  appearance: none;
+  cursor: pointer;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%2364748b' stroke-width='2'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.75rem center;
+  padding-right: 2.5rem;
+}
+
+/* ============================================================
+   Textarea
+   ============================================================ */
+.dark-form__textarea {
+  resize: vertical;
+  min-height: 80px;
+}
+
+/* ============================================================
+   Fieldset & Legend
+   ============================================================ */
+.dark-form__fieldset {
+  border: 1px solid var(--form-border);
+  border-radius: var(--input-radius);
+  padding: 1rem;
+}
+
+.dark-form__legend {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--form-label);
+  padding: 0 0.375rem;
+}
+
+/* ============================================================
+   Checkboxes — custom styled
+   ============================================================ */
+.dark-form__checkbox-group,
+.dark-form__radio-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.25rem;
+  margin-top: 0.375rem;
+}
+
+.dark-form__checkbox-label,
+.dark-form__radio-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  color: var(--form-text);
+  cursor: pointer;
+}
+
+/* Hidden native checkbox */
+.dark-form__checkbox {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+}
+
+/* Custom checkbox box */
+.dark-form__checkbox-custom {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  border: 2px solid var(--form-input-border);
+  border-radius: 4px;
+  background: var(--form-input-bg);
+  position: relative;
+  transition:
+    background var(--transition-speed) ease,
+    border-color var(--transition-speed) ease;
+}
+
+/* Checkmark via pseudo-element when checked */
+.dark-form__checkbox:checked + .dark-form__checkbox-custom {
+  background: var(--form-accent);
+  border-color: var(--form-accent);
+}
+
+.dark-form__checkbox:checked + .dark-form__checkbox-custom::after {
+  content: "";
+  position: absolute;
+  left: 5px;
+  top: 1px;
+  width: 5px;
+  height: 10px;
+  border: solid #ffffff;
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+}
+
+/* Focus ring on the custom box */
+.dark-form__checkbox:focus-visible + .dark-form__checkbox-custom {
+  box-shadow: 0 0 0 3px var(--form-input-focus-ring);
+}
+
+/* ============================================================
+   Radio Buttons — custom styled
+   ============================================================ */
+.dark-form__radio {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+}
+
+.dark-form__radio-custom {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  border: 2px solid var(--form-input-border);
+  border-radius: 50%;
+  background: var(--form-input-bg);
+  position: relative;
+  transition:
+    background var(--transition-speed) ease,
+    border-color var(--transition-speed) ease;
+}
+
+/* Filled dot when selected */
+.dark-form__radio:checked + .dark-form__radio-custom {
+  border-color: var(--form-accent);
+}
+
+.dark-form__radio:checked + .dark-form__radio-custom::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--form-accent);
+}
+
+.dark-form__radio:focus-visible + .dark-form__radio-custom {
+  box-shadow: 0 0 0 3px var(--form-input-focus-ring);
+}
+
+/* ============================================================
+   Toggle Switch
+   ============================================================ */
+.dark-form__toggle {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+}
+
+/* Track */
+.dark-form__toggle-track {
+  position: relative;
+  display: inline-block;
+  width: 44px;
+  height: 24px;
+  background: var(--form-toggle-bg);
+  border-radius: 12px;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background var(--transition-speed) ease;
+}
+
+/* Thumb */
+.dark-form__toggle-thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 20px;
+  height: 20px;
+  background: var(--form-toggle-thumb);
+  border-radius: 50%;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
+  transition: transform var(--transition-speed) cubic-bezier(0.34, 1.2, 0.64, 1);
+}
+
+/* Active state — slide thumb right */
+.dark-form__toggle:checked ~ .dark-form__toggle-track {
+  background: var(--form-toggle-active);
+}
+
+.dark-form__toggle:checked ~ .dark-form__toggle-track .dark-form__toggle-thumb {
+  transform: translateX(20px);
+}
+
+/* Focus ring on track */
+.dark-form__toggle:focus-visible ~ .dark-form__toggle-track {
+  box-shadow: 0 0 0 3px var(--form-input-focus-ring);
+}
+
+/* ============================================================
+   Range Slider
+   ============================================================ */
+.dark-form__range {
+  width: 100%;
+  height: 6px;
+  appearance: none;
+  background: var(--form-range-track);
+  border-radius: 3px;
+  outline: none;
+  cursor: pointer;
+  transition: background var(--transition-speed) ease;
+}
+
+/* Track styling */
+.dark-form__range::-webkit-slider-runnable-track {
+  height: 6px;
+  border-radius: 3px;
+  background: var(--form-range-track);
+}
+
+/* Thumb styling */
+.dark-form__range::-webkit-slider-thumb {
+  appearance: none;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--form-range-fill);
+  border: 2px solid var(--form-card-bg);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.15);
+  margin-top: -7px;
+  cursor: pointer;
+  transition: transform 0.15s ease;
+}
+
+.dark-form__range::-webkit-slider-thumb:hover {
+  transform: scale(1.15);
+}
+
+.dark-form__range::-moz-range-thumb {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--form-range-fill);
+  border: 2px solid var(--form-card-bg);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.15);
+  cursor: pointer;
+}
+
+.dark-form__range:focus-visible {
+  box-shadow: 0 0 0 3px var(--form-input-focus-ring);
+}
+
+/* ============================================================
+   Submit Button
+   ============================================================ */
+.dark-form__button {
+  width: 100%;
+  padding: 0.8rem 1rem;
+  margin-top: 0.5rem;
+
+  font-size: 0.9375rem;
+  font-weight: 600;
+  font-family: inherit;
+  color: var(--form-button-text);
+  background: var(--form-button-bg);
+  border: none;
+  border-radius: var(--input-radius);
+  cursor: pointer;
+
+  /* Gradient shine effect on hover */
+  position: relative;
+  overflow: hidden;
+  transition:
+    background var(--transition-speed) ease,
+    transform 0.15s ease;
+}
+
+.dark-form__button:hover {
+  background: var(--form-button-hover);
+}
+
+.dark-form__button:active {
+  transform: scale(0.98);
+}
+
+.dark-form__button:focus-visible {
+  outline: 2px solid var(--form-accent);
+  outline-offset: 2px;
+}
+
+/* ============================================================
+   Entrance Animation
+   ============================================================ */
+@keyframes cardFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* ============================================================
+   Responsive: Mobile
+   ============================================================ */
+@media (max-width: 520px) {
+  .form-card {
+    padding: 1.5rem 1.25rem;
+  }
+
+  .form-card__title {
+    font-size: 1.25rem;
+  }
+}
+
+/* ============================================================
+   Reduced Motion
+   ============================================================ */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a complete dark mode form set with all input types styled, addressing issue #68085.

---

## Type of Change

- [x] 🧩 New component

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/css-dark-mode-form-eranmol/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A complete form component with styled text inputs, email, password, select dropdown, textarea, custom checkboxes, custom radios, a toggle switch, and a range slider — all with automatic dark mode support.

**How does a developer use it?**

```html
<form class="dark-form" action="#" method="post">
  <div class="dark-form__group">
    <label for="email" class="dark-form__label">Email</label>
    <input type="email" id="email" class="dark-form__input" placeholder="jane@example.com">
  </div>
  <button type="submit" class="dark-form__button">Submit</button>
</form>