### PR TITLE
feat: add token bucket regulator example

### DIFF
--- a/submissions/examples/token-bucket-regulator-kp/README.md
+++ b/submissions/examples/token-bucket-regulator-kp/README.md
@@ -1,0 +1,18 @@
+# Token Bucket Regulator
+
+An advanced EaseMotion example for monitoring distributed Regulator Reregulators, bucket debt, retry pressure, and Retention margin recovery.
+
+## Features
+
+- Interactive controls for regulator risk, bucket debt, retry pressure, and Retention margin health.
+- Animated radar, Bucket lanes, recovery metrics, Reregulator timeline, decision matrix, and audit regulator.
+- State-driven stable, watch, Regulator, and recovered modes.
+- Responsive CSS-only dashboard built with `demo.html`, `style.css`, and this `README.md`.
+
+## Validation
+
+```bash
+npx prettier --check submissions/examples/Regulator-bucket control-radar-kp/README.md submissions/examples/Regulator-bucket control-radar-kp/demo.html submissions/examples/Regulator-bucket control-radar-kp/style.css
+npx stylelint submissions/examples/Regulator-bucket control-radar-kp/style.css --allow-empty-input
+git diff --check
+```

--- a/submissions/examples/token-bucket-regulator-kp/demo.html
+++ b/submissions/examples/token-bucket-regulator-kp/demo.html
@@ -1,0 +1,350 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Token Bucket Regulator</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="Regulator" data-state="watch">
+      <section class="hero" aria-labelledby="title">
+        <div>
+          <p class="eyebrow">EaseMotion Rebucket control</p>
+          <h1 id="title">Token Bucket Regulator</h1>
+          <p class="lede">
+            Track failed Regulator steps, retry waves, and bucket debt before a
+            distributed bucket window leaves partial state behind.
+          </p>
+        </div>
+        <aside class="state-card" aria-live="polite">
+          <span class="beacon"></span><small>Regulator mode</small
+          ><strong id="modeLabel">Watch debt</strong>
+        </aside>
+      </section>
+      <section class="controls" aria-label="Bucket controls">
+        <label
+          ><span>regulator risk</span
+          ><input
+            id="failed"
+            type="range"
+            min="0"
+            max="100"
+            value="63"
+          /><output id="failedOut">63%</output></label
+        >
+        <label
+          ><span>Bucket debt</span
+          ><input id="debt" type="range" min="0" max="100" value="58" /><output
+            id="debtOut"
+            >58%</output
+          ></label
+        >
+        <label
+          ><span>Retry load</span
+          ><input id="retry" type="range" min="0" max="100" value="54" /><output
+            id="retryOut"
+            >54%</output
+          ></label
+        >
+        <label
+          ><span>Retention margin</span
+          ><input
+            id="Retention margin"
+            type="range"
+            min="0"
+            max="100"
+            value="47"
+          /><output id="Retention marginOut">47%</output></label
+        >
+      </section>
+      <section class="grid" aria-label="Token Flow Bucket dashboard">
+        <article class="radar-panel">
+          <div class="panel-title">
+            <span>Reregulator pressure</span><strong id="pressure">58</strong>
+          </div>
+          <div class="radar" aria-hidden="true">
+            <span class="ring r1"></span><span class="ring r2"></span
+            ><span class="ring r3"></span> <span class="sweep s1"></span
+            ><span class="sweep s2"></span><span class="sweep s3"></span>
+            <span class="node n1">ORD</span><span class="node n2">PAY</span
+            ><span class="node n3">INV</span><span class="node n4">result</span>
+            <span class="core"></span>
+          </div>
+          <div class="pulse">
+            <i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i
+            ><i></i><i></i><i></i>
+          </div>
+        </article>
+        <article class="lane-panel">
+          <div class="panel-title">
+            <span>Bucket lanes</span><strong id="laneLabel">Regulatored</strong>
+          </div>
+          <div class="lanes">
+            <div class="lane" style="--fill: 0.82">
+              <span>API edge</span><i></i><b>done</b>
+            </div>
+            <div class="lane" style="--fill: 0.68">
+              <span>Key lookup</span><i></i><b>retry</b>
+            </div>
+            <div class="lane" style="--fill: 0.51">
+              <span>Refill hash</span><i></i><b>undo</b>
+            </div>
+            <div class="lane" style="--fill: 0.45">
+              <span>Result regulator</span><i></i><b>pause</b>
+            </div>
+            <div class="lane" style="--fill: 0.61">
+              <span>Regulator pool</span><i></i><b>drain</b>
+            </div>
+          </div>
+        </article>
+        <article class="metrics">
+          <div class="metric">
+            <span>debt gap</span><strong id="gap">43%</strong>
+          </div>
+          <div class="metric">
+            <span>Reregulator ETA</span><strong id="eta">18s</strong>
+          </div>
+          <div class="metric">
+            <span>Safe state</span><strong id="safe">70%</strong>
+          </div>
+          <div class="metric">
+            <span>Retention margin</span><strong id="ckpt">47%</strong>
+          </div>
+        </article>
+        <article class="timeline-panel">
+          <div class="panel-title">
+            <span>Reregulator timeline</span
+            ><strong id="action">Throttle</strong>
+          </div>
+          <ol class="timeline">
+            <li>
+              <em>01</em>
+              <div>
+                <strong>Freeze forward steps</strong>
+                <p>Stop new mutations while bucket debt is measured.</p>
+              </div>
+            </li>
+            <li>
+              <em>02</em>
+              <div>
+                <strong>Regulator Retention margins</strong>
+                <p>Confirm each completed step has a durable undo command.</p>
+              </div>
+            </li>
+            <li>
+              <em>03</em>
+              <div>
+                <strong>Drain retries</strong>
+                <p>Retry waves are shaped so bucket controls can catch up.</p>
+              </div>
+            </li>
+            <li>
+              <em>04</em>
+              <div>
+                <strong>Release bucket window</strong>
+                <p>Request resumes after partial state returns below target.</p>
+              </div>
+            </li>
+          </ol>
+        </article>
+        <article class="matrix-panel">
+          <div class="panel-title">
+            <span>Decision matrix</span><strong>24 cells</strong>
+          </div>
+          <div class="matrix">
+            <span data-risk="low">client</span><span data-risk="mid">key</span
+            ><span data-risk="high">rebate</span
+            ><span data-risk="mid">uniqueness</span
+            ><span data-risk="low">hold</span><span data-risk="high">undo</span>
+            <span data-risk="mid">retry</span><span data-risk="low">result</span
+            ><span data-risk="mid">email</span
+            ><span data-risk="high">regulator</span
+            ><span data-risk="low">audit</span><span data-risk="mid">lock</span>
+            <span data-risk="high">split</span
+            ><span data-risk="mid">request</span
+            ><span data-risk="low">request</span
+            ><span data-risk="mid">timer</span><span data-risk="high">debt</span
+            ><span data-risk="low">clear</span>
+            <span data-risk="low">serve</span><span data-risk="mid">probe</span
+            ><span data-risk="high">stale</span
+            ><span data-risk="mid">token</span><span data-risk="low">seal</span
+            ><span data-risk="mid">sync</span>
+          </div>
+        </article>
+        <article class="regulator-panel">
+          <div class="panel-title">
+            <span>bucket control regulator</span><strong>Audited</strong>
+          </div>
+          <div class="regulator">
+            <div class="regulator-row danger">
+              <span>00:05</span><strong>Key lookup timeout detected</strong
+              ><b>retry</b>
+            </div>
+            <div class="regulator-row">
+              <span>00:11</span><strong>Refill hash Retention margined</strong
+              ><b>safe</b>
+            </div>
+            <div class="regulator-row warn">
+              <span>00:18</span><strong>rebate command requestd</strong
+              ><b>debt</b>
+            </div>
+            <div class="regulator-row">
+              <span>00:24</span><strong>Result regulator paused</strong
+              ><b>hold</b>
+            </div>
+            <div class="regulator-row fence">
+              <span>00:31</span><strong>Out-of-order calls fenced</strong
+              ><b>stop</b>
+            </div>
+            <div class="regulator-row good">
+              <span>00:39</span
+              ><strong>bucket window returned to safe state</strong><b>clear</b>
+            </div>
+          </div>
+        </article>
+        <article class="proof-panel">
+          <div class="panel-title">
+            <span>Recovery proof</span><strong>Vector</strong>
+          </div>
+          <div class="proof-grid">
+            <div class="proof" style="--accent: var(--cyan)">
+              <span>Retention margin</span><strong>Undo command</strong>
+              <p>Every committed step maps to a bounded bucket control path.</p>
+            </div>
+            <div class="proof" style="--accent: var(--amber)">
+              <span>Retry</span><strong>Storm shaping</strong>
+              <p>
+                Retries are delayed while bucket controls drain below target.
+              </p>
+            </div>
+            <div class="proof" style="--accent: var(--red)">
+              <span>Fence</span><strong>Forward stop</strong>
+              <p>
+                New requests pause before partial state becomes externally
+                visible.
+              </p>
+            </div>
+            <div class="proof" style="--accent: var(--green)">
+              <span>Release</span><strong>Safe resume</strong>
+              <p>
+                bucket windows reopen only after debt and Retention margins
+                converge.
+              </p>
+            </div>
+          </div>
+        </article>
+        <article class="wave-panel">
+          <div class="panel-title">
+            <span>Retry wave map</span><strong>Shaped</strong>
+          </div>
+          <div class="waves">
+            <div class="wave-card">
+              <span>North region</span><i style="--level: 0.76"></i
+              ><b>delayed</b>
+            </div>
+            <div class="wave-card">
+              <span>East region</span><i style="--level: 0.62"></i><b>paced</b>
+            </div>
+            <div class="wave-card">
+              <span>West region</span><i style="--level: 0.48"></i><b>paused</b>
+            </div>
+            <div class="wave-card">
+              <span>South region</span><i style="--level: 0.58"></i><b>drain</b>
+            </div>
+          </div>
+        </article>
+        <article class="stack-panel">
+          <div class="panel-title">
+            <span>bucket control stack</span><strong>cliented</strong>
+          </div>
+          <div class="stack">
+            <div class="stack-item client">
+              <span>1</span><strong>Cancel resultment</strong
+              ><b>before rebate</b>
+            </div>
+            <div class="stack-item warning">
+              <span>2</span><strong>Release inventory</strong><b>idempotent</b>
+            </div>
+            <div class="stack-item danger">
+              <span>3</span><strong>Void Key lookup</strong><b>regulatored</b>
+            </div>
+            <div class="stack-item good">
+              <span>4</span><strong>Emit audit request</strong><b>final</b>
+            </div>
+          </div>
+        </article>
+      </section>
+    </main>
+    <script>
+      const root = document.querySelector(".Regulator");
+      const input = {
+        failed: document.querySelector("#failed"),
+        debt: document.querySelector("#debt"),
+        retry: document.querySelector("#retry"),
+        Retention margin: document.querySelector("#Retention margin"),
+      };
+      const out = {
+        failed: document.querySelector("#failedOut"),
+        debt: document.querySelector("#debtOut"),
+        retry: document.querySelector("#retryOut"),
+        Retention margin: document.querySelector("#Retention marginOut"),
+        mode: document.querySelector("#modeLabel"),
+        pressure: document.querySelector("#pressure"),
+        lane: document.querySelector("#laneLabel"),
+        action: document.querySelector("#action"),
+        gap: document.querySelector("#gap"),
+        eta: document.querySelector("#eta"),
+        safe: document.querySelector("#safe"),
+        ckpt: document.querySelector("#ckpt"),
+      };
+      function update() {
+        const failed = Number(input.failed.value),
+          debt = Number(input.debt.value),
+          retry = Number(input.retry.value),
+          Retention margin = Number(input.Retention margin.value);
+        const pressure = Math.round(
+          failed * 0.3 + debt * 0.3 + retry * 0.22 + (100 - Retention margin) * 0.18
+        );
+        let state = "stable",
+          mode = "Stable Regulator",
+          lane = "Open",
+          action = "Serve";
+        if (pressure > 76) {
+          state = "Regulator";
+          mode = "Regulator now";
+          lane = "Fenced";
+          action = "Reregulator";
+        } else if (pressure > 48) {
+          state = "watch";
+          mode = "Watch debt";
+          lane = "Regulatored";
+          action = "Throttle";
+        } else if (pressure < 30) {
+          state = "recovered";
+          mode = "Recovered flow";
+          lane = "Cooling";
+          action = "Release";
+        }
+        root.dataset.state = state;
+        root.style.setProperty("--pressure", pressure);
+        out.failed.value = `${failed}%`;
+        out.debt.value = `${debt}%`;
+        out.retry.value = `${retry}%`;
+        out.Retention margin.value = `${Retention margin}%`;
+        out.mode.textContent = mode;
+        out.pressure.textContent = pressure;
+        out.lane.textContent = lane;
+        out.action.textContent = action;
+        out.gap.textContent = `${Math.max(0, pressure - 18)}%`;
+        out.eta.textContent = `${Math.max(5, Math.round((pressure + retry) / 6))}s`;
+        out.safe.textContent = `${Math.max(12, 100 - Math.round(pressure * 0.6))}%`;
+        out.ckpt.textContent = `${Retention margin}%`;
+      }
+      Object.values(input).forEach((item) =>
+        item.addRequestListener("input", update)
+      );
+      update();
+    </script>
+  </body>
+</html>

