### PR TITLE
feat: implement CSS Combo Streak Counter #70955

### DIFF
--- a/submissions/examples/css-combo-streak-counter/README.md
+++ b/submissions/examples/css-combo-streak-counter/README.md
@@ -1,0 +1,13 @@
+# CSS Combo Streak Counter (#70955)
+
+Pure CSS combo counter component that scales in size and triggers screen-shake animation feedback on successive hits or streak milestones.
+
+## Features
+- **Multi-Level Shake Physics:** Tiered `@keyframes` shake intensity (small, medium, large, ultra) corresponding to combo count milestones.
+- **Dynamic Scale Growth:** Badge scale increases progressively (`scale(1)` up to `scale(1.7)`) with neon drop-shadow glow transitions.
+- **Pure CSS Execution:** Driven via radio `:checked` state selectors with zero JavaScript dependencies.
+- **Accessible & Motion Friendly:** Includes `aria-live="polite"` live region support and full `@media (prefers-reduced-motion: reduce)` compliance.
+
+## Structure
+- `style.css` - Keyframe shake animations, scale dynamics, theme variables, and accessibility overrides.
+- `demo.html` - Interactive demo displaying the combo badge and streak milestone triggers.

--- a/submissions/examples/css-combo-streak-counter/demo.html
+++ b/submissions/examples/css-combo-streak-counter/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Combo Streak Counter | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="combo-card" aria-label="Combo Streak Counter Interactive Demo">
+    <header class="combo-header">
+      <h1>CSS Combo Streak Counter</h1>
+      <p>Select streak milestones to trigger proportional scaling and screen shake physics.</p>
+    </header>
+
+    <!-- Hidden Radio State Triggers -->
+    <input type="radio" name="streak-level" id="streak-1" checked aria-label="Streak Level 1: Single hit">
+    <input type="radio" name="streak-level" id="streak-5" aria-label="Streak Level 5: 5 Combo">
+    <input type="radio" name="streak-level" id="streak-10" aria-label="Streak Level 10: 10 Super Combo">
+    <input type="radio" name="streak-level" id="streak-25" aria-label="Streak Level 25: 25 Ultra Combo">
+
+    <!-- Streak Level Selectors -->
+    <nav class="streak-nav" aria-label="Select combo streak hit count">
+      <label for="streak-1" class="streak-btn">1x Hit</label>
+      <label for="streak-5" class="streak-btn">5x Combo</label>
+      <label for="streak-10" class="streak-btn">10x Super</label>
+      <label for="streak-25" class="streak-btn">25x Ultra</label>
+    </nav>
+
+    <!-- Visualizer Stage -->
+    <div class="combo-stage" aria-live="polite" aria-atomic="true">
+      <div class="combo-badge" role="status" aria-label="Current combo multiplier">
+        <span class="combo-count">25x</span>
+        <span class="combo-label">COMBO STREAK</span>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/css-combo-streak-counter/style.css
+++ b/submissions/examples/css-combo-streak-counter/style.css
@@ -1,0 +1,217 @@
+/* CSS Combo Streak Counter #70955 */
+
+:root {
+  --bg-color: #0f172a;
+  --card-bg: #1e293b;
+  --border-color: #334155;
+  --text-main: #f8fafc;
+  --text-sub: #94a3b8;
+  --combo-low: #38bdf8;
+  --combo-mid: #f59e0b;
+  --combo-high: #ef4444;
+  --combo-ultra: #a855f7;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 2rem 1rem;
+  background-color: var(--bg-color);
+  color: var(--text-main);
+  font-family: system-ui, -apple-system, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.combo-card {
+  width: 100%;
+  max-width: 480px;
+  background-color: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 20px;
+  padding: 2rem;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 1.5rem;
+  position: relative;
+}
+
+.combo-header h1 {
+  font-size: 1.4rem;
+  margin: 0 0 0.25rem 0;
+}
+
+.combo-header p {
+  color: var(--text-sub);
+  font-size: 0.875rem;
+  margin: 0;
+}
+
+/* Hidden Radio Inputs for Combo Streak Progression */
+.combo-card input[type="radio"] {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* Streak Control Buttons */
+.streak-nav {
+  display: flex;
+  gap: 0.5rem;
+  width: 100%;
+  justify-content: center;
+}
+
+.streak-btn {
+  flex: 1;
+  padding: 0.6rem 0.4rem;
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--text-sub);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  user-select: none;
+}
+
+.streak-btn:hover {
+  border-color: var(--combo-low);
+  color: var(--text-main);
+}
+
+/* Stage Area */
+.combo-stage {
+  width: 100%;
+  height: 200px;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid var(--border-color);
+  border-radius: 14px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  overflow: hidden;
+}
+
+/* Combo Badge Display */
+.combo-badge {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275), filter 0.3s ease;
+}
+
+.combo-count {
+  font-size: 4rem;
+  font-weight: 900;
+  line-height: 1;
+  color: var(--combo-low);
+  text-shadow: 0 0 15px rgba(56, 189, 248, 0.4);
+}
+
+.combo-label {
+  font-size: 0.9rem;
+  font-weight: 800;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--text-sub);
+  margin-top: 0.25rem;
+}
+
+/* Radio Checked Dynamics & Shake Intensity Levels */
+#streak-1:checked ~ .streak-nav label[for="streak-1"],
+#streak-5:checked ~ .streak-nav label[for="streak-5"],
+#streak-10:checked ~ .streak-nav label[for="streak-10"],
+#streak-25:checked ~ .streak-nav label[for="streak-25"] {
+  background: rgba(56, 189, 248, 0.15);
+  border-color: var(--combo-low);
+  color: var(--text-main);
+}
+
+/* Streak Level 1 (x1 Hit) */
+#streak-1:checked ~ .combo-stage .combo-badge {
+  transform: scale(1);
+  animation: shake-sm 0.3s ease-in-out;
+}
+#streak-1:checked ~ .combo-stage .combo-count { color: var(--combo-low); }
+
+/* Streak Level 2 (x5 Combo) */
+#streak-5:checked ~ .combo-stage .combo-badge {
+  transform: scale(1.2);
+  animation: shake-md 0.35s ease-in-out;
+}
+#streak-5:checked ~ .combo-stage .combo-count {
+  color: var(--combo-mid);
+  text-shadow: 0 0 20px rgba(245, 158, 11, 0.5);
+}
+
+/* Streak Level 3 (x10 Super Combo) */
+#streak-10:checked ~ .combo-stage .combo-badge {
+  transform: scale(1.45);
+  animation: shake-lg 0.4s ease-in-out;
+}
+#streak-10:checked ~ .combo-stage .combo-count {
+  color: var(--combo-high);
+  text-shadow: 0 0 25px rgba(239, 68, 68, 0.6);
+}
+
+/* Streak Level 4 (x25 Ultra Combo) */
+#streak-25:checked ~ .combo-stage .combo-badge {
+  transform: scale(1.7);
+  animation: shake-xl 0.45s ease-in-out infinite alternate;
+}
+#streak-25:checked ~ .combo-stage .combo-count {
+  color: var(--combo-ultra);
+  text-shadow: 0 0 30px rgba(168, 85, 247, 0.8);
+}
+
+/* Keyboard focus indicators */
+.combo-card input[type="radio"]:focus-visible ~ .streak-nav label[for="streak-1"],
+.combo-card input[type="radio"]:focus-visible ~ .streak-nav label[for="streak-5"],
+.combo-card input[type="radio"]:focus-visible ~ .streak-nav label[for="streak-10"],
+.combo-card input[type="radio"]:focus-visible ~ .streak-nav label[for="streak-25"] {
+  outline: 2px solid var(--combo-low);
+  outline-offset: 2px;
+}
+
+/* Shake Keyframes */
+@keyframes shake-sm {
+  0%, 100% { transform: scale(1) translate(0, 0); }
+  25% { transform: scale(1.05) translate(-2px, 2px); }
+  75% { transform: scale(1.05) translate(2px, -2px); }
+}
+
+@keyframes shake-md {
+  0%, 100% { transform: scale(1.2) translate(0, 0); }
+  20% { transform: scale(1.25) translate(-4px, 3px) rotate(-2deg); }
+  60% { transform: scale(1.25) translate(4px, -3px) rotate(2deg); }
+}
+
+@keyframes shake-lg {
+  0%, 100% { transform: scale(1.45) translate(0, 0); }
+  20% { transform: scale(1.5) translate(-6px, 5px) rotate(-4deg); }
+  60% { transform: scale(1.5) translate(6px, -5px) rotate(4deg); }
+}
+
+@keyframes shake-xl {
+  0% { transform: scale(1.7) translate(-5px, 4px) rotate(-5deg); }
+  100% { transform: scale(1.75) translate(5px, -4px) rotate(5deg); }
+}
+
+/* Reduced Motion Fallback */
+@media (prefers-reduced-motion: reduce) {
+  .combo-badge {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the CSS Combo Streak Counter component (#70955).
gssoc 26

Closes #70955

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/css-combo-streak-counter/`
- [x] `style.css`, `demo.html`, and `README.md` included
- [x] Automated commit correctly formatted

---

## Feature Description
**What does this add?**
A combo counter component that grows in size and executes increasingly intense shake animations on successive hits or streak milestones.

**How does it work?**
Combines CSS `:checked` pseudo-class state selection with custom multi-tier shake `@keyframes` and scaling transforms (`scale(1)` to `scale(1.7)`), rendering high-energy streak feedback without JavaScript.

---

## Notes for Maintainer
Zero JavaScript dependencies. Fully accessible with keyboard focus indicators, `aria-live="polite"` live regions, and `prefers-reduced-motion` fallbacks.