### PR TITLE
feat: add pure CSS Chat Bubble Variants component (#68399)

### DIFF
--- a/submissions/examples/css-chat-bubble-variants-pure/README.md
+++ b/submissions/examples/css-chat-bubble-variants-pure/README.md
@@ -1,0 +1,21 @@
+# CSS Chat Bubble Variants
+
+A collection of pure CSS chat bubble designs including rounded iOS-style, flat corporate, minimal outlined, and oversized emoji variants. Built entirely without JavaScript or external SVGs.
+
+## Features
+- Pure CSS and HTML.
+- **Theming & Dark Mode**: Utilizes CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), generating a sleek dark mode UI with adjusted bubble colors for optimal contrast.
+- **Component Architecture (Documented in Code)**: 
+  - **CSS Shapes for Tails**: The most complex variant (the rounded iOS style) creates its smooth, curved tail using a combination of `border-radius` and pseudo-elements. 
+    - `::before` is positioned at the bottom corner and colored to match the bubble, creating the bulk of the tail.
+    - `::after` is positioned over the `::before` element and colored to match the *background* of the chat interface, carving out a curved negative space to create the final sharp tip.
+  - **Flat Triangles**: The flat corporate variant uses a simpler technique, utilizing transparent CSS borders on a `::before` pseudo-element to draw a sharp triangle attached to the top corner of the bubble.
+  - **Variant Classes**: The CSS is architected using a base `.bubble` class for shared typography and padding, with specific modifier classes (`.variant-rounded`, `.variant-flat`, `.variant-minimal`) handling the unique tail and border stylings.
+- Accessible semantic structure. Uses standard HTML flow and explicit `aria-label` tags for the emoji-only bubbles so screen readers can interpret the icons correctly.
+
+## Usage
+Open `demo.html` in your browser to view the different chat bubble styles in a mockup interface. 
+
+## Files
+- `demo.html`: The HTML structure containing the various bubble variants and their sent/received states.
+- `style.css`: The styling, CSS Custom Property theming blocks, and the heavily commented CSS Shapes techniques for drawing the bubble tails.

