### PR TITLE
feat: add CSS responsive scroll table component (#68240)

### DIFF
--- a/submissions/examples/css-responsive-scroll-table-eranmol/README.md
+++ b/submissions/examples/css-responsive-scroll-table-eranmol/README.md
@@ -1,0 +1,38 @@
+# CSS Responsive Scroll Table
+
+A wide data table that scrolls horizontally on mobile with a sticky first column, built entirely with pure CSS.
+
+## What does this do?
+
+It provides a responsive data table that works on all screen sizes. On desktop, the table displays all columns normally. On narrow screens, the table scrolls horizontally while the first column stays pinned to the left edge using `position: sticky`, so the user always knows which row they are looking at.
+
+## How is it used?
+
+Drop `demo.html` and `style.css` into your project. Wrap your table in a scrollable container:
+
+```html
+<div class="table-container" role="region" aria-label="Data table" tabindex="0">
+  <table class="scroll-table">
+    <thead>
+      <tr>
+        <th class="scroll-table__th--sticky">Name</th>
+        <th>Department</th>
+        <th>Status</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td class="scroll-table__td--sticky">Jane Cooper</td>
+        <td>Engineering</td>
+        <td><span class="scroll-table__badge scroll-table__badge--active">Active</span></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+```
+
+The key is adding `scroll-table__th--sticky` / `scroll-table__td--sticky` to the first column cells and wrapping the table in a container with `overflow-x: auto`.
+
+## Why is it useful?
+
+Responsive data tables are one of the trickiest UI patterns in CSS. This component gives developers a drop-in solution that scrolls horizontally on mobile while keeping the most important column visible. It includes `role="region"` and `tabindex="0"` for keyboard accessibility, status badges, alternate row striping, dark mode support, and CSS custom properties for theming.

--- a/submissions/examples/css-responsive-scroll-table-eranmol/demo.html
+++ b/submissions/examples/css-responsive-scroll-table-eranmol/demo.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Responsive Scroll Table</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="demo-container">
+
+    <h1 class="demo-title">Responsive Scroll Table</h1>
+    <p class="demo-subtitle">Wide data table that scrolls horizontally with sticky first column</p>
+
+    <div class="table-container" role="region" aria-label="Responsive data table" tabindex="0">
+
+      <table class="scroll-table">
+        <thead>
+          <tr>
+            <th class="scroll-table__th--sticky">Employee</th>
+            <th>Department</th>
+            <th>Location</th>
+            <th>Status</th>
+            <th>Start Date</th>
+            <th>Salary</th>
+            <th>Performance</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="scroll-table__td--sticky">Jane Cooper</td>
+            <td>Engineering</td>
+            <td>San Francisco, CA</td>
+            <td><span class="scroll-table__badge scroll-table__badge--active">Active</span></td>
+            <td>2023-01-15</td>
+            <td>$125,000</td>
+            <td>Exceeds</td>
+          </tr>
+          <tr>
+            <td class="scroll-table__td--sticky">Wade Warren</td>
+            <td>Design</td>
+            <td>New York, NY</td>
+            <td><span class="scroll-table__badge scroll-table__badge--active">Active</span></td>
+            <td>2022-08-03</td>
+            <td>$110,000</td>
+            <td>Meets</td>
+          </tr>
+          <tr>
+            <td class="scroll-table__td--sticky">Esther Howard</td>
+            <td>Marketing</td>
+            <td>Austin, TX</td>
+            <td><span class="scroll-table__badge scroll-table__badge--on-leave">On Leave</span></td>
+            <td>2021-11-20</td>
+            <td>$95,000</td>
+            <td>Exceeds</td>
+          </tr>
+          <tr>
+            <td class="scroll-table__td--sticky">Cameron Williamson</td>
+            <td>Product</td>
+            <td>Seattle, WA</td>
+            <td><span class="scroll-table__badge scroll-table__badge--active">Active</span></td>
+            <td>2023-03-07</td>
+            <td>$130,000</td>
+            <td>Meets</td>
+          </tr>
+          <tr>
+            <td class="scroll-table__td--sticky">Brooklyn Simmons</td>
+            <td>Engineering</td>
+            <td>Austin, TX</td>
+            <td><span class="scroll-table__badge scroll-table__badge--inactive">Inactive</span></td>
+            <td>2020-06-12</td>
+            <td>$115,000</td>
+            <td>Below</td>
+          </tr>
+          <tr>
+            <td class="scroll-table__td--sticky">Leslie Alexander</td>
+            <td>Design</td>
+            <td>San Francisco, CA</td>
+            <td><span class="scroll-table__badge scroll-table__badge--active">Active</span></td>
+            <td>2022-04-18</td>
+            <td>$105,000</td>
+            <td>Exceeds</td>
+          </tr>
+          <tr>
+            <td class="scroll-table__td--sticky">Guy Hawkins</td>
+            <td>Engineering</td>
+            <td>New York, NY</td>
+            <td><span class="scroll-table__badge scroll-table__badge--active">Active</span></td>
+            <td>2023-07-01</td>
+            <td>$140,000</td>
+            <td>Meets</td>
+          </tr>
+        </tbody>
+      </table>
+
+    </div>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/css-responsive-scroll-table-eranmol/style.css
+++ b/submissions/examples/css-responsive-scroll-table-eranmol/style.css
@@ -1,0 +1,306 @@
+/* ============================================================
+   CSS Responsive Scroll Table
+   Wide data table that scrolls horizontally on mobile
+   with a sticky first column. Pure CSS, no JavaScript.
+   ============================================================ */
+
+/* ---------- Reset ---------- */
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+/* ---------- CSS Custom Properties (Light Mode) ---------- */
+:root {
+  --page-bg: #f8fafc;
+  --page-text: #1e293b;
+  --page-text-muted: #64748b;
+
+  --table-bg: #ffffff;
+  --table-border: #e2e8f0;
+  --table-header-bg: #f1f5f9;
+  --table-header-text: #334155;
+  --table-row-hover: #f8fafc;
+  --table-sticky-bg: #ffffff;
+  --table-sticky-shadow: 4px 0 12px rgba(0, 0, 0, 0.06);
+
+  --badge-active-bg: #dcfce7;
+  --badge-active-text: #166534;
+  --badge-leave-bg: #fef3c7;
+  --badge-leave-text: #92400e;
+  --badge-inactive-bg: #fee2e2;
+  --badge-inactive-text: #991b1b;
+
+  --container-shadow: 0 1px 3px rgba(0, 0, 0, 0.06), 0 4px 16px rgba(0, 0, 0, 0.04);
+
+  --transition-speed: 0.2s;
+}
+
+/* ---------- Dark Mode ---------- */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --page-bg: #0f172a;
+    --page-text: #f1f5f9;
+    --page-text-muted: #94a3b8;
+
+    --table-bg: #1e293b;
+    --table-border: #334155;
+    --table-header-bg: #1e293b;
+    --table-header-text: #e2e8f0;
+    --table-row-hover: #334155;
+    --table-sticky-bg: #1e293b;
+    --table-sticky-shadow: 4px 0 12px rgba(0, 0, 0, 0.3);
+
+    --badge-active-bg: rgba(34, 197, 94, 0.15);
+    --badge-active-text: #4ade80;
+    --badge-leave-bg: rgba(234, 179, 8, 0.15);
+    --badge-leave-text: #facc15;
+    --badge-inactive-bg: rgba(239, 68, 68, 0.15);
+    --badge-inactive-text: #f87171;
+
+    --container-shadow: 0 1px 3px rgba(0, 0, 0, 0.3), 0 4px 16px rgba(0, 0, 0, 0.2);
+  }
+}
+
+/* ---------- Page Layout ---------- */
+body {
+  min-height: 100vh;
+  background: var(--page-bg);
+  color: var(--page-text);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  padding: 2rem 1rem;
+}
+
+.demo-container {
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.demo-title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  text-align: center;
+}
+
+.demo-subtitle {
+  font-size: 0.9375rem;
+  color: var(--page-text-muted);
+  text-align: center;
+  margin-bottom: 1.5rem;
+}
+
+/* ============================================================
+   Table Container
+   Wraps the table and handles horizontal scrolling.
+   On narrow screens, the container scrolls horizontally
+   while the first column stays pinned via position: sticky.
+   ============================================================ */
+.table-container {
+  overflow-x: auto;
+  border: 1px solid var(--table-border);
+  border-radius: 12px;
+  background: var(--table-bg);
+  box-shadow: var(--container-shadow);
+
+  /* Keyboard focusable for accessibility */
+  outline: none;
+
+  /* Smooth scroll */
+  scroll-behavior: smooth;
+
+  /* Fade edges hint that content is scrollable */
+  animation: tableFadeIn 0.4s ease both;
+}
+
+.table-container:focus-visible {
+  box-shadow: var(--container-shadow), 0 0 0 3px rgba(79, 70, 229, 0.25);
+}
+
+/* Scrollbar styling */
+.table-container::-webkit-scrollbar {
+  height: 6px;
+}
+
+.table-container::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.table-container::-webkit-scrollbar-thumb {
+  background: var(--page-text-muted);
+  border-radius: 3px;
+}
+
+/* ============================================================
+   Scroll Table
+   The table itself uses fixed layout to ensure consistent
+   column widths. The first column (th + td) is sticky.
+   ============================================================ */
+.scroll-table {
+  width: 100%;
+  min-width: 720px;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+
+/* ---------- Header ---------- */
+.scroll-table thead {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+}
+
+.scroll-table th {
+  padding: 0.875rem 1rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--table-header-text);
+  background: var(--table-header-bg);
+  text-align: left;
+  white-space: nowrap;
+  border-bottom: 2px solid var(--table-border);
+}
+
+/* ---------- Data Cells ---------- */
+.scroll-table td {
+  padding: 0.875rem 1rem;
+  font-size: 0.9375rem;
+  color: var(--page-text);
+  border-bottom: 1px solid var(--table-border);
+  white-space: nowrap;
+}
+
+/* Alternate row striping */
+.scroll-table tbody tr:nth-child(even) {
+  background: var(--table-row-hover);
+}
+
+/* Hover highlight */
+.scroll-table tbody tr:hover {
+  background: var(--table-row-hover);
+}
+
+/* ============================================================
+   Sticky First Column
+   The first th and td in each row are pinned to the left
+   edge using position: sticky. A subtle box-shadow on the
+   right edge indicates there is more content to scroll.
+   ============================================================ */
+.scroll-table__th--sticky,
+.scroll-table__td--sticky {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+  background: var(--table-sticky-bg);
+  box-shadow: var(--table-sticky-shadow);
+
+  /* Keep the shadow contained to the right side only */
+  border-right: 1px solid var(--table-border);
+}
+
+.scroll-table__th--sticky {
+  z-index: 3;
+  background: var(--table-header-bg);
+}
+
+/* ---------- Column Widths ---------- */
+.scroll-table th:nth-child(1),
+.scroll-table td:nth-child(1) { width: 180px; }
+
+.scroll-table th:nth-child(2),
+.scroll-table td:nth-child(2) { width: 140px; }
+
+.scroll-table th:nth-child(3),
+.scroll-table td:nth-child(3) { width: 170px; }
+
+.scroll-table th:nth-child(4),
+.scroll-table td:nth-child(4) { width: 110px; }
+
+.scroll-table th:nth-child(5),
+.scroll-table td:nth-child(5) { width: 120px; }
+
+.scroll-table th:nth-child(6),
+.scroll-table td:nth-child(6) { width: 110px; }
+
+.scroll-table th:nth-child(7),
+.scroll-table td:nth-child(7) { width: 120px; }
+
+/* ============================================================
+   Status Badges
+   ============================================================ */
+.scroll-table__badge {
+  display: inline-block;
+  padding: 0.2rem 0.625rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border-radius: 20px;
+  white-space: nowrap;
+}
+
+.scroll-table__badge--active {
+  background: var(--badge-active-bg);
+  color: var(--badge-active-text);
+}
+
+.scroll-table__badge--on-leave {
+  background: var(--badge-leave-bg);
+  color: var(--badge-leave-text);
+}
+
+.scroll-table__badge--inactive {
+  background: var(--badge-inactive-bg);
+  color: var(--badge-inactive-text);
+}
+
+/* ============================================================
+   Entrance Animation
+   ============================================================ */
+@keyframes tableFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* ============================================================
+   Responsive: Mobile
+   On narrow screens, the table scrolls horizontally.
+   The sticky column stays pinned so the user always
+   sees the employee name while scrolling.
+   ============================================================ */
+@media (max-width: 640px) {
+  .table-container {
+    margin-left: -1rem;
+    margin-right: -1rem;
+    border-radius: 0;
+    border-left: none;
+    border-right: none;
+  }
+
+  .demo-title {
+    font-size: 1.25rem;
+  }
+}
+
+/* ============================================================
+   Reduced Motion
+   ============================================================ */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
Closes #68240

## Pull Request Description

Adds a responsive data table that scrolls horizontally with a sticky first column, addressing issue #68240.

---

## Type of Change

- [x] 🧩 New component

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/css-responsive-scroll-table-eranmol/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A wide data table that scrolls horizontally on narrow screens while keeping the first column pinned via `position: sticky`. Includes status badges, alternate row striping, and keyboard-accessible scroll container.

**How does a developer use it?**

```html
<div class="table-container" role="region" aria-label="Data table" tabindex="0">
  <table class="scroll-table">
    <thead>
      <tr>
        <th class="scroll-table__th--sticky">Name</th>
        <th>Department</th>
        <th>Status</th>
      </tr>
    </thead>
    <tbody>
      <tr>
        <td class="scroll-table__td--sticky">Jane Cooper</td>
        <td>Engineering</td>
        <td><span class="scroll-table__badge scroll-table__badge--active">Active</span></td>
      </tr>
    </tbody>
  </table>
</div>