### PR TITLE
Add ease-camera-aperture-control component

### DIFF
--- a/submissions/examples/camera-aperture-control-ij/README.md
+++ b/submissions/examples/camera-aperture-control-ij/README.md
@@ -1,0 +1,11 @@
+# ease-camera-aperture-control
+
+A camera lens control where the iris blades pulse, the central opening widens, and the f-stop ticks.
+
+## Run
+Open `demo.html` directly in a browser to watch the iris open.
+
+## Notes
+- The six aperture blades pulse in sequence.
+- The central lens opening widens and closes.
+- The f-stop readout ticks beside the dial.

--- a/submissions/examples/camera-aperture-control-ij/demo.html
+++ b/submissions/examples/camera-aperture-control-ij/demo.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-camera-aperture-control demo</title>
+</head>
+<body>
+<div class="cac-body">
+  <div class="cac-aperture">
+    <i class="cac-blade"></i>
+    <i class="cac-blade"></i>
+    <i class="cac-blade"></i>
+    <i class="cac-blade"></i>
+    <i class="cac-blade"></i>
+    <i class="cac-blade"></i>
+    <span class="cac-lens"></span>
+  </div>
+  <div class="cac-dial"><span class="cac-notch"></span></div>
+  <div class="cac-meta">
+    <b class="cac-fstop">f/2.8</b>
+    <span class="cac-mode">APERTURE PRIORITY</span>
+  </div>
+  <button class="cac-shutter">SHUTTER</button>
+</div>
+</body>
+</html>

--- a/submissions/examples/camera-aperture-control-ij/style.css
+++ b/submissions/examples/camera-aperture-control-ij/style.css
@@ -1,0 +1,21 @@
+.cac-body{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:300px;background:linear-gradient(180deg,#22282e,#13161a);border:2px solid #333b44;border-radius:16px;padding:18px;display:flex;flex-direction:column;align-items:center;gap:14px}
+.cac-aperture{position:relative;width:120px;height:120px;border-radius:50%;background:#0b0e11;border:3px solid #3a434d;overflow:hidden}
+.cac-blade{position:absolute;left:50%;top:50%;width:56px;height:56px;background:linear-gradient(135deg,#2b323a,#1a1f24);border:1px solid #3f4a56;transform-origin:0 0;animation:cac-blade-pulse-camera-aperture-control 1.6s ease-in-out infinite}
+.cac-blade:nth-child(1){transform:translate(-50%,-50%) rotate(0deg)}
+.cac-blade:nth-child(2){transform:translate(-50%,-50%) rotate(60deg);animation-delay:.26s}
+.cac-blade:nth-child(3){transform:translate(-50%,-50%) rotate(120deg);animation-delay:.52s}
+.cac-blade:nth-child(4){transform:translate(-50%,-50%) rotate(180deg);animation-delay:.78s}
+.cac-blade:nth-child(5){transform:translate(-50%,-50%) rotate(240deg);animation-delay:1.04s}
+.cac-blade:nth-child(6){transform:translate(-50%,-50%) rotate(300deg);animation-delay:1.3s}
+.cac-lens{position:absolute;left:50%;top:50%;width:26px;height:26px;border-radius:50%;background:#7cebb0;transform:translate(-50%,-50%);animation:cac-lens-iris-camera-aperture-control 3s ease-in-out infinite}
+.cac-dial{width:56px;height:56px;border-radius:50%;background:#1c2228;border:4px solid #3a434d;position:relative;animation:cac-dial-turn-camera-aperture-control 4s linear infinite}
+.cac-notch{position:absolute;left:50%;top:-4px;width:8px;height:8px;background:#5ce1e6;transform:translateX(-50%);border-radius:2px}
+.cac-meta{display:flex;flex-direction:column;align-items:center;gap:4px}
+.cac-fstop{font-size:20px;font-weight:800;color:#ffd76a;font-family:'Courier New',monospace;animation:cac-fstop-tick-camera-aperture-control 1.8s steps(3) infinite}
+.cac-mode{font-size:9px;font-weight:800;letter-spacing:2px;color:#8b9bad}
+.cac-shutter{width:100%;font-size:11px;font-weight:800;letter-spacing:3px;color:#0b0e11;background:#ffd76a;border:none;border-radius:8px;padding:12px 0;cursor:pointer;animation:cac-shutter-pulse-camera-aperture-control 1.2s ease-in-out infinite}
+@keyframes cac-blade-pulse-camera-aperture-control{0%,100%{opacity:1}50%{opacity:.3}}
+@keyframes cac-lens-iris-camera-aperture-control{0%,100%{transform:translate(-50%,-50%) scale(1)}50%{transform:translate(-50%,-50%) scale(1.6)}}
+@keyframes cac-dial-turn-camera-aperture-control{0%{transform:rotate(0)}100%{transform:rotate(360deg)}}
+@keyframes cac-fstop-tick-camera-aperture-control{0%{opacity:1}50%{opacity:.35}100%{opacity:1}}
+@keyframes cac-shutter-pulse-camera-aperture-control{0%,100%{box-shadow:0 0 0 0 rgba(255,215,106,0)}50%{box-shadow:0 0 14px rgba(255,215,106,0.5)}100%{box-shadow:0 0 0 0 rgba(255,215,106,0)}}


### PR DESCRIPTION
## Component: ease-camera-aperture-control — blades pulse, iris widens, and f-stop ticks

**Closes #71406**

### What this adds
A camera lens control where the iris blades pulse, the central opening widens, and the f-stop ticks.

### Acceptance Criteria covered
- Iris blades pulse
- Central opening widens
- F-stop readout ticks

### Files
- `submissions/examples/camera-aperture-control-ij/demo.html`
- `submissions/examples/camera-aperture-control-ij/style.css`
- `submissions/examples/camera-aperture-control-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the blades pulse, the iris widen, and the f-stop tick.