### PR TITLE
feat: add CSS monochrome hover nav

### DIFF
--- a/submissions/examples/r-monochrome-hover-nav-70811/README.md
+++ b/submissions/examples/r-monochrome-hover-nav-70811/README.md
@@ -1,0 +1,35 @@
+# CSS Monochrome Hover Nav
+
+A minimalist navigation component where the selected navigation
+item becomes visually prominent while neighboring items are
+softly desaturated.
+
+## Features
+
+- Pure HTML and CSS
+- Monochrome visual design
+- Neighbor desaturation on hover
+- Keyboard focus interaction
+- Smooth hover transitions
+- Animated arrow indicator
+- Responsive layout
+- Semantic navigation markup
+- Reduced-motion support
+- No JavaScript required
+
+## Files
+
+- `demo.html` — Navigation markup and demonstration
+- `style.css` — Complete component styling
+
+## How It Works
+
+The navigation uses the CSS `:has()` selector together with
+sibling selectors to detect when a navigation item is hovered
+or focused.
+
+```css
+.mono-nav:has(.nav-item:hover) .nav-item:not(:hover) {
+  opacity: 0.32;
+  filter: grayscale(1);
+}

--- a/submissions/examples/r-monochrome-hover-nav-70811/demo.html
+++ b/submissions/examples/r-monochrome-hover-nav-70811/demo.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="CSS monochrome hover navigation">
+  <title>Monochrome Hover Nav</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="page">
+    <section class="intro">
+      <span class="eyebrow">EaseMotion CSS</span>
+      <h1>Monochrome Hover Nav</h1>
+      <p>
+        Hover or focus a navigation item to highlight it while
+        softly desaturating its neighbors.
+      </p>
+    </section>
+
+    <nav class="mono-nav" aria-label="Main navigation">
+      <a href="#home" class="nav-item active">
+        <span class="nav-number">01</span>
+        <span class="nav-label">Home</span>
+        <span class="nav-arrow" aria-hidden="true">↗</span>
+      </a>
+
+      <a href="#work" class="nav-item">
+        <span class="nav-number">02</span>
+        <span class="nav-label">Work</span>
+        <span class="nav-arrow" aria-hidden="true">↗</span>
+      </a>
+
+      <a href="#studio" class="nav-item">
+        <span class="nav-number">03</span>
+        <span class="nav-label">Studio</span>
+        <span class="nav-arrow" aria-hidden="true">↗</span>
+      </a>
+
+      <a href="#journal" class="nav-item">
+        <span class="nav-number">04</span>
+        <span class="nav-label">Journal</span>
+        <span class="nav-arrow" aria-hidden="true">↗</span>
+      </a>
+
+      <a href="#contact" class="nav-item">
+        <span class="nav-number">05</span>
+        <span class="nav-label">Contact</span>
+        <span class="nav-arrow" aria-hidden="true">↗</span>
+      </a>
+    </nav>
+
+    <p class="hint">Hover or tab through the navigation</p>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/r-monochrome-hover-nav-70811/style.css
+++ b/submissions/examples/r-monochrome-hover-nav-70811/style.css
@@ -1,0 +1,599 @@
+:root {
+  --bg: #0a0a0a;
+  --surface: #151515;
+  --border: #2b2b2b;
+  --text: #f5f5f5;
+  --muted: #777;
+  --accent: #ffffff;
+  --transition: 0.4s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  min-height: 100vh;
+  color: var(--text);
+  background:
+    radial-gradient(
+      circle at 50% 0%,
+      #202020 0,
+      transparent 35%
+    ),
+    var(--bg);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.page {
+  width: min(950px, 92%);
+  min-height: 100vh;
+  margin: 0 auto;
+  padding: 90px 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.intro {
+  max-width: 700px;
+  margin: 0 auto 55px;
+  text-align: center;
+}
+
+.eyebrow {
+  display: inline-block;
+  margin-bottom: 18px;
+  padding: 7px 14px;
+  border: 1px solid #333;
+  border-radius: 999px;
+  color: #aaa;
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.intro h1 {
+  margin-bottom: 17px;
+  font-size: clamp(2.5rem, 7vw, 5rem);
+  line-height: 0.98;
+  letter-spacing: -0.06em;
+}
+
+.intro p {
+  max-width: 590px;
+  margin: 0 auto;
+  color: #8b8b8b;
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.mono-nav {
+  position: relative;
+  width: 100%;
+  max-width: 780px;
+  margin: 0 auto;
+  border-top: 1px solid var(--border);
+}
+
+.nav-item {
+  position: relative;
+  display: grid;
+  grid-template-columns: 70px 1fr 45px;
+  align-items: center;
+  min-height: 82px;
+  padding: 0 24px;
+  overflow: hidden;
+  color: var(--text);
+  border-bottom: 1px solid var(--border);
+  text-decoration: none;
+  transition:
+    color var(--transition),
+    background-color var(--transition),
+    opacity var(--transition),
+    filter var(--transition),
+    transform var(--transition);
+}
+
+.nav-item::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  background: #f5f5f5;
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform var(--transition);
+}
+
+.nav-number {
+  color: #666;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  transition: color var(--transition);
+}
+
+.nav-label {
+  font-size: clamp(1.5rem, 4vw, 2.5rem);
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  transition:
+    transform var(--transition),
+    color var(--transition);
+}
+
+.nav-arrow {
+  justify-self: end;
+  color: #777;
+  font-size: 1.25rem;
+  opacity: 0;
+  transform: translate(-10px, 10px);
+  transition:
+    opacity var(--transition),
+    transform var(--transition),
+    color var(--transition);
+}
+
+/*
+ * When one item is hovered/focused, its neighbors are
+ * softened using sibling selectors.
+ */
+.mono-nav:has(.nav-item:hover) .nav-item:not(:hover),
+.mono-nav:has(.nav-item:focus-visible) .nav-item:not(:focus-visible) {
+  opacity: 0.32;
+  filter: grayscale(1);
+}
+
+.nav-item:hover,
+.nav-item:focus-visible {
+  color: #0a0a0a;
+  outline: none;
+}
+
+.nav-item:hover::before,
+.nav-item:focus-visible::before {
+  transform: scaleX(1);
+}
+
+.nav-item:hover .nav-number,
+.nav-item:focus-visible .nav-number {
+  color: #555;
+}
+
+.nav-item:hover .nav-label,
+.nav-item:focus-visible .nav-label {
+  transform: translateX(12px);
+}
+
+.nav-item:hover .nav-arrow,
+.nav-item:focus-visible .nav-arrow {
+  color: #0a0a0a;
+  opacity: 1;
+  transform: translate(0, 0);
+}
+
+.nav-item:focus-visible {
+  box-shadow: inset 0 0 0 3px #7dd3fc;
+}
+
+/* Active state */
+
+.nav-item.active {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.nav-item.active .nav-number {
+  color: #aaa;
+}
+
+/* Fallback for browsers without :has() */
+
+@supports not selector(:has(*)) {
+  .nav-item:hover,
+  .nav-item:focus-visible {
+    opacity: 1;
+    filter: none;
+  }
+}
+
+.hint {
+  margin-top: 28px;
+  color: #555;
+  text-align: center;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+/* Tablet */
+
+@media (max-width: 700px) {
+  .page {
+    padding: 65px 0;
+  }
+
+  .intro {
+    margin-bottom: 40px;
+  }
+
+  .nav-item {
+    grid-template-columns: 55px 1fr 35px;
+    min-height: 72px;
+    padding: 0 18px;
+  }
+
+  .nav-label {
+    font-size: 1.7rem;
+  }
+}
+
+/* Mobile */
+
+@media (max-width: 480px) {
+  .page {
+    width: 90%;
+  }
+
+  .intro h1 {
+    font-size: 2.6rem;
+  }
+
+  .intro p {
+    font-size: 0.9rem;
+  }
+
+  .nav-item {
+    grid-template-columns: 42px 1fr 25px;
+    min-height: 65px;
+    padding: 0 12px;
+  }
+
+  .nav-number {
+    font-size: 0.65rem;
+  }
+
+  .nav-label {
+    font-size: 1.4rem;
+  }
+
+  .nav-arrow {
+    font-size: 1rem;
+  }
+
+  .nav-item:hover .nav-label,
+  .nav-item:focus-visible .nav-label {
+    transform: translateX(6px);
+  }
+}
+
+/* Reduced motion */
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+  }
+}
+:root {
+  --bg: #0a0a0a;
+  --surface: #151515;
+  --border: #2b2b2b;
+  --text: #f5f5f5;
+  --muted: #777;
+  --accent: #ffffff;
+  --transition: 0.4s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  min-height: 100vh;
+  color: var(--text);
+  background:
+    radial-gradient(
+      circle at 50% 0%,
+      #202020 0,
+      transparent 35%
+    ),
+    var(--bg);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.page {
+  width: min(950px, 92%);
+  min-height: 100vh;
+  margin: 0 auto;
+  padding: 90px 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.intro {
+  max-width: 700px;
+  margin: 0 auto 55px;
+  text-align: center;
+}
+
+.eyebrow {
+  display: inline-block;
+  margin-bottom: 18px;
+  padding: 7px 14px;
+  border: 1px solid #333;
+  border-radius: 999px;
+  color: #aaa;
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.intro h1 {
+  margin-bottom: 17px;
+  font-size: clamp(2.5rem, 7vw, 5rem);
+  line-height: 0.98;
+  letter-spacing: -0.06em;
+}
+
+.intro p {
+  max-width: 590px;
+  margin: 0 auto;
+  color: #8b8b8b;
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.mono-nav {
+  position: relative;
+  width: 100%;
+  max-width: 780px;
+  margin: 0 auto;
+  border-top: 1px solid var(--border);
+}
+
+.nav-item {
+  position: relative;
+  display: grid;
+  grid-template-columns: 70px 1fr 45px;
+  align-items: center;
+  min-height: 82px;
+  padding: 0 24px;
+  overflow: hidden;
+  color: var(--text);
+  border-bottom: 1px solid var(--border);
+  text-decoration: none;
+  transition:
+    color var(--transition),
+    background-color var(--transition),
+    opacity var(--transition),
+    filter var(--transition),
+    transform var(--transition);
+}
+
+.nav-item::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  background: #f5f5f5;
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform var(--transition);
+}
+
+.nav-number {
+  color: #666;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  transition: color var(--transition);
+}
+
+.nav-label {
+  font-size: clamp(1.5rem, 4vw, 2.5rem);
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  transition:
+    transform var(--transition),
+    color var(--transition);
+}
+
+.nav-arrow {
+  justify-self: end;
+  color: #777;
+  font-size: 1.25rem;
+  opacity: 0;
+  transform: translate(-10px, 10px);
+  transition:
+    opacity var(--transition),
+    transform var(--transition),
+    color var(--transition);
+}
+
+/*
+ * When one item is hovered/focused, its neighbors are
+ * softened using sibling selectors.
+ */
+.mono-nav:has(.nav-item:hover) .nav-item:not(:hover),
+.mono-nav:has(.nav-item:focus-visible) .nav-item:not(:focus-visible) {
+  opacity: 0.32;
+  filter: grayscale(1);
+}
+
+.nav-item:hover,
+.nav-item:focus-visible {
+  color: #0a0a0a;
+  outline: none;
+}
+
+.nav-item:hover::before,
+.nav-item:focus-visible::before {
+  transform: scaleX(1);
+}
+
+.nav-item:hover .nav-number,
+.nav-item:focus-visible .nav-number {
+  color: #555;
+}
+
+.nav-item:hover .nav-label,
+.nav-item:focus-visible .nav-label {
+  transform: translateX(12px);
+}
+
+.nav-item:hover .nav-arrow,
+.nav-item:focus-visible .nav-arrow {
+  color: #0a0a0a;
+  opacity: 1;
+  transform: translate(0, 0);
+}
+
+.nav-item:focus-visible {
+  box-shadow: inset 0 0 0 3px #7dd3fc;
+}
+
+/* Active state */
+
+.nav-item.active {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.nav-item.active .nav-number {
+  color: #aaa;
+}
+
+/* Fallback for browsers without :has() */
+
+@supports not selector(:has(*)) {
+  .nav-item:hover,
+  .nav-item:focus-visible {
+    opacity: 1;
+    filter: none;
+  }
+}
+
+.hint {
+  margin-top: 28px;
+  color: #555;
+  text-align: center;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+/* Tablet */
+
+@media (max-width: 700px) {
+  .page {
+    padding: 65px 0;
+  }
+
+  .intro {
+    margin-bottom: 40px;
+  }
+
+  .nav-item {
+    grid-template-columns: 55px 1fr 35px;
+    min-height: 72px;
+    padding: 0 18px;
+  }
+
+  .nav-label {
+    font-size: 1.7rem;
+  }
+}
+
+/* Mobile */
+
+@media (max-width: 480px) {
+  .page {
+    width: 90%;
+  }
+
+  .intro h1 {
+    font-size: 2.6rem;
+  }
+
+  .intro p {
+    font-size: 0.9rem;
+  }
+
+  .nav-item {
+    grid-template-columns: 42px 1fr 25px;
+    min-height: 65px;
+    padding: 0 12px;
+  }
+
+  .nav-number {
+    font-size: 0.65rem;
+  }
+
+  .nav-label {
+    font-size: 1.4rem;
+  }
+
+  .nav-arrow {
+    font-size: 1rem;
+  }
+
+  .nav-item:hover .nav-label,
+  .nav-item:focus-visible .nav-label {
+    transform: translateX(6px);
+  }
+}
+
+/* Reduced motion */
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+  }
+}
+
+
+
+
+


### PR DESCRIPTION
## Description

Implemented the CSS Monochrome Hover Nav for issue #70811.

### Changes

- Added a monochrome navigation component.
- Added neighbor desaturation on hover and focus.
- Added smooth highlighted background animation.
- Added animated navigation arrows.
- Added keyboard focus styling.
- Added responsive desktop, tablet, and mobile layouts.
- Added reduced-motion support.
- Added `:has()` fallback behavior.
- Added README documentation.

### Files Added

- `submissions/examples/r-monochrome-hover-nav-70811/demo.html`
- `submissions/examples/r-monochrome-hover-nav-70811/style.css`
- `submissions/examples/r-monochrome-hover-nav-70811/README.md`

### Testing

- Tested hover interactions.
- Tested keyboard navigation.
- Tested responsive layouts.
- Verified neighbor desaturation effect.
- Verified reduced-motion behavior.

Closes #70811