### PR TITLE
feat: add ease-chronometer-balance-poise (#71663)

### DIFF
--- a/submissions/examples/chronometer-balance-poise-ns/README.md
+++ b/submissions/examples/chronometer-balance-poise-ns/README.md
@@ -1,0 +1,16 @@
+# Chronometer Balance Poise
+
+## What does this do?
+Renders a self-contained CSS-only `ease-chronometer-balance-poise` demo: Marine chronometer balance wheel oscillating with compensating poise screws.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-chronometer-balance-poise`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-chronometer-balance-poise">
+  <div class="ease-chronometer-balance-poise__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/chronometer-balance-poise-ns/demo.html
+++ b/submissions/examples/chronometer-balance-poise-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Chronometer Balance Poise — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Chronometer Balance Poise demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Chronometer Balance Poise</h1>
+      <p class="lede">Marine chronometer balance wheel oscillating with compensating poise screws</p>
+    </header>
+
+    <section class="ease-chronometer-balance-poise" data-demo="chronometer-balance-poise" aria-live="polite">
+      <div class="ease-chronometer-balance-poise__housing">
+        <div class="ease-chronometer-balance-poise__bezel">
+          <div class="ease-chronometer-balance-poise__face">
+            <div class="ease-chronometer-balance-poise__readout">
+              <span class="ease-chronometer-balance-poise__label">Chronometer Balance Poise</span>
+              <span class="ease-chronometer-balance-poise__value">LIVE</span>
+            </div>
+            <div class="ease-chronometer-balance-poise__motion" aria-hidden="true">
+              <span class="ease-chronometer-balance-poise__a"></span>
+              <span class="ease-chronometer-balance-poise__b"></span>
+              <span class="ease-chronometer-balance-poise__c"></span>
+              <span class="ease-chronometer-balance-poise__d"></span>
+            </div>
+            <div class="ease-chronometer-balance-poise__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-chronometer-balance-poise__controls">
+          <button type="button" class="ease-chronometer-balance-poise__btn primary">Engage</button>
+          <button type="button" class="ease-chronometer-balance-poise__btn">Reset</button>
+          <label class="ease-chronometer-balance-poise__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-chronometer-balance-poise__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/chronometer-balance-poise-ns/style.css
+++ b/submissions/examples/chronometer-balance-poise-ns/style.css
@@ -1,0 +1,239 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "Sora", "Avenir Next", sans-serif;
+  background:
+    radial-gradient(ellipse at 21% 0%, color-mix(in srgb, #fb923c 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 79% 100%, color-mix(in srgb, #fdba74 18%, transparent), transparent 42%),
+    #0c1016;
+}
+
+.stage {
+  width: min(648px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-chronometer-balance-poise {
+  --accent: #fb923c;
+  --accent-2: #fdba74;
+  --panel: color-mix(in srgb, #e8eef6 7%, #0c1016);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 16px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #0c1016 75%, #000);
+}
+
+.ease-chronometer-balance-poise__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-chronometer-balance-poise__bezel {
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #0c1016 90%, #fb923c);
+}
+
+.ease-chronometer-balance-poise__face {
+  position: relative;
+  min-height: 264px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 33% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #0c1016 85%, #000), color-mix(in srgb, #0c1016 65%, var(--accent-2)));
+}
+
+.ease-chronometer-balance-poise__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-chronometer-balance-poise__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-chronometer-balance-poise__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-chronometer-balance-poise__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-chronometer-balance-poise__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-chronometer-balance-poise__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-chronometer-balance-poise__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: chronometer_balance_poise_meter 1.45s ease-in-out infinite alternate;
+}
+
+.ease-chronometer-balance-poise__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-chronometer-balance-poise__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-chronometer-balance-poise__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-chronometer-balance-poise__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-chronometer-balance-poise__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-chronometer-balance-poise__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-chronometer-balance-poise__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-chronometer-balance-poise__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-chronometer-balance-poise__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-chronometer-balance-poise__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-chronometer-balance-poise__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-chronometer-balance-poise__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: chronometer_balance_poise_status 2.0s ease-out infinite;
+}
+
+@keyframes chronometer_balance_poise_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes chronometer_balance_poise_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-chronometer-balance-poise__a{position:absolute;left:26%;top:18%;width:48%;height:48%;border-radius:50%;border:3px solid color-mix(in srgb,var(--accent) 55%,transparent);background:radial-gradient(circle at center,color-mix(in srgb,var(--accent) 18%,transparent) 0 28%,transparent 29%),conic-gradient(from 90deg,transparent 0 40%,color-mix(in srgb,var(--accent-2) 30%,transparent) 40% 60%,transparent 60% 100%);animation:chronometer_balance_poise_wheel 1.6s cubic-bezier(.45,.05,.55,.95) infinite}
+.ease-chronometer-balance-poise__b{position:absolute;left:47%;top:22%;width:6%;height:40%;background:var(--accent);transform-origin:center 70%;border-radius:2px;animation:chronometer_balance_poise_spoke 1.6s cubic-bezier(.45,.05,.55,.95) infinite}
+.ease-chronometer-balance-poise__c{position:absolute;left:18%;bottom:20%;width:64%;height:8px;display:flex;justify-content:space-between}
+.ease-chronometer-balance-poise__c::after{content:"";width:8px;height:8px;border-radius:50%;background:var(--accent-2);box-shadow:28px 0 var(--accent),56px 0 var(--accent-2),84px 0 var(--accent),112px 0 var(--accent-2),140px 0 var(--accent);animation:chronometer_balance_poise_screws 1.6s ease-in-out infinite}
+.ease-chronometer-balance-poise__d{position:absolute;right:20%;top:26%;width:14%;height:14%;border:2px solid var(--accent);border-radius:50%;animation:chronometer_balance_poise_pulse 1.6s ease-out infinite}
+
+@keyframes chronometer_balance_poise_wheel{0%,100%{transform:rotate(-28deg)}50%{transform:rotate(28deg)}}
+@keyframes chronometer_balance_poise_spoke{0%,100%{transform:rotate(-28deg)}50%{transform:rotate(28deg)}}
+@keyframes chronometer_balance_poise_screws{0%,100%{opacity:.45}50%{opacity:1}}
+@keyframes chronometer_balance_poise_pulse{0%{transform:scale(.8);opacity:.8}100%{transform:scale(1.6);opacity:0}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-chronometer-balance-poise__a,
+  .ease-chronometer-balance-poise__b,
+  .ease-chronometer-balance-poise__c,
+  .ease-chronometer-balance-poise__d,
+  .ease-chronometer-balance-poise__meters i::after,
+  .ease-chronometer-balance-poise__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-chronometer-balance-poise` under `submissions/examples/chronometer-balance-poise-ns/` — CSS-only Marine chronometer balance wheel oscillating with compensating poise screws.

Fixes #71663

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Marine chronometer balance wheel oscillating with compensating poise screws.

**How does a developer use it?**

```html
<section class="ease-chronometer-balance-poise">
  <div class="ease-chronometer-balance-poise__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `chronometer_balance_poise_*` prefix. Reduced-motion disables animations.
