### PR TITLE
feat: implement CSS Crayon Stroke Button #70040

### DIFF
--- a/submissions/examples/css-crayon-stroke-button/README.md
+++ b/submissions/examples/css-crayon-stroke-button/README.md
@@ -1,0 +1,13 @@
+# CSS Crayon Stroke Button (#70040)
+
+A unique interactive button component featuring an animated rough crayon-stroke SVG border effect on hover, built entirely with pure CSS.
+
+## Features
+- **Semantic Structure:** Uses accessible button and landmark markup with keyboard focus support (`:focus-visible`).
+- **Pure CSS Animation:** Driven by SVG stroke-dasharray and stroke-dashoffset properties paired with custom cubic-bezier curves.
+- **Responsive Layout:** Fluidly scales across all standard viewports.
+
+## File Hierarchy
+- `style.css` - Component styling, stroke animations, and color variables.
+- `demo.html` - Semantic markup and accessible vector paths.
+- `README.md` - Technical specification and architecture overview.

--- a/submissions/examples/css-crayon-stroke-button/demo.html
+++ b/submissions/examples/css-crayon-stroke-button/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Crayon Stroke Button | EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<main class="showcase-card" tabindex="0" aria-label="Crayon Stroke Button Showcase">
+    <h1 class="showcase-title">Hand-Drawn Aesthetic</h1>
+    <p class="showcase-subtitle">Rough crayon stroke border animates around the button on hover.</p>
+
+    <button class="crayon-btn" type="button">
+        Explore Effect
+        <svg viewBox="0 0 160 50" preserveAspectRatio="none">
+            <path d="M 5,25 Q 25,2 80,5 Q 140,2 155,25 Q 140,48 80,45 Q 25,48 5,25 Z" />
+        </svg>
+    </button>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/css-crayon-stroke-button/style.css
+++ b/submissions/examples/css-crayon-stroke-button/style.css
@@ -1,0 +1,84 @@
+/* CSS Crayon Stroke Button #70040 */
+
+:root {
+    --bg-color: #090d16;
+    --card-bg: #111827;
+    --card-border: #1f2937;
+    --accent-crayon: #facc15;
+    --text-main: #f8fafc;
+    --text-sub: #94a3b8;
+}
+
+* { box-sizing: border-box; }
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: system-ui, -apple-system, sans-serif;
+    background-color: var(--bg-color);
+    color: var(--text-main);
+    padding: 2rem;
+}
+
+.showcase-card {
+    background-color: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 1rem;
+    padding: 3rem;
+    max-width: 420px;
+    width: 100%;
+    text-align: center;
+    box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.4);
+}
+
+.showcase-title {
+    font-size: 1.5rem;
+    font-weight: 800;
+    margin: 0 0 0.5rem 0;
+}
+
+.showcase-subtitle {
+    color: var(--text-sub);
+    font-size: 0.9rem;
+    margin: 0 0 2rem 0;
+}
+
+.crayon-btn {
+    position: relative;
+    background-color: transparent;
+    color: var(--text-main);
+    font-size: 1rem;
+    font-weight: 700;
+    padding: 0.85rem 2rem;
+    border: none;
+    cursor: pointer;
+    outline: none;
+    letter-spacing: 0.05em;
+    transition: color 0.3s ease;
+}
+
+.crayon-btn svg {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    fill: none;
+    stroke: var(--accent-crayon);
+    stroke-width: 3;
+    stroke-dasharray: 400;
+    stroke-dashoffset: 400;
+    transition: stroke-dashoffset 0.6s cubic-bezier(0.77, 0, 0.175, 1);
+    pointer-events: none;
+}
+
+.crayon-btn:hover svg,
+.crayon-btn:focus-visible svg {
+    stroke-dashoffset: 0;
+}
+
+.crayon-btn:hover {
+    color: var(--accent-crayon);
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the **CSS Crayon Stroke Button** component (#70040).
gssoc 26

Closes #70040

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component / motion pattern
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/css-crayon-stroke-button/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] Pure CSS implementation with zero JavaScript
- [x] Accessible with proper ARIA attributes, keyboard navigation support

---

## Feature Description
**What does this add?**
Rough crayon-stroke SVG border that animates smoothly around the button on hover or keyboard focus.

**How does it work?**
Constructed using an inline SVG path with `stroke-dasharray` and `stroke-dashoffset` properties adjusted dynamically on hover/focus states, requiring zero JavaScript libraries.