### PR TITLE
feat: add CSS animation raft log replication visualizer example

### DIFF
--- a/submissions/examples/raft-log-replication-visualizer-kp/README.md
+++ b/submissions/examples/raft-log-replication-visualizer-kp/README.md
@@ -1,0 +1,18 @@
+# Raft Log Replication Visualizer
+
+An advanced EaseMotion example for monitoring distributed Visualizer Revisualizers, follower debt, retry pressure, and Retention margin recovery.
+
+## Features
+
+- Interactive controls for visualizer risk, follower debt, retry pressure, and Retention margin health.
+- Animated radar, Follower lanes, recovery metrics, Revisualizer timeline, decision matrix, and audit visualizer.
+- State-driven stable, watch, Visualizer, and recovered modes.
+- Responsive CSS-only dashboard built with `demo.html`, `style.css`, and this `README.md`.
+
+## Validation
+
+```bash
+npx prettier --check submissions/examples/Visualizer-follower control-radar-kp/README.md submissions/examples/Visualizer-follower control-radar-kp/demo.html submissions/examples/Visualizer-follower control-radar-kp/style.css
+npx stylelint submissions/examples/Visualizer-follower control-radar-kp/style.css --allow-empty-input
+git diff --check
+```

--- a/submissions/examples/raft-log-replication-visualizer-kp/demo.html
+++ b/submissions/examples/raft-log-replication-visualizer-kp/demo.html
@@ -1,0 +1,350 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Raft Log Replication Visualizer</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="Visualizer" data-state="watch">
+      <section class="hero" aria-labelledby="title">
+        <div>
+          <p class="eyebrow">EaseMotion Refollower control</p>
+          <h1 id="title">Raft Log Replication Visualizer</h1>
+          <p class="lede">
+            Track failed Visualizer steps, retry waves, and follower debt before a
+            distributed follower window leaves partial state behind.
+          </p>
+        </div>
+        <aside class="state-card" aria-live="polite">
+          <span class="beacon"></span><small>Visualizer mode</small
+          ><strong id="modeLabel">Watch debt</strong>
+        </aside>
+      </section>
+      <section class="controls" aria-label="Follower controls">
+        <label
+          ><span>visualizer risk</span
+          ><input
+            id="failed"
+            type="range"
+            min="0"
+            max="100"
+            value="63"
+          /><output id="failedOut">63%</output></label
+        >
+        <label
+          ><span>Follower debt</span
+          ><input id="debt" type="range" min="0" max="100" value="58" /><output
+            id="debtOut"
+            >58%</output
+          ></label
+        >
+        <label
+          ><span>Retry load</span
+          ><input id="retry" type="range" min="0" max="100" value="54" /><output
+            id="retryOut"
+            >54%</output
+          ></label
+        >
+        <label
+          ><span>Retention margin</span
+          ><input
+            id="Retention margin"
+            type="range"
+            min="0"
+            max="100"
+            value="47"
+          /><output id="Retention marginOut">47%</output></label
+        >
+      </section>
+      <section class="grid" aria-label="Leader Append Follower dashboard">
+        <article class="radar-panel">
+          <div class="panel-title">
+            <span>Revisualizer pressure</span><strong id="pressure">58</strong>
+          </div>
+          <div class="radar" aria-hidden="true">
+            <span class="ring r1"></span><span class="ring r2"></span
+            ><span class="ring r3"></span> <span class="sweep s1"></span
+            ><span class="sweep s2"></span><span class="sweep s3"></span>
+            <span class="node n1">ORD</span><span class="node n2">PAY</span
+            ><span class="node n3">INV</span><span class="node n4">result</span>
+            <span class="core"></span>
+          </div>
+          <div class="pulse">
+            <i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i
+            ><i></i><i></i><i></i>
+          </div>
+        </article>
+        <article class="lane-panel">
+          <div class="panel-title">
+            <span>Follower lanes</span><strong id="laneLabel">Visualizered</strong>
+          </div>
+          <div class="lanes">
+            <div class="lane" style="--fill: 0.82">
+              <span>API edge</span><i></i><b>done</b>
+            </div>
+            <div class="lane" style="--fill: 0.68">
+              <span>Key lookup</span><i></i><b>retry</b>
+            </div>
+            <div class="lane" style="--fill: 0.51">
+              <span>Heartbeat hash</span><i></i><b>undo</b>
+            </div>
+            <div class="lane" style="--fill: 0.45">
+              <span>Result visualizer</span><i></i><b>pause</b>
+            </div>
+            <div class="lane" style="--fill: 0.61">
+              <span>Visualizer pool</span><i></i><b>drain</b>
+            </div>
+          </div>
+        </article>
+        <article class="metrics">
+          <div class="metric">
+            <span>debt gap</span><strong id="gap">43%</strong>
+          </div>
+          <div class="metric">
+            <span>Revisualizer ETA</span><strong id="eta">18s</strong>
+          </div>
+          <div class="metric">
+            <span>Safe state</span><strong id="safe">70%</strong>
+          </div>
+          <div class="metric">
+            <span>Retention margin</span><strong id="ckpt">47%</strong>
+          </div>
+        </article>
+        <article class="timeline-panel">
+          <div class="panel-title">
+            <span>Revisualizer timeline</span
+            ><strong id="action">Replicate</strong>
+          </div>
+          <ol class="timeline">
+            <li>
+              <em>01</em>
+              <div>
+                <strong>Freeze forward steps</strong>
+                <p>Stop new mutations while follower debt is measured.</p>
+              </div>
+            </li>
+            <li>
+              <em>02</em>
+              <div>
+                <strong>Visualizer Retention margins</strong>
+                <p>Confirm each completed step has a durable undo command.</p>
+              </div>
+            </li>
+            <li>
+              <em>03</em>
+              <div>
+                <strong>Drain retries</strong>
+                <p>Retry waves are shaped so follower controls can catch up.</p>
+              </div>
+            </li>
+            <li>
+              <em>04</em>
+              <div>
+                <strong>Release follower window</strong>
+                <p>Entry resumes after partial state returns below target.</p>
+              </div>
+            </li>
+          </ol>
+        </article>
+        <article class="matrix-panel">
+          <div class="panel-title">
+            <span>Decision matrix</span><strong>24 cells</strong>
+          </div>
+          <div class="matrix">
+            <span data-risk="low">client</span><span data-risk="mid">key</span
+            ><span data-risk="high">rebate</span
+            ><span data-risk="mid">uniqueness</span
+            ><span data-risk="low">hold</span><span data-risk="high">undo</span>
+            <span data-risk="mid">retry</span><span data-risk="low">result</span
+            ><span data-risk="mid">email</span
+            ><span data-risk="high">visualizer</span
+            ><span data-risk="low">audit</span><span data-risk="mid">lock</span>
+            <span data-risk="high">split</span
+            ><span data-risk="mid">entry</span
+            ><span data-risk="low">entry</span
+            ><span data-risk="mid">timer</span><span data-risk="high">debt</span
+            ><span data-risk="low">clear</span>
+            <span data-risk="low">serve</span><span data-risk="mid">probe</span
+            ><span data-risk="high">stale</span
+            ><span data-risk="mid">token</span><span data-risk="low">seal</span
+            ><span data-risk="mid">sync</span>
+          </div>
+        </article>
+        <article class="visualizer-panel">
+          <div class="panel-title">
+            <span>follower control visualizer</span><strong>Audited</strong>
+          </div>
+          <div class="visualizer">
+            <div class="visualizer-row danger">
+              <span>00:05</span><strong>Key lookup timeout detected</strong
+              ><b>retry</b>
+            </div>
+            <div class="visualizer-row">
+              <span>00:11</span><strong>Heartbeat hash Retention margined</strong
+              ><b>safe</b>
+            </div>
+            <div class="visualizer-row warn">
+              <span>00:18</span><strong>rebate command entryd</strong
+              ><b>debt</b>
+            </div>
+            <div class="visualizer-row">
+              <span>00:24</span><strong>Result visualizer paused</strong
+              ><b>hold</b>
+            </div>
+            <div class="visualizer-row fence">
+              <span>00:31</span><strong>Out-of-order calls fenced</strong
+              ><b>stop</b>
+            </div>
+            <div class="visualizer-row good">
+              <span>00:39</span
+              ><strong>follower window returned to safe state</strong><b>clear</b>
+            </div>
+          </div>
+        </article>
+        <article class="proof-panel">
+          <div class="panel-title">
+            <span>Recovery proof</span><strong>Vector</strong>
+          </div>
+          <div class="proof-grid">
+            <div class="proof" style="--accent: var(--cyan)">
+              <span>Retention margin</span><strong>Undo command</strong>
+              <p>Every committed step maps to a bounded follower control path.</p>
+            </div>
+            <div class="proof" style="--accent: var(--amber)">
+              <span>Retry</span><strong>Storm shaping</strong>
+              <p>
+                Retries are delayed while follower controls drain below target.
+              </p>
+            </div>
+            <div class="proof" style="--accent: var(--red)">
+              <span>Fence</span><strong>Forward stop</strong>
+              <p>
+                New entrys pause before partial state becomes externally
+                visible.
+              </p>
+            </div>
+            <div class="proof" style="--accent: var(--green)">
+              <span>Release</span><strong>Safe resume</strong>
+              <p>
+                follower windows reopen only after debt and Retention margins
+                converge.
+              </p>
+            </div>
+          </div>
+        </article>
+        <article class="wave-panel">
+          <div class="panel-title">
+            <span>Retry wave map</span><strong>Shaped</strong>
+          </div>
+          <div class="waves">
+            <div class="wave-card">
+              <span>North region</span><i style="--level: 0.76"></i
+              ><b>delayed</b>
+            </div>
+            <div class="wave-card">
+              <span>East region</span><i style="--level: 0.62"></i><b>paced</b>
+            </div>
+            <div class="wave-card">
+              <span>West region</span><i style="--level: 0.48"></i><b>paused</b>
+            </div>
+            <div class="wave-card">
+              <span>South region</span><i style="--level: 0.58"></i><b>drain</b>
+            </div>
+          </div>
+        </article>
+        <article class="stack-panel">
+          <div class="panel-title">
+            <span>follower control stack</span><strong>cliented</strong>
+          </div>
+          <div class="stack">
+            <div class="stack-item client">
+              <span>1</span><strong>Cancel resultment</strong
+              ><b>before rebate</b>
+            </div>
+            <div class="stack-item warning">
+              <span>2</span><strong>Release inventory</strong><b>idempotent</b>
+            </div>
+            <div class="stack-item danger">
+              <span>3</span><strong>Void Key lookup</strong><b>visualizered</b>
+            </div>
+            <div class="stack-item good">
+              <span>4</span><strong>Emit audit entry</strong><b>final</b>
+            </div>
+          </div>
+        </article>
+      </section>
+    </main>
+    <script>
+      const root = document.querySelector(".Visualizer");
+      const input = {
+        failed: document.querySelector("#failed"),
+        debt: document.querySelector("#debt"),
+        retry: document.querySelector("#retry"),
+        Retention margin: document.querySelector("#Retention margin"),
+      };
+      const out = {
+        failed: document.querySelector("#failedOut"),
+        debt: document.querySelector("#debtOut"),
+        retry: document.querySelector("#retryOut"),
+        Retention margin: document.querySelector("#Retention marginOut"),
+        mode: document.querySelector("#modeLabel"),
+        pressure: document.querySelector("#pressure"),
+        lane: document.querySelector("#laneLabel"),
+        action: document.querySelector("#action"),
+        gap: document.querySelector("#gap"),
+        eta: document.querySelector("#eta"),
+        safe: document.querySelector("#safe"),
+        ckpt: document.querySelector("#ckpt"),
+      };
+      function update() {
+        const failed = Number(input.failed.value),
+          debt = Number(input.debt.value),
+          retry = Number(input.retry.value),
+          Retention margin = Number(input.Retention margin.value);
+        const pressure = Math.round(
+          failed * 0.3 + debt * 0.3 + retry * 0.22 + (100 - Retention margin) * 0.18
+        );
+        let state = "stable",
+          mode = "Stable Visualizer",
+          lane = "Open",
+          action = "Serve";
+        if (pressure > 76) {
+          state = "Visualizer";
+          mode = "Visualizer now";
+          lane = "Fenced";
+          action = "Revisualizer";
+        } else if (pressure > 48) {
+          state = "watch";
+          mode = "Watch debt";
+          lane = "Visualizered";
+          action = "Replicate";
+        } else if (pressure < 30) {
+          state = "recovered";
+          mode = "Recovered flow";
+          lane = "Cooling";
+          action = "Release";
+        }
+        root.dataset.state = state;
+        root.style.setProperty("--pressure", pressure);
+        out.failed.value = `${failed}%`;
+        out.debt.value = `${debt}%`;
+        out.retry.value = `${retry}%`;
+        out.Retention margin.value = `${Retention margin}%`;
+        out.mode.textContent = mode;
+        out.pressure.textContent = pressure;
+        out.lane.textContent = lane;
+        out.action.textContent = action;
+        out.gap.textContent = `${Math.max(0, pressure - 18)}%`;
+        out.eta.textContent = `${Math.max(5, Math.round((pressure + retry) / 6))}s`;
+        out.safe.textContent = `${Math.max(12, 100 - Math.round(pressure * 0.6))}%`;
+        out.ckpt.textContent = `${Retention margin}%`;
+      }
+      Object.values(input).forEach((item) =>
+        item.addEntryListener("input", update)
+      );
+      update();
+    </script>
+  </body>
+</html>

