### PR TITLE
feat: add pure CSS Crystallize Button component (#70109)

### DIFF
--- a/submissions/examples/css-crystallize-button-pure/README.md
+++ b/submissions/examples/css-crystallize-button-pure/README.md
@@ -1,0 +1,19 @@
+# CSS Crystallize Button
+
+A purely CSS-animated interactive button that fractures into flying crystalline shards upon being clicked. Built entirely without JavaScript particle systems or HTML Canvas.
+
+## Features
+- Pure CSS and HTML implementation.
+- **Component Architecture (Documented in Code)**: 
+  - **The Checkbox Hack**: The core state of the button (Solid vs Shattered) is managed by a hidden `<input type="checkbox">`. The actual clickable button is a `<label>` tied to this checkbox, allowing a click to natively toggle the state without JavaScript event listeners.
+  - **Jigsaw Polygons**: Inside the button container sit 6 absolutely positioned `<div>` overlays (`.shard`). By default, each shard is sliced into a specific geometric shape using `clip-path: polygon(...)`. When positioned at `0,0`, these 6 unique polygons perfectly interlock to form the solid rectangular background of the button, mimicking a faceted crystal.
+  - **The Explosion Physics**: When the checkbox is checked, the CSS general sibling combinator (`~`) triggers a state change on all 6 shards simultaneously. A custom `cubic-bezier` transition rapidly animates the `transform: translate3d(...) rotate(...) scale(...)` properties of each shard, throwing them outwards in different directions while simultaneously fading their `opacity` to 0. 
+- **Theming & Dark Mode**: Configured via CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), generating a deep slate background to ensure the vibrant purple shards pop visually.
+- Fully accessible semantic structure. The `<label>` acts as the primary interactive element and is given `role="button"` and `tabindex="0"` for keyboard navigation. The shards are purely decorative visual effects and are explicitly hidden from screen readers via `aria-hidden="true"`. Honors the `prefers-reduced-motion` accessibility standard by disabling the fracture transition for motion-sensitive users, causing the button to simply disappear on click rather than exploding.
+
+## Usage
+Open `demo.html` in your browser. Click the "SHATTER ME" button to trigger the explosion. Click anywhere in the empty space where the button used to be (the invisible label hitbox remains active) to trigger the reverse animation and reform the crystal.
+
+## Files
+- `demo.html`: The HTML structure defining the hidden checkbox, the label hitbox, and the 6 interlocking shards.
+- `style.css`: The styling, the `clip-path: polygon` mathematics, and the critical explosion state transitions.

