### PR TITLE
feat: add CSS-only piano keys

### DIFF
--- a/submissions/examples/css-piano-keys-v2/README.md
+++ b/submissions/examples/css-piano-keys-v2/README.md
@@ -1,0 +1,29 @@
+# CSS-only Piano Keys
+
+A responsive piano keyboard component created using HTML and CSS only.
+
+## Features
+
+- Pure HTML and CSS implementation
+- Responsive piano keyboard
+- White and black piano keys
+- Hover interaction
+- Press animation using CSS
+- Keyboard focus support
+- Accessible labels for white keys
+- `prefers-reduced-motion` support
+- No JavaScript required
+
+## Demo
+
+Open `demo.html` in a modern web browser.
+
+Hover over the piano keys or use the keyboard `Tab` key to focus the white keys.
+
+## Files
+
+```text
+css-piano-keys/
+├── demo.html
+├── style.css
+└── README.md

--- a/submissions/examples/css-piano-keys-v2/demo.html
+++ b/submissions/examples/css-piano-keys-v2/demo.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS-only responsive piano keyboard with animated key press effects">
+  <title>CSS Piano Keys</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+  <main class="page">
+    <section class="piano-demo" aria-labelledby="piano-title">
+      <h1 id="piano-title">CSS Piano Keys</h1>
+      <p class="description">
+        A responsive piano keyboard built using HTML and CSS only.
+        Hover or focus a key to see the press animation.
+      </p>
+
+      <div class="piano" role="group" aria-label="Piano keyboard">
+        <div class="white-keys">
+          <button class="key white-key" type="button" aria-label="C note">
+            <span>C</span>
+          </button>
+
+          <button class="key white-key" type="button" aria-label="D note">
+            <span>D</span>
+          </button>
+
+          <button class="key white-key" type="button" aria-label="E note">
+            <span>E</span>
+          </button>
+
+          <button class="key white-key" type="button" aria-label="F note">
+            <span>F</span>
+          </button>
+
+          <button class="key white-key" type="button" aria-label="G note">
+            <span>G</span>
+          </button>
+
+          <button class="key white-key" type="button" aria-label="A note">
+            <span>A</span>
+          </button>
+
+          <button class="key white-key" type="button" aria-label="B note">
+            <span>B</span>
+          </button>
+
+          <button class="key white-key" type="button" aria-label="C note">
+            <span>C</span>
+          </button>
+        </div>
+
+        <div class="black-keys" aria-hidden="true">
+          <button class="key black-key black-c" type="button" tabindex="-1">
+            C#
+          </button>
+
+          <button class="key black-key black-d" type="button" tabindex="-1">
+            D#
+          </button>
+
+          <button class="key black-key black-f" type="button" tabindex="-1">
+            F#
+          </button>
+
+          <button class="key black-key black-g" type="button" tabindex="-1">
+            G#
+          </button>
+
+          <button class="key black-key black-a" type="button" tabindex="-1">
+            A#
+          </button>
+        </div>
+      </div>
+
+      <p class="hint">
+        Hover or use Tab to focus the white keys.
+      </p>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/css-piano-keys-v2/style.css
+++ b/submissions/examples/css-piano-keys-v2/style.css
@@ -1,0 +1,236 @@
+* {
+    box-sizing: border-box;
+  }
+  
+  :root {
+    --page-bg: #f4f6f8;
+    --card-bg: #ffffff;
+    --text: #1f2937;
+    --muted: #64748b;
+    --border: #d7dce2;
+    --white-key: #ffffff;
+    --white-key-hover: #eef2f7;
+    --black-key: #171717;
+    --black-key-hover: #303030;
+    --accent: #2563eb;
+  }
+  
+  body {
+    margin: 0;
+    min-height: 100vh;
+    font-family: Arial, Helvetica, sans-serif;
+    background: var(--page-bg);
+    color: var(--text);
+  }
+  
+  .page {
+    min-height: 100vh;
+    display: grid;
+    place-items: center;
+    padding: 2rem 1rem;
+  }
+  
+  .piano-demo {
+    width: min(900px, 100%);
+    padding: 2rem;
+    background: var(--card-bg);
+    border: 1px solid var(--border);
+    border-radius: 18px;
+    text-align: center;
+    box-shadow: 0 12px 30px rgb(0 0 0 / 8%);
+  }
+  
+  .piano-demo h1 {
+    margin: 0 0 0.5rem;
+    font-size: clamp(1.8rem, 4vw, 2.5rem);
+  }
+  
+  .description {
+    max-width: 620px;
+    margin: 0 auto 2rem;
+    color: var(--muted);
+    line-height: 1.6;
+  }
+  
+  .piano {
+    position: relative;
+    width: 100%;
+    max-width: 760px;
+    height: 300px;
+    margin: 0 auto;
+    overflow: hidden;
+    border: 2px solid #222;
+    border-radius: 10px;
+    background: #222;
+  }
+  
+  .white-keys {
+    display: flex;
+    width: 100%;
+    height: 100%;
+  }
+  
+  .key {
+    font: inherit;
+    cursor: pointer;
+    border: 0;
+  }
+  
+  .white-key {
+    position: relative;
+    flex: 1;
+    height: 100%;
+    padding: 0;
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    padding-bottom: 1.2rem;
+  
+    color: #555;
+    background: var(--white-key);
+    border-right: 1px solid #b8bec6;
+  
+    box-shadow:
+      inset 0 -5px 0 #d7d7d7,
+      0 2px 0 #999;
+  
+    transition:
+      transform 100ms ease,
+      background-color 100ms ease,
+      box-shadow 100ms ease;
+  }
+  
+  .white-key:last-child {
+    border-right: 0;
+  }
+  
+  .white-key:hover {
+    background: var(--white-key-hover);
+  }
+  
+  .white-key:active,
+  .white-key:focus-visible {
+    transform: translateY(5px);
+    background: #e3e8ee;
+  
+    box-shadow:
+      inset 0 -2px 0 #b7bcc3,
+      0 0 0 #999;
+  }
+  
+  .white-key:focus-visible,
+  .black-key:focus-visible {
+    outline: 3px solid var(--accent);
+    outline-offset: -3px;
+  }
+  
+  .white-key span {
+    font-size: 0.9rem;
+    font-weight: 700;
+  }
+  
+  .black-keys {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+  }
+  
+  .black-key {
+    position: absolute;
+    top: 0;
+    width: 8%;
+    height: 62%;
+    min-height: 120px;
+  
+    color: #fff;
+    background: var(--black-key);
+    border-radius: 0 0 7px 7px;
+  
+    box-shadow:
+      inset 0 -5px 0 #050505,
+      0 4px 5px rgb(0 0 0 / 35%);
+  
+    pointer-events: auto;
+  
+    transition:
+      transform 100ms ease,
+      background-color 100ms ease,
+      box-shadow 100ms ease;
+  }
+  
+  .black-key:hover {
+    background: var(--black-key-hover);
+  }
+  
+  .black-key:active,
+  .black-key:focus-visible {
+    transform: translateY(5px);
+  
+    box-shadow:
+      inset 0 -2px 0 #050505,
+      0 1px 2px rgb(0 0 0 / 30%);
+  }
+  
+  .black-c {
+    left: 8.5%;
+  }
+  
+  .black-d {
+    left: 21%;
+  }
+  
+  .black-f {
+    left: 46%;
+  }
+  
+  .black-g {
+    left: 58.5%;
+  }
+  
+  .black-a {
+    left: 71%;
+  }
+  
+  .hint {
+    margin: 1.5rem 0 0;
+    color: var(--muted);
+    font-size: 0.9rem;
+  }
+  
+  @media (max-width: 600px) {
+    .page {
+      padding: 1rem 0.5rem;
+    }
+  
+    .piano-demo {
+      padding: 1.25rem 0.75rem;
+      border-radius: 12px;
+    }
+  
+    .piano {
+      height: 220px;
+    }
+  
+    .black-key {
+      min-height: 90px;
+    }
+  
+    .white-key {
+      padding-bottom: 0.8rem;
+    }
+  
+    .white-key span {
+      font-size: 0.75rem;
+    }
+  
+    .black-key {
+      font-size: 0.65rem;
+    }
+  }
+  
+  @media (prefers-reduced-motion: reduce) {
+    .white-key,
+    .black-key {
+      transition: none;
+    }
+  }


### PR DESCRIPTION
## Description
Added a CSS-only piano keys component for Issue #70404.

## Features
- Pure HTML and CSS implementation
- Hover key-press animation
- Responsive layout
- Keyboard-focusable keys
- Accessible labels
- Includes demo.html, style.css, and README.md

Closes #70404