### PR TITLE
Feature/css slide in from right

### DIFF
--- a/submissions/examples/css-slide-in-from-right-ag/README.md
+++ b/submissions/examples/css-slide-in-from-right-ag/README.md
@@ -1,0 +1,30 @@
+# CSS Slide In from Right
+
+A beautiful scroll-triggered component that slides an element into view from the right side of the screen as the user scrolls down the page.
+
+## Features
+- **Modern Pure CSS Implementation**: This component showcases the cutting-edge CSS Scroll-Driven Animations specification. By utilizing `animation-timeline: view()` and `animation-range`, the slide-in animation is tied directly to the browser's native scroll engine entirely via CSS, offering massive performance gains over traditional JavaScript scroll listeners.
+- **Graceful JS Fallback**: For browsers that do not yet support CSS scroll timelines (like Safari), a minimal, highly optimized `IntersectionObserver` script fallback is provided. 
+- **Polished Micro-Interactions**: The element uses a custom `ease-out` timing function and horizontal translation (`translateX`) to create a frictionless, floating entry feel.
+- **Accessible & Responsive**: Employs `overflow-x: hidden` on the `body` to prevent horizontal scrollbar flashing during the animation sequence. Explicitly respects user preferences by gracefully disabling both the CSS and JS animations entirely if the system detects `@media (prefers-reduced-motion: reduce)`.
+
+## Usage
+
+Place the card in your HTML layout. The `demo-container` padding in the demo is only used to push the element down so you can physically scroll to it.
+
+```html
+<div class="slide-in-card">
+  <!-- Your content -->
+</div>
+```
+
+## CSS Custom Properties
+Easily customize the theme colors using the root variables in `style.css`:
+- `--card-bg`: Background color of the card (default: `#ffffff`)
+- `--text-main`: The main text color (default: `#0f172a`)
+- `--text-muted`: Body text color (default: `#64748b`)
+- `--shadow-color`: The ambient drop shadow color (default: `rgba(0, 0, 0, 0.1)`)
+
+## Browser Support
+- **Chrome/Edge**: Fully supported via native CSS `animation-timeline`.
+- **Firefox/Safari**: Fully supported via the included `IntersectionObserver` JS fallback until native support lands.

--- a/submissions/examples/css-slide-in-from-right-ag/demo.html
+++ b/submissions/examples/css-slide-in-from-right-ag/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Slide In from Right</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+
+  <div class="demo-container">
+    
+    <div class="instruction-text" aria-hidden="true">
+      Scroll Down ↓
+    </div>
+
+    <!-- The Element that will slide in from the right -->
+    <div class="slide-in-card" role="region" aria-label="Animated Content Card">
+      <div class="card-header">
+        <div class="card-avatar" aria-hidden="true"></div>
+        <h3 class="card-title">Scroll Triggered Card</h3>
+      </div>
+      <p class="card-body">
+        This card dynamically slid in from the right side of the screen using modern CSS scroll-driven animations (`animation-timeline: view()`). 
+      </p>
+    </div>
+
+  </div>
+
+  <!-- Minimal JS Fallback for browsers without CSS Scroll-Driven Animation support (e.g., Safari) -->
+  <script>
+    if (!CSS.supports('animation-timeline: view()')) {
+      const observer = new IntersectionObserver((entries) => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            entry.target.style.animation = 'slide-in-from-right 0.8s ease-out forwards';
+            observer.unobserve(entry.target);
+          }
+        });
+      }, { threshold: 0.2 });
+      
+      // Fallback respects reduced motion natively via CSS, but we check here to prevent flashing
+      const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      
+      document.querySelectorAll('.slide-in-card').forEach(el => {
+        if (!prefersReducedMotion) {
+          el.style.opacity = '0';
+          el.style.transform = 'translateX(150px)';
+          observer.observe(el);
+        }
+      });
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/css-slide-in-from-right-ag/style.css
+++ b/submissions/examples/css-slide-in-from-right-ag/style.css
@@ -1,0 +1,113 @@
+:root {
+  --bg-color: #f8fafc;
+  --card-bg: #ffffff;
+  --text-main: #0f172a;
+  --text-muted: #64748b;
+  --border-color: #e2e8f0;
+  --shadow-color: rgba(0, 0, 0, 0.1);
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--bg-color);
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  overflow-x: hidden; /* Prevent horizontal scrollbar during slide-in */
+}
+
+/* Add huge padding so we can scroll down to see the effect */
+.demo-container {
+  padding: 100vh 20px 100vh 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 100px;
+}
+
+.instruction-text {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--text-muted);
+  text-align: center;
+  animation: bounce 2s infinite;
+}
+
+@keyframes bounce {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-10px); }
+}
+
+/* The Element that will slide in */
+.slide-in-card {
+  background-color: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 16px;
+  padding: 32px;
+  width: 100%;
+  max-width: 500px;
+  box-shadow: 0 20px 25px -5px var(--shadow-color), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+}
+
+/* Modern CSS Scroll-Driven Animation Trigger */
+@supports (animation-timeline: view()) {
+  .slide-in-card {
+    /* Bind the animation to the element's visibility in the viewport */
+    animation: slide-in-from-right 1s ease-out forwards;
+    animation-timeline: view();
+    /* Play the animation from when it just enters to when it covers 25% of the viewport */
+    animation-range: entry 0% cover 25%;
+  }
+}
+
+@keyframes slide-in-from-right {
+  0% {
+    opacity: 0;
+    transform: translateX(150px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+/* Card Content Styling */
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.card-avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #3b82f6, #8b5cf6);
+}
+
+.card-title {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--text-main);
+}
+
+.card-body {
+  font-size: 1rem;
+  color: var(--text-muted);
+  line-height: 1.5;
+  margin: 0;
+}
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+  .slide-in-card {
+    /* Instantly disable the slide-in if the user prefers reduced motion */
+    animation: none !important;
+    opacity: 1 !important;
+    transform: translateX(0) !important;
+  }
+  .instruction-text {
+    animation: none;
+  }
+}

