### PR TITLE
feat: add CSS inline editable text

### DIFF
--- a/submissions/examples/r-inline-editable-text-70973/README.md
+++ b/submissions/examples/r-inline-editable-text-70973/README.md
@@ -1,0 +1,37 @@
+# CSS Inline Editable Text
+
+A responsive CSS inline-editable text component using the native `contenteditable` attribute.
+
+## Features
+
+- CSS-focused implementation
+- Native inline text editing
+- No JavaScript required
+- Keyboard accessible
+- Responsive design
+- Focus and hover states
+- Visual editing indicator
+- Reduced-motion support
+- Forced-colors support
+
+## Files
+
+- `demo.html` — Demonstration page
+- `style.css` — Component styles
+- `README.md` — Documentation
+
+## Usage
+
+Add `contenteditable="true"` to an element:
+
+```html
+<div
+  class="editable"
+  contenteditable="true"
+  role="textbox"
+  aria-label="Edit display name"
+  spellcheck="false"
+  tabindex="0"
+>
+  Richa Chauhan
+</div>

--- a/submissions/examples/r-inline-editable-text-70973/demo.html
+++ b/submissions/examples/r-inline-editable-text-70973/demo.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta
+    name="description"
+    content="CSS inline editable text component demonstration"
+  >
+  <title>CSS Inline Editable Text</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <section class="editor-card" aria-labelledby="page-title">
+      <div class="card-header">
+        <span class="eyebrow">EaseMotion CSS</span>
+        <h1 id="page-title">Inline Editable Text</h1>
+        <p>
+          A CSS-only editable text pattern using the native
+          <code>contenteditable</code> interaction.
+        </p>
+      </div>
+
+      <div class="profile">
+        <div class="avatar" aria-hidden="true">RC</div>
+
+        <div class="profile-content">
+          <span class="field-label">Display name</span>
+
+          <div
+            class="editable"
+            contenteditable="true"
+            role="textbox"
+            aria-label="Edit display name"
+            spellcheck="false"
+            tabindex="0"
+          >Richa Chauhan</div>
+
+          <span class="helper">
+            Click or focus the name to edit it.
+          </span>
+        </div>
+      </div>
+
+      <div class="profile">
+        <div class="avatar avatar-purple" aria-hidden="true">EM</div>
+
+        <div class="profile-content">
+          <span class="field-label">Project title</span>
+
+          <div
+            class="editable editable-large"
+            contenteditable="true"
+            role="textbox"
+            aria-label="Edit project title"
+            spellcheck="false"
+            tabindex="0"
+          >EaseMotion CSS</div>
+
+          <span class="helper">
+            Press Tab to move between editable fields.
+          </span>
+        </div>
+      </div>
+
+      <div class="tip" role="note">
+        <span class="tip-icon" aria-hidden="true">✦</span>
+        <span>
+          Double-clicking or focusing an editable field lets you
+          modify its text without JavaScript.
+        </span>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/r-inline-editable-text-70973/style.css
+++ b/submissions/examples/r-inline-editable-text-70973/style.css
@@ -1,0 +1,641 @@
+:root {
+  --bg: #070912;
+  --surface: #101522;
+  --surface-soft: #151c2b;
+  --border: rgba(255, 255, 255, 0.09);
+  --border-hover: rgba(124, 108, 255, 0.5);
+  --text: #f5f7ff;
+  --muted: #8d98ac;
+  --accent: #7c6cff;
+  --accent-light: #a49cff;
+  --cyan: #58d8ff;
+  --ease: 300ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--text);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background:
+    radial-gradient(
+      circle at 15% 20%,
+      rgba(124, 108, 255, 0.13),
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at 85% 80%,
+      rgba(88, 216, 255, 0.08),
+      transparent 28%
+    ),
+    var(--bg);
+}
+
+.page {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 32px 18px;
+}
+
+.editor-card {
+  width: min(680px, 100%);
+  padding: clamp(24px, 5vw, 42px);
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background:
+    linear-gradient(
+      145deg,
+      rgba(124, 108, 255, 0.07),
+      transparent 42%
+    ),
+    var(--surface);
+  box-shadow:
+    0 35px 90px rgba(0, 0, 0, 0.4),
+    inset 0 1px 0 rgba(255, 255, 255, 0.035);
+}
+
+.card-header {
+  margin-bottom: 34px;
+}
+
+.eyebrow {
+  display: inline-block;
+  margin-bottom: 10px;
+  color: var(--accent-light);
+  font-size: 0.68rem;
+  font-weight: 850;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 6vw, 3.3rem);
+  line-height: 1;
+  letter-spacing: -0.055em;
+}
+
+.card-header p {
+  max-width: 550px;
+  margin: 16px 0 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+code {
+  padding: 2px 6px;
+  border-radius: 6px;
+  color: #b7b1ff;
+  background: rgba(124, 108, 255, 0.1);
+  font-size: 0.85em;
+}
+
+.profile {
+  display: flex;
+  gap: 18px;
+  align-items: flex-start;
+  margin-top: 18px;
+  padding: 20px;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  background: var(--surface-soft);
+  transition:
+    border-color var(--ease),
+    transform var(--ease),
+    box-shadow var(--ease);
+}
+
+.profile:hover {
+  border-color: rgba(124, 108, 255, 0.25);
+  transform: translateY(-2px);
+}
+
+.avatar {
+  display: grid;
+  flex: 0 0 52px;
+  width: 52px;
+  height: 52px;
+  place-items: center;
+  border: 1px solid rgba(88, 216, 255, 0.18);
+  border-radius: 16px;
+  color: #8ee6ff;
+  font-size: 0.75rem;
+  font-weight: 850;
+  background:
+    linear-gradient(
+      135deg,
+      rgba(88, 216, 255, 0.16),
+      rgba(124, 108, 255, 0.12)
+    );
+}
+
+.avatar-purple {
+  color: #c1bbff;
+  border-color: rgba(124, 108, 255, 0.2);
+  background: rgba(124, 108, 255, 0.12);
+}
+
+.profile-content {
+  min-width: 0;
+  flex: 1;
+}
+
+.field-label {
+  display: block;
+  margin-bottom: 8px;
+  color: #788398;
+  font-size: 0.66rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.editable {
+  position: relative;
+  min-width: 100%;
+  padding: 8px 10px;
+  margin: -8px 0 0;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  outline: none;
+  color: var(--text);
+  font-size: 1.05rem;
+  font-weight: 750;
+  line-height: 1.5;
+  cursor: text;
+  transition:
+    color var(--ease),
+    background var(--ease),
+    border-color var(--ease),
+    box-shadow var(--ease);
+}
+
+.editable:hover {
+  border-color: rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.editable:focus {
+  border-color: var(--border-hover);
+  background: rgba(124, 108, 255, 0.08);
+  box-shadow:
+    0 0 0 3px rgba(124, 108, 255, 0.1),
+    0 8px 25px rgba(124, 108, 255, 0.08);
+}
+
+.editable:focus::after {
+  position: absolute;
+  right: 9px;
+  top: 50%;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--cyan);
+  box-shadow: 0 0 10px rgba(88, 216, 255, 0.7);
+  content: "";
+  transform: translateY(-50%);
+  animation: edit-pulse 1.5s ease-in-out infinite;
+}
+
+.editable-large {
+  font-size: 1.25rem;
+  letter-spacing: -0.02em;
+}
+
+.helper {
+  display: block;
+  margin-top: 6px;
+  padding-left: 10px;
+  color: #667186;
+  font-size: 0.7rem;
+  line-height: 1.5;
+}
+
+.tip {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  margin-top: 22px;
+  padding: 15px 17px;
+  border: 1px solid rgba(88, 216, 255, 0.1);
+  border-radius: 15px;
+  color: #8793a8;
+  font-size: 0.74rem;
+  line-height: 1.6;
+  background: rgba(88, 216, 255, 0.035);
+}
+
+.tip-icon {
+  flex: 0 0 auto;
+  color: var(--cyan);
+}
+
+@keyframes edit-pulse {
+  0%,
+  100% {
+    opacity: 0.45;
+    transform: translateY(-50%) scale(0.8);
+  }
+
+  50% {
+    opacity: 1;
+    transform: translateY(-50%) scale(1.15);
+  }
+}
+
+@media (max-width: 560px) {
+  .page {
+    padding: 18px 12px;
+  }
+
+  .editor-card {
+    border-radius: 22px;
+    padding: 24px 18px;
+  }
+
+  .profile {
+    gap: 12px;
+    padding: 15px;
+    border-radius: 17px;
+  }
+
+  .avatar {
+    flex-basis: 44px;
+    width: 44px;
+    height: 44px;
+    border-radius: 13px;
+  }
+
+  .editable {
+    font-size: 0.95rem;
+  }
+
+  .editable-large {
+    font-size: 1.08rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .profile,
+  .editable {
+    transition: none;
+  }
+
+  .editable:focus::after {
+    animation: none;
+  }
+}
+
+@media (forced-colors: active) {
+  .editor-card,
+  .profile,
+  .editable,
+  .tip {
+    border-color: CanvasText;
+    background: Canvas;
+    box-shadow: none;
+  }
+
+  .editable:focus {
+    outline: 2px solid Highlight;
+    box-shadow: none;
+  }
+
+  .avatar,
+  .tip-icon {
+    color: CanvasText;
+    background: Canvas;
+  }
+}:root {
+  --bg: #070912;
+  --surface: #101522;
+  --surface-soft: #151c2b;
+  --border: rgba(255, 255, 255, 0.09);
+  --border-hover: rgba(124, 108, 255, 0.5);
+  --text: #f5f7ff;
+  --muted: #8d98ac;
+  --accent: #7c6cff;
+  --accent-light: #a49cff;
+  --cyan: #58d8ff;
+  --ease: 300ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--text);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background:
+    radial-gradient(
+      circle at 15% 20%,
+      rgba(124, 108, 255, 0.13),
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at 85% 80%,
+      rgba(88, 216, 255, 0.08),
+      transparent 28%
+    ),
+    var(--bg);
+}
+
+.page {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 32px 18px;
+}
+
+.editor-card {
+  width: min(680px, 100%);
+  padding: clamp(24px, 5vw, 42px);
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background:
+    linear-gradient(
+      145deg,
+      rgba(124, 108, 255, 0.07),
+      transparent 42%
+    ),
+    var(--surface);
+  box-shadow:
+    0 35px 90px rgba(0, 0, 0, 0.4),
+    inset 0 1px 0 rgba(255, 255, 255, 0.035);
+}
+
+.card-header {
+  margin-bottom: 34px;
+}
+
+.eyebrow {
+  display: inline-block;
+  margin-bottom: 10px;
+  color: var(--accent-light);
+  font-size: 0.68rem;
+  font-weight: 850;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 6vw, 3.3rem);
+  line-height: 1;
+  letter-spacing: -0.055em;
+}
+
+.card-header p {
+  max-width: 550px;
+  margin: 16px 0 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+code {
+  padding: 2px 6px;
+  border-radius: 6px;
+  color: #b7b1ff;
+  background: rgba(124, 108, 255, 0.1);
+  font-size: 0.85em;
+}
+
+.profile {
+  display: flex;
+  gap: 18px;
+  align-items: flex-start;
+  margin-top: 18px;
+  padding: 20px;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  background: var(--surface-soft);
+  transition:
+    border-color var(--ease),
+    transform var(--ease),
+    box-shadow var(--ease);
+}
+
+.profile:hover {
+  border-color: rgba(124, 108, 255, 0.25);
+  transform: translateY(-2px);
+}
+
+.avatar {
+  display: grid;
+  flex: 0 0 52px;
+  width: 52px;
+  height: 52px;
+  place-items: center;
+  border: 1px solid rgba(88, 216, 255, 0.18);
+  border-radius: 16px;
+  color: #8ee6ff;
+  font-size: 0.75rem;
+  font-weight: 850;
+  background:
+    linear-gradient(
+      135deg,
+      rgba(88, 216, 255, 0.16),
+      rgba(124, 108, 255, 0.12)
+    );
+}
+
+.avatar-purple {
+  color: #c1bbff;
+  border-color: rgba(124, 108, 255, 0.2);
+  background: rgba(124, 108, 255, 0.12);
+}
+
+.profile-content {
+  min-width: 0;
+  flex: 1;
+}
+
+.field-label {
+  display: block;
+  margin-bottom: 8px;
+  color: #788398;
+  font-size: 0.66rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.editable {
+  position: relative;
+  min-width: 100%;
+  padding: 8px 10px;
+  margin: -8px 0 0;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  outline: none;
+  color: var(--text);
+  font-size: 1.05rem;
+  font-weight: 750;
+  line-height: 1.5;
+  cursor: text;
+  transition:
+    color var(--ease),
+    background var(--ease),
+    border-color var(--ease),
+    box-shadow var(--ease);
+}
+
+.editable:hover {
+  border-color: rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.editable:focus {
+  border-color: var(--border-hover);
+  background: rgba(124, 108, 255, 0.08);
+  box-shadow:
+    0 0 0 3px rgba(124, 108, 255, 0.1),
+    0 8px 25px rgba(124, 108, 255, 0.08);
+}
+
+.editable:focus::after {
+  position: absolute;
+  right: 9px;
+  top: 50%;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--cyan);
+  box-shadow: 0 0 10px rgba(88, 216, 255, 0.7);
+  content: "";
+  transform: translateY(-50%);
+  animation: edit-pulse 1.5s ease-in-out infinite;
+}
+
+.editable-large {
+  font-size: 1.25rem;
+  letter-spacing: -0.02em;
+}
+
+.helper {
+  display: block;
+  margin-top: 6px;
+  padding-left: 10px;
+  color: #667186;
+  font-size: 0.7rem;
+  line-height: 1.5;
+}
+
+.tip {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  margin-top: 22px;
+  padding: 15px 17px;
+  border: 1px solid rgba(88, 216, 255, 0.1);
+  border-radius: 15px;
+  color: #8793a8;
+  font-size: 0.74rem;
+  line-height: 1.6;
+  background: rgba(88, 216, 255, 0.035);
+}
+
+.tip-icon {
+  flex: 0 0 auto;
+  color: var(--cyan);
+}
+
+@keyframes edit-pulse {
+  0%,
+  100% {
+    opacity: 0.45;
+    transform: translateY(-50%) scale(0.8);
+  }
+
+  50% {
+    opacity: 1;
+    transform: translateY(-50%) scale(1.15);
+  }
+}
+
+@media (max-width: 560px) {
+  .page {
+    padding: 18px 12px;
+  }
+
+  .editor-card {
+    border-radius: 22px;
+    padding: 24px 18px;
+  }
+
+  .profile {
+    gap: 12px;
+    padding: 15px;
+    border-radius: 17px;
+  }
+
+  .avatar {
+    flex-basis: 44px;
+    width: 44px;
+    height: 44px;
+    border-radius: 13px;
+  }
+
+  .editable {
+    font-size: 0.95rem;
+  }
+
+  .editable-large {
+    font-size: 1.08rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .profile,
+  .editable {
+    transition: none;
+  }
+
+  .editable:focus::after {
+    animation: none;
+  }
+}
+
+@media (forced-colors: active) {
+  .editor-card,
+  .profile,
+  .editable,
+  .tip {
+    border-color: CanvasText;
+    background: Canvas;
+    box-shadow: none;
+  }
+
+  .editable:focus {
+    outline: 2px solid Highlight;
+    box-shadow: none;
+  }
+
+  .avatar,
+  .tip-icon {
+    color: CanvasText;
+    background: Canvas;
+  }
+}


### PR DESCRIPTION
## Description

Implemented the CSS Inline Editable Text component for EaseMotion CSS.

### What's included

- Added inline editable text fields
- Added native `contenteditable` interaction
- Added focus and hover animations
- Added responsive styling
- Added visual editing indicator
- Added reduced-motion support
- Added forced-colors support
- No JavaScript required

### Accessibility

- Added `role="textbox"`
- Added descriptive `aria-label` attributes
- Added keyboard focus support
- Preserves native text editing behavior
- Supports `prefers-reduced-motion`
- Supports forced-colors mode

### Files Changed

`submissions/examples/r-inline-editable-text-70973/`

- `demo.html`
- `style.css`
- `README.md`

### Related Issue

Closes #70973