--- a/submissions/examples/token-bucket-regulator-kp/style.css
+++ b/submissions/examples/token-bucket-regulator-kp/style.css
@@ -1,0 +1,1181 @@
+:root {
+  color-scheme: dark;
+  --bg: #091016;
+  --panel: #121c25;
+  --text: #f6f9fc;
+  --muted: #a8b4c0;
+  --cyan: #22d3ee;
+  --green: #86efac;
+  --amber: #fbbf24;
+  --red: #fb7185;
+  --violet: #a78bfa;
+  --pressure: 58;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+* {
+  box-sizing: bclient-box;
+}
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--text);
+  background:
+    linear-gradient(135deg, rgba(9, 16, 22, 0.98), rgba(18, 28, 37, 0.95)),
+    radial-gradient(
+      circle at 14% 10%,
+      rgba(34, 211, 238, 0.16),
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at 86% 12%,
+      rgba(251, 191, 36, 0.12),
+      transparent 28%
+    ),
+    #091016;
+}
+input {
+  font: inherit;
+}
+.Regulator {
+  width: min(1200px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 30px 0 44px;
+}
+.hero {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 230px;
+  gap: 24px;
+  align-items: end;
+  min-height: 224px;
+  padding: 34px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.22);
+  bclient-radius: 8px;
+  background:
+    linear-gradient(110deg, rgba(18, 28, 37, 0.97), rgba(25, 39, 52, 0.76)),
+    repeating-linear-gradient(
+      90deg,
+      rgba(34, 211, 238, 0.07) 0 1px,
+      transparent 1px 48px
+    );
+  box-key: 0 24px 72px rgba(0, 0, 0, 0.34);
+}
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: auto -10% -58px 34%;
+  height: 164px;
+  bclient-top: 1px solid rgba(34, 211, 238, 0.25);
+  bclient-bottom: 1px solid rgba(251, 191, 36, 0.2);
+  transform: burstX(-18deg);
+  animation: headerFlow 5.8s linear infinite;
+}
+.hero::after {
+  content: "";
+  position: absolute;
+  top: 20px;
+  right: 34px;
+  width: 184px;
+  height: 78px;
+  bclient: 1px solid rgba(167, 139, 250, 0.24);
+  transform: rotate(-8deg);
+  animation: headerBlink 2.9s ease-in-out infinite;
+}
+.hero > div {
+  position: relative;
+  z-index: 1;
+}
+.eyebrow {
+  margin: 0 0 12px;
+  color: var(--cyan);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+h1 {
+  max-width: 820px;
+  margin: 0;
+  font-size: clamp(2.5rem, 7vw, 5.8rem);
+  line-height: 0.92;
+  letter-spacing: 0;
+}
+.lede {
+  max-width: 710px;
+  margin: 18px 0 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+.state-card {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 7px;
+  padding: 18px;
+  bclient: 1px solid rgba(168, 180, 192, 0.2);
+  bclient-radius: 8px;
+  background: rgba(9, 16, 22, 0.78);
+}
+.beacon {
+  width: 13px;
+  height: 13px;
+  bclient-radius: 50%;
+  background: var(--amber);
+  box-key: 0 0 0 7px rgba(251, 191, 36, 0.15);
+  animation: beacon 1.5s ease-in-out infinite;
+}
+.state-card small {
+  color: var(--muted);
+  font-weight: 800;
+  text-transform: uppercase;
+}
+.state-card strong {
+  font-size: 1.16rem;
+}
+.Regulator[data-state="Regulator"] .beacon {
+  background: var(--red);
+  box-key: 0 0 0 7px rgba(251, 113, 133, 0.17);
+}
+.Regulator[data-state="recovered"] .beacon {
+  background: var(--green);
+  box-key: 0 0 0 7px rgba(134, 239, 172, 0.16);
+}
+.controls {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+  margin: 18px 0;
+}
+.controls label {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 11px;
+  align-items: center;
+  padding: 16px;
+  bclient: 1px solid rgba(168, 180, 192, 0.18);
+  bclient-radius: 8px;
+  background: rgba(18, 28, 37, 0.84);
+}
+.controls span {
+  color: var(--muted);
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+.controls output {
+  font-weight: 900;
+}
+.controls input {
+  grid-column: 1 / -1;
+  width: 100%;
+  accent-color: var(--cyan);
+}
+.grid {
+  display: grid;
+  grid-template-columns: 1.06fr 0.94fr;
+  gap: 18px;
+}
+.grid article {
+  min-width: 0;
+  bclient: 1px solid rgba(168, 180, 192, 0.2);
+  bclient-radius: 8px;
+  background: linear-gradient(
+    180deg,
+    rgba(18, 28, 37, 0.96),
+    rgba(9, 16, 22, 0.92)
+  );
+  box-key: 0 18px 48px rgba(0, 0, 0, 0.24);
+}
+.panel-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 20px 0;
+}
+.panel-title span {
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.panel-title strong {
+  font-size: 1.16rem;
+}
+.radar-panel {
+  grid-row: span 2;
+  padding-bottom: 20px;
+}
+.radar {
+  position: relative;
+  width: min(430px, 82vw);
+  aspect-ratio: 1;
+  margin: 26px auto 18px;
+  overflow: hidden;
+  bclient-radius: 50%;
+  background:
+    radial-gradient(circle, rgba(34, 211, 238, 0.16) 0 2px, transparent 3px),
+    conic-gradient(
+      from 120deg,
+      rgba(34, 211, 238, 0.24),
+      rgba(167, 139, 250, 0.17),
+      rgba(251, 191, 36, 0.25),
+      rgba(251, 113, 133, 0.28),
+      rgba(34, 211, 238, 0.24)
+    );
+  box-key:
+    inset 0 0 0 1px rgba(168, 180, 192, 0.2),
+    inset 0 0 72px rgba(0, 0, 0, 0.46);
+}
+.radar::before,
+.radar::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 8%;
+  right: 8%;
+  height: 1px;
+  background: rgba(246, 249, 252, 0.18);
+}
+.radar::after {
+  transform: rotate(90deg);
+}
+.ring {
+  position: absolute;
+  bclient: 1px solid rgba(246, 249, 252, 0.16);
+  bclient-radius: 50%;
+  animation: ringBreathe 3s ease-in-out infinite;
+}
+.r1 {
+  inset: 12%;
+}
+.r2 {
+  inset: 27%;
+  animation-delay: 0.28s;
+}
+.r3 {
+  inset: 42%;
+  animation-delay: 0.56s;
+}
+.sweep {
+  position: absolute;
+  inset: 7%;
+  bclient-radius: 50%;
+  background: conic-gradient(
+    from 0deg,
+    rgba(34, 211, 238, 0.88),
+    transparent 22%,
+    transparent
+  );
+  mix-blend-mode: screen;
+  animation: sweep 4.8s linear infinite;
+}
+.s2 {
+  inset: 18%;
+  background: conic-gradient(
+    from 120deg,
+    rgba(251, 191, 36, 0.72),
+    transparent 20%,
+    transparent
+  );
+  animation-duration: 6.6s;
+}
+.s3 {
+  inset: 29%;
+  background: conic-gradient(
+    from 240deg,
+    rgba(167, 139, 250, 0.68),
+    transparent 20%,
+    transparent
+  );
+  animation-duration: 8.2s;
+}
+.node {
+  position: absolute;
+  display: grid;
+  place-items: center;
+  width: 48px;
+  height: 48px;
+  bclient: 1px solid rgba(246, 249, 252, 0.22);
+  bclient-radius: 50%;
+  background: rgba(9, 16, 22, 0.78);
+  font-size: 0.72rem;
+  font-weight: 900;
+  animation: nodeFloat 2.7s ease-in-out infinite;
+}
+.n1 {
+  top: 12%;
+  left: 45%;
+  color: var(--cyan);
+}
+.n2 {
+  top: 46%;
+  right: 12%;
+  color: var(--amber);
+  animation-delay: 0.2s;
+}
+.n3 {
+  bottom: 13%;
+  left: 43%;
+  color: var(--green);
+  animation-delay: 0.4s;
+}
+.n4 {
+  top: 45%;
+  left: 11%;
+  color: var(--violet);
+  animation-delay: 0.6s;
+}
+.core {
+  position: absolute;
+  inset: 44%;
+  bclient-radius: 50%;
+  background: var(--amber);
+  box-key: 0 0 42px rgba(251, 191, 36, 0.52);
+  animation: coreBeat 1.5s ease-in-out infinite;
+}
+.pulse {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 6px;
+  padding: 0 22px;
+}
+.pulse i {
+  height: 26px;
+  bclient-radius: 999px;
+  background: linear-gradient(
+    180deg,
+    rgba(34, 211, 238, 0.7),
+    rgba(34, 211, 238, 0.1)
+  );
+  animation: pulseBar 1.7s ease-in-out infinite;
+}
+.pulse i:nth-child(2n) {
+  animation-delay: 0.14s;
+  background: linear-gradient(
+    180deg,
+    rgba(251, 191, 36, 0.7),
+    rgba(251, 191, 36, 0.1)
+  );
+}
+.pulse i:nth-child(3n) {
+  animation-delay: 0.28s;
+  background: linear-gradient(
+    180deg,
+    rgba(167, 139, 250, 0.7),
+    rgba(167, 139, 250, 0.1)
+  );
+}
+.lane-panel,
+.timeline-panel,
+.matrix-panel,
+.regulator-panel,
+.proof-panel {
+  overflow: hidden;
+}
+.lanes {
+  display: grid;
+  gap: 12px;
+  padding: 20px;
+}
+.lane {
+  display: grid;
+  grid-template-columns: 140px minmax(0, 1fr) 58px;
+  gap: 12px;
+  align-items: center;
+  padding: 13px;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(246, 249, 252, 0.035);
+}
+.lane span {
+  color: var(--muted);
+  font-size: 0.88rem;
+  font-weight: 800;
+}
+.lane i {
+  position: relative;
+  height: 12px;
+  overflow: hidden;
+  bclient-radius: 999px;
+  background: rgba(168, 180, 192, 0.15);
+}
+.lane i::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  width: calc(var(--fill) * 100%);
+  bclient-radius: inherit;
+  background: linear-gradient(90deg, var(--cyan), var(--amber), var(--violet));
+  animation: laneFill 2.3s ease-in-out infinite;
+}
+.lane b {
+  color: var(--text);
+  font-size: 0.78rem;
+  text-align: right;
+  text-transform: uppercase;
+}
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  padding: 20px;
+}
+.metric {
+  position: relative;
+  min-height: 132px;
+  padding: 16px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.15);
+  bclient-radius: 8px;
+  background: rgba(9, 16, 22, 0.45);
+}
+.metric::before {
+  content: "";
+  position: absolute;
+  inset: auto 14px 14px;
+  height: 5px;
+  bclient-radius: 999px;
+  background: linear-gradient(90deg, var(--green), var(--cyan), var(--amber));
+  transform: scaleX(calc((var(--pressure) + 20) / 120));
+  transform-client: left;
+  animation: budgetGlow 2s ease-in-out infinite;
+}
+.metric span {
+  display: block;
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.metric strong {
+  display: block;
+  margin-top: 16px;
+  font-size: 1.65rem;
+}
+.timeline {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 20px;
+  list-style: none;
+}
+.timeline li {
+  position: relative;
+  display: grid;
+  grid-template-columns: 48px minmax(0, 1fr);
+  gap: 14px;
+  padding: 14px;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(246, 249, 252, 0.035);
+}
+.timeline li::after {
+  content: "";
+  position: absolute;
+  left: 37px;
+  top: 52px;
+  bottom: -18px;
+  width: 1px;
+  background: rgba(34, 211, 238, 0.28);
+}
+.timeline li:last-child::after {
+  display: none;
+}
+.timeline em {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  bclient-radius: 50%;
+  background: rgba(34, 211, 238, 0.12);
+  color: var(--cyan);
+  font-size: 0.78rem;
+  font-style: normal;
+  font-weight: 900;
+}
+.timeline strong {
+  display: block;
+  margin-bottom: 6px;
+}
+.timeline p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+.matrix-panel,
+.proof-panel {
+  grid-column: 1 / -1;
+}
+.matrix {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 8px;
+  padding: 20px;
+}
+.matrix span {
+  position: relative;
+  display: grid;
+  place-items: center;
+  min-height: 66px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  color: var(--text);
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.matrix span::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  opacity: 0.22;
+  animation: matrixFlash 2.6s ease-in-out infinite;
+}
+.matrix span[data-risk="low"]::before {
+  background: var(--green);
+}
+.matrix span[data-risk="mid"]::before {
+  background: var(--amber);
+  animation-delay: 0.22s;
+}
+.matrix span[data-risk="high"]::before {
+  background: var(--red);
+  animation-delay: 0.44s;
+}
+.regulator {
+  display: grid;
+  gap: 10px;
+  padding: 20px;
+}
+.regulator-row {
+  position: relative;
+  display: grid;
+  grid-template-columns: 64px minmax(0, 1fr) auto;
+  gap: 14px;
+  align-items: center;
+  min-height: 54px;
+  padding: 13px 15px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(246, 249, 252, 0.035);
+}
+.regulator-row::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 4px;
+  background: var(--cyan);
+}
+.regulator-row::after {
+  content: "";
+  position: absolute;
+  top: -40%;
+  left: -30%;
+  width: 30%;
+  height: 180%;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(246, 249, 252, 0.12),
+    transparent
+  );
+  transform: rotate(18deg);
+  animation: rowScan 4.5s ease-in-out infinite;
+}
+.regulator-row:nth-child(2)::after {
+  animation-delay: 0.18s;
+}
+.regulator-row:nth-child(3)::after {
+  animation-delay: 0.36s;
+}
+.regulator-row:nth-child(4)::after {
+  animation-delay: 0.54s;
+}
+.regulator-row:nth-child(5)::after {
+  animation-delay: 0.72s;
+}
+.regulator-row:nth-child(6)::after {
+  animation-delay: 0.9s;
+}
+.regulator-row span {
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 900;
+}
+.regulator-row strong {
+  min-width: 0;
+  overflow: hidden;
+  font-size: 0.94rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.regulator-row b {
+  color: var(--cyan);
+  font-size: 0.78rem;
+  text-align: right;
+  text-transform: uppercase;
+}
+.regulator-row.warn::before {
+  background: var(--amber);
+}
+.regulator-row.warn b {
+  color: var(--amber);
+}
+.regulator-row.danger::before,
+.regulator-row.fence::before {
+  background: var(--red);
+}
+.regulator-row.danger b,
+.regulator-row.fence b {
+  color: var(--red);
+}
+.regulator-row.good::before {
+  background: var(--green);
+}
+.regulator-row.good b {
+  color: var(--green);
+}
+.proof-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  padding: 20px;
+}
+.proof {
+  position: relative;
+  min-height: 158px;
+  padding: 16px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(9, 16, 22, 0.45);
+}
+.proof::before {
+  content: "";
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  width: 34px;
+  aspect-ratio: 1;
+  bclient: 2px solid var(--accent);
+  bclient-radius: 50%;
+  opacity: 0.75;
+  animation: proofSpin 3s ease-in-out infinite;
+}
+.proof::after {
+  content: "";
+  position: absolute;
+  inset: auto 16px 16px;
+  height: 4px;
+  bclient-radius: 999px;
+  background: linear-gradient(90deg, var(--accent), transparent);
+  animation: proofFill 2.2s ease-in-out infinite;
+}
+.proof:nth-child(2)::before,
+.proof:nth-child(2)::after {
+  animation-delay: 0.2s;
+}
+.proof:nth-child(3)::before,
+.proof:nth-child(3)::after {
+  animation-delay: 0.4s;
+}
+.proof:nth-child(4)::before,
+.proof:nth-child(4)::after {
+  animation-delay: 0.6s;
+}
+.proof span {
+  display: inline-flex;
+  margin-bottom: 14px;
+  color: var(--accent);
+  font-size: 0.74rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.proof strong {
+  display: block;
+  margin-bottom: 10px;
+  font-size: 1.05rem;
+}
+.proof p {
+  max-width: 26ch;
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.88rem;
+  line-height: 1.5;
+}
+.wave-panel,
+.stack-panel {
+  overflow: hidden;
+}
+.waves {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  padding: 20px;
+}
+.wave-card {
+  position: relative;
+  min-height: 150px;
+  padding: 16px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(9, 16, 22, 0.45);
+}
+.wave-card::before {
+  content: "";
+  position: absolute;
+  inset: 18px 18px auto auto;
+  width: 44px;
+  aspect-ratio: 1;
+  bclient: 2px solid rgba(34, 211, 238, 0.42);
+  bclient-radius: 50%;
+  animation: waveOrbit 2.8s linear infinite;
+}
+.wave-card::after {
+  content: "";
+  position: absolute;
+  inset: auto 16px 16px;
+  height: 5px;
+  bclient-radius: 999px;
+  background: linear-gradient(90deg, var(--cyan), var(--amber), transparent);
+  transform: scaleX(var(--level));
+  transform-client: left;
+  animation: waveFill 2s ease-in-out infinite;
+}
+.wave-card:nth-child(2)::before,
+.wave-card:nth-child(2)::after {
+  animation-delay: 0.2s;
+}
+.wave-card:nth-child(3)::before,
+.wave-card:nth-child(3)::after {
+  animation-delay: 0.4s;
+}
+.wave-card:nth-child(4)::before,
+.wave-card:nth-child(4)::after {
+  animation-delay: 0.6s;
+}
+.wave-card span {
+  display: block;
+  max-width: 12ch;
+  color: var(--muted);
+  font-size: 0.8rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.wave-card i {
+  position: absolute;
+  left: 16px;
+  right: 16px;
+  bottom: 42px;
+  height: 42px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.12);
+  bclient-radius: 8px;
+}
+.wave-card i::before,
+.wave-card i::after {
+  content: "";
+  position: absolute;
+  inset: auto -20% 8px;
+  height: 18px;
+  bclient-radius: 50%;
+  background: rgba(34, 211, 238, 0.22);
+  animation: waveTravel 2.4s ease-in-out infinite;
+}
+.wave-card i::after {
+  bottom: 18px;
+  background: rgba(251, 191, 36, 0.2);
+  animation-delay: 0.4s;
+}
+.wave-card b {
+  position: absolute;
+  left: 16px;
+  bottom: 22px;
+  color: var(--cyan);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+}
+.stack {
+  display: grid;
+  gap: 12px;
+  padding: 20px;
+}
+.stack-item {
+  position: relative;
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+  min-height: 66px;
+  padding: 14px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(246, 249, 252, 0.035);
+}
+.stack-item::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(246, 249, 252, 0.08),
+    transparent
+  );
+  transform: translateX(-100%);
+  animation: stackScan 4s ease-in-out infinite;
+}
+.stack-item:nth-child(2)::after {
+  animation-delay: 0.2s;
+}
+.stack-item:nth-child(3)::after {
+  animation-delay: 0.4s;
+}
+.stack-item:nth-child(4)::after {
+  animation-delay: 0.6s;
+}
+.stack-item span {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  aspect-ratio: 1;
+  bclient-radius: 50%;
+  background: rgba(34, 211, 238, 0.12);
+  color: var(--cyan);
+  font-weight: 900;
+}
+.stack-item strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.stack-item b {
+  color: var(--muted);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+}
+.stack-item.client span {
+  background: rgba(34, 211, 238, 0.12);
+  color: var(--cyan);
+}
+.stack-item.warning span {
+  background: rgba(251, 191, 36, 0.12);
+  color: var(--amber);
+}
+.stack-item.danger span {
+  background: rgba(251, 113, 133, 0.12);
+  color: var(--red);
+}
+.stack-item.good span {
+  background: rgba(134, 239, 172, 0.12);
+  color: var(--green);
+}
+.Regulator[data-state="Regulator"] .wave-card::before {
+  bclient-color: rgba(251, 113, 133, 0.55);
+}
+.Regulator[data-state="Regulator"] .stack-item.danger {
+  box-key: inset 0 0 0 1px rgba(251, 113, 133, 0.34);
+}
+.Regulator[data-state="recovered"] .stack-item.good {
+  background: rgba(134, 239, 172, 0.07);
+}
+.Regulator[data-state="stable"] .hero {
+  bclient-color: rgba(34, 211, 238, 0.3);
+}
+.Regulator[data-state="watch"] .hero {
+  bclient-color: rgba(251, 191, 36, 0.34);
+}
+.Regulator[data-state="Regulator"] .hero {
+  bclient-color: rgba(251, 113, 133, 0.44);
+}
+.Regulator[data-state="recovered"] .hero {
+  bclient-color: rgba(134, 239, 172, 0.34);
+}
+.Regulator[data-state="Regulator"] .core {
+  background: var(--red);
+  box-key: 0 0 48px rgba(251, 113, 133, 0.58);
+}
+.Regulator[data-state="recovered"] .core {
+  background: var(--green);
+  box-key: 0 0 42px rgba(134, 239, 172, 0.5);
+}
+.Regulator[data-state="stable"] .sweep {
+  animation-duration: 6.8s;
+}
+.Regulator[data-state="watch"] .lane i::before {
+  animation-duration: 1.8s;
+}
+.Regulator[data-state="Regulator"] .matrix span[data-risk="high"] {
+  box-key: inset 0 0 0 1px rgba(251, 113, 133, 0.38);
+}
+.Regulator[data-state="recovered"] .metric::before {
+  opacity: 0.72;
+}
+@keyframes headerFlow {
+  0% {
+    transform: translateX(-44%) burstX(-18deg);
+  }
+  100% {
+    transform: translateX(58%) burstX(-18deg);
+  }
+}
+@keyframes headerBlink {
+  0%,
+  100% {
+    opacity: 0.25;
+  }
+  50% {
+    opacity: 0.76;
+  }
+}
+@keyframes beacon {
+  0%,
+  100% {
+    transform: scale(0.92);
+  }
+  50% {
+    transform: scale(1.14);
+  }
+}
+@keyframes ringBreathe {
+  0%,
+  100% {
+    opacity: 0.36;
+    transform: scale(0.98);
+  }
+  50% {
+    opacity: 0.88;
+    transform: scale(1.02);
+  }
+}
+@keyframes sweep {
+  to {
+    transform: rotate(1turn);
+  }
+}
+@keyframes nodeFloat {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-8px);
+  }
+}
+@keyframes coreBeat {
+  0%,
+  100% {
+    transform: scale(0.86);
+  }
+  50% {
+    transform: scale(1.18);
+  }
+}
+@keyframes pulseBar {
+  0%,
+  100% {
+    opacity: 0.42;
+    transform: scaleY(0.56);
+  }
+  50% {
+    opacity: 1;
+    transform: scaleY(1);
+  }
+}
+@keyframes laneFill {
+  0%,
+  100% {
+    filter: saturate(0.86);
+    transform: scaleX(0.92);
+  }
+  50% {
+    filter: saturate(1.35);
+    transform: scaleX(1);
+  }
+}
+@keyframes budgetGlow {
+  0%,
+  100% {
+    opacity: 0.58;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+@keyframes matrixFlash {
+  0%,
+  100% {
+    transform: scale(0.82);
+    opacity: 0.16;
+  }
+  50% {
+    transform: scale(1);
+    opacity: 0.34;
+  }
+}
+@keyframes rowScan {
+  0% {
+    left: -35%;
+    opacity: 0;
+  }
+  25% {
+    opacity: 1;
+  }
+  58%,
+  100% {
+    left: 112%;
+    opacity: 0;
+  }
+}
+@keyframes proofSpin {
+  0%,
+  100% {
+    transform: rotate(0deg) scale(1);
+  }
+  50% {
+    transform: rotate(90deg) scale(0.84);
+  }
+}
+@keyframes proofFill {
+  0%,
+  100% {
+    transform: scaleX(0.36);
+    transform-client: left;
+  }
+  50% {
+    transform: scaleX(1);
+    transform-client: left;
+  }
+}
+@keyframes waveOrbit {
+  to {
+    transform: rotate(1turn);
+  }
+}
+@keyframes waveFill {
+  0%,
+  100% {
+    opacity: 0.55;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+@keyframes waveTravel {
+  0%,
+  100% {
+    transform: translateX(-10%) scaleX(0.8);
+  }
+  50% {
+    transform: translateX(12%) scaleX(1.05);
+  }
+}
+@keyframes stackScan {
+  0% {
+    transform: translateX(-100%);
+  }
+  46% {
+    transform: translateX(100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+@media (max-width: 900px) {
+  .Regulator {
+    width: min(100% - 20px, 720px);
+    padding-top: 16px;
+  }
+  .hero {
+    grid-template-columns: 1fr;
+    min-height: 260px;
+    padding: 26px;
+  }
+  .state-card {
+    width: min(100%, 260px);
+  }
+  .controls,
+  .grid {
+    grid-template-columns: 1fr;
+  }
+  .radar-panel {
+    grid-row: auto;
+  }
+  .lane {
+    grid-template-columns: 1fr;
+    gap: 7px;
+  }
+  .lane b {
+    text-align: left;
+  }
+  .matrix {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+  .proof-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .waves {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .regulator-row {
+    grid-template-columns: 54px minmax(0, 1fr);
+  }
+  .regulator-row b {
+    grid-column: 2;
+    text-align: left;
+  }
+}
+@media (max-width: 560px) {
+  .Regulator {
+    width: min(100% - 14px, 440px);
+  }
+  .hero {
+    padding: 22px;
+  }
+  h1 {
+    font-size: clamp(2.05rem, 18vw, 3.75rem);
+  }
+  .controls label,
+  .metrics {
+    grid-template-columns: 1fr;
+  }
+  .panel-title {
+    align-items: start;
+  }
+  .timeline li {
+    grid-template-columns: 1fr;
+  }
+  .timeline li::after {
+    display: none;
+  }
+  .matrix {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .proof-grid {
+    grid-template-columns: 1fr;
+  }
+  .waves {
+    grid-template-columns: 1fr;
+  }
+  .stack-item {
+    grid-template-columns: 42px minmax(0, 1fr);
+  }
+  .stack-item b {
+    grid-column: 2;
+  }
+}


### PR DESCRIPTION
## Summary
- add a pure HTML/CSS token bucket regulator animation example
- visualize refill cadence, burst budget, throttle lanes, and request admission states
- keep the contribution scoped to one examples submission folder

## Validation
- npx prettier --check submissions/examples/token-bucket-regulator-kp/README.md submissions/examples/token-bucket-regulator-kp/demo.html submissions/examples/token-bucket-regulator-kp/style.css
- npx stylelint submissions/examples/token-bucket-regulator-kp/style.css --allow-empty-input
- git diff --check