### PR TITLE
feat: add pure CSS Follower Count Badge component (#68537)

### DIFF
--- a/submissions/examples/css-follower-count-badge-pure/README.md
+++ b/submissions/examples/css-follower-count-badge-pure/README.md
@@ -1,0 +1,18 @@
+# CSS Follower Count Badge
+
+An animated metric badge featuring a live pulse indicator, commonly used to display real-time audience or active user counts. Built entirely without JavaScript.
+
+## Features
+- Pure CSS and HTML implementation.
+- **Theming & Dark Mode**: Utilizes CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), generating a sleek dark mode UI where the badge background and border adjust to match dark surface panels.
+- **Component Architecture (Documented in Code)**: 
+  - **The Pill Layout**: A simple flex container with `border-radius: 30px` creates the pill shape, providing a clean frame for the metric.
+  - **The Live Pulse (`.status-ping`)**: The core animation logic relies on a secondary `<span>` positioned absolutely beneath a solid core indicator dot. An infinite `@keyframes` animation (`livePulse`) scales this secondary ring up (`transform: scale(3.5)`) while simultaneously fading it out (`opacity: 0`). The use of a slow `cubic-bezier` creates a calm, rhythmic "heartbeat" effect rather than an urgent flashing.
+- Fully accessible semantic structure. The badge utilizes `role="status"` to inform screen readers of its purpose as a live metric, along with an explicit `aria-label` providing the full context ("10,248 active followers"). The purely visual pulse indicator is hidden via `aria-hidden="true"` to prevent screen readers from attempting to parse empty decorative `<span>` tags. Honors the `prefers-reduced-motion` accessibility standard by disabling the pulse animation entirely for motion-sensitive users, reverting to a solid, static indicator dot.
+
+## Usage
+Open `demo.html` in your browser to view the pill-shaped layout and the continuous live pulse animation.
+
+## Files
+- `demo.html`: The HTML structure demonstrating the layout of the indicator dot and the metric typography.
+- `style.css`: The styling, CSS Custom Property theming blocks, and the heavily commented `@keyframes` pulse logic.

--- a/submissions/examples/css-follower-count-badge-pure/demo.html
+++ b/submissions/examples/css-follower-count-badge-pure/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Follower Count Badge</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Follower Count Badge</h1>
+            <p class="subtitle">An animated metric badge featuring a live pulse indicator, commonly used to display real-time audience or active user counts.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <!-- 
+              [TECHNIQUE] The Follower Badge
+              A pill-shaped container combining a pulsing status dot with a metric count.
+            -->
+            <div class="follower-badge" aria-label="10,248 active followers" role="status">
+                
+                <!-- The live indicator dot with ping animation -->
+                <div class="status-indicator" aria-hidden="true">
+                    <span class="status-dot"></span>
+                    <span class="status-ping"></span>
+                </div>
+                
+                <!-- The metric data -->
+                <div class="metric-data">
+                    <span class="metric-count">10.2K</span>
+                    <span class="metric-label">Followers</span>
+                </div>
+                
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-follower-count-badge-pure/style.css
+++ b/submissions/examples/css-follower-count-badge-pure/style.css
@@ -1,0 +1,190 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f1f5f9;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    
+    /* Badge Colors */
+    --badge-bg: #ffffff;
+    --badge-border: #e2e8f0;
+    --badge-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+    
+    /* Indicator Colors (Live/Active Green) */
+    --indicator-core: #22c55e;
+    --indicator-pulse: rgba(34, 197, 94, 0.4);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #020617;
+        --text-primary: #f8fafc;
+        --text-secondary: #94a3b8;
+        
+        --badge-bg: #0f172a;
+        --badge-border: #1e293b;
+        --badge-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.4);
+        
+        /* Indicator Colors (Live/Active Green - slightly adjusted for dark) */
+        --indicator-core: #4ade80;
+        --indicator-pulse: rgba(74, 222, 128, 0.2);
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 60px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    padding: 40px 0;
+}
+
+
+/* =========================================
+   The Follower Badge Layout
+   ========================================= */
+
+.follower-badge {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    
+    background-color: var(--badge-bg);
+    border: 1px solid var(--badge-border);
+    padding: 8px 16px 8px 12px;
+    border-radius: 30px; /* Pill shape */
+    box-shadow: var(--badge-shadow);
+    
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    cursor: default;
+}
+
+.follower-badge:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 12px -1px rgba(0, 0, 0, 0.08);
+}
+
+
+/* =========================================
+   [TECHNIQUE] The Live Pulse Indicator
+   ========================================= */
+
+.status-indicator {
+    position: relative;
+    width: 10px;
+    height: 10px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+/* The solid inner dot */
+.status-dot {
+    position: absolute;
+    width: 10px;
+    height: 10px;
+    background-color: var(--indicator-core);
+    border-radius: 50%;
+    z-index: 2;
+}
+
+/* The expanding, fading outer ring */
+.status-ping {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    background-color: var(--indicator-pulse);
+    border-radius: 50%;
+    z-index: 1;
+    
+    /* 
+      The animation scales the ring up while fading it out.
+      We use a slow, steady cubic-bezier for a calm "heartbeat" rhythm.
+    */
+    animation: livePulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
+@keyframes livePulse {
+    0% {
+        transform: scale(1);
+        opacity: 1;
+    }
+    100% {
+        transform: scale(3.5);
+        opacity: 0;
+    }
+}
+
+
+/* =========================================
+   Typography
+   ========================================= */
+
+.metric-data {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+}
+
+.metric-count {
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: var(--text-primary);
+    letter-spacing: -0.2px;
+}
+
+.metric-label {
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: var(--text-secondary);
+    text-transform: lowercase; /* Modern UI trend for secondary labels */
+}
+
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .status-ping {
+        animation: none !important;
+        opacity: 0 !important; /* Hide the pulse entirely, leave just the solid dot */
+    }
+    
+    .follower-badge:hover {
+        transform: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces an animated metric badge featuring a live pulse indicator, commonly used to display real-time audience or active user counts, built entirely without JavaScript, resolving issue #68537.

### Changes Made:
- Added `submissions/examples/css-follower-count-badge-pure/` directory.
- Created `demo.html` showcasing the HTML structure demonstrating the layout of the indicator dot and the metric typography.
- Created `style.css` featuring the UI mechanics:
  - **The Pill Layout**: A simple flex container with `border-radius: 30px` creates the pill shape, providing a clean frame for the metric.
  - **The Live Pulse (`.status-ping`)**: The core animation logic relies on a secondary `<span>` positioned absolutely beneath a solid core indicator dot. An infinite `@keyframes` animation (`livePulse`) scales this secondary ring up (`transform: scale(3.5)`) while simultaneously fading it out (`opacity: 0`). The use of a slow `cubic-bezier` creates a calm, rhythmic "heartbeat" effect rather than an urgent flashing.
  - **Theming & Dark Mode Supported**: Utilizes CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), generating a sleek dark mode UI where the badge background and border adjust to match dark surface panels.
- Added `README.md` documenting usage and the technical mechanics of the heavily commented `@keyframes` pulse logic.
- Fully accessible semantic structure. The badge utilizes `role="status"` to inform screen readers of its purpose as a live metric, along with an explicit `aria-label` providing the full context ("10,248 active followers"). The purely visual pulse indicator is hidden via `aria-hidden="true"` to prevent screen readers from attempting to parse empty decorative `<span>` tags. Honors the `prefers-reduced-motion` accessibility standard by disabling the pulse animation entirely for motion-sensitive users, reverting to a solid, static indicator dot.

Closes #68537
