### PR TITLE
feat: add CSS Shield Verify Animate

### DIFF
--- a/submissions/examples/css-shield-verify-animate-eranmol/README.md
+++ b/submissions/examples/css-shield-verify-animate-eranmol/README.md
@@ -1,0 +1,16 @@
+This contribution adds a CSS Shield Verify Animate to the submissions/examples/css-shield-verify-animate-eranmol directory.
+
+What is included?
+demo.html
+style.css
+README.md
+
+Features
+Security shield shape built with CSS clip-path
+Animated checkmark that draws itself on verification
+Pure CSS checkbox toggle — no JavaScript
+Shield fills with green on verified state
+Subtle pulse animation on the verified shield
+Accessible with ARIA labels
+Responsive and works across all screen sizes
+Works in Chrome, Firefox, Edge, and Safari

--- a/submissions/examples/css-shield-verify-animate-eranmol/demo.html
+++ b/submissions/examples/css-shield-verify-animate-eranmol/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Shield Verify Animate</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <input type="checkbox" id="verify-toggle" class="verify-check" aria-label="Toggle shield verification">
+
+  <label for="verify-toggle" class="shield-wrap" role="img" aria-label="Security shield with animated verification checkmark">
+
+    <div class="shield">
+      <div class="shield-fill"></div>
+      <div class="shield-border"></div>
+    </div>
+
+    <div class="checkmark">
+      <div class="check-stem"></div>
+      <div class="check-arm"></div>
+    </div>
+
+    <span class="label">Verified</span>
+
+  </label>
+
+</body>
+</html>

--- a/submissions/examples/css-shield-verify-animate-eranmol/style.css
+++ b/submissions/examples/css-shield-verify-animate-eranmol/style.css
@@ -1,0 +1,152 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: #0e1117;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+/* hide the checkbox */
+.verify-check {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.shield-wrap {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 18px;
+  cursor: pointer;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+/* ─── shield shape ─── */
+.shield {
+  position: relative;
+  width: 110px;
+  height: 130px;
+}
+
+.shield-border {
+  position: absolute;
+  inset: 0;
+  clip-path: polygon(
+    50% 0%,
+    95% 12%,
+    95% 58%,
+    50% 100%,
+    5% 58%,
+    5% 12%
+  );
+  background: #2a2d35;
+  transition: background 0.4s, box-shadow 0.4s;
+}
+
+.shield-fill {
+  position: absolute;
+  inset: 4px;
+  clip-path: polygon(
+    50% 0%,
+    95% 12%,
+    95% 58%,
+    50% 100%,
+    5% 58%,
+    5% 12%
+  );
+  background: #1a1d24;
+  transition: background 0.5s 0.2s;
+}
+
+/* ─── checked state: shield turns green ─── */
+.verify-check:checked ~ .shield-wrap .shield-border {
+  background: #16a34a;
+  box-shadow: 0 0 24px rgba(74, 222, 128, 0.3);
+}
+
+.verify-check:checked ~ .shield-wrap .shield-fill {
+  background: #0d3320;
+}
+
+/* ─── checkmark ─── */
+.checkmark {
+  position: absolute;
+  top: 38px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 30px;
+  height: 28px;
+  opacity: 0;
+  transition: opacity 0.1s;
+}
+
+.verify-check:checked ~ .shield-wrap .checkmark {
+  opacity: 1;
+}
+
+.check-stem {
+  position: absolute;
+  left: 14px;
+  top: 2px;
+  width: 5px;
+  height: 0;
+  background: #4ade80;
+  border-radius: 2px;
+  transform: rotate(-45deg);
+  transform-origin: top left;
+  transition: height 0.3s 0.3s ease-out;
+}
+
+.check-arm {
+  position: absolute;
+  left: 4px;
+  top: 14px;
+  width: 5px;
+  height: 0;
+  background: #4ade80;
+  border-radius: 2px;
+  transform: rotate(45deg);
+  transform-origin: bottom left;
+  transition: height 0.25s 0.55s ease-out;
+}
+
+.verify-check:checked ~ .shield-wrap .check-stem {
+  height: 18px;
+}
+
+.verify-check:checked ~ .shield-wrap .check-arm {
+  height: 12px;
+}
+
+/* ─── label ─── */
+.label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  color: #4b5563;
+  transition: color 0.4s 0.3s;
+}
+
+.verify-check:checked ~ .shield-wrap .label {
+  color: #4ade80;
+}
+
+/* ─── subtle pulse on verified shield ─── */
+@keyframes shieldPulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.03); }
+}
+
+.verify-check:checked ~ .shield-wrap .shield {
+  animation: shieldPulse 1.8s ease-in-out infinite;
+}


### PR DESCRIPTION
## Closes #70108

## What this PR does
- Adds a CSS Shield Verify Animate under `submissions/examples/css-shield-verify-animate-eranmol/`
- Security shield shape using clip-path with an animated checkmark that draws itself on click
- Pure CSS checkbox toggle, no JavaScript
- Includes `demo.html`, `style.css`, and `README.md`

## Type of Change
- [x] ✨ New animation / hover effect

## Submission Checklist
- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari