### PR TITLE
feat: add CSS range slider component (#68192)

### DIFF
--- a/submissions/examples/css-range-slider-eranmol/README.md
+++ b/submissions/examples/css-range-slider-eranmol/README.md
@@ -1,0 +1,33 @@
+# CSS Range Slider
+
+Custom-styled range input slider with animated thumb and value tooltip, built entirely with pure CSS.
+
+## What does this do?
+
+It provides a fully styled range input component with a custom thumb, hover ring animation, color variants (indigo, orange, purple), and a value tooltip above the thumb. The native `<input type="range">` is completely restyled using `appearance: none` and pseudo-elements.
+
+## How is it used?
+
+Drop `demo.html` and `style.css` into your project. Use the standard HTML range input with the `range-slider` class:
+
+```html
+<label for="volume" class="slider-demo__label">Volume</label>
+<div class="slider-wrapper">
+  <input
+    type="range"
+    id="volume"
+    class="range-slider"
+    min="0"
+    max="100"
+    value="60"
+    aria-label="Volume"
+  >
+  <span class="range-slider__tooltip" aria-hidden="true">60</span>
+</div>
+```
+
+Add a modifier class for color variants: `range-slider--warm` (orange) or `range-slider--accent` (purple).
+
+## Why is it useful?
+
+Range sliders are a common UI element for filters, settings, and pricing tools. The native browser slider looks inconsistent across platforms and is hard to style. This component gives developers a polished, cross-browser range slider with smooth hover animations, accessible focus states, color variants, and dark mode support, all without any JavaScript.

--- a/submissions/examples/css-range-slider-eranmol/demo.html
+++ b/submissions/examples/css-range-slider-eranmol/demo.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Range Slider</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="demo-container">
+
+    <h1 class="demo-title">CSS Range Sliders</h1>
+    <p class="demo-subtitle">Custom-styled range inputs with animated thumbs</p>
+
+    <!-- Basic slider -->
+    <div class="slider-demo">
+      <label for="slider-basic" class="slider-demo__label">Volume</label>
+      <div class="slider-wrapper">
+        <input
+          type="range"
+          id="slider-basic"
+          class="range-slider"
+          min="0"
+          max="100"
+          value="60"
+          step="1"
+          aria-label="Volume"
+        >
+        <span class="range-slider__tooltip" aria-hidden="true">60</span>
+      </div>
+    </div>
+
+    <!-- Slider with different range -->
+    <div class="slider-demo">
+      <label for="slider-temp" class="slider-demo__label">Temperature</label>
+      <div class="slider-wrapper">
+        <input
+          type="range"
+          id="slider-temp"
+          class="range-slider range-slider--warm"
+          min="0"
+          max="50"
+          value="24"
+          step="1"
+          aria-label="Temperature"
+        >
+        <span class="range-slider__tooltip" aria-hidden="true">24</span>
+      </div>
+    </div>
+
+    <!-- Slider with step markers -->
+    <div class="slider-demo">
+      <label for="slider-rating" class="slider-demo__label">Rating</label>
+      <div class="slider-wrapper">
+        <input
+          type="range"
+          id="slider-rating"
+          class="range-slider range-slider--accent"
+          min="0"
+          max="10"
+          value="7"
+          step="1"
+          aria-label="Rating"
+        >
+        <span class="range-slider__tooltip" aria-hidden="true">7</span>
+      </div>
+    </div>
+
+    <!-- Disabled slider -->
+    <div class="slider-demo">
+      <label for="slider-disabled" class="slider-demo__label">Locked</label>
+      <div class="slider-wrapper">
+        <input
+          type="range"
+          id="slider-disabled"
+          class="range-slider"
+          min="0"
+          max="100"
+          value="40"
+          step="1"
+          disabled
+          aria-label="Locked slider"
+        >
+        <span class="range-slider__tooltip" aria-hidden="true">40</span>
+      </div>
+    </div>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/css-range-slider-eranmol/style.css
+++ b/submissions/examples/css-range-slider-eranmol/style.css
@@ -1,0 +1,381 @@
+/* ============================================================
+   CSS Range Slider
+   Custom-styled range input slider with animated thumb
+   and value tooltip. Pure CSS — no JavaScript required.
+   ============================================================ */
+
+/* ---------- Reset ---------- */
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+/* ---------- CSS Custom Properties (Light Mode) ---------- */
+:root {
+  --page-bg: #f8fafc;
+  --page-text: #1e293b;
+  --page-text-muted: #64748b;
+
+  --slider-track-bg: #e2e8f0;
+  --slider-track-fill: #4f46e5;
+  --slider-thumb-bg: #4f46e5;
+  --slider-thumb-ring: rgba(79, 70, 229, 0.25);
+  --slider-thumb-size: 22px;
+  --slider-track-height: 6px;
+  --slider-thumb-hover-scale: 1.2;
+
+  --slider-warm-fill: #f97316;
+  --slider-warm-thumb: #f97316;
+  --slider-warm-ring: rgba(249, 115, 22, 0.25);
+
+  --slider-accent-fill: #8b5cf6;
+  --slider-accent-thumb: #8b5cf6;
+  --slider-accent-ring: rgba(139, 92, 246, 0.25);
+
+  --tooltip-bg: #1e293b;
+  --tooltip-text: #ffffff;
+  --card-bg: #ffffff;
+  --card-border: #e2e8f0;
+  --card-shadow: 0 1px 3px rgba(0, 0, 0, 0.06), 0 4px 12px rgba(0, 0, 0, 0.04);
+
+  --transition-speed: 0.2s;
+}
+
+/* ---------- Dark Mode ---------- */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --page-bg: #0f172a;
+    --page-text: #f1f5f9;
+    --page-text-muted: #94a3b8;
+
+    --slider-track-bg: #334155;
+    --slider-track-fill: #818cf8;
+    --slider-thumb-bg: #818cf8;
+    --slider-thumb-ring: rgba(129, 140, 248, 0.3);
+
+    --slider-warm-fill: #fb923c;
+    --slider-warm-thumb: #fb923c;
+    --slider-warm-ring: rgba(251, 146, 60, 0.3);
+
+    --slider-accent-fill: #a78bfa;
+    --slider-accent-thumb: #a78bfa;
+    --slider-accent-ring: rgba(167, 139, 250, 0.3);
+
+    --tooltip-bg: #e2e8f0;
+    --tooltip-text: #0f172a;
+    --card-bg: #1e293b;
+    --card-border: #334155;
+    --card-shadow: 0 1px 3px rgba(0, 0, 0, 0.3), 0 4px 12px rgba(0, 0, 0, 0.2);
+  }
+}
+
+/* ---------- Page Layout ---------- */
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--page-bg);
+  color: var(--page-text);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  padding: 2rem 1rem;
+}
+
+.demo-container {
+  width: 100%;
+  max-width: 480px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.demo-title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  text-align: center;
+}
+
+.demo-subtitle {
+  font-size: 0.9375rem;
+  color: var(--page-text-muted);
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+/* ============================================================
+   Slider Demo Row
+   Each slider sits in its own labeled card.
+   ============================================================ */
+.slider-demo {
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+  padding: 1.25rem 1.5rem;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 12px;
+  box-shadow: var(--card-shadow);
+  animation: sliderCardIn 0.4s ease both;
+}
+
+.slider-demo:nth-child(2) { animation-delay: 0.05s; }
+.slider-demo:nth-child(3) { animation-delay: 0.1s; }
+.slider-demo:nth-child(4) { animation-delay: 0.15s; }
+.slider-demo:nth-child(5) { animation-delay: 0.2s; }
+
+.slider-demo__label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--page-text);
+}
+
+.slider-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+/* ============================================================
+   Range Slider — Core Styles
+   Uses appearance: none to fully override the native input.
+   The track and thumb are styled via pseudo-elements.
+   ============================================================ */
+.range-slider {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: var(--slider-track-height);
+  background: var(--slider-track-bg);
+  border-radius: 3px;
+  outline: none;
+  cursor: pointer;
+  transition: background var(--transition-speed) ease;
+}
+
+/* ---------- Track (Webkit) ---------- */
+.range-slider::-webkit-slider-runnable-track {
+  width: 100%;
+  height: var(--slider-track-height);
+  border-radius: 3px;
+  background: var(--slider-track-bg);
+}
+
+/* ---------- Track (Firefox) ---------- */
+.range-slider::-moz-range-track {
+  width: 100%;
+  height: var(--slider-track-height);
+  border-radius: 3px;
+  background: var(--slider-track-bg);
+  border: none;
+}
+
+/* ---------- Thumb (Webkit) ---------- */
+/* The thumb is the draggable handle. It has a ring effect
+   that appears on hover/focus using box-shadow. */
+.range-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: var(--slider-thumb-size);
+  height: var(--slider-thumb-size);
+  border-radius: 50%;
+  background: var(--slider-thumb-bg);
+  border: 3px solid var(--card-bg);
+  box-shadow:
+    0 1px 4px rgba(0, 0, 0, 0.15),
+    0 0 0 0 var(--slider-thumb-ring);
+  cursor: pointer;
+  margin-top: calc((var(--slider-thumb-size) - var(--slider-track-height)) / -2);
+
+  /* Smooth scale animation on hover */
+  transition:
+    transform 0.2s cubic-bezier(0.34, 1.2, 0.64, 1),
+    box-shadow var(--transition-speed) ease;
+}
+
+.range-slider::-webkit-slider-thumb:hover {
+  transform: scale(var(--slider-thumb-hover-scale));
+  box-shadow:
+    0 2px 8px rgba(0, 0, 0, 0.2),
+    0 0 0 6px var(--slider-thumb-ring);
+}
+
+/* ---------- Thumb (Firefox) ---------- */
+.range-slider::-moz-range-thumb {
+  width: var(--slider-thumb-size);
+  height: var(--slider-thumb-size);
+  border-radius: 50%;
+  background: var(--slider-thumb-bg);
+  border: 3px solid var(--card-bg);
+  box-shadow:
+    0 1px 4px rgba(0, 0, 0, 0.15),
+    0 0 0 0 var(--slider-thumb-ring);
+  cursor: pointer;
+
+  transition:
+    transform 0.2s cubic-bezier(0.34, 1.2, 0.64, 1),
+    box-shadow var(--transition-speed) ease;
+}
+
+.range-slider::-moz-range-thumb:hover {
+  transform: scale(var(--slider-thumb-hover-scale));
+  box-shadow:
+    0 2px 8px rgba(0, 0, 0, 0.2),
+    0 0 0 6px var(--slider-thumb-ring);
+}
+
+/* ---------- Focus Ring ---------- */
+.range-slider:focus-visible::-webkit-slider-thumb {
+  box-shadow:
+    0 2px 8px rgba(0, 0, 0, 0.2),
+    0 0 0 4px var(--slider-thumb-ring);
+}
+
+.range-slider:focus-visible::-moz-range-thumb {
+  box-shadow:
+    0 2px 8px rgba(0, 0, 0, 0.2),
+    0 0 0 4px var(--slider-thumb-ring);
+}
+
+/* ============================================================
+   Disabled State
+   ============================================================ */
+.range-slider:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.range-slider:disabled::-webkit-slider-thumb {
+  cursor: not-allowed;
+  transform: none;
+}
+
+.range-slider:disabled::-moz-range-thumb {
+  cursor: not-allowed;
+  transform: none;
+}
+
+/* ============================================================
+   Color Variants
+   ============================================================ */
+
+/* Warm (orange) variant */
+.range-slider--warm::-webkit-slider-thumb {
+  background: var(--slider-warm-thumb);
+}
+
+.range-slider--warm::-webkit-slider-thumb:hover {
+  box-shadow:
+    0 2px 8px rgba(0, 0, 0, 0.2),
+    0 0 0 6px var(--slider-warm-ring);
+}
+
+.range-slider--warm::-moz-range-thumb {
+  background: var(--slider-warm-thumb);
+}
+
+.range-slider--warm::-moz-range-thumb:hover {
+  box-shadow:
+    0 2px 8px rgba(0, 0, 0, 0.2),
+    0 0 0 6px var(--slider-warm-ring);
+}
+
+/* Accent (purple) variant */
+.range-slider--accent::-webkit-slider-thumb {
+  background: var(--slider-accent-thumb);
+}
+
+.range-slider--accent::-webkit-slider-thumb:hover {
+  box-shadow:
+    0 2px 8px rgba(0, 0, 0, 0.2),
+    0 0 0 6px var(--slider-accent-ring);
+}
+
+.range-slider--accent::-moz-range-thumb {
+  background: var(--slider-accent-thumb);
+}
+
+.range-slider--accent::-moz-range-thumb:hover {
+  box-shadow:
+    0 2px 8px rgba(0, 0, 0, 0.2),
+    0 0 0 6px var(--slider-accent-ring);
+}
+
+/* ============================================================
+   Value Tooltip
+   Small pill above the thumb showing the current value.
+   Static in this pure-CSS demo; positioned above the thumb.
+   ============================================================ */
+.range-slider__tooltip {
+  position: absolute;
+  right: 0;
+  top: -28px;
+
+  padding: 0.2rem 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--tooltip-text);
+  background: var(--tooltip-bg);
+  border-radius: 6px;
+  white-space: nowrap;
+  pointer-events: none;
+
+  /* Fade in on page load */
+  animation: tooltipFadeIn 0.4s ease 0.3s both;
+}
+
+/* Triangle pointing down */
+.range-slider__tooltip::after {
+  content: "";
+  position: absolute;
+  bottom: -4px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 0;
+  height: 0;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: 5px solid var(--tooltip-bg);
+}
+
+/* ============================================================
+   Entrance Animation
+   ============================================================ */
+@keyframes sliderCardIn {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes tooltipFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* ============================================================
+   Reduced Motion
+   ============================================================ */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
Closes #68192

## Pull Request Description

Adds custom-styled range input sliders with animated thumb and value tooltip, addressing issue #68192.

---

## Type of Change

- [x] 🧩 New component

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/css-range-slider-eranmol/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A custom-styled range input slider with an animated thumb (scale on hover), expanding ring effect, color variants (indigo, orange, purple), and a value tooltip pill above the thumb.

**How does a developer use it?**

```html
<label for="volume">Volume</label>
<div class="slider-wrapper">
  <input
    type="range"
    id="volume"
    class="range-slider"
    min="0"
    max="100"
    value="60"
    aria-label="Volume"
  >
  <span class="range-slider__tooltip" aria-hidden="true">60</span>
</div>