### PR TITLE
feat: add CSS inline definition layout

### DIFF
--- a/submissions/examples/r-inline-definition-layout-70830/README.md
+++ b/submissions/examples/r-inline-definition-layout-70830/README.md
@@ -1,0 +1,29 @@
+# CSS Inline Definition Layout
+
+A responsive CSS-only term-definition layout using a hanging-indent
+style for clean documentation and glossary interfaces.
+
+## Features
+
+- Pure HTML and CSS
+- Hanging-indent definition layout
+- Clear term and description hierarchy
+- Responsive desktop and mobile layouts
+- Subtle hover interaction
+- No JavaScript required
+- Reduced-motion support
+- Forced-colors support
+- Semantic `<dl>`, `<dt>`, and `<dd>` markup
+
+## Usage
+
+```html
+<dl class="definitions">
+  <div class="definition-item">
+    <dt>Flexbox</dt>
+    <dd>
+      A one-dimensional CSS layout system for arranging elements
+      efficiently along a row or column.
+    </dd>
+  </div>
+</dl>

--- a/submissions/examples/r-inline-definition-layout-70830/demo.html
+++ b/submissions/examples/r-inline-definition-layout-70830/demo.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta
+    name="description"
+    content="Responsive CSS inline definition layout with hanging indentation"
+  >
+  <title>CSS Inline Definition Layout</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <section class="definition-card" aria-labelledby="page-title">
+      <div class="header">
+        <p class="eyebrow">EaseMotion CSS</p>
+        <h1 id="page-title">Inline Definition Layout</h1>
+        <p class="subtitle">
+          A clean term-definition pattern using CSS hanging indents.
+        </p>
+      </div>
+
+      <dl class="definitions">
+        <div class="definition-item">
+          <dt>API</dt>
+          <dd>
+            Application Programming Interface — a structured way for
+            software components to communicate with one another.
+          </dd>
+        </div>
+
+        <div class="definition-item">
+          <dt>CSS</dt>
+          <dd>
+            Cascading Style Sheets — the language used to control the
+            presentation and layout of web documents.
+          </dd>
+        </div>
+
+        <div class="definition-item">
+          <dt>Flexbox</dt>
+          <dd>
+            A one-dimensional CSS layout system designed for arranging
+            elements efficiently along a row or column.
+          </dd>
+        </div>
+
+        <div class="definition-item">
+          <dt>Grid</dt>
+          <dd>
+            A two-dimensional CSS layout system that organizes content
+            into rows and columns.
+          </dd>
+        </div>
+
+        <div class="definition-item">
+          <dt>Responsive Design</dt>
+          <dd>
+            An approach that adapts a website's layout and content to
+            different screen sizes and devices.
+          </dd>
+        </div>
+
+        <div class="definition-item">
+          <dt>Accessibility</dt>
+          <dd>
+            The practice of creating interfaces that can be used by
+            people with a wide range of abilities and assistive tools.
+          </dd>
+        </div>
+      </dl>
+
+      <div class="legend" aria-label="Layout information">
+        <span class="legend-dot" aria-hidden="true"></span>
+        <span>Terms align naturally while definitions flow beneath them.</span>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/r-inline-definition-layout-70830/style.css
+++ b/submissions/examples/r-inline-definition-layout-70830/style.css
@@ -1,0 +1,502 @@
+:root {
+  --bg: #070b16;
+  --surface: #111827;
+  --surface-soft: #172033;
+  --border: rgba(148, 163, 184, 0.16);
+  --text: #f8fafc;
+  --muted: #94a3b8;
+  --accent: #22d3ee;
+  --accent-soft: rgba(34, 211, 238, 0.11);
+  --definition: #cbd5e1;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  color-scheme: dark;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(
+      circle at 15% 15%,
+      rgba(34, 211, 238, 0.09),
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at 85% 85%,
+      rgba(99, 102, 241, 0.1),
+      transparent 30%
+    ),
+    var(--bg);
+}
+
+.page {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 40px 18px;
+}
+
+.definition-card {
+  width: min(100%, 900px);
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background:
+    linear-gradient(
+      145deg,
+      rgba(255, 255, 255, 0.035),
+      transparent 45%
+    ),
+    rgba(17, 24, 39, 0.95);
+  box-shadow: 0 30px 90px rgba(0, 0, 0, 0.42);
+}
+
+.header {
+  padding: 42px 44px 32px;
+  border-bottom: 1px solid var(--border);
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 3.3rem);
+  line-height: 1;
+  letter-spacing: -0.05em;
+}
+
+.subtitle {
+  max-width: 620px;
+  margin: 16px 0 0;
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.definitions {
+  margin: 0;
+  padding: 14px 44px 22px;
+}
+
+.definition-item {
+  position: relative;
+  padding: 21px 0 21px 176px;
+  border-bottom: 1px solid var(--border);
+}
+
+.definition-item:last-child {
+  border-bottom: 0;
+}
+
+.definition-item dt {
+  position: absolute;
+  top: 21px;
+  left: 0;
+  width: 155px;
+  color: var(--accent);
+  font-size: 0.92rem;
+  font-weight: 850;
+  line-height: 1.45;
+}
+
+.definition-item dd {
+  margin: 0;
+  color: var(--definition);
+  font-size: 0.94rem;
+  line-height: 1.7;
+}
+
+.definition-item:hover {
+  background: linear-gradient(
+    90deg,
+    var(--accent-soft),
+    transparent 70%
+  );
+}
+
+.definition-item:hover dt {
+  color: #67e8f9;
+}
+
+.legend {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 0 44px 34px;
+  padding: 14px 16px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  color: var(--muted);
+  background: rgba(255, 255, 255, 0.025);
+  font-size: 0.76rem;
+}
+
+.legend-dot {
+  flex: 0 0 auto;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 12px var(--accent);
+}
+
+@media (max-width: 700px) {
+  .header {
+    padding: 34px 26px 26px;
+  }
+
+  .definitions {
+    padding: 10px 26px 18px;
+  }
+
+  .definition-item {
+    padding: 18px 0 18px 135px;
+  }
+
+  .definition-item dt {
+    top: 18px;
+    width: 120px;
+    font-size: 0.82rem;
+  }
+
+  .definition-item dd {
+    font-size: 0.88rem;
+  }
+
+  .legend {
+    margin: 0 26px 26px;
+  }
+}
+
+@media (max-width: 520px) {
+  .page {
+    padding: 18px 10px;
+  }
+
+  .definition-card {
+    border-radius: 22px;
+  }
+
+  .header {
+    padding: 28px 20px 24px;
+  }
+
+  .definitions {
+    padding: 8px 20px 15px;
+  }
+
+  .definition-item {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 7px;
+    padding: 17px 0;
+  }
+
+  .definition-item dt {
+    position: static;
+    width: auto;
+  }
+
+  .definition-item dd {
+    font-size: 0.86rem;
+  }
+
+  .legend {
+    margin: 0 20px 20px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+  }
+}
+
+@media (forced-colors: active) {
+  .definition-card,
+  .definition-item,
+  .legend {
+    border-color: CanvasText;
+  }
+
+  .definition-item dt,
+  .legend {
+    color: CanvasText;
+  }
+}
+:root {
+  --bg: #070b16;
+  --surface: #111827;
+  --surface-soft: #172033;
+  --border: rgba(148, 163, 184, 0.16);
+  --text: #f8fafc;
+  --muted: #94a3b8;
+  --accent: #22d3ee;
+  --accent-soft: rgba(34, 211, 238, 0.11);
+  --definition: #cbd5e1;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  color-scheme: dark;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(
+      circle at 15% 15%,
+      rgba(34, 211, 238, 0.09),
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at 85% 85%,
+      rgba(99, 102, 241, 0.1),
+      transparent 30%
+    ),
+    var(--bg);
+}
+
+.page {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 40px 18px;
+}
+
+.definition-card {
+  width: min(100%, 900px);
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background:
+    linear-gradient(
+      145deg,
+      rgba(255, 255, 255, 0.035),
+      transparent 45%
+    ),
+    rgba(17, 24, 39, 0.95);
+  box-shadow: 0 30px 90px rgba(0, 0, 0, 0.42);
+}
+
+.header {
+  padding: 42px 44px 32px;
+  border-bottom: 1px solid var(--border);
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 3.3rem);
+  line-height: 1;
+  letter-spacing: -0.05em;
+}
+
+.subtitle {
+  max-width: 620px;
+  margin: 16px 0 0;
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.definitions {
+  margin: 0;
+  padding: 14px 44px 22px;
+}
+
+.definition-item {
+  position: relative;
+  padding: 21px 0 21px 176px;
+  border-bottom: 1px solid var(--border);
+}
+
+.definition-item:last-child {
+  border-bottom: 0;
+}
+
+.definition-item dt {
+  position: absolute;
+  top: 21px;
+  left: 0;
+  width: 155px;
+  color: var(--accent);
+  font-size: 0.92rem;
+  font-weight: 850;
+  line-height: 1.45;
+}
+
+.definition-item dd {
+  margin: 0;
+  color: var(--definition);
+  font-size: 0.94rem;
+  line-height: 1.7;
+}
+
+.definition-item:hover {
+  background: linear-gradient(
+    90deg,
+    var(--accent-soft),
+    transparent 70%
+  );
+}
+
+.definition-item:hover dt {
+  color: #67e8f9;
+}
+
+.legend {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 0 44px 34px;
+  padding: 14px 16px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  color: var(--muted);
+  background: rgba(255, 255, 255, 0.025);
+  font-size: 0.76rem;
+}
+
+.legend-dot {
+  flex: 0 0 auto;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 12px var(--accent);
+}
+
+@media (max-width: 700px) {
+  .header {
+    padding: 34px 26px 26px;
+  }
+
+  .definitions {
+    padding: 10px 26px 18px;
+  }
+
+  .definition-item {
+    padding: 18px 0 18px 135px;
+  }
+
+  .definition-item dt {
+    top: 18px;
+    width: 120px;
+    font-size: 0.82rem;
+  }
+
+  .definition-item dd {
+    font-size: 0.88rem;
+  }
+
+  .legend {
+    margin: 0 26px 26px;
+  }
+}
+
+@media (max-width: 520px) {
+  .page {
+    padding: 18px 10px;
+  }
+
+  .definition-card {
+    border-radius: 22px;
+  }
+
+  .header {
+    padding: 28px 20px 24px;
+  }
+
+  .definitions {
+    padding: 8px 20px 15px;
+  }
+
+  .definition-item {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 7px;
+    padding: 17px 0;
+  }
+
+  .definition-item dt {
+    position: static;
+    width: auto;
+  }
+
+  .definition-item dd {
+    font-size: 0.86rem;
+  }
+
+  .legend {
+    margin: 0 20px 20px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+  }
+}
+
+@media (forced-colors: active) {
+  .definition-card,
+  .definition-item,
+  .legend {
+    border-color: CanvasText;
+  }
+
+  .definition-item dt,
+  .legend {
+    color: CanvasText;
+  }
+}


### PR DESCRIPTION
## Description

Adds a responsive CSS Inline Definition Layout component for issue #70830.

### Features

* Pure HTML and CSS implementation
* Hanging-indent term-definition layout
* Semantic `<dl>`, `<dt>`, and `<dd>` markup
* Responsive desktop and mobile layouts
* Subtle hover interaction
* No JavaScript required
* Reduced-motion support
* Forced-colors support
* Accessible and readable typography

### Files Added

* `submissions/examples/r-inline-definition-layout-70830/demo.html`
* `submissions/examples/r-inline-definition-layout-70830/style.css`
* `submissions/examples/r-inline-definition-layout-70830/README.md`

### Testing

* Tested desktop layout
* Tested mobile responsive behavior
* Verified semantic definition-list structure
* Tested hover styling
* Verified reduced-motion support
* Verified forced-colors styling

Closes #70830
