### PR TITLE
feat: add CSS reading font sizer (#70932)

### DIFF
--- a/submissions/examples/reading-font-sizer-70932/README.md
+++ b/submissions/examples/reading-font-sizer-70932/README.md
@@ -1,0 +1,28 @@
+# CSS Reading Font Sizer
+
+Accessible article reader toolbar with smooth pure CSS font resizing, line-height scaling, and zero JavaScript.
+
+## 1. What does this do?
+Provides a reader toolbar with `A-`, `A`, `A+`, `A++` controls that smoothly transition body text sizes (14px, 16px, 19px, 22px) and line height using native CSS custom properties.
+
+## 2. How is it used?
+Link toolbar `<label for="size-N">` buttons to hidden `<input type="radio" name="font-size" id="size-N">` triggers:
+
+```html
+<input type="radio" name="font-size" id="size-sm" class="size-radio">
+<input type="radio" name="font-size" id="size-md" class="size-radio" checked>
+<input type="radio" name="font-size" id="size-lg" class="size-radio">
+
+<div class="reader-toolbar">
+  <label for="size-sm" class="size-btn">A-</label>
+  <label for="size-md" class="size-btn">A</label>
+  <label for="size-lg" class="size-btn">A+</label>
+</div>
+
+<div class="reader-body">
+  <p class="article-paragraph">Article content...</p>
+</div>
+```
+
+## 3. Why is it useful?
+Long-form article reading platforms (blogs, news sites, docs) need accessible text sizing controls. This pure CSS implementation eliminates JavaScript DOM manipulation, maintains high performance, and ensures smooth visual transitions.

--- a/submissions/examples/reading-font-sizer-70932/demo.html
+++ b/submissions/examples/reading-font-sizer-70932/demo.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Reading Font Sizer - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,600;1,400&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <main class="demo-container">
+    <header class="demo-header">
+      <span class="demo-badge">EaseMotion UI Pattern</span>
+      <h1>CSS Reading Font Sizer</h1>
+      <p>Accessible reader toolbar with smooth pure CSS font resizing, line-height scaling, active indicator Pill highlights, and zero JavaScript.</p>
+    </header>
+
+    <!-- Reading Container with Pure CSS Radio Inputs -->
+    <article class="reader-card" aria-label="Article Reader Component">
+      <!-- Pure CSS Radio State Controls -->
+      <input type="radio" name="font-size" id="size-sm" class="size-radio">
+      <input type="radio" name="font-size" id="size-md" class="size-radio" checked>
+      <input type="radio" name="font-size" id="size-lg" class="size-radio">
+      <input type="radio" name="font-size" id="size-xl" class="size-radio">
+
+      <!-- Reader Toolbar -->
+      <div class="reader-toolbar" role="toolbar" aria-label="Font Sizing Controls">
+        <span class="toolbar-title">
+          <svg class="book-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path>
+            <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path>
+          </svg>
+          Reader Settings
+        </span>
+
+        <div class="size-controls" role="radiogroup" aria-label="Select Typography Size">
+          <label for="size-sm" class="size-btn size-sm-btn" tabindex="0" title="Small Text (14px)">
+            <span class="btn-text">A-</span>
+            <span class="btn-tooltip">Small</span>
+          </label>
+
+          <label for="size-md" class="size-btn size-md-btn" tabindex="0" title="Default Text (16px)">
+            <span class="btn-text">A</span>
+            <span class="btn-tooltip">Default</span>
+          </label>
+
+          <label for="size-lg" class="size-btn size-lg-btn" tabindex="0" title="Large Text (19px)">
+            <span class="btn-text">A+</span>
+            <span class="btn-tooltip">Large</span>
+          </label>
+
+          <label for="size-xl" class="size-btn size-xl-btn" tabindex="0" title="Extra Large Text (22px)">
+            <span class="btn-text">A++</span>
+            <span class="btn-tooltip">Extra Large</span>
+          </label>
+        </div>
+      </div>
+
+      <!-- Article Content Body -->
+      <div class="reader-body">
+        <div class="article-meta">
+          <span class="meta-tag">Design Systems</span>
+          <span class="meta-date">August 10, 2026</span>
+        </div>
+        <h2 class="article-title">The Architecture of Motion Design</h2>
+        
+        <p class="article-paragraph">
+          Typography and smooth motion are fundamental pillars of modern web design. When users customize reading preferences, fluid transitions elevate the experience by maintaining visual continuity rather than triggering abrupt layout shifts.
+        </p>
+
+        <p class="article-paragraph">
+          By utilizing native CSS selector state engines and custom properties, developers can create accessible, high-performance UI components that scale seamlessly across device viewports without relying on external JavaScript bundles.
+        </p>
+      </div>
+    </article>
+  </main>
+</body>
+</html>

--- a/submissions/examples/reading-font-sizer-70932/style.css
+++ b/submissions/examples/reading-font-sizer-70932/style.css
@@ -1,0 +1,299 @@
+/* ==========================================================================
+   CSS Reading Font Sizer - EaseMotion CSS
+   ========================================================================== */
+
+:root {
+  --reader-bg: #1e293b;
+  --reader-border: rgba(148, 163, 184, 0.15);
+  --reader-accent: #38bdf8;
+  --reader-text: #f8fafc;
+  --reader-subtext: #94a3b8;
+  --article-font-size: 1rem;
+  --article-line-height: 1.75;
+  --transition-fluid: 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  background-color: #0f172a;
+  color: #f8fafc;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+.demo-container {
+  max-width: 820px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+.demo-header {
+  text-align: center;
+  margin-bottom: 2.5rem;
+}
+
+.demo-badge {
+  display: inline-block;
+  padding: 0.25rem 0.75rem;
+  background: rgba(56, 189, 248, 0.1);
+  color: var(--reader-accent);
+  border: 1px solid rgba(56, 189, 248, 0.25);
+  border-radius: 9999px;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.75rem;
+}
+
+.demo-header h1 {
+  font-size: 2.25rem;
+  font-weight: 700;
+  letter-spacing: -0.025em;
+  background: linear-gradient(135deg, #ffffff 0%, #cbd5e1 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  margin-bottom: 0.75rem;
+}
+
+.demo-header p {
+  color: #94a3b8;
+  font-size: 1rem;
+  max-width: 580px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+/* Reader Card */
+.reader-card {
+  background: rgba(30, 41, 59, 0.6);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid var(--reader-border);
+  border-radius: 1.5rem;
+  padding: 2rem;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.4);
+  position: relative;
+}
+
+/* Hidden Radio State Buttons */
+.size-radio {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+/* Reader Toolbar */
+.reader-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: 1.25rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  margin-bottom: 2rem;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.toolbar-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: #cbd5e1;
+}
+
+.book-icon {
+  width: 20px;
+  height: 20px;
+  color: var(--reader-accent);
+}
+
+.size-controls {
+  display: flex;
+  background: rgba(15, 23, 42, 0.6);
+  padding: 0.375rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  gap: 0.25rem;
+}
+
+.size-btn {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  height: 36px;
+  padding: 0 0.75rem;
+  border-radius: 9999px;
+  cursor: pointer;
+  user-select: none;
+  font-weight: 700;
+  font-size: 0.875rem;
+  color: #94a3b8;
+  transition: all var(--transition-fluid);
+  outline: none;
+}
+
+.size-btn:hover {
+  color: #f8fafc;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.size-btn:focus-visible {
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.4);
+}
+
+/* Tooltip on Buttons */
+.btn-tooltip {
+  position: absolute;
+  top: -36px;
+  left: 50%;
+  transform: translateX(-50%) translateY(4px);
+  background: #090d16;
+  color: #f8fafc;
+  padding: 0.25rem 0.625rem;
+  border-radius: 0.375rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: all 0.2s ease;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.size-btn:hover .btn-tooltip {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+/* Article Typography Body */
+.reader-body {
+  transition: all var(--transition-fluid);
+}
+
+.article-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.meta-tag {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--reader-accent);
+  background: rgba(56, 189, 248, 0.1);
+  padding: 0.2rem 0.625rem;
+  border-radius: 9999px;
+}
+
+.meta-date {
+  font-size: 0.8125rem;
+  color: #64748b;
+}
+
+.article-title {
+  font-family: 'Inter', sans-serif;
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: #f8fafc;
+  margin-bottom: 1.5rem;
+  line-height: 1.3;
+}
+
+.article-paragraph {
+  font-family: 'Lora', Georgia, serif;
+  font-size: var(--article-font-size);
+  line-height: var(--article-line-height);
+  color: #cbd5e1;
+  margin-bottom: 1.5rem;
+  transition: font-size var(--transition-fluid), line-height var(--transition-fluid);
+}
+
+/* Radio Triggered Font Size Scaling Rules */
+
+/* Small (14px) */
+#size-sm:checked ~ .reader-toolbar .size-sm-btn {
+  background: var(--reader-accent);
+  color: #0f172a;
+  box-shadow: 0 2px 10px rgba(56, 189, 248, 0.3);
+}
+#size-sm:checked ~ .reader-body {
+  --article-font-size: 0.875rem; /* 14px */
+  --article-line-height: 1.65;
+}
+
+/* Medium / Default (16px) */
+#size-md:checked ~ .reader-toolbar .size-md-btn {
+  background: var(--reader-accent);
+  color: #0f172a;
+  box-shadow: 0 2px 10px rgba(56, 189, 248, 0.3);
+}
+#size-md:checked ~ .reader-body {
+  --article-font-size: 1rem; /* 16px */
+  --article-line-height: 1.75;
+}
+
+/* Large (19px) */
+#size-lg:checked ~ .reader-toolbar .size-lg-btn {
+  background: var(--reader-accent);
+  color: #0f172a;
+  box-shadow: 0 2px 10px rgba(56, 189, 248, 0.3);
+}
+#size-lg:checked ~ .reader-body {
+  --article-font-size: 1.1875rem; /* 19px */
+  --article-line-height: 1.85;
+}
+
+/* Extra Large (22px) */
+#size-xl:checked ~ .reader-toolbar .size-xl-btn {
+  background: var(--reader-accent);
+  color: #0f172a;
+  box-shadow: 0 2px 10px rgba(56, 189, 248, 0.3);
+}
+#size-xl:checked ~ .reader-body {
+  --article-font-size: 1.375rem; /* 22px */
+  --article-line-height: 1.95;
+}
+
+/* Accessibility - Prefers Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+  .size-btn,
+  .article-paragraph,
+  .reader-body,
+  .btn-tooltip {
+    transition: none !important;
+  }
+}
+
+/* Responsive adjustments */
+@media (max-width: 600px) {
+  .reader-card {
+    padding: 1.25rem;
+  }
+  .reader-toolbar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .size-controls {
+    width: 100%;
+    justify-content: space-between;
+  }
+}


### PR DESCRIPTION
## Implementation Summary
- Implemented CSS Reading Font Sizer toolbar component with smooth pure CSS text scaling (A-, A, A+, A++), line-height adjustments, and active indicator pills.
- Submissions placed in \submissions/examples/reading-font-sizer-70932/\.

## Added Files
- \demo.html\
- \style.css\
- \README.md\

## Responsiveness & Accessibility
- Fully responsive across desktop, tablet, and mobile displays.
- Focus-visible outlines, tooltips, and ARIA toolbar accessibility.
- Includes \@media (prefers-reduced-motion: reduce)\ support.

## Testing & Verification
- Verified font scaling transitions across all 4 size states.
- Verified clean git diff.

Closes #70932