### PR TITLE
feat: add ease-onager-sling-release (#70577)

### DIFF
--- a/submissions/examples/onager-sling-release-ns/README.md
+++ b/submissions/examples/onager-sling-release-ns/README.md
@@ -1,0 +1,16 @@
+# Onager Sling Release
+
+## What does this do?
+Renders a self-contained CSS-only `ease-onager-sling-release` demo: Onager sling pouch release arc.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-onager-sling-release`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-onager-sling-release">
+  <div class="ease-onager-sling-release__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/onager-sling-release-ns/demo.html
+++ b/submissions/examples/onager-sling-release-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Onager Sling Release — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Onager Sling Release demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Onager Sling Release</h1>
+      <p class="lede">Onager sling pouch release arc</p>
+    </header>
+
+    <section class="ease-onager-sling-release" data-demo="onager-sling-release" aria-live="polite">
+      <div class="ease-onager-sling-release__housing">
+        <div class="ease-onager-sling-release__bezel">
+          <div class="ease-onager-sling-release__face">
+            <div class="ease-onager-sling-release__readout">
+              <span class="ease-onager-sling-release__label">Onager Sling Release</span>
+              <span class="ease-onager-sling-release__value">LIVE</span>
+            </div>
+            <div class="ease-onager-sling-release__motion" aria-hidden="true">
+              <span class="ease-onager-sling-release__a"></span>
+              <span class="ease-onager-sling-release__b"></span>
+              <span class="ease-onager-sling-release__c"></span>
+              <span class="ease-onager-sling-release__d"></span>
+            </div>
+            <div class="ease-onager-sling-release__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-onager-sling-release__controls">
+          <button type="button" class="ease-onager-sling-release__btn primary">Engage</button>
+          <button type="button" class="ease-onager-sling-release__btn">Reset</button>
+          <label class="ease-onager-sling-release__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-onager-sling-release__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/onager-sling-release-ns/style.css
+++ b/submissions/examples/onager-sling-release-ns/style.css
@@ -1,0 +1,239 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "Source Sans 3", "Helvetica Neue", sans-serif;
+  background:
+    radial-gradient(ellipse at 13% 0%, color-mix(in srgb, #ea580c 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 76% 100%, color-mix(in srgb, #fb923c 18%, transparent), transparent 42%),
+    #161008;
+}
+
+.stage {
+  width: min(696px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-onager-sling-release {
+  --accent: #ea580c;
+  --accent-2: #fb923c;
+  --panel: color-mix(in srgb, #e8eef6 7%, #161008);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 13px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #161008 75%, #000);
+}
+
+.ease-onager-sling-release__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-onager-sling-release__bezel {
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #161008 90%, #ea580c);
+}
+
+.ease-onager-sling-release__face {
+  position: relative;
+  min-height: 248px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 35% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #161008 85%, #000), color-mix(in srgb, #161008 65%, var(--accent-2)));
+}
+
+.ease-onager-sling-release__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-onager-sling-release__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-onager-sling-release__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-onager-sling-release__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-onager-sling-release__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-onager-sling-release__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-onager-sling-release__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: onager_sling_release_meter 1.86s ease-in-out infinite alternate;
+}
+
+.ease-onager-sling-release__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-onager-sling-release__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-onager-sling-release__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-onager-sling-release__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-onager-sling-release__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-onager-sling-release__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-onager-sling-release__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-onager-sling-release__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-onager-sling-release__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-onager-sling-release__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-onager-sling-release__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-onager-sling-release__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: onager_sling_release_status 1.75s ease-out infinite;
+}
+
+@keyframes onager_sling_release_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes onager_sling_release_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-onager-sling-release__a{left:48%;top:12%;width:4px;height:58%;background:linear-gradient(180deg,var(--accent),transparent);transform-origin:top center;animation:onager_sling_release_swing 2.2s ease-in-out infinite}
+.ease-onager-sling-release__b{left:42%;bottom:22%;width:16%;height:16%;border-radius:50%;background:radial-gradient(circle at 35% 30%,var(--accent-2),var(--accent));animation:onager_sling_release_bob 2.2s ease-in-out infinite}
+.ease-onager-sling-release__c{position:absolute;left:12%;bottom:18%;width:76%;height:3px;background:color-mix(in srgb,#e8eef6 18%,transparent);border-radius:2px}
+.ease-onager-sling-release__c::after{content:"";position:absolute;left:0;top:-4px;width:12px;height:12px;border-radius:50%;background:var(--accent);animation:onager_sling_release_slide 2.2s ease-in-out infinite}
+.ease-onager-sling-release__d{position:absolute;left:20%;top:22%;width:60%;height:2px;background:repeating-linear-gradient(90deg,var(--accent) 0 6px,transparent 6px 12px);opacity:.45;animation:onager_sling_release_flicker 1.1s linear infinite}
+
+@keyframes onager_sling_release_swing{0%,100%{transform:rotate(-18deg)}50%{transform:rotate(18deg)}}
+@keyframes onager_sling_release_bob{0%,100%{transform:translateX(-18px)}50%{transform:translateX(18px)}}
+@keyframes onager_sling_release_slide{0%,100%{transform:translateX(0)}50%{transform:translateX(calc(100% - 12px))}}
+@keyframes onager_sling_release_flicker{50%{opacity:.2}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-onager-sling-release__a,
+  .ease-onager-sling-release__b,
+  .ease-onager-sling-release__c,
+  .ease-onager-sling-release__d,
+  .ease-onager-sling-release__meters i::after,
+  .ease-onager-sling-release__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-onager-sling-release` under `submissions/examples/onager-sling-release-ns/` — CSS-only Onager sling pouch release arc.

Fixes #70577

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Onager sling pouch release arc.

**How does a developer use it?**

```html
<section class="ease-onager-sling-release">
  <div class="ease-onager-sling-release__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `onager_sling_release_*` prefix. Reduced-motion disables animations.
