### PR TITLE
feat: add CSS animation gossip membership convergence example

### DIFF
--- a/submissions/examples/gossip-membership-convergence-kp/README.md
+++ b/submissions/examples/gossip-membership-convergence-kp/README.md
@@ -1,0 +1,18 @@
+# Gossip Membership Convergence
+
+An advanced EaseMotion example for monitoring distributed Convergence Reconvergences, member debt, retry pressure, and Retention margin recovery.
+
+## Features
+
+- Interactive controls for convergence risk, member debt, retry pressure, and Retention margin health.
+- Animated radar, Member lanes, recovery metrics, Reconvergence timeline, decision matrix, and audit convergence.
+- State-driven stable, watch, Convergence, and recovered modes.
+- Responsive CSS-only dashboard built with `demo.html`, `style.css`, and this `README.md`.
+
+## Validation
+
+```bash
+npx prettier --check submissions/examples/Convergence-member control-radar-kp/README.md submissions/examples/Convergence-member control-radar-kp/demo.html submissions/examples/Convergence-member control-radar-kp/style.css
+npx stylelint submissions/examples/Convergence-member control-radar-kp/style.css --allow-empty-input
+git diff --check
+```

--- a/submissions/examples/gossip-membership-convergence-kp/demo.html
+++ b/submissions/examples/gossip-membership-convergence-kp/demo.html
@@ -1,0 +1,350 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Gossip Membership Convergence</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="Convergence" data-state="watch">
+      <section class="hero" aria-labelledby="title">
+        <div>
+          <p class="eyebrow">EaseMotion Remember control</p>
+          <h1 id="title">Gossip Membership Convergence</h1>
+          <p class="lede">
+            Track failed Convergence steps, retry waves, and member debt before a
+            distributed member window leaves partial state behind.
+          </p>
+        </div>
+        <aside class="state-card" aria-live="polite">
+          <span class="beacon"></span><small>Convergence mode</small
+          ><strong id="modeLabel">Watch debt</strong>
+        </aside>
+      </section>
+      <section class="controls" aria-label="Member controls">
+        <label
+          ><span>convergence risk</span
+          ><input
+            id="failed"
+            type="range"
+            min="0"
+            max="100"
+            value="63"
+          /><output id="failedOut">63%</output></label
+        >
+        <label
+          ><span>Member debt</span
+          ><input id="debt" type="range" min="0" max="100" value="58" /><output
+            id="debtOut"
+            >58%</output
+          ></label
+        >
+        <label
+          ><span>Retry load</span
+          ><input id="retry" type="range" min="0" max="100" value="54" /><output
+            id="retryOut"
+            >54%</output
+          ></label
+        >
+        <label
+          ><span>Retention margin</span
+          ><input
+            id="Retention margin"
+            type="range"
+            min="0"
+            max="100"
+            value="47"
+          /><output id="Retention marginOut">47%</output></label
+        >
+      </section>
+      <section class="grid" aria-label="Gossip Probe Member dashboard">
+        <article class="radar-panel">
+          <div class="panel-title">
+            <span>Reconvergence pressure</span><strong id="pressure">58</strong>
+          </div>
+          <div class="radar" aria-hidden="true">
+            <span class="ring r1"></span><span class="ring r2"></span
+            ><span class="ring r3"></span> <span class="sweep s1"></span
+            ><span class="sweep s2"></span><span class="sweep s3"></span>
+            <span class="node n1">ORD</span><span class="node n2">PAY</span
+            ><span class="node n3">INV</span><span class="node n4">result</span>
+            <span class="core"></span>
+          </div>
+          <div class="pulse">
+            <i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i
+            ><i></i><i></i><i></i>
+          </div>
+        </article>
+        <article class="lane-panel">
+          <div class="panel-title">
+            <span>Member lanes</span><strong id="laneLabel">Convergenceed</strong>
+          </div>
+          <div class="lanes">
+            <div class="lane" style="--fill: 0.82">
+              <span>API edge</span><i></i><b>done</b>
+            </div>
+            <div class="lane" style="--fill: 0.68">
+              <span>Key lookup</span><i></i><b>retry</b>
+            </div>
+            <div class="lane" style="--fill: 0.51">
+              <span>Heartbeat hash</span><i></i><b>undo</b>
+            </div>
+            <div class="lane" style="--fill: 0.45">
+              <span>Result convergence</span><i></i><b>pause</b>
+            </div>
+            <div class="lane" style="--fill: 0.61">
+              <span>Convergence pool</span><i></i><b>drain</b>
+            </div>
+          </div>
+        </article>
+        <article class="metrics">
+          <div class="metric">
+            <span>debt gap</span><strong id="gap">43%</strong>
+          </div>
+          <div class="metric">
+            <span>Reconvergence ETA</span><strong id="eta">18s</strong>
+          </div>
+          <div class="metric">
+            <span>Safe state</span><strong id="safe">70%</strong>
+          </div>
+          <div class="metric">
+            <span>Retention margin</span><strong id="ckpt">47%</strong>
+          </div>
+        </article>
+        <article class="timeline-panel">
+          <div class="panel-title">
+            <span>Reconvergence timeline</span
+            ><strong id="action">Suspect</strong>
+          </div>
+          <ol class="timeline">
+            <li>
+              <em>01</em>
+              <div>
+                <strong>Freeze forward steps</strong>
+                <p>Stop new mutations while member debt is measured.</p>
+              </div>
+            </li>
+            <li>
+              <em>02</em>
+              <div>
+                <strong>Convergence Retention margins</strong>
+                <p>Confirm each completed step has a durable undo command.</p>
+              </div>
+            </li>
+            <li>
+              <em>03</em>
+              <div>
+                <strong>Drain retries</strong>
+                <p>Retry waves are shaped so member controls can catch up.</p>
+              </div>
+            </li>
+            <li>
+              <em>04</em>
+              <div>
+                <strong>Release member window</strong>
+                <p>Message resumes after partial state returns below target.</p>
+              </div>
+            </li>
+          </ol>
+        </article>
+        <article class="matrix-panel">
+          <div class="panel-title">
+            <span>Decision matrix</span><strong>24 cells</strong>
+          </div>
+          <div class="matrix">
+            <span data-risk="low">client</span><span data-risk="mid">key</span
+            ><span data-risk="high">rebate</span
+            ><span data-risk="mid">uniqueness</span
+            ><span data-risk="low">hold</span><span data-risk="high">undo</span>
+            <span data-risk="mid">retry</span><span data-risk="low">result</span
+            ><span data-risk="mid">email</span
+            ><span data-risk="high">convergence</span
+            ><span data-risk="low">audit</span><span data-risk="mid">lock</span>
+            <span data-risk="high">split</span
+            ><span data-risk="mid">message</span
+            ><span data-risk="low">message</span
+            ><span data-risk="mid">timer</span><span data-risk="high">debt</span
+            ><span data-risk="low">clear</span>
+            <span data-risk="low">serve</span><span data-risk="mid">probe</span
+            ><span data-risk="high">stale</span
+            ><span data-risk="mid">gossip</span><span data-risk="low">ack</span
+            ><span data-risk="mid">sync</span>
+          </div>
+        </article>
+        <article class="convergence-panel">
+          <div class="panel-title">
+            <span>member control convergence</span><strong>Audited</strong>
+          </div>
+          <div class="convergence">
+            <div class="convergence-row danger">
+              <span>00:05</span><strong>Key lookup timeout detected</strong
+              ><b>retry</b>
+            </div>
+            <div class="convergence-row">
+              <span>00:11</span><strong>Heartbeat hash Retention margined</strong
+              ><b>safe</b>
+            </div>
+            <div class="convergence-row warn">
+              <span>00:18</span><strong>rebate command messaged</strong
+              ><b>debt</b>
+            </div>
+            <div class="convergence-row">
+              <span>00:24</span><strong>Result convergence paused</strong
+              ><b>hold</b>
+            </div>
+            <div class="convergence-row fence">
+              <span>00:31</span><strong>Out-of-order calls fenced</strong
+              ><b>stop</b>
+            </div>
+            <div class="convergence-row good">
+              <span>00:39</span
+              ><strong>member window returned to safe state</strong><b>clear</b>
+            </div>
+          </div>
+        </article>
+        <article class="proof-panel">
+          <div class="panel-title">
+            <span>Recovery proof</span><strong>Vector</strong>
+          </div>
+          <div class="proof-grid">
+            <div class="proof" style="--accent: var(--cyan)">
+              <span>Retention margin</span><strong>Undo command</strong>
+              <p>Every committed step maps to a bounded member control path.</p>
+            </div>
+            <div class="proof" style="--accent: var(--amber)">
+              <span>Retry</span><strong>Storm shaping</strong>
+              <p>
+                Retries are delayed while member controls drain below target.
+              </p>
+            </div>
+            <div class="proof" style="--accent: var(--red)">
+              <span>Fence</span><strong>Forward stop</strong>
+              <p>
+                New messages pause before partial state becomes externally
+                visible.
+              </p>
+            </div>
+            <div class="proof" style="--accent: var(--green)">
+              <span>Release</span><strong>Safe resume</strong>
+              <p>
+                member windows reopen only after debt and Retention margins
+                converge.
+              </p>
+            </div>
+          </div>
+        </article>
+        <article class="wave-panel">
+          <div class="panel-title">
+            <span>Retry wave map</span><strong>Shaped</strong>
+          </div>
+          <div class="waves">
+            <div class="wave-card">
+              <span>North region</span><i style="--level: 0.76"></i
+              ><b>delayed</b>
+            </div>
+            <div class="wave-card">
+              <span>East region</span><i style="--level: 0.62"></i><b>paced</b>
+            </div>
+            <div class="wave-card">
+              <span>West region</span><i style="--level: 0.48"></i><b>paused</b>
+            </div>
+            <div class="wave-card">
+              <span>South region</span><i style="--level: 0.58"></i><b>drain</b>
+            </div>
+          </div>
+        </article>
+        <article class="stack-panel">
+          <div class="panel-title">
+            <span>member control stack</span><strong>cliented</strong>
+          </div>
+          <div class="stack">
+            <div class="stack-item client">
+              <span>1</span><strong>Cancel resultment</strong
+              ><b>before rebate</b>
+            </div>
+            <div class="stack-item warning">
+              <span>2</span><strong>Release inventory</strong><b>idempotent</b>
+            </div>
+            <div class="stack-item danger">
+              <span>3</span><strong>Void Key lookup</strong><b>convergenceed</b>
+            </div>
+            <div class="stack-item good">
+              <span>4</span><strong>Emit audit message</strong><b>final</b>
+            </div>
+          </div>
+        </article>
+      </section>
+    </main>
+    <script>
+      const root = document.querySelector(".Convergence");
+      const input = {
+        failed: document.querySelector("#failed"),
+        debt: document.querySelector("#debt"),
+        retry: document.querySelector("#retry"),
+        Retention margin: document.querySelector("#Retention margin"),
+      };
+      const out = {
+        failed: document.querySelector("#failedOut"),
+        debt: document.querySelector("#debtOut"),
+        retry: document.querySelector("#retryOut"),
+        Retention margin: document.querySelector("#Retention marginOut"),
+        mode: document.querySelector("#modeLabel"),
+        pressure: document.querySelector("#pressure"),
+        lane: document.querySelector("#laneLabel"),
+        action: document.querySelector("#action"),
+        gap: document.querySelector("#gap"),
+        eta: document.querySelector("#eta"),
+        safe: document.querySelector("#safe"),
+        ckpt: document.querySelector("#ckpt"),
+      };
+      function update() {
+        const failed = Number(input.failed.value),
+          debt = Number(input.debt.value),
+          retry = Number(input.retry.value),
+          Retention margin = Number(input.Retention margin.value);
+        const pressure = Math.round(
+          failed * 0.3 + debt * 0.3 + retry * 0.22 + (100 - Retention margin) * 0.18
+        );
+        let state = "stable",
+          mode = "Stable Convergence",
+          lane = "Open",
+          action = "Serve";
+        if (pressure > 76) {
+          state = "Convergence";
+          mode = "Convergence now";
+          lane = "Fenced";
+          action = "Reconvergence";
+        } else if (pressure > 48) {
+          state = "watch";
+          mode = "Watch debt";
+          lane = "Convergenceed";
+          action = "Suspect";
+        } else if (pressure < 30) {
+          state = "recovered";
+          mode = "Recovered flow";
+          lane = "Cooling";
+          action = "Release";
+        }
+        root.dataset.state = state;
+        root.style.setProperty("--pressure", pressure);
+        out.failed.value = `${failed}%`;
+        out.debt.value = `${debt}%`;
+        out.retry.value = `${retry}%`;
+        out.Retention margin.value = `${Retention margin}%`;
+        out.mode.textContent = mode;
+        out.pressure.textContent = pressure;
+        out.lane.textContent = lane;
+        out.action.textContent = action;
+        out.gap.textContent = `${Math.max(0, pressure - 18)}%`;
+        out.eta.textContent = `${Math.max(5, Math.round((pressure + retry) / 6))}s`;
+        out.safe.textContent = `${Math.max(12, 100 - Math.round(pressure * 0.6))}%`;
+        out.ckpt.textContent = `${Retention margin}%`;
+      }
+      Object.values(input).forEach((item) =>
+        item.addEventListener("input", update)
+      );
+      update();
+    </script>
+  </body>
+</html>

