### PR TITLE
feat: add ease-traction-trebuchet-pull (#70580)

### DIFF
--- a/submissions/examples/traction-trebuchet-pull-ns/README.md
+++ b/submissions/examples/traction-trebuchet-pull-ns/README.md
@@ -1,0 +1,16 @@
+# Traction Trebuchet Pull
+
+## What does this do?
+Renders a self-contained CSS-only `ease-traction-trebuchet-pull` demo: Traction trebuchet team pull release.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-traction-trebuchet-pull`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-traction-trebuchet-pull">
+  <div class="ease-traction-trebuchet-pull__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/traction-trebuchet-pull-ns/demo.html
+++ b/submissions/examples/traction-trebuchet-pull-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Traction Trebuchet Pull — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Traction Trebuchet Pull demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Traction Trebuchet Pull</h1>
+      <p class="lede">Traction trebuchet team pull release</p>
+    </header>
+
+    <section class="ease-traction-trebuchet-pull" data-demo="traction-trebuchet-pull" aria-live="polite">
+      <div class="ease-traction-trebuchet-pull__housing">
+        <div class="ease-traction-trebuchet-pull__bezel">
+          <div class="ease-traction-trebuchet-pull__face">
+            <div class="ease-traction-trebuchet-pull__readout">
+              <span class="ease-traction-trebuchet-pull__label">Traction Trebuchet Pull</span>
+              <span class="ease-traction-trebuchet-pull__value">LIVE</span>
+            </div>
+            <div class="ease-traction-trebuchet-pull__motion" aria-hidden="true">
+              <span class="ease-traction-trebuchet-pull__a"></span>
+              <span class="ease-traction-trebuchet-pull__b"></span>
+              <span class="ease-traction-trebuchet-pull__c"></span>
+              <span class="ease-traction-trebuchet-pull__d"></span>
+            </div>
+            <div class="ease-traction-trebuchet-pull__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-traction-trebuchet-pull__controls">
+          <button type="button" class="ease-traction-trebuchet-pull__btn primary">Engage</button>
+          <button type="button" class="ease-traction-trebuchet-pull__btn">Reset</button>
+          <label class="ease-traction-trebuchet-pull__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-traction-trebuchet-pull__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/traction-trebuchet-pull-ns/style.css
+++ b/submissions/examples/traction-trebuchet-pull-ns/style.css
@@ -1,0 +1,239 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "Manrope", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 15% 0%, color-mix(in srgb, #be123c 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 78% 100%, color-mix(in srgb, #fb7185 18%, transparent), transparent 42%),
+    #16080c;
+}
+
+.stage {
+  width: min(648px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-traction-trebuchet-pull {
+  --accent: #be123c;
+  --accent-2: #fb7185;
+  --panel: color-mix(in srgb, #e8eef6 7%, #16080c);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 15px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #16080c 75%, #000);
+}
+
+.ease-traction-trebuchet-pull__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-traction-trebuchet-pull__bezel {
+  border: 1px solid var(--line);
+  border-radius: 11px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #16080c 90%, #be123c);
+}
+
+.ease-traction-trebuchet-pull__face {
+  position: relative;
+  min-height: 264px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 37% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #16080c 85%, #000), color-mix(in srgb, #16080c 65%, var(--accent-2)));
+}
+
+.ease-traction-trebuchet-pull__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-traction-trebuchet-pull__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-traction-trebuchet-pull__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-traction-trebuchet-pull__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-traction-trebuchet-pull__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-traction-trebuchet-pull__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-traction-trebuchet-pull__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: traction_trebuchet_pull_meter 2.10s ease-in-out infinite alternate;
+}
+
+.ease-traction-trebuchet-pull__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-traction-trebuchet-pull__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-traction-trebuchet-pull__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-traction-trebuchet-pull__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-traction-trebuchet-pull__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-traction-trebuchet-pull__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-traction-trebuchet-pull__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-traction-trebuchet-pull__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-traction-trebuchet-pull__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-traction-trebuchet-pull__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-traction-trebuchet-pull__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-traction-trebuchet-pull__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: traction_trebuchet_pull_status 2.05s ease-out infinite;
+}
+
+@keyframes traction_trebuchet_pull_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes traction_trebuchet_pull_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-traction-trebuchet-pull__a{left:35%;top:28%;width:30%;height:30%;border-radius:50%;border:2px solid color-mix(in srgb,var(--accent) 40%,transparent);animation:traction_trebuchet_pull_orbit 6s linear infinite}
+.ease-traction-trebuchet-pull__b{left:44%;top:36%;width:12%;height:12%;border-radius:50%;background:var(--accent);box-shadow:0 0 18px color-mix(in srgb,var(--accent) 50%,transparent);animation:traction_trebuchet_pull_pulse 1.6s ease-in-out infinite}
+.ease-traction-trebuchet-pull__c{position:absolute;left:20%;top:22%;width:8px;height:8px;border-radius:50%;background:var(--accent-2);animation:traction_trebuchet_pull_sat 4.5s linear infinite}
+.ease-traction-trebuchet-pull__c::after{content:"";position:absolute;left:48px;top:-6px;width:6px;height:6px;border-radius:50%;background:var(--accent)}
+.ease-traction-trebuchet-pull__d{position:absolute;left:15%;bottom:26%;width:70%;height:6px;border-radius:999px;background:linear-gradient(90deg,transparent,color-mix(in srgb,var(--accent) 40%,transparent),transparent);animation:traction_trebuchet_pull_wave 2.8s ease-in-out infinite}
+
+@keyframes traction_trebuchet_pull_orbit{to{transform:rotate(360deg)}}
+@keyframes traction_trebuchet_pull_pulse{0%,100%{transform:scale(.9)}50%{transform:scale(1.15)}}
+@keyframes traction_trebuchet_pull_sat{to{transform:rotate(-360deg) translateX(42px) rotate(360deg)}}
+@keyframes traction_trebuchet_pull_wave{0%,100%{opacity:.35;transform:scaleX(.85)}50%{opacity:1;transform:scaleX(1)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-traction-trebuchet-pull__a,
+  .ease-traction-trebuchet-pull__b,
+  .ease-traction-trebuchet-pull__c,
+  .ease-traction-trebuchet-pull__d,
+  .ease-traction-trebuchet-pull__meters i::after,
+  .ease-traction-trebuchet-pull__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-traction-trebuchet-pull` under `submissions/examples/traction-trebuchet-pull-ns/` — CSS-only Traction trebuchet team pull release.

Fixes #70580

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Traction trebuchet team pull release.

**How does a developer use it?**

```html
<section class="ease-traction-trebuchet-pull">
  <div class="ease-traction-trebuchet-pull__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `traction_trebuchet_pull_*` prefix. Reduced-motion disables animations.
