### PR TITLE
feat: add CSS coverage badge

### DIFF
--- a/submissions/examples/r-coverage-badge-70922/README.md
+++ b/submissions/examples/r-coverage-badge-70922/README.md
@@ -1,0 +1,33 @@
+# CSS Coverage Badge
+
+A responsive CSS-only coverage badge component for displaying code
+coverage percentages with color-coded status indicators.
+
+## Features
+
+- Pure HTML and CSS
+- High, medium, and low coverage states
+- Color-coded percentage badges
+- Animated progress bars
+- Accessible progressbar attributes
+- Responsive card layout
+- Hover interactions
+- Reduced-motion support
+- Forced-colors support
+- No JavaScript required
+
+## Files
+
+- `demo.html` — Demonstration page
+- `style.css` — Component styles and animations
+- `README.md` — Documentation
+
+## Usage
+
+A basic coverage badge can be created with:
+
+```html
+<span class="badge badge--high">
+  <span class="badge-dot" aria-hidden="true"></span>
+  Coverage 95%
+</span>

--- a/submissions/examples/r-coverage-badge-70922/demo.html
+++ b/submissions/examples/r-coverage-badge-70922/demo.html
@@ -1,0 +1,117 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta
+    name="description"
+    content="CSS code coverage percentage badges with color-coded status"
+  >
+  <title>CSS Coverage Badge</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <section class="showcase" aria-labelledby="page-title">
+      <p class="eyebrow">EaseMotion CSS</p>
+
+      <h1 id="page-title">Coverage Badges</h1>
+
+      <p class="intro">
+        Accessible, responsive coverage indicators with color-coded
+        percentages.
+      </p>
+
+      <div class="badge-grid">
+        <article class="coverage-card">
+          <div class="coverage-icon coverage-icon--high" aria-hidden="true">
+            <span>✓</span>
+          </div>
+
+          <div class="coverage-content">
+            <span class="coverage-label">Statements</span>
+            <strong class="coverage-value">96%</strong>
+
+            <div
+              class="progress"
+              role="progressbar"
+              aria-label="Statements coverage"
+              aria-valuemin="0"
+              aria-valuemax="100"
+              aria-valuenow="96"
+            >
+              <span class="progress-bar progress-bar--high"></span>
+            </div>
+          </div>
+        </article>
+
+        <article class="coverage-card">
+          <div class="coverage-icon coverage-icon--medium" aria-hidden="true">
+            <span>↗</span>
+          </div>
+
+          <div class="coverage-content">
+            <span class="coverage-label">Branches</span>
+            <strong class="coverage-value">78%</strong>
+
+            <div
+              class="progress"
+              role="progressbar"
+              aria-label="Branches coverage"
+              aria-valuemin="0"
+              aria-valuemax="100"
+              aria-valuenow="78"
+            >
+              <span class="progress-bar progress-bar--medium"></span>
+            </div>
+          </div>
+        </article>
+
+        <article class="coverage-card">
+          <div class="coverage-icon coverage-icon--low" aria-hidden="true">
+            <span>!</span>
+          </div>
+
+          <div class="coverage-content">
+            <span class="coverage-label">Functions</span>
+            <strong class="coverage-value">54%</strong>
+
+            <div
+              class="progress"
+              role="progressbar"
+              aria-label="Functions coverage"
+              aria-valuemin="0"
+              aria-valuemax="100"
+              aria-valuenow="54"
+            >
+              <span class="progress-bar progress-bar--low"></span>
+            </div>
+          </div>
+        </article>
+      </div>
+
+      <div class="standalone-section">
+        <span class="section-label">Badge variants</span>
+
+        <div class="badges" aria-label="Coverage badge examples">
+          <span class="badge badge--high">
+            <span class="badge-dot" aria-hidden="true"></span>
+            Coverage 95%
+          </span>
+
+          <span class="badge badge--medium">
+            <span class="badge-dot" aria-hidden="true"></span>
+            Coverage 76%
+          </span>
+
+          <span class="badge badge--low">
+            <span class="badge-dot" aria-hidden="true"></span>
+            Coverage 48%
+          </span>
+        </div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/r-coverage-badge-70922/style.css
+++ b/submissions/examples/r-coverage-badge-70922/style.css
@@ -1,0 +1,762 @@
+:root {
+  --bg: #070b14;
+  --surface: #111827;
+  --surface-light: #172033;
+  --border: rgba(148, 163, 184, 0.16);
+  --text: #f8fafc;
+  --muted: #94a3b8;
+
+  --green: #22c55e;
+  --green-soft: rgba(34, 197, 94, 0.13);
+
+  --yellow: #f59e0b;
+  --yellow-soft: rgba(245, 158, 11, 0.13);
+
+  --red: #ef4444;
+  --red-soft: rgba(239, 68, 68, 0.13);
+
+  --cyan: #22d3ee;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  color-scheme: dark;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(
+      circle at 20% 15%,
+      rgba(34, 211, 238, 0.09),
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at 80% 85%,
+      rgba(34, 197, 94, 0.07),
+      transparent 28%
+    ),
+    var(--bg);
+}
+
+.page {
+  min-height: 100vh;
+  padding: 48px 18px;
+  display: grid;
+  place-items: center;
+}
+
+.showcase {
+  width: min(100%, 850px);
+  padding: 42px;
+  border: 1px solid var(--border);
+  border-radius: 30px;
+  background:
+    linear-gradient(
+      145deg,
+      rgba(255, 255, 255, 0.035),
+      transparent 45%
+    ),
+    rgba(17, 24, 39, 0.94);
+  box-shadow: 0 30px 90px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: var(--cyan);
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 6vw, 3.3rem);
+  line-height: 1.05;
+  letter-spacing: -0.05em;
+}
+
+.intro {
+  max-width: 570px;
+  margin: 14px 0 34px;
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.badge-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+
+.coverage-card {
+  position: relative;
+  overflow: hidden;
+  padding: 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  background: rgba(23, 32, 51, 0.72);
+  transition:
+    transform 220ms ease,
+    border-color 220ms ease,
+    box-shadow 220ms ease;
+}
+
+.coverage-card::before {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 0.045),
+    transparent 45%
+  );
+  content: "";
+  pointer-events: none;
+}
+
+.coverage-card:hover {
+  transform: translateY(-5px);
+  border-color: rgba(148, 163, 184, 0.3);
+  box-shadow: 0 18px 45px rgba(0, 0, 0, 0.25);
+}
+
+.coverage-icon {
+  position: relative;
+  width: 46px;
+  height: 46px;
+  display: grid;
+  place-items: center;
+  border-radius: 14px;
+  font-size: 1.25rem;
+  font-weight: 900;
+}
+
+.coverage-icon--high {
+  color: var(--green);
+  background: var(--green-soft);
+}
+
+.coverage-icon--medium {
+  color: var(--yellow);
+  background: var(--yellow-soft);
+}
+
+.coverage-icon--low {
+  color: var(--red);
+  background: var(--red-soft);
+}
+
+.coverage-content {
+  position: relative;
+}
+
+.coverage-label {
+  display: block;
+  margin-bottom: 5px;
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.coverage-value {
+  display: block;
+  font-size: 2rem;
+  line-height: 1;
+  letter-spacing: -0.04em;
+}
+
+.progress {
+  width: 100%;
+  height: 6px;
+  margin-top: 18px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.progress-bar {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  transform-origin: left;
+  animation: progressReveal 900ms cubic-bezier(0.22, 1, 0.36, 1)
+    both;
+}
+
+.progress-bar--high {
+  width: 96%;
+  background: linear-gradient(90deg, #16a34a, #4ade80);
+}
+
+.progress-bar--medium {
+  width: 78%;
+  background: linear-gradient(90deg, #d97706, #fbbf24);
+}
+
+.progress-bar--low {
+  width: 54%;
+  background: linear-gradient(90deg, #dc2626, #fb7185);
+}
+
+.standalone-section {
+  margin-top: 34px;
+  padding-top: 30px;
+  border-top: 1px solid var(--border);
+}
+
+.section-label {
+  display: block;
+  margin-bottom: 15px;
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  padding: 9px 14px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 800;
+  letter-spacing: 0.01em;
+  transition:
+    transform 200ms ease,
+    box-shadow 200ms ease;
+}
+
+.badge:hover {
+  transform: translateY(-2px);
+}
+
+.badge--high {
+  color: #86efac;
+  border-color: rgba(34, 197, 94, 0.25);
+  background: var(--green-soft);
+}
+
+.badge--medium {
+  color: #fcd34d;
+  border-color: rgba(245, 158, 11, 0.25);
+  background: var(--yellow-soft);
+}
+
+.badge--low {
+  color: #fca5a5;
+  border-color: rgba(239, 68, 68, 0.25);
+  background: var(--red-soft);
+}
+
+.badge-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 10px currentColor;
+}
+
+@keyframes progressReveal {
+  from {
+    opacity: 0;
+    transform: scaleX(0);
+  }
+
+  to {
+    opacity: 1;
+    transform: scaleX(1);
+  }
+}
+
+@media (max-width: 720px) {
+  .showcase {
+    padding: 32px 24px;
+  }
+
+  .badge-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .coverage-card {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    align-items: center;
+  }
+
+  .coverage-content {
+    min-width: 0;
+  }
+
+  .progress {
+    margin-top: 12px;
+  }
+}
+
+@media (max-width: 480px) {
+  .page {
+    padding: 20px 12px;
+  }
+
+  .showcase {
+    padding: 28px 18px;
+    border-radius: 22px;
+  }
+
+  .intro {
+    margin-bottom: 26px;
+    font-size: 0.9rem;
+  }
+
+  .coverage-card {
+    padding: 18px;
+  }
+
+  .coverage-value {
+    font-size: 1.75rem;
+  }
+
+  .badges {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+
+  .progress-bar {
+    animation: none;
+  }
+}
+
+@media (forced-colors: active) {
+  .coverage-card,
+  .showcase,
+  .badge,
+  .progress {
+    border-color: CanvasText;
+  }
+
+  .progress-bar {
+    background: Highlight;
+  }
+
+  .badge-dot {
+    background: CanvasText;
+    box-shadow: none;
+  }
+}
+:root {
+  --bg: #070b14;
+  --surface: #111827;
+  --surface-light: #172033;
+  --border: rgba(148, 163, 184, 0.16);
+  --text: #f8fafc;
+  --muted: #94a3b8;
+
+  --green: #22c55e;
+  --green-soft: rgba(34, 197, 94, 0.13);
+
+  --yellow: #f59e0b;
+  --yellow-soft: rgba(245, 158, 11, 0.13);
+
+  --red: #ef4444;
+  --red-soft: rgba(239, 68, 68, 0.13);
+
+  --cyan: #22d3ee;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  color-scheme: dark;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(
+      circle at 20% 15%,
+      rgba(34, 211, 238, 0.09),
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at 80% 85%,
+      rgba(34, 197, 94, 0.07),
+      transparent 28%
+    ),
+    var(--bg);
+}
+
+.page {
+  min-height: 100vh;
+  padding: 48px 18px;
+  display: grid;
+  place-items: center;
+}
+
+.showcase {
+  width: min(100%, 850px);
+  padding: 42px;
+  border: 1px solid var(--border);
+  border-radius: 30px;
+  background:
+    linear-gradient(
+      145deg,
+      rgba(255, 255, 255, 0.035),
+      transparent 45%
+    ),
+    rgba(17, 24, 39, 0.94);
+  box-shadow: 0 30px 90px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: var(--cyan);
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 6vw, 3.3rem);
+  line-height: 1.05;
+  letter-spacing: -0.05em;
+}
+
+.intro {
+  max-width: 570px;
+  margin: 14px 0 34px;
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.badge-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+
+.coverage-card {
+  position: relative;
+  overflow: hidden;
+  padding: 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  background: rgba(23, 32, 51, 0.72);
+  transition:
+    transform 220ms ease,
+    border-color 220ms ease,
+    box-shadow 220ms ease;
+}
+
+.coverage-card::before {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 0.045),
+    transparent 45%
+  );
+  content: "";
+  pointer-events: none;
+}
+
+.coverage-card:hover {
+  transform: translateY(-5px);
+  border-color: rgba(148, 163, 184, 0.3);
+  box-shadow: 0 18px 45px rgba(0, 0, 0, 0.25);
+}
+
+.coverage-icon {
+  position: relative;
+  width: 46px;
+  height: 46px;
+  display: grid;
+  place-items: center;
+  border-radius: 14px;
+  font-size: 1.25rem;
+  font-weight: 900;
+}
+
+.coverage-icon--high {
+  color: var(--green);
+  background: var(--green-soft);
+}
+
+.coverage-icon--medium {
+  color: var(--yellow);
+  background: var(--yellow-soft);
+}
+
+.coverage-icon--low {
+  color: var(--red);
+  background: var(--red-soft);
+}
+
+.coverage-content {
+  position: relative;
+}
+
+.coverage-label {
+  display: block;
+  margin-bottom: 5px;
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.coverage-value {
+  display: block;
+  font-size: 2rem;
+  line-height: 1;
+  letter-spacing: -0.04em;
+}
+
+.progress {
+  width: 100%;
+  height: 6px;
+  margin-top: 18px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.progress-bar {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  transform-origin: left;
+  animation: progressReveal 900ms cubic-bezier(0.22, 1, 0.36, 1)
+    both;
+}
+
+.progress-bar--high {
+  width: 96%;
+  background: linear-gradient(90deg, #16a34a, #4ade80);
+}
+
+.progress-bar--medium {
+  width: 78%;
+  background: linear-gradient(90deg, #d97706, #fbbf24);
+}
+
+.progress-bar--low {
+  width: 54%;
+  background: linear-gradient(90deg, #dc2626, #fb7185);
+}
+
+.standalone-section {
+  margin-top: 34px;
+  padding-top: 30px;
+  border-top: 1px solid var(--border);
+}
+
+.section-label {
+  display: block;
+  margin-bottom: 15px;
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  padding: 9px 14px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 800;
+  letter-spacing: 0.01em;
+  transition:
+    transform 200ms ease,
+    box-shadow 200ms ease;
+}
+
+.badge:hover {
+  transform: translateY(-2px);
+}
+
+.badge--high {
+  color: #86efac;
+  border-color: rgba(34, 197, 94, 0.25);
+  background: var(--green-soft);
+}
+
+.badge--medium {
+  color: #fcd34d;
+  border-color: rgba(245, 158, 11, 0.25);
+  background: var(--yellow-soft);
+}
+
+.badge--low {
+  color: #fca5a5;
+  border-color: rgba(239, 68, 68, 0.25);
+  background: var(--red-soft);
+}
+
+.badge-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 10px currentColor;
+}
+
+@keyframes progressReveal {
+  from {
+    opacity: 0;
+    transform: scaleX(0);
+  }
+
+  to {
+    opacity: 1;
+    transform: scaleX(1);
+  }
+}
+
+@media (max-width: 720px) {
+  .showcase {
+    padding: 32px 24px;
+  }
+
+  .badge-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .coverage-card {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    align-items: center;
+  }
+
+  .coverage-content {
+    min-width: 0;
+  }
+
+  .progress {
+    margin-top: 12px;
+  }
+}
+
+@media (max-width: 480px) {
+  .page {
+    padding: 20px 12px;
+  }
+
+  .showcase {
+    padding: 28px 18px;
+    border-radius: 22px;
+  }
+
+  .intro {
+    margin-bottom: 26px;
+    font-size: 0.9rem;
+  }
+
+  .coverage-card {
+    padding: 18px;
+  }
+
+  .coverage-value {
+    font-size: 1.75rem;
+  }
+
+  .badges {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+
+  .progress-bar {
+    animation: none;
+  }
+}
+
+@media (forced-colors: active) {
+  .coverage-card,
+  .showcase,
+  .badge,
+  .progress {
+    border-color: CanvasText;
+  }
+
+  .progress-bar {
+    background: Highlight;
+  }
+
+  .badge-dot {
+    background: CanvasText;
+    box-shadow: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds a responsive CSS Coverage Badge component for issue #70922.

### Features

* Pure HTML and CSS implementation
* Color-coded coverage states
* High, medium, and low coverage variants
* Animated progress indicators
* Accessible ARIA progressbar attributes
* Responsive layout
* Hover interactions
* Reduced-motion support
* Forced-colors support
* No JavaScript required

### Files Added

* `submissions/examples/r-coverage-badge-70922/demo.html`
* `submissions/examples/r-coverage-badge-70922/style.css`
* `submissions/examples/r-coverage-badge-70922/README.md`

### Testing

* Verified coverage badge variants
* Verified progress bar animations
* Tested responsive layouts
* Tested hover interactions
* Verified accessibility attributes
* Verified reduced-motion behavior
* Verified forced-colors support

Closes #70922
