### PR TITLE
feat: implement CSS swipe delete row animation #71051

### DIFF
--- a/submissions/examples/swipe-delete-row-ns/README.md
+++ b/submissions/examples/swipe-delete-row-ns/README.md
@@ -1,0 +1,11 @@
+# CSS Swipe Delete Row (#71051)
+
+A pure CSS swipeable list row component that reveals a red delete action background upon swiping/scrolling left and smooths out removal transitions.
+
+## Features
+- Pure CSS touch & swipe handling powered by CSS Scroll Snap (`scroll-snap-type: x mandatory`).
+- Hidden state management controller for seamless row collapse on deletion.
+- Red destructive action background with trash icon and hover feedback.
+- Fully responsive across touch mobile devices and desktop trackpads.
+- BEM structure (`ease-swipe-row`).
+- Accessible keyboard activation with visible focus indicators and `prefers-reduced-motion` safety rules.

--- a/submissions/examples/swipe-delete-row-ns/demo.html
+++ b/submissions/examples/swipe-delete-row-ns/demo.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Swipe Delete Row | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="swipe-demo-container">
+    <header class="swipe-demo-header">
+      <h1>CSS Swipe Delete Row</h1>
+      <p>Swipe or scroll left on any row to reveal the delete action.</p>
+    </header>
+
+    <ul class="ease-swipe-list" aria-label="Notification List">
+      
+      <!-- Item 1 -->
+      <li>
+        <input type="checkbox" id="delete-row-1" class="ease-swipe-row__toggle" aria-label="Delete Notification 1">
+        <div class="ease-swipe-row">
+          <div class="ease-swipe-row__track" tabindex="0" role="region" aria-label="Swipeable notification item">
+            <div class="ease-swipe-row__content">
+              <div class="ease-swipe-row__info">
+                <span class="ease-swipe-row__title">Security Alert</span>
+                <span class="ease-swipe-row__subtitle">New login detected from Chrome on macOS</span>
+              </div>
+              <span class="ease-swipe-row__hint">&laquo; Swipe</span>
+            </div>
+            <div class="ease-swipe-row__action">
+              <label for="delete-row-1" class="ease-swipe-row__delete-btn" role="button" tabindex="0" aria-label="Confirm Delete">
+                <svg class="ease-swipe-row__icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/>
+                </svg>
+                Delete
+              </label>
+            </div>
+          </div>
+        </div>
+      </li>
+
+      <!-- Item 2 -->
+      <li>
+        <input type="checkbox" id="delete-row-2" class="ease-swipe-row__toggle" aria-label="Delete Notification 2">
+        <div class="ease-swipe-row">
+          <div class="ease-swipe-row__track" tabindex="0" role="region" aria-label="Swipeable notification item">
+            <div class="ease-swipe-row__content">
+              <div class="ease-swipe-row__info">
+                <span class="ease-swipe-row__title">Payment Received</span>
+                <span class="ease-swipe-row__subtitle">Invoice #1092 has been paid ($250.00)</span>
+              </div>
+              <span class="ease-swipe-row__hint">&laquo; Swipe</span>
+            </div>
+            <div class="ease-swipe-row__action">
+              <label for="delete-row-2" class="ease-swipe-row__delete-btn" role="button" tabindex="0" aria-label="Confirm Delete">
+                <svg class="ease-swipe-row__icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/>
+                </svg>
+                Delete
+              </label>
+            </div>
+          </div>
+        </div>
+      </li>
+
+      <!-- Item 3 -->
+      <li>
+        <input type="checkbox" id="delete-row-3" class="ease-swipe-row__toggle" aria-label="Delete Notification 3">
+        <div class="ease-swipe-row">
+          <div class="ease-swipe-row__track" tabindex="0" role="region" aria-label="Swipeable notification item">
+            <div class="ease-swipe-row__content">
+              <div class="ease-swipe-row__info">
+                <span class="ease-swipe-row__title">System Update</span>
+                <span class="ease-swipe-row__subtitle">Version 2.4.0 installed successfully</span>
+              </div>
+              <span class="ease-swipe-row__hint">&laquo; Swipe</span>
+            </div>
+            <div class="ease-swipe-row__action">
+              <label for="delete-row-3" class="ease-swipe-row__delete-btn" role="button" tabindex="0" aria-label="Confirm Delete">
+                <svg class="ease-swipe-row__icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/>
+                </svg>
+                Delete
+              </label>
+            </div>
+          </div>
+        </div>
+      </li>
+
+    </ul>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/swipe-delete-row-ns/style.css
+++ b/submissions/examples/swipe-delete-row-ns/style.css
@@ -1,0 +1,202 @@
+/* CSS Swipe Delete Row #71051 */
+
+:root {
+  --bg-color: #0f172a;
+  --card-bg: #1e293b;
+  --border-color: #334155;
+  --text-main: #f8fafc;
+  --text-sub: #94a3b8;
+  --row-bg: #1e293b;
+  --row-hover: #334155;
+  --delete-bg: #ef4444;
+  --delete-hover: #dc2626;
+  --transition-speed: 0.35s;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 2rem 1rem;
+  background-color: var(--bg-color);
+  color: var(--text-main);
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+/* Demo Container */
+.swipe-demo-container {
+  width: 100%;
+  max-width: 520px;
+  background-color: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 20px;
+  padding: 2rem 1.5rem;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+}
+
+.swipe-demo-header {
+  text-align: center;
+  margin-bottom: 1.5rem;
+}
+
+.swipe-demo-header h1 {
+  font-size: 1.5rem;
+  margin: 0 0 0.5rem 0;
+}
+
+.swipe-demo-header p {
+  color: var(--text-sub);
+  font-size: 0.95rem;
+  margin: 0;
+}
+
+/* List Container */
+.ease-swipe-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+/* Base Row Item & Deletion Controller */
+.ease-swipe-row {
+  position: relative;
+  overflow: hidden;
+  border-radius: 12px;
+  transition: max-height var(--transition-speed) ease,
+              opacity var(--transition-speed) ease,
+              margin var(--transition-speed) ease;
+  max-height: 100px;
+  opacity: 1;
+}
+
+.ease-swipe-row__toggle {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+}
+
+/* Horizontal Scroll Snap Track for Touch & Swipe */
+.ease-swipe-row__track {
+  display: flex;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scroll-behavior: smooth;
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none; /* IE/Edge */
+}
+
+.ease-swipe-row__track::-webkit-scrollbar {
+  display: none; /* Chrome/Safari */
+}
+
+/* Main Content Surface */
+.ease-swipe-row__content {
+  flex: 0 0 100%;
+  width: 100%;
+  scroll-snap-align: start;
+  background-color: #111827;
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  transition: background-color 0.2s ease;
+}
+
+.ease-swipe-row__info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.ease-swipe-row__title {
+  font-weight: 600;
+  font-size: 1rem;
+  color: var(--text-main);
+}
+
+.ease-swipe-row__subtitle {
+  font-size: 0.85rem;
+  color: var(--text-sub);
+}
+
+.ease-swipe-row__hint {
+  font-size: 0.75rem;
+  color: var(--text-sub);
+  opacity: 0.6;
+}
+
+/* Revealed Red Delete Action */
+.ease-swipe-row__action {
+  flex: 0 0 100px;
+  scroll-snap-align: end;
+  background-color: var(--delete-bg);
+  border-top-right-radius: 12px;
+  border-bottom-right-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ease-swipe-row__delete-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  width: 100%;
+  height: 100%;
+  color: #ffffff;
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+  user-select: none;
+  transition: background-color 0.2s ease;
+}
+
+.ease-swipe-row__delete-btn:hover {
+  background-color: var(--delete-hover);
+}
+
+.ease-swipe-row__delete-btn:focus-visible {
+  outline: 2px solid #ffffff;
+  outline-offset: -4px;
+}
+
+.ease-swipe-row__icon {
+  width: 18px;
+  height: 18px;
+  fill: currentColor;
+}
+
+/* Pure CSS Deletion Trigger State */
+.ease-swipe-row__toggle:checked ~ .ease-swipe-row {
+  max-height: 0;
+  opacity: 0;
+  margin: 0;
+  padding: 0;
+  border: none;
+  pointer-events: none;
+}
+
+/* Accessibility: Respect Reduced Motion Preferences */
+@media (prefers-reduced-motion: reduce) {
+  .ease-swipe-row,
+  .ease-swipe-row__track,
+  .ease-swipe-row__content {
+    transition: none !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the pure CSS Swipe Delete Row component (#71051).
gssoc 26

Closes #71051

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/swipe-delete-row-ns/`
- [x] `style.css`, `demo.html`, and `README.md` included
- [x] Automated commit correctly formatted

---

## Feature Description
**What does this add?**
A swipeable list row component that reveals a destructive red delete action button when swiped or scrolled horizontally, collapsing smoothly upon deletion without JavaScript.

**How does it work?**
Combines CSS Scroll Snap (`scroll-snap-type: x mandatory`) for touch-native swiping with a pure CSS checkbox state trigger (`:checked ~ .ease-swipe-row`) to animate row collapse (`max-height` & `opacity`).

---

## Notes for Maintainer
Zero JavaScript dependencies. BEM structure (`ease-swipe-row`). Fully responsive and includes `prefers-reduced-motion` accessibility support.