### PR TITLE
feat: add css error page card submission

### DIFF
--- a/submissions/examples/css-error-page-card-ag/README.md
+++ b/submissions/examples/css-error-page-card-ag/README.md
@@ -1,0 +1,32 @@
+# CSS Error Page Card
+
+A sleek, animated 500 server error card designed to provide a polished user experience even when things go wrong.
+
+## Features
+- **Pure CSS / HTML**: Built entirely without JavaScript.
+- **Micro-Interactions**: Hovering over the card triggers a sophisticated CSS `clip-path` glitch effect on the "500" error code using `::before` and `::after` pseudo-elements. The "Try Again" button gently elevates (`translateY`), and its internal refresh icon spins 180 degrees via a `cubic-bezier` transition.
+- **Dynamic Content Support**: The glitch effect utilizes the `attr(data-text)` CSS function, meaning you can easily swap the error code to "404" or "403" in the HTML and the animation will automatically adapt to the new text.
+- **Accessible**: Functions as a semantic `<main>` element with `aria-labelledby` and `aria-describedby` linking directly to the error message. Respects user preferences by gracefully disabling the glitch, slide, and spin animations via `@media (prefers-reduced-motion: reduce)`.
+
+## Usage
+
+Drop the HTML structure into your application's error handling layout or generic 500 page route.
+
+```html
+<main class="error-card">
+  <!-- Use data-text for the glitch effect -->
+  <h1 class="error-code" data-text="500">500</h1>
+  <h2 class="error-title">Internal Server Error</h2>
+  <!-- ... -->
+</main>
+```
+
+## CSS Custom Properties
+Easily customize the theme colors using the root variables in `style.css`:
+- `--card-bg`: Background color of the card (default: `#ffffff`)
+- `--error-color`: Color for the warning icon (default: `#ef4444`)
+- `--error-light`: Background for the warning icon (default: `#fee2e2`)
+- `--btn-bg`: Background color for the retry button (default: `#1e293b`)
+
+## Browser Support
+Works beautifully in all modern browsers (Chrome, Firefox, Safari, Edge). The `clip-path` property used for the glitch effect is fully supported across all major engines.

--- a/submissions/examples/css-error-page-card-ag/demo.html
+++ b/submissions/examples/css-error-page-card-ag/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Error Page Card</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+
+  <!-- Error Card Component -->
+  <main class="error-card" aria-labelledby="error-title" aria-describedby="error-desc">
+    
+    <div class="error-icon-wrapper" aria-hidden="true">
+      <!-- Server Crash/Warning Icon -->
+      <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path>
+      </svg>
+    </div>
+
+    <!-- Data attribute used for CSS glitch effect -->
+    <h1 class="error-code" data-text="500">500</h1>
+    <h2 id="error-title" class="error-title">Internal Server Error</h2>
+    <p id="error-desc" class="error-desc">Oops! Something went wrong on our end. Our engineers are investigating the issue.</p>
+    
+    <a href="#" class="btn-retry" aria-label="Refresh the page">
+      <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>
+      </svg>
+      Try Again
+    </a>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/css-error-page-card-ag/style.css
+++ b/submissions/examples/css-error-page-card-ag/style.css
@@ -1,0 +1,193 @@
+:root {
+  --bg-color: #f8fafc;
+  --card-bg: #ffffff;
+  --text-main: #0f172a;
+  --text-muted: #64748b;
+  --error-color: #ef4444;
+  --error-light: #fee2e2;
+  --btn-bg: #1e293b;
+  --btn-hover: #334155;
+  --shadow-sm: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  --shadow-lg: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+}
+
+body {
+  margin: 0;
+  padding: 20px;
+  background-color: var(--bg-color);
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+/* Card Container */
+.error-card {
+  width: 100%;
+  max-width: 400px;
+  background-color: var(--card-bg);
+  border-radius: 24px;
+  padding: 40px 32px;
+  text-align: center;
+  box-shadow: var(--shadow-lg);
+  border: 1px solid rgba(0, 0, 0, 0.05);
+  animation: slide-up 0.6s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@keyframes slide-up {
+  0% { transform: translateY(20px); opacity: 0; }
+  100% { transform: translateY(0); opacity: 1; }
+}
+
+/* Icon / Graphic */
+.error-icon-wrapper {
+  width: 80px;
+  height: 80px;
+  margin: 0 auto 24px;
+  background-color: var(--error-light);
+  border-radius: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: var(--error-color);
+  position: relative;
+}
+
+.error-icon-wrapper svg {
+  width: 40px;
+  height: 40px;
+}
+
+/* Glitching 500 Text */
+.error-code {
+  font-size: 4rem;
+  font-weight: 900;
+  color: var(--text-main);
+  margin: 0 0 8px 0;
+  line-height: 1;
+  position: relative;
+  display: inline-block;
+}
+
+/* Pseudo-elements for glitch effect dynamically pull from data-text */
+.error-code::before,
+.error-code::after {
+  content: attr(data-text);
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: var(--card-bg);
+  opacity: 0;
+}
+
+.error-card:hover .error-code::before {
+  left: -2px;
+  text-shadow: 2px 0 var(--error-color);
+  animation: glitch-anim 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94) both infinite;
+  opacity: 1;
+  z-index: 1;
+}
+
+.error-card:hover .error-code::after {
+  left: 2px;
+  text-shadow: -2px 0 #3b82f6;
+  animation: glitch-anim 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94) reverse both infinite;
+  opacity: 1;
+  z-index: 2;
+}
+
+@keyframes glitch-anim {
+  0% { clip-path: inset(20% 0 80% 0); }
+  20% { clip-path: inset(60% 0 10% 0); }
+  40% { clip-path: inset(40% 0 50% 0); }
+  60% { clip-path: inset(80% 0 5% 0); }
+  80% { clip-path: inset(10% 0 70% 0); }
+  100% { clip-path: inset(30% 0 50% 0); }
+}
+
+/* Typography */
+.error-title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--text-main);
+  margin: 0 0 12px 0;
+}
+
+.error-desc {
+  font-size: 1rem;
+  color: var(--text-muted);
+  margin: 0 0 32px 0;
+  line-height: 1.5;
+}
+
+/* Retry Button */
+.btn-retry {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  padding: 14px 24px;
+  background-color: var(--btn-bg);
+  color: #fff;
+  border: none;
+  border-radius: 12px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  box-shadow: var(--shadow-sm);
+  text-decoration: none;
+  box-sizing: border-box;
+}
+
+.btn-retry svg {
+  width: 18px;
+  height: 18px;
+  transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.btn-retry:hover {
+  background-color: var(--btn-hover);
+  transform: translateY(-2px);
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+}
+
+.btn-retry:active {
+  transform: translateY(0);
+}
+
+.btn-retry:focus-visible {
+  outline: 2px solid var(--btn-bg);
+  outline-offset: 4px;
+}
+
+/* Spin icon on hover */
+.btn-retry:hover svg {
+  transform: rotate(180deg);
+}
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+  .error-card {
+    animation: none;
+  }
+  .error-card:hover .error-code::before,
+  .error-card:hover .error-code::after {
+    animation: none;
+    opacity: 0;
+  }
+  .btn-retry,
+  .btn-retry svg {
+    transition: none;
+  }
+  .btn-retry:hover {
+    transform: none;
+  }
+  .btn-retry:hover svg {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #70765.

This PR adds the "CSS Error Page Card" submission. It introduces a sleek, animated 500 server error card designed to provide a polished user experience even when things go wrong.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

It adds a responsive, JavaScript-free 500 error component. Hovering over the card triggers a sophisticated CSS `clip-path` glitch effect on the "500" error code using `::before` and `::after` pseudo-elements. The "Try Again" button gently elevates (`translateY`), and its internal refresh icon spins 180 degrees via a `cubic-bezier` transition.

**How does a developer use it?**

```html
<main class="error-card">
  <!-- Use data-text for the glitch effect -->
  <h1 class="error-code" data-text="500">500</h1>
  <h2 class="error-title">Internal Server Error</h2>
  <!-- ... -->
</main>
