### PR TITLE
feat: implement CSS airport gate display #70988

### DIFF
--- a/submissions/examples/airport-gate-display-ns/README.md
+++ b/submissions/examples/airport-gate-display-ns/README.md
@@ -1,0 +1,9 @@
+# CSS Airport Gate Display (#70988)
+
+An authentic airport departure gate status board component featuring monospaced split-flap display panels, flight numbers, and live boarding status indicators.
+
+## Features
+- Pure CSS split-flap terminal board aesthetic layout.
+- Responsive grid structure adapting seamlessly to mobile screens.
+- Pulsing live status indicators with `prefers-reduced-motion` safety support.
+- Fully accessible via semantic regions and screen reader labels.

--- a/submissions/examples/airport-gate-display-ns/demo.html
+++ b/submissions/examples/airport-gate-display-ns/demo.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Airport Gate Display | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="airport-demo-container">
+    
+    <!-- Airport Gate Display Component -->
+    <article class="ease-gate-card" aria-label="Flight Departure Gate Status">
+      
+      <header class="ease-gate-header">
+        <div class="ease-airline-info">
+          <span class="ease-airline-logo" aria-hidden="true">✈️</span>
+          <span class="ease-airline-name">AeroStream Airways</span>
+        </div>
+        <div class="ease-flight-number" aria-label="Flight AS-409">AS 409</div>
+      </header>
+
+      <!-- Split-Flap Board Columns -->
+      <div class="ease-gate-board" role="region" aria-label="Flight schedule board">
+        <div class="ease-board-column">
+          <span class="ease-board-label">Gate</span>
+          <span class="ease-board-value">B 24</span>
+        </div>
+        <div class="ease-board-column">
+          <span class="ease-board-label">Boarding</span>
+          <span class="ease-board-value">14:45</span>
+        </div>
+        <div class="ease-board-column">
+          <span class="ease-board-label">Seat Close</span>
+          <span class="ease-board-value">15:15</span>
+        </div>
+      </div>
+
+      <!-- Footer Info -->
+      <footer class="ease-gate-footer">
+        <div class="ease-destination-label">
+          <span class="ease-dest-title">Destination</span>
+          <span class="ease-dest-city">San Francisco (SFO)</span>
+        </div>
+        <div class="ease-status-badge" role="status">
+          <span class="ease-status-dot" aria-hidden="true"></span>
+          <span>Boarding</span>
+        </div>
+      </footer>
+
+    </article>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/airport-gate-display-ns/style.css
+++ b/submissions/examples/airport-gate-display-ns/style.css
@@ -1,0 +1,206 @@
+/* CSS Airport Gate Display #70988 */
+
+:root {
+  --bg-color: #0b0f19;
+  --card-bg: #111827;
+  --border-color: #1f2937;
+  --text-main: #f9fafb;
+  --text-sub: #9ca3af;
+  --board-bg: #030712;
+  --board-border: #1e293b;
+  --amber-glow: #f59e0b;
+  --amber-bg: rgba(245, 158, 11, 0.1);
+  --green-glow: #10b981;
+  --green-bg: rgba(16, 185, 129, 0.1);
+  --card-radius: 20px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 2rem 1rem;
+  background-color: var(--bg-color);
+  color: var(--text-main);
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+/* Demo Container */
+.airport-demo-container {
+  width: 100%;
+  max-width: 580px;
+}
+
+/* ==========================================================================
+   CSS Airport Gate Display Component
+   ========================================================================== */
+
+.ease-gate-card {
+  background-color: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: var(--card-radius);
+  padding: 2.25rem 2rem;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.ease-gate-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid var(--border-color);
+  padding-bottom: 1rem;
+}
+
+.ease-airline-info {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.ease-airline-logo {
+  font-size: 1.25rem;
+}
+
+.ease-airline-name {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text-main);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.ease-flight-number {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--amber-glow);
+  background-color: var(--amber-bg);
+  padding: 0.25rem 0.6rem;
+  border-radius: 6px;
+}
+
+/* Split-Flap Board Viewport */
+.ease-gate-board {
+  background-color: var(--board-bg);
+  border: 2px solid var(--board-border);
+  border-radius: 14px;
+  padding: 1.5rem;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+  box-shadow: inset 0 4px 8px rgba(0, 0, 0, 0.4);
+}
+
+.ease-board-column {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.ease-board-label {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-sub);
+}
+
+.ease-board-value {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 1.25rem;
+  font-weight: 800;
+  color: var(--text-main);
+  background: linear-gradient(180deg, #1e293b 0%, #0f172a 100%);
+  border: 1px solid #334155;
+  border-radius: 8px;
+  padding: 0.6rem 0.75rem;
+  text-align: center;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  letter-spacing: 0.05em;
+}
+
+/* Status Indicator Footer */
+.ease-gate-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background-color: rgba(255, 255, 255, 0.02);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+}
+
+.ease-destination-label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.ease-dest-title {
+  font-size: 0.75rem;
+  color: var(--text-sub);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.ease-dest-city {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--text-main);
+}
+
+.ease-status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background-color: var(--green-bg);
+  color: var(--green-glow);
+  font-weight: 700;
+  font-size: 0.8rem;
+  padding: 0.4rem 0.8rem;
+  border-radius: 999px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  border: 1px solid rgba(16, 185, 129, 0.2);
+}
+
+.ease-status-dot {
+  width: 7px;
+  height: 7px;
+  background-color: var(--green-glow);
+  border-radius: 50%;
+  box-shadow: 0 0 8px var(--green-glow);
+  animation: ease-pulse-dot 2s infinite;
+}
+
+/* ==========================================================================
+   Keyframes & Responsiveness
+   ========================================================================== */
+
+@keyframes ease-pulse-dot {
+  0% { transform: scale(1); opacity: 1; }
+  50% { transform: scale(1.4); opacity: 0.5; }
+  100% { transform: scale(1); opacity: 1; }
+}
+
+@media (max-width: 540px) {
+  .ease-gate-board {
+    grid-template-columns: 1fr;
+    gap: 0.75rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-status-dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the pure CSS Airport Gate Display component (#70988).
gssoc 26

Closes #70988

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/airport-gate-display-ns/`
- [x] `style.css`, `demo.html`, and `README.md` included
- [x] Automated commit correctly formatted

---

## Feature Description
**What does this add?**
An airport departure gate information board component styled after classic split-flap display panels, including airline tags, gate numbers, boarding times, and destination status badges.

**How does it work?**
Uses robust CSS grid layouts, monospaced typography, and dark-themed container panels to create an authentic airport display aesthetic entirely without JavaScript.

---

## Notes for Maintainer
Zero JavaScript required. Fully accessible with proper ARIA regions, status role tags, and motion reduction safety rules.