### PR TITLE
feat: implement CSS Hover Preview Card #70962

### DIFF
--- a/submissions/examples/css-hover-preview-card/README.md
+++ b/submissions/examples/css-hover-preview-card/README.md
@@ -1,0 +1,13 @@
+# CSS Hover Preview Card (#70962)
+
+Pure CSS destination link hover preview card popover built without JavaScript dependencies.
+
+## Features
+- **Hover & Focus Triggers:** Uses CSS `:hover` and `:focus-within` selectors to trigger fluid preview cards.
+- **Accessible ARIA Linking:** Integrates `role="tooltip"` and `aria-describedby` linking for full screen-reader compliance.
+- **Pure CSS Execution:** Zero JavaScript required for positioning transitions or state management.
+- **Responsive & Motion Friendly:** Includes CSS support for `prefers-reduced-motion` and adaptive layout scaling.
+
+## Structure
+- `style.css` - Component variables, popover positioning, trigger selectors, and arrow indicator styles.
+- `demo.html` - Interactive demo displaying inline link trigger with destination preview card popover.

--- a/submissions/examples/css-hover-preview-card/demo.html
+++ b/submissions/examples/css-hover-preview-card/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Hover Preview Card | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-card">
+    <header class="demo-header">
+      <h1>CSS Hover Preview Card</h1>
+      <p>Hover or focus on inline links to preview destination metadata.</p>
+    </header>
+
+    <p class="content-paragraph">
+      Explore cutting-edge features in modern web development including 
+      <span class="preview-link-wrapper">
+        <a href="#easemotion-docs" class="preview-trigger-link" aria-describedby="preview-card-1">EaseMotion CSS</a>
+        <span id="preview-card-1" class="preview-card" role="tooltip">
+          <span class="preview-card-image">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <polygon points="12 2 2 7 12 12 22 7 12 2"></polygon>
+              <polyline points="2 17 12 22 22 17"></polyline>
+              <polyline points="2 12 12 17 22 12"></polyline>
+            </svg>
+          </span>
+          <span class="preview-card-title">EaseMotion CSS Library</span>
+          <span class="preview-card-desc">Zero-JS CSS animation library offering seamless UI components and interactions.</span>
+          <span class="preview-card-domain">easemotion.dev</span>
+        </span>
+      </span> 
+      for building lightweight, accessible interactive web interfaces without JavaScript.
+    </p>
+  </main>
+</body>
+</html>

--- a/submissions/examples/css-hover-preview-card/style.css
+++ b/submissions/examples/css-hover-preview-card/style.css
@@ -1,0 +1,166 @@
+/* CSS Hover Preview Card #70962 */
+
+:root {
+  --bg-color: #0f172a;
+  --card-bg: #1e293b;
+  --border-color: #334155;
+  --text-main: #f8fafc;
+  --text-sub: #94a3b8;
+  --accent-color: #38bdf8;
+  --preview-bg: #090d16;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 2rem 1rem;
+  background-color: var(--bg-color);
+  color: var(--text-main);
+  font-family: system-ui, -apple-system, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.demo-card {
+  width: 100%;
+  max-width: 520px;
+  background-color: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 20px;
+  padding: 2rem;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.demo-header h1 {
+  font-size: 1.4rem;
+  margin: 0 0 0.25rem 0;
+}
+
+.demo-header p {
+  color: var(--text-sub);
+  font-size: 0.875rem;
+  margin: 0;
+}
+
+.content-paragraph {
+  line-height: 1.7;
+  color: var(--text-sub);
+  font-size: 1rem;
+  margin: 0;
+}
+
+/* Hover Preview Anchor Wrapper */
+.preview-link-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
+.preview-trigger-link {
+  color: var(--accent-color);
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 4px;
+  transition: color 0.2s ease;
+  cursor: pointer;
+}
+
+.preview-trigger-link:hover,
+.preview-trigger-link:focus {
+  color: #7dd3fc;
+  outline: none;
+}
+
+/* Floating Tooltip/Preview Card */
+.preview-card {
+  position: absolute;
+  bottom: calc(100% + 12px);
+  left: 50%;
+  transform: translateX(-50%) translateY(8px) scale(0.95);
+  width: 280px;
+  background-color: var(--preview-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: 1rem;
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.5);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.25s ease, transform 0.25s cubic-bezier(0.175, 0.885, 0.32, 1.275), visibility 0.25s;
+  z-index: 50;
+}
+
+/* Arrow Tip */
+.preview-card::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 6px;
+  border-style: solid;
+  border-color: var(--border-color) transparent transparent transparent;
+}
+
+/* Trigger reveal on hover and focus-within */
+.preview-link-wrapper:hover .preview-card,
+.preview-link-wrapper:focus-within .preview-card {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transform: translateX(-50%) translateY(0) scale(1);
+}
+
+.preview-card-image {
+  width: 100%;
+  height: 120px;
+  background: linear-gradient(135deg, #1e3a8a, #4c1d95);
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 0.75rem;
+}
+
+.preview-card-image svg {
+  width: 48px;
+  height: 48px;
+  stroke: var(--accent-color);
+}
+
+.preview-card-title {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--text-main);
+  margin: 0 0 0.35rem 0;
+}
+
+.preview-card-desc {
+  font-size: 0.8rem;
+  color: var(--text-sub);
+  margin: 0 0 0.5rem 0;
+  line-height: 1.4;
+}
+
+.preview-card-domain {
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: var(--accent-color);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* Accessibility: Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+  .preview-card {
+    transition: opacity 0.15s ease, visibility 0.15s;
+    transform: translateX(-50%) translateY(0);
+  }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the CSS Hover Preview Card component (#70962).
gssoc 26

Closes #70962

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/css-hover-preview-card/`
- [x] `style.css`, `demo.html`, and `README.md` included
- [x] Automated commit correctly formatted

---

## Feature Description
**What does this add?**
A link hover preview popover card component displaying destination metadata prior to navigation.

**How does it work?**
Combines CSS positioning with `:hover` and `:focus-within` selectors to seamlessly animate the opacity and scale transform of an inline tooltip card without JavaScript.

---

## Notes for Maintainer
Zero JavaScript dependencies. Accessible implementation using `role="tooltip"` and `aria-describedby` associations.