### PR TITLE
feat: add pure CSS Discount Percentage Badge component (#68503)

### DIFF
--- a/submissions/examples/css-discount-percentage-badge-pure/README.md
+++ b/submissions/examples/css-discount-percentage-badge-pure/README.md
@@ -1,0 +1,18 @@
+# CSS Discount Percentage Badge
+
+An animated pricing component featuring a bouncing discount badge and a clean, pure CSS strikethrough effect for original pricing, built entirely without JavaScript.
+
+## Features
+- Pure CSS and HTML.
+- **Theming & Dark Mode**: Utilizes CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), generating a sleek dark mode UI where the badge color and shadow are slightly adjusted to maintain high visibility and contrast against dark backgrounds.
+- **Component Architecture (Documented in Code)**: 
+  - **The Strikethrough**: While it's possible to create custom strikethrough lines using CSS pseudo-elements (e.g., `::after`), it is best practice to use the semantic `<s>` HTML tag combined with standard `text-decoration` properties (`text-decoration: line-through`, `text-decoration-thickness`). This ensures screen readers correctly interpret the text as deleted/replaced.
+  - **The Badge Animation**: The badge uses a `@keyframes` animation (`badgePulse`) to draw attention. The animation combines `transform: scale()` with `transform: rotate()` to create a dynamic, physical "pop" effect. The animation is heavily weighted to the beginning of the cycle (`0%` to `30%`), leaving a long resting period (`30%` to `100%`) so it isn't constantly distracting the user.
+- Fully accessible semantic structure. The prices utilize explicit `aria-label`s to clearly announce "Original price" and "Current price" to screen readers, preventing confusion when reading out the raw numbers. Honors the `prefers-reduced-motion` accessibility standard by disabling the pulse animation entirely for motion-sensitive users, leaving the badge in its static, slightly rotated state.
+
+## Usage
+Open `demo.html` in your browser to view the pricing layout and the attention-grabbing badge animation.
+
+## Files
+- `demo.html`: The HTML structure demonstrating the semantic `<s>` tag and the `aria-label` setups for pricing.
+- `style.css`: The styling, CSS Custom Property theming blocks, and the heavily commented `@keyframes` pulse logic.

