### PR TITLE
feat: add pure CSS Slide-down Subnav component (#68384)

### DIFF
--- a/submissions/examples/css-slide-down-subnav-pure/README.md
+++ b/submissions/examples/css-slide-down-subnav-pure/README.md
@@ -1,0 +1,19 @@
+# CSS Slide-down Subnav
+
+A pure CSS dropdown menu featuring a smooth slide-down animation, chevron rotation, and a robust "invisible hover bridge" to prevent accidental dismissals, built entirely without JavaScript.
+
+## Features
+- Pure CSS and HTML (Zero JavaScript required for state management or sliding animations).
+- **Theming & Dark Mode**: Utilizes CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), generating a sleek dark mode UI with darker backgrounds and elevated dropdown shadows.
+- **Component Architecture (Documented in Code)**: 
+  - **The Hover Trigger**: The dropdown interaction is attached to the parent list item (`.nav-item:hover`) rather than just the link. This is crucial because it ensures the dropdown remains open as long as the user's mouse is anywhere inside the `<li>` (including over the dropdown itself).
+  - **Invisible Hover Bridge**: A common UX failure in CSS dropdowns is when moving the mouse from the nav link down to the menu causes the menu to close because the cursor briefly exits the hover area. We solve this by adding `padding-top: 12px;` to the `.dropdown-wrapper`. This padding acts as an invisible physical bridge, ensuring the mouse never leaves the hoverable area of the parent `.nav-item`.
+  - **Animation State**: The dropdown is hidden using `opacity: 0;`, `visibility: hidden;`, and `transform: translateY(10px);`. On hover, we smoothly transition these to `opacity: 1;`, `visibility: visible;`, and `transform: translateY(0);`, creating a slide-and-fade effect. The chevron SVG simultaneously rotates 180 degrees.
+- Fully accessible semantic structure. Wraps the navigation in a `<nav>` tag with `aria-label`. Submenus utilize `aria-haspopup` and `aria-expanded` (static fallback). Importantly, the dropdown opens via keyboard navigation thanks to the `:focus-within` pseudo-class applied alongside the `:hover` state. Honors the `prefers-reduced-motion` accessibility standard by disabling the slide transitions for motion-sensitive users.
+
+## Usage
+Open `demo.html` in your browser. Hover over the "Products" or "Resources" links to view the smooth slide-down animation. Try navigating using only the `Tab` key to verify keyboard accessibility.
+
+## Files
+- `demo.html`: The HTML structure containing the semantic nav elements and SVG chevrons.
+- `style.css`: The styling, CSS Custom Property theming blocks, and the heavily commented `:hover` and `:focus-within` transition logic.

