### PR TITLE
feat: add CSS Retro Pixel Button component

### DIFF
--- a/submissions/examples/css-retro-pixel-button/README.md
+++ b/submissions/examples/css-retro-pixel-button/README.md
@@ -1,0 +1,19 @@
+# CSS Retro Pixel Button
+
+A retro arcade-inspired pixel button built entirely with CSS. The component uses pixel-style shadows and a press-down animation to recreate classic video game UI elements.
+
+## Features
+
+- Pure CSS implementation
+- Retro pixel-art styling
+- Interactive press animation
+- Keyboard accessible
+- Responsive design
+- No JavaScript required
+
+## Usage
+
+```html
+<button class="pixel-btn">
+  START GAME
+</button>

--- a/submissions/examples/css-retro-pixel-button/demo.html
+++ b/submissions/examples/css-retro-pixel-button/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Retro Pixel Button</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <button class="pixel-btn" aria-label="Retro Pixel Button">
+      START GAME
+    </button>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/css-retro-pixel-button/style.css
+++ b/submissions/examples/css-retro-pixel-button/style.css
@@ -1,0 +1,68 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: #1a1a1a;
+  font-family: "Courier New", monospace;
+}
+
+.container {
+  text-align: center;
+}
+
+.pixel-btn {
+  background: #00d084;
+  color: #fff;
+  border: none;
+  padding: 18px 40px;
+  font-size: 1rem;
+  font-weight: bold;
+  text-transform: uppercase;
+  cursor: pointer;
+  position: relative;
+  image-rendering: pixelated;
+
+  box-shadow:
+    4px 0 0 #009966,
+    -4px 0 0 #009966,
+    0 4px 0 #009966,
+    0 -4px 0 #009966,
+    8px 8px 0 #004d33;
+
+  transition: transform 0.15s ease,
+              box-shadow 0.15s ease;
+}
+
+.pixel-btn:hover {
+  background: #18e29a;
+}
+
+.pixel-btn:active {
+  transform: translate(6px, 6px);
+
+  box-shadow:
+    2px 0 0 #009966,
+    -2px 0 0 #009966,
+    0 2px 0 #009966,
+    0 -2px 0 #009966,
+    2px 2px 0 #004d33;
+}
+
+.pixel-btn:focus-visible {
+  outline: 3px solid #fff;
+  outline-offset: 6px;
+}
+
+@media (max-width: 600px) {
+  .pixel-btn {
+    padding: 14px 28px;
+    font-size: 0.9rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---
## closes #68156 

## Feature Description

**What does this add?**

Adds a retro pixel-art styled button with arcade-inspired visuals and a satisfying press animation.

**How does a developer use it?**

```html
<button class="pixel-btn">
  START GAME
</button>