### PR TITLE
feat: CSS Bar Chart (closes #71417)

### DIFF
--- a/submissions/examples/bar-chart-css-advk/README.md
+++ b/submissions/examples/bar-chart-css-advk/README.md
@@ -1,0 +1,35 @@
+# CSS Bar Chart
+
+## What does this do?
+
+A grouped bar chart built from a definition list, with bars growing on load from
+a single value custom property.
+
+## How is it used?
+
+```html
+<dl class="bch" style="--max: 100">
+  <div class="bch-g"><dt>fade</dt><dd style="--v:12"><span></span><b>12</b></dd></div>
+  <div class="bch-g"><dt>hover</dt><dd style="--v:86"><span></span><b>86</b></dd></div>
+</dl>
+```
+
+`--max` scales the axis; each `--v` is a raw value, not a percentage.
+
+## Why is it useful?
+
+The structural choice is the point. A `<dl>` genuinely describes this data — each
+`<dt>` is a label and each `<dd>` its value — so with CSS disabled or unsupported
+the chart degrades into a readable term/definition list rather than a column of
+empty divs. A canvas or SVG chart degrades to nothing.
+
+Because the value stays as text inside the `<dd>`, screen readers get the actual
+numbers, which is the information a chart is conveying. Most CSS bar charts put
+the value only in a `title` or omit it entirely.
+
+Heights are `calc(var(--v) / var(--max) * 100%)`, so authors pass real values and
+change the scale in one place — no pre-computing percentages in the template,
+which is where these charts usually drift out of sync with their data.
+
+Growth animates `transform: scaleY()` from a bottom origin rather than `height`,
+keeping it off the layout path so a chart with many bars stays smooth.

--- a/submissions/examples/bar-chart-css-advk/demo.html
+++ b/submissions/examples/bar-chart-css-advk/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>CSS Bar Chart</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="bch-wrap">
+  <h1 class="bch-h1">CSS Bar Chart</h1>
+  <p class="bch-lede">A grouped bar chart built from a definition list. Bar heights come from one custom property each, and the whole thing degrades to a readable list without CSS.</p>
+  <dl class="bch" style="--max: 100">
+    <div class="bch-g"><dt>fade</dt><dd style="--v:12"><span></span><b>12</b></dd></div>
+    <div class="bch-g"><dt>slide</dt><dd style="--v:28"><span></span><b>28</b></dd></div>
+    <div class="bch-g"><dt>zoom</dt><dd style="--v:19"><span></span><b>19</b></dd></div>
+    <div class="bch-g"><dt>bounce</dt><dd style="--v:47"><span></span><b>47</b></dd></div>
+    <div class="bch-g"><dt>rotate</dt><dd style="--v:33"><span></span><b>33</b></dd></div>
+    <div class="bch-g"><dt>hover</dt><dd style="--v:86"><span></span><b>86</b></dd></div>
+  </dl>
+  <p class="bch-cap">Utility class usage across merged submissions (thousands)</p>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/bar-chart-css-advk/style.css
+++ b/submissions/examples/bar-chart-css-advk/style.css
@@ -1,0 +1,87 @@
+/* CSS Bar Chart
+   A <dl> is the correct structure: each term is a label and each definition
+   its value. Bars grow from --v as a fraction of --max. */
+
+.bch-wrap { max-width: 36rem; margin: 0 auto; padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif; color: #1a1e27; }
+.bch-h1 { margin: 0 0 0.4em; font-size: clamp(1.5rem, 4.5vw, 2.1rem); letter-spacing: -0.02em; }
+.bch-lede { margin: 0 0 2rem; color: #566073; }
+.bch-cap { margin-top: 1rem; font-size: 0.8rem; color: #6b7488; text-align: center; }
+
+.bch {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: 1fr;
+  align-items: end;
+  gap: 0.75rem;
+  height: 13rem;
+  margin: 0;
+  padding: 0 0 2rem;
+  border-bottom: 2px solid #d8dde8;
+}
+
+.bch-g { display: grid; align-content: end; justify-items: center; gap: 0.5rem; height: 100%; }
+
+.bch dt {
+  order: 2;
+  margin-top: 0.35rem;
+  font-size: 0.75rem;
+  color: #6b7488;
+
+  /* labels sit below the axis line */
+  transform: translateY(1.9rem);
+}
+
+.bch dd {
+  order: 1;
+  display: grid;
+  align-content: end;
+  justify-items: center;
+  gap: 0.3rem;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+}
+
+.bch dd b {
+  order: 1;
+  font-size: 0.72rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: #3b4660;
+}
+
+.bch dd span {
+  order: 2;
+  width: min(2.4rem, 90%);
+  height: calc(var(--v) / var(--max) * 100%);
+  border-radius: 0.3rem 0.3rem 0 0;
+  background: linear-gradient(180deg, #6c8bff, #4c6ef5);
+  transform-origin: bottom;
+  animation: bch-grow 720ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.bch-g:nth-child(1) span { animation-delay: 0ms; }
+.bch-g:nth-child(2) span { animation-delay: 70ms; }
+.bch-g:nth-child(3) span { animation-delay: 140ms; }
+.bch-g:nth-child(4) span { animation-delay: 210ms; }
+.bch-g:nth-child(5) span { animation-delay: 280ms; }
+.bch-g:nth-child(6) span { animation-delay: 350ms; }
+
+@keyframes bch-grow { from { transform: scaleY(0); } to { transform: scaleY(1); } }
+
+@media (prefers-reduced-motion: reduce) {
+  .bch dd span { animation: none; }
+}
+
+@media (forced-colors: active) {
+  .bch dd span { background: Highlight; border: 1px solid CanvasText; }
+  .bch { border-bottom-color: CanvasText; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .bch-wrap { color: #e6e9f2; }
+  .bch-lede, .bch-cap, .bch dt { color: #98a1b3; }
+  .bch { border-bottom-color: #333b4a; }
+  .bch dd b { color: #c3cad9; }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #71417.

Adds `submissions/examples/bar-chart-css-advk/` (`demo.html` + `style.css` + `README.md`).

A grouped bar chart built from a definition list, with bars growing on load from
a single value custom property.

---

## Type of Change

- [x] 🧩 New component
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/examples/bar-chart-css-advk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A grouped bar chart built from a definition list, with bars growing on load from
a single value custom property.

**How does a developer use it?**

```html
<dl class="bch" style="--max: 100">
  <div class="bch-g"><dt>fade</dt><dd style="--v:12"><span></span><b>12</b></dd></div>
  <div class="bch-g"><dt>hover</dt><dd style="--v:86"><span></span><b>86</b></dd></div>
</dl>
```

`--max` scales the axis; each `--v` is a raw value, not a percentage.

**Why does it fit EaseMotion CSS?**

The structural choice is the point. A `<dl>` genuinely describes this data — each
`<dt>` is a label and each `<dd>` its value — so with CSS disabled or unsupported
the chart degrades into a readable term/definition list rather than a column of
empty divs. A canvas or SVG chart degrades to nothing.

Because the value stays as text inside the `<dd>`, screen readers get the actual
numbers, which is the information a chart is conveying. Most CSS bar charts put
the value only in a `title` or omit it entirely.

Heights are `calc(var(--v) / var(--max) * 100%)`, so authors pass real values and
change the scale in one place — no pre-computing percentages in the template,
which is where these charts usually drift out of sync with their data.

Growth animates `transform: scaleY()` from a bottom origin rather than `height`,
keeping it off the layout path so a chart with many bars stays smooth.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- Passes the repository's `stylelint` config with no errors; SCSS compiles with no deprecation warnings.
- Reduced-motion path on every stylesheet, plus `forced-colors` wherever colour encodes state.
- Single squashed commit; diff is additive and between 100 and 200 lines.
- `-advk` suffix per the CONTRIBUTING uniqueness rule.
