### PR TITLE
feat: add CSS damage number float (#70798)

### DIFF
--- a/submissions/examples/css-damage-number-float/README.md
+++ b/submissions/examples/css-damage-number-float/README.md
@@ -1,0 +1,70 @@
+# CSS Damage Number Float
+
+A pure CSS RPG-style damage number animation that makes numeric values pop into view, float upward, and gradually fade away.
+
+## Features
+
+- Pure HTML and CSS
+- No JavaScript required
+- RPG-inspired floating damage effect
+- Pop and scale entrance
+- Upward movement
+- Smooth fade-out
+- Responsive design
+- Reduced-motion support
+- CSS custom properties for easy customization
+
+## Usage
+
+Add the animation element:
+
+```html
+<span class="damage-number" aria-label="Critical damage: 248">
+  -248
+</span>
+```
+
+Then include the stylesheet:
+
+```html
+<link rel="stylesheet" href="style.css">
+```
+
+The `.damage-number` class automatically applies the floating animation.
+
+## Customization
+
+The main colors can be customized through CSS variables:
+
+```css
+:root {
+  --damage-primary: #ff3b30;
+  --damage-secondary: #ffb020;
+}
+```
+
+The animation duration can also be adjusted:
+
+```css
+.damage-number {
+  animation-duration: 2.2s;
+}
+```
+
+## Animation Technique
+
+The animation combines:
+
+- `opacity` for the fade effect
+- `transform: translateY()` for upward movement
+- `scale()` for the impact/pop effect
+- `rotate()` for a subtle game-like motion
+- CSS keyframes for the complete animation sequence
+
+## Accessibility
+
+The demo provides an accessible label for the damage value and respects the user's `prefers-reduced-motion` setting.
+
+## Why it fits EaseMotion CSS
+
+This component provides a reusable CSS-only motion pattern commonly used in games, dashboards, statistics interfaces, and interactive UI experiences. It demonstrates how transforms and opacity can create expressive feedback without JavaScript.

--- a/submissions/examples/css-damage-number-float/demo.html
+++ b/submissions/examples/css-damage-number-float/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Damage Number Float</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="demo">
+    <header class="demo__header">
+      <p class="demo__eyebrow">EaseMotion CSS</p>
+      <h1>Damage Number Float</h1>
+      <p>
+        RPG-inspired damage numbers that rise, scale slightly,
+        and fade using pure CSS.
+      </p>
+    </header>
+
+    <section
+      class="battle-card"
+      aria-label="Damage number animation demonstration"
+    >
+      <div class="battle-card__character" aria-hidden="true">
+        <div class="character__shadow"></div>
+        <div class="character__body">
+          <span class="character__eye"></span>
+          <span class="character__eye"></span>
+        </div>
+      </div>
+
+      <span class="damage-number" aria-label="Critical damage: 248">
+        -248
+      </span>
+
+      <div class="battle-card__ground" aria-hidden="true"></div>
+    </section>
+
+    <p class="demo__hint">
+      The animation automatically restarts after each cycle.
+    </p>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/css-damage-number-float/style.css
+++ b/submissions/examples/css-damage-number-float/style.css
@@ -1,0 +1,246 @@
+:root {
+  --page-bg: #0f172a;
+  --panel-bg: #1e293b;
+  --panel-border: #334155;
+  --text-primary: #f8fafc;
+  --text-secondary: #94a3b8;
+  --damage-primary: #ff3b30;
+  --damage-secondary: #ffb020;
+  --shadow: rgba(0, 0, 0, 0.3);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+  background: var(--page-bg);
+  color: var(--text-primary);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.demo {
+  width: min(100%, 720px);
+  text-align: center;
+}
+
+.demo__header {
+  margin-bottom: 2rem;
+}
+
+.demo__eyebrow {
+  margin-bottom: 0.5rem;
+  color: var(--damage-secondary);
+  font-size: 0.8rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.demo__header h1 {
+  margin-bottom: 0.75rem;
+  font-size: clamp(2rem, 5vw, 3.25rem);
+  line-height: 1.1;
+}
+
+.demo__header > p:last-child {
+  max-width: 560px;
+  margin-inline: auto;
+  color: var(--text-secondary);
+  line-height: 1.7;
+}
+
+.battle-card {
+  position: relative;
+  isolation: isolate;
+  min-height: 360px;
+  overflow: hidden;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--panel-border);
+  border-radius: 24px;
+  background:
+    radial-gradient(circle at 50% 35%, #334155 0, transparent 32%),
+    var(--panel-bg);
+  box-shadow: 0 24px 60px var(--shadow);
+}
+
+.battle-card__ground {
+  position: absolute;
+  bottom: 58px;
+  left: 50%;
+  width: 180px;
+  height: 22px;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.3);
+  transform: translateX(-50%);
+}
+
+.battle-card__character {
+  position: absolute;
+  bottom: 75px;
+  left: 50%;
+  width: 86px;
+  height: 120px;
+  transform: translateX(-50%);
+}
+
+.character__body {
+  position: absolute;
+  left: 50%;
+  bottom: 0;
+  width: 70px;
+  height: 90px;
+  border-radius: 45% 45% 30% 30%;
+  background: #64748b;
+  transform: translateX(-50%);
+  box-shadow:
+    inset 0 -12px 0 rgba(0, 0, 0, 0.15),
+    0 10px 20px rgba(0, 0, 0, 0.25);
+}
+
+.character__eye {
+  position: absolute;
+  top: 27px;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: #f8fafc;
+}
+
+.character__eye:first-child {
+  left: 19px;
+}
+
+.character__eye:last-child {
+  right: 19px;
+}
+
+.character__shadow {
+  position: absolute;
+  bottom: -7px;
+  left: 50%;
+  width: 95px;
+  height: 18px;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.25);
+  transform: translateX(-50%);
+}
+
+.damage-number {
+  position: absolute;
+  z-index: 2;
+  left: 50%;
+  bottom: 165px;
+  display: block;
+  color: var(--damage-primary);
+  font-size: clamp(2.5rem, 8vw, 4.5rem);
+  font-weight: 950;
+  line-height: 1;
+  letter-spacing: -0.06em;
+  text-shadow:
+    2px 2px 0 #7f1d1d,
+    4px 4px 0 rgba(0, 0, 0, 0.3);
+  pointer-events: none;
+  user-select: none;
+  animation: damage-float 2.2s cubic-bezier(0.2, 0.75, 0.25, 1)
+    infinite;
+}
+
+@keyframes damage-float {
+  0% {
+    opacity: 0;
+    transform:
+      translate(-50%, 28px)
+      scale(0.7)
+      rotate(-3deg);
+  }
+
+  12% {
+    opacity: 1;
+    transform:
+      translate(-50%, 0)
+      scale(1.15)
+      rotate(-3deg);
+  }
+
+  28% {
+    transform:
+      translate(-50%, -8px)
+      scale(1)
+      rotate(2deg);
+  }
+
+  55% {
+    opacity: 1;
+    transform:
+      translate(-50%, -62px)
+      scale(1)
+      rotate(-1deg);
+  }
+
+  82% {
+    opacity: 0.75;
+    transform:
+      translate(-50%, -112px)
+      scale(0.95)
+      rotate(2deg);
+  }
+
+  100% {
+    opacity: 0;
+    transform:
+      translate(-50%, -155px)
+      scale(0.82)
+      rotate(4deg);
+  }
+}
+
+.demo__hint {
+  margin-top: 1.25rem;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 600px) {
+  body {
+    padding: 1rem;
+  }
+
+  .battle-card {
+    min-height: 320px;
+  }
+
+  .battle-card__ground {
+    bottom: 48px;
+  }
+
+  .battle-card__character {
+    bottom: 65px;
+  }
+
+  .damage-number {
+    bottom: 145px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .damage-number {
+    animation: none;
+    opacity: 1;
+    transform: translate(-50%, -40px);
+  }
+}


### PR DESCRIPTION
## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

## closes #70798 

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

### What does this add?

Adds a pure CSS RPG-style damage number animation that pops into view, floats upward, and fades out.

### How does a developer use it?

```html
<span class="damage-number" aria-label="Critical damage: 248">
  -248
</span>