### PR TITLE
feat: implement CSS simon says game board #71048

### DIFF
--- a/submissions/examples/css-simon-says-71048/README.md
+++ b/submissions/examples/css-simon-says-71048/README.md
@@ -1,0 +1,9 @@
+# CSS Simon Says Game Board (#71048)
+
+A responsive, interactive Simon Says color sequence game board built in pure CSS.
+
+## Features
+- Pure CSS design and sequence playback using `@keyframes` and staggered `animation-delay` offsets.
+- Fully interactive quadrants with keyboard focus management (`:focus-visible`) and `:active` press states.
+- Fully accessible button controls with dedicated `aria-label` tags.
+- Respects `prefers-reduced-motion` accessibility preferences.

--- a/submissions/examples/css-simon-says-71048/demo.html
+++ b/submissions/examples/css-simon-says-71048/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Simon Says Game Board | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="simon-container">
+    <header class="simon-header">
+      <h1>CSS Simon Says Board</h1>
+      <p>Classic color sequence game UI animated with pure CSS keyframe sequences.</p>
+    </header>
+
+    <div class="simon-board demo-active" role="region" aria-label="Simon Says color sequence game board">
+      <button class="simon-pad pad-green" aria-label="Green pad"></button>
+      <button class="simon-pad pad-red" aria-label="Red pad"></button>
+      <button class="simon-pad pad-yellow" aria-label="Yellow pad"></button>
+      <button class="simon-pad pad-blue" aria-label="Blue pad"></button>
+
+      <div class="simon-center" aria-hidden="true">
+        <span class="simon-title">SIMON</span>
+        <span class="simon-subtitle">CSS Edition</span>
+      </div>
+    </div>
+
+    <p class="simon-info">💡 Pure CSS sequence animation running automatically. Pads are fully focusable and interactive.</p>
+  </main>
+</body>
+</html>

--- a/submissions/examples/css-simon-says-71048/style.css
+++ b/submissions/examples/css-simon-says-71048/style.css
@@ -1,0 +1,197 @@
+/* CSS Simon Says #71048 */
+
+:root {
+  --bg-color: #0f172a;
+  --card-bg: #1e293b;
+  --text-main: #f8fafc;
+  --text-sub: #94a3b8;
+  --green: #22c55e;
+  --red: #ef4444;
+  --yellow: #eab308;
+  --blue: #3b82f6;
+  --center-bg: #0f172a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 2rem 1rem;
+  background-color: var(--bg-color);
+  color: var(--text-main);
+  font-family: system-ui, -apple-system, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.simon-container {
+  width: 100%;
+  max-width: 520px;
+  background-color: var(--card-bg);
+  border: 1px solid #334155;
+  border-radius: 16px;
+  padding: 2rem;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.simon-header h1 {
+  font-size: 1.5rem;
+  margin: 0 0 0.5rem 0;
+}
+
+.simon-header p {
+  color: var(--text-sub);
+  font-size: 0.95rem;
+  margin: 0 0 2rem 0;
+}
+
+/* Simon Board Container */
+.simon-board {
+  position: relative;
+  width: 280px;
+  height: 280px;
+  border-radius: 50%;
+  background-color: #090d16;
+  padding: 12px;
+  box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.8), 0 10px 25px rgba(0, 0, 0, 0.5);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr 1fr;
+  gap: 12px;
+}
+
+/* Simon Color Quadrants */
+.simon-pad {
+  position: relative;
+  border: none;
+  cursor: pointer;
+  opacity: 0.4;
+  transition: opacity 0.2s ease, transform 0.1s ease, filter 0.2s ease;
+  outline: none;
+}
+
+.simon-pad:hover {
+  opacity: 0.75;
+}
+
+.simon-pad:focus-visible {
+  opacity: 1;
+  outline: 3px solid #ffffff;
+  outline-offset: 4px;
+  z-index: 5;
+}
+
+.simon-pad:active {
+  transform: scale(0.97);
+}
+
+.pad-green {
+  background-color: var(--green);
+  border-top-left-radius: 100%;
+}
+
+.pad-red {
+  background-color: var(--red);
+  border-top-right-radius: 100%;
+}
+
+.pad-yellow {
+  background-color: var(--yellow);
+  border-bottom-left-radius: 100%;
+}
+
+.pad-blue {
+  background-color: var(--blue);
+  border-bottom-right-radius: 100%;
+}
+
+/* Demonstration Sequence Animation via Pure CSS Keyframes */
+.simon-board.demo-active .pad-green {
+  animation: flash-green 6s infinite 0s;
+}
+
+.simon-board.demo-active .pad-red {
+  animation: flash-red 6s infinite 1.5s;
+}
+
+.simon-board.demo-active .pad-blue {
+  animation: flash-blue 6s infinite 3s;
+}
+
+.simon-board.demo-active .pad-yellow {
+  animation: flash-yellow 6s infinite 4.5s;
+}
+
+@keyframes flash-green {
+  0%, 20%, 100% { opacity: 0.4; filter: drop-shadow(0 0 0px var(--green)); }
+  10% { opacity: 1; filter: drop-shadow(0 0 15px var(--green)); }
+}
+
+@keyframes flash-red {
+  0%, 20%, 100% { opacity: 0.4; filter: drop-shadow(0 0 0px var(--red)); }
+  10% { opacity: 1; filter: drop-shadow(0 0 15px var(--red)); }
+}
+
+@keyframes flash-blue {
+  0%, 20%, 100% { opacity: 0.4; filter: drop-shadow(0 0 0px var(--blue)); }
+  10% { opacity: 1; filter: drop-shadow(0 0 15px var(--blue)); }
+}
+
+@keyframes flash-yellow {
+  0%, 20%, 100% { opacity: 0.4; filter: drop-shadow(0 0 0px var(--yellow)); }
+  10% { opacity: 1; filter: drop-shadow(0 0 15px var(--yellow)); }
+}
+
+/* Central Console Hub */
+.simon-center {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 110px;
+  height: 110px;
+  background-color: var(--center-bg);
+  border: 10px solid var(--card-bg);
+  border-radius: 50%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);
+  z-index: 10;
+}
+
+.simon-title {
+  font-weight: 800;
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+  color: var(--text-main);
+  text-transform: uppercase;
+}
+
+.simon-subtitle {
+  font-size: 0.65rem;
+  color: var(--text-sub);
+  margin-top: 2px;
+}
+
+.simon-info {
+  font-size: 0.85rem;
+  color: var(--text-sub);
+  margin-top: 1.75rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .simon-board.demo-active .simon-pad {
+    animation: none;
+    opacity: 0.8;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements a pure CSS Simon Says game board component (#71048).
gssoc 26

Closes #71048

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/css-simon-says-71048/`
- [x] `style.css`, `demo.html`, and `README.md` included
- [x] Automated commit correctly formatted

---

## Feature Description
**What does this add?**
A classic Simon Says circular game board component complete with glowing quadrant sequence animations.

**How does it work?**
Employs pure CSS circular grid positioning and staggered `@keyframes` glow/opacity transitions to play back light sequences without JavaScript. Each pad is accessible via keyboard navigation.

---

## Notes for Maintainer
Zero JavaScript required. Fully compliant with ARIA accessibility requirements and `prefers-reduced-motion` media queries.