### PR TITLE
Add ease-car-speedometer-dial component

### DIFF
--- a/submissions/examples/car-speedometer-dial-ij/README.md
+++ b/submissions/examples/car-speedometer-dial-ij/README.md
@@ -1,0 +1,11 @@
+# ease-car-speedometer-dial
+
+A car speedometer where the needle swings, the readout ticks, and the cruise blinks.
+
+## Run
+Open `demo.html` directly in a browser to watch the dial.
+
+## Notes
+- The speed needle swings on the dial.
+- The readout ticks in the center.
+- The cruise status blinks below.

--- a/submissions/examples/car-speedometer-dial-ij/demo.html
+++ b/submissions/examples/car-speedometer-dial-ij/demo.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-car-speedometer-dial demo</title>
+</head>
+<body>
+<div class="csd-dial">
+  <div class="csd-scale"><span>0</span><span>40</span><span>80</span><span>120</span><span>160</span></div>
+  <i class="csd-needle"></i>
+  <div class="csd-read">
+    <b>86</b>
+    <small>KM/H</small>
+  </div>
+  <span class="csd-cruise">CRUISE ON</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/car-speedometer-dial-ij/style.css
+++ b/submissions/examples/car-speedometer-dial-ij/style.css
@@ -1,0 +1,11 @@
+.csd-dial{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:340px;height:340px;border-radius:50%;background:radial-gradient(circle at 50% 100%,#132038,#0d1624 62%);border:6px solid #24385a;display:grid;place-items:center}
+.csd-scale{display:flex;justify-content:space-between;width:190px;position:absolute;top:52px;left:50%;transform:translateX(-50%)}
+.csd-scale span{font-size:10px;color:#5d7690;font-family:"Courier New",monospace}
+.csd-needle{position:absolute;left:50%;top:50%;width:4px;height:120px;background:#ff3d5e;transform-origin:50% 100%;transform:translate(-50%,-100%) rotate(-40deg);animation:csd-needle-osc-car-speedometer-dial 3.2s ease-in-out infinite}
+.csd-read{text-align:center}
+.csd-read b{font-size:34px;font-weight:800;color:#e8f0f8;font-family:"Courier New",monospace;animation:csd-read-tick-car-speedometer-dial 1.4s ease-in-out infinite}
+.csd-read small{display:block;font-size:9px;letter-spacing:2px;color:#5d7690}
+.csd-cruise{position:absolute;bottom:34px;font-size:9px;font-weight:800;letter-spacing:2px;color:#7cebb0;border:1px solid #1f5c43;border-radius:20px;padding:4px 10px;animation:csd-cruise-blink-car-speedometer-dial 2s ease-in-out infinite}
+@keyframes csd-needle-osc-car-speedometer-dial{0%{transform:translate(-50%,-100%) rotate(-40deg)}50%{transform:translate(-50%,-100%) rotate(30deg)}100%{transform:translate(-50%,-100%) rotate(-40deg)}}
+@keyframes csd-read-tick-car-speedometer-dial{0%{opacity:0.7}50%{opacity:1}100%{opacity:0.7}}
+@keyframes csd-cruise-blink-car-speedometer-dial{0%{box-shadow:0 0 0 0 rgba(124,235,176,0)}50%{box-shadow:0 0 12px rgba(124,235,176,0.45)}100%{box-shadow:0 0 0 0 rgba(124,235,176,0)}}


### PR DESCRIPTION
## Component: ease-car-speedometer-dial — needle swings, readout ticks, and cruise blinks

**Closes #69879**

### What this adds
A car speedometer: the speed needle swings across the dial, the readout ticks, and the cruise status blinks.

### Acceptance Criteria covered
- Speed needle swings on the dial
- Readout ticks in the center
- Cruise status blinks below

### Files
- `submissions/examples/car-speedometer-dial-ij/demo.html`
- `submissions/examples/car-speedometer-dial-ij/style.css`
- `submissions/examples/car-speedometer-dial-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the dial.