### PR TITLE
Add ease-digital-piano-keys component

### DIFF
--- a/submissions/examples/digital-piano-keys-ij/README.md
+++ b/submissions/examples/digital-piano-keys-ij/README.md
@@ -1,0 +1,11 @@
+# ease-digital-piano-keys
+
+A digital piano where the keys press, the sustain blinks, and the tempo ticks.
+
+## Run
+Open `demo.html` directly in a browser to watch the piano.
+
+## Notes
+- The piano keys press in sequence.
+- The sustain LED blinks.
+- The tempo readout ticks.

--- a/submissions/examples/digital-piano-keys-ij/demo.html
+++ b/submissions/examples/digital-piano-keys-ij/demo.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-digital-piano-keys demo</title>
+</head>
+<body>
+<div class="dpk-piano">
+  <div class="dpk-led"><span class="dpk-sustain">SUSTAIN</span><b class="dpk-tempo">96 BPM</b></div>
+  <div class="dpk-keys">
+    <i class="dpk-key"></i><i class="dpk-black"></i><i class="dpk-key"></i><i class="dpk-black"></i><i class="dpk-key"></i><i class="dpk-key"></i><i class="dpk-black"></i><i class="dpk-key"></i><i class="dpk-black"></i><i class="dpk-key"></i><i class="dpk-black"></i><i class="dpk-key"></i>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/digital-piano-keys-ij/style.css
+++ b/submissions/examples/digital-piano-keys-ij/style.css
@@ -1,0 +1,22 @@
+.dpk-piano{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:360px;background:#0c1220;border:2px solid #2c3f6a;border-radius:12px;padding:16px;display:flex;flex-direction:column;gap:12px}
+.dpk-led{display:flex;justify-content:space-between;align-items:center}
+.dpk-sustain{font-size:9px;font-weight:800;letter-spacing:2px;color:#7cebb0;border:1px solid #1f5c43;border-radius:10px;padding:3px 8px;animation:dpk-sustain-blink-digital-piano-keys 2s ease-in-out infinite}
+.dpk-tempo{font-size:12px;font-weight:800;color:#f5c542;font-family:"Courier New",monospace;animation:dpk-tempo-tick-digital-piano-keys 1.4s ease-in-out infinite}
+.dpk-keys{position:relative;height:120px;display:flex}
+.dpk-key{flex:1;background:#f4f0ff;border:1px solid #8a93a6;border-radius:0 0 6px 6px;margin-right:2px;animation:dpk-key-press-digital-piano-keys 2.4s ease-in-out infinite}
+.dpk-key:last-child{margin-right:0}
+.dpk-key:nth-child(3){animation-delay:0.4s}
+.dpk-key:nth-child(5){animation-delay:0.8s}
+.dpk-key:nth-child(6){animation-delay:1.2s}
+.dpk-key:nth-child(8){animation-delay:1.6s}
+.dpk-key:nth-child(10){animation-delay:2s}
+.dpk-key:nth-child(12){animation-delay:2.4s}
+.dpk-black{position:absolute;top:0;width:16px;height:72px;background:#1c2333;border-radius:0 0 4px 4px;z-index:2}
+.dpk-black:nth-child(2){left:22px}
+.dpk-black:nth-child(4){left:76px}
+.dpk-black:nth-child(7){left:130px}
+.dpk-black:nth-child(9){left:184px}
+.dpk-black:nth-child(11){left:238px}
+@keyframes dpk-key-press-digital-piano-keys{0%,70%{transform:translateY(0);background:#f4f0ff}80%{transform:translateY(4px);background:#cfd6e6}100%{transform:translateY(0);background:#f4f0ff}}
+@keyframes dpk-sustain-blink-digital-piano-keys{0%{box-shadow:0 0 0 0 rgba(124,235,176,0)}50%{box-shadow:0 0 8px rgba(124,235,176,0.5)}100%{box-shadow:0 0 0 0 rgba(124,235,176,0)}}
+@keyframes dpk-tempo-tick-digital-piano-keys{0%{opacity:0.6}50%{opacity:1}100%{opacity:0.6}}


### PR DESCRIPTION
## Component: ease-digital-piano-keys — keys press, sustain blinks, and tempo ticks

**Closes #69980**

### What this adds
A digital piano: the keys press down in sequence, the sustain LED blinks, and the tempo readout ticks.

### Acceptance Criteria covered
- Piano keys press in sequence
- Sustain LED blinks
- Tempo readout ticks

### Files
- `submissions/examples/digital-piano-keys-ij/demo.html`
- `submissions/examples/digital-piano-keys-ij/style.css`
- `submissions/examples/digital-piano-keys-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the keys press, the sustain LED blink, and the tempo tick.