### PR TITLE
feat: add pure CSS Dark Theme Notification component (#68370)

### DIFF
--- a/submissions/examples/css-dark-theme-notification-pure/README.md
+++ b/submissions/examples/css-dark-theme-notification-pure/README.md
@@ -1,0 +1,19 @@
+# CSS Dark Theme Notification
+
+A pure CSS toast notification featuring a glassmorphism dark theme, an entrance animation, and a JavaScript-free dismissal mechanism utilizing the hidden checkbox hack.
+
+## Features
+- Pure CSS and HTML (Zero JavaScript required for the dismiss state).
+- **Theming**: While the component forces a dark, glassmorphism aesthetic (`backdrop-filter: blur()`) to achieve its specific look, it utilizes CSS Custom Properties and a `prefers-color-scheme: dark` media query to slightly intensify its drop shadows when the surrounding OS theme is dark, ensuring it stands out against dark app backgrounds.
+- **Component Architecture (Documented in Code)**: 
+  - **The Checkbox Dismiss Hack**: The dismissal logic is driven by a hidden `<input type="checkbox">`. The 'X' button is actually a `<label>` element linked to the checkbox via the `for` attribute. Clicking it checks the box.
+  - **Collapse Animation**: When the checkbox is checked (`.toast-checkbox:checked`), a CSS sibling selector (`+`) targets the adjacent `.toast-notification` and collapses it. We transition `max-height`, `opacity`, `padding`, and `margin` to zero to create a smooth slide-and-fade collapse effect.
+  - **Entrance Animation**: The toast uses a CSS `@keyframes` animation (`toastEnter`) on page load to smoothly slide up from the bottom while fading in, grabbing the user's attention.
+- Fully accessible semantic structure. Wraps the notification in `role="alert"` and `aria-live="assertive"` for screen readers. The 'X' button is reachable via keyboard (`tabindex="0"`) and has an explicit `aria-label`. Honors the `prefers-reduced-motion` accessibility standard by disabling the slide-up animation and collapse slide, falling back to a simple opacity fade.
+
+## Usage
+Open `demo.html` in your browser. Watch the toast animate in. Click the 'X' icon to dismiss it seamlessly without JS.
+
+## Files
+- `demo.html`: The HTML structure containing the hidden checkbox, the label masquerading as a dismiss button, and the toast content.
+- `style.css`: The styling, CSS Custom Property theming blocks, and the heavily commented `:checked` state collapse transitions.

--- a/submissions/examples/css-dark-theme-notification-pure/demo.html
+++ b/submissions/examples/css-dark-theme-notification-pure/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Dark Theme Notification</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Dark Theme Notification</h1>
+            <p class="subtitle">A pure CSS toast notification featuring a glassmorphism dark theme, entry animation, and a JavaScript-free dismissal mechanism using the hidden checkbox hack.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <!-- 
+              [TECHNIQUE] The Checkbox Dismissal
+              The input holds the visibility state.
+              The toast itself is adjacent to it, allowing CSS sibling selectors to hide it when checked.
+            -->
+            
+            <input type="checkbox" id="toast-dismiss" class="toast-checkbox sr-only" aria-hidden="true">
+            
+            <div class="toast-notification" role="alert" aria-live="assertive">
+                
+                <div class="toast-icon">
+                    <svg viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path>
+                        <polyline points="22 4 12 14.01 9 11.01"></polyline>
+                    </svg>
+                </div>
+                
+                <div class="toast-content">
+                    <h3 class="toast-title">Update Successful</h3>
+                    <p class="toast-message">Your profile settings have been saved to the cloud.</p>
+                </div>
+                
+                <!-- The label acts as the dismiss button linked to the hidden checkbox -->
+                <label for="toast-dismiss" class="toast-close" aria-label="Dismiss notification" tabindex="0">
+                    <svg viewBox="0 0 24 24" width="18" height="18" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                        <line x1="18" y1="6" x2="6" y2="18"></line>
+                        <line x1="6" y1="6" x2="18" y2="18"></line>
+                    </svg>
+                </label>
+                
+            </div>
+            
+            <p class="instruction-text">Click the 'X' icon to dismiss the toast notification.</p>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-dark-theme-notification-pure/style.css
+++ b/submissions/examples/css-dark-theme-notification-pure/style.css
@@ -1,0 +1,238 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    /* Main App Background (Light) */
+    --bg-base: #f1f5f9;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    
+    /* Toast Specific Colors (Always Dark Theme) */
+    /* Glassmorphism background */
+    --toast-bg: rgba(15, 23, 42, 0.85); 
+    --toast-border: rgba(255, 255, 255, 0.1);
+    
+    --toast-text-primary: #f8fafc;
+    --toast-text-secondary: #94a3b8;
+    
+    --toast-icon-bg: rgba(34, 197, 94, 0.2);
+    --toast-icon-color: #4ade80;
+    
+    --toast-close-hover: rgba(255, 255, 255, 0.15);
+    
+    --toast-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.2), 0 10px 10px -5px rgba(0, 0, 0, 0.1);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        /* Main App Background (Dark) */
+        --bg-base: #020617;
+        --text-primary: #f8fafc;
+        --text-secondary: #94a3b8;
+        
+        /* Toast remains dark, but shadows are intensified for contrast */
+        --toast-bg: rgba(30, 41, 59, 0.9);
+        --toast-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.5), 0 10px 10px -5px rgba(0, 0, 0, 0.3);
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 60px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.demo-area {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 40px;
+    padding: 20px 0;
+}
+
+.instruction-text {
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+    margin-top: 40px;
+}
+
+/* Accessibility helper */
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border-width: 0;
+}
+
+
+/* =========================================
+   [TECHNIQUE] The Dark Theme Toast
+   ========================================= */
+
+.toast-notification {
+    display: flex;
+    align-items: flex-start;
+    gap: 16px;
+    width: 100%;
+    max-width: 400px;
+    padding: 16px;
+    
+    /* Glassmorphism Effect */
+    background-color: var(--toast-bg);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    
+    border: 1px solid var(--toast-border);
+    border-radius: 12px;
+    box-shadow: var(--toast-shadow);
+    
+    /* Entrance Animation */
+    opacity: 0;
+    transform: translateY(20px);
+    animation: toastEnter 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+    
+    /* Setup for dismissal transition */
+    overflow: hidden;
+    max-height: 150px;
+    transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+@keyframes toastEnter {
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+
+/* =========================================
+   Toast Content
+   ========================================= */
+
+.toast-icon {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background-color: var(--toast-icon-bg);
+    color: var(--toast-icon-color);
+    flex-shrink: 0;
+}
+
+.toast-content {
+    flex-grow: 1;
+    padding-top: 2px;
+}
+
+.toast-title {
+    margin: 0 0 4px 0;
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--toast-text-primary);
+    letter-spacing: 0.2px;
+}
+
+.toast-message {
+    margin: 0;
+    font-size: 0.85rem;
+    line-height: 1.5;
+    color: var(--toast-text-secondary);
+}
+
+
+/* =========================================
+   Dismiss Button
+   ========================================= */
+
+.toast-close {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 28px;
+    height: 28px;
+    border-radius: 6px;
+    color: var(--toast-text-secondary);
+    cursor: pointer;
+    transition: all 0.2s ease;
+    flex-shrink: 0;
+}
+
+.toast-close:hover {
+    background-color: var(--toast-close-hover);
+    color: var(--toast-text-primary);
+}
+
+/* Accessibility Focus State */
+.toast-close:focus-visible {
+    outline: 2px solid var(--toast-text-primary);
+    outline-offset: 2px;
+}
+
+
+/* =========================================
+   [TECHNIQUE] Dismissal Logic
+   ========================================= */
+
+/* 
+  When the hidden checkbox is checked, hide the adjacent toast.
+  We animate max-height and margin to 0 for a smooth collapse,
+  rather than immediately setting display: none.
+*/
+.toast-checkbox:checked + .toast-notification {
+    opacity: 0;
+    max-height: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+    margin: 0;
+    border: none;
+    pointer-events: none; /* Prevent clicks during fade out */
+}
+
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .toast-notification {
+        animation: none !important;
+        opacity: 1 !important;
+        transform: none !important;
+        transition: opacity 0.2s ease !important; /* Simple fade on dismiss */
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a pure CSS toast notification featuring a glassmorphism dark theme, an entrance animation, and a JavaScript-free dismissal mechanism utilizing the hidden checkbox hack, resolving issue #68370.

### Changes Made:
- Added `submissions/examples/css-dark-theme-notification-pure/` directory.
- Created `demo.html` showcasing the HTML structure containing the hidden checkbox, the label masquerading as a dismiss button, and the toast content.
- Created `style.css` featuring the UI mechanics:
  - **The Checkbox Dismiss Hack**: The dismissal logic is driven by a hidden `<input type="checkbox">`. The 'X' button is actually a `<label>` element linked to the checkbox via the `for` attribute. Clicking it checks the box.
  - **Collapse Animation**: When the checkbox is checked (`.toast-checkbox:checked`), a CSS sibling selector (`+`) targets the adjacent `.toast-notification` and collapses it. We transition `max-height`, `opacity`, `padding`, and `margin` to zero to create a smooth slide-and-fade collapse effect.
  - **Entrance Animation**: The toast uses a CSS `@keyframes` animation (`toastEnter`) on page load to smoothly slide up from the bottom while fading in, grabbing the user's attention.
  - **Theming & Dark Mode Supported**: While the component forces a dark, glassmorphism aesthetic (`backdrop-filter: blur()`) to achieve its specific look, it utilizes CSS Custom Properties and a `prefers-color-scheme: dark` media query to slightly intensify its drop shadows when the surrounding OS theme is dark, ensuring it stands out against dark app backgrounds.
- Added `README.md` documenting usage and the technical mechanics of the `:checked` state collapse transitions.
- Fully accessible semantic structure. Wraps the notification in `role="alert"` and `aria-live="assertive"` for screen readers. The 'X' button is reachable via keyboard (`tabindex="0"`) and has an explicit `aria-label`. Honors the `prefers-reduced-motion` accessibility standard by disabling the slide-up animation and collapse slide, falling back to a simple opacity fade.

Closes #68370
