### PR TITLE
feat: add ease-shaduf-counterpoise (#70601)

### DIFF
--- a/submissions/examples/shaduf-counterpoise-ns/README.md
+++ b/submissions/examples/shaduf-counterpoise-ns/README.md
@@ -1,0 +1,16 @@
+# Shaduf Counterpoise
+
+## What does this do?
+Renders a self-contained CSS-only `ease-shaduf-counterpoise` demo: Shaduf counterpoise well sweep lift.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-shaduf-counterpoise`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-shaduf-counterpoise">
+  <div class="ease-shaduf-counterpoise__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/shaduf-counterpoise-ns/demo.html
+++ b/submissions/examples/shaduf-counterpoise-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Shaduf Counterpoise — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Shaduf Counterpoise demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Shaduf Counterpoise</h1>
+      <p class="lede">Shaduf counterpoise well sweep lift</p>
+    </header>
+
+    <section class="ease-shaduf-counterpoise" data-demo="shaduf-counterpoise" aria-live="polite">
+      <div class="ease-shaduf-counterpoise__housing">
+        <div class="ease-shaduf-counterpoise__bezel">
+          <div class="ease-shaduf-counterpoise__face">
+            <div class="ease-shaduf-counterpoise__readout">
+              <span class="ease-shaduf-counterpoise__label">Shaduf Counterpoise</span>
+              <span class="ease-shaduf-counterpoise__value">LIVE</span>
+            </div>
+            <div class="ease-shaduf-counterpoise__motion" aria-hidden="true">
+              <span class="ease-shaduf-counterpoise__a"></span>
+              <span class="ease-shaduf-counterpoise__b"></span>
+              <span class="ease-shaduf-counterpoise__c"></span>
+              <span class="ease-shaduf-counterpoise__d"></span>
+            </div>
+            <div class="ease-shaduf-counterpoise__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-shaduf-counterpoise__controls">
+          <button type="button" class="ease-shaduf-counterpoise__btn primary">Engage</button>
+          <button type="button" class="ease-shaduf-counterpoise__btn">Reset</button>
+          <label class="ease-shaduf-counterpoise__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-shaduf-counterpoise__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/shaduf-counterpoise-ns/style.css
+++ b/submissions/examples/shaduf-counterpoise-ns/style.css
@@ -1,0 +1,239 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 27% 0%, color-mix(in srgb, #854d0e 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #ca8a04 18%, transparent), transparent 42%),
+    #141008;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-shaduf-counterpoise {
+  --accent: #854d0e;
+  --accent-2: #ca8a04;
+  --panel: color-mix(in srgb, #e8eef6 7%, #141008);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 12px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #141008 75%, #000);
+}
+
+.ease-shaduf-counterpoise__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-shaduf-counterpoise__bezel {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #141008 90%, #854d0e);
+}
+
+.ease-shaduf-counterpoise__face {
+  position: relative;
+  min-height: 264px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 29% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #141008 85%, #000), color-mix(in srgb, #141008 65%, var(--accent-2)));
+}
+
+.ease-shaduf-counterpoise__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-shaduf-counterpoise__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-shaduf-counterpoise__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-shaduf-counterpoise__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-shaduf-counterpoise__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-shaduf-counterpoise__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-shaduf-counterpoise__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: shaduf_counterpoise_meter 1.86s ease-in-out infinite alternate;
+}
+
+.ease-shaduf-counterpoise__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-shaduf-counterpoise__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-shaduf-counterpoise__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-shaduf-counterpoise__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-shaduf-counterpoise__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-shaduf-counterpoise__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-shaduf-counterpoise__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-shaduf-counterpoise__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-shaduf-counterpoise__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-shaduf-counterpoise__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-shaduf-counterpoise__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-shaduf-counterpoise__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: shaduf_counterpoise_status 1.60s ease-out infinite;
+}
+
+@keyframes shaduf_counterpoise_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes shaduf_counterpoise_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-shaduf-counterpoise__a{left:28%;top:26%;width:44%;height:44%;border-radius:50%;border:3px dashed color-mix(in srgb,var(--accent) 50%,#64748b);animation:shaduf_counterpoise_spin 8s linear infinite}
+.ease-shaduf-counterpoise__b{left:40%;top:38%;width:20%;height:20%;border-radius:50%;background:radial-gradient(circle at 30% 30%,var(--accent-2),var(--accent));box-shadow:0 0 24px color-mix(in srgb,var(--accent) 45%,transparent);animation:shaduf_counterpoise_glow 2.6s ease-in-out infinite}
+.ease-shaduf-counterpoise__c{position:absolute;left:18%;bottom:24%;width:64%;height:8px;border-radius:999px;background:color-mix(in srgb,#e8eef6 12%,transparent);overflow:hidden}
+.ease-shaduf-counterpoise__c::after{content:"";display:block;height:100%;width:35%;background:linear-gradient(90deg,transparent,var(--accent),transparent);animation:shaduf_counterpoise_sweep 2.6s linear infinite}
+.ease-shaduf-counterpoise__d{position:absolute;right:16%;top:30%;width:10px;height:10px;border-radius:50%;background:var(--accent);animation:shaduf_counterpoise_blink 1.4s steps(2) infinite}
+
+@keyframes shaduf_counterpoise_spin{to{transform:rotate(360deg)}}
+@keyframes shaduf_counterpoise_glow{0%,100%{transform:scale(.92);filter:brightness(.85)}50%{transform:scale(1.08);filter:brightness(1.25)}}
+@keyframes shaduf_counterpoise_sweep{from{transform:translateX(-40%)}to{transform:translateX(220%)}}
+@keyframes shaduf_counterpoise_blink{50%{opacity:.2}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-shaduf-counterpoise__a,
+  .ease-shaduf-counterpoise__b,
+  .ease-shaduf-counterpoise__c,
+  .ease-shaduf-counterpoise__d,
+  .ease-shaduf-counterpoise__meters i::after,
+  .ease-shaduf-counterpoise__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-shaduf-counterpoise` under `submissions/examples/shaduf-counterpoise-ns/` — CSS-only Shaduf counterpoise well sweep lift.

Fixes #70601

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Shaduf counterpoise well sweep lift.

**How does a developer use it?**

```html
<section class="ease-shaduf-counterpoise">
  <div class="ease-shaduf-counterpoise__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `shaduf_counterpoise_*` prefix. Reduced-motion disables animations.
