### PR TITLE
feat: implement CSS pachinko progress bar #70997

### DIFF
--- a/submissions/examples/css-pachinko-progress-bar-70997/README.md
+++ b/submissions/examples/css-pachinko-progress-bar-70997/README.md
@@ -1,0 +1,9 @@
+# CSS Pachinko Progress Bar (#70997)
+
+A playful pure CSS progress indicator where animated balls drop through a pachinko peg field to incrementally fill a progress track.
+
+## Features
+- Pure CSS keyframes simulating physics deflection through pegs with zero JavaScript.
+- Fully accessible progress bar structure (`role="progressbar"`, ARIA value attributes).
+- Supports `prefers-reduced-motion` media queries for accessibility compliance.
+- Responsive layout designed for desktop and mobile web applications.

--- a/submissions/examples/css-pachinko-progress-bar-70997/demo.html
+++ b/submissions/examples/css-pachinko-progress-bar-70997/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Pachinko Progress Bar | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="pachinko-container">
+    <header class="pachinko-header">
+      <h1>Pachinko Progress Bar</h1>
+      <p>Interactive loading visualization using pure CSS keyframe physics.</p>
+    </header>
+
+    <section class="pachinko-board" aria-hidden="true">
+      <div class="peg-grid">
+        <div class="peg-row"><span class="peg"></span><span class="peg"></span><span class="peg"></span><span class="peg"></span></div>
+        <div class="peg-row offset"><span class="peg"></span><span class="peg"></span><span class="peg"></span><span class="peg"></span><span class="peg"></span></div>
+        <div class="peg-row"><span class="peg"></span><span class="peg"></span><span class="peg"></span><span class="peg"></span></div>
+        <div class="peg-row offset"><span class="peg"></span><span class="peg"></span><span class="peg"></span><span class="peg"></span><span class="peg"></span></div>
+      </div>
+
+      <div class="ball ball-1"></div>
+      <div class="ball ball-2"></div>
+      <div class="ball ball-3"></div>
+    </section>
+
+    <div class="progress-wrapper">
+      <div class="progress-header">
+        <span>Loading status</span>
+        <span>Collecting points...</span>
+      </div>
+      <div 
+        class="progress-track" 
+        role="progressbar" 
+        aria-valuenow="70" 
+        aria-valuemin="0" 
+        aria-valuemax="100" 
+        aria-label="Pachinko progress stream">
+        <div class="progress-fill"></div>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/css-pachinko-progress-bar-70997/style.css
+++ b/submissions/examples/css-pachinko-progress-bar-70997/style.css
@@ -1,0 +1,182 @@
+/* CSS Pachinko Progress Bar #70997 */
+
+:root {
+  --bg-color: #0f172a;
+  --card-bg: #1e293b;
+  --peg-color: #64748b;
+  --ball-color: #f59e0b;
+  --progress-bg: #334155;
+  --progress-fill: #10b981;
+  --text-main: #f8fafc;
+  --text-sub: #94a3b8;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 2rem 1rem;
+  background-color: var(--bg-color);
+  color: var(--text-main);
+  font-family: system-ui, -apple-system, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.pachinko-container {
+  width: 100%;
+  max-width: 480px;
+  background-color: var(--card-bg);
+  border: 1px solid #334155;
+  border-radius: 16px;
+  padding: 2rem;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+  text-align: center;
+}
+
+.pachinko-header h1 {
+  font-size: 1.4rem;
+  margin: 0 0 0.5rem 0;
+}
+
+.pachinko-header p {
+  color: var(--text-sub);
+  font-size: 0.9rem;
+  margin: 0 0 2rem 0;
+}
+
+/* Pachinko Board */
+.pachinko-board {
+  position: relative;
+  width: 280px;
+  height: 220px;
+  margin: 0 auto 1.5rem auto;
+  background: rgba(15, 23, 42, 0.6);
+  border: 2px solid #334155;
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+/* Pegs Layout */
+.peg-grid {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
+  padding: 20px 30px;
+}
+
+.peg-row {
+  display: flex;
+  justify-content: space-around;
+}
+
+.peg-row.offset {
+  padding: 0 20px;
+}
+
+.peg {
+  width: 8px;
+  height: 8px;
+  background-color: var(--peg-color);
+  border-radius: 50%;
+  box-shadow: 0 0 4px rgba(255, 255, 255, 0.3);
+}
+
+/* Falling Balls Animation */
+.ball {
+  position: absolute;
+  top: -12px;
+  width: 12px;
+  height: 12px;
+  background-color: var(--ball-color);
+  border-radius: 50%;
+  box-shadow: 0 0 8px var(--ball-color);
+  animation: pachinko-drop 3s infinite cubic-bezier(0.4, 0, 0.6, 1);
+}
+
+.ball-1 { left: 45%; animation-delay: 0s; }
+.ball-2 { left: 52%; animation-delay: 0.8s; }
+.ball-3 { left: 38%; animation-delay: 1.6s; }
+
+@keyframes pachinko-drop {
+  0% {
+    top: -12px;
+    transform: translateX(0);
+  }
+  20% {
+    top: 50px;
+    transform: translateX(-15px);
+  }
+  40% {
+    top: 100px;
+    transform: translateX(12px);
+  }
+  60% {
+    top: 150px;
+    transform: translateX(-8px);
+  }
+  80% {
+    top: 190px;
+    transform: translateX(5px);
+    opacity: 1;
+  }
+  90%, 100% {
+    top: 210px;
+    opacity: 0;
+  }
+}
+
+/* Progress Bar Container */
+.progress-wrapper {
+  margin-top: 1rem;
+}
+
+.progress-header {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  color: var(--text-sub);
+  margin-bottom: 0.5rem;
+}
+
+.progress-track {
+  width: 100%;
+  height: 16px;
+  background-color: var(--progress-bg);
+  border-radius: 10px;
+  overflow: hidden;
+  position: relative;
+  border: 1px solid #475569;
+}
+
+.progress-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #10b981, #34d399);
+  width: 0%;
+  border-radius: 10px;
+  animation: fill-bar 9s ease-in-out infinite;
+}
+
+@keyframes fill-bar {
+  0% { width: 0%; }
+  33% { width: 35%; }
+  66% { width: 70%; }
+  100% { width: 100%; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ball {
+    animation: none;
+    display: none;
+  }
+  .progress-fill {
+    animation: none;
+    width: 60%;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements a pure CSS Pachinko Progress Bar component (#70997).
gssoc 26

Closes #70997

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/css-pachinko-progress-bar-70997/`
- [x] `style.css`, `demo.html`, and `README.md` included
- [x] Automated commit correctly formatted

---

## Feature Description
**What does this add?**
A physics-inspired CSS loading component featuring falling pachinko balls bouncing off pegs to fill a lower progress indicator bar.

**How does it work?**
Uses overlapping keyframe animations with distinct easing curves (`cubic-bezier`) for ball drop deflections, paired with an accessible progress bar element using native ARIA semantics.

---

## Notes for Maintainer
Includes full `prefers-reduced-motion` handling and zero external dependencies or JavaScript scripts.