### PR TITLE
feat: implement CSS Overlap Image Grid #70969

### DIFF
--- a/submissions/examples/css-overlap-image-grid/README.md
+++ b/submissions/examples/css-overlap-image-grid/README.md
@@ -1,0 +1,13 @@
+# CSS Overlap Image Grid (#70969)
+
+Pure CSS layered grid composition where items overlap each other using z-index hierarchy, dynamically promoting hovered or focused elements to the foreground.
+
+## Features
+- **CSS Grid Layering:** Utilizes overlapping grid column and row spans to construct composite card layouts.
+- **Dynamic Z-Index Elevation:** Elevates hovered (`:hover`) and focused (`:focus-within`) items to `z-index: 10` with scale physics.
+- **Pure CSS Implementation:** Zero JavaScript required for layout recalculations or stack ordering.
+- **Accessible & Responsive:** Screen reader accessible links, focus ring indicators, and full `@media (prefers-reduced-motion: reduce)` support.
+
+## Structure
+- `style.css` - Component grid template, overlap spans, layering rules, and interactive transform state.
+- `demo.html` - Interactive demo featuring three layered gallery cards.

--- a/submissions/examples/css-overlap-image-grid/demo.html
+++ b/submissions/examples/css-overlap-image-grid/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Overlap Image Grid | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-card" aria-label="Overlapping Image Grid Component">
+    <header class="demo-header">
+      <h1>CSS Overlap Image Grid</h1>
+      <p>Layered grid composition with z-index elevation on focus and hover.</p>
+    </header>
+
+    <div class="overlap-grid" role="region" aria-label="Overlapping image gallery">
+      <!-- Item 1 -->
+      <article class="overlap-item overlap-item-1">
+        <a href="#gallery-1" class="overlap-item-link" aria-label="View Layer 1 Gallery Item">
+          <div class="overlap-item-content bg-grad-1">
+            <span class="overlap-item-caption">Layer 1 — Base View</span>
+          </div>
+        </a>
+      </article>
+
+      <!-- Item 2 -->
+      <article class="overlap-item overlap-item-2">
+        <a href="#gallery-2" class="overlap-item-link" aria-label="View Layer 2 Gallery Item">
+          <div class="overlap-item-content bg-grad-2">
+            <span class="overlap-item-caption">Layer 2 — Mid Offset</span>
+          </div>
+        </a>
+      </article>
+
+      <!-- Item 3 -->
+      <article class="overlap-item overlap-item-3">
+        <a href="#gallery-3" class="overlap-item-link" aria-label="View Layer 3 Gallery Item">
+          <div class="overlap-item-content bg-grad-3">
+            <span class="overlap-item-caption">Layer 3 — Top Overlay</span>
+          </div>
+        </a>
+      </article>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/css-overlap-image-grid/style.css
+++ b/submissions/examples/css-overlap-image-grid/style.css
@@ -1,0 +1,170 @@
+/* CSS Overlap Image Grid #70969 */
+
+:root {
+  --bg-color: #0f172a;
+  --card-bg: #1e293b;
+  --border-color: #334155;
+  --text-main: #f8fafc;
+  --text-sub: #94a3b8;
+  --accent-color: #38bdf8;
+  --accent-glow: rgba(56, 189, 248, 0.35);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 2rem 1rem;
+  background-color: var(--bg-color);
+  color: var(--text-main);
+  font-family: system-ui, -apple-system, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.demo-card {
+  width: 100%;
+  max-width: 600px;
+  background-color: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 20px;
+  padding: 2rem;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.demo-header h1 {
+  font-size: 1.4rem;
+  margin: 0 0 0.25rem 0;
+}
+
+.demo-header p {
+  color: var(--text-sub);
+  font-size: 0.875rem;
+  margin: 0;
+}
+
+/* Overlapping Grid Layout */
+.overlap-grid {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  grid-template-rows: repeat(8, 40px);
+  gap: 0;
+  position: relative;
+  width: 100%;
+  margin: 1rem 0;
+}
+
+/* Grid Items & Z-Index Layering */
+.overlap-item {
+  position: relative;
+  border-radius: 14px;
+  overflow: hidden;
+  border: 2px solid var(--border-color);
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.5);
+  transition: transform 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275), 
+              z-index 0.3s ease, 
+              border-color 0.3s ease, 
+              box-shadow 0.3s ease;
+  cursor: pointer;
+}
+
+.overlap-item-1 {
+  grid-column: 1 / span 7;
+  grid-row: 1 / span 5;
+  z-index: 1;
+}
+
+.overlap-item-2 {
+  grid-column: 5 / span 8;
+  grid-row: 3 / span 5;
+  z-index: 2;
+}
+
+.overlap-item-3 {
+  grid-column: 3 / span 7;
+  grid-row: 5 / span 4;
+  z-index: 3;
+}
+
+/* Hover & Focus State Transformations */
+.overlap-item:hover,
+.overlap-item:focus-within {
+  z-index: 10 !important;
+  transform: scale(1.06) translateY(-4px);
+  border-color: var(--accent-color);
+  box-shadow: 0 20px 35px rgba(0, 0, 0, 0.7), 0 0 20px var(--accent-glow);
+  outline: none;
+}
+
+.overlap-item-link {
+  display: block;
+  width: 100%;
+  height: 100%;
+  text-decoration: none;
+  color: inherit;
+  outline: none;
+}
+
+.overlap-item-link:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: -2px;
+}
+
+/* SVG Placeholder Styling */
+.overlap-item-content {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  padding: 1rem;
+  background-size: cover;
+  background-position: center;
+  position: relative;
+}
+
+.bg-grad-1 {
+  background: linear-gradient(135deg, #1e3a8a, #3b82f6);
+}
+
+.bg-grad-2 {
+  background: linear-gradient(135deg, #7c3aed, #c084fc);
+}
+
+.bg-grad-3 {
+  background: linear-gradient(135deg, #059669, #34d399);
+}
+
+.overlap-item-caption {
+  position: relative;
+  z-index: 2;
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #ffffff;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.6);
+}
+
+/* Responsive Scaling */
+@media (max-width: 480px) {
+  .overlap-grid {
+    grid-template-rows: repeat(8, 30px);
+  }
+}
+
+/* Reduced Motion Support */
+@media (prefers-reduced-motion: reduce) {
+  .overlap-item {
+    transition: none !important;
+  }
+  .overlap-item:hover,
+  .overlap-item:focus-within {
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the CSS Overlap Image Grid component (#70969).
gssoc 26

Closes #70969

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/css-overlap-image-grid/`
- [x] `style.css`, `demo.html`, and `README.md` included
- [x] Automated commit correctly formatted

---

## Feature Description
**What does this add?**
An overlapping grid component where images/cards layer over one another with explicit z-index hierarchy and lift into focus on hover/keyboard navigation.

**How does it work?**
Exploits overlapping CSS Grid tracks (shared grid-column and grid-row areas) alongside `:hover` and `:focus-within` z-index elevation and scale transforms without JavaScript.

---

## Notes for Maintainer
Zero JavaScript dependencies. Accessible implementation using semantic `<article>` containers, anchor tab indexing, focus ring indicators, and `prefers-reduced-motion` fallbacks.