### PR TITLE
feat: add ease-stereoscope-viewer-slide (#70526)

### DIFF
--- a/submissions/examples/stereoscope-viewer-slide-ns/README.md
+++ b/submissions/examples/stereoscope-viewer-slide-ns/README.md
@@ -1,0 +1,16 @@
+# Stereoscope Viewer Slide
+
+## What does this do?
+Renders a self-contained CSS-only `ease-stereoscope-viewer-slide` demo: Stereoscope viewer sliding twin photo plates.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-stereoscope-viewer-slide`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-stereoscope-viewer-slide">
+  <div class="ease-stereoscope-viewer-slide__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/stereoscope-viewer-slide-ns/demo.html
+++ b/submissions/examples/stereoscope-viewer-slide-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Stereoscope Viewer Slide — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Stereoscope Viewer Slide demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Stereoscope Viewer Slide</h1>
+      <p class="lede">Stereoscope viewer sliding twin photo plates</p>
+    </header>
+
+    <section class="ease-stereoscope-viewer-slide" data-demo="stereoscope-viewer-slide" aria-live="polite">
+      <div class="ease-stereoscope-viewer-slide__housing">
+        <div class="ease-stereoscope-viewer-slide__bezel">
+          <div class="ease-stereoscope-viewer-slide__face">
+            <div class="ease-stereoscope-viewer-slide__readout">
+              <span class="ease-stereoscope-viewer-slide__label">Stereoscope Viewer Slide</span>
+              <span class="ease-stereoscope-viewer-slide__value">LIVE</span>
+            </div>
+            <div class="ease-stereoscope-viewer-slide__motion" aria-hidden="true">
+              <span class="ease-stereoscope-viewer-slide__a"></span>
+              <span class="ease-stereoscope-viewer-slide__b"></span>
+              <span class="ease-stereoscope-viewer-slide__c"></span>
+              <span class="ease-stereoscope-viewer-slide__d"></span>
+            </div>
+            <div class="ease-stereoscope-viewer-slide__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-stereoscope-viewer-slide__controls">
+          <button type="button" class="ease-stereoscope-viewer-slide__btn primary">Engage</button>
+          <button type="button" class="ease-stereoscope-viewer-slide__btn">Reset</button>
+          <label class="ease-stereoscope-viewer-slide__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-stereoscope-viewer-slide__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/stereoscope-viewer-slide-ns/style.css
+++ b/submissions/examples/stereoscope-viewer-slide-ns/style.css
@@ -1,0 +1,239 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "DM Sans", "Trebuchet MS", sans-serif;
+  background:
+    radial-gradient(ellipse at 14% 0%, color-mix(in srgb, #a78bfa 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 72% 100%, color-mix(in srgb, #c4b5fd 18%, transparent), transparent 42%),
+    #100816;
+}
+
+.stage {
+  width: min(656px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-stereoscope-viewer-slide {
+  --accent: #a78bfa;
+  --accent-2: #c4b5fd;
+  --panel: color-mix(in srgb, #e8eef6 7%, #100816);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #100816 75%, #000);
+}
+
+.ease-stereoscope-viewer-slide__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-stereoscope-viewer-slide__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #100816 90%, #a78bfa);
+}
+
+.ease-stereoscope-viewer-slide__face {
+  position: relative;
+  min-height: 256px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 26% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #100816 85%, #000), color-mix(in srgb, #100816 65%, var(--accent-2)));
+}
+
+.ease-stereoscope-viewer-slide__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-stereoscope-viewer-slide__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-stereoscope-viewer-slide__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-stereoscope-viewer-slide__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-stereoscope-viewer-slide__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-stereoscope-viewer-slide__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-stereoscope-viewer-slide__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: stereoscope_viewer_slide_meter 1.74s ease-in-out infinite alternate;
+}
+
+.ease-stereoscope-viewer-slide__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-stereoscope-viewer-slide__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-stereoscope-viewer-slide__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-stereoscope-viewer-slide__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-stereoscope-viewer-slide__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-stereoscope-viewer-slide__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-stereoscope-viewer-slide__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-stereoscope-viewer-slide__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-stereoscope-viewer-slide__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-stereoscope-viewer-slide__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-stereoscope-viewer-slide__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-stereoscope-viewer-slide__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: stereoscope_viewer_slide_status 1.90s ease-out infinite;
+}
+
+@keyframes stereoscope_viewer_slide_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes stereoscope_viewer_slide_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-stereoscope-viewer-slide__a{left:46%;top:18%;width:8%;height:48%;border-radius:8px;background:linear-gradient(180deg,var(--accent-2),var(--accent));animation:stereoscope_viewer_slide_piston 1.8s ease-in-out infinite}
+.ease-stereoscope-viewer-slide__b{left:30%;top:30%;width:40%;height:40%;border-radius:50%;border:2px solid color-mix(in srgb,var(--accent) 55%,transparent);animation:stereoscope_viewer_slide_ring 2.4s ease-out infinite}
+.ease-stereoscope-viewer-slide__c{position:absolute;left:22%;bottom:20%;width:56%;height:10px;border-radius:6px;background:color-mix(in srgb,#e8eef6 10%,transparent);box-shadow:inset 0 0 0 1px color-mix(in srgb,var(--accent) 30%,transparent)}
+.ease-stereoscope-viewer-slide__c::after{content:"";display:block;height:100%;width:42%;border-radius:6px;background:var(--accent);animation:stereoscope_viewer_slide_fill 1.8s ease-in-out infinite alternate}
+.ease-stereoscope-viewer-slide__d{position:absolute;right:18%;top:24%;width:14px;height:14px;border-radius:3px;background:var(--accent-2);animation:stereoscope_viewer_slide_tick 1.8s steps(4) infinite}
+
+@keyframes stereoscope_viewer_slide_piston{0%,100%{transform:translateY(0)}50%{transform:translateY(28px)}}
+@keyframes stereoscope_viewer_slide_ring{0%{transform:scale(.6);opacity:.9}100%{transform:scale(1.35);opacity:0}}
+@keyframes stereoscope_viewer_slide_fill{from{width:22%}to{width:78%}}
+@keyframes stereoscope_viewer_slide_tick{50%{opacity:.35;transform:scale(.85)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-stereoscope-viewer-slide__a,
+  .ease-stereoscope-viewer-slide__b,
+  .ease-stereoscope-viewer-slide__c,
+  .ease-stereoscope-viewer-slide__d,
+  .ease-stereoscope-viewer-slide__meters i::after,
+  .ease-stereoscope-viewer-slide__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-stereoscope-viewer-slide` under `submissions/examples/stereoscope-viewer-slide-ns/` — CSS-only Stereoscope viewer sliding twin photo plates.

Fixes #70526

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Stereoscope viewer sliding twin photo plates.

**How does a developer use it?**

```html
<section class="ease-stereoscope-viewer-slide">
  <div class="ease-stereoscope-viewer-slide__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `stereoscope_viewer_slide_*` prefix. Reduced-motion disables animations.
