### PR TITLE
Add ease-data-transfer-progress component

### DIFF
--- a/submissions/examples/data-transfer-progress-ij/README.md
+++ b/submissions/examples/data-transfer-progress-ij/README.md
@@ -1,0 +1,11 @@
+# ease-data-transfer-progress
+
+A data transfer card where the packets travel between devices, the fill rises, and the percent ticks.
+
+## Run
+Open `demo.html` directly in a browser to watch the transfer run.
+
+## Notes
+- The packets travel from PC to phone.
+- The progress fill rises across the track.
+- The percent readout ticks beside it.

--- a/submissions/examples/data-transfer-progress-ij/demo.html
+++ b/submissions/examples/data-transfer-progress-ij/demo.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-data-transfer-progress demo</title>
+</head>
+<body>
+<div class="dtp-panel">
+  <div class="dtp-link">
+    <span class="dtp-device dtp-src">PC</span>
+    <div class="dtp-route"><em class="dtp-packet"></em><em class="dtp-packet"></em><em class="dtp-packet"></em></div>
+    <span class="dtp-device dtp-dst">PHONE</span>
+  </div>
+  <div class="dtp-track"><em class="dtp-fill"></em></div>
+  <div class="dtp-meta">
+    <span class="dtp-state">TRANSFERRING</span>
+    <b class="dtp-pct">58%</b>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/data-transfer-progress-ij/style.css
+++ b/submissions/examples/data-transfer-progress-ij/style.css
@@ -1,0 +1,16 @@
+.dtp-panel{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:320px;background:linear-gradient(180deg,#14202e,#0b1420);border:2px solid #2a3a4e;border-radius:16px;padding:20px;display:flex;flex-direction:column;gap:16px}
+.dtp-link{display:flex;align-items:center;gap:10px}
+.dtp-device{font-size:10px;font-weight:800;letter-spacing:1px;color:#7cebb0;background:#0a1420;border:2px solid #2a3a4e;border-radius:6px;padding:8px 10px}
+.dtp-route{position:relative;flex:1;height:20px;overflow:hidden}
+.dtp-packet{position:absolute;top:50%;width:10px;height:10px;border-radius:50%;background:#5ce1e6;transform:translateY(-50%);animation:dtp-packet-travel-data-transfer-progress 2.4s ease-in-out infinite}
+.dtp-packet:nth-child(2){animation-delay:.8s}
+.dtp-packet:nth-child(3){animation-delay:1.6s}
+.dtp-track{height:8px;background:#0a0f17;border-radius:4px;border:1px solid #22303f}
+.dtp-fill{display:block;width:58%;height:100%;background:linear-gradient(90deg,#ff6b9d,#5ce1e6);border-radius:4px;animation:dtp-fill-rise-data-transfer-progress 4s ease-in-out infinite}
+.dtp-meta{display:flex;justify-content:space-between;align-items:center}
+.dtp-state{font-size:10px;font-weight:800;letter-spacing:2px;color:#5ce1e6;animation:dtp-state-blink-data-transfer-progress 1.4s ease-in-out infinite}
+.dtp-pct{font-size:20px;font-weight:800;color:#ffd76a;font-family:'Courier New',monospace;animation:dtp-pct-tick-data-transfer-progress 1.8s steps(3) infinite}
+@keyframes dtp-packet-travel-data-transfer-progress{0%{left:0;opacity:0}20%{opacity:1}80%{opacity:1}100%{left:100%;opacity:0}}
+@keyframes dtp-fill-rise-data-transfer-progress{0%,100%{width:20%}50%{width:84%}}
+@keyframes dtp-state-blink-data-transfer-progress{0%,100%{opacity:1}50%{opacity:.3}}
+@keyframes dtp-pct-tick-data-transfer-progress{0%{opacity:1}50%{opacity:.35}100%{opacity:1}}


### PR DESCRIPTION
## Component: ease-data-transfer-progress — packets travel, fill rises, and pct ticks

**Closes #72044**

### What this adds
A data transfer card where the packets travel between devices, the fill rises, and the percent ticks.

### Acceptance Criteria covered
- Packets travel
- Fill rises
- Percent ticks

### Files
- `submissions/examples/data-transfer-progress-ij/demo.html`
- `submissions/examples/data-transfer-progress-ij/style.css`
- `submissions/examples/data-transfer-progress-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the packets travel, the fill rise, and the pct tick.