### PR TITLE
feat: implement CSS Mention Autocomplete #70937

### DIFF
--- a/submissions/examples/css-mention-autocomplete/README.md
+++ b/submissions/examples/css-mention-autocomplete/README.md
@@ -1,0 +1,13 @@
+# CSS Mention Autocomplete (#70937)
+
+A pure CSS `@` mention autocomplete dropdown component featuring avatars, user names, handles, and animated focus/hover transitions.
+
+## Features
+- **Pure CSS Execution:** Built using `:focus-within`, pseudo-classes, and CSS transforms without JavaScript dependencies.
+- **Rich User Items:** Includes avatar initials, display names, and user handles formatted inside a structured dropdown.
+- **Accessibility & Responsiveness:** Built with semantic `listbox`/`option` ARIA roles, focus state management, and `@media (prefers-reduced-motion: reduce)` fallbacks.
+
+## File Hierarchy
+- `style.css` - Autocomplete dropdown positioning, state visibility triggers, and visual styling.
+- `demo.html` - Interactive HTML markup showing the mention input and popover dropdown.
+- `README.md` - Technical specs and documentation.

--- a/submissions/examples/css-mention-autocomplete/demo.html
+++ b/submissions/examples/css-mention-autocomplete/demo.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Mention Autocomplete | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main>
+    <article class="autocomplete-card">
+      <h1 class="card-title">Mention Autocomplete</h1>
+      <p class="card-description">Focus or type in the input below to trigger the pure CSS @ mention autocomplete dropdown.</p>
+
+      <div class="mention-wrapper">
+        <div class="input-container">
+          <input 
+            type="text" 
+            class="mention-input" 
+            placeholder="Type @ to mention someone..." 
+            value="@a"
+            aria-label="User mention autocomplete input"
+            aria-expanded="true"
+            aria-controls="mention-list"
+          >
+        </div>
+
+        <ul class="mention-dropdown" id="mention-list" role="listbox" aria-label="Suggested mentions">
+          <li class="dropdown-header">Matching Members</li>
+          <li>
+            <a href="#alex" class="mention-item" role="option" tabindex="0">
+              <div class="avatar avatar-1">AR</div>
+              <div class="user-info">
+                <span class="name">Alex Rivera</span>
+                <span class="handle">@alexdev</span>
+              </div>
+            </a>
+          </li>
+          <li>
+            <a href="#amara" class="mention-item" role="option" tabindex="0">
+              <div class="avatar avatar-2">AC</div>
+              <div class="user-info">
+                <span class="name">Amara Chen</span>
+                <span class="handle">@amarac</span>
+              </div>
+            </a>
+          </li>
+          <li>
+            <a href="#aaron" class="mention-item" role="option" tabindex="0">
+              <div class="avatar avatar-3">AP</div>
+              <div class="user-info">
+                <span class="name">Aaron Patel</span>
+                <span class="handle">@aaronp</span>
+              </div>
+            </a>
+          </li>
+          <li>
+            <a href="#alyssa" class="mention-item" role="option" tabindex="0">
+              <div class="avatar avatar-4">AV</div>
+              <div class="user-info">
+                <span class="name">Alyssa Vance</span>
+                <span class="handle">@alyssav</span>
+              </div>
+            </a>
+          </li>
+        </ul>
+      </div>
+    </article>
+  </main>
+</body>
+</html>

--- a/submissions/examples/css-mention-autocomplete/style.css
+++ b/submissions/examples/css-mention-autocomplete/style.css
@@ -1,0 +1,178 @@
+/* CSS Mention Autocomplete #70937 */
+
+:root {
+  --bg-color: #0f172a;
+  --card-bg: #1e293b;
+  --border-color: #334155;
+  --border-focus: #38bdf8;
+  --text-main: #f8fafc;
+  --text-sub: #94a3b8;
+  --accent-color: #38bdf8;
+  --hover-bg: #334155;
+  --shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.5), 0 8px 10px -6px rgba(0, 0, 0, 0.5);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 2rem 1rem;
+  background-color: var(--bg-color);
+  color: var(--text-main);
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.autocomplete-card {
+  width: 100%;
+  max-width: 480px;
+  background-color: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 16px;
+  padding: 2rem 1.5rem;
+  box-shadow: var(--shadow);
+}
+
+.card-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin: 0 0 0.5rem 0;
+  color: var(--text-main);
+}
+
+.card-description {
+  font-size: 0.875rem;
+  color: var(--text-sub);
+  margin: 0 0 1.5rem 0;
+  line-height: 1.5;
+}
+
+.mention-wrapper {
+  position: relative;
+  width: 100%;
+}
+
+.input-container {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.mention-input {
+  width: 100%;
+  padding: 0.875rem 1rem;
+  background-color: #0f172a;
+  border: 1.5px solid var(--border-color);
+  border-radius: 10px;
+  color: var(--text-main);
+  font-size: 0.95rem;
+  outline: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.mention-input:focus {
+  border-color: var(--border-focus);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.15);
+}
+
+.mention-dropdown {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  right: 0;
+  background-color: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  box-shadow: var(--shadow);
+  padding: 0.5rem;
+  margin: 0;
+  list-style: none;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-8px) scale(0.98);
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s;
+  z-index: 50;
+}
+
+.mention-wrapper:focus-within .mention-dropdown,
+.mention-dropdown:hover {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.dropdown-header {
+  padding: 0.5rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-sub);
+  border-bottom: 1px solid var(--border-color);
+  margin-bottom: 0.25rem;
+}
+
+.mention-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.625rem 0.75rem;
+  border-radius: 8px;
+  cursor: pointer;
+  text-decoration: none;
+  color: var(--text-main);
+  transition: background-color 0.15s ease;
+}
+
+.mention-item:hover,
+.mention-item:focus {
+  background-color: var(--hover-bg);
+  outline: none;
+}
+
+.avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 0.875rem;
+  color: #0f172a;
+  flex-shrink: 0;
+}
+
+.avatar-1 { background-color: #38bdf8; }
+.avatar-2 { background-color: #a855f7; }
+.avatar-3 { background-color: #22c55e; }
+.avatar-4 { background-color: #f59e0b; }
+
+.user-info {
+  display: flex;
+  flex-direction: column;
+}
+
+.name {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text-main);
+}
+
+.handle {
+  font-size: 0.775rem;
+  color: var(--text-sub);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mention-dropdown {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the **CSS Mention Autocomplete** component (#70937).
gssoc 26

Closes #70937

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component / motion pattern
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/css-mention-autocomplete/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] Pure CSS implementation with zero JavaScript
- [x] Accessible with proper ARIA attributes, keyboard navigation (`:focus-within`), and `prefers-reduced-motion` compliance

---

## Feature Description
**What does this add?**
An `@` mention autocomplete dropdown popover featuring avatars, display names, and user handles.

**How does it work?**
Triggered via CSS `:focus-within` and hover states on the input container, creating a smooth scale and fade transition for the dropdown list without JavaScript.