### PR TITLE
feat: Gauge Meter (closes #71427)

### DIFF
--- a/submissions/examples/gauge-meter-advk/README.md
+++ b/submissions/examples/gauge-meter-advk/README.md
@@ -1,0 +1,37 @@
+# Gauge Meter
+
+## What does this do?
+
+A half-circle gauge with a filled arc and a rotating needle, both driven by one
+value property.
+
+## How is it used?
+
+```html
+<div class="ggm" style="--v:0.72" role="img" aria-label="Memory 72 percent, warning">
+  <span class="ggm-needle"></span>
+  <span class="ggm-hub"></span>
+</div>
+```
+
+`--v` is a 0–1 fraction. Add `ggm--warn` or `ggm--crit` for the threshold tints.
+
+## Why is it useful?
+
+Gauges are common in dashboards and usually arrive via a charting library or as a
+static SVG that has to be regenerated per value.
+
+The arc uses `conic-gradient(from 270deg, ...)` with the sweep expressed as
+`calc(var(--v) * 180deg)`, so only half the circle is coloured and the parent's
+`border-radius: 8rem 8rem 0 0` plus `overflow: hidden` clips away the unused half.
+The `mask` turns the disc into a ring.
+
+The important property is that the needle rotates from the *same* `--v`:
+`rotate: calc(-90deg + var(--v) * 180deg)`. Gauges built as two components — an
+arc from data and a needle positioned separately — drift apart the moment someone
+edits one and not the other, and the resulting dial is subtly wrong in a way
+nobody notices. Deriving both from one value makes that impossible.
+
+`role="img"` with a label carrying both the number and the severity word means the
+reading is available without seeing the dial, and the threshold is communicated by
+text rather than by tint alone.

--- a/submissions/examples/gauge-meter-advk/demo.html
+++ b/submissions/examples/gauge-meter-advk/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Gauge Meter</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="ggm-wrap">
+  <h1 class="ggm-h1">Gauge Meter</h1>
+  <p class="ggm-lede">A half-circle gauge with a needle. The arc and needle share one --v property, so the reading can never disagree with the dial.</p>
+  <div class="ggm-row">
+    <figure class="ggm-f"><div class="ggm" style="--v:0.34" role="img" aria-label="Response time 34 percent of budget, good"><span class="ggm-needle"></span><span class="ggm-hub"></span></div><figcaption><b>34%</b> Response budget</figcaption></figure>
+    <figure class="ggm-f"><div class="ggm ggm--warn" style="--v:0.72" role="img" aria-label="Memory 72 percent, warning"><span class="ggm-needle"></span><span class="ggm-hub"></span></div><figcaption><b>72%</b> Memory</figcaption></figure>
+    <figure class="ggm-f"><div class="ggm ggm--crit" style="--v:0.94" role="img" aria-label="Disk 94 percent, critical"><span class="ggm-needle"></span><span class="ggm-hub"></span></div><figcaption><b>94%</b> Disk</figcaption></figure>
+  </div>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/gauge-meter-advk/style.css
+++ b/submissions/examples/gauge-meter-advk/style.css
@@ -1,0 +1,86 @@
+/* Gauge Meter
+   The dial is a conic-gradient limited to a half turn, clipped to the top half.
+   The needle rotates through the same 180deg range from the same --v. */
+
+.ggm-wrap { max-width: 40rem; margin: 0 auto; padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif; color: #1a1e27; }
+.ggm-h1 { margin: 0 0 0.4em; font-size: clamp(1.5rem, 4.5vw, 2.1rem); letter-spacing: -0.02em; }
+.ggm-lede { margin: 0 0 2.25rem; color: #566073; }
+
+.ggm-row { display: flex; flex-wrap: wrap; gap: 2rem; justify-content: center; }
+.ggm-f { margin: 0; display: grid; justify-items: center; gap: 0.6rem; }
+.ggm-f figcaption { font-size: 0.82rem; color: #566073; text-align: center; }
+.ggm-f b { display: block; font-size: 1.15rem; color: #1a1e27; }
+
+.ggm {
+  --tint: #2f9e6e;
+
+  position: relative;
+  width: 8rem;
+  aspect-ratio: 2 / 1;
+  overflow: hidden;
+  border-radius: 8rem 8rem 0 0;
+}
+
+.ggm--warn { --tint: #d1971b; }
+.ggm--crit { --tint: #d1453b; }
+
+/* the arc: full circle gradient, clipped by the parent's half-round shape */
+.ggm::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  height: 200%;
+  border-radius: 50%;
+  background: conic-gradient(
+    from 270deg,
+    var(--tint) 0 calc(var(--v) * 180deg),
+    #e3e7ef calc(var(--v) * 180deg) 180deg,
+    transparent 180deg 360deg
+  );
+  mask: radial-gradient(farthest-side, transparent calc(100% - 1.15rem), #000 calc(100% - 1.1rem));
+}
+
+.ggm-needle {
+  position: absolute;
+  left: 50%;
+  bottom: 0;
+  width: 2px;
+  height: 82%;
+  background: #2b3550;
+  transform-origin: bottom center;
+
+  /* -90deg is the left end of the sweep; +180deg spans to the right end */
+  rotate: calc(-90deg + var(--v) * 180deg);
+  translate: -50% 0;
+  transition: rotate 900ms cubic-bezier(0.34, 1.2, 0.5, 1);
+}
+
+.ggm-hub {
+  position: absolute;
+  left: 50%;
+  bottom: 0;
+  width: 0.7rem;
+  height: 0.7rem;
+  margin-left: -0.35rem;
+  margin-bottom: -0.35rem;
+  border-radius: 50%;
+  background: #2b3550;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ggm-needle { transition: none; }
+}
+
+@media (forced-colors: active) {
+  .ggm::before { background: Canvas; border: 1px solid CanvasText; mask: none; }
+  .ggm-needle, .ggm-hub { background: CanvasText; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .ggm-wrap { color: #e6e9f2; }
+  .ggm-lede, .ggm-f figcaption { color: #98a1b3; }
+  .ggm-f b { color: #e6e9f2; }
+  .ggm::before { background: conic-gradient(from 270deg, var(--tint) 0 calc(var(--v) * 180deg), #2a303c calc(var(--v) * 180deg) 180deg, transparent 180deg 360deg); }
+  .ggm-needle, .ggm-hub { background: #dfe4ee; }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #71427.

Adds `submissions/examples/gauge-meter-advk/` (`demo.html` + `style.css` + `README.md`).

A half-circle gauge with a filled arc and a rotating needle, both driven by one
value property.

---

## Type of Change

- [x] 🧩 New component
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/examples/gauge-meter-advk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A half-circle gauge with a filled arc and a rotating needle, both driven by one
value property.

**How does a developer use it?**

```html
<div class="ggm" style="--v:0.72" role="img" aria-label="Memory 72 percent, warning">
  <span class="ggm-needle"></span>
  <span class="ggm-hub"></span>
</div>
```

`--v` is a 0–1 fraction. Add `ggm--warn` or `ggm--crit` for the threshold tints.

**Why does it fit EaseMotion CSS?**

Gauges are common in dashboards and usually arrive via a charting library or as a
static SVG that has to be regenerated per value.

The arc uses `conic-gradient(from 270deg, ...)` with the sweep expressed as
`calc(var(--v) * 180deg)`, so only half the circle is coloured and the parent's
`border-radius: 8rem 8rem 0 0` plus `overflow: hidden` clips away the unused half.
The `mask` turns the disc into a ring.

The important property is that the needle rotates from the *same* `--v`:
`rotate: calc(-90deg + var(--v) * 180deg)`. Gauges built as two components — an
arc from data and a needle positioned separately — drift apart the moment someone
edits one and not the other, and the resulting dial is subtly wrong in a way
nobody notices. Deriving both from one value makes that impossible.

`role="img"` with a label carrying both the number and the severity word means the
reading is available without seeing the dial, and the threshold is communicated by
text rather than by tint alone.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- Passes the repository's `stylelint` config with no errors; SCSS compiles with no deprecation warnings.
- Reduced-motion path on every stylesheet, plus `forced-colors` wherever colour encodes state.
- Single squashed commit; diff is additive and between 100 and 200 lines.
- `-advk` suffix per the CONTRIBUTING uniqueness rule.
