### PR TITLE
feat: implement CSS math formula display #70985

### DIFF
--- a/submissions/examples/math-formula-display-ns/README.md
+++ b/submissions/examples/math-formula-display-ns/README.md
@@ -1,0 +1,9 @@
+# CSS Math Formula Display (#70985)
+
+A lightweight, styled mathematical formula display block featuring fractions, radical symbols, superscripts, and subscripts using pure CSS.
+
+## Features
+- Pure CSS flexbox layout for fractions and mathematical notation without JavaScript.
+- Elegant serif-math typography bindings.
+- Responsive horizontal scrolling viewport for wide expressions.
+- Full accessibility support with descriptive `aria-label` screen reader equivalents.

--- a/submissions/examples/math-formula-display-ns/demo.html
+++ b/submissions/examples/math-formula-display-ns/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Math Formula Display | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="math-demo-container">
+    
+    <!-- Math Formula Display Component -->
+    <article class="ease-math-card" aria-label="Quadratic Formula Theorem">
+      
+      <header class="ease-math-header">
+        <h2>Quadratic Formula</h2>
+        <p>Pure CSS layout representation of algebraic fractions and radicals.</p>
+      </header>
+
+      <!-- Accessible Math Block -->
+      <div class="ease-math-viewport" role="region" aria-label="Formula: x equals negative b plus or minus square root of b squared minus 4 ac, all over 2 a">
+        <div class="ease-math-expression">
+          <span class="ease-math-var">x</span>
+          <span class="ease-math-operator">=</span>
+          
+          <!-- Fraction Block -->
+          <div class="ease-math-fraction">
+            <div class="ease-math-numerator">
+              <span>-</span><span class="ease-math-var">b</span> 
+              <span class="ease-math-operator">&plusmn;</span> 
+              <span>&radic;</span><span style="text-decoration: overline;"><span class="ease-math-var">b</span><sup>2</sup> &minus; 4<span class="ease-math-var">ac</span></span>
+            </div>
+            <div class="ease-math-denominator">
+              2<span class="ease-math-var">a</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="ease-math-meta">
+        <strong>Note:</strong> Built using semantic HTML and flexbox alignment rules without JavaScript rendering engines like KaTeX or MathJax.
+      </div>
+
+    </article>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/math-formula-display-ns/style.css
+++ b/submissions/examples/math-formula-display-ns/style.css
@@ -1,0 +1,151 @@
+/* CSS Math Formula Display #70985 */
+
+:root {
+  --bg-color: #0b0f19;
+  --card-bg: #111827;
+  --border-color: #1f2937;
+  --text-main: #f9fafb;
+  --text-sub: #9ca3af;
+  --math-bg: #030712;
+  --math-accent: #38bdf8;
+  --math-glow: rgba(56, 189, 248, 0.2);
+  --card-radius: 20px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 2rem 1rem;
+  background-color: var(--bg-color);
+  color: var(--text-main);
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+/* Demo Container */
+.math-demo-container {
+  width: 100%;
+  max-width: 560px;
+}
+
+/* ==========================================================================
+   CSS Math Formula Display Component
+   ========================================================================== */
+
+.ease-math-card {
+  background-color: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: var(--card-radius);
+  padding: 2.5rem 2rem;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.ease-math-header h2 {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin: 0 0 0.35rem 0;
+  color: var(--text-main);
+}
+
+.ease-math-header p {
+  font-size: 0.875rem;
+  color: var(--text-sub);
+  margin: 0;
+}
+
+/* Formula Block Viewport */
+.ease-math-viewport {
+  background-color: var(--math-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 14px;
+  padding: 2rem 1.5rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow-x: auto;
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+/* Mathematical Expression Styling */
+.ease-math-expression {
+  font-family: 'Cambria Math', 'Times New Roman', serif;
+  font-size: 1.5rem;
+  color: var(--text-main);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  white-space: nowrap;
+}
+
+.ease-math-var {
+  font-style: italic;
+  color: var(--math-accent);
+}
+
+.ease-math-operator {
+  margin: 0 0.25rem;
+  color: var(--text-sub);
+}
+
+/* Fraction Layout */
+.ease-math-fraction {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  vertical-align: middle;
+  margin: 0 0.35rem;
+  font-size: 1.35rem;
+}
+
+.ease-math-numerator {
+  padding: 0 0.25rem 0.2rem 0.25rem;
+  border-bottom: 1.5px solid var(--text-main);
+  text-align: center;
+}
+
+.ease-math-denominator {
+  padding: 0.2rem 0.25rem 0 0.25rem;
+  text-align: center;
+}
+
+/* Superscript / Subscript Helpers */
+sup {
+  font-size: 0.75em;
+  vertical-align: super;
+}
+
+sub {
+  font-size: 0.75em;
+  vertical-align: sub;
+  color: var(--text-sub);
+}
+
+/* Formula Description Metadata */
+.ease-math-meta {
+  font-size: 0.85rem;
+  color: var(--text-sub);
+  background-color: rgba(255, 255, 255, 0.02);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  padding: 0.85rem 1rem;
+  line-height: 1.4;
+}
+
+/* ==========================================================================
+   Accessibility Overrides
+   ========================================================================== */
+
+@media (forced-colors: active) {
+  .ease-math-fraction .ease-math-numerator {
+    border-bottom-color: Highlight;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the pure CSS Math Formula Display component (#70985).
gssoc 26

Closes #70985

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/math-formula-display-ns/`
- [x] `style.css`, `demo.html`, and `README.md` included
- [x] Automated commit correctly formatted

---

## Feature Description
**What does this add?**
A styled mathematical formula presentation block showcasing algebraic fractions, radicals, superscripts, and operators rendered entirely through CSS and HTML.

**How does it work?**
Uses inline flexbox column containers and border-bottom styling to construct clean stacked fraction notations and radical overlines without requiring external JavaScript math libraries.

---

## Notes for Maintainer
Zero JavaScript required. Fully accessible with screen reader text descriptions explaining the exact mathematical equation.