--- a/submissions/examples/css-discount-percentage-badge-pure/demo.html
+++ b/submissions/examples/css-discount-percentage-badge-pure/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Discount Percentage Badge</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Discount Percentage Badge</h1>
+            <p class="subtitle">An animated pricing component featuring a bouncing discount badge and a clean, pure CSS strikethrough effect for original pricing.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <div class="product-pricing">
+                
+                <div class="price-stack">
+                    <!-- 
+                      [TECHNIQUE] The Strikethrough
+                      We use a semantic <s> (strikethrough) tag for accessibility.
+                      CSS pseudo-elements can be used to animate the strike line if desired,
+                      but standard text-decoration is best for semantic meaning.
+                    -->
+                    <s class="price-original" aria-label="Original price: 120 dollars">$120.00</s>
+                    
+                    <span class="price-current" aria-label="Current price: 89 dollars">
+                        $89.00
+                    </span>
+                </div>
+                
+                <!-- 
+                  [TECHNIQUE] The Badge Animation
+                  Positioned absolutely or relatively depending on layout needs.
+                  Features a subtle pulsating scale animation to draw attention.
+                -->
+                <div class="discount-badge" aria-label="25 percent off">
+                    <span class="badge-value">-25%</span>
+                    <span class="badge-label">OFF</span>
+                </div>
+                
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-discount-percentage-badge-pure/style.css
+++ b/submissions/examples/css-discount-percentage-badge-pure/style.css
@@ -1,0 +1,207 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    --text-secondary: #94a3b8;
+    
+    --panel-bg: #ffffff;
+    --panel-border: #e2e8f0;
+    --panel-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.05);
+    
+    /* Pricing Colors */
+    --price-current: #0f172a;
+    --price-original: #94a3b8;
+    
+    /* Badge Colors */
+    --badge-bg: #ef4444; /* High-visibility red */
+    --badge-text: #ffffff;
+    --badge-shadow: rgba(239, 68, 68, 0.4);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a;
+        --text-primary: #f8fafc;
+        --text-secondary: #64748b;
+        
+        --panel-bg: #1e293b;
+        --panel-border: #334155;
+        --panel-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.4);
+        
+        --price-current: #f8fafc;
+        --price-original: #64748b;
+        
+        --badge-bg: #f87171; /* Slightly lighter red for dark mode contrast */
+        --badge-text: #020617;
+        --badge-shadow: rgba(248, 113, 113, 0.2);
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 60px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    padding: 40px 0;
+}
+
+
+/* =========================================
+   Product Pricing Layout
+   ========================================= */
+
+.product-pricing {
+    background-color: var(--panel-bg);
+    border: 1px solid var(--panel-border);
+    border-radius: 16px;
+    padding: 32px 40px;
+    box-shadow: var(--panel-shadow);
+    
+    display: flex;
+    align-items: center;
+    gap: 24px;
+    
+    /* Create stacking context for absolutely positioned badge if needed */
+    position: relative; 
+}
+
+.price-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+/* 
+  [TECHNIQUE] The Strikethrough
+  Using the native text-decoration property on an <s> tag is the most
+  robust and accessible way to handle original pricing.
+*/
+.price-original {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--price-original);
+    text-decoration: line-through;
+    text-decoration-thickness: 2px;
+    text-decoration-color: var(--price-original);
+    opacity: 0.8;
+}
+
+.price-current {
+    font-size: 2.5rem;
+    font-weight: 800;
+    letter-spacing: -1px;
+    color: var(--price-current);
+    line-height: 1;
+}
+
+
+/* =========================================
+   [TECHNIQUE] The Animated Badge
+   ========================================= */
+
+.discount-badge {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    
+    background-color: var(--badge-bg);
+    color: var(--badge-text);
+    
+    /* Perfect circle */
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
+    
+    /* Rotate slightly for a dynamic, "sticker" feel */
+    transform: rotate(12deg);
+    
+    box-shadow: 0 8px 16px -4px var(--badge-shadow);
+    
+    /* Attention-grabbing animation */
+    animation: badgePulse 2s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+}
+
+.badge-value {
+    font-size: 1.25rem;
+    font-weight: 800;
+    line-height: 1.1;
+    letter-spacing: -0.5px;
+}
+
+.badge-label {
+    font-size: 0.65rem;
+    font-weight: 700;
+    letter-spacing: 1px;
+    opacity: 0.9;
+}
+
+/* 
+  The Animation:
+  A subtle combination of scaling and rotation shifting to draw the eye
+  without being overly obnoxious.
+*/
+@keyframes badgePulse {
+    0% {
+        transform: rotate(12deg) scale(1);
+    }
+    10% {
+        /* Quick pop */
+        transform: rotate(16deg) scale(1.1);
+    }
+    20% {
+        /* Settle back down */
+        transform: rotate(10deg) scale(0.95);
+    }
+    30%, 100% {
+        /* Rest for the remainder of the cycle */
+        transform: rotate(12deg) scale(1);
+    }
+}
+
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .discount-badge {
+        animation: none !important;
+        /* Keep the slight rotation for style, but remove the motion */
+        transform: rotate(12deg) !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces an animated pricing component featuring a bouncing discount badge and a clean, pure CSS strikethrough effect for original pricing, built entirely without JavaScript, resolving issue #68503.

### Changes Made:
- Added `submissions/examples/css-discount-percentage-badge-pure/` directory.
- Created `demo.html` showcasing the HTML structure demonstrating the semantic `<s>` tag and the `aria-label` setups for pricing.
- Created `style.css` featuring the UI mechanics:
  - **The Strikethrough**: While it's possible to create custom strikethrough lines using CSS pseudo-elements (e.g., `::after`), it is best practice to use the semantic `<s>` HTML tag combined with standard `text-decoration` properties (`text-decoration: line-through`, `text-decoration-thickness`). This ensures screen readers correctly interpret the text as deleted/replaced.
  - **The Badge Animation**: The badge uses a `@keyframes` animation (`badgePulse`) to draw attention. The animation combines `transform: scale()` with `transform: rotate()` to create a dynamic, physical "pop" effect. The animation is heavily weighted to the beginning of the cycle (`0%` to `30%`), leaving a long resting period (`30%` to `100%`) so it isn't constantly distracting the user.
  - **Theming & Dark Mode Supported**: Utilizes CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), generating a sleek dark mode UI where the badge color and shadow are slightly adjusted to maintain high visibility and contrast against dark backgrounds.
- Added `README.md` documenting usage and the technical mechanics of the heavily commented `@keyframes` pulse logic.
- Fully accessible semantic structure. The prices utilize explicit `aria-label`s to clearly announce "Original price" and "Current price" to screen readers, preventing confusion when reading out the raw numbers. Honors the `prefers-reduced-motion` accessibility standard by disabling the pulse animation entirely for motion-sensitive users, leaving the badge in its static, slightly rotated state.

Closes #68503
