### PR TITLE
Add ease-download-speed-meter component

### DIFF
--- a/submissions/examples/download-speed-meter-ij/README.md
+++ b/submissions/examples/download-speed-meter-ij/README.md
@@ -1,0 +1,11 @@
+# ease-download-speed-meter
+
+A download meter where the speed readout ticks, the fill surges across the bar, and the tag blinks.
+
+## Run
+Open `demo.html` directly in a browser to watch the download surge.
+
+## Notes
+- The speed figure flickers like a live readout.
+- The progress fill surges across the track.
+- The downloading tag blinks above the file name.

--- a/submissions/examples/download-speed-meter-ij/demo.html
+++ b/submissions/examples/download-speed-meter-ij/demo.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-download-speed-meter demo</title>
+</head>
+<body>
+<div class="dsm-panel">
+  <div class="dsm-gauge">
+    <b class="dsm-speed">86.2</b>
+    <span class="dsm-unit">MB/s</span>
+  </div>
+  <div class="dsm-bar"><em class="dsm-fill"></em></div>
+  <div class="dsm-labels">
+    <span class="dsm-tag">DOWNLOADING</span>
+    <span class="dsm-file">movie-4k.mp4</span>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/download-speed-meter-ij/style.css
+++ b/submissions/examples/download-speed-meter-ij/style.css
@@ -1,0 +1,12 @@
+.dsm-panel{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:300px;background:linear-gradient(180deg,#141d2a,#0b1119);border:2px solid #2a3a4e;border-radius:16px;padding:20px;display:flex;flex-direction:column;gap:16px;align-items:center}
+.dsm-gauge{text-align:center;display:flex;align-items:baseline;gap:6px}
+.dsm-speed{font-size:38px;font-weight:800;color:#5ce1e6;font-family:'Courier New',monospace;animation:dsm-speed-tick-download-speed-meter 1.4s steps(3) infinite}
+.dsm-unit{font-size:12px;font-weight:800;color:#8b9bad}
+.dsm-bar{width:100%;height:12px;background:#0a0f17;border-radius:6px;border:1px solid #22303f;overflow:hidden}
+.dsm-fill{display:block;height:100%;width:70%;background:linear-gradient(90deg,#ff6b9d,#e74c3c);border-radius:6px;animation:dsm-fill-surge-download-speed-meter 3s ease-in-out infinite}
+.dsm-labels{width:100%;display:flex;justify-content:space-between;align-items:center}
+.dsm-tag{font-size:9px;font-weight:800;letter-spacing:2px;color:#7cebb0;animation:dsm-tag-blink-download-speed-meter 1.6s ease-in-out infinite}
+.dsm-file{font-size:10px;font-weight:700;color:#c7d6e8}
+@keyframes dsm-speed-tick-download-speed-meter{0%{opacity:1}50%{opacity:.4}100%{opacity:1}}
+@keyframes dsm-fill-surge-download-speed-meter{0%,100%{width:20%}50%{width:90%}}
+@keyframes dsm-tag-blink-download-speed-meter{0%,100%{opacity:1}50%{opacity:.3}}


### PR DESCRIPTION
## Component: ease-download-speed-meter — speed ticks, fill surges, and tag blinks

**Closes #71539**

### What this adds
A download meter where the speed readout ticks, the fill surges across the bar, and the tag blinks.

### Acceptance Criteria covered
- Speed readout ticks
- Fill surges across the bar
- Downloading tag blinks

### Files
- `submissions/examples/download-speed-meter-ij/demo.html`
- `submissions/examples/download-speed-meter-ij/style.css`
- `submissions/examples/download-speed-meter-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the speed tick, the fill surge, and the tag blink.