### PR TITLE
feat: add pure CSS Changelog Entry component (#68493)

### DIFF
--- a/submissions/examples/css-changelog-entry-pure/README.md
+++ b/submissions/examples/css-changelog-entry-pure/README.md
@@ -1,0 +1,19 @@
+# CSS Changelog Entry
+
+A pure CSS timeline-style changelog component featuring version tags, semantic release dates, and categorized update lists with custom list-style markers, built entirely without JavaScript.
+
+## Features
+- Pure CSS and HTML (Zero JavaScript or image assets required).
+- **Theming & Dark Mode**: Utilizes CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), generating a sleek dark mode UI with adjusted tag contrast and timeline colors.
+- **Component Architecture (Documented in Code)**: 
+  - **Timeline Architecture**: The vertical timeline is created efficiently by applying a `border-left` to the main `.changelog-container`. Each individual `.changelog-entry` then uses an absolutely positioned `::before` pseudo-element to draw a circular dot directly overlapping the border, creating the classic timeline look.
+  - **First-Child Highlighting**: The most recent changelog entry is automatically highlighted using the `:first-child` pseudo-class, which applies a thicker, colored border to its timeline dot (no extra HTML classes required).
+  - **Custom List Markers**: Instead of standard HTML bullets, the categorized update lists (`<ul>`) have their default `list-style` removed. We use `::before` pseudo-elements on the `<li>` items to draw custom circular dots that perfectly match the color of their respective category tags (e.g., blue dots for features, green for improvements).
+- Fully accessible semantic structure. Uses `<article>` for individual entries with `aria-labelledby` pointing to the version tag. Dates use the semantic `<time datetime="...">` element. Update lists use proper `<ul>` and `<li>` structure for screen reader compatibility.
+
+## Usage
+Open `demo.html` in your browser. Resize the window to see the responsive layout adapt cleanly to smaller screens. 
+
+## Files
+- `demo.html`: The HTML structure containing the semantic articles, time elements, and categorized lists.
+- `style.css`: The styling, CSS Custom Property theming blocks, and the heavily commented pseudo-element architecture.

