### PR TITLE
feat: add ease-gyrocompass-precession (#71658)

### DIFF
--- a/submissions/examples/gyrocompass-precession-ns/README.md
+++ b/submissions/examples/gyrocompass-precession-ns/README.md
@@ -1,0 +1,16 @@
+# Gyrocompass Precession
+
+## What does this do?
+Renders a self-contained CSS-only `ease-gyrocompass-precession` demo: Spinning gyro rotor with slow azimuth precession of the compass card.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-gyrocompass-precession`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-gyrocompass-precession">
+  <div class="ease-gyrocompass-precession__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/gyrocompass-precession-ns/demo.html
+++ b/submissions/examples/gyrocompass-precession-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Gyrocompass Precession — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Gyrocompass Precession demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Gyrocompass Precession</h1>
+      <p class="lede">Spinning gyro rotor with slow azimuth precession of the compass card</p>
+    </header>
+
+    <section class="ease-gyrocompass-precession" data-demo="gyrocompass-precession" aria-live="polite">
+      <div class="ease-gyrocompass-precession__housing">
+        <div class="ease-gyrocompass-precession__bezel">
+          <div class="ease-gyrocompass-precession__face">
+            <div class="ease-gyrocompass-precession__readout">
+              <span class="ease-gyrocompass-precession__label">Gyrocompass Precession</span>
+              <span class="ease-gyrocompass-precession__value">LIVE</span>
+            </div>
+            <div class="ease-gyrocompass-precession__motion" aria-hidden="true">
+              <span class="ease-gyrocompass-precession__a"></span>
+              <span class="ease-gyrocompass-precession__b"></span>
+              <span class="ease-gyrocompass-precession__c"></span>
+              <span class="ease-gyrocompass-precession__d"></span>
+            </div>
+            <div class="ease-gyrocompass-precession__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-gyrocompass-precession__controls">
+          <button type="button" class="ease-gyrocompass-precession__btn primary">Engage</button>
+          <button type="button" class="ease-gyrocompass-precession__btn">Reset</button>
+          <label class="ease-gyrocompass-precession__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-gyrocompass-precession__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/gyrocompass-precession-ns/style.css
+++ b/submissions/examples/gyrocompass-precession-ns/style.css
@@ -1,0 +1,239 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "Sora", "Avenir Next", sans-serif;
+  background:
+    radial-gradient(ellipse at 21% 0%, color-mix(in srgb, #38bdf8 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 79% 100%, color-mix(in srgb, #7dd3fc 18%, transparent), transparent 42%),
+    #0c1016;
+}
+
+.stage {
+  width: min(648px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-gyrocompass-precession {
+  --accent: #38bdf8;
+  --accent-2: #7dd3fc;
+  --panel: color-mix(in srgb, #e8eef6 7%, #0c1016);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 16px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #0c1016 75%, #000);
+}
+
+.ease-gyrocompass-precession__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-gyrocompass-precession__bezel {
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #0c1016 90%, #38bdf8);
+}
+
+.ease-gyrocompass-precession__face {
+  position: relative;
+  min-height: 264px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 33% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #0c1016 85%, #000), color-mix(in srgb, #0c1016 65%, var(--accent-2)));
+}
+
+.ease-gyrocompass-precession__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-gyrocompass-precession__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-gyrocompass-precession__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-gyrocompass-precession__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-gyrocompass-precession__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-gyrocompass-precession__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-gyrocompass-precession__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: gyrocompass_precession_meter 1.82s ease-in-out infinite alternate;
+}
+
+.ease-gyrocompass-precession__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-gyrocompass-precession__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-gyrocompass-precession__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-gyrocompass-precession__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-gyrocompass-precession__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-gyrocompass-precession__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-gyrocompass-precession__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-gyrocompass-precession__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-gyrocompass-precession__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-gyrocompass-precession__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-gyrocompass-precession__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-gyrocompass-precession__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: gyrocompass_precession_status 2.35s ease-out infinite;
+}
+
+@keyframes gyrocompass_precession_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes gyrocompass_precession_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-gyrocompass-precession__a{position:absolute;left:20%;top:18%;width:60%;height:60%;border-radius:50%;border:2px solid color-mix(in srgb,var(--accent) 55%,transparent);background:conic-gradient(from 0deg,transparent 0 70%,color-mix(in srgb,var(--accent) 35%,transparent) 70% 100%);animation:gyrocompass_precession_spin 2.4s linear infinite}
+.ease-gyrocompass-precession__b{position:absolute;left:42%;top:40%;width:16%;height:16%;border-radius:50%;background:var(--accent);box-shadow:0 0 18px color-mix(in srgb,var(--accent) 55%,transparent);animation:gyrocompass_precession_wobble 3.6s ease-in-out infinite}
+.ease-gyrocompass-precession__c{position:absolute;left:12%;bottom:18%;width:76%;height:10px;border-radius:999px;background:color-mix(in srgb,#e8eef6 10%,transparent);overflow:hidden}
+.ease-gyrocompass-precession__c::after{content:"";display:block;width:34%;height:100%;border-radius:999px;background:linear-gradient(90deg,var(--accent-2),var(--accent));animation:gyrocompass_precession_seek 2.8s ease-in-out infinite alternate}
+.ease-gyrocompass-precession__d{position:absolute;left:50%;top:12%;width:2px;height:38%;background:linear-gradient(180deg,var(--accent),transparent);transform-origin:bottom center;animation:gyrocompass_precession_needle 3.6s ease-in-out infinite}
+
+@keyframes gyrocompass_precession_spin{to{transform:rotate(360deg)}}
+@keyframes gyrocompass_precession_wobble{0%,100%{transform:translateY(0) scale(1)}50%{transform:translateY(-6px) scale(1.12)}}
+@keyframes gyrocompass_precession_seek{from{transform:translateX(8%)}to{transform:translateX(160%)}}
+@keyframes gyrocompass_precession_needle{0%,100%{transform:rotate(-18deg)}50%{transform:rotate(22deg)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-gyrocompass-precession__a,
+  .ease-gyrocompass-precession__b,
+  .ease-gyrocompass-precession__c,
+  .ease-gyrocompass-precession__d,
+  .ease-gyrocompass-precession__meters i::after,
+  .ease-gyrocompass-precession__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-gyrocompass-precession` under `submissions/examples/gyrocompass-precession-ns/` — CSS-only Spinning gyro rotor with slow azimuth precession of the compass card.

Fixes #71658

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Spinning gyro rotor with slow azimuth precession of the compass card.

**How does a developer use it?**

```html
<section class="ease-gyrocompass-precession">
  <div class="ease-gyrocompass-precession__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `gyrocompass_precession_*` prefix. Reduced-motion disables animations.
