### PR TITLE
feat:Added typing indicator

### DIFF
--- a/submissions/examples/typing-indicator/README.md
+++ b/submissions/examples/typing-indicator/README.md
@@ -1,0 +1,91 @@
+# Typing Indicator
+
+Three dots bouncing in a staggered wave, iMessage-style, built to sit
+inside a real chat bubble. Pure CSS.
+
+[`demo.html`](./demo.html) shows it in a chat thread (the actual use
+case) plus three standalone variants: default, compact, and an accent
+color.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `demo.html` | Chat thread context + 3 standalone variants |
+| `style.css` | The bounce animation, tokens, and chat bubble styling |
+| `README.md` | This file |
+
+## Markup
+
+```html
+<div class="typing-indicator" role="status" aria-label="Maya is typing">
+  <span class="typing-indicator__dot"></span>
+  <span class="typing-indicator__dot"></span>
+  <span class="typing-indicator__dot"></span>
+</div>
+```
+
+## How the stagger works
+
+Each dot runs the same `@keyframes`, offset by a fixed delay:
+
+```css
+.typing-indicator__dot {
+  animation: ti-bounce var(--ti-duration) ease-in-out infinite;
+}
+
+.typing-indicator__dot:nth-child(1) { animation-delay: 0ms; }
+.typing-indicator__dot:nth-child(2) { animation-delay: 160ms; }
+.typing-indicator__dot:nth-child(3) { animation-delay: 320ms; }
+
+@keyframes ti-bounce {
+  0%, 60%, 100% { transform: translateY(0);   opacity: 0.5; }
+  30%           { transform: translateY(-5px); opacity: 1; }
+}
+```
+
+The dots also dim slightly at rest and brighten at the peak of their
+bounce, which reads as more "alive" than movement alone.
+
+## CSS custom properties
+
+| Property | Default | Controls |
+|---|---|---|
+| `--ti-dot-size` | `8px` | Diameter of each dot |
+| `--ti-dot-color` | muted gray | Dot color |
+| `--ti-duration` | `1.3s` | One full bounce cycle per dot |
+
+## Variants
+
+- `.typing-indicator-sm` — smaller dots, tighter padding, for a compact
+  inline placement (e.g. next to a name in a dense list).
+- `.typing-indicator-accent` — swaps `--ti-dot-color` to the library
+  accent and tints the background to match, for use outside a plain chat
+  bubble context.
+
+## Accessibility
+
+- `role="status"` implies `aria-live="polite"` — a screen reader
+  announces the `aria-label` (e.g. "Maya is typing") once, politely, when
+  the indicator appears, without interrupting whatever the user is
+  currently doing.
+- The label text itself never changes while the indicator is visible, so
+  there's nothing for assistive tech to re-announce on every bounce —
+  screen reader users hear "Maya is typing" once, not a chatty loop.
+- The individual dots carry no text content and no independent
+  semantics, so they add no noise to the accessibility tree beyond the
+  single labeled status region.
+- Respects `prefers-reduced-motion: reduce`: the vertical bounce is
+  replaced with a slower, gentler opacity-only pulse — the "still
+  typing" signal stays visible, it just doesn't move.
+
+## Responsive behavior
+
+Chat bubbles widen slightly (up to 85% of the thread width) and drop to a
+smaller font size below `480px`; the indicator itself needs no
+breakpoint-specific changes.
+
+## Browser support
+
+Uses only `transform`, `opacity`, CSS custom properties, and standard
+keyframe animations — supported everywhere current, no fallback needed.

