### PR TITLE
feat: add pure CSS Perlin Noise Blob component (#70138)

### DIFF
--- a/submissions/examples/css-perlin-noise-blob-pure/README.md
+++ b/submissions/examples/css-perlin-noise-blob-pure/README.md
@@ -1,0 +1,19 @@
+# CSS Perlin Noise Blob
+
+An organic, fluid shape that morphs continuously, simulating the aesthetic of Perlin noise distortion. Built entirely in CSS without JavaScript or SVG `<feTurbulence>` filters.
+
+## Features
+- Pure CSS and HTML implementation.
+- **Component Architecture (Documented in Code)**: 
+  - **The 8-Value Border Radius**: Standard CSS `border-radius` uses 4 values (for the 4 corners) to create symmetrical curves. By passing 8 values separated by a slash (`/`), you independently control the horizontal and vertical radii of each corner (e.g., `border-radius: 40% 60% 70% 30% / 40% 50% 60% 50%`). This creates asymmetrical, organic "blob" shapes.
+  - **Morphing Animation**: The fluid, noise-like morphing is achieved by animating between multiple different 8-value `border-radius` configurations inside a CSS `@keyframes` block, combined with subtle scale transforms to simulate breathing/pulsing.
+  - **Color Mixing via Blend Modes**: To increase visual complexity and mimic true noise maps, two separate blobs are layered on top of each other. The bottom blob uses a Pink/Purple gradient, while the top uses Cyan/Blue. The top blob applies `mix-blend-mode: screen`. Because they are running the same `@keyframes` at slightly different durations (`8s` vs `11s`), they drift out of sync, creating a constantly evolving, unpredictable intersection of colors.
+- **Theming & Dark Mode**: Configured via CSS Custom Properties. The vibrant neon gradients contrast beautifully against the deep slate background provided for dark mode environments.
+- Fully accessible semantic structure. The blob animation is purely decorative background for the `.blob-content`. Honors the `prefers-reduced-motion` accessibility standard by disabling the `@keyframes` entirely for motion-sensitive users, falling back to a static but visually interesting organic shape.
+
+## Usage
+Open `demo.html` in your browser. The blobs will automatically begin morphing and blending their colors infinitely.
+
+## Files
+- `demo.html`: The HTML structure defining the layered blobs and the centered content container.
+- `style.css`: The styling, the 8-value `border-radius` trick, the `mix-blend-mode` logic, and the `@keyframes` definitions.

--- a/submissions/examples/css-perlin-noise-blob-pure/demo.html
+++ b/submissions/examples/css-perlin-noise-blob-pure/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Perlin Noise Blob</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Organic Morphing Blob</h1>
+            <p class="subtitle">Simulating organic, fluid shape morphing (often achieved via Perlin noise) entirely in CSS using advanced 8-value `border-radius` keyframe animations and gradient meshes.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <!-- 
+              [TECHNIQUE] The Morphing Blob
+              This container uses an advanced CSS border-radius trick to create 
+              organic, non-circular shapes. By animating these 8 values, it 
+              simulates fluid, noise-driven distortion.
+            -->
+            <div class="blob-container">
+                <div class="blob blob-1"></div>
+                <div class="blob blob-2"></div>
+                
+                <!-- Inner content can still be centered perfectly -->
+                <div class="blob-content">
+                    <span>Fluid</span>
+                </div>
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-perlin-noise-blob-pure/style.css
+++ b/submissions/examples/css-perlin-noise-blob-pure/style.css
@@ -1,0 +1,195 @@
+@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@700&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    
+    /* Blob Gradients */
+    --blob-color-1a: #ff0080;
+    --blob-color-1b: #7928ca;
+    
+    --blob-color-2a: #00dfd8;
+    --blob-color-2b: #007cf0;
+    
+    --blob-text: #ffffff;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a;
+        --text-primary: #f8fafc;
+        --text-secondary: #94a3b8;
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: system-ui, -apple-system, sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 80px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 60px 0;
+    min-height: 400px;
+}
+
+
+/* =========================================
+   [TECHNIQUE] The Organic Blob Shapes
+   ========================================= */
+
+.blob-container {
+    position: relative;
+    width: 300px;
+    height: 300px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    
+    /* Optional: subtle rotation of the entire container */
+    animation: slowSpin 30s linear infinite;
+}
+
+.blob {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    
+    /* 
+      CRITICAL: The 8-value border-radius.
+      The first 4 values define horizontal radii (Top-Left, Top-Right, Bottom-Right, Bottom-Left).
+      The last 4 values define vertical radii.
+      This allows for asymmetrical, non-circular shapes.
+    */
+    border-radius: 40% 60% 70% 30% / 40% 50% 60% 50%;
+    
+    /* Combine with animation to create the "morphing" effect */
+    animation: morphBlob 8s ease-in-out infinite alternate;
+}
+
+/* Layer 1: Pink/Purple */
+.blob-1 {
+    background: linear-gradient(45deg, var(--blob-color-1a), var(--blob-color-1b));
+    box-shadow: 0 10px 30px rgba(121, 40, 202, 0.3);
+    z-index: 1;
+}
+
+/* 
+  Layer 2: Cyan/Blue 
+  We add a second blob with a different gradient, animation duration, and blend mode 
+  to create complex, fluid color intersections similar to Perlin noise texture generation.
+*/
+.blob-2 {
+    background: linear-gradient(-45deg, var(--blob-color-2a), var(--blob-color-2b));
+    mix-blend-mode: screen; /* Blends colors dynamically */
+    opacity: 0.8;
+    z-index: 2;
+    
+    /* Different animation timing and reverse direction for chaotic movement */
+    animation: morphBlob 11s ease-in-out infinite alternate-reverse;
+}
+
+/* Center Text Content */
+.blob-content {
+    position: relative;
+    z-index: 10;
+    font-family: 'Space Grotesk', sans-serif;
+    font-size: 2.5rem;
+    font-weight: 700;
+    color: var(--blob-text);
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    
+    /* Counter-rotate so text stays upright */
+    animation: reverseSlowSpin 30s linear infinite;
+}
+
+
+/* =========================================
+   Keyframes
+   ========================================= */
+
+/* 
+  The core technique: transitioning smoothly between different 8-value radii.
+  This creates the fluid, organic stretching and squishing.
+*/
+@keyframes morphBlob {
+    0% {
+        border-radius: 40% 60% 70% 30% / 40% 50% 60% 50%;
+        transform: scale(1);
+    }
+    34% {
+        border-radius: 70% 30% 50% 50% / 30% 30% 70% 70%;
+        transform: scale(1.05);
+    }
+    67% {
+        border-radius: 100% 60% 60% 100% / 100% 100% 60% 60%;
+        transform: scale(0.95);
+    }
+    100% {
+        border-radius: 40% 60% 70% 30% / 40% 50% 60% 50%;
+        transform: scale(1);
+    }
+}
+
+@keyframes slowSpin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
+@keyframes reverseSlowSpin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(-360deg); }
+}
+
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .blob-container,
+    .blob,
+    .blob-content {
+        animation: none !important;
+    }
+    
+    /* Give it a static but interesting shape */
+    .blob-1 { border-radius: 70% 30% 50% 50% / 30% 30% 70% 70%; }
+    .blob-2 { border-radius: 40% 60% 70% 30% / 40% 50% 60% 50%; transform: rotate(45deg); }
+}


