### PR TITLE
docs: add interactive cards documentation modal with live 3D previews and code copy

### DIFF
--- a/docs/demo.html
+++ b/docs/demo.html
@@ -432,11 +432,11 @@
         </p>
 
         <!-- Hover Cards -->
-        <div class="demo-chip">// ease-card + ease-card-hover</div>
+        <div class="demo-chip">// ease-card + ease-card-hover (Click to Open Interactive Docs)</div>
         <div class="ease-grid ease-grid-auto ease-gap-6" style="margin-bottom: var(--ease-space-10);">
 
-          <article class="ease-card ease-card-shadow ease-card-hover ease-slide-up ease-delay-100" style="padding: 10px;">
-            <div class="ease-card-header" >
+          <article class="ease-card ease-card-shadow ease-card-hover ease-card-interactive-trigger ease-slide-up ease-delay-100" style="padding: 10px;" onclick="openCardDocModal('flip-card', event)">
+            <div class="ease-card-header">
               <span class="ease-badge ease-badge-primary">New</span>
             </div>
             <h3 class="ease-card-title">Animation First</h3>
@@ -446,11 +446,11 @@
                 difference.</p>
             </div>
             <div class="ease-card-footer">
-              <button class="ease-btn ease-btn-primary ease-btn-sm">Explore</button>
+              <button class="ease-btn ease-btn-primary ease-btn-sm" onclick="openCardDocModal('flip-card', event)">Explore 3D Flip ↗</button>
             </div>
           </article>
 
-          <article class="ease-card ease-card-shadow ease-card-hover ease-slide-up ease-delay-200" style="padding: 10px;">
+          <article class="ease-card ease-card-shadow ease-card-hover ease-card-interactive-trigger ease-slide-up ease-delay-200" style="padding: 10px;" onclick="openCardDocModal('tracker-card', event)">
             <div class="ease-card-header">
               <span class="ease-badge ease-badge-success">Stable</span>
             </div>
@@ -461,11 +461,11 @@
                 obvious.</p>
             </div>
             <div class="ease-card-footer">
-              <button class="ease-btn ease-btn-success ease-btn-sm">Learn More</button>
+              <button class="ease-btn ease-btn-success ease-btn-sm" onclick="openCardDocModal('tracker-card', event)">Learn Tracker ↗</button>
             </div>
           </article>
 
-          <article class="ease-card ease-card-shadow ease-card-hover ease-slide-up ease-delay-300" style="padding: 10px;">
+          <article class="ease-card ease-card-shadow ease-card-hover ease-card-interactive-trigger ease-slide-up ease-delay-300" style="padding: 10px;" onclick="openCardDocModal('glow-card', event)">
             <div class="ease-card-header">
               <span class="ease-badge ease-badge-danger">MVP</span>
             </div>
@@ -475,7 +475,7 @@
               <p>Link one stylesheet. No build steps, no dependencies, no configuration. Just write HTML.</p>
             </div>
             <div class="ease-card-footer">
-              <button class="ease-btn ease-btn-danger ease-btn-sm">Get Started</button>
+              <button class="ease-btn ease-btn-danger ease-btn-sm" onclick="openCardDocModal('glow-card', event)">Get Started ↗</button>
             </div>
           </article>
         </div>
