### PR TITLE
feat: add pure CSS @starting-style Demo component (#70149)

### DIFF
--- a/submissions/examples/css-starting-style-demo-pure/README.md
+++ b/submissions/examples/css-starting-style-demo-pure/README.md
@@ -1,0 +1,20 @@
+# CSS `@starting-style` Demo
+
+A demonstration of the modern CSS `@starting-style` rule, which finally allows developers to animate elements transitioning directly from `display: none` to `display: block` without requiring Javascript timeouts or requestAnimationFrame hacks.
+
+## Features
+- Pure CSS and HTML implementation utilizing the native HTML `popover` API.
+- **Component Architecture (Documented in Code)**: 
+  - **Native Popover**: The demo uses the native HTML attribute `popover` and `popovertarget`. This allows the button to open the modal into the browser's top layer entirely without JavaScript.
+  - **Discrete Transitions**: To animate a popover, it must transition from `display: none` to `display: block` (and `overlay: none` to `overlay: auto`). Historically, this caused CSS transitions to instantly jump. By adding `transition-behavior: allow-discrete` to the `display` and `overlay` properties, the browser is instructed to wait for the opacity/transform animations to finish before removing the element from the render tree.
+  - **The `@starting-style` Rule**: When the modal first opens, it enters the DOM. The browser needs to know what CSS state to transition *from*. The new `@starting-style` block defines the exact styles (`opacity: 0`, `transform: scale(0.95)`) that the element should hold at the very instant it becomes `display: block`. It then smoothly transitions to its natural `:popover-open` state.
+  - **Animated Backdrop**: The exact same `@starting-style` and discrete transition logic is applied to the native `::backdrop` pseudo-element to fade the dark overlay in and out synchronously with the modal.
+- **Theming & Dark Mode**: Configured via CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), adapting the modal surface, text colors, and shadows.
+- Fully accessible semantic structure. Because it relies on the native HTML `popover` specification, it automatically inherits Focus Management, Esc-key to dismiss, and light-dismiss (clicking the backdrop). Honors the `prefers-reduced-motion` accessibility standard by disabling the `@starting-style` transitions for motion-sensitive users.
+
+## Usage
+Open `demo.html` in your modern browser (Chrome 117+, Safari 17.5+). Click the "Open Modal" button to view the smooth entrance animation.
+
+## Files
+- `demo.html`: The HTML structure defining the native `popover` and trigger buttons.
+- `style.css`: The styling, the `allow-discrete` transitions, and the `@starting-style` blocks.

