### PR TITLE
feat: add pure CSS Sand Dune Waves component (#70079)

### DIFF
--- a/submissions/examples/css-sand-dune-waves-pure/README.md
+++ b/submissions/examples/css-sand-dune-waves-pure/README.md
@@ -1,0 +1,19 @@
+# CSS Sand Dune Waves
+
+A purely CSS-animated parallax background simulating flowing sand dunes. Built using overlapping SVG paths and continuous CSS translations, requiring zero JavaScript overhead for the animation loop.
+
+## Features
+- Pure CSS and HTML implementation.
+- **Component Architecture (Documented in Code)**: 
+  - **The Multi-layered Parallax**: The background consists of three distinct `<div>` layers (`.dune-back`, `.dune-middle`, `.dune-front`), each containing an SVG path. They are stacked using `z-index` and scaled to different heights (100%, 75%, 50%) to create a forced perspective of depth.
+  - **The Infinite Flow Animation**: Each dune layer is set to `width: 200%`, making it exactly twice as wide as the screen. A CSS `@keyframes` animation simply translates the element from `translateX(0)` to `translateX(-50%)` and alternates. Because the SVGs are drawn as continuous curves, this horizontal panning creates the optical illusion of waves rolling across the screen.
+  - **Differentiated Speeds**: By assigning different animation durations (25s, 18s, 12s) and alternating directions (`alternate` vs `alternate-reverse`) to the layers, we break visual repetition and simulate a complex, natural-looking parallax effect.
+- **Theming & Dark Mode**: Configured via CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), generating a deep indigo/violet night desert aesthetic that automatically swaps the sky gradient and dune fill colors.
+- Fully accessible semantic structure. The dunes are purely decorative background elements and are explicitly hidden from screen readers via `aria-hidden="true"` on the parent container. The foreground content uses standard semantic tags (`<main>`, `<h1>`). Honors the `prefers-reduced-motion` accessibility standard by disabling the parallax animation entirely for motion-sensitive users, freezing the dunes in a statically centered state.
+
+## Usage
+Open `demo.html` in your browser. The background animation will run automatically in an infinite loop.
+
+## Files
+- `demo.html`: The HTML structure defining the SVG paths and layer order.
+- `style.css`: The styling, layer scaling, and the critical `translateX` infinite keyframe animations.

--- a/submissions/examples/css-sand-dune-waves-pure/demo.html
+++ b/submissions/examples/css-sand-dune-waves-pure/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Sand Dune Waves</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <!-- The Animated Background -->
+    <div class="dune-container" aria-hidden="true">
+        <!-- 
+          [TECHNIQUE] Multi-layered Parallax Waves
+          We use absolute positioned SVG paths. Each layer has a different
+          opacity, z-index, animation speed, and animation delay to create
+          a rich, depth-filled desert dune effect.
+        -->
+        
+        <!-- Back Dune (Slowest, lightest) -->
+        <div class="dune dune-back">
+            <svg viewBox="0 0 1440 320" preserveAspectRatio="none">
+                <path fill="currentColor" fill-opacity="1" d="M0,256L48,229.3C96,203,192,149,288,154.7C384,160,480,224,576,218.7C672,213,768,139,864,128C960,117,1056,171,1152,197.3C1248,224,1344,224,1392,224L1440,224L1440,320L1392,320C1344,320,1248,320,1152,320C1056,320,960,320,864,320C768,320,672,320,576,320C480,320,384,320,288,320C192,320,96,320,48,320L0,320Z"></path>
+            </svg>
+        </div>
+
+        <!-- Middle Dune (Medium speed) -->
+        <div class="dune dune-middle">
+            <svg viewBox="0 0 1440 320" preserveAspectRatio="none">
+                <path fill="currentColor" fill-opacity="1" d="M0,128L48,154.7C96,181,192,235,288,240C384,245,480,203,576,170.7C672,139,768,117,864,138.7C960,160,1056,224,1152,245.3C1248,267,1344,245,1392,234.7L1440,224L1440,320L1392,320C1344,320,1248,320,1152,320C1056,320,960,320,864,320C768,320,672,320,576,320C480,320,384,320,288,320C192,320,96,320,48,320L0,320Z"></path>
+            </svg>
+        </div>
+
+        <!-- Front Dune (Fastest, darkest) -->
+        <div class="dune dune-front">
+            <svg viewBox="0 0 1440 320" preserveAspectRatio="none">
+                <path fill="currentColor" fill-opacity="1" d="M0,224L60,202.7C120,181,240,139,360,144C480,149,600,203,720,229.3C840,256,960,256,1080,234.7C1200,213,1320,171,1380,149.3L1440,128L1440,320L1380,320C1320,320,1200,320,1080,320C960,320,840,320,720,320C600,320,480,320,360,320C240,320,120,320,60,320L0,320Z"></path>
+            </svg>
+        </div>
+    </div>
+
+    <!-- Foreground Content -->
+    <main class="content-overlay">
+        <h1 class="hero-title">CSS Sand Dunes</h1>
+        <p class="hero-subtitle">A responsive, purely CSS-animated parallax landscape.</p>
+    </main>
+
+</body>
+</html>

