### PR TITLE
feat: add CSS ribbon banner component (#68250)

### DIFF
--- a/submissions/examples/css-ribbon-banner-sah/README.md
+++ b/submissions/examples/css-ribbon-banner-sah/README.md
@@ -1,0 +1,35 @@
+# css-ribbon-banner
+
+A corner ribbon/banner component for **EaseMotion CSS** that displays a rotated "New", "Sale", "Beta", or percentage label pinned to the top-right corner of a card, with a stitched-down fold look — pure CSS, no JavaScript.
+
+## 1. What does this do?
+
+It renders an absolutely-positioned corner ribbon on a card (or any `position: relative` container) so a label like "New", "Sale", or "-50%" appears rotated diagonally in the corner, with a small pop-in animation that respects `prefers-reduced-motion`.
+
+## 2. How is it used?
+
+Wrap a `.ribbon` (with a color modifier) and a `.ribbon__label` inside any container that has `position: relative`:
+
+```html
+<div style="position: relative;">
+  <span class="ribbon ribbon--new" aria-hidden="true">
+    <span class="ribbon__label">New</span>
+  </span>
+
+  <!-- your card content -->
+</div>
+```
+
+Available color modifiers: `ribbon--new` (green), `ribbon--sale` (red), `ribbon--info` (blue). Add `ribbon--lg` for a larger marketing variant.
+
+Because the ribbon is purely decorative, mark it `aria-hidden="true"` and provide the same information in the surrounding text (or via a visually-hidden `.sr-only` label) for screen-reader users — see `demo.html` for the accessible pattern.
+
+## 3. Why is it useful for EaseMotion CSS?
+
+Ribbon banners are a ubiquitous e-commerce and content-card pattern (product badges, "New" flags, sale tags) that front-end developers routinely rebuild with JavaScript or copy-paste snippets. A single, self-contained, animation-first component with a subtle pop-in entrance and a `prefers-reduced-motion` guard fits EaseMotion's philosophy of giving developers ready-to-use, accessible CSS building blocks without any JavaScript dependency.
+
+## Files
+
+- `style.css` — the ribbon component styles (CSS custom properties for size/colors, color modifiers, large variant, entrance animation, reduced-motion guard).
+- `demo.html` — self-contained demo showing five cards: `New`, `Sale`, `Beta`, a large `-50%` variant, and an accessible `Featured` example paired with a visually-hidden label. Opens directly in a browser — no server, CDNs, or frameworks.
+- `README.md` — this file.

--- a/submissions/examples/css-ribbon-banner-sah/demo.html
+++ b/submissions/examples/css-ribbon-banner-sah/demo.html
@@ -1,0 +1,114 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>css-ribbon-banner — EaseMotion CSS demo</title>
+    <link rel="stylesheet" href="style.css" />
+    <style>
+      /* Page scaffolding only — not part of the component */
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        gap: 24px;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 280px));
+        padding: 40px 20px;
+        background: #f8fafc;
+        font-family:
+          system-ui,
+          -apple-system,
+          "Segoe UI",
+          Roboto,
+          sans-serif;
+        color: #0f172a;
+      }
+      .demo-card {
+        position: relative;
+        background: #fff;
+        border: 1px solid #e2e8f0;
+        border-radius: 12px;
+        padding: 28px 20px 20px;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+        min-height: 150px;
+      }
+      .demo-card h2 {
+        margin: 0 0 6px;
+        font-size: 1rem;
+      }
+      .demo-card p {
+        margin: 0;
+        font-size: 0.875rem;
+        color: #475569;
+      }
+      h1 {
+        grid-column: 1 / -1;
+        font-size: 1.1rem;
+        text-align: center;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>CSS Ribbon Banner — three variants</h1>
+
+    <article class="demo-card">
+      <span class="ribbon ribbon--new" aria-hidden="true">
+        <span class="ribbon__label">New</span>
+      </span>
+      <h2>Launch Week</h2>
+      <p>Newly published course, just released.</p>
+    </article>
+
+    <article class="demo-card">
+      <span class="ribbon ribbon--sale" aria-hidden="true">
+        <span class="ribbon__label">Sale</span>
+      </span>
+      <h2>Winter Deals</h2>
+      <p>Limited-time markdown on the store.</p>
+    </article>
+
+    <article class="demo-card">
+      <span class="ribbon ribbon--info" aria-hidden="true">
+        <span class="ribbon__label">Beta</span>
+      </span>
+      <h2>Early Access</h2>
+      <p>Help us test the new dashboard.</p>
+    </article>
+
+    <article class="demo-card">
+      <span class="ribbon ribbon--sale ribbon--lg" aria-hidden="true">
+        <span class="ribbon__label">-50%</span>
+      </span>
+      <h2>Mega Sale</h2>
+      <p>Large variant for hero / marketing cards.</p>
+    </article>
+
+    <!-- Accessible label alternative: a screen-reader announcement paired with the visual ribbon -->
+    <article class="demo-card">
+      <span class="ribbon ribbon--new" aria-hidden="true">
+        <span class="ribbon__label">Featured</span>
+      </span>
+      <span
+        class="sr-only"
+        style="
+          position: absolute;
+          width: 1px;
+          height: 1px;
+          padding: 0;
+          margin: -1px;
+          overflow: hidden;
+          clip: rect(0, 0, 0, 0);
+          white-space: nowrap;
+          border: 0;
+        "
+        >Featured item</span
+      >
+      <h2>Editor's Pick</h2>
+      <p>
+        Pair the decorative ribbon with a visually-hidden label for screen
+        readers.
+      </p>
+    </article>
+  </body>
+</html>

--- a/submissions/examples/css-ribbon-banner-sah/style.css
+++ b/submissions/examples/css-ribbon-banner-sah/style.css
@@ -1,0 +1,123 @@
+/* ==========================================================
+   css-ribbon-banner — CSS Ribbon Banner
+   A corner ribbon/banner ("New", "Sale", etc.) for cards.
+   Pure CSS, responsive, accessible, no JavaScript.
+   ========================================================== */
+
+.ribbon {
+  --ribbon-size: 100px;
+  --ribbon-bg: #e11d48;
+  --ribbon-fg: #fff;
+  --ribbon-fold: #8b0f2c;
+
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: var(--ribbon-size);
+  height: var(--ribbon-size);
+  overflow: hidden;
+  pointer-events: none;
+  z-index: 2;
+}
+
+.ribbon__label {
+  position: absolute;
+  top: 16px;
+  right: -34px;
+  width: 150px;
+  transform: rotate(45deg);
+  text-align: center;
+  font-family:
+    system-ui,
+    -apple-system,
+    "Segoe UI",
+    Roboto,
+    sans-serif;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ribbon-fg);
+  background: var(--ribbon-bg);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+  padding: 0.4em 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  animation: ribbon-pop 0.5s ease-out both;
+}
+
+/* The two "fold" triangles that give the ribbon its stitched-down look */
+.ribbon__label::before,
+.ribbon__label::after {
+  content: "";
+  position: absolute;
+  bottom: 100%;
+  width: 0;
+  height: 0;
+  border: 4px solid transparent;
+}
+
+.ribbon__label::before {
+  left: 0;
+  border-top-color: var(--ribbon-fold);
+  border-right-color: var(--ribbon-fold);
+}
+
+.ribbon__label::after {
+  right: 0;
+  border-top-color: var(--ribbon-fold);
+  border-left-color: var(--ribbon-fold);
+}
+
+/* Color modifiers */
+.ribbon--sale .ribbon__label {
+  --ribbon-bg: #e11d48;
+  --ribbon-fold: #8b0f2c;
+}
+
+.ribbon--new .ribbon__label {
+  --ribbon-bg: #16a34a;
+  --ribbon-fold: #0c5c2a;
+}
+
+.ribbon--info .ribbon__label {
+  --ribbon-bg: #2563eb;
+  --ribbon-fold: #143a8b;
+}
+
+/* Larger variant for marketing cards */
+.ribbon--lg {
+  --ribbon-size: 140px;
+}
+
+.ribbon--lg .ribbon__label {
+  font-size: 0.85rem;
+}
+
+/* Ensure the ribbon container doesn't trap hover when off-card */
+.ribbon:focus-within .ribbon__label {
+  outline: 2px solid transparent;
+}
+
+@keyframes ribbon-pop {
+  0% {
+    transform: rotate(45deg) translateY(-120%) scale(0.6);
+    opacity: 0;
+  }
+  70% {
+    transform: rotate(45deg) translateY(4%) scale(1.05);
+    opacity: 1;
+  }
+  100% {
+    transform: rotate(45deg) translateY(0) scale(1);
+    opacity: 1;
+  }
+}
+
+/* Respect reduced-motion preferences */
+@media (prefers-reduced-motion: reduce) {
+  .ribbon__label {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This submission adds a **CSS Ribbon Banner** component (`submissions/examples/css-ribbon-banner-sah/`) implementing the corner ribbon/banner requested in the issue: a rotated "New", "Sale", "Beta", or percentage label pinned to the top-right corner of a card, with a stitched-down fold look. It is implemented entirely in CSS (no JavaScript), is responsive, and is accessible.

The component is built with CSS custom properties for easy theming (`--ribbon-size`, `--ribbon-bg`, `--ribbon-fg`, `--ribbon-fold`) and exposes three color modifiers — `ribbon--new` (green), `ribbon--sale` (red), and `ribbon--info` (blue) — plus a `ribbon--lg` variant for larger marketing cards. The label sits inside an absolutely-positioned, `overflow: hidden` corner container and is rotated 45°; two pseudo-element triangles form the "fold" that gives the ribbon its stitched-down appearance. A short `ribbon-pop` keyframe animation provides a subtle entrance, and the entire animation is gated behind a `prefers-reduced-motion` media query so users who request reduced motion get a static ribbon.

Because the ribbon is purely decorative, the demo marks the visual markup with `aria-hidden="true"` and demonstrates pairing it with a visually-hidden `.sr-only` label so the same information is announced to screen-reader users — keeping the component accessible without JavaScript.

The `demo.html` is fully self-contained: it links only the local `style.css` and opens directly in a browser with no server, CDNs, or external frameworks. It renders five sample cards (New, Sale, Beta, a large -50% marketing variant, and an accessible Featured example) so a reviewer can verify every modifier at a glance.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] Documentation improvement
- [ ] Bug fix
- [ ] Other

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g. `submissions/examples/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A corner ribbon/banner ("New", "Sale", "Beta", percentage) component for cards, animated with a pop-in entrance that respects reduced-motion.

**How does a developer use it?**

```html
<div style="position: relative;">
  <span class="ribbon ribbon--new" aria-hidden="true">
    <span class="ribbon__label">New</span>
  </span>
  <!-- card content -->
</div>
```

Color modifiers: `ribbon--new`, `ribbon--sale`, `ribbon--info`. Add `ribbon--lg` for a larger variant.

**Why does it fit EaseMotion CSS?**

Ribbon banners are a ubiquitous e-commerce and content-card pattern (product badges, "New" flags, sale tags) that developers routinely rebuild with JavaScript or copy-paste snippets. A single, self-contained, animation-first component with a `prefers-reduced-motion` guard fits EaseMotion's philosophy of ready-to-use, accessible CSS building blocks with no JavaScript dependency.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainer

- The ribbon uses CSS custom properties for size/colors, so it is trivial to retheme. The maintainer is welcome to rename classes to the `ease-` convention on integration.
- Accessibility: the visual ribbon is `aria-hidden`; pair it with a visually-hidden label (shown in the demo) for screen readers.
- Validated locally: `prettier --check` passes on all three files; the repo `vitest` suite (61 tests) remains green; `submissions/` is in `.stylelintignore` so it is excluded from the repo's stylelint run.

Closes #68250
