### PR TITLE
feat: add pure CSS Dissolve Text Effect component (#70071)

### DIFF
--- a/submissions/examples/css-dissolve-text-effect-pure/README.md
+++ b/submissions/examples/css-dissolve-text-effect-pure/README.md
@@ -1,0 +1,19 @@
+# CSS Dissolve Text Effect
+
+A pure CSS implementation of a particle dissolve effect. Hover over the text to watch it scatter into a cloud of blurred particles, achieved entirely without JavaScript or complex SVG filters.
+
+## Features
+- Pure CSS and HTML.
+- **Component Architecture (Documented in Code)**: 
+  - **The Base Animation**: When the main `.dissolve-text` element is hovered, it applies `filter: blur(10px)` and scales down slightly (`transform: scale(0.95)`) while fading its opacity to zero. This hides the solid structural text smoothly.
+  - **The Particle Hack**: The magic happens in the `::before` pseudo-element. Using `content: attr(data-text)`, we perfectly clone the text string. We set this clone to `color: transparent`, making the text itself invisible.
+  - **The Scattering Shadows**: We apply 8 identical, perfectly stacked `text-shadow` layers to the transparent clone. On hover, a CSS transition targets these shadows, moving them along distinct `X` and `Y` axes outward radially. Simultaneously, we increase the shadow's blur radius and fade its color to `rgba(..., 0)`. Because all 8 shadows animate outward at the same time, it creates the illusion of the word breaking apart into dissolving particles or smoke.
+- **Theming & Dark Mode**: Configured via CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), generating a deep slate dark mode aesthetic while correctly adjusting the shadow fade colors to blend into the dark background.
+- Fully accessible semantic structure. The text itself is a standard `<h2>` element, entirely readable by screen readers. The particle hack uses a pseudo-element which is safely ignored. Honors the `prefers-reduced-motion` accessibility standard by disabling the shadow explosion for motion-sensitive users, falling back to a simple opacity fade on hover.
+
+## Usage
+Open `demo.html` in your browser and hover your cursor over the word to trigger the radial text-shadow particle explosion.
+
+## Files
+- `demo.html`: The HTML structure demonstrating the `data-text` attribute injection required for the pseudo-element cloning.
+- `style.css`: The styling, state transitions, and the extensive multi-layered `text-shadow` matrix logic.

