### PR TITLE
feat: implement CSS Passport Stamp #70958

### DIFF
--- a/submissions/examples/css-passport-stamp/README.md
+++ b/submissions/examples/css-passport-stamp/README.md
@@ -1,0 +1,13 @@
+# CSS Passport Stamp (#70958)
+
+Passport entry stamp implementation featuring realistic impact bounce and fluid ink spread physics built entirely with pure CSS.
+
+## Features
+- **Impact Physics Animation:** Keyframe animation driving initial impact scale down and slight rotational offset.
+- **Ink Spread Effect:** Pseudo-element radial gradient expanding outwards simulating ink press transfer onto paper.
+- **Pure CSS Solution:** Zero JavaScript required for layout, timing, or animation.
+- **Accessible & Responsive:** Full support for ARIA image role labeling and `prefers-reduced-motion` accessibility standards.
+
+## Structure
+- `style.css` - Keyframe impact and ink bleed definitions, document texturing, and typography styling.
+- `demo.html` - Interactive demo displaying the passport page and stamped entry badge.

--- a/submissions/examples/css-passport-stamp/demo.html
+++ b/submissions/examples/css-passport-stamp/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Passport Stamp | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="stamp-card" aria-label="Passport stamp animation demo">
+    <header class="stamp-header">
+      <h1>CSS Passport Stamp</h1>
+      <p>Passport entry stamp with realistic ink spread physics.</p>
+    </header>
+
+    <div class="passport-page" aria-label="Passport entry document page">
+      <div class="passport-stamp" role="img" aria-label="Passport Entry Stamp: IMMIGRATION JAPAN, ARRIVED 10 AUG 2026">
+        <span class="stamp-country">JAPAN</span>
+        <span class="stamp-status">★ ARRIVED ★</span>
+        <span class="stamp-date">10 AUG 2026</span>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/css-passport-stamp/style.css
+++ b/submissions/examples/css-passport-stamp/style.css
@@ -1,0 +1,169 @@
+/* CSS Passport Stamp #70958 */
+
+:root {
+  --bg-color: #0f172a;
+  --card-bg: #1e293b;
+  --border-color: #334155;
+  --text-main: #f8fafc;
+  --text-sub: #94a3b8;
+  --stamp-ink: #dc2626;
+  --stamp-ink-glow: rgba(220, 38, 38, 0.35);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 2rem 1rem;
+  background-color: var(--bg-color);
+  color: var(--text-main);
+  font-family: system-ui, -apple-system, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.stamp-card {
+  width: 100%;
+  max-width: 480px;
+  background-color: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 20px;
+  padding: 2rem;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 1.5rem;
+}
+
+.stamp-header h1 {
+  font-size: 1.4rem;
+  margin: 0 0 0.25rem 0;
+}
+
+.stamp-header p {
+  color: var(--text-sub);
+  font-size: 0.875rem;
+  margin: 0;
+}
+
+/* Passport Page Canvas */
+.passport-page {
+  width: 100%;
+  height: 260px;
+  background: #f1f5f9;
+  background-image: 
+    radial-gradient(#cbd5e1 1px, transparent 1px),
+    linear-gradient(to right, rgba(0, 0, 0, 0.03) 1px, transparent 1px);
+  background-size: 16px 16px, 100% 100%;
+  border-radius: 12px;
+  border: 2px dashed #94a3b8;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  overflow: hidden;
+}
+
+/* Passport Stamp Outer Container */
+.passport-stamp {
+  padding: 1.25rem 1.75rem;
+  border: 4px double var(--stamp-ink);
+  border-radius: 12px;
+  color: var(--stamp-ink);
+  transform: rotate(-8deg) scale(2.5);
+  opacity: 0;
+  animation: stamp-impact 0.6s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards;
+  animation-delay: 0.2s;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  user-select: none;
+  position: relative;
+}
+
+/* Ink Bleed / Spread Radial Overlay */
+.passport-stamp::before {
+  content: '';
+  position: absolute;
+  inset: -12px;
+  background: radial-gradient(circle, var(--stamp-ink-glow) 0%, transparent 75%);
+  border-radius: 16px;
+  opacity: 0;
+  transform: scale(0.5);
+  animation: ink-spread 0.8s ease-out forwards;
+  animation-delay: 0.45s;
+  pointer-events: none;
+}
+
+.stamp-country {
+  font-size: 1.2rem;
+  font-weight: 900;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.stamp-status {
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  border-top: 2px solid var(--stamp-ink);
+  border-bottom: 2px solid var(--stamp-ink);
+  padding: 0.15rem 0.5rem;
+  text-transform: uppercase;
+}
+
+.stamp-date {
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+}
+
+/* Keyframe Animations */
+@keyframes stamp-impact {
+  0% {
+    transform: rotate(-8deg) scale(2.8);
+    opacity: 0;
+  }
+  70% {
+    transform: rotate(-8deg) scale(0.95);
+    opacity: 0.95;
+  }
+  100% {
+    transform: rotate(-8deg) scale(1);
+    opacity: 0.88;
+  }
+}
+
+@keyframes ink-spread {
+  0% {
+    opacity: 0;
+    transform: scale(0.6);
+  }
+  50% {
+    opacity: 0.7;
+  }
+  100% {
+    opacity: 0.35;
+    transform: scale(1.15);
+  }
+}
+
+/* Reduced Motion Support */
+@media (prefers-reduced-motion: reduce) {
+  .passport-stamp {
+    animation: none !important;
+    transform: rotate(-8deg) scale(1) !important;
+    opacity: 0.9 !important;
+  }
+  .passport-stamp::before {
+    animation: none !important;
+    opacity: 0.3 !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the CSS Passport Stamp component with realistic ink spread animation (#70958).
gssoc 26

Closes #70958

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/css-passport-stamp/`
- [x] `style.css`, `demo.html`, and `README.md` included
- [x] Automated commit correctly formatted

---

## Feature Description
**What does this add?**
A vintage passport entry stamp component featuring dynamic impact bouncing and outward ink bleeding animation.

**How does it work?**
Utilizes `@keyframes` to animate transform scaling and opacity for the initial stamp impact onto a paper canvas, paired with a pseudo-element radial gradient expansion (`::before`) simulating wet ink spread into paper fibers without JavaScript.

---

## Notes for Maintainer
Zero JavaScript dependencies. Includes `@media (prefers-reduced-motion: reduce)` accessibility fallback rules and proper ARIA role labeling.