--- a/submissions/examples/css-changelog-entry-pure/demo.html
+++ b/submissions/examples/css-changelog-entry-pure/demo.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Changelog Entry</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Product Changelog</h1>
+            <p class="subtitle">A pure CSS timeline-style changelog component featuring version tags, release dates, and categorized update lists with custom list-style markers.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <div class="changelog-container">
+                
+                <!-- 
+                  [TECHNIQUE] CSS Timeline Architecture
+                  The .changelog-container uses a left border to create the vertical line.
+                  Each .changelog-entry uses a ::before pseudo-element to draw the dot on the line.
+                -->
+                
+                <!-- Entry 1 -->
+                <article class="changelog-entry" aria-labelledby="v2-4-0">
+                    
+                    <div class="entry-meta">
+                        <span class="version-tag badge-primary" id="v2-4-0">v2.4.0</span>
+                        <time datetime="2023-11-15" class="release-date">November 15, 2023</time>
+                    </div>
+                    
+                    <div class="entry-content">
+                        <h2 class="entry-title">Dark Mode & Performance Boost</h2>
+                        <p class="entry-desc">This release introduces a fully native dark mode experience across the dashboard and significant performance improvements to the data tables.</p>
+                        
+                        <div class="update-category">
+                            <h3 class="category-title tag-feature">New Features</h3>
+                            <ul class="update-list feature-list">
+                                <li>Added system-level dark mode sync (prefers-color-scheme).</li>
+                                <li>New 'Export to PDF' option for quarterly reports.</li>
+                                <li>Introduced advanced filtering options in the analytics dashboard.</li>
+                            </ul>
+                        </div>
+                        
+                        <div class="update-category">
+                            <h3 class="category-title tag-improvement">Improvements</h3>
+                            <ul class="update-list improvement-list">
+                                <li>Data table rendering is now 40% faster on large datasets.</li>
+                                <li>Updated typography scale for better readability on mobile devices.</li>
+                            </ul>
+                        </div>
+                    </div>
+                    
+                </article>
+
+                <!-- Entry 2 -->
+                <article class="changelog-entry" aria-labelledby="v2-3-5">
+                    
+                    <div class="entry-meta">
+                        <span class="version-tag badge-secondary" id="v2-3-5">v2.3.5</span>
+                        <time datetime="2023-10-28" class="release-date">October 28, 2023</time>
+                    </div>
+                    
+                    <div class="entry-content">
+                        <h2 class="entry-title">Security Patch & Bug Fixes</h2>
+                        <p class="entry-desc">A minor release focused on resolving user-reported issues and updating underlying dependencies for better security.</p>
+                        
+                        <div class="update-category">
+                            <h3 class="category-title tag-bugfix">Bug Fixes</h3>
+                            <ul class="update-list bugfix-list">
+                                <li>Fixed an issue where the sidebar would not collapse properly on tablets.</li>
+                                <li>Resolved a race condition causing duplicate form submissions on the checkout page.</li>
+                                <li>Corrected timezone offset errors in the scheduling calendar.</li>
+                            </ul>
+                        </div>
+                    </div>
+                    
+                </article>
+                
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-changelog-entry-pure/style.css
+++ b/submissions/examples/css-changelog-entry-pure/style.css
@@ -1,0 +1,293 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    --text-muted: #94a3b8;
+    
+    --card-bg: #ffffff;
+    --card-border: #e2e8f0;
+    
+    /* Timeline Colors */
+    --timeline-line: #e2e8f0;
+    --timeline-dot: #cbd5e1;
+    --timeline-dot-active: #3b82f6;
+    
+    /* Tag Colors */
+    --tag-feature-bg: #dbeafe;
+    --tag-feature-text: #1d4ed8;
+    
+    --tag-improve-bg: #dcfce7;
+    --tag-improve-text: #15803d;
+    
+    --tag-bug-bg: #fee2e2;
+    --tag-bug-text: #b91c1c;
+    
+    --badge-primary-bg: #3b82f6;
+    --badge-primary-text: #ffffff;
+    
+    --badge-secondary-bg: #e2e8f0;
+    --badge-secondary-text: #475569;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a;
+        --text-primary: #f8fafc;
+        --text-secondary: #94a3b8;
+        --text-muted: #64748b;
+        
+        --card-bg: #1e293b;
+        --card-border: #334155;
+        
+        --timeline-line: #334155;
+        --timeline-dot: #475569;
+        
+        --tag-feature-bg: rgba(59, 130, 246, 0.2);
+        --tag-feature-text: #93c5fd;
+        
+        --tag-improve-bg: rgba(34, 197, 94, 0.2);
+        --tag-improve-text: #86efac;
+        
+        --tag-bug-bg: rgba(239, 68, 68, 0.2);
+        --tag-bug-text: #fca5a5;
+        
+        --badge-secondary-bg: #334155;
+        --badge-secondary-text: #cbd5e1;
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 60px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    padding: 20px 0;
+}
+
+
+/* =========================================
+   [TECHNIQUE] Timeline Architecture
+   ========================================= */
+
+.changelog-container {
+    width: 100%;
+    max-width: 700px;
+    /* The vertical timeline line */
+    border-left: 2px solid var(--timeline-line);
+    margin-left: 12px; /* Space for the dot */
+    padding-bottom: 20px;
+}
+
+.changelog-entry {
+    position: relative;
+    padding-left: 32px;
+    margin-bottom: 48px;
+}
+
+.changelog-entry:last-child {
+    margin-bottom: 0;
+}
+
+/* The timeline dot */
+.changelog-entry::before {
+    content: '';
+    position: absolute;
+    left: -7px; /* Align perfectly over the 2px border */
+    top: 4px;
+    width: 12px;
+    height: 12px;
+    background-color: var(--bg-base);
+    border: 2px solid var(--timeline-dot);
+    border-radius: 50%;
+    transition: border-color 0.3s ease;
+}
+
+/* Highlight the dot for the most recent entry */
+.changelog-entry:first-child::before {
+    border-color: var(--timeline-dot-active);
+    border-width: 3px;
+    left: -8px;
+    top: 3px;
+}
+
+
+/* =========================================
+   Entry Meta (Version & Date)
+   ========================================= */
+
+.entry-meta {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 12px;
+}
+
+.version-tag {
+    padding: 4px 12px;
+    border-radius: 16px;
+    font-size: 0.85rem;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+}
+
+.badge-primary {
+    background-color: var(--badge-primary-bg);
+    color: var(--badge-primary-text);
+}
+
+.badge-secondary {
+    background-color: var(--badge-secondary-bg);
+    color: var(--badge-secondary-text);
+}
+
+.release-date {
+    font-size: 0.9rem;
+    color: var(--text-muted);
+    font-weight: 500;
+}
+
+
+/* =========================================
+   Entry Content
+   ========================================= */
+
+.entry-title {
+    margin: 0 0 8px 0;
+    font-size: 1.4rem;
+    font-weight: 700;
+    color: var(--text-primary);
+}
+
+.entry-desc {
+    margin: 0 0 24px 0;
+    font-size: 1.05rem;
+    line-height: 1.6;
+    color: var(--text-secondary);
+}
+
+.update-category {
+    margin-bottom: 24px;
+    background-color: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 12px;
+    padding: 20px;
+}
+
+.update-category:last-child {
+    margin-bottom: 0;
+}
+
+.category-title {
+    display: inline-block;
+    margin: 0 0 16px 0;
+    font-size: 0.85rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    padding: 4px 10px;
+    border-radius: 6px;
+}
+
+
+/* Category Tags */
+.tag-feature {
+    background-color: var(--tag-feature-bg);
+    color: var(--tag-feature-text);
+}
+.tag-improvement {
+    background-color: var(--tag-improve-bg);
+    color: var(--tag-improve-text);
+}
+.tag-bugfix {
+    background-color: var(--tag-bug-bg);
+    color: var(--tag-bug-text);
+}
+
+
+/* =========================================
+   [TECHNIQUE] Custom List Markers
+   ========================================= */
+
+.update-list {
+    margin: 0;
+    padding: 0;
+    list-style: none; /* Remove default bullets */
+}
+
+.update-list li {
+    position: relative;
+    padding-left: 24px;
+    margin-bottom: 12px;
+    font-size: 0.95rem;
+    line-height: 1.5;
+    color: var(--text-primary);
+}
+
+.update-list li:last-child {
+    margin-bottom: 0;
+}
+
+/* Base custom bullet */
+.update-list li::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 8px;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+}
+
+/* Colored bullets matching the category */
+.feature-list li::before { background-color: var(--tag-feature-text); }
+.improvement-list li::before { background-color: var(--tag-improve-text); }
+.bugfix-list li::before { background-color: var(--tag-bug-text); }
+
+
+/* Responsive adjustments */
+@media (max-width: 600px) {
+    .update-category {
+        padding: 16px;
+    }
+    .entry-title {
+        font-size: 1.25rem;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a pure CSS timeline-style changelog component featuring version tags, semantic release dates, and categorized update lists with custom list-style markers, built entirely without JavaScript, resolving issue #68493.

### Changes Made:
- Added `submissions/examples/css-changelog-entry-pure/` directory.
- Created `demo.html` showcasing the HTML structure containing the semantic articles, time elements, and categorized lists.
- Created `style.css` featuring the UI mechanics:
  - **Timeline Architecture**: The vertical timeline is created efficiently by applying a `border-left` to the main `.changelog-container`. Each individual `.changelog-entry` then uses an absolutely positioned `::before` pseudo-element to draw a circular dot directly overlapping the border, creating the classic timeline look.
  - **First-Child Highlighting**: The most recent changelog entry is automatically highlighted using the `:first-child` pseudo-class, which applies a thicker, colored border to its timeline dot (no extra HTML classes required).
  - **Custom List Markers**: Instead of standard HTML bullets, the categorized update lists (`<ul>`) have their default `list-style` removed. We use `::before` pseudo-elements on the `<li>` items to draw custom circular dots that perfectly match the color of their respective category tags (e.g., blue dots for features, green for improvements).
  - **Theming & Dark Mode Supported**: Utilizes CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), generating a sleek dark mode UI with adjusted tag contrast and timeline colors.
- Added `README.md` documenting usage and the technical mechanics of the pseudo-element architecture.
- Fully accessible semantic structure. Uses `<article>` for individual entries with `aria-labelledby` pointing to the version tag. Dates use the semantic `<time datetime="...">` element. Update lists use proper `<ul>` and `<li>` structure for screen reader compatibility.

Closes #68493
