### PR TITLE
Add ease-metro-route-map component

### DIFF
--- a/submissions/examples/metro-route-map-ij/README.md
+++ b/submissions/examples/metro-route-map-ij/README.md
@@ -1,0 +1,11 @@
+# ease-metro-route-map
+
+A metro route map where the trains slide, the stations blink, and the labels flash.
+
+## Run
+Open `demo.html` directly in a browser to watch the map.
+
+## Notes
+- The trains slide along their colored lines.
+- The station dots blink in turn.
+- The line labels flash at the corner.

--- a/submissions/examples/metro-route-map-ij/demo.html
+++ b/submissions/examples/metro-route-map-ij/demo.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-metro-route-map demo</title>
+</head>
+<body>
+<div class="mrm-map">
+  <div class="mrm-legend">
+    <span class="mrm-tag mrm-tr">RED</span>
+    <span class="mrm-tag mrm-tg">GREEN</span>
+    <span class="mrm-tag mrm-tb">BLUE</span>
+  </div>
+  <div class="mrm-lines">
+    <div class="mrm-line mrm-lr"><i class="mrm-car mrm-car-r"></i></div>
+    <div class="mrm-line mrm-lg"><i class="mrm-car mrm-car-g"></i></div>
+    <div class="mrm-line mrm-lb"><i class="mrm-car mrm-car-b"></i></div>
+  </div>
+  <div class="mrm-stops">
+    <i class="mrm-stop mrm-sr"></i>
+    <i class="mrm-stop mrm-sg"></i>
+    <i class="mrm-stop mrm-sb"></i>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/metro-route-map-ij/style.css
+++ b/submissions/examples/metro-route-map-ij/style.css
@@ -1,0 +1,25 @@
+.mrm-map{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:384px;background:#0a1018;border:1px solid #1b2b42;border-radius:14px;padding:20px;display:flex;flex-direction:column;gap:12px}
+.mrm-legend{display:flex;justify-content:space-between;gap:8px}
+.mrm-tag{font-size:9px;font-weight:800;letter-spacing:2px;border-radius:20px;padding:3px 10px;animation:mrm-tag-flash-metro-route-map 2.4s ease-in-out infinite}
+.mrm-tr{color:#ff6b6b;border:1px solid #5c1f1f}
+.mrm-tg{color:#7cebb0;border:1px solid #1f5c43}
+.mrm-tb{color:#38bdf8;border:1px solid #1e4a6b}
+.mrm-lines{display:flex;flex-direction:column;gap:14px}
+.mrm-line{position:relative;height:8px;border-radius:4px}
+.mrm-lr{background:#ff6b6b}
+.mrm-lg{background:#7cebb0}
+.mrm-lb{background:#38bdf8}
+.mrm-car{position:absolute;top:-4px;left:-20px;width:18px;height:16px;border-radius:4px;background:#f4f0ff}
+.mrm-car-r{animation:mrm-car-red-metro-route-map 4s ease-in-out infinite}
+.mrm-car-g{animation:mrm-car-green-metro-route-map 4s ease-in-out 0.8s infinite}
+.mrm-car-b{animation:mrm-car-blue-metro-route-map 4s ease-in-out 1.6s infinite}
+.mrm-stops{display:flex;justify-content:space-around}
+.mrm-stop{width:12px;height:12px;border-radius:50%;background:#f4f0ff;border:3px solid #1b2b42;animation:mrm-stop-blink-metro-route-map 1.6s ease-in-out infinite}
+.mrm-sr{border-color:#ff6b6b}
+.mrm-sg{border-color:#7cebb0}
+.mrm-sb{border-color:#38bdf8}
+@keyframes mrm-car-red-metro-route-map{0%{transform:translateX(0)}100%{transform:translateX(360px)}}
+@keyframes mrm-car-green-metro-route-map{0%{transform:translateX(0)}100%{transform:translateX(360px)}}
+@keyframes mrm-car-blue-metro-route-map{0%{transform:translateX(0)}100%{transform:translateX(360px)}}
+@keyframes mrm-stop-blink-metro-route-map{0%,100%{opacity:0.5}50%{opacity:1}}
+@keyframes mrm-tag-flash-metro-route-map{0%,100%{opacity:0.6}50%{opacity:1}}


### PR DESCRIPTION
## Component: ease-metro-route-map — trains slide, stations blink, and labels flash

**Closes #69860**

### What this adds
A metro route map: the trains slide along their colored lines, the station dots blink in turn, and the line labels flash.

### Acceptance Criteria covered
- Trains slide along their lines
- Station dots blink in turn
- Line labels flash at the corner

### Files
- `submissions/examples/metro-route-map-ij/demo.html`
- `submissions/examples/metro-route-map-ij/style.css`
- `submissions/examples/metro-route-map-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the map.