### PR TITLE
feat: Add CSS Peel Transition Effect #70257

### DIFF
--- a/submissions/examples/css-peel-transition-70257/README.md
+++ b/submissions/examples/css-peel-transition-70257/README.md
@@ -1,0 +1,18 @@
+# CSS Peel Transition Effect
+
+What does this do?  
+This provides a pure CSS page transition where the top layer gracefully peels away from the bottom corner to reveal the content underneath, like a sticker or book page.
+
+How is it used?  
+Include the `peel-container` wrapper with nested `peel-layer-back`, `peel-layer-front`, and `peel-fold` elements.
+
+```html
+<div class="peel-container" tabindex="0">
+  <div class="peel-layer-back">...</div>
+  <div class="peel-layer-front">...</div>
+  <div class="peel-fold"></div>
+</div>
+```
+
+Why is it useful?  
+It expands EaseMotion CSS's collection of ready-to-use animations, allowing developers to create highly interactive, premium feel UI patterns without relying on JavaScript libraries. It leverages modern CSS like `clip-path` and `drop-shadow` for an elegant fold effect.

--- a/submissions/examples/css-peel-transition-70257/demo.html
+++ b/submissions/examples/css-peel-transition-70257/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Peel Transition Effect</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="peel-container" aria-label="Peel transition effect container" tabindex="0">
+    <!-- Back layer revealed after peeling -->
+    <div class="peel-layer-back">
+      <h2>EaseMotion CSS</h2>
+      <p>Pure CSS sticker peel transition with drop-shadow fold effect.</p>
+    </div>
+    
+    <!-- Front layer that peels away -->
+    <div class="peel-layer-front">
+      <h2>Hover or Focus to Peel</h2>
+    </div>
+    
+    <!-- The fold element -->
+    <div class="peel-fold"></div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/css-peel-transition-70257/style.css
+++ b/submissions/examples/css-peel-transition-70257/style.css
@@ -1,0 +1,115 @@
+/* Base reset for demo */
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: #f3f4f6;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+}
+
+/* Peel Transition Container */
+.peel-container {
+  position: relative;
+  width: 320px;
+  height: 400px;
+  border-radius: 12px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
+  background-color: #1f2937; /* Fallback for back layer */
+  overflow: hidden;
+  cursor: pointer;
+}
+
+.peel-container:focus {
+  outline: 3px solid #3b82f6;
+  outline-offset: 4px;
+}
+
+/* Back Layer (Revealed) */
+.peel-layer-back {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, #4f46e5 0%, #0ea5e9 100%);
+  color: white;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem;
+  text-align: center;
+  border-radius: 12px;
+}
+
+.peel-layer-back h2 {
+  margin: 0 0 1rem;
+  font-size: 1.8rem;
+  font-weight: 700;
+}
+
+.peel-layer-back p {
+  margin: 0;
+  opacity: 0.9;
+  line-height: 1.5;
+  font-size: 1rem;
+}
+
+/* Front Layer (The peeling part) */
+.peel-layer-front {
+  position: absolute;
+  inset: 0;
+  background: #ffffff;
+  color: #111827;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  border-radius: 12px;
+  
+  /* Initial state: Full polygon */
+  clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
+  transition: clip-path 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.peel-layer-front h2 {
+  font-size: 1.8rem;
+  font-weight: 600;
+  color: #374151;
+}
+
+/* The Fold Element */
+.peel-fold {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 0;
+  height: 0;
+  
+  /* Diagonal gradient from bottom-right (transparent) to top-left (solid fold) */
+  background: linear-gradient(-45deg, transparent 50%, rgba(255, 255, 255, 0.95) 50.1%, #e5e7eb 100%);
+  
+  /* Drop shadow only applies to the non-transparent part of the gradient */
+  filter: drop-shadow(-3px -3px 8px rgba(0, 0, 0, 0.15));
+  
+  transition: all 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+  pointer-events: none;
+  border-bottom-right-radius: 12px;
+}
+
+/* Hover and Focus States */
+.peel-container:hover .peel-layer-front,
+.peel-container:focus .peel-layer-front {
+  /* Cut the bottom right corner */
+  clip-path: polygon(0 0, 100% 0, 100% calc(100% - 150px), calc(100% - 150px) 100%, 0 100%);
+}
+
+.peel-container:hover .peel-fold,
+.peel-container:focus .peel-fold {
+  /* Size of the fold */
+  width: 150px;
+  height: 150px;
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a new pure CSS sticker peel transition effect (Issue #70257). It leverages modern CSS like `clip-path` and `drop-shadow` to create an elegant animation where a top layer seamlessly peels away from the bottom corner on hover, revealing the underlying content. The fold dynamically sizes itself and casts a realistic shadow over the underlying content without requiring any JavaScript.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

This adds a pure CSS page transition where the top layer gracefully peels away from the bottom corner to reveal the content underneath, resembling a peeling sticker.

**How does a developer use it?**

```html
<div class="peel-container" tabindex="0">
  <div class="peel-layer-back">
    <!-- Content to reveal -->
  </div>
  <div class="peel-layer-front">
    <!-- Top layer content -->
  </div>
  <div class="peel-fold"></div>
</div>
