### PR TITLE
feat: add ease-drag-reveal-panel-sap

### DIFF
--- a/submissions/examples/ease-drag-reveal-panel-sap/README.md
+++ b/submissions/examples/ease-drag-reveal-panel-sap/README.md
@@ -1,0 +1,18 @@
+# ease-drag-reveal-panel-sap
+
+A gamified reveal panel — drag a colored cover sideways to uncover hidden content (like a discount code), with a threshold-based snap to either open or closed.
+
+## Usage
+1. Include `style.css`.
+2. Add markup: `.reveal-content` (hidden message) behind a draggable `.reveal-cover`.
+3. Attach the drag logic from `demo.html`.
+
+## Customization
+- Cover color/gradient.
+- Snap threshold (`50%` of width) — adjust for how far a user must drag before it snaps fully open vs back closed.
+- Hidden content/message.
+
+## Notes
+- Drag distance is clamped between `0` and the container's full width, preventing the cover from being dragged past either edge.
+- On release, the cover snaps fully open or fully closed based on whether the drag passed the 50% threshold — never leaves the cover in a half-dragged state.
+- Respects `prefers-reduced-motion`: the snap-back/snap-open transition is disabled, so release causes an instant jump to the final position instead of an eased slide; live drag tracking is unaffected as direct input.

--- a/submissions/examples/ease-drag-reveal-panel-sap/demo.html
+++ b/submissions/examples/ease-drag-reveal-panel-sap/demo.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-drag-reveal-panel-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { height: 100vh; margin: 0; display: flex; align-items: center; justify-content: center; background: #f4f4f5; }
+  </style>
+</head>
+<body>
+  <div class="drag-reveal-sap">
+    <div class="reveal-content">🎁 Surprise! You've unlocked a special 15% discount code: WELCOME15</div>
+    <div class="reveal-cover" id="cover"></div>
+  </div>
+  <script>
+    const cover = document.getElementById('cover');
+    const parent = cover.parentElement;
+    let dragging = false;
+    let startX = 0;
+
+    function onDown(clientX) {
+      dragging = true;
+      startX = clientX;
+      cover.classList.add('dragging');
+    }
+
+    function onMove(clientX) {
+      if (!dragging) return;
+      const rect = parent.getBoundingClientRect();
+      let dx = clientX - startX;
+      dx = Math.max(0, Math.min(dx, rect.width));
+      cover.style.transform = `translateX(${dx}px)`;
+    }
+
+    function onUp(clientX) {
+      if (!dragging) return;
+      dragging = false;
+      cover.classList.remove('dragging');
+      const rect = parent.getBoundingClientRect();
+      const dx = clientX - startX;
+      if (dx > rect.width * 0.5) {
+        cover.style.transform = `translateX(${rect.width}px)`;
+      } else {
+        cover.style.transform = 'translateX(0)';
+      }
+    }
+
+    cover.addEventListener('mousedown', (e) => onDown(e.clientX));
+    window.addEventListener('mousemove', (e) => onMove(e.clientX));
+    window.addEventListener('mouseup', (e) => onUp(e.clientX));
+    cover.addEventListener('touchstart', (e) => onDown(e.touches[0].clientX), { passive: true });
+    cover.addEventListener('touchmove', (e) => onMove(e.touches[0].clientX), { passive: true });
+    cover.addEventListener('touchend', (e) => onUp(e.changedTouches[0].clientX));
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-drag-reveal-panel-sap/style.css
+++ b/submissions/examples/ease-drag-reveal-panel-sap/style.css
@@ -1,0 +1,53 @@
+.drag-reveal-sap {
+  position: relative;
+  width: 320px;
+  height: 220px;
+  border-radius: 16px;
+  overflow: hidden;
+  background: #111;
+}
+
+.drag-reveal-sap .reveal-content {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-family: system-ui, sans-serif;
+  font-size: 15px;
+  text-align: center;
+  padding: 20px;
+  box-sizing: border-box;
+}
+
+.drag-reveal-sap .reveal-cover {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, #2563eb, #7c3aed);
+  cursor: grab;
+  transition: transform 0.3s ease;
+}
+
+.drag-reveal-sap .reveal-cover.dragging {
+  transition: none;
+  cursor: grabbing;
+}
+
+.drag-reveal-sap .reveal-cover::after {
+  content: "Drag to reveal →";
+  position: absolute;
+  bottom: 14px;
+  left: 50%;
+  transform: translateX(-50%);
+  color: #fff;
+  font-size: 12px;
+  font-family: system-ui, sans-serif;
+  opacity: 0.8;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .drag-reveal-sap .reveal-cover {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-drag-reveal-panel-sap`, a drag-to-uncover gamified reveal panel.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-drag-reveal-panel-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Drag distance is clamped to the container bounds, preventing the cover from dragging past either edge.
- Release always snaps to fully open or fully closed based on a 50% threshold, never leaving an ambiguous half-open state.
- `prefers-reduced-motion` disables the snap transition, making release an instant jump; live drag tracking is unaffected as direct input.

## Feature Description

Adds a reusable drag-to-reveal panel component.

Level: Advanced

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.