### PR TITLE
feat: add CSS return policy icon row

### DIFF
--- a/submissions/examples/r-return-policy-icon-row-71019/README.md
+++ b/submissions/examples/r-return-policy-icon-row-71019/README.md
@@ -1,0 +1,39 @@
+# CSS Return Policy Icon Row
+
+A responsive policy information row built with pure HTML and CSS.
+
+## Features
+
+- Return policy card
+- Warranty information card
+- Shipping information card
+- CSS-only icons
+- Smooth hover interactions
+- Responsive layout
+- Keyboard-friendly semantic structure
+- Reduced-motion support
+- No JavaScript required
+
+## Files
+
+- `demo.html` — Interactive demonstration
+- `style.css` — Component styling
+- `README.md` — Documentation
+
+## Usage
+
+Each policy item uses a semantic `<article>` element:
+
+```html
+<article class="policy-card">
+  <div class="policy-icon" aria-hidden="true">
+    <span class="icon-return">↩</span>
+  </div>
+
+  <div class="policy-content">
+    <h2>Easy Returns</h2>
+    <p>
+      Return eligible products within 30 days of delivery.
+    </p>
+  </div>
+</article>

--- a/submissions/examples/r-return-policy-icon-row-71019/demo.html
+++ b/submissions/examples/r-return-policy-icon-row-71019/demo.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS return policy icon row">
+  <title>CSS Return Policy Icon Row</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <section class="policy-section" aria-labelledby="policy-title">
+      <p class="eyebrow">Shop with confidence</p>
+
+      <h1 id="policy-title">Our Promise to You</h1>
+
+      <p class="intro">
+        Simple policies designed to make every purchase easier.
+      </p>
+
+      <div class="policy-row">
+
+        <article class="policy-card">
+          <div class="policy-icon" aria-hidden="true">
+            <span class="icon-return">↩</span>
+          </div>
+
+          <div class="policy-content">
+            <h2>Easy Returns</h2>
+            <p>
+              Return eligible products within 30 days of delivery.
+            </p>
+          </div>
+        </article>
+
+        <article class="policy-card">
+          <div class="policy-icon warranty" aria-hidden="true">
+            <span class="icon-shield">✓</span>
+          </div>
+
+          <div class="policy-content">
+            <h2>Warranty</h2>
+            <p>
+              Selected products include reliable warranty coverage.
+            </p>
+          </div>
+        </article>
+
+        <article class="policy-card">
+          <div class="policy-icon shipping" aria-hidden="true">
+            <span class="icon-truck">→</span>
+          </div>
+
+          <div class="policy-content">
+            <h2>Fast Shipping</h2>
+            <p>
+              Get your order delivered quickly and securely.
+            </p>
+          </div>
+        </article>
+
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/r-return-policy-icon-row-71019/style.css
+++ b/submissions/examples/r-return-policy-icon-row-71019/style.css
@@ -1,0 +1,486 @@
+:root {
+  --bg: #070b14;
+  --surface: #101827;
+  --surface-hover: #162033;
+  --text: #f8fafc;
+  --muted: #94a3b8;
+  --border: rgba(255, 255, 255, 0.09);
+
+  --blue: #38bdf8;
+  --green: #34d399;
+  --violet: #a78bfa;
+
+  --ease: 280ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--text);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background:
+    radial-gradient(
+      circle at 15% 15%,
+      rgba(56, 189, 248, 0.12),
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at 85% 80%,
+      rgba(167, 139, 250, 0.1),
+      transparent 30%
+    ),
+    var(--bg);
+}
+
+.page {
+  width: min(1100px, calc(100% - 32px));
+  min-height: 100vh;
+  margin: auto;
+  display: grid;
+  place-items: center;
+  padding: 70px 0;
+}
+
+.policy-section {
+  width: 100%;
+  text-align: center;
+}
+
+.eyebrow {
+  margin: 0 0 12px;
+  color: var(--blue);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2.3rem, 6vw, 4.5rem);
+  line-height: 1;
+  letter-spacing: -0.05em;
+}
+
+.intro {
+  max-width: 620px;
+  margin: 20px auto 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.policy-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  margin-top: 52px;
+}
+
+.policy-card {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  min-height: 150px;
+  padding: 28px 24px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  background: var(--surface);
+  text-align: left;
+  transition:
+    transform var(--ease),
+    border-color var(--ease),
+    background var(--ease),
+    box-shadow var(--ease);
+}
+
+.policy-card::after {
+  position: absolute;
+  inset: auto -20px -35px auto;
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.025);
+  content: "";
+}
+
+.policy-card:hover {
+  transform: translateY(-7px);
+  border-color: rgba(255, 255, 255, 0.2);
+  background: var(--surface-hover);
+  box-shadow: 0 22px 45px rgba(0, 0, 0, 0.28);
+}
+
+.policy-icon {
+  flex: 0 0 62px;
+  width: 62px;
+  height: 62px;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  border-radius: 18px;
+  background: rgba(56, 189, 248, 0.1);
+  color: var(--blue);
+  transition:
+    transform var(--ease),
+    box-shadow var(--ease);
+}
+
+.policy-card:hover .policy-icon {
+  transform: rotate(-6deg) scale(1.08);
+  box-shadow: 0 0 25px rgba(56, 189, 248, 0.16);
+}
+
+.policy-icon.warranty {
+  border-color: rgba(52, 211, 153, 0.35);
+  background: rgba(52, 211, 153, 0.1);
+  color: var(--green);
+}
+
+.policy-icon.shipping {
+  border-color: rgba(167, 139, 250, 0.35);
+  background: rgba(167, 139, 250, 0.1);
+  color: var(--violet);
+}
+
+.icon-return {
+  font-size: 2rem;
+  font-weight: 500;
+}
+
+.icon-shield {
+  width: 30px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  border: 2px solid currentColor;
+  border-radius: 8px 8px 12px 12px;
+  font-size: 1rem;
+  font-weight: 900;
+}
+
+.icon-truck {
+  width: 38px;
+  height: 23px;
+  display: grid;
+  place-items: center;
+  border: 2px solid currentColor;
+  border-radius: 5px;
+  font-size: 1rem;
+  font-weight: 900;
+}
+
+.policy-content {
+  position: relative;
+  z-index: 1;
+}
+
+.policy-content h2 {
+  margin: 0;
+  font-size: 1.08rem;
+}
+
+.policy-content p {
+  margin: 8px 0 0;
+  color: var(--muted);
+  font-size: 0.82rem;
+  line-height: 1.55;
+}
+
+@media (max-width: 850px) {
+  .policy-row {
+    grid-template-columns: 1fr;
+    max-width: 620px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .policy-card {
+    min-height: 125px;
+  }
+}
+
+@media (max-width: 500px) {
+  .page {
+    width: min(100% - 24px, 450px);
+    padding: 50px 0;
+  }
+
+  .policy-card {
+    align-items: flex-start;
+    padding: 22px 18px;
+  }
+
+  .policy-icon {
+    flex-basis: 54px;
+    width: 54px;
+    height: 54px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .policy-card,
+  .policy-icon {
+    transition: none;
+  }
+
+  .policy-card:hover,
+  .policy-card:hover .policy-icon {
+    transform: none;
+  }
+}
+:root {
+  --bg: #070b14;
+  --surface: #101827;
+  --surface-hover: #162033;
+  --text: #f8fafc;
+  --muted: #94a3b8;
+  --border: rgba(255, 255, 255, 0.09);
+
+  --blue: #38bdf8;
+  --green: #34d399;
+  --violet: #a78bfa;
+
+  --ease: 280ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--text);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background:
+    radial-gradient(
+      circle at 15% 15%,
+      rgba(56, 189, 248, 0.12),
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at 85% 80%,
+      rgba(167, 139, 250, 0.1),
+      transparent 30%
+    ),
+    var(--bg);
+}
+
+.page {
+  width: min(1100px, calc(100% - 32px));
+  min-height: 100vh;
+  margin: auto;
+  display: grid;
+  place-items: center;
+  padding: 70px 0;
+}
+
+.policy-section {
+  width: 100%;
+  text-align: center;
+}
+
+.eyebrow {
+  margin: 0 0 12px;
+  color: var(--blue);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2.3rem, 6vw, 4.5rem);
+  line-height: 1;
+  letter-spacing: -0.05em;
+}
+
+.intro {
+  max-width: 620px;
+  margin: 20px auto 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.policy-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  margin-top: 52px;
+}
+
+.policy-card {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  min-height: 150px;
+  padding: 28px 24px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  background: var(--surface);
+  text-align: left;
+  transition:
+    transform var(--ease),
+    border-color var(--ease),
+    background var(--ease),
+    box-shadow var(--ease);
+}
+
+.policy-card::after {
+  position: absolute;
+  inset: auto -20px -35px auto;
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.025);
+  content: "";
+}
+
+.policy-card:hover {
+  transform: translateY(-7px);
+  border-color: rgba(255, 255, 255, 0.2);
+  background: var(--surface-hover);
+  box-shadow: 0 22px 45px rgba(0, 0, 0, 0.28);
+}
+
+.policy-icon {
+  flex: 0 0 62px;
+  width: 62px;
+  height: 62px;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  border-radius: 18px;
+  background: rgba(56, 189, 248, 0.1);
+  color: var(--blue);
+  transition:
+    transform var(--ease),
+    box-shadow var(--ease);
+}
+
+.policy-card:hover .policy-icon {
+  transform: rotate(-6deg) scale(1.08);
+  box-shadow: 0 0 25px rgba(56, 189, 248, 0.16);
+}
+
+.policy-icon.warranty {
+  border-color: rgba(52, 211, 153, 0.35);
+  background: rgba(52, 211, 153, 0.1);
+  color: var(--green);
+}
+
+.policy-icon.shipping {
+  border-color: rgba(167, 139, 250, 0.35);
+  background: rgba(167, 139, 250, 0.1);
+  color: var(--violet);
+}
+
+.icon-return {
+  font-size: 2rem;
+  font-weight: 500;
+}
+
+.icon-shield {
+  width: 30px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  border: 2px solid currentColor;
+  border-radius: 8px 8px 12px 12px;
+  font-size: 1rem;
+  font-weight: 900;
+}
+
+.icon-truck {
+  width: 38px;
+  height: 23px;
+  display: grid;
+  place-items: center;
+  border: 2px solid currentColor;
+  border-radius: 5px;
+  font-size: 1rem;
+  font-weight: 900;
+}
+
+.policy-content {
+  position: relative;
+  z-index: 1;
+}
+
+.policy-content h2 {
+  margin: 0;
+  font-size: 1.08rem;
+}
+
+.policy-content p {
+  margin: 8px 0 0;
+  color: var(--muted);
+  font-size: 0.82rem;
+  line-height: 1.55;
+}
+
+@media (max-width: 850px) {
+  .policy-row {
+    grid-template-columns: 1fr;
+    max-width: 620px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .policy-card {
+    min-height: 125px;
+  }
+}
+
+@media (max-width: 500px) {
+  .page {
+    width: min(100% - 24px, 450px);
+    padding: 50px 0;
+  }
+
+  .policy-card {
+    align-items: flex-start;
+    padding: 22px 18px;
+  }
+
+  .policy-icon {
+    flex-basis: 54px;
+    width: 54px;
+    height: 54px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .policy-card,
+  .policy-icon {
+    transition: none;
+  }
+
+  .policy-card:hover,
+  .policy-card:hover .policy-icon {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Description

Implemented the CSS Return Policy Icon Row feature for EaseMotion CSS.

### What's included

- Added return policy information card
- Added warranty information card
- Added shipping information card
- Added CSS-only visual icons
- Added smooth hover interactions
- Added responsive layouts
- Added reduced-motion support
- No JavaScript required

### Accessibility

- Uses semantic HTML
- Decorative icons use `aria-hidden="true"`
- Content remains accessible and readable
- Supports responsive layouts
- Respects `prefers-reduced-motion`

### Files Changed

`submissions/examples/r-return-policy-icon-row-71019/`

- `demo.html`
- `style.css`
- `README.md`

### Related Issue

Closes #71019