### PR TITLE
feat: add CSS torn paper card

### DIFF
--- a/submissions/examples/css-torn-paper-card/README.md
+++ b/submissions/examples/css-torn-paper-card/README.md
@@ -1,0 +1,35 @@
+# CSS Torn Paper Card
+
+A responsive CSS-only card component with a torn-paper edge effect created using `clip-path`.
+
+## Features
+
+- Pure CSS implementation
+- Torn paper edge using `clip-path: polygon()`
+- Responsive layout
+- Light and dark mode support
+- CSS custom properties for easy theming
+- No JavaScript required
+- Works by opening `demo.html` directly in a browser
+- Includes accessible semantic markup
+
+## Files
+
+- `demo.html` — Standalone demonstration of the component
+- `style.css` — CSS styles and torn-paper effect
+- `README.md` — Documentation and usage instructions
+
+## Usage
+
+Add the `torn-paper-card` class to a card element:
+
+```html
+<article class="torn-paper-card">
+  <div class="torn-paper-card__content">
+    <span class="torn-paper-card__tag">Featured</span>
+    <h2 class="torn-paper-card__title">Creative Design</h2>
+    <p class="torn-paper-card__text">
+      A CSS-only card with a paper-inspired torn edge effect.
+    </p>
+  </div>
+</article>

--- a/submissions/examples/css-torn-paper-card/demo.html
+++ b/submissions/examples/css-torn-paper-card/demo.html
@@ -1,0 +1,92 @@
+
+---
+
+## 2. `demo.html`
+
+Paste this:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="color-scheme" content="light dark">
+  <title>CSS Torn Paper Card</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="demo-page">
+    <header class="demo-header">
+      <p class="eyebrow">EaseMotion CSS</p>
+      <h1>CSS Torn Paper Card</h1>
+      <p>
+        A responsive paper-inspired card created entirely with CSS.
+      </p>
+    </header>
+
+    <section class="card-grid" aria-label="Torn paper card examples">
+
+      <article class="torn-paper-card">
+        <div class="torn-paper-card__content">
+          <span class="torn-paper-card__tag">Featured</span>
+
+          <h2 class="torn-paper-card__title">
+            Creative Design
+          </h2>
+
+          <p class="torn-paper-card__text">
+            Add a handcrafted paper aesthetic to your interface
+            with a responsive CSS-only card.
+          </p>
+
+          <a class="torn-paper-card__link" href="#design">
+            Explore design
+          </a>
+        </div>
+      </article>
+
+      <article class="torn-paper-card torn-paper-card--accent">
+        <div class="torn-paper-card__content">
+          <span class="torn-paper-card__tag">CSS Only</span>
+
+          <h2 class="torn-paper-card__title">
+            No JavaScript
+          </h2>
+
+          <p class="torn-paper-card__text">
+            The torn edge is created with CSS clip-path,
+            custom properties, and responsive layout techniques.
+          </p>
+
+          <a class="torn-paper-card__link" href="#css">
+            Learn more
+          </a>
+        </div>
+      </article>
+
+      <article class="torn-paper-card torn-paper-card--dark">
+        <div class="torn-paper-card__content">
+          <span class="torn-paper-card__tag">Reusable</span>
+
+          <h2 class="torn-paper-card__title">
+            Easy to Customize
+          </h2>
+
+          <p class="torn-paper-card__text">
+            Change the colors, spacing, radius, and accent using
+            simple CSS custom properties.
+          </p>
+
+          <a class="torn-paper-card__link" href="#customize">
+            Customize
+          </a>
+        </div>
+      </article>
+
+    </section>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/css-torn-paper-card/style.css
+++ b/submissions/examples/css-torn-paper-card/style.css
@@ -1,0 +1,288 @@
+/*
+  CSS Torn Paper Card
+  Pure CSS component for EaseMotion CSS
+*/
+
+:root {
+  --page-bg: #f3f4f6;
+  --page-text: #111827;
+  --muted-text: #6b7280;
+
+  --card-bg: #ffffff;
+  --card-text: #1f2937;
+  --card-muted: #6b7280;
+  --card-accent: #7c3aed;
+  --card-accent-dark: #5b21b6;
+
+  --card-radius: 1.25rem;
+  --card-shadow: 0 1.25rem 3rem rgba(15, 23, 42, 0.12);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --page-bg: #111827;
+    --page-text: #f9fafb;
+    --muted-text: #9ca3af;
+
+    --card-bg: #1f2937;
+    --card-text: #f9fafb;
+    --card-muted: #d1d5db;
+    --card-accent: #a78bfa;
+    --card-accent-dark: #8b5cf6;
+
+    --card-shadow: 0 1.25rem 3rem rgba(0, 0, 0, 0.3);
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--page-text);
+  background: var(--page-bg);
+}
+
+.demo-page {
+  width: min(1120px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 4rem 0;
+}
+
+.demo-header {
+  max-width: 680px;
+  margin: 0 auto 3rem;
+  text-align: center;
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: var(--card-accent);
+  font-size: 0.8rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.demo-header h1 {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  line-height: 1.05;
+}
+
+.demo-header p:last-child {
+  margin: 1rem auto 0;
+  max-width: 560px;
+  color: var(--muted-text);
+  line-height: 1.7;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 2rem;
+  align-items: stretch;
+}
+
+/*
+  The card uses clip-path to create an irregular torn-paper
+  edge along the bottom of the component.
+*/
+.torn-paper-card {
+  --card-bg: #ffffff;
+  --card-text: #1f2937;
+  --card-muted: #6b7280;
+  --card-accent: #7c3aed;
+
+  position: relative;
+  min-height: 330px;
+  overflow: hidden;
+
+  background: var(--card-bg);
+  color: var(--card-text);
+  border-radius: var(--card-radius);
+  box-shadow: var(--card-shadow);
+
+  /*
+    The final points create the irregular lower edge.
+    This produces the torn-paper silhouette without an image.
+  */
+  clip-path: polygon(
+    0 0,
+    100% 0,
+    100% 96%,
+    97% 97.2%,
+    94% 95.8%,
+    91% 98%,
+    87% 96.2%,
+    83% 98.5%,
+    79% 96.4%,
+    75% 98.2%,
+    71% 95.9%,
+    67% 97.8%,
+    63% 95.7%,
+    59% 98.4%,
+    55% 96.1%,
+    51% 98.1%,
+    47% 95.8%,
+    43% 97.7%,
+    39% 96%,
+    35% 98.3%,
+    31% 95.9%,
+    27% 97.9%,
+    23% 96.1%,
+    19% 98.4%,
+    15% 95.8%,
+    11% 97.6%,
+    7% 95.9%,
+    3% 97.4%,
+    0 96%
+  );
+
+  transition:
+    transform 300ms ease,
+    box-shadow 300ms ease;
+}
+
+.torn-paper-card:hover {
+  transform: translateY(-8px);
+  box-shadow: 0 1.5rem 3.5rem rgba(15, 23, 42, 0.18);
+}
+
+.torn-paper-card__content {
+  display: flex;
+  min-height: 330px;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 2rem;
+}
+
+.torn-paper-card__tag {
+  display: inline-flex;
+  align-items: center;
+
+  padding: 0.4rem 0.75rem;
+
+  border-radius: 999px;
+
+  background: color-mix(
+    in srgb,
+    var(--card-accent) 14%,
+    transparent
+  );
+
+  color: var(--card-accent);
+
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.torn-paper-card__title {
+  margin: 1.5rem 0 0.75rem;
+
+  font-size: clamp(1.4rem, 2vw, 1.8rem);
+  line-height: 1.15;
+}
+
+.torn-paper-card__text {
+  margin: 0;
+
+  color: var(--card-muted);
+  font-size: 0.98rem;
+  line-height: 1.7;
+}
+
+.torn-paper-card__link {
+  display: inline-flex;
+  margin-top: auto;
+  padding-top: 1.5rem;
+
+  color: var(--card-accent);
+  font-weight: 800;
+  text-decoration: none;
+
+  transition:
+    color 200ms ease,
+    transform 200ms ease;
+}
+
+.torn-paper-card__link::after {
+  content: " →";
+}
+
+.torn-paper-card__link:hover {
+  color: var(--card-accent-dark);
+  transform: translateX(4px);
+}
+
+.torn-paper-card__link:focus-visible {
+  outline: 3px solid var(--card-accent);
+  outline-offset: 4px;
+  border-radius: 0.25rem;
+}
+
+/* Accent variation */
+.torn-paper-card--accent {
+  --card-bg: #ede9fe;
+  --card-text: #2e1065;
+  --card-muted: #5b21b6;
+  --card-accent: #6d28d9;
+  --card-accent-dark: #4c1d95;
+}
+
+/* Dark variation */
+.torn-paper-card--dark {
+  --card-bg: #111827;
+  --card-text: #f9fafb;
+  --card-muted: #d1d5db;
+  --card-accent: #c4b5fd;
+  --card-accent-dark: #ddd6fe;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  .torn-paper-card,
+  .torn-paper-card__link {
+    transition: none;
+  }
+}
+
+@media (max-width: 900px) {
+  .card-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .demo-page {
+    padding: 2.5rem 0;
+  }
+
+  .card-grid {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+
+  .torn-paper-card__content {
+    padding: 1.75rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to** **`core/`**
- [x] **No changes to** **`components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds a responsive CSS Torn Paper Card component with an irregular torn-paper edge effect created using CSS `clip-path`. The component includes reusable styling, responsive behavior, light/dark mode support, CSS custom properties for theming, and a subtle hover interaction.

**How does a developer use it?**

```html
<article class="torn-paper-card">
  <div class="torn-paper-card__content">
    <span class="torn-paper-card__tag">Featured</span>
    <h2 class="torn-paper-card__title">Creative Design</h2>
    <p class="torn-paper-card__text">
      A CSS-only card with a paper-inspired torn edge effect.
    </p>
    <a class="torn-paper-card__link" href="#design">
      Explore design
    </a>
  </div>
</article>

**Why does it fit EaseMotion CSS?**

This component provides a reusable visual UI effect using pure CSS without external assets or JavaScript. The torn-paper edge demonstrates CSS clip-path, custom properties, responsive design, and motion-friendly hover interactions, making it suitable for feature cards, portfolios, announcements, and promotional sections.

---

## Demo

- [ ] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [*] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Implemented under submissions/examples/css-torn-paper-card/.
Uses pure HTML and CSS with no JavaScript dependencies.
Includes README.md, demo.html, and style.css.
The torn edge is created using CSS clip-path.
Includes responsive layouts, CSS custom properties, dark mode support, and prefers-reduced-motion handling.
Closes #68166.

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
