### PR TITLE
feat: add ease-sakia-ox-drive (#70600)

### DIFF
--- a/submissions/examples/sakia-ox-drive-ns/README.md
+++ b/submissions/examples/sakia-ox-drive-ns/README.md
@@ -1,0 +1,16 @@
+# Sakia Ox Drive
+
+## What does this do?
+Renders a self-contained CSS-only `ease-sakia-ox-drive` demo: Sakia ox-driven irrigation wheel.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-sakia-ox-drive`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-sakia-ox-drive">
+  <div class="ease-sakia-ox-drive__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/sakia-ox-drive-ns/demo.html
+++ b/submissions/examples/sakia-ox-drive-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sakia Ox Drive — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Sakia Ox Drive demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Sakia Ox Drive</h1>
+      <p class="lede">Sakia ox-driven irrigation wheel</p>
+    </header>
+
+    <section class="ease-sakia-ox-drive" data-demo="sakia-ox-drive" aria-live="polite">
+      <div class="ease-sakia-ox-drive__housing">
+        <div class="ease-sakia-ox-drive__bezel">
+          <div class="ease-sakia-ox-drive__face">
+            <div class="ease-sakia-ox-drive__readout">
+              <span class="ease-sakia-ox-drive__label">Sakia Ox Drive</span>
+              <span class="ease-sakia-ox-drive__value">LIVE</span>
+            </div>
+            <div class="ease-sakia-ox-drive__motion" aria-hidden="true">
+              <span class="ease-sakia-ox-drive__a"></span>
+              <span class="ease-sakia-ox-drive__b"></span>
+              <span class="ease-sakia-ox-drive__c"></span>
+              <span class="ease-sakia-ox-drive__d"></span>
+            </div>
+            <div class="ease-sakia-ox-drive__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-sakia-ox-drive__controls">
+          <button type="button" class="ease-sakia-ox-drive__btn primary">Engage</button>
+          <button type="button" class="ease-sakia-ox-drive__btn">Reset</button>
+          <label class="ease-sakia-ox-drive__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-sakia-ox-drive__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/sakia-ox-drive-ns/style.css
+++ b/submissions/examples/sakia-ox-drive-ns/style.css
@@ -1,0 +1,239 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "Sora", "Avenir Next", sans-serif;
+  background:
+    radial-gradient(ellipse at 26% 0%, color-mix(in srgb, #65a30d 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 89% 100%, color-mix(in srgb, #a3e635 18%, transparent), transparent 42%),
+    #0e1408;
+}
+
+.stage {
+  width: min(672px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-sakia-ox-drive {
+  --accent: #65a30d;
+  --accent-2: #a3e635;
+  --panel: color-mix(in srgb, #e8eef6 7%, #0e1408);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 16px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #0e1408 75%, #000);
+}
+
+.ease-sakia-ox-drive__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-sakia-ox-drive__bezel {
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #0e1408 90%, #65a30d);
+}
+
+.ease-sakia-ox-drive__face {
+  position: relative;
+  min-height: 256px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 28% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #0e1408 85%, #000), color-mix(in srgb, #0e1408 65%, var(--accent-2)));
+}
+
+.ease-sakia-ox-drive__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-sakia-ox-drive__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-sakia-ox-drive__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-sakia-ox-drive__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-sakia-ox-drive__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-sakia-ox-drive__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-sakia-ox-drive__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: sakia_ox_drive_meter 1.74s ease-in-out infinite alternate;
+}
+
+.ease-sakia-ox-drive__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-sakia-ox-drive__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-sakia-ox-drive__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-sakia-ox-drive__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-sakia-ox-drive__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-sakia-ox-drive__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-sakia-ox-drive__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-sakia-ox-drive__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-sakia-ox-drive__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-sakia-ox-drive__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-sakia-ox-drive__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-sakia-ox-drive__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: sakia_ox_drive_status 2.20s ease-out infinite;
+}
+
+@keyframes sakia_ox_drive_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes sakia_ox_drive_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-sakia-ox-drive__a{left:22%;top:24%;width:56%;height:46%;border-radius:10px;border:1px solid color-mix(in srgb,var(--accent) 45%,transparent);background:linear-gradient(145deg,color-mix(in srgb,var(--accent) 18%,transparent),transparent);transform-style:preserve-3d;animation:sakia_ox_drive_flip 3.4s ease-in-out infinite}
+.ease-sakia-ox-drive__b{left:38%;top:36%;width:24%;height:24%;border-radius:6px;background:var(--accent);animation:sakia_ox_drive_pop 3.4s ease-in-out infinite}
+.ease-sakia-ox-drive__c{position:absolute;left:18%;bottom:20%;display:flex;gap:6px;width:64%;height:8px}
+.ease-sakia-ox-drive__c::after{content:"";flex:1;height:100%;border-radius:4px;background:linear-gradient(90deg,var(--accent-2),var(--accent));animation:sakia_ox_drive_bar 1.5s ease-in-out infinite alternate}
+.ease-sakia-ox-drive__d{position:absolute;right:14%;top:28%;width:3px;height:28%;background:var(--accent);animation:sakia_ox_drive_scan 2s linear infinite}
+
+@keyframes sakia_ox_drive_flip{0%,100%{transform:perspective(400px) rotateY(0)}50%{transform:perspective(400px) rotateY(180deg)}}
+@keyframes sakia_ox_drive_pop{0%,100%{transform:scale(1);opacity:.7}50%{transform:scale(1.2);opacity:1}}
+@keyframes sakia_ox_drive_bar{from{opacity:.45}to{opacity:1}}
+@keyframes sakia_ox_drive_scan{from{transform:translateY(0);opacity:.3}to{transform:translateY(20px);opacity:1}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-sakia-ox-drive__a,
+  .ease-sakia-ox-drive__b,
+  .ease-sakia-ox-drive__c,
+  .ease-sakia-ox-drive__d,
+  .ease-sakia-ox-drive__meters i::after,
+  .ease-sakia-ox-drive__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-sakia-ox-drive` under `submissions/examples/sakia-ox-drive-ns/` — CSS-only Sakia ox-driven irrigation wheel.

Fixes #70600

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Sakia ox-driven irrigation wheel.

**How does a developer use it?**

```html
<section class="ease-sakia-ox-drive">
  <div class="ease-sakia-ox-drive__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `sakia_ox_drive_*` prefix. Reduced-motion disables animations.
