### PR TITLE
feat: add ease-ferrofluid-spike-field (#67343)

### DIFF
--- a/submissions/examples/ferrofluid-spike-field-ns/README.md
+++ b/submissions/examples/ferrofluid-spike-field-ns/README.md
@@ -1,24 +1,16 @@
-# Ease Ferrofluid Spike Field
+# Ferrofluid Spike Field
 
-A CSS-only animated ferrofluid spike field component created for EaseMotion CSS.
+## What does this do?
+Renders a self-contained CSS-only `ease-ferrofluid-spike-field` demo: Ferrofluid spikes rising under a magnetic field.
 
-## Overview
-
-`ease-ferrofluid-spike-field` simulates ferrofluid spikes rising and moving under the influence of a magnetic field.
-
-## Features
-
-- Pure CSS animation
-- No JavaScript dependency
-- Magnetic field visualization
-- Animated ferrofluid spikes
-- Real-world science inspired UI
-- Responsive layout
-- Reduced motion accessibility support
-
-
-## Usage
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-ferrofluid-spike-field`. No build step or JavaScript is required for the effect.
 
 ```html
-<div class="ease-ferrofluid-spike-field">
-</div>
+<section class="ease-ferrofluid-spike-field">
+  <div class="ease-ferrofluid-spike-field__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/ferrofluid-spike-field-ns/demo.html
+++ b/submissions/examples/ferrofluid-spike-field-ns/demo.html
@@ -3,37 +3,50 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Ease Ferrofluid Spike Field</title>
-  <link rel="stylesheet" href="style.css">
+  <title>Ferrofluid Spike Field — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
 </head>
-
 <body>
+  <main class="stage" aria-label="Ferrofluid Spike Field demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Ferrofluid Spike Field</h1>
+      <p class="lede">Ferrofluid spikes rising under a magnetic field</p>
+    </header>
 
-<div class="ease-ferrofluid-spike-field">
-
-  <div class="control-panel">
-
-    <h2>MAGNETIC FIELD</h2>
-    <p>FERROFLUID SPIKE MONITOR</p>
-
-    <div class="fluid-container">
-
-      <div class="spike spike-one"></div>
-      <div class="spike spike-two"></div>
-      <div class="spike spike-three"></div>
-      <div class="spike spike-four"></div>
-      <div class="fluid"></div>
-
-    </div>
-
-    <div class="indicator">
-      <span></span>
-      FIELD ACTIVE
-    </div>
-
-  </div>
-
-</div>
-
+    <section class="ease-ferrofluid-spike-field" data-demo="ferrofluid-spike-field" aria-live="polite">
+      <div class="ease-ferrofluid-spike-field__housing">
+        <div class="ease-ferrofluid-spike-field__bezel">
+          <div class="ease-ferrofluid-spike-field__face">
+            <div class="ease-ferrofluid-spike-field__readout">
+              <span class="ease-ferrofluid-spike-field__label">Ferrofluid Spike Field</span>
+              <span class="ease-ferrofluid-spike-field__value">LIVE</span>
+            </div>
+            <div class="ease-ferrofluid-spike-field__motion" aria-hidden="true">
+              <span class="ease-ferrofluid-spike-field__a"></span>
+              <span class="ease-ferrofluid-spike-field__b"></span>
+              <span class="ease-ferrofluid-spike-field__c"></span>
+              <span class="ease-ferrofluid-spike-field__d"></span>
+            </div>
+            <div class="ease-ferrofluid-spike-field__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-ferrofluid-spike-field__controls">
+          <button type="button" class="ease-ferrofluid-spike-field__btn primary">Engage</button>
+          <button type="button" class="ease-ferrofluid-spike-field__btn">Reset</button>
+          <label class="ease-ferrofluid-spike-field__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-ferrofluid-spike-field__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
 </body>
 </html>

--- a/submissions/examples/ferrofluid-spike-field-ns/style.css
+++ b/submissions/examples/ferrofluid-spike-field-ns/style.css
@@ -1,174 +1,234 @@
-*{
-  box-sizing:border-box;
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
 }
 
-
-body{
-
-  min-height:100vh;
-  margin:0;
-  display:flex;
-  justify-content:center;
-  align-items:center;
-  background:#020617;
-  font-family:Arial,sans-serif;
-
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #fb7185 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #fda4af 18%, transparent), transparent 42%),
+    #1a0b0e;
 }
 
-
-.ease-ferrofluid-spike-field{
-
-  width:380px;
-
+.stage {
+  width: min(680px, 100%);
 }
 
-
-.control-panel{
-
-  padding:25px;
-  text-align:center;
-  color:white;
-  background:rgba(15,23,42,.9);
-  border-radius:20px;
-  border:1px solid #334155;
-
+.stage-head {
+  margin-bottom: 1.25rem;
 }
 
-
-.control-panel p{
-
-  font-size:12px;
-  color:#94a3b8;
-
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
 }
 
-
-
-.fluid-container{
-
-  position:relative;
-  height:230px;
-  margin:20px 0;
-  background:#030712;
-  border-radius:18px;
-  overflow:hidden;
-
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
 }
 
-
-
-.fluid{
-
-  position:absolute;
-  bottom:25px;
-  left:50%;
-  transform:translateX(-50%);
-  width:170px;
-  height:50px;
-  background:#111827;
-  border-radius:50%;
-  box-shadow:0 0 25px #475569;
-
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
 }
 
-
-
-.spike{
-
-  position:absolute;
-  bottom:45px;
-  left:50%;
-  width:18px;
-  height:110px;
-  transform-origin:bottom;
-  background:#1e293b;
-  border-radius:50% 50% 5px 5px;
-  animation:ferrofluid_spike_field_motion 2s ease-in-out infinite;
-
+.ease-ferrofluid-spike-field {
+  --accent: #fb7185;
+  --accent-2: #fda4af;
+  --panel: color-mix(in srgb, #e8eef6 7%, #1a0b0e);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #1a0b0e 75%, #000);
 }
 
-
-
-.spike-one{
-
-  margin-left:-70px;
-
+.ease-ferrofluid-spike-field__housing {
+  display: grid;
+  gap: 0.9rem;
 }
 
-
-.spike-two{
-
-  margin-left:-25px;
-  height:150px;
-  animation-delay:.2s;
-
+.ease-ferrofluid-spike-field__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #1a0b0e 90%, #fb7185);
 }
 
-
-.spike-three{
-
-  margin-left:20px;
-  height:130px;
-  animation-delay:.4s;
-
+.ease-ferrofluid-spike-field__face {
+  position: relative;
+  min-height: 260px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 28% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #1a0b0e 85%, #000), color-mix(in srgb, #1a0b0e 65%, var(--accent-2)));
 }
 
-
-.spike-four{
-
-  margin-left:65px;
-  height:90px;
-  animation-delay:.6s;
-
+.ease-ferrofluid-spike-field__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
 }
 
-
-
-.indicator{
-
-  margin-top:15px;
-
+.ease-ferrofluid-spike-field__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
 }
 
-
-.indicator span{
-
-  display:inline-block;
-  width:10px;
-  height:10px;
-  background:#22c55e;
-  border-radius:50%;
-  margin-right:8px;
-
+.ease-ferrofluid-spike-field__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
 }
 
+.ease-ferrofluid-spike-field__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
 
+.ease-ferrofluid-spike-field__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
 
-@keyframes ferrofluid_spike_field_motion{
+.ease-ferrofluid-spike-field__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
 
-  0%,100%{
+.ease-ferrofluid-spike-field__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: ferrofluid_spike_field_meter 1.7s ease-in-out infinite alternate;
+}
 
-    transform:scaleY(.7);
+.ease-ferrofluid-spike-field__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-ferrofluid-spike-field__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-ferrofluid-spike-field__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-ferrofluid-spike-field__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-ferrofluid-spike-field__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
 
+.ease-ferrofluid-spike-field__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-ferrofluid-spike-field__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-ferrofluid-spike-field__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-ferrofluid-spike-field__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-ferrofluid-spike-field__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-ferrofluid-spike-field__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-ferrofluid-spike-field__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: ferrofluid_spike_field_status 1.8s ease-out infinite;
+}
+
+@keyframes ferrofluid_spike_field_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes ferrofluid_spike_field_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-ferrofluid-spike-field__a{position:absolute;inset:24% 18% 30%;border-radius:12px;border:2px solid #475569;background:linear-gradient(180deg,#0f172a,#111827);overflow:hidden}
+.ease-ferrofluid-spike-field__b{position:absolute;left:10%;top:20%;width:18%;height:60%;background:color-mix(in srgb,var(--accent) 55%,transparent);animation:ferrofluid_spike_field_rise 2.4s ease-in-out infinite}
+.ease-ferrofluid-spike-field__c{position:absolute;left:40%;top:20%;width:18%;height:60%;background:color-mix(in srgb,var(--accent-2) 55%,transparent);animation:ferrofluid_spike_field_rise 2.4s ease-in-out infinite .15s}
+.ease-ferrofluid-spike-field__d{position:absolute;left:70%;top:20%;width:18%;height:60%;background:color-mix(in srgb,var(--accent) 40%,transparent);animation:ferrofluid_spike_field_rise 2.4s ease-in-out infinite .3s}
+@keyframes ferrofluid_spike_field_rise{0%,100%{transform:scaleY(.35);transform-origin:bottom;opacity:.5}50%{transform:scaleY(1);opacity:1}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-ferrofluid-spike-field__a,
+  .ease-ferrofluid-spike-field__b,
+  .ease-ferrofluid-spike-field__c,
+  .ease-ferrofluid-spike-field__d,
+  .ease-ferrofluid-spike-field__meters i::after,
+  .ease-ferrofluid-spike-field__status .dot {
+    animation: none !important;
   }
-
-
-  50%{
-
-    transform:scaleY(1.15) rotate(3deg);
-
-  }
-
-}
-
-
-
-@media(prefers-reduced-motion:reduce){
-
-*{
-
-animation-duration:.01ms!important;
-
-}
-
 }


### PR DESCRIPTION
## Pull Request Description

Adds `ease-ferrofluid-spike-field` under `submissions/examples/ferrofluid-spike-field-ns/` — CSS-only Ferrofluid spikes rising under a magnetic field.

Fixes #67343

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Ferrofluid spikes rising under a magnetic field.

**How does a developer use it?**

```html
<section class="ease-ferrofluid-spike-field">
  <div class="ease-ferrofluid-spike-field__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `ferrofluid_spike_field_*` prefix. Reduced-motion disables animations.

Made with [Cursor](https://cursor.com)