### PR TITLE
feat: add CSS Loading Package Install

### DIFF
--- a/submissions/examples/css-loading-package-install-eranmol/README.md
+++ b/submissions/examples/css-loading-package-install-eranmol/README.md
@@ -1,0 +1,16 @@
+This contribution adds a CSS Loading Package Install to the submissions/examples/css-loading-package-install-eranmol directory.
+
+What is included?
+demo.html
+style.css
+README.md
+
+Features
+Terminal-style window with macOS traffic light dots
+Simulated npm install with staggered line-by-line appearance
+Animated progress bar with percentage counter
+Success checkmark and funding message
+Blinking cursor at the end
+Pure CSS — no JavaScript
+Responsive and accessible with ARIA label
+Works in Chrome, Firefox, Edge, and Safari

--- a/submissions/examples/css-loading-package-install-eranmol/demo.html
+++ b/submissions/examples/css-loading-package-install-eranmol/demo.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Loading Package Install</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="terminal" role="img" aria-label="Terminal simulating npm package install progress">
+
+    <div class="title-bar">
+      <span class="dot dot-red"></span>
+      <span class="dot dot-yellow"></span>
+      <span class="dot dot-green"></span>
+      <span class="title-text">package-install</span>
+    </div>
+
+    <div class="terminal-body">
+
+      <div class="line line-cmd">
+        <span class="prompt">$</span>
+        <span class="cmd-text">npm install easemotion</span>
+      </div>
+
+      <div class="line line-info">
+        <span class="fade-text">info</span> resolving packages...
+      </div>
+
+      <div class="line line-info">
+        <span class="fade-text">info</span> fetching easemotion@3.2.1
+      </div>
+
+      <div class="progress-wrap">
+        <div class="progress-track">
+          <div class="progress-bar"></div>
+        </div>
+        <span class="progress-pct"></span>
+      </div>
+
+      <div class="line line-success">
+        <span class="check">&#10003;</span> added 142 packages in 3.8s
+      </div>
+
+      <div class="line line-dim">
+        42 packages are looking for funding
+      </div>
+
+      <div class="line line-cmd line-final">
+        <span class="prompt">$</span>
+        <span class="cursor"></span>
+      </div>
+
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/css-loading-package-install-eranmol/style.css
+++ b/submissions/examples/css-loading-package-install-eranmol/style.css
@@ -1,0 +1,209 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: #0e1117;
+  font-family: 'Courier New', Courier, monospace;
+  padding: 20px;
+}
+
+/* ─── terminal window ─── */
+.terminal {
+  width: 100%;
+  max-width: 520px;
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.4);
+}
+
+.title-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  background: #1c2128;
+  border-bottom: 1px solid #30363d;
+}
+
+.dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+
+.dot-red { background: #ff5f57; }
+.dot-yellow { background: #febc2e; }
+.dot-green { background: #28c840; }
+
+.title-text {
+  margin-left: auto;
+  margin-right: auto;
+  font-size: 0.75rem;
+  color: #6e7681;
+  letter-spacing: 0.5px;
+}
+
+/* ─── body ─── */
+.terminal-body {
+  padding: 20px;
+  font-size: 0.82rem;
+  line-height: 1.7;
+  color: #c9d1d9;
+}
+
+.line {
+  opacity: 0;
+  animation: fadeIn 0.3s ease forwards;
+}
+
+.prompt {
+  color: #3fb950;
+  margin-right: 8px;
+  font-weight: 700;
+}
+
+.cmd-text {
+  color: #e6edf3;
+}
+
+.fade-text {
+  color: #58a6ff;
+  margin-right: 6px;
+}
+
+/* stagger each line */
+.line-cmd         { animation-delay: 0.2s; }
+.line-info:nth-of-type(1) { animation-delay: 1s; }
+.line-info:nth-of-type(2) { animation-delay: 1.8s; }
+
+/* ─── progress bar ─── */
+.progress-wrap {
+  position: relative;
+  height: 22px;
+  margin: 10px 0;
+  opacity: 0;
+  animation: fadeIn 0.3s ease 2.5s forwards;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.progress-track {
+  flex: 1;
+  height: 8px;
+  background: #21262d;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.progress-bar {
+  height: 100%;
+  width: 0;
+  background: linear-gradient(90deg, #1f6feb, #58a6ff, #79c0ff);
+  border-radius: 4px;
+  animation: fillBar 2.2s ease 2.6s forwards;
+}
+
+.progress-pct {
+  font-size: 0.75rem;
+  color: #58a6ff;
+  min-width: 32px;
+  text-align: right;
+}
+
+.progress-pct::after {
+  content: "0%";
+  animation: showPct 2.2s steps(1) 2.6s forwards;
+}
+
+@keyframes showPct {
+  0%  { content: "0%"; }
+  10% { content: "10%"; }
+  20% { content: "20%"; }
+  30% { content: "30%"; }
+  40% { content: "40%"; }
+  50% { content: "50%"; }
+  60% { content: "60%"; }
+  70% { content: "70%"; }
+  80% { content: "80%"; }
+  90% { content: "90%"; }
+  100% { content: "100%"; }
+}
+
+/* ─── success line ─── */
+.line-success {
+  animation-delay: 5s;
+  color: #3fb950;
+}
+
+.check {
+  font-weight: 700;
+  font-size: 1rem;
+  margin-right: 4px;
+}
+
+/* ─── dim line ─── */
+.line-dim {
+  animation-delay: 5.4s;
+  color: #6e7681;
+  font-size: 0.75rem;
+}
+
+/* ─── final prompt + cursor ─── */
+.line-final {
+  animation-delay: 5.8s;
+  margin-top: 6px;
+}
+
+.cursor {
+  display: inline-block;
+  width: 8px;
+  height: 14px;
+  background: #3fb950;
+  vertical-align: middle;
+  animation: blink 1s step-end infinite 5.8s;
+}
+
+/* ─── keyframes ─── */
+@keyframes fadeIn {
+  to { opacity: 1; }
+}
+
+@keyframes fillBar {
+  0%   { width: 0; }
+  12%  { width: 14%; }
+  28%  { width: 35%; }
+  48%  { width: 62%; }
+  68%  { width: 85%; }
+  100% { width: 100%; }
+}
+
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0; }
+}
+
+/* ─── responsive ─── */
+@media (max-width: 560px) {
+  .terminal {
+    border-radius: 8px;
+  }
+
+  .terminal-body {
+    font-size: 0.72rem;
+    padding: 14px;
+  }
+
+  .line {
+    white-space: normal;
+  }
+}


### PR DESCRIPTION
## Closes #70085

## What this PR does
- Adds a CSS Loading Package Install under `submissions/examples/css-loading-package-install-eranmol/`
- Terminal-style window simulating `npm install` with staggered line appearance, animated progress bar, percentage counter, and success message
- Pure CSS, no JavaScript
- Includes `demo.html`, `style.css`, and `README.md`

## Type of Change
- [x] ✨ New animation / hover effect

## Submission Checklist
- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari