### PR TITLE
feat: add ease-archimedes-screw-lift (#70603)

### DIFF
--- a/submissions/examples/archimedes-screw-lift-ns/README.md
+++ b/submissions/examples/archimedes-screw-lift-ns/README.md
@@ -1,0 +1,16 @@
+# Archimedes Screw Lift
+
+## What does this do?
+Renders a self-contained CSS-only `ease-archimedes-screw-lift` demo: Archimedes screw water lift spiral.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-archimedes-screw-lift`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-archimedes-screw-lift">
+  <div class="ease-archimedes-screw-lift__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/archimedes-screw-lift-ns/demo.html
+++ b/submissions/examples/archimedes-screw-lift-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Archimedes Screw Lift — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Archimedes Screw Lift demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Archimedes Screw Lift</h1>
+      <p class="lede">Archimedes screw water lift spiral</p>
+    </header>
+
+    <section class="ease-archimedes-screw-lift" data-demo="archimedes-screw-lift" aria-live="polite">
+      <div class="ease-archimedes-screw-lift__housing">
+        <div class="ease-archimedes-screw-lift__bezel">
+          <div class="ease-archimedes-screw-lift__face">
+            <div class="ease-archimedes-screw-lift__readout">
+              <span class="ease-archimedes-screw-lift__label">Archimedes Screw Lift</span>
+              <span class="ease-archimedes-screw-lift__value">LIVE</span>
+            </div>
+            <div class="ease-archimedes-screw-lift__motion" aria-hidden="true">
+              <span class="ease-archimedes-screw-lift__a"></span>
+              <span class="ease-archimedes-screw-lift__b"></span>
+              <span class="ease-archimedes-screw-lift__c"></span>
+              <span class="ease-archimedes-screw-lift__d"></span>
+            </div>
+            <div class="ease-archimedes-screw-lift__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-archimedes-screw-lift__controls">
+          <button type="button" class="ease-archimedes-screw-lift__btn primary">Engage</button>
+          <button type="button" class="ease-archimedes-screw-lift__btn">Reset</button>
+          <label class="ease-archimedes-screw-lift__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-archimedes-screw-lift__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/archimedes-screw-lift-ns/style.css
+++ b/submissions/examples/archimedes-screw-lift-ns/style.css
@@ -1,0 +1,239 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "Source Sans 3", "Helvetica Neue", sans-serif;
+  background:
+    radial-gradient(ellipse at 28% 0%, color-mix(in srgb, #0d9488 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 91% 100%, color-mix(in srgb, #5eead4 18%, transparent), transparent 42%),
+    #071412;
+}
+
+.stage {
+  width: min(688px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-archimedes-screw-lift {
+  --accent: #0d9488;
+  --accent-2: #5eead4;
+  --panel: color-mix(in srgb, #e8eef6 7%, #071412);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 13px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #071412 75%, #000);
+}
+
+.ease-archimedes-screw-lift__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-archimedes-screw-lift__bezel {
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #071412 90%, #0d9488);
+}
+
+.ease-archimedes-screw-lift__face {
+  position: relative;
+  min-height: 272px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 30% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #071412 85%, #000), color-mix(in srgb, #071412 65%, var(--accent-2)));
+}
+
+.ease-archimedes-screw-lift__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-archimedes-screw-lift__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-archimedes-screw-lift__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-archimedes-screw-lift__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-archimedes-screw-lift__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-archimedes-screw-lift__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-archimedes-screw-lift__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: archimedes_screw_lift_meter 1.98s ease-in-out infinite alternate;
+}
+
+.ease-archimedes-screw-lift__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-archimedes-screw-lift__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-archimedes-screw-lift__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-archimedes-screw-lift__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-archimedes-screw-lift__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-archimedes-screw-lift__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-archimedes-screw-lift__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-archimedes-screw-lift__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-archimedes-screw-lift__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-archimedes-screw-lift__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-archimedes-screw-lift__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-archimedes-screw-lift__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: archimedes_screw_lift_status 1.75s ease-out infinite;
+}
+
+@keyframes archimedes_screw_lift_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes archimedes_screw_lift_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-archimedes-screw-lift__a{left:48%;top:12%;width:4px;height:58%;background:linear-gradient(180deg,var(--accent),transparent);transform-origin:top center;animation:archimedes_screw_lift_swing 2.2s ease-in-out infinite}
+.ease-archimedes-screw-lift__b{left:42%;bottom:22%;width:16%;height:16%;border-radius:50%;background:radial-gradient(circle at 35% 30%,var(--accent-2),var(--accent));animation:archimedes_screw_lift_bob 2.2s ease-in-out infinite}
+.ease-archimedes-screw-lift__c{position:absolute;left:12%;bottom:18%;width:76%;height:3px;background:color-mix(in srgb,#e8eef6 18%,transparent);border-radius:2px}
+.ease-archimedes-screw-lift__c::after{content:"";position:absolute;left:0;top:-4px;width:12px;height:12px;border-radius:50%;background:var(--accent);animation:archimedes_screw_lift_slide 2.2s ease-in-out infinite}
+.ease-archimedes-screw-lift__d{position:absolute;left:20%;top:22%;width:60%;height:2px;background:repeating-linear-gradient(90deg,var(--accent) 0 6px,transparent 6px 12px);opacity:.45;animation:archimedes_screw_lift_flicker 1.1s linear infinite}
+
+@keyframes archimedes_screw_lift_swing{0%,100%{transform:rotate(-18deg)}50%{transform:rotate(18deg)}}
+@keyframes archimedes_screw_lift_bob{0%,100%{transform:translateX(-18px)}50%{transform:translateX(18px)}}
+@keyframes archimedes_screw_lift_slide{0%,100%{transform:translateX(0)}50%{transform:translateX(calc(100% - 12px))}}
+@keyframes archimedes_screw_lift_flicker{50%{opacity:.2}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-archimedes-screw-lift__a,
+  .ease-archimedes-screw-lift__b,
+  .ease-archimedes-screw-lift__c,
+  .ease-archimedes-screw-lift__d,
+  .ease-archimedes-screw-lift__meters i::after,
+  .ease-archimedes-screw-lift__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-archimedes-screw-lift` under `submissions/examples/archimedes-screw-lift-ns/` — CSS-only Archimedes screw water lift spiral.

Fixes #70603

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Archimedes screw water lift spiral.

**How does a developer use it?**

```html
<section class="ease-archimedes-screw-lift">
  <div class="ease-archimedes-screw-lift__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `archimedes_screw_lift_*` prefix. Reduced-motion disables animations.
