### PR TITLE
Add ease-battery-status-phone component

### DIFF
--- a/submissions/examples/battery-status-phone-ij/README.md
+++ b/submissions/examples/battery-status-phone-ij/README.md
@@ -1,0 +1,11 @@
+# ease-battery-status-phone
+
+A phone battery indicator where the charge fills and drains, the bolt flashes, and the percentage ticks.
+
+## Run
+Open `demo.html` directly in a browser to watch the battery drain.
+
+## Notes
+- The battery fill grows and shrinks.
+- The charging bolt flashes beside the meter.
+- The percentage readout ticks below it.

--- a/submissions/examples/battery-status-phone-ij/demo.html
+++ b/submissions/examples/battery-status-phone-ij/demo.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-battery-status-phone demo</title>
+</head>
+<body>
+<div class="bsp-phone">
+  <div class="bsp-screen">
+    <div class="bsp-statusbar">
+      <span class="bsp-time">9:41</span>
+      <i class="bsp-cap"><em class="bsp-fill"></em></i>
+    </div>
+    <div class="bsp-bolt">⚡</div>
+    <span class="bsp-percent">64%</span>
+    <div class="bsp-home"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/battery-status-phone-ij/style.css
+++ b/submissions/examples/battery-status-phone-ij/style.css
@@ -1,0 +1,12 @@
+.bsp-phone{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:210px;background:linear-gradient(180deg,#1e2935,#0e151e);border:3px solid #2f3f52;border-radius:26px;padding:8px}
+.bsp-screen{background:linear-gradient(180deg,#0a1f33,#071627);border-radius:20px;padding:14px;display:flex;flex-direction:column;align-items:center;gap:16px;border:1px solid #1d3a52}
+.bsp-statusbar{width:100%;display:flex;justify-content:space-between;align-items:center}
+.bsp-time{font-size:12px;font-weight:800;color:#c7d6e8}
+.bsp-cap{position:relative;width:36px;height:16px;background:#101f2e;border:2px solid #5ce1e6;border-radius:3px;padding:2px}
+.bsp-fill{position:absolute;left:2px;top:2px;bottom:2px;width:60%;background:linear-gradient(90deg,#7cebb0,#5ce1e6);border-radius:1px;animation:bsp-fill-charge-battery-status-phone 3s ease-in-out infinite}
+.bsp-bolt{font-size:30px;color:#ffd76a;animation:bsp-bolt-flash-battery-status-phone 1.2s ease-in-out infinite}
+.bsp-percent{font-size:20px;font-weight:800;color:#7cebb0;font-family:'Courier New',monospace;animation:bsp-percent-tick-battery-status-phone 2s steps(4) infinite}
+.bsp-home{width:46px;height:4px;background:#2f3f52;border-radius:2px}
+@keyframes bsp-fill-charge-battery-status-phone{0%,100%{width:25%}50%{width:75%}}
+@keyframes bsp-bolt-flash-battery-status-phone{0%,100%{opacity:1}50%{opacity:.25}}
+@keyframes bsp-percent-tick-battery-status-phone{0%{opacity:1}50%{opacity:.3}}


### PR DESCRIPTION
## Component: ease-battery-status-phone — charge fills, bolt flashes, and percent ticks

**Closes #71372**

### What this adds
A phone battery indicator where the charge fills and drains, the bolt flashes, and the percentage ticks.

### Acceptance Criteria covered
- Charge fills and drains
- Bolt flashes
- Percentage ticks

### Files
- `submissions/examples/battery-status-phone-ij/demo.html`
- `submissions/examples/battery-status-phone-ij/style.css`
- `submissions/examples/battery-status-phone-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the charge drain, the bolt flash, and the percent tick.