@@ -835,6 +835,481 @@
       } else {
         html.setAttribute("data-theme", targetTheme);
         localStorage.setItem("em-theme", targetTheme);
+      }
+    });
+  </script>
+
+  <!-- ══════════════════════════════════════════════════════════ -->
+  <!-- INTERACTIVE CARDS DOCUMENTATION MODAL                    -->
+  <!-- ══════════════════════════════════════════════════════════ -->
+  <div id="card-doc-modal" class="card-doc-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="card-modal-heading" onclick="handleCardDocModalOverlayClick(event)">
+    <div class="card-doc-modal-dialog">
+      <!-- Modal Header -->
+      <div class="card-doc-modal-header">
+        <div class="card-doc-modal-header-info">
+          <span class="demo-badge">INTERACTIVE COMPONENT DOCS</span>
+          <h2 id="card-modal-heading" class="card-doc-modal-title">Interactive Card Gallery & Code</h2>
+          <p class="card-doc-modal-desc">Hover over any card below to experience the interactive 3D motion effect, and switch between tabs to copy the HTML or CSS code.</p>
+        </div>
+        <button class="card-doc-modal-close" onclick="closeCardDocModal()" aria-label="Close modal">&times;</button>
+      </div>
+
+      <!-- Filter Tabs -->
+      <div class="card-doc-filter-bar">
+        <button class="card-filter-btn active" onclick="filterCardDocModal('all', this)">All Cards (3)</button>
+        <button class="card-filter-btn" onclick="filterCardDocModal('flip-card', this)">3D Flip Card</button>
+        <button class="card-filter-btn" onclick="filterCardDocModal('tracker-card', this)">Mouse Tracker Card</button>
+        <button class="card-filter-btn" onclick="filterCardDocModal('glow-card', this)">Neon Aurora Glow</button>
+      </div>
+
+      <!-- Modal Body (Cards Showcase) -->
+      <div class="card-doc-modal-body">
+
+        <!-- 1. 3D Flip Card -->
+        <article id="doc-card-flip" class="card-showcase-item" data-category="flip-card">
+          <div class="card-showcase-header">
+            <h3 class="card-showcase-title">
+              <span>🔄 3D Flip Card</span>
+            </h3>
+            <div class="card-tags">
+              <span class="card-tag">Pure CSS</span>
+              <span class="card-tag">180° Flip</span>
+              <span class="card-tag">GPU-Accelerated</span>
+              <span class="card-tag">Zero JS</span>
+            </div>
+          </div>
+
+          <!-- Live Interactive Hover Preview -->
+          <div class="card-preview-stage">
+            <div class="doc-flip-card">
+              <div class="doc-flip-card-inner">
+                <div class="doc-flip-card-front">
+                  <p class="doc-card-title">FLIP CARD</p>
+                  <p>Hover Me ✨</p>
+                </div>
+                <div class="doc-flip-card-back">
+                  <p class="doc-card-title">BACK SIDE</p>
+                  <p>180° 3D Rotation<br>Leave Me 🚀</p>
+                </div>
+              </div>
+            </div>
+            <div class="stage-instruction">
+              <span>👆 Hover over the card to trigger smooth 3D flip</span>
+            </div>
+          </div>
+
+          <!-- Code Box with HTML / CSS Tabs and One-Click Copy -->
+          <div class="card-code-container">
+            <div class="card-code-header">
+              <div class="card-code-tabs">
+                <button class="code-tab-btn active" onclick="switchCodeTab('flip', 'html', this)">HTML</button>
+                <button class="code-tab-btn" onclick="switchCodeTab('flip', 'css', this)">CSS</button>
+              </div>
+              <button class="code-copy-btn" onclick="copyCardSnippet('flip')">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
+                <span>Copy Code</span>
+              </button>
+            </div>
+            <pre id="code-flip-html" class="card-code-block"><code>&lt;div class="flip-card"&gt;
+  &lt;div class="flip-card-inner"&gt;
+    &lt;div class="flip-card-front"&gt;
+      &lt;p class="title"&gt;FLIP CARD&lt;/p&gt;
+      &lt;p&gt;Hover Me&lt;/p&gt;
+    &lt;/div&gt;
+    &lt;div class="flip-card-back"&gt;
+      &lt;p class="title"&gt;BACK&lt;/p&gt;
+      &lt;p&gt;Leave Me&lt;/p&gt;
+    &lt;/div&gt;
+  &lt;/div&gt;
+&lt;/div&gt;</code></pre>
+            <pre id="code-flip-css" class="card-code-block" style="display: none;"><code>.flip-card {
+  background-color: transparent;
+  width: 190px;
+  height: 254px;
+  perspective: 1000px;
+  font-family: inherit;
+}
+
+.flip-card-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  text-align: center;
+  transition: transform 0.8s;
+  transform-style: preserve-3d;
+}
+
+.flip-card:hover .flip-card-inner {
+  transform: rotateY(180deg);
+}
+
+.flip-card-front,
+.flip-card-back {
+  box-shadow: 0 8px 14px 0 rgba(0, 0, 0, 0.2);
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
+  border-radius: 1rem;
+}
+
+.flip-card-front {
+  background: linear-gradient(120deg, bisque 60%, rgb(255, 231, 222) 88%, coral 100%);
+  color: coral;
+}
+
+.flip-card-back {
+  background: linear-gradient(120deg, coral 60%, bisque 100%);
+  color: white;
+  transform: rotateY(180deg);
+}</code></pre>
+          </div>
+        </article>
+
+        <!-- 2. Mouse Hover 3D Tracker Card -->
+        <article id="doc-card-tracker" class="card-showcase-item" data-category="tracker-card">
+          <div class="card-showcase-header">
+            <h3 class="card-showcase-title">
+              <span>🎯 Mouse Hover 3D Tracker Card</span>
+            </h3>
+            <div class="card-tags">
+              <span class="card-tag">Pure CSS</span>
+              <span class="card-tag">5x5 Grid Canvas</span>
+              <span class="card-tag">Parallax Tilt</span>
+              <span class="card-tag">Zero JS</span>
+            </div>
+          </div>
+
+          <!-- Live Interactive Hover Preview -->
+          <div class="card-preview-stage">
+            <div class="doc-tracker-container">
+              <div class="doc-tracker-canvas">
+                <div class="doc-tracker-tile doc-tr-1"></div>
+                <div class="doc-tracker-tile doc-tr-2"></div>
+                <div class="doc-tracker-tile doc-tr-3"></div>
+                <div class="doc-tracker-tile doc-tr-4"></div>
+                <div class="doc-tracker-tile doc-tr-5"></div>
+                <div class="doc-tracker-tile doc-tr-6"></div>
+                <div class="doc-tracker-tile doc-tr-7"></div>
+                <div class="doc-tracker-tile doc-tr-8"></div>
+                <div class="doc-tracker-tile doc-tr-9"></div>
+                <div class="doc-tracker-tile doc-tr-10"></div>
+                <div class="doc-tracker-tile doc-tr-11"></div>
+                <div class="doc-tracker-tile doc-tr-12"></div>
+                <div class="doc-tracker-tile doc-tr-13"></div>
+                <div class="doc-tracker-tile doc-tr-14"></div>
+                <div class="doc-tracker-tile doc-tr-15"></div>
+                <div class="doc-tracker-tile doc-tr-16"></div>
+                <div class="doc-tracker-tile doc-tr-17"></div>
+                <div class="doc-tracker-tile doc-tr-18"></div>
+                <div class="doc-tracker-tile doc-tr-19"></div>
+                <div class="doc-tracker-tile doc-tr-20"></div>
+                <div class="doc-tracker-tile doc-tr-21"></div>
+                <div class="doc-tracker-tile doc-tr-22"></div>
+                <div class="doc-tracker-tile doc-tr-23"></div>
+                <div class="doc-tracker-tile doc-tr-24"></div>
+                <div class="doc-tracker-tile doc-tr-25"></div>
+                <div class="doc-tracker-card">
+                  <p class="tracker-prompt">HOVER OVER :D</p>
+                  <div class="tracker-title">look mom,<br>no JS</div>
+                  <div class="tracker-subtitle">mouse hover tracker</div>
+                </div>
+              </div>
+            </div>
+            <div class="stage-instruction">
+              <span>👆 Move cursor across different areas to tilt in real time</span>
+            </div>
+          </div>
+
+          <!-- Code Box -->
+          <div class="card-code-container">
+            <div class="card-code-header">
+              <div class="card-code-tabs">
+                <button class="code-tab-btn active" onclick="switchCodeTab('tracker', 'html', this)">HTML</button>
+                <button class="code-tab-btn" onclick="switchCodeTab('tracker', 'css', this)">CSS</button>
+              </div>
+              <button class="code-copy-btn" onclick="copyCardSnippet('tracker')">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
+                <span>Copy Code</span>
+              </button>
+            </div>
+            <pre id="code-tracker-html" class="card-code-block"><code>&lt;div class="container noselect"&gt;
+  &lt;div class="canvas"&gt;
+    &lt;div class="tracker tr-1"&gt;&lt;/div&gt;
+    &lt;div class="tracker tr-2"&gt;&lt;/div&gt;
+    &lt;!-- tr-3 to tr-24 --&gt;
+    &lt;div class="tracker tr-25"&gt;&lt;/div&gt;
+    &lt;div id="card"&gt;
+      &lt;p id="prompt"&gt;HOVER OVER :D&lt;/p&gt;
+      &lt;div class="title"&gt;look mom,&lt;br&gt;no JS&lt;/div&gt;
+      &lt;div class="subtitle"&gt;mouse hover tracker&lt;/div&gt;
+    &lt;/div&gt;
+  &lt;/div&gt;
+&lt;/div&gt;</code></pre>
+            <pre id="code-tracker-css" class="card-code-block" style="display: none;"><code>.container {
+  position: relative;
+  width: 190px;
+  height: 254px;
+  transition: 200ms;
+}
+
+.canvas {
+  perspective: 800px;
+  position: absolute;
+  inset: 0;
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  grid-template-rows: repeat(5, 1fr);
+}
+
+.tracker {
+  position: absolute;
+  z-index: 20;
+  width: 100%;
+  height: 100%;
+}
+
+#card {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 20px;
+  transition: 700ms;
+  background: linear-gradient(43deg, #4158d0 0%, #c850c0 46%, #ffcc70 100%);
+}
+
+.tr-1:hover ~ #card { transform: rotateX(20deg) rotateY(-10deg); }
+.tr-5:hover ~ #card { transform: rotateX(20deg) rotateY(10deg); }
+.tr-13:hover ~ #card { transform: rotateX(0deg) rotateY(0deg); }
+.tr-21:hover ~ #card { transform: rotateX(-20deg) rotateY(-10deg); }
+.tr-25:hover ~ #card { transform: rotateX(-20deg) rotateY(10deg); }</code></pre>
+          </div>
+        </article>
+
+        <!-- 3. Neon Aurora Glass Depth Card -->
+        <article id="doc-card-glow" class="card-showcase-item" data-category="glow-card">
+          <div class="card-showcase-header">
+            <h3 class="card-showcase-title">
+              <span>✨ Neon Aurora Glass Depth Card</span>
+            </h3>
+            <div class="card-tags">
+              <span class="card-tag">Glassmorphism</span>
+              <span class="card-tag">Neon Aurora</span>
+              <span class="card-tag">Border Glow</span>
+              <span class="card-tag">Depth Lift</span>
+            </div>
+          </div>
+
+          <!-- Live Interactive Hover Preview -->
+          <div class="card-preview-stage">
+            <div class="doc-glow-card">
+              <span class="doc-glow-card-badge">PRO EFFECT</span>
+              <div class="doc-glow-card-content">
+                <h4>Aurora Elevation</h4>
+                <p>Hover to activate the multi-color radiant neon border and floating depth.</p>
+              </div>
+            </div>
+            <div class="stage-instruction">
+              <span>👆 Hover to reveal glowing aurora border and elevation</span>
+            </div>
+          </div>
+
+          <!-- Code Box -->
+          <div class="card-code-container">
+            <div class="card-code-header">
+              <div class="card-code-tabs">
+                <button class="code-tab-btn active" onclick="switchCodeTab('glow', 'html', this)">HTML</button>
+                <button class="code-tab-btn" onclick="switchCodeTab('glow', 'css', this)">CSS</button>
+              </div>
+              <button class="code-copy-btn" onclick="copyCardSnippet('glow')">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
+                <span>Copy Code</span>
+              </button>
+            </div>
+            <pre id="code-glow-html" class="card-code-block"><code>&lt;div class="glow-card"&gt;
+  &lt;span class="glow-badge"&gt;PRO EFFECT&lt;/span&gt;
+  &lt;div class="glow-content"&gt;
+    &lt;h4&gt;Aurora Elevation&lt;/h4&gt;
+    &lt;p&gt;Hover to activate multi-color radiant neon glow.&lt;/p&gt;
+  &lt;/div&gt;
+&lt;/div&gt;</code></pre>
+            <pre id="code-glow-css" class="card-code-block" style="display: none;"><code>.glow-card {
+  position: relative;
+  width: 220px;
+  height: 250px;
+  background: rgba(255, 255, 255, 0.05);
+  backdrop-filter: blur(12px);
+  border-radius: 18px;
+  padding: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  transition: transform 0.4s ease, box-shadow 0.4s ease;
+}
+
+.glow-card::before {
+  content: '';
+  position: absolute;
+  inset: -2px;
+  border-radius: 20px;
+  background: linear-gradient(135deg, #6c63ff, #ec4899, #38bdf8, #a855f7);
+  z-index: -1;
+  opacity: 0;
+  filter: blur(10px);
+  transition: opacity 0.4s ease, filter 0.4s ease;
+}
+
+.glow-card:hover {
+  transform: translateY(-8px) scale(1.03);
+  box-shadow: 0 20px 40px rgba(108, 99, 255, 0.3);
+}
+
+.glow-card:hover::before {
+  opacity: 0.8;
+  filter: blur(14px);
+}</code></pre>
+          </div>
+        </article>
+
+      </div>
+    </div>
+  </div>
+
+  <script>
+    // ── Interactive Cards Documentation Modal Logic ──────────
+    function openCardDocModal(cardTarget, event) {
+      if (event) {
+        event.stopPropagation();
+      }
+      const modal = document.getElementById('card-doc-modal');
+      if (!modal) return;
+      
+      modal.classList.add('active');
+      document.body.style.overflow = 'hidden';
+
+      // Update filter tabs if specific card target is passed
+      if (cardTarget && cardTarget !== 'all') {
+        const filterBtn = document.querySelector(`.card-filter-btn[onclick*="'${cardTarget}'"]`);
+        if (filterBtn) {
+          filterCardDocModal(cardTarget, filterBtn);
+        }
+        const targetElement = document.getElementById(`doc-card-${cardTarget === 'flip-card' ? 'flip' : cardTarget === 'tracker-card' ? 'tracker' : 'glow'}`);
+        if (targetElement) {
+          setTimeout(() => {
+            targetElement.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          }, 150);
+        }
+      } else {
+        const allBtn = document.querySelector('.card-filter-btn');
+        if (allBtn) filterCardDocModal('all', allBtn);
+      }
+    }
+
+    function closeCardDocModal() {
+      const modal = document.getElementById('card-doc-modal');
+      if (!modal) return;
+      modal.classList.remove('active');
+      document.body.style.overflow = '';
+    }
+
+    function handleCardDocModalOverlayClick(event) {
+      if (event.target.id === 'card-doc-modal') {
+        closeCardDocModal();
+      }
+    }
+
+    function filterCardDocModal(category, btn) {
+      document.querySelectorAll('.card-filter-btn').forEach(b => b.classList.remove('active'));
+      if (btn) btn.classList.add('active');
+
+      const items = document.querySelectorAll('.card-showcase-item');
+      items.forEach(item => {
+        if (category === 'all' || item.getAttribute('data-category') === category) {
+          item.style.display = 'flex';
+        } else {
+          item.style.display = 'none';
+        }
+      });
+    }
+
+    function switchCodeTab(cardKey, tabType, btn) {
+      const parentTabs = btn.parentElement;
+      parentTabs.querySelectorAll('.code-tab-btn').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+
+      const htmlBlock = document.getElementById(`code-${cardKey}-html`);
+      const cssBlock = document.getElementById(`code-${cardKey}-css`);
+
+      if (tabType === 'html') {
+        if (htmlBlock) htmlBlock.style.display = 'block';
+        if (cssBlock) cssBlock.style.display = 'none';
+      } else {
+        if (htmlBlock) htmlBlock.style.display = 'none';
+        if (cssBlock) cssBlock.style.display = 'block';
+      }
+    }
+
+    function copyCardSnippet(cardKey) {
+      const htmlBlock = document.getElementById(`code-${cardKey}-html`);
+      const cssBlock = document.getElementById(`code-${cardKey}-css`);
+      const isHtmlActive = htmlBlock && htmlBlock.style.display !== 'none';
+      const activeBlock = isHtmlActive ? htmlBlock : cssBlock;
+
+      if (!activeBlock) return;
+      const textToCopy = activeBlock.innerText || activeBlock.textContent;
+
+      const showFeedback = () => {
+        const copyBtn = activeBlock.closest('.card-code-container').querySelector('.code-copy-btn');
+        if (copyBtn) {
+          const originalHTML = copyBtn.innerHTML;
+          copyBtn.classList.add('copied');
+          copyBtn.innerHTML = `
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
+            <span>Copied!</span>
+          `;
+          setTimeout(() => {
+            copyBtn.classList.remove('copied');
+            copyBtn.innerHTML = originalHTML;
+          }, 2000);
+        }
+      };
+
+      if (navigator.clipboard && window.isSecureContext) {
+        navigator.clipboard.writeText(textToCopy)
+          .then(showFeedback)
+          .catch(() => fallbackCopy(textToCopy, showFeedback));
+      } else {
+        fallbackCopy(textToCopy, showFeedback);
+      }
+    }
+
+    function fallbackCopy(text, callback) {
+      const textArea = document.createElement('textarea');
+      textArea.value = text;
+      textArea.style.position = 'fixed';
+      textArea.style.left = '-9999px';
+      textArea.style.top = '-9999px';
+      document.body.appendChild(textArea);
+      textArea.focus();
+      textArea.select();
+      try {
+        document.execCommand('copy');
+        if (callback) callback();
+      } catch (err) {
+        console.error('Fallback copy failed', err);
+      }
+      document.body.removeChild(textArea);
+    }
+
+    // Keyboard navigation (ESC to close)
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') {
+        closeCardDocModal();
       }
     });
   </script>

