### PR TITLE
feat: add CSS glitch art distortion grid

### DIFF
--- a/submissions/examples/css-glitch-art-distortion-grid/README.md
+++ b/submissions/examples/css-glitch-art-distortion-grid/README.md
@@ -1,0 +1,1 @@
+Feat : css glitch art distortion grid

--- a/submissions/examples/css-glitch-art-distortion-grid/demo.html
+++ b/submissions/examples/css-glitch-art-distortion-grid/demo.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Glitch Art Distortion Grid — EaseMotion CSS</title>
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="grid-overlay" aria-hidden="true"></div>
+  <div class="scanlines" aria-hidden="true"></div>
+
+  <!-- Lets anyone previewing the demo pause the periodic glitching -->
+  <input type="checkbox" id="glitch-pause" class="glitch-pause-toggle">
+
+  <header class="hero">
+    <p class="eyebrow">EaseMotion CSS &middot; showcase</p>
+    <h1 class="hero-title">Glitch art distortion grid</h1>
+    <p class="hero-sub">A grid of UI cards that periodically, briefly malfunction &mdash; jagged clip-path slicing, sudden skew, and layered RGB-fringed shadows &mdash; each on its own independent cycle. Pure CSS, no JavaScript.</p>
+
+    <label for="glitch-pause" class="pause-toggle">
+      <span class="pause-toggle-dot" aria-hidden="true"></span>
+      Pause the periodic glitching
+    </label>
+  </header>
+
+  <main class="showcase">
+
+    <div class="glitch-grid">
+
+      <article class="glitch-card glitch-card-1">
+        <span class="glitch-card__tag">MODULE&nbsp;01</span>
+        <h2 class="glitch-card__title">Signal Relay</h2>
+        <p class="glitch-card__text">Uplink stable. Packet loss within tolerance.</p>
+      </article>
+
+      <article class="glitch-card glitch-card-2">
+        <span class="glitch-card__tag">MODULE&nbsp;02</span>
+        <h2 class="glitch-card__title">Core Temp</h2>
+        <p class="glitch-card__text">42&deg;C. Cooling loop nominal.</p>
+      </article>
+
+      <article class="glitch-card glitch-card-3">
+        <span class="glitch-card__tag">MODULE&nbsp;03</span>
+        <h2 class="glitch-card__title">Auth Ledger</h2>
+        <p class="glitch-card__text">1,204 sessions verified this hour.</p>
+      </article>
+
+      <article class="glitch-card glitch-card-4">
+        <span class="glitch-card__tag">MODULE&nbsp;04</span>
+        <h2 class="glitch-card__title">Cache Layer</h2>
+        <p class="glitch-card__text">Hit rate 97.2%. Eviction queue clear.</p>
+      </article>
+
+      <article class="glitch-card glitch-card-5">
+        <span class="glitch-card__tag">MODULE&nbsp;05</span>
+        <h2 class="glitch-card__title">Edge Nodes</h2>
+        <p class="glitch-card__text">14 regions online, 0 degraded.</p>
+      </article>
+
+      <article class="glitch-card glitch-card-6">
+        <span class="glitch-card__tag">MODULE&nbsp;06</span>
+        <h2 class="glitch-card__title">Queue Depth</h2>
+        <p class="glitch-card__text">Backlog: 3 jobs. Avg wait 1.2s.</p>
+      </article>
+
+    </div>
+
+  </main>
+
+  <footer class="footer">
+    <p>EaseMotion CSS &middot; submissions/examples/css-glitch-art-distortion-grid</p>
+  </footer>
+
+</body>
+</html>

