### PR TITLE
feat: add ease-sounding-lead-drop (#71665)

### DIFF
--- a/submissions/examples/sounding-lead-drop-ns/README.md
+++ b/submissions/examples/sounding-lead-drop-ns/README.md
@@ -1,0 +1,16 @@
+# Sounding Lead Drop
+
+## What does this do?
+Renders a self-contained CSS-only `ease-sounding-lead-drop` demo: Nautical sounding lead descending on a marked line then retrieving.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-sounding-lead-drop`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-sounding-lead-drop">
+  <div class="ease-sounding-lead-drop__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/sounding-lead-drop-ns/demo.html
+++ b/submissions/examples/sounding-lead-drop-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sounding Lead Drop — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Sounding Lead Drop demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Sounding Lead Drop</h1>
+      <p class="lede">Nautical sounding lead descending on a marked line then retrieving</p>
+    </header>
+
+    <section class="ease-sounding-lead-drop" data-demo="sounding-lead-drop" aria-live="polite">
+      <div class="ease-sounding-lead-drop__housing">
+        <div class="ease-sounding-lead-drop__bezel">
+          <div class="ease-sounding-lead-drop__face">
+            <div class="ease-sounding-lead-drop__readout">
+              <span class="ease-sounding-lead-drop__label">Sounding Lead Drop</span>
+              <span class="ease-sounding-lead-drop__value">LIVE</span>
+            </div>
+            <div class="ease-sounding-lead-drop__motion" aria-hidden="true">
+              <span class="ease-sounding-lead-drop__a"></span>
+              <span class="ease-sounding-lead-drop__b"></span>
+              <span class="ease-sounding-lead-drop__c"></span>
+              <span class="ease-sounding-lead-drop__d"></span>
+            </div>
+            <div class="ease-sounding-lead-drop__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-sounding-lead-drop__controls">
+          <button type="button" class="ease-sounding-lead-drop__btn primary">Engage</button>
+          <button type="button" class="ease-sounding-lead-drop__btn">Reset</button>
+          <label class="ease-sounding-lead-drop__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-sounding-lead-drop__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/sounding-lead-drop-ns/style.css
+++ b/submissions/examples/sounding-lead-drop-ns/style.css
@@ -1,0 +1,238 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "Sora", "Avenir Next", sans-serif;
+  background:
+    radial-gradient(ellipse at 21% 0%, color-mix(in srgb, #60a5fa 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 79% 100%, color-mix(in srgb, #93c5fd 18%, transparent), transparent 42%),
+    #0c1016;
+}
+
+.stage {
+  width: min(648px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-sounding-lead-drop {
+  --accent: #60a5fa;
+  --accent-2: #93c5fd;
+  --panel: color-mix(in srgb, #e8eef6 7%, #0c1016);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 16px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #0c1016 75%, #000);
+}
+
+.ease-sounding-lead-drop__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-sounding-lead-drop__bezel {
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #0c1016 90%, #60a5fa);
+}
+
+.ease-sounding-lead-drop__face {
+  position: relative;
+  min-height: 264px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 33% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #0c1016 85%, #000), color-mix(in srgb, #0c1016 65%, var(--accent-2)));
+}
+
+.ease-sounding-lead-drop__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-sounding-lead-drop__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-sounding-lead-drop__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-sounding-lead-drop__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-sounding-lead-drop__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-sounding-lead-drop__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-sounding-lead-drop__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: sounding_lead_drop_meter 2.0s ease-in-out infinite alternate;
+}
+
+.ease-sounding-lead-drop__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-sounding-lead-drop__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-sounding-lead-drop__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-sounding-lead-drop__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-sounding-lead-drop__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-sounding-lead-drop__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-sounding-lead-drop__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-sounding-lead-drop__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-sounding-lead-drop__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-sounding-lead-drop__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-sounding-lead-drop__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-sounding-lead-drop__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: sounding_lead_drop_status 2.3s ease-out infinite;
+}
+
+@keyframes sounding_lead_drop_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes sounding_lead_drop_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-sounding-lead-drop__a{position:absolute;left:48%;top:12%;width:3px;height:58%;background:repeating-linear-gradient(180deg,var(--accent) 0 6px,transparent 6px 12px);transform-origin:top center;animation:sounding_lead_drop_line 3.8s ease-in-out infinite}
+.ease-sounding-lead-drop__b{position:absolute;left:44%;top:18%;width:12%;height:12%;clip-path:polygon(50% 100%,0 0,100% 0);background:var(--accent-2);animation:sounding_lead_drop_weight 3.8s cubic-bezier(.4,0,.2,1) infinite}
+.ease-sounding-lead-drop__c{position:absolute;left:18%;bottom:16%;width:64%;height:18px;border-radius:0 0 40% 40%/0 0 100% 100%;background:color-mix(in srgb,var(--accent) 22%,transparent);animation:sounding_lead_drop_sea 2.2s ease-in-out infinite alternate}
+.ease-sounding-lead-drop__d{position:absolute;right:16%;top:28%;width:18%;height:6px;border-radius:3px;background:var(--accent);animation:sounding_lead_drop_mark 3.8s linear infinite}
+
+@keyframes sounding_lead_drop_line{0%,100%{transform:scaleY(.35)}45%,55%{transform:scaleY(1)}}
+@keyframes sounding_lead_drop_weight{0%,100%{transform:translateY(0)}45%,55%{transform:translateY(110px)}}
+@keyframes sounding_lead_drop_sea{from{transform:scaleY(.85);opacity:.55}to{transform:scaleY(1.15);opacity:.9}}
+@keyframes sounding_lead_drop_mark{0%{opacity:.3;transform:translateY(0)}50%{opacity:1}100%{opacity:.3;transform:translateY(40px)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-sounding-lead-drop__a,
+  .ease-sounding-lead-drop__b,
+  .ease-sounding-lead-drop__c,
+  .ease-sounding-lead-drop__d,
+  .ease-sounding-lead-drop__meters i::after,
+  .ease-sounding-lead-drop__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-sounding-lead-drop` under `submissions/examples/sounding-lead-drop-ns/` — CSS-only Nautical sounding lead descending on a marked line then retrieving.

Fixes #71665

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Nautical sounding lead descending on a marked line then retrieving.

**How does a developer use it?**

```html
<section class="ease-sounding-lead-drop">
  <div class="ease-sounding-lead-drop__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `sounding_lead_drop_*` prefix. Reduced-motion disables animations.
