### PR TITLE
feat: add pure CSS Redacted Text Effect component (#68490)

### DIFF
--- a/submissions/examples/css-redacted-text-effect-pure/README.md
+++ b/submissions/examples/css-redacted-text-effect-pure/README.md
@@ -1,0 +1,18 @@
+# CSS Redacted Text Effect
+
+A pure CSS interaction simulating classified documents. Sensitive text is blacked out by default to mimic a heavy marker, and smoothly revealed upon hover or keyboard focus. Built entirely without JavaScript.
+
+## Features
+- Pure CSS and HTML (Zero JavaScript required for state management or CSS class toggling).
+- **Theming & Dark Mode**: Utilizes CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), generating a sleek dark mode UI where the redaction marker remains deeply black/dark to maintain the physical metaphor.
+- **Component Architecture (Documented in Code)**: 
+  - **Color Matching Technique**: The redaction effect is achieved without complex overlays or pseudo-elements. The background of the `.redacted` span is set to the marker color (e.g., black). Crucially, the text `color` is also set to that *exact same* marker color, rendering it invisible.
+  - **The Reveal**: On `:hover` or `:focus-visible`, we simply transition the text `color` to a contrasting color (e.g., white), leaving the background black. This creates a smooth fade-in reveal effect over the dark background block.
+- Fully accessible semantic structure. The redacted spans use `tabindex="0"` to ensure they are reachable via keyboard navigation. They also utilize `aria-label` to provide context to screen readers ("Redacted text. Hover to reveal."). Honors the `prefers-reduced-motion` accessibility standard by disabling the color fade transition and instantly revealing the text for motion-sensitive users.
+
+## Usage
+Open `demo.html` in your browser. Hover over the blacked-out text blocks, or navigate through them using the `Tab` key, to reveal the hidden classified information.
+
+## Files
+- `demo.html`: The HTML structure containing the simulated document layout and the `.redacted` spans.
+- `style.css`: The styling, CSS Custom Property theming blocks, and the color-matching transition logic.

