### PR TITLE
feat: Sticky Footer CTA (closes #71439)

### DIFF
--- a/submissions/examples/sticky-footer-cta-advk/README.md
+++ b/submissions/examples/sticky-footer-cta-advk/README.md
@@ -1,0 +1,41 @@
+# Sticky Footer CTA
+
+## What does this do?
+
+A docked purchase bar that retracts automatically once the real inline call to
+action scrolls into view.
+
+## How is it used?
+
+```css
+.sfc-inline { view-timeline-name: --inline-cta; view-timeline-axis: block; }
+
+.sfc {
+  animation: sfc-retract linear both;
+  animation-timeline: --inline-cta;
+  animation-range: entry 0% entry 60%;
+}
+```
+
+## Why is it useful?
+
+Sticky purchase bars are common on commerce pages and usually stay pinned for the
+entire session, including while the user is looking directly at the real buy
+button. Two competing calls to action is a genuine usability problem — it is
+unclear which one is authoritative — and the bar permanently occupies screen space
+on mobile.
+
+A **named** view timeline solves it declaratively. `view-timeline-name` is declared
+on the inline button, and the sticky bar references it with
+`animation-timeline: --inline-cta`. This is the part worth knowing: an anonymous
+`view()` timeline tracks the animated element itself, so a bar animating on its own
+`view()` would be meaningless. A named timeline lets one element's scroll position
+drive a completely different element's animation, with no observer and no shared
+state.
+
+`animation-range: entry 0% entry 60%` means the bar is fully retracted by the time
+the inline button is 60% into view, so the handover happens before the user reaches
+for it.
+
+Browsers without scroll-driven animations keep the bar permanently visible, which
+is the correct fallback — the current default behaviour, not a broken state.

--- a/submissions/examples/sticky-footer-cta-advk/demo.html
+++ b/submissions/examples/sticky-footer-cta-advk/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Sticky Footer CTA</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="sfc-wrap">
+  <h1 class="sfc-h1">Sticky Footer CTA</h1>
+  <p class="sfc-lede">A purchase bar that docks to the bottom while the inline buy button is off screen, and hides itself once the real one is visible — so the two never compete.</p>
+  <p>Scroll down to the inline action. As it enters the viewport the sticky bar retracts.</p>
+  <div class="sfc-filler"></div>
+  <div class="sfc-inline"><button class="sfc-btn" type="button">Add to cart — $29</button><p>The real action, inline in the page.</p></div>
+  <div class="sfc-filler"></div>
+  <p class="sfc-end">End.</p>
+  <div class="sfc"><span class="sfc-t"><b>EaseMotion Pro</b> $29 / one-time</span><button class="sfc-btn sfc-btn--sm" type="button">Add to cart</button></div>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/sticky-footer-cta-advk/style.css
+++ b/submissions/examples/sticky-footer-cta-advk/style.css
@@ -1,0 +1,79 @@
+/* Sticky Footer CTA
+   The bar is driven by a view() timeline on the inline button: as that button
+   enters the viewport the bar animates out, so only one CTA is ever active. */
+
+.sfc-wrap { max-width: 38rem; margin: 0 auto; padding: 3rem 1.25rem 8rem;
+  font: 400 1rem/1.7 ui-sans-serif, system-ui, sans-serif; color: #1a1e27; }
+.sfc-h1 { margin: 0 0 0.4em; font-size: clamp(1.5rem, 4.5vw, 2.1rem); letter-spacing: -0.02em; }
+.sfc-lede { margin: 0 0 1.5rem; color: #566073; }
+.sfc-filler { height: 90vh; }
+.sfc-end { color: #566073; }
+
+.sfc-inline {
+  padding: 1.5rem;
+  border: 1px solid #dfe3ec;
+  border-radius: 0.7rem;
+  background: #fbfcfe;
+  text-align: center;
+  view-timeline-name: --inline-cta;
+  view-timeline-axis: block;
+}
+
+.sfc-inline p { margin: 0.75rem 0 0; font-size: 0.85rem; color: #6b7488; }
+
+.sfc-btn {
+  padding: 0.75em 1.6em;
+  border: 0;
+  border-radius: 0.5rem;
+  background: #4c6ef5;
+  color: #ffffff;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 180ms ease;
+}
+
+.sfc-btn--sm { padding: 0.55em 1.1em; font-size: 0.88rem; }
+.sfc-btn:hover { background: #3b5bdb; }
+.sfc-btn:focus-visible { outline: 3px solid #1a1e27; outline-offset: 3px; }
+
+.sfc {
+  position: fixed;
+  inset: auto 0 0 0;
+  z-index: 25;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.85rem 1.25rem;
+  border-top: 1px solid #dfe3ec;
+  background: #ffffffee;
+  backdrop-filter: blur(8px);
+  animation: sfc-retract linear both;
+  animation-timeline: --inline-cta;
+  animation-range: entry 0% entry 60%;
+}
+
+.sfc-t { font-size: 0.88rem; }
+.sfc-t b { display: block; }
+
+@keyframes sfc-retract {
+  from { translate: 0 0; opacity: 1; }
+  to { translate: 0 100%; opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sfc { animation: none; }
+}
+
+@media (forced-colors: active) {
+  .sfc { background: Canvas; border-top-color: CanvasText; }
+  .sfc-btn { border: 1px solid CanvasText; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .sfc-wrap { color: #e6e9f2; }
+  .sfc-lede, .sfc-end, .sfc-inline p { color: #98a1b3; }
+  .sfc-inline { background: #171b23; border-color: #2a303c; }
+  .sfc { background: #10131aee; border-top-color: #2a303c; }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #71439.

Adds `submissions/examples/sticky-footer-cta-advk/` (`demo.html` + `style.css` + `README.md`).

A docked purchase bar that retracts automatically once the real inline call to
action scrolls into view.

---

## Type of Change

- [x] 🧩 New component
- [ ] ✨ New animation / hover effect
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission

---

## Submission Checklist

- [x] All changes are inside `submissions/` — specifically `submissions/examples/sticky-footer-cta-advk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A docked purchase bar that retracts automatically once the real inline call to
action scrolls into view.

**How does a developer use it?**

```css
.sfc-inline { view-timeline-name: --inline-cta; view-timeline-axis: block; }

.sfc {
  animation: sfc-retract linear both;
  animation-timeline: --inline-cta;
  animation-range: entry 0% entry 60%;
}
```

**Why does it fit EaseMotion CSS?**

Sticky purchase bars are common on commerce pages and usually stay pinned for the
entire session, including while the user is looking directly at the real buy
button. Two competing calls to action is a genuine usability problem — it is
unclear which one is authoritative — and the bar permanently occupies screen space
on mobile.

A **named** view timeline solves it declaratively. `view-timeline-name` is declared
on the inline button, and the sticky bar references it with
`animation-timeline: --inline-cta`. This is the part worth knowing: an anonymous
`view()` timeline tracks the animated element itself, so a bar animating on its own
`view()` would be meaningless. A named timeline lets one element's scroll position
drive a completely different element's animation, with no observer and no shared
state.

`animation-range: entry 0% entry 60%` means the bar is fully retracted by the time
the inline button is 60% into view, so the handover happens before the user reaches
for it.

Browsers without scroll-driven animations keep the bar permanently visible, which
is the correct fallback — the current default behaviour, not a broken state.

---

## Demo

- [x] Demo added and verified by opening the file directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

---

## Notes for Maintainer

- Passes the repository's `stylelint` config with no errors; SCSS compiles with no deprecation warnings.
- Reduced-motion path on every stylesheet, plus `forced-colors` wherever colour encodes state.
- Single squashed commit; diff is additive and between 100 and 200 lines.
- `-advk` suffix per the CONTRIBUTING uniqueness rule.
