### PR TITLE
feat: add skeleton loading list example

### DIFF
--- a/submissions/examples/skeleton-loading-list-dg/README.md
+++ b/submissions/examples/skeleton-loading-list-dg/README.md
@@ -1,0 +1,39 @@
+# Skeleton Loading List
+
+## What does this do?
+A pure CSS shimmer skeleton for a vertical list of content items (feeds, comment threads, notification lists) that placeholders content while it loads, with no JavaScript required for the animation itself.
+
+## How is it used?
+Wrap the list in a status region for accessibility, then repeat `.skeleton-item` for as many rows as you need:
+
+```html
+<div role="status" aria-live="polite" aria-busy="true">
+  <span class="sr-only">Loading list content, please wait…</span>
+
+  <ul class="skeleton-list" aria-hidden="true">
+    <li class="skeleton-item">
+      <div class="skeleton-avatar"></div>
+      <div class="skeleton-content">
+        <div class="skeleton-line skeleton-line--title"></div>
+        <div class="skeleton-line"></div>
+        <div class="skeleton-line skeleton-line--short"></div>
+      </div>
+    </li>
+    <!-- repeat .skeleton-item for as many rows as needed -->
+  </ul>
+</div>
+```
+
+Once real data arrives, hide/remove the skeleton list, render your actual content in its place, and set `aria-busy="false"` on the wrapper.
+
+Available classes:
+- `.skeleton-list` — the vertical list container (flex column)
+- `.skeleton-item` — one row (avatar + text lines)
+- `.skeleton-avatar` — circular image placeholder
+- `.skeleton-content` — stacked line container
+- `.skeleton-line` — a text-line placeholder (add `--title` or `--short` modifiers for varied widths)
+
+See `demo.html` for a full working example, including an optional (clearly-commented, demo-only) JS toggle that swaps the skeleton for sample content to illustrate the intended before/after state.
+
+## Why is it useful?
+It expands EaseMotion CSS's ready-to-use animation/component collection with a very common loading pattern, letting developers drop in a polished, accessible skeleton state without writing JS or pulling in a separate loading-state library. It's responsive out of the box, respects `prefers-reduced-motion` with a static pulse fallback instead of forcing motion on everyone, and uses proper ARIA (`role="status"`, `aria-live="polite"`, `aria-busy`, `aria-hidden` on decorative placeholders, and screen-reader-only loading text) so it fits the framework's philosophy of accessible-by-default components.

