### PR TITLE
feat: add native CSS scroll-driven progress bar (#68977)

### DIFF
--- a/submissions/examples/scroll-progress/README.md
+++ b/submissions/examples/scroll-progress/README.md
@@ -1,13 +1,24 @@
-# Scroll Progress Bar
+# Native CSS Scroll-Driven Progress Bar
 
-## 1. What does this do?
-A thin progress bar fixed at the top of the page that fills horizontally as the user scrolls, indicating reading progress.
+## Description
+This submission resolves Issue #68977 by implementing a native CSS scroll-driven progress bar that tracks the user's scroll position without requiring any JavaScript.
 
-## 2. How is it used?
-Add a `.progress-bar` element at the top of `<body>`. The inline JS updates its width based on scroll position.
+## Features
+- **Zero JavaScript**: Uses the modern CSS `@scroll-timeline` specification (via `animation-timeline: scroll()`).
+- **Dynamic Fill**: The progress bar's `transform: scaleX()` value is tied directly to the document root's scroll position, mapping 0% scroll to `scaleX(0)` and 100% scroll to `scaleX(1)`.
+- **Performance Optimized**: Hardware accelerated via `transform` properties.
+- **Graceful Fallback**: Implements `@supports not (animation-timeline: scroll())` to provide an indeterminate scrolling bar animation for older browsers that do not yet support the specification.
+
+## Usage
+Add the `<div class="ease-scroll-progress"></div>` element to your HTML, typically placed as a direct child of the `<body>`. Ensure you include the associated CSS to bind the animation to the document scroll.
+
 ```html
-<div class="progress-bar" id="progressBar"></div>
+<body>
+  <div class="ease-scroll-progress"></div>
+  
+  <header>...</header>
+  <main>
+    <!-- Long scrolling content here -->
+  </main>
+</body>
 ```
-
-## 3. Why is it useful?
-A lightweight reading progress indicator with minimal JavaScript. Updates in real-time via the `scroll` event. The gradient bar style is visually clean and non-intrusive.

--- a/submissions/examples/scroll-progress/demo.html
+++ b/submissions/examples/scroll-progress/demo.html
@@ -1,27 +1,121 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Scroll Progress Bar</title>
-  <link rel="stylesheet" href="style.css" />
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Scroll-Driven Progress Bar</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      line-height: 1.6;
+      color: #333;
+      background-color: #fafafa;
+    }
+    
+    header {
+      padding: 100px 20px;
+      text-align: center;
+      background-color: #fff;
+      border-bottom: 1px solid #eaeaea;
+    }
+    
+    header h1 {
+      margin: 0;
+      font-size: 2.5rem;
+      color: #111;
+    }
+    
+    header p {
+      color: #666;
+      font-size: 1.1rem;
+      max-width: 600px;
+      margin: 20px auto 0;
+    }
+    
+    main {
+      max-width: 800px;
+      margin: 0 auto;
+      padding: 40px 20px;
+    }
+    
+    .content-block {
+      margin-bottom: 60px;
+    }
+    
+    .content-block h2 {
+      font-size: 1.8rem;
+      color: #222;
+      margin-bottom: 20px;
+    }
+    
+    .content-block p {
+      font-size: 1.1rem;
+      margin-bottom: 20px;
+      color: #444;
+    }
+    
+    /* Simulate a long article */
+    .dummy-paragraph {
+      height: 150px;
+      background: linear-gradient(to bottom, #f0f0f0, #f8f8f8);
+      border-radius: 8px;
+      margin-bottom: 20px;
+    }
+    
+    footer {
+      padding: 60px 20px;
+      text-align: center;
+      background-color: #111;
+      color: #fff;
+    }
+  </style>
 </head>
 <body>
-  <div class="progress-bar" id="progressBar"></div>
-  <main class="scroll-content">
-    <h1>Scroll Down</h1>
-    <p>Watch the progress bar at the top fill as you scroll.</p>
-    <div style="height: 2000px"></div>
-    <p style="text-align: center; color: #64748b">You reached the bottom!</p>
-  </main>
 
-  <script>
-    const bar = document.getElementById('progressBar');
-    window.addEventListener('scroll', () => {
-      const scrollTop = document.documentElement.scrollTop;
-      const scrollHeight = document.documentElement.scrollHeight - window.innerHeight;
-      bar.style.width = (scrollTop / scrollHeight * 100) + '%';
-    });
-  </script>
+  <!-- The scroll progress indicator -->
+  <div class="ease-scroll-progress"></div>
+
+  <header>
+    <h1>The Beauty of CSS Scroll Timelines</h1>
+    <p>Scroll down to see the native progress bar fill up at the top of the screen, purely driven by CSS.</p>
+  </header>
+
+  <main>
+    <div class="content-block">
+      <h2>Introduction</h2>
+      <p>Scroll-driven animations are a new feature in CSS that allow us to link animations to the scroll position of a scroll container, rather than time.</p>
+      <div class="dummy-paragraph"></div>
+      <div class="dummy-paragraph"></div>
+    </div>
+    
+    <div class="content-block">
+      <h2>How it Works</h2>
+      <p>By using the `animation-timeline` property, we can set the timeline to `scroll()`. This transforms the scale of an element based on how far down the document the user has scrolled.</p>
+      <div class="dummy-paragraph"></div>
+      <div class="dummy-paragraph"></div>
+      <div class="dummy-paragraph"></div>
+    </div>
+    
+    <div class="content-block">
+      <h2>Graceful Degradation</h2>
+      <p>For browsers that don't yet support this modern specification, we can use `@supports not (animation-timeline: scroll())` to apply a fallback animation, such as an indeterminate loading bar.</p>
+      <div class="dummy-paragraph"></div>
+      <div class="dummy-paragraph"></div>
+    </div>
+    
+    <div class="content-block">
+      <h2>Conclusion</h2>
+      <p>Native CSS scroll timelines open up incredible possibilities for web design without the performance overhead of JavaScript event listeners.</p>
+      <div class="dummy-paragraph"></div>
+      <div class="dummy-paragraph"></div>
+    </div>
+  </main>
+  
+  <footer>
+    <p>End of article.</p>
+  </footer>
+
 </body>
 </html>

--- a/submissions/examples/scroll-progress/style.css
+++ b/submissions/examples/scroll-progress/style.css
@@ -1,45 +1,42 @@
-*, *::before, *::after {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
-}
+/* 
+  Native CSS Scroll-Driven Progress Bar
+  Issue: #68977
+*/
 
-body {
-  font-family: system-ui, -apple-system, sans-serif;
-  background: #0f172a;
-  color: #e2e8f0;
-}
-
-.progress-bar {
+.ease-scroll-progress {
   position: fixed;
   top: 0;
   left: 0;
-  width: 0%;
-  height: 4px;
-  background: linear-gradient(90deg, #6c63ff, #a09af8);
-  transition: width 0.1s linear;
-  z-index: 100;
+  height: 6px;
+  width: 100%;
+  background: linear-gradient(90deg, #FF416C 0%, #FF4B2B 100%);
+  transform-origin: 0% 50%;
+  transform: scaleX(0);
+  z-index: 10000;
+  
+  /* Bind animation to document scroll */
+  animation: ease-scroll-fill auto linear;
+  animation-timeline: scroll(root block);
 }
 
-.scroll-content {
-  max-width: 600px;
-  margin: 4rem auto;
-  padding: 0 1rem;
+@keyframes ease-scroll-fill {
+  0% { transform: scaleX(0); }
+  100% { transform: scaleX(1); }
 }
 
-.scroll-content h1 {
-  font-size: 2rem;
-  margin-bottom: 1rem;
-}
-
-.scroll-content p {
-  font-size: 1rem;
-  color: #94a3b8;
-  line-height: 1.6;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .progress-bar {
-    display: none;
+/* Fallback for older browsers without scroll-driven animations */
+@supports not (animation-timeline: scroll()) {
+  .ease-scroll-progress {
+    animation: ease-scroll-indeterminate 2.5s ease-in-out infinite;
+    width: 30%;
+    transform-origin: center;
+    transform: scaleX(1);
+    /* Change background for fallback to indicate it's indeterminate */
+    background: linear-gradient(90deg, transparent, #FF416C, #FF4B2B, transparent);
   }
+}
+
+@keyframes ease-scroll-indeterminate {
+  0% { left: -30%; }
+  100% { left: 100%; }
 }


### PR DESCRIPTION
## Description
This PR resolves #68977 by adding a native CSS scroll-driven progress bar that tracks the user's scroll depth down the page.

### Features
- Driven completely by native CSS `@scroll-timeline` (specifically `animation-timeline: scroll()`).
- Binds the `transform: scaleX()` of the progress bar to the root scroll position.
- Offers a seamless, smooth progress indication without relying on JavaScript event listeners like `window.onscroll`.
- Features fallback considerations for browsers not yet supporting modern scroll-driven animations.
- Located within `submissions/examples/scroll-progress/`.

### Issue Fixed
Fixes #68977