### PR TITLE
Add ease-nfc-tap-card component

### DIFF
--- a/submissions/examples/nfc-tap-card-ij/README.md
+++ b/submissions/examples/nfc-tap-card-ij/README.md
@@ -1,0 +1,11 @@
+# ease-nfc-tap-card
+
+A payment reader where the tap pad pulses, the waves ring outward, and the status blinks.
+
+## Run
+Open `demo.html` directly in a browser to watch the card tap.
+
+## Notes
+- The tap pad glows while scanning.
+- The signal waves ring outward from the pad.
+- The status label blinks below the card.

--- a/submissions/examples/nfc-tap-card-ij/demo.html
+++ b/submissions/examples/nfc-tap-card-ij/demo.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-nfc-tap-card demo</title>
+</head>
+<body>
+<div class="ntc-reader">
+  <div class="ntc-pad"><b class="ntc-check">✓</b><span class="ntc-waves"></span></div>
+  <div class="ntc-card">
+    <span class="ntc-chip"></span>
+    <b class="ntc-brand">CARDHOLDER</b>
+    <span class="ntc-num">•••• 4821</span>
+  </div>
+  <div class="ntc-status">
+    <span class="ntc-tag">TAP TO PAY</span>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/nfc-tap-card-ij/style.css
+++ b/submissions/examples/nfc-tap-card-ij/style.css
@@ -1,0 +1,13 @@
+.ntc-reader{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:320px;background:linear-gradient(180deg,#101c2c,#081320);border:2px solid #243a52;border-radius:16px;padding:18px;display:flex;flex-direction:column;align-items:center;gap:16px}
+.ntc-pad{position:relative;width:130px;height:130px;border-radius:50%;background:#0a1420;border:2px dashed #5ce1e6;display:flex;align-items:center;justify-content:center;animation:ntc-pad-pulse-nfc-tap-card 1.8s ease-in-out infinite}
+.ntc-check{font-size:40px;color:#7cebb0}
+.ntc-waves{position:absolute;inset:-8px;border-radius:50%;border:2px solid rgba(92,225,230,0.5);animation:ntc-waves-ring-nfc-tap-card 1.6s ease-out infinite}
+.ntc-card{width:200px;background:linear-gradient(135deg,#2a3a4e,#1a2736);border:2px solid #3d5066;border-radius:12px;padding:14px;display:flex;flex-direction:column;gap:8px}
+.ntc-chip{width:24px;height:18px;background:#ffd76a;border-radius:3px}
+.ntc-brand{font-size:10px;font-weight:800;letter-spacing:2px;color:#c7d6e8}
+.ntc-num{font-size:13px;font-weight:800;color:#8b9bad;font-family:'Courier New',monospace;letter-spacing:2px;animation:ntc-num-blink-nfc-tap-card 2s ease-in-out infinite}
+.ntc-tag{font-size:10px;font-weight:800;letter-spacing:3px;color:#5ce1e6;animation:ntc-tag-blink-nfc-tap-card 1s ease-in-out infinite}
+@keyframes ntc-pad-pulse-nfc-tap-card{0%,100%{box-shadow:0 0 0 0 rgba(92,225,230,0)}50%{box-shadow:0 0 18px rgba(92,225,230,0.4)}100%{box-shadow:0 0 0 0 rgba(92,225,230,0)}}
+@keyframes ntc-waves-ring-nfc-tap-card{0%{transform:scale(.7);opacity:1}100%{transform:scale(1.6);opacity:0}}
+@keyframes ntc-num-blink-nfc-tap-card{0%,100%{opacity:1}50%{opacity:.4}}
+@keyframes ntc-tag-blink-nfc-tap-card{0%,100%{opacity:1}50%{opacity:.3}}


### PR DESCRIPTION
## Component: ease-nfc-tap-card — pad pulses, waves ring, and status blinks

**Closes #71559**

### What this adds
A payment reader where the tap pad pulses, the signal waves ring outward, and the status blinks.

### Acceptance Criteria covered
- Tap pad pulses
- Signal waves ring
- Status blinks

### Files
- `submissions/examples/nfc-tap-card-ij/demo.html`
- `submissions/examples/nfc-tap-card-ij/style.css`
- `submissions/examples/nfc-tap-card-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the pad pulse, the waves ring, and the status blink.