### PR TITLE
feat: add pure CSS Subtle Input Focus Glow component (#68391)

### DIFF
--- a/submissions/examples/css-subtle-input-focus-glow-pure/README.md
+++ b/submissions/examples/css-subtle-input-focus-glow-pure/README.md
@@ -1,0 +1,20 @@
+# CSS Subtle Input Focus Glow
+
+A pure CSS form interaction featuring a soft, animated glow ring that expands outward when an input field receives focus, built without JavaScript.
+
+## Features
+- Pure CSS and HTML (Zero JavaScript required for focus state management).
+- **Theming & Dark Mode**: Utilizes CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), generating a sleek dark mode UI where the glow opacity is slightly increased for better visibility against dark backgrounds.
+- **Component Architecture (Documented in Code)**: 
+  - **The Wrapper Technique**: The standard browser `outline` property cannot be animated smoothly (it lacks transition support for `outline-offset` or `outline-width` in many browsers). To create a smooth, blooming glow, we wrap the `<input>` in a `.input-wrapper` `<div>`.
+  - **Pseudo-element Bloom**: We apply a `::before` pseudo-element to the `.input-wrapper`. This pseudo-element holds the actual colored `box-shadow` that acts as the glow. It is initially scaled down (`transform: scale(0.98)`) and invisible (`opacity: 0`).
+  - **Focus-Within Trigger**: When the user clicks or tabs into the input field, the `.input-wrapper` triggers the `:focus-within` pseudo-class. This state scales the `::before` element to `scale(1)` and fades it in, creating a hardware-accelerated "bloom" animation.
+  - **Custom Easing**: The animation utilizes a slight `cubic-bezier(0.175, 0.885, 0.32, 1.275)` curve to give the expanding ring a subtle, satisfying "bounce" as it settles into place.
+- Fully accessible semantic structure. The inputs have proper `<label>` elements associated via the `for` attribute. We explicitly disable the default browser focus ring (`outline: none;`) *only* because we are replacing it with a highly visible, custom focus indicator (the glow), ensuring keyboard accessibility is maintained and enhanced. Honors the `prefers-reduced-motion` accessibility standard by disabling the scale/bounce animation for motion-sensitive users, replacing it with a simple fade.
+
+## Usage
+Open `demo.html` in your browser. Click into the various input fields (or use the `Tab` key) to trigger the soft focus glow animation.
+
+## Files
+- `demo.html`: The HTML structure containing the form layout and the essential input wrapper elements.
+- `style.css`: The styling, CSS Custom Property theming blocks, and the heavily commented `:focus-within` animation architecture.

