### PR TITLE
feat: add CSS DNA Strand Progress (#70967)

### DIFF
--- a/submissions/examples/css-dna-strand-progress-70967/README.md
+++ b/submissions/examples/css-dna-strand-progress-70967/README.md
@@ -1,0 +1,26 @@
+# CSS DNA Strand Progress
+
+### What does this do?
+This component renders an animated, 3D double-helix DNA strand that fills with color from left to right based on a CSS custom property `--progress`, serving as a visually striking progress bar.
+
+### How is it used?
+Wrap two identical sets of `.dna-strand` elements (one unfilled and one filled) within a `.dna-progress-wrapper` container. Set the `--progress` CSS variable on the wrapper to control how much of the filled DNA strand is visible.
+
+```html
+<div class="dna-progress-wrapper" style="--progress: 75%;" role="progressbar" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100" tabindex="0" aria-label="DNA Replication Progress">
+  <!-- Unfilled DNA Track -->
+  <div class="dna-strand unfilled" aria-hidden="true">
+    <div class="base-pair"></div>
+    <!-- ... multiple base pairs ... -->
+  </div>
+
+  <!-- Filled DNA Track -->
+  <div class="dna-strand filled" aria-hidden="true">
+    <div class="base-pair"></div>
+    <!-- ... multiple base pairs ... -->
+  </div>
+</div>
+```
+
+### Why is it useful?
+It fits EaseMotion's philosophy by providing a highly complex, 3D animated data visualization using only pure CSS. It demonstrates advanced usage of `clip-path` and staggered CSS animations without relying on JavaScript or SVG, expanding the library's collection of creative, ready-to-use CSS UI patterns.

--- a/submissions/examples/css-dna-strand-progress-70967/demo.html
+++ b/submissions/examples/css-dna-strand-progress-70967/demo.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS DNA Strand Progress</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="demo-container">
+        <div class="text-content">
+            <h1>DNA Synthesis Progress</h1>
+            <p>Pure CSS animated DNA helix progress bar. Try changing the <code>--progress</code> variable in the wrapper.</p>
+        </div>
+
+        <div class="dna-progress-wrapper" role="progressbar" aria-valuenow="65" aria-valuemin="0" aria-valuemax="100" tabindex="0" aria-label="DNA Strand Progress" style="--progress: 65%;">
+            
+            <!-- Unfilled DNA Track -->
+            <div class="dna-strand unfilled" aria-hidden="true">
+                <div class="base-pair"></div>
+                <div class="base-pair"></div>
+                <div class="base-pair"></div>
+                <div class="base-pair"></div>
+                <div class="base-pair"></div>
+                <div class="base-pair"></div>
+                <div class="base-pair"></div>
+                <div class="base-pair"></div>
+                <div class="base-pair"></div>
+                <div class="base-pair"></div>
+                <div class="base-pair"></div>
+                <div class="base-pair"></div>
+                <div class="base-pair"></div>
+                <div class="base-pair"></div>
+                <div class="base-pair"></div>
+                <div class="base-pair"></div>
+                <div class="base-pair"></div>
+                <div class="base-pair"></div>
+                <div class="base-pair"></div>
+                <div class="base-pair"></div>
+            </div>
+
+            <!-- Filled DNA Track -->
+            <div class="dna-strand filled" aria-hidden="true">
+                <div class="base-pair"></div>
+                <div class="base-pair"></div>
+                <div class="base-pair"></div>
+                <div class="base-pair"></div>
+                <div class="base-pair"></div>
+                <div class="base-pair"></div>
+                <div class="base-pair"></div>
+                <div class="base-pair"></div>
+                <div class="base-pair"></div>
+                <div class="base-pair"></div>
+                <div class="base-pair"></div>
+                <div class="base-pair"></div>
+                <div class="base-pair"></div>
+                <div class="base-pair"></div>
+                <div class="base-pair"></div>
+                <div class="base-pair"></div>
+                <div class="base-pair"></div>
+                <div class="base-pair"></div>
+                <div class="base-pair"></div>
+                <div class="base-pair"></div>
+            </div>
+            
+        </div>
+        
+        <div class="progress-controls">
+            <span>0%</span>
+            <input type="range" id="progress-slider" min="0" max="100" value="65" aria-label="Adjust progress">
+            <span>100%</span>
+        </div>
+    </div>
+
+    <!-- Minimal JS just for the interactive demo slider -->
+    <script>
+        const slider = document.getElementById('progress-slider');
+        const wrapper = document.querySelector('.dna-progress-wrapper');
+        slider.addEventListener('input', (e) => {
+            const value = e.target.value;
+            wrapper.style.setProperty('--progress', `${value}%`);
+            wrapper.setAttribute('aria-valuenow', value);
+        });
+    </script>
+</body>
+</html>

--- a/submissions/examples/css-dna-strand-progress-70967/style.css
+++ b/submissions/examples/css-dna-strand-progress-70967/style.css
@@ -1,0 +1,211 @@
+:root {
+  --dna-bg: #0f172a;
+  --dna-text: #f8fafc;
+  --dna-unfilled-link: #334155;
+  --dna-unfilled-node: #475569;
+  --dna-filled-gradient: linear-gradient(to bottom, #0ea5e9, #8b5cf6);
+  --dna-node-top: #0ea5e9;
+  --dna-node-bottom: #8b5cf6;
+  --dna-glow-top: rgba(14, 165, 233, 0.6);
+  --dna-glow-bottom: rgba(139, 92, 246, 0.6);
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: var(--dna-bg);
+  color: var(--dna-text);
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+}
+
+.demo-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4rem;
+  width: 100%;
+  max-width: 800px;
+  padding: 2rem;
+}
+
+.text-content {
+  text-align: center;
+}
+
+.text-content h1 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+  font-weight: 700;
+  letter-spacing: -0.025em;
+  background: var(--dna-filled-gradient);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.text-content p {
+  color: #94a3b8;
+  margin: 0;
+}
+
+code {
+  background-color: #1e293b;
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.875em;
+  color: #cbd5e1;
+}
+
+/* 
+  DNA Progress Component Core CSS 
+*/
+.dna-progress-wrapper {
+  position: relative;
+  width: 100%;
+  height: 120px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  perspective: 1200px;
+  transform-style: preserve-3d;
+  outline: none;
+}
+
+.dna-progress-wrapper:focus-visible {
+  box-shadow: 0 0 0 2px #0ea5e9;
+  border-radius: 12px;
+}
+
+.dna-strand {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform-style: preserve-3d;
+}
+
+/* The filled track is stacked on top of the unfilled and clipped using --progress */
+.dna-strand.filled {
+  clip-path: inset(0 calc(100% - var(--progress, 0%)) 0 0);
+  transition: clip-path 0.3s ease-out;
+  z-index: 2;
+}
+
+.dna-strand.unfilled {
+  z-index: 1;
+}
+
+.base-pair {
+  position: relative;
+  width: 4px;
+  height: 80px;
+  border-radius: 2px;
+  transform-style: preserve-3d;
+  animation: dna-spin 3s linear infinite;
+}
+
+/* DNA Nodes (the dots at the end of the base pairs) */
+.base-pair::before,
+.base-pair::after {
+  content: '';
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  left: 50%;
+  transform: translateX(-50%) rotateX(0deg);
+}
+
+.base-pair::before {
+  top: -6px;
+}
+
+.base-pair::after {
+  bottom: -6px;
+}
+
+/* Unfilled Styles */
+.dna-strand.unfilled .base-pair {
+  background-color: var(--dna-unfilled-link);
+}
+
+.dna-strand.unfilled .base-pair::before,
+.dna-strand.unfilled .base-pair::after {
+  background-color: var(--dna-unfilled-node);
+}
+
+/* Filled Styles */
+.dna-strand.filled .base-pair {
+  background: var(--dna-filled-gradient);
+  box-shadow: 0 0 8px rgba(139, 92, 246, 0.3);
+}
+
+.dna-strand.filled .base-pair::before {
+  background-color: var(--dna-node-top);
+  box-shadow: 0 0 12px var(--dna-glow-top);
+}
+
+.dna-strand.filled .base-pair::after {
+  background-color: var(--dna-node-bottom);
+  box-shadow: 0 0 12px var(--dna-glow-bottom);
+}
+
+/* 3D Rotation Animation */
+@keyframes dna-spin {
+  0% { transform: rotateX(0deg); }
+  100% { transform: rotateX(360deg); }
+}
+
+/* Staggered Delays to create the double-helix wave */
+.base-pair:nth-child(1) { animation-delay: -0.15s; }
+.base-pair:nth-child(2) { animation-delay: -0.30s; }
+.base-pair:nth-child(3) { animation-delay: -0.45s; }
+.base-pair:nth-child(4) { animation-delay: -0.60s; }
+.base-pair:nth-child(5) { animation-delay: -0.75s; }
+.base-pair:nth-child(6) { animation-delay: -0.90s; }
+.base-pair:nth-child(7) { animation-delay: -1.05s; }
+.base-pair:nth-child(8) { animation-delay: -1.20s; }
+.base-pair:nth-child(9) { animation-delay: -1.35s; }
+.base-pair:nth-child(10) { animation-delay: -1.50s; }
+.base-pair:nth-child(11) { animation-delay: -1.65s; }
+.base-pair:nth-child(12) { animation-delay: -1.80s; }
+.base-pair:nth-child(13) { animation-delay: -1.95s; }
+.base-pair:nth-child(14) { animation-delay: -2.10s; }
+.base-pair:nth-child(15) { animation-delay: -2.25s; }
+.base-pair:nth-child(16) { animation-delay: -2.40s; }
+.base-pair:nth-child(17) { animation-delay: -2.55s; }
+.base-pair:nth-child(18) { animation-delay: -2.70s; }
+.base-pair:nth-child(19) { animation-delay: -2.85s; }
+.base-pair:nth-child(20) { animation-delay: -3.00s; }
+
+/* Demo Controls */
+.progress-controls {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  background: rgba(30, 41, 59, 0.5);
+  padding: 1rem 2rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.progress-controls input[type="range"] {
+  width: 200px;
+  accent-color: #0ea5e9;
+  cursor: pointer;
+}
+
+.progress-controls span {
+  font-variant-numeric: tabular-nums;
+  color: #94a3b8;
+  font-weight: 500;
+  font-size: 0.875rem;
+}


### PR DESCRIPTION
## Pull Request Description

This PR introduces a new pure CSS animated 3D DNA strand progress bar to the EaseMotion CSS library. It addresses issue #70967. The progress indicator uses CSS variables (`--progress`) to visually fill the dual-helix DNA strand with a vibrant gradient as progress increases, without relying on JavaScript or SVG elements.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

This adds a 3D animated double-helix DNA strand progress bar that dynamically fills with color based on a single CSS custom property.

**How does a developer use it?**

```html
<div class="dna-progress-wrapper" style="--progress: 75%;" role="progressbar" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100" tabindex="0" aria-label="DNA Replication Progress">
  <!-- Unfilled DNA Track -->
  <div class="dna-strand unfilled" aria-hidden="true">
    <div class="base-pair"></div>
    <!-- ... multiple base pairs ... -->
  </div>

  <!-- Filled DNA Track -->
  <div class="dna-strand filled" aria-hidden="true">
    <div class="base-pair"></div>
    <!-- ... multiple base pairs ... -->
  </div>
</div>
