### PR TITLE
feat: add CSS shaking error icon

### DIFF
--- a/submissions/examples/r-shaking-error-icon-71015/README.md
+++ b/submissions/examples/r-shaking-error-icon-71015/README.md
@@ -1,0 +1,29 @@
+# CSS Shaking Error Icon
+
+A CSS-only error indicator with a subtle shaking animation for drawing attention to invalid form states.
+
+## Features
+
+- Pure CSS shaking animation
+- Clear error indicator
+- Accessible form markup
+- `aria-invalid` support
+- Visible keyboard focus states
+- Responsive layout
+- Reduced-motion support
+- No JavaScript required
+
+## Files
+
+- `demo.html` — Interactive demonstration
+- `style.css` — Component styles
+- `README.md` — Documentation
+
+## Usage
+
+Add the `error-shake` animation to an error component:
+
+```css
+.error-panel {
+  animation: error-shake 1.2s ease-in-out infinite;
+}

--- a/submissions/examples/r-shaking-error-icon-71015/demo.html
+++ b/submissions/examples/r-shaking-error-icon-71015/demo.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta
+    name="description"
+    content="CSS shaking error icon demonstration"
+  >
+  <title>CSS Shaking Error Icon</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <section class="demo" aria-labelledby="title">
+      <p class="eyebrow">EaseMotion CSS</p>
+
+      <h1 id="title">Shaking Error Icon</h1>
+
+      <p class="intro">
+        A CSS-only error indicator that shakes to draw attention
+        to an invalid form state.
+      </p>
+
+      <div class="error-panel">
+        <div
+          class="error-icon"
+          role="img"
+          aria-label="Error"
+        >
+          <span aria-hidden="true">!</span>
+        </div>
+
+        <div class="error-content">
+          <p class="error-label">Validation Error</p>
+
+          <h2>Something went wrong</h2>
+
+          <p>
+            Please check the highlighted information and try again.
+          </p>
+        </div>
+      </div>
+
+      <div class="demo-form">
+        <label for="email">Email address</label>
+
+        <div class="input-row">
+          <input
+            id="email"
+            type="email"
+            placeholder="Enter your email"
+            aria-describedby="email-error"
+            aria-invalid="true"
+          >
+
+          <button type="button" class="error-trigger">
+            Show Error
+          </button>
+        </div>
+
+        <p id="email-error" class="field-error">
+          Please enter a valid email address.
+        </p>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/r-shaking-error-icon-71015/style.css
+++ b/submissions/examples/r-shaking-error-icon-71015/style.css
@@ -1,0 +1,614 @@
+:root {
+  --bg: #080b14;
+  --surface: #111827;
+  --surface-light: #182235;
+  --text: #f8fafc;
+  --muted: #94a3b8;
+  --border: rgba(255, 255, 255, 0.1);
+
+  --error: #f43f5e;
+  --error-light: #fb7185;
+  --error-bg: rgba(244, 63, 94, 0.1);
+
+  --transition: 260ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--text);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background:
+    radial-gradient(
+      circle at 15% 20%,
+      rgba(244, 63, 94, 0.1),
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at 85% 80%,
+      rgba(99, 102, 241, 0.09),
+      transparent 30%
+    ),
+    var(--bg);
+}
+
+.page {
+  width: min(850px, calc(100% - 32px));
+  min-height: 100vh;
+  margin: auto;
+  display: grid;
+  place-items: center;
+  padding: 70px 0;
+}
+
+.demo {
+  width: 100%;
+  text-align: center;
+}
+
+.eyebrow {
+  margin: 0 0 12px;
+  color: var(--error-light);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2.4rem, 7vw, 4.5rem);
+  line-height: 1;
+  letter-spacing: -0.055em;
+}
+
+.intro {
+  max-width: 620px;
+  margin: 22px auto 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.error-panel {
+  position: relative;
+  width: min(680px, 100%);
+  margin: 50px auto 0;
+  padding: 30px;
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  border: 1px solid rgba(244, 63, 94, 0.25);
+  border-radius: 24px;
+  background:
+    linear-gradient(
+      135deg,
+      var(--error-bg),
+      transparent
+    ),
+    var(--surface);
+  text-align: left;
+  box-shadow:
+    0 20px 55px rgba(0, 0, 0, 0.25),
+    inset 0 1px rgba(255, 255, 255, 0.03);
+  animation: error-shake 1.2s ease-in-out infinite;
+}
+
+.error-icon {
+  flex: 0 0 70px;
+  width: 70px;
+  height: 70px;
+  display: grid;
+  place-items: center;
+  border: 2px solid var(--error);
+  border-radius: 50%;
+  background: var(--error-bg);
+  color: var(--error-light);
+  box-shadow:
+    0 0 0 7px rgba(244, 63, 94, 0.05),
+    0 0 30px rgba(244, 63, 94, 0.18);
+}
+
+.error-icon span {
+  font-size: 2rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.error-content {
+  min-width: 0;
+}
+
+.error-label {
+  margin: 0 0 6px;
+  color: var(--error-light);
+  font-size: 0.68rem;
+  font-weight: 850;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.error-content h2 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.error-content > p:last-child {
+  margin: 8px 0 0;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.demo-form {
+  width: min(680px, 100%);
+  margin: 25px auto 0;
+  padding: 26px;
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  background: rgba(17, 24, 39, 0.78);
+  text-align: left;
+}
+
+.demo-form label {
+  display: block;
+  margin-bottom: 9px;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.input-row {
+  display: flex;
+  gap: 10px;
+}
+
+.input-row input {
+  min-width: 0;
+  flex: 1;
+  padding: 13px 15px;
+  border: 1px solid rgba(244, 63, 94, 0.5);
+  border-radius: 12px;
+  outline: none;
+  background: #0b1120;
+  color: var(--text);
+  font: inherit;
+  box-shadow: 0 0 0 3px rgba(244, 63, 94, 0.07);
+}
+
+.input-row input::placeholder {
+  color: #64748b;
+}
+
+.input-row input:focus-visible {
+  border-color: var(--error-light);
+  box-shadow:
+    0 0 0 3px rgba(244, 63, 94, 0.16);
+}
+
+.error-trigger {
+  padding: 12px 18px;
+  border: 0;
+  border-radius: 12px;
+  background: var(--error);
+  color: white;
+  font: inherit;
+  font-weight: 750;
+  cursor: pointer;
+  transition:
+    transform var(--transition),
+    background var(--transition),
+    box-shadow var(--transition);
+}
+
+.error-trigger:hover {
+  transform: translateY(-2px);
+  background: #e11d48;
+  box-shadow: 0 8px 22px rgba(244, 63, 94, 0.25);
+}
+
+.error-trigger:focus-visible {
+  outline: 3px solid var(--error-light);
+  outline-offset: 3px;
+}
+
+.field-error {
+  margin: 10px 0 0;
+  color: var(--error-light);
+  font-size: 0.82rem;
+}
+
+@keyframes error-shake {
+  0%,
+  78%,
+  100% {
+    transform: translateX(0);
+  }
+
+  80% {
+    transform: translateX(-5px);
+  }
+
+  82% {
+    transform: translateX(5px);
+  }
+
+  84% {
+    transform: translateX(-4px);
+  }
+
+  86% {
+    transform: translateX(4px);
+  }
+
+  88% {
+    transform: translateX(-2px);
+  }
+
+  90% {
+    transform: translateX(2px);
+  }
+
+  92% {
+    transform: translateX(0);
+  }
+}
+
+@media (max-width: 600px) {
+  .page {
+    width: min(100% - 24px, 500px);
+    padding: 50px 0;
+  }
+
+  .error-panel {
+    padding: 24px;
+    align-items: flex-start;
+  }
+
+  .error-icon {
+    flex-basis: 58px;
+    width: 58px;
+    height: 58px;
+  }
+
+  .error-icon span {
+    font-size: 1.6rem;
+  }
+
+  .input-row {
+    flex-direction: column;
+  }
+
+  .error-trigger {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .error-panel {
+    animation: none;
+  }
+
+  .error-trigger {
+    transition: none;
+  }
+
+  .error-trigger:hover {
+    transform: none;
+  }
+}
+:root {
+  --bg: #080b14;
+  --surface: #111827;
+  --surface-light: #182235;
+  --text: #f8fafc;
+  --muted: #94a3b8;
+  --border: rgba(255, 255, 255, 0.1);
+
+  --error: #f43f5e;
+  --error-light: #fb7185;
+  --error-bg: rgba(244, 63, 94, 0.1);
+
+  --transition: 260ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--text);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background:
+    radial-gradient(
+      circle at 15% 20%,
+      rgba(244, 63, 94, 0.1),
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at 85% 80%,
+      rgba(99, 102, 241, 0.09),
+      transparent 30%
+    ),
+    var(--bg);
+}
+
+.page {
+  width: min(850px, calc(100% - 32px));
+  min-height: 100vh;
+  margin: auto;
+  display: grid;
+  place-items: center;
+  padding: 70px 0;
+}
+
+.demo {
+  width: 100%;
+  text-align: center;
+}
+
+.eyebrow {
+  margin: 0 0 12px;
+  color: var(--error-light);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2.4rem, 7vw, 4.5rem);
+  line-height: 1;
+  letter-spacing: -0.055em;
+}
+
+.intro {
+  max-width: 620px;
+  margin: 22px auto 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.error-panel {
+  position: relative;
+  width: min(680px, 100%);
+  margin: 50px auto 0;
+  padding: 30px;
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  border: 1px solid rgba(244, 63, 94, 0.25);
+  border-radius: 24px;
+  background:
+    linear-gradient(
+      135deg,
+      var(--error-bg),
+      transparent
+    ),
+    var(--surface);
+  text-align: left;
+  box-shadow:
+    0 20px 55px rgba(0, 0, 0, 0.25),
+    inset 0 1px rgba(255, 255, 255, 0.03);
+  animation: error-shake 1.2s ease-in-out infinite;
+}
+
+.error-icon {
+  flex: 0 0 70px;
+  width: 70px;
+  height: 70px;
+  display: grid;
+  place-items: center;
+  border: 2px solid var(--error);
+  border-radius: 50%;
+  background: var(--error-bg);
+  color: var(--error-light);
+  box-shadow:
+    0 0 0 7px rgba(244, 63, 94, 0.05),
+    0 0 30px rgba(244, 63, 94, 0.18);
+}
+
+.error-icon span {
+  font-size: 2rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.error-content {
+  min-width: 0;
+}
+
+.error-label {
+  margin: 0 0 6px;
+  color: var(--error-light);
+  font-size: 0.68rem;
+  font-weight: 850;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.error-content h2 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.error-content > p:last-child {
+  margin: 8px 0 0;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.demo-form {
+  width: min(680px, 100%);
+  margin: 25px auto 0;
+  padding: 26px;
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  background: rgba(17, 24, 39, 0.78);
+  text-align: left;
+}
+
+.demo-form label {
+  display: block;
+  margin-bottom: 9px;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.input-row {
+  display: flex;
+  gap: 10px;
+}
+
+.input-row input {
+  min-width: 0;
+  flex: 1;
+  padding: 13px 15px;
+  border: 1px solid rgba(244, 63, 94, 0.5);
+  border-radius: 12px;
+  outline: none;
+  background: #0b1120;
+  color: var(--text);
+  font: inherit;
+  box-shadow: 0 0 0 3px rgba(244, 63, 94, 0.07);
+}
+
+.input-row input::placeholder {
+  color: #64748b;
+}
+
+.input-row input:focus-visible {
+  border-color: var(--error-light);
+  box-shadow:
+    0 0 0 3px rgba(244, 63, 94, 0.16);
+}
+
+.error-trigger {
+  padding: 12px 18px;
+  border: 0;
+  border-radius: 12px;
+  background: var(--error);
+  color: white;
+  font: inherit;
+  font-weight: 750;
+  cursor: pointer;
+  transition:
+    transform var(--transition),
+    background var(--transition),
+    box-shadow var(--transition);
+}
+
+.error-trigger:hover {
+  transform: translateY(-2px);
+  background: #e11d48;
+  box-shadow: 0 8px 22px rgba(244, 63, 94, 0.25);
+}
+
+.error-trigger:focus-visible {
+  outline: 3px solid var(--error-light);
+  outline-offset: 3px;
+}
+
+.field-error {
+  margin: 10px 0 0;
+  color: var(--error-light);
+  font-size: 0.82rem;
+}
+
+@keyframes error-shake {
+  0%,
+  78%,
+  100% {
+    transform: translateX(0);
+  }
+
+  80% {
+    transform: translateX(-5px);
+  }
+
+  82% {
+    transform: translateX(5px);
+  }
+
+  84% {
+    transform: translateX(-4px);
+  }
+
+  86% {
+    transform: translateX(4px);
+  }
+
+  88% {
+    transform: translateX(-2px);
+  }
+
+  90% {
+    transform: translateX(2px);
+  }
+
+  92% {
+    transform: translateX(0);
+  }
+}
+
+@media (max-width: 600px) {
+  .page {
+    width: min(100% - 24px, 500px);
+    padding: 50px 0;
+  }
+
+  .error-panel {
+    padding: 24px;
+    align-items: flex-start;
+  }
+
+  .error-icon {
+    flex-basis: 58px;
+    width: 58px;
+    height: 58px;
+  }
+
+  .error-icon span {
+    font-size: 1.6rem;
+  }
+
+  .input-row {
+    flex-direction: column;
+  }
+
+  .error-trigger {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .error-panel {
+    animation: none;
+  }
+
+  .error-trigger {
+    transition: none;
+  }
+
+  .error-trigger:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Description

Implemented the CSS Shaking Error Icon feature for EaseMotion CSS.

### What's included

- Added CSS-only shaking error indicator
- Added invalid form state demonstration
- Added accessible error messaging
- Added keyboard focus states
- Added responsive layout
- Added reduced-motion support
- No JavaScript required

### Accessibility

- Uses semantic form controls
- Includes `aria-invalid`
- Uses descriptive labels
- Provides visible `:focus-visible` states
- Respects `prefers-reduced-motion`

### Files Changed

`submissions/examples/r-shaking-error-icon-71015/`

- `demo.html`
- `style.css`
- `README.md`

### Related Issue

Closes #71015