### PR TITLE
feat: add Retro 8-bit Pixelated Utility (#68981)

### DIFF
--- a/submissions/examples/pixelated-utility-v1/README.md
+++ b/submissions/examples/pixelated-utility-v1/README.md
@@ -1,0 +1,19 @@
+# Retro 8-bit Pixelated Utility
+
+## Description
+This submission resolves Issue #68981 by introducing a simple, reusable utility class `.ease-pixelated`. It applies `image-rendering` CSS properties to enforce nearest-neighbor scaling (crisp edges).
+
+## Features
+- **Cross-Browser Support**: Uses standard `image-rendering: pixelated;` along with fallbacks for Firefox (`-moz-crisp-edges`), Webkit (`-webkit-optimize-contrast`), and older standards.
+- **Perfect for Pixel Art**: Prevents the browser from applying default bilinear or bicubic smoothing when scaling up small images (like 16x16 or 32x32 sprites).
+- **Canvas Compatible**: Works great on `<canvas>` elements as well, which is especially useful for retro web games.
+
+## Usage
+Simply apply the `.ease-pixelated` class to any `<img>` or `<canvas>` element that you are scaling up.
+
+```html
+<!-- A small 16x16 image scaled up to 200x200 via CSS or width attributes -->
+<img src="small-sprite.png" class="ease-pixelated" width="200" height="200" alt="Pixel Art">
+```
+
+Without this utility, browsers will blur the small image when stretching it. With `.ease-pixelated`, it scales with sharp, crisp squares, preserving the 8-bit retro aesthetic.

--- a/submissions/examples/pixelated-utility-v1/demo.html
+++ b/submissions/examples/pixelated-utility-v1/demo.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Retro Pixelated Utility Demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      margin: 0;
+      padding: 0;
+      background-color: #f0f0f0;
+      color: #333;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding-top: 50px;
+    }
+
+    h1 {
+      margin-bottom: 40px;
+    }
+
+    .demo-container {
+      display: flex;
+      gap: 50px;
+      margin-top: 20px;
+    }
+
+    .image-wrapper {
+      text-align: center;
+      background: #fff;
+      padding: 20px;
+      border-radius: 8px;
+      box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+    }
+
+    .image-wrapper img {
+      /* Scale a tiny 16x16 image up to 200x200 */
+      width: 200px;
+      height: 200px;
+      border: 1px solid #ddd;
+    }
+
+    .label {
+      margin-top: 15px;
+      font-weight: bold;
+      color: #555;
+    }
+    
+    .code-snippet {
+      margin-top: 5px;
+      font-size: 0.85rem;
+      color: #888;
+      font-family: monospace;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>Retro 8-bit Pixelated Utility</h1>
+  <p>Comparing default browser image scaling vs the <code>.ease-pixelated</code> class.</p>
+
+  <div class="demo-container">
+    
+    <!-- Without pixelated utility -->
+    <div class="image-wrapper">
+      <!-- A tiny 16x16 data URI of a smiley face -->
+      <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAGFJREFUOE/VkkEOwCAIAzH//+nm4mF0MFRITNsmXegY4Lqj3/0DMC8A8E8QjBwYyQhYJ4b150A6c/Tf06U53gO5G0C9c1mFfAKpB1A2gGqE2kR+DcgDcgH8B+gD0AHtXl2/6FMDqB150dYAAAAASUVORK5CYII=" alt="Default Scaled">
+      <div class="label">Default (Blurry)</div>
+      <div class="code-snippet">&lt;img src="..."&gt;</div>
+    </div>
+
+    <!-- With pixelated utility -->
+    <div class="image-wrapper">
+      <!-- Same tiny 16x16 data URI of a smiley face -->
+      <img class="ease-pixelated" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAGFJREFUOE/VkkEOwCAIAzH//+nm4mF0MFRITNsmXegY4Lqj3/0DMC8A8E8QjBwYyQhYJ4b150A6c/Tf06U53gO5G0C9c1mFfAKpB1A2gGqE2kR+DcgDcgH8B+gD0AHtXl2/6FMDqB150dYAAAAASUVORK5CYII=" alt="Pixelated Scaled">
+      <div class="label">With .ease-pixelated</div>
+      <div class="code-snippet">&lt;img class="ease-pixelated" src="..."&gt;</div>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/pixelated-utility-v1/style.css
+++ b/submissions/examples/pixelated-utility-v1/style.css
@@ -1,0 +1,16 @@
+/* 
+  Retro 8-bit Pixelated Utility
+  Issue: #68981
+*/
+
+.ease-pixelated {
+  /* Enforces harsh, aliased scaling (nearest-neighbor) on images or canvas */
+  image-rendering: -moz-crisp-edges;         /* Firefox */
+  image-rendering: -o-crisp-edges;           /* Opera */
+  image-rendering: -webkit-optimize-contrast;/* Webkit (non-standard naming) */
+  image-rendering: crisp-edges;              /* CSS3 Proposed */
+  image-rendering: pixelated;                /* Standard (Chrome, Safari, Edge) */
+  
+  /* Additional fallback for older IE if needed, though rarely used nowadays */
+  -ms-interpolation-mode: nearest-neighbor; 
+}


### PR DESCRIPTION
## Description
This PR resolves #68981 by adding a simple yet highly effective utility class `.ease-pixelated`. It forces browsers to use nearest-neighbor scaling on images and canvas elements, preserving crisp, sharp edges instead of blurring them.

### Features
- Applies standard `image-rendering: pixelated;` along with fallbacks for maximum cross-browser compatibility (`-moz-crisp-edges`, `-webkit-optimize-contrast`).
- Essential for retro 8-bit and pixel-art aesthetics on modern high-resolution displays.
- Located securely in a new isolated directory `submissions/examples/pixelated-utility-v1/`, complying with the strict "additions only" and "no deletion" guidelines.
- Accompanied by a demo that compares default image scaling vs the pixelated class.

### Issue Fixed
Fixes #68981