### PR TITLE
feat: add 3D book spine flip cover component for GSSoC 2026

### DIFF
--- a/submissions/examples/gssoc-2026-3d-book-spine-flip-cover-bb/README.md
+++ b/submissions/examples/gssoc-2026-3d-book-spine-flip-cover-bb/README.md
@@ -1,0 +1,12 @@
+# 3D Book Spine Flip Cover - GSSoC 2026
+
+An interactive 3D hardcover book component featuring left-hinge spine rotation to reveal inner content pages.
+
+## 1. What does this do?
+It simulates a realistic hardcover book cover opening along a 3D left-axis hinge on hover, revealing page contents inside.
+
+## 2. How is it used?
+Link `style.css` in your HTML file and enclose `.cover` and `.inside-page` inside a `.book` container element.
+
+## 3. Why is it useful?
+It provides an engaging interactive element for digital library catalogs, documentation hubs, and portfolio showcases.

--- a/submissions/examples/gssoc-2026-3d-book-spine-flip-cover-bb/demo.html
+++ b/submissions/examples/gssoc-2026-3d-book-spine-flip-cover-bb/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>3D Book Spine Flip Cover | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@600;700&family=Plus+Jakarta+Sans:wght@400;600&display=swap" rel="stylesheet">
+</head>
+<body>
+  <div class="book-container">
+    <div class="book">
+      <div class="cover">
+        <span class="edition">FIRST EDITION</span>
+        <h2>CSS MOTION MAGIC</h2>
+        <p>By Open Source Guild</p>
+      </div>
+      <div class="inside-page">
+        <h3>TABLE OF CONTENTS</h3>
+        <ul>
+          <li>01. 3D Keyframe Perspective</li>
+          <li>02. Hardware Acceleration</li>
+          <li>03. Glassmorphic Overlays</li>
+          <li>04. Responsive Layout Grids</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/gssoc-2026-3d-book-spine-flip-cover-bb/style.css
+++ b/submissions/examples/gssoc-2026-3d-book-spine-flip-cover-bb/style.css
@@ -1,0 +1,107 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  background-color: #0f172a;
+  color: #f8fafc;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.book-container {
+  padding: 2rem;
+  perspective: 1200px;
+}
+
+.book {
+  position: relative;
+  width: 260px;
+  height: 360px;
+  background: #ffffff;
+  color: #0f172a;
+  border-radius: 4px 16px 16px 4px;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.5);
+  transform-style: preserve-3d;
+  transition: transform 0.6s ease;
+}
+
+.cover {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, #1e1b4b, #312e81);
+  color: #fbbf24;
+  border-radius: 4px 16px 16px 4px;
+  padding: 2rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  transform-origin: left center;
+  transition: transform 0.8s cubic-bezier(0.645, 0.045, 0.355, 1);
+  box-shadow: 5px 0 15px rgba(0, 0, 0, 0.3);
+  z-index: 2;
+  backface-visibility: hidden;
+}
+
+.edition {
+  font-size: 0.7rem;
+  letter-spacing: 2px;
+  color: #93c5fd;
+}
+
+.cover h2 {
+  font-family: 'Cinzel', serif;
+  font-size: 1.6rem;
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+.cover p {
+  font-size: 0.85rem;
+  color: #e2e8f0;
+}
+
+.inside-page {
+  position: absolute;
+  inset: 0;
+  padding: 2rem 1.5rem;
+  background: #f8fafc;
+  color: #1e293b;
+  border-radius: 4px 16px 16px 4px;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.inside-page h3 {
+  font-size: 1.1rem;
+  margin-bottom: 1rem;
+  color: #312e81;
+  border-bottom: 2px solid #e2e8f0;
+  padding-bottom: 0.5rem;
+}
+
+.inside-page ul {
+  list-style: none;
+}
+
+.inside-page li {
+  font-size: 0.85rem;
+  margin-bottom: 0.65rem;
+  color: #475569;
+}
+
+/* 3D Book Cover Flip on Hover */
+.book-container:hover .book {
+  transform: rotateY(-10deg) scale(1.03);
+}
+
+.book-container:hover .cover {
+  transform: rotateY(-140deg);
+}


### PR DESCRIPTION
# Related Issue
Closes #70014

# Summary
Adds an interactive 3D hardcover book component featuring left-hinge spine rotation to reveal inner content pages.

# Changes Made
- Created `submissions/examples/gssoc-2026-3d-book-spine-flip-cover-bb/demo.html`
- Created `submissions/examples/gssoc-2026-3d-book-spine-flip-cover-bb/style.css`
- Created `submissions/examples/gssoc-2026-3d-book-spine-flip-cover-bb/README.md`

# Testing
- Verified 3D hinge perspective rendering across desktop browsers.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No existing repository files modified
