### PR TITLE
feat: add CSS puzzle scramble board demo

### DIFF
--- a/submissions/examples/css-puzzle-scramble-board/README.md
+++ b/submissions/examples/css-puzzle-scramble-board/README.md
@@ -1,0 +1,19 @@
+# CSS Puzzle Scramble Board
+
+**What does this do?**
+This is a pure CSS 15-puzzle component that features a dramatic "scramble" entrance animation on load and interactive jiggle hover effects.
+
+**How is it used?**
+Use the `puzzle-scramble-board` container with a grid layout and place `puzzle-tile` elements inside it, using the `puzzle-empty` class for the blank spot.
+
+```html
+<div class="puzzle-scramble-board" role="grid" aria-label="15 Puzzle Board">
+  <div class="puzzle-tile" role="gridcell" tabindex="0">1</div>
+  <div class="puzzle-tile" role="gridcell" tabindex="0">2</div>
+  <!-- ... tiles up to 15 ... -->
+  <div class="puzzle-tile puzzle-empty" role="gridcell" aria-hidden="true"></div>
+</div>
+```
+
+**Why is it useful?**
+This component fits seamlessly into the EaseMotion library by providing a complex, physics-like animation purely through CSS. It expands the collection of ready-to-use dynamic UI patterns, giving developers an eye-catching interactive element without relying on any JavaScript for the animations.