--- a/submissions/examples/skeleton-loading-list-dg/demo.html
+++ b/submissions/examples/skeleton-loading-list-dg/demo.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Skeleton Loading List — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<main style="max-width: 700px; margin: 40px auto; padding: 0 16px; font-family: system-ui, sans-serif;">
+
+  <h1 style="font-size: 20px;">Skeleton Loading List</h1>
+  <p style="color:#555; font-size: 14px;">
+    Pure CSS shimmer skeleton for a vertical list of content items (e.g. a feed,
+    comment thread, or notification list). The <code>demo-toggle</code> button below
+    is optional JavaScript included only to demonstrate the swap from skeleton to
+    real content — the skeleton and its animation work with CSS alone.
+  </p>
+
+  <button type="button" class="demo-toggle" id="toggleBtn" aria-controls="listRegion">
+    Simulate content load
+  </button>
+
+  <!--
+    aria-live="polite" + aria-busy="true": screen readers are told this region
+    is updating and shouldn't be interrupted mid-load. role="status" makes the
+    loading state itself announced politely without stealing focus.
+    Remove/flip aria-busy to "false" once real content replaces the skeleton.
+  -->
+  <div id="listRegion" role="status" aria-live="polite" aria-busy="true">
+
+    <span class="sr-only" id="loadingText">Loading list content, please wait…</span>
+
+    <ul class="skeleton-list" id="skeletonList" aria-hidden="true">
+      <li class="skeleton-item">
+        <div class="skeleton-avatar"></div>
+        <div class="skeleton-content">
+          <div class="skeleton-line skeleton-line--title"></div>
+          <div class="skeleton-line"></div>
+          <div class="skeleton-line skeleton-line--short"></div>
+        </div>
+      </li>
+      <li class="skeleton-item">
+        <div class="skeleton-avatar"></div>
+        <div class="skeleton-content">
+          <div class="skeleton-line skeleton-line--title"></div>
+          <div class="skeleton-line"></div>
+          <div class="skeleton-line skeleton-line--short"></div>
+        </div>
+      </li>
+      <li class="skeleton-item">
+        <div class="skeleton-avatar"></div>
+        <div class="skeleton-content">
+          <div class="skeleton-line skeleton-line--title"></div>
+          <div class="skeleton-line"></div>
+          <div class="skeleton-line skeleton-line--short"></div>
+        </div>
+      </li>
+      <li class="skeleton-item">
+        <div class="skeleton-avatar"></div>
+        <div class="skeleton-content">
+          <div class="skeleton-line skeleton-line--title"></div>
+          <div class="skeleton-line"></div>
+          <div class="skeleton-line skeleton-line--short"></div>
+        </div>
+      </li>
+    </ul>
+
+    <ul class="skeleton-list" id="contentList" hidden>
+      <li class="content-item">
+        <img class="avatar" src="https://i.pravatar.cc/48?img=1" alt="" />
+        <div>
+          <h3>Ananya Sharma</h3>
+          <p>Just shipped the new dashboard redesign — feedback welcome!</p>
+        </div>
+      </li>
+      <li class="content-item">
+        <img class="avatar" src="https://i.pravatar.cc/48?img=2" alt="" />
+        <div>
+          <h3>Rohit Verma</h3>
+          <p>Anyone else seeing the build fail on Node 20? Investigating now.</p>
+        </div>
+      </li>
+      <li class="content-item">
+        <img class="avatar" src="https://i.pravatar.cc/48?img=3" alt="" />
+        <div>
+          <h3>Priya Nair</h3>
+          <p>Merged the accessibility fixes for the modal component.</p>
+        </div>
+      </li>
+      <li class="content-item">
+        <img class="avatar" src="https://i.pravatar.cc/48?img=4" alt="" />
+        <div>
+          <h3>Karan Mehta</h3>
+          <p>Docs for the new API endpoints are up, take a look when you can.</p>
+        </div>
+      </li>
+    </ul>
+
+  </div>
+
+  <section style="margin-top: 48px; font-size: 13px; color: #555;">
+    <h2 style="font-size: 15px;">Usage</h2>
+    <pre style="background:#f5f5f5; padding: 12px; border-radius: 6px; overflow-x: auto;"><code>&lt;div role="status" aria-live="polite" aria-busy="true"&gt;
+  &lt;span class="sr-only"&gt;Loading list content, please wait…&lt;/span&gt;
+  &lt;ul class="skeleton-list" aria-hidden="true"&gt;
+    &lt;li class="skeleton-item"&gt;
+      &lt;div class="skeleton-avatar"&gt;&lt;/div&gt;
+      &lt;div class="skeleton-content"&gt;
+        &lt;div class="skeleton-line skeleton-line--title"&gt;&lt;/div&gt;
+        &lt;div class="skeleton-line"&gt;&lt;/div&gt;
+        &lt;div class="skeleton-line skeleton-line--short"&gt;&lt;/div&gt;
+      &lt;/div&gt;
+    &lt;/li&gt;
+    &lt;!-- repeat .skeleton-item for as many rows as needed --&gt;
+  &lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+    <p>
+      Once real data arrives, remove or hide the skeleton list, render your actual
+      list markup in its place, and set <code>aria-busy="false"</code> on the wrapper
+      so assistive tech knows loading is complete.
+    </p>
+  </section>
+
+</main>
+
+<script>
+  // Optional demo-only script: swaps the skeleton for sample content and
+  // updates the ARIA state. Not required to use the CSS component itself —
+  // in a real app you'd swap the markup when your data actually arrives.
+  (function () {
+    var btn = document.getElementById("toggleBtn");
+    var region = document.getElementById("listRegion");
+    var skeleton = document.getElementById("skeletonList");
+    var content = document.getElementById("contentList");
+    var loadingText = document.getElementById("loadingText");
+    var loaded = false;
+
+    btn.addEventListener("click", function () {
+      loaded = !loaded;
+
+      if (loaded) {
+        skeleton.hidden = true;
+        content.hidden = false;
+        region.setAttribute("aria-busy", "false");
+        loadingText.textContent = "Content loaded.";
+        btn.textContent = "Reset to loading state";
+      } else {
+        skeleton.hidden = false;
+        content.hidden = true;
+        region.setAttribute("aria-busy", "true");
+        loadingText.textContent = "Loading list content, please wait…";
+        btn.textContent = "Simulate content load";
+      }
+    });
+  })();
+</script>
+
+</body>
+</html>

