### PR TITLE
feat: add pure CSS Realtime Chart Line component (#70089)

### DIFF
--- a/submissions/examples/css-realtime-chart-line-pure/README.md
+++ b/submissions/examples/css-realtime-chart-line-pure/README.md
@@ -1,0 +1,20 @@
+# CSS Realtime Chart Line
+
+A pure CSS animated line chart that "draws" itself from left to right upon load, simulating real-time data plotting. Built entirely without JavaScript, utilizing inline SVG and CSS `clip-path` animations.
+
+## Features
+- Pure CSS and SVG implementation.
+- **Component Architecture (Documented in Code)**: 
+  - **The SVG Canvas**: The chart itself is a static SVG containing a linear gradient definition (`<linearGradient>`), an area fill path (`<path class="chart-area">`), and a stroke line (`<path class="chart-line">`). 
+  - **The Clip-Path Reveal**: Instead of complex JavaScript path-length calculations, the entire SVG is placed inside a `.chart-reveal-wrapper`. This wrapper uses CSS `@keyframes` to animate the `clip-path` property. It starts at `clip-path: inset(0 100% 0 0)` (meaning the right side is inset by 100%, completely hiding the chart) and transitions to `inset(0 0 0 0)` over 2 seconds. This acts like a curtain opening from left to right, smoothly revealing the complex SVG underneath as if it were being plotted in real time.
+  - **The Data Point**: A final SVG `<circle>` sits at the end of the line. It uses an `animation-delay` to fade in precisely as the chart finishes drawing, and then transitions into an infinite CSS `drop-shadow` pulse to indicate an active, "live" data feed.
+  - **Background Grid**: The horizontal grid lines sit outside the reveal wrapper (`z-index: 1`), ensuring they are visible immediately on load, while the chart draws over them.
+- **Theming & Dark Mode**: Configured via CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), shifting the card background to slate and modifying the grid line contrast.
+- Fully accessible semantic structure. The chart is purely decorative and utilizes proper DOM layering. Honors the `prefers-reduced-motion` accessibility standard by disabling the `clip-path` reveal and pulse animations for motion-sensitive users, immediately displaying the fully rendered chart.
+
+## Usage
+Open `demo.html` in your browser. The chart will automatically plot itself upon page load. Refresh the page to see the animation again.
+
+## Files
+- `demo.html`: The HTML structure defining the SVG vector paths, the gradient definition, and the wrapper hierarchy.
+- `style.css`: The styling, background grids, and the critical `clip-path: inset(...)` animation logic.

