### PR TITLE
feat: add ease-animated-radio-group-sap

### DIFF
--- a/submissions/examples/ease-animated-radio-group-sap/README.md
+++ b/submissions/examples/ease-animated-radio-group-sap/README.md
@@ -1,0 +1,29 @@
+# Animated Radio Group
+
+A custom-styled radio group where the selected dot pops in with a spring
+easing and the selected option gets a highlighted border + soft glow.
+
+**Level:** Beginner
+
+## Usage
+
+Standard `<input type="radio">` markup with a visually-hidden input plus a
+styled `.radio-dot` sibling. Uses `:has()` for selected-state card styling,
+so no JS is required at all.
+
+## Accessibility
+
+- Real `<input type="radio">` elements are used (visually hidden, not
+  `display: none`), so screen readers and keyboard nav work natively.
+- `fieldset`/`legend` group the options with a proper accessible name.
+- Focus is shown via `:focus-visible` on the option card, not just the
+  hidden input, so keyboard focus is always visible.
+- `prefers-reduced-motion` removes all transitions; selection still updates
+  instantly.
+
+## Notes
+
+- Relies on `:has()` (widely supported in current evergreen browsers) to
+  style the parent label based on its child input's checked state, avoiding
+  any JS for visual state.
+- No JavaScript included — this is a pure CSS component.

--- a/submissions/examples/ease-animated-radio-group-sap/demo.html
+++ b/submissions/examples/ease-animated-radio-group-sap/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Animated Radio Group</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="wrap">
+    <h1>Animated Radio Group</h1>
+
+    <fieldset class="radio-group">
+      <legend>Choose a plan</legend>
+
+      <label class="radio-option">
+        <input type="radio" name="plan" value="basic" checked>
+        <span class="radio-dot"></span>
+        <span class="radio-text">Basic — $9/mo</span>
+      </label>
+
+      <label class="radio-option">
+        <input type="radio" name="plan" value="pro">
+        <span class="radio-dot"></span>
+        <span class="radio-text">Pro — $19/mo</span>
+      </label>
+
+      <label class="radio-option">
+        <input type="radio" name="plan" value="team">
+        <span class="radio-dot"></span>
+        <span class="radio-text">Team — $49/mo</span>
+      </label>
+    </fieldset>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-animated-radio-group-sap/style.css
+++ b/submissions/examples/ease-animated-radio-group-sap/style.css
@@ -1,0 +1,109 @@
+* { box-sizing: border-box; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #f8fafc;
+  color: #1e293b;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+}
+
+.wrap { width: min(360px, 90vw); }
+
+h1 {
+  font-size: 1.25rem;
+  margin-bottom: 1.5rem;
+  color: #64748b;
+  font-weight: 600;
+  text-align: center;
+}
+
+.radio-group {
+  border: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.radio-group legend {
+  font-size: 0.85rem;
+  color: #94a3b8;
+  margin-bottom: 0.5rem;
+  padding: 0;
+}
+
+.radio-option {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.9rem 1rem;
+  border-radius: 12px;
+  border: 1.5px solid #e2e8f0;
+  background: white;
+  cursor: pointer;
+  transition: border-color 0.25s ease, box-shadow 0.25s ease, transform 0.15s ease;
+}
+
+.radio-option:hover { border-color: #c7d2fe; }
+.radio-option:active { transform: scale(0.98); }
+
+.radio-option input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.radio-dot {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 2px solid #cbd5e1;
+  flex-shrink: 0;
+  position: relative;
+  transition: border-color 0.25s ease;
+}
+
+.radio-dot::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #6366f1;
+  transform: translate(-50%, -50%) scale(0);
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.radio-option input:checked ~ .radio-dot {
+  border-color: #6366f1;
+}
+
+.radio-option input:checked ~ .radio-dot::after {
+  transform: translate(-50%, -50%) scale(1);
+}
+
+.radio-option:has(input:checked) {
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.12);
+}
+
+.radio-option:has(input:focus-visible) {
+  outline: 2px solid #6366f1;
+  outline-offset: 2px;
+}
+
+.radio-text { font-size: 0.9rem; }
+
+@media (prefers-reduced-motion: reduce) {
+  .radio-option, .radio-dot, .radio-dot::after {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-animated-radio-group-sap`, a radio group with a spring-eased selection dot.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-animated-radio-group-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Pure CSS — no JS needed. Selected-state styling uses `:has()` on the label
  to react to its own hidden radio input.
- Real `<input type="radio">` elements are kept in the DOM (visually hidden,
  not `display:none`) so native keyboard/screen-reader behavior is preserved.

## Feature Description

Adds a reusable animated radio-group component.

Level: Beginner

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.