--- a/submissions/examples/css-sand-dune-waves-pure/style.css
+++ b/submissions/examples/css-sand-dune-waves-pure/style.css
@@ -1,0 +1,161 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700;800&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    /* Desert Theme */
+    --sky-gradient-top: #fcd34d;
+    --sky-gradient-bottom: #f97316;
+    
+    --dune-back: #d97706;
+    --dune-middle: #b45309;
+    --dune-front: #78350f;
+    
+    --text-primary: #ffffff;
+    --text-secondary: rgba(255, 255, 255, 0.8);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        /* Night Desert Theme */
+        --sky-gradient-top: #0f172a;
+        --sky-gradient-bottom: #312e81;
+        
+        --dune-back: #4338ca;
+        --dune-middle: #312e81;
+        --dune-front: #1e1b4b;
+        
+        --text-primary: #f8fafc;
+        --text-secondary: #94a3b8;
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+    
+    /* 
+      The body acts as the viewport container for the background.
+      We use a linear gradient for the sky.
+    */
+    height: 100vh;
+    width: 100vw;
+    overflow: hidden;
+    background: linear-gradient(to bottom, var(--sky-gradient-top), var(--sky-gradient-bottom));
+}
+
+/* =========================================
+   [TECHNIQUE] The Animated Dune System
+   ========================================= */
+
+.dune-container {
+    position: absolute;
+    bottom: -10px; /* Hide the hard bottom edge */
+    left: 0;
+    width: 100%;
+    height: 60vh; /* Dunes cover the bottom 60% of the screen */
+    z-index: 1;
+    overflow: hidden;
+}
+
+/* Base styling for all dunes */
+.dune {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 200%; /* Important: Must be wider than screen to allow horizontal panning */
+    height: 100%;
+    
+    /* Center the SVG horizontally and stretch it vertically */
+    display: flex;
+    align-items: flex-end;
+}
+
+.dune svg {
+    width: 100%;
+    height: auto;
+    min-height: 200px; /* Ensure they don't collapse too much on ultra-wide screens */
+}
+
+
+/* 
+  [TECHNIQUE] Parallax Animation
+  Each dune layer has a different color, height scale, and animation speed.
+  The animation translates the dune left and right to simulate flowing sand.
+*/
+
+.dune-back {
+    color: var(--dune-back);
+    height: 100%;
+    z-index: 10;
+    animation: flowSand 25s ease-in-out infinite alternate;
+}
+
+.dune-middle {
+    color: var(--dune-middle);
+    height: 75%; /* Slightly shorter to show the back dune */
+    z-index: 20;
+    animation: flowSand 18s ease-in-out infinite alternate-reverse;
+}
+
+.dune-front {
+    color: var(--dune-front);
+    height: 50%; /* Shortest, stays in front */
+    z-index: 30;
+    animation: flowSand 12s ease-in-out infinite alternate;
+}
+
+/* The actual movement keyframes */
+@keyframes flowSand {
+    0% { transform: translateX(0); }
+    100% { transform: translateX(-50%); } 
+    /* Translates -50% because the width is 200%, perfectly wrapping the visible area */
+}
+
+
+/* =========================================
+   Foreground Content
+   ========================================= */
+
+.content-overlay {
+    position: relative;
+    z-index: 100; /* Must be above the dunes */
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    padding: 0 20px;
+}
+
+.hero-title {
+    font-size: clamp(3rem, 6vw, 5rem);
+    font-weight: 800;
+    letter-spacing: -1.5px;
+    margin: 0 0 16px 0;
+    text-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+.hero-subtitle {
+    font-size: clamp(1.1rem, 2vw, 1.5rem);
+    color: var(--text-secondary);
+    margin: 0;
+    max-width: 600px;
+    line-height: 1.5;
+    text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .dune {
+        animation: none !important;
+        /* Center them statically */
+        transform: translateX(-25%) !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a purely CSS-animated parallax background simulating flowing sand dunes. Built using overlapping SVG paths and continuous CSS translations, requiring zero JavaScript overhead for the animation loop, resolving issue #70079.

### Changes Made:
- Added `submissions/examples/css-sand-dune-waves-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the SVG paths and layer order.
- Created `style.css` featuring the UI mechanics:
  - **The Multi-layered Parallax**: The background consists of three distinct `<div>` layers (`.dune-back`, `.dune-middle`, `.dune-front`), each containing an SVG path. They are stacked using `z-index` and scaled to different heights (100%, 75%, 50%) to create a forced perspective of depth.
  - **The Infinite Flow Animation**: Each dune layer is set to `width: 200%`, making it exactly twice as wide as the screen. A CSS `@keyframes` animation simply translates the element from `translateX(0)` to `translateX(-50%)` and alternates. Because the SVGs are drawn as continuous curves, this horizontal panning creates the optical illusion of waves rolling across the screen.
  - **Differentiated Speeds**: By assigning different animation durations (25s, 18s, 12s) and alternating directions (`alternate` vs `alternate-reverse`) to the layers, we break visual repetition and simulate a complex, natural-looking parallax effect.
  - **Theming & Dark Mode Supported**: Configured via CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), generating a deep indigo/violet night desert aesthetic that automatically swaps the sky gradient and dune fill colors.
- Added `README.md` documenting usage and the technical mechanics of the SVG rendering approach.
- Fully accessible semantic structure. The dunes are purely decorative background elements and are explicitly hidden from screen readers via `aria-hidden="true"` on the parent container. The foreground content uses standard semantic tags (`<main>`, `<h1>`). Honors the `prefers-reduced-motion` accessibility standard by disabling the parallax animation entirely for motion-sensitive users, freezing the dunes in a statically centered state.

Closes #70079
