### PR TITLE
Add ease-submarine-depth-gauge component

### DIFF
--- a/submissions/examples/submarine-depth-gauge-ij/README.md
+++ b/submissions/examples/submarine-depth-gauge-ij/README.md
@@ -1,0 +1,11 @@
+# ease-submarine-depth-gauge
+
+A submarine depth gauge where the needle swings, the depth ticks, and the status blinks.
+
+## Run
+Open `demo.html` directly in a browser to watch the gauge.
+
+## Notes
+- The depth needle swings on the dial.
+- The depth readout ticks below.
+- The buoyancy status blinks beside.

--- a/submissions/examples/submarine-depth-gauge-ij/demo.html
+++ b/submissions/examples/submarine-depth-gauge-ij/demo.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-submarine-depth-gauge demo</title>
+</head>
+<body>
+<div class="sbd-panel">
+  <div class="sbd-dial">
+    <i class="sbd-needle"></i>
+    <b class="sbd-depth">120</b>
+    <small class="sbd-unit">FT</small>
+  </div>
+  <div class="sbd-status">
+    <span class="sbd-buoy">NEUTRAL</span>
+    <span class="sbd-air">O2 78%</span>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/submarine-depth-gauge-ij/style.css
+++ b/submissions/examples/submarine-depth-gauge-ij/style.css
@@ -1,0 +1,12 @@
+.sbd-panel{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:340px;background:#0b1626;border:2px solid #2a5a86;border-radius:16px;padding:22px;display:flex;flex-direction:column;gap:16px}
+.sbd-dial{position:relative;height:170px;background:radial-gradient(circle at 50% 100%,#122a44,#0b1626 65%);border-radius:170px 170px 14px 14px;display:flex;flex-direction:column;align-items:center;justify-content:flex-end;padding-bottom:24px}
+.sbd-needle{position:absolute;left:50%;top:14px;width:4px;height:112px;background:#7cebb0;transform-origin:50% 100%;transform:translateX(-50%) rotate(-12deg);animation:sbd-needle-osc-submarine-depth-gauge 3s ease-in-out infinite}
+.sbd-depth{font-size:34px;font-weight:800;color:#38bdf8;animation:sbd-depth-tick-submarine-depth-gauge 1.4s ease-in-out infinite}
+.sbd-unit{font-size:9px;letter-spacing:2px;color:#5d7690}
+.sbd-status{display:flex;justify-content:space-between;gap:10px}
+.sbd-buoy{font-size:10px;font-weight:800;letter-spacing:2px;color:#7cebb0;border:1px solid #1f5c43;border-radius:20px;padding:4px 10px;animation:sbd-buoy-blink-submarine-depth-gauge 1.8s ease-in-out infinite}
+.sbd-air{font-size:10px;font-weight:800;letter-spacing:2px;color:#f5c542;border:1px solid #4a3c14;border-radius:20px;padding:4px 10px;animation:sbd-air-blink-submarine-depth-gauge 2.4s ease-in-out infinite}
+@keyframes sbd-needle-osc-submarine-depth-gauge{0%{transform:translateX(-50%) rotate(-12deg)}50%{transform:translateX(-50%) rotate(34deg)}100%{transform:translateX(-50%) rotate(-12deg)}}
+@keyframes sbd-depth-tick-submarine-depth-gauge{0%{opacity:0.7}50%{opacity:1}100%{opacity:0.7}}
+@keyframes sbd-buoy-blink-submarine-depth-gauge{0%{box-shadow:0 0 0 0 rgba(124,235,176,0)}50%{box-shadow:0 0 10px rgba(124,235,176,0.4)}100%{box-shadow:0 0 0 0 rgba(124,235,176,0)}}
+@keyframes sbd-air-blink-submarine-depth-gauge{0%{opacity:0.6}50%{opacity:1}100%{opacity:0.6}}


### PR DESCRIPTION
## Component: ease-submarine-depth-gauge — needle swings, depth ticks, and status blinks

**Closes #69890**

### What this adds
A submarine depth gauge: the depth needle swings, the depth readout ticks, and the buoyancy status blinks.

### Acceptance Criteria covered
- Depth needle swings on the dial
- Depth readout ticks below
- Buoyancy status blinks beside

### Files
- `submissions/examples/submarine-depth-gauge-ij/demo.html`
- `submissions/examples/submarine-depth-gauge-ij/style.css`
- `submissions/examples/submarine-depth-gauge-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the gauge.