### PR TITLE
feat: add CSS genre tag pill

### DIFF
--- a/submissions/examples/r-genre-tag-pill-70832/README.md
+++ b/submissions/examples/r-genre-tag-pill-70832/README.md
@@ -1,0 +1,35 @@
+# CSS Genre Tag Pill
+
+A responsive CSS-only genre tag component for music, media,
+playlist, and content discovery interfaces.
+
+## Features
+
+- Pure HTML and CSS
+- Multiple color-coded genre variants
+- Rounded pill design
+- Subtle hover interaction
+- Responsive wrapping
+- Playlist usage example
+- No JavaScript required
+- Reduced-motion support
+- Forced-colors support
+
+## Available Variants
+
+- `genre-tag--pop`
+- `genre-tag--rock`
+- `genre-tag--jazz`
+- `genre-tag--hiphop`
+- `genre-tag--electronic`
+- `genre-tag--indie`
+- `genre-tag--classical`
+- `genre-tag--metal`
+
+## Usage
+
+```html
+<span class="genre-tag genre-tag--pop">
+  <span class="tag-icon" aria-hidden="true">♪</span>
+  Pop
+</span>

--- a/submissions/examples/r-genre-tag-pill-70832/demo.html
+++ b/submissions/examples/r-genre-tag-pill-70832/demo.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta
+    name="description"
+    content="CSS-only music genre tag pills with color-coded genres"
+  >
+  <title>CSS Genre Tag Pill</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <section class="showcase" aria-labelledby="title">
+      <p class="eyebrow">EaseMotion CSS</p>
+
+      <h1 id="title">Genre Tag Pills</h1>
+
+      <p class="intro">
+        Color-coded music genre tags designed for playlists,
+        media cards, and discovery interfaces.
+      </p>
+
+      <div class="tag-grid" aria-label="Music genre examples">
+        <span class="genre-tag genre-tag--pop">
+          <span class="tag-icon" aria-hidden="true">♪</span>
+          Pop
+        </span>
+
+        <span class="genre-tag genre-tag--rock">
+          <span class="tag-icon" aria-hidden="true">♬</span>
+          Rock
+        </span>
+
+        <span class="genre-tag genre-tag--jazz">
+          <span class="tag-icon" aria-hidden="true">♫</span>
+          Jazz
+        </span>
+
+        <span class="genre-tag genre-tag--hiphop">
+          <span class="tag-icon" aria-hidden="true">◉</span>
+          Hip-Hop
+        </span>
+
+        <span class="genre-tag genre-tag--electronic">
+          <span class="tag-icon" aria-hidden="true">◆</span>
+          Electronic
+        </span>
+
+        <span class="genre-tag genre-tag--indie">
+          <span class="tag-icon" aria-hidden="true">✦</span>
+          Indie
+        </span>
+
+        <span class="genre-tag genre-tag--classical">
+          <span class="tag-icon" aria-hidden="true">♩</span>
+          Classical
+        </span>
+
+        <span class="genre-tag genre-tag--metal">
+          <span class="tag-icon" aria-hidden="true">▲</span>
+          Metal
+        </span>
+      </div>
+
+      <div class="playlist">
+        <div class="playlist-heading">
+          <span>Featured playlist</span>
+          <span class="track-count">8 tracks</span>
+        </div>
+
+        <article class="song">
+          <div class="song-number">01</div>
+
+          <div class="song-info">
+            <strong>Neon Nights</strong>
+            <span>Nova Avenue</span>
+          </div>
+
+          <span class="genre-tag genre-tag--electronic">
+            Electronic
+          </span>
+        </article>
+
+        <article class="song">
+          <div class="song-number">02</div>
+
+          <div class="song-info">
+            <strong>Golden Hour</strong>
+            <span>Velvet Echo</span>
+          </div>
+
+          <span class="genre-tag genre-tag--indie">
+            Indie
+          </span>
+        </article>
+
+        <article class="song">
+          <div class="song-number">03</div>
+
+          <div class="song-info">
+            <strong>Midnight Drive</strong>
+            <span>Static Hearts</span>
+          </div>
+
+          <span class="genre-tag genre-tag--rock">
+            Rock
+          </span>
+        </article>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/r-genre-tag-pill-70832/style.css
+++ b/submissions/examples/r-genre-tag-pill-70832/style.css
@@ -1,0 +1,736 @@
+:root {
+  --bg: #070b16;
+  --surface: #111827;
+  --surface-light: #182236;
+  --border: rgba(148, 163, 184, 0.16);
+  --text: #f8fafc;
+  --muted: #94a3b8;
+
+  --pop: #ec4899;
+  --pop-bg: rgba(236, 72, 153, 0.13);
+
+  --rock: #f97316;
+  --rock-bg: rgba(249, 115, 22, 0.13);
+
+  --jazz: #a78bfa;
+  --jazz-bg: rgba(167, 139, 250, 0.13);
+
+  --hiphop: #facc15;
+  --hiphop-bg: rgba(250, 204, 21, 0.13);
+
+  --electronic: #22d3ee;
+  --electronic-bg: rgba(34, 211, 238, 0.13);
+
+  --indie: #34d399;
+  --indie-bg: rgba(52, 211, 153, 0.13);
+
+  --classical: #60a5fa;
+  --classical-bg: rgba(96, 165, 250, 0.13);
+
+  --metal: #f43f5e;
+  --metal-bg: rgba(244, 63, 94, 0.13);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  color-scheme: dark;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(
+      circle at 15% 15%,
+      rgba(139, 92, 246, 0.12),
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at 85% 85%,
+      rgba(34, 211, 238, 0.08),
+      transparent 28%
+    ),
+    var(--bg);
+}
+
+.page {
+  min-height: 100vh;
+  padding: 40px 18px;
+  display: grid;
+  place-items: center;
+}
+
+.showcase {
+  width: min(100%, 850px);
+  padding: 42px;
+  border: 1px solid var(--border);
+  border-radius: 30px;
+  background:
+    linear-gradient(
+      145deg,
+      rgba(255, 255, 255, 0.04),
+      transparent 45%
+    ),
+    rgba(17, 24, 39, 0.94);
+  box-shadow: 0 30px 90px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: #22d3ee;
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 6vw, 3.4rem);
+  line-height: 1;
+  letter-spacing: -0.05em;
+}
+
+.intro {
+  max-width: 600px;
+  margin: 15px 0 34px;
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.tag-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.genre-tag {
+  --tag-color: #fff;
+  --tag-bg: rgba(255, 255, 255, 0.08);
+
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 14px;
+  border: 1px solid color-mix(
+    in srgb,
+    var(--tag-color) 25%,
+    transparent
+  );
+  border-radius: 999px;
+  color: var(--tag-color);
+  background: var(--tag-bg);
+  font-size: 0.8rem;
+  font-weight: 800;
+  line-height: 1;
+  white-space: nowrap;
+  cursor: default;
+  transition:
+    transform 200ms ease,
+    box-shadow 200ms ease,
+    background 200ms ease;
+}
+
+.genre-tag:hover {
+  transform: translateY(-3px) scale(1.02);
+  background: color-mix(
+    in srgb,
+    var(--tag-color) 18%,
+    rgba(255, 255, 255, 0.04)
+  );
+  box-shadow:
+    0 8px 22px color-mix(
+      in srgb,
+      var(--tag-color) 15%,
+      transparent
+    );
+}
+
+.tag-icon {
+  display: grid;
+  width: 17px;
+  height: 17px;
+  place-items: center;
+  border-radius: 50%;
+  font-size: 0.72rem;
+  background: color-mix(
+    in srgb,
+    var(--tag-color) 18%,
+    transparent
+  );
+}
+
+.genre-tag--pop {
+  --tag-color: var(--pop);
+  --tag-bg: var(--pop-bg);
+}
+
+.genre-tag--rock {
+  --tag-color: var(--rock);
+  --tag-bg: var(--rock-bg);
+}
+
+.genre-tag--jazz {
+  --tag-color: var(--jazz);
+  --tag-bg: var(--jazz-bg);
+}
+
+.genre-tag--hiphop {
+  --tag-color: var(--hiphop);
+  --tag-bg: var(--hiphop-bg);
+}
+
+.genre-tag--electronic {
+  --tag-color: var(--electronic);
+  --tag-bg: var(--electronic-bg);
+}
+
+.genre-tag--indie {
+  --tag-color: var(--indie);
+  --tag-bg: var(--indie-bg);
+}
+
+.genre-tag--classical {
+  --tag-color: var(--classical);
+  --tag-bg: var(--classical-bg);
+}
+
+.genre-tag--metal {
+  --tag-color: var(--metal);
+  --tag-bg: var(--metal-bg);
+}
+
+.playlist {
+  margin-top: 38px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  background: rgba(24, 34, 54, 0.62);
+}
+
+.playlist-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 17px 20px;
+  border-bottom: 1px solid var(--border);
+  color: #e2e8f0;
+  font-size: 0.8rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.track-count {
+  color: var(--muted);
+  font-size: 0.7rem;
+}
+
+.song {
+  display: grid;
+  grid-template-columns: 40px 1fr auto;
+  align-items: center;
+  gap: 15px;
+  padding: 17px 20px;
+  border-bottom: 1px solid var(--border);
+  transition:
+    background 180ms ease,
+    padding 180ms ease;
+}
+
+.song:last-child {
+  border-bottom: 0;
+}
+
+.song:hover {
+  padding-left: 24px;
+  background: rgba(255, 255, 255, 0.035);
+}
+
+.song-number {
+  color: #64748b;
+  font-size: 0.75rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.song-info {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.song-info strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.9rem;
+}
+
+.song-info span {
+  color: var(--muted);
+  font-size: 0.75rem;
+}
+
+.song .genre-tag {
+  padding: 7px 11px;
+  font-size: 0.68rem;
+}
+
+.song .tag-icon {
+  display: none;
+}
+
+@media (max-width: 620px) {
+  .showcase {
+    padding: 30px 22px;
+    border-radius: 24px;
+  }
+
+  .tag-grid {
+    gap: 9px;
+  }
+
+  .genre-tag {
+    padding: 8px 11px;
+  }
+
+  .playlist {
+    margin-top: 30px;
+  }
+
+  .song {
+    grid-template-columns: 28px 1fr;
+  }
+
+  .song .genre-tag {
+    grid-column: 2;
+    justify-self: start;
+  }
+}
+
+@media (max-width: 420px) {
+  .page {
+    padding: 18px 10px;
+  }
+
+  .showcase {
+    padding: 26px 17px;
+  }
+
+  .intro {
+    font-size: 0.88rem;
+  }
+
+  .playlist-heading {
+    padding: 15px;
+  }
+
+  .song {
+    padding: 15px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+  }
+}
+
+@media (forced-colors: active) {
+  .showcase,
+  .playlist,
+  .genre-tag {
+    border-color: CanvasText;
+  }
+
+  .genre-tag {
+    color: CanvasText;
+    background: Canvas;
+  }
+}
+:root {
+  --bg: #070b16;
+  --surface: #111827;
+  --surface-light: #182236;
+  --border: rgba(148, 163, 184, 0.16);
+  --text: #f8fafc;
+  --muted: #94a3b8;
+
+  --pop: #ec4899;
+  --pop-bg: rgba(236, 72, 153, 0.13);
+
+  --rock: #f97316;
+  --rock-bg: rgba(249, 115, 22, 0.13);
+
+  --jazz: #a78bfa;
+  --jazz-bg: rgba(167, 139, 250, 0.13);
+
+  --hiphop: #facc15;
+  --hiphop-bg: rgba(250, 204, 21, 0.13);
+
+  --electronic: #22d3ee;
+  --electronic-bg: rgba(34, 211, 238, 0.13);
+
+  --indie: #34d399;
+  --indie-bg: rgba(52, 211, 153, 0.13);
+
+  --classical: #60a5fa;
+  --classical-bg: rgba(96, 165, 250, 0.13);
+
+  --metal: #f43f5e;
+  --metal-bg: rgba(244, 63, 94, 0.13);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  color-scheme: dark;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(
+      circle at 15% 15%,
+      rgba(139, 92, 246, 0.12),
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at 85% 85%,
+      rgba(34, 211, 238, 0.08),
+      transparent 28%
+    ),
+    var(--bg);
+}
+
+.page {
+  min-height: 100vh;
+  padding: 40px 18px;
+  display: grid;
+  place-items: center;
+}
+
+.showcase {
+  width: min(100%, 850px);
+  padding: 42px;
+  border: 1px solid var(--border);
+  border-radius: 30px;
+  background:
+    linear-gradient(
+      145deg,
+      rgba(255, 255, 255, 0.04),
+      transparent 45%
+    ),
+    rgba(17, 24, 39, 0.94);
+  box-shadow: 0 30px 90px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: #22d3ee;
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 6vw, 3.4rem);
+  line-height: 1;
+  letter-spacing: -0.05em;
+}
+
+.intro {
+  max-width: 600px;
+  margin: 15px 0 34px;
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.tag-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.genre-tag {
+  --tag-color: #fff;
+  --tag-bg: rgba(255, 255, 255, 0.08);
+
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 14px;
+  border: 1px solid color-mix(
+    in srgb,
+    var(--tag-color) 25%,
+    transparent
+  );
+  border-radius: 999px;
+  color: var(--tag-color);
+  background: var(--tag-bg);
+  font-size: 0.8rem;
+  font-weight: 800;
+  line-height: 1;
+  white-space: nowrap;
+  cursor: default;
+  transition:
+    transform 200ms ease,
+    box-shadow 200ms ease,
+    background 200ms ease;
+}
+
+.genre-tag:hover {
+  transform: translateY(-3px) scale(1.02);
+  background: color-mix(
+    in srgb,
+    var(--tag-color) 18%,
+    rgba(255, 255, 255, 0.04)
+  );
+  box-shadow:
+    0 8px 22px color-mix(
+      in srgb,
+      var(--tag-color) 15%,
+      transparent
+    );
+}
+
+.tag-icon {
+  display: grid;
+  width: 17px;
+  height: 17px;
+  place-items: center;
+  border-radius: 50%;
+  font-size: 0.72rem;
+  background: color-mix(
+    in srgb,
+    var(--tag-color) 18%,
+    transparent
+  );
+}
+
+.genre-tag--pop {
+  --tag-color: var(--pop);
+  --tag-bg: var(--pop-bg);
+}
+
+.genre-tag--rock {
+  --tag-color: var(--rock);
+  --tag-bg: var(--rock-bg);
+}
+
+.genre-tag--jazz {
+  --tag-color: var(--jazz);
+  --tag-bg: var(--jazz-bg);
+}
+
+.genre-tag--hiphop {
+  --tag-color: var(--hiphop);
+  --tag-bg: var(--hiphop-bg);
+}
+
+.genre-tag--electronic {
+  --tag-color: var(--electronic);
+  --tag-bg: var(--electronic-bg);
+}
+
+.genre-tag--indie {
+  --tag-color: var(--indie);
+  --tag-bg: var(--indie-bg);
+}
+
+.genre-tag--classical {
+  --tag-color: var(--classical);
+  --tag-bg: var(--classical-bg);
+}
+
+.genre-tag--metal {
+  --tag-color: var(--metal);
+  --tag-bg: var(--metal-bg);
+}
+
+.playlist {
+  margin-top: 38px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  background: rgba(24, 34, 54, 0.62);
+}
+
+.playlist-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 17px 20px;
+  border-bottom: 1px solid var(--border);
+  color: #e2e8f0;
+  font-size: 0.8rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.track-count {
+  color: var(--muted);
+  font-size: 0.7rem;
+}
+
+.song {
+  display: grid;
+  grid-template-columns: 40px 1fr auto;
+  align-items: center;
+  gap: 15px;
+  padding: 17px 20px;
+  border-bottom: 1px solid var(--border);
+  transition:
+    background 180ms ease,
+    padding 180ms ease;
+}
+
+.song:last-child {
+  border-bottom: 0;
+}
+
+.song:hover {
+  padding-left: 24px;
+  background: rgba(255, 255, 255, 0.035);
+}
+
+.song-number {
+  color: #64748b;
+  font-size: 0.75rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.song-info {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.song-info strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.9rem;
+}
+
+.song-info span {
+  color: var(--muted);
+  font-size: 0.75rem;
+}
+
+.song .genre-tag {
+  padding: 7px 11px;
+  font-size: 0.68rem;
+}
+
+.song .tag-icon {
+  display: none;
+}
+
+@media (max-width: 620px) {
+  .showcase {
+    padding: 30px 22px;
+    border-radius: 24px;
+  }
+
+  .tag-grid {
+    gap: 9px;
+  }
+
+  .genre-tag {
+    padding: 8px 11px;
+  }
+
+  .playlist {
+    margin-top: 30px;
+  }
+
+  .song {
+    grid-template-columns: 28px 1fr;
+  }
+
+  .song .genre-tag {
+    grid-column: 2;
+    justify-self: start;
+  }
+}
+
+@media (max-width: 420px) {
+  .page {
+    padding: 18px 10px;
+  }
+
+  .showcase {
+    padding: 26px 17px;
+  }
+
+  .intro {
+    font-size: 0.88rem;
+  }
+
+  .playlist-heading {
+    padding: 15px;
+  }
+
+  .song {
+    padding: 15px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+  }
+}
+
+@media (forced-colors: active) {
+  .showcase,
+  .playlist,
+  .genre-tag {
+    border-color: CanvasText;
+  }
+
+  .genre-tag {
+    color: CanvasText;
+    background: Canvas;
+  }
+}


### PR DESCRIPTION
## Description

Adds a responsive CSS Genre Tag Pill component for issue #70832.

### Features

* Pure HTML and CSS implementation
* Color-coded genre variants
* Pop, Rock, Jazz, Hip-Hop, Electronic, Indie, Classical, and Metal styles
* Rounded pill UI
* Hover interactions
* Responsive wrapping
* Playlist integration example
* Reduced-motion support
* Forced-colors support
* No JavaScript required

### Files Added

* `submissions/examples/r-genre-tag-pill-70832/demo.html`
* `submissions/examples/r-genre-tag-pill-70832/style.css`
* `submissions/examples/r-genre-tag-pill-70832/README.md`

### Testing

* Verified all genre variants
* Tested hover interactions
* Tested responsive layouts
* Verified accessibility of decorative icons
* Tested reduced-motion behavior
* Tested forced-colors styling

Closes #70832
