### PR TITLE
feat: implement CSS focus mode toggle #71016

### DIFF
--- a/submissions/examples/focus-mode-toggle-ns/README.md
+++ b/submissions/examples/focus-mode-toggle-ns/README.md
@@ -1,0 +1,9 @@
+# CSS Focus Mode Toggle (#71016)
+
+A zero-JS Focus Mode toggle component that dims peripheral UI distractions, sidebars, and widgets while highlighting core article reading content.
+
+## Features
+- Pure CSS state cascade powered by `:has()` container query logic.
+- Smooth transition effects (blur, opacity reduction, scale down) applied to peripheral components.
+- Keyboard accessible switch control (`role="switch"`, `:focus-visible`).
+- Fallbacks for responsive screens and `prefers-reduced-motion`.

--- a/submissions/examples/focus-mode-toggle-ns/demo.html
+++ b/submissions/examples/focus-mode-toggle-ns/demo.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Focus Mode Toggle | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="ease-focus-container">
+    
+    <!-- Header with Pure CSS Toggle Control -->
+    <header class="ease-focus-header">
+      <h1>Reader Interface</h1>
+      
+      <div class="ease-focus-toggle-wrapper">
+        <label for="focus-mode-switch" class="ease-focus-toggle-label">
+          <span>Focus Mode</span>
+        </label>
+
+        <input 
+          type="checkbox" 
+          id="focus-mode-switch" 
+          class="ease-focus-checkbox"
+          role="switch"
+          aria-checked="false"
+          aria-label="Toggle Focus Mode to hide distractions"
+        />
+        
+        <label for="focus-mode-switch" class="ease-switch-track" aria-hidden="true">
+          <span class="ease-switch-thumb"></span>
+        </label>
+      </div>
+    </header>
+
+    <!-- Main Reader Layout -->
+    <div class="ease-focus-layout">
+      
+      <!-- Main Content Article (Stays Focused) -->
+      <article class="ease-reader-article">
+        <h2>Distraction-Free Reading Experience</h2>
+        <p>
+          Focus Mode dims peripheral UI widgets, sidebars, and ads using pure CSS <code>:has()</code> selector state cascading.
+        </p>
+        <p>
+          By removing visual clutter smoothly without destroying layout structure, users can concentrate entirely on long-form content reading.
+        </p>
+      </article>
+
+      <!-- Sidebar Containing Peripheral Distractions -->
+      <aside class="ease-distraction-sidebar">
+        
+        <div class="ease-widget-card ease-distraction-widget">
+          <h3>Trending Topics</h3>
+          <p>#WebDev #CSS3 #Accessibility</p>
+        </div>
+
+        <div class="ease-widget-card ease-distraction-widget">
+          <h3>Sponsored Ad</h3>
+          <p>Check out our latest developer tooling productivity bundle!</p>
+        </div>
+
+        <div class="ease-widget-card ease-distraction-widget">
+          <h3>Notifications</h3>
+          <p>3 unread messages in your inbox.</p>
+        </div>
+
+      </aside>
+
+    </div>
+
+  </main>
+
+  <script>
+    // ARIA state mirror for assistive technologies
+    const focusSwitch = document.getElementById('focus-mode-switch');
+    focusSwitch.addEventListener('change', (e) => {
+      e.target.setAttribute('aria-checked', e.target.checked);
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/focus-mode-toggle-ns/style.css
+++ b/submissions/examples/focus-mode-toggle-ns/style.css
@@ -1,0 +1,222 @@
+/* CSS Focus Mode Toggle #71016 */
+
+:root {
+  --bg-color: #0f172a;
+  --card-bg: #1e293b;
+  --border-color: #334155;
+  --text-main: #f8fafc;
+  --text-sub: #94a3b8;
+  --accent-color: #10b981;
+  --toggle-bg: #334155;
+  --toggle-checked: #10b981;
+  
+  /* Focus mode dimming variables */
+  --distraction-opacity: 1;
+  --distraction-scale: 1;
+  --distraction-filter: blur(0px);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 2rem 1rem;
+  background-color: var(--bg-color);
+  color: var(--text-main);
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+/* Container */
+.ease-focus-container {
+  width: 100%;
+  max-width: 800px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+/* Header & Toggle Section */
+.ease-focus-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  padding: 1.25rem 1.5rem;
+  border-radius: 16px;
+  box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.2);
+}
+
+.ease-focus-header h1 {
+  font-size: 1.25rem;
+  margin: 0;
+  font-weight: 700;
+}
+
+/* ==========================================================================
+   Pure CSS Focus Mode Switch & Cascade Engine
+   ========================================================================== */
+
+.ease-focus-toggle-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.ease-focus-toggle-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  user-select: none;
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--text-sub);
+}
+
+/* Visually Hidden Checkbox for Accessibility */
+.ease-focus-checkbox {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Custom Switch Track */
+.ease-switch-track {
+  position: relative;
+  width: 50px;
+  height: 26px;
+  background-color: var(--toggle-bg);
+  border-radius: 13px;
+  transition: background-color 0.3s ease;
+  display: inline-block;
+  cursor: pointer;
+}
+
+/* Switch Thumb */
+.ease-switch-thumb {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 20px;
+  height: 20px;
+  background-color: #ffffff;
+  border-radius: 50%;
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.ease-focus-checkbox:checked + .ease-switch-track {
+  background-color: var(--toggle-checked);
+}
+
+.ease-focus-checkbox:checked + .ease-switch-track .ease-switch-thumb {
+  transform: translateX(24px);
+}
+
+.ease-focus-checkbox:focus-visible + .ease-switch-track {
+  outline: 3px solid var(--accent-color);
+  outline-offset: 2px;
+}
+
+/* ==========================================================================
+   Focus Mode UI Transitions driven by :has()
+   ========================================================================== */
+
+/* Distraction sidebars/widgets transition smoothly */
+.ease-distraction-widget {
+  transition: opacity 0.5s ease, filter 0.5s ease, transform 0.5s ease;
+  will-change: opacity, filter, transform;
+}
+
+/* Main Reader Article transitions */
+.ease-reader-article {
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 16px;
+  padding: 2.5rem;
+  transition: box-shadow 0.5s ease, border-color 0.5s ease, transform 0.5s ease;
+}
+
+/* CSS Cascade Triggered when Focus Checkbox is checked */
+.ease-focus-container:has(.ease-focus-checkbox:checked) .ease-distraction-widget {
+  opacity: 0.15;
+  filter: blur(3px);
+  transform: scale(0.98);
+  pointer-events: none;
+}
+
+.ease-focus-container:has(.ease-focus-checkbox:checked) .ease-reader-article {
+  border-color: var(--accent-color);
+  box-shadow: 0 20px 40px -10px rgba(16, 185, 129, 0.15);
+  transform: scale(1.01);
+}
+
+/* Grid Layout for Article + Distractions */
+.ease-focus-layout {
+  display: grid;
+  grid-template-columns: 1fr 260px;
+  gap: 1.5rem;
+}
+
+.ease-distraction-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.ease-widget-card {
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: 1.25rem;
+}
+
+.ease-widget-card h3 {
+  margin: 0 0 0.5rem 0;
+  font-size: 0.95rem;
+  color: var(--text-sub);
+}
+
+.ease-reader-article h2 {
+  margin: 0 0 1rem 0;
+  font-size: 1.6rem;
+  color: var(--text-main);
+}
+
+.ease-reader-article p {
+  color: var(--text-sub);
+  line-height: 1.7;
+  font-size: 1rem;
+  margin-bottom: 1rem;
+}
+
+/* ==========================================================================
+   Responsive & Accessibility Fallbacks
+   ========================================================================== */
+
+@media (max-width: 768px) {
+  .ease-focus-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-distraction-widget,
+  .ease-reader-article,
+  .ease-switch-thumb {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the pure CSS Focus Mode Toggle component (#71016).
gssoc 26

Closes #71016

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/focus-mode-toggle-ns/`
- [x] `style.css`, `demo.html`, and `README.md` included
- [x] Automated commit correctly formatted

---

## Feature Description
**What does this add?**
A distraction-free reading toggle component that smoothly dims, blurs, and de-emphasizes non-essential UI elements (such as sidebars, ads, and notification widgets) when enabled.

**How does it work?**
Utilizes the `:has()` parent selector triggered by an accessible checkbox switch (`role="switch"`) to dynamically update styles across distant sibling/child elements without JavaScript.

---

## Notes for Maintainer
Zero JavaScript required for style cascades. Fully compliant with keyboard navigation, screen reader ARIA roles (`role="switch"`), and `prefers-reduced-motion` preferences.