### PR TITLE
Add ease-movie-popcorn-counter component

### DIFF
--- a/submissions/examples/movie-popcorn-counter-ij/README.md
+++ b/submissions/examples/movie-popcorn-counter-ij/README.md
@@ -1,0 +1,11 @@
+# ease-movie-popcorn-counter
+
+A movie popcorn counter where the kernels pop, the count ticks, and the cups pulse.
+
+## Run
+Open `demo.html` directly in a browser to watch the counter.
+
+## Notes
+- The kernels pop in the bucket.
+- The sold count ticks below.
+- The striped cups pulse in turn.

--- a/submissions/examples/movie-popcorn-counter-ij/demo.html
+++ b/submissions/examples/movie-popcorn-counter-ij/demo.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-movie-popcorn-counter demo</title>
+</head>
+<body>
+<div class="mpc-stand">
+  <div class="mpc-bucket">
+    <i class="mpc-kernel"></i>
+    <i class="mpc-kernel"></i>
+    <i class="mpc-kernel"></i>
+    <i class="mpc-kernel"></i>
+    <i class="mpc-kernel"></i>
+  </div>
+  <div class="mpc-count">43</div>
+  <div class="mpc-cups"><span class="mpc-cup"></span><span class="mpc-cup"></span><span class="mpc-cup"></span></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/movie-popcorn-counter-ij/style.css
+++ b/submissions/examples/movie-popcorn-counter-ij/style.css
@@ -1,0 +1,14 @@
+.mpc-stand{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:340px;background:#1a1026;border:3px solid #c0392b;border-radius:16px;padding:20px;display:flex;flex-direction:column;align-items:center;gap:14px}
+.mpc-bucket{position:relative;width:150px;height:170px;background:linear-gradient(180deg,#e0392b,#a02818);border-radius:8px 8px 14px 14px;overflow:hidden}
+.mpc-kernel{position:absolute;width:16px;height:16px;border-radius:50%;background:#fff3d0;box-shadow:inset 0 -3px 0 rgba(0,0,0,0.15);animation:mpc-kernel-pop-movie-popcorn-counter 2.4s ease-in-out infinite}
+.mpc-kernel:nth-child(1){left:24px;top:70px}
+.mpc-kernel:nth-child(2){left:66px;top:44px;animation-delay:0.5s}
+.mpc-kernel:nth-child(3){left:106px;top:96px;animation-delay:1s}
+.mpc-kernel:nth-child(4){left:40px;top:110px;animation-delay:1.5s}
+.mpc-kernel:nth-child(5){left:90px;top:120px;animation-delay:2s}
+.mpc-count{font-size:34px;font-weight:800;color:#ffd23f;font-family:"Courier New",monospace;animation:mpc-count-tick-movie-popcorn-counter 1.2s ease-in-out infinite}
+.mpc-cups{display:flex;gap:16px}
+.mpc-cup{width:34px;height:46px;background:repeating-linear-gradient(45deg,#e0392b,#e0392b 6px,#fff 6px,#fff 8px);border-radius:4px 4px 10px 10px;animation:mpc-cup-pulse-movie-popcorn-counter 2s ease-in-out infinite}
+@keyframes mpc-kernel-pop-movie-popcorn-counter{0%,70%{transform:scale(1)}80%{transform:scale(1.3)}100%{transform:scale(1)}}
+@keyframes mpc-count-tick-movie-popcorn-counter{0%{transform:translateY(0)}30%{transform:translateY(-3px)}100%{transform:translateY(0)}}
+@keyframes mpc-cup-pulse-movie-popcorn-counter{0%,100%{opacity:0.7}50%{opacity:1}}


### PR DESCRIPTION
## Component: ease-movie-popcorn-counter — kernels pop, count ticks, and cups pulse

**Closes #69895**

### What this adds
A movie popcorn counter: the kernels pop in the bucket, the sold count ticks, and the striped cups pulse.

### Acceptance Criteria covered
- Kernels pop in the bucket
- Sold count ticks below
- Striped cups pulse in turn

### Files
- `submissions/examples/movie-popcorn-counter-ij/demo.html`
- `submissions/examples/movie-popcorn-counter-ij/style.css`
- `submissions/examples/movie-popcorn-counter-ij/README.md`

### How to review
Open `demo.html` directly in a browser and watch the counter.