### PR TITLE
feat: add ease-image-mask-reveal-sap

### DIFF
--- a/submissions/examples/ease-image-mask-reveal-sap/README.md
+++ b/submissions/examples/ease-image-mask-reveal-sap/README.md
@@ -1,0 +1,22 @@
+# ease-image-mask-reveal-sap
+
+An image that wipes into view left-to-right on load, using an animated `clip-path: inset()` mask rather than opacity or transform.
+
+## Usage
+1. Include `style.css`.
+2. Add markup:
+```html
+   <div class="mask-reveal-sap">
+     <img src="..." alt="...">
+   </div>
+```
+
+## Customization
+- `clip-path: inset()` direction: change `inset(0 100% 0 0)` to `inset(0 0 0 100%)` for a right-to-left wipe, or use top/bottom insets for a vertical wipe.
+- Animation duration/easing.
+- Trigger on scroll instead of load by combining with an `IntersectionObserver` (swap the `animation` for a class toggle).
+
+## Notes
+- `clip-path: inset(top right bottom left)` progressively reveals the image as the right-inset value shrinks from 100% to 0%, producing a true wipe rather than a fade or slide.
+- Unlike `overflow: hidden` + `transform: translateX()` reveals, this doesn't require the image to be larger than its container or offset outside it — the full image stays in place and is simply masked.
+- Respects `prefers-reduced-motion`: animation is disabled, `clip-path` is set directly to the fully-revealed state.

--- a/submissions/examples/ease-image-mask-reveal-sap/demo.html
+++ b/submissions/examples/ease-image-mask-reveal-sap/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-image-mask-reveal-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { height: 100vh; margin: 0; display: flex; align-items: center; justify-content: center; background: #f4f4f5; }
+  </style>
+</head>
+<body>
+  <div class="mask-reveal-sap">
+    <img src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=700" alt="Landscape">
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-image-mask-reveal-sap/style.css
+++ b/submissions/examples/ease-image-mask-reveal-sap/style.css
@@ -1,0 +1,27 @@
+.mask-reveal-sap {
+  position: relative;
+  width: 320px;
+  height: 220px;
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+.mask-reveal-sap img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  clip-path: inset(0 100% 0 0);
+  animation: mask-wipe-sap 1.2s cubic-bezier(0.65, 0, 0.35, 1) forwards;
+}
+
+@keyframes mask-wipe-sap {
+  to { clip-path: inset(0 0 0 0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mask-reveal-sap img {
+    animation: none;
+    clip-path: inset(0 0 0 0);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-image-mask-reveal-sap`, an animated clip-path wipe reveal for images.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-image-mask-reveal-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Uses `clip-path: inset()` animation for a true progressive wipe, distinct from `overflow: hidden` + `translateX()` reveals which require oversized/offset image positioning.
- README documents how to flip wipe direction (horizontal/vertical) by changing which inset side animates.
- `prefers-reduced-motion` disables the animation, setting `clip-path` directly to the fully-revealed state.

## Feature Description

Adds a reusable clip-path image wipe reveal component.

Level: Intermediate

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.