### PR TITLE
feat: add pure CSS Image 360 Viewer component (#70103)

### DIFF
--- a/submissions/examples/css-image-360-viewer-pure/README.md
+++ b/submissions/examples/css-image-360-viewer-pure/README.md
@@ -1,0 +1,19 @@
+# CSS Image 360 Viewer
+
+An interactive 360-degree product rotation viewer built entirely without JavaScript. Users can drag their mouse horizontally across the viewer to rotate the product.
+
+## Features
+- Pure CSS and HTML implementation.
+- **Component Architecture (Documented in Code)**: 
+  - **The Grid System**: The `.viewer-container` acts as a CSS Grid overlaying the product. Inside, we place 12 invisible `.slice` `<div>` elements, stacking them side-by-side using `grid-template-columns: repeat(12, 1fr)`.
+  - **Hover State Mapping**: As the user moves their mouse horizontally across the viewer, they inherently hover over different invisible slices. We utilize the CSS general sibling combinator (`~`) to map the `:hover` state of a specific slice to a specific CSS `transform` on the product stage (e.g., `slice-3:hover ~ .product-stage .cube { transform: rotateY(60deg) }`). This simulates a Javascript `mousemove` or `drag` event listener completely natively.
+  - **The 3D Product**: While this technique is often used with a sprite-sheet (changing `background-position` for each slice), this demo utilizes a CSS 3D geometric shape (a cube) so the rotation can be mathematically generated and styled without needing external image assets. A `transition: transform 0.1s linear` is applied to smooth the snapping between slices.
+- **Theming & Dark Mode**: Configured via CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), generating deep slate container colors with translucent colored cube faces.
+- Fully accessible semantic structure. The invisible slice overlays are purely functional and hidden from screen-reader focus flows.
+
+## Usage
+Open `demo.html` in your browser. Move your mouse horizontally across the viewer container to rotate the 3D cube.
+
+## Files
+- `demo.html`: The HTML structure defining the CSS Grid slices and the 3D cube faces.
+- `style.css`: The styling, 3D perspective rules, and the critical `slice:hover ~ cube` state logic.

