### PR TITLE
Add ease-camera-app-viewfinder component

### DIFF
--- a/submissions/examples/camera-app-viewfinder-ij/README.md
+++ b/submissions/examples/camera-app-viewfinder-ij/README.md
@@ -1,0 +1,11 @@
+# ease-camera-app-viewfinder
+
+A camera app viewfinder where the focus pulses, the shutter clicks, and the settings blink.
+
+## Run
+Open `demo.html` directly in a browser to watch the viewfinder.
+
+## Notes
+- The focus ring pulses in the viewfinder.
+- The shutter button clicks below.
+- The settings row blinks at the foot.

--- a/submissions/examples/camera-app-viewfinder-ij/demo.html
+++ b/submissions/examples/camera-app-viewfinder-ij/demo.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-camera-app-viewfinder demo</title>
+</head>
+<body>
+<div class="cam-app">
+  <div class="cam-top">
+    <span class="cam-mode">PHOTO</span>
+    <span class="cam-flash">FLASH OFF</span>
+  </div>
+  <div class="cam-frame">
+    <i class="cam-grid-h"></i>
+    <i class="cam-grid-v"></i>
+    <span class="cam-focus"></span>
+  </div>
+  <div class="cam-shutter"></div>
+  <div class="cam-settings">
+    <span>ISO 100</span>
+    <span>WB AUTO</span>
+    <span>2:1</span>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/camera-app-viewfinder-ij/style.css
+++ b/submissions/examples/camera-app-viewfinder-ij/style.css
@@ -1,0 +1,14 @@
+.cam-app{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:340px;background:#0a0a0a;border:2px solid #2a2a2a;border-radius:18px;padding:16px;display:flex;flex-direction:column;gap:12px}
+.cam-top{display:flex;justify-content:space-between;font-size:10px;letter-spacing:2px;color:#9aa;font-family:"Courier New",monospace}
+.cam-flash{color:#f5c542;animation:cam-flash-blink-camera-app-viewfinder 2s ease-in-out infinite}
+.cam-frame{position:relative;height:220px;background:linear-gradient(180deg,#1a2a3a,#0d1624);border-radius:10px;overflow:hidden}
+.cam-grid-h{position:absolute;left:0;right:0;top:50%;height:1px;background:rgba(255,255,255,0.15)}
+.cam-grid-v{position:absolute;top:0;bottom:0;left:50%;width:1px;background:rgba(255,255,255,0.15)}
+.cam-focus{position:absolute;left:50%;top:50%;width:64px;height:64px;transform:translate(-50%,-50%);border:2px solid #f5c542;border-radius:50%;animation:cam-focus-pulse-camera-app-viewfinder 2s ease-in-out infinite}
+.cam-shutter{width:56px;height:56px;border-radius:50%;background:#fff;border:6px solid #555;margin:0 auto;animation:cam-shutter-click-camera-app-viewfinder 2.4s ease-in-out infinite}
+.cam-settings{display:flex;justify-content:space-around;font-size:9px;letter-spacing:1px;color:#9aa;font-family:"Courier New",monospace}
+.cam-settings span{animation:cam-setting-blink-camera-app-viewfinder 1.8s ease-in-out infinite}
+@keyframes cam-focus-pulse-camera-app-viewfinder{0%,100%{transform:translate(-50%,-50%) scale(1)}50%{transform:translate(-50%,-50%) scale(0.9)}}
+@keyframes cam-shutter-click-camera-app-viewfinder{0%,78%{transform:scale(1)}85%{transform:scale(0.85)}100%{transform:scale(1)}}
+@keyframes cam-flash-blink-camera-app-viewfinder{0%{opacity:0.5}50%{opacity:1}100%{opacity:0.5}}
+@keyframes cam-setting-blink-camera-app-viewfinder{0%{opacity:0.6}50%{opacity:1}100%{opacity:0.6}}


### PR DESCRIPTION
## Component: ease-camera-app-viewfinder — focus pulses, shutter clicks, and settings blink

**Closes #69874**

### What this adds
A camera app viewfinder: the focus ring pulses, the shutter button clicks, and the settings row blinks.

### Acceptance Criteria covered
- Focus ring pulses in the viewfinder
- Shutter button clicks below
- Settings row blinks at the foot

### Files
- `submissions/examples/camera-app-viewfinder-ij/demo.html`
- `submissions/examples/camera-app-viewfinder-ij/style.css`
- `submissions/examples/camera-app-viewfinder-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the viewfinder.