### PR TITLE
feat: add pure CSS Frozen Ice Text component (#70112)

### DIFF
--- a/submissions/examples/css-frozen-ice-text-pure/README.md
+++ b/submissions/examples/css-frozen-ice-text-pure/README.md
@@ -1,0 +1,19 @@
+# CSS Frozen Ice Text
+
+A pure CSS typography effect simulating text freezing over, complete with expanding, staggered ice crystals. Built entirely without JavaScript or Canvas.
+
+## Features
+- Pure CSS and HTML implementation.
+- **Component Architecture (Documented in Code)**: 
+  - **The Frozen Text Base**: The main text utilizes a `-webkit-background-clip: text` paired with an icy linear gradient (`--ice-light` to `--ice-dark`) to create the base frozen look. A standard CSS `@keyframes` animation scales the text slightly and increases its opacity/drop-shadow to simulate the act of "freezing over".
+  - **The Frost Overlay**: A pseudo-element (`::after`) is generated with the exact same text content via `content: attr(data-text)`. It overlays a subtle SVG noise pattern (encoded as a data URI) to give the text surface a micro-texture resembling frost or condensation.
+  - **The Expanding Crystals**: Behind the text, multiple absolutely positioned `<span>` elements act as ice shards. They are sliced into sharp geometric triangles using `clip-path: polygon(...)`. A custom `cubic-bezier` keyframe animates them from `transform: scale(0)` to `scale(1)`. Their `animation-delay` properties are staggered to create an organic, sequential growth pattern bursting outward from the text.
+- **Theming & Dark Mode**: Configured via CSS Custom Properties. The icy effect visually pops best on a dark background, so the root theme defaults to deep slate colors, but accommodates light themes gracefully.
+- Fully accessible semantic structure. The main text is standard HTML text inside an `<h2>`. The decorative shards and frost overlays are explicitly hidden from screen readers via `aria-hidden="true"` and `color: transparent`. Honors the `prefers-reduced-motion` accessibility standard by disabling the freezing keyframes for motion-sensitive users, rendering the text fully frozen immediately upon load.
+
+## Usage
+Open `demo.html` in your browser. The freezing animation triggers automatically upon page load. Refresh the page to replay the effect.
+
+## Files
+- `demo.html`: The HTML structure defining the core text wrapper and the staggered crystal spans.
+- `style.css`: The styling, the SVG noise overlay, the `clip-path` crystal definitions, and the freezing `@keyframes`.

--- a/submissions/examples/css-frozen-ice-text-pure/demo.html
+++ b/submissions/examples/css-frozen-ice-text-pure/demo.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Frozen Ice Text</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Frozen Ice Text</h1>
+            <p class="subtitle">A pure CSS typography effect simulating text freezing over, complete with expanding, staggered ice crystals using `clip-path` and keyframes.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <div class="ice-stage">
+                
+                <!-- 
+                  [TECHNIQUE] The Frozen Text Wrapper
+                  The main text uses `-webkit-background-clip: text` with a frosty gradient.
+                  The crystals are generated using pseudo-elements and child spans that scale up.
+                -->
+                <h2 class="frozen-text" data-text="FREEZE">
+                    <span class="main-text">FREEZE</span>
+                    
+                    <!-- 
+                      [TECHNIQUE] Growing Crystals
+                      These absolutely positioned spans represent shards of ice growing 
+                      off the text. They use `clip-path: polygon(...)` to look sharp 
+                      and animate their scale to simulate growth.
+                    -->
+                    <div class="crystals-container" aria-hidden="true">
+                        <span class="crystal c-1"></span>
+                        <span class="crystal c-2"></span>
+                        <span class="crystal c-3"></span>
+                        <span class="crystal c-4"></span>
+                        <span class="crystal c-5"></span>
+                        <span class="crystal c-6"></span>
+                    </div>
+                </h2>
+                
+            </div>
+            
+        </div>
+        
+    </div>
+    
+    <!-- Replay button for demonstration purposes only -->
+    <div class="demo-controls">
+        <p>Refresh the page to replay the freeze animation.</p>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-frozen-ice-text-pure/style.css
+++ b/submissions/examples/css-frozen-ice-text-pure/style.css
@@ -1,0 +1,265 @@
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@900&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #0f172a; /* Deep cold blue */
+    --text-primary: #f8fafc;
+    --text-secondary: #94a3b8;
+    
+    /* Ice Colors */
+    --ice-light: #e0f2fe;
+    --ice-mid: #7dd3fc;
+    --ice-dark: #0ea5e9;
+    --ice-glow: rgba(125, 211, 252, 0.6);
+}
+
+@media (prefers-color-scheme: light) {
+    :root {
+        /* Ice looks best on dark backgrounds, but we accommodate light mode */
+        --bg-base: #f1f5f9;
+        --text-primary: #0f172a;
+        --text-secondary: #64748b;
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Montserrat', sans-serif; /* Thick, heavy font works best for masking */
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 80px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 900;
+    margin: 0 0 16px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+    font-family: system-ui, -apple-system, sans-serif;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 300px;
+}
+
+
+/* =========================================
+   [TECHNIQUE] The Frozen Text Styling
+   ========================================= */
+
+.ice-stage {
+    position: relative;
+    padding: 40px;
+}
+
+.frozen-text {
+    position: relative;
+    font-size: clamp(4rem, 10vw, 8rem);
+    font-weight: 900;
+    margin: 0;
+    letter-spacing: 4px;
+    text-transform: uppercase;
+    
+    /* Center the container for the absolute crystal spans */
+    display: inline-block;
+}
+
+/* 
+  The Core Text 
+  Uses a background clip gradient to look like solid, frozen ice.
+*/
+.main-text {
+    position: relative;
+    z-index: 10;
+    
+    background: linear-gradient(
+        135deg, 
+        var(--ice-light) 0%, 
+        var(--ice-mid) 40%, 
+        var(--ice-light) 60%, 
+        var(--ice-dark) 100%
+    );
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    
+    /* 
+      Add a frosty drop shadow.
+      We use the pseudo-element trick if standard text-shadow ruins the clip,
+      but modern browsers handle filter: drop-shadow on clipped text well.
+    */
+    filter: drop-shadow(0 0 15px var(--ice-glow));
+    
+    /* Animation: It "freezes" (fades in from dull to bright) */
+    animation: freezeText 2s ease-out forwards;
+}
+
+/* 
+  An overlay using ::after to add a frosted glass texture over the text.
+*/
+.frozen-text::after {
+    content: attr(data-text);
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 11;
+    color: transparent;
+    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="4" height="4"><rect width="4" height="4" fill="white" fill-opacity="0.2"/><circle cx="2" cy="2" r="1" fill="rgba(0,0,0,0.1)"/></svg>');
+    -webkit-background-clip: text;
+    pointer-events: none;
+    opacity: 0;
+    animation: frostOver 1s ease-in 1.5s forwards;
+}
+
+
+/* =========================================
+   [TECHNIQUE] Growing Crystals
+   ========================================= */
+
+.crystals-container {
+    position: absolute;
+    inset: 0;
+    z-index: 5;
+    /* Crystals grow out from behind the text */
+}
+
+.crystal {
+    position: absolute;
+    background: linear-gradient(180deg, var(--ice-light), var(--ice-mid));
+    
+    /* Sharp geometric shards using clip-path */
+    clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
+    
+    /* Hardware acceleration */
+    transform: scale(0) rotate(0deg);
+    opacity: 0;
+    
+    /* Optional: Slight glow on the crystals */
+    box-shadow: 0 0 10px var(--ice-glow);
+}
+
+/* 
+  Positioning and sizing the individual crystals.
+  We stagger their animation delays so they "grow" sequentially.
+*/
+.c-1 {
+    width: 30px; height: 100px;
+    top: -40px; left: 10%;
+    clip-path: polygon(50% 0%, 100% 100%, 0% 100%);
+    animation: growCrystal 1s cubic-bezier(0.175, 0.885, 0.32, 1.275) 0.8s forwards;
+}
+
+.c-2 {
+    width: 20px; height: 80px;
+    top: 40px; left: 80%;
+    clip-path: polygon(0 0, 100% 50%, 0 100%);
+    animation: growCrystal 1s cubic-bezier(0.175, 0.885, 0.32, 1.275) 1.2s forwards;
+}
+
+.c-3 {
+    width: 40px; height: 120px;
+    bottom: -50px; left: 30%;
+    clip-path: polygon(50% 100%, 100% 0, 0 0);
+    animation: growCrystal 1s cubic-bezier(0.175, 0.885, 0.32, 1.275) 1.5s forwards;
+}
+
+.c-4 {
+    width: 25px; height: 90px;
+    top: -20px; left: 60%;
+    clip-path: polygon(100% 0, 100% 100%, 0 50%);
+    animation: growCrystal 1s cubic-bezier(0.175, 0.885, 0.32, 1.275) 1.8s forwards;
+}
+
+.c-5 {
+    width: 15px; height: 60px;
+    bottom: -20px; left: 90%;
+    clip-path: polygon(50% 0%, 100% 100%, 0% 100%);
+    animation: growCrystal 1s cubic-bezier(0.175, 0.885, 0.32, 1.275) 2.1s forwards;
+}
+
+.c-6 {
+    width: 35px; height: 85px;
+    top: 60%; left: -20px;
+    clip-path: polygon(0 0, 100% 50%, 0 100%);
+    animation: growCrystal 1s cubic-bezier(0.175, 0.885, 0.32, 1.275) 1.0s forwards;
+}
+
+
+/* =========================================
+   Keyframes
+   ========================================= */
+
+@keyframes freezeText {
+    0% {
+        opacity: 0.2;
+        filter: drop-shadow(0 0 0px var(--ice-glow)) grayscale(100%);
+        transform: scale(0.98);
+    }
+    100% {
+        opacity: 1;
+        filter: drop-shadow(0 0 15px var(--ice-glow)) grayscale(0%);
+        transform: scale(1);
+    }
+}
+
+@keyframes frostOver {
+    to { opacity: 0.8; }
+}
+
+@keyframes growCrystal {
+    0% {
+        transform: scale(0) rotate(var(--rot, 0deg));
+        opacity: 0;
+    }
+    100% {
+        transform: scale(1) rotate(var(--rot, 0deg));
+        opacity: 0.9;
+    }
+}
+
+
+/* Demo Controls */
+.demo-controls {
+    text-align: center;
+    padding: 40px;
+    color: var(--text-secondary);
+    font-style: italic;
+    font-size: 0.9rem;
+    font-family: system-ui, -apple-system, sans-serif;
+}
+
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .main-text,
+    .frozen-text::after,
+    .crystal {
+        animation: none !important;
+        opacity: 1 !important;
+        transform: scale(1) !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a pure CSS typography effect simulating text freezing over, complete with expanding, staggered ice crystals. Built entirely without JavaScript or Canvas, resolving issue #70112.

### Changes Made:
- Added `submissions/examples/css-frozen-ice-text-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the core text wrapper and the staggered crystal spans.
- Created `style.css` featuring the UI mechanics:
  - **The Frozen Text Base**: The main text utilizes a `-webkit-background-clip: text` paired with an icy linear gradient (`--ice-light` to `--ice-dark`) to create the base frozen look. A standard CSS `@keyframes` animation scales the text slightly and increases its opacity/drop-shadow to simulate the act of "freezing over".
  - **The Frost Overlay**: A pseudo-element (`::after`) is generated with the exact same text content via `content: attr(data-text)`. It overlays a subtle SVG noise pattern (encoded as a data URI) to give the text surface a micro-texture resembling frost or condensation.
  - **The Expanding Crystals**: Behind the text, multiple absolutely positioned `<span>` elements act as ice shards. They are sliced into sharp geometric triangles using `clip-path: polygon(...)`. A custom `cubic-bezier` keyframe animates them from `transform: scale(0)` to `scale(1)`. Their `animation-delay` properties are staggered to create an organic, sequential growth pattern bursting outward from the text.
  - **Theming & Dark Mode Supported**: Configured via CSS Custom Properties. The icy effect visually pops best on a dark background, so the root theme defaults to deep slate colors, but accommodates light themes gracefully.
- Added `README.md` documenting usage and the technical mechanics of the `clip-path` crystal definitions and SVG noise overlay.
- Fully accessible semantic structure. The main text is standard HTML text inside an `<h2>`. The decorative shards and frost overlays are explicitly hidden from screen readers via `aria-hidden="true"` and `color: transparent`. Honors the `prefers-reduced-motion` accessibility standard by disabling the freezing keyframes for motion-sensitive users.

Closes #70112
