### PR TITLE
feat: add CSS Neon Tab Switcher (#70794)

### DIFF
--- a/submissions/examples/css-neon-tab-switcher/README.md
+++ b/submissions/examples/css-neon-tab-switcher/README.md
@@ -1,0 +1,102 @@
+# CSS Neon Tab Switcher
+
+A responsive CSS-only tab switcher featuring a glowing neon underline that moves between active tabs.
+
+## Features
+
+- Pure HTML and CSS
+- No JavaScript
+- Animated neon active indicator
+- CSS-only tab state management
+- Smooth panel transitions
+- Responsive layout
+- Keyboard focus styling
+- Reduced-motion support
+- CSS custom properties
+- No external dependencies
+
+## Usage
+
+Include the stylesheet:
+
+```html
+<link rel="stylesheet" href="style.css">
+```
+
+Create the tab controls using radio inputs and labels:
+
+```html
+<div class="tabs">
+  <input
+    class="tabs__input"
+    type="radio"
+    name="neon-tabs"
+    id="tab-overview"
+    checked
+  >
+
+  <label class="tabs__label" for="tab-overview">
+    Overview
+  </label>
+
+  <input
+    class="tabs__input"
+    type="radio"
+    name="neon-tabs"
+    id="tab-features"
+  >
+
+  <label class="tabs__label" for="tab-features">
+    Features
+  </label>
+
+  <span class="tabs__indicator"></span>
+</div>
+```
+
+The checked radio input determines the active tab and moves the neon indicator using CSS sibling selectors.
+
+## Customization
+
+Change the theme using CSS variables:
+
+```css
+:root {
+  --cyan: #39f6ff;
+  --purple: #9d5cff;
+  --pink: #ff42d0;
+  --page-bg: #070914;
+}
+```
+
+The indicator transition can also be adjusted:
+
+```css
+.tabs__indicator {
+  transition: transform 280ms ease;
+}
+```
+
+## Accessibility
+
+The component provides:
+
+- Native radio controls for state management
+- Associated labels for keyboard interaction
+- Visible keyboard focus styling
+- Semantic headings and content
+- Reduced-motion support
+
+The radio controls remain available to keyboard users even though they are visually hidden.
+
+## Browser Support
+
+The component uses standard CSS selectors, transitions, animations, gradients, and media queries.
+
+No JavaScript or external libraries are required.
+
+## Why it fits EaseMotion CSS
+
+This component demonstrates reusable CSS motion techniques through an animated neon indicator, active-state transitions, panel reveal animation, hover effects, and responsive behavior.
+
+It remains dependency-free and can be copied into a project as a standalone CSS component.

--- a/submissions/examples/css-neon-tab-switcher/demo.html
+++ b/submissions/examples/css-neon-tab-switcher/demo.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta
+    name="description"
+    content="Pure CSS neon tab switcher with an animated active indicator."
+  >
+  <title>CSS Neon Tab Switcher</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="demo">
+    <section class="tabs-card" aria-labelledby="tabs-title">
+      <p class="eyebrow">CSS COMPONENT</p>
+
+      <h1 id="tabs-title">Neon Tab Switcher</h1>
+
+      <p class="intro">
+        A CSS-only tab interface with a glowing indicator that zaps
+        between active tabs.
+      </p>
+
+      <div class="tabs">
+        <input
+          class="tabs__input"
+          type="radio"
+          name="neon-tabs"
+          id="tab-overview"
+          checked
+        >
+        <label class="tabs__label" for="tab-overview">
+          Overview
+        </label>
+
+        <input
+          class="tabs__input"
+          type="radio"
+          name="neon-tabs"
+          id="tab-features"
+        >
+        <label class="tabs__label" for="tab-features">
+          Features
+        </label>
+
+        <input
+          class="tabs__input"
+          type="radio"
+          name="neon-tabs"
+          id="tab-performance"
+        >
+        <label class="tabs__label" for="tab-performance">
+          Performance
+        </label>
+
+        <span class="tabs__indicator" aria-hidden="true"></span>
+
+        <div class="tabs__panels">
+          <article class="tabs__panel panel-overview">
+            <span class="panel__number">01</span>
+            <h2>Clean Interface</h2>
+            <p>
+              A lightweight tab pattern using semantic labels,
+              CSS selectors, and a glowing active-state indicator.
+            </p>
+          </article>
+
+          <article class="tabs__panel panel-features">
+            <span class="panel__number">02</span>
+            <h2>Pure CSS Motion</h2>
+            <p>
+              The active underline animates between tabs without
+              JavaScript or external dependencies.
+            </p>
+          </article>
+
+          <article class="tabs__panel panel-performance">
+            <span class="panel__number">03</span>
+            <h2>Responsive Design</h2>
+            <p>
+              The layout adapts to smaller screens while maintaining
+              accessible focus states and readable content.
+            </p>
+          </article>
+        </div>
+      </div>
+    </section>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/css-neon-tab-switcher/style.css
+++ b/submissions/examples/css-neon-tab-switcher/style.css
@@ -1,0 +1,355 @@
+:root {
+  --page-bg: #070914;
+  --card-bg: rgba(15, 22, 43, 0.78);
+
+  --cyan: #39f6ff;
+  --purple: #9d5cff;
+  --pink: #ff42d0;
+
+  --text: #f5f8ff;
+  --muted: #9ca9c2;
+
+  --border: rgba(57, 246, 255, 0.2);
+  --transition: 280ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.5rem;
+
+  color: var(--text);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+
+  background:
+    radial-gradient(
+      circle at 20% 20%,
+      rgba(57, 246, 255, 0.1),
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at 80% 75%,
+      rgba(157, 92, 255, 0.12),
+      transparent 32%
+    ),
+    var(--page-bg);
+}
+
+.demo {
+  width: 100%;
+  display: grid;
+  place-items: center;
+}
+
+.tabs-card {
+  position: relative;
+  width: min(100%, 780px);
+  padding: clamp(1.5rem, 5vw, 3rem);
+
+  border: 1px solid var(--border);
+  border-radius: 26px;
+
+  background: var(--card-bg);
+
+  box-shadow:
+    0 30px 80px rgba(0, 0, 0, 0.45),
+    inset 0 1px 0 rgba(255, 255, 255, 0.07);
+
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+}
+
+.eyebrow {
+  margin-bottom: 0.8rem;
+
+  color: var(--cyan);
+
+  font-size: 0.65rem;
+  font-weight: 900;
+  letter-spacing: 0.18em;
+}
+
+.tabs-card > h1 {
+  margin-bottom: 0.7rem;
+
+  font-size: clamp(2rem, 6vw, 3.4rem);
+  line-height: 1;
+  letter-spacing: -0.05em;
+
+  background:
+    linear-gradient(
+      100deg,
+      var(--text),
+      var(--cyan),
+      var(--purple)
+    );
+
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.intro {
+  max-width: 600px;
+  margin-bottom: 2rem;
+
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+/*
+ * The radio inputs provide the state.
+ * Labels act as the visible tab controls.
+ * No JavaScript is required.
+ */
+
+.tabs {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.tabs__input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.tabs__label {
+  position: relative;
+  z-index: 2;
+
+  padding: 1rem 0.5rem;
+
+  color: var(--muted);
+  text-align: center;
+
+  font-size: 0.8rem;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+
+  cursor: pointer;
+
+  transition:
+    color var(--transition),
+    text-shadow var(--transition);
+}
+
+.tabs__label:hover {
+  color: var(--text);
+}
+
+.tabs__label::after {
+  position: absolute;
+  inset: 0;
+
+  content: "";
+
+  border-radius: 10px 10px 0 0;
+
+  background:
+    linear-gradient(
+      180deg,
+      rgba(57, 246, 255, 0.08),
+      transparent
+    );
+
+  opacity: 0;
+
+  transition: opacity var(--transition);
+  pointer-events: none;
+}
+
+.tabs__label:hover::after {
+  opacity: 1;
+}
+
+/*
+ * The indicator uses the checked radio state.
+ * It moves by changing its grid column.
+ */
+
+.tabs__indicator {
+  position: absolute;
+  z-index: 3;
+
+  bottom: -2px;
+  left: 0;
+
+  width: 33.333%;
+  height: 3px;
+
+  border-radius: 999px;
+
+  background:
+    linear-gradient(
+      90deg,
+      var(--cyan),
+      var(--purple),
+      var(--pink)
+    );
+
+  box-shadow:
+    0 0 8px var(--cyan),
+    0 0 20px rgba(57, 246, 255, 0.6),
+    0 0 35px rgba(157, 92, 255, 0.3);
+
+  transition:
+    transform var(--transition),
+    width var(--transition);
+}
+
+#tab-features:checked ~ .tabs__indicator {
+  transform: translateX(100%);
+}
+
+#tab-performance:checked ~ .tabs__indicator {
+  transform: translateX(200%);
+}
+
+#tab-overview:checked ~ .tabs__indicator {
+  transform: translateX(0);
+}
+
+/* Active tab text */
+
+#tab-overview:checked ~ .tabs__label[for="tab-overview"],
+#tab-features:checked ~ .tabs__label[for="tab-features"],
+#tab-performance:checked ~ .tabs__label[for="tab-performance"] {
+  color: var(--cyan);
+  text-shadow:
+    0 0 10px rgba(57, 246, 255, 0.5);
+}
+
+/* Panels */
+
+.tabs__panels {
+  grid-column: 1 / -1;
+  position: relative;
+  min-height: 230px;
+  padding-top: 2rem;
+}
+
+.tabs__panel {
+  display: none;
+  animation: panel-enter 360ms ease both;
+}
+
+#tab-overview:checked ~ .tabs__panels .panel-overview,
+#tab-features:checked ~ .tabs__panels .panel-features,
+#tab-performance:checked ~ .tabs__panels .panel-performance {
+  display: block;
+}
+
+.panel__number {
+  display: inline-flex;
+  margin-bottom: 1rem;
+
+  color: var(--cyan);
+
+  font-family: monospace;
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+}
+
+.tabs__panel h2 {
+  margin-bottom: 0.7rem;
+
+  font-size: clamp(1.35rem, 4vw, 2rem);
+  letter-spacing: -0.03em;
+}
+
+.tabs__panel p {
+  max-width: 600px;
+
+  color: var(--muted);
+
+  line-height: 1.75;
+}
+
+@keyframes panel-enter {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/*
+ * Keyboard focus.
+ * Since the radio inputs are visually hidden, focus styling is
+ * transferred to the associated label using :has().
+ */
+
+.tabs__input:focus-visible + .tabs__label {
+  outline: 2px solid var(--pink);
+  outline-offset: -3px;
+  border-radius: 8px;
+}
+
+/* Responsive */
+
+@media (max-width: 600px) {
+  .tabs-card {
+    border-radius: 20px;
+  }
+
+  .tabs__label {
+    padding: 0.85rem 0.25rem;
+
+    font-size: 0.68rem;
+    letter-spacing: 0;
+  }
+
+  .tabs__panels {
+    min-height: 250px;
+  }
+}
+
+@media (max-width: 420px) {
+  .tabs__label {
+    font-size: 0.62rem;
+  }
+
+  .tabs__panel p {
+    font-size: 0.9rem;
+  }
+}
+
+/* Reduced motion */
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## closes #70794 

## Feature Description

**What does this add?**

Adds a responsive CSS-only tab switcher with a glowing neon underline that moves to the active tab and animated content panels.

**How does a developer use it?**

```html
<link rel="stylesheet" href="style.css">

<div class="tabs">
  <input
    class="tabs__input"
    type="radio"
    name="neon-tabs"
    id="tab-overview"
    checked
  >

  <label class="tabs__label" for="tab-overview">
    Overview
  </label>

  <input
    class="tabs__input"
    type="radio"
    name="neon-tabs"
    id="tab-features"
  >

  <label class="tabs__label" for="tab-features">
    Features
  </label>

  <span class="tabs__indicator"></span>
</div>