### PR TITLE
feat: add CSS focus ring utility

### DIFF
--- a/submissions/examples/r-focus-ring-utility-68372/README.md
+++ b/submissions/examples/r-focus-ring-utility-68372/README.md
@@ -1,0 +1,34 @@
+# CSS Focus Ring Utility
+
+A responsive and accessible pure CSS focus ring utility for interactive
+elements such as links, buttons, inputs, and form controls.
+
+## Features
+
+- Pure CSS implementation
+- No JavaScript required
+- Uses `:focus-visible` for keyboard-friendly focus states
+- Customizable focus ring colors
+- Multiple color variants
+- Animated focus ring transition
+- Responsive design
+- Works with buttons, links, inputs, and form controls
+- Visible keyboard focus
+- `prefers-reduced-motion` support
+- Forced-colors support
+- No external dependencies
+
+## Files
+
+- `demo.html` — Component demonstration and examples
+- `style.css` — Focus ring utility styles
+- `README.md` — Documentation
+
+## Usage
+
+Add the base utility class to an interactive element:
+
+```html
+<button class="focus-ring">
+  Submit
+</button>

--- a/submissions/examples/r-focus-ring-utility-68372/demo.html
+++ b/submissions/examples/r-focus-ring-utility-68372/demo.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta
+    name="description"
+    content="Accessible CSS focus ring utility demonstration"
+  >
+  <title>CSS Focus Ring Utility</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+  <main class="page">
+    <section class="focus-demo" aria-labelledby="focus-title">
+      <div class="intro">
+        <p class="eyebrow">Accessibility Utility</p>
+
+        <h1 id="focus-title">CSS Focus Ring Utility</h1>
+
+        <p class="description">
+          A customizable pure CSS focus ring utility designed to make
+          keyboard navigation clear, visible, and accessible.
+        </p>
+      </div>
+
+      <div class="demo-card">
+        <h2>Interactive Elements</h2>
+
+        <p class="helper-text">
+          Use the <kbd>Tab</kbd> key to move between the controls and
+          preview the focus ring.
+        </p>
+
+        <div class="controls">
+          <a class="focus-ring focus-blue" href="#primary">
+            Primary Link
+          </a>
+
+          <button class="focus-ring focus-purple" type="button">
+            Purple Focus
+          </button>
+
+          <button class="focus-ring focus-green" type="button">
+            Green Focus
+          </button>
+
+          <button class="focus-ring focus-orange" type="button">
+            Orange Focus
+          </button>
+
+          <button class="focus-ring focus-pink" type="button">
+            Pink Focus
+          </button>
+        </div>
+
+        <div class="form-demo">
+          <label for="demo-input">Example Input</label>
+
+          <input
+            id="demo-input"
+            class="focus-ring focus-blue input"
+            type="text"
+            placeholder="Focus this field"
+          >
+        </div>
+
+        <div class="checkbox-demo">
+          <input
+            id="demo-check"
+            class="focus-ring focus-green"
+            type="checkbox"
+          >
+
+          <label for="demo-check">
+            Enable notifications
+          </label>
+        </div>
+      </div>
+
+      <div class="utility-info">
+        <h2>Utility Classes</h2>
+
+        <div class="code-list">
+          <code>.focus-ring</code>
+          <code>.focus-blue</code>
+          <code>.focus-purple</code>
+          <code>.focus-green</code>
+          <code>.focus-orange</code>
+          <code>.focus-pink</code>
+        </div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/r-focus-ring-utility-68372/style.css
+++ b/submissions/examples/r-focus-ring-utility-68372/style.css
@@ -1,0 +1,780 @@
+:root {
+  --page-bg: #080d1a;
+  --panel-bg: #111827;
+  --panel-border: rgba(255, 255, 255, 0.1);
+
+  --text: #f8fafc;
+  --muted: #aab4c5;
+
+  --blue: #60a5fa;
+  --purple: #a78bfa;
+  --green: #4ade80;
+  --orange: #fb923c;
+  --pink: #f472b6;
+
+  --focus-width: 3px;
+  --focus-offset: 4px;
+  --focus-blur: 0;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  padding: 24px;
+
+  display: grid;
+  place-items: center;
+
+  color: var(--text);
+
+  background:
+    radial-gradient(
+      circle at 15% 15%,
+      rgba(96, 165, 250, 0.14),
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at 85% 80%,
+      rgba(167, 139, 250, 0.12),
+      transparent 30%
+    ),
+    var(--page-bg);
+
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+button,
+input {
+  font: inherit;
+}
+
+.page {
+  width: min(100%, 900px);
+}
+
+.focus-demo {
+  padding: clamp(24px, 5vw, 48px);
+
+  border: 1px solid var(--panel-border);
+  border-radius: 28px;
+
+  background:
+    linear-gradient(
+      145deg,
+      rgba(255, 255, 255, 0.06),
+      rgba(255, 255, 255, 0.015)
+    ),
+    var(--panel-bg);
+
+  box-shadow:
+    0 30px 80px rgba(0, 0, 0, 0.45),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.intro {
+  margin-bottom: 32px;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+
+  color: #93c5fd;
+
+  font-size: 0.75rem;
+  font-weight: 800;
+
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+h1,
+h2 {
+  margin: 0;
+  letter-spacing: -0.03em;
+}
+
+h1 {
+  font-size: clamp(2rem, 5vw, 3.2rem);
+  line-height: 1.05;
+}
+
+h2 {
+  font-size: 1.2rem;
+}
+
+.description {
+  max-width: 680px;
+  margin: 16px 0 0;
+
+  color: var(--muted);
+
+  line-height: 1.7;
+}
+
+.demo-card {
+  padding: 28px;
+
+  border: 1px solid var(--panel-border);
+  border-radius: 20px;
+
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.helper-text {
+  margin: 10px 0 24px;
+
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+kbd {
+  padding: 3px 7px;
+
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-bottom-width: 2px;
+  border-radius: 6px;
+
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+
+  font-size: 0.85em;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+}
+
+.focus-ring {
+  --ring-color: var(--blue);
+
+  position: relative;
+
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  min-height: 44px;
+  padding: 10px 18px;
+
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 12px;
+
+  color: #fff;
+  background: rgba(255, 255, 255, 0.06);
+
+  font-weight: 700;
+  text-decoration: none;
+
+  cursor: pointer;
+
+  transition:
+    transform 180ms ease,
+    background-color 180ms ease,
+    border-color 180ms ease;
+}
+
+.focus-ring:hover {
+  transform: translateY(-2px);
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+.focus-ring:active {
+  transform: translateY(0);
+}
+
+/*
+ * Core Focus Ring Utility
+ *
+ * Uses :focus-visible so the ring is primarily shown
+ * for keyboard navigation instead of every pointer click.
+ */
+.focus-ring:focus-visible {
+  outline: var(--focus-width) solid var(--ring-color);
+  outline-offset: var(--focus-offset);
+
+  box-shadow:
+    0 0 var(--focus-blur) var(--ring-color),
+    0 0 0 calc(var(--focus-width) + 1px)
+      color-mix(in srgb, var(--ring-color) 18%, transparent);
+
+  animation: focus-ring-pulse 900ms ease-out;
+}
+
+.focus-blue {
+  --ring-color: var(--blue);
+}
+
+.focus-purple {
+  --ring-color: var(--purple);
+}
+
+.focus-green {
+  --ring-color: var(--green);
+}
+
+.focus-orange {
+  --ring-color: var(--orange);
+}
+
+.focus-pink {
+  --ring-color: var(--pink);
+}
+
+@keyframes focus-ring-pulse {
+  0% {
+    outline-offset: 2px;
+  }
+
+  100% {
+    outline-offset: var(--focus-offset);
+  }
+}
+
+.form-demo {
+  margin-top: 28px;
+}
+
+.form-demo label {
+  display: block;
+
+  margin-bottom: 9px;
+
+  color: #dbeafe;
+
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.input {
+  width: 100%;
+
+  color: var(--text);
+  background: rgba(0, 0, 0, 0.18);
+
+  border-color: rgba(255, 255, 255, 0.14);
+}
+
+.input::placeholder {
+  color: #718096;
+}
+
+.checkbox-demo {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+
+  margin-top: 22px;
+
+  color: var(--muted);
+}
+
+.checkbox-demo input {
+  width: 18px;
+  height: 18px;
+  margin: 0;
+
+  accent-color: var(--green);
+}
+
+.utility-info {
+  margin-top: 32px;
+  padding-top: 28px;
+
+  border-top: 1px solid var(--panel-border);
+}
+
+.code-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+
+  margin-top: 18px;
+}
+
+.code-list code {
+  padding: 8px 11px;
+
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+
+  color: #c4b5fd;
+  background: rgba(139, 92, 246, 0.08);
+
+  font-size: 0.85rem;
+}
+
+/*
+ * Keep focus visible for browsers/environments
+ * that do not support :focus-visible.
+ */
+.focus-ring:focus {
+  outline-color: transparent;
+}
+
+.focus-ring:focus-visible {
+  outline-color: var(--ring-color);
+}
+
+/*
+ * Accessibility:
+ * Users who request reduced motion should not
+ * receive the focus-ring animation.
+ */
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+/*
+ * High contrast / forced colors support.
+ */
+@media (forced-colors: active) {
+  .focus-ring:focus-visible {
+    outline: 3px solid Highlight;
+    box-shadow: none;
+  }
+
+  .focus-ring {
+    border-color: ButtonText;
+  }
+}
+
+@media (max-width: 600px) {
+  body {
+    padding: 12px;
+  }
+
+  .focus-demo {
+    padding: 24px 18px;
+    border-radius: 20px;
+  }
+
+  .demo-card {
+    padding: 20px;
+  }
+
+  .controls {
+    flex-direction: column;
+  }
+
+  .controls .focus-ring {
+    width: 100%;
+  }
+}
+:root {
+  --page-bg: #080d1a;
+  --panel-bg: #111827;
+  --panel-border: rgba(255, 255, 255, 0.1);
+
+  --text: #f8fafc;
+  --muted: #aab4c5;
+
+  --blue: #60a5fa;
+  --purple: #a78bfa;
+  --green: #4ade80;
+  --orange: #fb923c;
+  --pink: #f472b6;
+
+  --focus-width: 3px;
+  --focus-offset: 4px;
+  --focus-blur: 0;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  padding: 24px;
+
+  display: grid;
+  place-items: center;
+
+  color: var(--text);
+
+  background:
+    radial-gradient(
+      circle at 15% 15%,
+      rgba(96, 165, 250, 0.14),
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at 85% 80%,
+      rgba(167, 139, 250, 0.12),
+      transparent 30%
+    ),
+    var(--page-bg);
+
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+button,
+input {
+  font: inherit;
+}
+
+.page {
+  width: min(100%, 900px);
+}
+
+.focus-demo {
+  padding: clamp(24px, 5vw, 48px);
+
+  border: 1px solid var(--panel-border);
+  border-radius: 28px;
+
+  background:
+    linear-gradient(
+      145deg,
+      rgba(255, 255, 255, 0.06),
+      rgba(255, 255, 255, 0.015)
+    ),
+    var(--panel-bg);
+
+  box-shadow:
+    0 30px 80px rgba(0, 0, 0, 0.45),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.intro {
+  margin-bottom: 32px;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+
+  color: #93c5fd;
+
+  font-size: 0.75rem;
+  font-weight: 800;
+
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+h1,
+h2 {
+  margin: 0;
+  letter-spacing: -0.03em;
+}
+
+h1 {
+  font-size: clamp(2rem, 5vw, 3.2rem);
+  line-height: 1.05;
+}
+
+h2 {
+  font-size: 1.2rem;
+}
+
+.description {
+  max-width: 680px;
+  margin: 16px 0 0;
+
+  color: var(--muted);
+
+  line-height: 1.7;
+}
+
+.demo-card {
+  padding: 28px;
+
+  border: 1px solid var(--panel-border);
+  border-radius: 20px;
+
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.helper-text {
+  margin: 10px 0 24px;
+
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+kbd {
+  padding: 3px 7px;
+
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-bottom-width: 2px;
+  border-radius: 6px;
+
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+
+  font-size: 0.85em;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+}
+
+.focus-ring {
+  --ring-color: var(--blue);
+
+  position: relative;
+
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  min-height: 44px;
+  padding: 10px 18px;
+
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 12px;
+
+  color: #fff;
+  background: rgba(255, 255, 255, 0.06);
+
+  font-weight: 700;
+  text-decoration: none;
+
+  cursor: pointer;
+
+  transition:
+    transform 180ms ease,
+    background-color 180ms ease,
+    border-color 180ms ease;
+}
+
+.focus-ring:hover {
+  transform: translateY(-2px);
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+.focus-ring:active {
+  transform: translateY(0);
+}
+
+/*
+ * Core Focus Ring Utility
+ *
+ * Uses :focus-visible so the ring is primarily shown
+ * for keyboard navigation instead of every pointer click.
+ */
+.focus-ring:focus-visible {
+  outline: var(--focus-width) solid var(--ring-color);
+  outline-offset: var(--focus-offset);
+
+  box-shadow:
+    0 0 var(--focus-blur) var(--ring-color),
+    0 0 0 calc(var(--focus-width) + 1px)
+      color-mix(in srgb, var(--ring-color) 18%, transparent);
+
+  animation: focus-ring-pulse 900ms ease-out;
+}
+
+.focus-blue {
+  --ring-color: var(--blue);
+}
+
+.focus-purple {
+  --ring-color: var(--purple);
+}
+
+.focus-green {
+  --ring-color: var(--green);
+}
+
+.focus-orange {
+  --ring-color: var(--orange);
+}
+
+.focus-pink {
+  --ring-color: var(--pink);
+}
+
+@keyframes focus-ring-pulse {
+  0% {
+    outline-offset: 2px;
+  }
+
+  100% {
+    outline-offset: var(--focus-offset);
+  }
+}
+
+.form-demo {
+  margin-top: 28px;
+}
+
+.form-demo label {
+  display: block;
+
+  margin-bottom: 9px;
+
+  color: #dbeafe;
+
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.input {
+  width: 100%;
+
+  color: var(--text);
+  background: rgba(0, 0, 0, 0.18);
+
+  border-color: rgba(255, 255, 255, 0.14);
+}
+
+.input::placeholder {
+  color: #718096;
+}
+
+.checkbox-demo {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+
+  margin-top: 22px;
+
+  color: var(--muted);
+}
+
+.checkbox-demo input {
+  width: 18px;
+  height: 18px;
+  margin: 0;
+
+  accent-color: var(--green);
+}
+
+.utility-info {
+  margin-top: 32px;
+  padding-top: 28px;
+
+  border-top: 1px solid var(--panel-border);
+}
+
+.code-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+
+  margin-top: 18px;
+}
+
+.code-list code {
+  padding: 8px 11px;
+
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+
+  color: #c4b5fd;
+  background: rgba(139, 92, 246, 0.08);
+
+  font-size: 0.85rem;
+}
+
+/*
+ * Keep focus visible for browsers/environments
+ * that do not support :focus-visible.
+ */
+.focus-ring:focus {
+  outline-color: transparent;
+}
+
+.focus-ring:focus-visible {
+  outline-color: var(--ring-color);
+}
+
+/*
+ * Accessibility:
+ * Users who request reduced motion should not
+ * receive the focus-ring animation.
+ */
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+/*
+ * High contrast / forced colors support.
+ */
+@media (forced-colors: active) {
+  .focus-ring:focus-visible {
+    outline: 3px solid Highlight;
+    box-shadow: none;
+  }
+
+  .focus-ring {
+    border-color: ButtonText;
+  }
+}
+
+@media (max-width: 600px) {
+  body {
+    padding: 12px;
+  }
+
+  .focus-demo {
+    padding: 24px 18px;
+    border-radius: 20px;
+  }
+
+  .demo-card {
+    padding: 20px;
+  }
+
+  .controls {
+    flex-direction: column;
+  }
+
+  .controls .focus-ring {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Description

Adds a pure CSS **Focus Ring Utility** for accessible and customizable keyboard focus states.

### Features

* Pure HTML and CSS implementation
* No JavaScript required
* Uses `:focus-visible` for keyboard-friendly focus states
* Customizable focus ring colors
* Multiple color variants
* Animated focus ring interaction
* Responsive design
* Works with links, buttons, inputs, and form controls
* Reduced-motion support
* Forced-colors support
* No external dependencies

### Files Added

* `submissions/examples/r-focus-ring-utility-68372/demo.html`
* `submissions/examples/r-focus-ring-utility-68372/style.css`
* `submissions/examples/r-focus-ring-utility-68372/README.md`

### Testing

* Verified keyboard navigation using the `Tab` key
* Verified visible focus rings on interactive elements
* Verified all focus color variants
* Verified responsive behavior
* Verified form control focus states
* Verified `prefers-reduced-motion` behavior
* Verified forced-colors support
* Ran `git diff --check`

### Related Issue

Closes #68372