--- a/submissions/examples/css-image-360-viewer-pure/demo.html
+++ b/submissions/examples/css-image-360-viewer-pure/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS 360 Product Viewer</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Interactive 360 Viewer</h1>
+            <p class="subtitle">Drag your mouse horizontally across the object to rotate it. Built entirely without JavaScript using invisible hover slices and sibling combinators.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <div class="viewer-container">
+                
+                <!-- 
+                  [TECHNIQUE] The Interactive Slices
+                  We lay an invisible grid of 12 vertical slices over the entire container.
+                  When the user hovers over a specific slice, we use the general sibling 
+                  combinator (~) in CSS to rotate the 3D product to a specific angle.
+                  This simulates a JS mouse-drag or touch-swipe event purely in CSS!
+                -->
+                <div class="slice slice-1"></div>
+                <div class="slice slice-2"></div>
+                <div class="slice slice-3"></div>
+                <div class="slice slice-4"></div>
+                <div class="slice slice-5"></div>
+                <div class="slice slice-6"></div>
+                <div class="slice slice-7"></div>
+                <div class="slice slice-8"></div>
+                <div class="slice slice-9"></div>
+                <div class="slice slice-10"></div>
+                <div class="slice slice-11"></div>
+                <div class="slice slice-12"></div>
+                
+                <!-- 
+                  The Product
+                  Normally this would be a single `<img>` whose `background-position` changes 
+                  to scrub through a sprite sheet. For this pure CSS demo, we will use a 
+                  CSS 3D geometric shape (a cube) so the rotation is mathematically generated.
+                -->
+                <div class="product-stage">
+                    <div class="cube" aria-label="3D Rotating Product">
+                        <div class="face front">1</div>
+                        <div class="face back">4</div>
+                        <div class="face right">2</div>
+                        <div class="face left">6</div>
+                        <div class="face top">Top</div>
+                        <div class="face bottom">Bottom</div>
+                    </div>
+                </div>
+                
+                <div class="instruction-overlay">Hover & Drag Horizontally</div>
+                
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-image-360-viewer-pure/style.css
+++ b/submissions/examples/css-image-360-viewer-pure/style.css
@@ -1,0 +1,224 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700;900&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    
+    /* Viewer Colors */
+    --viewer-bg: #ffffff;
+    --viewer-border: #e2e8f0;
+    
+    /* Cube Colors */
+    --cube-front: rgba(59, 130, 246, 0.9);   /* Blue */
+    --cube-back: rgba(239, 68, 68, 0.9);    /* Red */
+    --cube-right: rgba(16, 185, 129, 0.9);  /* Green */
+    --cube-left: rgba(245, 158, 11, 0.9);   /* Yellow */
+    --cube-top: rgba(139, 92, 246, 0.9);    /* Purple */
+    --cube-bottom: rgba(100, 116, 139, 0.9); /* Slate */
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a;
+        --text-primary: #f8fafc;
+        --text-secondary: #94a3b8;
+        
+        --viewer-bg: #1e293b;
+        --viewer-border: #334155;
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 60px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 900;
+    margin: 0 0 16px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    padding: 20px 0;
+}
+
+
+/* =========================================
+   [TECHNIQUE] The Interactive Viewer
+   ========================================= */
+
+.viewer-container {
+    position: relative;
+    width: 400px;
+    height: 400px;
+    background-color: var(--viewer-bg);
+    border: 1px solid var(--viewer-border);
+    border-radius: 20px;
+    box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+    
+    /* Display grid allows us to easily lay out the 12 vertical slices side-by-side */
+    display: grid;
+    grid-template-columns: repeat(12, 1fr);
+    overflow: hidden;
+    cursor: ew-resize; /* Indicates horizontal draggable interaction */
+}
+
+.instruction-overlay {
+    position: absolute;
+    bottom: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: rgba(0,0,0,0.7);
+    color: white;
+    padding: 8px 16px;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    pointer-events: none; /* Crucial: Prevents this overlay from blocking hover events on slices */
+    z-index: 100;
+    opacity: 0.5;
+    transition: opacity 0.3s;
+}
+
+.viewer-container:hover .instruction-overlay {
+    opacity: 0; /* Fade out instructions when interacting */
+}
+
+
+/* 
+  The 12 Slices
+  These are stacked side-by-side filling the container.
+  They are completely invisible but catch mouse hover events.
+*/
+.slice {
+    height: 100%;
+    z-index: 50; /* Above the product */
+    /* Optional debug border to visualize slices: 
+       border-right: 1px solid rgba(255,0,0,0.1); 
+    */
+}
+
+
+/* =========================================
+   The 3D Product Stage
+   ========================================= */
+
+.product-stage {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none; /* Prevents stage from blocking slice hovers */
+    
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    
+    /* Adds perspective for the 3D cube */
+    perspective: 800px; 
+}
+
+/* 
+  The Object (A CSS Cube)
+*/
+.cube {
+    width: 150px;
+    height: 150px;
+    position: relative;
+    transform-style: preserve-3d;
+    
+    /* 
+      We set a transition so the rotation snaps smoothly between frames, 
+      simulating image interpolation.
+    */
+    transition: transform 0.1s linear;
+    
+    /* Initial state */
+    transform: rotateX(-15deg) rotateY(0deg);
+}
+
+.face {
+    position: absolute;
+    width: 150px;
+    height: 150px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 4rem;
+    font-weight: 900;
+    color: white;
+    border: 2px solid rgba(255, 255, 255, 0.5);
+    box-sizing: border-box;
+}
+
+/* Position the 6 faces of the cube */
+.front  { transform: rotateY(0deg) translateZ(75px); background: var(--cube-front); }
+.right  { transform: rotateY(90deg) translateZ(75px); background: var(--cube-right); }
+.back   { transform: rotateY(180deg) translateZ(75px); background: var(--cube-back); }
+.left   { transform: rotateY(-90deg) translateZ(75px); background: var(--cube-left); }
+.top    { transform: rotateX(90deg) translateZ(75px); background: var(--cube-top); }
+.bottom { transform: rotateX(-90deg) translateZ(75px); background: var(--cube-bottom); }
+
+
+/* =========================================
+   [TECHNIQUE] Sibling Combinator State Logic
+   Map the 12 horizontal slice hovers to 360-degree rotation states.
+   360 / 12 = 30 degrees per slice.
+   ========================================= */
+
+/* 
+  When the user hovers over a specific slice, we use the general 
+  sibling combinator (~) to find the `.product-stage .cube` and apply the exact rotation.
+*/
+.slice-1:hover  ~ .product-stage .cube { transform: rotateX(-15deg) rotateY(0deg); }
+.slice-2:hover  ~ .product-stage .cube { transform: rotateX(-15deg) rotateY(30deg); }
+.slice-3:hover  ~ .product-stage .cube { transform: rotateX(-15deg) rotateY(60deg); }
+.slice-4:hover  ~ .product-stage .cube { transform: rotateX(-15deg) rotateY(90deg); }
+.slice-5:hover  ~ .product-stage .cube { transform: rotateX(-15deg) rotateY(120deg); }
+.slice-6:hover  ~ .product-stage .cube { transform: rotateX(-15deg) rotateY(150deg); }
+.slice-7:hover  ~ .product-stage .cube { transform: rotateX(-15deg) rotateY(180deg); }
+.slice-8:hover  ~ .product-stage .cube { transform: rotateX(-15deg) rotateY(210deg); }
+.slice-9:hover  ~ .product-stage .cube { transform: rotateX(-15deg) rotateY(240deg); }
+.slice-10:hover ~ .product-stage .cube { transform: rotateX(-15deg) rotateY(270deg); }
+.slice-11:hover ~ .product-stage .cube { transform: rotateX(-15deg) rotateY(300deg); }
+.slice-12:hover ~ .product-stage .cube { transform: rotateX(-15deg) rotateY(330deg); }
+
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .cube {
+        transition: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces an interactive 360-degree product rotation viewer built entirely without JavaScript. Users can drag their mouse horizontally across the viewer to seamlessly rotate the 3D product, resolving issue #70103.

### Changes Made:
- Added `submissions/examples/css-image-360-viewer-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the CSS Grid slices and the 3D cube faces.
- Created `style.css` featuring the UI mechanics:
  - **The Grid System**: The `.viewer-container` acts as a CSS Grid overlaying the product. Inside, we place 12 invisible `.slice` `<div>` elements, stacking them side-by-side using `grid-template-columns: repeat(12, 1fr)`.
  - **Hover State Mapping**: As the user moves their mouse horizontally across the viewer, they inherently hover over different invisible slices. We utilize the CSS general sibling combinator (`~`) to map the `:hover` state of a specific slice to a specific CSS `transform` on the product stage (e.g., `slice-3:hover ~ .product-stage .cube { transform: rotateY(60deg) }`). This simulates a Javascript `mousemove` or `drag` event listener completely natively.
  - **The 3D Product**: While this technique is often used with a sprite-sheet (changing `background-position` for each slice), this demo utilizes a CSS 3D geometric shape (a cube) so the rotation can be mathematically generated and styled without needing external image assets. A `transition: transform 0.1s linear` is applied to smooth the snapping between slices.
  - **Theming & Dark Mode Supported**: Configured via CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), generating deep slate container colors with translucent colored cube faces.
- Added `README.md` documenting usage and the technical mechanics of the critical `slice:hover ~ cube` state logic.
- Fully accessible semantic structure. The invisible slice overlays are purely functional and hidden from screen-reader focus flows. Honors the `prefers-reduced-motion` accessibility standard by disabling the interpolation transition for motion-sensitive users.

Closes #70103
