### PR TITLE
feat: add ease-nocturlabe-star-pointer (#70607)

### DIFF
--- a/submissions/examples/nocturlabe-star-pointer-ns/README.md
+++ b/submissions/examples/nocturlabe-star-pointer-ns/README.md
@@ -1,0 +1,16 @@
+# Nocturlabe Star Pointer
+
+## What does this do?
+Renders a self-contained CSS-only `ease-nocturlabe-star-pointer` demo: Nocturlabe star pointer nighttime dial.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-nocturlabe-star-pointer`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-nocturlabe-star-pointer">
+  <div class="ease-nocturlabe-star-pointer__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/nocturlabe-star-pointer-ns/demo.html
+++ b/submissions/examples/nocturlabe-star-pointer-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Nocturlabe Star Pointer — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Nocturlabe Star Pointer demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Nocturlabe Star Pointer</h1>
+      <p class="lede">Nocturlabe star pointer nighttime dial</p>
+    </header>
+
+    <section class="ease-nocturlabe-star-pointer" data-demo="nocturlabe-star-pointer" aria-live="polite">
+      <div class="ease-nocturlabe-star-pointer__housing">
+        <div class="ease-nocturlabe-star-pointer__bezel">
+          <div class="ease-nocturlabe-star-pointer__face">
+            <div class="ease-nocturlabe-star-pointer__readout">
+              <span class="ease-nocturlabe-star-pointer__label">Nocturlabe Star Pointer</span>
+              <span class="ease-nocturlabe-star-pointer__value">LIVE</span>
+            </div>
+            <div class="ease-nocturlabe-star-pointer__motion" aria-hidden="true">
+              <span class="ease-nocturlabe-star-pointer__a"></span>
+              <span class="ease-nocturlabe-star-pointer__b"></span>
+              <span class="ease-nocturlabe-star-pointer__c"></span>
+              <span class="ease-nocturlabe-star-pointer__d"></span>
+            </div>
+            <div class="ease-nocturlabe-star-pointer__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-nocturlabe-star-pointer__controls">
+          <button type="button" class="ease-nocturlabe-star-pointer__btn primary">Engage</button>
+          <button type="button" class="ease-nocturlabe-star-pointer__btn">Reset</button>
+          <label class="ease-nocturlabe-star-pointer__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-nocturlabe-star-pointer__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/nocturlabe-star-pointer-ns/style.css
+++ b/submissions/examples/nocturlabe-star-pointer-ns/style.css
@@ -1,0 +1,239 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "Sora", "Avenir Next", sans-serif;
+  background:
+    radial-gradient(ellipse at 31% 0%, color-mix(in srgb, #818cf8 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 94% 100%, color-mix(in srgb, #c7d2fe 18%, transparent), transparent 42%),
+    #080a16;
+}
+
+.stage {
+  width: min(648px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-nocturlabe-star-pointer {
+  --accent: #818cf8;
+  --accent-2: #c7d2fe;
+  --panel: color-mix(in srgb, #e8eef6 7%, #080a16);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 16px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #080a16 75%, #000);
+}
+
+.ease-nocturlabe-star-pointer__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-nocturlabe-star-pointer__bezel {
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #080a16 90%, #818cf8);
+}
+
+.ease-nocturlabe-star-pointer__face {
+  position: relative;
+  min-height: 248px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 33% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #080a16 85%, #000), color-mix(in srgb, #080a16 65%, var(--accent-2)));
+}
+
+.ease-nocturlabe-star-pointer__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-nocturlabe-star-pointer__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-nocturlabe-star-pointer__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-nocturlabe-star-pointer__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-nocturlabe-star-pointer__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-nocturlabe-star-pointer__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-nocturlabe-star-pointer__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: nocturlabe_star_pointer_meter 1.50s ease-in-out infinite alternate;
+}
+
+.ease-nocturlabe-star-pointer__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-nocturlabe-star-pointer__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-nocturlabe-star-pointer__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-nocturlabe-star-pointer__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-nocturlabe-star-pointer__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-nocturlabe-star-pointer__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-nocturlabe-star-pointer__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-nocturlabe-star-pointer__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-nocturlabe-star-pointer__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-nocturlabe-star-pointer__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-nocturlabe-star-pointer__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-nocturlabe-star-pointer__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: nocturlabe_star_pointer_status 2.20s ease-out infinite;
+}
+
+@keyframes nocturlabe_star_pointer_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes nocturlabe_star_pointer_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-nocturlabe-star-pointer__a{left:22%;top:24%;width:56%;height:46%;border-radius:10px;border:1px solid color-mix(in srgb,var(--accent) 45%,transparent);background:linear-gradient(145deg,color-mix(in srgb,var(--accent) 18%,transparent),transparent);transform-style:preserve-3d;animation:nocturlabe_star_pointer_flip 3.4s ease-in-out infinite}
+.ease-nocturlabe-star-pointer__b{left:38%;top:36%;width:24%;height:24%;border-radius:6px;background:var(--accent);animation:nocturlabe_star_pointer_pop 3.4s ease-in-out infinite}
+.ease-nocturlabe-star-pointer__c{position:absolute;left:18%;bottom:20%;display:flex;gap:6px;width:64%;height:8px}
+.ease-nocturlabe-star-pointer__c::after{content:"";flex:1;height:100%;border-radius:4px;background:linear-gradient(90deg,var(--accent-2),var(--accent));animation:nocturlabe_star_pointer_bar 1.5s ease-in-out infinite alternate}
+.ease-nocturlabe-star-pointer__d{position:absolute;right:14%;top:28%;width:3px;height:28%;background:var(--accent);animation:nocturlabe_star_pointer_scan 2s linear infinite}
+
+@keyframes nocturlabe_star_pointer_flip{0%,100%{transform:perspective(400px) rotateY(0)}50%{transform:perspective(400px) rotateY(180deg)}}
+@keyframes nocturlabe_star_pointer_pop{0%,100%{transform:scale(1);opacity:.7}50%{transform:scale(1.2);opacity:1}}
+@keyframes nocturlabe_star_pointer_bar{from{opacity:.45}to{opacity:1}}
+@keyframes nocturlabe_star_pointer_scan{from{transform:translateY(0);opacity:.3}to{transform:translateY(20px);opacity:1}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-nocturlabe-star-pointer__a,
+  .ease-nocturlabe-star-pointer__b,
+  .ease-nocturlabe-star-pointer__c,
+  .ease-nocturlabe-star-pointer__d,
+  .ease-nocturlabe-star-pointer__meters i::after,
+  .ease-nocturlabe-star-pointer__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-nocturlabe-star-pointer` under `submissions/examples/nocturlabe-star-pointer-ns/` — CSS-only Nocturlabe star pointer nighttime dial.

Fixes #70607

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Nocturlabe star pointer nighttime dial.

**How does a developer use it?**

```html
<section class="ease-nocturlabe-star-pointer">
  <div class="ease-nocturlabe-star-pointer__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `nocturlabe_star_pointer_*` prefix. Reduced-motion disables animations.