--- a/docs/docs.css
+++ b/docs/docs.css
@@ -1298,3 +1298,732 @@ body > .docs-shell {
     justify-content: center;
   }
 }
+
+/* ══════════════════════════════════════════════════════════════
+   INTERACTIVE CARDS DOCUMENTATION MODAL & COMPONENT STYLES
+   ══════════════════════════════════════════════════════════════ */
+
+/* Clickable card hint */
+.ease-card-interactive-trigger {
+  cursor: pointer;
+  transition: transform var(--ease-speed-fast) var(--ease-ease), box-shadow var(--ease-speed-fast) var(--ease-ease), border-color var(--ease-speed-fast) var(--ease-ease);
+}
+.ease-card-interactive-trigger:hover {
+  border-color: rgba(108, 99, 255, 0.4);
+}
+.ease-card-interactive-trigger:active {
+  transform: translateY(-2px) scale(0.99);
+}
+
+/* Modal Overlay */
+.card-doc-modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 99999;
+  background: rgba(8, 7, 14, 0.85);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.3s cubic-bezier(0.16, 1, 0.3, 1), visibility 0.3s ease;
+}
+
+.card-doc-modal-overlay.active {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+/* Modal Dialog */
+.card-doc-modal-dialog {
+  background: var(--page-bg, #0f0e17);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 20px;
+  width: 100%;
+  max-width: 1040px;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 30px 80px -15px rgba(0, 0, 0, 0.8), 0 0 40px rgba(108, 99, 255, 0.18);
+  transform: translateY(24px) scale(0.96);
+  transition: transform 0.35s cubic-bezier(0.16, 1, 0.3, 1);
+  overflow: hidden;
+}
+
+.card-doc-modal-overlay.active .card-doc-modal-dialog {
+  transform: translateY(0) scale(1);
+}
+
+/* Modal Header */
+.card-doc-modal-header {
+  padding: 1.5rem 1.75rem 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.card-doc-modal-header-info {
+  flex: 1;
+}
+
+.card-doc-modal-title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin: 0.35rem 0 0.25rem;
+  background: linear-gradient(135deg, #ffffff 30%, #a78bfa 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.card-doc-modal-desc {
+  font-size: 0.9rem;
+  color: var(--page-text-muted, rgba(255, 255, 255, 0.65));
+  margin: 0;
+}
+
+.card-doc-modal-close {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: var(--page-text, #fff);
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  font-size: 1.4rem;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.card-doc-modal-close:hover {
+  background: rgba(255, 75, 75, 0.2);
+  border-color: rgba(255, 75, 75, 0.4);
+  color: #ff6b6b;
+  transform: rotate(90deg);
+}
+
+/* Filter Navigation Bar */
+.card-doc-filter-bar {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.75rem 1.75rem;
+  background: rgba(0, 0, 0, 0.2);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  overflow-x: auto;
+}
+
+.card-filter-btn {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: var(--page-text-muted, rgba(255, 255, 255, 0.7));
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  white-space: nowrap;
+}
+
+.card-filter-btn:hover {
+  color: #fff;
+  background: rgba(108, 99, 255, 0.15);
+  border-color: rgba(108, 99, 255, 0.3);
+}
+
+.card-filter-btn.active {
+  background: #6c63ff;
+  color: #fff;
+  border-color: #6c63ff;
+  box-shadow: 0 0 12px rgba(108, 99, 255, 0.4);
+}
+
+/* Modal Body */
+.card-doc-modal-body {
+  padding: 1.5rem 1.75rem;
+  overflow-y: auto;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+/* Card Showcase Item Box */
+.card-showcase-item {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 1.5rem;
+  transition: border-color 0.25s ease, box-shadow 0.25s ease;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.card-showcase-item:hover {
+  border-color: rgba(108, 99, 255, 0.25);
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.3);
+}
+
+.card-showcase-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.card-showcase-title {
+  font-size: 1.2rem;
+  font-weight: 600;
+  margin: 0;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.card-tags {
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.card-tag {
+  font-size: 0.72rem;
+  padding: 3px 8px;
+  border-radius: 6px;
+  font-weight: 600;
+  background: rgba(108, 99, 255, 0.15);
+  color: #a78bfa;
+  border: 1px solid rgba(108, 99, 255, 0.25);
+}
+
+/* Interactive Preview Stage */
+.card-preview-stage {
+  background: radial-gradient(circle at 50% 50%, rgba(30, 27, 45, 0.9), rgba(15, 14, 23, 0.95));
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 14px;
+  min-height: 310px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  overflow: hidden;
+  padding: 1.5rem;
+}
+
+.card-preview-stage::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image: radial-gradient(rgba(255, 255, 255, 0.08) 1px, transparent 1px);
+  background-size: 20px 20px;
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.stage-instruction {
+  margin-top: 1rem;
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.45);
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  z-index: 1;
+}
+
+/* ── 1. 3D Flip Card Component Styles ── */
+.doc-flip-card {
+  background-color: transparent;
+  width: 200px;
+  height: 250px;
+  perspective: 1000px;
+  font-family: inherit;
+  cursor: pointer;
+  z-index: 2;
+}
+
+.doc-flip-card-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  text-align: center;
+  transition: transform 0.8s cubic-bezier(0.4, 0.2, 0.2, 1);
+  transform-style: preserve-3d;
+}
+
+.doc-flip-card:hover .doc-flip-card-inner {
+  transform: rotateY(180deg);
+}
+
+.doc-flip-card-front,
+.doc-flip-card-back {
+  box-shadow: 0 10px 24px 0 rgba(0, 0, 0, 0.35);
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
+  border-radius: 1rem;
+  padding: 1.25rem;
+  box-sizing: border-box;
+}
+
+.doc-flip-card-front {
+  background: linear-gradient(135deg, bisque 30%, #ffe7de 70%, #ff7f50 100%);
+  color: #d95328;
+  border: 1px solid #ff7f50;
+}
+
+.doc-flip-card-front .doc-card-title {
+  font-size: 1.35rem;
+  font-weight: 800;
+  margin: 0 0 0.5rem;
+  letter-spacing: 0.05em;
+}
+
+.doc-flip-card-front p {
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin: 0;
+  opacity: 0.9;
+}
+
+.doc-flip-card-back {
+  background: linear-gradient(135deg, #ff7f50 20%, #d95328 80%, bisque 100%);
+  color: white;
+  transform: rotateY(180deg);
+  border: 1px solid bisque;
+}
+
+.doc-flip-card-back .doc-card-title {
+  font-size: 1.35rem;
+  font-weight: 800;
+  margin: 0 0 0.5rem;
+}
+
+.doc-flip-card-back p {
+  font-size: 0.85rem;
+  margin: 0;
+  line-height: 1.4;
+  opacity: 0.95;
+}
+
+/* ── 2. 3D Mouse Hover Tracker Card Styles ── */
+.doc-tracker-container {
+  position: relative;
+  width: 200px;
+  height: 250px;
+  transition: 200ms;
+  user-select: none;
+  -webkit-user-select: none;
+  z-index: 2;
+}
+
+.doc-tracker-container:active {
+  width: 190px;
+  height: 240px;
+}
+
+.doc-tracker-canvas {
+  perspective: 800px;
+  inset: 0;
+  z-index: 10;
+  position: absolute;
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  grid-template-rows: repeat(5, 1fr);
+  gap: 0;
+}
+
+.doc-tracker-tile {
+  position: absolute;
+  z-index: 20;
+  width: 100%;
+  height: 100%;
+}
+
+.doc-tracker-tile:hover {
+  cursor: pointer;
+}
+
+.doc-tracker-card {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  border-radius: 18px;
+  transition: transform 700ms cubic-bezier(0.16, 1, 0.3, 1), box-shadow 700ms ease;
+  background: linear-gradient(43deg, rgb(65, 88, 208) 0%, rgb(200, 80, 192) 46%, rgb(255, 204, 112) 100%);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.4);
+  padding: 1rem;
+  box-sizing: border-box;
+  text-align: center;
+}
+
+.doc-tracker-card .tracker-title {
+  opacity: 0;
+  transition: opacity 300ms ease-in-out;
+  position: absolute;
+  font-size: 1.25rem;
+  font-weight: 800;
+  color: white;
+  text-shadow: 0 2px 8px rgba(0,0,0,0.3);
+}
+
+.doc-tracker-card .tracker-subtitle {
+  position: absolute;
+  bottom: 12px;
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.doc-tracker-card .tracker-prompt {
+  position: absolute;
+  top: 14px;
+  left: 14px;
+  font-size: 0.85rem;
+  font-weight: 800;
+  color: white;
+  margin: 0;
+}
+
+.doc-tracker-tile:hover ~ .doc-tracker-card .tracker-title {
+  opacity: 1;
+}
+
+.doc-tracker-tile:hover ~ .doc-tracker-card .tracker-prompt {
+  opacity: 0.3;
+}
+
+/* 5x5 Grid Positions */
+.doc-tr-1 { grid-area: 1 / 1; }
+.doc-tr-2 { grid-area: 1 / 2; }
+.doc-tr-3 { grid-area: 1 / 3; }
+.doc-tr-4 { grid-area: 1 / 4; }
+.doc-tr-5 { grid-area: 1 / 5; }
+.doc-tr-6 { grid-area: 2 / 1; }
+.doc-tr-7 { grid-area: 2 / 2; }
+.doc-tr-8 { grid-area: 2 / 3; }
+.doc-tr-9 { grid-area: 2 / 4; }
+.doc-tr-10 { grid-area: 2 / 5; }
+.doc-tr-11 { grid-area: 3 / 1; }
+.doc-tr-12 { grid-area: 3 / 2; }
+.doc-tr-13 { grid-area: 3 / 3; }
+.doc-tr-14 { grid-area: 3 / 4; }
+.doc-tr-15 { grid-area: 3 / 5; }
+.doc-tr-16 { grid-area: 4 / 1; }
+.doc-tr-17 { grid-area: 4 / 2; }
+.doc-tr-18 { grid-area: 4 / 3; }
+.doc-tr-19 { grid-area: 4 / 4; }
+.doc-tr-20 { grid-area: 4 / 5; }
+.doc-tr-21 { grid-area: 5 / 1; }
+.doc-tr-22 { grid-area: 5 / 2; }
+.doc-tr-23 { grid-area: 5 / 3; }
+.doc-tr-24 { grid-area: 5 / 4; }
+.doc-tr-25 { grid-area: 5 / 5; }
+
+/* Dynamic 3D Matrix Rotations */
+.doc-tr-1:hover ~ .doc-tracker-card { transform: rotateX(20deg) rotateY(-10deg) rotateZ(0deg); }
+.doc-tr-2:hover ~ .doc-tracker-card { transform: rotateX(20deg) rotateY(-5deg) rotateZ(0deg); }
+.doc-tr-3:hover ~ .doc-tracker-card { transform: rotateX(20deg) rotateY(0deg) rotateZ(0deg); }
+.doc-tr-4:hover ~ .doc-tracker-card { transform: rotateX(20deg) rotateY(5deg) rotateZ(0deg); }
+.doc-tr-5:hover ~ .doc-tracker-card { transform: rotateX(20deg) rotateY(10deg) rotateZ(0deg); }
+.doc-tr-6:hover ~ .doc-tracker-card { transform: rotateX(10deg) rotateY(-10deg) rotateZ(0deg); }
+.doc-tr-7:hover ~ .doc-tracker-card { transform: rotateX(10deg) rotateY(-5deg) rotateZ(0deg); }
+.doc-tr-8:hover ~ .doc-tracker-card { transform: rotateX(10deg) rotateY(0deg) rotateZ(0deg); }
+.doc-tr-9:hover ~ .doc-tracker-card { transform: rotateX(10deg) rotateY(5deg) rotateZ(0deg); }
+.doc-tr-10:hover ~ .doc-tracker-card { transform: rotateX(10deg) rotateY(10deg) rotateZ(0deg); }
+.doc-tr-11:hover ~ .doc-tracker-card { transform: rotateX(0deg) rotateY(-10deg) rotateZ(0deg); }
+.doc-tr-12:hover ~ .doc-tracker-card { transform: rotateX(0deg) rotateY(-5deg) rotateZ(0deg); }
+.doc-tr-13:hover ~ .doc-tracker-card { transform: rotateX(0deg) rotateY(0deg) rotateZ(0deg); }
+.doc-tr-14:hover ~ .doc-tracker-card { transform: rotateX(0deg) rotateY(5deg) rotateZ(0deg); }
+.doc-tr-15:hover ~ .doc-tracker-card { transform: rotateX(0deg) rotateY(10deg) rotateZ(0deg); }
+.doc-tr-16:hover ~ .doc-tracker-card { transform: rotateX(-10deg) rotateY(-10deg) rotateZ(0deg); }
+.doc-tr-17:hover ~ .doc-tracker-card { transform: rotateX(-10deg) rotateY(-5deg) rotateZ(0deg); }
+.doc-tr-18:hover ~ .doc-tracker-card { transform: rotateX(-10deg) rotateY(0deg) rotateZ(0deg); }
+.doc-tr-19:hover ~ .doc-tracker-card { transform: rotateX(-10deg) rotateY(5deg) rotateZ(0deg); }
+.doc-tr-20:hover ~ .doc-tracker-card { transform: rotateX(-10deg) rotateY(10deg) rotateZ(0deg); }
+.doc-tr-21:hover ~ .doc-tracker-card { transform: rotateX(-20deg) rotateY(-10deg) rotateZ(0deg); }
+.doc-tr-22:hover ~ .doc-tracker-card { transform: rotateX(-20deg) rotateY(-5deg) rotateZ(0deg); }
+.doc-tr-23:hover ~ .doc-tracker-card { transform: rotateX(-20deg) rotateY(0deg) rotateZ(0deg); }
+.doc-tr-24:hover ~ .doc-tracker-card { transform: rotateX(-20deg) rotateY(5deg) rotateZ(0deg); }
+.doc-tr-25:hover ~ .doc-tracker-card { transform: rotateX(-20deg) rotateY(10deg) rotateZ(0deg); }
+
+/* ── 3. Neon Aurora Glass Depth Card Styles ── */
+.doc-glow-card {
+  position: relative;
+  width: 220px;
+  height: 250px;
+  background: rgba(255, 255, 255, 0.05);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-radius: 18px;
+  padding: 1.5rem;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+  transition: transform 0.4s cubic-bezier(0.16, 1, 0.3, 1), box-shadow 0.4s ease, border-color 0.4s ease;
+  z-index: 2;
+  cursor: pointer;
+}
+
+.doc-glow-card::before {
+  content: '';
+  position: absolute;
+  inset: -2px;
+  border-radius: 20px;
+  background: linear-gradient(135deg, #6c63ff, #ec4899, #38bdf8, #a855f7);
+  z-index: -1;
+  opacity: 0;
+  transition: opacity 0.4s ease, filter 0.4s ease;
+  filter: blur(10px);
+}
+
+.doc-glow-card:hover {
+  transform: translateY(-8px) scale(1.03);
+  border-color: rgba(255, 255, 255, 0.3);
+  box-shadow: 0 20px 40px rgba(108, 99, 255, 0.3), 0 0 20px rgba(236, 72, 153, 0.2);
+}
+
+.doc-glow-card:hover::before {
+  opacity: 0.8;
+  filter: blur(14px);
+}
+
+.doc-glow-card-badge {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(108, 99, 255, 0.2);
+  color: #a78bfa;
+  border: 1px solid rgba(108, 99, 255, 0.3);
+  align-self: flex-start;
+}
+
+.doc-glow-card-content h4 {
+  font-size: 1.15rem;
+  margin: 0.5rem 0 0.25rem;
+  color: #fff;
+}
+
+.doc-glow-card-content p {
+  font-size: 0.82rem;
+  color: rgba(255, 255, 255, 0.7);
+  margin: 0;
+  line-height: 1.35;
+}
+
+/* ── Code Viewers & Tabs ── */
+.card-code-container {
+  background: #09080e;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.card-code-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.6rem 1rem;
+  background: rgba(255, 255, 255, 0.02);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.card-code-tabs {
+  display: flex;
+  gap: 0.35rem;
+}
+
+.code-tab-btn {
+  background: transparent;
+  border: none;
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 4px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.code-tab-btn:hover {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.code-tab-btn.active {
+  color: #a78bfa;
+  background: rgba(108, 99, 255, 0.15);
+}
+
+.code-copy-btn {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 0.78rem;
+  font-weight: 600;
+  padding: 5px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  transition: all 0.2s ease;
+}
+
+.code-copy-btn:hover {
+  background: rgba(108, 99, 255, 0.25);
+  border-color: rgba(108, 99, 255, 0.4);
+  color: #fff;
+}
+
+.code-copy-btn.copied {
+  background: rgba(34, 197, 94, 0.2);
+  border-color: rgba(34, 197, 94, 0.4);
+  color: #4ade80;
+}
+
+.card-code-block {
+  margin: 0;
+  padding: 1rem 1.25rem;
+  font-family: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
+  font-size: 0.82rem;
+  line-height: 1.5;
+  color: #e2e8f0;
+  max-height: 240px;
+  overflow-y: auto;
+  white-space: pre;
+}
+
+.card-code-block::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+.card-code-block::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.15);
+  border-radius: 4px;
+}
+
+@media (max-width: 640px) {
+  .card-doc-modal-dialog {
+    max-height: 95vh;
+  }
+  .card-doc-modal-header {
+    padding: 1rem;
+  }
+  .card-doc-modal-body {
+    padding: 1rem;
+  }
+  .card-showcase-item {
+    padding: 1rem;
+  }
+}
+
+/* Light Theme Enhancements for Modal */
+[data-theme="light"] .card-doc-modal-dialog {
+  background: #ffffff;
+  border-color: rgba(0, 0, 0, 0.1);
+  box-shadow: 0 30px 80px -15px rgba(0, 0, 0, 0.25), 0 0 30px rgba(108, 99, 255, 0.12);
+}
+
+[data-theme="light"] .card-doc-modal-header {
+  background: #f8fafc;
+  border-bottom-color: rgba(0, 0, 0, 0.08);
+}
+
+[data-theme="light"] .card-doc-modal-title {
+  background: linear-gradient(135deg, #0f172a 30%, #6c63ff 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+[data-theme="light"] .card-doc-modal-close {
+  background: rgba(0, 0, 0, 0.05);
+  border-color: rgba(0, 0, 0, 0.1);
+  color: #334155;
+}
+
+[data-theme="light"] .card-doc-filter-bar {
+  background: #f1f5f9;
+  border-bottom-color: rgba(0, 0, 0, 0.06);
+}
+
+[data-theme="light"] .card-filter-btn {
+  background: #ffffff;
+  border-color: rgba(0, 0, 0, 0.1);
+  color: #475569;
+}
+
+[data-theme="light"] .card-filter-btn.active {
+  background: #6c63ff;
+  color: #ffffff;
+  border-color: #6c63ff;
+}
+
+[data-theme="light"] .card-showcase-item {
+  background: #ffffff;
+  border-color: rgba(0, 0, 0, 0.08);
+}
+
+[data-theme="light"] .card-showcase-title {
+  color: #0f172a;
+}
+
+[data-theme="light"] .card-preview-stage {
+  background: radial-gradient(circle at 50% 50%, #f1f5f9, #e2e8f0);
+  border-color: rgba(0, 0, 0, 0.08);
+}
+
+[data-theme="light"] .card-preview-stage::before {
+  background-image: radial-gradient(rgba(0, 0, 0, 0.1) 1px, transparent 1px);
+}
+
+[data-theme="light"] .stage-instruction {
+  color: #64748b;
+}
+
+[data-theme="light"] .doc-glow-card {
+  background: rgba(255, 255, 255, 0.85);
+  border-color: rgba(0, 0, 0, 0.12);
+}
+
+[data-theme="light"] .doc-glow-card-content h4 {
+  color: #0f172a;
+}
+
+[data-theme="light"] .doc-glow-card-content p {
+  color: #475569;
+}
+
+


### PR DESCRIPTION
## Pull Request Description

Adds an interactive **Cards Documentation Modal** to the documentation showcase (`docs/demo.html` and `docs/docs.css`). Clicking the showcase cards or action buttons opens an interactive gallery modal featuring live 3D hover animations (3D Flip Card, Mouse Hover Tracker, Neon Aurora Glow) alongside tabbed HTML/CSS code viewers with instant one-click copy-to-clipboard functionality.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] Documentation and demo changes in `docs/` (`docs/demo.html` and `docs/docs.css`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes raw CSS for the proposed features in `docs.css`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

An interactive Cards Documentation Modal that allows developers to test live 3D card animations directly in the browser and instantly copy the ready-to-use HTML and CSS code for each variant.

**How does a developer use it?**

```html
<!-- Trigger interactive documentation modal for specific card variant -->
<article class="ease-card ease-card-hover ease-card-interactive-trigger" onclick="openCardDocModal('flip-card', event)">
  ...
  <button class="ease-btn ease-btn-primary ease-btn-sm" onclick="openCardDocModal('flip-card', event)">
    Explore 3D Flip ↗
  </button>
</article>
