### PR TITLE
feat: implement CSS Sticky Buy Button #70845

### DIFF
--- a/submissions/examples/css-sticky-buy-button/README.md
+++ b/submissions/examples/css-sticky-buy-button/README.md
@@ -1,0 +1,13 @@
+# CSS Sticky Buy Button (#70845)
+
+A pure CSS sticky call-to-action (CTA) purchase bar that remains fixed at the bottom of the mobile viewport and integrates inline on desktop breakpoints.
+
+## Features
+- **Mobile-First Sticky Positioning:** Docked at the bottom of the screen on narrow viewports using `position: fixed` and `backdrop-filter`.
+- **Responsive Layout:** Automatically transitions into a standard inline card element on desktop viewports via media queries.
+- **Accessibility:** High-contrast focus indicators, explicit ARIA region labels, and `@media (prefers-reduced-motion: reduce)` compliance.
+
+## File Hierarchy
+- `style.css` - Sticky bottom bar layout, backdrop filters, responsive breakpoints, and hover animations.
+- `demo.html` - Product overview layout showcasing the sticky CTA bar.
+- `README.md` - Technical specification and documentation.

--- a/submissions/examples/css-sticky-buy-button/demo.html
+++ b/submissions/examples/css-sticky-buy-button/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Sticky Buy Button | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page-wrapper">
+    <article class="product-card">
+      <div class="product-image" role="img" aria-label="Wireless Headphones Preview">
+        🎧 Product Preview
+      </div>
+      <span class="badge">In Stock</span>
+      <h1 class="product-title">Pro Sound Wireless Headphones</h1>
+      <p class="product-description">
+        Experience studio-grade active noise cancellation with 40-hour battery life and custom dynamic drivers. Designed for maximum comfort during extended listening sessions.
+      </p>
+
+      <ul class="spec-list">
+        <li class="spec-item">
+          <span class="spec-label">Battery Life</span>
+          <span class="spec-value">40 Hours</span>
+        </li>
+        <li class="spec-item">
+          <span class="spec-label">Connectivity</span>
+          <span class="spec-value">Bluetooth 5.3</span>
+        </li>
+        <li class="spec-item">
+          <span class="spec-label">Noise Cancellation</span>
+          <span class="spec-value">Active (ANC)</span>
+        </li>
+        <li class="spec-item">
+          <span class="spec-label">Warranty</span>
+          <span class="spec-value">2 Years</span>
+        </li>
+      </ul>
+
+      <div class="sticky-bar" aria-label="Purchase Bar">
+        <div class="sticky-content">
+          <div class="price-details">
+            <span class="price-label">Total Price</span>
+            <span class="price-val">$199.99</span>
+          </div>
+          <a href="#checkout" class="buy-btn" role="button">
+            <span>Buy Now</span>
+            <span aria-hidden="true">→</span>
+          </a>
+        </div>
+      </div>
+    </article>
+  </main>
+</body>
+</html>

--- a/submissions/examples/css-sticky-buy-button/style.css
+++ b/submissions/examples/css-sticky-buy-button/style.css
@@ -1,0 +1,197 @@
+/* CSS Sticky Buy Button #70845 */
+
+:root {
+  --bg-color: #0f172a;
+  --card-bg: #1e293b;
+  --border-color: #334155;
+  --text-main: #f8fafc;
+  --text-sub: #94a3b8;
+  --accent-blue: #38bdf8;
+  --accent-green: #22c55e;
+  --shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.5);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--bg-color);
+  color: var(--text-main);
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  min-height: 100vh;
+  padding-bottom: 90px;
+}
+
+.page-wrapper {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+
+.product-card {
+  background-color: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 20px;
+  padding: 1.75rem;
+  box-shadow: var(--shadow);
+  margin-bottom: 2rem;
+}
+
+.product-image {
+  width: 100%;
+  height: 240px;
+  background: linear-gradient(135deg, #1e293b, #0f172a);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 1.5rem;
+  color: var(--accent-blue);
+  font-weight: 700;
+  font-size: 1.1rem;
+}
+
+.badge {
+  display: inline-block;
+  background-color: rgba(56, 189, 248, 0.15);
+  color: var(--accent-blue);
+  padding: 0.25rem 0.65rem;
+  border-radius: 50px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+}
+
+.product-title {
+  font-size: 1.5rem;
+  font-weight: 800;
+  margin: 0 0 0.5rem 0;
+}
+
+.product-description {
+  font-size: 0.9rem;
+  color: var(--text-sub);
+  line-height: 1.6;
+  margin-bottom: 1.5rem;
+}
+
+.spec-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.spec-item {
+  display: flex;
+  justify-content: space-between;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px dashed var(--border-color);
+  font-size: 0.85rem;
+}
+
+.spec-label {
+  color: var(--text-sub);
+}
+
+.spec-value {
+  font-weight: 600;
+  color: var(--text-main);
+}
+
+.sticky-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: rgba(30, 41, 59, 0.95);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-top: 1px solid var(--border-color);
+  padding: 0.85rem 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  z-index: 100;
+  box-shadow: 0 -10px 25px rgba(0, 0, 0, 0.4);
+}
+
+.sticky-content {
+  max-width: 600px;
+  width: 100%;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.price-details {
+  display: flex;
+  flex-direction: column;
+}
+
+.price-label {
+  font-size: 0.75rem;
+  color: var(--text-sub);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.price-val {
+  font-size: 1.35rem;
+  font-weight: 800;
+  color: var(--text-main);
+}
+
+.buy-btn {
+  background-color: var(--accent-blue);
+  color: #0f172a;
+  border: none;
+  padding: 0.85rem 1.75rem;
+  font-size: 0.925rem;
+  font-weight: 800;
+  border-radius: 12px;
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  transition: background-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.buy-btn:hover,
+.buy-btn:focus-visible {
+  background-color: #7dd3fc;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 15px rgba(56, 189, 248, 0.3);
+  outline: none;
+}
+
+@media (min-width: 768px) {
+  body {
+    padding-bottom: 0;
+  }
+
+  .sticky-bar {
+    position: relative;
+    border-top: none;
+    background-color: transparent;
+    padding: 0;
+    box-shadow: none;
+    backdrop-filter: none;
+    margin-top: 1.5rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .buy-btn {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the **CSS Sticky Buy Button** component (#70845).
gssoc 26

Closes #70845

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component / motion pattern
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/css-sticky-buy-button/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] Pure CSS implementation with zero JavaScript
- [x] Accessible with proper ARIA attributes, keyboard navigation support, and `prefers-reduced-motion` compliance

---

## Feature Description
**What does this add?**
A sticky purchase call-to-action bar that stays anchored to the bottom of the mobile viewport with blurred backdrop effects and seamlessly shifts inline on desktop viewports.

**How does it work?**
Uses CSS fixed positioning, CSS backdrop-filter, and breakpoint media queries to deliver a responsive mobile e-commerce CTA bar without JavaScript.