### PR TITLE
feat: implement CSS Focus Spotlight Section #70941

### DIFF
--- a/submissions/examples/css-focus-spotlight-section/README.md
+++ b/submissions/examples/css-focus-spotlight-section/README.md
@@ -1,0 +1,14 @@
+# CSS Focus Spotlight Section (#70941)
+
+A pure CSS focus spotlight section where hovering or keyboard-focusing an item spotlights it while smoothly dimming and blurring surrounding elements.
+
+## Features
+- **Pure CSS `:focus-within` & `:hover` Mechanics:** Combines parent state rules (`.spotlight-grid:hover`, `.spotlight-grid:focus-within`) with child selector specificity to spotlight the active item while dimming non-active siblings.
+- **Full Keyboard Accessibility:** Native focus handling using semantic `<a>` link elements, complete with `:focus-visible` ring indicators.
+- **Smooth Depth & Scale Transitions:** Applies subtle scaling (`scale(0.97)` vs `scale(1.02)`), grayscale filtering, and depth blur effects without relying on JavaScript event listeners.
+- **Accessible Motion:** Fully supports `prefers-reduced-motion: reduce` by disabling transform and blur transitions for motion-sensitive users.
+
+## File Hierarchy
+- `style.css` - Grid layout, focus-within selector rules, and spotlight motion parameters.
+- `demo.html` - Interactive card grid demonstration accessible via mouse hover and keyboard navigation.
+- `README.md` - Technical specification and feature breakdown.

--- a/submissions/examples/css-focus-spotlight-section/demo.html
+++ b/submissions/examples/css-focus-spotlight-section/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Focus Spotlight Section | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo-container">
+    <header class="header-section">
+      <h1 class="header-title">Developer Tools</h1>
+      <p class="header-subtitle">Hover or tab through the items below to trigger the focus spotlight</p>
+    </header>
+
+    <section class="spotlight-grid" aria-label="Featured Developer Tools">
+      <a href="#analytics" class="spotlight-card">
+        <div class="card-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24"><line x1="18" y1="20" x2="18" y2="10"></line><line x1="12" y1="20" x2="12" y2="4"></line><line x1="6" y1="20" x2="6" y2="14"></line></svg>
+        </div>
+        <h2 class="card-title">Real-time Analytics</h2>
+        <p class="card-description">Track network response latencies, active sessions, and request telemetry with low overhead.</p>
+        <span class="card-footer">Explore Metrics &rarr;</span>
+      </a>
+
+      <a href="#security" class="spotlight-card">
+        <div class="card-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path></svg>
+        </div>
+        <h2 class="card-title">Security Sentinel</h2>
+        <p class="card-description">Automated vulnerability scanning, secret detection, and strict access controls for API endpoints.</p>
+        <span class="card-footer">View Audit Logs &rarr;</span>
+      </a>
+
+      <a href="#deployments" class="spotlight-card">
+        <div class="card-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24"><polygon points="12 2 2 7 12 12 22 7 12 2"></polygon><polyline points="2 17 12 22 22 17"></polyline><polyline points="2 12 12 17 22 12"></polyline></svg>
+        </div>
+        <h2 class="card-title">Edge Deployments</h2>
+        <p class="card-description">Instantly route and deploy serverless workers across global edge locations with zero downtime.</p>
+        <span class="card-footer">Manage Pipelines &rarr;</span>
+      </a>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/css-focus-spotlight-section/style.css
+++ b/submissions/examples/css-focus-spotlight-section/style.css
@@ -1,0 +1,161 @@
+/* CSS Focus Spotlight Section #70941 */
+
+:root {
+  --bg-color: #0f172a;
+  --card-bg: #1e293b;
+  --border-color: #334155;
+  --text-main: #f8fafc;
+  --text-sub: #94a3b8;
+  --accent-cyan: #38bdf8;
+  --shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.4);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 3rem 1.5rem;
+  background-color: var(--bg-color);
+  color: var(--text-main);
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.demo-container {
+  width: 100%;
+  max-width: 900px;
+}
+
+.header-section {
+  text-align: center;
+  margin-bottom: 2.5rem;
+}
+
+.header-title {
+  font-size: 1.85rem;
+  font-weight: 800;
+  margin: 0 0 0.5rem 0;
+}
+
+.header-subtitle {
+  color: var(--text-sub);
+  font-size: 0.95rem;
+  margin: 0;
+}
+
+/* Spotlight Grid Container */
+.spotlight-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+/* Base Card Item */
+.spotlight-card {
+  background-color: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 16px;
+  padding: 1.75rem;
+  text-decoration: none;
+  color: inherit;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: var(--shadow);
+  transition: opacity 0.4s ease, filter 0.4s ease, transform 0.4s cubic-bezier(0.16, 1, 0.3, 1), border-color 0.3s ease, box-shadow 0.3s ease;
+  position: relative;
+  outline: none;
+}
+
+/* Card Elements */
+.card-icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  background-color: rgba(56, 189, 248, 0.1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent-cyan);
+}
+
+.card-icon svg {
+  width: 24px;
+  height: 24px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.card-title {
+  font-size: 1.15rem;
+  font-weight: 700;
+  margin: 0;
+  color: var(--text-main);
+}
+
+.card-description {
+  font-size: 0.875rem;
+  color: var(--text-sub);
+  line-height: 1.5;
+  margin: 0;
+}
+
+.card-footer {
+  margin-top: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--accent-cyan);
+}
+
+/* Pure CSS Focus Spotlight Effect */
+/* 1. When parent grid is hovered or contains active focus, dim ALL cards */
+.spotlight-grid:hover .spotlight-card,
+.spotlight-grid:focus-within .spotlight-card {
+  opacity: 0.35;
+  filter: grayscale(0.5) blur(1px);
+  transform: scale(0.97);
+}
+
+/* 2. Elevate and highlight ONLY the active card being hovered or focused */
+.spotlight-grid .spotlight-card:hover,
+.spotlight-grid .spotlight-card:focus-visible {
+  opacity: 1;
+  filter: grayscale(0) blur(0);
+  transform: translateY(-6px) scale(1.02);
+  border-color: var(--accent-cyan);
+  box-shadow: 0 25px 30px -10px rgba(56, 189, 248, 0.2);
+  z-index: 2;
+}
+
+.spotlight-card:focus-visible {
+  outline: 2px solid var(--accent-cyan);
+  outline-offset: 4px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spotlight-card {
+    transition: opacity 0.2s ease, border-color 0.2s ease !important;
+  }
+  
+  .spotlight-grid:hover .spotlight-card,
+  .spotlight-grid:focus-within .spotlight-card {
+    filter: none;
+    transform: none;
+  }
+
+  .spotlight-grid .spotlight-card:hover,
+  .spotlight-grid .spotlight-card:focus-visible {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the **CSS Focus Spotlight Section** component (#70941).
gssoc 26

Closes #70941

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component / motion pattern
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/css-focus-spotlight-section/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] Pure CSS implementation with zero JavaScript
- [x] Accessible with proper ARIA attributes, keyboard navigation support, and `prefers-reduced-motion` compliance

---

## Feature Description
**What does this add?**
A section grid component where hovering or focusing a single item highlights it with full opacity and elevated positioning while dimming and blurring all sibling elements.

**How does it work?**
Leverages pure CSS `:hover` and `:focus-within` state cascading combined with `:focus-visible` handling, scaling, and CSS filter effects with zero JavaScript.