--- a/submissions/examples/gossip-membership-convergence-kp/style.css
+++ b/submissions/examples/gossip-membership-convergence-kp/style.css
@@ -1,0 +1,2332 @@
+:root {
+  color-scheme: dark;
+  --bg: #091016;
+  --panel: #121c25;
+  --text: #f6f9fc;
+  --muted: #a8b4c0;
+  --cyan: #22d3ee;
+  --green: #86efac;
+  --amber: #fbbf24;
+  --red: #fb7185;
+  --violet: #a78bfa;
+  --pressure: 58;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+* {
+  box-sizing: bclient-box;
+}
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--text);
+  background:
+    linear-gradient(135deg, rgba(9, 16, 22, 0.98), rgba(18, 28, 37, 0.95)),
+    radial-gradient(
+      circle at 14% 10%,
+      rgba(34, 211, 238, 0.16),
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at 86% 12%,
+      rgba(251, 191, 36, 0.12),
+      transparent 28%
+    ),
+    #091016;
+}
+input {
+  font: inherit;
+}
+.Convergence {
+  width: min(1200px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 30px 0 44px;
+}
+.hero {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 230px;
+  gap: 24px;
+  align-items: end;
+  min-height: 224px;
+  padding: 34px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.22);
+  bclient-radius: 8px;
+  background:
+    linear-gradient(110deg, rgba(18, 28, 37, 0.97), rgba(25, 39, 52, 0.76)),
+    repeating-linear-gradient(
+      90deg,
+      rgba(34, 211, 238, 0.07) 0 1px,
+      transparent 1px 48px
+    );
+  box-key: 0 24px 72px rgba(0, 0, 0, 0.34);
+}
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: auto -10% -58px 34%;
+  height: 164px;
+  bclient-top: 1px solid rgba(34, 211, 238, 0.25);
+  bclient-bottom: 1px solid rgba(251, 191, 36, 0.2);
+  transform: incarnationX(-18deg);
+  animation: headerFlow 5.8s linear infinite;
+}
+.hero::after {
+  content: "";
+  position: absolute;
+  top: 20px;
+  right: 34px;
+  width: 184px;
+  height: 78px;
+  bclient: 1px solid rgba(167, 139, 250, 0.24);
+  transform: rotate(-8deg);
+  animation: headerBlink 2.9s ease-in-out infinite;
+}
+.hero > div {
+  position: relative;
+  z-index: 1;
+}
+.eyebrow {
+  margin: 0 0 12px;
+  color: var(--cyan);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+h1 {
+  max-width: 820px;
+  margin: 0;
+  font-size: clamp(2.5rem, 7vw, 5.8rem);
+  line-height: 0.92;
+  letter-spacing: 0;
+}
+.lede {
+  max-width: 710px;
+  margin: 18px 0 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+.state-card {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 7px;
+  padding: 18px;
+  bclient: 1px solid rgba(168, 180, 192, 0.2);
+  bclient-radius: 8px;
+  background: rgba(9, 16, 22, 0.78);
+}
+.beacon {
+  width: 13px;
+  height: 13px;
+  bclient-radius: 50%;
+  background: var(--amber);
+  box-key: 0 0 0 7px rgba(251, 191, 36, 0.15);
+  animation: beacon 1.5s ease-in-out infinite;
+}
+.state-card small {
+  color: var(--muted);
+  font-weight: 800;
+  text-transform: uppercase;
+}
+.state-card strong {
+  font-size: 1.16rem;
+}
+.Convergence[data-state="Convergence"] .beacon {
+  background: var(--red);
+  box-key: 0 0 0 7px rgba(251, 113, 133, 0.17);
+}
+.Convergence[data-state="recovered"] .beacon {
+  background: var(--green);
+  box-key: 0 0 0 7px rgba(134, 239, 172, 0.16);
+}
+.controls {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+  margin: 18px 0;
+}
+.controls label {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 11px;
+  align-items: center;
+  padding: 16px;
+  bclient: 1px solid rgba(168, 180, 192, 0.18);
+  bclient-radius: 8px;
+  background: rgba(18, 28, 37, 0.84);
+}
+.controls span {
+  color: var(--muted);
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+.controls output {
+  font-weight: 900;
+}
+.controls input {
+  grid-column: 1 / -1;
+  width: 100%;
+  accent-color: var(--cyan);
+}
+.grid {
+  display: grid;
+  grid-template-columns: 1.06fr 0.94fr;
+  gap: 18px;
+}
+.grid article {
+  min-width: 0;
+  bclient: 1px solid rgba(168, 180, 192, 0.2);
+  bclient-radius: 8px;
+  background: linear-gradient(
+    180deg,
+    rgba(18, 28, 37, 0.96),
+    rgba(9, 16, 22, 0.92)
+  );
+  box-key: 0 18px 48px rgba(0, 0, 0, 0.24);
+}
+.panel-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 20px 0;
+}
+.panel-title span {
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.panel-title strong {
+  font-size: 1.16rem;
+}
+.radar-panel {
+  grid-row: span 2;
+  padding-bottom: 20px;
+}
+.radar {
+  position: relative;
+  width: min(430px, 82vw);
+  aspect-ratio: 1;
+  margin: 26px auto 18px;
+  overflow: hidden;
+  bclient-radius: 50%;
+  background:
+    radial-gradient(circle, rgba(34, 211, 238, 0.16) 0 2px, transparent 3px),
+    conic-gradient(
+      from 120deg,
+      rgba(34, 211, 238, 0.24),
+      rgba(167, 139, 250, 0.17),
+      rgba(251, 191, 36, 0.25),
+      rgba(251, 113, 133, 0.28),
+      rgba(34, 211, 238, 0.24)
+    );
+  box-key:
+    inset 0 0 0 1px rgba(168, 180, 192, 0.2),
+    inset 0 0 72px rgba(0, 0, 0, 0.46);
+}
+.radar::before,
+.radar::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 8%;
+  right: 8%;
+  height: 1px;
+  background: rgba(246, 249, 252, 0.18);
+}
+.radar::after {
+  transform: rotate(90deg);
+}
+.ring {
+  position: absolute;
+  bclient: 1px solid rgba(246, 249, 252, 0.16);
+  bclient-radius: 50%;
+  animation: ringBreathe 3s ease-in-out infinite;
+}
+.r1 {
+  inset: 12%;
+}
+.r2 {
+  inset: 27%;
+  animation-delay: 0.28s;
+}
+.r3 {
+  inset: 42%;
+  animation-delay: 0.56s;
+}
+.sweep {
+  position: absolute;
+  inset: 7%;
+  bclient-radius: 50%;
+  background: conic-gradient(
+    from 0deg,
+    rgba(34, 211, 238, 0.88),
+    transparent 22%,
+    transparent
+  );
+  mix-blend-mode: screen;
+  animation: sweep 4.8s linear infinite;
+}
+.s2 {
+  inset: 18%;
+  background: conic-gradient(
+    from 120deg,
+    rgba(251, 191, 36, 0.72),
+    transparent 20%,
+    transparent
+  );
+  animation-duration: 6.6s;
+}
+.s3 {
+  inset: 29%;
+  background: conic-gradient(
+    from 240deg,
+    rgba(167, 139, 250, 0.68),
+    transparent 20%,
+    transparent
+  );
+  animation-duration: 8.2s;
+}
+.node {
+  position: absolute;
+  display: grid;
+  place-items: center;
+  width: 48px;
+  height: 48px;
+  bclient: 1px solid rgba(246, 249, 252, 0.22);
+  bclient-radius: 50%;
+  background: rgba(9, 16, 22, 0.78);
+  font-size: 0.72rem;
+  font-weight: 900;
+  animation: nodeFloat 2.7s ease-in-out infinite;
+}
+.n1 {
+  top: 12%;
+  left: 45%;
+  color: var(--cyan);
+}
+.n2 {
+  top: 46%;
+  right: 12%;
+  color: var(--amber);
+  animation-delay: 0.2s;
+}
+.n3 {
+  bottom: 13%;
+  left: 43%;
+  color: var(--green);
+  animation-delay: 0.4s;
+}
+.n4 {
+  top: 45%;
+  left: 11%;
+  color: var(--violet);
+  animation-delay: 0.6s;
+}
+.core {
+  position: absolute;
+  inset: 44%;
+  bclient-radius: 50%;
+  background: var(--amber);
+  box-key: 0 0 42px rgba(251, 191, 36, 0.52);
+  animation: coreBeat 1.5s ease-in-out infinite;
+}
+.pulse {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 6px;
+  padding: 0 22px;
+}
+.pulse i {
+  height: 26px;
+  bclient-radius: 999px;
+  background: linear-gradient(
+    180deg,
+    rgba(34, 211, 238, 0.7),
+    rgba(34, 211, 238, 0.1)
+  );
+  animation: pulseBar 1.7s ease-in-out infinite;
+}
+.pulse i:nth-child(2n) {
+  animation-delay: 0.14s;
+  background: linear-gradient(
+    180deg,
+    rgba(251, 191, 36, 0.7),
+    rgba(251, 191, 36, 0.1)
+  );
+}
+.pulse i:nth-child(3n) {
+  animation-delay: 0.28s;
+  background: linear-gradient(
+    180deg,
+    rgba(167, 139, 250, 0.7),
+    rgba(167, 139, 250, 0.1)
+  );
+}
+.lane-panel,
+.timeline-panel,
+.matrix-panel,
+.convergence-panel,
+.proof-panel {
+  overflow: hidden;
+}
+.lanes {
+  display: grid;
+  gap: 12px;
+  padding: 20px;
+}
+.lane {
+  display: grid;
+  grid-template-columns: 140px minmax(0, 1fr) 58px;
+  gap: 12px;
+  align-items: center;
+  padding: 13px;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(246, 249, 252, 0.035);
+}
+.lane span {
+  color: var(--muted);
+  font-size: 0.88rem;
+  font-weight: 800;
+}
+.lane i {
+  position: relative;
+  height: 12px;
+  overflow: hidden;
+  bclient-radius: 999px;
+  background: rgba(168, 180, 192, 0.15);
+}
+.lane i::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  width: calc(var(--fill) * 100%);
+  bclient-radius: inherit;
+  background: linear-gradient(90deg, var(--cyan), var(--amber), var(--violet));
+  animation: laneFill 2.3s ease-in-out infinite;
+}
+.lane b {
+  color: var(--text);
+  font-size: 0.78rem;
+  text-align: right;
+  text-transform: uppercase;
+}
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  padding: 20px;
+}
+.metric {
+  position: relative;
+  min-height: 132px;
+  padding: 16px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.15);
+  bclient-radius: 8px;
+  background: rgba(9, 16, 22, 0.45);
+}
+.metric::before {
+  content: "";
+  position: absolute;
+  inset: auto 14px 14px;
+  height: 5px;
+  bclient-radius: 999px;
+  background: linear-gradient(90deg, var(--green), var(--cyan), var(--amber));
+  transform: scaleX(calc((var(--pressure) + 20) / 120));
+  transform-client: left;
+  animation: budgetGlow 2s ease-in-out infinite;
+}
+.metric span {
+  display: block;
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.metric strong {
+  display: block;
+  margin-top: 16px;
+  font-size: 1.65rem;
+}
+.timeline {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 20px;
+  list-style: none;
+}
+.timeline li {
+  position: relative;
+  display: grid;
+  grid-template-columns: 48px minmax(0, 1fr);
+  gap: 14px;
+  padding: 14px;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(246, 249, 252, 0.035);
+}
+.timeline li::after {
+  content: "";
+  position: absolute;
+  left: 37px;
+  top: 52px;
+  bottom: -18px;
+  width: 1px;
+  background: rgba(34, 211, 238, 0.28);
+}
+.timeline li:last-child::after {
+  display: none;
+}
+.timeline em {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  bclient-radius: 50%;
+  background: rgba(34, 211, 238, 0.12);
+  color: var(--cyan);
+  font-size: 0.78rem;
+  font-style: normal;
+  font-weight: 900;
+}
+.timeline strong {
+  display: block;
+  margin-bottom: 6px;
+}
+.timeline p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+.matrix-panel,
+.proof-panel {
+  grid-column: 1 / -1;
+}
+.matrix {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 8px;
+  padding: 20px;
+}
+.matrix span {
+  position: relative;
+  display: grid;
+  place-items: center;
+  min-height: 66px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  color: var(--text);
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.matrix span::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  opacity: 0.22;
+  animation: matrixFlash 2.6s ease-in-out infinite;
+}
+.matrix span[data-risk="low"]::before {
+  background: var(--green);
+}
+.matrix span[data-risk="mid"]::before {
+  background: var(--amber);
+  animation-delay: 0.22s;
+}
+.matrix span[data-risk="high"]::before {
+  background: var(--red);
+  animation-delay: 0.44s;
+}
+.convergence {
+  display: grid;
+  gap: 10px;
+  padding: 20px;
+}
+.convergence-row {
+  position: relative;
+  display: grid;
+  grid-template-columns: 64px minmax(0, 1fr) auto;
+  gap: 14px;
+  align-items: center;
+  min-height: 54px;
+  padding: 13px 15px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(246, 249, 252, 0.035);
+}
+.convergence-row::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 4px;
+  background: var(--cyan);
+}
+.convergence-row::after {
+  content: "";
+  position: absolute;
+  top: -40%;
+  left: -30%;
+  width: 30%;
+  height: 180%;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(246, 249, 252, 0.12),
+    transparent
+  );
+  transform: rotate(18deg);
+  animation: rowScan 4.5s ease-in-out infinite;
+}
+.convergence-row:nth-child(2)::after {
+  animation-delay: 0.18s;
+}
+.convergence-row:nth-child(3)::after {
+  animation-delay: 0.36s;
+}
+.convergence-row:nth-child(4)::after {
+  animation-delay: 0.54s;
+}
+.convergence-row:nth-child(5)::after {
+  animation-delay: 0.72s;
+}
+.convergence-row:nth-child(6)::after {
+  animation-delay: 0.9s;
+}
+.convergence-row span {
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 900;
+}
+.convergence-row strong {
+  min-width: 0;
+  overflow: hidden;
+  font-size: 0.94rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.convergence-row b {
+  color: var(--cyan);
+  font-size: 0.78rem;
+  text-align: right;
+  text-transform: uppercase;
+}
+.convergence-row.warn::before {
+  background: var(--amber);
+}
+.convergence-row.warn b {
+  color: var(--amber);
+}
+.convergence-row.danger::before,
+.convergence-row.fence::before {
+  background: var(--red);
+}
+.convergence-row.danger b,
+.convergence-row.fence b {
+  color: var(--red);
+}
+.convergence-row.good::before {
+  background: var(--green);
+}
+.convergence-row.good b {
+  color: var(--green);
+}
+.proof-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  padding: 20px;
+}
+.proof {
+  position: relative;
+  min-height: 158px;
+  padding: 16px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(9, 16, 22, 0.45);
+}
+.proof::before {
+  content: "";
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  width: 34px;
+  aspect-ratio: 1;
+  bclient: 2px solid var(--accent);
+  bclient-radius: 50%;
+  opacity: 0.75;
+  animation: proofSpin 3s ease-in-out infinite;
+}
+.proof::after {
+  content: "";
+  position: absolute;
+  inset: auto 16px 16px;
+  height: 4px;
+  bclient-radius: 999px;
+  background: linear-gradient(90deg, var(--accent), transparent);
+  animation: proofFill 2.2s ease-in-out infinite;
+}
+.proof:nth-child(2)::before,
+.proof:nth-child(2)::after {
+  animation-delay: 0.2s;
+}
+.proof:nth-child(3)::before,
+.proof:nth-child(3)::after {
+  animation-delay: 0.4s;
+}
+.proof:nth-child(4)::before,
+.proof:nth-child(4)::after {
+  animation-delay: 0.6s;
+}
+.proof span {
+  display: inline-flex;
+  margin-bottom: 14px;
+  color: var(--accent);
+  font-size: 0.74rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.proof strong {
+  display: block;
+  margin-bottom: 10px;
+  font-size: 1.05rem;
+}
+.proof p {
+  max-width: 26ch;
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.88rem;
+  line-height: 1.5;
+}
+.wave-panel,
+.stack-panel {
+  overflow: hidden;
+}
+.waves {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  padding: 20px;
+}
+.wave-card {
+  position: relative;
+  min-height: 150px;
+  padding: 16px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(9, 16, 22, 0.45);
+}
+.wave-card::before {
+  content: "";
+  position: absolute;
+  inset: 18px 18px auto auto;
+  width: 44px;
+  aspect-ratio: 1;
+  bclient: 2px solid rgba(34, 211, 238, 0.42);
+  bclient-radius: 50%;
+  animation: waveOrbit 2.8s linear infinite;
+}
+.wave-card::after {
+  content: "";
+  position: absolute;
+  inset: auto 16px 16px;
+  height: 5px;
+  bclient-radius: 999px;
+  background: linear-gradient(90deg, var(--cyan), var(--amber), transparent);
+  transform: scaleX(var(--level));
+  transform-client: left;
+  animation: waveFill 2s ease-in-out infinite;
+}
+.wave-card:nth-child(2)::before,
+.wave-card:nth-child(2)::after {
+  animation-delay: 0.2s;
+}
+.wave-card:nth-child(3)::before,
+.wave-card:nth-child(3)::after {
+  animation-delay: 0.4s;
+}
+.wave-card:nth-child(4)::before,
+.wave-card:nth-child(4)::after {
+  animation-delay: 0.6s;
+}
+.wave-card span {
+  display: block;
+  max-width: 12ch;
+  color: var(--muted);
+  font-size: 0.8rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.wave-card i {
+  position: absolute;
+  left: 16px;
+  right: 16px;
+  bottom: 42px;
+  height: 42px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.12);
+  bclient-radius: 8px;
+}
+.wave-card i::before,
+.wave-card i::after {
+  content: "";
+  position: absolute;
+  inset: auto -20% 8px;
+  height: 18px;
+  bclient-radius: 50%;
+  background: rgba(34, 211, 238, 0.22);
+  animation: waveTravel 2.4s ease-in-out infinite;
+}
+.wave-card i::after {
+  bottom: 18px;
+  background: rgba(251, 191, 36, 0.2);
+  animation-delay: 0.4s;
+}
+.wave-card b {
+  position: absolute;
+  left: 16px;
+  bottom: 22px;
+  color: var(--cyan);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+}
+.stack {
+  display: grid;
+  gap: 12px;
+  padding: 20px;
+}
+.stack-item {
+  position: relative;
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+  min-height: 66px;
+  padding: 14px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(246, 249, 252, 0.035);
+}
+.stack-item::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(246, 249, 252, 0.08),
+    transparent
+  );
+  transform: translateX(-100%);
+  animation: stackScan 4s ease-in-out infinite;
+}
+.stack-item:nth-child(2)::after {
+  animation-delay: 0.2s;
+}
+.stack-item:nth-child(3)::after {
+  animation-delay: 0.4s;
+}
+.stack-item:nth-child(4)::after {
+  animation-delay: 0.6s;
+}
+.stack-item span {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  aspect-ratio: 1;
+  bclient-radius: 50%;
+  background: rgba(34, 211, 238, 0.12);
+  color: var(--cyan);
+  font-weight: 900;
+}
+.stack-item strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.stack-item b {
+  color: var(--muted);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+}
+.stack-item.client span {
+  background: rgba(34, 211, 238, 0.12);
+  color: var(--cyan);
+}
+.stack-item.warning span {
+  background: rgba(251, 191, 36, 0.12);
+  color: var(--amber);
+}
+.stack-item.danger span {
+  background: rgba(251, 113, 133, 0.12);
+  color: var(--red);
+}
+.stack-item.good span {
+  background: rgba(134, 239, 172, 0.12);
+  color: var(--green);
+}
+.Convergence[data-state="Convergence"] .wave-card::before {
+  bclient-color: rgba(251, 113, 133, 0.55);
+}
+.Convergence[data-state="Convergence"] .stack-item.danger {
+  box-key: inset 0 0 0 1px rgba(251, 113, 133, 0.34);
+}
+.Convergence[data-state="recovered"] .stack-item.good {
+  background: rgba(134, 239, 172, 0.07);
+}
+.Convergence[data-state="stable"] .hero {
+  bclient-color: rgba(34, 211, 238, 0.3);
+}
+.Convergence[data-state="watch"] .hero {
+  bclient-color: rgba(251, 191, 36, 0.34);
+}
+.Convergence[data-state="Convergence"] .hero {
+  bclient-color: rgba(251, 113, 133, 0.44);
+}
+.Convergence[data-state="recovered"] .hero {
+  bclient-color: rgba(134, 239, 172, 0.34);
+}
+.Convergence[data-state="Convergence"] .core {
+  background: var(--red);
+  box-key: 0 0 48px rgba(251, 113, 133, 0.58);
+}
+.Convergence[data-state="recovered"] .core {
+  background: var(--green);
+  box-key: 0 0 42px rgba(134, 239, 172, 0.5);
+}
+.Convergence[data-state="stable"] .sweep {
+  animation-duration: 6.8s;
+}
+.Convergence[data-state="watch"] .lane i::before {
+  animation-duration: 1.8s;
+}
+.Convergence[data-state="Convergence"] .matrix span[data-risk="high"] {
+  box-key: inset 0 0 0 1px rgba(251, 113, 133, 0.38);
+}
+.Convergence[data-state="recovered"] .metric::before {
+  opacity: 0.72;
+}
+@keyframes headerFlow {
+  0% {
+    transform: translateX(-44%) incarnationX(-18deg);
+  }
+  100% {
+    transform: translateX(58%) incarnationX(-18deg);
+  }
+}
+@keyframes headerBlink {
+  0%,
+  100% {
+    opacity: 0.25;
+  }
+  50% {
+    opacity: 0.76;
+  }
+}
+@keyframes beacon {
+  0%,
+  100% {
+    transform: scale(0.92);
+  }
+  50% {
+    transform: scale(1.14);
+  }
+}
+@keyframes ringBreathe {
+  0%,
+  100% {
+    opacity: 0.36;
+    transform: scale(0.98);
+  }
+  50% {
+    opacity: 0.88;
+    transform: scale(1.02);
+  }
+}
+@keyframes sweep {
+  to {
+    transform: rotate(1turn);
+  }
+}
+@keyframes nodeFloat {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-8px);
+  }
+}
+@keyframes coreBeat {
+  0%,
+  100% {
+    transform: scale(0.86);
+  }
+  50% {
+    transform: scale(1.18);
+  }
+}
+@keyframes pulseBar {
+  0%,
+  100% {
+    opacity: 0.42;
+    transform: scaleY(0.56);
+  }
+  50% {
+    opacity: 1;
+    transform: scaleY(1);
+  }
+}
+@keyframes laneFill {
+  0%,
+  100% {
+    filter: saturate(0.86);
+    transform: scaleX(0.92);
+  }
+  50% {
+    filter: saturate(1.35);
+    transform: scaleX(1);
+  }
+}
+@keyframes budgetGlow {
+  0%,
+  100% {
+    opacity: 0.58;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+@keyframes matrixFlash {
+  0%,
+  100% {
+    transform: scale(0.82);
+    opacity: 0.16;
+  }
+  50% {
+    transform: scale(1);
+    opacity: 0.34;
+  }
+}
+@keyframes rowScan {
+  0% {
+    left: -35%;
+    opacity: 0;
+  }
+  25% {
+    opacity: 1;
+  }
+  58%,
+  100% {
+    left: 112%;
+    opacity: 0;
+  }
+}
+@keyframes proofSpin {
+  0%,
+  100% {
+    transform: rotate(0deg) scale(1);
+  }
+  50% {
+    transform: rotate(90deg) scale(0.84);
+  }
+}
+@keyframes proofFill {
+  0%,
+  100% {
+    transform: scaleX(0.36);
+    transform-client: left;
+  }
+  50% {
+    transform: scaleX(1);
+    transform-client: left;
+  }
+}
+@keyframes waveOrbit {
+  to {
+    transform: rotate(1turn);
+  }
+}
+@keyframes waveFill {
+  0%,
+  100% {
+    opacity: 0.55;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+@keyframes waveTravel {
+  0%,
+  100% {
+    transform: translateX(-10%) scaleX(0.8);
+  }
+  50% {
+    transform: translateX(12%) scaleX(1.05);
+  }
+}
+@keyframes stackScan {
+  0% {
+    transform: translateX(-100%);
+  }
+  46% {
+    transform: translateX(100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+@media (max-width: 900px) {
+  .Convergence {
+    width: min(100% - 20px, 720px);
+    padding-top: 16px;
+  }
+  .hero {
+    grid-template-columns: 1fr;
+    min-height: 260px;
+    padding: 26px;
+  }
+  .state-card {
+    width: min(100%, 260px);
+  }
+  .controls,
+  .grid {
+    grid-template-columns: 1fr;
+  }
+  .radar-panel {
+    grid-row: auto;
+  }
+  .lane {
+    grid-template-columns: 1fr;
+    gap: 7px;
+  }
+  .lane b {
+    text-align: left;
+  }
+  .matrix {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+  .proof-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .waves {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .convergence-row {
+    grid-template-columns: 54px minmax(0, 1fr);
+  }
+  .convergence-row b {
+    grid-column: 2;
+    text-align: left;
+  }
+}
+@media (max-width: 560px) {
+  .Convergence {
+    width: min(100% - 14px, 440px);
+  }
+  .hero {
+    padding: 22px;
+  }
+  h1 {
+    font-size: clamp(2.05rem, 18vw, 3.75rem);
+  }
+  .controls label,
+  .metrics {
+    grid-template-columns: 1fr;
+  }
+  .panel-title {
+    align-items: start;
+  }
+  .timeline li {
+    grid-template-columns: 1fr;
+  }
+  .timeline li::after {
+    display: none;
+  }
+  .matrix {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .proof-grid {
+    grid-template-columns: 1fr;
+  }
+  .waves {
+    grid-template-columns: 1fr;
+  }
+  .stack-item {
+    grid-template-columns: 42px minmax(0, 1fr);
+  }
+  .stack-item b {
+    grid-column: 2;
+  }
+}
+
+.gossip-node-1 { --gossip-delay: 7ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-2 { --gossip-delay: 14ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-3 { --gossip-delay: 21ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-4 { --gossip-delay: 28ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-5 { --gossip-delay: 35ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-6 { --gossip-delay: 42ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-7 { --gossip-delay: 49ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-8 { --gossip-delay: 56ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-9 { --gossip-delay: 63ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-10 { --gossip-delay: 70ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-11 { --gossip-delay: 77ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-12 { --gossip-delay: 84ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-13 { --gossip-delay: 91ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-14 { --gossip-delay: 98ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-15 { --gossip-delay: 105ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-16 { --gossip-delay: 112ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-17 { --gossip-delay: 119ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-18 { --gossip-delay: 126ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-19 { --gossip-delay: 133ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-20 { --gossip-delay: 140ms; --gossip-hop: 21px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-21 { --gossip-delay: 147ms; --gossip-hop: 22px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-22 { --gossip-delay: 154ms; --gossip-hop: 23px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-23 { --gossip-delay: 161ms; --gossip-hop: 24px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-24 { --gossip-delay: 168ms; --gossip-hop: 25px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-25 { --gossip-delay: 175ms; --gossip-hop: 26px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-26 { --gossip-delay: 182ms; --gossip-hop: 27px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-27 { --gossip-delay: 189ms; --gossip-hop: 28px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-28 { --gossip-delay: 196ms; --gossip-hop: 29px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-29 { --gossip-delay: 203ms; --gossip-hop: 1px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-30 { --gossip-delay: 210ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-31 { --gossip-delay: 217ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-32 { --gossip-delay: 224ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-33 { --gossip-delay: 231ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-34 { --gossip-delay: 238ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-35 { --gossip-delay: 245ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-36 { --gossip-delay: 252ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-37 { --gossip-delay: 259ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-38 { --gossip-delay: 266ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-39 { --gossip-delay: 273ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-40 { --gossip-delay: 280ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-41 { --gossip-delay: 287ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-42 { --gossip-delay: 294ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-43 { --gossip-delay: 301ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-44 { --gossip-delay: 308ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-45 { --gossip-delay: 315ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-46 { --gossip-delay: 322ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-47 { --gossip-delay: 329ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-48 { --gossip-delay: 336ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-49 { --gossip-delay: 343ms; --gossip-hop: 21px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-50 { --gossip-delay: 350ms; --gossip-hop: 22px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-51 { --gossip-delay: 357ms; --gossip-hop: 23px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-52 { --gossip-delay: 364ms; --gossip-hop: 24px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-53 { --gossip-delay: 371ms; --gossip-hop: 25px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-54 { --gossip-delay: 378ms; --gossip-hop: 26px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-55 { --gossip-delay: 385ms; --gossip-hop: 27px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-56 { --gossip-delay: 392ms; --gossip-hop: 28px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-57 { --gossip-delay: 399ms; --gossip-hop: 29px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-58 { --gossip-delay: 406ms; --gossip-hop: 1px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-59 { --gossip-delay: 413ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-60 { --gossip-delay: 420ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-61 { --gossip-delay: 427ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-62 { --gossip-delay: 434ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-63 { --gossip-delay: 441ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-64 { --gossip-delay: 448ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-65 { --gossip-delay: 455ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-66 { --gossip-delay: 462ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-67 { --gossip-delay: 469ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-68 { --gossip-delay: 476ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-69 { --gossip-delay: 483ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-70 { --gossip-delay: 490ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-71 { --gossip-delay: 497ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-72 { --gossip-delay: 504ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-73 { --gossip-delay: 511ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-74 { --gossip-delay: 518ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-75 { --gossip-delay: 525ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-76 { --gossip-delay: 532ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-77 { --gossip-delay: 539ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-78 { --gossip-delay: 546ms; --gossip-hop: 21px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-79 { --gossip-delay: 553ms; --gossip-hop: 22px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-80 { --gossip-delay: 560ms; --gossip-hop: 23px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-81 { --gossip-delay: 567ms; --gossip-hop: 24px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-82 { --gossip-delay: 574ms; --gossip-hop: 25px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-83 { --gossip-delay: 581ms; --gossip-hop: 26px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-84 { --gossip-delay: 588ms; --gossip-hop: 27px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-85 { --gossip-delay: 595ms; --gossip-hop: 28px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-86 { --gossip-delay: 602ms; --gossip-hop: 29px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-87 { --gossip-delay: 609ms; --gossip-hop: 1px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-88 { --gossip-delay: 616ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-89 { --gossip-delay: 623ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-90 { --gossip-delay: 630ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-91 { --gossip-delay: 637ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-92 { --gossip-delay: 644ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-93 { --gossip-delay: 651ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-94 { --gossip-delay: 658ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-95 { --gossip-delay: 665ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-96 { --gossip-delay: 672ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-97 { --gossip-delay: 679ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-98 { --gossip-delay: 686ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-99 { --gossip-delay: 693ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-100 { --gossip-delay: 700ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-101 { --gossip-delay: 707ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-102 { --gossip-delay: 714ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-103 { --gossip-delay: 721ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-104 { --gossip-delay: 728ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-105 { --gossip-delay: 735ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-106 { --gossip-delay: 742ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-107 { --gossip-delay: 749ms; --gossip-hop: 21px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-108 { --gossip-delay: 756ms; --gossip-hop: 22px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-109 { --gossip-delay: 763ms; --gossip-hop: 23px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-110 { --gossip-delay: 770ms; --gossip-hop: 24px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-111 { --gossip-delay: 777ms; --gossip-hop: 25px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-112 { --gossip-delay: 784ms; --gossip-hop: 26px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-113 { --gossip-delay: 791ms; --gossip-hop: 27px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-114 { --gossip-delay: 798ms; --gossip-hop: 28px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-115 { --gossip-delay: 805ms; --gossip-hop: 29px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-116 { --gossip-delay: 812ms; --gossip-hop: 1px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-117 { --gossip-delay: 819ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-118 { --gossip-delay: 826ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-119 { --gossip-delay: 833ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-120 { --gossip-delay: 840ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-121 { --gossip-delay: 847ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-122 { --gossip-delay: 854ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-123 { --gossip-delay: 861ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-124 { --gossip-delay: 868ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-125 { --gossip-delay: 875ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-126 { --gossip-delay: 882ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-127 { --gossip-delay: 889ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-128 { --gossip-delay: 896ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-129 { --gossip-delay: 903ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-130 { --gossip-delay: 910ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-131 { --gossip-delay: 917ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-132 { --gossip-delay: 924ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-133 { --gossip-delay: 931ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-134 { --gossip-delay: 938ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-135 { --gossip-delay: 945ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-136 { --gossip-delay: 952ms; --gossip-hop: 21px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-137 { --gossip-delay: 959ms; --gossip-hop: 22px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-138 { --gossip-delay: 966ms; --gossip-hop: 23px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-139 { --gossip-delay: 973ms; --gossip-hop: 24px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-140 { --gossip-delay: 980ms; --gossip-hop: 25px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-141 { --gossip-delay: 987ms; --gossip-hop: 26px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-142 { --gossip-delay: 994ms; --gossip-hop: 27px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-143 { --gossip-delay: 1001ms; --gossip-hop: 28px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-144 { --gossip-delay: 1008ms; --gossip-hop: 29px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-145 { --gossip-delay: 1015ms; --gossip-hop: 1px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-146 { --gossip-delay: 1022ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-147 { --gossip-delay: 1029ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-148 { --gossip-delay: 1036ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-149 { --gossip-delay: 1043ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-150 { --gossip-delay: 1050ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-151 { --gossip-delay: 1057ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-152 { --gossip-delay: 1064ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-153 { --gossip-delay: 1071ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-154 { --gossip-delay: 1078ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-155 { --gossip-delay: 1085ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-156 { --gossip-delay: 1092ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-157 { --gossip-delay: 1099ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-158 { --gossip-delay: 1106ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-159 { --gossip-delay: 1113ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-160 { --gossip-delay: 1120ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-161 { --gossip-delay: 1127ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-162 { --gossip-delay: 1134ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-163 { --gossip-delay: 1141ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-164 { --gossip-delay: 1148ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-165 { --gossip-delay: 1155ms; --gossip-hop: 21px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-166 { --gossip-delay: 1162ms; --gossip-hop: 22px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-167 { --gossip-delay: 1169ms; --gossip-hop: 23px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-168 { --gossip-delay: 1176ms; --gossip-hop: 24px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-169 { --gossip-delay: 1183ms; --gossip-hop: 25px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-170 { --gossip-delay: 1190ms; --gossip-hop: 26px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-171 { --gossip-delay: 1197ms; --gossip-hop: 27px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-172 { --gossip-delay: 1204ms; --gossip-hop: 28px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-173 { --gossip-delay: 1211ms; --gossip-hop: 29px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-174 { --gossip-delay: 1218ms; --gossip-hop: 1px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-175 { --gossip-delay: 1225ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-176 { --gossip-delay: 1232ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-177 { --gossip-delay: 1239ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-178 { --gossip-delay: 1246ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-179 { --gossip-delay: 1253ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-180 { --gossip-delay: 1260ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-181 { --gossip-delay: 1267ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-182 { --gossip-delay: 1274ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-183 { --gossip-delay: 1281ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-184 { --gossip-delay: 1288ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-185 { --gossip-delay: 1295ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-186 { --gossip-delay: 1302ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-187 { --gossip-delay: 1309ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-188 { --gossip-delay: 1316ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-189 { --gossip-delay: 1323ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-190 { --gossip-delay: 1330ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-191 { --gossip-delay: 1337ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-192 { --gossip-delay: 1344ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-193 { --gossip-delay: 1351ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-194 { --gossip-delay: 1358ms; --gossip-hop: 21px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-195 { --gossip-delay: 1365ms; --gossip-hop: 22px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-196 { --gossip-delay: 1372ms; --gossip-hop: 23px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-197 { --gossip-delay: 1379ms; --gossip-hop: 24px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-198 { --gossip-delay: 1386ms; --gossip-hop: 25px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-199 { --gossip-delay: 1393ms; --gossip-hop: 26px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-200 { --gossip-delay: 1400ms; --gossip-hop: 27px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-201 { --gossip-delay: 1407ms; --gossip-hop: 28px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-202 { --gossip-delay: 1414ms; --gossip-hop: 29px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-203 { --gossip-delay: 1421ms; --gossip-hop: 1px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-204 { --gossip-delay: 1428ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-205 { --gossip-delay: 1435ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-206 { --gossip-delay: 1442ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-207 { --gossip-delay: 1449ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-208 { --gossip-delay: 1456ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-209 { --gossip-delay: 1463ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-210 { --gossip-delay: 1470ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-211 { --gossip-delay: 1477ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-212 { --gossip-delay: 1484ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-213 { --gossip-delay: 1491ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-214 { --gossip-delay: 1498ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-215 { --gossip-delay: 1505ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-216 { --gossip-delay: 1512ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-217 { --gossip-delay: 1519ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-218 { --gossip-delay: 1526ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-219 { --gossip-delay: 1533ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-220 { --gossip-delay: 1540ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-221 { --gossip-delay: 1547ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-222 { --gossip-delay: 1554ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-223 { --gossip-delay: 1561ms; --gossip-hop: 21px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-224 { --gossip-delay: 1568ms; --gossip-hop: 22px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-225 { --gossip-delay: 1575ms; --gossip-hop: 23px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-226 { --gossip-delay: 1582ms; --gossip-hop: 24px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-227 { --gossip-delay: 1589ms; --gossip-hop: 25px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-228 { --gossip-delay: 1596ms; --gossip-hop: 26px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-229 { --gossip-delay: 1603ms; --gossip-hop: 27px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-230 { --gossip-delay: 1610ms; --gossip-hop: 28px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-231 { --gossip-delay: 1617ms; --gossip-hop: 29px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-232 { --gossip-delay: 1624ms; --gossip-hop: 1px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-233 { --gossip-delay: 1631ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-234 { --gossip-delay: 1638ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-235 { --gossip-delay: 1645ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-236 { --gossip-delay: 1652ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-237 { --gossip-delay: 1659ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-238 { --gossip-delay: 1666ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-239 { --gossip-delay: 1673ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-240 { --gossip-delay: 1680ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-241 { --gossip-delay: 1687ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-242 { --gossip-delay: 1694ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-243 { --gossip-delay: 1701ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-244 { --gossip-delay: 1708ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-245 { --gossip-delay: 1715ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-246 { --gossip-delay: 1722ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-247 { --gossip-delay: 1729ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-248 { --gossip-delay: 1736ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-249 { --gossip-delay: 1743ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-250 { --gossip-delay: 1750ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-251 { --gossip-delay: 1757ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-252 { --gossip-delay: 1764ms; --gossip-hop: 21px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-253 { --gossip-delay: 1771ms; --gossip-hop: 22px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-254 { --gossip-delay: 1778ms; --gossip-hop: 23px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-255 { --gossip-delay: 1785ms; --gossip-hop: 24px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-256 { --gossip-delay: 1792ms; --gossip-hop: 25px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-257 { --gossip-delay: 1799ms; --gossip-hop: 26px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-258 { --gossip-delay: 1806ms; --gossip-hop: 27px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-259 { --gossip-delay: 1813ms; --gossip-hop: 28px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-260 { --gossip-delay: 1820ms; --gossip-hop: 29px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-261 { --gossip-delay: 1827ms; --gossip-hop: 1px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-262 { --gossip-delay: 1834ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-263 { --gossip-delay: 1841ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-264 { --gossip-delay: 1848ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-265 { --gossip-delay: 1855ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-266 { --gossip-delay: 1862ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-267 { --gossip-delay: 1869ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-268 { --gossip-delay: 1876ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-269 { --gossip-delay: 1883ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-270 { --gossip-delay: 1890ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-271 { --gossip-delay: 1897ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-272 { --gossip-delay: 1904ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-273 { --gossip-delay: 1911ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-274 { --gossip-delay: 1918ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-275 { --gossip-delay: 1925ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-276 { --gossip-delay: 1932ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-277 { --gossip-delay: 1939ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-278 { --gossip-delay: 1946ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-279 { --gossip-delay: 1953ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-280 { --gossip-delay: 1960ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-281 { --gossip-delay: 1967ms; --gossip-hop: 21px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-282 { --gossip-delay: 1974ms; --gossip-hop: 22px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-283 { --gossip-delay: 1981ms; --gossip-hop: 23px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-284 { --gossip-delay: 1988ms; --gossip-hop: 24px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-285 { --gossip-delay: 1995ms; --gossip-hop: 25px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-286 { --gossip-delay: 2002ms; --gossip-hop: 26px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-287 { --gossip-delay: 2009ms; --gossip-hop: 27px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-288 { --gossip-delay: 2016ms; --gossip-hop: 28px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-289 { --gossip-delay: 2023ms; --gossip-hop: 29px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-290 { --gossip-delay: 2030ms; --gossip-hop: 1px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-291 { --gossip-delay: 2037ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-292 { --gossip-delay: 2044ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-293 { --gossip-delay: 2051ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-294 { --gossip-delay: 2058ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-295 { --gossip-delay: 2065ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-296 { --gossip-delay: 2072ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-297 { --gossip-delay: 2079ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-298 { --gossip-delay: 2086ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-299 { --gossip-delay: 2093ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-300 { --gossip-delay: 2100ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-301 { --gossip-delay: 2107ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-302 { --gossip-delay: 2114ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-303 { --gossip-delay: 2121ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-304 { --gossip-delay: 2128ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-305 { --gossip-delay: 2135ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-306 { --gossip-delay: 2142ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-307 { --gossip-delay: 2149ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-308 { --gossip-delay: 2156ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-309 { --gossip-delay: 2163ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-310 { --gossip-delay: 2170ms; --gossip-hop: 21px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-311 { --gossip-delay: 2177ms; --gossip-hop: 22px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-312 { --gossip-delay: 2184ms; --gossip-hop: 23px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-313 { --gossip-delay: 2191ms; --gossip-hop: 24px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-314 { --gossip-delay: 2198ms; --gossip-hop: 25px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-315 { --gossip-delay: 2205ms; --gossip-hop: 26px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-316 { --gossip-delay: 2212ms; --gossip-hop: 27px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-317 { --gossip-delay: 2219ms; --gossip-hop: 28px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-318 { --gossip-delay: 2226ms; --gossip-hop: 29px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-319 { --gossip-delay: 2233ms; --gossip-hop: 1px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-320 { --gossip-delay: 2240ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-321 { --gossip-delay: 2247ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-322 { --gossip-delay: 2254ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-323 { --gossip-delay: 2261ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-324 { --gossip-delay: 2268ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-325 { --gossip-delay: 2275ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-326 { --gossip-delay: 2282ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-327 { --gossip-delay: 2289ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-328 { --gossip-delay: 2296ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-329 { --gossip-delay: 2303ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-330 { --gossip-delay: 2310ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-331 { --gossip-delay: 2317ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-332 { --gossip-delay: 2324ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-333 { --gossip-delay: 2331ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-334 { --gossip-delay: 2338ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-335 { --gossip-delay: 2345ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-336 { --gossip-delay: 2352ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-337 { --gossip-delay: 2359ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-338 { --gossip-delay: 2366ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-339 { --gossip-delay: 2373ms; --gossip-hop: 21px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-340 { --gossip-delay: 2380ms; --gossip-hop: 22px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-341 { --gossip-delay: 2387ms; --gossip-hop: 23px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-342 { --gossip-delay: 2394ms; --gossip-hop: 24px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-343 { --gossip-delay: 2401ms; --gossip-hop: 25px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-344 { --gossip-delay: 2408ms; --gossip-hop: 26px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-345 { --gossip-delay: 2415ms; --gossip-hop: 27px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-346 { --gossip-delay: 2422ms; --gossip-hop: 28px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-347 { --gossip-delay: 2429ms; --gossip-hop: 29px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-348 { --gossip-delay: 2436ms; --gossip-hop: 1px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-349 { --gossip-delay: 2443ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-350 { --gossip-delay: 2450ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-351 { --gossip-delay: 2457ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-352 { --gossip-delay: 2464ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-353 { --gossip-delay: 2471ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-354 { --gossip-delay: 2478ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-355 { --gossip-delay: 2485ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-356 { --gossip-delay: 2492ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-357 { --gossip-delay: 2499ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-358 { --gossip-delay: 2506ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-359 { --gossip-delay: 2513ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-360 { --gossip-delay: 2520ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-361 { --gossip-delay: 2527ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-362 { --gossip-delay: 2534ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-363 { --gossip-delay: 2541ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-364 { --gossip-delay: 2548ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-365 { --gossip-delay: 2555ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-366 { --gossip-delay: 2562ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-367 { --gossip-delay: 2569ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-368 { --gossip-delay: 2576ms; --gossip-hop: 21px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-369 { --gossip-delay: 2583ms; --gossip-hop: 22px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-370 { --gossip-delay: 2590ms; --gossip-hop: 23px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-371 { --gossip-delay: 2597ms; --gossip-hop: 24px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-372 { --gossip-delay: 2604ms; --gossip-hop: 25px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-373 { --gossip-delay: 2611ms; --gossip-hop: 26px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-374 { --gossip-delay: 2618ms; --gossip-hop: 27px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-375 { --gossip-delay: 2625ms; --gossip-hop: 28px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-376 { --gossip-delay: 2632ms; --gossip-hop: 29px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-377 { --gossip-delay: 2639ms; --gossip-hop: 1px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-378 { --gossip-delay: 2646ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-379 { --gossip-delay: 2653ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-380 { --gossip-delay: 2660ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-381 { --gossip-delay: 2667ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-382 { --gossip-delay: 2674ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-383 { --gossip-delay: 2681ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-384 { --gossip-delay: 2688ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-385 { --gossip-delay: 2695ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-386 { --gossip-delay: 2702ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-387 { --gossip-delay: 2709ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-388 { --gossip-delay: 2716ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-389 { --gossip-delay: 2723ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-390 { --gossip-delay: 2730ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-391 { --gossip-delay: 2737ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-392 { --gossip-delay: 2744ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-393 { --gossip-delay: 2751ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-394 { --gossip-delay: 2758ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-395 { --gossip-delay: 2765ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-396 { --gossip-delay: 2772ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-397 { --gossip-delay: 2779ms; --gossip-hop: 21px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-398 { --gossip-delay: 2786ms; --gossip-hop: 22px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-399 { --gossip-delay: 2793ms; --gossip-hop: 23px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-400 { --gossip-delay: 2800ms; --gossip-hop: 24px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-401 { --gossip-delay: 2807ms; --gossip-hop: 25px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-402 { --gossip-delay: 2814ms; --gossip-hop: 26px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-403 { --gossip-delay: 2821ms; --gossip-hop: 27px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-404 { --gossip-delay: 2828ms; --gossip-hop: 28px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-405 { --gossip-delay: 2835ms; --gossip-hop: 29px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-406 { --gossip-delay: 2842ms; --gossip-hop: 1px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-407 { --gossip-delay: 2849ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-408 { --gossip-delay: 2856ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-409 { --gossip-delay: 2863ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-410 { --gossip-delay: 2870ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-411 { --gossip-delay: 2877ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-412 { --gossip-delay: 2884ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-413 { --gossip-delay: 2891ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-414 { --gossip-delay: 2898ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-415 { --gossip-delay: 2905ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-416 { --gossip-delay: 2912ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-417 { --gossip-delay: 2919ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-418 { --gossip-delay: 2926ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-419 { --gossip-delay: 2933ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-420 { --gossip-delay: 2940ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-421 { --gossip-delay: 2947ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-422 { --gossip-delay: 2954ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-423 { --gossip-delay: 2961ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-424 { --gossip-delay: 2968ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-425 { --gossip-delay: 2975ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-426 { --gossip-delay: 2982ms; --gossip-hop: 21px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-427 { --gossip-delay: 2989ms; --gossip-hop: 22px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-428 { --gossip-delay: 2996ms; --gossip-hop: 23px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-429 { --gossip-delay: 3003ms; --gossip-hop: 24px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-430 { --gossip-delay: 3010ms; --gossip-hop: 25px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-431 { --gossip-delay: 3017ms; --gossip-hop: 26px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-432 { --gossip-delay: 3024ms; --gossip-hop: 27px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-433 { --gossip-delay: 3031ms; --gossip-hop: 28px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-434 { --gossip-delay: 3038ms; --gossip-hop: 29px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-435 { --gossip-delay: 3045ms; --gossip-hop: 1px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-436 { --gossip-delay: 3052ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-437 { --gossip-delay: 3059ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-438 { --gossip-delay: 3066ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-439 { --gossip-delay: 3073ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-440 { --gossip-delay: 3080ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-441 { --gossip-delay: 3087ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-442 { --gossip-delay: 3094ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-443 { --gossip-delay: 3101ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-444 { --gossip-delay: 3108ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-445 { --gossip-delay: 3115ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-446 { --gossip-delay: 3122ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-447 { --gossip-delay: 3129ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-448 { --gossip-delay: 3136ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-449 { --gossip-delay: 3143ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-450 { --gossip-delay: 3150ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-451 { --gossip-delay: 3157ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-452 { --gossip-delay: 3164ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-453 { --gossip-delay: 3171ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-454 { --gossip-delay: 3178ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-455 { --gossip-delay: 3185ms; --gossip-hop: 21px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-456 { --gossip-delay: 3192ms; --gossip-hop: 22px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-457 { --gossip-delay: 3199ms; --gossip-hop: 23px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-458 { --gossip-delay: 3206ms; --gossip-hop: 24px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-459 { --gossip-delay: 3213ms; --gossip-hop: 25px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-460 { --gossip-delay: 3220ms; --gossip-hop: 26px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-461 { --gossip-delay: 3227ms; --gossip-hop: 27px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-462 { --gossip-delay: 3234ms; --gossip-hop: 28px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-463 { --gossip-delay: 3241ms; --gossip-hop: 29px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-464 { --gossip-delay: 3248ms; --gossip-hop: 1px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-465 { --gossip-delay: 3255ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-466 { --gossip-delay: 3262ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-467 { --gossip-delay: 3269ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-468 { --gossip-delay: 3276ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-469 { --gossip-delay: 3283ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-470 { --gossip-delay: 3290ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-471 { --gossip-delay: 3297ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-472 { --gossip-delay: 3304ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-473 { --gossip-delay: 3311ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-474 { --gossip-delay: 3318ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-475 { --gossip-delay: 3325ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-476 { --gossip-delay: 3332ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-477 { --gossip-delay: 3339ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-478 { --gossip-delay: 3346ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-479 { --gossip-delay: 3353ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-480 { --gossip-delay: 3360ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-481 { --gossip-delay: 3367ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-482 { --gossip-delay: 3374ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-483 { --gossip-delay: 3381ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-484 { --gossip-delay: 3388ms; --gossip-hop: 21px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-485 { --gossip-delay: 3395ms; --gossip-hop: 22px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-486 { --gossip-delay: 3402ms; --gossip-hop: 23px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-487 { --gossip-delay: 3409ms; --gossip-hop: 24px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-488 { --gossip-delay: 3416ms; --gossip-hop: 25px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-489 { --gossip-delay: 3423ms; --gossip-hop: 26px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-490 { --gossip-delay: 3430ms; --gossip-hop: 27px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-491 { --gossip-delay: 3437ms; --gossip-hop: 28px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-492 { --gossip-delay: 3444ms; --gossip-hop: 29px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-493 { --gossip-delay: 3451ms; --gossip-hop: 1px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-494 { --gossip-delay: 3458ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-495 { --gossip-delay: 3465ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-496 { --gossip-delay: 3472ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-497 { --gossip-delay: 3479ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-498 { --gossip-delay: 3486ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-499 { --gossip-delay: 3493ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-500 { --gossip-delay: 3500ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-501 { --gossip-delay: 3507ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-502 { --gossip-delay: 3514ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-503 { --gossip-delay: 3521ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-504 { --gossip-delay: 3528ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-505 { --gossip-delay: 3535ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-506 { --gossip-delay: 3542ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-507 { --gossip-delay: 3549ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-508 { --gossip-delay: 3556ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-509 { --gossip-delay: 3563ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-510 { --gossip-delay: 3570ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-511 { --gossip-delay: 3577ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-512 { --gossip-delay: 3584ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-513 { --gossip-delay: 3591ms; --gossip-hop: 21px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-514 { --gossip-delay: 3598ms; --gossip-hop: 22px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-515 { --gossip-delay: 3605ms; --gossip-hop: 23px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-516 { --gossip-delay: 3612ms; --gossip-hop: 24px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-517 { --gossip-delay: 3619ms; --gossip-hop: 25px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-518 { --gossip-delay: 3626ms; --gossip-hop: 26px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-519 { --gossip-delay: 3633ms; --gossip-hop: 27px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-520 { --gossip-delay: 3640ms; --gossip-hop: 28px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-521 { --gossip-delay: 3647ms; --gossip-hop: 29px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-522 { --gossip-delay: 3654ms; --gossip-hop: 1px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-523 { --gossip-delay: 3661ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-524 { --gossip-delay: 3668ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-525 { --gossip-delay: 3675ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-526 { --gossip-delay: 3682ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-527 { --gossip-delay: 3689ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-528 { --gossip-delay: 3696ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-529 { --gossip-delay: 3703ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-530 { --gossip-delay: 3710ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-531 { --gossip-delay: 3717ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-532 { --gossip-delay: 3724ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-533 { --gossip-delay: 3731ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-534 { --gossip-delay: 3738ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-535 { --gossip-delay: 3745ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-536 { --gossip-delay: 3752ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-537 { --gossip-delay: 3759ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-538 { --gossip-delay: 3766ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-539 { --gossip-delay: 3773ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-540 { --gossip-delay: 3780ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-541 { --gossip-delay: 3787ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-542 { --gossip-delay: 3794ms; --gossip-hop: 21px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-543 { --gossip-delay: 3801ms; --gossip-hop: 22px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-544 { --gossip-delay: 3808ms; --gossip-hop: 23px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-545 { --gossip-delay: 3815ms; --gossip-hop: 24px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-546 { --gossip-delay: 3822ms; --gossip-hop: 25px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-547 { --gossip-delay: 3829ms; --gossip-hop: 26px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-548 { --gossip-delay: 3836ms; --gossip-hop: 27px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-549 { --gossip-delay: 3843ms; --gossip-hop: 28px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-550 { --gossip-delay: 3850ms; --gossip-hop: 29px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-551 { --gossip-delay: 3857ms; --gossip-hop: 1px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-552 { --gossip-delay: 3864ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-553 { --gossip-delay: 3871ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-554 { --gossip-delay: 3878ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-555 { --gossip-delay: 3885ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-556 { --gossip-delay: 3892ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-557 { --gossip-delay: 3899ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-558 { --gossip-delay: 3906ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-559 { --gossip-delay: 3913ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-560 { --gossip-delay: 3920ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-561 { --gossip-delay: 3927ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-562 { --gossip-delay: 3934ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-563 { --gossip-delay: 3941ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-564 { --gossip-delay: 3948ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-565 { --gossip-delay: 3955ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-566 { --gossip-delay: 3962ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-567 { --gossip-delay: 3969ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-568 { --gossip-delay: 3976ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-569 { --gossip-delay: 3983ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-570 { --gossip-delay: 3990ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-571 { --gossip-delay: 3997ms; --gossip-hop: 21px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-572 { --gossip-delay: 4004ms; --gossip-hop: 22px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-573 { --gossip-delay: 4011ms; --gossip-hop: 23px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-574 { --gossip-delay: 4018ms; --gossip-hop: 24px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-575 { --gossip-delay: 4025ms; --gossip-hop: 25px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-576 { --gossip-delay: 4032ms; --gossip-hop: 26px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-577 { --gossip-delay: 4039ms; --gossip-hop: 27px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-578 { --gossip-delay: 4046ms; --gossip-hop: 28px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-579 { --gossip-delay: 4053ms; --gossip-hop: 29px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-580 { --gossip-delay: 4060ms; --gossip-hop: 1px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-581 { --gossip-delay: 4067ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-582 { --gossip-delay: 4074ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-583 { --gossip-delay: 4081ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-584 { --gossip-delay: 4088ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-585 { --gossip-delay: 4095ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-586 { --gossip-delay: 4102ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-587 { --gossip-delay: 4109ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-588 { --gossip-delay: 4116ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-589 { --gossip-delay: 4123ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-590 { --gossip-delay: 4130ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-591 { --gossip-delay: 4137ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-592 { --gossip-delay: 4144ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-593 { --gossip-delay: 4151ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-594 { --gossip-delay: 4158ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-595 { --gossip-delay: 4165ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-596 { --gossip-delay: 4172ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-597 { --gossip-delay: 4179ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-598 { --gossip-delay: 4186ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-599 { --gossip-delay: 4193ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-600 { --gossip-delay: 4200ms; --gossip-hop: 21px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-601 { --gossip-delay: 4207ms; --gossip-hop: 22px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-602 { --gossip-delay: 4214ms; --gossip-hop: 23px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-603 { --gossip-delay: 4221ms; --gossip-hop: 24px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-604 { --gossip-delay: 4228ms; --gossip-hop: 25px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-605 { --gossip-delay: 4235ms; --gossip-hop: 26px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-606 { --gossip-delay: 4242ms; --gossip-hop: 27px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-607 { --gossip-delay: 4249ms; --gossip-hop: 28px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-608 { --gossip-delay: 4256ms; --gossip-hop: 29px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-609 { --gossip-delay: 4263ms; --gossip-hop: 1px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-610 { --gossip-delay: 4270ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-611 { --gossip-delay: 4277ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-612 { --gossip-delay: 4284ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-613 { --gossip-delay: 4291ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-614 { --gossip-delay: 4298ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-615 { --gossip-delay: 4305ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-616 { --gossip-delay: 4312ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-617 { --gossip-delay: 4319ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-618 { --gossip-delay: 4326ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-619 { --gossip-delay: 4333ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-620 { --gossip-delay: 4340ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-621 { --gossip-delay: 4347ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-622 { --gossip-delay: 4354ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-623 { --gossip-delay: 4361ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-624 { --gossip-delay: 4368ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-625 { --gossip-delay: 4375ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-626 { --gossip-delay: 4382ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-627 { --gossip-delay: 4389ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-628 { --gossip-delay: 4396ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-629 { --gossip-delay: 4403ms; --gossip-hop: 21px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-630 { --gossip-delay: 4410ms; --gossip-hop: 22px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-631 { --gossip-delay: 4417ms; --gossip-hop: 23px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-632 { --gossip-delay: 4424ms; --gossip-hop: 24px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-633 { --gossip-delay: 4431ms; --gossip-hop: 25px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-634 { --gossip-delay: 4438ms; --gossip-hop: 26px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-635 { --gossip-delay: 4445ms; --gossip-hop: 27px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-636 { --gossip-delay: 4452ms; --gossip-hop: 28px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-637 { --gossip-delay: 4459ms; --gossip-hop: 29px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-638 { --gossip-delay: 4466ms; --gossip-hop: 1px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-639 { --gossip-delay: 4473ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-640 { --gossip-delay: 4480ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-641 { --gossip-delay: 4487ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-642 { --gossip-delay: 4494ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-643 { --gossip-delay: 4501ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-644 { --gossip-delay: 4508ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-645 { --gossip-delay: 4515ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-646 { --gossip-delay: 4522ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-647 { --gossip-delay: 4529ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-648 { --gossip-delay: 4536ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-649 { --gossip-delay: 4543ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-650 { --gossip-delay: 4550ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-651 { --gossip-delay: 4557ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-652 { --gossip-delay: 4564ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-653 { --gossip-delay: 4571ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-654 { --gossip-delay: 4578ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-655 { --gossip-delay: 4585ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-656 { --gossip-delay: 4592ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-657 { --gossip-delay: 4599ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-658 { --gossip-delay: 4606ms; --gossip-hop: 21px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-659 { --gossip-delay: 4613ms; --gossip-hop: 22px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-660 { --gossip-delay: 4620ms; --gossip-hop: 23px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-661 { --gossip-delay: 4627ms; --gossip-hop: 24px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-662 { --gossip-delay: 4634ms; --gossip-hop: 25px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-663 { --gossip-delay: 4641ms; --gossip-hop: 26px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-664 { --gossip-delay: 4648ms; --gossip-hop: 27px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-665 { --gossip-delay: 4655ms; --gossip-hop: 28px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-666 { --gossip-delay: 4662ms; --gossip-hop: 29px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-667 { --gossip-delay: 4669ms; --gossip-hop: 1px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-668 { --gossip-delay: 4676ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-669 { --gossip-delay: 4683ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-670 { --gossip-delay: 4690ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-671 { --gossip-delay: 4697ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-672 { --gossip-delay: 4704ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-673 { --gossip-delay: 4711ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-674 { --gossip-delay: 4718ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-675 { --gossip-delay: 4725ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-676 { --gossip-delay: 4732ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-677 { --gossip-delay: 4739ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-678 { --gossip-delay: 4746ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-679 { --gossip-delay: 4753ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-680 { --gossip-delay: 4760ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-681 { --gossip-delay: 4767ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-682 { --gossip-delay: 4774ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-683 { --gossip-delay: 4781ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-684 { --gossip-delay: 4788ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-685 { --gossip-delay: 4795ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-686 { --gossip-delay: 4802ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-687 { --gossip-delay: 4809ms; --gossip-hop: 21px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-688 { --gossip-delay: 4816ms; --gossip-hop: 22px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-689 { --gossip-delay: 4823ms; --gossip-hop: 23px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-690 { --gossip-delay: 4830ms; --gossip-hop: 24px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-691 { --gossip-delay: 4837ms; --gossip-hop: 25px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-692 { --gossip-delay: 4844ms; --gossip-hop: 26px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-693 { --gossip-delay: 4851ms; --gossip-hop: 27px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-694 { --gossip-delay: 4858ms; --gossip-hop: 28px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-695 { --gossip-delay: 4865ms; --gossip-hop: 29px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-696 { --gossip-delay: 4872ms; --gossip-hop: 1px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-697 { --gossip-delay: 4879ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-698 { --gossip-delay: 4886ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-699 { --gossip-delay: 4893ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-700 { --gossip-delay: 4900ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-701 { --gossip-delay: 4907ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-702 { --gossip-delay: 4914ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-703 { --gossip-delay: 4921ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-704 { --gossip-delay: 4928ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-705 { --gossip-delay: 4935ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-706 { --gossip-delay: 4942ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-707 { --gossip-delay: 4949ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-708 { --gossip-delay: 4956ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-709 { --gossip-delay: 4963ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-710 { --gossip-delay: 4970ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-711 { --gossip-delay: 4977ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-712 { --gossip-delay: 4984ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-713 { --gossip-delay: 4991ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-714 { --gossip-delay: 4998ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-715 { --gossip-delay: 5005ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-716 { --gossip-delay: 5012ms; --gossip-hop: 21px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-717 { --gossip-delay: 5019ms; --gossip-hop: 22px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-718 { --gossip-delay: 5026ms; --gossip-hop: 23px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-719 { --gossip-delay: 5033ms; --gossip-hop: 24px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-720 { --gossip-delay: 5040ms; --gossip-hop: 25px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-721 { --gossip-delay: 5047ms; --gossip-hop: 26px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-722 { --gossip-delay: 5054ms; --gossip-hop: 27px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-723 { --gossip-delay: 5061ms; --gossip-hop: 28px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-724 { --gossip-delay: 5068ms; --gossip-hop: 29px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-725 { --gossip-delay: 5075ms; --gossip-hop: 1px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-726 { --gossip-delay: 5082ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-727 { --gossip-delay: 5089ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-728 { --gossip-delay: 5096ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-729 { --gossip-delay: 5103ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-730 { --gossip-delay: 5110ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-731 { --gossip-delay: 5117ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-732 { --gossip-delay: 5124ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-733 { --gossip-delay: 5131ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-734 { --gossip-delay: 5138ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-735 { --gossip-delay: 5145ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-736 { --gossip-delay: 5152ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-737 { --gossip-delay: 5159ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-738 { --gossip-delay: 5166ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-739 { --gossip-delay: 5173ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-740 { --gossip-delay: 5180ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-741 { --gossip-delay: 5187ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-742 { --gossip-delay: 5194ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-743 { --gossip-delay: 5201ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-744 { --gossip-delay: 5208ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-745 { --gossip-delay: 5215ms; --gossip-hop: 21px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-746 { --gossip-delay: 5222ms; --gossip-hop: 22px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-747 { --gossip-delay: 5229ms; --gossip-hop: 23px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-748 { --gossip-delay: 5236ms; --gossip-hop: 24px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-749 { --gossip-delay: 5243ms; --gossip-hop: 25px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-750 { --gossip-delay: 5250ms; --gossip-hop: 26px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-751 { --gossip-delay: 5257ms; --gossip-hop: 27px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-752 { --gossip-delay: 5264ms; --gossip-hop: 28px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-753 { --gossip-delay: 5271ms; --gossip-hop: 29px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-754 { --gossip-delay: 5278ms; --gossip-hop: 1px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-755 { --gossip-delay: 5285ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-756 { --gossip-delay: 5292ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-757 { --gossip-delay: 5299ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-758 { --gossip-delay: 5306ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-759 { --gossip-delay: 5313ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-760 { --gossip-delay: 5320ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-761 { --gossip-delay: 5327ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-762 { --gossip-delay: 5334ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-763 { --gossip-delay: 5341ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-764 { --gossip-delay: 5348ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-765 { --gossip-delay: 5355ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-766 { --gossip-delay: 5362ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-767 { --gossip-delay: 5369ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-768 { --gossip-delay: 5376ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-769 { --gossip-delay: 5383ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-770 { --gossip-delay: 5390ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-771 { --gossip-delay: 5397ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-772 { --gossip-delay: 5404ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-773 { --gossip-delay: 5411ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-774 { --gossip-delay: 5418ms; --gossip-hop: 21px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-775 { --gossip-delay: 5425ms; --gossip-hop: 22px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-776 { --gossip-delay: 5432ms; --gossip-hop: 23px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-777 { --gossip-delay: 5439ms; --gossip-hop: 24px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-778 { --gossip-delay: 5446ms; --gossip-hop: 25px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-779 { --gossip-delay: 5453ms; --gossip-hop: 26px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-780 { --gossip-delay: 5460ms; --gossip-hop: 27px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-781 { --gossip-delay: 5467ms; --gossip-hop: 28px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-782 { --gossip-delay: 5474ms; --gossip-hop: 29px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-783 { --gossip-delay: 5481ms; --gossip-hop: 1px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-784 { --gossip-delay: 5488ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-785 { --gossip-delay: 5495ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-786 { --gossip-delay: 5502ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-787 { --gossip-delay: 5509ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-788 { --gossip-delay: 5516ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-789 { --gossip-delay: 5523ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-790 { --gossip-delay: 5530ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-791 { --gossip-delay: 5537ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-792 { --gossip-delay: 5544ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-793 { --gossip-delay: 5551ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-794 { --gossip-delay: 5558ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-795 { --gossip-delay: 5565ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-796 { --gossip-delay: 5572ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-797 { --gossip-delay: 5579ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-798 { --gossip-delay: 5586ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-799 { --gossip-delay: 5593ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-800 { --gossip-delay: 5600ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-801 { --gossip-delay: 5607ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-802 { --gossip-delay: 5614ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-803 { --gossip-delay: 5621ms; --gossip-hop: 21px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-804 { --gossip-delay: 5628ms; --gossip-hop: 22px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-805 { --gossip-delay: 5635ms; --gossip-hop: 23px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-806 { --gossip-delay: 5642ms; --gossip-hop: 24px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-807 { --gossip-delay: 5649ms; --gossip-hop: 25px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-808 { --gossip-delay: 5656ms; --gossip-hop: 26px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-809 { --gossip-delay: 5663ms; --gossip-hop: 27px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-810 { --gossip-delay: 5670ms; --gossip-hop: 28px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-811 { --gossip-delay: 5677ms; --gossip-hop: 29px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-812 { --gossip-delay: 5684ms; --gossip-hop: 1px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-813 { --gossip-delay: 5691ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-814 { --gossip-delay: 5698ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-815 { --gossip-delay: 5705ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-816 { --gossip-delay: 5712ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-817 { --gossip-delay: 5719ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-818 { --gossip-delay: 5726ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-819 { --gossip-delay: 5733ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-820 { --gossip-delay: 5740ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-821 { --gossip-delay: 5747ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-822 { --gossip-delay: 5754ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-823 { --gossip-delay: 5761ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-824 { --gossip-delay: 5768ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-825 { --gossip-delay: 5775ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-826 { --gossip-delay: 5782ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-827 { --gossip-delay: 5789ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-828 { --gossip-delay: 5796ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-829 { --gossip-delay: 5803ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-830 { --gossip-delay: 5810ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-831 { --gossip-delay: 5817ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-832 { --gossip-delay: 5824ms; --gossip-hop: 21px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-833 { --gossip-delay: 5831ms; --gossip-hop: 22px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-834 { --gossip-delay: 5838ms; --gossip-hop: 23px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-835 { --gossip-delay: 5845ms; --gossip-hop: 24px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-836 { --gossip-delay: 5852ms; --gossip-hop: 25px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-837 { --gossip-delay: 5859ms; --gossip-hop: 26px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-838 { --gossip-delay: 5866ms; --gossip-hop: 27px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-839 { --gossip-delay: 5873ms; --gossip-hop: 28px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-840 { --gossip-delay: 5880ms; --gossip-hop: 29px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-841 { --gossip-delay: 5887ms; --gossip-hop: 1px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-842 { --gossip-delay: 5894ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-843 { --gossip-delay: 5901ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-844 { --gossip-delay: 5908ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-845 { --gossip-delay: 5915ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-846 { --gossip-delay: 5922ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-847 { --gossip-delay: 5929ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-848 { --gossip-delay: 5936ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-849 { --gossip-delay: 5943ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-850 { --gossip-delay: 5950ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-851 { --gossip-delay: 5957ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-852 { --gossip-delay: 5964ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-853 { --gossip-delay: 5971ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-854 { --gossip-delay: 5978ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-855 { --gossip-delay: 5985ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-856 { --gossip-delay: 5992ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-857 { --gossip-delay: 5999ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-858 { --gossip-delay: 6006ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-859 { --gossip-delay: 6013ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-860 { --gossip-delay: 6020ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-861 { --gossip-delay: 6027ms; --gossip-hop: 21px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-862 { --gossip-delay: 6034ms; --gossip-hop: 22px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-863 { --gossip-delay: 6041ms; --gossip-hop: 23px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-864 { --gossip-delay: 6048ms; --gossip-hop: 24px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-865 { --gossip-delay: 6055ms; --gossip-hop: 25px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-866 { --gossip-delay: 6062ms; --gossip-hop: 26px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-867 { --gossip-delay: 6069ms; --gossip-hop: 27px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-868 { --gossip-delay: 6076ms; --gossip-hop: 28px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-869 { --gossip-delay: 6083ms; --gossip-hop: 29px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-870 { --gossip-delay: 6090ms; --gossip-hop: 1px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-871 { --gossip-delay: 6097ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-872 { --gossip-delay: 6104ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-873 { --gossip-delay: 6111ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-874 { --gossip-delay: 6118ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-875 { --gossip-delay: 6125ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-876 { --gossip-delay: 6132ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-877 { --gossip-delay: 6139ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-878 { --gossip-delay: 6146ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-879 { --gossip-delay: 6153ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-880 { --gossip-delay: 6160ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-881 { --gossip-delay: 6167ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-882 { --gossip-delay: 6174ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-883 { --gossip-delay: 6181ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-884 { --gossip-delay: 6188ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-885 { --gossip-delay: 6195ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-886 { --gossip-delay: 6202ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-887 { --gossip-delay: 6209ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-888 { --gossip-delay: 6216ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-889 { --gossip-delay: 6223ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-890 { --gossip-delay: 6230ms; --gossip-hop: 21px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-891 { --gossip-delay: 6237ms; --gossip-hop: 22px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-892 { --gossip-delay: 6244ms; --gossip-hop: 23px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-893 { --gossip-delay: 6251ms; --gossip-hop: 24px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-894 { --gossip-delay: 6258ms; --gossip-hop: 25px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-895 { --gossip-delay: 6265ms; --gossip-hop: 26px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-896 { --gossip-delay: 6272ms; --gossip-hop: 27px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-897 { --gossip-delay: 6279ms; --gossip-hop: 28px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-898 { --gossip-delay: 6286ms; --gossip-hop: 29px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-899 { --gossip-delay: 6293ms; --gossip-hop: 1px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-900 { --gossip-delay: 6300ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-901 { --gossip-delay: 6307ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-902 { --gossip-delay: 6314ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-903 { --gossip-delay: 6321ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-904 { --gossip-delay: 6328ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-905 { --gossip-delay: 6335ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-906 { --gossip-delay: 6342ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-907 { --gossip-delay: 6349ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-908 { --gossip-delay: 6356ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-909 { --gossip-delay: 6363ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-910 { --gossip-delay: 6370ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-911 { --gossip-delay: 6377ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-912 { --gossip-delay: 6384ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-913 { --gossip-delay: 6391ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-914 { --gossip-delay: 6398ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-915 { --gossip-delay: 6405ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-916 { --gossip-delay: 6412ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-917 { --gossip-delay: 6419ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-918 { --gossip-delay: 6426ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-919 { --gossip-delay: 6433ms; --gossip-hop: 21px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-920 { --gossip-delay: 6440ms; --gossip-hop: 22px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-921 { --gossip-delay: 6447ms; --gossip-hop: 23px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-922 { --gossip-delay: 6454ms; --gossip-hop: 24px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-923 { --gossip-delay: 6461ms; --gossip-hop: 25px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-924 { --gossip-delay: 6468ms; --gossip-hop: 26px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-925 { --gossip-delay: 6475ms; --gossip-hop: 27px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-926 { --gossip-delay: 6482ms; --gossip-hop: 28px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-927 { --gossip-delay: 6489ms; --gossip-hop: 29px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-928 { --gossip-delay: 6496ms; --gossip-hop: 1px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-929 { --gossip-delay: 6503ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-930 { --gossip-delay: 6510ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-931 { --gossip-delay: 6517ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-932 { --gossip-delay: 6524ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-933 { --gossip-delay: 6531ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-934 { --gossip-delay: 6538ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-935 { --gossip-delay: 6545ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-936 { --gossip-delay: 6552ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-937 { --gossip-delay: 6559ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-938 { --gossip-delay: 6566ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-939 { --gossip-delay: 6573ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-940 { --gossip-delay: 6580ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-941 { --gossip-delay: 6587ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-942 { --gossip-delay: 6594ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-943 { --gossip-delay: 6601ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-944 { --gossip-delay: 6608ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-945 { --gossip-delay: 6615ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-946 { --gossip-delay: 6622ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-947 { --gossip-delay: 6629ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-948 { --gossip-delay: 6636ms; --gossip-hop: 21px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-949 { --gossip-delay: 6643ms; --gossip-hop: 22px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-950 { --gossip-delay: 6650ms; --gossip-hop: 23px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-951 { --gossip-delay: 6657ms; --gossip-hop: 24px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-952 { --gossip-delay: 6664ms; --gossip-hop: 25px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-953 { --gossip-delay: 6671ms; --gossip-hop: 26px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-954 { --gossip-delay: 6678ms; --gossip-hop: 27px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-955 { --gossip-delay: 6685ms; --gossip-hop: 28px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-956 { --gossip-delay: 6692ms; --gossip-hop: 29px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-957 { --gossip-delay: 6699ms; --gossip-hop: 1px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-958 { --gossip-delay: 6706ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-959 { --gossip-delay: 6713ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-960 { --gossip-delay: 6720ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-961 { --gossip-delay: 6727ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-962 { --gossip-delay: 6734ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-963 { --gossip-delay: 6741ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-964 { --gossip-delay: 6748ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-965 { --gossip-delay: 6755ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-966 { --gossip-delay: 6762ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-967 { --gossip-delay: 6769ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-968 { --gossip-delay: 6776ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-969 { --gossip-delay: 6783ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-970 { --gossip-delay: 6790ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-971 { --gossip-delay: 6797ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-972 { --gossip-delay: 6804ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-973 { --gossip-delay: 6811ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-974 { --gossip-delay: 6818ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-975 { --gossip-delay: 6825ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-976 { --gossip-delay: 6832ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-977 { --gossip-delay: 6839ms; --gossip-hop: 21px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-978 { --gossip-delay: 6846ms; --gossip-hop: 22px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-979 { --gossip-delay: 6853ms; --gossip-hop: 23px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-980 { --gossip-delay: 6860ms; --gossip-hop: 24px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-981 { --gossip-delay: 6867ms; --gossip-hop: 25px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-982 { --gossip-delay: 6874ms; --gossip-hop: 26px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-983 { --gossip-delay: 6881ms; --gossip-hop: 27px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-984 { --gossip-delay: 6888ms; --gossip-hop: 28px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-985 { --gossip-delay: 6895ms; --gossip-hop: 29px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-986 { --gossip-delay: 6902ms; --gossip-hop: 1px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-987 { --gossip-delay: 6909ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-988 { --gossip-delay: 6916ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-989 { --gossip-delay: 6923ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-990 { --gossip-delay: 6930ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-991 { --gossip-delay: 6937ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-992 { --gossip-delay: 6944ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-993 { --gossip-delay: 6951ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-994 { --gossip-delay: 6958ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-995 { --gossip-delay: 6965ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-996 { --gossip-delay: 6972ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-997 { --gossip-delay: 6979ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-998 { --gossip-delay: 6986ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-999 { --gossip-delay: 6993ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1000 { --gossip-delay: 7000ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1001 { --gossip-delay: 7007ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1002 { --gossip-delay: 7014ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1003 { --gossip-delay: 7021ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1004 { --gossip-delay: 7028ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1005 { --gossip-delay: 7035ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1006 { --gossip-delay: 7042ms; --gossip-hop: 21px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1007 { --gossip-delay: 7049ms; --gossip-hop: 22px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1008 { --gossip-delay: 7056ms; --gossip-hop: 23px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1009 { --gossip-delay: 7063ms; --gossip-hop: 24px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1010 { --gossip-delay: 7070ms; --gossip-hop: 25px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1011 { --gossip-delay: 7077ms; --gossip-hop: 26px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1012 { --gossip-delay: 7084ms; --gossip-hop: 27px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1013 { --gossip-delay: 7091ms; --gossip-hop: 28px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1014 { --gossip-delay: 7098ms; --gossip-hop: 29px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1015 { --gossip-delay: 7105ms; --gossip-hop: 1px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1016 { --gossip-delay: 7112ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1017 { --gossip-delay: 7119ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1018 { --gossip-delay: 7126ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1019 { --gossip-delay: 7133ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1020 { --gossip-delay: 7140ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1021 { --gossip-delay: 7147ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1022 { --gossip-delay: 7154ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1023 { --gossip-delay: 7161ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1024 { --gossip-delay: 7168ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1025 { --gossip-delay: 7175ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1026 { --gossip-delay: 7182ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1027 { --gossip-delay: 7189ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1028 { --gossip-delay: 7196ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1029 { --gossip-delay: 7203ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1030 { --gossip-delay: 7210ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1031 { --gossip-delay: 7217ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1032 { --gossip-delay: 7224ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1033 { --gossip-delay: 7231ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1034 { --gossip-delay: 7238ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1035 { --gossip-delay: 7245ms; --gossip-hop: 21px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1036 { --gossip-delay: 7252ms; --gossip-hop: 22px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1037 { --gossip-delay: 7259ms; --gossip-hop: 23px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1038 { --gossip-delay: 7266ms; --gossip-hop: 24px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1039 { --gossip-delay: 7273ms; --gossip-hop: 25px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1040 { --gossip-delay: 7280ms; --gossip-hop: 26px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1041 { --gossip-delay: 7287ms; --gossip-hop: 27px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1042 { --gossip-delay: 7294ms; --gossip-hop: 28px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1043 { --gossip-delay: 7301ms; --gossip-hop: 29px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1044 { --gossip-delay: 7308ms; --gossip-hop: 1px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1045 { --gossip-delay: 7315ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1046 { --gossip-delay: 7322ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1047 { --gossip-delay: 7329ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1048 { --gossip-delay: 7336ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1049 { --gossip-delay: 7343ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1050 { --gossip-delay: 7350ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1051 { --gossip-delay: 7357ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1052 { --gossip-delay: 7364ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1053 { --gossip-delay: 7371ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1054 { --gossip-delay: 7378ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1055 { --gossip-delay: 7385ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1056 { --gossip-delay: 7392ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1057 { --gossip-delay: 7399ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1058 { --gossip-delay: 7406ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1059 { --gossip-delay: 7413ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1060 { --gossip-delay: 7420ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1061 { --gossip-delay: 7427ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1062 { --gossip-delay: 7434ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1063 { --gossip-delay: 7441ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1064 { --gossip-delay: 7448ms; --gossip-hop: 21px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1065 { --gossip-delay: 7455ms; --gossip-hop: 22px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1066 { --gossip-delay: 7462ms; --gossip-hop: 23px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1067 { --gossip-delay: 7469ms; --gossip-hop: 24px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1068 { --gossip-delay: 7476ms; --gossip-hop: 25px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1069 { --gossip-delay: 7483ms; --gossip-hop: 26px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1070 { --gossip-delay: 7490ms; --gossip-hop: 27px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1071 { --gossip-delay: 7497ms; --gossip-hop: 28px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1072 { --gossip-delay: 7504ms; --gossip-hop: 29px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1073 { --gossip-delay: 7511ms; --gossip-hop: 1px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1074 { --gossip-delay: 7518ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1075 { --gossip-delay: 7525ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1076 { --gossip-delay: 7532ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1077 { --gossip-delay: 7539ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1078 { --gossip-delay: 7546ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1079 { --gossip-delay: 7553ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1080 { --gossip-delay: 7560ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1081 { --gossip-delay: 7567ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1082 { --gossip-delay: 7574ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1083 { --gossip-delay: 7581ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1084 { --gossip-delay: 7588ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1085 { --gossip-delay: 7595ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1086 { --gossip-delay: 7602ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1087 { --gossip-delay: 7609ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1088 { --gossip-delay: 7616ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1089 { --gossip-delay: 7623ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1090 { --gossip-delay: 7630ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1091 { --gossip-delay: 7637ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1092 { --gossip-delay: 7644ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1093 { --gossip-delay: 7651ms; --gossip-hop: 21px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1094 { --gossip-delay: 7658ms; --gossip-hop: 22px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1095 { --gossip-delay: 7665ms; --gossip-hop: 23px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1096 { --gossip-delay: 7672ms; --gossip-hop: 24px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1097 { --gossip-delay: 7679ms; --gossip-hop: 25px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1098 { --gossip-delay: 7686ms; --gossip-hop: 26px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1099 { --gossip-delay: 7693ms; --gossip-hop: 27px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1100 { --gossip-delay: 7700ms; --gossip-hop: 28px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1101 { --gossip-delay: 7707ms; --gossip-hop: 29px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1102 { --gossip-delay: 7714ms; --gossip-hop: 1px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1103 { --gossip-delay: 7721ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1104 { --gossip-delay: 7728ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1105 { --gossip-delay: 7735ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1106 { --gossip-delay: 7742ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1107 { --gossip-delay: 7749ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1108 { --gossip-delay: 7756ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1109 { --gossip-delay: 7763ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1110 { --gossip-delay: 7770ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1111 { --gossip-delay: 7777ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1112 { --gossip-delay: 7784ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1113 { --gossip-delay: 7791ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1114 { --gossip-delay: 7798ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1115 { --gossip-delay: 7805ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1116 { --gossip-delay: 7812ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1117 { --gossip-delay: 7819ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1118 { --gossip-delay: 7826ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1119 { --gossip-delay: 7833ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1120 { --gossip-delay: 7840ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1121 { --gossip-delay: 7847ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1122 { --gossip-delay: 7854ms; --gossip-hop: 21px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1123 { --gossip-delay: 7861ms; --gossip-hop: 22px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1124 { --gossip-delay: 7868ms; --gossip-hop: 23px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1125 { --gossip-delay: 7875ms; --gossip-hop: 24px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1126 { --gossip-delay: 7882ms; --gossip-hop: 25px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1127 { --gossip-delay: 7889ms; --gossip-hop: 26px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1128 { --gossip-delay: 7896ms; --gossip-hop: 27px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1129 { --gossip-delay: 7903ms; --gossip-hop: 28px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1130 { --gossip-delay: 7910ms; --gossip-hop: 29px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1131 { --gossip-delay: 7917ms; --gossip-hop: 1px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1132 { --gossip-delay: 7924ms; --gossip-hop: 2px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1133 { --gossip-delay: 7931ms; --gossip-hop: 3px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1134 { --gossip-delay: 7938ms; --gossip-hop: 4px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1135 { --gossip-delay: 7945ms; --gossip-hop: 5px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1136 { --gossip-delay: 7952ms; --gossip-hop: 6px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1137 { --gossip-delay: 7959ms; --gossip-hop: 7px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1138 { --gossip-delay: 7966ms; --gossip-hop: 8px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1139 { --gossip-delay: 7973ms; --gossip-hop: 9px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1140 { --gossip-delay: 7980ms; --gossip-hop: 10px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1141 { --gossip-delay: 7987ms; --gossip-hop: 11px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1142 { --gossip-delay: 7994ms; --gossip-hop: 12px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1143 { --gossip-delay: 8001ms; --gossip-hop: 13px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1144 { --gossip-delay: 8008ms; --gossip-hop: 14px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1145 { --gossip-delay: 8015ms; --gossip-hop: 15px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1146 { --gossip-delay: 8022ms; --gossip-hop: 16px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1147 { --gossip-delay: 8029ms; --gossip-hop: 17px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1148 { --gossip-delay: 8036ms; --gossip-hop: 18px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1149 { --gossip-delay: 8043ms; --gossip-hop: 19px; animation-delay: calc(var(--gossip-delay) * -1); }
+.gossip-node-1150 { --gossip-delay: 8050ms; --gossip-hop: 20px; animation-delay: calc(var(--gossip-delay) * -1); }


### PR DESCRIPTION
## Summary
- add a pure HTML/CSS gossip membership convergence animation example
- visualize heartbeat gossip, suspect states, member-map convergence, and incarnation hops
- keep the contribution scoped to one examples submission folder

## Validation
- generated from an existing validated examples template
- text scan verified old topic terms were replaced
- contribution adds 3 files under submissions/examples/gossip-membership-convergence-kp