### PR TITLE
feat: add CSS outline stroke text

### DIFF
--- a/submissions/examples/outline-stroke-text/README.md
+++ b/submissions/examples/outline-stroke-text/README.md
@@ -1,0 +1,26 @@
+# CSS Outline Stroke Text
+
+A pure CSS animated outline stroke text effect for the EaseMotion CSS library.
+
+## Features
+
+- Pure CSS implementation
+- No JavaScript required
+- Animated draw-on text effect
+- Uses `clip-path` for the reveal animation
+- CSS custom properties for easy theming
+- Responsive typography
+- Light and dark mode support
+- Reduced-motion accessibility support
+
+## Files
+
+- `demo.html` - Demo page
+- `style.css` - Component styles and animation
+
+## How It Works
+
+The text is initially hidden using:
+
+```css
+clip-path: inset(0 100% 0 0);

--- a/submissions/examples/outline-stroke-text/demo.html
+++ b/submissions/examples/outline-stroke-text/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta
+    name="description"
+    content="CSS animated outline stroke text draw-on effect"
+  >
+  <title>CSS Outline Stroke Text</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+  <main class="demo">
+    <section class="text-demo" aria-labelledby="stroke-title">
+      <p class="label">CSS Animation</p>
+
+      <h1 id="stroke-title" class="stroke-text" aria-label="EASEMOTION">
+        EASEMOTION
+      </h1>
+
+      <p class="description">
+        Animated outline stroke text using pure CSS.
+      </p>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/outline-stroke-text/style.css
+++ b/submissions/examples/outline-stroke-text/style.css
@@ -1,0 +1,117 @@
+:root {
+    --background: #0f172a;
+    --text-color: #f8fafc;
+    --stroke-color: #38bdf8;
+    --accent-color: #818cf8;
+    --animation-duration: 3s;
+  }
+  
+  * {
+    box-sizing: border-box;
+  }
+  
+  body {
+    margin: 0;
+    min-height: 100vh;
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+      sans-serif;
+    background: var(--background);
+    color: var(--text-color);
+  }
+  
+  .demo {
+    min-height: 100vh;
+    display: grid;
+    place-items: center;
+    padding: 2rem;
+  }
+  
+  .text-demo {
+    width: min(100%, 1000px);
+    text-align: center;
+  }
+  
+  .label {
+    margin: 0 0 1rem;
+    font-size: 0.9rem;
+    font-weight: 700;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--accent-color);
+  }
+  
+  .stroke-text {
+    margin: 0;
+    position: relative;
+  
+    font-size: clamp(3rem, 12vw, 9rem);
+    font-weight: 900;
+    line-height: 1;
+  
+    color: transparent;
+    -webkit-text-stroke: 2px var(--stroke-color);
+  
+    background: linear-gradient(
+      90deg,
+      var(--stroke-color),
+      var(--accent-color)
+    );
+  
+    background-clip: text;
+    -webkit-background-clip: text;
+  
+    clip-path: inset(0 100% 0 0);
+  
+    animation: draw-stroke var(--animation-duration) ease-out forwards;
+  }
+  
+  /*
+   * The clip-path starts with the text completely hidden.
+   * It progressively reveals the text from left to right,
+   * creating a draw-on / stroke-reveal effect.
+   */
+  @keyframes draw-stroke {
+    from {
+      clip-path: inset(0 100% 0 0);
+    }
+  
+    to {
+      clip-path: inset(0 0 0 0);
+    }
+  }
+  
+  .description {
+    margin: 1.5rem auto 0;
+    max-width: 600px;
+    font-size: clamp(1rem, 2vw, 1.2rem);
+    color: color-mix(in srgb, var(--text-color) 70%, transparent);
+  }
+  
+  /* Light-mode support */
+  @media (prefers-color-scheme: light) {
+    :root {
+      --background: #f8fafc;
+      --text-color: #0f172a;
+      --stroke-color: #0284c7;
+      --accent-color: #4f46e5;
+    }
+  }
+  
+  /* Accessibility: respect reduced-motion preferences */
+  @media (prefers-reduced-motion: reduce) {
+    .stroke-text {
+      animation: none;
+      clip-path: inset(0 0 0 0);
+    }
+  }
+  
+  /* Smaller screens */
+  @media (max-width: 600px) {
+    .demo {
+      padding: 1rem;
+    }
+  
+    .stroke-text {
+      -webkit-text-stroke-width: 1.5px;
+    }
+  }


### PR DESCRIPTION
## Description

Adds a pure CSS animated outline stroke text component for issue #68094.

## Features

- Pure CSS implementation
- Draw-on stroke reveal animation
- Uses CSS `clip-path`
- Responsive design
- CSS custom properties for theming
- Light and dark mode support
- Reduced-motion accessibility support
- Includes demo.html, style.css and README.md

## Issue

Closes #68094