### PR TITLE
feat: add pure CSS focus mode overlay (#70750)

### DIFF
--- a/submissions/examples/focus-mode-overlay/README.md
+++ b/submissions/examples/focus-mode-overlay/README.md
@@ -1,0 +1,15 @@
+# CSS Focus Mode Overlay
+
+A pure CSS "Spotlight" reading mode that automatically dims surrounding content to minimize distractions. When a user hovers over or tabs into a paragraph, the surrounding environment fades and blurs, drawing complete attention to the active text.
+
+## 🎯 Features
+- **Pure CSS/HTML:** Zero JavaScript required. Uses a combination of `:hover` and `:focus-within` on the parent container to drive the state.
+- **Keyboard Accessible:** Fully supports keyboard navigation. Pressing `Tab` triggers the exact same spotlight effect as hovering, utilizing `tabindex="0"` and `:focus-within`.
+- **Performance Optimized:** Uses hardware-accelerated CSS properties (`opacity`, `filter`, `transform`).
+- **Accessible:** Respects `@media (prefers-reduced-motion: reduce)` by gracefully stripping the blur and scale animations, leaving a clean opacity fade.
+
+## 📁 Files Included
+```text
+demo.html
+style.css
+README.md

--- a/submissions/examples/focus-mode-overlay/demo.html
+++ b/submissions/examples/focus-mode-overlay/demo.html
@@ -1,0 +1,38 @@
+<!-- submissions/examples/focus-mode-overlay/demo.html -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Focus Mode Overlay | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="demo-container">
+    <h1>Reader Focus Mode</h1>
+    
+    <!-- Focus Mode Wrapper -->
+    <div class="ease-focus-mode" role="region" aria-label="Interactive Focus Reading Mode">
+      
+      <!-- Paragraph 1 -->
+      <div class="ease-focus-paragraph" tabindex="0">
+        <strong>The Genesis of CSS.</strong> Cascading Style Sheets were introduced to separate content from presentation. Before CSS, HTML tags dictated both the structure and the visual formatting of a document, leading to bloated, unmaintainable codebases.
+      </div>
+
+      <!-- Paragraph 2 -->
+      <div class="ease-focus-paragraph" tabindex="0">
+        <strong>The Power of Pseudo-classes.</strong> Modern CSS allows developers to manage complex states without a single line of JavaScript. Using selectors like <code>:hover</code>, <code>:focus-within</code>, and <code>:has()</code>, entire interactive ecosystems can be built directly in the stylesheet.
+      </div>
+
+      <!-- Paragraph 3 -->
+      <div class="ease-focus-paragraph" tabindex="0">
+        <strong>Accessibility First.</strong> A beautiful interface is meaningless if it cannot be navigated by everyone. By implementing proper <code>tabindex</code> attributes and respecting <code>prefers-reduced-motion</code> media queries, we ensure an inclusive web experience.
+      </div>
+
+    </div>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/focus-mode-overlay/style.css
+++ b/submissions/examples/focus-mode-overlay/style.css
@@ -1,0 +1,114 @@
+/* submissions/examples/focus-mode-overlay/style.css */
+
+/* ==========================================================================
+   1. DEMO PRESENTATION STYLES
+   ========================================================================== */
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: #0f172a;
+  font-family: 'Inter', system-ui, sans-serif;
+  color: #94a3b8;
+  padding: 2rem;
+}
+
+.demo-container {
+  width: 100%;
+  max-width: 768px;
+}
+
+h1 {
+  text-align: center;
+  color: #f8fafc;
+  margin-bottom: 2rem;
+  font-size: 1.75rem;
+}
+
+/* ==========================================================================
+   2. FOCUS MODE OVERLAY COMPONENT
+   ========================================================================== */
+.ease-focus-mode {
+  position: relative;
+  padding: 2rem;
+  border-radius: 16px;
+  background-color: transparent;
+  transition: background-color 0.4s ease, box-shadow 0.4s ease;
+}
+
+/* Dim the background of the wrapper when active */
+.ease-focus-mode:hover,
+.ease-focus-mode:focus-within {
+  background-color: #020617;
+  box-shadow: inset 0 0 80px rgba(0, 0, 0, 0.8);
+}
+
+.ease-focus-paragraph {
+  padding: 1.5rem;
+  margin-bottom: 1rem;
+  border-radius: 12px;
+  font-size: 1.1rem;
+  line-height: 1.7;
+  color: #cbd5e1;
+  background: transparent;
+  outline: none;
+  cursor: default;
+  /* Smooth transitions for the spotlight effect */
+  transition: all 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.ease-focus-paragraph:last-child {
+  margin-bottom: 0;
+}
+
+/* ── The Spotlight Logic ── */
+
+/* 1. Dim ALL paragraphs when the wrapper is interacted with */
+.ease-focus-mode:hover .ease-focus-paragraph,
+.ease-focus-mode:focus-within .ease-focus-paragraph {
+  opacity: 0.2;
+  filter: blur(2px);
+  transform: scale(0.98);
+}
+
+/* 2. Bring ONLY the hovered/focused paragraph back into absolute focus */
+.ease-focus-mode .ease-focus-paragraph:hover,
+.ease-focus-mode .ease-focus-paragraph:focus-within {
+  opacity: 1;
+  filter: blur(0);
+  transform: scale(1.02);
+  background: rgba(255, 255, 255, 0.03);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+  color: #f8fafc;
+  z-index: 10;
+  position: relative;
+}
+
+/* Highlight a specific accent color on active focus state for accessibility */
+.ease-focus-mode .ease-focus-paragraph:focus-visible {
+  border-left: 4px solid #38bdf8;
+  padding-left: calc(1.5rem - 4px);
+}
+
+/* ==========================================================================
+   3. ACCESSIBILITY
+   ========================================================================== */
+@media (prefers-reduced-motion: reduce) {
+  .ease-focus-paragraph {
+    transition: opacity 0.2s ease, background 0.2s ease !important;
+  }
+  
+  /* Disable scaling and blurring for reduced motion */
+  .ease-focus-mode:hover .ease-focus-paragraph,
+  .ease-focus-mode:focus-within .ease-focus-paragraph {
+    filter: none !important;
+    transform: none !important;
+  }
+  
+  .ease-focus-mode .ease-focus-paragraph:hover,
+  .ease-focus-mode .ease-focus-paragraph:focus-within {
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #70750. This PR introduces the **CSS Focus Mode Overlay**. It adds a pure CSS "Spotlight" reading feature that dims and blurs surrounding paragraphs when a specific block of text is hovered or focused via keyboard navigation.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A distraction-free reading mode overlay that highlights active paragraphs by dimming, blurring, and scaling down inactive sibling elements purely via CSS pseudo-classes.

**How does a developer use it?**

```html
<div class="ease-focus-mode">
  <p class="ease-focus-paragraph" tabindex="0">Hover or tab to focus this block.</p>
  <p class="ease-focus-paragraph" tabindex="0">The sibling block will dim gracefully.</p>
</div>