### PR TITLE
feat: implement CSS Snap Scroll v2 #70977

### DIFF
--- a/submissions/examples/css-snap-scroll-v2/README.md
+++ b/submissions/examples/css-snap-scroll-v2/README.md
@@ -1,0 +1,13 @@
+# CSS Snap Scroll v2 (#70977)
+
+Vertical scroll-snap implementation with named scroll markers for seamless section navigation without JavaScript.
+
+## Features
+- **Pure CSS Execution:** Built using standard scroll-snap-type: y mandatory and scroll-snap-align: start.
+- **Named Scroll Markers:** Anchor-linked navigation jump markers connected directly to tagged sections.
+- **Accessible & Responsive:** Fully keyboard navigable (tabindex="0" on viewport) and responsive across screen sizes.
+- **Zero JS Dependencies:** Lightweight, smooth native scroll performance.
+
+## Structure
+- `style.css` - Component variables, scroll snap layout, and transition styles.
+- `demo.html` - Interactive HTML demo featuring vertical scroll viewport and marker controls.

--- a/submissions/examples/css-snap-scroll-v2/demo.html
+++ b/submissions/examples/css-snap-scroll-v2/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Snap Scroll v2 | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="snap-demo-container">
+    <header class="snap-demo-header">
+      <h1>CSS Snap Scroll v2</h1>
+      <p>Pure CSS vertical scroll snap with named scroll markers.</p>
+    </header>
+
+    <div class="snap-viewport" tabindex="0" aria-label="Vertical scroll snap container">
+      <section id="marker-overview" class="snap-section" aria-labelledby="heading-overview">
+        <span class="snap-marker-tag">Marker 01</span>
+        <h2 id="heading-overview">Overview</h2>
+        <p>Vertical scroll-snap container utilizing CSS snap alignment and hardware-accelerated smooth scrolling.</p>
+      </section>
+
+      <section id="marker-features" class="snap-section" aria-labelledby="heading-features">
+        <span class="snap-marker-tag">Marker 02</span>
+        <h2 id="heading-features">Key Features</h2>
+        <p>Zero JavaScript required. Seamless keyboard navigation support and accessible ARIA labeling built-in.</p>
+      </section>
+
+      <section id="marker-architecture" class="snap-section" aria-labelledby="heading-architecture">
+        <span class="snap-marker-tag">Marker 03</span>
+        <h2 id="heading-architecture">Architecture</h2>
+        <p>Utilizes CSS scroll-snap-type: y mandatory and scroll-snap-stop: always for clean frame alignment.</p>
+      </section>
+
+      <section id="marker-usage" class="snap-section" aria-labelledby="heading-usage">
+        <span class="snap-marker-tag">Marker 04</span>
+        <h2 id="heading-usage">Usage</h2>
+        <p>Ideal for full-screen feature decks, onboarding guides, or hero showcase presentations.</p>
+      </section>
+    </div>
+
+    <nav class="snap-markers-nav" aria-label="Scroll marker navigation">
+      <a href="#marker-overview" class="snap-marker-link">Overview</a>
+      <a href="#marker-features" class="snap-marker-link">Features</a>
+      <a href="#marker-architecture" class="snap-marker-link">Architecture</a>
+      <a href="#marker-usage" class="snap-marker-link">Usage</a>
+    </nav>
+  </main>
+</body>
+</html>

--- a/submissions/examples/css-snap-scroll-v2/style.css
+++ b/submissions/examples/css-snap-scroll-v2/style.css
@@ -1,0 +1,129 @@
+/* CSS Snap Scroll v2 #70977 */
+
+:root {
+  --bg-color: #0f172a;
+  --card-bg: #1e293b;
+  --border-color: #334155;
+  --text-main: #f8fafc;
+  --text-sub: #94a3b8;
+  --accent-color: #38bdf8;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 2rem 1rem;
+  background-color: var(--bg-color);
+  color: var(--text-main);
+  font-family: system-ui, -apple-system, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.snap-demo-container {
+  width: 100%;
+  max-width: 600px;
+  background-color: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 16px;
+  padding: 2rem;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.snap-demo-header h1 {
+  font-size: 1.5rem;
+  margin: 0 0 0.5rem 0;
+}
+
+.snap-demo-header p {
+  color: var(--text-sub);
+  font-size: 0.95rem;
+  margin: 0;
+}
+
+.snap-viewport {
+  height: 350px;
+  overflow-y: scroll;
+  scroll-snap-type: y mandatory;
+  scroll-behavior: smooth;
+  border-radius: 12px;
+  border: 1px solid var(--border-color);
+}
+
+.snap-section {
+  height: 350px;
+  scroll-snap-align: start;
+  scroll-snap-stop: always;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+}
+
+.snap-section:nth-child(1) { background: linear-gradient(135deg, #1e293b, #0f172a); }
+.snap-section:nth-child(2) { background: linear-gradient(135deg, #1e3a8a, #0f172a); }
+.snap-section:nth-child(3) { background: linear-gradient(135deg, #312e81, #0f172a); }
+.snap-section:nth-child(4) { background: linear-gradient(135deg, #4c1d95, #0f172a); }
+
+.snap-marker-tag {
+  display: inline-block;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--accent-color);
+  background: rgba(56, 189, 248, 0.1);
+  border: 1px solid rgba(56, 189, 248, 0.3);
+  border-radius: 20px;
+  margin-bottom: 0.75rem;
+}
+
+.snap-section h2 {
+  font-size: 1.5rem;
+  margin: 0 0 0.5rem 0;
+}
+
+.snap-section p {
+  color: var(--text-sub);
+  font-size: 0.95rem;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.snap-markers-nav {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-top: 0.5rem;
+}
+
+.snap-marker-link {
+  display: inline-block;
+  padding: 0.4rem 0.8rem;
+  font-size: 0.85rem;
+  color: var(--text-sub);
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  text-decoration: none;
+  transition: all 0.2s ease;
+}
+
+.snap-marker-link:hover,
+.snap-marker-link:focus {
+  color: var(--text-main);
+  border-color: var(--accent-color);
+  background: rgba(56, 189, 248, 0.15);
+  outline: none;
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the CSS Snap Scroll v2 component featuring vertical scroll-snap with named scroll markers (#70977).
gssoc 26

Closes #70977

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/css-snap-scroll-v2/`
- [x] `style.css`, `demo.html`, and `README.md` included
- [x] Automated commit correctly formatted

---

## Feature Description
**What does this add?**
A pure CSS vertical scroll-snap layout component paired with interactive named scroll markers for quick section targeting.

**How does it work?**
Uses `scroll-snap-type: y mandatory` and `scroll-snap-stop: always` on a scroll viewport, enabling precise section locking during vertical scroll. Jump markers link cleanly via anchor IDs with native smooth scrolling (`scroll-behavior: smooth`).

---

## Notes for Maintainer
Zero JavaScript dependencies. Fully accessible with `tabindex="0"` on the viewport and proper `aria-labelledby` linkages.