### PR TITLE
feat: add pure CSS Ant Trail Loader component (#70139)

### DIFF
--- a/submissions/examples/css-ant-trail-loader-pure/README.md
+++ b/submissions/examples/css-ant-trail-loader-pure/README.md
@@ -1,0 +1,19 @@
+# CSS Ant Trail Loader
+
+A classic "marching ants" circular loading animation built entirely in CSS. No JavaScript, no SVG `stroke-dasharray`, just pure CSS gradients and masks.
+
+## Features
+- Pure CSS and HTML implementation.
+- **Component Architecture (Documented in Code)**: 
+  - **The Ants**: Rather than using SVG paths or multiple DOM elements, the "ants" are drawn using a single CSS `repeating-conic-gradient`. It draws a sliver of color (the ant) from 0 to 4 degrees, then transparent space from 4 to 12 degrees, and repeats this pattern automatically around the 360-degree circle.
+  - **The Trail Ring**: A conic gradient fills the entire circle by default. To hollow out the center and create a thin ring (a trail), a CSS `mask` (with `-webkit-mask` fallback) is applied using a `radial-gradient`. The radial gradient is completely transparent from the center up to 60%, and solid black from 61% outward, cleanly clipping the inner portion of the conic gradient.
+  - **The March**: The marching animation is achieved simply by applying a continuous linear `@keyframes` rotation to the outer container.
+- **Theming & Dark Mode**: Configured via CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`). The ants are a dark slate color in light mode, but swap to a glowing neon blue in dark mode for a cybernetic aesthetic.
+- Fully accessible semantic structure. The loader wrapper is given `role="status"` and `aria-label="Loading"`. Honors the `prefers-reduced-motion` accessibility standard by entirely disabling the spinning and pulsing animations for motion-sensitive users, rendering it as a static dashed ring.
+
+## Usage
+Open `demo.html` in your browser. The ant trail will automatically animate.
+
+## Files
+- `demo.html`: The HTML structure defining the loader wrapper and the text container.
+- `style.css`: The styling, the `repeating-conic-gradient` trick, the `radial-gradient` mask, and the infinite linear rotation.

--- a/submissions/examples/css-ant-trail-loader-pure/demo.html
+++ b/submissions/examples/css-ant-trail-loader-pure/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Ant Trail Loader</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Ant Trail Loader</h1>
+            <p class="subtitle">A classic "marching ants" circular loading animation built entirely in CSS without SVG, using `repeating-conic-gradient` and CSS `mask`.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <!-- 
+              [TECHNIQUE] The Ant Trail Loader
+              The outer container spins infinitely.
+              The inner "ants" are drawn using a repeating conic gradient.
+              The center is hollowed out using a CSS radial-gradient mask.
+            -->
+            <div class="loader-wrapper" role="status" aria-label="Loading">
+                <div class="ant-trail"></div>
+                <div class="loading-text">Loading</div>
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-ant-trail-loader-pure/style.css
+++ b/submissions/examples/css-ant-trail-loader-pure/style.css
@@ -1,0 +1,156 @@
+@import url('https://fonts.googleapis.com/css2?family=Space+Mono:wght@700&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    
+    /* Loader Colors */
+    --ant-color: #0f172a; /* Black/Dark slate ants */
+    --loader-text: #64748b;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a;
+        --text-primary: #f8fafc;
+        --text-secondary: #94a3b8;
+        
+        --ant-color: #38bdf8; /* Neon blue ants for dark mode */
+        --loader-text: #94a3b8;
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: system-ui, -apple-system, sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 80px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 900;
+    margin: 0 0 16px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 60px 0;
+    min-height: 300px;
+}
+
+
+/* =========================================
+   [TECHNIQUE] The Ant Trail Logic
+   ========================================= */
+
+.loader-wrapper {
+    position: relative;
+    width: 120px;
+    height: 120px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.ant-trail {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    
+    /* 
+      1. Draw the "Ants"
+      We use a repeating conic gradient. It draws a slice of color (the ant) 
+      from 0 to 4 degrees, then transparent space from 4 to 12 degrees, 
+      and repeats this around the 360-degree circle.
+    */
+    background: repeating-conic-gradient(
+        var(--ant-color) 0deg, 
+        var(--ant-color) 4deg, 
+        transparent 4deg, 
+        transparent 12deg
+    );
+    
+    /* 
+      2. Hollow out the center
+      A conic gradient fills the entire circle. To make it a "trail" (a ring), 
+      we apply a CSS mask. The radial gradient mask hides everything from the 
+      center up to 60%, revealing only the outer edge.
+      (We include -webkit prefixes for maximum browser compatibility).
+    */
+    -webkit-mask: radial-gradient(transparent 60%, black 61%);
+    mask: radial-gradient(transparent 60%, black 61%);
+    
+    /* 
+      3. The March
+      We simply spin the entire div continuously.
+    */
+    animation: march 4s linear infinite;
+}
+
+.loading-text {
+    font-family: 'Space Mono', monospace;
+    font-size: 0.8rem;
+    font-weight: 700;
+    color: var(--loader-text);
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    z-index: 10;
+    /* Slight pulse on the text */
+    animation: pulse 1.5s ease-in-out infinite alternate;
+}
+
+
+/* =========================================
+   Keyframes
+   ========================================= */
+
+@keyframes march {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
+@keyframes pulse {
+    from { opacity: 0.5; }
+    to { opacity: 1; }
+}
+
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .ant-trail,
+    .loading-text {
+        animation: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a classic "marching ants" circular loading animation built entirely in CSS. No JavaScript, no SVG `stroke-dasharray`, just pure CSS gradients and masks. Resolves issue #70139.

### Changes Made:
- Added `submissions/examples/css-ant-trail-loader-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the loader wrapper and the text container.
- Created `style.css` featuring the UI mechanics:
  - **The Ants**: Rather than using SVG paths or multiple DOM elements, the "ants" are drawn using a single CSS `repeating-conic-gradient`. It draws a sliver of color (the ant) from 0 to 4 degrees, then transparent space from 4 to 12 degrees, and repeats this pattern automatically around the 360-degree circle.
  - **The Trail Ring**: A conic gradient fills the entire circle by default. To hollow out the center and create a thin ring (a trail), a CSS `mask` (with `-webkit-mask` fallback) is applied using a `radial-gradient`. The radial gradient is completely transparent from the center up to 60%, and solid black from 61% outward, cleanly clipping the inner portion of the conic gradient.
  - **The March**: The marching animation is achieved simply by applying a continuous linear `@keyframes` rotation to the outer container.
  - **Theming & Dark Mode Supported**: Configured via CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`). The ants are a dark slate color in light mode, but swap to a glowing neon blue in dark mode for a cybernetic aesthetic.
- Added `README.md` documenting usage and the technical mechanics of the CSS radial-gradient mask trick.
- Fully accessible semantic structure. The loader wrapper is given `role="status"` and `aria-label="Loading"`. Honors the `prefers-reduced-motion` accessibility standard by entirely disabling the spinning and pulsing animations for motion-sensitive users, rendering it as a static dashed ring.

Closes #70139
