### PR TITLE
feat: implement CSS Snow Covered Text #70966

### DIFF
--- a/submissions/examples/css-snow-covered-text/README.md
+++ b/submissions/examples/css-snow-covered-text/README.md
@@ -1,0 +1,13 @@
+# CSS Snow Covered Text (#70966)
+
+Pure CSS winter typography effect featuring dynamic snow accumulation caps on top of letters and background snowfall animation.
+
+## Features
+- **Pure CSS Snow Caps:** Uses radial gradient text masking (`background-clip: text`) on pseudo-elements to render realistic snow caps over individual letterheads.
+- **Ambient CSS Snowfall:** Multi-layer particle snowfall using repeated `radial-gradient` keyframe translations.
+- **Zero JavaScript Dependencies:** Built entirely with pure CSS variables, pseudo-elements, and keyframe physics.
+- **Accessible & Responsive:** Screen reader accessible text structures, responsive typography scaling, and full `prefers-reduced-motion` compliance.
+
+## Structure
+- `style.css` - Radial gradient text clipping, keyframe animations, snow cap layering, and accessibility overrides.
+- `demo.html` - Interactive demo featuring snow-covered heading presentation.

--- a/submissions/examples/css-snow-covered-text/demo.html
+++ b/submissions/examples/css-snow-covered-text/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Snow Covered Text | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="snow-card" aria-label="Snow Covered Text Effect Demo">
+    <header class="snow-header">
+      <h1>CSS Snow Covered Text</h1>
+      <p>Pure CSS typography snow cap accumulation and ambient snowfall effect.</p>
+    </header>
+
+    <div class="snow-stage" role="region" aria-label="Snow text visualizer stage">
+      <div class="snow-text-wrapper">
+        <h2 class="snow-text" aria-label="WINTER">WINTER</h2>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/css-snow-covered-text/style.css
+++ b/submissions/examples/css-snow-covered-text/style.css
@@ -1,0 +1,188 @@
+/* CSS Snow Covered Text #70966 */
+
+:root {
+  --bg-color: #0b1329;
+  --card-bg: #131e3a;
+  --border-color: #21325e;
+  --text-main: #f8fafc;
+  --text-sub: #94a3b8;
+  --snow-white: #ffffff;
+  --snow-shadow: rgba(255, 255, 255, 0.25);
+  --ice-accent: #38bdf8;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 2rem 1rem;
+  background-color: var(--bg-color);
+  color: var(--text-main);
+  font-family: system-ui, -apple-system, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.snow-card {
+  width: 100%;
+  max-width: 520px;
+  background-color: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 20px;
+  padding: 2.5rem 2rem;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 1.5rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.snow-header h1 {
+  font-size: 1.3rem;
+  margin: 0 0 0.25rem 0;
+}
+
+.snow-header p {
+  color: var(--text-sub);
+  font-size: 0.875rem;
+  margin: 0;
+}
+
+/* Stage Area */
+.snow-stage {
+  width: 100%;
+  height: 180px;
+  background: rgba(11, 19, 41, 0.7);
+  border: 1px solid var(--border-color);
+  border-radius: 14px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  overflow: hidden;
+}
+
+/* Snow Covered Typography Container */
+.snow-text-wrapper {
+  position: relative;
+  display: inline-block;
+  padding: 0 1rem;
+}
+
+/* Core Bold Text */
+.snow-text {
+  font-size: 4rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  color: var(--text-main);
+  text-transform: uppercase;
+  position: relative;
+  z-index: 1;
+  margin: 0;
+  line-height: 1;
+  text-shadow: 0 4px 12px rgba(0, 0, 0, 0.6);
+}
+
+/* Accumulated Snow Cap Effect via Pseudo-Element */
+.snow-text-wrapper::before {
+  content: "WINTER";
+  position: absolute;
+  top: -6px;
+  left: 1rem;
+  right: 1rem;
+  font-size: 4rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: transparent;
+  z-index: 2;
+  line-height: 1;
+  pointer-events: none;
+  
+  /* Snow Caps Shader Mask */
+  background: radial-gradient(circle at 50% 15%, var(--snow-white) 65%, transparent 70%);
+  background-size: 0.38em 0.38em;
+  background-repeat: repeat-x;
+  background-position: top left;
+  -webkit-background-clip: text;
+  background-clip: text;
+  
+  filter: drop-shadow(0 2px 4px rgba(255, 255, 255, 0.8));
+  animation: snow-accumulate 4s ease-in-out infinite alternate;
+}
+
+/* Subtle Snowfall Particles */
+.snow-stage::before,
+.snow-stage::after {
+  content: "";
+  position: absolute;
+  top: -100%;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-image: 
+    radial-gradient(4px 4px at 20px 30px, var(--snow-white), transparent),
+    radial-gradient(3px 3px at 80px 70px, var(--snow-white), transparent),
+    radial-gradient(5px 5px at 150px 40px, var(--snow-white), transparent),
+    radial-gradient(3px 3px at 220px 80px, var(--snow-white), transparent),
+    radial-gradient(4px 4px at 300px 20px, var(--snow-white), transparent),
+    radial-gradient(5px 5px at 380px 60px, var(--snow-white), transparent);
+  background-size: 400px 200px;
+  animation: snowfall 6s linear infinite;
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.snow-stage::after {
+  animation-duration: 9s;
+  animation-delay: -3s;
+  opacity: 0.3;
+}
+
+/* Accumulation Animation */
+@keyframes snow-accumulate {
+  0% {
+    filter: drop-shadow(0 1px 2px rgba(255, 255, 255, 0.4));
+    transform: translateY(2px);
+  }
+  100% {
+    filter: drop-shadow(0 3px 8px rgba(255, 255, 255, 0.9));
+    transform: translateY(0);
+  }
+}
+
+@keyframes snowfall {
+  0% {
+    transform: translateY(0);
+  }
+  100% {
+    transform: translateY(200px);
+  }
+}
+
+/* Accessibility Focus States & Reduced Motion */
+.snow-card:focus-within {
+  border-color: var(--ice-accent);
+}
+
+@media (max-width: 480px) {
+  .snow-text,
+  .snow-text-wrapper::before {
+    font-size: 2.8rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .snow-text-wrapper::before,
+  .snow-stage::before,
+  .snow-stage::after {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the CSS Snow Covered Text component (#70966).
gssoc 26

Closes #70966

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/css-snow-covered-text/`
- [x] `style.css`, `demo.html`, and `README.md` included
- [x] Automated commit correctly formatted

---

## Feature Description
**What does this add?**
A winter typography component displaying snow accumulating on top of letterheads alongside ambient background snowfall.

**How does it work?**
Exploits radial gradient background masking clipped to text (`-webkit-background-clip: text`) on pseudo-elements layered above bold typography, combined with keyframe CSS translate physics without JavaScript.

---

## Notes for Maintainer
Zero JavaScript dependencies. Accessible semantic layout with screen reader `aria-label` tags and full `@media (prefers-reduced-motion: reduce)` fallbacks.