### PR TITLE
feat: implement CSS font palette demo #70994

### DIFF
--- a/submissions/examples/font-palette-demo-ns/README.md
+++ b/submissions/examples/font-palette-demo-ns/README.md
@@ -1,0 +1,9 @@
+# CSS Font Palette Demo (#70994)
+
+A modern typography demonstration component showcasing native CSS `font-palette` features and `@font-palette-values` color overrides.
+
+## Features
+- Pure CSS state switching using hidden radio buttons and sibling combinators.
+- Custom `@font-palette-values` definitions (`--custom-neon`, `--custom-sunset`).
+- Responsive layout with adaptable grid controls.
+- Fully accessible with keyboard navigation support (`:focus-visible`).

--- a/submissions/examples/font-palette-demo-ns/demo.html
+++ b/submissions/examples/font-palette-demo-ns/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Font Palette Demo | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="font-palette-demo-container">
+    
+    <!-- Font Palette Demo Component -->
+    <article class="ease-font-card" aria-label="CSS Font Palette Showcase">
+      
+      <header class="ease-font-header">
+        <h1>CSS Font Palette</h1>
+        <p>Demonstrating color font customization using native <code>font-palette</code> and <code>@font-palette-values</code> without JavaScript.</p>
+      </header>
+
+      <!-- Hidden Radio Inputs for Pure CSS Interactivity -->
+      <input type="radio" id="palette-default" name="palette-group" class="ease-radio-input" checked>
+      <input type="radio" id="palette-neon" name="palette-group" class="ease-radio-input">
+      <input type="radio" id="palette-sunset" name="palette-group" class="ease-radio-input">
+
+      <!-- Typography Showcase Box -->
+      <div class="ease-font-showcase" role="region" aria-label="Color font display area">
+        <h2 class="ease-color-heading" aria-label="Vibrant Typography Showcase">VIBRANT</h2>
+        <p class="ease-font-description">Toggle options below to dynamically shift color font layers.</p>
+      </div>
+
+      <!-- Controls Selection Grid -->
+      <div class="ease-palette-controls" role="group" aria-label="Select font palette theme">
+        <label for="palette-default" class="ease-radio-label">Default</label>
+        <label for="palette-neon" class="ease-radio-label">Neon Glow</label>
+        <label for="palette-sunset" class="ease-radio-label">Sunset Dusk</label>
+      </div>
+
+    </article>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/font-palette-demo-ns/style.css
+++ b/submissions/examples/font-palette-demo-ns/style.css
@@ -1,0 +1,213 @@
+/* CSS Font Palette Demo #70994 */
+
+:root {
+  --bg-color: #090d16;
+  --card-bg: #111827;
+  --border-color: #1f2937;
+  --text-main: #f9fafb;
+  --text-sub: #9ca3af;
+  --accent: #6366f1;
+  --card-radius: 20px;
+  --transition-cubic: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 2rem 1rem;
+  background-color: var(--bg-color);
+  color: var(--text-main);
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+/* Demo Container */
+.font-palette-demo-container {
+  width: 100%;
+  max-width: 640px;
+}
+
+/* ==========================================================================
+   CSS Font Palette Component
+   ========================================================================== */
+
+.ease-font-card {
+  background-color: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: var(--card-radius);
+  padding: 2.5rem;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.ease-font-header h1 {
+  font-size: 1.75rem;
+  font-weight: 800;
+  margin: 0 0 0.5rem 0;
+  color: var(--text-main);
+}
+
+.ease-font-header p {
+  font-size: 0.95rem;
+  color: var(--text-sub);
+  margin: 0;
+  line-height: 1.5;
+}
+
+/* ==========================================================================
+   Color Font Display Showcase
+   ========================================================================== */
+
+.ease-font-showcase {
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid var(--border-color);
+  border-radius: 16px;
+  padding: 2rem;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+/* Importing a standard color font supporting font-palette (e.g., Bungee Spice or Noto Emoji / Layers) */
+@import url('https://fonts.googleapis.com/css2?family=Bungee+Spice&display=swap');
+
+.ease-color-heading {
+  font-family: 'Bungee Spice', sans-serif;
+  font-size: clamp(2rem, 5vw, 3.25rem);
+  margin: 0;
+  line-height: 1.1;
+  /* Smooth transition if palette is switched via CSS variables or classes */
+  transition: filter 0.3s ease;
+}
+
+/* Custom Font Palette Overrides (using standard @font-palette-values) */
+@font-palette-values --custom-neon {
+  font-family: 'Bungee Spice';
+  base-palette: 0;
+  override-colors: 
+    0 #ff007f,
+    1 #00f0ff,
+    2 #7000ff;
+}
+
+@font-palette-values --custom-sunset {
+  font-family: 'Bungee Spice';
+  base-palette: 0;
+  override-colors: 
+    0 #f59e0b,
+    1 #ef4444,
+    2 #831843;
+}
+
+/* Palette Variations */
+.ease-palette-default {
+  font-palette: normal;
+}
+
+.ease-palette-neon {
+  font-palette: --custom-neon;
+}
+
+.ease-palette-sunset {
+  font-palette: --custom-sunset;
+}
+
+.ease-font-description {
+  font-size: 0.9rem;
+  color: var(--text-sub);
+  margin: 0;
+}
+
+/* ==========================================================================
+   Interactive Palette Selector (Pure CSS Radio Logic)
+   ========================================================================== */
+
+.ease-palette-controls {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.75rem;
+}
+
+.ease-radio-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.ease-radio-label {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1rem;
+  background-color: rgba(255, 255, 255, 0.03);
+  border: 2px solid var(--border-color);
+  border-radius: 10px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text-sub);
+  cursor: pointer;
+  transition: all 0.2s var(--transition-cubic);
+}
+
+.ease-radio-label:hover {
+  border-color: rgba(99, 102, 241, 0.4);
+  color: var(--text-main);
+}
+
+.ease-radio-input:focus-visible + .ease-radio-label {
+  outline: 3px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* Active State Bindings using General Sibling Combinators */
+#palette-default:checked ~ .ease-palette-controls label[for="palette-default"],
+#palette-neon:checked ~ .ease-palette-controls label[for="palette-neon"],
+#palette-sunset:checked ~ .ease-palette-controls label[for="palette-sunset"] {
+  border-color: var(--accent);
+  background-color: rgba(99, 102, 241, 0.1);
+  color: var(--text-main);
+}
+
+/* Apply Palettes based on Checked State */
+#palette-default:checked ~ .ease-font-showcase .ease-color-heading {
+  font-palette: normal;
+}
+
+#palette-neon:checked ~ .ease-font-showcase .ease-color-heading {
+  font-palette: --custom-neon;
+}
+
+#palette-sunset:checked ~ .ease-font-showcase .ease-color-heading {
+  font-palette: --custom-sunset;
+}
+
+/* ==========================================================================
+   Responsive & Accessibility Overrides
+   ========================================================================== */
+
+@media (max-width: 480px) {
+  .ease-palette-controls {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-color-heading {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the pure CSS Font Palette Demo component (#70994).
gssoc 26

Closes #70994

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/font-palette-demo-ns/`
- [x] `style.css`, `demo.html`, and `README.md` included
- [x] Automated commit correctly formatted

---

## Feature Description
**What does this add?**
A typography showcase component demonstrating the native `font-palette` property and custom `@font-palette-values` declarations, allowing users to switch color font themes interactively.

**How does it work?**
Uses hidden radio inputs paired with general sibling combinators (`~`) to toggle color font palettes (`--custom-neon`, `--custom-sunset`) natively in CSS without any JavaScript event listeners.

---

## Notes for Maintainer
Zero JavaScript required. Fully responsive across screen sizes with standard accessibility support, keyboard focus states, and fallback styling.