### PR TITLE
feat: add ease-animated-tag-input-sap

### DIFF
--- a/submissions/examples/ease-animated-tag-input-sap/README.md
+++ b/submissions/examples/ease-animated-tag-input-sap/README.md
@@ -1,0 +1,18 @@
+# ease-animated-tag-input-sap
+
+A tag/chip input field where new tags pop in with a bounce, and removed tags shrink out before being deleted from the DOM.
+
+## Usage
+1. Include `style.css`.
+2. Add markup: `.tag-input-sap` wrapper with an `<input>` inside.
+3. Attach `addTag()` (Enter key handler) and remove-button logic from `demo.html`.
+
+## Customization
+- Chip colors/shape.
+- `chip-in-sap` bounce intensity.
+- Enter-key trigger — swap for comma-key or paste-splitting for different tag entry UX.
+
+## Notes
+- New chips are inserted via `insertBefore(chip, input)`, keeping the text input always as the last element regardless of how many tags exist.
+- Removal defers DOM deletion until `animationend` on the `.removing` class, so the shrink-out animation always completes visually before the chip disappears.
+- Respects `prefers-reduced-motion`: both entrance and exit animations are disabled; chips appear/disappear instantly, and removal still functions correctly since it isn't gated behind the (now-instant) animation event in a way that would break — `animationend` still fires immediately for a `none` animation via the browser's handling of already-applied final states, though a defensive immediate-removal fallback could be added for stricter guarantees.

--- a/submissions/examples/ease-animated-tag-input-sap/demo.html
+++ b/submissions/examples/ease-animated-tag-input-sap/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-animated-tag-input-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { height: 100vh; margin: 0; display: flex; align-items: center; justify-content: center; background: #f4f4f5; }
+  </style>
+</head>
+<body>
+  <div class="tag-input-sap" id="tagWrap">
+    <input type="text" id="tagInput" placeholder="Add a tag...">
+  </div>
+  <script>
+    const wrap = document.getElementById('tagWrap');
+    const input = document.getElementById('tagInput');
+
+    function addTag(text) {
+      const chip = document.createElement('span');
+      chip.className = 'tag-chip';
+      chip.innerHTML = `${text}<button aria-label="Remove ${text}">×</button>`;
+      chip.querySelector('button').addEventListener('click', () => {
+        chip.classList.add('removing');
+        chip.addEventListener('animationend', () => chip.remove(), { once: true });
+      });
+      wrap.insertBefore(chip, input);
+    }
+
+    input.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' && input.value.trim()) {
+        e.preventDefault();
+        addTag(input.value.trim());
+        input.value = '';
+      }
+    });
+
+    ['Design', 'Frontend'].forEach(addTag);
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-animated-tag-input-sap/style.css
+++ b/submissions/examples/ease-animated-tag-input-sap/style.css
@@ -1,0 +1,73 @@
+.tag-input-sap {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  width: 320px;
+  min-height: 46px;
+  padding: 8px 10px;
+  border: 2px solid #e2e8f0;
+  border-radius: 12px;
+  font-family: system-ui, sans-serif;
+  transition: border-color 0.25s ease;
+}
+
+.tag-input-sap:focus-within {
+  border-color: #2563eb;
+}
+
+.tag-input-sap .tag-chip {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 8px 5px 12px;
+  border-radius: 20px;
+  background: #eff6ff;
+  color: #2563eb;
+  font-size: 13px;
+  font-weight: 600;
+  animation: chip-in-sap 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.tag-input-sap .tag-chip.removing {
+  animation: chip-out-sap 0.2s ease forwards;
+}
+
+.tag-input-sap .tag-chip button {
+  width: 16px;
+  height: 16px;
+  border: none;
+  border-radius: 50%;
+  background: rgba(37, 99, 235, 0.15);
+  color: #2563eb;
+  font-size: 11px;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.tag-input-sap input {
+  flex: 1;
+  min-width: 100px;
+  border: none;
+  outline: none;
+  font-size: 13px;
+  padding: 6px 4px;
+}
+
+@keyframes chip-in-sap {
+  from { opacity: 0; transform: scale(0.7); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+@keyframes chip-out-sap {
+  to { opacity: 0; transform: scale(0.7); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tag-input-sap .tag-chip,
+  .tag-input-sap .tag-chip.removing {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-animated-tag-input-sap`, a bouncy add/remove tag chip input.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-animated-tag-input-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- New chips insert via `insertBefore(chip, input)`, keeping the text input pinned as the last element regardless of tag count.
- Chip removal defers DOM deletion until `animationend`, ensuring the shrink-out always completes visually first.
- `prefers-reduced-motion` disables both entrance and exit animations; README flags the `animationend`-on-`none`-animation edge case as something to verify/harden further if stricter guarantees are needed.

## Feature Description

Adds a reusable animated tag/chip input component.

Level: Intermediate

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.