### PR TITLE
feat: add pure CSS Product Image Thumbnail Strip component (#68521)

### DIFF
--- a/submissions/examples/css-product-image-thumbnail-strip-pure/README.md
+++ b/submissions/examples/css-product-image-thumbnail-strip-pure/README.md
@@ -1,0 +1,19 @@
+# CSS Product Image Thumbnail Strip
+
+A pure CSS interactive image gallery using hidden radio buttons to synchronize a sliding main viewport with a scrollable horizontal thumbnail strip, built entirely without JavaScript.
+
+## Features
+- Pure CSS and HTML (Zero JavaScript required for state management or sliding animations).
+- **Theming & Dark Mode**: Utilizes CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), generating a sleek dark mode UI.
+- **Component Architecture (Documented in Code)**: 
+  - **The Radio Hack**: We place 5 hidden `<input type="radio">` elements at the top of the gallery container. Both the main viewport and the thumbnail strip react to the `:checked` state of these radios using the general sibling selector (`~`).
+  - **Main Viewport Slider**: The `.viewport-slider` is set to `500%` width (containing 5 images, each at `100%` width of the parent). When a radio button is checked, a CSS transform slides the container horizontally (e.g., `#img-2:checked ~ .gallery-viewport .viewport-slider { transform: translateX(-20%); }`).
+  - **Active Thumbnail Highlight**: The thumbnails are actually `<label>` elements linked to the hidden radios via the `for` attribute. Clicking a thumbnail checks the corresponding radio. The CSS then detects which radio is checked and highlights the correct `<label>` below it by changing its border color and opacity.
+- Fully accessible semantic structure. Screen readers are instructed to ignore the hidden state radios via `aria-hidden="true"`, interacting directly with the styled `<label>` buttons, which feature `role="tab"` and `tabindex="0"` for keyboard navigation. Honors the `prefers-reduced-motion` accessibility standard by disabling the sliding transitions in favor of instantaneous swaps for motion-sensitive users.
+
+## Usage
+Open `demo.html` in your browser. Click the thumbnails in the bottom strip to watch the main image viewport slide to the correct position, while the active thumbnail highlights.
+
+## Files
+- `demo.html`: The HTML structure containing the hidden radio state inputs, the main viewport slider, and the scrollable thumbnail labels.
+- `style.css`: The styling, CSS Custom Property theming blocks, and the heavily commented `:checked ~` state transition logic.