--- a/submissions/examples/typing-indicator/demo.html
+++ b/submissions/examples/typing-indicator/demo.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Typing Indicator — EaseMotion CSS</title>
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@600;700&family=Inter:wght@400;500;600&family=IBM+Plex+Mono:wght@500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="noise" aria-hidden="true"></div>
+
+  <header class="hero">
+    <p class="eyebrow">EaseMotion CSS &middot; showcase</p>
+    <h1 class="hero-title">Typing indicator</h1>
+    <p class="hero-sub">Three dots bouncing in a staggered wave, iMessage-style, inside a real chat bubble. Pure CSS, announced to screen readers politely once &mdash; not on every bounce.</p>
+  </header>
+
+  <main class="showcase">
+
+    <!-- ================= Chat thread context ================= -->
+    <section class="demo-block" aria-labelledby="thread-title">
+      <h2 id="thread-title" class="demo-block-title">In a conversation</h2>
+
+      <div class="chat-thread">
+        <div class="chat-row chat-row-in">
+          <span class="chat-avatar" aria-hidden="true">M</span>
+          <div class="chat-bubble chat-bubble-in">Hey, are we still on for the 3pm sync?</div>
+        </div>
+
+        <div class="chat-row chat-row-out">
+          <div class="chat-bubble chat-bubble-out">Yep! Just wrapping something up.</div>
+        </div>
+
+        <div class="chat-row chat-row-in">
+          <span class="chat-avatar" aria-hidden="true">M</span>
+          <div class="typing-indicator" role="status" aria-label="Maya is typing">
+            <span class="typing-indicator__dot"></span>
+            <span class="typing-indicator__dot"></span>
+            <span class="typing-indicator__dot"></span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ================= Standalone variants ================= -->
+    <section class="demo-block" aria-labelledby="variants-title">
+      <h2 id="variants-title" class="demo-block-title">Standalone &amp; size variants</h2>
+
+      <div class="variant-row">
+        <div class="variant-card">
+          <span class="variant-label">Default</span>
+          <div class="typing-indicator" role="status" aria-label="Someone is typing">
+            <span class="typing-indicator__dot"></span>
+            <span class="typing-indicator__dot"></span>
+            <span class="typing-indicator__dot"></span>
+          </div>
+        </div>
+
+        <div class="variant-card">
+          <span class="variant-label">Compact</span>
+          <div class="typing-indicator typing-indicator-sm" role="status" aria-label="Someone is typing">
+            <span class="typing-indicator__dot"></span>
+            <span class="typing-indicator__dot"></span>
+            <span class="typing-indicator__dot"></span>
+          </div>
+        </div>
+
+        <div class="variant-card">
+          <span class="variant-label">Accent color</span>
+          <div class="typing-indicator typing-indicator-accent" role="status" aria-label="Someone is typing">
+            <span class="typing-indicator__dot"></span>
+            <span class="typing-indicator__dot"></span>
+            <span class="typing-indicator__dot"></span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <footer class="footer">
+    <p>EaseMotion CSS &middot; submissions/examples/css-typing-indicator</p>
+  </footer>
+
+</body>
+</html>