--- a/submissions/examples/css-slide-down-subnav-pure/demo.html
+++ b/submissions/examples/css-slide-down-subnav-pure/demo.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Slide-down Subnav</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Slide-down Subnav</h1>
+            <p class="subtitle">A pure CSS dropdown menu featuring a smooth slide-down animation and robust hover bridge to prevent accidental dismissals.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <nav class="main-nav" aria-label="Main Navigation">
+                <ul class="nav-list">
+                    
+                    <li class="nav-item">
+                        <a href="#" class="nav-link">Home</a>
+                    </li>
+                    
+                    <!-- 
+                      [TECHNIQUE] The Hover Bridge Parent
+                      This li acts as the trigger. When hovered, the child subnav is revealed.
+                      Padding ensures a continuous hover target between the link and the dropdown.
+                    -->
+                    <li class="nav-item has-dropdown">
+                        <a href="#" class="nav-link" aria-haspopup="true" aria-expanded="false">
+                            Products
+                            <svg class="chevron" viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2" fill="none"><polyline points="6 9 12 15 18 9"></polyline></svg>
+                        </a>
+                        
+                        <div class="dropdown-wrapper">
+                            <ul class="subnav-list" aria-label="Products Submenu">
+                                <li><a href="#" class="subnav-link">Analytics Pro</a></li>
+                                <li><a href="#" class="subnav-link">CRM Database</a></li>
+                                <li><a href="#" class="subnav-link">Marketing Suite</a></li>
+                                <li><a href="#" class="subnav-link">Cloud Storage</a></li>
+                            </ul>
+                        </div>
+                    </li>
+                    
+                    <li class="nav-item has-dropdown">
+                        <a href="#" class="nav-link" aria-haspopup="true" aria-expanded="false">
+                            Resources
+                            <svg class="chevron" viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2" fill="none"><polyline points="6 9 12 15 18 9"></polyline></svg>
+                        </a>
+                        
+                        <div class="dropdown-wrapper">
+                            <ul class="subnav-list" aria-label="Resources Submenu">
+                                <li><a href="#" class="subnav-link">Documentation</a></li>
+                                <li><a href="#" class="subnav-link">API Reference</a></li>
+                                <li><a href="#" class="subnav-link">Community Forum</a></li>
+                            </ul>
+                        </div>
+                    </li>
+                    
+                    <li class="nav-item">
+                        <a href="#" class="nav-link">Pricing</a>
+                    </li>
+                    
+                </ul>
+            </nav>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-slide-down-subnav-pure/style.css
+++ b/submissions/examples/css-slide-down-subnav-pure/style.css
@@ -1,0 +1,212 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    
+    --nav-bg: #ffffff;
+    --nav-border: #e2e8f0;
+    
+    --nav-link: #475569;
+    --nav-link-hover: #0f172a;
+    --nav-link-bg-hover: #f1f5f9;
+    
+    --dropdown-bg: #ffffff;
+    --dropdown-border: #e2e8f0;
+    --dropdown-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a;
+        --text-primary: #f8fafc;
+        --text-secondary: #94a3b8;
+        
+        --nav-bg: #1e293b;
+        --nav-border: #334155;
+        
+        --nav-link: #94a3b8;
+        --nav-link-hover: #f8fafc;
+        --nav-link-bg-hover: #334155;
+        
+        --dropdown-bg: #1e293b;
+        --dropdown-border: #334155;
+        --dropdown-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.5), 0 4px 6px -2px rgba(0, 0, 0, 0.3);
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 1000px;
+    margin: 0 auto;
+    padding: 60px 20px 200px 20px; /* Extra bottom padding for demo dropdown space */
+}
+
+.section-header {
+    margin-bottom: 60px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    padding: 20px 0;
+}
+
+
+/* =========================================
+   Main Navigation Bar
+   ========================================= */
+
+.main-nav {
+    background-color: var(--nav-bg);
+    border: 1px solid var(--nav-border);
+    border-radius: 12px;
+    padding: 8px 24px;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+}
+
+.nav-list {
+    display: flex;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    gap: 16px;
+}
+
+.nav-item {
+    position: relative; /* Anchor for the absolutely positioned dropdown */
+}
+
+.nav-link {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 10px 16px;
+    text-decoration: none;
+    color: var(--nav-link);
+    font-weight: 500;
+    border-radius: 8px;
+    transition: all 0.2s ease;
+}
+
+.nav-link:hover,
+.nav-link:focus-visible {
+    color: var(--nav-link-hover);
+    background-color: var(--nav-link-bg-hover);
+}
+
+.chevron {
+    transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+
+/* =========================================
+   [TECHNIQUE] The Slide-down Dropdown
+   ========================================= */
+
+.dropdown-wrapper {
+    position: absolute;
+    top: 100%; /* Position right below the parent nav item */
+    left: 0;
+    min-width: 220px;
+    
+    /* 
+      Invisible Hover Bridge:
+      Padding ensures the cursor doesn't leave the hoverable area 
+      when moving from the link down into the dropdown menu. 
+    */
+    padding-top: 12px;
+    
+    /* Hidden by default using opacity, visibility, and transform */
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(10px);
+    
+    transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+    z-index: 100;
+}
+
+.subnav-list {
+    background-color: var(--dropdown-bg);
+    border: 1px solid var(--dropdown-border);
+    border-radius: 12px;
+    box-shadow: var(--dropdown-shadow);
+    list-style: none;
+    margin: 0;
+    padding: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.subnav-link {
+    display: block;
+    padding: 10px 16px;
+    text-decoration: none;
+    color: var(--nav-link);
+    font-size: 0.95rem;
+    font-weight: 500;
+    border-radius: 6px;
+    transition: all 0.2s ease;
+}
+
+.subnav-link:hover,
+.subnav-link:focus-visible {
+    color: var(--nav-link-hover);
+    background-color: var(--nav-link-bg-hover);
+}
+
+
+/* 
+  The Interaction:
+  When the parent <li> is hovered, OR when a link inside it receives keyboard focus,
+  reveal the dropdown and flip the chevron.
+*/
+.nav-item:hover .dropdown-wrapper,
+.nav-item:focus-within .dropdown-wrapper {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+}
+
+.nav-item:hover .chevron,
+.nav-item:focus-within .chevron {
+    transform: rotate(180deg);
+}
+
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .dropdown-wrapper,
+    .chevron {
+        transition: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a pure CSS dropdown menu featuring a smooth slide-down animation, chevron rotation, and a robust "invisible hover bridge" to prevent accidental dismissals, built entirely without JavaScript, resolving issue #68384.

### Changes Made:
- Added `submissions/examples/css-slide-down-subnav-pure/` directory.
- Created `demo.html` showcasing the HTML structure containing the semantic nav elements and SVG chevrons.
- Created `style.css` featuring the UI mechanics:
  - **The Hover Trigger**: The dropdown interaction is attached to the parent list item (`.nav-item:hover`) rather than just the link. This is crucial because it ensures the dropdown remains open as long as the user's mouse is anywhere inside the `<li>` (including over the dropdown itself).
  - **Invisible Hover Bridge**: A common UX failure in CSS dropdowns is when moving the mouse from the nav link down to the menu causes the menu to close because the cursor briefly exits the hover area. We solve this by adding `padding-top: 12px;` to the `.dropdown-wrapper`. This padding acts as an invisible physical bridge, ensuring the mouse never leaves the hoverable area of the parent `.nav-item`.
  - **Animation State**: The dropdown is hidden using `opacity: 0;`, `visibility: hidden;`, and `transform: translateY(10px);`. On hover, we smoothly transition these to `opacity: 1;`, `visibility: visible;`, and `transform: translateY(0);`, creating a slide-and-fade effect. The chevron SVG simultaneously rotates 180 degrees.
  - **Theming & Dark Mode Supported**: Utilizes CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), generating a sleek dark mode UI with darker backgrounds and elevated dropdown shadows.
- Added `README.md` documenting usage and the technical mechanics of the `:hover` and `:focus-within` transition logic.
- Fully accessible semantic structure. Wraps the navigation in a `<nav>` tag with `aria-label`. Submenus utilize `aria-haspopup` and `aria-expanded` (static fallback). Importantly, the dropdown opens via keyboard navigation thanks to the `:focus-within` pseudo-class applied alongside the `:hover` state. Honors the `prefers-reduced-motion` accessibility standard by disabling the slide transitions for motion-sensitive users.

Closes #68384
