### PR TITLE
feat: add CSS inline tag chip

### DIFF
--- a/submissions/examples/r-inline-tag-chip-68375/README.md
+++ b/submissions/examples/r-inline-tag-chip-68375/README.md
@@ -1,0 +1,57 @@
+# CSS Inline Tag / Chip
+
+A responsive pure CSS inline tag and chip component with removable controls
+and multiple color variants.
+
+## Features
+
+- Pure HTML and CSS
+- Pill-shaped inline tags
+- Remove button for each tag
+- Blue, purple, green, orange, and pink variants
+- Responsive wrapping layout
+- Hover interaction
+- Keyboard-accessible remove buttons
+- Visible `:focus-visible` states
+- `prefers-reduced-motion` support
+- Forced-colors support
+- No external dependencies
+
+## Files
+
+- `demo.html` — Component markup and demo
+- `style.css` — Component styling
+- `README.md` — Documentation
+
+## Usage
+
+Open `demo.html` directly in a modern browser.
+
+The example demonstrates several tag variants:
+
+- Design
+- Development
+- Accessibility
+- Animation
+- CSS
+
+Each chip includes a button with an accessible label for removing the tag.
+
+## Accessibility
+
+The component uses:
+
+- Semantic `<button>` elements for remove controls
+- Descriptive `aria-label` values
+- `:focus-visible` styles for keyboard users
+- Responsive layout
+- `prefers-reduced-motion` support
+- `forced-colors` support
+
+The remove buttons are keyboard accessible using the standard Tab
+navigation.
+
+## Browser Support
+
+Works in modern browsers supporting CSS flexbox, transitions, media queries,
+and standard accessibility features.

--- a/submissions/examples/r-inline-tag-chip-68375/demo.html
+++ b/submissions/examples/r-inline-tag-chip-68375/demo.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta
+    name="description"
+    content="Accessible CSS inline tag and chip collection"
+  >
+  <title>CSS Inline Tag &amp; Chip</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+  <main class="page">
+    <section class="tag-panel" aria-labelledby="tag-title">
+      <div class="heading">
+        <p class="eyebrow">UI Components</p>
+        <h1 id="tag-title">Inline Tags &amp; Chips</h1>
+        <p>
+          Flexible pill-shaped labels with color variants and accessible
+          remove controls.
+        </p>
+      </div>
+
+      <div class="tag-group" aria-label="Selected filters">
+        <span class="tag tag-blue">
+          Design
+          <button
+            type="button"
+            class="tag-remove"
+            aria-label="Remove Design tag"
+          >
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </span>
+
+        <span class="tag tag-purple">
+          Development
+          <button
+            type="button"
+            class="tag-remove"
+            aria-label="Remove Development tag"
+          >
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </span>
+
+        <span class="tag tag-green">
+          Accessibility
+          <button
+            type="button"
+            class="tag-remove"
+            aria-label="Remove Accessibility tag"
+          >
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </span>
+
+        <span class="tag tag-orange">
+          Animation
+          <button
+            type="button"
+            class="tag-remove"
+            aria-label="Remove Animation tag"
+          >
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </span>
+
+        <span class="tag tag-pink">
+          CSS
+          <button
+            type="button"
+            class="tag-remove"
+            aria-label="Remove CSS tag"
+          >
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </span>
+      </div>
+
+      <div class="variant-section">
+        <h2>Color Variants</h2>
+
+        <div class="tag-group" aria-label="Tag color variants">
+          <span class="tag tag-blue">
+            Blue
+            <button
+              type="button"
+              class="tag-remove"
+              aria-label="Remove Blue tag"
+            >
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </span>
+
+          <span class="tag tag-purple">
+            Purple
+            <button
+              type="button"
+              class="tag-remove"
+              aria-label="Remove Purple tag"
+            >
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </span>
+
+          <span class="tag tag-green">
+            Green
+            <button
+              type="button"
+              class="tag-remove"
+              aria-label="Remove Green tag"
+            >
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </span>
+
+          <span class="tag tag-orange">
+            Orange
+            <button
+              type="button"
+              class="tag-remove"
+              aria-label="Remove Orange tag"
+            >
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </span>
+
+          <span class="tag tag-pink">
+            Pink
+            <button
+              type="button"
+              class="tag-remove"
+              aria-label="Remove Pink tag"
+            >
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </span>
+        </div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/r-inline-tag-chip-68375/style.css
+++ b/submissions/examples/r-inline-tag-chip-68375/style.css
@@ -1,0 +1,506 @@
+:root {
+  --page-bg: #0b1020;
+  --panel: #121a2e;
+  --panel-border: rgba(255, 255, 255, 0.1);
+  --text: #f8fafc;
+  --muted: #a8b1c2;
+
+  --blue-bg: rgba(59, 130, 246, 0.16);
+  --blue-border: rgba(96, 165, 250, 0.42);
+  --blue-text: #bfdbfe;
+
+  --purple-bg: rgba(139, 92, 246, 0.16);
+  --purple-border: rgba(167, 139, 250, 0.42);
+  --purple-text: #ddd6fe;
+
+  --green-bg: rgba(34, 197, 94, 0.16);
+  --green-border: rgba(74, 222, 128, 0.42);
+  --green-text: #bbf7d0;
+
+  --orange-bg: rgba(249, 115, 22, 0.16);
+  --orange-border: rgba(251, 146, 60, 0.42);
+  --orange-text: #fed7aa;
+
+  --pink-bg: rgba(236, 72, 153, 0.16);
+  --pink-border: rgba(244, 114, 182, 0.42);
+  --pink-text: #fbcfe8;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  color: var(--text);
+  background:
+    radial-gradient(
+      circle at 15% 15%,
+      rgba(99, 102, 241, 0.16),
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at 85% 85%,
+      rgba(236, 72, 153, 0.1),
+      transparent 30%
+    ),
+    var(--page-bg);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.page {
+  width: min(100%, 900px);
+}
+
+.tag-panel {
+  padding: clamp(24px, 5vw, 48px);
+  border: 1px solid var(--panel-border);
+  border-radius: 28px;
+  background:
+    linear-gradient(
+      145deg,
+      rgba(255, 255, 255, 0.06),
+      rgba(255, 255, 255, 0.015)
+    ),
+    var(--panel);
+  box-shadow:
+    0 30px 80px rgba(0, 0, 0, 0.4),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.heading {
+  margin-bottom: 32px;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: #a5b4fc;
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+h1,
+h2 {
+  margin: 0;
+  letter-spacing: -0.03em;
+}
+
+h1 {
+  font-size: clamp(2rem, 5vw, 3.2rem);
+  line-height: 1.05;
+}
+
+.heading > p:last-child {
+  max-width: 650px;
+  margin: 16px 0 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.tag-group {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 38px;
+  padding: 6px 8px 6px 14px;
+  border: 1px solid;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  font-weight: 700;
+  line-height: 1;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    border-color 180ms ease;
+}
+
+.tag:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
+}
+
+.tag-blue {
+  color: var(--blue-text);
+  background: var(--blue-bg);
+  border-color: var(--blue-border);
+}
+
+.tag-purple {
+  color: var(--purple-text);
+  background: var(--purple-bg);
+  border-color: var(--purple-border);
+}
+
+.tag-green {
+  color: var(--green-text);
+  background: var(--green-bg);
+  border-color: var(--green-border);
+}
+
+.tag-orange {
+  color: var(--orange-text);
+  background: var(--orange-bg);
+  border-color: var(--orange-border);
+}
+
+.tag-pink {
+  color: var(--pink-text);
+  background: var(--pink-bg);
+  border-color: var(--pink-border);
+}
+
+.tag-remove {
+  width: 24px;
+  height: 24px;
+  display: grid;
+  place-items: center;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  color: currentColor;
+  background: rgba(255, 255, 255, 0.08);
+  cursor: pointer;
+  font: inherit;
+  transition:
+    background 160ms ease,
+    transform 160ms ease;
+}
+
+.tag-remove:hover {
+  background: rgba(255, 255, 255, 0.18);
+  transform: scale(1.08);
+}
+
+.tag-remove:focus-visible {
+  outline: 3px solid #fff;
+  outline-offset: 3px;
+}
+
+.tag-remove span {
+  display: block;
+  margin-top: -1px;
+  font-size: 1.15rem;
+  font-weight: 400;
+  line-height: 1;
+}
+
+.variant-section {
+  margin-top: 42px;
+  padding-top: 28px;
+  border-top: 1px solid var(--panel-border);
+}
+
+h2 {
+  margin-bottom: 18px;
+  font-size: 1.15rem;
+}
+
+@media (max-width: 600px) {
+  body {
+    padding: 12px;
+  }
+
+  .tag-panel {
+    padding: 26px 20px;
+    border-radius: 20px;
+  }
+
+  .tag {
+    min-height: 36px;
+    font-size: 0.85rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+@media (forced-colors: active) {
+  .tag,
+  .tag-remove {
+    border-color: CanvasText;
+  }
+
+  .tag-remove:focus-visible {
+    outline-color: Highlight;
+  }
+}
+:root {
+  --page-bg: #0b1020;
+  --panel: #121a2e;
+  --panel-border: rgba(255, 255, 255, 0.1);
+  --text: #f8fafc;
+  --muted: #a8b1c2;
+
+  --blue-bg: rgba(59, 130, 246, 0.16);
+  --blue-border: rgba(96, 165, 250, 0.42);
+  --blue-text: #bfdbfe;
+
+  --purple-bg: rgba(139, 92, 246, 0.16);
+  --purple-border: rgba(167, 139, 250, 0.42);
+  --purple-text: #ddd6fe;
+
+  --green-bg: rgba(34, 197, 94, 0.16);
+  --green-border: rgba(74, 222, 128, 0.42);
+  --green-text: #bbf7d0;
+
+  --orange-bg: rgba(249, 115, 22, 0.16);
+  --orange-border: rgba(251, 146, 60, 0.42);
+  --orange-text: #fed7aa;
+
+  --pink-bg: rgba(236, 72, 153, 0.16);
+  --pink-border: rgba(244, 114, 182, 0.42);
+  --pink-text: #fbcfe8;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  color: var(--text);
+  background:
+    radial-gradient(
+      circle at 15% 15%,
+      rgba(99, 102, 241, 0.16),
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at 85% 85%,
+      rgba(236, 72, 153, 0.1),
+      transparent 30%
+    ),
+    var(--page-bg);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.page {
+  width: min(100%, 900px);
+}
+
+.tag-panel {
+  padding: clamp(24px, 5vw, 48px);
+  border: 1px solid var(--panel-border);
+  border-radius: 28px;
+  background:
+    linear-gradient(
+      145deg,
+      rgba(255, 255, 255, 0.06),
+      rgba(255, 255, 255, 0.015)
+    ),
+    var(--panel);
+  box-shadow:
+    0 30px 80px rgba(0, 0, 0, 0.4),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.heading {
+  margin-bottom: 32px;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: #a5b4fc;
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+h1,
+h2 {
+  margin: 0;
+  letter-spacing: -0.03em;
+}
+
+h1 {
+  font-size: clamp(2rem, 5vw, 3.2rem);
+  line-height: 1.05;
+}
+
+.heading > p:last-child {
+  max-width: 650px;
+  margin: 16px 0 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.tag-group {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 38px;
+  padding: 6px 8px 6px 14px;
+  border: 1px solid;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  font-weight: 700;
+  line-height: 1;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    border-color 180ms ease;
+}
+
+.tag:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
+}
+
+.tag-blue {
+  color: var(--blue-text);
+  background: var(--blue-bg);
+  border-color: var(--blue-border);
+}
+
+.tag-purple {
+  color: var(--purple-text);
+  background: var(--purple-bg);
+  border-color: var(--purple-border);
+}
+
+.tag-green {
+  color: var(--green-text);
+  background: var(--green-bg);
+  border-color: var(--green-border);
+}
+
+.tag-orange {
+  color: var(--orange-text);
+  background: var(--orange-bg);
+  border-color: var(--orange-border);
+}
+
+.tag-pink {
+  color: var(--pink-text);
+  background: var(--pink-bg);
+  border-color: var(--pink-border);
+}
+
+.tag-remove {
+  width: 24px;
+  height: 24px;
+  display: grid;
+  place-items: center;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  color: currentColor;
+  background: rgba(255, 255, 255, 0.08);
+  cursor: pointer;
+  font: inherit;
+  transition:
+    background 160ms ease,
+    transform 160ms ease;
+}
+
+.tag-remove:hover {
+  background: rgba(255, 255, 255, 0.18);
+  transform: scale(1.08);
+}
+
+.tag-remove:focus-visible {
+  outline: 3px solid #fff;
+  outline-offset: 3px;
+}
+
+.tag-remove span {
+  display: block;
+  margin-top: -1px;
+  font-size: 1.15rem;
+  font-weight: 400;
+  line-height: 1;
+}
+
+.variant-section {
+  margin-top: 42px;
+  padding-top: 28px;
+  border-top: 1px solid var(--panel-border);
+}
+
+h2 {
+  margin-bottom: 18px;
+  font-size: 1.15rem;
+}
+
+@media (max-width: 600px) {
+  body {
+    padding: 12px;
+  }
+
+  .tag-panel {
+    padding: 26px 20px;
+    border-radius: 20px;
+  }
+
+  .tag {
+    min-height: 36px;
+    font-size: 0.85rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+@media (forced-colors: active) {
+  .tag,
+  .tag-remove {
+    border-color: CanvasText;
+  }
+
+  .tag-remove:focus-visible {
+    outline-color: Highlight;
+  }
+}


### PR DESCRIPTION
## Description

Adds a pure CSS **Inline Tag / Chip** component with removable controls and multiple color variants.

### Features

* Pure HTML and CSS implementation
* Pill-shaped inline tags
* Removable tag controls
* Multiple color variants
* Responsive wrapping layout
* Smooth hover interactions
* Keyboard-accessible remove buttons
* Visible `:focus-visible` states
* `prefers-reduced-motion` support
* Forced-colors support
* No JavaScript or external dependencies

### Files Added

* `submissions/examples/r-inline-tag-chip-68375/demo.html`
* `submissions/examples/r-inline-tag-chip-68375/style.css`
* `submissions/examples/r-inline-tag-chip-68375/README.md`

### Testing

* Verified the component in a modern browser
* Checked responsive behavior
* Verified all tag color variants
* Verified hover interactions
* Verified keyboard focus states
* Verified accessible remove-button labels
* Verified reduced-motion behavior
* Verified forced-colors behavior
* Ran `git diff --check`

### Related Issue

Closes #68375
