### PR TITLE
feat: implement CSS scale up on hover #71050

### DIFF
--- a/submissions/examples/scale-up-on-hover-ns/README.md
+++ b/submissions/examples/scale-up-on-hover-ns/README.md
@@ -1,0 +1,9 @@
+# CSS Scale Up on Hover (#71050)
+
+A lightweight component demonstrating smooth, GPU-accelerated scaling and drop-shadow elevation interactions on hover and focus state transitions.
+
+## Features
+- Pure CSS performance utilizing `transform: scale()` and custom cubic-bezier timing curves.
+- Synchronized internal icon scaling effect.
+- Accessible keyboard focus states (`:focus-visible`) matching hover state behaviors.
+- Native `prefers-reduced-motion` overrides for motion-sensitive users.

--- a/submissions/examples/scale-up-on-hover-ns/demo.html
+++ b/submissions/examples/scale-up-on-hover-ns/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Scale Up on Hover | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="scale-hover-demo-container">
+    <header class="scale-hover-demo-header">
+      <h1>CSS Scale Up on Hover</h1>
+      <p>Smooth, GPU-accelerated scaling cards with elevated drop shadows on hover or focus.</p>
+    </header>
+
+    <div class="scale-hover-grid">
+      
+      <!-- Interactive Scale Card 1 -->
+      <a href="#feature-1" class="ease-scale-card" aria-label="Fast Performance Card">
+        <div class="ease-scale-card__icon" aria-hidden="true">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon>
+          </svg>
+        </div>
+        <h2 class="ease-scale-card__title">Lightning Fast</h2>
+        <p class="ease-scale-card__desc">
+          Uses composited <code>transform: scale()</code> transitions to maintain buttery 60fps performance without triggering browser reflows.
+        </p>
+      </a>
+
+      <!-- Interactive Scale Card 2 -->
+      <a href="#feature-2" class="ease-scale-card" aria-label="Responsive Layout Card">
+        <div class="ease-scale-card__icon" aria-hidden="true">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect>
+            <line x1="8" y1="21" x2="16" y2="21"></line>
+            <line x1="12" y1="17" x2="12" y2="21"></line>
+          </svg>
+        </div>
+        <h2 class="ease-scale-card__title">Fully Responsive</h2>
+        <p class="ease-scale-card__desc">
+          Grid auto-fits smoothly across mobile viewports, tablets, and wide desktop displays without layout breakage.
+        </p>
+      </a>
+
+      <!-- Interactive Scale Card 3 -->
+      <a href="#feature-3" class="ease-scale-card" aria-label="Accessible Navigation Card">
+        <div class="ease-scale-card__icon" aria-hidden="true">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path>
+          </svg>
+        </div>
+        <h2 class="ease-scale-card__title">Keyboard Accessible</h2>
+        <p class="ease-scale-card__desc">
+          Triggering focus via <code>Tab</code> applies identical scale and glow highlights for keyboard navigation users.
+        </p>
+      </a>
+
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/scale-up-on-hover-ns/style.css
+++ b/submissions/examples/scale-up-on-hover-ns/style.css
@@ -1,0 +1,150 @@
+/* CSS Scale Up on Hover #71050 */
+
+:root {
+  --bg-color: #0f172a;
+  --card-bg: #1e293b;
+  --border-color: #334155;
+  --text-main: #f8fafc;
+  --text-sub: #94a3b8;
+  --accent-cyan: #06b6d4;
+  --accent-glow: rgba(6, 182, 212, 0.25);
+  --card-radius: 16px;
+  --transition-cubic: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 2rem 1rem;
+  background-color: var(--bg-color);
+  color: var(--text-main);
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+/* Demo Layout Container */
+.scale-hover-demo-container {
+  width: 100%;
+  max-width: 900px;
+}
+
+.scale-hover-demo-header {
+  text-align: center;
+  margin-bottom: 2.5rem;
+}
+
+.scale-hover-demo-header h1 {
+  font-size: 2rem;
+  margin: 0 0 0.5rem 0;
+}
+
+.scale-hover-demo-header p {
+  color: var(--text-sub);
+  font-size: 1rem;
+  margin: 0;
+}
+
+/* Grid Layout */
+.scale-hover-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 2rem;
+}
+
+/* ==========================================================================
+   CSS Scale Up on Hover Core Component
+   ========================================================================== */
+
+.ease-scale-card {
+  background-color: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: var(--card-radius);
+  padding: 2rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  text-decoration: none;
+  color: inherit;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
+  will-change: transform, box-shadow, border-color;
+  transition: transform 0.35s var(--transition-cubic),
+              box-shadow 0.35s var(--transition-cubic),
+              border-color 0.35s ease;
+  cursor: pointer;
+  position: relative;
+}
+
+/* Hover & Focus Interaction State */
+.ease-scale-card:hover,
+.ease-scale-card:focus-visible {
+  transform: scale(1.05) translateY(-4px);
+  border-color: var(--accent-cyan);
+  box-shadow: 0 20px 30px -10px rgba(0, 0, 0, 0.5),
+              0 0 20px var(--accent-glow);
+}
+
+.ease-scale-card:focus-visible {
+  outline: 3px solid var(--accent-cyan);
+  outline-offset: 4px;
+}
+
+/* Icon / Header Graphic */
+.ease-scale-card__icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 12px;
+  background: rgba(6, 182, 212, 0.1);
+  color: var(--accent-cyan);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.35s var(--transition-cubic);
+}
+
+.ease-scale-card:hover .ease-scale-card__icon,
+.ease-scale-card:focus-visible .ease-scale-card__icon {
+  transform: scale(1.1);
+}
+
+.ease-scale-card__title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin: 0;
+  color: var(--text-main);
+}
+
+.ease-scale-card__desc {
+  font-size: 0.925rem;
+  color: var(--text-sub);
+  margin: 0;
+  line-height: 1.5;
+}
+
+/* ==========================================================================
+   Accessibility & Reduced Motion Overrides
+   ========================================================================== */
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-scale-card,
+  .ease-scale-card__icon {
+    transition: none !important;
+  }
+
+  .ease-scale-card:hover,
+  .ease-scale-card:focus-visible {
+    transform: none !important;
+  }
+}
+
+@media (forced-colors: active) {
+  .ease-scale-card:hover,
+  .ease-scale-card:focus-visible {
+    border: 2px solid Highlight;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the pure CSS Scale Up on Hover component (#71050).
gssoc 26

Closes #71050

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/scale-up-on-hover-ns/`
- [x] `style.css`, `demo.html`, and `README.md` included
- [x] Automated commit correctly formatted

---

## Feature Description
**What does this add?**
A component demonstrating smooth, GPU-accelerated card expansion and shadow elevation upon hover or focus navigation.

**How does it work?**
Applies `transform: scale(1.05) translateY(-4px)` with custom `cubic-bezier(0.16, 1, 0.3, 1)` easing transitions on `:hover` and `:focus-visible` pseudo-classes to achieve a smooth 60fps animation.

---

## Notes for Maintainer
Zero JavaScript required. Includes accessible keyboard focus indicators (`:focus-visible`), high-contrast forced colors support, and `prefers-reduced-motion` safety fallbacks.