### PR TITLE
feat(submission): add ease-typewriter-multiline component (#68985)

### DIFF
--- a/submissions/examples/ease-typewriter-multiline-ksk/README.md
+++ b/submissions/examples/ease-typewriter-multiline-ksk/README.md
@@ -1,0 +1,30 @@
+# Multi-line CSS Typewriter Effect (`ease-typewriter-multiline-ksk`)
+
+1. What does this do?  
+An animated typing reveal effect that supports wrapping paragraphs across multiple lines in pure CSS. It works by overlaying an absolute pseudo-element `.ease-typewriter-mask` (`::after`) on each word span, animating its width to scale horizontally (`scaleX(1)` → `scaleX(0)`) sequentially with staggered animation delays.
+
+2. How is it used?  
+Wrap each word of your text in a `.type-word` span inside `.ease-typewriter-multiline`. The staggered character entrance delays execute natively:
+
+```html
+<p class="ease-typewriter-multiline">
+  <span class="type-word">Word</span>
+  <span class="type-word">by</span>
+  <span class="type-word">word.</span>
+</p>
+```
+
+Configure parameters using CSS variables:
+```css
+.ease-typewriter-multiline {
+  --ease-type-speed:    0.16s;            /* reveal duration per word */
+  --ease-type-delay:    0.12s;            /* staggered delay multiplier */
+  --ease-bg:            #0f111a;          /* must match background color */
+}
+```
+
+3. Why is it useful?  
+Standard single-line typewriters animate element widths using fixed character counts (`ch`), which breaks when text wraps onto multiple lines. This utility segments elements into individual relative word spans with absolute overlay masks, enabling organic multi-line typing layouts without any external JavaScript runtimes, maintaining full responsiveness, prefers-reduced-motion safety overrides, and Dark/Light theme modes.
+
+---
+*Created for ECSoC-26 / GSSoC-26 — Resolves #68985.*

--- a/submissions/examples/ease-typewriter-multiline-ksk/demo.html
+++ b/submissions/examples/ease-typewriter-multiline-ksk/demo.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Multi-line Typewriter Demo — EaseMotion CSS</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+
+  <!-- Main Showcase Container -->
+  <div class="demo-page" id="app-root">
+
+    <div class="demo-card">
+      <h1 class="demo-title">Multi-line Typewriter Effect</h1>
+
+      <!-- Typewriter Container -->
+      <div class="ease-typewriter-multiline">
+        <span class="type-word">This</span>
+        <span class="type-word">is</span>
+        <span class="type-word">a</span>
+        <span class="type-word">highly</span>
+        <span class="type-word">customizable,</span>
+        <span class="type-word">pure</span>
+        <span class="type-word">CSS</span>
+        <span class="type-word">typewriter</span>
+        <span class="type-word">effect</span>
+        <span class="type-word">designed</span>
+        <span class="type-word">specifically</span>
+        <span class="type-word">to</span>
+        <span class="type-word">support</span>
+        <span class="type-word">wrapped</span>
+        <span class="type-word">multiline</span>
+        <span class="type-word">paragraphs</span>
+        <span class="type-word">without</span>
+        <span class="type-word">any</span>
+        <span class="type-word">external</span>
+        <span class="type-word">JavaScript</span>
+        <span class="type-word">runtimes</span>
+        <span class="type-word">or</span>
+        <span class="type-word">fixed-width</span>
+        <span class="type-word">constraints.</span>
+      </div>
+
+      <div style="display:flex;gap:12px;margin-top:16px;">
+        <button class="demo-btn" id="replayBtn">Replay Typewriter</button>
+        <button class="demo-btn" id="themeBtn" style="background:rgba(255,255,255,0.06);color:inherit;border:1px solid rgba(255,255,255,0.1);">
+          Toggle Theme
+        </button>
+      </div>
+    </div>
+
+  </div>
+
+  <script>
+    // Theme toggle helper
+    const themeBtn = document.getElementById('themeBtn');
+    const appRoot = document.getElementById('app-root');
+    themeBtn.addEventListener('click', () => {
+      appRoot.classList.toggle('light-theme');
+      document.querySelector('.ease-typewriter-multiline').classList.toggle('light-theme');
+    });
+
+    // Replay helper (triggers css animation repaint)
+    const replayBtn = document.getElementById('replayBtn');
+    replayBtn.addEventListener('click', () => {
+      const parent = document.querySelector('.ease-typewriter-multiline');
+      const html = parent.innerHTML;
+      parent.innerHTML = '';
+      setTimeout(() => {
+        parent.innerHTML = html;
+      }, 20);
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-typewriter-multiline-ksk/style.css
+++ b/submissions/examples/ease-typewriter-multiline-ksk/style.css
@@ -1,0 +1,170 @@
+/* ============================================================
+   EaseMotion CSS — Multi-line CSS Typewriter Effect
+   submissions/examples/ease-typewriter-multiline-ksk/style.css
+   ============================================================ */
+
+/* ── CSS Custom Properties ──────────────────────────────────
+   Override on .ease-typewriter-multiline or any ancestor.
+   ─────────────────────────────────────────────────────────── */
+:root {
+  --ease-type-speed:    0.16s;            /* reveal duration per word     */
+  --ease-type-delay:    0.12s;            /* staggered delay multiplier   */
+  --ease-bg:            #0f111a;          /* must match viewport background */
+  --ease-color:         #f8fafc;
+  --ease-accent:        #6366f1;
+}
+
+/* Light Theme Overrides */
+.light-theme {
+  --ease-bg:            #f8fafc;
+  --ease-color:         #0f172a;
+  --ease-accent:        #4f46e5;
+}
+
+/* ── Multi-line Typewriter Container ─────────────────────── */
+.ease-typewriter-multiline {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 1.1rem;
+  line-height: 1.8;
+  color: var(--ease-color);
+  display: inline;
+}
+
+/* Individual Wrap Word Block */
+.type-word {
+  position: relative;
+  display: inline-block;
+  white-space: nowrap;
+  margin-right: 0.28em;
+}
+
+/* ── .ease-typewriter-mask Pseudo-element Cover ──────────── */
+.type-word::after {
+  content: '';
+  position: absolute;
+  inset: -1px -2px;
+  background: var(--ease-bg);
+  transform-origin: right;
+  
+  /* Initial state: covers word completely */
+  transform: scaleX(1);
+  
+  /* Reveal step animation */
+  animation: ease-typewriter-mask-reveal var(--ease-type-speed) steps(5) forwards;
+}
+
+/* Step Reveal Keyframe */
+@keyframes ease-typewriter-mask-reveal {
+  to {
+    transform: scaleX(0);
+  }
+}
+
+/* ── Staggered Delays for up to 40 Words ─────────────────── */
+.type-word:nth-child(1)::after  { animation-delay: calc(var(--ease-type-delay) * 1); }
+.type-word:nth-child(2)::after  { animation-delay: calc(var(--ease-type-delay) * 2); }
+.type-word:nth-child(3)::after  { animation-delay: calc(var(--ease-type-delay) * 3); }
+.type-word:nth-child(4)::after  { animation-delay: calc(var(--ease-type-delay) * 4); }
+.type-word:nth-child(5)::after  { animation-delay: calc(var(--ease-type-delay) * 5); }
+.type-word:nth-child(6)::after  { animation-delay: calc(var(--ease-type-delay) * 6); }
+.type-word:nth-child(7)::after  { animation-delay: calc(var(--ease-type-delay) * 7); }
+.type-word:nth-child(8)::after  { animation-delay: calc(var(--ease-type-delay) * 8); }
+.type-word:nth-child(9)::after  { animation-delay: calc(var(--ease-type-delay) * 9); }
+.type-word:nth-child(10)::after { animation-delay: calc(var(--ease-type-delay) * 10); }
+.type-word:nth-child(11)::after { animation-delay: calc(var(--ease-type-delay) * 11); }
+.type-word:nth-child(12)::after { animation-delay: calc(var(--ease-type-delay) * 12); }
+.type-word:nth-child(13)::after { animation-delay: calc(var(--ease-type-delay) * 13); }
+.type-word:nth-child(14)::after { animation-delay: calc(var(--ease-type-delay) * 14); }
+.type-word:nth-child(15)::after { animation-delay: calc(var(--ease-type-delay) * 15); }
+.type-word:nth-child(16)::after { animation-delay: calc(var(--ease-type-delay) * 16); }
+.type-word:nth-child(17)::after { animation-delay: calc(var(--ease-type-delay) * 17); }
+.type-word:nth-child(18)::after { animation-delay: calc(var(--ease-type-delay) * 18); }
+.type-word:nth-child(19)::after { animation-delay: calc(var(--ease-type-delay) * 19); }
+.type-word:nth-child(20)::after { animation-delay: calc(var(--ease-type-delay) * 20); }
+.type-word:nth-child(21)::after { animation-delay: calc(var(--ease-type-delay) * 21); }
+.type-word:nth-child(22)::after { animation-delay: calc(var(--ease-type-delay) * 22); }
+.type-word:nth-child(23)::after { animation-delay: calc(var(--ease-type-delay) * 23); }
+.type-word:nth-child(24)::after { animation-delay: calc(var(--ease-type-delay) * 24); }
+.type-word:nth-child(25)::after { animation-delay: calc(var(--ease-type-delay) * 25); }
+.type-word:nth-child(26)::after { animation-delay: calc(var(--ease-type-delay) * 26); }
+.type-word:nth-child(27)::after { animation-delay: calc(var(--ease-type-delay) * 27); }
+.type-word:nth-child(28)::after { animation-delay: calc(var(--ease-type-delay) * 28); }
+.type-word:nth-child(29)::after { animation-delay: calc(var(--ease-type-delay) * 29); }
+.type-word:nth-child(30)::after { animation-delay: calc(var(--ease-type-delay) * 30); }
+.type-word:nth-child(31)::after { animation-delay: calc(var(--ease-type-delay) * 31); }
+.type-word:nth-child(32)::after { animation-delay: calc(var(--ease-type-delay) * 32); }
+.type-word:nth-child(33)::after { animation-delay: calc(var(--ease-type-delay) * 33); }
+.type-word:nth-child(34)::after { animation-delay: calc(var(--ease-type-delay) * 34); }
+.type-word:nth-child(35)::after { animation-delay: calc(var(--ease-type-delay) * 35); }
+.type-word:nth-child(36)::after { animation-delay: calc(var(--ease-type-delay) * 36); }
+.type-word:nth-child(37)::after { animation-delay: calc(var(--ease-type-delay) * 37); }
+.type-word:nth-child(38)::after { animation-delay: calc(var(--ease-type-delay) * 38); }
+.type-word:nth-child(39)::after { animation-delay: calc(var(--ease-type-delay) * 39); }
+.type-word:nth-child(40)::after { animation-delay: calc(var(--ease-type-delay) * 40); }
+
+/* ── prefers-reduced-motion Support ─────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .type-word::after {
+    animation: none !important;
+    display: none !important;
+  }
+}
+
+/* ── Demo Page Layout ───────────────────────────────────── */
+.demo-page {
+  min-height: 100vh;
+  background: var(--ease-bg);
+  color: var(--ease-color);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 24px;
+  box-sizing: border-box;
+  font-family: system-ui, -apple-system, sans-serif;
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+.demo-card {
+  width: 100%;
+  max-width: 640px;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid var(--ease-grid-border, rgba(255,255,255,0.06));
+  border-radius: 16px;
+  padding: 36px;
+  box-shadow: 0 16px 40px rgba(0,0,0,0.3);
+}
+
+.demo-title {
+  font-size: 1.5rem;
+  font-weight: 850;
+  margin: 0 0 24px;
+  background: linear-gradient(135deg, var(--ease-accent), #a855f7);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  font-family: system-ui, sans-serif;
+}
+
+.demo-btn {
+  margin-top: 32px;
+  display: inline-block;
+  padding: 10px 20px;
+  border-radius: 10px;
+  background: var(--ease-accent);
+  color: #fff;
+  font-size: 0.82rem;
+  font-weight: 700;
+  cursor: pointer;
+  border: none;
+  transition: transform 0.2s ease;
+  font-family: system-ui, sans-serif;
+}
+
+.demo-btn:hover {
+  transform: translateY(-1px);
+}
+.light-theme .demo-card {
+  background: #ffffff;
+  border-color: rgba(15, 23, 42, 0.08);
+  box-shadow: 0 16px 40px rgba(148, 163, 184, 0.15);
+}


### PR DESCRIPTION
Closes #68985

Adds a Multi-line CSS Typewriter Effect component under `submissions/examples/ease-typewriter-multiline-ksk/`.

#### Key Features & Requirements Met
- **Multi-line Word Segmentation** — Solves typewriter word wrapping boundary limits in pure CSS by wrapping individual text terms inside relative spans with absolute mask overlays.
- **Pseudo-element step animations** — Directs each word mask (`::after` acting as `.ease-typewriter-mask`) to slide rightwards using horizontal transforms (`transform: scaleX(1)` → `scaleX(0)`) with staggered delays.
- **prefers-reduced-motion Support** — Disables typewriter mask reveals on systems with reduced-motion preferences enabled, leaving text fully visible.
- **Light & Dark Theme Overrides** — Built-in CSS custom property variables supporting dark console backgrounds and light console overrides (`.light-theme`).