### PR TITLE
feat: implement CSS game over screen #71021

### DIFF
--- a/submissions/examples/game-over-screen-ns/README.md
+++ b/submissions/examples/game-over-screen-ns/README.md
@@ -1,0 +1,10 @@
+# CSS Game Over Screen (#71021)
+
+A retro arcade-inspired Game Over screen component built with pure CSS keyframe flashing animations, neon styling, and CRT scanline overlay aesthetics.
+
+## Features
+- Arcade text flicker & glow keyframe animations (`ease-arcade-flash`).
+- Built-in retro score counter layout panel.
+- CRT monitor scanline background effect via pseudo-elements.
+- Full keyboard focusability and ARIA accessibility markup (`aria-live="assertive"`).
+- Safe fallback modes for `prefers-reduced-motion` and `forced-colors`.

--- a/submissions/examples/game-over-screen-ns/demo.html
+++ b/submissions/examples/game-over-screen-ns/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Game Over Screen | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="game-over-demo-container">
+    
+    <!-- Game Over Screen Component -->
+    <article class="ease-game-over-card" role="region" aria-label="Game Over Screen">
+      
+      <!-- Flashing Arcade Header -->
+      <h1 class="ease-game-over__title" aria-live="assertive">Game Over</h1>
+
+      <!-- Scoreboard -->
+      <div class="ease-game-over__scores">
+        <div class="ease-score-item">
+          <span class="ease-score-item__label">Score</span>
+          <span class="ease-score-item__value">042,900</span>
+        </div>
+        <div class="ease-score-item">
+          <span class="ease-score-item__label">High Score</span>
+          <span class="ease-score-item__value">099,990</span>
+        </div>
+      </div>
+
+      <!-- Prompt Text -->
+      <p class="ease-game-over__prompt">Insert Coin or Press Start</p>
+
+      <!-- Restart Action Button -->
+      <button type="button" class="ease-game-over__btn">
+        Try Again
+      </button>
+
+    </article>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/game-over-screen-ns/style.css
+++ b/submissions/examples/game-over-screen-ns/style.css
@@ -1,0 +1,202 @@
+/* CSS Game Over Screen #71021 */
+
+:root {
+  --bg-color: #050508;
+  --card-bg: #0d0e15;
+  --border-color: #ff0055;
+  --text-main: #ffffff;
+  --text-sub: #a0a5c0;
+  --neon-red: #ff0055;
+  --neon-yellow: #ffe600;
+  --neon-cyan: #00f0ff;
+  --arcade-font: 'Courier New', Courier, monospace;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 1rem;
+  background-color: var(--bg-color);
+  color: var(--text-main);
+  font-family: var(--arcade-font);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+}
+
+/* CRT Scanline Overlay Effect */
+body::before {
+  content: "";
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: linear-gradient(
+    rgba(18, 16, 16, 0) 50%, 
+    rgba(0, 0, 0, 0.25) 50%
+  );
+  background-size: 100% 4px;
+  z-index: 10;
+  pointer-events: none;
+  opacity: 0.6;
+}
+
+/* Container Wrapper */
+.game-over-demo-container {
+  width: 100%;
+  max-width: 520px;
+  z-index: 1;
+}
+
+/* ==========================================================================
+   CSS Game Over Screen Core Component
+   ========================================================================== */
+
+.ease-game-over-card {
+  background-color: var(--card-bg);
+  border: 3px solid var(--neon-red);
+  border-radius: 12px;
+  padding: 3rem 2rem;
+  text-align: center;
+  box-shadow: 0 0 25px rgba(255, 0, 85, 0.4), inset 0 0 15px rgba(255, 0, 85, 0.2);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+/* Arcade Flashing Header */
+.ease-game-over__title {
+  font-size: clamp(2rem, 8vw, 3.2rem);
+  font-weight: 900;
+  color: var(--neon-red);
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  text-shadow: 0 0 10px var(--neon-red), 0 0 20px var(--neon-red);
+  animation: ease-arcade-flash 1s steps(2, start) infinite;
+}
+
+/* Score Display Board */
+.ease-game-over__scores {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  max-width: 320px;
+  background: rgba(0, 0, 0, 0.6);
+  border: 1px dashed var(--neon-cyan);
+  padding: 1rem;
+  border-radius: 6px;
+}
+
+.ease-score-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.ease-score-item__label {
+  font-size: 0.75rem;
+  color: var(--neon-cyan);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.ease-score-item__value {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: var(--neon-yellow);
+}
+
+/* Flashing Subtext */
+.ease-game-over__prompt {
+  font-size: 0.95rem;
+  color: var(--text-sub);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  margin: 0;
+  animation: ease-pulse-opacity 1.5s ease-in-out infinite;
+}
+
+/* Retro Restart Action Button */
+.ease-game-over__btn {
+  display: inline-block;
+  width: 100%;
+  max-width: 280px;
+  padding: 1rem 1.5rem;
+  background: var(--neon-yellow);
+  color: #000000;
+  font-family: var(--arcade-font);
+  font-size: 1.1rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  text-decoration: none;
+  box-shadow: 0 0 15px rgba(255, 230, 0, 0.5);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.ease-game-over__btn:hover {
+  background: #ffffff;
+  transform: scale(1.05);
+  box-shadow: 0 0 25px rgba(255, 255, 255, 0.8);
+}
+
+.ease-game-over__btn:focus-visible {
+  outline: 3px solid var(--neon-cyan);
+  outline-offset: 4px;
+}
+
+/* ==========================================================================
+   Keyframe Animations
+   ========================================================================== */
+
+@keyframes ease-arcade-flash {
+  0%, 100% {
+    opacity: 1;
+    text-shadow: 0 0 10px var(--neon-red), 0 0 20px var(--neon-red);
+  }
+  50% {
+    opacity: 0.3;
+    text-shadow: none;
+  }
+}
+
+@keyframes ease-pulse-opacity {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}
+
+/* ==========================================================================
+   Accessibility & Reduced Motion Overrides
+   ========================================================================== */
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-game-over__title,
+  .ease-game-over__prompt {
+    animation: none !important;
+  }
+
+  body::before {
+    display: none;
+  }
+}
+
+@media (forced-colors: active) {
+  .ease-game-over-card {
+    border: 2px solid CanvasText;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the pure CSS Game Over Screen component (#71021).
gssoc 26

Closes #71021

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/game-over-screen-ns/`
- [x] `style.css`, `demo.html`, and `README.md` included
- [x] Automated commit correctly formatted

---

## Feature Description
**What does this add?**
A retro 80s arcade Game Over overlay card component with neon glows, flashing title typography, score readouts, and interactive restart call-to-action buttons.

**How does it work?**
Uses pure CSS `@keyframes` with `steps()` timing functions to recreate authentic CRT retro text flashing and pulsating prompts, combined with CSS linear gradients for visual scanlines.

---

## Notes for Maintainer
Zero JavaScript required. Fully accessible with `aria-live` screen-reader messaging, keyboard focus ring indicators, and automatic motion disabling under `prefers-reduced-motion`.