### PR TITLE
fix: add bottom sheet drawer files

### DIFF
--- a/submissions/examples/ss-bottom-sheet-drawer/README.md
+++ b/submissions/examples/ss-bottom-sheet-drawer/README.md
@@ -1,0 +1,20 @@
+# CSS Bottom Sheet Drawer
+
+A pure CSS Bottom Sheet Drawer component inspired by modern mobile interfaces. The drawer slides up from the bottom of the viewport with a smooth animation and provides a clean space for actions, menus, or additional content.
+
+## Features
+
+- Pure HTML and CSS implementation
+- Smooth slide-up animation
+- Responsive design
+- Mobile-inspired UI pattern
+- Accessible structure using ARIA roles
+- No JavaScript required
+- Lightweight and reusable
+
+## Usage
+
+Include the stylesheet:
+
+```html
+<link rel="stylesheet" href="style.css">

--- a/submissions/examples/ss-bottom-sheet-drawer/demo.html
+++ b/submissions/examples/ss-bottom-sheet-drawer/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Bottom Sheet Drawer</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <input type="checkbox" id="sheet-toggle" hidden>
+
+  <div class="container">
+    <h1>CSS Bottom Sheet Drawer</h1>
+    <p>Pure CSS mobile-style bottom sheet component.</p>
+
+    <label for="sheet-toggle" class="open-btn">
+      Open Bottom Sheet
+    </label>
+  </div>
+
+  <label for="sheet-toggle" class="overlay"></label>
+
+  <div
+    class="bottom-sheet"
+    role="dialog"
+    aria-labelledby="sheet-title"
+    aria-modal="true"
+  >
+    <div class="handle"></div>
+
+    <h2 id="sheet-title">Bottom Sheet Drawer</h2>
+
+    <p>
+      This is a CSS-only bottom sheet drawer that slides up smoothly from
+      the bottom of the viewport.
+    </p>
+
+    <ul class="sheet-menu">
+      <li>Profile</li>
+      <li>Settings</li>
+      <li>Notifications</li>
+      <li>Help Center</li>
+    </ul>
+
+    <label for="sheet-toggle" class="close-btn">
+      Close
+    </label>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ss-bottom-sheet-drawer/style.css
+++ b/submissions/examples/ss-bottom-sheet-drawer/style.css
@@ -1,0 +1,130 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  font-family: Arial, sans-serif;
+}
+
+body {
+  min-height: 100vh;
+  background: linear-gradient(135deg, #4f46e5, #7c3aed);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: #fff;
+}
+
+.container {
+  text-align: center;
+  padding: 2rem;
+}
+
+.container h1 {
+  margin-bottom: 1rem;
+}
+
+.container p {
+  margin-bottom: 1.5rem;
+}
+
+.open-btn,
+.close-btn {
+  display: inline-block;
+  padding: 0.8rem 1.5rem;
+  background: #ffffff;
+  color: #4f46e5;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.3s ease;
+}
+
+.open-btn:hover,
+.close-btn:hover {
+  transform: translateY(-2px);
+}
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  opacity: 0;
+  visibility: hidden;
+  transition: 0.3s ease;
+}
+
+.bottom-sheet {
+  position: fixed;
+  left: 0;
+  bottom: -100%;
+  width: 100%;
+  max-height: 80vh;
+  background: #ffffff;
+  color: #333;
+  border-radius: 24px 24px 0 0;
+  padding: 1.5rem;
+  transition: bottom 0.4s ease;
+  box-shadow: 0 -10px 30px rgba(0, 0, 0, 0.2);
+}
+
+.handle {
+  width: 60px;
+  height: 6px;
+  background: #d1d5db;
+  border-radius: 999px;
+  margin: 0 auto 1rem;
+}
+
+.bottom-sheet h2 {
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.bottom-sheet p {
+  text-align: center;
+  margin-bottom: 1.5rem;
+  line-height: 1.6;
+}
+
+.sheet-menu {
+  list-style: none;
+  margin-bottom: 1.5rem;
+}
+
+.sheet-menu li {
+  padding: 1rem;
+  border-bottom: 1px solid #e5e7eb;
+  transition: background 0.3s ease;
+}
+
+.sheet-menu li:hover {
+  background: #f3f4f6;
+}
+
+.close-btn {
+  width: 100%;
+  text-align: center;
+}
+
+#sheet-toggle:checked ~ .overlay {
+  opacity: 1;
+  visibility: visible;
+}
+
+#sheet-toggle:checked ~ .bottom-sheet {
+  bottom: 0;
+}
+
+@media (min-width: 768px) {
+  .bottom-sheet {
+    width: 500px;
+    left: 50%;
+    transform: translateX(-50%);
+    border-radius: 24px;
+    bottom: -100%;
+  }
+
+  #sheet-toggle:checked ~ .bottom-sheet {
+    bottom: 20px;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---
## closes #68206 

## Feature Description

### What does this add?

A CSS-only Bottom Sheet Drawer component that slides up from the bottom of the viewport, inspired by modern mobile application interfaces. It includes a smooth slide-up animation, rounded top corners, and an overlay backdrop.

### How does a developer use it?

```html
<link rel="stylesheet" href="style.css">

<input type="checkbox" id="sheet-toggle" hidden>

<label for="sheet-toggle" class="open-btn">
  Open Bottom Sheet
</label>

<div class="overlay"></div>

<div class="bottom-sheet">
  <label for="sheet-toggle" class="close-btn">&times;</label>
  <h2>Bottom Sheet Drawer</h2>
  <p>Mobile-style drawer built using pure CSS.</p>
</div>