### PR TITLE
feat: add CSS diagonal split hero component (#68091)

### DIFF
--- a/submissions/examples/css-diagonal-split-hero-eranmol/README.md
+++ b/submissions/examples/css-diagonal-split-hero-eranmol/README.md
@@ -1,0 +1,31 @@
+# CSS Diagonal Split Hero
+
+A hero section split diagonally with an image on one side and text on the other, built entirely with pure CSS.
+
+## What does this do?
+
+It creates a hero section where the image area is clipped at a diagonal angle using `clip-path: polygon()`, creating a dynamic split layout. One half holds text content and the other holds a visual. A reversed variant flips the layout.
+
+## How is it used?
+
+Drop `demo.html` and `style.css` into your project. The hero uses a simple grid layout with a clip-path on the image:
+
+```html
+<section class="diagonal-hero" role="banner" aria-label="Hero section">
+  <div class="diagonal-hero__content">
+    <span class="diagonal-hero__badge">New</span>
+    <h1 class="diagonal-hero__title">Your headline</h1>
+    <p class="diagonal-hero__text">Description text.</p>
+    <div class="diagonal-hero__actions">
+      <a class="diagonal-hero__button diagonal-hero__button--primary">CTA</a>
+    </div>
+  </div>
+  <div class="diagonal-hero__image" aria-hidden="true"></div>
+</section>
+```
+
+Add `diagonal-hero--reversed` to flip the layout (image left, text right).
+
+## Why is it useful?
+
+Hero sections are the first thing visitors see on a landing page. A diagonal split creates visual interest and breaks the monotony of rectangular layouts. This implementation uses CSS `clip-path` for the diagonal edge, CSS Grid for layout, staggered entrance animations, CSS custom properties for theming, and automatic dark mode support, all without any JavaScript.

--- a/submissions/examples/css-diagonal-split-hero-eranmol/demo.html
+++ b/submissions/examples/css-diagonal-split-hero-eranmol/demo.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Diagonal Split Hero</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="demo-container">
+
+    <!-- Hero Section: split diagonally with image on one side, text on the other -->
+    <section class="diagonal-hero" role="banner" aria-label="Hero section with diagonal split layout">
+
+      <!-- Text side (left) -->
+      <div class="diagonal-hero__content">
+        <span class="diagonal-hero__badge">New Release</span>
+        <h1 class="diagonal-hero__title">Build faster with modern CSS</h1>
+        <p class="diagonal-hero__text">Ship beautiful, responsive interfaces without the overhead of JavaScript frameworks. Pure CSS solutions for real-world problems.</p>
+        <div class="diagonal-hero__actions">
+          <a href="#" class="diagonal-hero__button diagonal-hero__button--primary" role="button">Get Started</a>
+          <a href="#" class="diagonal-hero__button diagonal-hero__button--secondary" role="button">Learn More</a>
+        </div>
+      </div>
+
+      <!-- Image side (right) — gradient placeholder -->
+      <div class="diagonal-hero__image" aria-hidden="true">
+        <div class="diagonal-hero__image-inner"></div>
+      </div>
+
+    </section>
+
+    <!-- Variant: reversed (image on left, text on right) -->
+    <section class="diagonal-hero diagonal-hero--reversed" role="banner" aria-label="Reversed hero section">
+
+      <div class="diagonal-hero__content">
+        <span class="diagonal-hero__badge">Open Source</span>
+        <h1 class="diagonal-hero__title">No dependencies required</h1>
+        <p class="diagonal-hero__text">Every component is hand-crafted CSS. No build step, no runtime, no bloat. Just copy, paste, and ship.</p>
+        <div class="diagonal-hero__actions">
+          <a href="#" class="diagonal-hero__button diagonal-hero__button--primary" role="button">View on GitHub</a>
+          <a href="#" class="diagonal-hero__button diagonal-hero__button--secondary" role="button">Read Docs</a>
+        </div>
+      </div>
+
+      <div class="diagonal-hero__image" aria-hidden="true">
+        <div class="diagonal-hero__image-inner"></div>
+      </div>
+
+    </section>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/css-diagonal-split-hero-eranmol/style.css
+++ b/submissions/examples/css-diagonal-split-hero-eranmol/style.css
@@ -1,0 +1,315 @@
+/* ============================================================
+   CSS Diagonal Split Hero
+   Hero section split diagonally with image on one side
+   and text on the other. Uses clip-path for the diagonal.
+   ============================================================ */
+
+/* ---------- Reset ---------- */
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+/* ---------- CSS Custom Properties (Light Mode) ---------- */
+:root {
+  --hero-bg: #ffffff;
+  --hero-content-bg: #ffffff;
+  --hero-text: #1e293b;
+  --hero-text-muted: #64748b;
+  --hero-badge-bg: #e0e7ff;
+  --hero-badge-text: #4338ca;
+  --hero-button-primary-bg: #4f46e5;
+  --hero-button-primary-text: #ffffff;
+  --hero-button-primary-hover: #4338ca;
+  --hero-button-secondary-bg: transparent;
+  --hero-button-secondary-text: #4f46e5;
+  --hero-button-secondary-border: #4f46e5;
+  --hero-button-secondary-hover: #f0f0ff;
+  --hero-image-1: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  --hero-image-2: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
+  --page-bg: #f1f5f9;
+  --transition-speed: 0.35s;
+}
+
+/* ---------- Dark Mode ---------- */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --hero-bg: #0f172a;
+    --hero-content-bg: #1e293b;
+    --hero-text: #f1f5f9;
+    --hero-text-muted: #94a3b8;
+    --hero-badge-bg: rgba(99, 102, 241, 0.2);
+    --hero-badge-text: #a5b4fc;
+    --hero-button-primary-bg: #6366f1;
+    --hero-button-primary-text: #ffffff;
+    --hero-button-primary-hover: #818cf8;
+    --hero-button-secondary-bg: transparent;
+    --hero-button-secondary-text: #a5b4fc;
+    --hero-button-secondary-border: #818cf8;
+    --hero-button-secondary-hover: rgba(99, 102, 241, 0.1);
+    --page-bg: #0f172a;
+  }
+}
+
+/* ---------- Page Layout ---------- */
+body {
+  min-height: 100vh;
+  background: var(--page-bg);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  padding: 2rem 1rem;
+}
+
+.demo-container {
+  max-width: 1080px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+}
+
+/* ============================================================
+   Diagonal Split Hero
+   The hero is split into two halves using a CSS grid.
+   The image side uses clip-path to create the diagonal edge.
+   ============================================================ */
+.diagonal-hero {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  min-height: 420px;
+  background: var(--hero-bg);
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.06);
+  position: relative;
+  animation: heroFadeIn 0.5s ease both;
+}
+
+/* ---------- Content Side (Left) ---------- */
+.diagonal-hero__content {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 3rem 2.5rem;
+  gap: 1rem;
+
+  /* Slide in from left */
+  animation: heroContentIn 0.6s ease 0.15s both;
+}
+
+.diagonal-hero__badge {
+  display: inline-block;
+  align-self: flex-start;
+  padding: 0.3rem 0.875rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--hero-badge-text);
+  background: var(--hero-badge-bg);
+  border-radius: 20px;
+  letter-spacing: 0.02em;
+}
+
+.diagonal-hero__title {
+  font-size: 2rem;
+  font-weight: 800;
+  line-height: 1.2;
+  color: var(--hero-text);
+}
+
+.diagonal-hero__text {
+  font-size: 1rem;
+  line-height: 1.6;
+  color: var(--hero-text-muted);
+  max-width: 420px;
+}
+
+.diagonal-hero__actions {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+  flex-wrap: wrap;
+}
+
+/* ============================================================
+   Buttons
+   ============================================================ */
+.diagonal-hero__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.7rem 1.5rem;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  font-family: inherit;
+  text-decoration: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition:
+    background var(--transition-speed) ease,
+    color var(--transition-speed) ease,
+    border-color var(--transition-speed) ease,
+    transform 0.15s ease;
+}
+
+.diagonal-hero__button:active {
+  transform: scale(0.97);
+}
+
+.diagonal-hero__button:focus-visible {
+  outline: 2px solid var(--hero-button-primary-bg);
+  outline-offset: 2px;
+}
+
+/* Primary button */
+.diagonal-hero__button--primary {
+  background: var(--hero-button-primary-bg);
+  color: var(--hero-button-primary-text);
+  border: 2px solid var(--hero-button-primary-bg);
+}
+
+.diagonal-hero__button--primary:hover {
+  background: var(--hero-button-primary-hover);
+  border-color: var(--hero-button-primary-hover);
+}
+
+/* Secondary button */
+.diagonal-hero__button--secondary {
+  background: var(--hero-button-secondary-bg);
+  color: var(--hero-button-secondary-text);
+  border: 2px solid var(--hero-button-secondary-border);
+}
+
+.diagonal-hero__button--secondary:hover {
+  background: var(--hero-button-secondary-hover);
+}
+
+/* ============================================================
+   Image Side (Right)
+   Uses clip-path to create the diagonal edge.
+   The clip cuts the left edge of the image container at an
+   angle, revealing the content behind it on the left.
+   ============================================================ */
+.diagonal-hero__image {
+  position: relative;
+  background: var(--hero-image-1);
+
+  /* Diagonal clip: top starts further left, bottom extends right */
+  clip-path: polygon(12% 0%, 100% 0%, 100% 100%, 0% 100%);
+
+  /* Entrance: slide in from right */
+  animation: heroImageIn 0.6s ease 0.25s both;
+}
+
+/* Inner gradient overlay for visual interest */
+.diagonal-hero__image-inner {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 30% 50%, rgba(255, 255, 255, 0.15) 0%, transparent 50%),
+    radial-gradient(circle at 70% 80%, rgba(255, 255, 255, 0.1) 0%, transparent 40%);
+}
+
+/* ============================================================
+   Reversed Variant
+   Image on left, text on right.
+   The clip-path mirrors to cut from the right side.
+   ============================================================ */
+.diagonal-hero--reversed {
+  direction: rtl;
+}
+
+.diagonal-hero--reversed > * {
+  direction: ltr;
+}
+
+.diagonal-hero--reversed .diagonal-hero__image {
+  /* Mirror the diagonal: top starts at left, bottom clips further left */
+  clip-path: polygon(0% 0%, 88% 0%, 100% 100%, 0% 100%);
+}
+
+/* ============================================================
+   Entrance Animations
+   ============================================================ */
+@keyframes heroFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes heroContentIn {
+  from {
+    opacity: 0;
+    transform: translateX(-24px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes heroImageIn {
+  from {
+    opacity: 0;
+    transform: translateX(24px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+/* ============================================================
+   Responsive: Mobile — stack vertically
+   On small screens the diagonal split switches to a
+   top/bottom layout instead of left/right.
+   ============================================================ */
+@media (max-width: 720px) {
+  .diagonal-hero {
+    grid-template-columns: 1fr;
+    min-height: auto;
+  }
+
+  .diagonal-hero__content {
+    padding: 2rem 1.5rem;
+    order: 1;
+  }
+
+  .diagonal-hero__title {
+    font-size: 1.5rem;
+  }
+
+  .diagonal-hero__image {
+    order: 2;
+    min-height: 220px;
+
+    /* Switch to horizontal diagonal on mobile */
+    clip-path: polygon(0% 0%, 100% 0%, 100% 85%, 0% 100%);
+  }
+
+  .diagonal-hero--reversed .diagonal-hero__image {
+    clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 85%);
+  }
+}
+
+/* ============================================================
+   Reduced Motion
+   ============================================================ */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
Closes #68091

## Pull Request Description

Adds a hero section split diagonally with image and text, addressing issue #68091.

---

## Type of Change

- [x] 🧩 New component

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/css-diagonal-split-hero-eranmol/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A hero section where the image area is clipped at a diagonal angle using `clip-path: polygon()`, creating a dynamic split layout. Includes a normal variant (image right) and a reversed variant (image left).

**How does a developer use it?**

```html
<section class="diagonal-hero" role="banner" aria-label="Hero section">
  <div class="diagonal-hero__content">
    <span class="diagonal-hero__badge">New</span>
    <h1 class="diagonal-hero__title">Your headline</h1>
    <p class="diagonal-hero__text">Description text.</p>
    <div class="diagonal-hero__actions">
      <a class="diagonal-hero__button diagonal-hero__button--primary">CTA</a>
    </div>
  </div>
  <div class="diagonal-hero__image" aria-hidden="true"></div>
</section>