### PR TITLE
feat: add ease-lithograph-stone-ink (#70543)

### DIFF
--- a/submissions/examples/lithograph-stone-ink-ns/README.md
+++ b/submissions/examples/lithograph-stone-ink-ns/README.md
@@ -1,0 +1,16 @@
+# Lithograph Stone Ink
+
+## What does this do?
+Renders a self-contained CSS-only `ease-lithograph-stone-ink` demo: Lithograph stone ink roller pass.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-lithograph-stone-ink`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-lithograph-stone-ink">
+  <div class="ease-lithograph-stone-ink__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/lithograph-stone-ink-ns/demo.html
+++ b/submissions/examples/lithograph-stone-ink-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Lithograph Stone Ink — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Lithograph Stone Ink demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Lithograph Stone Ink</h1>
+      <p class="lede">Lithograph stone ink roller pass</p>
+    </header>
+
+    <section class="ease-lithograph-stone-ink" data-demo="lithograph-stone-ink" aria-live="polite">
+      <div class="ease-lithograph-stone-ink__housing">
+        <div class="ease-lithograph-stone-ink__bezel">
+          <div class="ease-lithograph-stone-ink__face">
+            <div class="ease-lithograph-stone-ink__readout">
+              <span class="ease-lithograph-stone-ink__label">Lithograph Stone Ink</span>
+              <span class="ease-lithograph-stone-ink__value">LIVE</span>
+            </div>
+            <div class="ease-lithograph-stone-ink__motion" aria-hidden="true">
+              <span class="ease-lithograph-stone-ink__a"></span>
+              <span class="ease-lithograph-stone-ink__b"></span>
+              <span class="ease-lithograph-stone-ink__c"></span>
+              <span class="ease-lithograph-stone-ink__d"></span>
+            </div>
+            <div class="ease-lithograph-stone-ink__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-lithograph-stone-ink__controls">
+          <button type="button" class="ease-lithograph-stone-ink__btn primary">Engage</button>
+          <button type="button" class="ease-lithograph-stone-ink__btn">Reset</button>
+          <label class="ease-lithograph-stone-ink__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-lithograph-stone-ink__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/lithograph-stone-ink-ns/style.css
+++ b/submissions/examples/lithograph-stone-ink-ns/style.css
@@ -1,0 +1,239 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 22% 0%, color-mix(in srgb, #64748b 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 80% 100%, color-mix(in srgb, #94a3b8 18%, transparent), transparent 42%),
+    #0e1116;
+}
+
+.stage {
+  width: min(656px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-lithograph-stone-ink {
+  --accent: #64748b;
+  --accent-2: #94a3b8;
+  --panel: color-mix(in srgb, #e8eef6 7%, #0e1116);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 12px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #0e1116 75%, #000);
+}
+
+.ease-lithograph-stone-ink__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-lithograph-stone-ink__bezel {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #0e1116 90%, #64748b);
+}
+
+.ease-lithograph-stone-ink__face {
+  position: relative;
+  min-height: 272px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 34% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #0e1116 85%, #000), color-mix(in srgb, #0e1116 65%, var(--accent-2)));
+}
+
+.ease-lithograph-stone-ink__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-lithograph-stone-ink__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-lithograph-stone-ink__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-lithograph-stone-ink__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-lithograph-stone-ink__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-lithograph-stone-ink__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-lithograph-stone-ink__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: lithograph_stone_ink_meter 1.86s ease-in-out infinite alternate;
+}
+
+.ease-lithograph-stone-ink__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-lithograph-stone-ink__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-lithograph-stone-ink__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-lithograph-stone-ink__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-lithograph-stone-ink__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-lithograph-stone-ink__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-lithograph-stone-ink__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-lithograph-stone-ink__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-lithograph-stone-ink__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-lithograph-stone-ink__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-lithograph-stone-ink__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-lithograph-stone-ink__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: lithograph_stone_ink_status 1.60s ease-out infinite;
+}
+
+@keyframes lithograph_stone_ink_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes lithograph_stone_ink_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-lithograph-stone-ink__a{left:28%;top:26%;width:44%;height:44%;border-radius:50%;border:3px dashed color-mix(in srgb,var(--accent) 50%,#64748b);animation:lithograph_stone_ink_spin 8s linear infinite}
+.ease-lithograph-stone-ink__b{left:40%;top:38%;width:20%;height:20%;border-radius:50%;background:radial-gradient(circle at 30% 30%,var(--accent-2),var(--accent));box-shadow:0 0 24px color-mix(in srgb,var(--accent) 45%,transparent);animation:lithograph_stone_ink_glow 2.6s ease-in-out infinite}
+.ease-lithograph-stone-ink__c{position:absolute;left:18%;bottom:24%;width:64%;height:8px;border-radius:999px;background:color-mix(in srgb,#e8eef6 12%,transparent);overflow:hidden}
+.ease-lithograph-stone-ink__c::after{content:"";display:block;height:100%;width:35%;background:linear-gradient(90deg,transparent,var(--accent),transparent);animation:lithograph_stone_ink_sweep 2.6s linear infinite}
+.ease-lithograph-stone-ink__d{position:absolute;right:16%;top:30%;width:10px;height:10px;border-radius:50%;background:var(--accent);animation:lithograph_stone_ink_blink 1.4s steps(2) infinite}
+
+@keyframes lithograph_stone_ink_spin{to{transform:rotate(360deg)}}
+@keyframes lithograph_stone_ink_glow{0%,100%{transform:scale(.92);filter:brightness(.85)}50%{transform:scale(1.08);filter:brightness(1.25)}}
+@keyframes lithograph_stone_ink_sweep{from{transform:translateX(-40%)}to{transform:translateX(220%)}}
+@keyframes lithograph_stone_ink_blink{50%{opacity:.2}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-lithograph-stone-ink__a,
+  .ease-lithograph-stone-ink__b,
+  .ease-lithograph-stone-ink__c,
+  .ease-lithograph-stone-ink__d,
+  .ease-lithograph-stone-ink__meters i::after,
+  .ease-lithograph-stone-ink__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-lithograph-stone-ink` under `submissions/examples/lithograph-stone-ink-ns/` — CSS-only Lithograph stone ink roller pass.

Fixes #70543

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Lithograph stone ink roller pass.

**How does a developer use it?**

```html
<section class="ease-lithograph-stone-ink">
  <div class="ease-lithograph-stone-ink__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `lithograph_stone_ink_*` prefix. Reduced-motion disables animations.
