### PR TITLE
feat: Donut Chart (closes #71425)

### DIFF
--- a/submissions/examples/donut-chart-advk/README.md
+++ b/submissions/examples/donut-chart-advk/README.md
@@ -1,0 +1,39 @@
+# Donut Chart
+
+## What does this do?
+
+A segmented donut chart drawn with a single `conic-gradient`, sweeping in on
+load, with a value in the centre.
+
+## How is it used?
+
+```html
+<div class="dnt" style="--a:42%; --b:69%; --c:88%"
+     role="img" aria-label="core 42 percent, components 27 percent, engine 19 percent, other 12 percent">
+  <span class="dnt-hole"><b>18.4</b><small>kB</small></span>
+</div>
+```
+
+`--a`, `--b`, `--c` are **cumulative** boundaries, not slice widths: for slices of
+42/27/19/12 they are 42%, 69%, 88%.
+
+## Why is it useful?
+
+Charting libraries are heavy for a single donut, and the SVG alternative needs
+`stroke-dasharray` arithmetic per slice plus a rotation offset for each. A
+`conic-gradient` with hard stops expresses the whole chart in one declaration,
+and the browser handles the geometry.
+
+Using cumulative boundaries rather than widths is what keeps it declarative — each
+stop is simply where the previous one ended, so a template can emit a running sum
+without any per-slice rotation.
+
+The hole is a real inner element rather than a `mask`, which is a deliberate
+trade: a masked donut is transparent in the middle and cannot hold a label, while
+an inner disc can carry the total, which is the number people actually want.
+
+`role="img"` with a full `aria-label` matters here more than usual — a gradient is
+completely opaque to assistive technology, so without it the chart conveys nothing.
+Under `forced-colors` the gradient is dropped for a plain bordered ring, since
+conic gradients are not painted in High Contrast, and the legend swatches keep
+`forced-color-adjust: none` so the colour key stays meaningful.

--- a/submissions/examples/donut-chart-advk/demo.html
+++ b/submissions/examples/donut-chart-advk/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Donut Chart</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="dnt-wrap">
+  <h1 class="dnt-h1">Donut Chart</h1>
+  <p class="dnt-lede">A segmented donut drawn with one conic-gradient, where each slice is a hard stop computed from cumulative percentages. No SVG, no charting library.</p>
+  <div class="dnt-row">
+    <figure class="dnt-fig">
+      <div class="dnt" style="--a:42%; --b:69%; --c:88%" role="img" aria-label="Bundle composition: core 42 percent, components 27 percent, engine 19 percent, other 12 percent">
+        <span class="dnt-hole"><b>18.4</b><small>kB</small></span>
+      </div>
+      <figcaption class="dnt-key">
+        <span><i class="dnt-s dnt-s--1"></i>core 42%</span>
+        <span><i class="dnt-s dnt-s--2"></i>components 27%</span>
+        <span><i class="dnt-s dnt-s--3"></i>engine 19%</span>
+        <span><i class="dnt-s dnt-s--4"></i>other 12%</span>
+      </figcaption>
+    </figure>
+  </div>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/donut-chart-advk/style.css
+++ b/submissions/examples/donut-chart-advk/style.css
@@ -1,0 +1,83 @@
+/* Donut Chart
+   Slices are hard stops in a single conic-gradient. Each boundary is the
+   cumulative total, so --a/--b/--c are running sums, not slice widths. */
+
+.dnt-wrap { max-width: 36rem; margin: 0 auto; padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif; color: #1a1e27; }
+.dnt-h1 { margin: 0 0 0.4em; font-size: clamp(1.5rem, 4.5vw, 2.1rem); letter-spacing: -0.02em; }
+.dnt-lede { margin: 0 0 2.25rem; color: #566073; }
+
+.dnt-row { display: flex; justify-content: center; }
+.dnt-fig { display: grid; justify-items: center; gap: 1.25rem; margin: 0; }
+
+.dnt {
+  --c1: #4c6ef5;
+  --c2: #2f9e6e;
+  --c3: #d1971b;
+  --c4: #b95fd6;
+
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 11rem;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: conic-gradient(
+    var(--c1) 0 var(--a),
+    var(--c2) var(--a) var(--b),
+    var(--c3) var(--b) var(--c),
+    var(--c4) var(--c) 100%
+  );
+  animation: dnt-sweep 900ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+/* the hole: an inner disc rather than a mask, so it can hold content */
+.dnt-hole {
+  display: grid;
+  place-items: center;
+  width: 62%;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: #ffffff;
+  text-align: center;
+  line-height: 1.15;
+}
+
+.dnt-hole b { font-size: 1.5rem; font-weight: 800; font-variant-numeric: tabular-nums; }
+.dnt-hole small { font-size: 0.72rem; color: #6b7488; }
+
+@keyframes dnt-sweep {
+  from { clip-path: polygon(50% 50%, 50% 0, 50% 0); }
+  to { clip-path: polygon(50% 50%, 50% 0, 150% -50%, 150% 150%, -50% 150%, -50% -50%, 50% 0); }
+}
+
+.dnt-key {
+  display: grid;
+  grid-template-columns: repeat(2, auto);
+  gap: 0.35rem 1.25rem;
+  font-size: 0.82rem;
+}
+
+.dnt-key span { display: flex; align-items: center; gap: 0.4rem; }
+
+.dnt-s { width: 0.7rem; height: 0.7rem; border-radius: 0.2rem; }
+.dnt-s--1 { background: #4c6ef5; }
+.dnt-s--2 { background: #2f9e6e; }
+.dnt-s--3 { background: #d1971b; }
+.dnt-s--4 { background: #b95fd6; }
+
+@media (prefers-reduced-motion: reduce) {
+  .dnt { animation: none; }
+}
+
+@media (forced-colors: active) {
+  .dnt { background: Canvas; border: 1px solid CanvasText; }
+  .dnt-hole { border: 1px solid CanvasText; }
+  .dnt-s { border: 1px solid CanvasText; forced-color-adjust: none; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .dnt-wrap { color: #e6e9f2; }
+  .dnt-lede, .dnt-hole small { color: #98a1b3; }
+  .dnt-hole { background: #10131a; }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #71425.

Adds `submissions/examples/donut-chart-advk/` (`demo.html` + `style.css` + `README.md`).

A segmented donut chart drawn with a single `conic-gradient`, sweeping in on
load, with a value in the centre.

---

## Type of Change

- [x] 🧩 New component
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/examples/donut-chart-advk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A segmented donut chart drawn with a single `conic-gradient`, sweeping in on
load, with a value in the centre.

**How does a developer use it?**

```html
<div class="dnt" style="--a:42%; --b:69%; --c:88%"
     role="img" aria-label="core 42 percent, components 27 percent, engine 19 percent, other 12 percent">
  <span class="dnt-hole"><b>18.4</b><small>kB</small></span>
</div>
```

`--a`, `--b`, `--c` are **cumulative** boundaries, not slice widths: for slices of
42/27/19/12 they are 42%, 69%, 88%.

**Why does it fit EaseMotion CSS?**

Charting libraries are heavy for a single donut, and the SVG alternative needs
`stroke-dasharray` arithmetic per slice plus a rotation offset for each. A
`conic-gradient` with hard stops expresses the whole chart in one declaration,
and the browser handles the geometry.

Using cumulative boundaries rather than widths is what keeps it declarative — each
stop is simply where the previous one ended, so a template can emit a running sum
without any per-slice rotation.

The hole is a real inner element rather than a `mask`, which is a deliberate
trade: a masked donut is transparent in the middle and cannot hold a label, while
an inner disc can carry the total, which is the number people actually want.

`role="img"` with a full `aria-label` matters here more than usual — a gradient is
completely opaque to assistive technology, so without it the chart conveys nothing.
Under `forced-colors` the gradient is dropped for a plain bordered ring, since
conic gradients are not painted in High Contrast, and the legend swatches keep
`forced-color-adjust: none` so the colour key stays meaningful.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- Passes the repository's `stylelint` config with no errors; SCSS compiles with no deprecation warnings.
- Reduced-motion path on every stylesheet, plus `forced-colors` wherever colour encodes state.
- Single squashed commit; diff is additive and between 100 and 200 lines.
- `-advk` suffix per the CONTRIBUTING uniqueness rule.
