### PR TITLE
Add ease-trivia-score-tracker component

### DIFF
--- a/submissions/examples/trivia-score-tracker-ij/README.md
+++ b/submissions/examples/trivia-score-tracker-ij/README.md
@@ -1,0 +1,11 @@
+# ease-trivia-score-tracker
+
+A trivia score tracker where the points tick, the bar fills, and the badge blinks.
+
+## Run
+Open `demo.html` directly in a browser to watch the tracker.
+
+## Notes
+- The player points tick upward.
+- The streak bar fills across.
+- The category badge blinks beside.

--- a/submissions/examples/trivia-score-tracker-ij/demo.html
+++ b/submissions/examples/trivia-score-tracker-ij/demo.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-trivia-score-tracker demo</title>
+</head>
+<body>
+<div class="tst-panel">
+  <div class="tst-head">
+    <span class="tst-badge">SCIENCE</span>
+    <em>ROUND 2</em>
+  </div>
+  <div class="tst-score">12,400</div>
+  <div class="tst-streak">
+    <span>STREAK</span>
+    <i class="tst-fill"></i>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/trivia-score-tracker-ij/style.css
+++ b/submissions/examples/trivia-score-tracker-ij/style.css
@@ -1,0 +1,11 @@
+.tst-panel{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:360px;background:#0d1624;border:1px solid #1e3350;border-radius:16px;padding:22px;display:flex;flex-direction:column;gap:16px}
+.tst-head{display:flex;align-items:center;justify-content:space-between}
+.tst-badge{font-size:10px;font-weight:800;letter-spacing:2px;color:#f5c542;border:1px solid #4a3c14;border-radius:20px;padding:4px 10px;animation:tst-badge-blink-trivia-score-tracker 1.8s ease-in-out infinite}
+.tst-head em{font-style:normal;font-size:10px;color:#7e95ab}
+.tst-score{font-size:40px;font-weight:800;color:#7cebb0;font-family:"Courier New",monospace;text-align:center;animation:tst-points-tick-trivia-score-tracker 1.2s ease-in-out infinite}
+.tst-streak{background:#0a1520;border-radius:8px;padding:10px;display:flex;flex-direction:column;gap:6px}
+.tst-streak span{font-size:10px;letter-spacing:2px;color:#7e95ab}
+.tst-fill{display:block;height:12px;border-radius:6px;background:linear-gradient(90deg,#1f5c3e,#34d399);animation:tst-bar-fill-trivia-score-tracker 2.4s ease-in-out infinite}
+@keyframes tst-points-tick-trivia-score-tracker{0%{transform:scale(1)}30%{transform:scale(1.06)}100%{transform:scale(1)}}
+@keyframes tst-bar-fill-trivia-score-tracker{0%{transform:scaleX(0.4)}50%{transform:scaleX(1)}100%{transform:scaleX(0.4)}}
+@keyframes tst-badge-blink-trivia-score-tracker{0%{opacity:0.5}50%{opacity:1}100%{opacity:0.5}}


### PR DESCRIPTION
## Component: ease-trivia-score-tracker — points tick, bars fill, and badges blink

**Closes #69862**

### What this adds
A trivia score tracker: the player points tick upward, the streak bar fills across, and the category badge blinks.

### Acceptance Criteria covered
- Player points tick upward
- Streak bar fills across
- Category badge blinks beside

### Files
- `submissions/examples/trivia-score-tracker-ij/demo.html`
- `submissions/examples/trivia-score-tracker-ij/style.css`
- `submissions/examples/trivia-score-tracker-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the tracker.