### PR TITLE
feat: add CSS metallic liquid mercury

### DIFF
--- a/submissions/examples/css-metallic-liquid-mercur/README.md
+++ b/submissions/examples/css-metallic-liquid-mercur/README.md
@@ -1,0 +1,79 @@
+Metallic Liquid Mercury
+
+A puddle of fluid mercury: a harsh monochrome metallic gradient, two independently-drifting specular highlights for a wet, reflective glint, and an organic border-radius morph simulating shifting surface tension. Pure CSS — no SVG filters, no images, no JavaScript.
+
+Files
+File	Purpose
+demo.html	One large puddle + three smaller droplet variants
+style.css	The layered gradient, morph, and shimmer mechanics
+README.md	This file
+How the metal look works
+
+The blob's background is a single conic-gradient alternating between near-black and near-white stops — no color anywhere, which is what gives it the "harsh monochrome" chrome read rather than a soft, colorful blob:
+
+css
+background: conic-gradient(
+  from 200deg at 50% 45%,
+  var(--hg-metal-1) 0deg,
+  var(--hg-metal-2) 55deg,
+  var(--hg-metal-3) 95deg,
+  var(--hg-metal-4) 150deg,
+  var(--hg-metal-1) 200deg,
+  var(--hg-metal-2) 260deg,
+  var(--hg-metal-5) 310deg,
+  var(--hg-metal-1) 360deg
+);
+
+On top of that, three stacked inset shadows do the volumetric work: a large dark one for the shaded underside, a smaller light one for the lit edge, and a soft dark one pulled all the way in for core depth — plus one regular (non-inset) shadow so the whole puddle casts a shadow onto the page beneath it.
+
+How the shimmer works
+
+Two absolutely-positioned ::-style children (.mercury-blob__highlight-1 and -2, real <span>s rather than pseudo-elements so they're easy to retarget from the demo markup) each carry their own radial-gradient glint and their own @keyframes drifting the gradient's background-position back and forth on independent durations:
+
+css
+.mercury-blob__highlight-1 {
+  background: radial-gradient(circle at 30% 25%, ...);
+  animation: hg-drift-1 var(--hg-shimmer-duration) ease-in-out infinite;
+}
+
+.mercury-blob__highlight-2 {
+  background: radial-gradient(circle at 68% 70%, ...);
+  animation: hg-drift-2 calc(var(--hg-shimmer-duration) * 1.4) ease-in-out infinite;
+}
+
+Because the two highlights move at different speeds and from different starting positions, they never stay in sync — that's what keeps the surface reading as liquid rather than a fixed metal texture with a static glare baked in.
+
+How the surface-tension morph works
+
+border-radius accepts up to eight independent values (four corners, each with a horizontal and vertical radius), which is enough to describe a properly irregular blob rather than a uniform oval. A single @keyframes animates between four such shapes:
+
+css
+@keyframes hg-morph {
+  0%, 100% { border-radius: 42% 58% 70% 30% / 45% 45% 55% 55%; }
+  25%      { border-radius: 62% 38% 30% 70% / 50% 62% 38% 50%; }
+  50%      { border-radius: 50% 50% 62% 38% / 38% 55% 45% 62%; }
+  75%      { border-radius: 35% 65% 46% 54% / 60% 38% 62% 40%; }
+}
+Hover interaction
+
+Hovering the large puddle tightens it toward a rounder shape (as if disturbed and settling), deepens the inset shadows slightly, and doubles the shimmer speed — a small piece of feedback that the surface is reactive, not just decorative.
+
+CSS custom properties
+Property	Default	Controls
+--hg-size	320px	Blob width (height is derived at a fixed aspect ratio)
+--hg-morph-duration	11s	One full surface-tension cycle
+--hg-shimmer-duration	7s	Base duration for highlight drift (highlight 2 runs at 1.4× this)
+--hg-metal-1 … --hg-metal-5	near-black/near-white pairs	The conic-gradient's monochrome stops
+
+The three droplet variants in the demo are each just 1–2 token overrides (--hg-size, plus --hg-morph-duration/--hg-shimmer-duration for the fast/slow pair) on top of the same markup and mechanism.
+
+Accessibility
+The blobs are marked aria-hidden="true" — they're decorative art with no informational content, so they're removed from the accessibility tree entirely rather than announced as empty elements.
+Respects prefers-reduced-motion: reduce: both the morph and the shimmer animations are removed, and the blob holds at a single mid-morph shape (not its literal 0%/100% resting frame) so it still reads as a deliberately-shaped puddle rather than an animation that simply got interrupted.
+Responsive behavior
+
+--hg-size steps down at 560px for the hero puddle, and the droplet row's individual size token drops to match, so the three droplets stay proportionate to the (now smaller) hero piece rather than looking oversized next to it on a phone screen.
+
+Browser support
+
+Uses conic-gradient, multi-value border-radius, and standard background-position animation — all supported in current evergreen browsers. No fallback needed; in the rare case conic-gradient isn't supported, the element still renders as a shaped, shadowed shape using whatever the browser's default background handling produces.

--- a/submissions/examples/css-metallic-liquid-mercur/demo.html
+++ b/submissions/examples/css-metallic-liquid-mercur/demo.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Metallic Liquid Mercury — EaseMotion CSS</title>
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@600;700&family=Inter:wght@400;500;600&family=IBM+Plex+Mono:wght@500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="noise" aria-hidden="true"></div>
+
+  <header class="hero">
+    <p class="eyebrow">EaseMotion CSS &middot; showcase</p>
+    <h1 class="hero-title">Metallic liquid mercury</h1>
+    <p class="hero-sub">A puddle of fluid mercury: a harsh monochrome metallic gradient, layered specular highlights that drift independently, and an organic border-radius morph simulating shifting surface tension. Pure CSS.</p>
+  </header>
+
+  <main class="showcase">
+
+    <div class="mercury-stage">
+      <div class="mercury-blob mercury-blob-hero" aria-hidden="true">
+        <span class="mercury-blob__highlight mercury-blob__highlight-1"></span>
+        <span class="mercury-blob__highlight mercury-blob__highlight-2"></span>
+      </div>
+      <div class="mercury-blob__reflection" aria-hidden="true"></div>
+    </div>
+
+    <section class="droplets" aria-label="Smaller mercury droplets, same mechanism">
+      <div class="droplet-stage">
+        <div class="mercury-blob mercury-blob-sm mercury-blob-fast" aria-hidden="true">
+          <span class="mercury-blob__highlight mercury-blob__highlight-1"></span>
+          <span class="mercury-blob__highlight mercury-blob__highlight-2"></span>
+        </div>
+      </div>
+      <div class="droplet-stage">
+        <div class="mercury-blob mercury-blob-sm" aria-hidden="true">
+          <span class="mercury-blob__highlight mercury-blob__highlight-1"></span>
+          <span class="mercury-blob__highlight mercury-blob__highlight-2"></span>
+        </div>
+      </div>
+      <div class="droplet-stage">
+        <div class="mercury-blob mercury-blob-sm mercury-blob-slow" aria-hidden="true">
+          <span class="mercury-blob__highlight mercury-blob__highlight-1"></span>
+          <span class="mercury-blob__highlight mercury-blob__highlight-2"></span>
+        </div>
+      </div>
+    </section>
+
+    <p class="hint">Hover the large puddle &mdash; surface tension tightens and the shimmer speeds up.</p>
+
+  </main>
+
+  <footer class="footer">
+    <p>EaseMotion CSS &middot; submissions/examples/css-metallic-liquid-mercury</p>
+  </footer>
+
+</body>
+</html>

--- a/submissions/examples/css-metallic-liquid-mercur/style.css
+++ b/submissions/examples/css-metallic-liquid-mercur/style.css
@@ -1,0 +1,349 @@
+/* =========================================================================
+   Metallic Liquid Mercury — EaseMotion CSS
+   A puddle of fluid mercury built from three layers on one element: a
+   conic-gradient chrome banding for the harsh monochrome metal look,
+   deep inset shadows for volume, and two independently-drifting radial
+   specular highlights for the wet, reflective glint. Surface tension is
+   simulated by animating border-radius through several irregular blob
+   shapes. Pure CSS — no SVG filters, no images.
+   ========================================================================= */
+ 
+ 
+/* -------------------------------------------------------------------------
+   1. Design tokens
+   ------------------------------------------------------------------------- */
+ 
+:root {
+  --hg-bg: #060607;
+  --hg-floor: #0a0a0b;
+ 
+  /* Harsh monochrome only — no accent color anywhere in the metal itself */
+  --hg-metal-1: #020202;
+  --hg-metal-2: #d8dbdd;
+  --hg-metal-3: #0c0c0d;
+  --hg-metal-4: #eef1f2;
+  --hg-metal-5: #050505;
+ 
+  --hg-text: #e8eaec;
+  --hg-text-muted: #86898d;
+ 
+  --hg-font-display: "Space Grotesk", "Segoe UI", sans-serif;
+  --hg-font-body: "Inter", "Segoe UI", sans-serif;
+  --hg-font-mono: "IBM Plex Mono", "Courier New", monospace;
+ 
+  /* Mercury tuning — override per instance to retune */
+  --hg-morph-duration: 11s;
+  --hg-shimmer-duration: 7s;
+  --hg-size: 320px;
+}
+ 
+* {
+  box-sizing: border-box;
+}
+ 
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--hg-bg);
+  color: var(--hg-text);
+  font-family: var(--hg-font-body);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+ 
+.noise {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.05;
+  z-index: 0;
+  background-image: radial-gradient(circle at 1px 1px, #ffffff 1px, transparent 0);
+  background-size: 3px 3px;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   2. Hero
+   ------------------------------------------------------------------------- */
+ 
+.hero {
+  position: relative;
+  z-index: 1;
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 92px 24px 24px;
+  text-align: center;
+}
+ 
+.eyebrow {
+  font-family: var(--hg-font-mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--hg-text-muted);
+  margin: 0 0 20px;
+}
+ 
+.hero-title {
+  font-family: var(--hg-font-display);
+  font-weight: 600;
+  font-size: clamp(30px, 5.5vw, 48px);
+  line-height: 1.1;
+  letter-spacing: -0.01em;
+  margin: 0 0 16px;
+}
+ 
+.hero-sub {
+  font-size: 15px;
+  color: var(--hg-text-muted);
+  max-width: 500px;
+  margin: 0 auto;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   3. Stage
+   ------------------------------------------------------------------------- */
+ 
+.showcase {
+  position: relative;
+  z-index: 1;
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 40px 24px 100px;
+}
+ 
+.mercury-stage {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  padding-bottom: 60px;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   4. The mercury blob itself
+   ------------------------------------------------------------------------- */
+ 
+.mercury-blob {
+  position: relative;
+  width: var(--hg-size);
+  height: calc(var(--hg-size) * 0.72);
+  overflow: hidden;
+ 
+  background: conic-gradient(
+    from 200deg at 50% 45%,
+    var(--hg-metal-1) 0deg,
+    var(--hg-metal-2) 55deg,
+    var(--hg-metal-3) 95deg,
+    var(--hg-metal-4) 150deg,
+    var(--hg-metal-1) 200deg,
+    var(--hg-metal-2) 260deg,
+    var(--hg-metal-5) 310deg,
+    var(--hg-metal-1) 360deg
+  );
+ 
+  box-shadow:
+    inset -26px -30px 60px rgba(0, 0, 0, 0.85),
+    inset 22px 24px 50px rgba(255, 255, 255, 0.14),
+    inset 0 0 40px rgba(0, 0, 0, 0.6),
+    0 40px 70px -24px rgba(0, 0, 0, 0.75);
+ 
+  border-radius: 42% 58% 70% 30% / 45% 45% 55% 55%;
+ 
+  animation: hg-morph var(--hg-morph-duration) ease-in-out infinite;
+  transition: border-radius 900ms ease, box-shadow 500ms ease;
+}
+ 
+@keyframes hg-morph {
+  0%, 100% {
+    border-radius: 42% 58% 70% 30% / 45% 45% 55% 55%;
+  }
+  25% {
+    border-radius: 62% 38% 30% 70% / 50% 62% 38% 50%;
+  }
+  50% {
+    border-radius: 50% 50% 62% 38% / 38% 55% 45% 62%;
+  }
+  75% {
+    border-radius: 35% 65% 46% 54% / 60% 38% 62% 40%;
+  }
+}
+ 
+/* Hover: surface tension tightens toward a rounder puddle and the
+   shimmer speeds up, as if disturbed */
+.mercury-blob-hero:hover {
+  border-radius: 48% 52% 55% 45% / 48% 52% 48% 52%;
+  box-shadow:
+    inset -30px -34px 66px rgba(0, 0, 0, 0.9),
+    inset 26px 28px 56px rgba(255, 255, 255, 0.2),
+    inset 0 0 44px rgba(0, 0, 0, 0.65),
+    0 44px 80px -22px rgba(0, 0, 0, 0.8);
+}
+ 
+.mercury-blob-hero:hover .mercury-blob__highlight-1,
+.mercury-blob-hero:hover .mercury-blob__highlight-2 {
+  animation-duration: calc(var(--hg-shimmer-duration) * 0.5);
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   5. Specular highlights — two independent drifting glints
+   ------------------------------------------------------------------------- */
+ 
+.mercury-blob__highlight {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+ 
+.mercury-blob__highlight-1 {
+  background: radial-gradient(
+    circle at 30% 25%,
+    rgba(255, 255, 255, 0.95) 0%,
+    rgba(255, 255, 255, 0.25) 10%,
+    transparent 22%
+  );
+  animation: hg-drift-1 var(--hg-shimmer-duration) ease-in-out infinite;
+}
+ 
+.mercury-blob__highlight-2 {
+  background: radial-gradient(
+    circle at 68% 70%,
+    rgba(255, 255, 255, 0.6) 0%,
+    rgba(255, 255, 255, 0.12) 12%,
+    transparent 24%
+  );
+  animation: hg-drift-2 calc(var(--hg-shimmer-duration) * 1.4) ease-in-out infinite;
+}
+ 
+@keyframes hg-drift-1 {
+  0%, 100% { background-position: 0% 0%; }
+  50% { background-position: 18% -12%; }
+}
+ 
+@keyframes hg-drift-2 {
+  0%, 100% { background-position: 0% 0%; }
+  50% { background-position: -14% 10%; }
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   6. Floor reflection
+   ------------------------------------------------------------------------- */
+ 
+.mercury-blob__reflection {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: calc(var(--hg-size) * 0.7);
+  height: 30px;
+  transform: translateX(-50%);
+  background: radial-gradient(
+    ellipse at center,
+    rgba(255, 255, 255, 0.16) 0%,
+    transparent 70%
+  );
+  filter: blur(6px);
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   7. Droplet variants
+   ------------------------------------------------------------------------- */
+ 
+.droplets {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+  margin-top: 8px;
+}
+ 
+.droplet-stage {
+  display: flex;
+  justify-content: center;
+}
+ 
+.mercury-blob-sm {
+  --hg-size: 120px;
+}
+ 
+.mercury-blob-fast {
+  --hg-morph-duration: 6s;
+  --hg-shimmer-duration: 4s;
+}
+ 
+.mercury-blob-slow {
+  --hg-morph-duration: 16s;
+  --hg-shimmer-duration: 11s;
+}
+ 
+.hint {
+  text-align: center;
+  font-size: 12.5px;
+  color: var(--hg-text-muted);
+  margin: 32px 0 0;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   8. Footer
+   ------------------------------------------------------------------------- */
+ 
+.footer {
+  position: relative;
+  z-index: 1;
+  text-align: center;
+  padding: 8px 24px 48px;
+  font-size: 12.5px;
+  color: var(--hg-text-muted);
+  font-family: var(--hg-font-mono);
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   9. Responsive
+   ------------------------------------------------------------------------- */
+ 
+@media (max-width: 560px) {
+  .hero {
+    padding: 68px 20px 20px;
+  }
+ 
+  :root {
+    --hg-size: 240px;
+  }
+ 
+  .droplets {
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 12px;
+  }
+ 
+  .mercury-blob-sm {
+    --hg-size: 84px;
+  }
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   10. Reduced motion
+   ------------------------------------------------------------------------- */
+ 
+@media (prefers-reduced-motion: reduce) {
+  .mercury-blob,
+  .mercury-blob__highlight-1,
+  .mercury-blob__highlight-2 {
+    animation: none;
+  }
+ 
+  /* Hold a single, still, mid-morph shape rather than the resting one —
+     reads as a deliberate puddle rather than an animation that got cut
+     off at frame zero. */
+  .mercury-blob {
+    border-radius: 50% 50% 62% 38% / 38% 55% 45% 62%;
+  }
+ 
+  .mercury-blob-hero:hover {
+    transition-duration: 1ms;
+  }
+}


### PR DESCRIPTION
Closes #67246

## Pull Request Description
Adds a pure CSS liquid mercury puddle — monochrome conic-gradient metal banding, two independently-drifting specular highlights, and an organic border-radius morph for surface tension. No JavaScript, no SVG filters, no images.

## Type of Change
- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/css-metallic-liquid-mercury/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A `.mercury-blob` element — a harsh monochrome metallic puddle with animated surface tension and two independently drifting specular highlights.

**How does a developer use it?**
```html
<div class="mercury-blob">
  <span class="mercury-blob__highlight mercury-blob__highlight-1"></span>
  <span class="mercury-blob__highlight mercury-blob__highlight-2"></span>
</div>
```
Override `--hg-size` for scale, `--hg-morph-duration`/`--hg-shimmer-duration` for pacing — see the three droplet variants in the demo, each just 1–2 token overrides.

**Why does it fit EaseMotion CSS?**
Matches the issue's own ask closely: harsh monochrome palette, intense specular inset shadows, and organic keyframes simulating surface tension — all fully declarative, fully tunable via custom properties, no images or filters required.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

## Notes for Maintainer
Uses `conic-gradient` and multi-value `border-radius` (8 independent corner values) — both long-supported in evergreen browsers, no fallback needed. Under `prefers-reduced-motion`, the blob holds at a single mid-morph shape rather than its literal resting frame, so it still reads as an intentional puddle shape rather than an animation that got cut off.