### PR TITLE
feat: add CSS ripped paper card

### DIFF
--- a/submissions/examples/r-ripped-paper-card-70810/README.md
+++ b/submissions/examples/r-ripped-paper-card-70810/README.md
@@ -1,0 +1,39 @@
+# CSS Ripped Paper Card
+
+A paper-inspired card component with a torn top edge created
+entirely with CSS.
+
+## Features
+
+- Pure HTML and CSS
+- CSS `clip-path` ripped paper effect
+- Paper texture styling
+- Decorative tape element
+- Responsive design
+- Hover lift animation
+- Semantic HTML structure
+- Keyboard focus styling
+- Reduced-motion support
+- No JavaScript required
+
+## Files
+
+- `demo.html` — Demo markup and card content
+- `style.css` — Component styling and ripped-edge effect
+
+## How It Works
+
+The torn paper effect is created using CSS `clip-path` with
+multiple polygon points:
+
+```css
+clip-path: polygon(
+  0 0,
+  3% 45%,
+  6% 20%,
+  9% 65%,
+  12% 30%,
+  15% 75%,
+  100% 60%,
+  100% 0
+);

--- a/submissions/examples/r-ripped-paper-card-70810/demo.html
+++ b/submissions/examples/r-ripped-paper-card-70810/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS ripped paper card component">
+  <title>Ripped Paper Card</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="page">
+    <section class="intro">
+      <span class="eyebrow">EaseMotion CSS</span>
+      <h1>Ripped Paper Card</h1>
+      <p>
+        A paper-inspired card featuring a decorative torn top edge
+        created entirely with CSS.
+      </p>
+    </section>
+
+    <section class="card-area" aria-label="Ripped paper card example">
+      <article class="paper-card">
+        <div class="paper-tape" aria-hidden="true"></div>
+
+        <div class="card-content">
+          <span class="card-label">Creative Note</span>
+
+          <h2>Make Something<br>Worth Remembering.</h2>
+
+          <p>
+            Simple ideas can become meaningful experiences when thoughtful
+            design, motion, and creativity come together.
+          </p>
+
+          <div class="card-footer">
+            <span>CSS Collection</span>
+            <span aria-hidden="true">✦</span>
+          </div>
+        </div>
+      </article>
+    </section>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/r-ripped-paper-card-70810/style.css
+++ b/submissions/examples/r-ripped-paper-card-70810/style.css
@@ -1,0 +1,659 @@
+:root {
+  --bg: #111827;
+  --paper: #fff8e7;
+  --paper-shadow: rgba(0, 0, 0, 0.35);
+  --text: #292524;
+  --muted: #57534e;
+  --accent: #ea580c;
+  --accent-light: #fed7aa;
+  --line: rgba(87, 83, 78, 0.2);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: #f8fafc;
+  background:
+    radial-gradient(
+      circle at 15% 15%,
+      rgba(234, 88, 12, 0.15),
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at 85% 85%,
+      rgba(251, 191, 36, 0.1),
+      transparent 30%
+    ),
+    var(--bg);
+}
+
+.page {
+  width: min(900px, 92%);
+  margin: 0 auto;
+  padding: 75px 0;
+}
+
+.intro {
+  max-width: 650px;
+  margin: 0 auto 55px;
+  text-align: center;
+}
+
+.eyebrow {
+  display: inline-block;
+  margin-bottom: 15px;
+  padding: 7px 14px;
+  border: 1px solid rgba(251, 146, 60, 0.3);
+  border-radius: 999px;
+  color: #fdba74;
+  background: rgba(234, 88, 12, 0.1);
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.intro h1 {
+  margin-bottom: 16px;
+  font-size: clamp(2.4rem, 6vw, 4.2rem);
+  line-height: 1;
+  letter-spacing: -0.05em;
+  background: linear-gradient(
+    135deg,
+    #fff,
+    #fed7aa,
+    #fb923c
+  );
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.intro p {
+  color: #9ca3af;
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.card-area {
+  display: flex;
+  justify-content: center;
+  padding: 25px 0 45px;
+}
+
+.paper-card {
+  position: relative;
+  width: min(620px, 100%);
+  color: var(--text);
+  background: var(--paper);
+  box-shadow:
+    0 25px 50px var(--paper-shadow),
+    0 5px 10px rgba(0, 0, 0, 0.15);
+  transform: rotate(-1.2deg);
+  transition:
+    transform 0.4s ease,
+    box-shadow 0.4s ease;
+}
+
+/*
+ * Torn paper edge.
+ * Multiple polygon points create an irregular paper tear.
+ */
+.paper-card::before {
+  content: "";
+  position: absolute;
+  z-index: 2;
+  top: -1px;
+  right: 0;
+  left: 0;
+  height: 22px;
+  background: var(--paper);
+  clip-path: polygon(
+    0 0,
+    3% 45%,
+    6% 20%,
+    9% 65%,
+    12% 30%,
+    15% 75%,
+    18% 35%,
+    21% 68%,
+    24% 25%,
+    27% 72%,
+    30% 38%,
+    33% 80%,
+    36% 30%,
+    39% 67%,
+    42% 20%,
+    45% 72%,
+    48% 34%,
+    51% 78%,
+    54% 25%,
+    57% 70%,
+    60% 32%,
+    63% 76%,
+    66% 22%,
+    69% 67%,
+    72% 35%,
+    75% 78%,
+    78% 27%,
+    81% 70%,
+    84% 30%,
+    87% 73%,
+    90% 25%,
+    93% 68%,
+    96% 32%,
+    100% 60%,
+    100% 0
+  );
+}
+
+.paper-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    repeating-linear-gradient(
+      0deg,
+      transparent 0,
+      transparent 4px,
+      rgba(120, 53, 15, 0.025) 5px
+    );
+}
+
+.paper-card:hover {
+  transform: rotate(0deg) translateY(-8px);
+  box-shadow:
+    0 35px 65px rgba(0, 0, 0, 0.42),
+    0 8px 15px rgba(0, 0, 0, 0.18);
+}
+
+.card-content {
+  position: relative;
+  z-index: 3;
+  padding: 65px 55px 45px;
+}
+
+.paper-tape {
+  position: absolute;
+  z-index: 4;
+  top: -16px;
+  left: 50%;
+  width: 125px;
+  height: 38px;
+  transform: translateX(-50%) rotate(2deg);
+  background: rgba(251, 191, 36, 0.55);
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.08);
+  opacity: 0.9;
+}
+
+.paper-tape::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+    90deg,
+    transparent 0,
+    transparent 7px,
+    rgba(255, 255, 255, 0.14) 8px
+  );
+}
+
+.card-label {
+  display: inline-block;
+  margin-bottom: 18px;
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.card-content h2 {
+  margin-bottom: 22px;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(2rem, 5vw, 3.2rem);
+  line-height: 1.05;
+  letter-spacing: -0.04em;
+}
+
+.card-content p {
+  max-width: 500px;
+  margin-bottom: 35px;
+  color: var(--muted);
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 1.05rem;
+  line-height: 1.8;
+}
+
+.card-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-top: 20px;
+  border-top: 1px dashed var(--line);
+  color: #78716c;
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.card-footer span:last-child {
+  color: var(--accent);
+  font-size: 1.2rem;
+}
+
+/* Accessibility */
+
+.paper-card:focus-within {
+  outline: 3px solid rgba(251, 146, 60, 0.6);
+  outline-offset: 6px;
+}
+
+/* Tablet */
+
+@media (max-width: 650px) {
+  .page {
+    padding: 55px 0;
+  }
+
+  .card-content {
+    padding: 58px 38px 38px;
+  }
+}
+
+/* Mobile */
+
+@media (max-width: 480px) {
+  .page {
+    width: 90%;
+  }
+
+  .intro h1 {
+    font-size: 2.4rem;
+  }
+
+  .intro p {
+    font-size: 0.95rem;
+  }
+
+  .paper-card {
+    transform: rotate(0);
+  }
+
+  .paper-card:hover {
+    transform: translateY(-5px);
+  }
+
+  .card-content {
+    padding: 55px 25px 30px;
+  }
+
+  .card-content h2 {
+    font-size: 2rem;
+  }
+
+  .card-content p {
+    font-size: 0.98rem;
+  }
+
+  .paper-tape {
+    width: 100px;
+  }
+}
+
+/* Reduced motion */
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}
+
+:root {
+  --bg: #111827;
+  --paper: #fff8e7;
+  --paper-shadow: rgba(0, 0, 0, 0.35);
+  --text: #292524;
+  --muted: #57534e;
+  --accent: #ea580c;
+  --accent-light: #fed7aa;
+  --line: rgba(87, 83, 78, 0.2);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: #f8fafc;
+  background:
+    radial-gradient(
+      circle at 15% 15%,
+      rgba(234, 88, 12, 0.15),
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at 85% 85%,
+      rgba(251, 191, 36, 0.1),
+      transparent 30%
+    ),
+    var(--bg);
+}
+
+.page {
+  width: min(900px, 92%);
+  margin: 0 auto;
+  padding: 75px 0;
+}
+
+.intro {
+  max-width: 650px;
+  margin: 0 auto 55px;
+  text-align: center;
+}
+
+.eyebrow {
+  display: inline-block;
+  margin-bottom: 15px;
+  padding: 7px 14px;
+  border: 1px solid rgba(251, 146, 60, 0.3);
+  border-radius: 999px;
+  color: #fdba74;
+  background: rgba(234, 88, 12, 0.1);
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.intro h1 {
+  margin-bottom: 16px;
+  font-size: clamp(2.4rem, 6vw, 4.2rem);
+  line-height: 1;
+  letter-spacing: -0.05em;
+  background: linear-gradient(
+    135deg,
+    #fff,
+    #fed7aa,
+    #fb923c
+  );
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.intro p {
+  color: #9ca3af;
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.card-area {
+  display: flex;
+  justify-content: center;
+  padding: 25px 0 45px;
+}
+
+.paper-card {
+  position: relative;
+  width: min(620px, 100%);
+  color: var(--text);
+  background: var(--paper);
+  box-shadow:
+    0 25px 50px var(--paper-shadow),
+    0 5px 10px rgba(0, 0, 0, 0.15);
+  transform: rotate(-1.2deg);
+  transition:
+    transform 0.4s ease,
+    box-shadow 0.4s ease;
+}
+
+/*
+ * Torn paper edge.
+ * Multiple polygon points create an irregular paper tear.
+ */
+.paper-card::before {
+  content: "";
+  position: absolute;
+  z-index: 2;
+  top: -1px;
+  right: 0;
+  left: 0;
+  height: 22px;
+  background: var(--paper);
+  clip-path: polygon(
+    0 0,
+    3% 45%,
+    6% 20%,
+    9% 65%,
+    12% 30%,
+    15% 75%,
+    18% 35%,
+    21% 68%,
+    24% 25%,
+    27% 72%,
+    30% 38%,
+    33% 80%,
+    36% 30%,
+    39% 67%,
+    42% 20%,
+    45% 72%,
+    48% 34%,
+    51% 78%,
+    54% 25%,
+    57% 70%,
+    60% 32%,
+    63% 76%,
+    66% 22%,
+    69% 67%,
+    72% 35%,
+    75% 78%,
+    78% 27%,
+    81% 70%,
+    84% 30%,
+    87% 73%,
+    90% 25%,
+    93% 68%,
+    96% 32%,
+    100% 60%,
+    100% 0
+  );
+}
+
+.paper-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    repeating-linear-gradient(
+      0deg,
+      transparent 0,
+      transparent 4px,
+      rgba(120, 53, 15, 0.025) 5px
+    );
+}
+
+.paper-card:hover {
+  transform: rotate(0deg) translateY(-8px);
+  box-shadow:
+    0 35px 65px rgba(0, 0, 0, 0.42),
+    0 8px 15px rgba(0, 0, 0, 0.18);
+}
+
+.card-content {
+  position: relative;
+  z-index: 3;
+  padding: 65px 55px 45px;
+}
+
+.paper-tape {
+  position: absolute;
+  z-index: 4;
+  top: -16px;
+  left: 50%;
+  width: 125px;
+  height: 38px;
+  transform: translateX(-50%) rotate(2deg);
+  background: rgba(251, 191, 36, 0.55);
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.08);
+  opacity: 0.9;
+}
+
+.paper-tape::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+    90deg,
+    transparent 0,
+    transparent 7px,
+    rgba(255, 255, 255, 0.14) 8px
+  );
+}
+
+.card-label {
+  display: inline-block;
+  margin-bottom: 18px;
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.card-content h2 {
+  margin-bottom: 22px;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(2rem, 5vw, 3.2rem);
+  line-height: 1.05;
+  letter-spacing: -0.04em;
+}
+
+.card-content p {
+  max-width: 500px;
+  margin-bottom: 35px;
+  color: var(--muted);
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 1.05rem;
+  line-height: 1.8;
+}
+
+.card-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-top: 20px;
+  border-top: 1px dashed var(--line);
+  color: #78716c;
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.card-footer span:last-child {
+  color: var(--accent);
+  font-size: 1.2rem;
+}
+
+/* Accessibility */
+
+.paper-card:focus-within {
+  outline: 3px solid rgba(251, 146, 60, 0.6);
+  outline-offset: 6px;
+}
+
+/* Tablet */
+
+@media (max-width: 650px) {
+  .page {
+    padding: 55px 0;
+  }
+
+  .card-content {
+    padding: 58px 38px 38px;
+  }
+}
+
+/* Mobile */
+
+@media (max-width: 480px) {
+  .page {
+    width: 90%;
+  }
+
+  .intro h1 {
+    font-size: 2.4rem;
+  }
+
+  .intro p {
+    font-size: 0.95rem;
+  }
+
+  .paper-card {
+    transform: rotate(0);
+  }
+
+  .paper-card:hover {
+    transform: translateY(-5px);
+  }
+
+  .card-content {
+    padding: 55px 25px 30px;
+  }
+
+  .card-content h2 {
+    font-size: 2rem;
+  }
+
+  .card-content p {
+    font-size: 0.98rem;
+  }
+
+  .paper-tape {
+    width: 100px;
+  }
+}
+
+/* Reduced motion */
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}


### PR DESCRIPTION
## Description

Implemented the CSS Ripped Paper Card for issue #70810.

### Changes

- Added a paper-style card component.
- Created the torn top edge using CSS `clip-path`.
- Added decorative paper tape.
- Added subtle paper texture using CSS gradients.
- Added hover lift interaction.
- Added responsive mobile and tablet layouts.
- Added keyboard focus styling.
- Added reduced-motion support.
- Added README documentation.

### Files Added

- `submissions/examples/r-ripped-paper-card-70810/demo.html`
- `submissions/examples/r-ripped-paper-card-70810/style.css`
- `submissions/examples/r-ripped-paper-card-70810/README.md`

### Testing

- Tested desktop and mobile layouts.
- Verified ripped paper edge rendering.
- Verified hover animation.
- Verified responsive behavior.
- Verified reduced-motion support.

Closes #70810