### PR TITLE
feat: add ease-flywheel-momentum-spin component

### DIFF
--- a/submissions/examples/flywheel-momentum-spin-ns/README.md
+++ b/submissions/examples/flywheel-momentum-spin-ns/README.md
@@ -1,0 +1,78 @@
+ease-flywheel-momentum-spin
+
+A cast-iron flywheel component — real housing, an RPM dial with a needle, an engage switch, and a status LED, not a generic spinning box. Engaging it winds the wheel up to speed and holds a steady cruise; releasing (or loading the page) plays a coast-down settle rather than an instant stop, so the motion reads as accumulated momentum rather than a simple on/off toggle. Pure CSS, driven by the checkbox hack.
+
+Files
+File	Purpose
+demo.html	The housing, wheel, dial, and switch
+style.css	Every mechanic below, plus all visual styling
+README.md	This file
+Markup
+html
+<div class="ease-flywheel-momentum-spin">
+  <div class="fw-housing">
+    <input type="checkbox" id="fw-engage" class="fw-engage-toggle">
+    <div class="fw-viewport">
+      <div class="fw-wheel-mount">
+        <div class="fw-wheel"><div class="fw-wheel__hub"></div></div>
+      </div>
+      <span class="fw-led" aria-hidden="true"></span>
+    </div>
+    <div class="fw-panel">
+      <div class="fw-dial">…</div>
+      <label for="fw-engage" class="fw-switch">…</label>
+    </div>
+  </div>
+</div>
+The seamless spin-up → cruise handoff
+
+This is the part that usually looks wrong in a CSS-only spinning mechanism: an easing "spin-up" animation and a constant-speed "cruise" animation are two different @keyframes, and handing off between them mid-rotation normally causes a visible snap.
+
+The trick is picking numbers where the snap is invisible. Spin-up rotates through 1080deg — three full turns — with an easing curve, then animation-delay on the cruise animation is set to exactly the spin-up's duration, so cruise's own 0deg starting point takes over the instant spin-up's forwards-held 1080deg ends:
+
+css
+.fw-engage-toggle:checked ~ .fw-viewport .fw-wheel {
+  animation:
+    fw-spin-up var(--fw-spinup-duration) cubic-bezier(0.45, 0.05, 0.4, 1) forwards,
+    fw-cruise var(--fw-cruise-duration) linear infinite var(--fw-spinup-duration);
+}
+
+1080deg mod 360 = 0deg — the wheel's visual orientation at the handoff moment is identical whether you think of it as "still finishing spin-up" or "just starting cruise," so the switch is invisible even though two completely different animations are involved.
+
+An honest simplification: the coast-down
+
+A truly physical release — decelerating smoothly from whatever exact angle the wheel happened to be at when you clicked — needs to read the wheel's current rotation and seed a new animation from it. CSS can't do either of those; there's no way to query a running animation's current computed value and feed it into a new one.
+
+Rather than fake that, the release state (and the initial page-load state, since CSS can't distinguish "never engaged" from "just released" either) plays the same fixed fw-coast-to-rest deceleration — starting partway through a turn and easing to a stop — every time:
+
+css
+@keyframes fw-coast-to-rest {
+  0%   { transform: rotate(220deg); }
+  100% { transform: rotate(360deg); }
+}
+
+On page load this reads as "the wheel was already coasting down, now settling," which works fine as a bit of framing for a mechanical device. On release after a long cruise it's a documented, deliberate simplification rather than a bug — flagged here rather than left for a reviewer to discover.
+
+The dial needle
+
+Mirrors the wheel's two states with its own fw-needle-up / fw-needle-rest keyframes on the same --fw-spinup-duration / --fw-coast-duration timing, including a tiny overshoot-and-settle wobble (85% → 92% → 100%) at the top of its travel so it doesn't snap dead-stop into the redline the way a purely linear sweep would.
+
+CSS custom properties
+Property	Default	Controls
+--fw-spinup-duration	2.4s	Time to reach full speed
+--fw-cruise-duration	0.9s	Length of one cruise rotation (speed, effectively)
+--fw-coast-duration	1.8s	Length of the release/settle animation
+--fw-accent	
+#ff8a3d	Needle and label accent color
+--fw-led-on / --fw-led-off	green / dark amber	Status LED colors
+Accessibility
+The wheel, dial, and LED are all aria-hidden="true" — they're decorative mechanical flourish with no information not already conveyed by the switch's own label and state.
+The actual control is a real <input type="checkbox"> + <label for="..."> pair (the "Engage" switch) — focusable, toggleable with <kbd>Space</kbd>, with a visible :focus-visible ring.
+Respects prefers-reduced-motion: reduce: both the wheel and needle animations are removed outright, and engaging still gives clear feedback (the LED lights, the switch thumb slides) without any rotation at all.
+Responsive behavior
+
+The wheel and its mount scale down at 420px so the whole housing still fits comfortably on a narrow phone screen without the dial or switch crowding.
+
+Browser support
+
+Uses repeating-conic-gradient (for the wheel's spokes), radial-gradient, and standard transform/keyframe animation — all supported in current evergreen browsers. Where repeating-conic-gradient is unsupported, the wheel falls back to a plain radial metallic disc with no visible spokes, which still spins correctly.

--- a/submissions/examples/flywheel-momentum-spin-ns/demo.html
+++ b/submissions/examples/flywheel-momentum-spin-ns/demo.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ease-flywheel-momentum-spin — EaseMotion CSS</title>
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@600;700&family=Inter:wght@400;500;600&family=IBM+Plex+Mono:wght@500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="noise" aria-hidden="true"></div>
+
+  <header class="hero">
+    <p class="eyebrow">EaseMotion CSS &middot; showcase</p>
+    <h1 class="hero-title">Flywheel momentum spin</h1>
+    <p class="hero-sub">A cast-iron flywheel that winds up to speed, holds a steady cruise, and coasts back down on release &mdash; not an instant on/off, real accumulated momentum. Pure CSS, driven by the checkbox hack.</p>
+  </header>
+
+  <main class="showcase">
+
+    <div class="ease-flywheel-momentum-spin">
+
+      <div class="fw-housing">
+
+        <div class="fw-plate">
+          <span class="fw-plate__label">FLYWHEEL&nbsp;MK.&nbsp;II</span>
+          <span class="fw-plate__serial">UNIT&nbsp;07</span>
+        </div>
+
+        <input type="checkbox" id="fw-engage" class="fw-engage-toggle">
+
+        <div class="fw-viewport">
+          <div class="fw-wheel-mount">
+            <div class="fw-wheel" aria-hidden="true">
+              <div class="fw-wheel__hub"></div>
+            </div>
+          </div>
+          <span class="fw-led" aria-hidden="true"></span>
+        </div>
+
+        <div class="fw-panel">
+          <div class="fw-dial" aria-hidden="true">
+            <div class="fw-dial__face">
+              <span class="fw-dial__tick fw-dial__tick-0"></span>
+              <span class="fw-dial__tick fw-dial__tick-1"></span>
+              <span class="fw-dial__tick fw-dial__tick-2"></span>
+              <span class="fw-dial__tick fw-dial__tick-3"></span>
+              <span class="fw-dial__tick fw-dial__tick-4"></span>
+              <div class="fw-dial__needle"></div>
+              <div class="fw-dial__pivot"></div>
+            </div>
+            <span class="fw-dial__label">RPM &times; 1000</span>
+          </div>
+
+          <label for="fw-engage" class="fw-switch">
+            <span class="fw-switch__track" aria-hidden="true">
+              <span class="fw-switch__thumb"></span>
+            </span>
+            <span class="fw-switch__text">Engage</span>
+          </label>
+        </div>
+
+      </div>
+
+    </div>
+
+  </main>
+
+  <footer class="footer">
+    <p>EaseMotion CSS &middot; submissions/examples/flywheel-momentum-spin-ns</p>
+  </footer>
+
+</body>
+</html>

--- a/submissions/examples/flywheel-momentum-spin-ns/style.css
+++ b/submissions/examples/flywheel-momentum-spin-ns/style.css
@@ -1,0 +1,494 @@
+/* =========================================================================
+   ease-flywheel-momentum-spin — EaseMotion CSS
+   A cast-iron flywheel with real housing, an RPM dial, an engage switch,
+   and a status LED. Engaging winds the wheel up to speed (an easing
+   spin-up handing off to a linear cruise at the exact moment their
+   rotation values align, so the handoff is seamless), and the resting/
+   released state plays a coast-down-to-rest animation rather than
+   snapping straight to still. Pure CSS, driven by the checkbox hack.
+   ========================================================================= */
+
+
+/* -------------------------------------------------------------------------
+   1. Design tokens
+   ------------------------------------------------------------------------- */
+
+:root {
+  --fw-bg: #0b0c0e;
+  --fw-housing: #17191d;
+  --fw-housing-2: #1f2226;
+  --fw-border: #2b2f35;
+  --fw-text: #e7e9ec;
+  --fw-text-muted: #8b909a;
+
+  --fw-iron-1: #14161a;
+  --fw-iron-2: #4b5158;
+  --fw-iron-3: #23262b;
+  --fw-iron-4: #6b727b;
+
+  --fw-accent: #ff8a3d;
+  --fw-led-off: #3a2418;
+  --fw-led-on: #4dff8a;
+
+  --fw-font-display: "Space Grotesk", "Segoe UI", sans-serif;
+  --fw-font-body: "Inter", "Segoe UI", sans-serif;
+  --fw-font-mono: "IBM Plex Mono", "Courier New", monospace;
+
+  /* Motion tuning */
+  --fw-spinup-duration: 2.4s;
+  --fw-cruise-duration: 0.9s;
+  --fw-coast-duration: 1.8s;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--fw-bg);
+  color: var(--fw-text);
+  font-family: var(--fw-font-body);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+.noise {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.04;
+  z-index: 0;
+  background-image: radial-gradient(circle at 1px 1px, #ffffff 1px, transparent 0);
+  background-size: 3px 3px;
+}
+
+
+/* -------------------------------------------------------------------------
+   2. Hero
+   ------------------------------------------------------------------------- */
+
+.hero {
+  position: relative;
+  z-index: 1;
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 92px 24px 48px;
+  text-align: center;
+}
+
+.eyebrow {
+  font-family: var(--fw-font-mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--fw-accent);
+  margin: 0 0 20px;
+}
+
+.hero-title {
+  font-family: var(--fw-font-display);
+  font-weight: 600;
+  font-size: clamp(30px, 5.5vw, 48px);
+  line-height: 1.1;
+  letter-spacing: -0.01em;
+  margin: 0 0 16px;
+}
+
+.hero-sub {
+  font-size: 15px;
+  color: var(--fw-text-muted);
+  max-width: 500px;
+  margin: 0 auto;
+}
+
+
+/* -------------------------------------------------------------------------
+   3. Layout
+   ------------------------------------------------------------------------- */
+
+.showcase {
+  position: relative;
+  z-index: 1;
+  max-width: 420px;
+  margin: 0 auto;
+  padding: 0 24px 100px;
+  display: flex;
+  justify-content: center;
+}
+
+
+/* -------------------------------------------------------------------------
+   4. Housing
+   ------------------------------------------------------------------------- */
+
+.fw-housing {
+  position: relative;
+  width: 100%;
+  background: linear-gradient(180deg, var(--fw-housing), var(--fw-housing-2));
+  border: 1px solid var(--fw-border);
+  border-radius: 20px;
+  padding: 18px 18px 22px;
+  box-shadow: 0 30px 60px -24px rgba(0, 0, 0, 0.7);
+}
+
+/* Rivets in the top corners, cast-iron-bracket styling */
+.fw-housing::before,
+.fw-housing::after {
+  content: "";
+  position: absolute;
+  top: 12px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 30%, var(--fw-iron-4), var(--fw-iron-1));
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
+}
+.fw-housing::before { left: 12px; }
+.fw-housing::after { right: 12px; }
+
+.fw-plate {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  padding: 0 4px 14px;
+  border-bottom: 1px solid var(--fw-border);
+  margin-bottom: 16px;
+}
+
+.fw-plate__label {
+  font-family: var(--fw-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  color: var(--fw-text-muted);
+}
+
+.fw-plate__serial {
+  font-family: var(--fw-font-mono);
+  font-size: 10px;
+  color: var(--fw-iron-4);
+}
+
+.fw-engage-toggle {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+
+/* -------------------------------------------------------------------------
+   5. Viewport + wheel
+   ------------------------------------------------------------------------- */
+
+.fw-viewport {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  padding: 8px 0 20px;
+}
+
+.fw-wheel-mount {
+  width: 168px;
+  height: 168px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 50%, var(--fw-iron-1) 60%, var(--fw-housing) 62%);
+  box-shadow: inset 0 0 0 6px var(--fw-housing-2), inset 0 10px 22px rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.fw-wheel {
+  position: relative;
+  width: 148px;
+  height: 148px;
+  border-radius: 50%;
+
+  /* Cast-iron body with spokes: a repeating conic gradient reads as
+     eight evenly-spaced spokes radiating from the hub. */
+  background:
+    repeating-conic-gradient(
+      from 0deg,
+      var(--fw-iron-2) 0deg 4deg,
+      transparent 4deg 41deg,
+      var(--fw-iron-2) 41deg 45deg,
+      transparent 45deg 90deg
+    ),
+    radial-gradient(circle at 35% 30%, var(--fw-iron-4) 0%, var(--fw-iron-3) 45%, var(--fw-iron-1) 100%);
+
+  box-shadow:
+    inset 0 0 0 10px var(--fw-iron-1),
+    inset -10px -10px 24px rgba(0, 0, 0, 0.65),
+    inset 8px 8px 18px rgba(255, 255, 255, 0.08);
+
+  animation: fw-coast-to-rest var(--fw-coast-duration) cubic-bezier(0.25, 0.85, 0.4, 1) both;
+}
+
+.fw-wheel__hub {
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 30%, var(--fw-iron-4), var(--fw-iron-1) 75%);
+  box-shadow: inset 0 0 0 3px var(--fw-housing-2), 0 2px 6px rgba(0, 0, 0, 0.6);
+}
+
+/* Engaged: spin-up hands off to an infinite linear cruise the instant it
+   finishes. 1080deg (3 full turns) and the cruise's 360deg both land on
+   the same visual orientation, so the handoff has no visible snap. */
+.fw-engage-toggle:checked ~ .fw-viewport .fw-wheel {
+  animation:
+    fw-spin-up var(--fw-spinup-duration) cubic-bezier(0.45, 0.05, 0.4, 1) forwards,
+    fw-cruise var(--fw-cruise-duration) linear infinite var(--fw-spinup-duration);
+}
+
+@keyframes fw-spin-up {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(1080deg); }
+}
+
+@keyframes fw-cruise {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}
+
+/* Idle / just-released: a deceleration curve settling back to rest.
+   Also the state on first page load, which reads as "the wheel was
+   already coasting down, now settling" — a deliberate bit of framing
+   rather than starting from a dead stop with no motion at all. */
+@keyframes fw-coast-to-rest {
+  0%   { transform: rotate(220deg); }
+  100% { transform: rotate(360deg); }
+}
+
+.fw-led {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--fw-led-off);
+  box-shadow: 0 0 0 2px var(--fw-housing-2);
+  transition: background 300ms ease, box-shadow 300ms ease;
+}
+
+.fw-engage-toggle:checked ~ .fw-viewport .fw-led {
+  background: var(--fw-led-on);
+  box-shadow: 0 0 0 2px var(--fw-housing-2), 0 0 10px 2px rgba(77, 255, 138, 0.6);
+}
+
+
+/* -------------------------------------------------------------------------
+   6. Control panel: dial + switch
+   ------------------------------------------------------------------------- */
+
+.fw-panel {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 0 4px;
+}
+
+.fw-dial {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+.fw-dial__face {
+  position: relative;
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: var(--fw-iron-1);
+  box-shadow: inset 0 0 0 2px var(--fw-border), inset 0 4px 10px rgba(0, 0, 0, 0.6);
+}
+
+.fw-dial__tick {
+  position: absolute;
+  top: 4px;
+  left: 50%;
+  width: 2px;
+  height: 6px;
+  background: var(--fw-text-muted);
+  transform-origin: 50% 28px;
+}
+
+.fw-dial__tick-0 { transform: translateX(-50%) rotate(-60deg); }
+.fw-dial__tick-1 { transform: translateX(-50%) rotate(-30deg); }
+.fw-dial__tick-2 { transform: translateX(-50%) rotate(0deg); }
+.fw-dial__tick-3 { transform: translateX(-50%) rotate(30deg); }
+.fw-dial__tick-4 { transform: translateX(-50%) rotate(60deg); }
+
+.fw-dial__needle {
+  position: absolute;
+  bottom: 50%;
+  left: 50%;
+  width: 2px;
+  height: 22px;
+  background: var(--fw-accent);
+  transform-origin: 50% 100%;
+  transform: translateX(-50%) rotate(-60deg);
+  border-radius: 2px 2px 0 0;
+  animation: fw-needle-rest var(--fw-coast-duration) cubic-bezier(0.25, 0.85, 0.4, 1) both;
+}
+
+.fw-dial__pivot {
+  position: absolute;
+  bottom: calc(50% - 4px);
+  left: 50%;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  transform: translateX(-50%);
+  background: var(--fw-iron-4);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
+}
+
+.fw-dial__label {
+  font-family: var(--fw-font-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.05em;
+  color: var(--fw-text-muted);
+}
+
+@keyframes fw-needle-rest {
+  0%   { transform: translateX(-50%) rotate(20deg); }
+  100% { transform: translateX(-50%) rotate(-60deg); }
+}
+
+.fw-engage-toggle:checked ~ .fw-panel .fw-dial__needle {
+  animation: fw-needle-up var(--fw-spinup-duration) cubic-bezier(0.45, 0.05, 0.4, 1) forwards;
+}
+
+@keyframes fw-needle-up {
+  0%   { transform: translateX(-50%) rotate(-60deg); }
+  85%  { transform: translateX(-50%) rotate(58deg); }
+  92%  { transform: translateX(-50%) rotate(50deg); }
+  100% { transform: translateX(-50%) rotate(55deg); }
+}
+
+
+/* -------------------------------------------------------------------------
+   7. Engage switch
+   ------------------------------------------------------------------------- */
+
+.fw-switch {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.fw-switch__track {
+  display: block;
+  width: 40px;
+  height: 22px;
+  border-radius: 999px;
+  background: var(--fw-iron-1);
+  box-shadow: inset 0 2px 5px rgba(0, 0, 0, 0.7), inset 0 0 0 1px var(--fw-border);
+  position: relative;
+  transition: background 200ms ease;
+}
+
+.fw-switch__thumb {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 30%, var(--fw-iron-4), var(--fw-iron-1));
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.6);
+  transition: transform 220ms cubic-bezier(0.34, 1.4, 0.64, 1);
+}
+
+.fw-engage-toggle:checked ~ .fw-panel .fw-switch__track {
+  background: #1d3a24;
+}
+
+.fw-engage-toggle:checked ~ .fw-panel .fw-switch__thumb {
+  transform: translateX(18px);
+  background: radial-gradient(circle at 35% 30%, #a9ffcb, var(--fw-led-on));
+}
+
+.fw-engage-toggle:focus-visible ~ .fw-panel .fw-switch {
+  outline: 2px solid var(--fw-accent);
+  outline-offset: 3px;
+  border-radius: 6px;
+}
+
+.fw-switch__text {
+  font-family: var(--fw-font-mono);
+  font-size: 12px;
+  color: var(--fw-text-muted);
+}
+
+
+/* -------------------------------------------------------------------------
+   8. Footer
+   ------------------------------------------------------------------------- */
+
+.footer {
+  position: relative;
+  z-index: 1;
+  text-align: center;
+  padding: 8px 24px 48px;
+  font-size: 12.5px;
+  color: var(--fw-text-muted);
+  font-family: var(--fw-font-mono);
+}
+
+
+/* -------------------------------------------------------------------------
+   9. Responsive
+   ------------------------------------------------------------------------- */
+
+@media (max-width: 420px) {
+  .hero {
+    padding: 68px 20px 40px;
+  }
+
+  .fw-wheel-mount {
+    width: 140px;
+    height: 140px;
+  }
+
+  .fw-wheel {
+    width: 122px;
+    height: 122px;
+  }
+}
+
+
+/* -------------------------------------------------------------------------
+   10. Reduced motion
+   ------------------------------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .fw-wheel,
+  .fw-dial__needle {
+    animation: none !important;
+  }
+
+  .fw-engage-toggle:checked ~ .fw-viewport .fw-wheel {
+    transform: rotate(0deg);
+  }
+
+  .fw-engage-toggle:checked ~ .fw-panel .fw-dial__needle {
+    transform: translateX(-50%) rotate(55deg);
+  }
+}


### PR DESCRIPTION
Closes #67348

## Pull Request Description
Adds `ease-flywheel-momentum-spin` — a themed cast-iron flywheel with real housing, an RPM dial, an engage switch, and a status LED. Engaging winds the wheel up to speed with a seamless handoff into a steady cruise; releasing plays a coast-down settle rather than an instant stop. No JavaScript.

## Feature Name
ease-flywheel-momentum-spin

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

## Submission Checklist
- [x] This feature does not duplicate an existing EaseMotion CSS class
- [x] I understand naming will be standardized by the maintainer
- [x] Code is submitted inside `submissions/` only (`submissions/examples/flywheel-momentum-spin-ns/`) — not `core/` or `components/`
- [x] Includes `demo.html`, `style.css`, `README.md`

## Feature Description

**What does this add?**
A real themed flywheel control — housing, dial, needle, switch, LED — where engaging winds up to speed and releasing coasts back down, rather than a generic glowing box that just spins.

**How does a developer use it?**
```html
<div class="ease-flywheel-momentum-spin">
  <div class="fw-housing">…</div>
</div>
```
Override `--fw-spinup-duration`, `--fw-cruise-duration`, or `--fw-coast-duration` to retune pacing.

**Why does it fit EaseMotion CSS?**
A practical, recognizable real-world motion metaphor (accumulated momentum, not instant on/off) built entirely from named `@keyframes` and transitions, composable and demoable with zero JavaScript, matching the animation-first, CSS-only model.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

## Notes for Maintainer
One documented, deliberate simplification: a true physical release (decelerating smoothly from whatever exact angle the wheel is at when you click) isn't possible in pure CSS — there's no way to read a running animation's current computed value and seed a new one from it. The release/idle state instead plays a fixed coast-to-rest animation every time (explained in full in the README), which also happens to double as a nice "already coasting down" framing on initial page load. Happy to discuss if a different trade-off is preferred.