--- a/submissions/examples/css-realtime-chart-line-pure/demo.html
+++ b/submissions/examples/css-realtime-chart-line-pure/demo.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Realtime Chart Line</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Realtime Chart Line</h1>
+            <p class="subtitle">A pure CSS animated line chart that "draws" itself from left to right upon load, simulating real-time data plotting.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <div class="chart-card">
+                <div class="chart-header">
+                    <h2 class="chart-title">Revenue Growth</h2>
+                    <span class="chart-badge">+24.5%</span>
+                </div>
+                
+                <div class="chart-container">
+                    
+                    <!-- 
+                      [TECHNIQUE] Animated Clip Path
+                      The SVG contains the fully drawn chart (the gradient fill and the stroke line).
+                      The parent container has an animation that transitions `clip-path: inset(...)`
+                      from 100% on the right down to 0%. This reveals the chart exactly as if it 
+                      were being plotted in real-time from left to right.
+                    -->
+                    <div class="chart-reveal-wrapper">
+                        
+                        <svg class="chart-svg" viewBox="0 0 600 200" preserveAspectRatio="none">
+                            
+                            <!-- Defs for the gradient fill under the line -->
+                            <defs>
+                                <linearGradient id="chartFill" x1="0" y1="0" x2="0" y2="1">
+                                    <stop offset="0%" stop-color="var(--chart-line)" stop-opacity="0.4" />
+                                    <stop offset="100%" stop-color="var(--chart-line)" stop-opacity="0" />
+                                </linearGradient>
+                            </defs>
+                            
+                            <!-- The Gradient Area Fill -->
+                            <path class="chart-area" d="M 0,200 L 0,160 Q 50,140 100,150 T 200,120 T 300,140 T 400,80 T 500,90 T 600,40 L 600,200 Z" />
+                            
+                            <!-- The Line Plot -->
+                            <path class="chart-line" d="M 0,160 Q 50,140 100,150 T 200,120 T 300,140 T 400,80 T 500,90 T 600,40" />
+                            
+                            <!-- The Final Data Point Marker -->
+                            <circle class="chart-point" cx="600" cy="40" r="6" />
+                            
+                        </svg>
+                        
+                    </div>
+                    
+                    <!-- Grid Lines (Background layer, not animated) -->
+                    <div class="chart-grid">
+                        <div class="grid-line"></div>
+                        <div class="grid-line"></div>
+                        <div class="grid-line"></div>
+                        <div class="grid-line"></div>
+                        <div class="grid-line"></div>
+                    </div>
+                    
+                </div>
+            </div>
+            
+        </div>
+        
+    </div>
+
+    <!-- Replay button for demonstration purposes only -->
+    <div class="demo-controls">
+        <p>Refresh the page to replay the load animation.</p>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-realtime-chart-line-pure/style.css
+++ b/submissions/examples/css-realtime-chart-line-pure/style.css
@@ -1,0 +1,237 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f1f5f9;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    
+    /* Card Colors */
+    --card-bg: #ffffff;
+    --card-border: #e2e8f0;
+    
+    /* Chart Colors */
+    --chart-line: #10b981; /* Emerald Green */
+    --chart-grid: #e2e8f0;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #020617;
+        --text-primary: #f8fafc;
+        --text-secondary: #94a3b8;
+        
+        --card-bg: #0f172a;
+        --card-border: #1e293b;
+        
+        --chart-grid: #1e293b;
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 60px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    padding: 20px 0;
+}
+
+
+/* =========================================
+   Chart Card Layout
+   ========================================= */
+
+.chart-card {
+    width: 100%;
+    max-width: 600px;
+    background-color: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 16px;
+    padding: 24px;
+    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.05);
+}
+
+.chart-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 30px;
+}
+
+.chart-title {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin: 0;
+}
+
+.chart-badge {
+    background-color: rgba(16, 185, 129, 0.15);
+    color: var(--chart-line);
+    padding: 4px 12px;
+    border-radius: 9999px;
+    font-size: 0.85rem;
+    font-weight: 700;
+}
+
+
+/* =========================================
+   [TECHNIQUE] The Animated Chart Container
+   ========================================= */
+
+.chart-container {
+    position: relative;
+    width: 100%;
+    height: 200px; /* Fixed height for the SVG viewBox ratio */
+}
+
+/* 
+  The Grid Lines
+  These sit BEHIND the chart and do not animate in.
+*/
+.chart-grid {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    z-index: 1;
+}
+
+.grid-line {
+    width: 100%;
+    height: 1px;
+    background-color: var(--chart-grid);
+}
+
+/* 
+  [TECHNIQUE] The Reveal Wrapper
+  This wrapper sits ABOVE the grid. 
+  It uses the CSS clip-path property to mask out the chart.
+  By animating the right-side inset from 100% to 0%, it acts like a 
+  curtain opening from left to right, revealing the chart underneath.
+*/
+.chart-reveal-wrapper {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 10;
+    
+    /* clip-path: inset(top right bottom left) */
+    clip-path: inset(0 100% 0 0);
+    animation: drawChart 2s cubic-bezier(0.2, 0.8, 0.2, 1) 0.5s forwards;
+}
+
+@keyframes drawChart {
+    0% { clip-path: inset(0 100% 0 0); }
+    100% { clip-path: inset(0 0 0 0); }
+}
+
+
+/* =========================================
+   The SVG Chart Elements
+   ========================================= */
+
+.chart-svg {
+    width: 100%;
+    height: 100%;
+    /* Ensure the path strokes don't get clipped by the SVG bounds */
+    overflow: visible; 
+}
+
+.chart-area {
+    fill: url(#chartFill);
+}
+
+.chart-line {
+    fill: none;
+    stroke: var(--chart-line);
+    stroke-width: 4;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}
+
+.chart-point {
+    fill: var(--card-bg);
+    stroke: var(--chart-line);
+    stroke-width: 3;
+    
+    /* 
+      Optional: We can add a slight pulse to the final data point 
+      after the chart finishes drawing.
+    */
+    opacity: 0;
+    animation: fadeInPoint 0.3s ease 2.5s forwards, pulsePoint 2s infinite 2.5s;
+}
+
+@keyframes fadeInPoint {
+    to { opacity: 1; }
+}
+
+@keyframes pulsePoint {
+    0% { filter: drop-shadow(0 0 0 rgba(16, 185, 129, 0.6)); }
+    50% { filter: drop-shadow(0 0 10px rgba(16, 185, 129, 0.8)); }
+    100% { filter: drop-shadow(0 0 0 rgba(16, 185, 129, 0.6)); }
+}
+
+
+/* Demo Controls */
+.demo-controls {
+    text-align: center;
+    padding: 40px;
+    color: var(--text-secondary);
+    font-style: italic;
+    font-size: 0.9rem;
+}
+
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .chart-reveal-wrapper {
+        clip-path: inset(0 0 0 0) !important;
+        animation: none !important;
+    }
+    .chart-point {
+        opacity: 1 !important;
+        animation: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a pure CSS animated line chart that "draws" itself from left to right upon load, simulating real-time data plotting. Built entirely without JavaScript, utilizing inline SVG and CSS `clip-path` animations, resolving issue #70089.

### Changes Made:
- Added `submissions/examples/css-realtime-chart-line-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the SVG vector paths, the gradient definition, and the wrapper hierarchy.
- Created `style.css` featuring the UI mechanics:
  - **The SVG Canvas**: The chart itself is a static SVG containing a linear gradient definition (`<linearGradient>`), an area fill path (`<path class="chart-area">`), and a stroke line (`<path class="chart-line">`). 
  - **The Clip-Path Reveal**: Instead of complex JavaScript path-length calculations, the entire SVG is placed inside a `.chart-reveal-wrapper`. This wrapper uses CSS `@keyframes` to animate the `clip-path` property. It starts at `clip-path: inset(0 100% 0 0)` (meaning the right side is inset by 100%, completely hiding the chart) and transitions to `inset(0 0 0 0)` over 2 seconds. This acts like a curtain opening from left to right, smoothly revealing the complex SVG underneath as if it were being plotted in real time.
  - **The Data Point**: A final SVG `<circle>` sits at the end of the line. It uses an `animation-delay` to fade in precisely as the chart finishes drawing, and then transitions into an infinite CSS `drop-shadow` pulse to indicate an active, "live" data feed.
  - **Background Grid**: The horizontal grid lines sit outside the reveal wrapper (`z-index: 1`), ensuring they are visible immediately on load, while the chart draws over them.
  - **Theming & Dark Mode Supported**: Configured via CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), shifting the card background to slate and modifying the grid line contrast.
- Added `README.md` documenting usage and the technical mechanics of the critical `clip-path: inset(...)` animation logic.
- Fully accessible semantic structure. The chart is purely decorative and utilizes proper DOM layering. Honors the `prefers-reduced-motion` accessibility standard by disabling the `clip-path` reveal and pulse animations for motion-sensitive users, immediately displaying the fully rendered chart.

Closes #70089
