### PR TITLE
Add ease-commit-hash-badge component

### DIFF
--- a/submissions/examples/commit-hash-badge-x1a/README.md
+++ b/submissions/examples/commit-hash-badge-x1a/README.md
@@ -1,0 +1,19 @@
+1. What does this do?
+A developer commit hash badge component featuring active status beacon pulses and terminal typography.
+
+2. How is it used?
+<main class="chb-container">
+  <div class="chb-card">
+    <div class="chb-badge-wrapper">
+      <div class="chb-status-dot"></div>
+      <span class="chb-prefix">git</span>
+      <code class="chb-hash">#a8f3c29</code>
+      <span class="chb-copy-icon">
+        <span class="chb-clip"></span>
+      </span>
+    </div>
+  </div>
+</main>
+
+3. Why is it useful?
+It gives developers an accessible, zero-dependency git commit status badge for dashboards, release notes, and documentation pages.

--- a/submissions/examples/commit-hash-badge-x1a/demo.html
+++ b/submissions/examples/commit-hash-badge-x1a/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="./style.css">
+<title>Commit Hash Badge Demo</title>
+</head>
+<body>
+<main class="chb-container" role="main" aria-label="Commit Hash Badge Visualizer">
+  <div class="chb-card">
+    <div class="chb-badge-wrapper">
+      <div class="chb-status-dot"></div>
+      <span class="chb-prefix">git</span>
+      <code class="chb-hash">#a8f3c29</code>
+      <span class="chb-copy-icon" title="Copy Hash">
+        <span class="chb-clip"></span>
+      </span>
+    </div>
+    <h1 class="chb-title">Latest Commit</h1>
+    <p class="chb-description">A developer badge component showing an active commit hash with subtle status beacon motion and high-contrast terminal styling.</p>
+  </div>
+</main>
+</body>
+</html>

--- a/submissions/examples/commit-hash-badge-x1a/style.css
+++ b/submissions/examples/commit-hash-badge-x1a/style.css
@@ -1,0 +1,140 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: #090d16;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  padding: 20px;
+}
+
+.chb-container {
+  width: 100%;
+  max-width: 420px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.chb-card {
+  width: 100%;
+  background-color: #121829;
+  border-radius: 20px;
+  padding: 32px 24px;
+  border: 1px solid rgba(16, 185, 129, 0.2);
+  box-shadow: 0 20px 40px -15px rgba(0, 0, 0, 0.7);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+.chb-badge-wrapper {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  background: rgba(16, 185, 129, 0.08);
+  border: 1px solid rgba(16, 185, 129, 0.3);
+  padding: 8px 16px;
+  border-radius: 30px;
+  margin-bottom: 20px;
+  box-shadow: 0 0 15px rgba(16, 185, 129, 0.1);
+}
+
+.chb-status-dot {
+  width: 8px;
+  height: 8px;
+  background-color: #10b981;
+  border-radius: 50%;
+  animation: chb-beacon 1.5s ease-in-out infinite alternate;
+}
+
+.chb-prefix {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #64748b;
+  text-transform: uppercase;
+}
+
+.chb-hash {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.88rem;
+  font-weight: 700;
+  color: #10b981;
+  letter-spacing: 0.05em;
+}
+
+.chb-copy-icon {
+  position: relative;
+  width: 14px;
+  height: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  opacity: 0.7;
+  transition: opacity 0.2s;
+}
+
+.chb-copy-icon:hover {
+  opacity: 1;
+}
+
+.chb-clip {
+  width: 10px;
+  height: 12px;
+  border: 1.5px solid #10b981;
+  border-radius: 2px;
+  position: relative;
+}
+
+.chb-clip::before {
+  content: "";
+  position: absolute;
+  top: -3px;
+  left: -3px;
+  width: 10px;
+  height: 12px;
+  border: 1.5px solid rgba(16, 185, 129, 0.4);
+  border-radius: 2px;
+}
+
+.chb-title {
+  color: #f8fafc;
+  font-size: 1.5rem;
+  font-weight: 800;
+  margin-bottom: 8px;
+  letter-spacing: -0.02em;
+}
+
+.chb-description {
+  color: #94a3b8;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+@keyframes chb-beacon {
+  0% {
+    opacity: 0.4;
+    transform: scale(0.85);
+    box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.4);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1.15);
+    box-shadow: 0 0 8px 2px rgba(16, 185, 129, 0.6);
+  }
+}
+
+@media (max-width: 480px) {
+  .chb-card {
+    padding: 24px 16px;
+  }
+}


### PR DESCRIPTION
Add ease-commit-hash-badge component — Closes #70680

Closes: #70680

🚀 What this PR adds
This PR introduces the commit-hash-badge-x1a component under submissions/examples/commit-hash-badge-x1a/.

Key features include:
- A developer git commit hash badge styled for dark-mode dashboard UIs.
- Continuous keyframe beacon pulse animation on the active status indicator.
- Semantic HTML <main> structure with accessible labeling and zero external fonts.

✅ Acceptance Criteria covered:
- Pure CSS implementation with zero JavaScript runtime logic.
- Fully un-indented root structural tags (<!DOCTYPE html>, <html>, <head>, <body>) ensuring automated regex validator compliance.
- Links strictly to the local stylesheet ./style.css.
- Zero usage of ease- prefix in class names or keyframe rules.

📁 Files Included:
- submissions/examples/commit-hash-badge-x1a/demo.html
- submissions/examples/commit-hash-badge-x1a/style.css
- submissions/examples/commit-hash-badge-x1a/README.md

🔍 How to Review:
1. Open submissions/examples/commit-hash-badge-x1a/demo.html directly in any browser.
2. Confirm the glowing green status dot beacon pulse animation and layout responsiveness.