### PR TITLE
feat: add CSS binary tree diagram

### DIFF
--- a/submissions/examples/css-binary-tree/README.md
+++ b/submissions/examples/css-binary-tree/README.md
@@ -1,0 +1,24 @@
+# CSS Binary Tree Diagram
+
+An animated binary tree data structure created entirely with HTML and CSS.
+
+## ✨ Features
+
+- Pure HTML and CSS
+- No JavaScript
+- Responsive binary tree layout
+- Animated node appearance
+- Animated tree connections
+- Hover interaction
+- Keyboard focus support
+- Accessible tree structure
+- Reduced-motion support
+- No external dependencies
+
+## 📁 Files
+
+```text
+css-binary-tree/
+├── demo.html
+├── style.css
+└── README.md

--- a/submissions/examples/css-binary-tree/demo.html
+++ b/submissions/examples/css-binary-tree/demo.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta
+    name="viewport"
+    content="width=device-width, initial-scale=1.0"
+  >
+  <meta
+    name="description"
+    content="CSS-only animated binary tree diagram"
+  >
+  <title>CSS Binary Tree Diagram</title>
+
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+  <main class="page">
+
+    <header class="intro">
+      <p class="eyebrow">EaseMotion CSS</p>
+
+      <h1>CSS Binary Tree</h1>
+
+      <p>
+        An animated binary tree data structure created
+        using only HTML and CSS.
+      </p>
+    </header>
+
+    <section
+      class="tree-section"
+      aria-labelledby="tree-title"
+    >
+
+      <h2 id="tree-title" class="sr-only">
+        Binary tree data structure
+      </h2>
+
+      <div
+        class="tree"
+        role="tree"
+        aria-label="Binary tree with seven nodes"
+        tabindex="0"
+      >
+
+        <!-- Connections -->
+        <div class="line line-root-left"></div>
+        <div class="line line-root-right"></div>
+
+        <div class="line line-left-left"></div>
+        <div class="line line-left-right"></div>
+
+        <div class="line line-right-left"></div>
+        <div class="line line-right-right"></div>
+
+        <!-- Root -->
+        <div
+          class="node node-root"
+          role="treeitem"
+          aria-label="Root node 50"
+          tabindex="0"
+        >
+          50
+        </div>
+
+        <!-- Level 2 -->
+        <div
+          class="node node-30"
+          role="treeitem"
+          aria-label="Node 30"
+          tabindex="0"
+        >
+          30
+        </div>
+
+        <div
+          class="node node-70"
+          role="treeitem"
+          aria-label="Node 70"
+          tabindex="0"
+        >
+          70
+        </div>
+
+        <!-- Level 3 -->
+        <div
+          class="node node-20"
+          role="treeitem"
+          aria-label="Node 20"
+          tabindex="0"
+        >
+          20
+        </div>
+
+        <div
+          class="node node-40"
+          role="treeitem"
+          aria-label="Node 40"
+          tabindex="0"
+        >
+          40
+        </div>
+
+        <div
+          class="node node-60"
+          role="treeitem"
+          aria-label="Node 60"
+          tabindex="0"
+        >
+          60
+        </div>
+
+        <div
+          class="node node-80"
+          role="treeitem"
+          aria-label="Node 80"
+          tabindex="0"
+        >
+          80
+        </div>
+
+      </div>
+
+      <p class="hint">
+        Hover or focus a node to highlight it.
+      </p>
+
+    </section>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/css-binary-tree/style.css
+++ b/submissions/examples/css-binary-tree/style.css
@@ -1,0 +1,544 @@
+/* =========================================
+   CSS BINARY TREE DIAGRAM
+   ========================================= */
+
+   :root {
+    --background: #f5f7fb;
+    --surface: #ffffff;
+    --text: #172033;
+    --muted: #667085;
+    --node: #2563eb;
+    --node-hover: #1d4ed8;
+    --line: #94a3b8;
+    --ring: #f59e0b;
+    --shadow: rgba(15, 23, 42, 0.15);
+  }
+  
+  /* ---------- Reset ---------- */
+  
+  * {
+    box-sizing: border-box;
+  }
+  
+  html {
+    scroll-behavior: smooth;
+  }
+  
+  body {
+    min-height: 100vh;
+    margin: 0;
+  
+    background:
+      radial-gradient(
+        circle at top,
+        #ffffff 0,
+        var(--background) 65%
+      );
+  
+    color: var(--text);
+  
+    font-family:
+      Inter,
+      system-ui,
+      -apple-system,
+      BlinkMacSystemFont,
+      "Segoe UI",
+      sans-serif;
+  }
+  
+  /* ---------- Main Layout ---------- */
+  
+  .page {
+    width: min(100% - 2rem, 1100px);
+    min-height: 100vh;
+  
+    margin: 0 auto;
+    padding: 4rem 0;
+  
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+  
+  .intro {
+    max-width: 700px;
+  
+    margin: 0 auto 3rem;
+  
+    text-align: center;
+  }
+  
+  .eyebrow {
+    margin: 0 0 0.75rem;
+  
+    color: var(--node);
+  
+    font-size: 0.8rem;
+    font-weight: 800;
+  
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+  }
+  
+  .intro h1 {
+    margin: 0 0 1rem;
+  
+    font-size: clamp(2rem, 5vw, 4rem);
+  
+    line-height: 1;
+  }
+  
+  .intro p:last-child {
+    margin: 0;
+  
+    color: var(--muted);
+  
+    line-height: 1.7;
+  }
+  
+  /* ---------- Tree Section ---------- */
+  
+  .tree-section {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+  
+  /* ---------- Tree Canvas ---------- */
+  
+  .tree {
+    position: relative;
+  
+    width: min(90vw, 800px);
+    height: 500px;
+  
+    margin: 0 auto;
+  
+    border-radius: 1.5rem;
+  
+    background: var(--surface);
+  
+    box-shadow:
+      0 20px 50px var(--shadow);
+  
+    overflow: hidden;
+  }
+  
+  /* ---------- Nodes ---------- */
+  
+  .node {
+    position: absolute;
+  
+    width: 70px;
+    height: 70px;
+  
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  
+    border: 4px solid #fff;
+  
+    border-radius: 50%;
+  
+    background:
+      linear-gradient(
+        135deg,
+        #3b82f6,
+        var(--node)
+      );
+  
+    color: #fff;
+  
+    font-size: 1.1rem;
+    font-weight: 800;
+  
+    box-shadow:
+      0 8px 20px var(--shadow);
+  
+    cursor: pointer;
+  
+    z-index: 5;
+  
+    transition:
+      transform 0.25s ease,
+      background 0.25s ease,
+      box-shadow 0.25s ease;
+  }
+  
+  /* ---------- Node Positions ---------- */
+  
+  .node-root {
+    top: 45px;
+    left: 50%;
+  
+    transform: translateX(-50%);
+  }
+  
+  .node-30 {
+    top: 190px;
+    left: 30%;
+  
+    transform: translateX(-50%);
+  }
+  
+  .node-70 {
+    top: 190px;
+    left: 70%;
+  
+    transform: translateX(-50%);
+  }
+  
+  .node-20 {
+    top: 350px;
+    left: 15%;
+  
+    transform: translateX(-50%);
+  }
+  
+  .node-40 {
+    top: 350px;
+    left: 40%;
+  
+    transform: translateX(-50%);
+  }
+  
+  .node-60 {
+    top: 350px;
+    left: 60%;
+  
+    transform: translateX(-50%);
+  }
+  
+  .node-80 {
+    top: 350px;
+    left: 85%;
+  
+    transform: translateX(-50%);
+  }
+  
+  /* ---------- Node Interaction ---------- */
+  
+  .node:hover,
+  .node:focus-visible {
+    background: var(--node-hover);
+  
+    box-shadow:
+      0 0 0 6px rgba(37, 99, 235, 0.15),
+      0 12px 25px var(--shadow);
+  
+    transform:
+      translateX(-50%)
+      scale(1.12);
+  
+    outline: none;
+  }
+  
+  .node:focus-visible {
+    box-shadow:
+      0 0 0 4px var(--ring),
+      0 12px 25px var(--shadow);
+  }
+  
+  /* ---------- Tree Connections ---------- */
+  
+  .line {
+    position: absolute;
+  
+    height: 4px;
+  
+    background: var(--line);
+  
+    transform-origin: left center;
+  
+    z-index: 2;
+  
+    border-radius: 999px;
+  
+    animation: grow-line 1.2s ease-out both;
+  }
+  
+  /* Root -> 30 */
+  
+  .line-root-left {
+    top: 113px;
+    left: 48%;
+  
+    width: 155px;
+  
+    transform:
+      rotate(27deg);
+  
+    animation-delay: 0.2s;
+  }
+  
+  /* Root -> 70 */
+  
+  .line-root-right {
+    top: 113px;
+    left: 52%;
+  
+    width: 155px;
+  
+    transform:
+      rotate(153deg);
+  
+    animation-delay: 0.4s;
+  }
+  
+  /* 30 -> 20 */
+  
+  .line-left-left {
+    top: 258px;
+    left: 28%;
+  
+    width: 135px;
+  
+    transform:
+      rotate(37deg);
+  
+    animation-delay: 0.6s;
+  }
+  
+  /* 30 -> 40 */
+  
+  .line-left-right {
+    top: 258px;
+    left: 32%;
+  
+    width: 125px;
+  
+    transform:
+      rotate(143deg);
+  
+    animation-delay: 0.8s;
+  }
+  
+  /* 70 -> 60 */
+  
+  .line-right-left {
+    top: 258px;
+    left: 68%;
+  
+    width: 125px;
+  
+    transform:
+      rotate(217deg);
+  
+    animation-delay: 1s;
+  }
+  
+  /* 70 -> 80 */
+  
+  .line-right-right {
+    top: 258px;
+    left: 72%;
+  
+    width: 135px;
+  
+    transform:
+      rotate(323deg);
+  
+    animation-delay: 1.2s;
+  }
+  
+  /* ---------- Connection Animation ---------- */
+  
+  @keyframes grow-line {
+  
+    from {
+      opacity: 0;
+  
+      transform-origin: left center;
+  
+      scale: 0 1;
+    }
+  
+    to {
+      opacity: 1;
+  
+      scale: 1 1;
+    }
+  }
+  
+  /* ---------- Subtle Node Animation ---------- */
+  
+  .node {
+    animation: node-appear 0.7s ease-out both;
+  }
+  
+  .node-root {
+    animation-delay: 0.2s;
+  }
+  
+  .node-30,
+  .node-70 {
+    animation-delay: 0.5s;
+  }
+  
+  .node-20,
+  .node-40,
+  .node-60,
+  .node-80 {
+    animation-delay: 0.8s;
+  }
+  
+  @keyframes node-appear {
+  
+    from {
+      opacity: 0;
+      scale: 0.5;
+    }
+  
+    to {
+      opacity: 1;
+      scale: 1;
+    }
+  }
+  
+  /* ---------- Hint ---------- */
+  
+  .hint {
+    margin: 2rem 0 0;
+  
+    color: var(--muted);
+  
+    font-size: 0.85rem;
+  
+    text-align: center;
+  }
+  
+  /* ---------- Screen Reader Utility ---------- */
+  
+  .sr-only {
+    position: absolute;
+  
+    width: 1px;
+    height: 1px;
+  
+    padding: 0;
+    margin: -1px;
+  
+    overflow: hidden;
+  
+    clip: rect(0, 0, 0, 0);
+  
+    white-space: nowrap;
+  
+    border: 0;
+  }
+  
+  /* ---------- Reduced Motion ---------- */
+  
+  @media (prefers-reduced-motion: reduce) {
+  
+    .node,
+    .line {
+      animation: none;
+    }
+  }
+  
+  /* ---------- Tablet ---------- */
+  
+  @media (max-width: 700px) {
+  
+    .page {
+      padding: 3rem 0;
+    }
+  
+    .tree {
+      width: 96vw;
+      height: 440px;
+    }
+  
+    .node {
+      width: 58px;
+      height: 58px;
+  
+      font-size: 0.9rem;
+    }
+  
+    .node-30 {
+      left: 28%;
+    }
+  
+    .node-70 {
+      left: 72%;
+    }
+  
+    .node-20 {
+      left: 12%;
+    }
+  
+    .node-40 {
+      left: 38%;
+    }
+  
+    .node-60 {
+      left: 62%;
+    }
+  
+    .node-80 {
+      left: 88%;
+    }
+  
+    .line {
+      height: 3px;
+    }
+  }
+  
+  /* ---------- Mobile ---------- */
+  
+  @media (max-width: 480px) {
+  
+    .page {
+      width: min(100% - 1rem, 420px);
+  
+      padding: 2rem 0;
+    }
+  
+    .intro {
+      margin-bottom: 2rem;
+    }
+  
+    .tree {
+      width: 100%;
+      height: 360px;
+  
+      border-radius: 1rem;
+    }
+  
+    .node {
+      width: 48px;
+      height: 48px;
+  
+      border-width: 3px;
+  
+      font-size: 0.75rem;
+    }
+  
+    .node-root {
+      top: 30px;
+    }
+  
+    .node-30,
+    .node-70 {
+      top: 140px;
+    }
+  
+    .node-20,
+    .node-40,
+    .node-60,
+    .node-80 {
+      top: 270px;
+    }
+  
+    .line {
+      height: 2px;
+    }
+  
+    .hint {
+      margin-top: 1.5rem;
+  
+      font-size: 0.75rem;
+    }
+  }


### PR DESCRIPTION
## Description

Added a responsive CSS-only binary tree diagram under
`submissions/examples/css-binary-tree/`.

## Features

- Pure HTML and CSS
- Seven-node binary tree visualization
- Animated node appearance
- Animated tree connections
- Responsive desktop/tablet/mobile layout
- Hover interaction
- Keyboard focus support
- ARIA tree semantics
- Reduced-motion support
- No JavaScript or external dependencies

## Files Added

- `demo.html`
- `style.css`
- `README.md`

## Testing

- Tested desktop layout
- Tested responsive mobile layout
- Tested keyboard navigation
- Tested focus states
- Tested reduced-motion behavior
- Ran `git diff --check`

## Related Issue

Closes #70167