--- a/submissions/examples/typing-indicator/style.css
+++ b/submissions/examples/typing-indicator/style.css
@@ -1,0 +1,308 @@
+/* =========================================================================
+   Typing Indicator — EaseMotion CSS
+   Three dots bouncing in a staggered wave, iMessage-style. Built to sit
+   inside a real chat bubble, announced to assistive tech once via
+   role="status" rather than re-announced on every bounce (the label text
+   itself never changes, so a screen reader has nothing new to repeat).
+   Pure CSS.
+   ========================================================================= */
+
+
+/* -------------------------------------------------------------------------
+   1. Design tokens
+   ------------------------------------------------------------------------- */
+
+:root {
+  --ti-bg: #0e1116;
+  --ti-surface: #151a21;
+  --ti-surface-2: #1c222b;
+  --ti-border: #262e39;
+  --ti-text: #edeff2;
+  --ti-text-muted: #98a2b3;
+
+  --ti-accent: #7de0c0;
+  --ti-bubble-in: #1c222b;
+  --ti-bubble-out: #2a6f5c;
+
+  --ti-font-display: "Space Grotesk", "Segoe UI", sans-serif;
+  --ti-font-body: "Inter", "Segoe UI", sans-serif;
+  --ti-font-mono: "IBM Plex Mono", "Courier New", monospace;
+
+  /* Typing-indicator tuning — override per instance to retune */
+  --ti-dot-size: 8px;
+  --ti-dot-color: var(--ti-text-muted);
+  --ti-duration: 1.3s;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--ti-bg);
+  color: var(--ti-text);
+  font-family: var(--ti-font-body);
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+.noise {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.035;
+  z-index: 0;
+  background-image: radial-gradient(circle at 1px 1px, #ffffff 1px, transparent 0);
+  background-size: 3px 3px;
+}
+
+
+/* -------------------------------------------------------------------------
+   2. Hero
+   ------------------------------------------------------------------------- */
+
+.hero {
+  position: relative;
+  z-index: 1;
+  max-width: 620px;
+  margin: 0 auto;
+  padding: 92px 24px 48px;
+  text-align: center;
+}
+
+.eyebrow {
+  font-family: var(--ti-font-mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ti-accent);
+  margin: 0 0 20px;
+}
+
+.hero-title {
+  font-family: var(--ti-font-display);
+  font-weight: 600;
+  font-size: clamp(30px, 5.5vw, 48px);
+  line-height: 1.1;
+  letter-spacing: -0.01em;
+  margin: 0 0 16px;
+}
+
+.hero-sub {
+  font-size: 15px;
+  color: var(--ti-text-muted);
+  max-width: 480px;
+  margin: 0 auto;
+}
+
+
+/* -------------------------------------------------------------------------
+   3. Layout
+   ------------------------------------------------------------------------- */
+
+.showcase {
+  position: relative;
+  z-index: 1;
+  max-width: 520px;
+  margin: 0 auto;
+  padding: 0 24px 90px;
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+}
+
+.demo-block-title {
+  font-family: var(--ti-font-display);
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0 0 18px;
+  text-align: center;
+}
+
+
+/* -------------------------------------------------------------------------
+   4. Chat thread context
+   ------------------------------------------------------------------------- */
+
+.chat-thread {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.chat-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+}
+
+.chat-row-out {
+  justify-content: flex-end;
+}
+
+.chat-avatar {
+  flex: 0 0 auto;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--ti-surface-2);
+  color: var(--ti-text-muted);
+  font-family: var(--ti-font-mono);
+  font-size: 11px;
+}
+
+.chat-bubble {
+  max-width: 78%;
+  padding: 10px 14px;
+  border-radius: 18px;
+  font-size: 14px;
+}
+
+.chat-bubble-in {
+  background: var(--ti-bubble-in);
+  color: var(--ti-text);
+  border-bottom-left-radius: 6px;
+}
+
+.chat-bubble-out {
+  background: var(--ti-bubble-out);
+  color: #eafff6;
+  border-bottom-right-radius: 6px;
+}
+
+
+/* -------------------------------------------------------------------------
+   5. The typing indicator itself
+   ------------------------------------------------------------------------- */
+
+.typing-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 13px 16px;
+  border-radius: 18px;
+  border-bottom-left-radius: 6px;
+  background: var(--ti-bubble-in);
+  width: fit-content;
+}
+
+.typing-indicator__dot {
+  width: var(--ti-dot-size);
+  height: var(--ti-dot-size);
+  border-radius: 50%;
+  background: var(--ti-dot-color);
+  animation: ti-bounce var(--ti-duration) ease-in-out infinite;
+}
+
+.typing-indicator__dot:nth-child(1) { animation-delay: 0ms; }
+.typing-indicator__dot:nth-child(2) { animation-delay: 160ms; }
+.typing-indicator__dot:nth-child(3) { animation-delay: 320ms; }
+
+@keyframes ti-bounce {
+  0%, 60%, 100% {
+    transform: translateY(0);
+    opacity: 0.5;
+  }
+  30% {
+    transform: translateY(-5px);
+    opacity: 1;
+  }
+}
+
+
+/* -------------------------------------------------------------------------
+   6. Variants
+   ------------------------------------------------------------------------- */
+
+.variant-row {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.variant-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 20px 18px;
+  background: var(--ti-surface);
+  border: 1px solid var(--ti-border);
+  border-radius: 14px;
+}
+
+.variant-label {
+  font-family: var(--ti-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  color: var(--ti-text-muted);
+}
+
+.typing-indicator-sm {
+  --ti-dot-size: 5px;
+  padding: 9px 12px;
+  gap: 4px;
+}
+
+.typing-indicator-accent {
+  --ti-dot-color: var(--ti-accent);
+  background: rgba(125, 224, 192, 0.1);
+}
+
+
+/* -------------------------------------------------------------------------
+   7. Footer
+   ------------------------------------------------------------------------- */
+
+.footer {
+  position: relative;
+  z-index: 1;
+  text-align: center;
+  padding: 8px 24px 48px;
+  font-size: 12.5px;
+  color: var(--ti-text-muted);
+  font-family: var(--ti-font-mono);
+}
+
+
+/* -------------------------------------------------------------------------
+   8. Responsive
+   ------------------------------------------------------------------------- */
+
+@media (max-width: 480px) {
+  .hero {
+    padding: 68px 20px 40px;
+  }
+
+  .chat-bubble {
+    max-width: 85%;
+    font-size: 13.5px;
+  }
+
+  .variant-row {
+    gap: 10px;
+  }
+}
+
+
+/* -------------------------------------------------------------------------
+   9. Reduced motion
+   ------------------------------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .typing-indicator__dot {
+    animation: ti-fade calc(var(--ti-duration) * 1.6) ease-in-out infinite;
+  }
+}
+
+/* A gentler opacity-only pulse for reduced motion — keeps the "still
+   typing" signal alive without any vertical movement. */
+@keyframes ti-fade {
+  0%, 60%, 100% { opacity: 0.4; }
+  30% { opacity: 1; }
+}


### PR DESCRIPTION
Closes #68260

## Pull Request Description
Adds a pure CSS three-dot typing indicator (iMessage-style), shown inside a real chat bubble plus compact and accent-color variants. No JavaScript.

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/css-typing-indicator/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A `.typing-indicator` — three dots bouncing in a staggered wave via one `@keyframes` rule with per-dot `animation-delay`.

**How does a developer use it?**
```html
<div class="typing-indicator" role="status" aria-label="Maya is typing">
  <span class="typing-indicator__dot"></span>
  <span class="typing-indicator__dot"></span>
  <span class="typing-indicator__dot"></span>
</div>
```
Add `.typing-indicator-sm` for a compact size, `.typing-indicator-accent` for the library accent color, or override `--ti-dot-size`/`--ti-dot-color`/`--ti-duration` directly.

**Why does it fit EaseMotion CSS?**
Exactly the pattern the issue asks for: a common chat-UI primitive most developers currently reach for a JS library to get, done in ~15 lines of real animation logic, fully tunable via custom properties.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

## Notes for Maintainer
Used `role="status"` (implies `aria-live="polite"`) with a static `aria-label` rather than per-dot ARIA, so a screen reader announces "X is typing" once when the indicator appears instead of re-announcing on every bounce. Under `prefers-reduced-motion`, the vertical bounce becomes an opacity-only pulse rather than disappearing — the "still typing" signal stays visible without motion.