### PR TITLE
feat: implement CSS Cloud Puff Button #70838

### DIFF
--- a/submissions/examples/css-cloud-puff-button/README.md
+++ b/submissions/examples/css-cloud-puff-button/README.md
@@ -1,0 +1,13 @@
+# CSS Cloud Puff Button (#70838)
+
+A pure CSS button component featuring soft cloud puff micro-animations that burst from the outer edges upon click (`:active`).
+
+## Features
+- **Pure CSS Click Micro-Animations:** Cloud puffs generated using CSS pseudo-elements (`::before` & `::after`) and CSS box-shadows animated on the `:active` pseudo-class.
+- **Accessibility:** Accessible focus outlines, ARIA labels, and `@media (prefers-reduced-motion: reduce)` fallbacks.
+- **Zero JavaScript:** Built entirely with native CSS keyframe animations.
+
+## File Hierarchy
+- `style.css` - Button base styling, cloud puff box-shadows, and keyframe animations.
+- `demo.html` - Demo preview for testing the cloud puff button effect.
+- `README.md` - Technical documentation and usage overview.

--- a/submissions/examples/css-cloud-puff-button/demo.html
+++ b/submissions/examples/css-cloud-puff-button/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Cloud Puff Button | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main>
+    <article class="demo-card">
+      <h1 class="card-title">Cloud Puff Button</h1>
+      <p class="card-desc">
+        Click or press the button below to see small cloud puffs burst from the edges without using JavaScript.
+      </p>
+
+      <div class="button-container">
+        <button type="button" class="cloud-btn" aria-label="Launch application with cloud effect">
+          <span>Launch App ☁️</span>
+        </button>
+      </div>
+    </article>
+  </main>
+</body>
+</html>

--- a/submissions/examples/css-cloud-puff-button/style.css
+++ b/submissions/examples/css-cloud-puff-button/style.css
@@ -1,0 +1,177 @@
+/* CSS Cloud Puff Button #70838 */
+
+:root {
+  --bg-color: #0f172a;
+  --card-bg: #1e293b;
+  --border-color: #334155;
+  --text-main: #f8fafc;
+  --text-sub: #94a3b8;
+  --btn-bg: #38bdf8;
+  --btn-hover: #7dd3fc;
+  --cloud-color: rgba(255, 255, 255, 0.85);
+  --shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.4);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 2rem 1rem;
+  background-color: var(--bg-color);
+  color: var(--text-main);
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.demo-card {
+  width: 100%;
+  max-width: 440px;
+  background-color: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 20px;
+  padding: 2.5rem 2rem;
+  box-shadow: var(--shadow);
+  text-align: center;
+}
+
+.card-title {
+  font-size: 1.5rem;
+  font-weight: 800;
+  margin: 0 0 0.5rem 0;
+}
+
+.card-desc {
+  font-size: 0.9rem;
+  color: var(--text-sub);
+  margin-bottom: 2.25rem;
+  line-height: 1.5;
+}
+
+.button-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+/* Cloud Puff Button Base */
+.cloud-btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.9rem 2.25rem;
+  font-size: 1rem;
+  font-weight: 800;
+  color: #0f172a;
+  background-color: var(--btn-bg);
+  border: none;
+  border-radius: 50px;
+  cursor: pointer;
+  outline: none;
+  text-decoration: none;
+  user-select: none;
+  transition: background-color 0.2s ease, transform 0.15s ease, box-shadow 0.2s ease;
+  box-shadow: 0 10px 20px -5px rgba(56, 189, 248, 0.4);
+}
+
+.cloud-btn:hover,
+.cloud-btn:focus-visible {
+  background-color: var(--btn-hover);
+  transform: translateY(-2px);
+  box-shadow: 0 14px 25px -5px rgba(56, 189, 248, 0.5);
+  outline: 2px solid var(--btn-hover);
+  outline-offset: 4px;
+}
+
+.cloud-btn:active {
+  transform: translateY(1px) scale(0.98);
+}
+
+/* Pseudo Cloud Puffs */
+.cloud-btn::before,
+.cloud-btn::after {
+  content: "";
+  position: absolute;
+  pointer-events: none;
+  opacity: 0;
+  border-radius: 50%;
+  background: var(--cloud-color);
+}
+
+/* Left Cloud Cluster Pseudo-element */
+.cloud-btn::before {
+  left: -12px;
+  top: 50%;
+  width: 18px;
+  height: 18px;
+  box-shadow: 
+    -10px -8px 0 6px var(--cloud-color),
+    -16px 6px 0 4px var(--cloud-color),
+    -4px 12px 0 5px var(--cloud-color);
+  transform: translateY(-50%) scale(0.2);
+}
+
+/* Right Cloud Cluster Pseudo-element */
+.cloud-btn::after {
+  right: -12px;
+  top: 50%;
+  width: 18px;
+  height: 18px;
+  box-shadow: 
+    10px -8px 0 6px var(--cloud-color),
+    16px 6px 0 4px var(--cloud-color),
+    4px 12px 0 5px var(--cloud-color);
+  transform: translateY(-50%) scale(0.2);
+}
+
+/* Trigger Puff Animations on Click (:active) */
+.cloud-btn:active::before {
+  animation: puff-left 0.45s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+.cloud-btn:active::after {
+  animation: puff-right 0.45s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+@keyframes puff-left {
+  0% {
+    opacity: 0.9;
+    transform: translateY(-50%) translate(0, 0) scale(0.4);
+  }
+  50% {
+    opacity: 0.8;
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-50%) translate(-28px, -6px) scale(1.3);
+  }
+}
+
+@keyframes puff-right {
+  0% {
+    opacity: 0.9;
+    transform: translateY(-50%) translate(0, 0) scale(0.4);
+  }
+  50% {
+    opacity: 0.8;
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-50%) translate(28px, -6px) scale(1.3);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cloud-btn {
+    transition: none !important;
+  }
+  .cloud-btn:active::before,
+  .cloud-btn:active::after {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the **CSS Cloud Puff Button** component (#70838).
gssoc 26

Closes #70838

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component / motion pattern
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/css-cloud-puff-button/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] Pure CSS implementation with zero JavaScript
- [x] Accessible with proper ARIA attributes, keyboard navigation support, and `prefers-reduced-motion` compliance

---

## Feature Description
**What does this add?**
A button component that triggers cloud puff micro-animations along its side borders on click/active states.

**How does it work?**
Constructed using CSS pseudo-elements with multi-radius CSS `box-shadow` configurations and CSS `@keyframes` triggered via native `:active` state selectors without JavaScript.