--- a/submissions/examples/css-dissolve-text-effect-pure/demo.html
+++ b/submissions/examples/css-dissolve-text-effect-pure/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Dissolve Text Effect</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Dissolve Text Effect</h1>
+            <p class="subtitle">A pure CSS implementation of a particle dissolve effect. Hover over the text to watch it scatter into a cloud of blurred text-shadow particles.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <!-- 
+              [TECHNIQUE] The Text-Shadow Particle Hack
+              We use a single HTML element. In CSS, we will duplicate the text string
+              into a ::before pseudo-element and apply complex text-shadows to it
+              to simulate individual dissolving particles.
+            -->
+            <div class="dissolve-wrapper">
+                
+                <!-- 
+                  data-text attribute is used so the CSS pseudo-element can read
+                  the exact same text string dynamically.
+                -->
+                <h2 class="dissolve-text" data-text="Evaporate">Evaporate</h2>
+                
+            </div>
+            
+            <p class="instruction-text">
+                Hover over the word above to activate the effect.
+            </p>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-dissolve-text-effect-pure/style.css
+++ b/submissions/examples/css-dissolve-text-effect-pure/style.css
@@ -1,0 +1,195 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700;900&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    
+    /* Dissolve Text Specifics */
+    --dissolve-color: #0f172a;
+    --particle-spread: 120px; /* How far the particles scatter */
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a;
+        --text-primary: #f8fafc;
+        --text-secondary: #94a3b8;
+        
+        --dissolve-color: #f8fafc;
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 60px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.demo-area {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 40px;
+    padding: 60px 0;
+    min-height: 200px;
+}
+
+.instruction-text {
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+    font-style: italic;
+    text-align: center;
+}
+
+
+/* =========================================
+   [TECHNIQUE] The Dissolve Effect
+   ========================================= */
+
+.dissolve-wrapper {
+    position: relative;
+    cursor: default;
+}
+
+/* 
+  The Base Text
+  We apply a transition so that when hovered, the actual text 
+  fades out slightly and blurs, hiding the "solid" body.
+*/
+.dissolve-text {
+    position: relative;
+    font-size: 5rem;
+    font-weight: 900;
+    letter-spacing: -2px;
+    text-transform: uppercase;
+    color: var(--dissolve-color);
+    margin: 0;
+    
+    transition: all 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Hover State: Hide the base text */
+.dissolve-wrapper:hover .dissolve-text {
+    opacity: 0;
+    filter: blur(10px);
+    transform: scale(0.95);
+}
+
+
+/* 
+  [TECHNIQUE] The Particles
+  We use the ::before pseudo-element to duplicate the text exactly
+  using the attr(data-text) function. 
+  We set its color to transparent, but give it a complex multi-layered 
+  text-shadow. On hover, these shadows translate outwards.
+*/
+.dissolve-text::before {
+    content: attr(data-text);
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    
+    /* Make the actual text invisible, we only want the shadows */
+    color: transparent;
+    
+    /* Ensure shadows don't get cut off */
+    z-index: 10;
+    pointer-events: none;
+    
+    /* Base State: Shadows are stacked directly underneath the text, perfectly aligned */
+    text-shadow: 
+        0 0 0 var(--dissolve-color),
+        0 0 0 var(--dissolve-color),
+        0 0 0 var(--dissolve-color),
+        0 0 0 var(--dissolve-color),
+        0 0 0 var(--dissolve-color),
+        0 0 0 var(--dissolve-color),
+        0 0 0 var(--dissolve-color),
+        0 0 0 var(--dissolve-color);
+        
+    transition: all 0.6s cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+/* 
+  Hover State: Scatter the shadows
+  We move each shadow in a different direction (using X, Y offsets)
+  and apply significant blur to simulate dissolution/smoke.
+  Because the transition takes time, it looks like an explosion of particles.
+*/
+.dissolve-wrapper:hover .dissolve-text::before {
+    text-shadow: 
+        calc(var(--particle-spread) * -1) calc(var(--particle-spread) * -0.5) 20px rgba(15, 23, 42, 0),
+        calc(var(--particle-spread) * -0.5) calc(var(--particle-spread) * -1) 25px rgba(15, 23, 42, 0),
+        0 calc(var(--particle-spread) * -1.2) 30px rgba(15, 23, 42, 0),
+        calc(var(--particle-spread) * 0.5) calc(var(--particle-spread) * -1) 20px rgba(15, 23, 42, 0),
+        var(--particle-spread) calc(var(--particle-spread) * -0.5) 25px rgba(15, 23, 42, 0),
+        var(--particle-spread) 0 30px rgba(15, 23, 42, 0),
+        calc(var(--particle-spread) * 0.5) calc(var(--particle-spread) * 0.8) 20px rgba(15, 23, 42, 0),
+        calc(var(--particle-spread) * -0.5) calc(var(--particle-spread) * 0.8) 25px rgba(15, 23, 42, 0);
+        
+    /* Note: In dark mode we ideally fade to the dark background color. 
+       The rgba(15, 23, 42, 0) relies on opacity 0 for the final dissolve state. */
+}
+
+/* Dark mode shadow adjustment */
+@media (prefers-color-scheme: dark) {
+    .dissolve-wrapper:hover .dissolve-text::before {
+        text-shadow: 
+            calc(var(--particle-spread) * -1) calc(var(--particle-spread) * -0.5) 20px rgba(248, 250, 252, 0),
+            calc(var(--particle-spread) * -0.5) calc(var(--particle-spread) * -1) 25px rgba(248, 250, 252, 0),
+            0 calc(var(--particle-spread) * -1.2) 30px rgba(248, 250, 252, 0),
+            calc(var(--particle-spread) * 0.5) calc(var(--particle-spread) * -1) 20px rgba(248, 250, 252, 0),
+            var(--particle-spread) calc(var(--particle-spread) * -0.5) 25px rgba(248, 250, 252, 0),
+            var(--particle-spread) 0 30px rgba(248, 250, 252, 0),
+            calc(var(--particle-spread) * 0.5) calc(var(--particle-spread) * 0.8) 20px rgba(248, 250, 252, 0),
+            calc(var(--particle-spread) * -0.5) calc(var(--particle-spread) * 0.8) 25px rgba(248, 250, 252, 0);
+    }
+}
+
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .dissolve-wrapper:hover .dissolve-text {
+        opacity: 0.5;
+        filter: none;
+        transform: none;
+    }
+    .dissolve-text::before {
+        display: none; /* Turn off the shadow particle hack completely */
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a pure CSS implementation of a particle dissolve effect. Hovering over the text watches it scatter into a cloud of blurred particles, achieved entirely without JavaScript or complex SVG filters, resolving issue #70071.

### Changes Made:
- Added `submissions/examples/css-dissolve-text-effect-pure/` directory.
- Created `demo.html` showcasing the HTML structure demonstrating the `data-text` attribute injection required for the pseudo-element cloning.
- Created `style.css` featuring the UI mechanics:
  - **The Base Animation**: When the main `.dissolve-text` element is hovered, it applies `filter: blur(10px)` and scales down slightly (`transform: scale(0.95)`) while fading its opacity to zero. This hides the solid structural text smoothly.
  - **The Particle Hack**: The magic happens in the `::before` pseudo-element. Using `content: attr(data-text)`, we perfectly clone the text string. We set this clone to `color: transparent`, making the text itself invisible.
  - **The Scattering Shadows**: We apply 8 identical, perfectly stacked `text-shadow` layers to the transparent clone. On hover, a CSS transition targets these shadows, moving them along distinct `X` and `Y` axes outward radially. Simultaneously, we increase the shadow's blur radius and fade its color to `rgba(..., 0)`. Because all 8 shadows animate outward at the same time, it creates the illusion of the word breaking apart into dissolving particles or smoke.
  - **Theming & Dark Mode Supported**: Configured via CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), generating a deep slate dark mode aesthetic while correctly adjusting the shadow fade colors to blend into the dark background.
- Added `README.md` documenting usage and the technical mechanics of the multi-layered `text-shadow` matrix logic.
- Fully accessible semantic structure. The text itself is a standard `<h2>` element, entirely readable by screen readers. The particle hack uses a pseudo-element which is safely ignored. Honors the `prefers-reduced-motion` accessibility standard by disabling the shadow explosion for motion-sensitive users, falling back to a simple opacity fade on hover.

Closes #70071
