### PR TITLE
feat: implement CSS Drawer with Handle #70927

### DIFF
--- a/submissions/examples/css-drawer-with-handle/README.md
+++ b/submissions/examples/css-drawer-with-handle/README.md
@@ -1,0 +1,14 @@
+# CSS Drawer with Handle (#70927)
+
+A bottom-aligned UI drawer component that utilizes a stylized handle and CSS state-based transformations for expansion and snapping.
+
+## Features
+- **CSS-Powered State Snap:** Uses `:focus-within` and `:hover` selectors to handle drawer expansion mechanics without external JavaScript.
+- **Accessible Dialog Role:** Implemented with `role="dialog"`, `aria-labelledby`, and `tabindex="0"` for robust screen reader support and keyboard interaction.
+- **Responsive Geometry:** Scales height relative to the viewport using VH units.
+- **Reduced Motion Support:** Complies with system-level motion preferences by disabling CSS transitions.
+
+## File Hierarchy
+- `style.css` - Drawer positioning, handle styling, content scroll properties, and expansion animation.
+- `demo.html` - Semantic markup configured for ARIA-compliant dialogue interaction.
+- `README.md` - Technical specification and architecture overview.

--- a/submissions/examples/css-drawer-with-handle/demo.html
+++ b/submissions/examples/css-drawer-with-handle/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Drawer with Handle | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main>
+    <section 
+      class="drawer-wrapper" 
+      role="dialog" 
+      aria-labelledby="drawer-title" 
+      tabindex="0"
+    >
+      <div class="drawer-handle" aria-hidden="true">
+        <div class="handle-bar"></div>
+      </div>
+      
+      <div class="drawer-content">
+        <header class="drawer-header">
+          <h2 id="drawer-title" class="drawer-title">Settings & Options</h2>
+        </header>
+        
+        <ul class="item-list">
+          <li class="item">Account Security</li>
+          <li class="item">Privacy Controls</li>
+          <li class="item">Notification Preferences</li>
+          <li class="item">App Storage Management</li>
+        </ul>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/css-drawer-with-handle/style.css
+++ b/submissions/examples/css-drawer-with-handle/style.css
@@ -1,0 +1,84 @@
+/* CSS Drawer with Handle #70927 */
+
+:root {
+  --drawer-bg: #1e293b;
+  --drawer-handle: #475569;
+  --text-main: #f8fafc;
+  --text-sub: #94a3b8;
+  --accent-blue: #38bdf8;
+  --shadow: 0 -10px 25px -5px rgba(0, 0, 0, 0.3);
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, sans-serif;
+  background-color: #0f172a;
+  color: var(--text-main);
+  height: 100vh;
+  overflow: hidden;
+  display: flex;
+  justify-content: center;
+}
+
+/* Drawer Container */
+.drawer-wrapper {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 60vh;
+  background-color: var(--drawer-bg);
+  border-top-left-radius: 24px;
+  border-top-right-radius: 24px;
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  transition: transform 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+  transform: translateY(calc(60vh - 80px)); /* Snapped to handle view */
+}
+
+/* Handle Indicator */
+.drawer-handle {
+  height: 60px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: grab;
+}
+
+.handle-bar {
+  width: 48px;
+  height: 6px;
+  background-color: var(--drawer-handle);
+  border-radius: 3px;
+}
+
+/* Drawer Content */
+.drawer-content {
+  padding: 0 1.5rem 2rem 1.5rem;
+  overflow-y: auto;
+}
+
+.drawer-header { margin-bottom: 1.5rem; }
+.drawer-title { font-size: 1.25rem; font-weight: 700; margin: 0; }
+
+.item-list { list-style: none; padding: 0; }
+.item {
+  padding: 1rem;
+  background: rgba(255,255,255,0.03);
+  border-radius: 12px;
+  margin-bottom: 0.75rem;
+  font-size: 0.9rem;
+}
+
+/* Interactive Drawer States */
+.drawer-wrapper:focus-within,
+.drawer-wrapper:hover {
+  transform: translateY(0); /* Expands to full height on focus/hover */
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .drawer-wrapper { transition: none; }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the **CSS Drawer with Handle** component (#70927).
gssoc 26

Closes #70927

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component / motion pattern
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/css-drawer-with-handle/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] Pure CSS implementation with zero JavaScript
- [x] Accessible with proper ARIA attributes, keyboard navigation support, and `prefers-reduced-motion` compliance

---

## Feature Description
**What does this add?**
A bottom-snapping UI drawer featuring a visual drag-handle indicator and smooth state-based expansion.

**How does it work?**
Constructed using CSS `transform` properties toggled via `:focus-within` and `:hover`, eliminating the need for JavaScript interaction handlers.