### PR TITLE
feat: implement CSS Ripped Paper Card #70810

### DIFF
--- a/submissions/examples/css-ripped-paper-card/README.md
+++ b/submissions/examples/css-ripped-paper-card/README.md
@@ -1,0 +1,13 @@
+# CSS Ripped Paper Card (#70810)
+
+A card component featuring a custom ripped and torn paper top edge decoration, designed completely without JavaScript.
+
+## Features
+- **Semantic Structure:** Uses `<article>` with full keyboard navigation and accessibility support.
+- **Pure CSS Styling:** Utilizes repeating linear gradients to simulate a realistic ripped paper top border.
+- **Responsive Design:** Adapts smoothly across various device viewports.
+
+## File Hierarchy
+- `style.css` - Component design, variables, and ripped top edge styling.
+- `demo.html` - Semantic markup and accessible structure.
+- `README.md` - Technical specification and architecture overview.

--- a/submissions/examples/css-ripped-paper-card/demo.html
+++ b/submissions/examples/css-ripped-paper-card/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Ripped Paper Card | EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<article class="ripped-card" tabindex="0" aria-label="Ripped Paper Card Component">
+    <div class="ripped-top-edge" aria-hidden="true"></div>
+    <div class="ripped-content">
+        <span class="ripped-tag">Limited Edition</span>
+        <h2 class="ripped-title">Vintage Ticket Voucher</h2>
+        <p class="ripped-description">Handcrafted note style card featuring an authentic ripped paper top edge decoration built with pure CSS.</p>
+        <div class="ripped-footer">
+            <span>Valid thru 2026</span>
+            <a href="#redeem" class="ripped-action">Redeem</a>
+        </div>
+    </div>
+</article>
+
+</body>
+</html>

--- a/submissions/examples/css-ripped-paper-card/style.css
+++ b/submissions/examples/css-ripped-paper-card/style.css
@@ -1,0 +1,105 @@
+/* CSS Ripped Paper Card #70810 */
+
+:root {
+    --card-bg: #fdfbf7;
+    --card-text: #1e293b;
+    --card-sub: #64748b;
+    --accent-red: #e11d48;
+    --border-color: #e2e8f0;
+}
+
+* { box-sizing: border-box; }
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: system-ui, -apple-system, sans-serif;
+    background-color: #0f172a;
+    color: var(--card-text);
+    padding: 2rem;
+}
+
+.ripped-card {
+    background-color: var(--card-bg);
+    border-radius: 0 0 0.75rem 0.75rem;
+    width: 100%;
+    max-width: 380px;
+    position: relative;
+    box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.3);
+    overflow: hidden;
+    transition: transform 0.3s ease;
+}
+
+.ripped-card:hover {
+    transform: translateY(-4px);
+}
+
+/* Ripped top edge decoration using repeating gradients */
+.ripped-top-edge {
+    height: 14px;
+    background-color: var(--card-bg);
+    width: 100%;
+    background-image: linear-gradient(135deg, transparent 50%, var(--card-bg) 50%), 
+                      linear-gradient(45deg, transparent 50%, var(--card-bg) 50%);
+    background-size: 14px 14px;
+    background-repeat: repeat-x;
+    position: relative;
+}
+
+.ripped-content {
+    padding: 2rem;
+}
+
+.ripped-tag {
+    display: inline-block;
+    background: rgba(225, 29, 72, 0.1);
+    color: var(--accent-red);
+    padding: 0.25rem 0.75rem;
+    border-radius: 1rem;
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 1rem;
+}
+
+.ripped-title {
+    font-size: 1.35rem;
+    margin: 0 0 0.75rem 0;
+    font-weight: 700;
+    color: var(--card-text);
+}
+
+.ripped-description {
+    color: var(--card-sub);
+    font-size: 0.95rem;
+    line-height: 1.6;
+    margin: 0 0 1.5rem 0;
+}
+
+.ripped-footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding-top: 1rem;
+    border-top: 1px solid var(--border-color);
+    font-size: 0.85rem;
+    color: var(--card-sub);
+}
+
+.ripped-action {
+    background-color: var(--card-text);
+    color: #fdfbf7;
+    padding: 0.5rem 1rem;
+    border-radius: 0.375rem;
+    text-decoration: none;
+    font-weight: 600;
+    transition: opacity 0.2s ease;
+}
+
+.ripped-action:hover {
+    opacity: 0.9;
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the **CSS Ripped Paper Card** component (#70810).
gssoc 26

Closes #70810

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component / motion pattern
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/css-ripped-paper-card/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] Pure CSS implementation with zero JavaScript
- [x] Accessible with proper ARIA attributes, keyboard navigation support

---

## Feature Description
**What does this add?**
Card with a ripped/torn paper top edge decoration.

**How does it work?**
Constructed using CSS repeating linear gradients to render a precise ripped paper aesthetic along the top border of the card without external images or scripts.