### PR TITLE
Add ease-stock-candlestick-chart component

### DIFF
--- a/submissions/examples/stock-candlestick-chart-ij/README.md
+++ b/submissions/examples/stock-candlestick-chart-ij/README.md
@@ -1,0 +1,11 @@
+# ease-stock-candlestick-chart
+
+A stock candlestick chart where the candles pulse, the gain blinks, and the volume ticks.
+
+## Run
+Open `demo.html` directly in a browser to watch the chart.
+
+## Notes
+- The green and red candles pulse.
+- The gain badge blinks on the head.
+- The volume readout ticks below.

--- a/submissions/examples/stock-candlestick-chart-ij/demo.html
+++ b/submissions/examples/stock-candlestick-chart-ij/demo.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-stock-candlestick-chart demo</title>
+</head>
+<body>
+<div class="scc-chart">
+  <div class="scc-head">
+    <b>ACME</b>
+    <span>+2.4%</span>
+  </div>
+  <div class="scc-plot">
+    <i class="scc-candle scc-up"></i>
+    <i class="scc-candle scc-down"></i>
+    <i class="scc-candle scc-up"></i>
+    <i class="scc-candle scc-up"></i>
+    <i class="scc-candle scc-down"></i>
+  </div>
+  <div class="scc-foot"><span>VOL 1.2M</span><span>LAST 154.30</span></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/stock-candlestick-chart-ij/style.css
+++ b/submissions/examples/stock-candlestick-chart-ij/style.css
@@ -1,0 +1,18 @@
+.scc-chart{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:400px;background:#0a1018;border:1px solid #1b2b42;border-radius:12px;padding:18px;display:flex;flex-direction:column;gap:14px}
+.scc-head{display:flex;justify-content:space-between;align-items:center}
+.scc-head b{font-size:14px;font-weight:800;color:#e8f0f8}
+.scc-head span{font-size:12px;font-weight:800;color:#7cebb0;animation:scc-gain-blink-stock-candlestick-chart 1.8s ease-in-out infinite}
+.scc-plot{display:flex;align-items:flex-end;gap:16px;height:150px;background:#0c1520;border:1px solid #16263b;border-radius:8px;padding:14px}
+.scc-candle{position:relative;width:14px;background:#34d399;border-radius:2px;animation:scc-candle-pulse-stock-candlestick-chart 2s ease-in-out infinite}
+.scc-candle::before{content:"";position:absolute;left:50%;bottom:100%;width:2px;height:26px;background:inherit;transform:translateX(-50%)}
+.scc-candle::after{content:"";position:absolute;left:50%;top:100%;width:2px;height:20px;background:inherit;transform:translateX(-50%)}
+.scc-candle:nth-child(1){height:70px}
+.scc-candle:nth-child(2){height:44px;background:#ff6b6b;animation-delay:0.4s}
+.scc-candle:nth-child(3){height:92px;animation-delay:0.8s}
+.scc-candle:nth-child(4){height:110px;animation-delay:1.2s}
+.scc-candle:nth-child(5){height:60px;background:#ff6b6b;animation-delay:1.6s}
+.scc-foot{display:flex;justify-content:space-between;font-size:10px;letter-spacing:1px;color:#5d7690;font-family:"Courier New",monospace}
+.scc-foot span{animation:scc-vol-blink-stock-candlestick-chart 2.4s ease-in-out infinite}
+@keyframes scc-candle-pulse-stock-candlestick-chart{0%,100%{transform:scaleY(1)}50%{transform:scaleY(1.08)}}
+@keyframes scc-gain-blink-stock-candlestick-chart{0%{opacity:0.6}50%{opacity:1}100%{opacity:0.6}}
+@keyframes scc-vol-blink-stock-candlestick-chart{0%{opacity:0.5}50%{opacity:1}100%{opacity:0.5}}


### PR DESCRIPTION
## Component: ease-stock-candlestick-chart — candles pulse, gain blinks, and volume ticks

**Closes #69881**

### What this adds
A stock candlestick chart: the green and red candles pulse, the gain badge blinks, and the volume readout ticks.

### Acceptance Criteria covered
- Green and red candles pulse
- Gain badge blinks on the head
- Volume readout ticks below

### Files
- `submissions/examples/stock-candlestick-chart-ij/demo.html`
- `submissions/examples/stock-candlestick-chart-ij/style.css`
- `submissions/examples/stock-candlestick-chart-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the chart.