### PR TITLE
feat: add ease-springald-bolt-launch (#70572)

### DIFF
--- a/submissions/examples/springald-bolt-launch-ns/README.md
+++ b/submissions/examples/springald-bolt-launch-ns/README.md
@@ -1,0 +1,16 @@
+# Springald Bolt Launch
+
+## What does this do?
+Renders a self-contained CSS-only `ease-springald-bolt-launch` demo: Springald torsion bolt launch.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-springald-bolt-launch`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-springald-bolt-launch">
+  <div class="ease-springald-bolt-launch__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/springald-bolt-launch-ns/demo.html
+++ b/submissions/examples/springald-bolt-launch-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Springald Bolt Launch — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Springald Bolt Launch demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Springald Bolt Launch</h1>
+      <p class="lede">Springald torsion bolt launch</p>
+    </header>
+
+    <section class="ease-springald-bolt-launch" data-demo="springald-bolt-launch" aria-live="polite">
+      <div class="ease-springald-bolt-launch__housing">
+        <div class="ease-springald-bolt-launch__bezel">
+          <div class="ease-springald-bolt-launch__face">
+            <div class="ease-springald-bolt-launch__readout">
+              <span class="ease-springald-bolt-launch__label">Springald Bolt Launch</span>
+              <span class="ease-springald-bolt-launch__value">LIVE</span>
+            </div>
+            <div class="ease-springald-bolt-launch__motion" aria-hidden="true">
+              <span class="ease-springald-bolt-launch__a"></span>
+              <span class="ease-springald-bolt-launch__b"></span>
+              <span class="ease-springald-bolt-launch__c"></span>
+              <span class="ease-springald-bolt-launch__d"></span>
+            </div>
+            <div class="ease-springald-bolt-launch__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-springald-bolt-launch__controls">
+          <button type="button" class="ease-springald-bolt-launch__btn primary">Engage</button>
+          <button type="button" class="ease-springald-bolt-launch__btn">Reset</button>
+          <label class="ease-springald-bolt-launch__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-springald-bolt-launch__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/springald-bolt-launch-ns/style.css
+++ b/submissions/examples/springald-bolt-launch-ns/style.css
@@ -1,0 +1,239 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "Manrope", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 40% 0%, color-mix(in srgb, #dc2626 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 73% 100%, color-mix(in srgb, #f87171 18%, transparent), transparent 42%),
+    #160909;
+}
+
+.stage {
+  width: min(672px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-springald-bolt-launch {
+  --accent: #dc2626;
+  --accent-2: #f87171;
+  --panel: color-mix(in srgb, #e8eef6 7%, #160909);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 15px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #160909 75%, #000);
+}
+
+.ease-springald-bolt-launch__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-springald-bolt-launch__bezel {
+  border: 1px solid var(--line);
+  border-radius: 11px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #160909 90%, #dc2626);
+}
+
+.ease-springald-bolt-launch__face {
+  position: relative;
+  min-height: 272px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 32% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #160909 85%, #000), color-mix(in srgb, #160909 65%, var(--accent-2)));
+}
+
+.ease-springald-bolt-launch__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-springald-bolt-launch__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-springald-bolt-launch__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-springald-bolt-launch__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-springald-bolt-launch__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-springald-bolt-launch__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-springald-bolt-launch__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: springald_bolt_launch_meter 1.50s ease-in-out infinite alternate;
+}
+
+.ease-springald-bolt-launch__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-springald-bolt-launch__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-springald-bolt-launch__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-springald-bolt-launch__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-springald-bolt-launch__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-springald-bolt-launch__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-springald-bolt-launch__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-springald-bolt-launch__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-springald-bolt-launch__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-springald-bolt-launch__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-springald-bolt-launch__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-springald-bolt-launch__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: springald_bolt_launch_status 2.05s ease-out infinite;
+}
+
+@keyframes springald_bolt_launch_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes springald_bolt_launch_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-springald-bolt-launch__a{left:35%;top:28%;width:30%;height:30%;border-radius:50%;border:2px solid color-mix(in srgb,var(--accent) 40%,transparent);animation:springald_bolt_launch_orbit 6s linear infinite}
+.ease-springald-bolt-launch__b{left:44%;top:36%;width:12%;height:12%;border-radius:50%;background:var(--accent);box-shadow:0 0 18px color-mix(in srgb,var(--accent) 50%,transparent);animation:springald_bolt_launch_pulse 1.6s ease-in-out infinite}
+.ease-springald-bolt-launch__c{position:absolute;left:20%;top:22%;width:8px;height:8px;border-radius:50%;background:var(--accent-2);animation:springald_bolt_launch_sat 4.5s linear infinite}
+.ease-springald-bolt-launch__c::after{content:"";position:absolute;left:48px;top:-6px;width:6px;height:6px;border-radius:50%;background:var(--accent)}
+.ease-springald-bolt-launch__d{position:absolute;left:15%;bottom:26%;width:70%;height:6px;border-radius:999px;background:linear-gradient(90deg,transparent,color-mix(in srgb,var(--accent) 40%,transparent),transparent);animation:springald_bolt_launch_wave 2.8s ease-in-out infinite}
+
+@keyframes springald_bolt_launch_orbit{to{transform:rotate(360deg)}}
+@keyframes springald_bolt_launch_pulse{0%,100%{transform:scale(.9)}50%{transform:scale(1.15)}}
+@keyframes springald_bolt_launch_sat{to{transform:rotate(-360deg) translateX(42px) rotate(360deg)}}
+@keyframes springald_bolt_launch_wave{0%,100%{opacity:.35;transform:scaleX(.85)}50%{opacity:1;transform:scaleX(1)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-springald-bolt-launch__a,
+  .ease-springald-bolt-launch__b,
+  .ease-springald-bolt-launch__c,
+  .ease-springald-bolt-launch__d,
+  .ease-springald-bolt-launch__meters i::after,
+  .ease-springald-bolt-launch__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-springald-bolt-launch` under `submissions/examples/springald-bolt-launch-ns/` — CSS-only Springald torsion bolt launch.

Fixes #70572

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Springald torsion bolt launch.

**How does a developer use it?**

```html
<section class="ease-springald-bolt-launch">
  <div class="ease-springald-bolt-launch__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `springald_bolt_launch_*` prefix. Reduced-motion disables animations.
