### PR TITLE
Add Spacing to "Studio" Button Icon

### DIFF
--- a/submissions/examples/spacing/README.md
+++ b/submissions/examples/spacing/README.md
@@ -1,0 +1,9 @@
+# Bug 5 Fix: Button Icon Spacing
+
+## Overview
+This fix addresses the cramped appearance of the "Studio" button by adding appropriate spacing between the gamepad icon and the text label.
+
+## Implementation Details
+* Converted the `.btn-icon` class to use `display: inline-flex;`.
+* Utilized the `gap: 8px;` property to enforce strict, clean spacing between the icon span and the text node.
+* Added `align-items: center;` to ensure the icon and text share the same vertical baseline.

--- a/submissions/examples/spacing/demo.html
+++ b/submissions/examples/spacing/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Bug 5: Icon Spacing Fix</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="button-group">
+        <button class="btn btn-primary">Animation Builder</button>
+        <!-- Button with cramped icon -->
+        <button class="btn btn-icon">
+            <span class="icon">🎮</span> Studio
+        </button>
+    </div>
+</body>
+</html>

--- a/submissions/examples/spacing/style.css
+++ b/submissions/examples/spacing/style.css
@@ -1,0 +1,31 @@
+/* Boilerplate */
+body {
+    background-color: #0d0e15;
+    display: flex;
+    justify-content: center;
+    padding: 3rem;
+    font-family: sans-serif;
+}
+
+.btn {
+    padding: 8px 16px;
+    border-radius: 8px;
+    border: none;
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: 600;
+}
+
+/* Fix: Flexbox and gap for icon spacing */
+.btn-icon {
+    background: linear-gradient(135deg, #6b4cff, #a55cff);
+    color: white;
+    display: inline-flex; /* Turns button into a flex container */
+    align-items: center; /* Vertically centers icon and text */
+    justify-content: center;
+    gap: 8px; /* Adds consistent spacing between the icon and text */
+}
+
+.icon {
+    font-size: 16px; /* Ensure icon scales appropriately */
+}


### PR DESCRIPTION
fixes #71795
Title: fix(ui): add spacing between icon and text in Studio button

Description:
This PR resolves a spacing issue inside the header's "Studio" button, where the gamepad icon was rendering without a margin and touching the text directly.

Changes Made:

Converted the button .btn-icon to an inline-flex container in style.css.

Added a gap: 8px; property to enforce consistent spacing between the icon and the text.

Added align-items: center; to ensure perfect vertical alignment between the emoji/icon and the text baseline.