--- a/submissions/examples/css-chat-bubble-variants-pure/demo.html
+++ b/submissions/examples/css-chat-bubble-variants-pure/demo.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Chat Bubble Variants</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Chat Bubble Variants</h1>
+            <p class="subtitle">A collection of pure CSS chat bubble designs including rounded iOS-style, flat corporate, minimal outlined, and oversized emoji variants. Utilizes CSS Shapes and Pseudo-elements for the directional tails.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <div class="chat-interface">
+                
+                <!-- Variant 1: Rounded (iOS Style) -->
+                <div class="chat-message received variant-rounded">
+                    <div class="bubble">
+                        Hey there! 👋 Did you see the new CSS specs for styling these bubbles?
+                    </div>
+                </div>
+                
+                <div class="chat-message sent variant-rounded">
+                    <div class="bubble">
+                        Yeah, it's pretty incredible what you can do without SVGs now.
+                    </div>
+                </div>
+                
+                
+                <div class="chat-divider">
+                    <span>Flat Corporate Style</span>
+                </div>
+                
+                <!-- Variant 2: Flat (Corporate/Android Style) -->
+                <div class="chat-message received variant-flat">
+                    <div class="bubble">
+                        Please review the Q3 earnings report attached below.
+                    </div>
+                </div>
+                
+                <div class="chat-message sent variant-flat">
+                    <div class="bubble">
+                        Will do. I'll send my notes by EOD.
+                    </div>
+                </div>
+                
+                
+                <div class="chat-divider">
+                    <span>Minimal Outlined Style</span>
+                </div>
+                
+                <!-- Variant 3: Minimal (Outlined) -->
+                <div class="chat-message received variant-minimal">
+                    <div class="bubble">
+                        Are we still on for lunch at 12:30?
+                    </div>
+                </div>
+                
+                <div class="chat-message sent variant-minimal">
+                    <div class="bubble">
+                        Yes! Meet me in the lobby.
+                    </div>
+                </div>
+                
+                
+                <div class="chat-divider">
+                    <span>Emoji Only (Jumbo Size)</span>
+                </div>
+                
+                <!-- Variant 4: Emoji (No tail, larger text, transparent bg) -->
+                <div class="chat-message received variant-emoji">
+                    <div class="bubble" aria-label="Party popper and smiling face">
+                        🎉 😊
+                    </div>
+                </div>
+                
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-chat-bubble-variants-pure/style.css
+++ b/submissions/examples/css-chat-bubble-variants-pure/style.css
@@ -1,0 +1,313 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    
+    --chat-bg: #ffffff;
+    --chat-border: #e2e8f0;
+    
+    /* Sent Bubbles (Usually Blue/Primary) */
+    --sent-bg: #3b82f6;
+    --sent-text: #ffffff;
+    
+    /* Received Bubbles (Usually Gray) */
+    --received-bg: #e2e8f0;
+    --received-text: #0f172a;
+    --received-border: #cbd5e1;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a;
+        --text-primary: #f8fafc;
+        --text-secondary: #94a3b8;
+        
+        --chat-bg: #1e293b;
+        --chat-border: #334155;
+        
+        --sent-bg: #2563eb;
+        
+        --received-bg: #334155;
+        --received-text: #f8fafc;
+        --received-border: #475569;
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 40px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    padding: 20px 0;
+}
+
+
+/* =========================================
+   Chat Interface Layout
+   ========================================= */
+
+.chat-interface {
+    background-color: var(--chat-bg);
+    border: 1px solid var(--chat-border);
+    border-radius: 20px;
+    padding: 24px;
+    width: 100%;
+    max-width: 500px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.05);
+}
+
+.chat-divider {
+    text-align: center;
+    margin: 20px 0;
+    position: relative;
+}
+
+.chat-divider span {
+    background-color: var(--chat-bg);
+    padding: 0 12px;
+    color: var(--text-secondary);
+    font-size: 0.75rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    position: relative;
+    z-index: 1;
+}
+
+.chat-divider::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 0;
+    right: 0;
+    height: 1px;
+    background-color: var(--chat-border);
+    z-index: 0;
+}
+
+
+/* =========================================
+   Base Chat Message Structure
+   ========================================= */
+
+.chat-message {
+    display: flex;
+    width: 100%;
+}
+
+.chat-message.sent {
+    justify-content: flex-end;
+}
+
+.chat-message.received {
+    justify-content: flex-start;
+}
+
+.bubble {
+    max-width: 75%;
+    padding: 10px 16px;
+    font-size: 0.95rem;
+    line-height: 1.5;
+    position: relative; /* For pseudo-element tails */
+    word-break: break-word;
+}
+
+/* Base Colors */
+.sent .bubble {
+    background-color: var(--sent-bg);
+    color: var(--sent-text);
+}
+
+.received .bubble {
+    background-color: var(--received-bg);
+    color: var(--received-text);
+}
+
+
+/* =========================================
+   Variant 1: Rounded (iOS Style)
+   ========================================= */
+
+.variant-rounded .bubble {
+    border-radius: 20px;
+}
+
+/* 
+  [TECHNIQUE] CSS Shapes for Tails
+  We use the ::before pseudo-element to draw the tail.
+  By manipulating border-radius and background color, we can create smooth curves
+  that seamlessly attach to the main bubble.
+*/
+.variant-rounded.sent .bubble {
+    border-bottom-right-radius: 4px; /* Flattens the corner where tail attaches */
+}
+
+.variant-rounded.sent .bubble::before {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    right: -8px;
+    width: 20px;
+    height: 20px;
+    background-color: var(--sent-bg);
+    border-bottom-left-radius: 16px;
+    z-index: -1;
+}
+
+/* A second pseudo-element creates the outer negative space curve */
+.variant-rounded.sent .bubble::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    right: -10px;
+    width: 10px;
+    height: 20px;
+    background-color: var(--chat-bg);
+    border-bottom-left-radius: 10px;
+    z-index: -1;
+}
+
+
+.variant-rounded.received .bubble {
+    border-bottom-left-radius: 4px;
+}
+
+.variant-rounded.received .bubble::before {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: -8px;
+    width: 20px;
+    height: 20px;
+    background-color: var(--received-bg);
+    border-bottom-right-radius: 16px;
+    z-index: -1;
+}
+
+.variant-rounded.received .bubble::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: -10px;
+    width: 10px;
+    height: 20px;
+    background-color: var(--chat-bg);
+    border-bottom-right-radius: 10px;
+    z-index: -1;
+}
+
+
+/* =========================================
+   Variant 2: Flat Corporate Style
+   ========================================= */
+
+.variant-flat .bubble {
+    border-radius: 8px;
+    /* Uses CSS borders to create a sharp triangle tail */
+}
+
+.variant-flat.sent .bubble {
+    border-top-right-radius: 0;
+}
+
+.variant-flat.sent .bubble::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    right: -8px;
+    border-top: 10px solid var(--sent-bg);
+    border-right: 8px solid transparent;
+}
+
+.variant-flat.received .bubble {
+    border-top-left-radius: 0;
+}
+
+.variant-flat.received .bubble::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: -8px;
+    border-top: 10px solid var(--received-bg);
+    border-left: 8px solid transparent;
+}
+
+
+/* =========================================
+   Variant 3: Minimal Outlined Style
+   ========================================= */
+
+.variant-minimal .bubble {
+    border-radius: 16px;
+    background-color: transparent !important; /* Override base bg */
+}
+
+.variant-minimal.sent .bubble {
+    color: var(--sent-bg);
+    border: 1.5px solid var(--sent-bg);
+    border-bottom-right-radius: 2px;
+}
+
+.variant-minimal.received .bubble {
+    color: var(--text-primary);
+    border: 1.5px solid var(--received-border);
+    border-bottom-left-radius: 2px;
+}
+
+
+/* =========================================
+   Variant 4: Emoji Only (Jumbo Size)
+   ========================================= */
+
+.variant-emoji .bubble {
+    background-color: transparent !important;
+    padding: 4px;
+    font-size: 3rem;
+    line-height: 1;
+    /* Remove tails */
+}
+.variant-emoji .bubble::before,
+.variant-emoji .bubble::after {
+    display: none;
+}


### PR DESCRIPTION
### Description
This PR introduces a collection of pure CSS chat bubble designs including rounded iOS-style, flat corporate, minimal outlined, and oversized emoji variants, built entirely without JavaScript or external SVGs, resolving issue #68399.

### Changes Made:
- Added `submissions/examples/css-chat-bubble-variants-pure/` directory.
- Created `demo.html` showcasing the HTML structure containing the various bubble variants and their sent/received states.
- Created `style.css` featuring the UI mechanics:
  - **CSS Shapes for Tails**: The most complex variant (the rounded iOS style) creates its smooth, curved tail using a combination of `border-radius` and pseudo-elements. 
    - `::before` is positioned at the bottom corner and colored to match the bubble, creating the bulk of the tail.
    - `::after` is positioned over the `::before` element and colored to match the *background* of the chat interface, carving out a curved negative space to create the final sharp tip.
  - **Flat Triangles**: The flat corporate variant uses a simpler technique, utilizing transparent CSS borders on a `::before` pseudo-element to draw a sharp triangle attached to the top corner of the bubble.
  - **Variant Classes**: The CSS is architected using a base `.bubble` class for shared typography and padding, with specific modifier classes (`.variant-rounded`, `.variant-flat`, `.variant-minimal`) handling the unique tail and border stylings.
  - **Theming & Dark Mode Supported**: Utilizes CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), generating a sleek dark mode UI with adjusted bubble colors for optimal contrast.
- Added `README.md` documenting usage and the technical mechanics of the CSS Shapes techniques.
- Fully accessible semantic structure. Uses standard HTML flow and explicit `aria-label` tags for the emoji-only bubbles so screen readers can interpret the icons correctly.

Closes #68399