--- a/submissions/examples/skeleton-loading-list-dg/style.css
+++ b/submissions/examples/skeleton-loading-list-dg/style.css
@@ -1,0 +1,226 @@
+/* ==========================================================================
+   Skeleton Loading List — EaseMotion CSS
+   Pure CSS shimmer skeleton for vertical content lists (e.g. feeds, comments,
+   notification lists). No JavaScript required for the animation itself.
+   ========================================================================== */
+
+:root {
+  --skeleton-base: #e2e2e2;
+  --skeleton-highlight: #f5f5f5;
+  --skeleton-radius: 8px;
+  --skeleton-gap: 16px;
+  --skeleton-duration: 1.5s;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --skeleton-base: #2a2a2e;
+    --skeleton-highlight: #3a3a3f;
+  }
+}
+
+/* ---- List container --------------------------------------------------- */
+
+.skeleton-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--skeleton-gap);
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 0;
+  list-style: none;
+}
+
+/* ---- Individual item ---------------------------------------------------
+   Each item is a horizontal row: avatar circle + stacked text lines.
+   Mirrors the shape of a typical list item so the swap to real content
+   causes minimal layout shift.
+   ------------------------------------------------------------------------ */
+
+.skeleton-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px;
+  border-radius: var(--skeleton-radius);
+}
+
+.skeleton-avatar {
+  flex-shrink: 0;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+}
+
+.skeleton-content {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.skeleton-line {
+  height: 12px;
+  border-radius: 4px;
+  width: 100%;
+}
+
+.skeleton-line--title {
+  height: 14px;
+  width: 55%;
+}
+
+.skeleton-line--short {
+  width: 40%;
+}
+
+/* ---- Shimmer effect ----------------------------------------------------
+   A moving gradient sweep, applied to any element carrying
+   .skeleton-avatar or .skeleton-line.
+   ------------------------------------------------------------------------ */
+
+.skeleton-avatar,
+.skeleton-line {
+  position: relative;
+  overflow: hidden;
+  background-color: var(--skeleton-base);
+}
+
+.skeleton-avatar::after,
+.skeleton-line::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background-image: linear-gradient(
+    90deg,
+    transparent 0%,
+    var(--skeleton-highlight) 50%,
+    transparent 100%
+  );
+  animation: skeleton-shimmer var(--skeleton-duration) ease-in-out infinite;
+}
+
+@keyframes skeleton-shimmer {
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+/* Respect users who don't want motion: fall back to a static, gently
+   pulsing block instead of the sweeping gradient. */
+@media (prefers-reduced-motion: reduce) {
+  .skeleton-avatar::after,
+  .skeleton-line::after {
+    animation: none;
+  }
+
+  .skeleton-avatar,
+  .skeleton-line {
+    animation: skeleton-pulse 2s ease-in-out infinite;
+  }
+
+  @keyframes skeleton-pulse {
+    0%,
+    100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.6;
+    }
+  }
+}
+
+/* ---- Responsive tweaks --------------------------------------------------
+   Smaller avatar and tighter gaps on narrow viewports.
+   ------------------------------------------------------------------------ */
+
+@media (max-width: 480px) {
+  .skeleton-list {
+    gap: 12px;
+  }
+
+  .skeleton-item {
+    padding: 10px;
+    gap: 10px;
+  }
+
+  .skeleton-avatar {
+    width: 36px;
+    height: 36px;
+  }
+
+  .skeleton-line {
+    height: 10px;
+  }
+
+  .skeleton-line--title {
+    height: 12px;
+  }
+}
+
+/* ---- Screen-reader-only helper text ------------------------------------ */
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ---- Real content list (used by the demo toggle) ------------------------
+   Shares layout classes with the skeleton so swapping the two doesn't
+   shift the page.
+   ------------------------------------------------------------------------ */
+
+.content-item img.avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  object-fit: cover;
+}
+
+.content-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px;
+  border-radius: var(--skeleton-radius);
+}
+
+.content-item h3 {
+  margin: 0 0 4px;
+  font-size: 15px;
+}
+
+.content-item p {
+  margin: 0;
+  font-size: 13px;
+  color: #666;
+}
+
+.demo-toggle {
+  display: block;
+  margin: 0 auto 24px;
+  padding: 8px 16px;
+  border-radius: 6px;
+  border: 1px solid #ccc;
+  background: #fff;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.demo-toggle:hover {
+  background: #f5f5f5;
+}
+
+[hidden] {
+  display: none !important;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pure CSS skeleton loading list — a shimmer placeholder for vertical lists of content items (feeds, comment threads, notification lists) that works without any JavaScript. Solves the common need for a polished, accessible loading state that developers currently have to hand-roll or pull in a separate library for.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/skeleton-loading-list-dg/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A pure CSS shimmer skeleton for a vertical list of content items, placeholdering content while it loads.

**How does a developer use it?**

```html
<div role="status" aria-live="polite" aria-busy="true">
  <span class="sr-only">Loading list content, please wait…</span>

  <ul class="skeleton-list" aria-hidden="true">
    <li class="skeleton-item">
      <div class="skeleton-avatar"></div>
      <div class="skeleton-content">
        <div class="skeleton-line skeleton-line--title"></div>
        <div class="skeleton-line"></div>
        <div class="skeleton-line skeleton-line--short"></div>
      </div>
    </li>
    <!-- repeat .skeleton-item for as many rows as needed -->
  </ul>
</div>
```

**Why does it fit EaseMotion CSS?**

It expands the library's ready-to-use animation/component collection with a very common loading pattern, letting developers drop in an accessible skeleton state without writing JS. It's responsive, respects `prefers-reduced-motion` with a static pulse fallback, and uses proper ARIA (`role="status"`, `aria-live`, `aria-busy`, `aria-hidden` on decorative placeholders, sr-only loading text), matching the framework's accessible-by-default, animation-first philosophy.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The shimmer sweep and colors are controlled via CSS custom properties (`--skeleton-base`, `--skeleton-highlight`, `--skeleton-duration`) for easy theming/dark-mode overrides — feel free to fold these into the framework's existing token system when standardizing to `ease-*` naming. `demo.html` includes an optional, clearly-commented JS toggle purely to illustrate swapping skeleton → real content; it's not required for the CSS component to function.