### PR TITLE
Add ease-gps-navigation-prompt component

### DIFF
--- a/submissions/examples/gps-navigation-prompt-ij/README.md
+++ b/submissions/examples/gps-navigation-prompt-ij/README.md
@@ -1,0 +1,11 @@
+# ease-gps-navigation-prompt
+
+A GPS navigation prompt where the arrow turns, the distance ticks, and the ETA blinks.
+
+## Run
+Open `demo.html` directly in a browser to watch the prompt.
+
+## Notes
+- The turn arrow rotates on the map.
+- The distance readout ticks down.
+- The ETA label blinks.

--- a/submissions/examples/gps-navigation-prompt-ij/demo.html
+++ b/submissions/examples/gps-navigation-prompt-ij/demo.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-gps-navigation-prompt demo</title>
+</head>
+<body>
+<div class="gnp-nav">
+  <div class="gnp-map">
+    <i class="gnp-road gnp-road-h"></i>
+    <i class="gnp-road gnp-road-v"></i>
+    <span class="gnp-arrow"></span>
+    <i class="gnp-pin"></i>
+  </div>
+  <div class="gnp-bar"><b class="gnp-dist">2.4 KM</b><span class="gnp-eta">ETA 08:15</span></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/gps-navigation-prompt-ij/style.css
+++ b/submissions/examples/gps-navigation-prompt-ij/style.css
@@ -1,0 +1,13 @@
+.gnp-nav{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:340px;background:#0d1624;border:2px solid #1e3350;border-radius:14px;padding:16px;display:flex;flex-direction:column;gap:12px}
+.gnp-map{position:relative;height:200px;background:linear-gradient(180deg,#0f2a2f,#0d1624);border-radius:10px;overflow:hidden}
+.gnp-road-h{position:absolute;left:0;right:0;top:50%;height:22px;background:#1e3350;transform:translateY(-50%)}
+.gnp-road-v{position:absolute;top:0;bottom:0;left:50%;width:22px;background:#1e3350;transform:translateX(-50%)}
+.gnp-arrow{position:absolute;left:32%;top:34%;width:0;height:0;border-left:10px solid transparent;border-right:10px solid transparent;border-bottom:22px solid #ffd23f;transform-origin:50% 100%;animation:gnp-arrow-turn-gps-navigation-prompt 3s ease-in-out infinite}
+.gnp-pin{position:absolute;right:24%;bottom:18%;width:12px;height:12px;border-radius:50% 50% 50% 0;background:#ff5e3a;transform:rotate(-45deg);animation:gnp-pin-pulse-gps-navigation-prompt 1.8s ease-in-out infinite}
+.gnp-bar{display:flex;justify-content:space-between;align-items:center}
+.gnp-dist{font-size:15px;font-weight:800;color:#7cebb0;font-family:"Courier New",monospace;animation:gnp-dist-tick-gps-navigation-prompt 1.4s ease-in-out infinite}
+.gnp-eta{font-size:10px;font-weight:800;letter-spacing:2px;color:#f5c542;border:1px solid #4a3c14;border-radius:12px;padding:4px 10px;animation:gnp-eta-blink-gps-navigation-prompt 1.8s ease-in-out infinite}
+@keyframes gnp-arrow-turn-gps-navigation-prompt{0%,100%{transform:rotate(-28deg)}50%{transform:rotate(22deg)}}
+@keyframes gnp-dist-tick-gps-navigation-prompt{0%{opacity:0.7}50%{opacity:1}100%{opacity:0.7}}
+@keyframes gnp-eta-blink-gps-navigation-prompt{0%{box-shadow:0 0 0 0 rgba(255,210,63,0)}50%{box-shadow:0 0 10px rgba(255,210,63,0.4)}100%{box-shadow:0 0 0 0 rgba(255,210,63,0)}}
+@keyframes gnp-pin-pulse-gps-navigation-prompt{0%,100%{transform:rotate(-45deg) scale(1)}50%{transform:rotate(-45deg) scale(1.2)}}


### PR DESCRIPTION
## Component: ease-gps-navigation-prompt — arrow turns, distance ticks, and ETA blinks

**Closes #69992**

### What this adds
A GPS navigation prompt: the turn arrow rotates on the map, the distance readout ticks down, and the ETA blinks.

### Acceptance Criteria covered
- Turn arrow rotates on the map
- Distance readout ticks down
- ETA label blinks

### Files
- `submissions/examples/gps-navigation-prompt-ij/demo.html`
- `submissions/examples/gps-navigation-prompt-ij/style.css`
- `submissions/examples/gps-navigation-prompt-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the arrow turn, the distance tick, and the ETA blink.