### PR TITLE
feat: implement CSS Copy to Clipboard Button #70824

### DIFF
--- a/submissions/examples/css-copy-clipboard-button/README.md
+++ b/submissions/examples/css-copy-clipboard-button/README.md
@@ -1,0 +1,14 @@
+# CSS Copy to Clipboard Button (#70824)
+
+A pure CSS interactive button that morphs into a success state with an animated checkmark icon and confirmation label when triggered.
+
+## Features
+- **Pure CSS State Management:** Utilizes a native hidden checkbox (`:checked`) combined with sibling selectors (`+`) to toggle button styling, label text, and icon visibility with zero JavaScript.
+- **Animated Checkmark Pop:** Features an elastic pop-in keyframe animation (`check-pop`) on the success checkmark.
+- **Accessible Interaction:** Linked via `<label for="...">` associated with a focusable control element complete with `:focus-visible` outline indicators.
+- **Motion Preference Compliant:** Automatically disables checkmark scaling animations when `@media (prefers-reduced-motion: reduce)` is enabled.
+
+## File Hierarchy
+- `style.css` - Button theme styling, checkbox state triggers, and checkmark keyframe pop animation.
+- `demo.html` - Semantic component card featuring snippet copy simulation.
+- `README.md` - Technical specification and architecture overview.

--- a/submissions/examples/css-copy-clipboard-button/demo.html
+++ b/submissions/examples/css-copy-clipboard-button/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Copy to Clipboard Button | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main>
+    <article class="demo-card">
+      <header class="card-header">
+        <h1 class="card-title">Snippet Share</h1>
+        <p class="card-subtitle">Click the button below to copy configuration code</p>
+      </header>
+
+      <!-- Code Snippet Display -->
+      <div class="code-snippet-box">
+        <span>npm install @easemotion/css</span>
+      </div>
+
+      <!-- Pure CSS State Toggle -->
+      <input type="checkbox" id="copy-toggle" class="copy-state-checkbox" aria-label="Toggle copy to clipboard state">
+
+      <label for="copy-toggle" class="copy-btn" role="button" tabindex="0">
+        <!-- Copy Icon -->
+        <svg class="icon-copy" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
+        <!-- Animated Checkmark Icon -->
+        <svg class="icon-check" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"></polyline></svg>
+        <span class="btn-text"></span>
+      </label>
+    </article>
+  </main>
+</body>
+</html>

--- a/submissions/examples/css-copy-clipboard-button/style.css
+++ b/submissions/examples/css-copy-clipboard-button/style.css
@@ -1,0 +1,161 @@
+/* CSS Copy to Clipboard Button #70824 */
+
+:root {
+  --bg-color: #0f172a;
+  --card-bg: #1e293b;
+  --border-color: #334155;
+  --text-main: #f8fafc;
+  --text-sub: #94a3b8;
+  --accent-cyan: #38bdf8;
+  --accent-green: #4ade80;
+  --shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.4);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 3rem 1.5rem;
+  background-color: var(--bg-color);
+  color: var(--text-main);
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.demo-card {
+  width: 100%;
+  max-width: 440px;
+  background-color: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 20px;
+  padding: 2.25rem;
+  box-shadow: var(--shadow);
+  text-align: center;
+}
+
+.card-header {
+  margin-bottom: 2rem;
+}
+
+.card-title {
+  font-size: 1.35rem;
+  font-weight: 800;
+  margin: 0 0 0.35rem 0;
+}
+
+.card-subtitle {
+  font-size: 0.875rem;
+  color: var(--text-sub);
+  margin: 0;
+}
+
+/* Code Snippet Box */
+.code-snippet-box {
+  background-color: #0f172a;
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.875rem;
+  color: var(--accent-cyan);
+  text-align: left;
+  margin-bottom: 1.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+/* Hidden State Checkbox */
+.copy-state-checkbox {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+}
+
+/* Copy Button Styling */
+.copy-btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.85rem 1.5rem;
+  background-color: rgba(56, 189, 248, 0.12);
+  color: var(--accent-cyan);
+  border: 1px solid rgba(56, 189, 248, 0.3);
+  border-radius: 12px;
+  font-weight: 700;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: background-color 0.25s ease, border-color 0.25s ease, color 0.25s ease, transform 0.2s ease;
+  user-select: none;
+}
+
+.copy-btn:hover {
+  background-color: rgba(56, 189, 248, 0.2);
+  border-color: var(--accent-cyan);
+}
+
+.copy-state-checkbox:focus-visible + .copy-btn {
+  outline: 2px solid var(--accent-cyan);
+  outline-offset: 3px;
+}
+
+/* Icon Switching */
+.icon-check {
+  display: none;
+  color: var(--accent-green);
+}
+
+.copy-state-checkbox:checked + .copy-btn {
+  background-color: rgba(74, 222, 128, 0.15);
+  border-color: var(--accent-green);
+  color: var(--accent-green);
+}
+
+.copy-state-checkbox:checked + .copy-btn .icon-copy {
+  display: none;
+}
+
+.copy-state-checkbox:checked + .copy-btn .icon-check {
+  display: inline-block;
+  animation: check-pop 0.35s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+
+/* Label Text Switching */
+.copy-state-checkbox:checked + .copy-btn .btn-text::after {
+  content: "Successfully Copied!";
+}
+
+.btn-text::after {
+  content: "Copy to Clipboard";
+}
+
+/* Success Checkmark Pop Animation */
+@keyframes check-pop {
+  0% {
+    transform: scale(0.4);
+    opacity: 0;
+  }
+  70% {
+    transform: scale(1.2);
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .icon-check {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the **CSS Copy to Clipboard Button** component (#70824).
gssoc 25

Closes #70824

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component / motion pattern
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/css-copy-clipboard-button/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] Pure CSS implementation with zero JavaScript
- [x] Accessible with proper ARIA attributes, keyboard navigation support, and `prefers-reduced-motion` compliance

---

## Feature Description
**What does this add?**
An interactive copy button component that transforms into a success state with an animated checkmark and confirmation text upon being clicked.

**How does it work?**
Leverages native HTML checkbox state toggles (`:checked`) and CSS sibling selectors to switch between icons, styles, and text content with zero JavaScript.