### PR TITLE
feat: add ease-escape-wheel-tick (#71661)

### DIFF
--- a/submissions/examples/escape-wheel-tick-ns/README.md
+++ b/submissions/examples/escape-wheel-tick-ns/README.md
@@ -1,0 +1,16 @@
+# Escape Wheel Tick
+
+## What does this do?
+Renders a self-contained CSS-only `ease-escape-wheel-tick` demo: Watch escapement escape wheel advancing in discrete locking ticks.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-escape-wheel-tick`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-escape-wheel-tick">
+  <div class="ease-escape-wheel-tick__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/escape-wheel-tick-ns/demo.html
+++ b/submissions/examples/escape-wheel-tick-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Escape Wheel Tick — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Escape Wheel Tick demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Escape Wheel Tick</h1>
+      <p class="lede">Watch escapement escape wheel advancing in discrete locking ticks</p>
+    </header>
+
+    <section class="ease-escape-wheel-tick" data-demo="escape-wheel-tick" aria-live="polite">
+      <div class="ease-escape-wheel-tick__housing">
+        <div class="ease-escape-wheel-tick__bezel">
+          <div class="ease-escape-wheel-tick__face">
+            <div class="ease-escape-wheel-tick__readout">
+              <span class="ease-escape-wheel-tick__label">Escape Wheel Tick</span>
+              <span class="ease-escape-wheel-tick__value">LIVE</span>
+            </div>
+            <div class="ease-escape-wheel-tick__motion" aria-hidden="true">
+              <span class="ease-escape-wheel-tick__a"></span>
+              <span class="ease-escape-wheel-tick__b"></span>
+              <span class="ease-escape-wheel-tick__c"></span>
+              <span class="ease-escape-wheel-tick__d"></span>
+            </div>
+            <div class="ease-escape-wheel-tick__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-escape-wheel-tick__controls">
+          <button type="button" class="ease-escape-wheel-tick__btn primary">Engage</button>
+          <button type="button" class="ease-escape-wheel-tick__btn">Reset</button>
+          <label class="ease-escape-wheel-tick__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-escape-wheel-tick__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/escape-wheel-tick-ns/style.css
+++ b/submissions/examples/escape-wheel-tick-ns/style.css
@@ -1,0 +1,239 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "Sora", "Avenir Next", sans-serif;
+  background:
+    radial-gradient(ellipse at 21% 0%, color-mix(in srgb, #34d399 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 79% 100%, color-mix(in srgb, #6ee7b7 18%, transparent), transparent 42%),
+    #0c1016;
+}
+
+.stage {
+  width: min(648px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-escape-wheel-tick {
+  --accent: #34d399;
+  --accent-2: #6ee7b7;
+  --panel: color-mix(in srgb, #e8eef6 7%, #0c1016);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 16px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #0c1016 75%, #000);
+}
+
+.ease-escape-wheel-tick__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-escape-wheel-tick__bezel {
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #0c1016 90%, #34d399);
+}
+
+.ease-escape-wheel-tick__face {
+  position: relative;
+  min-height: 264px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 33% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #0c1016 85%, #000), color-mix(in srgb, #0c1016 65%, var(--accent-2)));
+}
+
+.ease-escape-wheel-tick__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-escape-wheel-tick__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-escape-wheel-tick__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-escape-wheel-tick__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-escape-wheel-tick__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-escape-wheel-tick__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-escape-wheel-tick__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: escape_wheel_tick_meter 1.2s ease-in-out infinite alternate;
+}
+
+.ease-escape-wheel-tick__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-escape-wheel-tick__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-escape-wheel-tick__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-escape-wheel-tick__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-escape-wheel-tick__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-escape-wheel-tick__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-escape-wheel-tick__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-escape-wheel-tick__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-escape-wheel-tick__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-escape-wheel-tick__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-escape-wheel-tick__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-escape-wheel-tick__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: escape_wheel_tick_status 1.8s ease-out infinite;
+}
+
+@keyframes escape_wheel_tick_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes escape_wheel_tick_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-escape-wheel-tick__a{position:absolute;left:28%;top:20%;width:44%;height:44%;border-radius:50%;border:3px solid color-mix(in srgb,var(--accent) 50%,transparent);background:repeating-conic-gradient(from 0deg,color-mix(in srgb,var(--accent) 40%,transparent) 0 8deg,transparent 8deg 24deg);animation:escape_wheel_tick_step 1.2s steps(15,end) infinite}
+.ease-escape-wheel-tick__b{position:absolute;left:46%;top:18%;width:8%;height:28%;background:var(--accent);transform-origin:bottom center;border-radius:2px;animation:escape_wheel_tick_pallet 1.2s steps(2,end) infinite}
+.ease-escape-wheel-tick__c{position:absolute;left:20%;bottom:22%;width:60%;height:6px;background:color-mix(in srgb,#e8eef6 12%,transparent);border-radius:3px;overflow:hidden}
+.ease-escape-wheel-tick__c::after{content:"";display:block;height:100%;width:18%;background:var(--accent-2);animation:escape_wheel_tick_impulse 1.2s steps(5,end) infinite}
+.ease-escape-wheel-tick__d{position:absolute;right:18%;top:30%;width:10px;height:10px;border-radius:50%;background:var(--accent);animation:escape_wheel_tick_lock 1.2s steps(2,start) infinite}
+
+@keyframes escape_wheel_tick_step{to{transform:rotate(360deg)}}
+@keyframes escape_wheel_tick_pallet{0%{transform:rotate(-18deg)}50%{transform:rotate(16deg)}100%{transform:rotate(-18deg)}}
+@keyframes escape_wheel_tick_impulse{to{transform:translateX(360%)}}
+@keyframes escape_wheel_tick_lock{0%,49%{opacity:1;transform:scale(1)}50%,100%{opacity:.35;transform:scale(.7)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-escape-wheel-tick__a,
+  .ease-escape-wheel-tick__b,
+  .ease-escape-wheel-tick__c,
+  .ease-escape-wheel-tick__d,
+  .ease-escape-wheel-tick__meters i::after,
+  .ease-escape-wheel-tick__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-escape-wheel-tick` under `submissions/examples/escape-wheel-tick-ns/` — CSS-only Watch escapement escape wheel advancing in discrete locking ticks.

Fixes #71661

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Watch escapement escape wheel advancing in discrete locking ticks.

**How does a developer use it?**

```html
<section class="ease-escape-wheel-tick">
  <div class="ease-escape-wheel-tick__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `escape_wheel_tick_*` prefix. Reduced-motion disables animations.
