### PR TITLE
feat: implement CSS Jelly Squash Animation #70972

### DIFF
--- a/submissions/examples/css-jelly-squash-animation/README.md
+++ b/submissions/examples/css-jelly-squash-animation/README.md
@@ -1,0 +1,13 @@
+# CSS Jelly Squash Animation (#70972)
+
+Pure CSS elastic squash and stretch physics animation simulating realistic jelly inertia on interaction.
+
+## Features
+- **Squash & Stretch Physics:** Keyframe animation using variable `scale(X, Y)` transformations preserving volume.
+- **Interactive Triggers:** Reacts on idle float, `:hover`, `:active`, and `:focus-visible` state triggers.
+- **Pure CSS Implementation:** Zero JavaScript required for spring physics calculations.
+- **Accessible & Responsive:** Full support for standard focus outlines and `prefers-reduced-motion` accessibility standards.
+
+## Structure
+- `style.css` - Keyframe physics definitions, stage framing, and button interaction styling.
+- `demo.html` - Interactive demo showcasing the squash & stretch animation in action.

--- a/submissions/examples/css-jelly-squash-animation/demo.html
+++ b/submissions/examples/css-jelly-squash-animation/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Jelly Squash Animation | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="jelly-card" aria-label="Jelly squash and stretch animation demo">
+    <header class="jelly-header">
+      <h1>CSS Jelly Squash Animation</h1>
+      <p>Hover, click, or tap the element to trigger elastic squash & stretch physics.</p>
+    </header>
+
+    <div class="jelly-stage" aria-label="Interactive animation playground">
+      <button type="button" class="jelly-element" aria-label="Interactive elastic jelly button">
+        Squash Me!
+      </button>
+      <div class="jelly-floor-shadow" aria-hidden="true"></div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/css-jelly-squash-animation/style.css
+++ b/submissions/examples/css-jelly-squash-animation/style.css
@@ -1,0 +1,153 @@
+/* CSS Jelly Squash Animation #70972 */
+
+:root {
+  --bg-color: #0f172a;
+  --card-bg: #1e293b;
+  --border-color: #334155;
+  --text-main: #f8fafc;
+  --text-sub: #94a3b8;
+  --jelly-color: #ec4899;
+  --jelly-gradient: linear-gradient(135deg, #f43f5e, #ec4899, #8b5cf6);
+  --jelly-shadow: rgba(236, 72, 153, 0.4);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 2rem 1rem;
+  background-color: var(--bg-color);
+  color: var(--text-main);
+  font-family: system-ui, -apple-system, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.jelly-card {
+  width: 100%;
+  max-width: 480px;
+  background-color: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 20px;
+  padding: 2rem;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 1.75rem;
+}
+
+.jelly-header h1 {
+  font-size: 1.4rem;
+  margin: 0 0 0.35rem 0;
+}
+
+.jelly-header p {
+  color: var(--text-sub);
+  font-size: 0.875rem;
+  margin: 0;
+}
+
+/* Stage Area for Squash Physics */
+.jelly-stage {
+  width: 100%;
+  height: 220px;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid var(--border-color);
+  border-radius: 14px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  align-items: center;
+  padding-bottom: 2.5rem;
+  position: relative;
+  overflow: hidden;
+}
+
+/* Interactive Jelly Button Component */
+.jelly-element {
+  position: relative;
+  padding: 1rem 2.25rem;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #ffffff;
+  background: var(--jelly-gradient);
+  border: none;
+  border-radius: 50px;
+  cursor: pointer;
+  box-shadow: 0 12px 25px var(--jelly-shadow);
+  transform-origin: center bottom;
+  user-select: none;
+  outline: none;
+  transition: transform 0.15 ease, box-shadow 0.2s ease;
+  animation: jelly-bounce 3.5s infinite ease-in-out;
+}
+
+.jelly-element:hover {
+  animation: jelly-squash 0.85s ease-in-out;
+  box-shadow: 0 16px 32px var(--jelly-shadow);
+}
+
+.jelly-element:active,
+.jelly-element:focus-visible {
+  animation: jelly-squash-active 0.6s cubic-bezier(0.36, 0.07, 0.19, 0.97);
+  outline: 2px solid #ec4899;
+  outline-offset: 4px;
+}
+
+/* Dynamic Shadow Beneath Jelly */
+.jelly-floor-shadow {
+  width: 120px;
+  height: 12px;
+  background: radial-gradient(ellipse at center, rgba(0, 0, 0, 0.6), transparent 70%);
+  border-radius: 50%;
+  margin-top: 10px;
+  animation: shadow-scale 3.5s infinite ease-in-out;
+}
+
+/* Keyframe Physics Animations */
+@keyframes jelly-squash {
+  0% { transform: scale(1, 1); }
+  15% { transform: scale(1.35, 0.65); }
+  30% { transform: scale(0.75, 1.25); }
+  45% { transform: scale(1.15, 0.85); }
+  60% { transform: scale(0.95, 1.05); }
+  75% { transform: scale(1.03, 0.97); }
+  100% { transform: scale(1, 1); }
+}
+
+@keyframes jelly-squash-active {
+  0% { transform: scale(1, 1); }
+  25% { transform: scale(1.4, 0.6); }
+  50% { transform: scale(0.8, 1.2); }
+  75% { transform: scale(1.1, 0.9); }
+  100% { transform: scale(1, 1); }
+}
+
+@keyframes jelly-bounce {
+  0%, 100% { transform: translateY(0) scale(1, 1); }
+  50% { transform: translateY(-18px) scale(0.95, 1.05); }
+  55% { transform: translateY(-18px) scale(1.05, 0.95); }
+  70% { transform: translateY(0) scale(1.2, 0.8); }
+  80% { transform: translateY(0) scale(0.95, 1.05); }
+}
+
+@keyframes shadow-scale {
+  0%, 100% { transform: scale(1); opacity: 0.7; }
+  50% { transform: scale(0.65); opacity: 0.3; }
+  70% { transform: scale(1.15); opacity: 0.8; }
+}
+
+/* Reduced Motion Accessibility */
+@media (prefers-reduced-motion: reduce) {
+  .jelly-element,
+  .jelly-floor-shadow {
+    animation: none !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the CSS Jelly Squash Animation component (#70972).
gssoc 26

Closes #70972

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/css-jelly-squash-animation/`
- [x] `style.css`, `demo.html`, and `README.md` included
- [x] Automated commit correctly formatted

---

## Feature Description
**What does this add?**
A fluid squash-and-stretch jelly physics component that reacts with realistic spring inertia upon hover, tap, and click actions.

**How does it work?**
Employs pure CSS `@keyframes` with opposing multi-axis scaling (`scale(X, Y)`) relative to a bottom transform-origin to mimic volume preservation and bounce dynamics without JavaScript.

---

## Notes for Maintainer
Zero JavaScript dependencies. Includes `@media (prefers-reduced-motion: reduce)` rules for strict accessibility compliance.