### PR TITLE
feat: add pure CSS masonry layout fallback (#68983)

### DIFF
--- a/submissions/examples/css-masonry-fallback-v1/README.md
+++ b/submissions/examples/css-masonry-fallback-v1/README.md
@@ -1,0 +1,25 @@
+# CSS-Only Masonry Grid Fallback
+
+## Description
+This submission addresses Issue #68983 by providing a lightweight, pure CSS fallback for masonry layouts. While native `grid-template-rows: masonry` remains experimental and lacks cross-browser support, this solution uses the CSS Columns module to achieve a visually similar effect without requiring JavaScript like Masonry.js.
+
+## Features
+- **Zero JavaScript**: Built purely on CSS properties.
+- **CSS Columns Module**: Utilizes `column-count` and `column-gap` to distribute items into columns.
+- **Responsive by Design**: Easily adapts column counts via media queries.
+- **Break-Inside Avoidance**: Applies `break-inside: avoid;` to ensure individual cards/items do not get split abruptly across columns.
+
+## Limitations
+Due to the nature of CSS columns, items are ordered sequentially from **top-to-bottom** and then left-to-right (column by column). This is different from Flexbox or Grid, which typically order items left-to-right first. This solution is ideal for visual galleries, blogs, or varied-height cards where exact left-to-right chronological ordering is not strictly required.
+
+## Usage
+Simply wrap your items inside a container with the `.ease-masonry-grid` class.
+
+```html
+<div class="ease-masonry-grid">
+  <!-- Your cards here -->
+  <div class="card" style="height: 200px;">Item 1</div>
+  <div class="card" style="height: 400px;">Item 2</div>
+  <div class="card" style="height: 150px;">Item 3</div>
+</div>
+```

--- a/submissions/examples/css-masonry-fallback-v1/demo.html
+++ b/submissions/examples/css-masonry-fallback-v1/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS-Only Masonry Grid Fallback</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      background-color: #f0f2f5;
+      padding: 40px 20px;
+      margin: 0;
+      color: #333;
+    }
+
+    h1 {
+      text-align: center;
+      margin-bottom: 40px;
+    }
+
+    /* Dummy card styles for demo */
+    .card {
+      background-color: #fff;
+      border-radius: 12px;
+      padding: 24px;
+      box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      text-align: center;
+      font-size: 1.25rem;
+      font-weight: bold;
+      color: #555;
+    }
+
+    .card:hover {
+      transform: translateY(-5px);
+      box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    }
+
+    /* Varied heights to simulate masonry */
+    .card-small { height: 150px; background: #e0f2fe; color: #0369a1; }
+    .card-medium { height: 250px; background: #fef3c7; color: #b45309; }
+    .card-large { height: 350px; background: #dcfce7; color: #15803d; }
+    .card-xlarge { height: 450px; background: #fae8ff; color: #a21caf; }
+  </style>
+</head>
+<body>
+
+  <h1>CSS-Only Masonry Fallback</h1>
+
+  <div class="ease-masonry-grid">
+    <div class="card card-small">Card 1<br>(Small)</div>
+    <div class="card card-large">Card 2<br>(Large)</div>
+    <div class="card card-medium">Card 3<br>(Medium)</div>
+    <div class="card card-xlarge">Card 4<br>(X-Large)</div>
+    <div class="card card-small">Card 5<br>(Small)</div>
+    <div class="card card-medium">Card 6<br>(Medium)</div>
+    <div class="card card-large">Card 7<br>(Large)</div>
+    <div class="card card-small">Card 8<br>(Small)</div>
+    <div class="card card-xlarge">Card 9<br>(X-Large)</div>
+    <div class="card card-medium">Card 10<br>(Medium)</div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/css-masonry-fallback-v1/style.css
+++ b/submissions/examples/css-masonry-fallback-v1/style.css
@@ -1,0 +1,42 @@
+/* 
+  CSS-Only Masonry Layout Fallback
+  Issue: #68983
+*/
+
+.ease-masonry-grid {
+  /* Default to 3 columns, easily overridden with inline styles or media queries */
+  column-count: 3;
+  column-gap: 20px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+/* Ensure items don't break across columns */
+.ease-masonry-grid > * {
+  break-inside: avoid;
+  page-break-inside: avoid;
+  -webkit-column-break-inside: avoid;
+  
+  /* Prevent margin collapse issues at the top/bottom of columns */
+  margin-bottom: 20px;
+  
+  /* Make sure children take full width of the column */
+  display: block;
+  width: 100%;
+  
+  /* Base transitions if they get hovered or interacted with */
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+/* Optional responsive fallbacks - can be tailored to the project */
+@media (max-width: 1024px) {
+  .ease-masonry-grid {
+    column-count: 2;
+  }
+}
+
+@media (max-width: 640px) {
+  .ease-masonry-grid {
+    column-count: 1;
+  }
+}


### PR DESCRIPTION
## Description
This PR resolves #68983 by implementing a CSS-only masonry layout fallback using the CSS Columns module, bypassing the need for JavaScript (like Masonry.js) or the experimental `grid-template-rows: masonry`.

### Features
- Driven entirely by pure CSS (`column-count` and `column-gap`).
- Prevents awkward splits and ensures cards stay whole using `break-inside: avoid;`.
- Provides built-in responsiveness to adapt column counts based on viewport size.
- A fully functional `demo.html` to visually showcase the staggered masonry layout.
- Limitations regarding the top-to-bottom item ordering are properly outlined in `README.md`.
- Contained entirely inside `submissions/examples/css-masonry-fallback-v1/`.

### Issue Fixed
Fixes #68983