### PR TITLE
feat: add ease-chladni-plate-nodes (#71666)

### DIFF
--- a/submissions/examples/chladni-plate-nodes-ns/README.md
+++ b/submissions/examples/chladni-plate-nodes-ns/README.md
@@ -1,0 +1,16 @@
+# Chladni Plate Nodes
+
+## What does this do?
+Renders a self-contained CSS-only `ease-chladni-plate-nodes` demo: Vibrating Chladni plate with sand gathering into shifting nodal lines.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-chladni-plate-nodes`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-chladni-plate-nodes">
+  <div class="ease-chladni-plate-nodes__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/chladni-plate-nodes-ns/demo.html
+++ b/submissions/examples/chladni-plate-nodes-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Chladni Plate Nodes — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Chladni Plate Nodes demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Chladni Plate Nodes</h1>
+      <p class="lede">Vibrating Chladni plate with sand gathering into shifting nodal lines</p>
+    </header>
+
+    <section class="ease-chladni-plate-nodes" data-demo="chladni-plate-nodes" aria-live="polite">
+      <div class="ease-chladni-plate-nodes__housing">
+        <div class="ease-chladni-plate-nodes__bezel">
+          <div class="ease-chladni-plate-nodes__face">
+            <div class="ease-chladni-plate-nodes__readout">
+              <span class="ease-chladni-plate-nodes__label">Chladni Plate Nodes</span>
+              <span class="ease-chladni-plate-nodes__value">LIVE</span>
+            </div>
+            <div class="ease-chladni-plate-nodes__motion" aria-hidden="true">
+              <span class="ease-chladni-plate-nodes__a"></span>
+              <span class="ease-chladni-plate-nodes__b"></span>
+              <span class="ease-chladni-plate-nodes__c"></span>
+              <span class="ease-chladni-plate-nodes__d"></span>
+            </div>
+            <div class="ease-chladni-plate-nodes__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-chladni-plate-nodes__controls">
+          <button type="button" class="ease-chladni-plate-nodes__btn primary">Engage</button>
+          <button type="button" class="ease-chladni-plate-nodes__btn">Reset</button>
+          <label class="ease-chladni-plate-nodes__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-chladni-plate-nodes__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/chladni-plate-nodes-ns/style.css
+++ b/submissions/examples/chladni-plate-nodes-ns/style.css
@@ -1,0 +1,238 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "Sora", "Avenir Next", sans-serif;
+  background:
+    radial-gradient(ellipse at 21% 0%, color-mix(in srgb, #e879f9 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 79% 100%, color-mix(in srgb, #f0abfc 18%, transparent), transparent 42%),
+    #0c1016;
+}
+
+.stage {
+  width: min(648px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-chladni-plate-nodes {
+  --accent: #e879f9;
+  --accent-2: #f0abfc;
+  --panel: color-mix(in srgb, #e8eef6 7%, #0c1016);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 16px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #0c1016 75%, #000);
+}
+
+.ease-chladni-plate-nodes__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-chladni-plate-nodes__bezel {
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #0c1016 90%, #e879f9);
+}
+
+.ease-chladni-plate-nodes__face {
+  position: relative;
+  min-height: 264px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 33% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #0c1016 85%, #000), color-mix(in srgb, #0c1016 65%, var(--accent-2)));
+}
+
+.ease-chladni-plate-nodes__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-chladni-plate-nodes__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-chladni-plate-nodes__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-chladni-plate-nodes__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-chladni-plate-nodes__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-chladni-plate-nodes__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-chladni-plate-nodes__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: chladni_plate_nodes_meter 1.7s ease-in-out infinite alternate;
+}
+
+.ease-chladni-plate-nodes__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-chladni-plate-nodes__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-chladni-plate-nodes__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-chladni-plate-nodes__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-chladni-plate-nodes__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-chladni-plate-nodes__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-chladni-plate-nodes__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-chladni-plate-nodes__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-chladni-plate-nodes__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-chladni-plate-nodes__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-chladni-plate-nodes__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-chladni-plate-nodes__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: chladni_plate_nodes_status 2.1s ease-out infinite;
+}
+
+@keyframes chladni_plate_nodes_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes chladni_plate_nodes_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-chladni-plate-nodes__a{position:absolute;left:18%;top:18%;width:64%;height:52%;border-radius:8px;border:1px solid color-mix(in srgb,var(--accent) 45%,transparent);background:radial-gradient(circle at 50% 50%,color-mix(in srgb,var(--accent) 10%,transparent),transparent 55%);animation:chladni_plate_nodes_plate 3s ease-in-out infinite}
+.ease-chladni-plate-nodes__b{position:absolute;left:22%;top:22%;width:56%;height:44%;border-radius:6px;background:repeating-linear-gradient(0deg,transparent 0 10px,color-mix(in srgb,var(--accent-2) 35%,transparent) 10px 11px),repeating-linear-gradient(90deg,transparent 0 14px,color-mix(in srgb,var(--accent) 30%,transparent) 14px 15px);opacity:.7;animation:chladni_plate_nodes_sand 3s ease-in-out infinite}
+.ease-chladni-plate-nodes__c{position:absolute;left:46%;bottom:14%;width:8%;height:10%;border-radius:50%;background:var(--accent);animation:chladni_plate_nodes_bow 0.35s linear infinite}
+.ease-chladni-plate-nodes__d{position:absolute;right:14%;top:24%;width:10px;height:10px;border-radius:50%;background:var(--accent-2);animation:chladni_plate_nodes_grain 1.4s ease-in-out infinite alternate}
+
+@keyframes chladni_plate_nodes_plate{0%,100%{transform:scale(1)}50%{transform:scale(1.02)}}
+@keyframes chladni_plate_nodes_sand{0%,100%{transform:rotate(0deg) scale(1);filter:contrast(1)}50%{transform:rotate(2deg) scale(1.04);filter:contrast(1.35)}}
+@keyframes chladni_plate_nodes_bow{0%,100%{transform:translateX(-6px)}50%{transform:translateX(6px)}}
+@keyframes chladni_plate_nodes_grain{from{transform:translate(0,0);opacity:.4}to{transform:translate(-40px,20px);opacity:1}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-chladni-plate-nodes__a,
+  .ease-chladni-plate-nodes__b,
+  .ease-chladni-plate-nodes__c,
+  .ease-chladni-plate-nodes__d,
+  .ease-chladni-plate-nodes__meters i::after,
+  .ease-chladni-plate-nodes__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-chladni-plate-nodes` under `submissions/examples/chladni-plate-nodes-ns/` — CSS-only Vibrating Chladni plate with sand gathering into shifting nodal lines.

Fixes #71666

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Vibrating Chladni plate with sand gathering into shifting nodal lines.

**How does a developer use it?**

```html
<section class="ease-chladni-plate-nodes">
  <div class="ease-chladni-plate-nodes__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `chladni_plate_nodes_*` prefix. Reduced-motion disables animations.
