### PR TITLE
Add ease-tag-cloud-viz component

### DIFF
--- a/submissions/examples/tag-cloud-viz-ij/README.md
+++ b/submissions/examples/tag-cloud-viz-ij/README.md
@@ -1,0 +1,11 @@
+# ease-tag-cloud-viz
+
+A tag cloud where the tags float, the sizes pulse, and the cloud glows.
+
+## Run
+Open `demo.html` directly in a browser to watch the cloud.
+
+## Notes
+- The text tags float across the cloud.
+- The large tags pulse in place.
+- The medium tags glow in turn.

--- a/submissions/examples/tag-cloud-viz-ij/demo.html
+++ b/submissions/examples/tag-cloud-viz-ij/demo.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-tag-cloud-viz demo</title>
+</head>
+<body>
+<div class="tcv-cloud">
+  <span class="tcv-tag tcv-s1">CSS</span>
+  <span class="tcv-tag tcv-s2">ANIMATION</span>
+  <span class="tcv-tag tcv-s3">EASE</span>
+  <span class="tcv-tag tcv-s2">LAYOUT</span>
+  <span class="tcv-tag tcv-s4">GRID</span>
+  <span class="tcv-tag tcv-s1">FLEX</span>
+  <span class="tcv-tag tcv-s3">KEYFRAMES</span>
+  <span class="tcv-tag tcv-s2">COLOR</span>
+  <span class="tcv-tag tcv-s4">DESIGN</span>
+  <span class="tcv-tag tcv-s1">MOTION</span>
+  <span class="tcv-tag tcv-s2">STYLE</span>
+  <span class="tcv-tag tcv-s3">UI</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/tag-cloud-viz-ij/style.css
+++ b/submissions/examples/tag-cloud-viz-ij/style.css
@@ -1,0 +1,11 @@
+.tcv-cloud{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:420px;background:#0d1624;border:1px solid #1e3350;border-radius:16px;padding:24px;display:flex;flex-wrap:wrap;gap:12px;align-items:center;justify-content:center}
+.tcv-tag{color:#7cebb0;border:1px solid #1f5c43;border-radius:20px;padding:4px 12px;background:#0a1520;animation:tcv-float-tag-cloud-viz 2.6s ease-in-out infinite}
+.tcv-s1{font-size:11px}
+.tcv-s2{font-size:14px}
+.tcv-s3{font-size:18px;animation:tcv-glow-tag-cloud-viz 2.2s ease-in-out infinite}
+.tcv-s4{font-size:24px;color:#f5c542;border-color:#4a3c14;animation:tcv-pulse-tag-cloud-viz 1.6s ease-in-out infinite}
+.tcv-tag:nth-child(2n){animation-delay:0.3s}
+.tcv-tag:nth-child(3n){animation-delay:0.6s}
+@keyframes tcv-float-tag-cloud-viz{0%,100%{transform:translateY(0)}50%{transform:translateY(-6px)}}
+@keyframes tcv-pulse-tag-cloud-viz{0%,100%{transform:scale(1)}50%{transform:scale(1.1)}}
+@keyframes tcv-glow-tag-cloud-viz{0%,100%{opacity:0.7}50%{opacity:1}}


### PR DESCRIPTION
## Component: ease-tag-cloud-viz — tags float, sizes pulse, and cloud glows

**Closes #69864**

### What this adds
A tag cloud: the text tags float in the cloud, the large tags pulse, and the medium tags glow in turn.

### Acceptance Criteria covered
- Text tags float across the cloud
- Large tags pulse in place
- Medium tags glow in turn

### Files
- `submissions/examples/tag-cloud-viz-ij/demo.html`
- `submissions/examples/tag-cloud-viz-ij/style.css`
- `submissions/examples/tag-cloud-viz-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the cloud.