### PR TITLE
feat: add Open Source Project Card component [Issue #70947]

### DIFF
--- a/submissions/examples/open-source-project-card/README.md
+++ b/submissions/examples/open-source-project-card/README.md
@@ -1,0 +1,47 @@
+# Open Source Project Card
+
+## What does this do?
+Renders a GitHub-style repository/project card that displays the project name, short description, open-source visibility badge, star count, fork count, and a language indicator dot — all styled with pure CSS and no JavaScript.
+
+## How is it used?
+
+```html
+<article class="repo-card" aria-label="My Project">
+  <div class="repo-card__header">
+    <!-- repository icon SVG (aria-hidden) -->
+    <a href="#my-project" class="repo-card__name" aria-label="Open My Project repository">
+      org / my-project
+    </a>
+    <span class="repo-card__visibility">Public</span>
+  </div>
+
+  <p class="repo-card__description">
+    A short description of the project goes here.
+  </p>
+
+  <footer class="repo-card__footer">
+    <dl class="repo-card__stats">
+      <div class="repo-card__stat">
+        <!-- star icon SVG (aria-hidden) -->
+        <dt class="visually-hidden">Stars</dt>
+        <dd><a href="#stars" aria-label="1,234 stars">1.2k</a></dd>
+      </div>
+      <div class="repo-card__stat">
+        <!-- fork icon SVG (aria-hidden) -->
+        <dt class="visually-hidden">Forks</dt>
+        <dd><a href="#forks" aria-label="89 forks">89</a></dd>
+      </div>
+    </dl>
+
+    <div class="repo-card__lang">
+      <span class="repo-card__lang-dot" style="--lang-color: #f1e05a;" aria-hidden="true"></span>
+      <span>JavaScript</span>
+    </div>
+  </footer>
+</article>
+```
+
+Place multiple cards inside the `.card-grid` list for a responsive grid layout.
+
+## Why is it useful?
+Open-source project cards are a common UI pattern on portfolios, dashboards, and landing pages. This component provides a polished, accessible, zero-dependency alternative that plugs directly into EaseMotion CSS without requiring any JavaScript or external icon fonts.

--- a/submissions/examples/open-source-project-card/demo.html
+++ b/submissions/examples/open-source-project-card/demo.html
@@ -1,0 +1,321 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Open Source Project Card – EaseMotion CSS</title>
+  <meta name="description" content="A GitHub-style open source project card component built with pure CSS. Displays project name, description, stars, forks, and language badge.">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="stage">
+
+    <header class="page-header">
+      <div class="badge">
+        <span class="badge-dot" aria-hidden="true"></span>
+        Pure CSS · Zero JavaScript
+      </div>
+      <h1 class="page-title">Open Source Project Card</h1>
+      <p class="page-subtitle">GitHub-style repository cards with stars, forks, and language indicators.</p>
+    </header>
+
+    <!-- Card Grid -->
+    <section aria-label="Open source project card examples">
+      <ul class="card-grid" role="list">
+
+        <!-- Card 1 -->
+        <li>
+          <article class="repo-card" aria-label="EaseMotion CSS project">
+            <div class="repo-card__header">
+              <svg class="repo-card__icon" aria-hidden="true" focusable="false" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                <path d="M2 2.5A2.5 2.5 0 0 1 4.5 0h8.75a.75.75 0 0 1 .75.75v12.5a.75.75 0 0 1-.75.75h-2.5a.75.75 0 0 1 0-1.5h1.75v-2h-8a1 1 0 0 0-.714 1.7.75.75 0 1 1-1.072 1.05A2.495 2.495 0 0 1 2 11.5Zm10.5-1h-8a1 1 0 0 0-1 1v6.708A2.486 2.486 0 0 1 4.5 9h8Z"/>
+              </svg>
+              <a href="#easemotion-css" class="repo-card__name" aria-label="Open EaseMotion CSS repository">
+                EaseMotion CSS
+              </a>
+              <span class="repo-card__visibility">Public</span>
+            </div>
+
+            <p class="repo-card__description">
+              A human-readable, animation-first CSS framework with zero dependencies and no build step required.
+            </p>
+
+            <footer class="repo-card__footer">
+              <dl class="repo-card__stats">
+                <div class="repo-card__stat">
+                  <svg class="repo-card__stat-icon" aria-hidden="true" focusable="false" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                    <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/>
+                  </svg>
+                  <dt class="visually-hidden">Stars</dt>
+                  <dd>
+                    <a href="#stars" aria-label="2,847 stars">2,847</a>
+                  </dd>
+                </div>
+
+                <div class="repo-card__stat">
+                  <svg class="repo-card__stat-icon" aria-hidden="true" focusable="false" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                    <path d="M5 5.372v.878c0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75v-.878a2.25 2.25 0 1 1 1.5 0v.878a2.25 2.25 0 0 1-2.25 2.25h-1.5v2.128a2.251 2.251 0 1 1-1.5 0V8.5h-1.5A2.25 2.25 0 0 1 3.5 6.25v-.878a2.25 2.25 0 1 1 1.5 0ZM5 3.25a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Zm6.75.75a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm-3 8.75a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Z"/>
+                  </svg>
+                  <dt class="visually-hidden">Forks</dt>
+                  <dd>
+                    <a href="#forks" aria-label="418 forks">418</a>
+                  </dd>
+                </div>
+              </dl>
+
+              <div class="repo-card__lang">
+                <span class="repo-card__lang-dot" style="--lang-color: #563d7c;" aria-hidden="true"></span>
+                <span>CSS</span>
+              </div>
+            </footer>
+          </article>
+        </li>
+
+        <!-- Card 2 -->
+        <li>
+          <article class="repo-card" aria-label="Vite project">
+            <div class="repo-card__header">
+              <svg class="repo-card__icon" aria-hidden="true" focusable="false" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                <path d="M2 2.5A2.5 2.5 0 0 1 4.5 0h8.75a.75.75 0 0 1 .75.75v12.5a.75.75 0 0 1-.75.75h-2.5a.75.75 0 0 1 0-1.5h1.75v-2h-8a1 1 0 0 0-.714 1.7.75.75 0 1 1-1.072 1.05A2.495 2.495 0 0 1 2 11.5Zm10.5-1h-8a1 1 0 0 0-1 1v6.708A2.486 2.486 0 0 1 4.5 9h8Z"/>
+              </svg>
+              <a href="#vite" class="repo-card__name" aria-label="Open vitejs/vite repository">
+                vitejs / vite
+              </a>
+              <span class="repo-card__visibility">Public</span>
+            </div>
+
+            <p class="repo-card__description">
+              Next Generation Frontend Tooling. It's fast! A build tool that aims to provide a faster and leaner development experience.
+            </p>
+
+            <footer class="repo-card__footer">
+              <dl class="repo-card__stats">
+                <div class="repo-card__stat">
+                  <svg class="repo-card__stat-icon" aria-hidden="true" focusable="false" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                    <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/>
+                  </svg>
+                  <dt class="visually-hidden">Stars</dt>
+                  <dd>
+                    <a href="#stars" aria-label="67,200 stars">67.2k</a>
+                  </dd>
+                </div>
+
+                <div class="repo-card__stat">
+                  <svg class="repo-card__stat-icon" aria-hidden="true" focusable="false" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                    <path d="M5 5.372v.878c0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75v-.878a2.25 2.25 0 1 1 1.5 0v.878a2.25 2.25 0 0 1-2.25 2.25h-1.5v2.128a2.251 2.251 0 1 1-1.5 0V8.5h-1.5A2.25 2.25 0 0 1 3.5 6.25v-.878a2.25 2.25 0 1 1 1.5 0ZM5 3.25a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Zm6.75.75a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm-3 8.75a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Z"/>
+                  </svg>
+                  <dt class="visually-hidden">Forks</dt>
+                  <dd>
+                    <a href="#forks" aria-label="5,920 forks">5.9k</a>
+                  </dd>
+                </div>
+              </dl>
+
+              <div class="repo-card__lang">
+                <span class="repo-card__lang-dot" style="--lang-color: #f1e05a;" aria-hidden="true"></span>
+                <span>JavaScript</span>
+              </div>
+            </footer>
+          </article>
+        </li>
+
+        <!-- Card 3 -->
+        <li>
+          <article class="repo-card" aria-label="React project">
+            <div class="repo-card__header">
+              <svg class="repo-card__icon" aria-hidden="true" focusable="false" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                <path d="M2 2.5A2.5 2.5 0 0 1 4.5 0h8.75a.75.75 0 0 1 .75.75v12.5a.75.75 0 0 1-.75.75h-2.5a.75.75 0 0 1 0-1.5h1.75v-2h-8a1 1 0 0 0-.714 1.7.75.75 0 1 1-1.072 1.05A2.495 2.495 0 0 1 2 11.5Zm10.5-1h-8a1 1 0 0 0-1 1v6.708A2.486 2.486 0 0 1 4.5 9h8Z"/>
+              </svg>
+              <a href="#react" class="repo-card__name" aria-label="Open facebook/react repository">
+                facebook / react
+              </a>
+              <span class="repo-card__visibility">Public</span>
+            </div>
+
+            <p class="repo-card__description">
+              The library for web and native user interfaces. Build user interfaces out of individual pieces called components.
+            </p>
+
+            <footer class="repo-card__footer">
+              <dl class="repo-card__stats">
+                <div class="repo-card__stat">
+                  <svg class="repo-card__stat-icon" aria-hidden="true" focusable="false" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                    <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/>
+                  </svg>
+                  <dt class="visually-hidden">Stars</dt>
+                  <dd>
+                    <a href="#stars" aria-label="226,000 stars">226k</a>
+                  </dd>
+                </div>
+
+                <div class="repo-card__stat">
+                  <svg class="repo-card__stat-icon" aria-hidden="true" focusable="false" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                    <path d="M5 5.372v.878c0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75v-.878a2.25 2.25 0 1 1 1.5 0v.878a2.25 2.25 0 0 1-2.25 2.25h-1.5v2.128a2.251 2.251 0 1 1-1.5 0V8.5h-1.5A2.25 2.25 0 0 1 3.5 6.25v-.878a2.25 2.25 0 1 1 1.5 0ZM5 3.25a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Zm6.75.75a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm-3 8.75a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Z"/>
+                  </svg>
+                  <dt class="visually-hidden">Forks</dt>
+                  <dd>
+                    <a href="#forks" aria-label="46,200 forks">46.2k</a>
+                  </dd>
+                </div>
+              </dl>
+
+              <div class="repo-card__lang">
+                <span class="repo-card__lang-dot" style="--lang-color: #3178c6;" aria-hidden="true"></span>
+                <span>TypeScript</span>
+              </div>
+            </footer>
+          </article>
+        </li>
+
+        <!-- Card 4 -->
+        <li>
+          <article class="repo-card" aria-label="Tailwind CSS project">
+            <div class="repo-card__header">
+              <svg class="repo-card__icon" aria-hidden="true" focusable="false" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                <path d="M2 2.5A2.5 2.5 0 0 1 4.5 0h8.75a.75.75 0 0 1 .75.75v12.5a.75.75 0 0 1-.75.75h-2.5a.75.75 0 0 1 0-1.5h1.75v-2h-8a1 1 0 0 0-.714 1.7.75.75 0 1 1-1.072 1.05A2.495 2.495 0 0 1 2 11.5Zm10.5-1h-8a1 1 0 0 0-1 1v6.708A2.486 2.486 0 0 1 4.5 9h8Z"/>
+              </svg>
+              <a href="#tailwind" class="repo-card__name" aria-label="Open tailwindlabs/tailwindcss repository">
+                tailwindlabs / tailwindcss
+              </a>
+              <span class="repo-card__visibility">Public</span>
+            </div>
+
+            <p class="repo-card__description">
+              A utility-first CSS framework packed with classes like flex, pt-4, text-center and rotate-90 that can be composed to build any design.
+            </p>
+
+            <footer class="repo-card__footer">
+              <dl class="repo-card__stats">
+                <div class="repo-card__stat">
+                  <svg class="repo-card__stat-icon" aria-hidden="true" focusable="false" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                    <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/>
+                  </svg>
+                  <dt class="visually-hidden">Stars</dt>
+                  <dd>
+                    <a href="#stars" aria-label="83,500 stars">83.5k</a>
+                  </dd>
+                </div>
+
+                <div class="repo-card__stat">
+                  <svg class="repo-card__stat-icon" aria-hidden="true" focusable="false" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                    <path d="M5 5.372v.878c0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75v-.878a2.25 2.25 0 1 1 1.5 0v.878a2.25 2.25 0 0 1-2.25 2.25h-1.5v2.128a2.251 2.251 0 1 1-1.5 0V8.5h-1.5A2.25 2.25 0 0 1 3.5 6.25v-.878a2.25 2.25 0 1 1 1.5 0ZM5 3.25a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Zm6.75.75a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm-3 8.75a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Z"/>
+                  </svg>
+                  <dt class="visually-hidden">Forks</dt>
+                  <dd>
+                    <a href="#forks" aria-label="4,290 forks">4.3k</a>
+                  </dd>
+                </div>
+              </dl>
+
+              <div class="repo-card__lang">
+                <span class="repo-card__lang-dot" style="--lang-color: #563d7c;" aria-hidden="true"></span>
+                <span>CSS</span>
+              </div>
+            </footer>
+          </article>
+        </li>
+
+        <!-- Card 5 -->
+        <li>
+          <article class="repo-card" aria-label="Rust project">
+            <div class="repo-card__header">
+              <svg class="repo-card__icon" aria-hidden="true" focusable="false" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                <path d="M2 2.5A2.5 2.5 0 0 1 4.5 0h8.75a.75.75 0 0 1 .75.75v12.5a.75.75 0 0 1-.75.75h-2.5a.75.75 0 0 1 0-1.5h1.75v-2h-8a1 1 0 0 0-.714 1.7.75.75 0 1 1-1.072 1.05A2.495 2.495 0 0 1 2 11.5Zm10.5-1h-8a1 1 0 0 0-1 1v6.708A2.486 2.486 0 0 1 4.5 9h8Z"/>
+              </svg>
+              <a href="#tokio" class="repo-card__name" aria-label="Open tokio-rs/tokio repository">
+                tokio-rs / tokio
+              </a>
+              <span class="repo-card__visibility">Public</span>
+            </div>
+
+            <p class="repo-card__description">
+              An asynchronous runtime for the Rust programming language, providing building blocks for writing network applications.
+            </p>
+
+            <footer class="repo-card__footer">
+              <dl class="repo-card__stats">
+                <div class="repo-card__stat">
+                  <svg class="repo-card__stat-icon" aria-hidden="true" focusable="false" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                    <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/>
+                  </svg>
+                  <dt class="visually-hidden">Stars</dt>
+                  <dd>
+                    <a href="#stars" aria-label="25,800 stars">25.8k</a>
+                  </dd>
+                </div>
+
+                <div class="repo-card__stat">
+                  <svg class="repo-card__stat-icon" aria-hidden="true" focusable="false" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                    <path d="M5 5.372v.878c0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75v-.878a2.25 2.25 0 1 1 1.5 0v.878a2.25 2.25 0 0 1-2.25 2.25h-1.5v2.128a2.251 2.251 0 1 1-1.5 0V8.5h-1.5A2.25 2.25 0 0 1 3.5 6.25v-.878a2.25 2.25 0 1 1 1.5 0ZM5 3.25a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Zm6.75.75a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm-3 8.75a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Z"/>
+                  </svg>
+                  <dt class="visually-hidden">Forks</dt>
+                  <dd>
+                    <a href="#forks" aria-label="2,370 forks">2.4k</a>
+                  </dd>
+                </div>
+              </dl>
+
+              <div class="repo-card__lang">
+                <span class="repo-card__lang-dot" style="--lang-color: #dea584;" aria-hidden="true"></span>
+                <span>Rust</span>
+              </div>
+            </footer>
+          </article>
+        </li>
+
+        <!-- Card 6 -->
+        <li>
+          <article class="repo-card" aria-label="Python project">
+            <div class="repo-card__header">
+              <svg class="repo-card__icon" aria-hidden="true" focusable="false" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                <path d="M2 2.5A2.5 2.5 0 0 1 4.5 0h8.75a.75.75 0 0 1 .75.75v12.5a.75.75 0 0 1-.75.75h-2.5a.75.75 0 0 1 0-1.5h1.75v-2h-8a1 1 0 0 0-.714 1.7.75.75 0 1 1-1.072 1.05A2.495 2.495 0 0 1 2 11.5Zm10.5-1h-8a1 1 0 0 0-1 1v6.708A2.486 2.486 0 0 1 4.5 9h8Z"/>
+              </svg>
+              <a href="#fastapi" class="repo-card__name" aria-label="Open tiangolo/fastapi repository">
+                tiangolo / fastapi
+              </a>
+              <span class="repo-card__visibility">Public</span>
+            </div>
+
+            <p class="repo-card__description">
+              FastAPI framework, high performance, easy to learn, fast to code, ready for production.
+            </p>
+
+            <footer class="repo-card__footer">
+              <dl class="repo-card__stats">
+                <div class="repo-card__stat">
+                  <svg class="repo-card__stat-icon" aria-hidden="true" focusable="false" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                    <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/>
+                  </svg>
+                  <dt class="visually-hidden">Stars</dt>
+                  <dd>
+                    <a href="#stars" aria-label="74,100 stars">74.1k</a>
+                  </dd>
+                </div>
+
+                <div class="repo-card__stat">
+                  <svg class="repo-card__stat-icon" aria-hidden="true" focusable="false" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                    <path d="M5 5.372v.878c0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75v-.878a2.25 2.25 0 1 1 1.5 0v.878a2.25 2.25 0 0 1-2.25 2.25h-1.5v2.128a2.251 2.251 0 1 1-1.5 0V8.5h-1.5A2.25 2.25 0 0 1 3.5 6.25v-.878a2.25 2.25 0 1 1 1.5 0ZM5 3.25a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Zm6.75.75a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm-3 8.75a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Z"/>
+                  </svg>
+                  <dt class="visually-hidden">Forks</dt>
+                  <dd>
+                    <a href="#forks" aria-label="6,180 forks">6.2k</a>
+                  </dd>
+                </div>
+              </dl>
+
+              <div class="repo-card__lang">
+                <span class="repo-card__lang-dot" style="--lang-color: #3572A5;" aria-hidden="true"></span>
+                <span>Python</span>
+              </div>
+            </footer>
+          </article>
+        </li>
+
+      </ul>
+    </section>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/open-source-project-card/style.css
+++ b/submissions/examples/open-source-project-card/style.css
@@ -1,0 +1,403 @@
+/* ==========================================================================
+   OPEN SOURCE PROJECT CARD
+   Library: EaseMotion CSS
+   Track:   Pure CSS / HTML Showcase
+   ========================================================================== */
+
+/* ==========================================================================
+   1. DESIGN TOKENS
+   ========================================================================== */
+:root {
+  /* Typography */
+  --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif;
+
+  /* Colors – Card Surface */
+  --card-bg: #ffffff;
+  --card-border: #d0d7de;
+  --card-border-hover: #0969da;
+  --card-shadow: 0 1px 3px rgba(31, 35, 40, 0.1);
+  --card-shadow-hover:
+    0 8px 24px rgba(31, 35, 40, 0.12),
+    0 0 0 2px #0969da;
+  --card-radius: 10px;
+
+  /* Colors – Text */
+  --text-primary: #1f2328;
+  --text-secondary: #656d76;
+  --text-link: #0969da;
+  --text-link-hover: #0550ae;
+
+  /* Colors – UI Elements */
+  --badge-bg: #ddf4ff;
+  --badge-color: #0550ae;
+  --badge-border: #80ccff;
+  --stat-color: #656d76;
+  --stat-hover: #0969da;
+
+  /* Page Stage */
+  --stage-bg: #f6f8fa;
+  --stage-padding: clamp(24px, 5vw, 64px);
+}
+
+/* ==========================================================================
+   2. BASE RESET
+   ========================================================================== */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-size: 16px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  font-family: var(--font-family);
+  background-color: var(--stage-bg);
+  color: var(--text-primary);
+  min-height: 100vh;
+  line-height: 1.5;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+/* ==========================================================================
+   3. ACCESSIBILITY UTILITY
+   ========================================================================== */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ==========================================================================
+   4. PAGE STAGE (DEMO WRAPPER)
+   ========================================================================== */
+.stage {
+  width: 100%;
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: var(--stage-padding);
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+/* --------------------------------------------------------------------------
+   Page Header
+   -------------------------------------------------------------------------- */
+.page-header {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 12px;
+  border-radius: 9999px;
+  background: var(--badge-bg);
+  border: 1px solid var(--badge-border);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--badge-color);
+  letter-spacing: 0.01em;
+}
+
+.badge-dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background-color: var(--badge-color);
+  animation: badge-pulse 2.4s ease-in-out infinite;
+}
+
+@keyframes badge-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}
+
+.page-title {
+  font-size: clamp(1.5rem, 4vw, 2.25rem);
+  font-weight: 800;
+  letter-spacing: -0.025em;
+  color: var(--text-primary);
+  line-height: 1.2;
+}
+
+.page-subtitle {
+  font-size: clamp(0.875rem, 1.5vw, 1rem);
+  color: var(--text-secondary);
+  max-width: 52ch;
+}
+
+/* ==========================================================================
+   5. CARD GRID LAYOUT
+   ========================================================================== */
+.card-grid {
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 320px), 1fr));
+  gap: 16px;
+}
+
+/* ==========================================================================
+   6. REPO CARD COMPONENT
+   ========================================================================== */
+.repo-card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: var(--card-radius);
+  box-shadow: var(--card-shadow);
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  transition:
+    border-color 200ms ease,
+    box-shadow 200ms ease,
+    transform 200ms ease;
+  /* Ensure the card itself is a stacking context */
+  position: relative;
+}
+
+.repo-card:hover {
+  border-color: var(--card-border-hover);
+  box-shadow: var(--card-shadow-hover);
+  transform: translateY(-2px);
+}
+
+/* --------------------------------------------------------------------------
+   6a. Card Header (icon + name + visibility badge)
+   -------------------------------------------------------------------------- */
+.repo-card__header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+.repo-card__icon {
+  flex-shrink: 0;
+  color: var(--text-secondary);
+}
+
+.repo-card__name {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--text-link);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+  transition: color 150ms ease;
+  /* Extend the click target to the whole card via a pseudo-element */
+}
+
+/* Stretch the link so the entire card is accessible as a single tap target
+   without nesting interactive elements in an <a> wrapping the whole card */
+.repo-card__name::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: var(--card-radius);
+  z-index: 0;
+}
+
+.repo-card__name:hover {
+  color: var(--text-link-hover);
+  text-decoration: underline;
+}
+
+.repo-card__name:focus-visible {
+  outline: 2px solid var(--text-link);
+  outline-offset: 2px;
+  border-radius: 3px;
+}
+
+/* Raise stat links above the stretched pseudo-element so they remain clickable */
+.repo-card__stats,
+.repo-card__stat a {
+  position: relative;
+  z-index: 1;
+}
+
+.repo-card__visibility {
+  display: inline-block;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  padding: 2px 8px;
+  border-radius: 9999px;
+  border: 1px solid var(--card-border);
+  color: var(--text-secondary);
+  flex-shrink: 0;
+  line-height: 1.6;
+}
+
+/* --------------------------------------------------------------------------
+   6b. Description
+   -------------------------------------------------------------------------- */
+.repo-card__description {
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  flex: 1;
+}
+
+/* --------------------------------------------------------------------------
+   6c. Footer (stats + language)
+   -------------------------------------------------------------------------- */
+.repo-card__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: auto;
+  padding-top: 4px;
+}
+
+/* Definition list used for star / fork stats */
+.repo-card__stats {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  list-style: none;
+}
+
+.repo-card__stat {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.repo-card__stat-icon {
+  flex-shrink: 0;
+  color: var(--stat-color);
+}
+
+.repo-card__stat dd {
+  font-size: 0.8125rem;
+  color: var(--stat-color);
+}
+
+.repo-card__stat dd a {
+  color: var(--stat-color);
+  transition: color 150ms ease;
+}
+
+.repo-card__stat dd a:hover {
+  color: var(--stat-hover);
+  text-decoration: underline;
+}
+
+.repo-card__stat dd a:focus-visible {
+  outline: 2px solid var(--text-link);
+  outline-offset: 2px;
+  border-radius: 3px;
+}
+
+/* Language indicator */
+.repo-card__lang {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+}
+
+.repo-card__lang-dot {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background-color: var(--lang-color, #ccc);
+  flex-shrink: 0;
+}
+
+/* ==========================================================================
+   7. REDUCED MOTION
+   ========================================================================== */
+@media (prefers-reduced-motion: reduce) {
+  .repo-card {
+    transition: none;
+  }
+
+  .repo-card:hover {
+    transform: none;
+  }
+
+  .badge-dot {
+    animation: none;
+  }
+}
+
+/* ==========================================================================
+   8. RESPONSIVE
+   ========================================================================== */
+
+/* Narrow mobile – avoid any horizontal scroll */
+@media (max-width: 400px) {
+  .stage {
+    padding: 16px;
+  }
+
+  .repo-card {
+    padding: 16px;
+  }
+
+  .repo-card__header {
+    flex-wrap: nowrap;
+  }
+
+  .repo-card__name {
+    font-size: 0.875rem;
+    /* Allow the name to truncate on very narrow screens */
+    max-width: calc(100% - 80px);
+  }
+
+  .repo-card__footer {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+  }
+}
+
+/* Tablet breakpoint – enforce at least 2 columns when space allows */
+@media (min-width: 640px) {
+  .card-grid {
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  }
+}
+
+/* Large desktop – cap columns at 3 to keep cards readable */
+@media (min-width: 1100px) {
+  .card-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}


### PR DESCRIPTION
## Summary

Closes #70947

Implements a GitHub-style **Open Source Project Card** component as a pure CSS + HTML submission with zero JavaScript.

---

## What was added

**Files created** (no existing files modified):

| File | Description |
|------|-------------|
| `submissions/examples/open-source-project-card/demo.html` | Self-contained HTML demo, opens directly in a browser |
| `submissions/examples/open-source-project-card/style.css` | Pure CSS implementation, zero JavaScript |
| `submissions/examples/open-source-project-card/README.md` | Component usage documentation |

---

## Component features

- **Project name** — styled as an accessible link with a descriptive `aria-label`
- **Short description** — clamped to 3 lines with CSS (`-webkit-line-clamp`) to prevent overflow
- **"Public" visibility badge** — communicates open-source status
- **Star & fork counts** — marked up as a `<dl>` definition list; screen-reader-friendly labels via `.visually-hidden` `<dt>` elements (e.g. announces "Stars: 2,847")
- **Language dot indicator** — configurable per-card via `--lang-color` CSS custom property
- **Hover lift effect** — `translateY(-2px)` + blue border glow, smooth via `transition`
- **Responsive card grid** — `grid-template-columns: repeat(auto-fill, minmax(..., 1fr))` auto-adapts from 1 → 3 columns across all screen sizes

---

## CSS techniques

- **CSS custom properties** on `:root` for all colours, shadows, and radii — easy to theme
- **Grid auto-fill** with `minmax()` for fully fluid, no-media-query-required column reflow
- **`::after` full-card tap target** on the repo name link — the whole card is clickable without nesting `<a>` inside `<a>`
- **`z-index: 1`** on stat links to keep them independently clickable above the tap-target pseudo-element
- **`@media (prefers-reduced-motion: reduce)`** disables all transforms and animations for accessibility
- **`:focus-visible`** on every interactive element with a clearly visible 2 px outline

---

## Accessibility

- ✅ Semantic HTML: `<main>`, `<section>`, `<ul role="list">`, `<article>`, `<footer>`, `<dl>/<dt>/<dd>`
- ✅ Decorative SVGs: `aria-hidden="true" focusable="false"`
- ✅ Stats announced to screen readers as labelled pairs via `.visually-hidden` `<dt>`
- ✅ Each card `<article>` has a descriptive `aria-label`
- ✅ All content visible without hover — no hover-only information
- ✅ Full keyboard navigation via native `<a>` elements
- ✅ `:focus-visible` outline on all interactive elements
- ✅ No JavaScript

---

## Responsive behaviour

| Viewport | Columns |
|----------|---------|
| < 400 px | 1 (footer stacks vertically) |
| 400–639 px | 1–2 auto |
| 640–1099 px | 2–3 auto |
| ≥ 1100 px | 3 (capped for readability) |

No horizontal overflow at any viewport width.

---

## Validation

- `npm run lint` (stylelint) — ✅ 0 errors
- `npm run lint:duplicates` — ✅ no new duplicates
- `npm test` (vitest, 13 tests) — ✅ all passed
- Static structural checks (Node.js script) — ✅ 20/20 passed
- `git status` — only `submissions/examples/open-source-project-card/` added; no unrelated files touched

---

## Checklist

- [x] Files added only under `submissions/examples/`
- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] Pure CSS — zero JavaScript
- [x] No external frameworks or npm dependencies
- [x] No existing files modified
- [x] All lint and test checks pass
