### PR TITLE
feat: add CSS skeleton screen loader (#68088)

### DIFF
--- a/submissions/examples/css-skeleton-screen-eranmol/README.md
+++ b/submissions/examples/css-skeleton-screen-eranmol/README.md
@@ -1,0 +1,28 @@
+# CSS Skeleton Screen Loader
+
+Shimmer skeleton placeholders for content loading states, built entirely with pure CSS.
+
+## What does this do?
+
+It provides reusable skeleton loading components that mimic the shape of real content (cards, profiles, lists) while data is being fetched. A subtle shimmer gradient sweeps across each placeholder to indicate activity.
+
+## How is it used?
+
+Drop `demo.html` and `style.css` into your project. Use the skeleton classes to build loading placeholders:
+
+```html
+<div class="skeleton-card" role="status" aria-label="Loading content">
+  <div class="skeleton-card__image skeleton-shimmer"></div>
+  <div class="skeleton-card__body">
+    <div class="skeleton-card__title skeleton-shimmer"></div>
+    <div class="skeleton-card__text skeleton-shimmer"></div>
+  </div>
+  <span class="sr-only">Loading content, please wait...</span>
+</div>
+```
+
+The key class is `skeleton-shimmer` — apply it to any element to give it the shimmer loading effect. The skeleton structure classes (`skeleton-card`, `skeleton-profile`, `skeleton-list`) provide ready-made layouts.
+
+## Why is it useful?
+
+Skeleton screens are a standard pattern in modern web apps for showing loading states. They reduce perceived wait time compared to spinners because users can see the layout forming. This component gives developers a drop-in skeleton kit with card, profile, and list variants, all pure CSS with no JavaScript, customizable via CSS custom properties, and with built-in dark mode and reduced-motion support.

--- a/submissions/examples/css-skeleton-screen-eranmol/demo.html
+++ b/submissions/examples/css-skeleton-screen-eranmol/demo.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Skeleton Screen Loader</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="demo-container">
+
+    <h1 class="demo-title">Skeleton Screen Loaders</h1>
+    <p class="demo-subtitle">Shimmer placeholders for content loading states</p>
+
+    <!-- Card skeleton -->
+    <section class="skeleton-demo" aria-label="Card skeleton example">
+      <h2 class="skeleton-demo__heading">Card</h2>
+      <div class="skeleton-card" role="status" aria-label="Loading card content">
+        <div class="skeleton-card__image skeleton-shimmer"></div>
+        <div class="skeleton-card__body">
+          <div class="skeleton-card__title skeleton-shimmer"></div>
+          <div class="skeleton-card__text skeleton-shimmer"></div>
+          <div class="skeleton-card__text skeleton-card__text--short skeleton-shimmer"></div>
+        </div>
+        <div class="skeleton-card__footer">
+          <div class="skeleton-card__avatar skeleton-shimmer"></div>
+          <div class="skeleton-card__meta">
+            <div class="skeleton-card__line skeleton-card__line--medium skeleton-shimmer"></div>
+            <div class="skeleton-card__line skeleton-card__line--short skeleton-shimmer"></div>
+          </div>
+        </div>
+        <span class="sr-only">Loading content, please wait...</span>
+      </div>
+    </section>
+
+    <!-- Profile skeleton -->
+    <section class="skeleton-demo" aria-label="Profile skeleton example">
+      <h2 class="skeleton-demo__heading">Profile</h2>
+      <div class="skeleton-profile" role="status" aria-label="Loading profile">
+        <div class="skeleton-profile__avatar skeleton-shimmer"></div>
+        <div class="skeleton-profile__info">
+          <div class="skeleton-profile__name skeleton-shimmer"></div>
+          <div class="skeleton-profile__handle skeleton-shimmer"></div>
+          <div class="skeleton-profile__bio skeleton-shimmer"></div>
+          <div class="skeleton-profile__bio skeleton-profile__bio--short skeleton-shimmer"></div>
+        </div>
+        <span class="sr-only">Loading profile, please wait...</span>
+      </div>
+    </section>
+
+    <!-- List skeleton -->
+    <section class="skeleton-demo" aria-label="List skeleton example">
+      <h2 class="skeleton-demo__heading">List</h2>
+      <div class="skeleton-list" role="status" aria-label="Loading list">
+        <div class="skeleton-list__item">
+          <div class="skeleton-list__avatar skeleton-shimmer"></div>
+          <div class="skeleton-list__content">
+            <div class="skeleton-list__line skeleton-list__line--wide skeleton-shimmer"></div>
+            <div class="skeleton-list__line skeleton-list__line--narrow skeleton-shimmer"></div>
+          </div>
+        </div>
+        <div class="skeleton-list__item">
+          <div class="skeleton-list__avatar skeleton-shimmer"></div>
+          <div class="skeleton-list__content">
+            <div class="skeleton-list__line skeleton-list__line--wide skeleton-shimmer"></div>
+            <div class="skeleton-list__line skeleton-list__line--narrow skeleton-shimmer"></div>
+          </div>
+        </div>
+        <div class="skeleton-list__item">
+          <div class="skeleton-list__avatar skeleton-shimmer"></div>
+          <div class="skeleton-list__content">
+            <div class="skeleton-list__line skeleton-list__line--wide skeleton-shimmer"></div>
+            <div class="skeleton-list__line skeleton-list__line--narrow skeleton-shimmer"></div>
+          </div>
+        </div>
+        <span class="sr-only">Loading list, please wait...</span>
+      </div>
+    </section>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/css-skeleton-screen-eranmol/style.css
+++ b/submissions/examples/css-skeleton-screen-eranmol/style.css
@@ -1,0 +1,346 @@
+/* ============================================================
+   CSS Skeleton Screen Loader
+   Shimmer skeleton placeholder for content loading states.
+   Pure CSS — no JavaScript required.
+   The shimmer effect is achieved with a CSS gradient that
+   slides across the element using @keyframes.
+   ============================================================ */
+
+/* ---------- Reset ---------- */
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+/* ---------- CSS Custom Properties (Light Mode) ---------- */
+:root {
+  --skeleton-bg: #e2e8f0;
+  --skeleton-shine: #f8fafc;
+  --skeleton-radius: 8px;
+  --page-bg: #f8fafc;
+  --page-text: #1e293b;
+  --page-text-muted: #64748b;
+  --demo-heading: #475569;
+
+  --shimmer-duration: 1.8s;
+}
+
+/* ---------- Dark Mode ---------- */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --skeleton-bg: #334155;
+    --skeleton-shine: #475569;
+    --page-bg: #0f172a;
+    --page-text: #f1f5f9;
+    --page-text-muted: #94a3b8;
+    --demo-heading: #94a3b8;
+  }
+}
+
+/* ---------- Page Layout ---------- */
+body {
+  min-height: 100vh;
+  background: var(--page-bg);
+  color: var(--page-text);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  padding: 2rem 1rem;
+}
+
+.demo-container {
+  max-width: 640px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.demo-title {
+  font-size: 1.75rem;
+  font-weight: 700;
+  text-align: center;
+}
+
+.demo-subtitle {
+  color: var(--page-text-muted);
+  text-align: center;
+  margin-top: -1.5rem;
+}
+
+/* Screen reader only — hides text visually but keeps it accessible */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+}
+
+/* ============================================================
+   Shimmer Animation
+   A linear-gradient moves from left to right across the
+   skeleton element, creating a shimmer/loading effect.
+   The gradient uses transparent edges and a lighter center
+   band that sweeps across repeatedly.
+   ============================================================ */
+.skeleton-shimmer {
+  background: var(--skeleton-bg);
+  border-radius: var(--skeleton-radius);
+  position: relative;
+  overflow: hidden;
+}
+
+/* Pseudo-element carries the shimmer gradient overlay */
+.skeleton-shimmer::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+
+  /* The gradient: transparent -> light -> transparent */
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    var(--skeleton-shine) 50%,
+    transparent 100%
+  );
+
+  /* Start off-screen to the left */
+  transform: translateX(-100%);
+
+  /* Animate the shimmer sliding across */
+  animation: shimmerSweep var(--shimmer-duration) ease-in-out infinite;
+}
+
+@keyframes shimmerSweep {
+  0% {
+    transform: translateX(-100%);
+  }
+
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+/* ============================================================
+   Section headings
+   ============================================================ */
+.skeleton-demo {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.skeleton-demo__heading {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--demo-heading);
+}
+
+/* ============================================================
+   Card Skeleton
+   Mimics a card with an image, text lines, avatar, and meta.
+   ============================================================ */
+.skeleton-card {
+  display: flex;
+  flex-direction: column;
+  background: var(--page-bg);
+  border: 1px solid var(--skeleton-bg);
+  border-radius: 12px;
+  padding: 1rem;
+  gap: 1rem;
+}
+
+/* Image placeholder — takes full width, fixed height */
+.skeleton-card__image {
+  width: 100%;
+  height: 160px;
+  border-radius: 8px;
+}
+
+/* Body section */
+.skeleton-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+}
+
+/* Title bar */
+.skeleton-card__title {
+  width: 65%;
+  height: 16px;
+}
+
+/* Text lines */
+.skeleton-card__text {
+  width: 100%;
+  height: 12px;
+}
+
+.skeleton-card__text--short {
+  width: 45%;
+}
+
+/* Footer with avatar and meta lines */
+.skeleton-card__footer {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--skeleton-bg);
+}
+
+.skeleton-card__avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.skeleton-card__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  flex: 1;
+}
+
+.skeleton-card__line {
+  height: 10px;
+}
+
+.skeleton-card__line--medium {
+  width: 80px;
+}
+
+.skeleton-card__line--short {
+  width: 50px;
+}
+
+/* ============================================================
+   Profile Skeleton
+   Mimics a user profile with avatar, name, handle, bio.
+   ============================================================ */
+.skeleton-profile {
+  display: flex;
+  align-items: flex-start;
+  gap: 1.25rem;
+  background: var(--page-bg);
+  border: 1px solid var(--skeleton-bg);
+  border-radius: 12px;
+  padding: 1.25rem;
+}
+
+.skeleton-profile__avatar {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.skeleton-profile__info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.skeleton-profile__name {
+  width: 140px;
+  height: 14px;
+}
+
+.skeleton-profile__handle {
+  width: 100px;
+  height: 10px;
+}
+
+.skeleton-profile__bio {
+  width: 100%;
+  height: 10px;
+  margin-top: 0.25rem;
+}
+
+.skeleton-profile__bio--short {
+  width: 70%;
+}
+
+/* ============================================================
+   List Skeleton
+   Mimics a list of items, each with avatar and text lines.
+   ============================================================ */
+.skeleton-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.skeleton-list__item {
+  display: flex;
+  align-items: center;
+  gap: 0.875rem;
+  background: var(--page-bg);
+  border: 1px solid var(--skeleton-bg);
+  border-radius: 10px;
+  padding: 0.875rem;
+}
+
+.skeleton-list__avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.skeleton-list__content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.skeleton-list__line {
+  height: 10px;
+}
+
+.skeleton-list__line--wide {
+  width: 100%;
+}
+
+.skeleton-list__line--narrow {
+  width: 60%;
+}
+
+/* ============================================================
+   Responsive: Mobile
+   ============================================================ */
+@media (max-width: 480px) {
+  .demo-container {
+    gap: 2rem;
+  }
+
+  .skeleton-card__image {
+    height: 120px;
+  }
+
+  .skeleton-profile {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
+
+  .skeleton-profile__info {
+    align-items: center;
+  }
+}
+
+/* ============================================================
+   Reduced Motion
+   Disable shimmer animation for users who prefer it.
+   ============================================================ */
+@media (prefers-reduced-motion: reduce) {
+  .skeleton-shimmer::after {
+    animation: none;
+  }
+}


### PR DESCRIPTION
closes #68088

## Pull Request Description

Adds shimmer skeleton screen loaders for content loading states, addressing issue #68088.

---

## Type of Change

- [x] 🧩 New component

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/css-skeleton-screen-eranmol/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Skeleton screen loaders with a shimmer animation effect. Includes three variants: card skeleton, profile skeleton, and list skeleton — each mimicking the layout of real content while data loads.

**How does a developer use it?**

```html
<div class="skeleton-card" role="status" aria-label="Loading content">
  <div class="skeleton-card__image skeleton-shimmer"></div>
  <div class="skeleton-card__body">
    <div class="skeleton-card__title skeleton-shimmer"></div>
    <div class="skeleton-card__text skeleton-shimmer"></div>
  </div>
  <span class="sr-only">Loading content, please wait...</span>
</div>
