### PR TITLE
feat: add ease-drag-handle-resize-sap

### DIFF
--- a/submissions/examples/ease-drag-handle-resize-sap/README.md
+++ b/submissions/examples/ease-drag-handle-resize-sap/README.md
@@ -1,0 +1,31 @@
+# Drag Handle Resize
+
+A two-panel layout with a draggable vertical handle that resizes the left
+panel, using pointer events (mouse, touch, and pen unified) and keyboard
+arrow-key support.
+
+**Level:** Advanced
+
+## Usage
+
+Drag `.handle` left/right to resize `#panel`. Width is clamped between a
+`MIN` and `MAX` defined in the script (180px–520px by default). Keyboard
+users can focus the handle and use ArrowLeft/ArrowRight to resize in 10px steps.
+
+## Accessibility
+
+- Handle uses `role="separator"` with `aria-orientation="vertical"` and
+  `aria-valuemin`/`aria-valuemax`/`aria-valuenow` kept in sync on every resize.
+- Fully keyboard-operable via Arrow keys, independent of pointer dragging.
+- The only animation is a small hover/focus scale on the handle's grip
+  indicator; `prefers-reduced-motion` removes that transition. The resize
+  itself is a direct width change, not an eased animation, so reduced-motion
+  users lose no functionality.
+
+## Notes
+
+- Uses Pointer Events (`pointerdown`/`pointermove`/`pointerup` +
+  `setPointerCapture`) instead of separate mouse/touch listeners, so dragging
+  keeps working smoothly even if the pointer leaves the handle mid-drag.
+- `touch-action: none` on the handle prevents the browser from also trying to
+  scroll/pan during a drag on touch devices.

--- a/submissions/examples/ease-drag-handle-resize-sap/demo.html
+++ b/submissions/examples/ease-drag-handle-resize-sap/demo.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Drag Handle Resize</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="wrap">
+    <h1>Drag Handle Resize</h1>
+
+    <div class="resize-box">
+      <div class="panel" id="panel">
+        <p>Drag the handle to resize this panel.</p>
+      </div>
+      <div
+        class="handle"
+        id="handle"
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize panel"
+        aria-valuemin="180"
+        aria-valuemax="520"
+        aria-valuenow="280"
+        tabindex="0"
+      ></div>
+      <div class="panel panel-fixed">
+        <p>Fixed content area.</p>
+      </div>
+    </div>
+  </main>
+
+  <script>
+    const panel = document.getElementById('panel');
+    const handle = document.getElementById('handle');
+    const container = document.querySelector('.resize-box');
+    const MIN = 180, MAX = 520;
+    let dragging = false;
+
+    function setWidth(px) {
+      const clamped = Math.min(MAX, Math.max(MIN, px));
+      panel.style.width = clamped + 'px';
+      handle.setAttribute('aria-valuenow', Math.round(clamped));
+    }
+
+    handle.addEventListener('pointerdown', (e) => {
+      dragging = true;
+      handle.setPointerCapture(e.pointerId);
+      document.body.classList.add('is-resizing');
+    });
+
+    handle.addEventListener('pointermove', (e) => {
+      if (!dragging) return;
+      const rect = container.getBoundingClientRect();
+      setWidth(e.clientX - rect.left);
+    });
+
+    ['pointerup', 'pointercancel'].forEach(evt => {
+      handle.addEventListener(evt, () => {
+        dragging = false;
+        document.body.classList.remove('is-resizing');
+      });
+    });
+
+    handle.addEventListener('keydown', (e) => {
+      const current = parseInt(handle.getAttribute('aria-valuenow'), 10);
+      if (e.key === 'ArrowLeft') setWidth(current - 10);
+      if (e.key === 'ArrowRight') setWidth(current + 10);
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-drag-handle-resize-sap/style.css
+++ b/submissions/examples/ease-drag-handle-resize-sap/style.css
@@ -1,0 +1,89 @@
+* { box-sizing: border-box; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #f1f5f9;
+  color: #1e293b;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+}
+
+.wrap { width: min(700px, 92vw); text-align: center; }
+
+h1 {
+  font-size: 1.25rem;
+  margin-bottom: 2rem;
+  color: #64748b;
+  font-weight: 600;
+}
+
+.resize-box {
+  display: flex;
+  height: 260px;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid #cbd5e1;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.06);
+}
+
+.panel {
+  width: 280px;
+  flex-shrink: 0;
+  background: white;
+  padding: 1.5rem;
+  text-align: left;
+  transition: width 0.05s linear;
+}
+
+.panel-fixed {
+  flex: 1;
+  background: #f8fafc;
+  transition: none;
+}
+
+.panel p { color: #64748b; font-size: 0.9rem; margin: 0; }
+
+.handle {
+  width: 10px;
+  flex-shrink: 0;
+  background: #e2e8f0;
+  cursor: col-resize;
+  position: relative;
+  touch-action: none;
+}
+
+.handle::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 4px;
+  height: 32px;
+  background: #94a3b8;
+  border-radius: 2px;
+  transform: translate(-50%, -50%);
+  transition: background 0.2s, transform 0.2s;
+}
+
+.handle:hover::after,
+.handle:focus-visible::after {
+  background: #6366f1;
+  transform: translate(-50%, -50%) scaleY(1.15);
+}
+
+.handle:focus-visible {
+  outline: 2px solid #6366f1;
+  outline-offset: -2px;
+}
+
+body.is-resizing {
+  cursor: col-resize;
+  user-select: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .handle::after { transition: none; }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-drag-handle-resize-sap`, a draggable resize handle between two panels.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-drag-handle-resize-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Uses Pointer Events with `setPointerCapture` so drags stay reliable even if
  the cursor moves off the thin handle mid-drag.
- Handle is a proper `role="separator"` with live `aria-valuenow` updates and
  full ArrowLeft/ArrowRight keyboard support, not just pointer-only.

## Feature Description

Adds a reusable draggable resize-handle component for split panel layouts.

Level: Advanced

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.
