### PR TITLE
center active state indicator in top navigation

### DIFF
--- a/submissions/examples/active-indicator/README.md
+++ b/submissions/examples/active-indicator/README.md
@@ -1,0 +1,9 @@
+# Bug 4 Fix: Active Nav Indicator Centering
+
+## Overview
+This patch centers the active state indicator (the purple bottom border) under the active navigation item in the top header.
+
+## Implementation Details
+* Used an `::after` pseudo-element on `.nav-link.active` to create the underline.
+* Applied `position: relative;` to the parent `.nav-link`.
+* Used `left: 50%;` combined with `transform: translateX(-50%);` on the pseudo-element to guarantee mathematically perfect centering, regardless of the text length.

--- a/submissions/examples/active-indicator/demo.html
+++ b/submissions/examples/active-indicator/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Bug 4: Active Indicator Fix</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <nav class="top-nav">
+        <!-- The active nav item with the misaligned indicator -->
+        <a href="#" class="nav-link active">Getting Started</a>
+        <a href="#" class="nav-link">Utilities</a>
+        <a href="#" class="nav-link">Animations</a>
+    </nav>
+</body>
+</html>

--- a/submissions/examples/active-indicator/style.css
+++ b/submissions/examples/active-indicator/style.css
@@ -1,0 +1,36 @@
+/* Boilerplate */
+body {
+    background-color: #0b0b13;
+    font-family: system-ui, sans-serif;
+    padding: 2rem;
+}
+
+.top-nav {
+    display: flex;
+    gap: 2rem;
+    border-bottom: 1px solid #1f202e;
+}
+
+/* Fix: Positioning the active indicator pseudo-element properly */
+.nav-link {
+    color: #a0a0b0;
+    text-decoration: none;
+    position: relative; /* Required for absolute positioning of pseudo-element */
+    padding-bottom: 12px;
+}
+
+.nav-link.active {
+    color: #ffffff;
+}
+
+.nav-link.active::after {
+    content: '';
+    position: absolute;
+    bottom: -1px; /* Align with bottom border */
+    left: 50%; /* Center start point */
+    transform: translateX(-50%); /* Pull back exactly half its width to center */
+    width: 80%; /* Width of the underline relative to text */
+    height: 3px;
+    background-color: #5c45fd;
+    border-radius: 3px 3px 0 0;
+}


### PR DESCRIPTION
Description:
This PR fixes a visual imbalance in the top navigation bar where the purple active state underline was shifted to the left, rather than being perfectly centered beneath the active tab's text.

Changes Made:

Updated .nav-link.active::after in style.css.

Implemented left: 50% and transform: translateX(-50%) to ensure the underline mathematically centers itself relative to its parent container, regardless of the text string length.

Ensured position: relative was set on the parent element.

Related Issue:

Fixes #71794 