### PR TITLE
feat: add iridescent holographic card deck component for GSSoC 2026

### DIFF
--- a/submissions/examples/gssoc-2026-iridescent-holographic-card-deck-bb/README.md
+++ b/submissions/examples/gssoc-2026-iridescent-holographic-card-deck-bb/README.md
@@ -1,0 +1,12 @@
+# Iridescent Holographic Card Deck - GSSoC 2026
+
+An iridescent holographic card deck component with stacked glassmorphic layers and light reflection shimmer animations.
+
+## 1. What does this do?
+It displays a stacked deck of futuristic cards that fan out in 3D space with an iridescent light gleam sweep upon hover.
+
+## 2. How is it used?
+Link `style.css` in your HTML document and copy `.deck-container` with its child `.holo-card` elements.
+
+## 3. Why is it useful?
+It provides interactive visual flair for Web3 passes, feature tiers, and credit card portfolio showcases.

--- a/submissions/examples/gssoc-2026-iridescent-holographic-card-deck-bb/demo.html
+++ b/submissions/examples/gssoc-2026-iridescent-holographic-card-deck-bb/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Iridescent Holographic Card Deck | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@500;700;800&display=swap" rel="stylesheet">
+</head>
+<body>
+  <div class="deck-container">
+    <div class="holo-card card-1">
+      <div class="holo-shimmer"></div>
+      <div class="card-content">
+        <span class="chip">PASS #01</span>
+        <h2>Quantum Access</h2>
+        <p>Tier 1 Encryption Key</p>
+      </div>
+    </div>
+    <div class="holo-card card-2">
+      <div class="holo-shimmer"></div>
+      <div class="card-content">
+        <span class="chip">PASS #02</span>
+        <h2>Cyber Nexus</h2>
+        <p>Neural Mesh Gateway</p>
+      </div>
+    </div>
+    <div class="holo-card card-3">
+      <div class="holo-shimmer"></div>
+      <div class="card-content">
+        <span class="chip">PASS #03</span>
+        <h2>Aether Vault</h2>
+        <p>Holographic Storage</p>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/gssoc-2026-iridescent-holographic-card-deck-bb/style.css
+++ b/submissions/examples/gssoc-2026-iridescent-holographic-card-deck-bb/style.css
@@ -1,0 +1,123 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  background-color: #030712;
+  color: #f9fafb;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+}
+
+.deck-container {
+  position: relative;
+  width: 320px;
+  height: 420px;
+  perspective: 1000px;
+}
+
+.holo-card {
+  position: absolute;
+  inset: 0;
+  border-radius: 20px;
+  padding: 2rem;
+  background: rgba(17, 24, 39, 0.7);
+  backdrop-filter: blur(16px);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  box-shadow: 0 15px 35px rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+  transition: transform 0.6s cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 0.6s ease;
+  cursor: pointer;
+}
+
+.holo-shimmer {
+  position: absolute;
+  top: -50%;
+  left: -50%;
+  width: 200%;
+  height: 200%;
+  background: linear-gradient(
+    115deg,
+    transparent 20%,
+    rgba(255, 0, 128, 0.2) 35%,
+    rgba(0, 255, 255, 0.3) 50%,
+    rgba(255, 255, 0, 0.2) 65%,
+    transparent 80%
+  );
+  transform: rotate(-30deg) translateY(-100%);
+  transition: transform 0.8s ease;
+  pointer-events: none;
+}
+
+.card-1 {
+  transform: translateY(0) scale(1) rotate(0deg);
+  z-index: 3;
+}
+
+.card-2 {
+  transform: translateY(20px) scale(0.94) rotate(-4deg);
+  z-index: 2;
+  opacity: 0.85;
+}
+
+.card-3 {
+  transform: translateY(40px) scale(0.88) rotate(4deg);
+  z-index: 1;
+  opacity: 0.7;
+}
+
+/* Hover Stagger Deck Expansion */
+.deck-container:hover .card-1 {
+  transform: translateY(-40px) scale(1.02) rotate(-6deg);
+  box-shadow: 0 25px 50px rgba(0, 255, 255, 0.25);
+}
+
+.deck-container:hover .card-2 {
+  transform: translateY(10px) scale(0.98) rotate(0deg);
+  opacity: 0.95;
+}
+
+.deck-container:hover .card-3 {
+  transform: translateY(60px) scale(0.94) rotate(6deg);
+  opacity: 0.9;
+}
+
+.holo-card:hover .holo-shimmer {
+  transform: rotate(-30deg) translateY(100%);
+}
+
+.card-content {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.chip {
+  align-self: flex-start;
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 1px;
+  padding: 0.35rem 0.75rem;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 6px;
+  color: #38bdf8;
+  border: 1px solid rgba(56, 189, 248, 0.3);
+}
+
+.card-content h2 {
+  font-size: 1.75rem;
+  font-weight: 800;
+  line-height: 1.2;
+}
+
+.card-content p {
+  font-size: 0.9rem;
+  color: #9ca3af;
+}


### PR DESCRIPTION
# Related Issue
Closes #69997

# Summary
Adds an iridescent holographic card deck component with stacked glassmorphic layers and light reflection shimmer animations.

# Changes Made
- Created `submissions/examples/gssoc-2026-iridescent-holographic-card-deck-bb/demo.html`
- Created `submissions/examples/gssoc-2026-iridescent-holographic-card-deck-bb/style.css`
- Created `submissions/examples/gssoc-2026-iridescent-holographic-card-deck-bb/README.md`

# Testing
- Tested staggered card fanning and light sweep animations across devices.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No existing repository files modified