--- a/submissions/examples/css-crystallize-button-pure/demo.html
+++ b/submissions/examples/css-crystallize-button-pure/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Crystallize Button</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Crystallize Button</h1>
+            <p class="subtitle">A purely CSS-animated button that shatters into crystalline shards upon clicking, utilizing the hidden checkbox hack and overlapping `clip-path` polygons.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <!-- 
+              [TECHNIQUE] The Checkbox Hack
+              The hidden checkbox controls the shattered state.
+              Checking the box shatters the button. Unchecking it reforms it.
+            -->
+            <input type="checkbox" id="shatter-toggle" class="shatter-toggle" aria-hidden="true">
+            
+            <div class="button-wrapper">
+                
+                <!-- The actual clickable trigger -->
+                <label for="shatter-toggle" class="btn-hitbox" role="button" tabindex="0" aria-label="Shatter Button">
+                    
+                    <!-- The Button Text -->
+                    <span class="btn-text">SHATTER ME</span>
+                    
+                    <!-- 
+                      [TECHNIQUE] The Shards
+                      Each shard is an absolutely positioned overlay that completely covers the button.
+                      We use `clip-path: polygon(...)` to slice each overlay into a specific geometric shard.
+                      When the button is NOT shattered, they fit together seamlessly to form the solid button background.
+                    -->
+                    <div class="shards-container" aria-hidden="true">
+                        <div class="shard shard-1"></div>
+                        <div class="shard shard-2"></div>
+                        <div class="shard shard-3"></div>
+                        <div class="shard shard-4"></div>
+                        <div class="shard shard-5"></div>
+                        <div class="shard shard-6"></div>
+                    </div>
+                    
+                </label>
+                
+                <p class="instruction-text">Click the button to fracture it. Click again to reform.</p>
+                
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-crystallize-button-pure/style.css
+++ b/submissions/examples/css-crystallize-button-pure/style.css
@@ -1,0 +1,232 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700;900&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f1f5f9;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    
+    /* Button Theme */
+    --btn-primary: #8b5cf6; /* Vibrant Purple */
+    --btn-primary-dark: #6d28d9;
+    --btn-text: #ffffff;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a;
+        --text-primary: #f8fafc;
+        --text-secondary: #94a3b8;
+        
+        --btn-primary: #a78bfa;
+        --btn-primary-dark: #7c3aed;
+        --btn-text: #0f172a;
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 80px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 900;
+    margin: 0 0 16px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    padding: 40px 0;
+}
+
+
+/* =========================================
+   [TECHNIQUE] The Shatter Button Mechanics
+   ========================================= */
+
+.button-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 30px;
+}
+
+.instruction-text {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    font-style: italic;
+}
+
+.shatter-toggle {
+    display: none;
+}
+
+.btn-hitbox {
+    position: relative;
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    width: 240px;
+    height: 70px;
+    cursor: pointer;
+    /* Remove background from the hitbox itself, the shards provide the background */
+    background: transparent;
+    border-radius: 8px;
+    user-select: none;
+    -webkit-tap-highlight-color: transparent;
+}
+
+.btn-text {
+    position: relative;
+    z-index: 20;
+    font-size: 1.25rem;
+    font-weight: 900;
+    letter-spacing: 2px;
+    color: var(--btn-text);
+    transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.shards-container {
+    position: absolute;
+    inset: 0;
+    z-index: 10;
+    /* Must not clip overflow so the shards can fly out! */
+}
+
+/* 
+  The Base Shard
+*/
+.shard {
+    position: absolute;
+    inset: 0;
+    background-color: var(--btn-primary);
+    border-radius: 8px;
+    /* Hardware acceleration for smoother shard flying */
+    transform: translate3d(0, 0, 0) rotate(0deg) scale(1);
+    transition: all 0.6s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+/* Optional: Give the shards slightly different tints to look like 3D facets */
+.shard:nth-child(even) {
+    background-color: var(--btn-primary-dark);
+}
+
+
+/* 
+  [TECHNIQUE] The Polygons
+  We slice the 100% x 100% rectangle into 6 distinct jigsaw pieces using clip-path.
+  When pieced together, they form the solid button.
+*/
+
+/* Top Left Triangle */
+.shard-1 { clip-path: polygon(0 0, 40% 0, 20% 50%, 0 100%); }
+/* Top Right Angle */
+.shard-2 { clip-path: polygon(40% 0, 100% 0, 100% 40%, 60% 60%, 20% 50%); }
+/* Bottom Right Corner */
+.shard-3 { clip-path: polygon(100% 40%, 100% 100%, 70% 100%, 60% 60%); }
+/* Bottom Mid Wedge */
+.shard-4 { clip-path: polygon(70% 100%, 30% 100%, 45% 70%, 60% 60%); }
+/* Bottom Left Corner */
+.shard-5 { clip-path: polygon(0 100%, 30% 100%, 45% 70%, 20% 50%); }
+/* Center Fragment (Optional depth piece) */
+.shard-6 { clip-path: polygon(20% 50%, 60% 60%, 45% 70%); background-color: rgba(255,255,255,0.2); }
+
+
+/* =========================================
+   The Shatter State (Sibling Combinator)
+   ========================================= */
+
+/* 1. Hide the text */
+.shatter-toggle:checked ~ .button-wrapper .btn-text {
+    opacity: 0;
+    transform: scale(0.8);
+    transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+/* 
+   2. Explode the Shards 
+   We translate them rapidly outwards, rotate them chaotically, 
+   and fade them out to simulate shattering glass/crystal.
+*/
+.shatter-toggle:checked ~ .button-wrapper .shard {
+    opacity: 0;
+    /* Use a linear ease-out for the explosion physics rather than a bounce */
+    transition: all 0.5s cubic-bezier(0.165, 0.84, 0.44, 1);
+}
+
+.shatter-toggle:checked ~ .button-wrapper .shard-1 {
+    transform: translate3d(-100px, -80px, 0) rotate(-45deg) scale(0.5);
+}
+
+.shatter-toggle:checked ~ .button-wrapper .shard-2 {
+    transform: translate3d(120px, -100px, 0) rotate(60deg) scale(0.6);
+}
+
+.shatter-toggle:checked ~ .button-wrapper .shard-3 {
+    transform: translate3d(150px, 80px, 0) rotate(120deg) scale(0.4);
+}
+
+.shatter-toggle:checked ~ .button-wrapper .shard-4 {
+    transform: translate3d(30px, 120px, 0) rotate(-30deg) scale(0.7);
+}
+
+.shatter-toggle:checked ~ .button-wrapper .shard-5 {
+    transform: translate3d(-120px, 100px, 0) rotate(-90deg) scale(0.5);
+}
+
+.shatter-toggle:checked ~ .button-wrapper .shard-6 {
+    transform: translate3d(0, 0, 100px) rotate(180deg) scale(2);
+    opacity: 0;
+}
+
+
+/* =========================================
+   Hover Effect (Pre-Shatter Shake)
+   ========================================= */
+
+.btn-hitbox:hover .shard {
+    /* Subtle breathing/shifting of the crystal plates on hover */
+    filter: brightness(1.1);
+}
+
+.btn-hitbox:hover .shard-6 {
+    /* The center shard glows */
+    background-color: rgba(255,255,255,0.4);
+}
+
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .btn-text,
+    .shard {
+        transition: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a purely CSS-animated interactive button that fractures into flying crystalline shards upon being clicked. Built entirely without JavaScript particle systems or HTML Canvas, resolving issue #70109.

### Changes Made:
- Added `submissions/examples/css-crystallize-button-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the hidden checkbox, the label hitbox, and the 6 interlocking shards.
- Created `style.css` featuring the UI mechanics:
  - **The Checkbox Hack**: The core state of the button (Solid vs Shattered) is managed by a hidden `<input type="checkbox">`. The actual clickable button is a `<label>` tied to this checkbox, allowing a click to natively toggle the state without JavaScript event listeners.
  - **Jigsaw Polygons**: Inside the button container sit 6 absolutely positioned `<div>` overlays (`.shard`). By default, each shard is sliced into a specific geometric shape using `clip-path: polygon(...)`. When positioned at `0,0`, these 6 unique polygons perfectly interlock to form the solid rectangular background of the button, mimicking a faceted crystal.
  - **The Explosion Physics**: When the checkbox is checked, the CSS general sibling combinator (`~`) triggers a state change on all 6 shards simultaneously. A custom `cubic-bezier` transition rapidly animates the `transform: translate3d(...) rotate(...) scale(...)` properties of each shard, throwing them outwards in different directions while simultaneously fading their `opacity` to 0. 
  - **Theming & Dark Mode Supported**: Configured via CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), generating a deep slate background to ensure the vibrant purple shards pop visually.
- Added `README.md` documenting usage and the technical mechanics of the critical `clip-path` jigsaw logic.
- Fully accessible semantic structure. The `<label>` acts as the primary interactive element and is given `role="button"` and `tabindex="0"` for keyboard navigation. The shards are purely decorative visual effects and are explicitly hidden from screen readers via `aria-hidden="true"`. Honors the `prefers-reduced-motion` accessibility standard by disabling the fracture transition for motion-sensitive users.

Closes #70109
