### PR TITLE
feat: add CSS 3D foldable origami card (#68978)

### DIFF
--- a/submissions/examples/origami-card-v1/README.md
+++ b/submissions/examples/origami-card-v1/README.md
@@ -1,0 +1,32 @@
+# CSS 3D Foldable Origami Card
+
+## Description
+This submission resolves Issue #68978 by creating an interactive 3D foldable "origami" card using pure CSS. Nested child panels swing downward (unfold) upon hovering the main card.
+
+## Features
+- **Pure CSS 3D Transforms**: Uses `perspective` and `transform: rotateX()` to create realistic 3D depth and folding mechanics.
+- **Nested Segmentation**: Child panels are nested inside the parent panel within the HTML. Because they are anchored to the bottom (`top: 100%`) with `transform-origin: top`, unfolding a parent inherently moves the child down with it.
+- **Staggered Animations**: By applying calculated `transition-delay` values, the panels unfold one-by-one from top to bottom, rather than all at once. The reverse delay logic handles the folding back animation smoothly when the mouse leaves.
+
+## Usage
+Wrap the panels in a `.ease-origami-wrapper` to provide perspective. The root card is `.ease-origami-card`, and subsequent foldable panels should be classed as `.ease-origami-panel` and nested within their respective parent element.
+
+```html
+<div class="ease-origami-wrapper">
+  <div class="ease-origami-card">
+    <p>Main visible card</p>
+
+    <!-- First folded section -->
+    <div class="ease-origami-panel">
+      <p>Folded panel 1</p>
+
+      <!-- Second folded section -->
+      <div class="ease-origami-panel">
+        <p>Folded panel 2</p>
+      </div>
+
+    </div>
+
+  </div>
+</div>
+```

--- a/submissions/examples/origami-card-v1/demo.html
+++ b/submissions/examples/origami-card-v1/demo.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Origami 3D Foldable Card Demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      background-color: #2c3e50;
+      color: #333;
+    }
+
+    h1 {
+      color: #fff;
+      margin-bottom: 60px;
+      text-align: center;
+    }
+
+    /* Just styling the inner content to look like a realistic card */
+    .card-header {
+      font-size: 1.25rem;
+      font-weight: bold;
+      color: #2c3e50;
+      margin-bottom: 10px;
+    }
+
+    .card-text {
+      font-size: 0.95rem;
+      color: #555;
+      line-height: 1.5;
+    }
+
+    .demo-container {
+      margin-bottom: 150px; /* Leave space for it to unfold */
+    }
+  </style>
+</head>
+<body>
+
+  <h1>Hover the Card to Unfold! 📄</h1>
+
+  <div class="demo-container">
+    
+    <!-- Wrapper provides the 3D perspective -->
+    <div class="ease-origami-wrapper">
+      
+      <!-- Main visible card -->
+      <div class="ease-origami-card">
+        <div class="card-header">Main Panel</div>
+        <div class="card-text">
+          Hover over this area to see the magic. The nested panels below will unfold seamlessly in a 3D space.
+        </div>
+        
+        <!-- First folding panel -->
+        <div class="ease-origami-panel">
+          <div class="card-header">Panel 2</div>
+          <div class="card-text">
+            I was hidden underneath! This uses `rotateX` to swing down.
+          </div>
+          
+          <!-- Second folding panel (nested inside the first) -->
+          <div class="ease-origami-panel">
+            <div class="card-header">Panel 3</div>
+            <div class="card-text">
+              Staggered transitions make this feel like a piece of paper being unrolled!
+            </div>
+          </div>
+          <!-- End second folding panel -->
+
+        </div>
+        <!-- End first folding panel -->
+
+      </div>
+    </div>
+    
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/origami-card-v1/style.css
+++ b/submissions/examples/origami-card-v1/style.css
@@ -1,0 +1,86 @@
+/* 
+  CSS 3D Foldable Origami Card
+  Issue: #68978
+*/
+
+.ease-origami-wrapper {
+  perspective: 1000px;
+  display: inline-block;
+}
+
+.ease-origami-card {
+  position: relative;
+  width: 300px;
+  background-color: #fff;
+  border-radius: 8px 8px 0 0;
+  box-shadow: 0 4px 15px rgba(0,0,0,0.1);
+  padding: 20px;
+  z-index: 2;
+  transition: transform 0.4s ease;
+  transform-style: preserve-3d;
+}
+
+/* The hidden panels that fold down */
+.ease-origami-panel {
+  position: absolute;
+  top: 100%; /* Anchor to the bottom of the parent panel */
+  left: 0;
+  width: 100%;
+  background-color: #f9f9f9;
+  box-sizing: border-box;
+  padding: 20px;
+  border-top: 1px dashed #ddd;
+  
+  /* 3D Fold settings */
+  transform-origin: top;
+  transform: rotateX(-90deg);
+  opacity: 0;
+  visibility: hidden;
+  
+  transition: transform 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275), 
+              opacity 0.4s ease, 
+              visibility 0.4s;
+  
+  box-shadow: 0 10px 15px rgba(0,0,0,0.1);
+  border-radius: 0 0 8px 8px;
+}
+
+/* Second hidden panel anchors to the bottom of the first hidden panel */
+.ease-origami-panel .ease-origami-panel {
+  box-shadow: 0 10px 15px rgba(0,0,0,0.15);
+  background-color: #f1f1f1;
+}
+
+/* Hover logic to unfold */
+.ease-origami-wrapper:hover .ease-origami-panel {
+  transform: rotateX(0deg);
+  opacity: 1;
+  visibility: visible;
+}
+
+/* Staggered transitions for child panels */
+/* First panel unfolds */
+.ease-origami-wrapper:hover > .ease-origami-card > .ease-origami-panel {
+  transition-delay: 0s;
+}
+
+/* Second panel unfolds slightly after */
+.ease-origami-wrapper:hover .ease-origami-panel > .ease-origami-panel {
+  transition-delay: 0.15s;
+}
+
+/* Third panel unfolds after that */
+.ease-origami-wrapper:hover .ease-origami-panel > .ease-origami-panel > .ease-origami-panel {
+  transition-delay: 0.3s;
+}
+
+/* Reverse transitions when mouse leaves */
+.ease-origami-wrapper > .ease-origami-card > .ease-origami-panel {
+  transition-delay: 0.3s;
+}
+.ease-origami-panel > .ease-origami-panel {
+  transition-delay: 0.15s;
+}
+.ease-origami-panel > .ease-origami-panel > .ease-origami-panel {
+  transition-delay: 0s;
+}


### PR DESCRIPTION
## Description
This PR resolves #68978 by implementing an interactive 3D foldable "origami" card entirely via CSS. It demonstrates the use of nested 3D transforms to create a realistic unfolding paper effect.

### Features
- Provides `.ease-origami-wrapper` with a 3D perspective to give depth to the rotations.
- Implements `transform-origin: top` and `rotateX(-90deg)` to keep child panels folded seamlessly behind their parent panels.
- Utilizes precise `transition-delay` calculations to stagger the unfold animation sequentially upon hovering.
- Reverse sequence logic handles the folding back smoothly upon mouse-out.
- Confined to a brand new directory `submissions/examples/origami-card-v1/`, adhering to the strict "additions only" and "no deletion" policies.

### Issue Fixed
Fixes #68978