### PR TITLE
feat: add ease-spectroscope-prism-fan (#71662)

### DIFF
--- a/submissions/examples/spectroscope-prism-fan-ns/README.md
+++ b/submissions/examples/spectroscope-prism-fan-ns/README.md
@@ -1,0 +1,16 @@
+# Spectroscope Prism Fan
+
+## What does this do?
+Renders a self-contained CSS-only `ease-spectroscope-prism-fan` demo: Dispersion fan of spectral bands through a triangular prism slit.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-spectroscope-prism-fan`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-spectroscope-prism-fan">
+  <div class="ease-spectroscope-prism-fan__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/spectroscope-prism-fan-ns/demo.html
+++ b/submissions/examples/spectroscope-prism-fan-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Spectroscope Prism Fan — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Spectroscope Prism Fan demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Spectroscope Prism Fan</h1>
+      <p class="lede">Dispersion fan of spectral bands through a triangular prism slit</p>
+    </header>
+
+    <section class="ease-spectroscope-prism-fan" data-demo="spectroscope-prism-fan" aria-live="polite">
+      <div class="ease-spectroscope-prism-fan__housing">
+        <div class="ease-spectroscope-prism-fan__bezel">
+          <div class="ease-spectroscope-prism-fan__face">
+            <div class="ease-spectroscope-prism-fan__readout">
+              <span class="ease-spectroscope-prism-fan__label">Spectroscope Prism Fan</span>
+              <span class="ease-spectroscope-prism-fan__value">LIVE</span>
+            </div>
+            <div class="ease-spectroscope-prism-fan__motion" aria-hidden="true">
+              <span class="ease-spectroscope-prism-fan__a"></span>
+              <span class="ease-spectroscope-prism-fan__b"></span>
+              <span class="ease-spectroscope-prism-fan__c"></span>
+              <span class="ease-spectroscope-prism-fan__d"></span>
+            </div>
+            <div class="ease-spectroscope-prism-fan__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-spectroscope-prism-fan__controls">
+          <button type="button" class="ease-spectroscope-prism-fan__btn primary">Engage</button>
+          <button type="button" class="ease-spectroscope-prism-fan__btn">Reset</button>
+          <label class="ease-spectroscope-prism-fan__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-spectroscope-prism-fan__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/spectroscope-prism-fan-ns/style.css
+++ b/submissions/examples/spectroscope-prism-fan-ns/style.css
@@ -1,0 +1,239 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "Sora", "Avenir Next", sans-serif;
+  background:
+    radial-gradient(ellipse at 21% 0%, color-mix(in srgb, #f472b6 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 79% 100%, color-mix(in srgb, #22d3ee 18%, transparent), transparent 42%),
+    #0c1016;
+}
+
+.stage {
+  width: min(648px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-spectroscope-prism-fan {
+  --accent: #f472b6;
+  --accent-2: #22d3ee;
+  --panel: color-mix(in srgb, #e8eef6 7%, #0c1016);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 16px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #0c1016 75%, #000);
+}
+
+.ease-spectroscope-prism-fan__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-spectroscope-prism-fan__bezel {
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #0c1016 90%, #f472b6);
+}
+
+.ease-spectroscope-prism-fan__face {
+  position: relative;
+  min-height: 264px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 33% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #0c1016 85%, #000), color-mix(in srgb, #0c1016 65%, var(--accent-2)));
+}
+
+.ease-spectroscope-prism-fan__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-spectroscope-prism-fan__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-spectroscope-prism-fan__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-spectroscope-prism-fan__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-spectroscope-prism-fan__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-spectroscope-prism-fan__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-spectroscope-prism-fan__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: spectroscope_prism_fan_meter 1.68s ease-in-out infinite alternate;
+}
+
+.ease-spectroscope-prism-fan__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-spectroscope-prism-fan__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-spectroscope-prism-fan__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-spectroscope-prism-fan__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-spectroscope-prism-fan__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-spectroscope-prism-fan__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-spectroscope-prism-fan__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-spectroscope-prism-fan__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-spectroscope-prism-fan__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-spectroscope-prism-fan__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-spectroscope-prism-fan__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-spectroscope-prism-fan__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: spectroscope_prism_fan_status 2.15s ease-out infinite;
+}
+
+@keyframes spectroscope_prism_fan_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes spectroscope_prism_fan_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-spectroscope-prism-fan__a{position:absolute;left:16%;top:30%;width:0;height:0;border-left:40px solid transparent;border-right:40px solid transparent;border-bottom:70px solid color-mix(in srgb,var(--accent) 35%,transparent);animation:spectroscope_prism_fan_prism 3.1s ease-in-out infinite}
+.ease-spectroscope-prism-fan__b{position:absolute;left:48%;top:26%;width:3px;height:42%;background:linear-gradient(180deg,#fff,color-mix(in srgb,var(--accent-2) 60%,transparent));animation:spectroscope_prism_fan_slit 2.2s ease-in-out infinite alternate}
+.ease-spectroscope-prism-fan__c{position:absolute;left:52%;top:34%;display:flex;gap:4px;width:34%;height:40%;align-items:stretch}
+.ease-spectroscope-prism-fan__c::after{content:"";flex:1;border-radius:2px;background:linear-gradient(180deg,#ef4444,#eab308,#22c55e,#3b82f6,#a855f7);animation:spectroscope_prism_fan_band 1.8s ease-in-out infinite alternate}
+.ease-spectroscope-prism-fan__d{position:absolute;left:12%;top:24%;width:18%;height:4px;background:#fff;opacity:.55;animation:spectroscope_prism_fan_beam 2.6s linear infinite}
+
+@keyframes spectroscope_prism_fan_prism{0%,100%{transform:translateY(0) rotate(0)}50%{transform:translateY(-4px) rotate(4deg)}}
+@keyframes spectroscope_prism_fan_slit{from{opacity:.4;transform:scaleY(.85)}to{opacity:1;transform:scaleY(1.1)}}
+@keyframes spectroscope_prism_fan_band{from{transform:scaleY(.55);opacity:.55}to{transform:scaleY(1.15);opacity:1}}
+@keyframes spectroscope_prism_fan_beam{0%{transform:translateX(0);opacity:.2}100%{transform:translateX(120px);opacity:.9}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-spectroscope-prism-fan__a,
+  .ease-spectroscope-prism-fan__b,
+  .ease-spectroscope-prism-fan__c,
+  .ease-spectroscope-prism-fan__d,
+  .ease-spectroscope-prism-fan__meters i::after,
+  .ease-spectroscope-prism-fan__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-spectroscope-prism-fan` under `submissions/examples/spectroscope-prism-fan-ns/` — CSS-only Dispersion fan of spectral bands through a triangular prism slit.

Fixes #71662

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Dispersion fan of spectral bands through a triangular prism slit.

**How does a developer use it?**

```html
<section class="ease-spectroscope-prism-fan">
  <div class="ease-spectroscope-prism-fan__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `spectroscope_prism_fan_*` prefix. Reduced-motion disables animations.
