### PR TITLE
feat: implement SCSS truncate mixins with flex fix #71448

### DIFF
--- a/submissions/scss/truncate-advk/README.md
+++ b/submissions/scss/truncate-advk/README.md
@@ -1,0 +1,17 @@
+# SCSS Truncate Mixins with Flex/Grid Fix (#71448)
+
+Robust SCSS text truncation mixins including automatic min-width: 0 resets to ensure truncation functions properly within flexbox and CSS grid layouts.
+
+## Features
+- **Flexbox/Grid Safe:** Automatically resets min-width: 0 to prevent layout overflow bugs.
+- **Single Line & Line Clamp:** Clean single-line truncation and -webkit-line-clamp multi-line truncation.
+- **Soft Fade Clamp:** Decorative text truncation utilizing dynamic bottom CSS linear-gradient fades.
+- **Truncate Start:** RTL-based start truncation with unicode-bidi: plaintext fix to protect punctuation rendering.
+
+## Usage
+@use "truncate" as t;
+
+.card__title { @include t.truncate; }
+.card__excerpt { @include t.line-clamp(3); }
+.preview { @include t.fade-clamp(6em, 2em, #1e293b); }
+.file-path { @include t.truncate-start; }

--- a/submissions/scss/truncate-advk/_truncate.scss
+++ b/submissions/scss/truncate-advk/_truncate.scss
@@ -1,0 +1,47 @@
+// SCSS Truncate Mixins #71448
+
+@mixin truncate {
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+@mixin line-clamp($lines: 3) {
+  min-width: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: $lines;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+@mixin fade-clamp($max-height: 6em, $fade-height: 2em, $bg-color: #1e293b) {
+  min-width: 0;
+  position: relative;
+  max-height: $max-height;
+  overflow: hidden;
+
+  &::after {
+    content: "";
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    width: 100%;
+    height: $fade-height;
+    background: linear-gradient(to bottom, rgba($bg-color, 0), $bg-color);
+    pointer-events: none;
+  }
+}
+
+@mixin truncate-start {
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  direction: rtl;
+  text-align: left;
+
+  * {
+    unicode-bidi: plaintext;
+  }
+}

--- a/submissions/scss/truncate-advk/demo.html
+++ b/submissions/scss/truncate-advk/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SCSS Truncate Mixins | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="truncate-demo-container">
+    <header class="truncate-demo-header">
+      <h1>SCSS Truncate Mixins Demo</h1>
+      <p>Demonstration of flex/grid robust text truncation techniques.</p>
+    </header>
+
+    <section>
+      <h3>Single Line Truncate</h3>
+      <div class="card__title">
+        This is a very long title that would normally overflow its flex/grid parent container without min-width: 0.
+      </div>
+    </section>
+
+    <section>
+      <h3>Multi-Line Clamp (3 Lines)</h3>
+      <div class="card__excerpt">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+      </div>
+    </section>
+
+    <section>
+      <h3>Soft Fade Clamp</h3>
+      <div class="preview">
+        This excerpt uses a soft gradient fade out effect instead of an explicit ellipsis, making it suitable for decorative text teasers where a mid-sentence ellipsis is undesirable.
+      </div>
+    </section>
+
+    <section>
+      <h3>Truncate Start (File Paths)</h3>
+      <div class="file-path">
+        /var/www/project/src/components/utilities/text-formatting/truncate-advk.scss
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/scss/truncate-advk/style.css
+++ b/submissions/scss/truncate-advk/style.css
@@ -1,0 +1,104 @@
+/* SCSS Truncate Mixins with min-width flex fix #71448 */
+
+:root {
+  --bg-color: #0f172a;
+  --card-bg: #1e293b;
+  --border-color: #334155;
+  --text-main: #f8fafc;
+  --text-sub: #94a3b8;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 2rem 1rem;
+  background-color: var(--bg-color);
+  color: var(--text-main);
+  font-family: system-ui, -apple-system, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.truncate-demo-container {
+  width: 100%;
+  max-width: 520px;
+  background-color: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 16px;
+  padding: 2rem;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.truncate-demo-header h1 {
+  font-size: 1.5rem;
+  margin: 0 0 0.5rem 0;
+}
+
+.truncate-demo-header p {
+  color: var(--text-sub);
+  font-size: 0.95rem;
+  margin: 0;
+}
+
+.card__title {
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 600;
+  font-size: 1.1rem;
+}
+
+.card__excerpt {
+  min-width: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  color: var(--text-sub);
+  line-height: 1.5;
+}
+
+.preview {
+  min-width: 0;
+  position: relative;
+  max-height: 6em;
+  overflow: hidden;
+  line-height: 1.5;
+}
+
+.preview::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 100%;
+  height: 2em;
+  background: linear-gradient(to bottom, rgba(30, 41, 59, 0), #1e293b);
+  pointer-events: none;
+}
+
+.file-path {
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  direction: rtl;
+  text-align: left;
+  font-family: monospace;
+  background: rgba(0, 0, 0, 0.2);
+  padding: 0.5rem;
+  border-radius: 6px;
+}
+
+.file-path * {
+  unicode-bidi: plaintext;
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements SCSS text truncation mixins with automatic flex/grid `min-width: 0` resets (#71448).
gssoc 26

Closes #71448

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/scss/truncate-advk/`
- [x] `style.css`, `_truncate.scss`, `demo.html`, and `README.md` included
- [x] Automated commit correctly formatted

---

## Feature Description
**What does this add?**
A comprehensive suite of SCSS truncation mixins (`truncate`, `line-clamp`, `fade-clamp`, and `truncate-start`) designed to resolve common flexbox/grid layout overflow issues.

**How does it work?**
Bakes `min-width: 0` into all mixins to prevent flex/grid item content intrinsic sizing locks. Handles start truncation cleanly via RTL direction alongside `unicode-bidi: plaintext` to avoid reordering punctuation.

---

## Notes for Maintainer
Zero JavaScript dependencies. Conforms to SCSS track layout standards and passes Stylelint.