### PR TITLE
feat: add ease-foucault-knife-edge (#71667)

### DIFF
--- a/submissions/examples/foucault-knife-edge-ns/README.md
+++ b/submissions/examples/foucault-knife-edge-ns/README.md
@@ -1,0 +1,16 @@
+# Foucault Knife Edge
+
+## What does this do?
+Renders a self-contained CSS-only `ease-foucault-knife-edge` demo: Foucault knife-edge test shadow sweeping across a mirror figure.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-foucault-knife-edge`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-foucault-knife-edge">
+  <div class="ease-foucault-knife-edge__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/foucault-knife-edge-ns/demo.html
+++ b/submissions/examples/foucault-knife-edge-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Foucault Knife Edge — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Foucault Knife Edge demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Foucault Knife Edge</h1>
+      <p class="lede">Foucault knife-edge test shadow sweeping across a mirror figure</p>
+    </header>
+
+    <section class="ease-foucault-knife-edge" data-demo="foucault-knife-edge" aria-live="polite">
+      <div class="ease-foucault-knife-edge__housing">
+        <div class="ease-foucault-knife-edge__bezel">
+          <div class="ease-foucault-knife-edge__face">
+            <div class="ease-foucault-knife-edge__readout">
+              <span class="ease-foucault-knife-edge__label">Foucault Knife Edge</span>
+              <span class="ease-foucault-knife-edge__value">LIVE</span>
+            </div>
+            <div class="ease-foucault-knife-edge__motion" aria-hidden="true">
+              <span class="ease-foucault-knife-edge__a"></span>
+              <span class="ease-foucault-knife-edge__b"></span>
+              <span class="ease-foucault-knife-edge__c"></span>
+              <span class="ease-foucault-knife-edge__d"></span>
+            </div>
+            <div class="ease-foucault-knife-edge__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-foucault-knife-edge__controls">
+          <button type="button" class="ease-foucault-knife-edge__btn primary">Engage</button>
+          <button type="button" class="ease-foucault-knife-edge__btn">Reset</button>
+          <label class="ease-foucault-knife-edge__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-foucault-knife-edge__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/foucault-knife-edge-ns/style.css
+++ b/submissions/examples/foucault-knife-edge-ns/style.css
@@ -1,0 +1,239 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "Sora", "Avenir Next", sans-serif;
+  background:
+    radial-gradient(ellipse at 21% 0%, color-mix(in srgb, #94a3b8 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 79% 100%, color-mix(in srgb, #e2e8f0 18%, transparent), transparent 42%),
+    #0c1016;
+}
+
+.stage {
+  width: min(648px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-foucault-knife-edge {
+  --accent: #94a3b8;
+  --accent-2: #e2e8f0;
+  --panel: color-mix(in srgb, #e8eef6 7%, #0c1016);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 16px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #0c1016 75%, #000);
+}
+
+.ease-foucault-knife-edge__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-foucault-knife-edge__bezel {
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #0c1016 90%, #94a3b8);
+}
+
+.ease-foucault-knife-edge__face {
+  position: relative;
+  min-height: 264px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, #e8eef6 10%, transparent);
+  background:
+    radial-gradient(circle at 33% 20%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 42%),
+    linear-gradient(145deg, color-mix(in srgb, #0c1016 85%, #000), color-mix(in srgb, #0c1016 65%, var(--accent-2)));
+}
+
+.ease-foucault-knife-edge__readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.85rem 1rem 0;
+  position: relative;
+  z-index: 3;
+}
+
+.ease-foucault-knife-edge__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.ease-foucault-knife-edge__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.ease-foucault-knife-edge__motion {
+  position: absolute;
+  inset: 16% 6% 24%;
+  z-index: 1;
+}
+
+.ease-foucault-knife-edge__meters {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+  z-index: 2;
+}
+
+.ease-foucault-knife-edge__meters i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e8eef6 12%, transparent);
+  overflow: hidden;
+}
+
+.ease-foucault-knife-edge__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent-2), var(--accent));
+  animation: foucault_knife_edge_meter 1.6s ease-in-out infinite alternate;
+}
+
+.ease-foucault-knife-edge__meters i:nth-child(2)::after { animation-delay: 0.1s; width: 58%; }
+.ease-foucault-knife-edge__meters i:nth-child(3)::after { animation-delay: 0.2s; width: 72%; }
+.ease-foucault-knife-edge__meters i:nth-child(4)::after { animation-delay: 0.3s; width: 50%; }
+.ease-foucault-knife-edge__meters i:nth-child(5)::after { animation-delay: 0.4s; width: 84%; }
+.ease-foucault-knife-edge__meters i:nth-child(6)::after { animation-delay: 0.5s; width: 63%; }
+
+.ease-foucault-knife-edge__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.ease-foucault-knife-edge__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.ease-foucault-knife-edge__btn.primary {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.ease-foucault-knife-edge__btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ease-foucault-knife-edge__switch {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-foucault-knife-edge__status {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.ease-foucault-knife-edge__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: foucault_knife_edge_status 2.2s ease-out infinite;
+}
+
+@keyframes foucault_knife_edge_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes foucault_knife_edge_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-foucault-knife-edge__a{position:absolute;left:22%;top:20%;width:56%;height:48%;border-radius:50%;border:2px solid color-mix(in srgb,var(--accent) 55%,transparent);background:radial-gradient(circle at 42% 40%,color-mix(in srgb,var(--accent-2) 28%,transparent),transparent 55%);overflow:hidden;animation:foucault_knife_edge_mirror 2.7s ease-in-out infinite}
+.ease-foucault-knife-edge__b{position:absolute;left:22%;top:20%;width:8%;height:48%;background:linear-gradient(90deg,#0c1016,transparent);animation:foucault_knife_edge_knife 2.7s linear infinite}
+.ease-foucault-knife-edge__c{position:absolute;left:18%;bottom:16%;width:64%;height:8px;border-radius:4px;background:color-mix(in srgb,#e8eef6 10%,transparent);overflow:hidden}
+.ease-foucault-knife-edge__c::after{content:"";display:block;height:100%;width:30%;background:linear-gradient(90deg,var(--accent),var(--accent-2));animation:foucault_knife_edge_zone 2.7s ease-in-out infinite}
+.ease-foucault-knife-edge__d{position:absolute;right:16%;top:26%;width:3px;height:30%;background:var(--accent-2);animation:foucault_knife_edge_ray 2.7s ease-in-out infinite alternate}
+
+@keyframes foucault_knife_edge_mirror{0%,100%{filter:brightness(.9)}50%{filter:brightness(1.15)}}
+@keyframes foucault_knife_edge_knife{0%{transform:translateX(0);opacity:.95}100%{transform:translateX(220px);opacity:.55}}
+@keyframes foucault_knife_edge_zone{0%{transform:translateX(0)}100%{transform:translateX(200%)}}
+@keyframes foucault_knife_edge_ray{from{opacity:.3;transform:scaleY(.7)}to{opacity:1;transform:scaleY(1.15)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-foucault-knife-edge__a,
+  .ease-foucault-knife-edge__b,
+  .ease-foucault-knife-edge__c,
+  .ease-foucault-knife-edge__d,
+  .ease-foucault-knife-edge__meters i::after,
+  .ease-foucault-knife-edge__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-foucault-knife-edge` under `submissions/examples/foucault-knife-edge-ns/` — CSS-only Foucault knife-edge test shadow sweeping across a mirror figure.

Fixes #71667

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Foucault knife-edge test shadow sweeping across a mirror figure.

**How does a developer use it?**

```html
<section class="ease-foucault-knife-edge">
  <div class="ease-foucault-knife-edge__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Recognizable real-world motion, pure CSS keyframes, no JS.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Motion keyframes use the `foucault_knife_edge_*` prefix. Reduced-motion disables animations.
