### PR TITLE
feat: add CSS torn bottom card (#70934)

### DIFF
--- a/submissions/examples/torn-bottom-card-70934/README.md
+++ b/submissions/examples/torn-bottom-card-70934/README.md
@@ -1,0 +1,30 @@
+# CSS Torn Bottom Card
+
+Ticket pass and coupon voucher cards featuring pure CSS jagged torn bottom edges, perforated dividers, and hover tilt motion.
+
+## 1. What does this do?
+Displays a ticket or receipt voucher card with a CSS polygon `clip-path` jagged torn edge, side circle notches, perforated tear lines, and hover elevation.
+
+## 2. How is it used?
+Wrap ticket information inside `<article class="torn-card">` with `.tear-divider` and `.card-stub`:
+
+```html
+<article class="torn-card VIP-variant">
+  <div class="card-main">
+    <h2 class="event-title">Cyberpunk Symphony</h2>
+  </div>
+
+  <div class="tear-divider">
+    <div class="circle-notch notch-left"></div>
+    <div class="perforated-line"></div>
+    <div class="circle-notch notch-right"></div>
+  </div>
+
+  <div class="card-stub">
+    <div class="barcode-graphic"></div>
+  </div>
+</article>
+```
+
+## 3. Why is it useful?
+Event ticketing platforms, coupon promotion sites, and booking apps need realistic physical ticket aesthetics. This pure CSS torn card pattern delivers realistic paper tear geometry without SVG image dependencies or heavy JavaScript scripts.

--- a/submissions/examples/torn-bottom-card-70934/demo.html
+++ b/submissions/examples/torn-bottom-card-70934/demo.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Torn Bottom Card - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <main class="demo-container">
+    <header class="demo-header">
+      <span class="demo-badge">EaseMotion UI Pattern</span>
+      <h1>CSS Torn Bottom Card</h1>
+      <p>Authentic ticket voucher and receipt cards with pure CSS jagged torn edge clip-paths, perforated tear lines, and hover tilt motion.</p>
+    </header>
+
+    <!-- Showcase Grid -->
+    <section class="tickets-grid" aria-label="Torn Bottom Voucher Cards Showcase">
+      
+      <!-- Variant 1: Concert Event Pass Card -->
+      <article class="torn-card VIP-variant" tabindex="0">
+        <div class="card-top">
+          <div class="card-badge">VIP PASS</div>
+          <span class="ticket-id">#TKT-9042</span>
+        </div>
+
+        <div class="card-main">
+          <span class="event-category">NEON PULSE MUSIC FESTIVAL</span>
+          <h2 class="event-title">Cyberpunk Symphony Live</h2>
+          
+          <div class="event-details">
+            <div class="detail-group">
+              <span class="detail-label">DATE</span>
+              <span class="detail-val">OCT 24, 2026</span>
+            </div>
+            <div class="detail-group">
+              <span class="detail-label">TIME</span>
+              <span class="detail-val">20:00 EST</span>
+            </div>
+            <div class="detail-group">
+              <span class="detail-label">SECTION</span>
+              <span class="detail-val">STAGE A1</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Perforated Tear Divider -->
+        <div class="tear-divider" aria-hidden="true">
+          <div class="circle-notch notch-left"></div>
+          <div class="perforated-line"></div>
+          <div class="circle-notch notch-right"></div>
+        </div>
+
+        <!-- Stub & Barcode Bottom Section -->
+        <div class="card-stub">
+          <div class="barcode-graphic" aria-label="Ticket Barcode">
+            <span></span><span></span><span></span><span></span><span></span>
+            <span></span><span></span><span></span><span></span><span></span>
+            <span></span><span></span><span></span><span></span><span></span>
+          </div>
+          <span class="barcode-num">9042 8173 0019</span>
+        </div>
+
+        <!-- Jagged Torn Edge Cutout Bottom -->
+        <div class="torn-edge-mask" aria-hidden="true"></div>
+      </article>
+
+      <!-- Variant 2: Discount Coupon Voucher -->
+      <article class="torn-card coupon-variant" tabindex="0">
+        <div class="card-top">
+          <div class="card-badge alt-badge">PROMO COUPON</div>
+          <span class="ticket-id">SAVE25%</span>
+        </div>
+
+        <div class="card-main">
+          <span class="event-category">E-COMMERCE SPECIAL</span>
+          <h2 class="event-title">$50 Off Next Purchase</h2>
+          <p class="coupon-desc">Valid on all audio equipment & accessories. Minimum order $150.</p>
+        </div>
+
+        <div class="tear-divider" aria-hidden="true">
+          <div class="circle-notch notch-left"></div>
+          <div class="perforated-line"></div>
+          <div class="circle-notch notch-right"></div>
+        </div>
+
+        <div class="card-stub">
+          <div class="claim-code-box">
+            <span class="code-label">REDEEM CODE</span>
+            <strong class="code-text">EASE-SUMMER26</strong>
+          </div>
+        </div>
+
+        <div class="torn-edge-mask" aria-hidden="true"></div>
+      </article>
+
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/torn-bottom-card-70934/style.css
+++ b/submissions/examples/torn-bottom-card-70934/style.css
@@ -1,0 +1,314 @@
+/* ==========================================================================
+   CSS Torn Bottom Card - EaseMotion CSS
+   ========================================================================== */
+
+:root {
+  --card-bg-vip: linear-gradient(135deg, #1e1b4b 0%, #312e81 100%);
+  --card-bg-coupon: linear-gradient(135deg, #064e3b 0%, #065f46 100%);
+  --card-border: rgba(255, 255, 255, 0.12);
+  --card-accent: #6366f1;
+  --card-text: #f8fafc;
+  --card-subtext: #94a3b8;
+  --transition-bounce: 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  background-color: #0f172a;
+  color: #f8fafc;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+.demo-container {
+  max-width: 860px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+.demo-header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.demo-badge {
+  display: inline-block;
+  padding: 0.25rem 0.75rem;
+  background: rgba(99, 102, 241, 0.15);
+  color: #818cf8;
+  border: 1px solid rgba(99, 102, 241, 0.3);
+  border-radius: 9999px;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.75rem;
+}
+
+.demo-header h1 {
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 2.25rem;
+  font-weight: 700;
+  letter-spacing: -0.025em;
+  background: linear-gradient(135deg, #ffffff 0%, #cbd5e1 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  margin-bottom: 0.75rem;
+}
+
+.demo-header p {
+  color: #94a3b8;
+  font-size: 1rem;
+  max-width: 580px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+/* Showcase Grid */
+.tickets-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 2rem;
+}
+
+/* Torn Card Core Container */
+.torn-card {
+  position: relative;
+  background: var(--card-bg-vip);
+  border-radius: 1.25rem 1.25rem 0 0;
+  padding: 1.75rem 1.75rem 2.5rem;
+  box-shadow: 0 20px 30px -10px rgba(0, 0, 0, 0.5);
+  transition: transform var(--transition-bounce), box-shadow var(--transition-bounce);
+  outline: none;
+  cursor: pointer;
+  filter: drop-shadow(0 15px 15px rgba(0,0,0,0.4));
+  
+  /* Pure CSS Torn Edge Clip Path at Bottom */
+  clip-path: polygon(
+    0% 0%, 100% 0%, 100% calc(100% - 15px),
+    95% 100%, 90% calc(100% - 15px), 85% 100%,
+    80% calc(100% - 15px), 75% 100%, 70% calc(100% - 15px),
+    65% 100%, 60% calc(100% - 15px), 55% 100%,
+    50% calc(100% - 15px), 45% 100%, 40% calc(100% - 15px),
+    35% 100%, 30% calc(100% - 15px), 25% 100%,
+    20% calc(100% - 15px), 15% 100%, 10% calc(100% - 15px),
+    5% 100%, 0% calc(100% - 15px)
+  );
+}
+
+.torn-card.coupon-variant {
+  background: var(--card-bg-coupon);
+}
+
+.torn-card:hover {
+  transform: translateY(-6px) rotate(-1deg);
+  box-shadow: 0 30px 40px -10px rgba(0, 0, 0, 0.6);
+}
+
+.torn-card:focus-visible {
+  box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.5);
+}
+
+/* Card Top Bar */
+.card-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.25rem;
+}
+
+.card-badge {
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  padding: 0.25rem 0.625rem;
+  border-radius: 9999px;
+  background: rgba(99, 102, 241, 0.3);
+  color: #a5b4fc;
+  border: 1px solid rgba(165, 180, 252, 0.3);
+}
+
+.card-badge.alt-badge {
+  background: rgba(16, 185, 129, 0.3);
+  color: #6ee7b7;
+  border-color: rgba(110, 231, 183, 0.3);
+}
+
+.ticket-id {
+  font-family: monospace;
+  font-size: 0.8125rem;
+  color: rgba(255, 255, 255, 0.6);
+  letter-spacing: 0.05em;
+}
+
+/* Main Content */
+.event-category {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  color: rgba(255, 255, 255, 0.6);
+  text-transform: uppercase;
+}
+
+.event-title {
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 1.375rem;
+  font-weight: 700;
+  color: #ffffff;
+  margin: 0.25rem 0 1rem;
+  line-height: 1.2;
+}
+
+.coupon-desc {
+  font-size: 0.875rem;
+  color: rgba(255, 255, 255, 0.8);
+  line-height: 1.5;
+  margin-bottom: 1rem;
+}
+
+.event-details {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 1.25rem;
+}
+
+.detail-group {
+  display: flex;
+  flex-direction: column;
+}
+
+.detail-label {
+  font-size: 0.625rem;
+  font-weight: 700;
+  color: rgba(255, 255, 255, 0.5);
+  letter-spacing: 0.05em;
+}
+
+.detail-val {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: #f1f5f9;
+  margin-top: 0.125rem;
+}
+
+/* Perforated Tear Divider with Notches */
+.tear-divider {
+  position: relative;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  margin: 0 -1.75rem 1.25rem;
+}
+
+.circle-notch {
+  position: absolute;
+  width: 20px;
+  height: 20px;
+  background: #0f172a;
+  border-radius: 50%;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.notch-left {
+  left: -10px;
+}
+
+.notch-right {
+  right: -10px;
+}
+
+.perforated-line {
+  flex-grow: 1;
+  height: 2px;
+  border-bottom: 2px dashed rgba(255, 255, 255, 0.3);
+}
+
+/* Stub & Barcode Graphic */
+.card-stub {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.barcode-graphic {
+  display: flex;
+  gap: 3px;
+  height: 32px;
+  align-items: center;
+  opacity: 0.85;
+}
+
+.barcode-graphic span {
+  height: 100%;
+  background: #ffffff;
+  border-radius: 1px;
+}
+
+.barcode-graphic span:nth-child(3n) { width: 1px; }
+.barcode-graphic span:nth-child(3n+1) { width: 3px; }
+.barcode-graphic span:nth-child(3n+2) { width: 2px; }
+
+.barcode-num {
+  font-family: monospace;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.6);
+  letter-spacing: 0.15em;
+}
+
+.claim-code-box {
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px dashed rgba(255, 255, 255, 0.3);
+  padding: 0.625rem 1.25rem;
+  border-radius: 0.5rem;
+  text-align: center;
+  width: 100%;
+}
+
+.code-label {
+  display: block;
+  font-size: 0.625rem;
+  font-weight: 700;
+  color: rgba(255, 255, 255, 0.6);
+  letter-spacing: 0.05em;
+}
+
+.code-text {
+  font-family: monospace;
+  font-size: 1rem;
+  color: #6ee7b7;
+  letter-spacing: 0.1em;
+}
+
+/* Reduced Motion Support */
+@media (prefers-reduced-motion: reduce) {
+  .torn-card {
+    transition: none !important;
+  }
+  .torn-card:hover {
+    transform: none;
+  }
+}
+
+/* Responsive adjustments */
+@media (max-width: 480px) {
+  .torn-card {
+    padding: 1.25rem 1.25rem 2rem;
+  }
+  .event-details {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+}


### PR DESCRIPTION
## Implementation Summary
- Implemented CSS Torn Bottom Card component featuring pure CSS jagged torn edge clip-paths, perforated tear line dividers, side circle notches, barcode graphics, and hover tilt motion.
- Submissions placed in \submissions/examples/torn-bottom-card-70934/\.

## Added Files
- \demo.html\
- \style.css\
- \README.md\

## Responsiveness & Accessibility
- Responsive card grid layout with keyboard focus-visible styling.
- ARIA semantics for ticket pass and voucher details.
- Includes \@media (prefers-reduced-motion: reduce)\ support.

## Testing & Verification
- Verified torn edge polygon rendering across viewports.
- Verified clean git diff.

Closes #70934