### PR TITLE
feat: implement CSS cyberpunk data chip #71026

### DIFF
--- a/submissions/examples/css-cyberpunk-data-chip-71026/README.md
+++ b/submissions/examples/css-cyberpunk-data-chip-71026/README.md
@@ -1,0 +1,11 @@
+# CSS Cyberpunk Data Chip (#71026)
+
+A futuristic data chip UI card component designed with pure CSS geometric cuts, background grid lines, and holographic scanlines.
+
+## Features
+- Chamfered cut corners generated via pure CSS `clip-path: polygon()`.
+- Background grid lines built using repeating CSS linear gradients.
+- Animated continuous scanline effect and glowing status indicators.
+- Hover and focus micro-interactions switching between neon cyan and neon magenta palettes.
+- Fully accessible via keyboard focus (`tabindex="0"` with custom focus rings and ARIA markup).
+- Respects `prefers-reduced-motion` settings by disabling scanline animations.

--- a/submissions/examples/css-cyberpunk-data-chip-71026/demo.html
+++ b/submissions/examples/css-cyberpunk-data-chip-71026/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Cyberpunk Data Chip | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="data-chip-container">
+    <!-- Accessible Focusable Cyberpunk Data Chip Card -->
+    <article class="data-chip" tabindex="0" role="region" aria-label="Cyberpunk Data Chip: Neural Memory Core">
+      <header class="chip-header">
+        <span class="chip-id">MEM-CHIP // 71026</span>
+        <span class="chip-status">
+          <span class="status-dot" aria-hidden="true"></span>
+          ONLINE
+        </span>
+      </header>
+
+      <!-- Hardware Gold Connector Pins -->
+      <div class="chip-pins" aria-hidden="true">
+        <div class="pin"></div>
+        <div class="pin"></div>
+        <div class="pin"></div>
+        <div class="pin"></div>
+        <div class="pin"></div>
+      </div>
+
+      <div class="chip-body">
+        <h1 class="chip-title">Neural Core v2.4</h1>
+        <p class="chip-desc">
+          High-density bio-synthetic storage component equipped with continuous keyframe scanlines and a glowing grid matrix.
+        </p>
+      </div>
+
+      <footer class="chip-footer">
+        <span>TYPE: OPTICAL-RAM</span>
+        <span class="chip-capacity">128 TB</span>
+      </footer>
+    </article>
+
+    <p class="chip-hint">💡 Hover or focus with key navigation to trigger neon glow transitions.</p>
+  </main>
+</body>
+</html>