--- a/submissions/examples/css-glitch-art-distortion-grid/style.css
+++ b/submissions/examples/css-glitch-art-distortion-grid/style.css
@@ -1,0 +1,357 @@
+/* =========================================================================
+   Glitch Art Distortion Grid — EaseMotion CSS
+   A grid of UI cards that periodically, briefly malfunction: jagged
+   clip-path polygon slicing, a sudden skew(), and layered colored
+   box-shadows simulating RGB channel separation — each card runs its own
+   independent cycle (different duration + delay) so the grid never
+   glitches in unison. Idle 90%+ of each cycle; the "burst" window uses
+   steps() timing for sharp digital jumps rather than a smooth ease.
+   Pure CSS/HTML, no JavaScript.
+   ========================================================================= */
+ 
+ 
+/* -------------------------------------------------------------------------
+   1. Design tokens
+   ------------------------------------------------------------------------- */
+ 
+:root {
+  --gg-bg: #06070a;
+  --gg-surface: #0e1016;
+  --gg-border: #1e222c;
+  --gg-text: #e8ecf5;
+  --gg-text-muted: #7d8494;
+ 
+  --gg-cyan: #37f2f2;
+  --gg-magenta: #ff3ec8;
+ 
+  --gg-font-display: "Space Grotesk", "Segoe UI", sans-serif;
+  --gg-font-body: "Inter", "Segoe UI", sans-serif;
+  --gg-font-mono: "JetBrains Mono", "Courier New", monospace;
+ 
+  /* Per-card glitch tuning — overridden per nth-child below so cards
+     desync from one another */
+  --gg-cycle: 6200ms;
+  --gg-delay: 0ms;
+}
+ 
+* {
+  box-sizing: border-box;
+}
+ 
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--gg-bg);
+  color: var(--gg-text);
+  font-family: var(--gg-font-body);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+ 
+.grid-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(rgba(55, 242, 242, 0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(55, 242, 242, 0.05) 1px, transparent 1px);
+  background-size: 42px 42px;
+  -webkit-mask-image: radial-gradient(circle at 50% 0%, black 0%, transparent 70%);
+  mask-image: radial-gradient(circle at 50% 0%, black 0%, transparent 70%);
+}
+ 
+.scanlines {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  opacity: 0.4;
+  background-image: repeating-linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.025) 0px,
+    rgba(255, 255, 255, 0.025) 1px,
+    transparent 1px,
+    transparent 3px
+  );
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   2. Pause toggle (checkbox hack)
+   ------------------------------------------------------------------------- */
+ 
+.glitch-pause-toggle {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+ 
+.pause-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 26px;
+  font-family: var(--gg-font-mono);
+  font-size: 12px;
+  color: var(--gg-text-muted);
+  cursor: pointer;
+  user-select: none;
+}
+ 
+.pause-toggle-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--gg-border);
+  box-shadow: 0 0 0 1px var(--gg-border);
+  transition: background 160ms ease, box-shadow 160ms ease;
+}
+ 
+.glitch-pause-toggle:checked ~ .hero .pause-toggle-dot {
+  background: var(--gg-cyan);
+  box-shadow: 0 0 8px 1px var(--gg-cyan);
+}
+ 
+.glitch-pause-toggle:checked ~ main .glitch-card {
+  animation-play-state: paused;
+}
+ 
+.glitch-pause-toggle:focus-visible ~ .hero .pause-toggle {
+  outline: 2px solid var(--gg-cyan);
+  outline-offset: 3px;
+  border-radius: 4px;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   3. Hero
+   ------------------------------------------------------------------------- */
+ 
+.hero {
+  position: relative;
+  z-index: 1;
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 96px 24px 20px;
+  text-align: center;
+}
+ 
+.eyebrow {
+  font-family: var(--gg-font-mono);
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--gg-cyan);
+  margin: 0 0 22px;
+}
+ 
+.hero-title {
+  font-family: var(--gg-font-display);
+  font-weight: 700;
+  font-size: clamp(28px, 5.5vw, 44px);
+  line-height: 1.12;
+  letter-spacing: -0.01em;
+  margin: 0 0 16px;
+}
+ 
+.hero-sub {
+  font-size: 15px;
+  color: var(--gg-text-muted);
+  max-width: 520px;
+  margin: 0 auto;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   4. Grid layout
+   ------------------------------------------------------------------------- */
+ 
+.showcase {
+  position: relative;
+  z-index: 1;
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 40px 24px 100px;
+}
+ 
+.glitch-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   5. Card base
+   ------------------------------------------------------------------------- */
+ 
+.glitch-card {
+  position: relative;
+  padding: 22px 20px 24px;
+  background: var(--gg-surface);
+  border: 1px solid var(--gg-border);
+  border-radius: 10px;
+ 
+  clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
+  transform: skew(0deg, 0deg);
+  box-shadow: 0 0 0 rgba(0, 0, 0, 0);
+ 
+  animation-name: gg-glitch-burst;
+  animation-duration: var(--gg-cycle);
+  animation-delay: var(--gg-delay);
+  animation-iteration-count: infinite;
+  animation-timing-function: steps(1, end);
+}
+ 
+.glitch-card__tag {
+  display: inline-block;
+  font-family: var(--gg-font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.06em;
+  color: var(--gg-text-muted);
+  margin-bottom: 12px;
+}
+ 
+.glitch-card__title {
+  font-family: var(--gg-font-display);
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0 0 8px;
+}
+ 
+.glitch-card__text {
+  font-family: var(--gg-font-mono);
+  font-size: 12px;
+  color: var(--gg-text-muted);
+  margin: 0;
+}
+ 
+/* Desync every card: different total cycle length and start offset so
+   the grid never glitches in visible unison. */
+.glitch-card-1 { --gg-cycle: 6200ms; --gg-delay: 0ms; }
+.glitch-card-2 { --gg-cycle: 7400ms; --gg-delay: -2100ms; }
+.glitch-card-3 { --gg-cycle: 5600ms; --gg-delay: -900ms; }
+.glitch-card-4 { --gg-cycle: 8100ms; --gg-delay: -4300ms; }
+.glitch-card-5 { --gg-cycle: 6800ms; --gg-delay: -3200ms; }
+.glitch-card-6 { --gg-cycle: 7000ms; --gg-delay: -1500ms; }
+ 
+ 
+/* -------------------------------------------------------------------------
+   6. The glitch burst
+   Idle for the vast majority of the cycle; the burst itself lives in a
+   narrow band (roughly 90%–96%) so it reads as a brief malfunction, not
+   a rhythmic pulse. steps(1, end) on the animation as a whole keeps each
+   keyframe stop a hard cut rather than an interpolated tween.
+   ------------------------------------------------------------------------- */
+ 
+@keyframes gg-glitch-burst {
+  0%, 89% {
+    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
+    transform: skew(0deg, 0deg) translate(0, 0);
+    box-shadow: 0 0 0 rgba(0, 0, 0, 0);
+  }
+  90% {
+    clip-path: polygon(0 0, 100% 0, 100% 40%, 0 46%, 100% 60%, 0 66%, 100% 100%, 0 100%);
+    transform: skew(-6deg, 0.6deg) translate(-4px, 0);
+    box-shadow:
+      6px 0 0 rgba(255, 62, 200, 0.55),
+      -6px 0 0 rgba(55, 242, 242, 0.5);
+  }
+  91.5% {
+    clip-path: polygon(0 8%, 100% 0, 100% 100%, 0 92%);
+    transform: skew(4deg, -0.4deg) translate(5px, -2px);
+    box-shadow:
+      -7px 0 0 rgba(255, 62, 200, 0.5),
+      7px 0 0 rgba(55, 242, 242, 0.55);
+  }
+  92.5% {
+    clip-path: polygon(0 0, 100% 0, 100% 24%, 0 30%, 100% 46%, 0 52%, 100% 74%, 0 80%, 100% 100%, 0 100%);
+    transform: skew(-3deg, 0.3deg) translate(-6px, 1px);
+    box-shadow:
+      8px 0 0 rgba(255, 62, 200, 0.6),
+      -8px 0 0 rgba(55, 242, 242, 0.5);
+  }
+  93.5% {
+    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
+    transform: skew(2deg, -0.2deg) translate(3px, 0);
+    box-shadow:
+      4px 0 0 rgba(255, 62, 200, 0.4),
+      -4px 0 0 rgba(55, 242, 242, 0.4);
+  }
+  94.5% {
+    clip-path: polygon(0 14%, 100% 6%, 100% 90%, 0 100%);
+    transform: skew(-5deg, 0.5deg) translate(-3px, 2px);
+    box-shadow:
+      7px 0 0 rgba(255, 62, 200, 0.55),
+      -7px 0 0 rgba(55, 242, 242, 0.5);
+  }
+  96%, 100% {
+    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
+    transform: skew(0deg, 0deg) translate(0, 0);
+    box-shadow: 0 0 0 rgba(0, 0, 0, 0);
+  }
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   7. Footer
+   ------------------------------------------------------------------------- */
+ 
+.footer {
+  position: relative;
+  z-index: 1;
+  text-align: center;
+  padding: 8px 24px 48px;
+  font-size: 12px;
+  color: var(--gg-text-muted);
+  font-family: var(--gg-font-mono);
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   8. Responsive
+   ------------------------------------------------------------------------- */
+ 
+@media (max-width: 760px) {
+  .glitch-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+ 
+@media (max-width: 480px) {
+  .hero {
+    padding: 76px 20px 16px;
+  }
+ 
+  .glitch-grid {
+    grid-template-columns: 1fr;
+  }
+}
+ 
+ 
+/* -------------------------------------------------------------------------
+   9. Reduced motion
+   ------------------------------------------------------------------------- */
+ 
+@media (prefers-reduced-motion: reduce) {
+  /* Unsolicited, automatically-repeating distortion is exactly the kind
+     of motion prefers-reduced-motion exists to suppress — this removes
+     it entirely rather than just slowing it down. */
+  .glitch-card {
+    animation: none;
+    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
+    transform: none;
+    box-shadow: none;
+  }
+ 
+  .pause-toggle {
+    display: none;
+  }
+}


### PR DESCRIPTION
Closes #67244

## Pull Request Description
Adds a pure CSS grid of UI cards that periodically, briefly glitch — jagged clip-path polygon slicing, sudden skew(), and layered RGB-separated box-shadows — each card on its own independent, desynced cycle. No JavaScript.

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/css-glitch-art-distortion-grid/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A `.glitch-card` that runs an idle→burst→idle cycle automatically: `clip-path` polygon slicing, `skew()`, and layered magenta/cyan `box-shadow`s during a brief `steps()`-timed burst window, on a per-card desynced schedule.

**How does a developer use it?**
```html
<article class="glitch-card glitch-card-1">
  <h2>Title</h2>
  <p>Body text</p>
</article>
```
Set `--gg-cycle` and `--gg-delay` per instance (see the six `.glitch-card-N` variants in the demo) to control timing and desync multiple cards from each other.

**Why does it fit EaseMotion CSS?**
Matches the issue's ask directly: clip-path polygon changes, skew(), and RGB separation via layered shadows, applied to a real grid of UI elements rather than an isolated demo box, entirely declarative and tunable via custom properties.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

## Notes for Maintainer
Worth flagging explicitly: under `prefers-reduced-motion: reduce`, this removes the glitch entirely rather than just shortening it, since unsolicited, automatically-repeating distortion is exactly the category that setting exists to suppress — different from a hover-triggered effect the user caused themselves. Also includes a manual pause toggle (checkbox hack) for anyone previewing without an OS-level setting. Happy to adjust either call if the maintainer prefers a lighter touch.