### PR TITLE
feat: add pure CSS Reveal Nav on Hover component (#70131)

### DIFF
--- a/submissions/examples/css-reveal-nav-on-hover-pure/README.md
+++ b/submissions/examples/css-reveal-nav-on-hover-pure/README.md
@@ -1,0 +1,19 @@
+# CSS Reveal Nav on Hover
+
+A minimalist navigation bar that hides completely off-screen until the user moves their mouse near the top edge of the viewport. Built entirely without JavaScript event listeners.
+
+## Features
+- Pure CSS and HTML implementation.
+- **Component Architecture (Documented in Code)**: 
+  - **The Hidden Nav**: The `.proximity-nav` is positioned `fixed` to the top of the viewport. However, it is entirely pushed off-screen using `transform: translateY(-100%)`.
+  - **The Invisible Proximity Trigger**: To detect when the mouse gets "close" to the top of the screen without Javascript, a CSS pseudo-element (`::after`) is attached to the nav bar. This pseudo-element is configured to extend exactly 50px below the bottom edge of the nav (`top: 100%; height: 50px`). Because it technically belongs to the nav element, it catches mouse hover events.
+  - **The Reveal**: When the user's mouse enters the invisible 50px trigger zone at the top of the screen, the `:hover` pseudo-class activates on the `.proximity-nav`. The CSS ruleset then applies `transform: translateY(0)`, smoothly sliding the navigation bar back onto the screen.
+- **Theming & Dark Mode**: Configured via CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), generating a deep slate glassmorphism bar in dark mode and a crisp white frosted glass bar in light mode using `backdrop-filter: blur(10px)`.
+- Fully accessible semantic structure. Uses `<nav>`, `<ul>`, and `<header>` tags. Includes `focus-within` fallback logic: if a user relies on keyboard navigation (Tab), tabbing into the hidden navigation links will trigger `:focus-within` and automatically reveal the nav bar, ensuring accessibility is not compromised by the hover-only design. Honors the `prefers-reduced-motion` accessibility standard by disabling the slide animation for motion-sensitive users.
+
+## Usage
+Open `demo.html` in your browser. Move your mouse to the very top edge of the viewport to trigger the proximity reveal.
+
+## Files
+- `demo.html`: The HTML structure defining the nav wrapper and content.
+- `style.css`: The styling, the critical `::after` proximity trigger, and the `focus-within` accessibility fallback.