### PR DESCRIPTION
### Description
This PR introduces an organic, fluid shape that morphs continuously, simulating the aesthetic of Perlin noise distortion. Built entirely in CSS without JavaScript or SVG `<feTurbulence>` filters, resolving issue #70138.

### Changes Made:
- Added `submissions/examples/css-perlin-noise-blob-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the layered blobs and the centered content container.
- Created `style.css` featuring the UI mechanics:
  - **The 8-Value Border Radius**: Standard CSS `border-radius` uses 4 values (for the 4 corners) to create symmetrical curves. By passing 8 values separated by a slash (`/`), you independently control the horizontal and vertical radii of each corner (e.g., `border-radius: 40% 60% 70% 30% / 40% 50% 60% 50%`). This creates asymmetrical, organic "blob" shapes.
  - **Morphing Animation**: The fluid, noise-like morphing is achieved by animating between multiple different 8-value `border-radius` configurations inside a CSS `@keyframes` block, combined with subtle scale transforms to simulate breathing/pulsing.
  - **Color Mixing via Blend Modes**: To increase visual complexity and mimic true noise maps, two separate blobs are layered on top of each other. The bottom blob uses a Pink/Purple gradient, while the top uses Cyan/Blue. The top blob applies `mix-blend-mode: screen`. Because they are running the same `@keyframes` at slightly different durations (`8s` vs `11s`), they drift out of sync, creating a constantly evolving, unpredictable intersection of colors.
  - **Theming & Dark Mode Supported**: Configured via CSS Custom Properties. The vibrant neon gradients contrast beautifully against the deep slate background provided for dark mode environments.
- Added `README.md` documenting usage and the technical mechanics of the 8-value border radius trick.
- Fully accessible semantic structure. The blob animation is purely decorative background for the `.blob-content`. Honors the `prefers-reduced-motion` accessibility standard by disabling the `@keyframes` entirely for motion-sensitive users, falling back to a static but visually interesting organic shape.

Closes #70138
