### PR TITLE
Add ease-audio-visualizer-bars component

### DIFF
--- a/submissions/examples/audio-visualizer-bars-ij/README.md
+++ b/submissions/examples/audio-visualizer-bars-ij/README.md
@@ -1,0 +1,11 @@
+# ease-audio-visualizer-bars
+
+An audio visualizer where the bars beat to the track, the scrub line runs, and the play button glows.
+
+## Run
+Open `demo.html` directly in a browser to watch the waves.
+
+## Notes
+- The eight bars beat in a wave pattern.
+- The scrub line travels across the track.
+- The level readout ticks beside the play button.

--- a/submissions/examples/audio-visualizer-bars-ij/demo.html
+++ b/submissions/examples/audio-visualizer-bars-ij/demo.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-audio-visualizer-bars demo</title>
+</head>
+<body>
+<div class="avb-player">
+  <div class="avb-screen">
+    <span class="avb-bar"></span>
+    <span class="avb-bar"></span>
+    <span class="avb-bar"></span>
+    <span class="avb-bar"></span>
+    <span class="avb-bar"></span>
+    <span class="avb-bar"></span>
+    <span class="avb-bar"></span>
+    <span class="avb-bar"></span>
+  </div>
+  <div class="avb-track"></div>
+  <div class="avb-controls">
+    <button class="avb-play">PLAY</button>
+    <span class="avb-level">-6 dB</span>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/audio-visualizer-bars-ij/style.css
+++ b/submissions/examples/audio-visualizer-bars-ij/style.css
@@ -1,0 +1,18 @@
+.avb-player{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:320px;background:linear-gradient(180deg,#121a26,#0a0f17);border:2px solid #26344a;border-radius:16px;padding:18px;display:flex;flex-direction:column;gap:14px}
+.avb-screen{display:flex;align-items:flex-end;gap:8px;height:130px;background:#080d14;border-radius:10px;padding:14px;border:1px solid #1d2a3c}
+.avb-bar{flex:1;height:20px;background:linear-gradient(180deg,#ff6b9d,#5ce1e6);border-radius:3px;transform-origin:bottom;animation:avb-bar-beat-audio-visualizer-bars 1s ease-in-out infinite}
+.avb-bar:nth-child(2){animation-delay:.12s}
+.avb-bar:nth-child(3){animation-delay:.24s}
+.avb-bar:nth-child(4){animation-delay:.36s}
+.avb-bar:nth-child(5){animation-delay:.48s}
+.avb-bar:nth-child(6){animation-delay:.6s}
+.avb-bar:nth-child(7){animation-delay:.72s}
+.avb-bar:nth-child(8){animation-delay:.84s}
+.avb-track{height:4px;border-radius:2px;background:repeating-linear-gradient(90deg,#26344a 0,#26344a 6px,#141e2e 6px,#141e2e 12px);animation:avb-track-scrub-audio-visualizer-bars 6s linear infinite}
+.avb-controls{display:flex;justify-content:space-between;align-items:center}
+.avb-play{font-size:10px;font-weight:800;letter-spacing:2px;color:#0a0f17;background:#ff6b9d;border:none;border-radius:8px;padding:8px 18px;cursor:pointer;animation:avb-play-glow-audio-visualizer-bars 2s ease-in-out infinite}
+.avb-level{font-size:10px;font-weight:700;color:#8b9bad;font-family:'Courier New',monospace;animation:avb-level-tick-audio-visualizer-bars 1.6s steps(2) infinite}
+@keyframes avb-bar-beat-audio-visualizer-bars{0%,100%{transform:scaleY(.25)}50%{transform:scaleY(1)}}
+@keyframes avb-track-scrub-audio-visualizer-bars{0%{background-position:0 0}100%{background-position:120px 0}}
+@keyframes avb-play-glow-audio-visualizer-bars{0%,100%{box-shadow:0 0 0 0 rgba(255,107,157,0)}50%{box-shadow:0 0 12px rgba(255,107,157,0.6)}100%{box-shadow:0 0 0 0 rgba(255,107,157,0)}}
+@keyframes avb-level-tick-audio-visualizer-bars{0%{opacity:1}50%{opacity:.3}}


### PR DESCRIPTION
## Component: ease-audio-visualizer-bars — bars beat, scrub line runs, and play glows

**Closes #71354**

### What this adds
An audio visualizer where the bars beat to the track, the scrub line runs across the display, and the play button glows.

### Acceptance Criteria covered
- Bars beat to the track
- Scrub line runs
- Play button glows

### Files
- `submissions/examples/audio-visualizer-bars-ij/demo.html`
- `submissions/examples/audio-visualizer-bars-ij/style.css`
- `submissions/examples/audio-visualizer-bars-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the bars beat, the scrub run, and the play glow.