--- a/submissions/examples/css-cyberpunk-data-chip-71026/style.css
+++ b/submissions/examples/css-cyberpunk-data-chip-71026/style.css
@@ -1,0 +1,232 @@
+/* CSS Cyberpunk Data Chip #71026 */
+
+:root {
+  --bg-color: #050811;
+  --chip-bg: #0d1527;
+  --chip-border: #00f0ff;
+  --neon-cyan: #00f0ff;
+  --neon-magenta: #ff007f;
+  --grid-line: rgba(0, 240, 255, 0.12);
+  --text-main: #f8fafc;
+  --text-sub: #7dd3fc;
+  --gold-pin: #eab308;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 2rem 1rem;
+  background-color: var(--bg-color);
+  color: var(--text-main);
+  font-family: 'Courier New', Courier, monospace, system-ui;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.data-chip-container {
+  width: 100%;
+  max-width: 520px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+/* Data Chip Outer Card Shell */
+.data-chip {
+  position: relative;
+  width: 100%;
+  max-width: 420px;
+  background-color: var(--chip-bg);
+  border: 2px solid var(--chip-border);
+  /* Cyberpunk Chamfered Corner Cuts */
+  clip-path: polygon(
+    0 16px, 
+    16px 0, 
+    calc(100% - 16px) 0, 
+    100% 16px, 
+    100% calc(100% - 16px), 
+    calc(100% - 16px) 100%, 
+    16px 100%, 
+    0 calc(100% - 16px)
+  );
+  padding: 2rem;
+  box-shadow: 0 0 25px rgba(0, 240, 255, 0.25), inset 0 0 15px rgba(0, 240, 255, 0.15);
+  overflow: hidden;
+  transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+  outline: none;
+}
+
+/* Background Cyber Grid Background Pattern */
+.data-chip::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: 
+    linear-gradient(var(--grid-line) 1px, transparent 1px),
+    linear-gradient(90deg, var(--grid-line) 1px, transparent 1px);
+  background-size: 16px 16px;
+  pointer-events: none;
+  z-index: 1;
+}
+
+/* Animated Holographic Scanline Overlay */
+.data-chip::after {
+  content: "";
+  position: absolute;
+  top: -100%;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(
+    180deg,
+    transparent 0%,
+    rgba(0, 240, 255, 0.15) 50%,
+    transparent 100%
+  );
+  animation: scanline 4s linear infinite;
+  pointer-events: none;
+  z-index: 2;
+}
+
+@keyframes scanline {
+  0% { top: -100%; }
+  100% { top: 100%; }
+}
+
+/* Focus and Hover Micro-Interactions */
+.data-chip:hover,
+.data-chip:focus-visible {
+  transform: translateY(-4px) scale(1.02);
+  border-color: var(--neon-magenta);
+  box-shadow: 0 0 35px rgba(255, 0, 127, 0.4), inset 0 0 20px rgba(255, 0, 127, 0.2);
+}
+
+.data-chip:focus-visible {
+  outline: 2px dashed var(--neon-cyan);
+  outline-offset: 6px;
+}
+
+/* Header Circuit Elements */
+.chip-header {
+  position: relative;
+  z-index: 3;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid var(--grid-line);
+  padding-bottom: 0.75rem;
+  margin-bottom: 1.25rem;
+}
+
+.chip-id {
+  font-size: 0.75rem;
+  letter-spacing: 0.15em;
+  color: var(--text-sub);
+  text-transform: uppercase;
+}
+
+.chip-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  color: var(--neon-cyan);
+  text-transform: uppercase;
+}
+
+.status-dot {
+  width: 6px;
+  height: 6px;
+  background-color: var(--neon-cyan);
+  border-radius: 50%;
+  box-shadow: 0 0 8px var(--neon-cyan);
+  animation: pulse-dot 1.5s ease-in-out infinite alternate;
+}
+
+@keyframes pulse-dot {
+  0% { opacity: 0.3; transform: scale(0.8); }
+  100% { opacity: 1; transform: scale(1.2); }
+}
+
+/* Hardware Interface Gold Pins */
+.chip-pins {
+  position: relative;
+  z-index: 3;
+  display: flex;
+  gap: 6px;
+  margin-bottom: 1.25rem;
+}
+
+.pin {
+  width: 14px;
+  height: 20px;
+  background: linear-gradient(180deg, var(--gold-pin) 0%, #a16207 100%);
+  border-radius: 2px 2px 0 0;
+  box-shadow: 0 0 4px rgba(234, 179, 8, 0.4);
+}
+
+/* Body Content */
+.chip-body {
+  position: relative;
+  z-index: 3;
+}
+
+.chip-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--text-main);
+  margin: 0 0 0.5rem 0;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  text-shadow: 0 0 8px rgba(0, 240, 255, 0.5);
+}
+
+.chip-desc {
+  font-size: 0.85rem;
+  color: var(--text-sub);
+  line-height: 1.5;
+  margin: 0 0 1.5rem 0;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+/* Footer Metadata */
+.chip-footer {
+  position: relative;
+  z-index: 3;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.7rem;
+  color: var(--text-sub);
+  letter-spacing: 0.1em;
+  border-top: 1px dashed var(--grid-line);
+  padding-top: 0.75rem;
+}
+
+.chip-capacity {
+  color: var(--neon-magenta);
+  font-weight: bold;
+}
+
+.chip-hint {
+  font-size: 0.8rem;
+  color: var(--text-sub);
+  text-align: center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .data-chip::after,
+  .status-dot {
+    animation: none;
+  }
+  .data-chip {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements a pure CSS Cyberpunk Data Chip component (#71026).
gssoc 26

Closes #71026

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/css-cyberpunk-data-chip-71026/`
- [x] `style.css`, `demo.html`, and `README.md` included
- [x] Automated commit correctly formatted

---

## Feature Description
**What does this add?**
A futuristic cyberpunk data chip card component complete with metallic gold connection pins, background grid lines, and glowing neon holographic effects.

**How does it work?**
Uses CSS `clip-path` polygon cuts for the angular chip silhouette, repeating linear gradients for the grid matrix, and CSS `@keyframes` for the continuous holographic scanline overlay.

---

## Notes for Maintainer
Zero JavaScript required. Fully accessible with keyboard focus indicators (`:focus-visible`) and `prefers-reduced-motion` support.