### PR TITLE
feat: add ease-polybolos-chain-drive (#70578)

### DIFF
--- a/submissions/examples/polybolos-chain-drive-ns/README.md
+++ b/submissions/examples/polybolos-chain-drive-ns/README.md
@@ -1,0 +1,16 @@
+# Polybolos Chain Drive
+
+## What does this do?
+Renders a self-contained CSS-only `ease-polybolos-chain-drive` demo: Polybolos repeating chain-drive reload.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-polybolos-chain-drive`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-polybolos-chain-drive">
+  <div class="ease-polybolos-chain-drive__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/polybolos-chain-drive-ns/demo.html
+++ b/submissions/examples/polybolos-chain-drive-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Polybolos Chain Drive — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Polybolos Chain Drive demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Polybolos Chain Drive</h1>
+      <p class="lede">Polybolos repeating chain-drive reload</p>
+    </header>
+
+    <section class="ease-polybolos-chain-drive" data-demo="polybolos-chain-drive" aria-live="polite">
+      <div class="ease-polybolos-chain-drive__housing">
+        <div class="ease-polybolos-chain-drive__bezel">
+          <div class="ease-polybolos-chain-drive__face">
+            <div class="ease-polybolos-chain-drive__readout">
+              <span class="ease-polybolos-chain-drive__label">Polybolos Chain Drive</span>
+              <span class="ease-polybolos-chain-drive__value">LIVE</span>
+            </div>
+            <div class="ease-polybolos-chain-drive__motion" aria-hidden="true">
+              <span class="ease-polybolos-chain-drive__a"></span>
+              <span class="ease-polybolos-chain-drive__b"></span>
+              <span class="ease-polybolos-chain-drive__c"></span>
+              <span class="ease-polybolos-chain-drive__d"></span>
+            </div>
+            <div class="ease-polybolos-chain-drive__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-polybolos-chain-drive__controls">
+          <button type="button" class="ease-polybolos-chain-drive__btn primary">Engage</button>
+          <button type="button" class="ease-polybolos-chain-drive__btn">Reset</button>
+          <label class="ease-polybolos-chain-drive__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-polybolos-chain-drive__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/polybolos-chain-drive-ns/style.css
+++ b/submissions/examples/polybolos-chain-drive-ns/style.css
@@ -1,0 +1,239 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "DM Sans", "Trebuchet MS", sans-serif;
+  background:
+    radial-gradient(ellipse at 14% 0%, color-mix(in srgb, #2563eb 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 77% 100%, color-mix(in srgb, #60a5fa 18%, transparent), transparent 42%),
+    #081018;
+}
+
+.stage {
+  width: min(640px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-polybolos-chain-drive {
+  --accent: #2563eb;
+  --accent-2: #60a5fa;
+  --panel: color-mix(in srgb, #e8eef6 7%, #081018);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #081018 75%, #000);
+}
+
+.ease-polybolos-chain-drive__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-polybolos-chain-drive__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #081018 90%, #2563eb);
+}
+
+.ease-polybolos-chain-drive__face {
+  position: relative;
+  min-height: 256px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 36% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #081018 85%, #000), color-mix(in srgb, #081018 65%, var(--accent-2)));
+}
+
+.ease-polybolos-chain-drive__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-polybolos-chain-drive__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-polybolos-chain-drive__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-polybolos-chain-drive__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-polybolos-chain-drive__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-polybolos-chain-drive__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-polybolos-chain-drive__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: polybolos_chain_drive_meter 1.98s ease-in-out infinite alternate;
+}
+
+.ease-polybolos-chain-drive__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-polybolos-chain-drive__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-polybolos-chain-drive__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-polybolos-chain-drive__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-polybolos-chain-drive__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-polybolos-chain-drive__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-polybolos-chain-drive__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-polybolos-chain-drive__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-polybolos-chain-drive__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-polybolos-chain-drive__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-polybolos-chain-drive__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-polybolos-chain-drive__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: polybolos_chain_drive_status 1.90s ease-out infinite;
+}
+
+@keyframes polybolos_chain_drive_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes polybolos_chain_drive_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-polybolos-chain-drive__a{left:46%;top:18%;width:8%;height:48%;border-radius:8px;background:linear-gradient(180deg,var(--accent-2),var(--accent));animation:polybolos_chain_drive_piston 1.8s ease-in-out infinite}
+.ease-polybolos-chain-drive__b{left:30%;top:30%;width:40%;height:40%;border-radius:50%;border:2px solid color-mix(in srgb,var(--accent) 55%,transparent);animation:polybolos_chain_drive_ring 2.4s ease-out infinite}
+.ease-polybolos-chain-drive__c{position:absolute;left:22%;bottom:20%;width:56%;height:10px;border-radius:6px;background:color-mix(in srgb,#e8eef6 10%,transparent);box-shadow:inset 0 0 0 1px color-mix(in srgb,var(--accent) 30%,transparent)}
+.ease-polybolos-chain-drive__c::after{content:"";display:block;height:100%;width:42%;border-radius:6px;background:var(--accent);animation:polybolos_chain_drive_fill 1.8s ease-in-out infinite alternate}
+.ease-polybolos-chain-drive__d{position:absolute;right:18%;top:24%;width:14px;height:14px;border-radius:3px;background:var(--accent-2);animation:polybolos_chain_drive_tick 1.8s steps(4) infinite}
+
+@keyframes polybolos_chain_drive_piston{0%,100%{transform:translateY(0)}50%{transform:translateY(28px)}}
+@keyframes polybolos_chain_drive_ring{0%{transform:scale(.6);opacity:.9}100%{transform:scale(1.35);opacity:0}}
+@keyframes polybolos_chain_drive_fill{from{width:22%}to{width:78%}}
+@keyframes polybolos_chain_drive_tick{50%{opacity:.35;transform:scale(.85)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-polybolos-chain-drive__a,
+  .ease-polybolos-chain-drive__b,
+  .ease-polybolos-chain-drive__c,
+  .ease-polybolos-chain-drive__d,
+  .ease-polybolos-chain-drive__meters i::after,
+  .ease-polybolos-chain-drive__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-polybolos-chain-drive` under `submissions/examples/polybolos-chain-drive-ns/` — CSS-only Polybolos repeating chain-drive reload.

Fixes #70578

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Polybolos repeating chain-drive reload.

**How does a developer use it?**

```html
<section class="ease-polybolos-chain-drive">
  <div class="ease-polybolos-chain-drive__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `polybolos_chain_drive_*` prefix. Reduced-motion disables animations.
