### PR TITLE
feat: add css wobble on click submission

### DIFF
--- a/submissions/examples/css-wobble-on-click-ag/README.md
+++ b/submissions/examples/css-wobble-on-click-ag/README.md
@@ -1,0 +1,29 @@
+# CSS Wobble on Click
+
+A playful button component that executes a full "wobble" animation immediately after being clicked, built entirely without JavaScript.
+
+## Features
+- **Pure CSS / HTML**: Built entirely without JavaScript event listeners. 
+- **The Trigger Trick**: Standard CSS `:active` animations stop abruptly the moment the mouse is released. This component uses the `:focus:not(:active)` selector trick to reset the animation state during the click (`:active`), and perfectly trigger the full `wobble` keyframe sequence the moment the mouse is released (`:focus`).
+- **Keyboard Friendly**: Because the animation is tied to the `:focus` state, it acts as an immediate, delightful visual cue when a user tabs to the button via keyboard navigation.
+- **Accessible**: Functions as a semantic `<button>` with clear hover and focus states. Respects user preferences by gracefully disabling the transform wobble animations and active scaling via `@media (prefers-reduced-motion: reduce)`.
+
+## Usage
+
+Drop the HTML button directly into your layout. 
+
+```html
+<button type="button" class="wobble-btn">
+  Click Me
+</button>
+```
+
+## CSS Custom Properties
+Easily customize the theme colors using the root variables in `style.css`:
+- `--btn-bg`: Background color of the button (default: `#8b5cf6`)
+- `--btn-hover`: Hover state color (default: `#7c3aed`)
+- `--btn-active`: Pressed state color (default: `#6d28d9`)
+- `--shadow-color`: The ambient drop shadow color (default: `rgba(139, 92, 246, 0.4)`)
+
+## Browser Support
+Works flawlessly in all modern browsers (Chrome, Firefox, Safari, Edge). The `:focus:not(:active)` pseudo-class combination is standard CSS behavior supported universally.

--- a/submissions/examples/css-wobble-on-click-ag/demo.html
+++ b/submissions/examples/css-wobble-on-click-ag/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Wobble on Click</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+
+  <!-- Wobble Button Component -->
+  <!-- We use type="button" to prevent form submission side effects -->
+  <button type="button" class="wobble-btn" aria-label="Wobble this button">
+    Click Me to Wobble
+  </button>
+
+</body>
+</html>

--- a/submissions/examples/css-wobble-on-click-ag/style.css
+++ b/submissions/examples/css-wobble-on-click-ag/style.css
@@ -1,0 +1,93 @@
+:root {
+  --bg-color: #f3f4f6;
+  --btn-bg: #8b5cf6; /* Vibrant Purple */
+  --btn-hover: #7c3aed;
+  --btn-active: #6d28d9;
+  --btn-text: #ffffff;
+  --shadow-color: rgba(139, 92, 246, 0.4);
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--bg-color);
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.wobble-btn {
+  padding: 16px 32px;
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: var(--btn-text);
+  background-color: var(--btn-bg);
+  border: none;
+  border-radius: 12px;
+  cursor: pointer;
+  box-shadow: 0 10px 20px -10px var(--shadow-color), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  transition: background-color 0.2s ease, box-shadow 0.2s ease;
+  position: relative;
+  /* Prevent text selection during rapid clicking */
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.wobble-btn:hover {
+  background-color: var(--btn-hover);
+  box-shadow: 0 15px 25px -10px var(--shadow-color), 0 6px 10px -2px rgba(0, 0, 0, 0.05);
+}
+
+.wobble-btn:active {
+  background-color: var(--btn-active);
+  /* Compress the button slightly on press */
+  transform: scale(0.95);
+  box-shadow: 0 5px 10px -5px var(--shadow-color);
+  transition: transform 0.1s, background-color 0.2s, box-shadow 0.1s;
+}
+
+/* 
+  The Magic Pure CSS Trigger Trick 
+  When the button is focused but NOT actively being pressed, play the wobble.
+  This allows the animation to play fully *after* a click is released, 
+  and it re-triggers perfectly on subsequent clicks because clicking 
+  temporarily forces :active, which resets the animation.
+*/
+.wobble-btn:focus:not(:active) {
+  animation: wobble 0.8s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
+}
+
+/* Add a custom outline for focus visibility that doesn't interfere with the wobble */
+.wobble-btn:focus-visible {
+  outline: 3px solid var(--btn-hover);
+  outline-offset: 4px;
+}
+.wobble-btn:focus:not(:focus-visible) {
+  outline: none;
+}
+
+/* Wobble Keyframes */
+@keyframes wobble {
+  0% { transform: translateX(0) rotate(0deg); }
+  15% { transform: translateX(-15px) rotate(-5deg); }
+  30% { transform: translateX(12px) rotate(4deg); }
+  45% { transform: translateX(-9px) rotate(-3deg); }
+  60% { transform: translateX(6px) rotate(2deg); }
+  75% { transform: translateX(-3px) rotate(-1deg); }
+  100% { transform: translateX(0) rotate(0deg); }
+}
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+  .wobble-btn {
+    transition: none;
+  }
+  .wobble-btn:active {
+    transform: none;
+  }
+  .wobble-btn:focus:not(:active) {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #70781.

This PR adds the "CSS Wobble on Click" submission. It introduces a playful button component that executes a full "wobble" animation immediately after being clicked, built entirely without JavaScript.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

It adds a fully functional CSS button that wobbles on click. Standard CSS `:active` animations stop abruptly the moment the mouse is released. This component circumvents that limitation by using a clever `:focus:not(:active)` selector trick. This resets the animation state during the click (`:active`), and perfectly triggers the full `wobble` keyframe sequence the moment the mouse is released (`:focus`).

**How does a developer use it?**

```html
<button type="button" class="wobble-btn">
  Click Me
</button>
