### PR TITLE
feat: implement CSS Typewriter Delete Loop #70924

### DIFF
--- a/submissions/examples/css-typewriter-delete-loop/README.md
+++ b/submissions/examples/css-typewriter-delete-loop/README.md
@@ -1,0 +1,13 @@
+# CSS Typewriter Delete Loop (#70924)
+
+Pure CSS endless typewriter typing and deletion loop with blinking cursor caret effect.
+
+## Features
+- **Pure CSS Keyframe Mechanics:** Uses `ch` width units and `steps()` timing functions to simulate realistic character-by-character typing and backspacing without JavaScript.
+- **Blinking Caret Effect:** Integrated step-based border keyframe animation simulating terminal input cursors.
+- **Zero JavaScript Dependencies:** Built entirely with native CSS variables and `@keyframes`.
+- **Accessible & Responsive:** Screen reader accessible `aria-label` declarations, responsive font scaling, and `prefers-reduced-motion` compliance.
+
+## Structure
+- `style.css` - Typewriting keyframes, step functions, blinking cursor styling, and motion accessibility overrides.
+- `demo.html` - Interactive demo showcasing the looping typewriter effect.

--- a/submissions/examples/css-typewriter-delete-loop/demo.html
+++ b/submissions/examples/css-typewriter-delete-loop/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Typewriter Delete Loop | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="typewriter-card" aria-label="CSS Typewriter Delete Loop Demo">
+    <header class="typewriter-header">
+      <h1>CSS Typewriter Delete Loop</h1>
+      <p>Endless pure CSS typing and backspacing animation loop with terminal caret effect.</p>
+    </header>
+
+    <div class="typewriter-stage" role="region" aria-label="Typewriter animation stage">
+      <div class="typewriter-container">
+        <span class="typewriter-text" aria-label="Pure CSS Motion Engine"></span>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/css-typewriter-delete-loop/style.css
+++ b/submissions/examples/css-typewriter-delete-loop/style.css
@@ -1,0 +1,136 @@
+/* CSS Typewriter Delete Loop #70924 */
+
+:root {
+  --bg-color: #0f172a;
+  --card-bg: #1e293b;
+  --border-color: #334155;
+  --text-main: #f8fafc;
+  --text-sub: #94a3b8;
+  --accent-color: #38bdf8;
+  --caret-color: #38bdf8;
+  --accent-glow: rgba(56, 189, 248, 0.4);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 2rem 1rem;
+  background-color: var(--bg-color);
+  color: var(--text-main);
+  font-family: system-ui, -apple-system, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.typewriter-card {
+  width: 100%;
+  max-width: 580px;
+  background-color: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 20px;
+  padding: 2.5rem 2rem;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 1.5rem;
+}
+
+.typewriter-header h1 {
+  font-size: 1.3rem;
+  margin: 0 0 0.25rem 0;
+}
+
+.typewriter-header p {
+  color: var(--text-sub);
+  font-size: 0.875rem;
+  margin: 0;
+}
+
+/* Typewriter Stage Box */
+.typewriter-stage {
+  width: 100%;
+  padding: 2rem 1rem;
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid var(--border-color);
+  border-radius: 14px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 120px;
+}
+
+/* Typewriter Container */
+.typewriter-container {
+  display: inline-flex;
+  align-items: center;
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 1.8rem;
+  font-weight: 700;
+  color: var(--text-main);
+}
+
+/* Typing & Deleting Animated Element */
+.typewriter-text {
+  position: relative;
+  display: inline-block;
+  white-space: nowrap;
+  overflow: hidden;
+  border-right: 3px solid var(--caret-color);
+  width: 0;
+  animation: 
+    typewrite-delete 6s steps(22, end) infinite,
+    blink-caret 0.75s step-end infinite;
+}
+
+.typewriter-text::before {
+  content: "Pure CSS Motion Engine";
+  color: var(--accent-color);
+}
+
+/* Keyframe Animations */
+@keyframes typewrite-delete {
+  0% {
+    width: 0;
+  }
+  30%, 55% {
+    width: 22ch; /* Full length of text */
+  }
+  85%, 100% {
+    width: 0;
+  }
+}
+
+@keyframes blink-caret {
+  from, to {
+    border-color: transparent;
+  }
+  50% {
+    border-color: var(--caret-color);
+  }
+}
+
+/* Accessibility Focus States & Motion Preferences */
+.typewriter-card:focus-within {
+  border-color: var(--accent-color);
+}
+
+@media (max-width: 580px) {
+  .typewriter-container {
+    font-size: 1.2rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .typewriter-text {
+    animation: blink-caret 0.75s step-end infinite !important;
+    width: auto !important;
+    border-right: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the CSS Typewriter Delete Loop component (#70924).
gssoc 26

Closes #70924

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/css-typewriter-delete-loop/`
- [x] `style.css`, `demo.html`, and `README.md` included
- [x] Automated commit correctly formatted

---

## Feature Description
**What does this add?**
A typography component that types out text character-by-character, pauses, backspaces/deletes the text, and repeats in an infinite loop.

**How does it work?**
Combines CSS `@keyframes` manipulating element `width` using `ch` units alongside `steps()` animation timing functions and a blinking cursor border effect.

---

## Notes for Maintainer
Zero JavaScript dependencies. Accessible implementation featuring explicit `aria-label` text for screen readers and `@media (prefers-reduced-motion: reduce)` fallbacks.