--- a/submissions/examples/css-puzzle-scramble-board/demo.html
+++ b/submissions/examples/css-puzzle-scramble-board/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Puzzle Scramble Board Demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      margin: 0;
+      padding: 0;
+      min-height: 100vh;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      background-color: #1a1a1a;
+      font-family: system-ui, -apple-system, sans-serif;
+    }
+  </style>
+</head>
+<body>
+  <div class="puzzle-scramble-board" role="grid" aria-label="15 Puzzle Board">
+    <div class="puzzle-tile" role="gridcell" tabindex="0">1</div>
+    <div class="puzzle-tile" role="gridcell" tabindex="0">2</div>
+    <div class="puzzle-tile" role="gridcell" tabindex="0">3</div>
+    <div class="puzzle-tile" role="gridcell" tabindex="0">4</div>
+    <div class="puzzle-tile" role="gridcell" tabindex="0">5</div>
+    <div class="puzzle-tile" role="gridcell" tabindex="0">6</div>
+    <div class="puzzle-tile" role="gridcell" tabindex="0">7</div>
+    <div class="puzzle-tile" role="gridcell" tabindex="0">8</div>
+    <div class="puzzle-tile" role="gridcell" tabindex="0">9</div>
+    <div class="puzzle-tile" role="gridcell" tabindex="0">10</div>
+    <div class="puzzle-tile" role="gridcell" tabindex="0">11</div>
+    <div class="puzzle-tile" role="gridcell" tabindex="0">12</div>
+    <div class="puzzle-tile" role="gridcell" tabindex="0">13</div>
+    <div class="puzzle-tile" role="gridcell" tabindex="0">14</div>
+    <div class="puzzle-tile" role="gridcell" tabindex="0">15</div>
+    <div class="puzzle-tile puzzle-empty" role="gridcell" aria-hidden="true"></div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/css-puzzle-scramble-board/style.css
+++ b/submissions/examples/css-puzzle-scramble-board/style.css
@@ -1,0 +1,122 @@
+.puzzle-scramble-board {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  grid-template-rows: repeat(4, 1fr);
+  gap: 8px;
+  width: 100%;
+  max-width: 320px;
+  aspect-ratio: 1;
+  background: #22252a;
+  padding: 12px;
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5), inset 0 0 20px rgba(0, 0, 0, 0.8);
+  margin: 2rem auto;
+}
+
+.puzzle-tile {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: #fff;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 1.5rem;
+  font-weight: 800;
+  border-radius: 8px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2), inset 0 2px 4px rgba(255, 255, 255, 0.2);
+  cursor: pointer;
+  transition: transform 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275), box-shadow 0.2s ease, filter 0.2s ease;
+  user-select: none;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  /* Scramble entrance animation */
+  animation: puzzle-scramble-in 0.8s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+.puzzle-tile:focus-visible {
+  outline: 3px solid #4facfe;
+  outline-offset: 2px;
+  z-index: 10;
+}
+
+.puzzle-tile:hover {
+  transform: translateY(-4px) scale(1.05);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.3), inset 0 2px 4px rgba(255, 255, 255, 0.4);
+  z-index: 5;
+  filter: brightness(1.15);
+}
+
+.puzzle-tile:active {
+  transform: translateY(2px) scale(0.95);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2), inset 0 1px 2px rgba(255, 255, 255, 0.1);
+}
+
+.puzzle-empty {
+  background: rgba(255, 255, 255, 0.03);
+  box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.3);
+  border: 2px dashed rgba(255, 255, 255, 0.15);
+  cursor: default;
+  animation: none;
+}
+
+.puzzle-empty:hover {
+  transform: none;
+  box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.3);
+  filter: none;
+  z-index: 1;
+}
+
+/* Staggered and randomized entrance variables */
+.puzzle-tile:nth-child(1) { --tx: -150%; --ty: -150%; --tr: -45deg; animation-delay: 0.1s; }
+.puzzle-tile:nth-child(2) { --tx: 50%; --ty: -200%; --tr: 25deg; animation-delay: 0.15s; }
+.puzzle-tile:nth-child(3) { --tx: 150%; --ty: -100%; --tr: -15deg; animation-delay: 0.05s; }
+.puzzle-tile:nth-child(4) { --tx: 250%; --ty: -150%; --tr: 45deg; animation-delay: 0.2s; }
+.puzzle-tile:nth-child(5) { --tx: -200%; --ty: -50%; --tr: 30deg; animation-delay: 0.25s; }
+.puzzle-tile:nth-child(6) { --tx: -50%; --ty: -50%; --tr: -20deg; animation-delay: 0.1s; }
+.puzzle-tile:nth-child(7) { --tx: 100%; --ty: -50%; --tr: 10deg; animation-delay: 0.3s; }
+.puzzle-tile:nth-child(8) { --tx: 200%; --ty: 50%; --tr: -35deg; animation-delay: 0.05s; }
+.puzzle-tile:nth-child(9) { --tx: -150%; --ty: 100%; --tr: -60deg; animation-delay: 0.15s; }
+.puzzle-tile:nth-child(10) { --tx: -50%; --ty: 150%; --tr: 40deg; animation-delay: 0.35s; }
+.puzzle-tile:nth-child(11) { --tx: 50%; --ty: 100%; --tr: -10deg; animation-delay: 0.2s; }
+.puzzle-tile:nth-child(12) { --tx: 150%; --ty: 150%; --tr: 55deg; animation-delay: 0.1s; }
+.puzzle-tile:nth-child(13) { --tx: -250%; --ty: 200%; --tr: -25deg; animation-delay: 0.3s; }
+.puzzle-tile:nth-child(14) { --tx: -100%; --ty: 250%; --tr: 15deg; animation-delay: 0.25s; }
+.puzzle-tile:nth-child(15) { --tx: 50%; --ty: 200%; --tr: -50deg; animation-delay: 0.15s; }
+
+@keyframes puzzle-scramble-in {
+  0% {
+    opacity: 0;
+    transform: translate(var(--tx), var(--ty)) rotate(var(--tr)) scale(0.5);
+  }
+  100% {
+    opacity: 1;
+    transform: translate(0, 0) rotate(0deg) scale(1);
+  }
+}
+
+/* Interactive board hover - subtle jiggle to invite interaction */
+.puzzle-scramble-board:hover .puzzle-tile:not(.puzzle-empty) {
+  animation: puzzle-jiggle 0.4s ease-in-out infinite alternate;
+}
+
+/* Stagger the jiggle */
+.puzzle-scramble-board:hover .puzzle-tile:nth-child(even) {
+  animation-duration: 0.5s;
+  animation-direction: alternate-reverse;
+}
+.puzzle-scramble-board:hover .puzzle-tile:nth-child(3n) {
+  animation-duration: 0.3s;
+  animation-delay: 0.1s;
+}
+
+/* Pause jiggle on the tile being hovered to allow normal hover effect */
+.puzzle-scramble-board:hover .puzzle-tile:hover {
+  animation: none;
+  transform: translateY(-4px) scale(1.05);
+}
+
+@keyframes puzzle-jiggle {
+  0% { transform: translate(0, 0) rotate(0deg); }
+  25% { transform: translate(1px, -1px) rotate(0.5deg); }
+  50% { transform: translate(-1px, 1px) rotate(-0.5deg); }
+  75% { transform: translate(-1.5px, -1px) rotate(0.2deg); }
+  100% { transform: translate(1px, 1.5px) rotate(-0.2deg); }
+}


### PR DESCRIPTION
## Pull Request Description

This PR introduces a pure CSS 15-puzzle scramble board component (Resolves #70683). It features a complex entrance animation that scatters the tiles and settles them into a grid layout, along with interactive jiggle hover effects, entirely without JavaScript.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A pure CSS 15-puzzle component that features a dramatic "scramble" entrance animation on load and interactive jiggle hover effects.

**How does a developer use it?**

```html
<div class="puzzle-scramble-board" role="grid" aria-label="15 Puzzle Board">
  <div class="puzzle-tile" role="gridcell" tabindex="0">1</div>
  <div class="puzzle-tile" role="gridcell" tabindex="0">2</div>
  <!-- ... remaining tiles ... -->
  <div class="puzzle-tile" role="gridcell" tabindex="0">15</div>
  <div class="puzzle-tile puzzle-empty" role="gridcell" aria-hidden="true"></div>
</div>