--- a/submissions/examples/css-product-image-thumbnail-strip-pure/demo.html
+++ b/submissions/examples/css-product-image-thumbnail-strip-pure/demo.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Product Image Thumbnail Strip</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Product Thumbnail Strip</h1>
+            <p class="subtitle">A pure CSS interactive image gallery using radio buttons to sync a main viewport with a scrollable horizontal thumbnail strip.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <div class="product-gallery">
+                
+                <!-- 
+                  [TECHNIQUE] The Radio Hack for Gallery State
+                  We use hidden radio buttons to track which image is currently active.
+                  Both the main viewport and the thumbnail strip will react to this state.
+                -->
+                <input type="radio" name="gallery" id="img-1" class="gallery-radio sr-only" checked aria-hidden="true">
+                <input type="radio" name="gallery" id="img-2" class="gallery-radio sr-only" aria-hidden="true">
+                <input type="radio" name="gallery" id="img-3" class="gallery-radio sr-only" aria-hidden="true">
+                <input type="radio" name="gallery" id="img-4" class="gallery-radio sr-only" aria-hidden="true">
+                <input type="radio" name="gallery" id="img-5" class="gallery-radio sr-only" aria-hidden="true">
+                
+                
+                <!-- Main Display Viewport -->
+                <div class="gallery-viewport">
+                    <!-- The images slide horizontally based on which radio is checked -->
+                    <div class="viewport-slider">
+                        <!-- Placeholder images generated via CSS for demo purposes -->
+                        <div class="main-img img-blue" aria-label="Product Image 1"></div>
+                        <div class="main-img img-purple" aria-label="Product Image 2"></div>
+                        <div class="main-img img-green" aria-label="Product Image 3"></div>
+                        <div class="main-img img-orange" aria-label="Product Image 4"></div>
+                        <div class="main-img img-teal" aria-label="Product Image 5"></div>
+                    </div>
+                </div>
+                
+                
+                <!-- Thumbnail Strip Navigation -->
+                <!-- We use a scrolling container for overflow -->
+                <div class="thumbnail-scroller" role="tablist" aria-label="Product Image Thumbnails">
+                    <div class="thumbnail-strip">
+                        
+                        <!-- Each label acts as a clickable thumbnail targeting a specific radio -->
+                        <label for="img-1" class="thumb-label" role="tab" tabindex="0" aria-label="View Image 1">
+                            <div class="thumb-img img-blue"></div>
+                        </label>
+                        
+                        <label for="img-2" class="thumb-label" role="tab" tabindex="0" aria-label="View Image 2">
+                            <div class="thumb-img img-purple"></div>
+                        </label>
+                        
+                        <label for="img-3" class="thumb-label" role="tab" tabindex="0" aria-label="View Image 3">
+                            <div class="thumb-img img-green"></div>
+                        </label>
+                        
+                        <label for="img-4" class="thumb-label" role="tab" tabindex="0" aria-label="View Image 4">
+                            <div class="thumb-img img-orange"></div>
+                        </label>
+                        
+                        <label for="img-5" class="thumb-label" role="tab" tabindex="0" aria-label="View Image 5">
+                            <div class="thumb-img img-teal"></div>
+                        </label>
+                        
+                    </div>
+                </div>
+                
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-product-image-thumbnail-strip-pure/style.css
+++ b/submissions/examples/css-product-image-thumbnail-strip-pure/style.css
@@ -1,0 +1,230 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    
+    --card-bg: #ffffff;
+    --card-border: #e2e8f0;
+    --card-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.05), 0 4px 6px -2px rgba(0, 0, 0, 0.025);
+    
+    --thumb-border: transparent;
+    --thumb-active-border: #3b82f6; /* Blue highlight */
+    
+    /* Demo Image Colors */
+    --img-blue: linear-gradient(135deg, #60a5fa, #2563eb);
+    --img-purple: linear-gradient(135deg, #a78bfa, #7c3aed);
+    --img-green: linear-gradient(135deg, #34d399, #059669);
+    --img-orange: linear-gradient(135deg, #fbbf24, #ea580c);
+    --img-teal: linear-gradient(135deg, #2dd4bf, #0d9488);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a;
+        --text-primary: #f8fafc;
+        --text-secondary: #94a3b8;
+        
+        --card-bg: #1e293b;
+        --card-border: #334155;
+        --card-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.4), 0 4px 6px -2px rgba(0, 0, 0, 0.2);
+        
+        --thumb-active-border: #60a5fa;
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 60px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 500px;
+}
+
+/* Accessibility helper */
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border-width: 0;
+}
+
+/* CSS Mock Images */
+.img-blue { background: var(--img-blue); }
+.img-purple { background: var(--img-purple); }
+.img-green { background: var(--img-green); }
+.img-orange { background: var(--img-orange); }
+.img-teal { background: var(--img-teal); }
+
+
+/* =========================================
+   Gallery Container
+   ========================================= */
+
+.product-gallery {
+    width: 100%;
+    max-width: 500px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+
+/* =========================================
+   Main Viewport
+   ========================================= */
+
+.gallery-viewport {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 4 / 3; /* Standard product photo aspect */
+    background-color: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 16px;
+    overflow: hidden;
+    box-shadow: var(--card-shadow);
+}
+
+.viewport-slider {
+    display: flex;
+    width: 500%; /* 5 images * 100% */
+    height: 100%;
+    transition: transform 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.main-img {
+    width: 100%; /* Relative to the viewport, not the slider */
+    height: 100%;
+    flex-shrink: 0;
+}
+
+
+/* =========================================
+   Thumbnail Strip
+   ========================================= */
+
+.thumbnail-scroller {
+    width: 100%;
+    overflow-x: auto;
+    /* Hide scrollbar for cleaner look, but keep functionality */
+    -ms-overflow-style: none;  /* IE and Edge */
+    scrollbar-width: none;  /* Firefox */
+    padding-bottom: 8px; /* Room for focus rings */
+}
+.thumbnail-scroller::-webkit-scrollbar {
+    display: none; /* Chrome/Safari */
+}
+
+.thumbnail-strip {
+    display: flex;
+    gap: 12px;
+    /* Ensure strip doesn't squish thumbnails if container is small */
+    width: max-content; 
+}
+
+.thumb-label {
+    display: block;
+    width: 80px;
+    height: 80px;
+    border-radius: 12px;
+    cursor: pointer;
+    position: relative;
+    /* Border is reserved for the active state outline */
+    border: 2px solid var(--thumb-border);
+    padding: 2px; /* Creates a gap between the border and image */
+    transition: all 0.2s ease;
+    opacity: 0.6; /* Dim inactive thumbnails */
+}
+
+.thumb-img {
+    width: 100%;
+    height: 100%;
+    border-radius: 8px; /* Slightly smaller than outer label */
+    background-size: cover;
+    background-position: center;
+}
+
+.thumb-label:hover {
+    opacity: 0.8;
+}
+
+/* Accessibility focus state */
+.thumb-label:focus-visible {
+    outline: none;
+    border-color: var(--text-secondary);
+    opacity: 1;
+}
+
+
+/* =========================================
+   [TECHNIQUE] State Toggling Logic
+   ========================================= */
+
+/* 1. Slide the Main Viewport based on checked radio */
+#img-1:checked ~ .gallery-viewport .viewport-slider { transform: translateX(0%); }
+#img-2:checked ~ .gallery-viewport .viewport-slider { transform: translateX(-20%); }
+#img-3:checked ~ .gallery-viewport .viewport-slider { transform: translateX(-40%); }
+#img-4:checked ~ .gallery-viewport .viewport-slider { transform: translateX(-60%); }
+#img-5:checked ~ .gallery-viewport .viewport-slider { transform: translateX(-80%); }
+
+/* 2. Highlight the active thumbnail */
+#img-1:checked ~ .thumbnail-scroller label[for="img-1"],
+#img-2:checked ~ .thumbnail-scroller label[for="img-2"],
+#img-3:checked ~ .thumbnail-scroller label[for="img-3"],
+#img-4:checked ~ .thumbnail-scroller label[for="img-4"],
+#img-5:checked ~ .thumbnail-scroller label[for="img-5"] {
+    border-color: var(--thumb-active-border);
+    opacity: 1;
+}
+
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .viewport-slider,
+    .thumb-label {
+        transition: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a pure CSS interactive image gallery using hidden radio buttons to synchronize a sliding main viewport with a scrollable horizontal thumbnail strip, built entirely without JavaScript, resolving issue #68521.

### Changes Made:
- Added `submissions/examples/css-product-image-thumbnail-strip-pure/` directory.
- Created `demo.html` showcasing the HTML structure containing the hidden radio state inputs, the main viewport slider, and the scrollable thumbnail labels.
- Created `style.css` featuring the UI mechanics:
  - **The Radio Hack**: We place 5 hidden `<input type="radio">` elements at the top of the gallery container. Both the main viewport and the thumbnail strip react to the `:checked` state of these radios using the general sibling selector (`~`).
  - **Main Viewport Slider**: The `.viewport-slider` is set to `500%` width (containing 5 images, each at `100%` width of the parent). When a radio button is checked, a CSS transform slides the container horizontally (e.g., `#img-2:checked ~ .gallery-viewport .viewport-slider { transform: translateX(-20%); }`).
  - **Active Thumbnail Highlight**: The thumbnails are actually `<label>` elements linked to the hidden radios via the `for` attribute. Clicking a thumbnail checks the corresponding radio. The CSS then detects which radio is checked and highlights the correct `<label>` below it by changing its border color and opacity.
  - **Theming & Dark Mode Supported**: Utilizes CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), generating a sleek dark mode UI.
- Added `README.md` documenting usage and the technical mechanics of the `:checked ~` state transition logic.
- Fully accessible semantic structure. Screen readers are instructed to ignore the hidden state radios via `aria-hidden="true"`, interacting directly with the styled `<label>` buttons, which feature `role="tab"` and `tabindex="0"` for keyboard navigation. Honors the `prefers-reduced-motion` accessibility standard by disabling the sliding transitions in favor of instantaneous swaps for motion-sensitive users.

Closes #68521