--- a/submissions/examples/css-redacted-text-effect-pure/demo.html
+++ b/submissions/examples/css-redacted-text-effect-pure/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Redacted Text Effect</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Redacted Text Effect</h1>
+            <p class="subtitle">A pure CSS interaction simulating classified documents. Text is blacked out by default and smoothly revealed upon hover or keyboard focus.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <div class="document-panel">
+                <div class="doc-header">
+                    <span class="doc-stamp">TOP SECRET // EYES ONLY</span>
+                    <span class="doc-date">14 OCT 1983</span>
+                </div>
+                
+                <h2 class="doc-title">Incident Report #74-B</h2>
+                
+                <p class="doc-body">
+                    At approximately 0300 hours, operative <span class="redacted" tabindex="0" aria-label="Redacted text. Hover to reveal.">J. Bourne</span> was spotted near the perimeter of the facility located in <span class="redacted" tabindex="0" aria-label="Redacted text. Hover to reveal.">Zurich, Switzerland</span>. 
+                </p>
+                <p class="doc-body">
+                    Security footage indicates that the subject utilized a <span class="redacted" tabindex="0" aria-label="Redacted text. Hover to reveal.">Class 4 override key</span> to bypass the primary firewall. The objective appears to have been the retrieval of the <span class="redacted" tabindex="0" aria-label="Redacted text. Hover to reveal.">Treadstone project files</span>, which were heavily encrypted and stored on an offline mainframe.
+                </p>
+                <p class="doc-body">
+                    Current whereabouts are <span class="redacted" tabindex="0" aria-label="Redacted text. Hover to reveal.">unknown, presumed armed and extremely dangerous</span>. Immediate action is required to secure remaining assets.
+                </p>
+                
+                <div class="doc-footer">
+                    END OF REPORT
+                </div>
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-redacted-text-effect-pure/style.css
+++ b/submissions/examples/css-redacted-text-effect-pure/style.css
@@ -1,0 +1,190 @@
+@import url('https://fonts.googleapis.com/css2?family=Courier+Prime:ital,wght@0,400;0,700;1,400&family=Inter:wght@400;700&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #e2e8f0;
+    --text-primary: #0f172a;
+    --text-secondary: #475569;
+    
+    --doc-bg: #f8fafc;
+    --doc-border: #cbd5e1;
+    --doc-text: #1e293b;
+    --doc-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+    
+    /* Redaction Colors */
+    --redact-bg: #0f172a;       /* Black marker color */
+    --redact-text-hidden: #0f172a; /* Same as bg to hide text */
+    --redact-text-reveal: #f8fafc; /* White text when revealed */
+    
+    --stamp-color: #ef4444;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a;
+        --text-primary: #f8fafc;
+        --text-secondary: #94a3b8;
+        
+        --doc-bg: #1e293b;
+        --doc-border: #334155;
+        --doc-text: #cbd5e1;
+        --doc-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.4), 0 10px 10px -5px rgba(0, 0, 0, 0.2);
+        
+        /* In dark mode, redaction is still black/very dark to look like a marker */
+        --redact-bg: #020617; 
+        --redact-text-hidden: #020617;
+        --redact-text-reveal: #f8fafc;
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 60px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    padding: 20px 0;
+}
+
+
+/* =========================================
+   Document Layout (Mockup)
+   ========================================= */
+
+.document-panel {
+    background-color: var(--doc-bg);
+    border: 1px solid var(--doc-border);
+    padding: 40px;
+    box-shadow: var(--doc-shadow);
+    width: 100%;
+    max-width: 600px;
+    /* Use a typewriter font for the document feel */
+    font-family: 'Courier Prime', monospace;
+    color: var(--doc-text);
+}
+
+.doc-header {
+    display: flex;
+    justify-content: space-between;
+    border-bottom: 2px solid var(--doc-border);
+    padding-bottom: 20px;
+    margin-bottom: 30px;
+}
+
+.doc-stamp {
+    color: var(--stamp-color);
+    font-weight: 700;
+    font-size: 1.1rem;
+    letter-spacing: 1px;
+    /* Simulate a slight rotation of a hand stamp */
+    transform: rotate(-2deg);
+    display: inline-block;
+}
+
+.doc-date {
+    font-weight: 700;
+}
+
+.doc-title {
+    margin: 0 0 24px 0;
+    font-size: 1.5rem;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.doc-body {
+    font-size: 1.05rem;
+    line-height: 1.8;
+    margin: 0 0 20px 0;
+}
+
+.doc-footer {
+    text-align: center;
+    margin-top: 40px;
+    padding-top: 20px;
+    border-top: 1px dashed var(--doc-border);
+    font-weight: 700;
+    letter-spacing: 2px;
+}
+
+
+/* =========================================
+   [TECHNIQUE] The Redacted Effect
+   ========================================= */
+
+.redacted {
+    /* Set background to black (marker color) */
+    background-color: var(--redact-bg);
+    /* Set text to match background color to hide it completely */
+    color: var(--redact-text-hidden);
+    
+    padding: 0 4px;
+    border-radius: 2px;
+    cursor: help;
+    
+    /* 
+      We only transition the color property.
+      Background stays black, text fades from black to white.
+    */
+    transition: color 0.3s ease;
+    
+    /* Slight variation to make it look like a physical marker block */
+    box-shadow: inset 0 0 0 1px rgba(0,0,0,0.1);
+}
+
+/* 
+  The Reveal Interaction:
+  When hovered or focused via keyboard, change the text color to white.
+*/
+.redacted:hover,
+.redacted:focus-visible {
+    color: var(--redact-text-reveal);
+    outline: none; /* Custom focus handling below */
+}
+
+/* Keyboard focus specific styling for accessibility */
+.redacted:focus-visible {
+    box-shadow: 0 0 0 2px var(--bg-base), 0 0 0 4px var(--stamp-color);
+}
+
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .redacted {
+        transition: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a pure CSS interaction simulating classified documents. Sensitive text is blacked out by default to mimic a heavy marker, and smoothly revealed upon hover or keyboard focus, built entirely without JavaScript, resolving issue #68490.

### Changes Made:
- Added `submissions/examples/css-redacted-text-effect-pure/` directory.
- Created `demo.html` showcasing the HTML structure containing the simulated document layout and the `.redacted` spans.
- Created `style.css` featuring the UI mechanics:
  - **Color Matching Technique**: The redaction effect is achieved without complex overlays or pseudo-elements. The background of the `.redacted` span is set to the marker color (e.g., black). Crucially, the text `color` is also set to that *exact same* marker color, rendering it invisible.
  - **The Reveal**: On `:hover` or `:focus-visible`, we simply transition the text `color` to a contrasting color (e.g., white), leaving the background black. This creates a smooth fade-in reveal effect over the dark background block.
  - **Theming & Dark Mode Supported**: Utilizes CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), generating a sleek dark mode UI where the redaction marker remains deeply black/dark to maintain the physical metaphor.
- Added `README.md` documenting usage and the technical mechanics of the color-matching transition logic.
- Fully accessible semantic structure. The redacted spans use `tabindex="0"` to ensure they are reachable via keyboard navigation. They also utilize `aria-label` to provide context to screen readers ("Redacted text. Hover to reveal."). Honors the `prefers-reduced-motion` accessibility standard by disabling the color fade transition and instantly revealing the text for motion-sensitive users.

Closes #68490
