### PR TITLE
feat: add CSS Aspect Ratio Calculator

### DIFF
--- a/submissions/examples/css-aspect-ratio-calculator-eranmol/README.md
+++ b/submissions/examples/css-aspect-ratio-calculator-eranmol/README.md
@@ -1,0 +1,16 @@
+This contribution adds a CSS Aspect Ratio Calculator to the submissions/examples/css-aspect-ratio-calculator-eranmol directory.
+
+What is included?
+demo.html
+style.css
+README.md
+
+Features
+Aspect ratio calculator widget with visual preview box
+6 common presets: 16:9, 4:3, 1:1, 3:2, 21:9, 9:16
+Preview box smoothly animates between ratios using CSS aspect-ratio
+Color-coded buttons per ratio
+Displays decimal value of each ratio
+Pure CSS — uses :has() selector and radio buttons, no JavaScript
+Responsive and accessible with ARIA radiogroup
+Works in Chrome, Firefox, Edge, and Safari

--- a/submissions/examples/css-aspect-ratio-calculator-eranmol/demo.html
+++ b/submissions/examples/css-aspect-ratio-calculator-eranmol/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Aspect Ratio Calculator</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="calc-widget" role="region" aria-label="Aspect Ratio Calculator">
+
+    <h2 class="calc-title">Aspect Ratio Calculator</h2>
+
+    <input type="radio" name="ratio" id="r-16-9" class="ratio-input" value="16/9" checked>
+    <input type="radio" name="ratio" id="r-4-3" class="ratio-input" value="4/3">
+    <input type="radio" name="ratio" id="r-1-1" class="ratio-input" value="1/1">
+    <input type="radio" name="ratio" id="r-3-2" class="ratio-input" value="3/2">
+    <input type="radio" name="ratio" id="r-21-9" class="ratio-input" value="21/9">
+    <input type="radio" name="ratio" id="r-9-16" class="ratio-input" value="9/16">
+
+    <div class="preview-area">
+      <div class="preview-box">
+        <span class="preview-label"></span>
+      </div>
+    </div>
+
+    <div class="ratio-buttons" role="radiogroup" aria-label="Choose aspect ratio">
+      <label for="r-16-9" class="ratio-btn">16:9</label>
+      <label for="r-4-3" class="ratio-btn">4:3</label>
+      <label for="r-1-1" class="ratio-btn">1:1</label>
+      <label for="r-3-2" class="ratio-btn">3:2</label>
+      <label for="r-21-9" class="ratio-btn">21:9</label>
+      <label for="r-9-16" class="ratio-btn">9:16</label>
+    </div>
+
+    <div class="info-row">
+      <div class="info-item">
+        <span class="info-label">Formula</span>
+        <span class="info-value">width &divide; height</span>
+      </div>
+      <div class="info-item">
+        <span class="info-label">Decimal</span>
+        <span class="info-value decimal-val"></span>
+      </div>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/css-aspect-ratio-calculator-eranmol/style.css
+++ b/submissions/examples/css-aspect-ratio-calculator-eranmol/style.css
@@ -1,0 +1,249 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: #0e1117;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  padding: 20px;
+}
+
+.calc-widget {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 14px;
+  padding: 32px 28px;
+  width: 100%;
+  max-width: 420px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.calc-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #e6edf3;
+  text-align: center;
+}
+
+/* hide radios */
+.ratio-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* ─── preview ─── */
+.preview-area {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 180px;
+  background: #0d1117;
+  border: 1px dashed #30363d;
+  border-radius: 10px;
+  padding: 20px;
+}
+
+.preview-box {
+  width: 100%;
+  max-width: 280px;
+  aspect-ratio: 16 / 9;
+  background: linear-gradient(135deg, #1f6feb 0%, #388bfd 50%, #58a6ff 100%);
+  border-radius: 8px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  transition: aspect-ratio 0.4s ease, background 0.4s ease;
+}
+
+.preview-label {
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: #fff;
+  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
+  letter-spacing: 1px;
+}
+
+.preview-label::after {
+  content: "16 : 9";
+}
+
+/* ─── ratio buttons ─── */
+.ratio-buttons {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+}
+
+.ratio-btn {
+  padding: 10px 0;
+  text-align: center;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #8b949e;
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.25s ease;
+  letter-spacing: 0.5px;
+}
+
+.ratio-btn:hover {
+  color: #e6edf3;
+  border-color: #58a6ff;
+}
+
+/* ─── info row ─── */
+.info-row {
+  display: flex;
+  gap: 12px;
+}
+
+.info-item {
+  flex: 1;
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.info-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: #6e7681;
+}
+
+.info-value {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #e6edf3;
+}
+
+.decimal-val::after {
+  content: "1.778";
+}
+
+/* ═══════════════════════════════════════
+   :has() — update preview per checked radio
+   ═══════════════════════════════════════ */
+
+/* 16:9 */
+.calc-widget:has(#r-16-9:checked) .preview-box {
+  aspect-ratio: 16 / 9;
+  background: linear-gradient(135deg, #1f6feb, #388bfd, #58a6ff);
+}
+.calc-widget:has(#r-16-9:checked) .preview-label::after { content: "16 : 9"; }
+.calc-widget:has(#r-16-9:checked) .decimal-val::after { content: "1.778"; }
+.calc-widget:has(#r-16-9:checked) [for="r-16-9"] {
+  color: #fff;
+  background: #1f6feb;
+  border-color: #1f6feb;
+}
+
+/* 4:3 */
+.calc-widget:has(#r-4-3:checked) .preview-box {
+  aspect-ratio: 4 / 3;
+  background: linear-gradient(135deg, #238636, #2ea043, #3fb950);
+}
+.calc-widget:has(#r-4-3:checked) .preview-label::after { content: "4 : 3"; }
+.calc-widget:has(#r-4-3:checked) .decimal-val::after { content: "1.333"; }
+.calc-widget:has(#r-4-3:checked) [for="r-4-3"] {
+  color: #fff;
+  background: #238636;
+  border-color: #238636;
+}
+
+/* 1:1 */
+.calc-widget:has(#r-1-1:checked) .preview-box {
+  aspect-ratio: 1 / 1;
+  background: linear-gradient(135deg, #8957e5, #a371f7, #bc8cff);
+}
+.calc-widget:has(#r-1-1:checked) .preview-label::after { content: "1 : 1"; }
+.calc-widget:has(#r-1-1:checked) .decimal-val::after { content: "1.000"; }
+.calc-widget:has(#r-1-1:checked) [for="r-1-1"] {
+  color: #fff;
+  background: #8957e5;
+  border-color: #8957e5;
+}
+
+/* 3:2 */
+.calc-widget:has(#r-3-2:checked) .preview-box {
+  aspect-ratio: 3 / 2;
+  background: linear-gradient(135deg, #da3633, #f85149, #ff7b72);
+}
+.calc-widget:has(#r-3-2:checked) .preview-label::after { content: "3 : 2"; }
+.calc-widget:has(#r-3-2:checked) .decimal-val::after { content: "1.500"; }
+.calc-widget:has(#r-3-2:checked) [for="r-3-2"] {
+  color: #fff;
+  background: #da3633;
+  border-color: #da3633;
+}
+
+/* 21:9 */
+.calc-widget:has(#r-21-9:checked) .preview-box {
+  aspect-ratio: 21 / 9;
+  background: linear-gradient(135deg, #bf8700, #d29922, #e3b341);
+}
+.calc-widget:has(#r-21-9:checked) .preview-label::after { content: "21 : 9"; }
+.calc-widget:has(#r-21-9:checked) .decimal-val::after { content: "2.333"; }
+.calc-widget:has(#r-21-9:checked) [for="r-21-9"] {
+  color: #fff;
+  background: #bf8700;
+  border-color: #bf8700;
+}
+
+/* 9:16 */
+.calc-widget:has(#r-9-16:checked) .preview-box {
+  aspect-ratio: 9 / 16;
+  background: linear-gradient(135deg, #768390, #8b949e, #b1bac4);
+}
+.calc-widget:has(#r-9-16:checked) .preview-label::after { content: "9 : 16"; }
+.calc-widget:has(#r-9-16:checked) .decimal-val::after { content: "0.563"; }
+.calc-widget:has(#r-9-16:checked) [for="r-9-16"] {
+  color: #fff;
+  background: #768390;
+  border-color: #768390;
+}
+
+/* highlight the checked button */
+.calc-widget:has(#r-16-9:checked) [for="r-16-9"],
+.calc-widget:has(#r-4-3:checked) [for="r-4-3"],
+.calc-widget:has(#r-1-1:checked) [for="r-1-1"],
+.calc-widget:has(#r-3-2:checked) [for="r-3-2"],
+.calc-widget:has(#r-21-9:checked) [for="r-21-9"],
+.calc-widget:has(#r-9-16:checked) [for="r-9-16"] {
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.15);
+}
+
+/* ─── responsive ─── */
+@media (max-width: 480px) {
+  .calc-widget {
+    padding: 24px 18px;
+  }
+
+  .ratio-btn {
+    font-size: 0.78rem;
+    padding: 8px 0;
+  }
+
+  .preview-box {
+    max-width: 220px;
+  }
+
+  .preview-label {
+    font-size: 1.1rem;
+  }
+}


### PR DESCRIPTION
## Closes #70107

## What this PR does
- Adds a CSS Aspect Ratio Calculator under `submissions/examples/css-aspect-ratio-calculator-eranmol/`
- Widget with visual preview box, 6 preset ratios (16:9, 4:3, 1:1, 3:2, 21:9, 9:16)
- Preview box animates between ratios using CSS `aspect-ratio` and `:has()` selector
- Pure CSS, no JavaScript
- Includes `demo.html`, `style.css`, and `README.md`

## Type of Change
- [x] 🧩 New component

## Submission Checklist
- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari