### PR TITLE
feat: add pure CSS Floating Navigation Dots component (#68339)

### DIFF
--- a/submissions/examples/css-floating-navigation-dots-pure/README.md
+++ b/submissions/examples/css-floating-navigation-dots-pure/README.md
@@ -1,0 +1,19 @@
+# CSS Floating Navigation Dots
+
+A pure CSS side navigation component commonly used for full-page scrolling sites. Features smooth hover expansions and sliding tooltips utilizing pure CSS pseudo-elements and GPU-accelerated transforms.
+
+## Features
+- Pure CSS and HTML (Zero JavaScript required for the hover/focus animations). Note: In a production environment, you would use JavaScript (like an Intersection Observer) to dynamically add/remove the `.active` class as the user scrolls down the page.
+- **Theming & Dark Mode**: Utilizes CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), generating a sleek dark mode UI with appropriate contrast for the tooltips.
+- **Component Architecture (Documented in Code)**: 
+  - **Dot Scaling**: The interactive dots grow when hovered or marked active. To ensure this animation is 60fps smooth, we use `transform: scale(1.4)` combined with a custom `cubic-bezier` spring easing, rather than animating `width` or `height` which triggers expensive browser layout repaints.
+  - **Sliding Tooltips**: The tooltips (`.nav-tooltip`) are positioned absolutely relative to their parent anchor link. They are hidden initially using `opacity: 0` and pushed slightly out of place using `transform: translateX(-10px)`.
+  - **The Reveal**: When the parent anchor receives a `:hover` or `:focus-visible` event, the child tooltip transitions to `opacity: 1` and `transform: translateX(0)`, creating a satisfying fade-and-slide-in effect.
+- Fully accessible semantic structure. Wraps the navigation in a `<nav>` tag. The anchor links use explicit `aria-label`s to describe their destination to screen readers, while the visual tooltips are hidden from screen readers (`aria-hidden="true"`) to prevent duplicate announcements. The `.active` link utilizes `aria-current="page"`. Honors the `prefers-reduced-motion` accessibility standard by disabling the scaling and sliding transform animations, replacing them with static outlines and simple opacity fades for motion-sensitive users.
+
+## Usage
+Open `demo.html` in your browser. Hover over the navigation dots to see the expansion effect and the sliding tooltips.
+
+## Files
+- `demo.html`: The HTML structure containing the `<nav>` semantic wrapper and the anchor links with embedded tooltips.
+- `style.css`: The styling, CSS Custom Property theming blocks, and the heavily commented GPU-accelerated transition logic.

--- a/submissions/examples/css-floating-navigation-dots-pure/demo.html
+++ b/submissions/examples/css-floating-navigation-dots-pure/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Floating Navigation Dots</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <!-- Note: For a true full-page implementation, the nav would be position: fixed. 
+         We use absolute within a relative container here for demonstration purposes. -->
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Floating Navigation Dots</h1>
+            <p class="subtitle">A side navigation component commonly used for full-page scrolling sites. Features smooth hover expansions and tooltips using pure CSS pseudo-elements.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <!-- 
+              [TECHNIQUE] The Navigation Container 
+              Placed on the side, it holds a list of anchor links.
+            -->
+            <nav class="floating-nav" aria-label="Page Sections">
+                <ul class="nav-dots">
+                    
+                    <li class="nav-item">
+                        <!-- Active state is usually managed by JS scroll spy, 
+                             we hardcode the first one as active for the demo -->
+                        <a href="#section-intro" class="nav-link active" aria-label="Introduction" aria-current="page">
+                            <span class="nav-tooltip" aria-hidden="true">Introduction</span>
+                        </a>
+                    </li>
+                    
+                    <li class="nav-item">
+                        <a href="#section-features" class="nav-link" aria-label="Features">
+                            <span class="nav-tooltip" aria-hidden="true">Features</span>
+                        </a>
+                    </li>
+                    
+                    <li class="nav-item">
+                        <a href="#section-pricing" class="nav-link" aria-label="Pricing">
+                            <span class="nav-tooltip" aria-hidden="true">Pricing</span>
+                        </a>
+                    </li>
+                    
+                    <li class="nav-item">
+                        <a href="#section-contact" class="nav-link" aria-label="Contact Us">
+                            <span class="nav-tooltip" aria-hidden="true">Contact Us</span>
+                        </a>
+                    </li>
+                    
+                </ul>
+            </nav>
+            
+            <div class="mock-content">
+                <p>Interact with the dots on the left. Hover over a dot to see it expand and reveal its tooltip label.</p>
+                <p>The active dot (Introduction) maintains its expanded state to indicate current position.</p>
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-floating-navigation-dots-pure/style.css
+++ b/submissions/examples/css-floating-navigation-dots-pure/style.css
@@ -1,0 +1,224 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    
+    /* Navigation Dot Colors */
+    --dot-bg: #cbd5e1;
+    --dot-hover: #94a3b8;
+    --dot-active: #3b82f6; /* Blue for the active section */
+    
+    /* Tooltip Colors */
+    --tooltip-bg: #1e293b;
+    --tooltip-text: #f8fafc;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a;
+        --text-primary: #f8fafc;
+        --text-secondary: #94a3b8;
+        
+        --dot-bg: #475569;
+        --dot-hover: #cbd5e1;
+        --dot-active: #60a5fa;
+        
+        --tooltip-bg: #f8fafc;
+        --tooltip-text: #0f172a;
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 60px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.demo-area {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 60px;
+    padding: 40px 0;
+    /* Container needs to be relative if we were positioning nav absolutely within it */
+    position: relative; 
+}
+
+.mock-content {
+    max-width: 400px;
+    color: var(--text-secondary);
+    line-height: 1.6;
+}
+
+
+/* =========================================
+   [TECHNIQUE] Floating Navigation
+   ========================================= */
+
+.floating-nav {
+    /* 
+      In a real full-page scenario, this would be:
+      position: fixed;
+      right: 30px;
+      top: 50%;
+      transform: translateY(-50%);
+      
+      For the demo layout, we just use relative positioning.
+    */
+    display: flex;
+    z-index: 100;
+}
+
+.nav-dots {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 16px; /* Spacing between dots */
+}
+
+.nav-item {
+    display: flex;
+    align-items: center;
+    position: relative;
+}
+
+
+/* =========================================
+   The Dots
+   ========================================= */
+
+.nav-link {
+    display: block;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background-color: var(--dot-bg);
+    
+    /* 
+      We use a transform to scale the dot on hover.
+      Using transform is GPU accelerated and smoother than animating width/height.
+    */
+    transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1), 
+                background-color 0.3s ease;
+    
+    /* Remove default focus ring, we'll replace it with scaling */
+    outline: none;
+}
+
+/* Hover and Focus States */
+.nav-link:hover,
+.nav-link:focus-visible {
+    background-color: var(--dot-hover);
+    transform: scale(1.4);
+}
+
+/* Active State (The section currently being viewed) */
+.nav-link.active {
+    background-color: var(--dot-active);
+    transform: scale(1.4);
+}
+
+
+/* =========================================
+   [TECHNIQUE] Tooltips
+   ========================================= */
+
+/* 
+  Tooltips are positioned absolutely relative to the dot.
+  They are hidden by default via opacity and transform (pushed slightly left).
+*/
+.nav-tooltip {
+    position: absolute;
+    right: 100%; /* Position it to the left of the dot */
+    top: 50%;
+    transform: translateY(-50%) translateX(-10px);
+    margin-right: 16px; /* Spacing from the dot */
+    
+    background-color: var(--tooltip-bg);
+    color: var(--tooltip-text);
+    padding: 6px 12px;
+    border-radius: 6px;
+    font-size: 0.85rem;
+    font-weight: 500;
+    white-space: nowrap;
+    
+    opacity: 0;
+    visibility: hidden;
+    transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+    pointer-events: none; /* Prevent tooltips from blocking clicks */
+}
+
+/* A small triangle pointing to the dot */
+.nav-tooltip::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 100%;
+    transform: translateY(-50%);
+    border-width: 5px;
+    border-style: solid;
+    border-color: transparent transparent transparent var(--tooltip-bg);
+}
+
+/* Reveal tooltip when the parent link is hovered or focused */
+.nav-link:hover .nav-tooltip,
+.nav-link:focus-visible .nav-tooltip {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(-50%) translateX(0); /* Slide into place */
+}
+
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .nav-link {
+        transition: background-color 0.2s ease !important;
+    }
+    .nav-link:hover,
+    .nav-link:focus-visible,
+    .nav-link.active {
+        transform: scale(1) !important; /* No scaling */
+        box-shadow: 0 0 0 2px var(--bg-base), 0 0 0 4px var(--dot-active); /* Use outline instead */
+    }
+    
+    .nav-tooltip {
+        transition: opacity 0.2s ease !important;
+        transform: translateY(-50%) translateX(0) !important; /* Always in position, just fade */
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a pure CSS side navigation component commonly used for full-page scrolling sites. It features smooth hover expansions and sliding tooltips utilizing pure CSS pseudo-elements and GPU-accelerated transforms without requiring JavaScript for the hover/focus states, resolving issue #68339.

### Changes Made:
- Added `submissions/examples/css-floating-navigation-dots-pure/` directory.
- Created `demo.html` showcasing the HTML structure containing the `<nav>` semantic wrapper and the anchor links with embedded tooltips.
- Created `style.css` featuring the UI mechanics:
  - **Dot Scaling**: The interactive dots grow when hovered or marked active. To ensure this animation is 60fps smooth, we use `transform: scale(1.4)` combined with a custom `cubic-bezier` spring easing, rather than animating `width` or `height` which triggers expensive browser layout repaints.
  - **Sliding Tooltips**: The tooltips (`.nav-tooltip`) are positioned absolutely relative to their parent anchor link. They are hidden initially using `opacity: 0` and pushed slightly out of place using `transform: translateX(-10px)`.
  - **The Reveal**: When the parent anchor receives a `:hover` or `:focus-visible` event, the child tooltip transitions to `opacity: 1` and `transform: translateX(0)`, creating a satisfying fade-and-slide-in effect.
  - **Theming & Dark Mode Supported**: Utilizes CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), generating a sleek dark mode UI with appropriate contrast for the tooltips.
- Added `README.md` documenting usage and the technical mechanics of the GPU-accelerated transition logic.
- Fully accessible semantic structure. Wraps the navigation in a `<nav>` tag. The anchor links use explicit `aria-label`s to describe their destination to screen readers, while the visual tooltips are hidden from screen readers (`aria-hidden="true"`) to prevent duplicate announcements. The `.active` link utilizes `aria-current="page"`. Honors the `prefers-reduced-motion` accessibility standard by disabling the scaling and sliding transform animations, replacing them with static outlines and simple opacity fades for motion-sensitive users.

Closes #68339
