### PR TITLE
feat: implement CSS Damage Number Float #70798

### DIFF
--- a/submissions/examples/css-damage-number-float/README.md
+++ b/submissions/examples/css-damage-number-float/README.md
@@ -1,0 +1,13 @@
+# CSS Damage Number Float (#70798)
+
+An RPG-style floating damage number animation component built entirely with pure CSS.
+
+## Features
+- **Semantic Structure:** Uses accessible `<main>` container markup with decorative combat indicators hidden from screen readers.
+- **Pure CSS Keyframes:** Smooth upward floating, scaling, and opacity fade animations.
+- **Responsive Layout:** Cleanly framed inside a modern card component scaling across viewports.
+
+## File Hierarchy
+- `style.css` - Keyframe animations, styling, and combat typography layout.
+- `demo.html` - Semantic markup and accessibility attributes.
+- `README.md` - Technical specification and architecture summary.

--- a/submissions/examples/css-damage-number-float/demo.html
+++ b/submissions/examples/css-damage-number-float/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Damage Number Float | EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<main class="arena-card" tabindex="0" aria-label="RPG Damage Number Float Demonstration">
+    <h1 class="arena-title">Combat Arena</h1>
+    <p class="arena-subtitle">Simulated RPG floating damage numbers</p>
+    
+    <div class="target-dummy" aria-hidden="true">
+        🛡️
+        <span class="damage-number normal">-425</span>
+        <span class="damage-number crit">1,280!</span>
+    </div>
+
+    <p class="arena-info">Zero JavaScript animation using pure CSS keyframes and transforms.</p>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/css-damage-number-float/style.css
+++ b/submissions/examples/css-damage-number-float/style.css
@@ -1,0 +1,110 @@
+/* CSS Damage Number Float #70798 */
+
+:root {
+    --bg-color: #090d16;
+    --card-bg: #111827;
+    --card-border: #1f2937;
+    --accent-red: #ef4444;
+    --accent-crit: #f59e0b;
+    --text-main: #f8fafc;
+    --text-sub: #94a3b8;
+}
+
+* { box-sizing: border-box; }
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: system-ui, -apple-system, sans-serif;
+    background-color: var(--bg-color);
+    color: var(--text-main);
+    padding: 2rem;
+}
+
+.arena-card {
+    background-color: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 1rem;
+    padding: 3rem;
+    width: 100%;
+    max-width: 450px;
+    text-align: center;
+    box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.4);
+    position: relative;
+    overflow: hidden;
+}
+
+.arena-title {
+    font-size: 1.5rem;
+    font-weight: 800;
+    margin: 0 0 0.5rem 0;
+}
+
+.arena-subtitle {
+    color: var(--text-sub);
+    font-size: 0.9rem;
+    margin: 0 0 2rem 0;
+}
+
+.target-dummy {
+    width: 100px;
+    height: 100px;
+    background: linear-gradient(135deg, #1e293b, #0f172a);
+    border: 2px dashed var(--card-border);
+    border-radius: 50%;
+    margin: 0 auto 2rem auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 2rem;
+    position: relative;
+}
+
+/* Floating Damage Number Animations */
+.damage-number {
+    position: absolute;
+    font-weight: 900;
+    font-size: 1.5rem;
+    pointer-events: none;
+    user-select: none;
+    animation: floatUp 1.5s ease-out infinite;
+}
+
+.damage-number.normal {
+    color: var(--accent-red);
+    top: 20%;
+    left: 55%;
+    animation-delay: 0s;
+}
+
+.damage-number.crit {
+    color: var(--accent-crit);
+    font-size: 2.25rem;
+    top: 10%;
+    left: 35%;
+    animation-delay: 0.75s;
+    text-shadow: 0 0 10px rgba(245, 158, 11, 0.5);
+}
+
+@keyframes floatUp {
+    0% {
+        transform: translateY(0) scale(0.8);
+        opacity: 0;
+    }
+    20% {
+        transform: translateY(-10px) scale(1.2);
+        opacity: 1;
+    }
+    100% {
+        transform: translateY(-60px) scale(1);
+        opacity: 0;
+    }
+}
+
+.arena-info {
+    font-size: 0.85rem;
+    color: var(--text-sub);
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the **CSS Damage Number Float** component (#70798).
gssoc 26
Closes #70798

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component / motion pattern
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/css-damage-number-float/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] Pure CSS implementation with zero JavaScript
- [x] Accessible with proper ARIA attributes, keyboard navigation support

---

## Feature Description
**What does this add?**
RPG-style damage numbers that float upward, scale dynamically, and fade out.

**How does it work?**
Constructed using custom CSS `@keyframes` animations controlling `transform` (translation and scaling) and `opacity`, delivering immersive combat feedback without external JavaScript libraries.