### PR TITLE
feat: add CSS-only flip book example

### DIFF
--- a/submissions/examples/css-flip-book/README.md
+++ b/submissions/examples/css-flip-book/README.md
@@ -1,0 +1,23 @@
+# CSS-Only Flip Book
+
+A lightweight animated flip book created using only HTML and CSS.
+
+## ✨ Features
+
+- Pure HTML and CSS
+- No JavaScript
+- 3D page-flip animation
+- Responsive design
+- Hover-to-pause interaction
+- Reduced-motion support
+- Semantic HTML
+- Accessible descriptive labels
+- Works on desktop, tablet, and mobile
+
+## 📁 Files
+
+```text
+css-flip-book/
+├── demo.html
+├── style.css
+└── README.md

--- a/submissions/examples/css-flip-book/demo.html
+++ b/submissions/examples/css-flip-book/demo.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta
+    name="viewport"
+    content="width=device-width, initial-scale=1.0"
+  >
+  <meta
+    name="description"
+    content="CSS-only animated flip book demonstration"
+  >
+  <title>CSS Flip Book</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+  <main class="page">
+    <header class="intro">
+      <p class="eyebrow">EaseMotion CSS</p>
+      <h1>CSS-Only Flip Book</h1>
+      <p>
+        An animated flip book created using only HTML and CSS.
+        No JavaScript is required.
+      </p>
+    </header>
+
+    <section
+      class="flipbook-section"
+      aria-labelledby="flipbook-title"
+    >
+      <h2 id="flipbook-title" class="sr-only">
+        Animated CSS flip book
+      </h2>
+
+      <div
+        class="flipbook"
+        role="img"
+        aria-label="Animated flip book with four pages"
+      >
+        <div class="book">
+
+          <div class="page-card page-1">
+            <div class="page-content">
+              <span class="page-number">01</span>
+              <h3>Explore</h3>
+              <p>
+                Discover the smooth page-turning effect
+                created completely with CSS.
+              </p>
+            </div>
+          </div>
+
+          <div class="page-card page-2">
+            <div class="page-content">
+              <span class="page-number">02</span>
+              <h3>Create</h3>
+              <p>
+                CSS transforms and keyframes bring
+                every page to life.
+              </p>
+            </div>
+          </div>
+
+          <div class="page-card page-3">
+            <div class="page-content">
+              <span class="page-number">03</span>
+              <h3>Animate</h3>
+              <p>
+                Perspective and 3D rotation produce
+                the realistic flipping motion.
+              </p>
+            </div>
+          </div>
+
+          <div class="page-card page-4">
+            <div class="page-content">
+              <span class="page-number">04</span>
+              <h3>Enjoy</h3>
+              <p>
+                A lightweight animation that works
+                without JavaScript.
+              </p>
+            </div>
+          </div>
+
+          <div class="book-cover">
+            <div class="cover-content">
+              <span>CSS</span>
+              <h2>Flip<br>Book</h2>
+              <p>Pure CSS Animation</p>
+            </div>
+          </div>
+
+        </div>
+      </div>
+
+      <p class="hint">
+        Hover over the book to pause the animation.
+      </p>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/css-flip-book/style.css
+++ b/submissions/examples/css-flip-book/style.css
@@ -1,0 +1,378 @@
+/* =========================================
+   CSS-ONLY FLIP BOOK
+   ========================================= */
+
+   :root {
+    --bg: #f4f1ea;
+    --text: #202124;
+    --muted: #666;
+    --paper: #fffdf7;
+    --paper-alt: #f7f0df;
+    --cover: #263238;
+    --accent: #d97706;
+    --shadow: rgba(0, 0, 0, 0.18);
+  }
+  
+  /* ---------- Reset ---------- */
+  
+  * {
+    box-sizing: border-box;
+  }
+  
+  html {
+    scroll-behavior: smooth;
+  }
+  
+  body {
+    min-height: 100vh;
+    margin: 0;
+    background:
+      radial-gradient(
+        circle at top,
+        #ffffff 0,
+        var(--bg) 55%,
+        #e9e3d7 100%
+      );
+    color: var(--text);
+    font-family:
+      Inter,
+      system-ui,
+      -apple-system,
+      BlinkMacSystemFont,
+      "Segoe UI",
+      sans-serif;
+  }
+  
+  /* ---------- Layout ---------- */
+  
+  .page {
+    width: min(100% - 2rem, 1100px);
+    margin: 0 auto;
+    padding: 4rem 0;
+  }
+  
+  .intro {
+    max-width: 700px;
+    margin: 0 auto 3rem;
+    text-align: center;
+  }
+  
+  .eyebrow {
+    margin: 0 0 0.5rem;
+    color: var(--accent);
+    font-size: 0.8rem;
+    font-weight: 800;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+  }
+  
+  .intro h1 {
+    margin: 0 0 1rem;
+    font-size: clamp(2rem, 5vw, 4rem);
+    line-height: 1;
+  }
+  
+  .intro p:last-child {
+    margin: 0;
+    color: var(--muted);
+    line-height: 1.7;
+  }
+  
+  /* ---------- Flip Book ---------- */
+  
+  .flipbook-section {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+  
+  .flipbook {
+    width: min(90vw, 620px);
+    aspect-ratio: 1.45 / 1;
+    perspective: 1800px;
+  }
+  
+  .book {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    transform-style: preserve-3d;
+  }
+  
+  /* ---------- Pages ---------- */
+  
+  .page-card,
+  .book-cover {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 50%;
+    height: 100%;
+    transform-origin: left center;
+    transform-style: preserve-3d;
+    border-radius: 0 10px 10px 0;
+  }
+  
+  .page-card {
+    z-index: 1;
+    padding: 2rem;
+    overflow: hidden;
+    background: var(--paper);
+    box-shadow:
+      0 12px 25px var(--shadow),
+      inset -1px 0 rgba(0, 0, 0, 0.08);
+    backface-visibility: hidden;
+  }
+  
+  .page-card::before {
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    background:
+      repeating-linear-gradient(
+        0deg,
+        transparent,
+        transparent 24px,
+        rgba(0, 0, 0, 0.025) 25px
+      );
+    content: "";
+  }
+  
+  .page-content {
+    display: flex;
+    height: 100%;
+    flex-direction: column;
+    justify-content: center;
+  }
+  
+  .page-number {
+    margin-bottom: 1rem;
+    color: var(--accent);
+    font-size: 0.75rem;
+    font-weight: 800;
+    letter-spacing: 0.15em;
+  }
+  
+  .page-content h3 {
+    margin: 0 0 0.75rem;
+    font-size: clamp(1.4rem, 3vw, 2.2rem);
+  }
+  
+  .page-content p {
+    max-width: 250px;
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.95rem;
+    line-height: 1.7;
+  }
+  
+  /* ---------- Page Animation ---------- */
+  
+  .page-1 {
+    animation: flip-page 12s infinite;
+    animation-delay: 0s;
+  }
+  
+  .page-2 {
+    animation: flip-page 12s infinite;
+    animation-delay: 3s;
+  }
+  
+  .page-3 {
+    animation: flip-page 12s infinite;
+    animation-delay: 6s;
+  }
+  
+  .page-4 {
+    animation: flip-page 12s infinite;
+    animation-delay: 9s;
+  }
+  
+  @keyframes flip-page {
+    0%,
+    18% {
+      transform: rotateY(0deg);
+    }
+  
+    25%,
+    93% {
+      transform: rotateY(-180deg);
+    }
+  
+    100% {
+      transform: rotateY(-180deg);
+    }
+  }
+  
+  /* ---------- Cover ---------- */
+  
+  .book-cover {
+    z-index: 10;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background:
+      linear-gradient(
+        135deg,
+        #37474f,
+        var(--cover)
+      );
+    color: #fff;
+    box-shadow: 0 15px 30px var(--shadow);
+    transform-origin: left center;
+    animation: cover-flip 12s infinite;
+  }
+  
+  .cover-content {
+    width: 80%;
+    text-align: center;
+  }
+  
+  .cover-content span {
+    display: block;
+    margin-bottom: 0.75rem;
+    color: #ffcc80;
+    font-size: 0.75rem;
+    font-weight: 800;
+    letter-spacing: 0.2em;
+  }
+  
+  .cover-content h2 {
+    margin: 0;
+    font-family: Georgia, serif;
+    font-size: clamp(2rem, 6vw, 4rem);
+    line-height: 0.9;
+  }
+  
+  .cover-content p {
+    margin: 1.25rem 0 0;
+    color: #cfd8dc;
+    font-size: 0.8rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+  
+  @keyframes cover-flip {
+    0%,
+    18% {
+      transform: rotateY(0deg);
+    }
+  
+    25%,
+    93% {
+      transform: rotateY(-180deg);
+    }
+  
+    100% {
+      transform: rotateY(-180deg);
+    }
+  }
+  
+  /* ---------- Hover / Interaction ---------- */
+  
+  .book:hover .page-card,
+  .book:hover .book-cover {
+    animation-play-state: paused;
+  }
+  
+  /* ---------- Hint ---------- */
+  
+  .hint {
+    margin: 2rem 0 0;
+    color: var(--muted);
+    font-size: 0.85rem;
+    text-align: center;
+  }
+  
+  /* ---------- Accessibility ---------- */
+  
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+  
+  /* ---------- Reduced Motion ---------- */
+  
+  @media (prefers-reduced-motion: reduce) {
+    .page-card,
+    .book-cover {
+      animation: none;
+    }
+  
+    .page-card {
+      transform: rotateY(0);
+    }
+  
+    .book-cover {
+      transform: rotateY(0);
+    }
+  }
+  
+  /* ---------- Tablet ---------- */
+  
+  @media (max-width: 700px) {
+    .page {
+      padding: 3rem 0;
+    }
+  
+    .flipbook {
+      width: min(94vw, 560px);
+    }
+  
+    .page-card {
+      padding: 1.25rem;
+    }
+  
+    .page-content p {
+      font-size: 0.8rem;
+    }
+  }
+  
+  /* ---------- Mobile ---------- */
+  
+  @media (max-width: 480px) {
+    .page {
+      width: min(100% - 1rem, 420px);
+      padding: 2rem 0;
+    }
+  
+    .intro {
+      margin-bottom: 2rem;
+    }
+  
+    .flipbook {
+      width: 100%;
+    }
+  
+    .page-card {
+      padding: 1rem;
+    }
+  
+    .page-number {
+      margin-bottom: 0.5rem;
+    }
+  
+    .page-content h3 {
+      font-size: 1.25rem;
+    }
+  
+    .page-content p {
+      font-size: 0.72rem;
+      line-height: 1.5;
+    }
+  
+    .cover-content h2 {
+      font-size: 2.2rem;
+    }
+  
+    .hint {
+      font-size: 0.75rem;
+    }
+  }


### PR DESCRIPTION
## Description

Added a responsive CSS-only flip book animation under
`submissions/examples/css-flip-book/`.

## Features

- Pure HTML and CSS
- 3D page-flip animation
- Responsive layout
- Hover-to-pause interaction
- Reduced-motion support
- Accessible semantic markup
- No JavaScript or external dependencies

## Files Added

- `demo.html`
- `style.css`
- `README.md`

## Testing

- Tested desktop layout
- Tested mobile responsive layout
- Tested hover interaction
- Tested reduced-motion behavior
- Ran `git diff --check`

## Related Issue

Closes #70117