### PR TITLE
feat: add pure CSS Credit Card Form component (#70121)

### DIFF
--- a/submissions/examples/css-credit-card-form-pure/README.md
+++ b/submissions/examples/css-credit-card-form-pure/README.md
@@ -1,0 +1,19 @@
+# CSS Credit Card Form
+
+A three-field credit card payment form that visually auto-detects the card type (Visa, Mastercard, Amex) based on the first digit typed, using CSS attribute selectors.
+
+## Features
+- Mostly CSS implementation with a tiny inline Javascript helper.
+- **Component Architecture (Documented in Code)**: 
+  - **The Form Layout**: A standard 3-field layout (`Card Number`, `Expiry Date`, `CVV`). Uses CSS Flexbox for the side-by-side split row on the bottom fields.
+  - **The Attribute Selector Trick**: Natively, CSS attribute selectors like `input[value^="4"]` only read the initial `value` attribute present in the HTML source, not the live value typed by the user. To bridge this gap and allow CSS to drive the UI logic, a tiny inline Javascript helper is added to the input: `oninput="this.setAttribute('value', this.value)"`.
+  - **Auto-Detection Logic**: The `.card-logos` wrapper contains multiple hidden brand text logos (`VISA`, `MC`, `AMEX`) and a default generic icon. We use the CSS general sibling combinator (`~`) to link the input value to the logos. If the input value starts with `4` (Visa), `5` (Mastercard), or `3` (Amex), the CSS ruleset animates the default logo out (`opacity: 0`, `transform: translateY(-5px)`) and animates the corresponding brand logo in.
+- **Theming & Dark Mode**: Configured via CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), adapting the form background, borders, and input focus states while preserving the brand colors (Visa Blue, Mastercard Red).
+- Fully accessible semantic structure. Uses `<form>`, `<label>`, and `<input>` tags. The dynamically updating logos are purely visual feedback and are hidden from screen readers via `aria-hidden="true"`, ensuring they don't interrupt the user's typing flow with redundant announcements.
+
+## Usage
+Open `demo.html` in your browser. Type a number starting with 4, 5, or 3 into the Card Number field to watch the logo smoothly update.
+
+## Files
+- `demo.html`: The HTML structure defining the form, inputs, and the inline attribute syncing script.
+- `style.css`: The styling, flexbox layouts, and the critical `input[value^="X"] ~ .logo` UI routing logic.

