### PR TITLE
Add ease-progress-ring-dial component

### DIFF
--- a/submissions/examples/progress-ring-dial-ij/README.md
+++ b/submissions/examples/progress-ring-dial-ij/README.md
@@ -1,0 +1,11 @@
+# ease-progress-ring-dial
+
+A storage dial where the ring fills with usage, the percentage ticks, and the knob turns.
+
+## Run
+Open `demo.html` directly in a browser to watch the ring fill.
+
+## Notes
+- The outer ring grows with usage.
+- The percent readout ticks in the middle.
+- The control knob rotates below it.

--- a/submissions/examples/progress-ring-dial-ij/demo.html
+++ b/submissions/examples/progress-ring-dial-ij/demo.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-progress-ring-dial demo</title>
+</head>
+<body>
+<div class="prd-dial">
+  <div class="prd-ring">
+    <span class="prd-arc"></span>
+    <b class="prd-value">72%</b>
+  </div>
+  <div class="prd-knob"><span class="prd-grip"></span></div>
+  <div class="prd-label">
+    <span class="prd-caption">MEMORY USED</span>
+    <span class="prd-usage">6.4 GB of 8 GB</span>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/progress-ring-dial-ij/style.css
+++ b/submissions/examples/progress-ring-dial-ij/style.css
@@ -1,0 +1,12 @@
+.prd-dial{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:290px;background:linear-gradient(180deg,#182231,#0d131d);border:2px solid #2d3c50;border-radius:16px;padding:18px;display:flex;flex-direction:column;align-items:center;gap:14px}
+.prd-ring{position:relative;width:150px;height:150px;border-radius:50%;background:conic-gradient(#7cebb0 0 72%,#24334a 72% 100%);display:flex;align-items:center;justify-content:center;animation:prd-ring-fill-progress-ring-dial 4s ease-in-out infinite}
+.prd-ring::after{content:"";position:absolute;inset:12px;border-radius:50%;background:#0d131d}
+.prd-value{position:relative;z-index:2;font-size:26px;font-weight:800;color:#e8eef7;font-family:'Courier New',monospace;animation:prd-value-tick-progress-ring-dial 1.6s steps(3) infinite}
+.prd-knob{width:48px;height:48px;border-radius:50%;background:#1a2634;border:4px solid #3d4f66;display:flex;align-items:center;justify-content:center;animation:prd-knob-turn-progress-ring-dial 4s linear infinite}
+.prd-grip{width:12px;height:12px;border-radius:50%;background:#5ce1e6}
+.prd-label{text-align:center;display:flex;flex-direction:column;gap:4px}
+.prd-caption{font-size:10px;font-weight:800;letter-spacing:2px;color:#8b9bad}
+.prd-usage{font-size:11px;font-weight:700;color:#c7d6e8}
+@keyframes prd-ring-fill-progress-ring-dial{0%,100%{background:conic-gradient(#7cebb0 0 30%,#24334a 30% 100%)}50%{background:conic-gradient(#7cebb0 0 72%,#24334a 72% 100%)}}
+@keyframes prd-value-tick-progress-ring-dial{0%{opacity:1}50%{opacity:.3}}
+@keyframes prd-knob-turn-progress-ring-dial{0%{transform:rotate(0)}100%{transform:rotate(360deg)}}


### PR DESCRIPTION
## Component: ease-progress-ring-dial — ring fills, percent ticks, and knob turns

**Closes #71449**

### What this adds
A storage dial where the ring fills with usage, the percentage ticks, and the knob turns.

### Acceptance Criteria covered
- Ring fills with usage
- Percentage ticks
- Knob turns

### Files
- `submissions/examples/progress-ring-dial-ij/demo.html`
- `submissions/examples/progress-ring-dial-ij/style.css`
- `submissions/examples/progress-ring-dial-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the ring fill, the percent tick, and the knob turn.