--- a/submissions/examples/css-reveal-nav-on-hover-pure/demo.html
+++ b/submissions/examples/css-reveal-nav-on-hover-pure/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Reveal Nav on Hover</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <!-- 
+      [TECHNIQUE] The Reveal Nav
+      The nav is fixed to the top of the screen but translated off-screen (Y: -100%).
+      It has a large invisible pseudo-element hanging below it that catches mouse hovers.
+      When the mouse gets close to the top of the screen, it triggers the hover state 
+      and pulls the nav down.
+    -->
+    <nav class="proximity-nav" aria-label="Main Navigation">
+        <div class="nav-content">
+            <div class="nav-brand">Logo</div>
+            <ul class="nav-links">
+                <li><a href="#">Home</a></li>
+                <li><a href="#">About</a></li>
+                <li><a href="#">Services</a></li>
+                <li><a href="#">Contact</a></li>
+            </ul>
+        </div>
+        <!-- 
+          The invisible "hitbox" is created in CSS via `::after`. 
+          It extends 50px below the nav bar.
+        -->
+    </nav>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Reveal Nav on Hover</h1>
+            <p class="subtitle">Move your mouse to the top edge of the screen to reveal the hidden navigation bar. Built entirely without JavaScript using a pseudo-element proximity trigger.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <div class="content-block">
+                <h2>How it Works</h2>
+                <p>The navigation bar is positioned `fixed` at the top of the viewport, but pushed off-screen using `transform: translateY(-100%)`.</p>
+                <p>We attach a CSS `::after` pseudo-element to the nav bar that extends exactly 50px below it. Because this pseudo-element is technically part of the nav, hovering over it triggers the `nav:hover` state.</p>
+                <p>When the hover state is active, the nav bar seamlessly translates back to `0`, pulling itself on-screen.</p>
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-reveal-nav-on-hover-pure/style.css
+++ b/submissions/examples/css-reveal-nav-on-hover-pure/style.css
@@ -1,0 +1,196 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    
+    /* Nav Theme */
+    --nav-bg: rgba(255, 255, 255, 0.9);
+    --nav-border: #e2e8f0;
+    --nav-shadow: rgba(0, 0, 0, 0.1);
+    --nav-text: #0f172a;
+    --nav-hover: #3b82f6;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a;
+        --text-primary: #f8fafc;
+        --text-secondary: #94a3b8;
+        
+        --nav-bg: rgba(30, 41, 59, 0.9);
+        --nav-border: #334155;
+        --nav-shadow: rgba(0, 0, 0, 0.5);
+        --nav-text: #f8fafc;
+        --nav-hover: #60a5fa;
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 120px 20px 60px 20px; /* Extra top padding to clear the nav when it reveals */
+}
+
+.section-header {
+    margin-bottom: 60px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    padding: 20px 0;
+}
+
+.content-block {
+    background: rgba(128, 128, 128, 0.05);
+    padding: 40px;
+    border-radius: 16px;
+    border: 1px solid rgba(128, 128, 128, 0.1);
+}
+
+.content-block h2 {
+    margin-top: 0;
+    font-size: 1.5rem;
+}
+
+.content-block p {
+    line-height: 1.7;
+    color: var(--text-secondary);
+    margin-bottom: 16px;
+}
+
+
+/* =========================================
+   [TECHNIQUE] The Reveal Navigation
+   ========================================= */
+
+.proximity-nav {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    z-index: 1000;
+    background-color: var(--nav-bg);
+    border-bottom: 1px solid var(--nav-border);
+    box-shadow: 0 4px 20px var(--nav-shadow);
+    
+    /* Modern glassmorphism blur */
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    
+    /* 
+      CRITICAL: Hide it completely off-screen by translating it up 100% of its own height.
+    */
+    transform: translateY(-100%);
+    
+    /* Smooth slide animation */
+    transition: transform 0.4s cubic-bezier(0.165, 0.84, 0.44, 1);
+}
+
+/* 
+  [TECHNIQUE] The Invisible Proximity Trigger 
+  We attach a pseudo-element that extends 50px BELOW the hidden nav bar.
+  Because it belongs to the nav, hovering over this invisible box triggers nav:hover!
+*/
+.proximity-nav::after {
+    content: '';
+    position: absolute;
+    top: 100%; /* Start exactly at the bottom edge of the nav */
+    left: 0;
+    width: 100%;
+    height: 50px; /* The "proximity" distance */
+    
+    /* Optional: uncomment to visualize the hit box */
+    /* background: rgba(255, 0, 0, 0.2); */
+}
+
+/* 
+  The Hover State
+  When the user hovers over the nav (or its invisible pseudo-element), 
+  translate it back down to its natural position on screen.
+*/
+.proximity-nav:hover,
+.proximity-nav:focus-within {
+    transform: translateY(0);
+}
+
+
+/* =========================================
+   Standard Nav Styling
+   ========================================= */
+
+.nav-content {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 24px;
+    height: 70px; /* Fixed height for the visible bar */
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.nav-brand {
+    font-size: 1.5rem;
+    font-weight: 700;
+    letter-spacing: -1px;
+}
+
+.nav-links {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    gap: 32px;
+}
+
+.nav-links a {
+    text-decoration: none;
+    color: var(--nav-text);
+    font-weight: 600;
+    font-size: 0.95rem;
+    transition: color 0.2s;
+}
+
+.nav-links a:hover,
+.nav-links a:focus {
+    color: var(--nav-hover);
+    outline: none;
+}
+
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .proximity-nav {
+        transition: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a minimalist navigation bar that hides completely off-screen until the user moves their mouse near the top edge of the viewport. Built entirely without JavaScript event listeners, resolving issue #70131.

### Changes Made:
- Added `submissions/examples/css-reveal-nav-on-hover-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the nav wrapper and content.
- Created `style.css` featuring the UI mechanics:
  - **The Hidden Nav**: The `.proximity-nav` is positioned `fixed` to the top of the viewport. However, it is entirely pushed off-screen using `transform: translateY(-100%)`.
  - **The Invisible Proximity Trigger**: To detect when the mouse gets "close" to the top of the screen without Javascript, a CSS pseudo-element (`::after`) is attached to the nav bar. This pseudo-element is configured to extend exactly 50px below the bottom edge of the nav (`top: 100%; height: 50px`). Because it technically belongs to the nav element, it catches mouse hover events.
  - **The Reveal**: When the user's mouse enters the invisible 50px trigger zone at the top of the screen, the `:hover` pseudo-class activates on the `.proximity-nav`. The CSS ruleset then applies `transform: translateY(0)`, smoothly sliding the navigation bar back onto the screen.
  - **Theming & Dark Mode Supported**: Configured via CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), generating a deep slate glassmorphism bar in dark mode and a crisp white frosted glass bar in light mode using `backdrop-filter: blur(10px)`.
- Added `README.md` documenting usage and the technical mechanics of the `focus-within` accessibility fallback.
- Fully accessible semantic structure. Uses `<nav>`, `<ul>`, and `<header>` tags. Includes `focus-within` fallback logic: if a user relies on keyboard navigation (Tab), tabbing into the hidden navigation links will trigger `:focus-within` and automatically reveal the nav bar, ensuring accessibility is not compromised by the hover-only design. Honors the `prefers-reduced-motion` accessibility standard by disabling the slide animation for motion-sensitive users.

Closes #70131
