### PR TITLE
feat: add pure CSS Spotlight Button component (#70057)

### DIFF
--- a/submissions/examples/css-spotlight-button-pure/README.md
+++ b/submissions/examples/css-spotlight-button-pure/README.md
@@ -1,0 +1,20 @@
+# CSS Spotlight Button
+
+A pure CSS implementation of a cursor-tracking spotlight glow. Achieved entirely without JavaScript by utilizing an invisible CSS Grid of hover targets to calculate approximate cursor position.
+
+## Features
+- Pure CSS and HTML.
+- **Theming & Dark Mode**: Utilizes CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), generating a deep slate dark mode aesthetic that makes the cyan spotlight glow stand out.
+- **Component Architecture (Documented in Code)**: 
+  - **The Grid Hover Hack**: Because pure CSS cannot read raw mouse `(x, y)` coordinates, we have to simulate tracking. We do this by creating a wrapper and defining a 3x3 CSS Grid over it.
+  - **The Invisible Zones**: We fill the grid with 9 invisible `<div>` elements (`.hover-zone`). Because they sit on top of the button via `z-index`, they intercept the mouse hover events.
+  - **The Sibling Selector (`~`)**: When the user hovers over a specific zone (e.g., `.zone-tc` for top-center), we use the general sibling combinator to find the button element that comes after it in the DOM, and then target the `.spotlight-glow` element inside that button.
+  - **The Movement**: Depending on which zone is hovered, we apply a specific `transform: translate()` calculation to the glow element, shifting it smoothly to that quadrant using a `cubic-bezier` transition. 
+- Fully accessible semantic structure. The button itself is a native `<button>` element with an explicit `aria-label`, ensuring keyboard focus and screen reader compatibility are maintained despite the hacky overlay grid. The purely visual spotlight element is hidden from screen readers via `aria-hidden="true"`. Honors the `prefers-reduced-motion` accessibility standard by disabling the movement tracking for motion-sensitive users, falling back to a static, centered glow on hover.
+
+## Usage
+Open `demo.html` in your browser and move your cursor across the surface of the button to observe the glowing spotlight smoothly following your mouse position.
+
+## Files
+- `demo.html`: The HTML structure demonstrating the 9-zone layout and sibling DOM order required for the hack to function.
+- `style.css`: The styling, Grid setup, and the extensive matrix of `~` selectors mapping zones to translation coordinates.