--- a/submissions/examples/css-sortable-column-header-ag/README.md
+++ b/submissions/examples/css-sortable-column-header-ag/README.md
@@ -1,0 +1,38 @@
+# CSS Sortable Column Header
+
+A beautifully animated, accessible table column header that simulates sorting state toggles using purely CSS.
+
+## Features
+- **Pure CSS / HTML**: Built entirely without JavaScript event listeners or state management.
+- **The Checkbox Hack**: Uses a visually hidden `<input type="checkbox">` coupled with a semantic `<label>` to store the Ascending/Descending sort state natively in the DOM. CSS sibling selectors (`:checked + .sort-header`) trigger the state transitions.
+- **Micro-Interactions**: Clicking the header subtly scales down the sort icon (`:active`), before transitioning it through a playful 180-degree `cubic-bezier` rotation. The active sorted column is highlighted with an accent color.
+- **Accessible & Responsive**: The hidden checkbox remains in the focus flow, allowing perfect keyboard navigation. `focus-visible` styles are properly forwarded to the label via sibling selectors. Screen readers can toggle the checkbox natively. Respects user preferences by gracefully disabling the scale and rotation animations via `@media (prefers-reduced-motion: reduce)`.
+
+## Usage
+
+Drop the HTML structure directly into your `<thead>` elements.
+
+```html
+<th>
+  <!-- Hidden Checkbox for State -->
+  <input type="checkbox" id="sort-name" class="sort-checkbox">
+  
+  <!-- The clickable Header Label -->
+  <label for="sort-name" class="sort-header" aria-label="Sort by Name">
+    Name
+    <span class="sort-icon-wrapper">
+      <svg>...</svg> <!-- Chevron Down -->
+    </span>
+  </label>
+</th>
+```
+
+## CSS Custom Properties
+Easily customize the theme colors using the root variables in `style.css`:
+- `--header-bg`: Background color of the table header (default: `#f8fafc`)
+- `--header-hover`: Hover state color for the header (default: `#f1f5f9`)
+- `--accent-color`: Active sorted highlight color (default: `#3b82f6`)
+- `--text-muted`: Default un-sorted text color (default: `#64748b`)
+
+## Browser Support
+Works flawlessly in all modern browsers (Chrome, Firefox, Safari, Edge). The checkbox sibling selector hack is a universally supported standard CSS technique.

