### PR TITLE
feat: implement CSS Recovery Score Ring #70803

### DIFF
--- a/submissions/examples/css-recovery-score-ring/README.md
+++ b/submissions/examples/css-recovery-score-ring/README.md
@@ -1,0 +1,13 @@
+# CSS Recovery Score Ring (#70803)
+
+A circular recovery score ring component featuring color gradients and smooth metrics display, built entirely without JavaScript.
+
+## Features
+- **Semantic Structure:** Uses `<article>` with accessibility support and descriptive ARIA labelling.
+- **Pure CSS Styling:** Styled using SVG circle stroke-dashoffset properties, linear gradients, and modern variables.
+- **Responsive Layout:** Fluidly scales across all screen viewports.
+
+## File Hierarchy
+- `style.css` - Ring styles, gradients, and typography layout.
+- `demo.html` - Semantic markup and accessible vector integration.
+- `README.md` - Technical specification and architecture overview.

--- a/submissions/examples/css-recovery-score-ring/demo.html
+++ b/submissions/examples/css-recovery-score-ring/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Recovery Score Ring | EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<article class="recovery-card" tabindex="0" aria-label="Recovery Score: 82 Percent, Optimal">
+    <h1 class="recovery-title">Daily Recovery Score</h1>
+    
+    <div class="ring-container" aria-hidden="true">
+        <svg class="ring-svg" viewBox="0 0 160 160">
+            <defs>
+                <linearGradient id="emeraldGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+                    <stop offset="0%" stop-color="#34d399" />
+                    <stop offset="100%" stop-color="#059669" />
+                </linearGradient>
+            </defs>
+            <circle class="ring-track" cx="80" cy="80" r="70" />
+            <circle class="ring-progress" cx="80" cy="80" r="70" />
+        </svg>
+        <div class="ring-content">
+            <span class="ring-score">82%</span>
+            <span class="ring-label">Optimal</span>
+        </div>
+    </div>
+
+    <div class="recovery-status">Ready for high performance</div>
+</article>
+
+</body>
+</html>

--- a/submissions/examples/css-recovery-score-ring/style.css
+++ b/submissions/examples/css-recovery-score-ring/style.css
@@ -1,0 +1,105 @@
+/* CSS Recovery Score Ring #70803 */
+
+:root {
+    --bg-color: #090d16;
+    --card-bg: #111827;
+    --card-border: #1f2937;
+    --accent-emerald: #10b981;
+    --ring-bg: rgba(255, 255, 255, 0.05);
+    --text-main: #f8fafc;
+    --text-sub: #94a3b8;
+}
+
+* { box-sizing: border-box; }
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: system-ui, -apple-system, sans-serif;
+    background-color: var(--bg-color);
+    color: var(--text-main);
+    padding: 2rem;
+}
+
+.recovery-card {
+    background-color: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 1rem;
+    padding: 2.5rem;
+    width: 100%;
+    max-width: 360px;
+    text-align: center;
+    box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.4);
+}
+
+.recovery-title {
+    font-size: 1.25rem;
+    font-weight: 700;
+    margin: 0 0 2rem 0;
+}
+
+.ring-container {
+    position: relative;
+    width: 160px;
+    height: 160px;
+    margin: 0 auto 2rem auto;
+}
+
+.ring-svg {
+    width: 100%;
+    height: 100%;
+    transform: rotate(-90deg);
+}
+
+.ring-track {
+    fill: none;
+    stroke: var(--ring-bg);
+    stroke-width: 10;
+}
+
+.ring-progress {
+    fill: none;
+    stroke: url(#emeraldGradient);
+    stroke-width: 10;
+    stroke-linecap: round;
+    stroke-dasharray: 440;
+    stroke-dashoffset: 88; /* Represents 80% progress (440 * 0.2) */
+    transition: stroke-dashoffset 1s ease;
+}
+
+.ring-content {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+}
+
+.ring-score {
+    font-size: 2.5rem;
+    font-weight: 800;
+    margin: 0;
+    color: var(--text-main);
+}
+
+.ring-label {
+    font-size: 0.8rem;
+    color: var(--text-sub);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-top: 0.25rem;
+}
+
+.recovery-status {
+    background: rgba(16, 185, 129, 0.1);
+    color: var(--accent-emerald);
+    padding: 0.5rem 1rem;
+    border-radius: 2rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+    display: inline-block;
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the **CSS Recovery Score Ring** component (#70803).
gssoc 26

Closes #70803

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component / motion pattern
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/css-recovery-score-ring/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] Pure CSS implementation with zero JavaScript
- [x] Accessible with proper ARIA attributes, keyboard navigation support

---

## Feature Description
**What does this add?**
Recovery score circular ring with color gradient and centered metric readout.

**How does it work?**
Constructed using an inline SVG circular progress bar with gradient definitions and stroke dash properties, paired with a clean CSS card layout without JavaScript dependencies.