--- a/submissions/examples/css-spotlight-button-pure/demo.html
+++ b/submissions/examples/css-spotlight-button-pure/demo.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Spotlight Button</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Spotlight Hover Button</h1>
+            <p class="subtitle">A pure CSS implementation of a cursor-tracking spotlight glow. Achieved without JavaScript by utilizing an invisible grid of hover targets.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <!-- 
+              [TECHNIQUE] The Grid Hover Hack
+              To track the cursor without JS, we overlay the button with a 3x3 grid
+              of invisible div elements. When a specific grid cell is hovered, 
+              we use the general sibling selector (~) to move the spotlight element
+              to that quadrant.
+            -->
+            
+            <div class="spotlight-wrapper">
+                
+                <!-- The Invisible Grid Layers (3x3 = 9 zones) -->
+                <!-- Top Row -->
+                <div class="hover-zone zone-tl"></div>
+                <div class="hover-zone zone-tc"></div>
+                <div class="hover-zone zone-tr"></div>
+                
+                <!-- Middle Row -->
+                <div class="hover-zone zone-ml"></div>
+                <div class="hover-zone zone-mc"></div>
+                <div class="hover-zone zone-mr"></div>
+                
+                <!-- Bottom Row -->
+                <div class="hover-zone zone-bl"></div>
+                <div class="hover-zone zone-bc"></div>
+                <div class="hover-zone zone-br"></div>
+                
+                <!-- The Actual Button Content -->
+                <button class="spotlight-btn" aria-label="Explore features">
+                    <span class="btn-text">Explore Features</span>
+                    <!-- The moving spotlight glow -->
+                    <span class="spotlight-glow" aria-hidden="true"></span>
+                </button>
+                
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-spotlight-button-pure/style.css
+++ b/submissions/examples/css-spotlight-button-pure/style.css
@@ -1,0 +1,208 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@500;600&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    
+    /* Button Base */
+    --btn-bg: #1e293b;
+    --btn-border: rgba(255, 255, 255, 0.1);
+    --btn-text: #f8fafc;
+    
+    /* Spotlight Effect */
+    --spotlight-color: rgba(56, 189, 248, 0.6); /* Cyan glow */
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #020617;
+        --text-primary: #f8fafc;
+        --text-secondary: #94a3b8;
+        
+        --btn-bg: #0f172a;
+        --btn-border: rgba(255, 255, 255, 0.15);
+        --spotlight-color: rgba(56, 189, 248, 0.5);
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 60px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    padding: 40px 0;
+}
+
+
+/* =========================================
+   [TECHNIQUE] The Grid Hover Hack Wrapper
+   ========================================= */
+
+.spotlight-wrapper {
+    position: relative;
+    display: inline-block;
+    
+    /* Set fixed dimensions for the wrapper to contain the grid */
+    width: 220px;
+    height: 64px;
+    
+    /* 
+      We set up a 3x3 CSS Grid spanning the entire wrapper.
+      This grid will hold our invisible hover zones.
+    */
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    grid-template-rows: repeat(3, 1fr);
+}
+
+
+/* The Invisible Hover Zones */
+.hover-zone {
+    position: relative;
+    z-index: 10; /* Must sit ABOVE the button to intercept mouse events */
+    cursor: pointer;
+}
+
+/* 
+  The Actual Button 
+  It spans all rows and columns, sitting underneath the hover zones.
+*/
+.spotlight-btn {
+    grid-column: 1 / -1;
+    grid-row: 1 / -1;
+    
+    position: relative;
+    width: 100%;
+    height: 100%;
+    
+    background-color: var(--btn-bg);
+    border: 1px solid var(--btn-border);
+    border-radius: 12px;
+    overflow: hidden; /* Contains the spotlight glow */
+    
+    /* Disable pointer events so the hover zones above it catch everything */
+    pointer-events: none;
+}
+
+/* Ensure focus works properly for keyboard users */
+.spotlight-wrapper:focus-within .spotlight-btn {
+    outline: 2px solid var(--text-primary);
+    outline-offset: 4px;
+}
+
+.btn-text {
+    position: relative;
+    z-index: 2; /* Sits above the spotlight glow */
+    color: var(--btn-text);
+    font-family: 'Inter', sans-serif;
+    font-size: 1.1rem;
+    font-weight: 600;
+    letter-spacing: 0.5px;
+    
+    /* Center text perfectly */
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100%;
+}
+
+
+/* =========================================
+   The Spotlight Glow Element
+   ========================================= */
+
+.spotlight-glow {
+    position: absolute;
+    width: 80px;
+    height: 80px;
+    background: radial-gradient(circle, var(--spotlight-color) 0%, transparent 70%);
+    border-radius: 50%;
+    
+    /* Start exactly in the center */
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    
+    /* Hidden until the wrapper is hovered */
+    opacity: 0;
+    transition: transform 0.3s cubic-bezier(0.2, 0, 0, 1), opacity 0.3s ease;
+    z-index: 1; /* Below text, above background */
+}
+
+/* Fade in the glow when hovering anywhere in the wrapper */
+.spotlight-wrapper:hover .spotlight-glow {
+    opacity: 1;
+}
+
+
+/* =========================================
+   [TECHNIQUE] Moving the Spotlight
+   ========================================= */
+
+/* 
+  When a specific hover zone is hovered, we use the general sibling 
+  combinator (~) to find the button, then target the glow inside it.
+  We adjust the transform translation to move the glow to that quadrant.
+*/
+
+/* Top Row */
+.zone-tl:hover ~ .spotlight-btn .spotlight-glow { transform: translate(-100%, -100%); }
+.zone-tc:hover ~ .spotlight-btn .spotlight-glow { transform: translate(-50%, -100%); }
+.zone-tr:hover ~ .spotlight-btn .spotlight-glow { transform: translate(0%, -100%); }
+
+/* Middle Row */
+.zone-ml:hover ~ .spotlight-btn .spotlight-glow { transform: translate(-100%, -50%); }
+.zone-mc:hover ~ .spotlight-btn .spotlight-glow { transform: translate(-50%, -50%); }
+.zone-mr:hover ~ .spotlight-btn .spotlight-glow { transform: translate(0%, -50%); }
+
+/* Bottom Row */
+.zone-bl:hover ~ .spotlight-btn .spotlight-glow { transform: translate(-100%, 0%); }
+.zone-bc:hover ~ .spotlight-btn .spotlight-glow { transform: translate(-50%, 0%); }
+.zone-br:hover ~ .spotlight-btn .spotlight-glow { transform: translate(0%, 0%); }
+
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .spotlight-glow {
+        transition: opacity 0.2s ease !important;
+        /* Keep it centered for static fallback */
+        transform: translate(-50%, -50%) !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a pure CSS implementation of a cursor-tracking spotlight glow. Achieved entirely without JavaScript by utilizing an invisible CSS Grid of hover targets to calculate approximate cursor position, resolving issue #70057.

### Changes Made:
- Added `submissions/examples/css-spotlight-button-pure/` directory.
- Created `demo.html` showcasing the HTML structure demonstrating the 9-zone layout and sibling DOM order required for the hack to function.
- Created `style.css` featuring the UI mechanics:
  - **The Grid Hover Hack**: Because pure CSS cannot read raw mouse `(x, y)` coordinates, we have to simulate tracking. We do this by creating a wrapper and defining a 3x3 CSS Grid over it.
  - **The Invisible Zones**: We fill the grid with 9 invisible `<div>` elements (`.hover-zone`). Because they sit on top of the button via `z-index`, they intercept the mouse hover events.
  - **The Sibling Selector (`~`)**: When the user hovers over a specific zone (e.g., `.zone-tc` for top-center), we use the general sibling combinator to find the button element that comes after it in the DOM, and then target the `.spotlight-glow` element inside that button.
  - **The Movement**: Depending on which zone is hovered, we apply a specific `transform: translate()` calculation to the glow element, shifting it smoothly to that quadrant using a `cubic-bezier` transition. 
  - **Theming & Dark Mode Supported**: Utilizes CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), generating a deep slate dark mode aesthetic that makes the cyan spotlight glow stand out.
- Added `README.md` documenting usage and the extensive matrix of `~` selectors mapping zones to translation coordinates.
- Fully accessible semantic structure. The button itself is a native `<button>` element with an explicit `aria-label`, ensuring keyboard focus and screen reader compatibility are maintained despite the hacky overlay grid. The purely visual spotlight element is hidden from screen readers via `aria-hidden="true"`. Honors the `prefers-reduced-motion` accessibility standard by disabling the movement tracking for motion-sensitive users, falling back to a static, centered glow on hover.

Closes #70057