--- a/submissions/examples/css-credit-card-form-pure/demo.html
+++ b/submissions/examples/css-credit-card-form-pure/demo.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Credit Card Form</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Smart Credit Card Form</h1>
+            <p class="subtitle">A three-field form with CSS-driven card type auto-detection. Type a Visa (4), Mastercard (5), or Amex (3) number to see the logo dynamically update.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <form class="cc-form" onsubmit="event.preventDefault();">
+                
+                <div class="form-header">
+                    <h2>Payment Details</h2>
+                </div>
+                
+                <!-- 
+                  [TECHNIQUE] The Auto-Detection Wrapper
+                  The wrapper contains the input and the logo elements.
+                  We use `oninput="this.setAttribute('value', this.value)"` 
+                  because CSS attribute selectors `[value^="4"]` normally only read 
+                  the *initial* HTML value, not the live typed value. This tiny 
+                  inline script bridges the gap so CSS can handle the UI logic.
+                -->
+                <div class="input-group group-full cc-wrapper">
+                    <label for="cc-number">Card Number</label>
+                    <div class="input-with-icon">
+                        <input 
+                            type="text" 
+                            id="cc-number" 
+                            name="cc-number" 
+                            placeholder="0000 0000 0000 0000" 
+                            maxlength="19"
+                            pattern="[0-9\s]*"
+                            oninput="this.setAttribute('value', this.value)"
+                            required
+                        >
+                        <!-- Logos that will be toggled by CSS sibling combinators -->
+                        <div class="card-logos" aria-hidden="true">
+                            <span class="logo logo-default">💳</span>
+                            <span class="logo logo-visa">VISA</span>
+                            <span class="logo logo-mastercard">MC</span>
+                            <span class="logo logo-amex">AMEX</span>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="form-row">
+                    <div class="input-group group-half">
+                        <label for="cc-expiry">Expiry Date</label>
+                        <input 
+                            type="text" 
+                            id="cc-expiry" 
+                            name="cc-expiry" 
+                            placeholder="MM/YY" 
+                            maxlength="5"
+                            required
+                        >
+                    </div>
+                    
+                    <div class="input-group group-half">
+                        <label for="cc-cvv">CVV</label>
+                        <input 
+                            type="password" 
+                            id="cc-cvv" 
+                            name="cc-cvv" 
+                            placeholder="•••" 
+                            maxlength="4"
+                            required
+                        >
+                    </div>
+                </div>
+                
+                <button type="submit" class="submit-btn">Pay Now</button>
+                
+            </form>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-credit-card-form-pure/style.css
+++ b/submissions/examples/css-credit-card-form-pure/style.css
@@ -1,0 +1,257 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f1f5f9;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    
+    /* Form Theme */
+    --form-bg: #ffffff;
+    --form-border: #e2e8f0;
+    --input-bg: #f8fafc;
+    --input-border: #cbd5e1;
+    --input-focus: #3b82f6;
+    
+    /* Button Theme */
+    --btn-bg: #0f172a;
+    --btn-text: #ffffff;
+    
+    /* Brand Colors */
+    --visa-color: #1a1f71;
+    --mc-color: #eb001b;
+    --amex-color: #2e77bc;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a;
+        --text-primary: #f8fafc;
+        --text-secondary: #94a3b8;
+        
+        --form-bg: #1e293b;
+        --form-border: #334155;
+        --input-bg: #0f172a;
+        --input-border: #475569;
+        --input-focus: #60a5fa;
+        
+        --btn-bg: #3b82f6;
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 60px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 600;
+    margin: 0 0 16px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    padding: 20px 0;
+}
+
+
+/* =========================================
+   The Form Layout
+   ========================================= */
+
+.cc-form {
+    width: 100%;
+    max-width: 400px;
+    background-color: var(--form-bg);
+    border: 1px solid var(--form-border);
+    border-radius: 12px;
+    padding: 32px;
+    box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.05);
+}
+
+.form-header h2 {
+    margin: 0 0 24px 0;
+    font-size: 1.25rem;
+    font-weight: 600;
+}
+
+.form-row {
+    display: flex;
+    gap: 16px;
+    margin-bottom: 24px;
+}
+
+.input-group {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 20px;
+}
+
+.group-full { width: 100%; }
+.group-half { width: 50%; }
+
+label {
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: var(--text-secondary);
+    margin-bottom: 8px;
+}
+
+input {
+    width: 100%;
+    padding: 12px 16px;
+    font-family: 'Inter', sans-serif;
+    font-size: 1rem;
+    color: var(--text-primary);
+    background-color: var(--input-bg);
+    border: 1px solid var(--input-border);
+    border-radius: 8px;
+    outline: none;
+    transition: border-color 0.2s, box-shadow 0.2s;
+    box-sizing: border-box;
+}
+
+input:focus {
+    border-color: var(--input-focus);
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
+}
+
+.submit-btn {
+    width: 100%;
+    padding: 14px;
+    background-color: var(--btn-bg);
+    color: var(--btn-text);
+    border: none;
+    border-radius: 8px;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: opacity 0.2s;
+}
+
+.submit-btn:hover {
+    opacity: 0.9;
+}
+
+
+/* =========================================
+   [TECHNIQUE] CSS-Driven Auto Detection
+   ========================================= */
+
+.input-with-icon {
+    position: relative;
+    display: flex;
+    align-items: center;
+}
+
+.input-with-icon input {
+    padding-right: 50px; /* Make room for the logo */
+}
+
+.card-logos {
+    position: absolute;
+    right: 16px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    pointer-events: none; /* Let clicks pass to the input */
+}
+
+.logo {
+    position: absolute;
+    right: 0;
+    font-weight: 900;
+    font-size: 0.8rem;
+    font-style: italic;
+    opacity: 0;
+    transform: translateY(5px);
+    transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+/* Default state: Generic Icon */
+.logo-default {
+    opacity: 1;
+    transform: translateY(0);
+    font-size: 1.2rem;
+    font-style: normal;
+    transition-delay: 0.1s;
+}
+
+.logo-visa { color: var(--visa-color); }
+.logo-mastercard { color: var(--mc-color); letter-spacing: -0.5px; }
+.logo-amex { color: var(--amex-color); }
+
+/* 
+  The Magic CSS Attribute Selectors 
+  By reading the value attribute (which is synced via the tiny inline JS), 
+  we use the sibling combinator (~) to reveal the specific brand logo.
+*/
+
+/* VISA: Starts with 4 */
+input[value^="4"] ~ .card-logos .logo-visa {
+    opacity: 1;
+    transform: translateY(0);
+}
+input[value^="4"] ~ .card-logos .logo-default {
+    opacity: 0;
+    transform: translateY(-5px);
+    transition-delay: 0s;
+}
+
+/* MASTERCARD: Starts with 5 */
+input[value^="5"] ~ .card-logos .logo-mastercard {
+    opacity: 1;
+    transform: translateY(0);
+}
+input[value^="5"] ~ .card-logos .logo-default {
+    opacity: 0;
+    transform: translateY(-5px);
+    transition-delay: 0s;
+}
+
+/* AMEX: Starts with 3 */
+input[value^="3"] ~ .card-logos .logo-amex {
+    opacity: 1;
+    transform: translateY(0);
+}
+input[value^="3"] ~ .card-logos .logo-default {
+    opacity: 0;
+    transform: translateY(-5px);
+    transition-delay: 0s;
+}
+
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .logo {
+        transition: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a three-field credit card payment form that visually auto-detects the card type (Visa, Mastercard, Amex) based on the first digit typed, utilizing advanced CSS sibling combinators and attribute selectors. Resolves issue #70121.

### Changes Made:
- Added `submissions/examples/css-credit-card-form-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the form, inputs, and the inline attribute syncing script.
- Created `style.css` featuring the UI mechanics:
  - **The Form Layout**: A standard 3-field layout (`Card Number`, `Expiry Date`, `CVV`). Uses CSS Flexbox for the side-by-side split row on the bottom fields.
  - **The Attribute Selector Trick**: Natively, CSS attribute selectors like `input[value^="4"]` only read the initial `value` attribute present in the HTML source, not the live value typed by the user. To bridge this gap and allow CSS to drive the UI logic, a tiny inline Javascript helper is added to the input: `oninput="this.setAttribute('value', this.value)"`.
  - **Auto-Detection Logic**: The `.card-logos` wrapper contains multiple hidden brand text logos (`VISA`, `MC`, `AMEX`) and a default generic icon. We use the CSS general sibling combinator (`~`) to link the input value to the logos. If the input value starts with `4` (Visa), `5` (Mastercard), or `3` (Amex), the CSS ruleset animates the default logo out (`opacity: 0`, `transform: translateY(-5px)`) and animates the corresponding brand logo in.
  - **Theming & Dark Mode Supported**: Configured via CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), adapting the form background, borders, and input focus states while preserving the brand colors (Visa Blue, Mastercard Red).
- Added `README.md` documenting usage and the technical mechanics of the attribute selector trick.
- Fully accessible semantic structure. Uses `<form>`, `<label>`, and `<input>` tags. The dynamically updating logos are purely visual feedback and are hidden from screen readers via `aria-hidden="true"`, ensuring they don't interrupt the user's typing flow with redundant announcements.

Closes #70121
