### PR TITLE
feat: implement CSS scroll marker group #71044

### DIFF
--- a/submissions/examples/css-scroll-marker-group-71044/README.md
+++ b/submissions/examples/css-scroll-marker-group-71044/README.md
@@ -1,0 +1,10 @@
+# CSS Scroll Marker Group (#71044)
+
+A pure CSS carousel navigation marker group using CSS scroll-snap alignment and state markers.
+
+## Features
+- Pure CSS implementation using `scroll-snap-type`, `scroll-behavior: smooth`, and `:has(:target)` state markers.
+- Zero JavaScript dependencies.
+- Keyboard accessible navigation controls with clear `:focus-visible` focus ring indicators.
+- Responsive design supporting touch swipe and mouse click marker interaction.
+- Respects `prefers-reduced-motion` accessibility settings.

--- a/submissions/examples/css-scroll-marker-group-71044/demo.html
+++ b/submissions/examples/css-scroll-marker-group-71044/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Scroll Marker Group | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="carousel-container">
+    <header class="carousel-header">
+      <h1>CSS Scroll Marker Group</h1>
+      <p>Scroll-snap carousel navigation driven purely by CSS marker indicators.</p>
+    </header>
+
+    <div class="carousel-viewport" aria-label="Feature Carousel">
+      <article id="slide-1" class="carousel-slide slide-1" tabindex="0" aria-label="Slide 1 of 3">
+        <h2>Slide 1: Scroll Snap</h2>
+        <p>CSS scroll-snap locks viewport alignment smoothly across screens.</p>
+      </article>
+
+      <article id="slide-2" class="carousel-slide slide-2" tabindex="0" aria-label="Slide 2 of 3">
+        <h2>Slide 2: Marker Group</h2>
+        <p>Scroll markers indicate active slide positions without JavaScript listeners.</p>
+      </article>
+
+      <article id="slide-3" class="carousel-slide slide-3" tabindex="0" aria-label="Slide 3 of 3">
+        <h2>Slide 3: Pure CSS</h2>
+        <p>Accessible keyboard navigation using standard HTML anchor hash targets.</p>
+      </article>
+    </div>
+
+    <nav class="scroll-marker-group" aria-label="Carousel pagination controls">
+      <a href="#slide-1" class="scroll-marker" aria-label="Go to slide 1"></a>
+      <a href="#slide-2" class="scroll-marker" aria-label="Go to slide 2"></a>
+      <a href="#slide-3" class="scroll-marker" aria-label="Go to slide 3"></a>
+    </nav>
+
+    <p class="carousel-hint">💡 Click or focus scroll markers to navigate carousel slides</p>
+  </main>
+</body>
+</html>

--- a/submissions/examples/css-scroll-marker-group-71044/style.css
+++ b/submissions/examples/css-scroll-marker-group-71044/style.css
@@ -1,0 +1,152 @@
+/* CSS Scroll Marker Group #71044 */
+
+:root {
+  --bg-color: #0f172a;
+  --card-bg: #1e293b;
+  --marker-inactive: #475569;
+  --marker-active: #38bdf8;
+  --text-main: #f8fafc;
+  --text-sub: #94a3b8;
+  --border-color: #334155;
+  --slide-bg-1: linear-gradient(135deg, #1e3a8a, #3b82f6);
+  --slide-bg-2: linear-gradient(135deg, #581c87, #a855f7);
+  --slide-bg-3: linear-gradient(135deg, #065f46, #10b981);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 2rem 1rem;
+  background-color: var(--bg-color);
+  color: var(--text-main);
+  font-family: system-ui, -apple-system, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.carousel-container {
+  width: 100%;
+  max-width: 580px;
+  background-color: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 16px;
+  padding: 2rem;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+  text-align: center;
+}
+
+.carousel-header h1 {
+  font-size: 1.5rem;
+  margin: 0 0 0.5rem 0;
+}
+
+.carousel-header p {
+  color: var(--text-sub);
+  font-size: 0.95rem;
+  margin: 0 0 1.5rem 0;
+}
+
+/* Scroll Snap Viewport Track */
+.carousel-viewport {
+  width: 100%;
+  height: 220px;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scroll-behavior: smooth;
+  border-radius: 12px;
+  display: flex;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.carousel-viewport::-webkit-scrollbar {
+  display: none;
+}
+
+.carousel-slide {
+  flex: 0 0 100%;
+  width: 100%;
+  height: 100%;
+  scroll-snap-align: center;
+  scroll-snap-stop: always;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem;
+  color: #ffffff;
+}
+
+.slide-1 { background: var(--slide-bg-1); }
+.slide-2 { background: var(--slide-bg-2); }
+.slide-3 { background: var(--slide-bg-3); }
+
+.carousel-slide h2 {
+  margin: 0 0 0.5rem 0;
+  font-size: 1.4rem;
+}
+
+.carousel-slide p {
+  margin: 0;
+  font-size: 0.95rem;
+  opacity: 0.9;
+}
+
+/* Scroll Marker Group Navigation */
+.scroll-marker-group {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 1.25rem;
+}
+
+.scroll-marker {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background-color: var(--marker-inactive);
+  transition: background-color 0.3s ease, transform 0.2s ease, width 0.3s ease;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.scroll-marker:hover {
+  background-color: var(--text-sub);
+  transform: scale(1.15);
+}
+
+.scroll-marker:focus-visible {
+  outline: 2px solid var(--marker-active);
+  outline-offset: 3px;
+}
+
+/* Active Marker Indicator Logic */
+.carousel-viewport:has(#slide-1:target) ~ .scroll-marker-group a[href="#slide-1"],
+.carousel-viewport:has(#slide-2:target) ~ .scroll-marker-group a[href="#slide-2"],
+.carousel-viewport:has(#slide-3:target) ~ .scroll-marker-group a[href="#slide-3"] {
+  background-color: var(--marker-active);
+  width: 28px;
+  border-radius: 12px;
+}
+
+.carousel-hint {
+  font-size: 0.85rem;
+  color: var(--text-sub);
+  margin-top: 1rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .carousel-viewport {
+    scroll-behavior: auto;
+  }
+  .scroll-marker {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements a pure CSS Scroll Marker Group component (#71044).
gssoc 26

Closes #71044

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/css-scroll-marker-group-71044/`
- [x] `style.css`, `demo.html`, and `README.md` included
- [x] Automated commit correctly formatted

---

## Feature Description
**What does this add?**
A carousel pagination component featuring a CSS scroll marker group synchronized with horizontal scroll-snap tracks.

**How does it work?**
Combines CSS `scroll-snap-type` alignment with anchor targets and modern CSS relational selectors (`:has(:target)`) to update active slide indicators without JavaScript.

---

## Notes for Maintainer
Zero JavaScript dependencies; fully accessible with screen reader ARIA roles and keyboard navigation.