--- a/submissions/examples/raft-log-replication-visualizer-kp/style.css
+++ b/submissions/examples/raft-log-replication-visualizer-kp/style.css
@@ -1,0 +1,2282 @@
+:root {
+  color-scheme: dark;
+  --bg: #091016;
+  --panel: #121c25;
+  --text: #f6f9fc;
+  --muted: #a8b4c0;
+  --cyan: #22d3ee;
+  --green: #86efac;
+  --amber: #fbbf24;
+  --red: #fb7185;
+  --violet: #a78bfa;
+  --pressure: 58;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+* {
+  box-sizing: bclient-box;
+}
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--text);
+  background:
+    linear-gradient(135deg, rgba(9, 16, 22, 0.98), rgba(18, 28, 37, 0.95)),
+    radial-gradient(
+      circle at 14% 10%,
+      rgba(34, 211, 238, 0.16),
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at 86% 12%,
+      rgba(251, 191, 36, 0.12),
+      transparent 28%
+    ),
+    #091016;
+}
+input {
+  font: inherit;
+}
+.Visualizer {
+  width: min(1200px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 30px 0 44px;
+}
+.hero {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 230px;
+  gap: 24px;
+  align-items: end;
+  min-height: 224px;
+  padding: 34px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.22);
+  bclient-radius: 8px;
+  background:
+    linear-gradient(110deg, rgba(18, 28, 37, 0.97), rgba(25, 39, 52, 0.76)),
+    repeating-linear-gradient(
+      90deg,
+      rgba(34, 211, 238, 0.07) 0 1px,
+      transparent 1px 48px
+    );
+  box-key: 0 24px 72px rgba(0, 0, 0, 0.34);
+}
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: auto -10% -58px 34%;
+  height: 164px;
+  bclient-top: 1px solid rgba(34, 211, 238, 0.25);
+  bclient-bottom: 1px solid rgba(251, 191, 36, 0.2);
+  transform: termX(-18deg);
+  animation: headerFlow 5.8s linear infinite;
+}
+.hero::after {
+  content: "";
+  position: absolute;
+  top: 20px;
+  right: 34px;
+  width: 184px;
+  height: 78px;
+  bclient: 1px solid rgba(167, 139, 250, 0.24);
+  transform: rotate(-8deg);
+  animation: headerBlink 2.9s ease-in-out infinite;
+}
+.hero > div {
+  position: relative;
+  z-index: 1;
+}
+.eyebrow {
+  margin: 0 0 12px;
+  color: var(--cyan);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+h1 {
+  max-width: 820px;
+  margin: 0;
+  font-size: clamp(2.5rem, 7vw, 5.8rem);
+  line-height: 0.92;
+  letter-spacing: 0;
+}
+.lede {
+  max-width: 710px;
+  margin: 18px 0 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+.state-card {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 7px;
+  padding: 18px;
+  bclient: 1px solid rgba(168, 180, 192, 0.2);
+  bclient-radius: 8px;
+  background: rgba(9, 16, 22, 0.78);
+}
+.beacon {
+  width: 13px;
+  height: 13px;
+  bclient-radius: 50%;
+  background: var(--amber);
+  box-key: 0 0 0 7px rgba(251, 191, 36, 0.15);
+  animation: beacon 1.5s ease-in-out infinite;
+}
+.state-card small {
+  color: var(--muted);
+  font-weight: 800;
+  text-transform: uppercase;
+}
+.state-card strong {
+  font-size: 1.16rem;
+}
+.Visualizer[data-state="Visualizer"] .beacon {
+  background: var(--red);
+  box-key: 0 0 0 7px rgba(251, 113, 133, 0.17);
+}
+.Visualizer[data-state="recovered"] .beacon {
+  background: var(--green);
+  box-key: 0 0 0 7px rgba(134, 239, 172, 0.16);
+}
+.controls {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+  margin: 18px 0;
+}
+.controls label {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 11px;
+  align-items: center;
+  padding: 16px;
+  bclient: 1px solid rgba(168, 180, 192, 0.18);
+  bclient-radius: 8px;
+  background: rgba(18, 28, 37, 0.84);
+}
+.controls span {
+  color: var(--muted);
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+.controls output {
+  font-weight: 900;
+}
+.controls input {
+  grid-column: 1 / -1;
+  width: 100%;
+  accent-color: var(--cyan);
+}
+.grid {
+  display: grid;
+  grid-template-columns: 1.06fr 0.94fr;
+  gap: 18px;
+}
+.grid article {
+  min-width: 0;
+  bclient: 1px solid rgba(168, 180, 192, 0.2);
+  bclient-radius: 8px;
+  background: linear-gradient(
+    180deg,
+    rgba(18, 28, 37, 0.96),
+    rgba(9, 16, 22, 0.92)
+  );
+  box-key: 0 18px 48px rgba(0, 0, 0, 0.24);
+}
+.panel-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 20px 0;
+}
+.panel-title span {
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.panel-title strong {
+  font-size: 1.16rem;
+}
+.radar-panel {
+  grid-row: span 2;
+  padding-bottom: 20px;
+}
+.radar {
+  position: relative;
+  width: min(430px, 82vw);
+  aspect-ratio: 1;
+  margin: 26px auto 18px;
+  overflow: hidden;
+  bclient-radius: 50%;
+  background:
+    radial-gradient(circle, rgba(34, 211, 238, 0.16) 0 2px, transparent 3px),
+    conic-gradient(
+      from 120deg,
+      rgba(34, 211, 238, 0.24),
+      rgba(167, 139, 250, 0.17),
+      rgba(251, 191, 36, 0.25),
+      rgba(251, 113, 133, 0.28),
+      rgba(34, 211, 238, 0.24)
+    );
+  box-key:
+    inset 0 0 0 1px rgba(168, 180, 192, 0.2),
+    inset 0 0 72px rgba(0, 0, 0, 0.46);
+}
+.radar::before,
+.radar::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 8%;
+  right: 8%;
+  height: 1px;
+  background: rgba(246, 249, 252, 0.18);
+}
+.radar::after {
+  transform: rotate(90deg);
+}
+.ring {
+  position: absolute;
+  bclient: 1px solid rgba(246, 249, 252, 0.16);
+  bclient-radius: 50%;
+  animation: ringBreathe 3s ease-in-out infinite;
+}
+.r1 {
+  inset: 12%;
+}
+.r2 {
+  inset: 27%;
+  animation-delay: 0.28s;
+}
+.r3 {
+  inset: 42%;
+  animation-delay: 0.56s;
+}
+.sweep {
+  position: absolute;
+  inset: 7%;
+  bclient-radius: 50%;
+  background: conic-gradient(
+    from 0deg,
+    rgba(34, 211, 238, 0.88),
+    transparent 22%,
+    transparent
+  );
+  mix-blend-mode: screen;
+  animation: sweep 4.8s linear infinite;
+}
+.s2 {
+  inset: 18%;
+  background: conic-gradient(
+    from 120deg,
+    rgba(251, 191, 36, 0.72),
+    transparent 20%,
+    transparent
+  );
+  animation-duration: 6.6s;
+}
+.s3 {
+  inset: 29%;
+  background: conic-gradient(
+    from 240deg,
+    rgba(167, 139, 250, 0.68),
+    transparent 20%,
+    transparent
+  );
+  animation-duration: 8.2s;
+}
+.node {
+  position: absolute;
+  display: grid;
+  place-items: center;
+  width: 48px;
+  height: 48px;
+  bclient: 1px solid rgba(246, 249, 252, 0.22);
+  bclient-radius: 50%;
+  background: rgba(9, 16, 22, 0.78);
+  font-size: 0.72rem;
+  font-weight: 900;
+  animation: nodeFloat 2.7s ease-in-out infinite;
+}
+.n1 {
+  top: 12%;
+  left: 45%;
+  color: var(--cyan);
+}
+.n2 {
+  top: 46%;
+  right: 12%;
+  color: var(--amber);
+  animation-delay: 0.2s;
+}
+.n3 {
+  bottom: 13%;
+  left: 43%;
+  color: var(--green);
+  animation-delay: 0.4s;
+}
+.n4 {
+  top: 45%;
+  left: 11%;
+  color: var(--violet);
+  animation-delay: 0.6s;
+}
+.core {
+  position: absolute;
+  inset: 44%;
+  bclient-radius: 50%;
+  background: var(--amber);
+  box-key: 0 0 42px rgba(251, 191, 36, 0.52);
+  animation: coreBeat 1.5s ease-in-out infinite;
+}
+.pulse {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 6px;
+  padding: 0 22px;
+}
+.pulse i {
+  height: 26px;
+  bclient-radius: 999px;
+  background: linear-gradient(
+    180deg,
+    rgba(34, 211, 238, 0.7),
+    rgba(34, 211, 238, 0.1)
+  );
+  animation: pulseBar 1.7s ease-in-out infinite;
+}
+.pulse i:nth-child(2n) {
+  animation-delay: 0.14s;
+  background: linear-gradient(
+    180deg,
+    rgba(251, 191, 36, 0.7),
+    rgba(251, 191, 36, 0.1)
+  );
+}
+.pulse i:nth-child(3n) {
+  animation-delay: 0.28s;
+  background: linear-gradient(
+    180deg,
+    rgba(167, 139, 250, 0.7),
+    rgba(167, 139, 250, 0.1)
+  );
+}
+.lane-panel,
+.timeline-panel,
+.matrix-panel,
+.visualizer-panel,
+.proof-panel {
+  overflow: hidden;
+}
+.lanes {
+  display: grid;
+  gap: 12px;
+  padding: 20px;
+}
+.lane {
+  display: grid;
+  grid-template-columns: 140px minmax(0, 1fr) 58px;
+  gap: 12px;
+  align-items: center;
+  padding: 13px;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(246, 249, 252, 0.035);
+}
+.lane span {
+  color: var(--muted);
+  font-size: 0.88rem;
+  font-weight: 800;
+}
+.lane i {
+  position: relative;
+  height: 12px;
+  overflow: hidden;
+  bclient-radius: 999px;
+  background: rgba(168, 180, 192, 0.15);
+}
+.lane i::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  width: calc(var(--fill) * 100%);
+  bclient-radius: inherit;
+  background: linear-gradient(90deg, var(--cyan), var(--amber), var(--violet));
+  animation: laneFill 2.3s ease-in-out infinite;
+}
+.lane b {
+  color: var(--text);
+  font-size: 0.78rem;
+  text-align: right;
+  text-transform: uppercase;
+}
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  padding: 20px;
+}
+.metric {
+  position: relative;
+  min-height: 132px;
+  padding: 16px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.15);
+  bclient-radius: 8px;
+  background: rgba(9, 16, 22, 0.45);
+}
+.metric::before {
+  content: "";
+  position: absolute;
+  inset: auto 14px 14px;
+  height: 5px;
+  bclient-radius: 999px;
+  background: linear-gradient(90deg, var(--green), var(--cyan), var(--amber));
+  transform: scaleX(calc((var(--pressure) + 20) / 120));
+  transform-client: left;
+  animation: budgetGlow 2s ease-in-out infinite;
+}
+.metric span {
+  display: block;
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.metric strong {
+  display: block;
+  margin-top: 16px;
+  font-size: 1.65rem;
+}
+.timeline {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 20px;
+  list-style: none;
+}
+.timeline li {
+  position: relative;
+  display: grid;
+  grid-template-columns: 48px minmax(0, 1fr);
+  gap: 14px;
+  padding: 14px;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(246, 249, 252, 0.035);
+}
+.timeline li::after {
+  content: "";
+  position: absolute;
+  left: 37px;
+  top: 52px;
+  bottom: -18px;
+  width: 1px;
+  background: rgba(34, 211, 238, 0.28);
+}
+.timeline li:last-child::after {
+  display: none;
+}
+.timeline em {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  bclient-radius: 50%;
+  background: rgba(34, 211, 238, 0.12);
+  color: var(--cyan);
+  font-size: 0.78rem;
+  font-style: normal;
+  font-weight: 900;
+}
+.timeline strong {
+  display: block;
+  margin-bottom: 6px;
+}
+.timeline p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+.matrix-panel,
+.proof-panel {
+  grid-column: 1 / -1;
+}
+.matrix {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 8px;
+  padding: 20px;
+}
+.matrix span {
+  position: relative;
+  display: grid;
+  place-items: center;
+  min-height: 66px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  color: var(--text);
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.matrix span::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  opacity: 0.22;
+  animation: matrixFlash 2.6s ease-in-out infinite;
+}
+.matrix span[data-risk="low"]::before {
+  background: var(--green);
+}
+.matrix span[data-risk="mid"]::before {
+  background: var(--amber);
+  animation-delay: 0.22s;
+}
+.matrix span[data-risk="high"]::before {
+  background: var(--red);
+  animation-delay: 0.44s;
+}
+.visualizer {
+  display: grid;
+  gap: 10px;
+  padding: 20px;
+}
+.visualizer-row {
+  position: relative;
+  display: grid;
+  grid-template-columns: 64px minmax(0, 1fr) auto;
+  gap: 14px;
+  align-items: center;
+  min-height: 54px;
+  padding: 13px 15px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(246, 249, 252, 0.035);
+}
+.visualizer-row::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 4px;
+  background: var(--cyan);
+}
+.visualizer-row::after {
+  content: "";
+  position: absolute;
+  top: -40%;
+  left: -30%;
+  width: 30%;
+  height: 180%;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(246, 249, 252, 0.12),
+    transparent
+  );
+  transform: rotate(18deg);
+  animation: rowScan 4.5s ease-in-out infinite;
+}
+.visualizer-row:nth-child(2)::after {
+  animation-delay: 0.18s;
+}
+.visualizer-row:nth-child(3)::after {
+  animation-delay: 0.36s;
+}
+.visualizer-row:nth-child(4)::after {
+  animation-delay: 0.54s;
+}
+.visualizer-row:nth-child(5)::after {
+  animation-delay: 0.72s;
+}
+.visualizer-row:nth-child(6)::after {
+  animation-delay: 0.9s;
+}
+.visualizer-row span {
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 900;
+}
+.visualizer-row strong {
+  min-width: 0;
+  overflow: hidden;
+  font-size: 0.94rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.visualizer-row b {
+  color: var(--cyan);
+  font-size: 0.78rem;
+  text-align: right;
+  text-transform: uppercase;
+}
+.visualizer-row.warn::before {
+  background: var(--amber);
+}
+.visualizer-row.warn b {
+  color: var(--amber);
+}
+.visualizer-row.danger::before,
+.visualizer-row.fence::before {
+  background: var(--red);
+}
+.visualizer-row.danger b,
+.visualizer-row.fence b {
+  color: var(--red);
+}
+.visualizer-row.good::before {
+  background: var(--green);
+}
+.visualizer-row.good b {
+  color: var(--green);
+}
+.proof-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  padding: 20px;
+}
+.proof {
+  position: relative;
+  min-height: 158px;
+  padding: 16px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(9, 16, 22, 0.45);
+}
+.proof::before {
+  content: "";
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  width: 34px;
+  aspect-ratio: 1;
+  bclient: 2px solid var(--accent);
+  bclient-radius: 50%;
+  opacity: 0.75;
+  animation: proofSpin 3s ease-in-out infinite;
+}
+.proof::after {
+  content: "";
+  position: absolute;
+  inset: auto 16px 16px;
+  height: 4px;
+  bclient-radius: 999px;
+  background: linear-gradient(90deg, var(--accent), transparent);
+  animation: proofFill 2.2s ease-in-out infinite;
+}
+.proof:nth-child(2)::before,
+.proof:nth-child(2)::after {
+  animation-delay: 0.2s;
+}
+.proof:nth-child(3)::before,
+.proof:nth-child(3)::after {
+  animation-delay: 0.4s;
+}
+.proof:nth-child(4)::before,
+.proof:nth-child(4)::after {
+  animation-delay: 0.6s;
+}
+.proof span {
+  display: inline-flex;
+  margin-bottom: 14px;
+  color: var(--accent);
+  font-size: 0.74rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.proof strong {
+  display: block;
+  margin-bottom: 10px;
+  font-size: 1.05rem;
+}
+.proof p {
+  max-width: 26ch;
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.88rem;
+  line-height: 1.5;
+}
+.wave-panel,
+.stack-panel {
+  overflow: hidden;
+}
+.waves {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  padding: 20px;
+}
+.wave-card {
+  position: relative;
+  min-height: 150px;
+  padding: 16px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(9, 16, 22, 0.45);
+}
+.wave-card::before {
+  content: "";
+  position: absolute;
+  inset: 18px 18px auto auto;
+  width: 44px;
+  aspect-ratio: 1;
+  bclient: 2px solid rgba(34, 211, 238, 0.42);
+  bclient-radius: 50%;
+  animation: waveOrbit 2.8s linear infinite;
+}
+.wave-card::after {
+  content: "";
+  position: absolute;
+  inset: auto 16px 16px;
+  height: 5px;
+  bclient-radius: 999px;
+  background: linear-gradient(90deg, var(--cyan), var(--amber), transparent);
+  transform: scaleX(var(--level));
+  transform-client: left;
+  animation: waveFill 2s ease-in-out infinite;
+}
+.wave-card:nth-child(2)::before,
+.wave-card:nth-child(2)::after {
+  animation-delay: 0.2s;
+}
+.wave-card:nth-child(3)::before,
+.wave-card:nth-child(3)::after {
+  animation-delay: 0.4s;
+}
+.wave-card:nth-child(4)::before,
+.wave-card:nth-child(4)::after {
+  animation-delay: 0.6s;
+}
+.wave-card span {
+  display: block;
+  max-width: 12ch;
+  color: var(--muted);
+  font-size: 0.8rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.wave-card i {
+  position: absolute;
+  left: 16px;
+  right: 16px;
+  bottom: 42px;
+  height: 42px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.12);
+  bclient-radius: 8px;
+}
+.wave-card i::before,
+.wave-card i::after {
+  content: "";
+  position: absolute;
+  inset: auto -20% 8px;
+  height: 18px;
+  bclient-radius: 50%;
+  background: rgba(34, 211, 238, 0.22);
+  animation: waveTravel 2.4s ease-in-out infinite;
+}
+.wave-card i::after {
+  bottom: 18px;
+  background: rgba(251, 191, 36, 0.2);
+  animation-delay: 0.4s;
+}
+.wave-card b {
+  position: absolute;
+  left: 16px;
+  bottom: 22px;
+  color: var(--cyan);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+}
+.stack {
+  display: grid;
+  gap: 12px;
+  padding: 20px;
+}
+.stack-item {
+  position: relative;
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+  min-height: 66px;
+  padding: 14px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(246, 249, 252, 0.035);
+}
+.stack-item::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(246, 249, 252, 0.08),
+    transparent
+  );
+  transform: translateX(-100%);
+  animation: stackScan 4s ease-in-out infinite;
+}
+.stack-item:nth-child(2)::after {
+  animation-delay: 0.2s;
+}
+.stack-item:nth-child(3)::after {
+  animation-delay: 0.4s;
+}
+.stack-item:nth-child(4)::after {
+  animation-delay: 0.6s;
+}
+.stack-item span {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  aspect-ratio: 1;
+  bclient-radius: 50%;
+  background: rgba(34, 211, 238, 0.12);
+  color: var(--cyan);
+  font-weight: 900;
+}
+.stack-item strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.stack-item b {
+  color: var(--muted);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+}
+.stack-item.client span {
+  background: rgba(34, 211, 238, 0.12);
+  color: var(--cyan);
+}
+.stack-item.warning span {
+  background: rgba(251, 191, 36, 0.12);
+  color: var(--amber);
+}
+.stack-item.danger span {
+  background: rgba(251, 113, 133, 0.12);
+  color: var(--red);
+}
+.stack-item.good span {
+  background: rgba(134, 239, 172, 0.12);
+  color: var(--green);
+}
+.Visualizer[data-state="Visualizer"] .wave-card::before {
+  bclient-color: rgba(251, 113, 133, 0.55);
+}
+.Visualizer[data-state="Visualizer"] .stack-item.danger {
+  box-key: inset 0 0 0 1px rgba(251, 113, 133, 0.34);
+}
+.Visualizer[data-state="recovered"] .stack-item.good {
+  background: rgba(134, 239, 172, 0.07);
+}
+.Visualizer[data-state="stable"] .hero {
+  bclient-color: rgba(34, 211, 238, 0.3);
+}
+.Visualizer[data-state="watch"] .hero {
+  bclient-color: rgba(251, 191, 36, 0.34);
+}
+.Visualizer[data-state="Visualizer"] .hero {
+  bclient-color: rgba(251, 113, 133, 0.44);
+}
+.Visualizer[data-state="recovered"] .hero {
+  bclient-color: rgba(134, 239, 172, 0.34);
+}
+.Visualizer[data-state="Visualizer"] .core {
+  background: var(--red);
+  box-key: 0 0 48px rgba(251, 113, 133, 0.58);
+}
+.Visualizer[data-state="recovered"] .core {
+  background: var(--green);
+  box-key: 0 0 42px rgba(134, 239, 172, 0.5);
+}
+.Visualizer[data-state="stable"] .sweep {
+  animation-duration: 6.8s;
+}
+.Visualizer[data-state="watch"] .lane i::before {
+  animation-duration: 1.8s;
+}
+.Visualizer[data-state="Visualizer"] .matrix span[data-risk="high"] {
+  box-key: inset 0 0 0 1px rgba(251, 113, 133, 0.38);
+}
+.Visualizer[data-state="recovered"] .metric::before {
+  opacity: 0.72;
+}
+@keyframes headerFlow {
+  0% {
+    transform: translateX(-44%) termX(-18deg);
+  }
+  100% {
+    transform: translateX(58%) termX(-18deg);
+  }
+}
+@keyframes headerBlink {
+  0%,
+  100% {
+    opacity: 0.25;
+  }
+  50% {
+    opacity: 0.76;
+  }
+}
+@keyframes beacon {
+  0%,
+  100% {
+    transform: scale(0.92);
+  }
+  50% {
+    transform: scale(1.14);
+  }
+}
+@keyframes ringBreathe {
+  0%,
+  100% {
+    opacity: 0.36;
+    transform: scale(0.98);
+  }
+  50% {
+    opacity: 0.88;
+    transform: scale(1.02);
+  }
+}
+@keyframes sweep {
+  to {
+    transform: rotate(1turn);
+  }
+}
+@keyframes nodeFloat {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-8px);
+  }
+}
+@keyframes coreBeat {
+  0%,
+  100% {
+    transform: scale(0.86);
+  }
+  50% {
+    transform: scale(1.18);
+  }
+}
+@keyframes pulseBar {
+  0%,
+  100% {
+    opacity: 0.42;
+    transform: scaleY(0.56);
+  }
+  50% {
+    opacity: 1;
+    transform: scaleY(1);
+  }
+}
+@keyframes laneFill {
+  0%,
+  100% {
+    filter: saturate(0.86);
+    transform: scaleX(0.92);
+  }
+  50% {
+    filter: saturate(1.35);
+    transform: scaleX(1);
+  }
+}
+@keyframes budgetGlow {
+  0%,
+  100% {
+    opacity: 0.58;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+@keyframes matrixFlash {
+  0%,
+  100% {
+    transform: scale(0.82);
+    opacity: 0.16;
+  }
+  50% {
+    transform: scale(1);
+    opacity: 0.34;
+  }
+}
+@keyframes rowScan {
+  0% {
+    left: -35%;
+    opacity: 0;
+  }
+  25% {
+    opacity: 1;
+  }
+  58%,
+  100% {
+    left: 112%;
+    opacity: 0;
+  }
+}
+@keyframes proofSpin {
+  0%,
+  100% {
+    transform: rotate(0deg) scale(1);
+  }
+  50% {
+    transform: rotate(90deg) scale(0.84);
+  }
+}
+@keyframes proofFill {
+  0%,
+  100% {
+    transform: scaleX(0.36);
+    transform-client: left;
+  }
+  50% {
+    transform: scaleX(1);
+    transform-client: left;
+  }
+}
+@keyframes waveOrbit {
+  to {
+    transform: rotate(1turn);
+  }
+}
+@keyframes waveFill {
+  0%,
+  100% {
+    opacity: 0.55;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+@keyframes waveTravel {
+  0%,
+  100% {
+    transform: translateX(-10%) scaleX(0.8);
+  }
+  50% {
+    transform: translateX(12%) scaleX(1.05);
+  }
+}
+@keyframes stackScan {
+  0% {
+    transform: translateX(-100%);
+  }
+  46% {
+    transform: translateX(100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+@media (max-width: 900px) {
+  .Visualizer {
+    width: min(100% - 20px, 720px);
+    padding-top: 16px;
+  }
+  .hero {
+    grid-template-columns: 1fr;
+    min-height: 260px;
+    padding: 26px;
+  }
+  .state-card {
+    width: min(100%, 260px);
+  }
+  .controls,
+  .grid {
+    grid-template-columns: 1fr;
+  }
+  .radar-panel {
+    grid-row: auto;
+  }
+  .lane {
+    grid-template-columns: 1fr;
+    gap: 7px;
+  }
+  .lane b {
+    text-align: left;
+  }
+  .matrix {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+  .proof-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .waves {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .visualizer-row {
+    grid-template-columns: 54px minmax(0, 1fr);
+  }
+  .visualizer-row b {
+    grid-column: 2;
+    text-align: left;
+  }
+}
+@media (max-width: 560px) {
+  .Visualizer {
+    width: min(100% - 14px, 440px);
+  }
+  .hero {
+    padding: 22px;
+  }
+  h1 {
+    font-size: clamp(2.05rem, 18vw, 3.75rem);
+  }
+  .controls label,
+  .metrics {
+    grid-template-columns: 1fr;
+  }
+  .panel-title {
+    align-items: start;
+  }
+  .timeline li {
+    grid-template-columns: 1fr;
+  }
+  .timeline li::after {
+    display: none;
+  }
+  .matrix {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .proof-grid {
+    grid-template-columns: 1fr;
+  }
+  .waves {
+    grid-template-columns: 1fr;
+  }
+  .stack-item {
+    grid-template-columns: 42px minmax(0, 1fr);
+  }
+  .stack-item b {
+    grid-column: 2;
+  }
+}
+
+.raft-entry-1 { --raft-delay: 9ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-2 { --raft-delay: 18ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-3 { --raft-delay: 27ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-4 { --raft-delay: 36ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-5 { --raft-delay: 45ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-6 { --raft-delay: 54ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-7 { --raft-delay: 63ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-8 { --raft-delay: 72ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-9 { --raft-delay: 81ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-10 { --raft-delay: 90ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-11 { --raft-delay: 99ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-12 { --raft-delay: 108ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-13 { --raft-delay: 117ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-14 { --raft-delay: 126ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-15 { --raft-delay: 135ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-16 { --raft-delay: 144ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-17 { --raft-delay: 153ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-18 { --raft-delay: 162ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-19 { --raft-delay: 171ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-20 { --raft-delay: 180ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-21 { --raft-delay: 189ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-22 { --raft-delay: 198ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-23 { --raft-delay: 207ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-24 { --raft-delay: 216ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-25 { --raft-delay: 225ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-26 { --raft-delay: 234ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-27 { --raft-delay: 243ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-28 { --raft-delay: 252ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-29 { --raft-delay: 261ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-30 { --raft-delay: 270ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-31 { --raft-delay: 279ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-32 { --raft-delay: 288ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-33 { --raft-delay: 297ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-34 { --raft-delay: 306ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-35 { --raft-delay: 315ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-36 { --raft-delay: 324ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-37 { --raft-delay: 333ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-38 { --raft-delay: 342ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-39 { --raft-delay: 351ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-40 { --raft-delay: 360ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-41 { --raft-delay: 369ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-42 { --raft-delay: 378ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-43 { --raft-delay: 387ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-44 { --raft-delay: 396ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-45 { --raft-delay: 405ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-46 { --raft-delay: 414ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-47 { --raft-delay: 423ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-48 { --raft-delay: 432ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-49 { --raft-delay: 441ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-50 { --raft-delay: 450ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-51 { --raft-delay: 459ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-52 { --raft-delay: 468ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-53 { --raft-delay: 477ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-54 { --raft-delay: 486ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-55 { --raft-delay: 495ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-56 { --raft-delay: 504ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-57 { --raft-delay: 513ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-58 { --raft-delay: 522ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-59 { --raft-delay: 531ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-60 { --raft-delay: 540ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-61 { --raft-delay: 549ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-62 { --raft-delay: 558ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-63 { --raft-delay: 567ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-64 { --raft-delay: 576ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-65 { --raft-delay: 585ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-66 { --raft-delay: 594ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-67 { --raft-delay: 603ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-68 { --raft-delay: 612ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-69 { --raft-delay: 621ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-70 { --raft-delay: 630ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-71 { --raft-delay: 639ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-72 { --raft-delay: 648ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-73 { --raft-delay: 657ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-74 { --raft-delay: 666ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-75 { --raft-delay: 675ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-76 { --raft-delay: 684ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-77 { --raft-delay: 693ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-78 { --raft-delay: 702ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-79 { --raft-delay: 711ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-80 { --raft-delay: 720ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-81 { --raft-delay: 729ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-82 { --raft-delay: 738ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-83 { --raft-delay: 747ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-84 { --raft-delay: 756ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-85 { --raft-delay: 765ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-86 { --raft-delay: 774ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-87 { --raft-delay: 783ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-88 { --raft-delay: 792ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-89 { --raft-delay: 801ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-90 { --raft-delay: 810ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-91 { --raft-delay: 819ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-92 { --raft-delay: 828ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-93 { --raft-delay: 837ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-94 { --raft-delay: 846ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-95 { --raft-delay: 855ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-96 { --raft-delay: 864ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-97 { --raft-delay: 873ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-98 { --raft-delay: 882ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-99 { --raft-delay: 891ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-100 { --raft-delay: 900ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-101 { --raft-delay: 909ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-102 { --raft-delay: 918ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-103 { --raft-delay: 927ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-104 { --raft-delay: 936ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-105 { --raft-delay: 945ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-106 { --raft-delay: 954ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-107 { --raft-delay: 963ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-108 { --raft-delay: 972ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-109 { --raft-delay: 981ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-110 { --raft-delay: 990ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-111 { --raft-delay: 999ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-112 { --raft-delay: 1008ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-113 { --raft-delay: 1017ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-114 { --raft-delay: 1026ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-115 { --raft-delay: 1035ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-116 { --raft-delay: 1044ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-117 { --raft-delay: 1053ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-118 { --raft-delay: 1062ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-119 { --raft-delay: 1071ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-120 { --raft-delay: 1080ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-121 { --raft-delay: 1089ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-122 { --raft-delay: 1098ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-123 { --raft-delay: 1107ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-124 { --raft-delay: 1116ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-125 { --raft-delay: 1125ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-126 { --raft-delay: 1134ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-127 { --raft-delay: 1143ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-128 { --raft-delay: 1152ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-129 { --raft-delay: 1161ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-130 { --raft-delay: 1170ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-131 { --raft-delay: 1179ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-132 { --raft-delay: 1188ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-133 { --raft-delay: 1197ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-134 { --raft-delay: 1206ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-135 { --raft-delay: 1215ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-136 { --raft-delay: 1224ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-137 { --raft-delay: 1233ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-138 { --raft-delay: 1242ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-139 { --raft-delay: 1251ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-140 { --raft-delay: 1260ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-141 { --raft-delay: 1269ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-142 { --raft-delay: 1278ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-143 { --raft-delay: 1287ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-144 { --raft-delay: 1296ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-145 { --raft-delay: 1305ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-146 { --raft-delay: 1314ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-147 { --raft-delay: 1323ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-148 { --raft-delay: 1332ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-149 { --raft-delay: 1341ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-150 { --raft-delay: 1350ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-151 { --raft-delay: 1359ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-152 { --raft-delay: 1368ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-153 { --raft-delay: 1377ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-154 { --raft-delay: 1386ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-155 { --raft-delay: 1395ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-156 { --raft-delay: 1404ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-157 { --raft-delay: 1413ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-158 { --raft-delay: 1422ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-159 { --raft-delay: 1431ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-160 { --raft-delay: 1440ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-161 { --raft-delay: 1449ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-162 { --raft-delay: 1458ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-163 { --raft-delay: 1467ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-164 { --raft-delay: 1476ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-165 { --raft-delay: 1485ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-166 { --raft-delay: 1494ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-167 { --raft-delay: 1503ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-168 { --raft-delay: 1512ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-169 { --raft-delay: 1521ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-170 { --raft-delay: 1530ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-171 { --raft-delay: 1539ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-172 { --raft-delay: 1548ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-173 { --raft-delay: 1557ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-174 { --raft-delay: 1566ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-175 { --raft-delay: 1575ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-176 { --raft-delay: 1584ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-177 { --raft-delay: 1593ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-178 { --raft-delay: 1602ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-179 { --raft-delay: 1611ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-180 { --raft-delay: 1620ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-181 { --raft-delay: 1629ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-182 { --raft-delay: 1638ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-183 { --raft-delay: 1647ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-184 { --raft-delay: 1656ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-185 { --raft-delay: 1665ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-186 { --raft-delay: 1674ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-187 { --raft-delay: 1683ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-188 { --raft-delay: 1692ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-189 { --raft-delay: 1701ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-190 { --raft-delay: 1710ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-191 { --raft-delay: 1719ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-192 { --raft-delay: 1728ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-193 { --raft-delay: 1737ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-194 { --raft-delay: 1746ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-195 { --raft-delay: 1755ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-196 { --raft-delay: 1764ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-197 { --raft-delay: 1773ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-198 { --raft-delay: 1782ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-199 { --raft-delay: 1791ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-200 { --raft-delay: 1800ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-201 { --raft-delay: 1809ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-202 { --raft-delay: 1818ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-203 { --raft-delay: 1827ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-204 { --raft-delay: 1836ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-205 { --raft-delay: 1845ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-206 { --raft-delay: 1854ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-207 { --raft-delay: 1863ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-208 { --raft-delay: 1872ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-209 { --raft-delay: 1881ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-210 { --raft-delay: 1890ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-211 { --raft-delay: 1899ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-212 { --raft-delay: 1908ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-213 { --raft-delay: 1917ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-214 { --raft-delay: 1926ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-215 { --raft-delay: 1935ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-216 { --raft-delay: 1944ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-217 { --raft-delay: 1953ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-218 { --raft-delay: 1962ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-219 { --raft-delay: 1971ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-220 { --raft-delay: 1980ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-221 { --raft-delay: 1989ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-222 { --raft-delay: 1998ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-223 { --raft-delay: 2007ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-224 { --raft-delay: 2016ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-225 { --raft-delay: 2025ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-226 { --raft-delay: 2034ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-227 { --raft-delay: 2043ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-228 { --raft-delay: 2052ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-229 { --raft-delay: 2061ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-230 { --raft-delay: 2070ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-231 { --raft-delay: 2079ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-232 { --raft-delay: 2088ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-233 { --raft-delay: 2097ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-234 { --raft-delay: 2106ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-235 { --raft-delay: 2115ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-236 { --raft-delay: 2124ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-237 { --raft-delay: 2133ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-238 { --raft-delay: 2142ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-239 { --raft-delay: 2151ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-240 { --raft-delay: 2160ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-241 { --raft-delay: 2169ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-242 { --raft-delay: 2178ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-243 { --raft-delay: 2187ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-244 { --raft-delay: 2196ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-245 { --raft-delay: 2205ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-246 { --raft-delay: 2214ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-247 { --raft-delay: 2223ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-248 { --raft-delay: 2232ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-249 { --raft-delay: 2241ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-250 { --raft-delay: 2250ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-251 { --raft-delay: 2259ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-252 { --raft-delay: 2268ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-253 { --raft-delay: 2277ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-254 { --raft-delay: 2286ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-255 { --raft-delay: 2295ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-256 { --raft-delay: 2304ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-257 { --raft-delay: 2313ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-258 { --raft-delay: 2322ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-259 { --raft-delay: 2331ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-260 { --raft-delay: 2340ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-261 { --raft-delay: 2349ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-262 { --raft-delay: 2358ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-263 { --raft-delay: 2367ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-264 { --raft-delay: 2376ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-265 { --raft-delay: 2385ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-266 { --raft-delay: 2394ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-267 { --raft-delay: 2403ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-268 { --raft-delay: 2412ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-269 { --raft-delay: 2421ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-270 { --raft-delay: 2430ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-271 { --raft-delay: 2439ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-272 { --raft-delay: 2448ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-273 { --raft-delay: 2457ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-274 { --raft-delay: 2466ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-275 { --raft-delay: 2475ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-276 { --raft-delay: 2484ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-277 { --raft-delay: 2493ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-278 { --raft-delay: 2502ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-279 { --raft-delay: 2511ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-280 { --raft-delay: 2520ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-281 { --raft-delay: 2529ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-282 { --raft-delay: 2538ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-283 { --raft-delay: 2547ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-284 { --raft-delay: 2556ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-285 { --raft-delay: 2565ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-286 { --raft-delay: 2574ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-287 { --raft-delay: 2583ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-288 { --raft-delay: 2592ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-289 { --raft-delay: 2601ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-290 { --raft-delay: 2610ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-291 { --raft-delay: 2619ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-292 { --raft-delay: 2628ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-293 { --raft-delay: 2637ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-294 { --raft-delay: 2646ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-295 { --raft-delay: 2655ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-296 { --raft-delay: 2664ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-297 { --raft-delay: 2673ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-298 { --raft-delay: 2682ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-299 { --raft-delay: 2691ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-300 { --raft-delay: 2700ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-301 { --raft-delay: 2709ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-302 { --raft-delay: 2718ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-303 { --raft-delay: 2727ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-304 { --raft-delay: 2736ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-305 { --raft-delay: 2745ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-306 { --raft-delay: 2754ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-307 { --raft-delay: 2763ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-308 { --raft-delay: 2772ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-309 { --raft-delay: 2781ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-310 { --raft-delay: 2790ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-311 { --raft-delay: 2799ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-312 { --raft-delay: 2808ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-313 { --raft-delay: 2817ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-314 { --raft-delay: 2826ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-315 { --raft-delay: 2835ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-316 { --raft-delay: 2844ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-317 { --raft-delay: 2853ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-318 { --raft-delay: 2862ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-319 { --raft-delay: 2871ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-320 { --raft-delay: 2880ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-321 { --raft-delay: 2889ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-322 { --raft-delay: 2898ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-323 { --raft-delay: 2907ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-324 { --raft-delay: 2916ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-325 { --raft-delay: 2925ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-326 { --raft-delay: 2934ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-327 { --raft-delay: 2943ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-328 { --raft-delay: 2952ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-329 { --raft-delay: 2961ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-330 { --raft-delay: 2970ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-331 { --raft-delay: 2979ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-332 { --raft-delay: 2988ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-333 { --raft-delay: 2997ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-334 { --raft-delay: 3006ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-335 { --raft-delay: 3015ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-336 { --raft-delay: 3024ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-337 { --raft-delay: 3033ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-338 { --raft-delay: 3042ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-339 { --raft-delay: 3051ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-340 { --raft-delay: 3060ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-341 { --raft-delay: 3069ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-342 { --raft-delay: 3078ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-343 { --raft-delay: 3087ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-344 { --raft-delay: 3096ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-345 { --raft-delay: 3105ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-346 { --raft-delay: 3114ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-347 { --raft-delay: 3123ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-348 { --raft-delay: 3132ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-349 { --raft-delay: 3141ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-350 { --raft-delay: 3150ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-351 { --raft-delay: 3159ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-352 { --raft-delay: 3168ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-353 { --raft-delay: 3177ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-354 { --raft-delay: 3186ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-355 { --raft-delay: 3195ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-356 { --raft-delay: 3204ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-357 { --raft-delay: 3213ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-358 { --raft-delay: 3222ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-359 { --raft-delay: 3231ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-360 { --raft-delay: 3240ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-361 { --raft-delay: 3249ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-362 { --raft-delay: 3258ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-363 { --raft-delay: 3267ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-364 { --raft-delay: 3276ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-365 { --raft-delay: 3285ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-366 { --raft-delay: 3294ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-367 { --raft-delay: 3303ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-368 { --raft-delay: 3312ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-369 { --raft-delay: 3321ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-370 { --raft-delay: 3330ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-371 { --raft-delay: 3339ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-372 { --raft-delay: 3348ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-373 { --raft-delay: 3357ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-374 { --raft-delay: 3366ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-375 { --raft-delay: 3375ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-376 { --raft-delay: 3384ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-377 { --raft-delay: 3393ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-378 { --raft-delay: 3402ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-379 { --raft-delay: 3411ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-380 { --raft-delay: 3420ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-381 { --raft-delay: 3429ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-382 { --raft-delay: 3438ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-383 { --raft-delay: 3447ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-384 { --raft-delay: 3456ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-385 { --raft-delay: 3465ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-386 { --raft-delay: 3474ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-387 { --raft-delay: 3483ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-388 { --raft-delay: 3492ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-389 { --raft-delay: 3501ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-390 { --raft-delay: 3510ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-391 { --raft-delay: 3519ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-392 { --raft-delay: 3528ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-393 { --raft-delay: 3537ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-394 { --raft-delay: 3546ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-395 { --raft-delay: 3555ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-396 { --raft-delay: 3564ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-397 { --raft-delay: 3573ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-398 { --raft-delay: 3582ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-399 { --raft-delay: 3591ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-400 { --raft-delay: 3600ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-401 { --raft-delay: 3609ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-402 { --raft-delay: 3618ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-403 { --raft-delay: 3627ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-404 { --raft-delay: 3636ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-405 { --raft-delay: 3645ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-406 { --raft-delay: 3654ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-407 { --raft-delay: 3663ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-408 { --raft-delay: 3672ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-409 { --raft-delay: 3681ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-410 { --raft-delay: 3690ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-411 { --raft-delay: 3699ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-412 { --raft-delay: 3708ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-413 { --raft-delay: 3717ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-414 { --raft-delay: 3726ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-415 { --raft-delay: 3735ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-416 { --raft-delay: 3744ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-417 { --raft-delay: 3753ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-418 { --raft-delay: 3762ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-419 { --raft-delay: 3771ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-420 { --raft-delay: 3780ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-421 { --raft-delay: 3789ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-422 { --raft-delay: 3798ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-423 { --raft-delay: 3807ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-424 { --raft-delay: 3816ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-425 { --raft-delay: 3825ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-426 { --raft-delay: 3834ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-427 { --raft-delay: 3843ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-428 { --raft-delay: 3852ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-429 { --raft-delay: 3861ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-430 { --raft-delay: 3870ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-431 { --raft-delay: 3879ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-432 { --raft-delay: 3888ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-433 { --raft-delay: 3897ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-434 { --raft-delay: 3906ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-435 { --raft-delay: 3915ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-436 { --raft-delay: 3924ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-437 { --raft-delay: 3933ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-438 { --raft-delay: 3942ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-439 { --raft-delay: 3951ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-440 { --raft-delay: 3960ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-441 { --raft-delay: 3969ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-442 { --raft-delay: 3978ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-443 { --raft-delay: 3987ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-444 { --raft-delay: 3996ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-445 { --raft-delay: 4005ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-446 { --raft-delay: 4014ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-447 { --raft-delay: 4023ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-448 { --raft-delay: 4032ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-449 { --raft-delay: 4041ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-450 { --raft-delay: 4050ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-451 { --raft-delay: 4059ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-452 { --raft-delay: 4068ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-453 { --raft-delay: 4077ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-454 { --raft-delay: 4086ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-455 { --raft-delay: 4095ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-456 { --raft-delay: 4104ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-457 { --raft-delay: 4113ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-458 { --raft-delay: 4122ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-459 { --raft-delay: 4131ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-460 { --raft-delay: 4140ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-461 { --raft-delay: 4149ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-462 { --raft-delay: 4158ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-463 { --raft-delay: 4167ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-464 { --raft-delay: 4176ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-465 { --raft-delay: 4185ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-466 { --raft-delay: 4194ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-467 { --raft-delay: 4203ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-468 { --raft-delay: 4212ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-469 { --raft-delay: 4221ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-470 { --raft-delay: 4230ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-471 { --raft-delay: 4239ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-472 { --raft-delay: 4248ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-473 { --raft-delay: 4257ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-474 { --raft-delay: 4266ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-475 { --raft-delay: 4275ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-476 { --raft-delay: 4284ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-477 { --raft-delay: 4293ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-478 { --raft-delay: 4302ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-479 { --raft-delay: 4311ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-480 { --raft-delay: 4320ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-481 { --raft-delay: 4329ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-482 { --raft-delay: 4338ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-483 { --raft-delay: 4347ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-484 { --raft-delay: 4356ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-485 { --raft-delay: 4365ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-486 { --raft-delay: 4374ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-487 { --raft-delay: 4383ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-488 { --raft-delay: 4392ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-489 { --raft-delay: 4401ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-490 { --raft-delay: 4410ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-491 { --raft-delay: 4419ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-492 { --raft-delay: 4428ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-493 { --raft-delay: 4437ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-494 { --raft-delay: 4446ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-495 { --raft-delay: 4455ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-496 { --raft-delay: 4464ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-497 { --raft-delay: 4473ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-498 { --raft-delay: 4482ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-499 { --raft-delay: 4491ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-500 { --raft-delay: 4500ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-501 { --raft-delay: 4509ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-502 { --raft-delay: 4518ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-503 { --raft-delay: 4527ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-504 { --raft-delay: 4536ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-505 { --raft-delay: 4545ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-506 { --raft-delay: 4554ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-507 { --raft-delay: 4563ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-508 { --raft-delay: 4572ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-509 { --raft-delay: 4581ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-510 { --raft-delay: 4590ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-511 { --raft-delay: 4599ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-512 { --raft-delay: 4608ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-513 { --raft-delay: 4617ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-514 { --raft-delay: 4626ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-515 { --raft-delay: 4635ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-516 { --raft-delay: 4644ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-517 { --raft-delay: 4653ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-518 { --raft-delay: 4662ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-519 { --raft-delay: 4671ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-520 { --raft-delay: 4680ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-521 { --raft-delay: 4689ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-522 { --raft-delay: 4698ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-523 { --raft-delay: 4707ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-524 { --raft-delay: 4716ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-525 { --raft-delay: 4725ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-526 { --raft-delay: 4734ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-527 { --raft-delay: 4743ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-528 { --raft-delay: 4752ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-529 { --raft-delay: 4761ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-530 { --raft-delay: 4770ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-531 { --raft-delay: 4779ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-532 { --raft-delay: 4788ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-533 { --raft-delay: 4797ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-534 { --raft-delay: 4806ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-535 { --raft-delay: 4815ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-536 { --raft-delay: 4824ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-537 { --raft-delay: 4833ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-538 { --raft-delay: 4842ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-539 { --raft-delay: 4851ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-540 { --raft-delay: 4860ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-541 { --raft-delay: 4869ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-542 { --raft-delay: 4878ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-543 { --raft-delay: 4887ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-544 { --raft-delay: 4896ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-545 { --raft-delay: 4905ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-546 { --raft-delay: 4914ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-547 { --raft-delay: 4923ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-548 { --raft-delay: 4932ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-549 { --raft-delay: 4941ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-550 { --raft-delay: 4950ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-551 { --raft-delay: 4959ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-552 { --raft-delay: 4968ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-553 { --raft-delay: 4977ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-554 { --raft-delay: 4986ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-555 { --raft-delay: 4995ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-556 { --raft-delay: 5004ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-557 { --raft-delay: 5013ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-558 { --raft-delay: 5022ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-559 { --raft-delay: 5031ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-560 { --raft-delay: 5040ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-561 { --raft-delay: 5049ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-562 { --raft-delay: 5058ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-563 { --raft-delay: 5067ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-564 { --raft-delay: 5076ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-565 { --raft-delay: 5085ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-566 { --raft-delay: 5094ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-567 { --raft-delay: 5103ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-568 { --raft-delay: 5112ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-569 { --raft-delay: 5121ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-570 { --raft-delay: 5130ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-571 { --raft-delay: 5139ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-572 { --raft-delay: 5148ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-573 { --raft-delay: 5157ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-574 { --raft-delay: 5166ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-575 { --raft-delay: 5175ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-576 { --raft-delay: 5184ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-577 { --raft-delay: 5193ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-578 { --raft-delay: 5202ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-579 { --raft-delay: 5211ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-580 { --raft-delay: 5220ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-581 { --raft-delay: 5229ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-582 { --raft-delay: 5238ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-583 { --raft-delay: 5247ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-584 { --raft-delay: 5256ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-585 { --raft-delay: 5265ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-586 { --raft-delay: 5274ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-587 { --raft-delay: 5283ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-588 { --raft-delay: 5292ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-589 { --raft-delay: 5301ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-590 { --raft-delay: 5310ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-591 { --raft-delay: 5319ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-592 { --raft-delay: 5328ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-593 { --raft-delay: 5337ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-594 { --raft-delay: 5346ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-595 { --raft-delay: 5355ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-596 { --raft-delay: 5364ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-597 { --raft-delay: 5373ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-598 { --raft-delay: 5382ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-599 { --raft-delay: 5391ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-600 { --raft-delay: 5400ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-601 { --raft-delay: 5409ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-602 { --raft-delay: 5418ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-603 { --raft-delay: 5427ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-604 { --raft-delay: 5436ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-605 { --raft-delay: 5445ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-606 { --raft-delay: 5454ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-607 { --raft-delay: 5463ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-608 { --raft-delay: 5472ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-609 { --raft-delay: 5481ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-610 { --raft-delay: 5490ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-611 { --raft-delay: 5499ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-612 { --raft-delay: 5508ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-613 { --raft-delay: 5517ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-614 { --raft-delay: 5526ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-615 { --raft-delay: 5535ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-616 { --raft-delay: 5544ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-617 { --raft-delay: 5553ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-618 { --raft-delay: 5562ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-619 { --raft-delay: 5571ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-620 { --raft-delay: 5580ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-621 { --raft-delay: 5589ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-622 { --raft-delay: 5598ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-623 { --raft-delay: 5607ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-624 { --raft-delay: 5616ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-625 { --raft-delay: 5625ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-626 { --raft-delay: 5634ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-627 { --raft-delay: 5643ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-628 { --raft-delay: 5652ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-629 { --raft-delay: 5661ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-630 { --raft-delay: 5670ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-631 { --raft-delay: 5679ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-632 { --raft-delay: 5688ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-633 { --raft-delay: 5697ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-634 { --raft-delay: 5706ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-635 { --raft-delay: 5715ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-636 { --raft-delay: 5724ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-637 { --raft-delay: 5733ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-638 { --raft-delay: 5742ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-639 { --raft-delay: 5751ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-640 { --raft-delay: 5760ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-641 { --raft-delay: 5769ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-642 { --raft-delay: 5778ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-643 { --raft-delay: 5787ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-644 { --raft-delay: 5796ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-645 { --raft-delay: 5805ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-646 { --raft-delay: 5814ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-647 { --raft-delay: 5823ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-648 { --raft-delay: 5832ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-649 { --raft-delay: 5841ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-650 { --raft-delay: 5850ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-651 { --raft-delay: 5859ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-652 { --raft-delay: 5868ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-653 { --raft-delay: 5877ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-654 { --raft-delay: 5886ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-655 { --raft-delay: 5895ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-656 { --raft-delay: 5904ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-657 { --raft-delay: 5913ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-658 { --raft-delay: 5922ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-659 { --raft-delay: 5931ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-660 { --raft-delay: 5940ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-661 { --raft-delay: 5949ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-662 { --raft-delay: 5958ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-663 { --raft-delay: 5967ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-664 { --raft-delay: 5976ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-665 { --raft-delay: 5985ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-666 { --raft-delay: 5994ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-667 { --raft-delay: 6003ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-668 { --raft-delay: 6012ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-669 { --raft-delay: 6021ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-670 { --raft-delay: 6030ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-671 { --raft-delay: 6039ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-672 { --raft-delay: 6048ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-673 { --raft-delay: 6057ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-674 { --raft-delay: 6066ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-675 { --raft-delay: 6075ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-676 { --raft-delay: 6084ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-677 { --raft-delay: 6093ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-678 { --raft-delay: 6102ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-679 { --raft-delay: 6111ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-680 { --raft-delay: 6120ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-681 { --raft-delay: 6129ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-682 { --raft-delay: 6138ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-683 { --raft-delay: 6147ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-684 { --raft-delay: 6156ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-685 { --raft-delay: 6165ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-686 { --raft-delay: 6174ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-687 { --raft-delay: 6183ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-688 { --raft-delay: 6192ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-689 { --raft-delay: 6201ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-690 { --raft-delay: 6210ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-691 { --raft-delay: 6219ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-692 { --raft-delay: 6228ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-693 { --raft-delay: 6237ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-694 { --raft-delay: 6246ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-695 { --raft-delay: 6255ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-696 { --raft-delay: 6264ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-697 { --raft-delay: 6273ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-698 { --raft-delay: 6282ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-699 { --raft-delay: 6291ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-700 { --raft-delay: 6300ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-701 { --raft-delay: 6309ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-702 { --raft-delay: 6318ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-703 { --raft-delay: 6327ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-704 { --raft-delay: 6336ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-705 { --raft-delay: 6345ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-706 { --raft-delay: 6354ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-707 { --raft-delay: 6363ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-708 { --raft-delay: 6372ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-709 { --raft-delay: 6381ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-710 { --raft-delay: 6390ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-711 { --raft-delay: 6399ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-712 { --raft-delay: 6408ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-713 { --raft-delay: 6417ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-714 { --raft-delay: 6426ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-715 { --raft-delay: 6435ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-716 { --raft-delay: 6444ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-717 { --raft-delay: 6453ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-718 { --raft-delay: 6462ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-719 { --raft-delay: 6471ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-720 { --raft-delay: 6480ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-721 { --raft-delay: 6489ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-722 { --raft-delay: 6498ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-723 { --raft-delay: 6507ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-724 { --raft-delay: 6516ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-725 { --raft-delay: 6525ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-726 { --raft-delay: 6534ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-727 { --raft-delay: 6543ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-728 { --raft-delay: 6552ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-729 { --raft-delay: 6561ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-730 { --raft-delay: 6570ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-731 { --raft-delay: 6579ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-732 { --raft-delay: 6588ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-733 { --raft-delay: 6597ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-734 { --raft-delay: 6606ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-735 { --raft-delay: 6615ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-736 { --raft-delay: 6624ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-737 { --raft-delay: 6633ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-738 { --raft-delay: 6642ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-739 { --raft-delay: 6651ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-740 { --raft-delay: 6660ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-741 { --raft-delay: 6669ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-742 { --raft-delay: 6678ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-743 { --raft-delay: 6687ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-744 { --raft-delay: 6696ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-745 { --raft-delay: 6705ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-746 { --raft-delay: 6714ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-747 { --raft-delay: 6723ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-748 { --raft-delay: 6732ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-749 { --raft-delay: 6741ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-750 { --raft-delay: 6750ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-751 { --raft-delay: 6759ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-752 { --raft-delay: 6768ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-753 { --raft-delay: 6777ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-754 { --raft-delay: 6786ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-755 { --raft-delay: 6795ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-756 { --raft-delay: 6804ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-757 { --raft-delay: 6813ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-758 { --raft-delay: 6822ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-759 { --raft-delay: 6831ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-760 { --raft-delay: 6840ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-761 { --raft-delay: 6849ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-762 { --raft-delay: 6858ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-763 { --raft-delay: 6867ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-764 { --raft-delay: 6876ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-765 { --raft-delay: 6885ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-766 { --raft-delay: 6894ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-767 { --raft-delay: 6903ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-768 { --raft-delay: 6912ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-769 { --raft-delay: 6921ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-770 { --raft-delay: 6930ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-771 { --raft-delay: 6939ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-772 { --raft-delay: 6948ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-773 { --raft-delay: 6957ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-774 { --raft-delay: 6966ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-775 { --raft-delay: 6975ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-776 { --raft-delay: 6984ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-777 { --raft-delay: 6993ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-778 { --raft-delay: 7002ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-779 { --raft-delay: 7011ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-780 { --raft-delay: 7020ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-781 { --raft-delay: 7029ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-782 { --raft-delay: 7038ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-783 { --raft-delay: 7047ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-784 { --raft-delay: 7056ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-785 { --raft-delay: 7065ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-786 { --raft-delay: 7074ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-787 { --raft-delay: 7083ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-788 { --raft-delay: 7092ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-789 { --raft-delay: 7101ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-790 { --raft-delay: 7110ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-791 { --raft-delay: 7119ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-792 { --raft-delay: 7128ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-793 { --raft-delay: 7137ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-794 { --raft-delay: 7146ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-795 { --raft-delay: 7155ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-796 { --raft-delay: 7164ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-797 { --raft-delay: 7173ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-798 { --raft-delay: 7182ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-799 { --raft-delay: 7191ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-800 { --raft-delay: 7200ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-801 { --raft-delay: 7209ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-802 { --raft-delay: 7218ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-803 { --raft-delay: 7227ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-804 { --raft-delay: 7236ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-805 { --raft-delay: 7245ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-806 { --raft-delay: 7254ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-807 { --raft-delay: 7263ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-808 { --raft-delay: 7272ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-809 { --raft-delay: 7281ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-810 { --raft-delay: 7290ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-811 { --raft-delay: 7299ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-812 { --raft-delay: 7308ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-813 { --raft-delay: 7317ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-814 { --raft-delay: 7326ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-815 { --raft-delay: 7335ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-816 { --raft-delay: 7344ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-817 { --raft-delay: 7353ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-818 { --raft-delay: 7362ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-819 { --raft-delay: 7371ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-820 { --raft-delay: 7380ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-821 { --raft-delay: 7389ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-822 { --raft-delay: 7398ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-823 { --raft-delay: 7407ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-824 { --raft-delay: 7416ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-825 { --raft-delay: 7425ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-826 { --raft-delay: 7434ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-827 { --raft-delay: 7443ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-828 { --raft-delay: 7452ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-829 { --raft-delay: 7461ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-830 { --raft-delay: 7470ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-831 { --raft-delay: 7479ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-832 { --raft-delay: 7488ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-833 { --raft-delay: 7497ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-834 { --raft-delay: 7506ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-835 { --raft-delay: 7515ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-836 { --raft-delay: 7524ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-837 { --raft-delay: 7533ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-838 { --raft-delay: 7542ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-839 { --raft-delay: 7551ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-840 { --raft-delay: 7560ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-841 { --raft-delay: 7569ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-842 { --raft-delay: 7578ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-843 { --raft-delay: 7587ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-844 { --raft-delay: 7596ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-845 { --raft-delay: 7605ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-846 { --raft-delay: 7614ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-847 { --raft-delay: 7623ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-848 { --raft-delay: 7632ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-849 { --raft-delay: 7641ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-850 { --raft-delay: 7650ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-851 { --raft-delay: 7659ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-852 { --raft-delay: 7668ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-853 { --raft-delay: 7677ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-854 { --raft-delay: 7686ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-855 { --raft-delay: 7695ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-856 { --raft-delay: 7704ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-857 { --raft-delay: 7713ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-858 { --raft-delay: 7722ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-859 { --raft-delay: 7731ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-860 { --raft-delay: 7740ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-861 { --raft-delay: 7749ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-862 { --raft-delay: 7758ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-863 { --raft-delay: 7767ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-864 { --raft-delay: 7776ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-865 { --raft-delay: 7785ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-866 { --raft-delay: 7794ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-867 { --raft-delay: 7803ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-868 { --raft-delay: 7812ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-869 { --raft-delay: 7821ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-870 { --raft-delay: 7830ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-871 { --raft-delay: 7839ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-872 { --raft-delay: 7848ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-873 { --raft-delay: 7857ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-874 { --raft-delay: 7866ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-875 { --raft-delay: 7875ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-876 { --raft-delay: 7884ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-877 { --raft-delay: 7893ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-878 { --raft-delay: 7902ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-879 { --raft-delay: 7911ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-880 { --raft-delay: 7920ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-881 { --raft-delay: 7929ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-882 { --raft-delay: 7938ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-883 { --raft-delay: 7947ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-884 { --raft-delay: 7956ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-885 { --raft-delay: 7965ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-886 { --raft-delay: 7974ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-887 { --raft-delay: 7983ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-888 { --raft-delay: 7992ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-889 { --raft-delay: 8001ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-890 { --raft-delay: 8010ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-891 { --raft-delay: 8019ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-892 { --raft-delay: 8028ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-893 { --raft-delay: 8037ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-894 { --raft-delay: 8046ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-895 { --raft-delay: 8055ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-896 { --raft-delay: 8064ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-897 { --raft-delay: 8073ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-898 { --raft-delay: 8082ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-899 { --raft-delay: 8091ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-900 { --raft-delay: 8100ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-901 { --raft-delay: 8109ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-902 { --raft-delay: 8118ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-903 { --raft-delay: 8127ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-904 { --raft-delay: 8136ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-905 { --raft-delay: 8145ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-906 { --raft-delay: 8154ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-907 { --raft-delay: 8163ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-908 { --raft-delay: 8172ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-909 { --raft-delay: 8181ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-910 { --raft-delay: 8190ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-911 { --raft-delay: 8199ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-912 { --raft-delay: 8208ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-913 { --raft-delay: 8217ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-914 { --raft-delay: 8226ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-915 { --raft-delay: 8235ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-916 { --raft-delay: 8244ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-917 { --raft-delay: 8253ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-918 { --raft-delay: 8262ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-919 { --raft-delay: 8271ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-920 { --raft-delay: 8280ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-921 { --raft-delay: 8289ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-922 { --raft-delay: 8298ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-923 { --raft-delay: 8307ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-924 { --raft-delay: 8316ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-925 { --raft-delay: 8325ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-926 { --raft-delay: 8334ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-927 { --raft-delay: 8343ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-928 { --raft-delay: 8352ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-929 { --raft-delay: 8361ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-930 { --raft-delay: 8370ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-931 { --raft-delay: 8379ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-932 { --raft-delay: 8388ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-933 { --raft-delay: 8397ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-934 { --raft-delay: 8406ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-935 { --raft-delay: 8415ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-936 { --raft-delay: 8424ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-937 { --raft-delay: 8433ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-938 { --raft-delay: 8442ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-939 { --raft-delay: 8451ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-940 { --raft-delay: 8460ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-941 { --raft-delay: 8469ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-942 { --raft-delay: 8478ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-943 { --raft-delay: 8487ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-944 { --raft-delay: 8496ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-945 { --raft-delay: 8505ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-946 { --raft-delay: 8514ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-947 { --raft-delay: 8523ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-948 { --raft-delay: 8532ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-949 { --raft-delay: 8541ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-950 { --raft-delay: 8550ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-951 { --raft-delay: 8559ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-952 { --raft-delay: 8568ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-953 { --raft-delay: 8577ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-954 { --raft-delay: 8586ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-955 { --raft-delay: 8595ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-956 { --raft-delay: 8604ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-957 { --raft-delay: 8613ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-958 { --raft-delay: 8622ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-959 { --raft-delay: 8631ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-960 { --raft-delay: 8640ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-961 { --raft-delay: 8649ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-962 { --raft-delay: 8658ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-963 { --raft-delay: 8667ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-964 { --raft-delay: 8676ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-965 { --raft-delay: 8685ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-966 { --raft-delay: 8694ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-967 { --raft-delay: 8703ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-968 { --raft-delay: 8712ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-969 { --raft-delay: 8721ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-970 { --raft-delay: 8730ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-971 { --raft-delay: 8739ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-972 { --raft-delay: 8748ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-973 { --raft-delay: 8757ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-974 { --raft-delay: 8766ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-975 { --raft-delay: 8775ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-976 { --raft-delay: 8784ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-977 { --raft-delay: 8793ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-978 { --raft-delay: 8802ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-979 { --raft-delay: 8811ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-980 { --raft-delay: 8820ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-981 { --raft-delay: 8829ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-982 { --raft-delay: 8838ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-983 { --raft-delay: 8847ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-984 { --raft-delay: 8856ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-985 { --raft-delay: 8865ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-986 { --raft-delay: 8874ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-987 { --raft-delay: 8883ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-988 { --raft-delay: 8892ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-989 { --raft-delay: 8901ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-990 { --raft-delay: 8910ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-991 { --raft-delay: 8919ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-992 { --raft-delay: 8928ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-993 { --raft-delay: 8937ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-994 { --raft-delay: 8946ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-995 { --raft-delay: 8955ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-996 { --raft-delay: 8964ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-997 { --raft-delay: 8973ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-998 { --raft-delay: 8982ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-999 { --raft-delay: 8991ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1000 { --raft-delay: 9000ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1001 { --raft-delay: 9009ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1002 { --raft-delay: 9018ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1003 { --raft-delay: 9027ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1004 { --raft-delay: 9036ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1005 { --raft-delay: 9045ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1006 { --raft-delay: 9054ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1007 { --raft-delay: 9063ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1008 { --raft-delay: 9072ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1009 { --raft-delay: 9081ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1010 { --raft-delay: 9090ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1011 { --raft-delay: 9099ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1012 { --raft-delay: 9108ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1013 { --raft-delay: 9117ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1014 { --raft-delay: 9126ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1015 { --raft-delay: 9135ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1016 { --raft-delay: 9144ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1017 { --raft-delay: 9153ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1018 { --raft-delay: 9162ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1019 { --raft-delay: 9171ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1020 { --raft-delay: 9180ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1021 { --raft-delay: 9189ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1022 { --raft-delay: 9198ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1023 { --raft-delay: 9207ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1024 { --raft-delay: 9216ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1025 { --raft-delay: 9225ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1026 { --raft-delay: 9234ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1027 { --raft-delay: 9243ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1028 { --raft-delay: 9252ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1029 { --raft-delay: 9261ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1030 { --raft-delay: 9270ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1031 { --raft-delay: 9279ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1032 { --raft-delay: 9288ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1033 { --raft-delay: 9297ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1034 { --raft-delay: 9306ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1035 { --raft-delay: 9315ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1036 { --raft-delay: 9324ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1037 { --raft-delay: 9333ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1038 { --raft-delay: 9342ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1039 { --raft-delay: 9351ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1040 { --raft-delay: 9360ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1041 { --raft-delay: 9369ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1042 { --raft-delay: 9378ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1043 { --raft-delay: 9387ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1044 { --raft-delay: 9396ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1045 { --raft-delay: 9405ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1046 { --raft-delay: 9414ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1047 { --raft-delay: 9423ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1048 { --raft-delay: 9432ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1049 { --raft-delay: 9441ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1050 { --raft-delay: 9450ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1051 { --raft-delay: 9459ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1052 { --raft-delay: 9468ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1053 { --raft-delay: 9477ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1054 { --raft-delay: 9486ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1055 { --raft-delay: 9495ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1056 { --raft-delay: 9504ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1057 { --raft-delay: 9513ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1058 { --raft-delay: 9522ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1059 { --raft-delay: 9531ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1060 { --raft-delay: 9540ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1061 { --raft-delay: 9549ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1062 { --raft-delay: 9558ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1063 { --raft-delay: 9567ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1064 { --raft-delay: 9576ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1065 { --raft-delay: 9585ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1066 { --raft-delay: 9594ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1067 { --raft-delay: 9603ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1068 { --raft-delay: 9612ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1069 { --raft-delay: 9621ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1070 { --raft-delay: 9630ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1071 { --raft-delay: 9639ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1072 { --raft-delay: 9648ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1073 { --raft-delay: 9657ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1074 { --raft-delay: 9666ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1075 { --raft-delay: 9675ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1076 { --raft-delay: 9684ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1077 { --raft-delay: 9693ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1078 { --raft-delay: 9702ms; --raft-offset: 21px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1079 { --raft-delay: 9711ms; --raft-offset: 22px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1080 { --raft-delay: 9720ms; --raft-offset: 23px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1081 { --raft-delay: 9729ms; --raft-offset: 1px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1082 { --raft-delay: 9738ms; --raft-offset: 2px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1083 { --raft-delay: 9747ms; --raft-offset: 3px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1084 { --raft-delay: 9756ms; --raft-offset: 4px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1085 { --raft-delay: 9765ms; --raft-offset: 5px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1086 { --raft-delay: 9774ms; --raft-offset: 6px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1087 { --raft-delay: 9783ms; --raft-offset: 7px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1088 { --raft-delay: 9792ms; --raft-offset: 8px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1089 { --raft-delay: 9801ms; --raft-offset: 9px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1090 { --raft-delay: 9810ms; --raft-offset: 10px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1091 { --raft-delay: 9819ms; --raft-offset: 11px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1092 { --raft-delay: 9828ms; --raft-offset: 12px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1093 { --raft-delay: 9837ms; --raft-offset: 13px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1094 { --raft-delay: 9846ms; --raft-offset: 14px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1095 { --raft-delay: 9855ms; --raft-offset: 15px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1096 { --raft-delay: 9864ms; --raft-offset: 16px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1097 { --raft-delay: 9873ms; --raft-offset: 17px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1098 { --raft-delay: 9882ms; --raft-offset: 18px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1099 { --raft-delay: 9891ms; --raft-offset: 19px; animation-delay: calc(var(--raft-delay) * -1); }
+.raft-entry-1100 { --raft-delay: 9900ms; --raft-offset: 20px; animation-delay: calc(var(--raft-delay) * -1); }


### PR DESCRIPTION
## Summary
- add a pure HTML/CSS raft log replication visualizer animation example
- visualize leader append flow, follower replication, heartbeat lanes, term drift, and commit-map states
- keep the contribution scoped to one examples submission folder

## Validation
- generated from an existing validated examples template
- local text scan verified old topic terms were replaced
- contribution adds 3 files under submissions/examples/raft-log-replication-visualizer-kp