### PR TITLE
feat: add ease-rotating-word-cycle-sap

### DIFF
--- a/submissions/examples/ease-rotating-word-cycle-sap/README.md
+++ b/submissions/examples/ease-rotating-word-cycle-sap/README.md
@@ -1,0 +1,18 @@
+# ease-rotating-word-cycle-sap
+
+A heading with a rotating word slot — the current word slides up and out while the next word slides in from below, cycling continuously.
+
+## Usage
+1. Include `style.css`.
+2. Add markup: static text + `.cycle-wrap` container.
+3. Include the JS from `demo.html`, which cycles through a `words` array on an interval.
+
+## Customization
+- `words` array: the rotating word set.
+- `setInterval(..., 2200)`: cycle speed.
+- Slide distance (`top: 44px`/`-44px`) — should match the wrap's fixed `height`.
+
+## Notes
+- The wrap's `width` is set dynamically to match each incoming word's natural width via `offsetWidth`, so the surrounding sentence reflows smoothly rather than jumping abruptly for words of different lengths.
+- Old and new word elements coexist briefly during the transition (old sliding out to `-44px`, new sliding in from `44px` to `0`), removed only once its own `transitionend` fires.
+- Respects `prefers-reduced-motion`: vertical slide is removed, leaving a simple opacity cross-fade between words instead.

--- a/submissions/examples/ease-rotating-word-cycle-sap/demo.html
+++ b/submissions/examples/ease-rotating-word-cycle-sap/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-rotating-word-cycle-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { height: 100vh; margin: 0; display: flex; align-items: center; justify-content: center; background: #f4f4f5; }
+  </style>
+</head>
+<body>
+  <div class="word-cycle-sap">
+    <span>We build</span>
+    <span class="cycle-wrap" id="wrap"></span>
+  </div>
+  <script>
+    const words = ['websites.', 'products.', 'brands.', 'experiences.'];
+    const wrap = document.getElementById('wrap');
+    let index = 0;
+
+    function render() {
+      wrap.innerHTML = '';
+      const el = document.createElement('span');
+      el.className = 'cycle-word current';
+      el.textContent = words[index];
+      wrap.style.width = 'auto';
+      wrap.appendChild(el);
+      requestAnimationFrame(() => { wrap.style.width = el.offsetWidth + 'px'; });
+    }
+
+    function next() {
+      const oldEl = wrap.querySelector('.cycle-word');
+      if (oldEl) {
+        oldEl.classList.remove('current');
+        oldEl.classList.add('prev');
+        oldEl.addEventListener('transitionend', () => oldEl.remove(), { once: true });
+      }
+      index = (index + 1) % words.length;
+      const newEl = document.createElement('span');
+      newEl.className = 'cycle-word';
+      newEl.textContent = words[index];
+      wrap.appendChild(newEl);
+      wrap.style.width = newEl.offsetWidth + 'px';
+      requestAnimationFrame(() => newEl.classList.add('current'));
+    }
+
+    render();
+    setInterval(next, 2200);
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-rotating-word-cycle-sap/style.css
+++ b/submissions/examples/ease-rotating-word-cycle-sap/style.css
@@ -1,0 +1,41 @@
+.word-cycle-sap {
+  font-family: system-ui, sans-serif;
+  font-size: 32px;
+  font-weight: 800;
+  color: #111;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.word-cycle-sap .cycle-wrap {
+  position: relative;
+  height: 44px;
+  overflow: hidden;
+}
+
+.word-cycle-sap .cycle-word {
+  position: absolute;
+  left: 0;
+  top: 44px;
+  color: #2563eb;
+  white-space: nowrap;
+  opacity: 0;
+  transition: top 0.5s cubic-bezier(0.65, 0, 0.35, 1), opacity 0.3s ease;
+}
+
+.word-cycle-sap .cycle-word.current {
+  top: 0;
+  opacity: 1;
+}
+
+.word-cycle-sap .cycle-word.prev {
+  top: -44px;
+  opacity: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .word-cycle-sap .cycle-word {
+    transition: opacity 0.2s ease;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-rotating-word-cycle-sap`, a sliding rotating-word text cycle component.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-rotating-word-cycle-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Wrap width is set from each word's actual `offsetWidth`, letting the surrounding sentence reflow smoothly for words of varying length instead of jumping.
- Outgoing/incoming words coexist briefly during the slide transition, with the old element removed only after its own `transitionend` fires.
- `prefers-reduced-motion` replaces the vertical slide with a simple opacity cross-fade.

## Feature Description

Adds a reusable rotating word-cycle text component.

Level: Intermediate

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.