--- a/submissions/examples/css-sortable-column-header-ag/demo.html
+++ b/submissions/examples/css-sortable-column-header-ag/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Sortable Column Header</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+
+  <div class="demo-table-wrapper">
+    <table>
+      <thead>
+        <tr>
+          <th>
+            <!-- Checkbox Hack for State -->
+            <input type="checkbox" id="sort-name" class="sort-checkbox">
+            <label for="sort-name" class="sort-header" aria-label="Sort by Name">
+              Name
+              <span class="sort-icon-wrapper">
+                <!-- Chevron Down SVG -->
+                <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M19 9l-7 7-7-7"></path>
+                </svg>
+              </span>
+            </label>
+          </th>
+          <th style="padding: 16px; font-size: 0.875rem; font-weight: 600; color: var(--text-muted);">
+            Status
+          </th>
+          <th style="padding: 16px; text-align: right; font-size: 0.875rem; font-weight: 600; color: var(--text-muted);">
+            Role
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Jane Cooper</td>
+          <td>Active</td>
+          <td style="text-align: right;">Admin</td>
+        </tr>
+        <tr>
+          <td>Cody Fisher</td>
+          <td>Offline</td>
+          <td style="text-align: right;">Editor</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/css-sortable-column-header-ag/style.css
+++ b/submissions/examples/css-sortable-column-header-ag/style.css
@@ -1,0 +1,152 @@
+:root {
+  --bg-color: #f1f5f9;
+  --table-bg: #ffffff;
+  --border-color: #e2e8f0;
+  --text-main: #0f172a;
+  --text-muted: #64748b;
+  --header-bg: #f8fafc;
+  --header-hover: #f1f5f9;
+  --accent-color: #3b82f6;
+  --focus-ring: rgba(59, 130, 246, 0.15);
+}
+
+body {
+  margin: 0;
+  padding: 40px 20px;
+  background-color: var(--bg-color);
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+/* Demo Table Container */
+.demo-table-wrapper {
+  background-color: var(--table-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+  width: 100%;
+  max-width: 600px;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  text-align: left;
+}
+
+th {
+  background-color: var(--header-bg);
+  border-bottom: 2px solid var(--border-color);
+  padding: 0; /* Padding is handled by the label for clickability */
+}
+
+td {
+  padding: 16px;
+  border-bottom: 1px solid var(--border-color);
+  color: var(--text-main);
+  font-size: 0.875rem;
+}
+
+table tr:last-child td {
+  border-bottom: none;
+}
+
+/* Hide the checkbox visually but keep it accessible for keyboard navigation */
+.sort-checkbox {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
+/* Header Label as Button */
+.sort-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 16px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  cursor: pointer;
+  user-select: none;
+  transition: background-color 0.2s ease, color 0.2s ease;
+  box-sizing: border-box;
+}
+
+.sort-header:hover {
+  background-color: var(--header-hover);
+  color: var(--text-main);
+}
+
+/* Focus styles for accessibility */
+.sort-checkbox:focus-visible + .sort-header {
+  outline: 2px solid var(--accent-color);
+  outline-offset: -2px;
+  background-color: var(--header-hover);
+}
+
+/* Sort Icon Wrapper */
+.sort-icon-wrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+  color: var(--text-muted);
+  background-color: transparent;
+  transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.sort-header:hover .sort-icon-wrapper {
+  background-color: rgba(0, 0, 0, 0.05);
+  color: var(--text-main);
+}
+
+.sort-icon-wrapper svg {
+  width: 16px;
+  height: 16px;
+  transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* Checked State Animations */
+.sort-checkbox:checked + .sort-header .sort-icon-wrapper svg {
+  transform: rotate(180deg);
+}
+
+.sort-checkbox:checked + .sort-header {
+  color: var(--accent-color);
+}
+
+.sort-checkbox:checked + .sort-header .sort-icon-wrapper {
+  color: var(--accent-color);
+  background-color: var(--focus-ring);
+}
+
+/* Active/Click Animation */
+.sort-header:active .sort-icon-wrapper {
+  transform: scale(0.8);
+}
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+  .sort-header,
+  .sort-icon-wrapper,
+  .sort-icon-wrapper svg {
+    transition: none;
+  }
+  .sort-header:active .sort-icon-wrapper {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #70816.

This PR adds the "CSS Slide In from Right" submission. It introduces a beautiful scroll-triggered component that slides an element into view from the right side of the screen as the user scrolls down the page.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

It adds a responsive component that slides in as it enters the viewport. It utilizes the cutting-edge CSS Scroll-Driven Animations specification (`animation-timeline: view()`) and `animation-range`, tying the slide-in animation directly to the browser's native scroll engine entirely via CSS, offering massive performance gains over traditional JavaScript scroll listeners.

**How does a developer use it?**

```html
<div class="slide-in-card">
  <!-- Your content -->
</div>

