### PR TITLE
feat: add CSS graffiti spray text effect

### DIFF
--- a/submissions/examples/css-graffiti-spray-text/README.md
+++ b/submissions/examples/css-graffiti-spray-text/README.md
@@ -1,0 +1,27 @@
+# CSS Graffiti Spray Text
+
+A responsive graffiti-style text animation created entirely
+with HTML and CSS.
+
+## ✨ Features
+
+- Pure HTML and CSS
+- No JavaScript
+- Spray-paint appearance
+- Animated paint cloud
+- Paint splatter particles
+- Text reveal animation
+- Graffiti shadow
+- Responsive design
+- Hover-to-pause interaction
+- Keyboard focus support
+- Reduced-motion support
+- No external dependencies
+
+## 📁 Files
+
+```text
+css-graffiti-spray-text/
+├── demo.html
+├── style.css
+└── README.md

--- a/submissions/examples/css-graffiti-spray-text/demo.html
+++ b/submissions/examples/css-graffiti-spray-text/demo.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+
+  <meta
+    name="viewport"
+    content="width=device-width, initial-scale=1.0"
+  >
+
+  <meta
+    name="description"
+    content="CSS-only animated graffiti spray text effect"
+  >
+
+  <title>CSS Graffiti Spray Text</title>
+
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+  <main class="page">
+
+    <header class="intro">
+      <p class="eyebrow">EaseMotion CSS</p>
+
+      <h1>CSS Graffiti Spray Text</h1>
+
+      <p>
+        A pure CSS text effect that looks like
+        spray paint appearing on a wall.
+      </p>
+    </header>
+
+    <section
+      class="graffiti-section"
+      aria-labelledby="graffiti-title"
+    >
+
+      <h2 id="graffiti-title" class="sr-only">
+        Animated graffiti spray text
+      </h2>
+
+      <div
+        class="wall"
+        tabindex="0"
+        role="img"
+        aria-label="Graffiti spray painted text displaying CREATE"
+      >
+
+        <div class="spray-cloud" aria-hidden="true"></div>
+
+        <div class="paint-splatter" aria-hidden="true">
+          <span></span>
+          <span></span>
+          <span></span>
+          <span></span>
+          <span></span>
+          <span></span>
+          <span></span>
+          <span></span>
+          <span></span>
+          <span></span>
+        </div>
+
+        <div class="graffiti-text" aria-hidden="true">
+          CREATE
+        </div>
+
+        <div class="graffiti-shadow" aria-hidden="true">
+          CREATE
+        </div>
+
+        <p class="wall-label">
+          SPRAY PAINT
+        </p>
+
+      </div>
+
+      <p class="hint">
+        Hover or focus the wall to pause the spray animation.
+      </p>
+
+    </section>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/css-graffiti-spray-text/style.css
+++ b/submissions/examples/css-graffiti-spray-text/style.css
@@ -1,0 +1,686 @@
+/* =========================================
+   CSS GRAFFITI SPRAY TEXT
+   ========================================= */
+
+   :root {
+    --wall: #c9c1b4;
+    --wall-dark: #aaa092;
+  
+    --paint: #e11d48;
+    --paint-light: #fb7185;
+    --paint-dark: #881337;
+  
+    --shadow: rgba(0, 0, 0, 0.25);
+  
+    --text: #202020;
+    --muted: #5f5a54;
+  }
+  
+  /* ---------- Reset ---------- */
+  
+  * {
+    box-sizing: border-box;
+  }
+  
+  html {
+    scroll-behavior: smooth;
+  }
+  
+  body {
+    min-height: 100vh;
+    margin: 0;
+  
+    background:
+      linear-gradient(
+        135deg,
+        #ebe7df,
+        #cfc8bc
+      );
+  
+    color: var(--text);
+  
+    font-family:
+      Inter,
+      system-ui,
+      -apple-system,
+      BlinkMacSystemFont,
+      "Segoe UI",
+      sans-serif;
+  }
+  
+  /* ---------- Main Layout ---------- */
+  
+  .page {
+    width: min(100% - 2rem, 1100px);
+  
+    min-height: 100vh;
+  
+    margin: 0 auto;
+  
+    padding: 4rem 0;
+  
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+  
+  .intro {
+    max-width: 700px;
+  
+    margin: 0 auto 3rem;
+  
+    text-align: center;
+  }
+  
+  .eyebrow {
+    margin: 0 0 0.75rem;
+  
+    color: var(--paint);
+  
+    font-size: 0.8rem;
+    font-weight: 800;
+  
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+  }
+  
+  .intro h1 {
+    margin: 0 0 1rem;
+  
+    font-size: clamp(2rem, 5vw, 4rem);
+  
+    line-height: 1;
+  }
+  
+  .intro p:last-child {
+    margin: 0;
+  
+    color: var(--muted);
+  
+    line-height: 1.7;
+  }
+  
+  /* ---------- Graffiti Section ---------- */
+  
+  .graffiti-section {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+  
+  /* ---------- Wall ---------- */
+  
+  .wall {
+    position: relative;
+  
+    width: min(92vw, 900px);
+  
+    aspect-ratio: 16 / 9;
+  
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  
+    overflow: hidden;
+  
+    border-radius: 0.75rem;
+  
+    background:
+      linear-gradient(
+        135deg,
+        var(--wall),
+        var(--wall-dark)
+      );
+  
+    box-shadow:
+      0 25px 50px var(--shadow);
+  
+    isolation: isolate;
+  
+    cursor: default;
+  
+    outline: none;
+  }
+  
+  /* Wall texture */
+  
+  .wall::before {
+    position: absolute;
+  
+    inset: 0;
+  
+    z-index: -1;
+  
+    background:
+      repeating-linear-gradient(
+        0deg,
+        rgba(255, 255, 255, 0.04) 0,
+        rgba(255, 255, 255, 0.04) 1px,
+        transparent 1px,
+        transparent 4px
+      );
+  
+    opacity: 0.8;
+  
+    content: "";
+  }
+  
+  /* Wall cracks / imperfections */
+  
+  .wall::after {
+    position: absolute;
+  
+    inset: 0;
+  
+    z-index: 0;
+  
+    background:
+      radial-gradient(
+        circle at 20% 30%,
+        rgba(0, 0, 0, 0.08) 0 1px,
+        transparent 2px
+      ),
+      radial-gradient(
+        circle at 80% 65%,
+        rgba(0, 0, 0, 0.07) 0 1px,
+        transparent 2px
+      );
+  
+    background-size:
+      45px 50px,
+      60px 70px;
+  
+    pointer-events: none;
+  
+    content: "";
+  }
+  
+  /* ---------- Spray Cloud ---------- */
+  
+  .spray-cloud {
+    position: absolute;
+  
+    width: 65%;
+    height: 55%;
+  
+    border-radius: 50%;
+  
+    background:
+      radial-gradient(
+        ellipse,
+        rgba(225, 29, 72, 0.3) 0%,
+        rgba(225, 29, 72, 0.16) 35%,
+        rgba(225, 29, 72, 0.05) 60%,
+        transparent 75%
+      );
+  
+    filter: blur(18px);
+  
+    opacity: 0;
+  
+    transform: scale(0.5);
+  
+    animation: spray-cloud 3s ease-out infinite;
+  }
+  
+  /* ---------- Graffiti Shadow ---------- */
+  
+  .graffiti-shadow,
+  .graffiti-text {
+    position: absolute;
+  
+    font-family:
+      Impact,
+      Haettenschweiler,
+      "Arial Narrow Bold",
+      sans-serif;
+  
+    font-size: clamp(4rem, 13vw, 10rem);
+  
+    font-weight: 900;
+  
+    line-height: 0.9;
+  
+    letter-spacing: 0.04em;
+  
+    white-space: nowrap;
+  
+    user-select: none;
+  }
+  
+  /* Shadow */
+  
+  .graffiti-shadow {
+    z-index: 1;
+  
+    color: var(--paint-dark);
+  
+    transform:
+      translate(9px, 10px)
+      rotate(-3deg);
+  
+    filter: blur(2px);
+  
+    opacity: 0;
+  
+    animation:
+      graffiti-appear 3s ease-out infinite;
+  }
+  
+  /* Main paint */
+  
+  .graffiti-text {
+    z-index: 2;
+  
+    color: var(--paint);
+  
+    transform: rotate(-3deg);
+  
+    text-shadow:
+      2px 3px 0 var(--paint-dark),
+      0 0 4px var(--paint-light),
+      0 0 10px rgba(225, 29, 72, 0.65);
+  
+    filter:
+      saturate(1.2)
+      contrast(1.1);
+  
+    opacity: 0;
+  
+    clip-path: inset(100% 0 0 0);
+  
+    animation:
+      graffiti-appear 3s ease-out infinite;
+  }
+  
+  /* ---------- Paint Splatter ---------- */
+  
+  .paint-splatter {
+    position: absolute;
+  
+    inset: 0;
+  
+    z-index: 3;
+  
+    pointer-events: none;
+  }
+  
+  .paint-splatter span {
+    position: absolute;
+  
+    display: block;
+  
+    width: 8px;
+    height: 8px;
+  
+    border-radius: 50%;
+  
+    background: var(--paint);
+  
+    opacity: 0;
+  
+    transform: scale(0);
+  
+    animation:
+      splatter 3s ease-out infinite;
+  }
+  
+  /* Different splatter positions */
+  
+  .paint-splatter span:nth-child(1) {
+    top: 27%;
+    left: 18%;
+    width: 10px;
+    height: 10px;
+  }
+  
+  .paint-splatter span:nth-child(2) {
+    top: 36%;
+    left: 76%;
+    width: 6px;
+    height: 6px;
+    animation-delay: 0.1s;
+  }
+  
+  .paint-splatter span:nth-child(3) {
+    top: 65%;
+    left: 20%;
+    width: 5px;
+    height: 5px;
+    animation-delay: 0.2s;
+  }
+  
+  .paint-splatter span:nth-child(4) {
+    top: 70%;
+    left: 78%;
+    width: 11px;
+    height: 11px;
+    animation-delay: 0.3s;
+  }
+  
+  .paint-splatter span:nth-child(5) {
+    top: 22%;
+    left: 60%;
+    width: 5px;
+    height: 5px;
+    animation-delay: 0.4s;
+  }
+  
+  .paint-splatter span:nth-child(6) {
+    top: 74%;
+    left: 42%;
+    width: 7px;
+    height: 7px;
+    animation-delay: 0.5s;
+  }
+  
+  .paint-splatter span:nth-child(7) {
+    top: 32%;
+    left: 31%;
+    width: 4px;
+    height: 4px;
+    animation-delay: 0.6s;
+  }
+  
+  .paint-splatter span:nth-child(8) {
+    top: 58%;
+    left: 87%;
+    width: 5px;
+    height: 5px;
+    animation-delay: 0.7s;
+  }
+  
+  .paint-splatter span:nth-child(9) {
+    top: 77%;
+    left: 65%;
+    width: 4px;
+    height: 4px;
+    animation-delay: 0.8s;
+  }
+  
+  .paint-splatter span:nth-child(10) {
+    top: 18%;
+    left: 42%;
+    width: 7px;
+    height: 7px;
+    animation-delay: 0.9s;
+  }
+  
+  /* ---------- Spray Animation ---------- */
+  
+  @keyframes spray-cloud {
+  
+    0% {
+      opacity: 0;
+  
+      transform: scale(0.5);
+    }
+  
+    20% {
+      opacity: 0.8;
+  
+      transform: scale(0.8);
+    }
+  
+    55% {
+      opacity: 0.45;
+  
+      transform: scale(1.1);
+    }
+  
+    100% {
+      opacity: 0;
+  
+      transform: scale(1.4);
+    }
+  }
+  
+  /* ---------- Text Appearance ---------- */
+  
+  @keyframes graffiti-appear {
+  
+    0% {
+      opacity: 0;
+  
+      clip-path: inset(100% 0 0 0);
+  
+      filter:
+        blur(8px)
+        saturate(0.5);
+    }
+  
+    20% {
+      opacity: 0.4;
+  
+      clip-path: inset(75% 0 0 0);
+    }
+  
+    45% {
+      opacity: 0.85;
+  
+      clip-path: inset(35% 0 0 0);
+  
+      filter:
+        blur(2px)
+        saturate(1);
+    }
+  
+    65% {
+      opacity: 1;
+  
+      clip-path: inset(0 0 0 0);
+  
+      filter:
+        blur(0)
+        saturate(1.2);
+    }
+  
+    90% {
+      opacity: 1;
+  
+      clip-path: inset(0 0 0 0);
+    }
+  
+    100% {
+      opacity: 0;
+  
+      clip-path: inset(0 0 0 0);
+    }
+  }
+  
+  /* ---------- Splatter Animation ---------- */
+  
+  @keyframes splatter {
+  
+    0% {
+      opacity: 0;
+  
+      transform: scale(0);
+    }
+  
+    20% {
+      opacity: 0.9;
+  
+      transform: scale(0.7);
+    }
+  
+    45% {
+      opacity: 0.8;
+  
+      transform: scale(1.3);
+    }
+  
+    70% {
+      opacity: 0.45;
+  
+      transform: scale(1);
+    }
+  
+    100% {
+      opacity: 0;
+  
+      transform: scale(0.8);
+    }
+  }
+  
+  /* ---------- Interaction ---------- */
+  
+  .wall:hover .spray-cloud,
+  .wall:hover .graffiti-text,
+  .wall:hover .graffiti-shadow,
+  .wall:hover .paint-splatter span,
+  .wall:focus .spray-cloud,
+  .wall:focus .graffiti-text,
+  .wall:focus .graffiti-shadow,
+  .wall:focus .paint-splatter span {
+    animation-play-state: paused;
+  }
+  
+  .wall:focus-visible {
+    outline: 4px solid var(--paint);
+    outline-offset: 6px;
+  }
+  
+  /* ---------- Label ---------- */
+  
+  .wall-label {
+    position: absolute;
+  
+    right: 1.5rem;
+    bottom: 1rem;
+  
+    z-index: 4;
+  
+    margin: 0;
+  
+    color: rgba(0, 0, 0, 0.35);
+  
+    font-family:
+      monospace;
+  
+    font-size: 0.7rem;
+  
+    letter-spacing: 0.15em;
+  }
+  
+  /* ---------- Hint ---------- */
+  
+  .hint {
+    margin: 2rem 0 0;
+  
+    color: var(--muted);
+  
+    font-size: 0.85rem;
+  
+    text-align: center;
+  }
+  
+  /* ---------- Screen Reader Utility ---------- */
+  
+  .sr-only {
+    position: absolute;
+  
+    width: 1px;
+    height: 1px;
+  
+    padding: 0;
+    margin: -1px;
+  
+    overflow: hidden;
+  
+    clip: rect(0, 0, 0, 0);
+  
+    white-space: nowrap;
+  
+    border: 0;
+  }
+  
+  /* ---------- Reduced Motion ---------- */
+  
+  @media (prefers-reduced-motion: reduce) {
+  
+    .spray-cloud,
+    .graffiti-text,
+    .graffiti-shadow,
+    .paint-splatter span {
+      animation: none;
+    }
+  
+    .spray-cloud {
+      opacity: 0.3;
+      transform: scale(1);
+    }
+  
+    .graffiti-text,
+    .graffiti-shadow {
+      opacity: 1;
+  
+      clip-path: inset(0 0 0 0);
+  
+      filter: none;
+    }
+  
+    .paint-splatter span {
+      opacity: 0.6;
+      transform: scale(1);
+    }
+  }
+  
+  /* ---------- Tablet ---------- */
+  
+  @media (max-width: 700px) {
+  
+    .page {
+      padding: 3rem 0;
+    }
+  
+    .wall {
+      width: 96vw;
+    }
+  
+    .graffiti-shadow,
+    .graffiti-text {
+      font-size: clamp(3.5rem, 13vw, 7rem);
+    }
+  }
+  
+  /* ---------- Mobile ---------- */
+  
+  @media (max-width: 480px) {
+  
+    .page {
+      width: min(100% - 1rem, 420px);
+  
+      padding: 2rem 0;
+    }
+  
+    .intro {
+      margin-bottom: 2rem;
+    }
+  
+    .wall {
+      width: 100%;
+  
+      aspect-ratio: 4 / 3;
+  
+      border-radius: 0.5rem;
+    }
+  
+    .graffiti-shadow,
+    .graffiti-text {
+      font-size: clamp(2.7rem, 15vw, 5rem);
+    }
+  
+    .wall-label {
+      right: 0.75rem;
+      bottom: 0.6rem;
+  
+      font-size: 0.55rem;
+    }
+  
+    .hint {
+      margin-top: 1.5rem;
+  
+      font-size: 0.75rem;
+    }
+  }


### PR DESCRIPTION
## Description

Added a responsive CSS-only graffiti spray text effect
under `submissions/examples/css-graffiti-spray-text/`.

## Features

- Pure HTML and CSS
- Spray-paint text reveal
- Animated aerosol cloud
- Paint splatter particles
- Graffiti shadow
- Responsive desktop/tablet/mobile layout
- Hover interaction
- Keyboard focus support
- Reduced-motion support
- No JavaScript or external dependencies

## Files Added

- `demo.html`
- `style.css`
- `README.md`

## Testing

- Tested desktop layout
- Tested mobile responsive layout
- Tested hover interaction
- Tested keyboard focus
- Tested reduced-motion behavior
- Ran `git diff --check`

## Related Issue

Closes #70197