### PR TITLE
feat: add ease-rose-engine-chuck-spin (#70561)

### DIFF
--- a/submissions/examples/rose-engine-chuck-spin-ns/README.md
+++ b/submissions/examples/rose-engine-chuck-spin-ns/README.md
@@ -1,0 +1,16 @@
+# Rose Engine Chuck Spin
+
+## What does this do?
+Renders a self-contained CSS-only `ease-rose-engine-chuck-spin` demo: Rose engine chuck oscillating cut.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-rose-engine-chuck-spin`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-rose-engine-chuck-spin">
+  <div class="ease-rose-engine-chuck-spin__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/rose-engine-chuck-spin-ns/demo.html
+++ b/submissions/examples/rose-engine-chuck-spin-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Rose Engine Chuck Spin — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Rose Engine Chuck Spin demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Rose Engine Chuck Spin</h1>
+      <p class="lede">Rose engine chuck oscillating cut</p>
+    </header>
+
+    <section class="ease-rose-engine-chuck-spin" data-demo="rose-engine-chuck-spin" aria-live="polite">
+      <div class="ease-rose-engine-chuck-spin__housing">
+        <div class="ease-rose-engine-chuck-spin__bezel">
+          <div class="ease-rose-engine-chuck-spin__face">
+            <div class="ease-rose-engine-chuck-spin__readout">
+              <span class="ease-rose-engine-chuck-spin__label">Rose Engine Chuck Spin</span>
+              <span class="ease-rose-engine-chuck-spin__value">LIVE</span>
+            </div>
+            <div class="ease-rose-engine-chuck-spin__motion" aria-hidden="true">
+              <span class="ease-rose-engine-chuck-spin__a"></span>
+              <span class="ease-rose-engine-chuck-spin__b"></span>
+              <span class="ease-rose-engine-chuck-spin__c"></span>
+              <span class="ease-rose-engine-chuck-spin__d"></span>
+            </div>
+            <div class="ease-rose-engine-chuck-spin__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-rose-engine-chuck-spin__controls">
+          <button type="button" class="ease-rose-engine-chuck-spin__btn primary">Engage</button>
+          <button type="button" class="ease-rose-engine-chuck-spin__btn">Reset</button>
+          <label class="ease-rose-engine-chuck-spin__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-rose-engine-chuck-spin__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/rose-engine-chuck-spin-ns/style.css
+++ b/submissions/examples/rose-engine-chuck-spin-ns/style.css
@@ -1,0 +1,239 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "Source Sans 3", "Helvetica Neue", sans-serif;
+  background:
+    radial-gradient(ellipse at 33% 0%, color-mix(in srgb, #f43f5e 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 91% 100%, color-mix(in srgb, #fb7185 18%, transparent), transparent 42%),
+    #16080c;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-rose-engine-chuck-spin {
+  --accent: #f43f5e;
+  --accent-2: #fb7185;
+  --panel: color-mix(in srgb, #e8eef6 7%, #16080c);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 13px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #16080c 75%, #000);
+}
+
+.ease-rose-engine-chuck-spin__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-rose-engine-chuck-spin__bezel {
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #16080c 90%, #f43f5e);
+}
+
+.ease-rose-engine-chuck-spin__face {
+  position: relative;
+  min-height: 264px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 25% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #16080c 85%, #000), color-mix(in srgb, #16080c 65%, var(--accent-2)));
+}
+
+.ease-rose-engine-chuck-spin__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-rose-engine-chuck-spin__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-rose-engine-chuck-spin__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-rose-engine-chuck-spin__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-rose-engine-chuck-spin__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-rose-engine-chuck-spin__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-rose-engine-chuck-spin__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: rose_engine_chuck_spin_meter 1.50s ease-in-out infinite alternate;
+}
+
+.ease-rose-engine-chuck-spin__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-rose-engine-chuck-spin__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-rose-engine-chuck-spin__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-rose-engine-chuck-spin__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-rose-engine-chuck-spin__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-rose-engine-chuck-spin__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-rose-engine-chuck-spin__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-rose-engine-chuck-spin__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-rose-engine-chuck-spin__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-rose-engine-chuck-spin__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-rose-engine-chuck-spin__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-rose-engine-chuck-spin__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: rose_engine_chuck_spin_status 1.75s ease-out infinite;
+}
+
+@keyframes rose_engine_chuck_spin_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes rose_engine_chuck_spin_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-rose-engine-chuck-spin__a{left:48%;top:12%;width:4px;height:58%;background:linear-gradient(180deg,var(--accent),transparent);transform-origin:top center;animation:rose_engine_chuck_spin_swing 2.2s ease-in-out infinite}
+.ease-rose-engine-chuck-spin__b{left:42%;bottom:22%;width:16%;height:16%;border-radius:50%;background:radial-gradient(circle at 35% 30%,var(--accent-2),var(--accent));animation:rose_engine_chuck_spin_bob 2.2s ease-in-out infinite}
+.ease-rose-engine-chuck-spin__c{position:absolute;left:12%;bottom:18%;width:76%;height:3px;background:color-mix(in srgb,#e8eef6 18%,transparent);border-radius:2px}
+.ease-rose-engine-chuck-spin__c::after{content:"";position:absolute;left:0;top:-4px;width:12px;height:12px;border-radius:50%;background:var(--accent);animation:rose_engine_chuck_spin_slide 2.2s ease-in-out infinite}
+.ease-rose-engine-chuck-spin__d{position:absolute;left:20%;top:22%;width:60%;height:2px;background:repeating-linear-gradient(90deg,var(--accent) 0 6px,transparent 6px 12px);opacity:.45;animation:rose_engine_chuck_spin_flicker 1.1s linear infinite}
+
+@keyframes rose_engine_chuck_spin_swing{0%,100%{transform:rotate(-18deg)}50%{transform:rotate(18deg)}}
+@keyframes rose_engine_chuck_spin_bob{0%,100%{transform:translateX(-18px)}50%{transform:translateX(18px)}}
+@keyframes rose_engine_chuck_spin_slide{0%,100%{transform:translateX(0)}50%{transform:translateX(calc(100% - 12px))}}
+@keyframes rose_engine_chuck_spin_flicker{50%{opacity:.2}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-rose-engine-chuck-spin__a,
+  .ease-rose-engine-chuck-spin__b,
+  .ease-rose-engine-chuck-spin__c,
+  .ease-rose-engine-chuck-spin__d,
+  .ease-rose-engine-chuck-spin__meters i::after,
+  .ease-rose-engine-chuck-spin__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-rose-engine-chuck-spin` under `submissions/examples/rose-engine-chuck-spin-ns/` — CSS-only Rose engine chuck oscillating cut.

Fixes #70561

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Rose engine chuck oscillating cut.

**How does a developer use it?**

```html
<section class="ease-rose-engine-chuck-spin">
  <div class="ease-rose-engine-chuck-spin__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `rose_engine_chuck_spin_*` prefix. Reduced-motion disables animations.
