### PR TITLE
feat: add CSS Side Panel Overlay component

### DIFF
--- a/submissions/examples/css-side-panel-overlay/README.md
+++ b/submissions/examples/css-side-panel-overlay/README.md
@@ -1,0 +1,19 @@
+# CSS Side Panel Overlay
+
+A pure CSS side panel component that slides in from the right side of the viewport with a smooth overlay fade effect.
+
+## Features
+
+- Pure HTML and CSS
+- Right-side slide-in animation
+- Background overlay fade effect
+- Responsive design
+- Accessible structure
+- No JavaScript required
+
+## Usage
+
+Include the stylesheet:
+
+```html
+<link rel="stylesheet" href="style.css">

--- a/submissions/examples/css-side-panel-overlay/demo.html
+++ b/submissions/examples/css-side-panel-overlay/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Side Panel Overlay</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <input type="checkbox" id="panel-toggle" hidden>
+
+  <div class="container">
+    <h1>CSS Side Panel Overlay</h1>
+    <p>Click the button below to open the side panel.</p>
+
+    <label for="panel-toggle" class="open-btn">
+      Open Panel
+    </label>
+  </div>
+
+  <label for="panel-toggle" class="overlay"></label>
+
+  <aside class="side-panel" role="dialog" aria-labelledby="panel-title">
+    <div class="panel-header">
+      <h2 id="panel-title">Side Panel</h2>
+      <label for="panel-toggle" class="close-btn">&times;</label>
+    </div>
+
+    <div class="panel-content">
+      <p>
+        This is a CSS-only side panel overlay component. It slides in
+        smoothly from the right and includes a fading backdrop.
+      </p>
+
+      <ul>
+        <li>Pure CSS implementation</li>
+        <li>Smooth slide animation</li>
+        <li>Responsive design</li>
+        <li>Reusable component structure</li>
+      </ul>
+    </div>
+  </aside>
+
+</body>
+</html>

--- a/submissions/examples/css-side-panel-overlay/style.css
+++ b/submissions/examples/css-side-panel-overlay/style.css
@@ -1,0 +1,115 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  font-family: Arial, sans-serif;
+}
+
+body {
+  min-height: 100vh;
+  background: linear-gradient(135deg, #667eea, #764ba2);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: #fff;
+}
+
+.container {
+  text-align: center;
+  padding: 2rem;
+}
+
+.container h1 {
+  margin-bottom: 1rem;
+}
+
+.container p {
+  margin-bottom: 1.5rem;
+}
+
+.open-btn {
+  display: inline-block;
+  padding: 12px 24px;
+  background: #ffffff;
+  color: #333;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 600;
+  transition: transform 0.3s ease;
+}
+
+.open-btn:hover {
+  transform: translateY(-2px);
+}
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.35s ease;
+  z-index: 10;
+}
+
+.side-panel {
+  position: fixed;
+  top: 0;
+  right: -360px;
+  width: 340px;
+  max-width: 90%;
+  height: 100vh;
+  background: #ffffff;
+  color: #333;
+  box-shadow: -4px 0 20px rgba(0, 0, 0, 0.2);
+  transition: right 0.35s ease;
+  z-index: 20;
+  overflow-y: auto;
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.2rem;
+  border-bottom: 1px solid #e5e5e5;
+}
+
+.close-btn {
+  font-size: 1.8rem;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.panel-content {
+  padding: 1.5rem;
+}
+
+.panel-content p {
+  margin-bottom: 1rem;
+  line-height: 1.6;
+}
+
+.panel-content ul {
+  padding-left: 1.2rem;
+}
+
+.panel-content li {
+  margin-bottom: 0.75rem;
+}
+
+#panel-toggle:checked ~ .overlay {
+  opacity: 1;
+  visibility: visible;
+}
+
+#panel-toggle:checked ~ .side-panel {
+  right: 0;
+}
+
+@media (max-width: 480px) {
+  .side-panel {
+    width: 100%;
+    max-width: 100%;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---
## closes #68207 

## Feature Description

### What does this add?

A CSS-only Side Panel Overlay component that slides in from the right side of the screen while fading in a background overlay. The component provides a modern off-canvas panel experience suitable for navigation menus, settings panels, notifications, and contextual content.

### How does a developer use it?

```html
<link rel="stylesheet" href="style.css">

<input type="checkbox" id="panel-toggle" hidden>

<label for="panel-toggle" class="open-btn">
  Open Panel
</label>

<label for="panel-toggle" class="overlay"></label>

<aside class="side-panel">
  <label for="panel-toggle" class="close-btn">&times;</label>
  <h2>Side Panel Overlay</h2>
  <p>Content goes here.</p>
</aside>