--- a/submissions/examples/css-starting-style-demo-pure/demo.html
+++ b/submissions/examples/css-starting-style-demo-pure/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS @starting-style Demo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Modern CSS `@starting-style`</h1>
+            <p class="subtitle">Historically, CSS could not animate elements transitioning from `display: none` to `display: block`. The new `@starting-style` rule fixes this natively.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <!-- 
+              [TECHNIQUE] Native HTML Popover
+              We use the native HTML `popover` attribute. It requires zero JavaScript to open/close!
+              The `popovertarget` attribute links the button to the popover ID.
+            -->
+            <button class="trigger-btn" popovertarget="demo-modal">
+                Open Modal
+            </button>
+            
+            <!-- The Popover Modal -->
+            <div id="demo-modal" class="modal-card" popover>
+                <div class="modal-header">
+                    <h2>Success!</h2>
+                    <button class="close-btn" popovertarget="demo-modal" popovertargetaction="hide" aria-label="Close modal">&times;</button>
+                </div>
+                <div class="modal-body">
+                    <p>This modal animated directly from `display: none` to the top layer. The scale and opacity transitions were made possible by the CSS <code>@starting-style</code> rule and <code>transition-behavior: allow-discrete</code>.</p>
+                </div>
+                <div class="modal-footer">
+                    <button class="btn-primary" popovertarget="demo-modal" popovertargetaction="hide">Got it</button>
+                </div>
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-starting-style-demo-pure/style.css
+++ b/submissions/examples/css-starting-style-demo-pure/style.css
@@ -1,0 +1,258 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    
+    /* Button Theme */
+    --btn-bg: #3b82f6;
+    --btn-text: #ffffff;
+    --btn-hover: #2563eb;
+    
+    /* Modal Theme */
+    --modal-bg: #ffffff;
+    --modal-border: #e2e8f0;
+    --modal-shadow: rgba(0, 0, 0, 0.1);
+    --modal-backdrop: rgba(15, 23, 42, 0.4);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a;
+        --text-primary: #f8fafc;
+        --text-secondary: #94a3b8;
+        
+        --modal-bg: #1e293b;
+        --modal-border: #334155;
+        --modal-shadow: rgba(0, 0, 0, 0.5);
+        --modal-backdrop: rgba(0, 0, 0, 0.6);
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 80px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 60px 0;
+}
+
+/* Trigger Button */
+.trigger-btn {
+    padding: 14px 28px;
+    font-size: 1.1rem;
+    font-weight: 600;
+    background-color: var(--btn-bg);
+    color: var(--btn-text);
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    box-shadow: 0 4px 6px -1px rgba(59, 130, 246, 0.2);
+    transition: background-color 0.2s, transform 0.2s;
+}
+
+.trigger-btn:hover {
+    background-color: var(--btn-hover);
+    transform: translateY(-2px);
+}
+
+
+/* =========================================
+   [TECHNIQUE] The @starting-style Modal
+   ========================================= */
+
+.modal-card {
+    /* Basic Styling */
+    padding: 0;
+    margin: auto; /* Centers the popover */
+    border: 1px solid var(--modal-border);
+    border-radius: 12px;
+    background-color: var(--modal-bg);
+    color: var(--text-primary);
+    max-width: 400px;
+    box-shadow: 0 20px 25px -5px var(--modal-shadow), 0 10px 10px -5px var(--modal-shadow);
+    
+    /* 
+      1. Define the base "open" state styles.
+    */
+    opacity: 1;
+    transform: scale(1) translateY(0);
+    
+    /* 
+      2. Set up the transitions.
+      CRITICAL: We must transition the `display` and `overlay` properties using `allow-discrete`.
+      This tells the browser to keep the element rendered during the animation before flipping to display:none.
+    */
+    transition: 
+        opacity 0.4s cubic-bezier(0.165, 0.84, 0.44, 1), 
+        transform 0.4s cubic-bezier(0.165, 0.84, 0.44, 1),
+        overlay 0.4s allow-discrete,
+        display 0.4s allow-discrete;
+}
+
+/* 
+  3. Define the "closed" state styles. 
+*/
+.modal-card:not(:popover-open) {
+    opacity: 0;
+    transform: scale(0.95) translateY(20px);
+}
+
+/* 
+  4. Define the initial DOM insertion styles.
+  CRITICAL: `@starting-style` defines what the element looks like at the very instant 
+  it becomes `display: block`. Without this, the browser jumps straight to the "open" state 
+  without transitioning.
+*/
+@starting-style {
+    .modal-card:popover-open {
+        opacity: 0;
+        transform: scale(0.95) translateY(20px);
+    }
+}
+
+/* 
+  Bonus: Animating the backdrop!
+  We apply the exact same `@starting-style` logic to the native ::backdrop pseudo-element.
+*/
+.modal-card::backdrop {
+    background-color: var(--modal-backdrop);
+    backdrop-filter: blur(4px);
+    opacity: 1;
+    transition: opacity 0.4s ease, display 0.4s allow-discrete, overlay 0.4s allow-discrete;
+}
+
+.modal-card:not(:popover-open)::backdrop {
+    opacity: 0;
+}
+
+@starting-style {
+    .modal-card:popover-open::backdrop {
+        opacity: 0;
+    }
+}
+
+
+/* =========================================
+   Modal Inner Content
+   ========================================= */
+
+.modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 20px 24px;
+    border-bottom: 1px solid var(--modal-border);
+}
+
+.modal-header h2 {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 700;
+}
+
+.close-btn {
+    background: transparent;
+    border: none;
+    font-size: 1.5rem;
+    color: var(--text-secondary);
+    cursor: pointer;
+    line-height: 1;
+    padding: 4px;
+    border-radius: 4px;
+    transition: background-color 0.2s, color 0.2s;
+}
+
+.close-btn:hover {
+    background-color: rgba(128, 128, 128, 0.1);
+    color: var(--text-primary);
+}
+
+.modal-body {
+    padding: 24px;
+    line-height: 1.6;
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+}
+
+.modal-body p {
+    margin: 0;
+}
+
+code {
+    background-color: rgba(128, 128, 128, 0.1);
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 0.85em;
+    font-family: monospace;
+}
+
+.modal-footer {
+    padding: 20px 24px;
+    border-top: 1px solid var(--modal-border);
+    display: flex;
+    justify-content: flex-end;
+}
+
+.btn-primary {
+    padding: 10px 20px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    background-color: var(--btn-bg);
+    color: var(--btn-text);
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: opacity 0.2s;
+}
+
+.btn-primary:hover {
+    opacity: 0.9;
+}
+
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .modal-card,
+    .modal-card::backdrop {
+        transition: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a demonstration of the modern CSS `@starting-style` rule, which finally allows developers to animate elements transitioning directly from `display: none` to `display: block` without requiring Javascript timeouts or requestAnimationFrame hacks. Resolves issue #70149.

### Changes Made:
- Added `submissions/examples/css-starting-style-demo-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the native `popover` and trigger buttons.
- Created `style.css` featuring the UI mechanics:
  - **Native Popover**: The demo uses the native HTML attribute `popover` and `popovertarget`. This allows the button to open the modal into the browser's top layer entirely without JavaScript.
  - **Discrete Transitions**: To animate a popover, it must transition from `display: none` to `display: block` (and `overlay: none` to `overlay: auto`). Historically, this caused CSS transitions to instantly jump. By adding `transition-behavior: allow-discrete` to the `display` and `overlay` properties, the browser is instructed to wait for the opacity/transform animations to finish before removing the element from the render tree.
  - **The `@starting-style` Rule**: When the modal first opens, it enters the DOM. The browser needs to know what CSS state to transition *from*. The new `@starting-style` block defines the exact styles (`opacity: 0`, `transform: scale(0.95)`) that the element should hold at the very instant it becomes `display: block`. It then smoothly transitions to its natural `:popover-open` state.
  - **Animated Backdrop**: The exact same `@starting-style` and discrete transition logic is applied to the native `::backdrop` pseudo-element to fade the dark overlay in and out synchronously with the modal.
  - **Theming & Dark Mode Supported**: Configured via CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), adapting the modal surface, text colors, and shadows.
- Added `README.md` documenting usage and the technical mechanics of discrete transitions.
- Fully accessible semantic structure. Because it relies on the native HTML `popover` specification, it automatically inherits Focus Management, Esc-key to dismiss, and light-dismiss (clicking the backdrop). Honors the `prefers-reduced-motion` accessibility standard by disabling the `@starting-style` transitions for motion-sensitive users.

Closes #70149
