### PR TITLE
feat: add CSS Zoom-In Image Lightbox component

### DIFF
--- a/submissions/examples/css-zoom-in-image-lightbox/README.md
+++ b/submissions/examples/css-zoom-in-image-lightbox/README.md
@@ -1,0 +1,51 @@
+# CSS Zoom-In Image Lightbox
+
+A pure CSS image lightbox that expands an image into a fullscreen overlay with a smooth zoom-in animation.
+
+## Features
+
+- Pure HTML and CSS
+- Fullscreen image preview
+- Smooth zoom-in effect
+- Overlay backdrop
+- Responsive design
+- No JavaScript required
+
+## Usage
+
+Include the stylesheet:
+
+```html
+<link rel="stylesheet" href="style.css">
+```
+
+Add the image and lightbox markup:
+
+```html
+<a href="#lightbox">
+  <img src="image.jpg" alt="Preview" class="thumbnail">
+</a>
+
+<div id="lightbox" class="lightbox">
+  <a href="#" class="close"></a>
+  <img src="image.jpg" alt="Preview" class="lightbox-image">
+</div>
+```
+
+## Accessibility
+
+- Meaningful image alt text
+- Keyboard accessible anchor navigation
+- Large click target for closing overlay
+- Responsive layout for all screen sizes
+
+## Browser Support
+
+- Chrome
+- Firefox
+- Edge
+- Safari
+
+## Why it fits EaseMotion CSS
+
+This component provides a reusable image preview pattern with smooth zoom animations and overlay effects using only HTML and CSS. It aligns with EaseMotion CSS by offering lightweight, dependency-free UI interactions that can be easily integrated into modern web projects.

--- a/submissions/examples/css-zoom-in-image-lightbox/demo.html
+++ b/submissions/examples/css-zoom-in-image-lightbox/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Zoom-In Image Lightbox</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <h1>CSS Zoom-In Image Lightbox</h1>
+    <p>Click the image to view it in fullscreen.</p>
+
+    <a href="#lightbox">
+      <img
+        src="https://images.unsplash.com/photo-1506744038136-46273834b3fb?w=1200"
+        alt="Landscape"
+        class="thumbnail"
+      >
+    </a>
+  </div>
+
+  <div id="lightbox" class="lightbox">
+    <a href="#" class="close"></a>
+
+    <img
+      src="https://images.unsplash.com/photo-1506744038136-46273834b3fb?w=1200"
+      alt="Fullscreen Landscape"
+      class="lightbox-image"
+    >
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/css-zoom-in-image-lightbox/style.css
+++ b/submissions/examples/css-zoom-in-image-lightbox/style.css
@@ -1,0 +1,88 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  font-family: Arial, sans-serif;
+  background: linear-gradient(135deg, #0f172a, #1e293b);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: #fff;
+}
+
+.container {
+  text-align: center;
+  padding: 2rem;
+}
+
+.container h1 {
+  margin-bottom: 1rem;
+}
+
+.container p {
+  margin-bottom: 2rem;
+}
+
+.thumbnail {
+  width: 320px;
+  max-width: 90vw;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: transform 0.35s ease;
+  box-shadow: 0 12px 30px rgba(0,0,0,0.3);
+}
+
+.thumbnail:hover {
+  transform: scale(1.05);
+}
+
+.lightbox {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.9);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.35s ease;
+  z-index: 1000;
+}
+
+.lightbox:target {
+  opacity: 1;
+  visibility: visible;
+}
+
+.lightbox-image {
+  max-width: 90%;
+  max-height: 85%;
+  border-radius: 14px;
+  transform: scale(0.7);
+  transition: transform 0.35s ease;
+  box-shadow: 0 20px 50px rgba(0,0,0,0.5);
+}
+
+.lightbox:target .lightbox-image {
+  transform: scale(1);
+}
+
+.close {
+  position: absolute;
+  inset: 0;
+  cursor: default;
+}
+
+@media (max-width: 768px) {
+  .thumbnail {
+    width: 260px;
+  }
+
+  .lightbox-image {
+    max-width: 95%;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---
## closes #68210 

## Feature Description

### What does this add?

A CSS-only Zoom-In Image Lightbox component that allows users to click an image thumbnail and view it in a fullscreen overlay with a smooth zoom-in animation. The lightbox uses CSS `:target` selectors to create an interactive experience without JavaScript.

### How does a developer use it?

```html
<link rel="stylesheet" href="style.css">

<a href="#lightbox">
  <img src="image.jpg" alt="Preview" class="thumbnail">
</a>

<div id="lightbox" class="lightbox">
  <a href="#" class="close"></a>

  <img
    src="image.jpg"
    alt="Fullscreen Preview"
    class="lightbox-image"
  >
</div>