### PR TITLE
feat: add Mesh Gradient Background showcase 

### DIFF
--- a/submissions/examples/mesh-gradient-background-av/README.md
+++ b/submissions/examples/mesh-gradient-background-av/README.md
@@ -1,0 +1,58 @@
+# Mesh Gradient Background
+
+## What does this do?
+
+Demonstrates an animated **multicolor mesh gradient background** built entirely with pure CSS — no JavaScript, no canvas, no SVG filters. Five radial-gradient blobs drift independently behind a glassmorphism content panel.
+
+## Features
+
+- **Layered radial gradients** — five `radial-gradient()` blobs, each absolutely positioned and styled with `filter: blur` and `mix-blend-mode: screen` to produce smooth color blending.
+- **Purple · Cyan · Blue · Pink · Violet** color palette defined via CSS custom properties.
+- **Smooth background movement** — each blob animates on its own `@keyframes` track at a different duration (15 s – 26 s), so they never move in sync. Only `transform: translate() scale()` is animated (GPU-composited, no layout shifts).
+- **Glassmorphism content panel** — `backdrop-filter: blur(18px)`, translucent background, subtle border and box-shadow.
+- **Responsive** — blob sizes use `clamp()`, panel padding uses `clamp()`, layout is viewport-relative.
+- **Reduced-motion safe** — all drift animations stop under `prefers-reduced-motion: reduce`; the gradient remains visible as a static composition.
+- **Zero JavaScript** — pure HTML + CSS.
+
+## How the animation works
+
+Each `.mgb-layer` element is a large colored circle positioned `absolute` inside a `fixed` canvas:
+
+```css
+.mgb-layer--purple {
+  animation: mgb-drift-1 18s ease-in-out infinite alternate;
+}
+
+@keyframes mgb-drift-1 {
+  0%   { transform: translate(0, 0)    scale(1);    }
+  33%  { transform: translate(8%, 12%) scale(1.06); }
+  100% { transform: translate(10%, -5%) scale(1.04); }
+}
+```
+
+Because each blob has a unique keyframe path and duration, they orbit at different speeds and produce an organic mesh effect when their blurred, screen-blended halos overlap.
+
+## Responsive behavior
+
+| Viewport | Behavior |
+|----------|----------|
+| ≥ 1440 px | Full-size blobs; panel max-width 560 px centred |
+| 768–1440 px | `clamp()` scales blob sizes and panel padding naturally |
+| ≤ 768 px | `overflow-x: hidden` on body prevents horizontal scroll |
+| ≤ 400 px | Panel padding tightened; buttons stack vertically |
+
+## Reduced-motion behavior
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  .mgb-layer { animation: none; }
+}
+```
+
+The five gradient blobs remain visible as a static layered composition — no blank or broken state.
+
+## How to run
+
+Open `demo.html` directly in any modern browser.
+
+No build step, server, or dependencies are required.

--- a/submissions/examples/mesh-gradient-background-av/demo.html
+++ b/submissions/examples/mesh-gradient-background-av/demo.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Mesh Gradient Background – EaseMotion CSS</title>
+  <meta name="description" content="Animated multicolor mesh gradient background built with pure CSS: layered radial gradients, smooth movement, and a glassmorphism content panel.">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <!-- Animated mesh gradient (decorative, aria-hidden from the accessibility tree) -->
+  <div class="mgb-canvas" aria-hidden="true">
+    <div class="mgb-layer mgb-layer--purple"></div>
+    <div class="mgb-layer mgb-layer--cyan"></div>
+    <div class="mgb-layer mgb-layer--blue"></div>
+    <div class="mgb-layer mgb-layer--pink"></div>
+    <div class="mgb-layer mgb-layer--violet"></div>
+  </div>
+
+  <!-- Page content rendered above the gradient -->
+  <main class="mgb-page">
+
+    <!-- Glassmorphism content panel -->
+    <article class="mgb-panel" aria-label="Mesh Gradient Background showcase">
+
+      <header class="mgb-panel__header">
+        <span class="mgb-chip" aria-hidden="true">✦ Pure CSS</span>
+        <h1 class="mgb-panel__title">Mesh Gradient Background</h1>
+        <p class="mgb-panel__subtitle">
+          An animated multicolor background built entirely with layered
+          CSS radial gradients — no JavaScript, no canvas, no SVG filters.
+        </p>
+      </header>
+
+      <dl class="mgb-features">
+        <div class="mgb-features__item">
+          <dt>Layers</dt>
+          <dd>5 independently animated radial gradient blobs</dd>
+        </div>
+        <div class="mgb-features__item">
+          <dt>Palette</dt>
+          <dd>Purple · Cyan · Blue · Pink · Violet</dd>
+        </div>
+        <div class="mgb-features__item">
+          <dt>Animation</dt>
+          <dd>Smooth orbital drift via CSS <code>transform</code></dd>
+        </div>
+        <div class="mgb-features__item">
+          <dt>Motion safe</dt>
+          <dd>Respects <code>prefers-reduced-motion</code></dd>
+        </div>
+      </dl>
+
+      <footer class="mgb-panel__footer">
+        <a
+          href="https://github.com/saptarshi-coder/EaseMotion-css"
+          class="mgb-btn mgb-btn--primary"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="View EaseMotion CSS on GitHub (opens in new tab)"
+        >
+          View on GitHub
+        </a>
+        <a
+          href="style.css"
+          class="mgb-btn mgb-btn--ghost"
+          aria-label="View the CSS source for this component"
+        >
+          View CSS source
+        </a>
+      </footer>
+
+    </article>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/mesh-gradient-background-av/style.css
+++ b/submissions/examples/mesh-gradient-background-av/style.css
@@ -1,0 +1,421 @@
+/* ==========================================================================
+   MESH GRADIENT BACKGROUND
+   Library: EaseMotion CSS
+   Track:   Pure CSS / HTML Showcase
+   Issue:   #71695
+   ========================================================================== */
+
+/* ==========================================================================
+   1. DESIGN TOKENS
+   ========================================================================== */
+:root {
+  /* Color palette */
+  --mgb-purple:   hsla(270, 80%, 55%, 0.82);
+  --mgb-cyan:     hsla(188, 90%, 52%, 0.72);
+  --mgb-blue:     hsla(218, 85%, 52%, 0.76);
+  --mgb-pink:     hsla(330, 80%, 60%, 0.74);
+  --mgb-violet:   hsla(285, 70%, 45%, 0.68);
+
+  /* Base background shown through the blobs */
+  --mgb-base:     #0c0a1e;
+
+  /* Animation timing — individual layers have different durations for
+     the organic "mesh" effect */
+  --mgb-dur-1: 18s;
+  --mgb-dur-2: 23s;
+  --mgb-dur-3: 20s;
+  --mgb-dur-4: 26s;
+  --mgb-dur-5: 15s;
+  --mgb-easing: ease-in-out;
+
+  /* Glassmorphism panel */
+  --panel-bg:       rgba(255, 255, 255, 0.06);
+  --panel-border:   rgba(255, 255, 255, 0.14);
+  --panel-shadow:
+    0 8px 32px rgba(0, 0, 0, 0.45),
+    0 0 0 1px rgba(255, 255, 255, 0.08);
+  --panel-blur:     18px;
+  --panel-radius:   20px;
+
+  /* Typography */
+  --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif;
+
+  /* Text colors — light on dark background */
+  --text-primary:   #f0edfb;
+  --text-secondary: rgba(240, 237, 251, 0.68);
+  --text-muted:     rgba(240, 237, 251, 0.45);
+  --text-code:      #a9d9f7;
+
+  /* Focus ring */
+  --focus-ring: #a78bfa;
+}
+
+/* ==========================================================================
+   2. BASE RESET
+   ========================================================================== */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html,
+body {
+  width: 100%;
+  min-height: 100%;
+  font-family: var(--font);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  background-color: var(--mgb-base);
+  color: var(--text-primary);
+}
+
+/* ==========================================================================
+   3. CANVAS  —  The animated mesh gradient background layer
+   Positioned fixed so it fills the entire viewport and sits behind content.
+   ========================================================================== */
+.mgb-canvas {
+  position: fixed;
+  inset: 0;                /* top/right/bottom/left: 0 */
+  z-index: 0;
+  overflow: hidden;
+  background-color: var(--mgb-base);
+
+  /* Subtle noise texture via a repeating radial gradient */
+  background-image:
+    radial-gradient(circle at 50% 50%, rgba(255,255,255,0.012) 0%, transparent 70%);
+}
+
+/* ==========================================================================
+   4. GRADIENT LAYERS
+   Each layer is a large radial gradient blob absolutely positioned and
+   animated independently with transform — no layout shifts.
+   ========================================================================== */
+.mgb-layer {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(80px);
+  /* Performance hint: tell the browser this element uses transform */
+  will-change: transform;
+  /* Blending makes overlapping blobs mix like true mesh gradients */
+  mix-blend-mode: screen;
+  opacity: 0.85;
+}
+
+/* --------------------------------------------------------------------------
+   Purple blob — top-left anchor
+   -------------------------------------------------------------------------- */
+.mgb-layer--purple {
+  width: clamp(420px, 55vw, 900px);
+  height: clamp(380px, 50vw, 820px);
+  background: radial-gradient(circle, var(--mgb-purple) 0%, transparent 70%);
+  top: -10%;
+  left: -5%;
+  animation: mgb-drift-1 var(--mgb-dur-1) var(--mgb-easing) infinite alternate;
+}
+
+/* --------------------------------------------------------------------------
+   Cyan blob — right side
+   -------------------------------------------------------------------------- */
+.mgb-layer--cyan {
+  width: clamp(360px, 50vw, 800px);
+  height: clamp(340px, 45vw, 760px);
+  background: radial-gradient(circle, var(--mgb-cyan) 0%, transparent 68%);
+  top: 10%;
+  right: -8%;
+  animation: mgb-drift-2 var(--mgb-dur-2) var(--mgb-easing) infinite alternate;
+}
+
+/* --------------------------------------------------------------------------
+   Blue blob — bottom-left area
+   -------------------------------------------------------------------------- */
+.mgb-layer--blue {
+  width: clamp(340px, 45vw, 760px);
+  height: clamp(340px, 45vw, 760px);
+  background: radial-gradient(circle, var(--mgb-blue) 0%, transparent 66%);
+  bottom: -5%;
+  left: 5%;
+  animation: mgb-drift-3 var(--mgb-dur-3) var(--mgb-easing) infinite alternate;
+}
+
+/* --------------------------------------------------------------------------
+   Pink blob — bottom-right area
+   -------------------------------------------------------------------------- */
+.mgb-layer--pink {
+  width: clamp(380px, 48vw, 840px);
+  height: clamp(360px, 46vw, 800px);
+  background: radial-gradient(circle, var(--mgb-pink) 0%, transparent 65%);
+  bottom: -8%;
+  right: -6%;
+  animation: mgb-drift-4 var(--mgb-dur-4) var(--mgb-easing) infinite alternate;
+}
+
+/* --------------------------------------------------------------------------
+   Violet accent blob — centered, adds depth between all other blobs
+   -------------------------------------------------------------------------- */
+.mgb-layer--violet {
+  width: clamp(300px, 42vw, 680px);
+  height: clamp(300px, 42vw, 680px);
+  background: radial-gradient(circle, var(--mgb-violet) 0%, transparent 70%);
+  top: 30%;
+  left: 30%;
+  animation: mgb-drift-5 var(--mgb-dur-5) var(--mgb-easing) infinite alternate;
+}
+
+/* ==========================================================================
+   5. ANIMATION KEYFRAMES
+   Each blob drifts along a unique translate path so they orbit independently,
+   producing an organic mesh effect. Only transform is animated.
+   ========================================================================== */
+@keyframes mgb-drift-1 {
+  0%   { transform: translate(0,    0)    scale(1);    }
+  33%  { transform: translate(8%,   12%)  scale(1.06); }
+  66%  { transform: translate(-4%,  6%)   scale(0.96); }
+  100% { transform: translate(10%,  -5%)  scale(1.04); }
+}
+
+@keyframes mgb-drift-2 {
+  0%   { transform: translate(0,    0)    scale(1);    }
+  40%  { transform: translate(-12%, 8%)   scale(1.08); }
+  80%  { transform: translate(-5%,  -10%) scale(0.94); }
+  100% { transform: translate(6%,   -8%)  scale(1.02); }
+}
+
+@keyframes mgb-drift-3 {
+  0%   { transform: translate(0,    0)    scale(1);    }
+  30%  { transform: translate(14%,  -8%)  scale(1.05); }
+  70%  { transform: translate(6%,   -12%) scale(0.97); }
+  100% { transform: translate(-8%,  -6%)  scale(1.03); }
+}
+
+@keyframes mgb-drift-4 {
+  0%   { transform: translate(0,    0)    scale(1);    }
+  50%  { transform: translate(-10%, -14%) scale(1.1);  }
+  100% { transform: translate(8%,   -4%)  scale(0.95); }
+}
+
+@keyframes mgb-drift-5 {
+  0%   { transform: translate(0,    0)    scale(1);    }
+  25%  { transform: translate(-8%,  10%)  scale(1.07); }
+  75%  { transform: translate(10%,  -8%)  scale(0.93); }
+  100% { transform: translate(4%,   6%)   scale(1.05); }
+}
+
+/* ==========================================================================
+   6. PAGE LAYOUT  —  Content sits above the fixed canvas
+   ========================================================================== */
+.mgb-page {
+  position: relative;
+  z-index: 1;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(24px, 6vw, 80px) clamp(16px, 4vw, 48px);
+}
+
+/* ==========================================================================
+   7. GLASSMORPHISM PANEL
+   ========================================================================== */
+.mgb-panel {
+  width: 100%;
+  max-width: 560px;
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--panel-radius);
+  box-shadow: var(--panel-shadow);
+  /* The blur is what makes it glassmorphic */
+  backdrop-filter: blur(var(--panel-blur));
+  -webkit-backdrop-filter: blur(var(--panel-blur));
+  padding: clamp(28px, 5vw, 52px);
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+/* --------------------------------------------------------------------------
+   Panel header
+   -------------------------------------------------------------------------- */
+.mgb-panel__header {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.mgb-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  align-self: flex-start;
+  padding: 4px 12px;
+  border-radius: 9999px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(167, 139, 250, 0.18);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: #c4b5fd;
+  text-transform: uppercase;
+}
+
+.mgb-panel__title {
+  font-size: clamp(1.6rem, 4vw, 2.25rem);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  color: var(--text-primary);
+  line-height: 1.15;
+}
+
+.mgb-panel__subtitle {
+  font-size: clamp(0.875rem, 1.4vw, 1rem);
+  color: var(--text-secondary);
+  line-height: 1.65;
+}
+
+/* --------------------------------------------------------------------------
+   Feature list (definition list)
+   -------------------------------------------------------------------------- */
+.mgb-features {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 12px;
+}
+
+.mgb-features__item {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.mgb-features__item dt {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+.mgb-features__item dd {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.mgb-features__item code {
+  font-family: "SF Mono", "Fira Code", "Consolas", monospace;
+  font-size: 0.82em;
+  color: var(--text-code);
+}
+
+/* --------------------------------------------------------------------------
+   Panel footer / actions
+   -------------------------------------------------------------------------- */
+.mgb-panel__footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+/* ==========================================================================
+   8. BUTTONS
+   ========================================================================== */
+.mgb-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 10px 22px;
+  border-radius: 10px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  font-family: var(--font);
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 180ms ease, transform 180ms ease, box-shadow 180ms ease;
+  white-space: nowrap;
+}
+
+.mgb-btn--primary {
+  background: linear-gradient(135deg, #7c3aed, #4f46e5);
+  color: #ffffff;
+  box-shadow: 0 4px 16px rgba(124, 58, 237, 0.4);
+}
+
+.mgb-btn--primary:hover {
+  background: linear-gradient(135deg, #6d28d9, #4338ca);
+  transform: translateY(-1px);
+  box-shadow: 0 6px 20px rgba(124, 58, 237, 0.55);
+}
+
+.mgb-btn--ghost {
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text-secondary);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+}
+
+.mgb-btn--ghost:hover {
+  background: rgba(255, 255, 255, 0.12);
+  color: var(--text-primary);
+  transform: translateY(-1px);
+}
+
+.mgb-btn:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 3px;
+}
+
+/* ==========================================================================
+   9. REDUCED MOTION
+   Stop all drift animations; keep the gradient visible and static.
+   ========================================================================== */
+@media (prefers-reduced-motion: reduce) {
+  .mgb-layer {
+    animation: none;
+    will-change: auto;
+  }
+
+  .mgb-btn {
+    transition: none;
+  }
+}
+
+/* ==========================================================================
+   10. RESPONSIVE OVERRIDES
+   ========================================================================== */
+
+/* Narrow mobile — ensure no horizontal scroll from oversized blobs */
+@media (max-width: 400px) {
+  .mgb-panel {
+    padding: 24px 20px;
+    border-radius: 16px;
+  }
+
+  .mgb-panel__footer {
+    flex-direction: column;
+  }
+
+  .mgb-btn {
+    width: 100%;
+    justify-content: center;
+  }
+
+  /* Scale down blur radius on very small screens for performance */
+  .mgb-canvas {
+    --panel-blur: 12px;
+  }
+}
+
+/* Keep blobs from creating scrollbars — canvas is fixed so overflow:hidden
+   is on the canvas itself, but ensure body doesn't scroll horizontally */
+@media (max-width: 768px) {
+  body {
+    overflow-x: hidden;
+  }
+}


### PR DESCRIPTION
## Summary

Closes #71695

Implements the **Mesh Gradient Background** showcase — an animated multicolor background built entirely with pure CSS. No JavaScript, no canvas, no SVG filters.

---

## Files created

| File | Description |
|------|-------------|
| `submissions/examples/mesh-gradient-background-av/demo.html` | Standalone demo, opens directly in a browser |
| `submissions/examples/mesh-gradient-background-av/style.css` | Pure CSS implementation — zero JavaScript |
| `submissions/examples/mesh-gradient-background-av/README.md` | Component documentation |

No existing files modified. Nothing under `core/` or `components/` touched.

---

## What was implemented

### Mesh gradient background
- **5 radial-gradient blobs** — each an absolutely-positioned `<div>` inside a `position: fixed` canvas
- `filter: blur(80px)` + `mix-blend-mode: screen` on every blob → colors blend naturally at overlaps
- **Purple · Cyan · Blue · Pink · Violet** palette via `hsla()` CSS custom properties

### Animation
- 5 independent `@keyframes mgb-drift-N` — each with a unique multi-stop `translate/scale` path
- Durations staggered across **15 s – 26 s** with `alternate` direction → blobs never snap back
- Only `transform` is animated (GPU-composited, zero layout shifts)
- `will-change: transform` promotes each blob to a GPU compositor layer

### Glassmorphism content panel
- `backdrop-filter: blur(18px)` + `rgba` background → glass effect
- Translucent border, multi-layer `box-shadow`, `border-radius: 20px`
- Contains heading, feature `<dl>`, and two CTA buttons

---

## CSS techniques

- CSS custom properties (`:root`) for palette, timing, panel styling
- `clamp()` for responsive blob sizes and panel padding
- `position: fixed` canvas → gradient always covers the viewport
- `mix-blend-mode: screen` for organic color blending between layers
- `will-change: transform` for GPU compositing

---

## Accessibility

- ✅ Canvas `<div>` carries `aria-hidden="true"` — animated blobs never reach the accessibility tree
- ✅ Semantic HTML: `<main>`, `<article aria-label>`, `<header>`, `<footer>`, `<dl>`, `<h1>`
- ✅ Both links are native `<a href>` elements with descriptive `aria-label`
- ✅ `:focus-visible` ring on all interactive elements
- ✅ Light text (`#f0edfb`) on dark base (`#0c0a1e`) — readable contrast
- ✅ Zero JavaScript

---

## Reduced-motion

```css
@media (prefers-reduced-motion: reduce) {
  .mgb-layer { animation: none; }
}
