### PR TITLE
feat: implement CSS body weight chart #71001

### DIFF
--- a/submissions/examples/body-weight-chart-ns/README.md
+++ b/submissions/examples/body-weight-chart-ns/README.md
@@ -1,0 +1,10 @@
+# CSS Body Weight Chart (#71001)
+
+A responsive, zero-JS body weight tracking sparkline component with interactive data hover/focus tooltips and trend badges.
+
+## Features
+- Pure CSS & inline SVG vector sparkline rendering with gradient area fill.
+- Interactive data points (`:hover`, `:focus-visible`) with popover weight tooltips.
+- Trend status badge with directional indicator.
+- Screen reader accessible (`role="img"`, `tabindex="0"`, `aria-label` point inspectability).
+- Fallbacks for `prefers-reduced-motion` and high-contrast environments (`forced-colors`).

--- a/submissions/examples/body-weight-chart-ns/demo.html
+++ b/submissions/examples/body-weight-chart-ns/demo.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Body Weight Chart | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="weight-chart-demo-container">
+    
+    <!-- Body Weight Sparkline Tracking Card -->
+    <article class="ease-weight-card" aria-label="Body Weight Tracking Card">
+      
+      <!-- Card Summary Header -->
+      <header class="ease-weight-header">
+        <div class="ease-weight-title-group">
+          <h2>Current Weight</h2>
+          <div class="ease-weight-stat">
+            <span class="ease-weight-stat__value">74.2</span>
+            <span class="ease-weight-stat__unit">kg</span>
+          </div>
+        </div>
+
+        <!-- Weekly Trend Indicator -->
+        <div class="ease-trend-badge ease-trend-badge--down" aria-label="Weight decreased by 1.4 kilograms this week">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <line x1="12" y1="5" x2="12" y2="19"></line>
+            <polyline points="19 12 12 19 5 12"></polyline>
+          </svg>
+          <span>-1.4 kg (7 days)</span>
+        </div>
+      </header>
+
+      <!-- SVG Sparkline Chart -->
+      <div class="ease-sparkline-wrapper">
+        <svg class="ease-sparkline-svg" viewBox="0 0 500 140" role="img" aria-label="Weight trend sparkline graph showing steady decline from 75.6 kg on Mon to 74.2 kg on Sun">
+          
+          <defs>
+            <linearGradient id="weight-gradient" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stop-color="#10b981" stop-opacity="0.35"/>
+              <stop offset="100%" stop-color="#10b981" stop-opacity="0.0"/>
+            </linearGradient>
+          </defs>
+
+          <!-- Gradient Area Fill -->
+          <path class="ease-sparkline-area" d="M 10,20 L 80,45 L 150,35 L 220,70 L 290,60 L 360,95 L 490,115 L 490,140 L 10,140 Z" />
+
+          <!-- Main Sparkline Trend Line -->
+          <path class="ease-sparkline-line" d="M 10,20 L 80,45 L 150,35 L 220,70 L 290,60 L 360,95 L 490,115" />
+
+          <!-- Interactive Data Point 1 (Mon) -->
+          <g class="ease-chart-point" tabindex="0" aria-label="Monday: 75.6 kg">
+            <circle cx="10" cy="20" r="5" />
+            <foreignObject x="-20" y="-25" width="60" height="30">
+              <div class="ease-point-tooltip">75.6 kg</div>
+            </foreignObject>
+          </g>
+
+          <!-- Interactive Data Point 2 (Tue) -->
+          <g class="ease-chart-point" tabindex="0" aria-label="Tuesday: 75.2 kg">
+            <circle cx="80" cy="45" r="5" />
+            <foreignObject x="50" y="0" width="60" height="30">
+              <div class="ease-point-tooltip">75.2 kg</div>
+            </foreignObject>
+          </g>
+
+          <!-- Interactive Data Point 3 (Wed) -->
+          <g class="ease-chart-point" tabindex="0" aria-label="Wednesday: 75.4 kg">
+            <circle cx="150" cy="35" r="5" />
+            <foreignObject x="120" y="-10" width="60" height="30">
+              <div class="ease-point-tooltip">75.4 kg</div>
+            </foreignObject>
+          </g>
+
+          <!-- Interactive Data Point 4 (Thu) -->
+          <g class="ease-chart-point" tabindex="0" aria-label="Thursday: 74.8 kg">
+            <circle cx="220" cy="70" r="5" />
+            <foreignObject x="190" y="25" width="60" height="30">
+              <div class="ease-point-tooltip">74.8 kg</div>
+            </foreignObject>
+          </g>
+
+          <!-- Interactive Data Point 5 (Fri) -->
+          <g class="ease-chart-point" tabindex="0" aria-label="Friday: 75.0 kg">
+            <circle cx="290" cy="60" r="5" />
+            <foreignObject x="260" y="15" width="60" height="30">
+              <div class="ease-point-tooltip">75.0 kg</div>
+            </foreignObject>
+          </g>
+
+          <!-- Interactive Data Point 6 (Sat) -->
+          <g class="ease-chart-point" tabindex="0" aria-label="Saturday: 74.5 kg">
+            <circle cx="360" cy="95" r="5" />
+            <foreignObject x="330" y="50" width="60" height="30">
+              <div class="ease-point-tooltip">74.5 kg</div>
+            </foreignObject>
+          </g>
+
+          <!-- Interactive Data Point 7 (Sun) -->
+          <g class="ease-chart-point" tabindex="0" aria-label="Sunday: 74.2 kg">
+            <circle cx="490" cy="115" r="5" />
+            <foreignObject x="435" y="70" width="60" height="30">
+              <div class="ease-point-tooltip">74.2 kg</div>
+            </foreignObject>
+          </g>
+
+        </svg>
+
+        <!-- Timeline X-Axis -->
+        <div class="ease-chart-axis" aria-hidden="true">
+          <span>Mon</span>
+          <span>Tue</span>
+          <span>Wed</span>
+          <span>Thu</span>
+          <span>Fri</span>
+          <span>Sat</span>
+          <span>Sun</span>
+        </div>
+      </div>
+
+      <!-- Footer Metric Targets -->
+      <footer class="ease-weight-metrics">
+        <div class="ease-metric-item">
+          <span class="ease-metric-item__label">Start Weight</span>
+          <span class="ease-metric-item__value">78.0 kg</span>
+        </div>
+        <div class="ease-metric-item">
+          <span class="ease-metric-item__label">Target Weight</span>
+          <span class="ease-metric-item__value">72.0 kg</span>
+        </div>
+        <div class="ease-metric-item">
+          <span class="ease-metric-item__label">Remaining</span>
+          <span class="ease-metric-item__value">2.2 kg</span>
+        </div>
+      </footer>
+
+    </article>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/body-weight-chart-ns/style.css
+++ b/submissions/examples/body-weight-chart-ns/style.css
@@ -1,0 +1,258 @@
+/* CSS Body Weight Chart #71001 */
+
+:root {
+  --bg-color: #0f172a;
+  --card-bg: #1e293b;
+  --border-color: #334155;
+  --text-main: #f8fafc;
+  --text-sub: #94a3b8;
+  --accent-green: #10b981;
+  --accent-green-bg: rgba(16, 185, 129, 0.12);
+  --accent-blue: #38bdf8;
+  --chart-line: #10b981;
+  --chart-fill: rgba(16, 185, 129, 0.15);
+  --card-radius: 20px;
+  --transition-cubic: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 2rem 1rem;
+  background-color: var(--bg-color);
+  color: var(--text-main);
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+/* Demo Layout Container */
+.weight-chart-demo-container {
+  width: 100%;
+  max-width: 580px;
+}
+
+/* ==========================================================================
+   CSS Body Weight Chart Component
+   ========================================================================== */
+
+.ease-weight-card {
+  background-color: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: var(--card-radius);
+  padding: 2rem;
+  box-shadow: 0 20px 40px -15px rgba(0, 0, 0, 0.4);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+/* Header & Stat Summary */
+.ease-weight-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.ease-weight-title-group h2 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-sub);
+  margin: 0 0 0.35rem 0;
+}
+
+.ease-weight-stat {
+  display: flex;
+  align-items: baseline;
+  gap: 0.35rem;
+}
+
+.ease-weight-stat__value {
+  font-size: 2.25rem;
+  font-weight: 800;
+  color: var(--text-main);
+  line-height: 1;
+}
+
+.ease-weight-stat__unit {
+  font-size: 1rem;
+  color: var(--text-sub);
+  font-weight: 600;
+}
+
+/* Trend Indicator Badge */
+.ease-trend-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.4rem 0.75rem;
+  border-radius: 30px;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.ease-trend-badge--down {
+  background-color: var(--accent-green-bg);
+  color: var(--accent-green);
+  border: 1px solid rgba(16, 185, 129, 0.3);
+}
+
+.ease-trend-badge svg {
+  width: 16px;
+  height: 16px;
+}
+
+/* Sparkline Chart Container */
+.ease-sparkline-wrapper {
+  position: relative;
+  width: 100%;
+  padding-top: 1rem;
+}
+
+.ease-sparkline-svg {
+  width: 100%;
+  height: 140px;
+  overflow: visible;
+}
+
+/* Sparkline Visual Line & Gradient Area */
+.ease-sparkline-line {
+  fill: none;
+  stroke: var(--chart-line);
+  stroke-width: 3.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  filter: drop-shadow(0 4px 12px rgba(16, 185, 129, 0.3));
+}
+
+.ease-sparkline-area {
+  fill: url(#weight-gradient);
+  opacity: 0.8;
+}
+
+/* Interactive Interactive Data Points */
+.ease-chart-point {
+  cursor: pointer;
+  outline: none;
+}
+
+.ease-chart-point circle {
+  fill: var(--card-bg);
+  stroke: var(--chart-line);
+  stroke-width: 3;
+  transition: transform 0.25s var(--transition-cubic), fill 0.25s ease, r 0.25s ease;
+}
+
+.ease-chart-point:hover circle,
+.ease-chart-point:focus-visible circle {
+  r: 7;
+  fill: var(--chart-line);
+  transform: scale(1.2);
+}
+
+.ease-chart-point:focus-visible circle {
+  stroke: var(--text-main);
+  stroke-width: 4;
+}
+
+/* Tooltip Popup on Hover/Focus */
+.ease-chart-point foreignObject {
+  overflow: visible;
+  pointer-events: none;
+}
+
+.ease-point-tooltip {
+  opacity: 0;
+  transform: translateY(6px);
+  transition: opacity 0.2s ease, transform 0.2s var(--transition-cubic);
+  background: #090d16;
+  border: 1px solid var(--border-color);
+  color: var(--text-main);
+  padding: 0.35rem 0.6rem;
+  border-radius: 6px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  white-space: nowrap;
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.5);
+  text-align: center;
+}
+
+.ease-chart-point:hover .ease-point-tooltip,
+.ease-chart-point:focus-visible .ease-point-tooltip {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* X-Axis Timeline Labels */
+.ease-chart-axis {
+  display: flex;
+  justify-content: space-between;
+  padding-top: 0.75rem;
+  border-top: 1px dashed var(--border-color);
+  font-size: 0.8rem;
+  color: var(--text-sub);
+  font-weight: 500;
+}
+
+/* Footer Metrics Grid */
+.ease-weight-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+  padding-top: 0.5rem;
+}
+
+.ease-metric-item {
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: 0.85rem;
+  text-align: center;
+}
+
+.ease-metric-item__label {
+  display: block;
+  font-size: 0.75rem;
+  color: var(--text-sub);
+  margin-bottom: 0.25rem;
+}
+
+.ease-metric-item__value {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text-main);
+}
+
+/* ==========================================================================
+   Responsive & Accessibility Overrides
+   ========================================================================== */
+
+@media (max-width: 480px) {
+  .ease-weight-card {
+    padding: 1.25rem;
+  }
+  
+  .ease-weight-metrics {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-chart-point circle,
+  .ease-point-tooltip {
+    transition: none !important;
+  }
+}
+
+@media (forced-colors: active) {
+  .ease-sparkline-line {
+    stroke: CanvasText;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the pure CSS Body Weight Chart component (#71001).
gssoc 26

Closes #71001

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/body-weight-chart-ns/`
- [x] `style.css`, `demo.html`, and `README.md` included
- [x] Automated commit correctly formatted

---

## Feature Description
**What does this add?**
A body weight sparkline chart component featuring progress metrics, a weekly weight delta trend badge, and interactive data inspection tooltips.

**How does it work?**
Leverages an SVG vector sparkline styled with CSS gradients, stroke filters, and pure CSS `:hover` / `:focus-visible` states on focusable `<g>` chart nodes to render tooltips without JavaScript.

---

## Notes for Maintainer
Zero JavaScript dependencies. Keyboard navigable (`tabindex="0"` on sparkline data nodes) with ARIA labels and `prefers-reduced-motion` safety fallbacks.