### PR TITLE
Add ease-signal-strength-bars component

### DIFF
--- a/submissions/examples/signal-strength-bars-ij/README.md
+++ b/submissions/examples/signal-strength-bars-ij/README.md
@@ -1,0 +1,11 @@
+# ease-signal-strength-bars
+
+A signal meter where the bars fade in sequence, the radar sweep spins, and the strength readout ticks.
+
+## Run
+Open `demo.html` directly in a browser to watch the signal pulse.
+
+## Notes
+- The five bars blink from weak to strong.
+- The radar sweep spins above the meter.
+- The dBm readout ticks below it.

--- a/submissions/examples/signal-strength-bars-ij/demo.html
+++ b/submissions/examples/signal-strength-bars-ij/demo.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-signal-strength-bars demo</title>
+</head>
+<body>
+<div class="ssb-box">
+  <div class="ssb-antenna"><span class="ssb-post"></span><span class="ssb-sweep"></span></div>
+  <div class="ssb-meter">
+    <i class="ssb-bar"></i>
+    <i class="ssb-bar"></i>
+    <i class="ssb-bar"></i>
+    <i class="ssb-bar"></i>
+    <i class="ssb-bar"></i>
+  </div>
+  <div class="ssb-read">
+    <span class="ssb-label">SIGNAL</span>
+    <b class="ssb-strength">-61 dBm</b>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/signal-strength-bars-ij/style.css
+++ b/submissions/examples/signal-strength-bars-ij/style.css
@@ -1,0 +1,16 @@
+.ssb-box{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:260px;background:linear-gradient(180deg,#14202e,#0b1420);border:2px solid #2a3a4e;border-radius:16px;padding:18px;display:flex;flex-direction:column;align-items:center;gap:14px}
+.ssb-antenna{position:relative;width:50px;height:90px;display:flex;align-items:center;justify-content:center}
+.ssb-post{width:6px;height:70px;background:#5c6b7c;border-radius:3px}
+.ssb-sweep{position:absolute;width:44px;height:44px;border-radius:50%;border:2px dashed rgba(92,225,230,0.6);animation:ssb-sweep-spin-signal-strength-bars 5s linear infinite}
+.ssb-meter{display:flex;align-items:flex-end;gap:6px;height:70px}
+.ssb-bar{width:12px;height:20px;background:linear-gradient(180deg,#7cebb0,#5ce1e6);border-radius:3px;animation:ssb-bar-fade-signal-strength-bars 1.6s ease-in-out infinite}
+.ssb-bar:nth-child(2){height:34px;animation-delay:.25s}
+.ssb-bar:nth-child(3){height:48px;animation-delay:.5s}
+.ssb-bar:nth-child(4){height:60px;animation-delay:.75s}
+.ssb-bar:nth-child(5){height:70px;animation-delay:1s}
+.ssb-read{display:flex;flex-direction:column;align-items:center;gap:4px}
+.ssb-label{font-size:9px;font-weight:800;letter-spacing:3px;color:#8b9bad}
+.ssb-strength{font-size:16px;font-weight:800;color:#ffd76a;font-family:'Courier New',monospace;animation:ssb-strength-tick-signal-strength-bars 2s steps(3) infinite}
+@keyframes ssb-sweep-spin-signal-strength-bars{0%{transform:rotate(0)}100%{transform:rotate(360deg)}}
+@keyframes ssb-bar-fade-signal-strength-bars{0%,100%{opacity:1}50%{opacity:.35}}
+@keyframes ssb-strength-tick-signal-strength-bars{0%{opacity:1}50%{opacity:.4}100%{opacity:1}}


### PR DESCRIPTION
## Component: ease-signal-strength-bars — bars fade, sweep spins, and dBm ticks

**Closes #71949**

### What this adds
A signal meter where the bars fade in sequence, the radar sweep spins, and the strength readout ticks.

### Acceptance Criteria covered
- Bars fade in sequence
- Radar sweep spins
- Strength readout ticks

### Files
- `submissions/examples/signal-strength-bars-ij/demo.html`
- `submissions/examples/signal-strength-bars-ij/style.css`
- `submissions/examples/signal-strength-bars-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the bars fade, the sweep spin, and the dBm tick.