### PR TITLE
feat: add ease-armillary-sphere-roll (#71660)

### DIFF
--- a/submissions/examples/armillary-sphere-roll-ns/README.md
+++ b/submissions/examples/armillary-sphere-roll-ns/README.md
@@ -1,0 +1,16 @@
+# Armillary Sphere Roll
+
+## What does this do?
+Renders a self-contained CSS-only `ease-armillary-sphere-roll` demo: Nested celestial rings rolling on an armillary sphere meridian.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-armillary-sphere-roll`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-armillary-sphere-roll">
+  <div class="ease-armillary-sphere-roll__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/armillary-sphere-roll-ns/demo.html
+++ b/submissions/examples/armillary-sphere-roll-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Armillary Sphere Roll — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Armillary Sphere Roll demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Armillary Sphere Roll</h1>
+      <p class="lede">Nested celestial rings rolling on an armillary sphere meridian</p>
+    </header>
+
+    <section class="ease-armillary-sphere-roll" data-demo="armillary-sphere-roll" aria-live="polite">
+      <div class="ease-armillary-sphere-roll__housing">
+        <div class="ease-armillary-sphere-roll__bezel">
+          <div class="ease-armillary-sphere-roll__face">
+            <div class="ease-armillary-sphere-roll__readout">
+              <span class="ease-armillary-sphere-roll__label">Armillary Sphere Roll</span>
+              <span class="ease-armillary-sphere-roll__value">LIVE</span>
+            </div>
+            <div class="ease-armillary-sphere-roll__motion" aria-hidden="true">
+              <span class="ease-armillary-sphere-roll__a"></span>
+              <span class="ease-armillary-sphere-roll__b"></span>
+              <span class="ease-armillary-sphere-roll__c"></span>
+              <span class="ease-armillary-sphere-roll__d"></span>
+            </div>
+            <div class="ease-armillary-sphere-roll__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-armillary-sphere-roll__controls">
+          <button type="button" class="ease-armillary-sphere-roll__btn primary">Engage</button>
+          <button type="button" class="ease-armillary-sphere-roll__btn">Reset</button>
+          <label class="ease-armillary-sphere-roll__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-armillary-sphere-roll__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/armillary-sphere-roll-ns/style.css
+++ b/submissions/examples/armillary-sphere-roll-ns/style.css
@@ -1,0 +1,238 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "Sora", "Avenir Next", sans-serif;
+  background:
+    radial-gradient(ellipse at 21% 0%, color-mix(in srgb, #fbbf24 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 79% 100%, color-mix(in srgb, #fde68a 18%, transparent), transparent 42%),
+    #0c1016;
+}
+
+.stage {
+  width: min(648px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-armillary-sphere-roll {
+  --accent: #fbbf24;
+  --accent-2: #fde68a;
+  --panel: color-mix(in srgb, #e8eef6 7%, #0c1016);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 16px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #0c1016 75%, #000);
+}
+
+.ease-armillary-sphere-roll__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-armillary-sphere-roll__bezel {
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #0c1016 90%, #fbbf24);
+}
+
+.ease-armillary-sphere-roll__face {
+  position: relative;
+  min-height: 264px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 33% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #0c1016 85%, #000), color-mix(in srgb, #0c1016 65%, var(--accent-2)));
+}
+
+.ease-armillary-sphere-roll__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-armillary-sphere-roll__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-armillary-sphere-roll__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-armillary-sphere-roll__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-armillary-sphere-roll__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-armillary-sphere-roll__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-armillary-sphere-roll__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: armillary_sphere_roll_meter 1.95s ease-in-out infinite alternate;
+}
+
+.ease-armillary-sphere-roll__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-armillary-sphere-roll__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-armillary-sphere-roll__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-armillary-sphere-roll__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-armillary-sphere-roll__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-armillary-sphere-roll__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-armillary-sphere-roll__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-armillary-sphere-roll__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-armillary-sphere-roll__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-armillary-sphere-roll__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-armillary-sphere-roll__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-armillary-sphere-roll__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: armillary_sphere_roll_status 2.4s ease-out infinite;
+}
+
+@keyframes armillary_sphere_roll_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes armillary_sphere_roll_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-armillary-sphere-roll__a{position:absolute;left:22%;top:16%;width:56%;height:56%;border-radius:50%;border:2px solid color-mix(in srgb,var(--accent) 60%,transparent);animation:armillary_sphere_roll_outer 8s linear infinite}
+.ease-armillary-sphere-roll__b{position:absolute;left:30%;top:24%;width:40%;height:40%;border-radius:50%;border:2px dashed color-mix(in srgb,var(--accent-2) 70%,transparent);animation:armillary_sphere_roll_inner 5.5s linear infinite reverse}
+.ease-armillary-sphere-roll__c{position:absolute;left:44%;top:20%;width:12%;height:48%;border-radius:999px;background:linear-gradient(180deg,transparent,var(--accent),transparent);animation:armillary_sphere_roll_axis 4.2s ease-in-out infinite}
+.ease-armillary-sphere-roll__d{position:absolute;left:46%;top:42%;width:8%;height:8%;border-radius:50%;background:var(--accent-2);box-shadow:0 0 16px var(--accent);animation:armillary_sphere_roll_earth 2.6s ease-in-out infinite}
+
+@keyframes armillary_sphere_roll_outer{to{transform:rotate(360deg)}}
+@keyframes armillary_sphere_roll_inner{to{transform:rotate(-360deg)}}
+@keyframes armillary_sphere_roll_axis{0%,100%{transform:rotate(18deg)}50%{transform:rotate(-14deg)}}
+@keyframes armillary_sphere_roll_earth{0%,100%{transform:scale(1);opacity:.85}50%{transform:scale(1.25);opacity:1}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-armillary-sphere-roll__a,
+  .ease-armillary-sphere-roll__b,
+  .ease-armillary-sphere-roll__c,
+  .ease-armillary-sphere-roll__d,
+  .ease-armillary-sphere-roll__meters i::after,
+  .ease-armillary-sphere-roll__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-armillary-sphere-roll` under `submissions/examples/armillary-sphere-roll-ns/` — CSS-only Nested celestial rings rolling on an armillary sphere meridian.

Fixes #71660

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Nested celestial rings rolling on an armillary sphere meridian.

**How does a developer use it?**

```html
<section class="ease-armillary-sphere-roll">
  <div class="ease-armillary-sphere-roll__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `armillary_sphere_roll_*` prefix. Reduced-motion disables animations.
