### PR TITLE
feat: implement CSS Torn Bottom Card #70934

### DIFF
--- a/submissions/examples/css-torn-bottom-card/README.md
+++ b/submissions/examples/css-torn-bottom-card/README.md
@@ -1,0 +1,13 @@
+# CSS Torn Bottom Card (#70934)
+
+A card component featuring a CSS torn and jagged bottom edge effect, built entirely without JavaScript.
+
+## Features
+- **Semantic Structure:** Uses `<article>` with accessibility support and keyboard navigation.
+- **Pure CSS Styling:** Utilizes repeating linear gradients to form a clean, custom jagged bottom edge.
+- **Responsive Layout:** Adapts seamlessly across all standard device viewports.
+
+## File Hierarchy
+- `style.css` - Card layout, typography, and torn edge styling.
+- `demo.html` - Semantic markup and accessible structure.
+- `README.md` - Technical specification and architecture overview.

--- a/submissions/examples/css-torn-bottom-card/demo.html
+++ b/submissions/examples/css-torn-bottom-card/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Torn Bottom Card | EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<article class="torn-card" tabindex="0" aria-label="Torn Bottom Card Component">
+    <div class="torn-content">
+        <span class="torn-tag">Exclusive Ticket</span>
+        <h2 class="torn-title">VIP Access Pass</h2>
+        <p class="torn-description">Experience the main stage event with front-row privileges, backstage entry, and complimentary refreshments.</p>
+    </div>
+    <div class="torn-bottom-edge" aria-hidden="true"></div>
+</article>
+
+</body>
+</html>

--- a/submissions/examples/css-torn-bottom-card/style.css
+++ b/submissions/examples/css-torn-bottom-card/style.css
@@ -1,0 +1,81 @@
+/* CSS Torn Bottom Card #70934 */
+
+:root {
+    --card-bg: #1e293b;
+    --card-border: #334155;
+    --accent-orange: #f97316;
+    --text-main: #f8fafc;
+    --text-sub: #94a3b8;
+}
+
+* { box-sizing: border-box; }
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: system-ui, -apple-system, sans-serif;
+    background-color: #0f172a;
+    color: var(--text-main);
+    padding: 2rem;
+}
+
+.torn-card {
+    background-color: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 0.75rem 0.75rem 0 0;
+    width: 100%;
+    max-width: 360px;
+    position: relative;
+    overflow: hidden;
+    box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.3);
+    transition: transform 0.3s ease;
+}
+
+.torn-card:hover {
+    transform: translateY(-4px);
+}
+
+.torn-content {
+    padding: 2rem;
+}
+
+.torn-tag {
+    display: inline-block;
+    background: rgba(249, 115, 22, 0.15);
+    color: var(--accent-orange);
+    padding: 0.25rem 0.75rem;
+    border-radius: 1rem;
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 1rem;
+}
+
+.torn-title {
+    font-size: 1.25rem;
+    margin: 0 0 0.75rem 0;
+    font-weight: 700;
+}
+
+.torn-description {
+    color: var(--text-sub);
+    font-size: 0.9rem;
+    line-height: 1.6;
+    margin: 0;
+}
+
+/* Torn / jagged bottom edge using a linear gradient mask or SVG/mask pattern */
+.torn-bottom-edge {
+    height: 16px;
+    background-color: var(--card-bg);
+    width: 100%;
+    background-image: linear-gradient(135deg, transparent 50%, var(--card-bg) 50%), 
+                      linear-gradient(45deg, transparent 50%, var(--card-bg) 50%);
+    background-size: 16px 16px;
+    background-repeat: repeat-x;
+    position: relative;
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the **CSS Torn Bottom Card** component (#70934).
gssoc 26

Closes #70934

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component / motion pattern
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/css-torn-bottom-card/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] Pure CSS implementation with zero JavaScript
- [x] Accessible with proper ARIA attributes, keyboard navigation support

---

## Feature Description
**What does this add?**
A card component featuring a CSS torn/jagged bottom edge effect.

**How does it work?**
Constructed using CSS gradient patterns to achieve a jagged paper-tear aesthetic at the base of the card without external images or JavaScript.