--- a/submissions/examples/css-subtle-input-focus-glow-pure/demo.html
+++ b/submissions/examples/css-subtle-input-focus-glow-pure/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Subtle Input Focus Glow</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Subtle Input Focus Glow</h1>
+            <p class="subtitle">A pure CSS form interaction featuring a soft, animated glow ring that expands outward when an input field receives focus.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <form class="form-panel" onsubmit="event.preventDefault();">
+                
+                <h2 class="form-title">Account Details</h2>
+                
+                <div class="form-group">
+                    <label for="email" class="form-label">Email Address</label>
+                    <!-- 
+                      [TECHNIQUE] The Glow Wrapper
+                      We wrap the input in a container.
+                      The container uses a ::before pseudo-element to draw the glow ring.
+                      When the input inside has :focus-visible, the container reacts.
+                    -->
+                    <div class="input-wrapper">
+                        <input type="email" id="email" class="glow-input" placeholder="you@example.com" required>
+                    </div>
+                </div>
+                
+                <div class="form-group">
+                    <label for="username" class="form-label">Username</label>
+                    <div class="input-wrapper">
+                        <!-- We can apply a custom color class to change the glow tint -->
+                        <input type="text" id="username" class="glow-input tint-purple" placeholder="johndoe123" required>
+                    </div>
+                </div>
+                
+                <div class="form-group">
+                    <label for="password" class="form-label">Password</label>
+                    <div class="input-wrapper">
+                        <input type="password" id="password" class="glow-input tint-emerald" placeholder="••••••••" required>
+                    </div>
+                </div>
+                
+                <button type="submit" class="btn-submit">Save Changes</button>
+                
+            </form>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-subtle-input-focus-glow-pure/style.css
+++ b/submissions/examples/css-subtle-input-focus-glow-pure/style.css
@@ -1,0 +1,251 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f1f5f9;
+    --text-primary: #0f172a;
+    --text-secondary: #475569;
+    
+    --panel-bg: #ffffff;
+    --panel-border: #e2e8f0;
+    --panel-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.05);
+    
+    --input-bg: #ffffff;
+    --input-border: #cbd5e1;
+    --input-text: #0f172a;
+    --input-placeholder: #94a3b8;
+    
+    /* Default Glow Color (Blue) */
+    --glow-color: rgba(59, 130, 246, 0.4);
+    --glow-border: #3b82f6;
+    
+    --btn-bg: #0f172a;
+    --btn-text: #ffffff;
+    --btn-hover: #334155;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a;
+        --text-primary: #f8fafc;
+        --text-secondary: #94a3b8;
+        
+        --panel-bg: #1e293b;
+        --panel-border: #334155;
+        --panel-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.4);
+        
+        --input-bg: #0f172a;
+        --input-border: #475569;
+        --input-text: #f8fafc;
+        --input-placeholder: #64748b;
+        
+        /* Glow needs to be slightly brighter in dark mode */
+        --glow-color: rgba(96, 165, 250, 0.5);
+        --glow-border: #60a5fa;
+        
+        --btn-bg: #3b82f6;
+        --btn-text: #ffffff;
+        --btn-hover: #60a5fa;
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 60px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    padding: 20px 0;
+}
+
+
+/* =========================================
+   Form Layout
+   ========================================= */
+
+.form-panel {
+    background-color: var(--panel-bg);
+    border: 1px solid var(--panel-border);
+    border-radius: 16px;
+    padding: 32px;
+    box-shadow: var(--panel-shadow);
+    width: 100%;
+    max-width: 420px;
+}
+
+.form-title {
+    margin: 0 0 24px 0;
+    font-size: 1.25rem;
+    font-weight: 600;
+}
+
+.form-group {
+    margin-bottom: 20px;
+}
+
+.form-label {
+    display: block;
+    margin-bottom: 8px;
+    font-size: 0.9rem;
+    font-weight: 500;
+    color: var(--text-primary);
+}
+
+
+/* =========================================
+   [TECHNIQUE] The Focus Glow
+   ========================================= */
+
+.input-wrapper {
+    position: relative;
+    /* Create an isolation context so the glow doesn't bleed weirdly */
+    isolation: isolate; 
+}
+
+/* 
+  The Glow Element:
+  We use a pseudo-element behind the input field. 
+  By default, it is scaled down and has 0 opacity.
+*/
+.input-wrapper::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    border-radius: 10px; /* Slightly larger than input radius */
+    background-color: transparent;
+    box-shadow: 0 0 0 4px var(--glow-color);
+    
+    /* Initial hidden state */
+    opacity: 0;
+    transform: scale(0.98);
+    
+    /* Place it behind the actual input */
+    z-index: -1;
+    
+    /* Smooth transition for the bloom effect */
+    transition: opacity 0.3s ease, 
+                transform 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275); /* Slight bounce */
+}
+
+/* The actual input field */
+.glow-input {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 12px 16px;
+    background-color: var(--input-bg);
+    border: 1px solid var(--input-border);
+    border-radius: 8px;
+    font-family: inherit;
+    font-size: 1rem;
+    color: var(--input-text);
+    transition: border-color 0.2s ease;
+    
+    /* Important: We disable the default browser focus ring! */
+    outline: none; 
+}
+
+.glow-input::placeholder {
+    color: var(--input-placeholder);
+}
+
+/* Color Modifier Classes (Applied to input, affects wrapper via variables) */
+.tint-purple {
+    --glow-color: rgba(168, 85, 247, 0.4);
+    --glow-border: #a855f7;
+}
+.tint-emerald {
+    --glow-color: rgba(16, 185, 129, 0.4);
+    --glow-border: #10b981;
+}
+
+/* 
+  The Interaction:
+  When the input receives focus, target the wrapper's ::before pseudo-element
+  using the :focus-within pseudo-class.
+*/
+.input-wrapper:focus-within::before {
+    opacity: 1;
+    transform: scale(1);
+}
+
+/* Also change the border color of the actual input */
+.input-wrapper:focus-within .glow-input {
+    border-color: var(--glow-border);
+}
+
+
+/* =========================================
+   Submit Button
+   ========================================= */
+
+.btn-submit {
+    display: block;
+    width: 100%;
+    margin-top: 32px;
+    padding: 12px 20px;
+    background-color: var(--btn-bg);
+    color: var(--btn-text);
+    border: none;
+    border-radius: 8px;
+    font-family: inherit;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+
+.btn-submit:hover {
+    background-color: var(--btn-hover);
+}
+
+/* Accessibility Focus State for Button */
+.btn-submit:focus-visible {
+    outline: 2px solid var(--glow-border);
+    outline-offset: 2px;
+}
+
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .input-wrapper::before {
+        transition: opacity 0.1s ease !important; /* Only fade, no scale/bounce */
+        transform: scale(1) !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a pure CSS form interaction featuring a soft, animated glow ring that expands outward when an input field receives focus, built without JavaScript, resolving issue #68391.

### Changes Made:
- Added `submissions/examples/css-subtle-input-focus-glow-pure/` directory.
- Created `demo.html` showcasing the HTML structure containing the form layout and the essential input wrapper elements.
- Created `style.css` featuring the UI mechanics:
  - **The Wrapper Technique**: The standard browser `outline` property cannot be animated smoothly (it lacks transition support for `outline-offset` or `outline-width` in many browsers). To create a smooth, blooming glow, we wrap the `<input>` in a `.input-wrapper` `<div>`.
  - **Pseudo-element Bloom**: We apply a `::before` pseudo-element to the `.input-wrapper`. This pseudo-element holds the actual colored `box-shadow` that acts as the glow. It is initially scaled down (`transform: scale(0.98)`) and invisible (`opacity: 0`).
  - **Focus-Within Trigger**: When the user clicks or tabs into the input field, the `.input-wrapper` triggers the `:focus-within` pseudo-class. This state scales the `::before` element to `scale(1)` and fades it in, creating a hardware-accelerated "bloom" animation.
  - **Custom Easing**: The animation utilizes a slight `cubic-bezier(0.175, 0.885, 0.32, 1.275)` curve to give the expanding ring a subtle, satisfying "bounce" as it settles into place.
  - **Theming & Dark Mode Supported**: Utilizes CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), generating a sleek dark mode UI where the glow opacity is slightly increased for better visibility against dark backgrounds.
- Added `README.md` documenting usage and the technical mechanics of the `:focus-within` animation architecture.
- Fully accessible semantic structure. The inputs have proper `<label>` elements associated via the `for` attribute. We explicitly disable the default browser focus ring (`outline: none;`) *only* because we are replacing it with a highly visible, custom focus indicator (the glow), ensuring keyboard accessibility is maintained and enhanced. Honors the `prefers-reduced-motion` accessibility standard by disabling the scale/bounce animation for motion-sensitive users, replacing it with a simple fade.

Closes #68391
