### PR TITLE
feat: add CSS focus mode overlay

### DIFF
--- a/submissions/examples/css-focus-mode-overlay/README.md
+++ b/submissions/examples/css-focus-mode-overlay/README.md
@@ -1,0 +1,19 @@
+# CSS Focus Mode Overlay
+
+A pure CSS reading-focus component that dims surrounding page content while highlighting the focused paragraph.
+
+## Features
+
+- Pure CSS implementation
+- Focus-based overlay effect
+- Smooth transition animation
+- Keyboard accessible
+- Responsive layout
+- No JavaScript required
+
+## Usage
+
+Include the stylesheet:
+
+```html
+<link rel="stylesheet" href="style.css">

--- a/submissions/examples/css-focus-mode-overlay/demo.html
+++ b/submissions/examples/css-focus-mode-overlay/demo.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Focus Mode Overlay</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="page">
+    <section class="hero">
+      <p class="eyebrow">FOCUS MODE</p>
+      <h1>Read Without Distractions</h1>
+      <p class="intro">
+        Focus mode highlights the important paragraph while dimming
+        the surrounding content.
+      </p>
+    </section>
+
+    <section class="content">
+      <article class="focus-card" tabindex="0" aria-label="Focused reading paragraph">
+        <span class="focus-label">Focused Reading</span>
+        <p>
+          Focused reading helps reduce visual distractions and keeps
+          attention on the content that matters most. This CSS-only
+          pattern creates a clear reading area while the surrounding
+          page remains visually subdued.
+        </p>
+      </article>
+
+      <div class="extra-content" aria-hidden="true">
+        <h2>Additional Content</h2>
+        <p>
+          Supporting information stays visible but receives less visual
+          emphasis while the focused paragraph is active.
+        </p>
+      </div>
+    </section>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/css-focus-mode-overlay/style.css
+++ b/submissions/examples/css-focus-mode-overlay/style.css
@@ -1,0 +1,147 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  font-family: Arial, sans-serif;
+  background: #eef2f7;
+  color: #1f2937;
+  transition: background 0.3s ease;
+}
+
+.page {
+  width: min(900px, 100%);
+  margin: auto;
+  padding: 70px 24px;
+}
+
+.hero {
+  text-align: center;
+  margin-bottom: 45px;
+}
+
+.eyebrow {
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 2px;
+  color: #6366f1;
+  margin-bottom: 12px;
+}
+
+.hero h1 {
+  font-size: clamp(32px, 6vw, 52px);
+  margin-bottom: 16px;
+}
+
+.intro {
+  max-width: 620px;
+  margin: auto;
+  color: #64748b;
+  line-height: 1.7;
+}
+
+.content {
+  position: relative;
+}
+
+.focus-card {
+  position: relative;
+  z-index: 2;
+  max-width: 720px;
+  margin: auto;
+  padding: 35px;
+  border-radius: 18px;
+  background: #ffffff;
+  box-shadow: 0 18px 45px rgba(15, 23, 42, 0.12);
+  cursor: text;
+  transition:
+    transform 0.3s ease,
+    box-shadow 0.3s ease;
+}
+
+.focus-card:focus,
+.focus-card:focus-within {
+  outline: 3px solid #6366f1;
+  outline-offset: 5px;
+  transform: scale(1.02);
+  box-shadow: 0 25px 60px rgba(15, 23, 42, 0.2);
+}
+
+.focus-label {
+  display: inline-block;
+  margin-bottom: 16px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: #eef2ff;
+  color: #4f46e5;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.focus-card p {
+  font-size: 18px;
+  line-height: 1.9;
+}
+
+.extra-content {
+  max-width: 650px;
+  margin: 45px auto 0;
+  padding: 30px;
+  border-radius: 16px;
+  background: #ffffff;
+  color: #64748b;
+  line-height: 1.8;
+}
+
+/* Focus overlay effect */
+.page:has(.focus-card:focus)::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: 1;
+  background: rgba(15, 23, 42, 0.72);
+  pointer-events: none;
+  animation: fade-in 0.3s ease;
+}
+
+.page:has(.focus-card:focus) .hero,
+.page:has(.focus-card:focus) .extra-content {
+  position: relative;
+  z-index: 0;
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@media (max-width: 600px) {
+  .page {
+    padding: 45px 16px;
+  }
+
+  .focus-card {
+    padding: 25px 20px;
+  }
+
+  .focus-card p {
+    font-size: 16px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to** **`core/`**
- [x] **No changes to** **`components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds a CSS Focus Mode Overlay that highlights a focused reading paragraph while dimming the surrounding page content. The effect is implemented using CSS focus states and transitions without JavaScript.

**How does a developer use it?**

```html
<article class="focus-card" tabindex="0">
  <p>
    Your focused reading content goes here.
  </p>
</article>

**Why does it fit EaseMotion CSS?**

This is a reusable CSS interaction pattern that creates a focused reading experience through a smooth overlay effect. It uses pure CSS, requires no external libraries, and can be integrated into different content layouts.
---

## Demo

- [ ] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [*] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Implemented the CSS Focus Mode Overlay under:

submissions/examples/css-focus-mode-overlay/

The demo was tested by opening demo.html directly in a browser.
Closes #70750


---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
