### PR TITLE
feat: add ease-card-shine-sweep-sap

### DIFF
--- a/submissions/examples/ease-card-shine-sweep-sap/README.md
+++ b/submissions/examples/ease-card-shine-sweep-sap/README.md
@@ -1,0 +1,27 @@
+# Card Shine Sweep
+
+Cards with a diagonal light-sweep highlight that glides across the surface
+on hover, a common "premium" card affordance.
+
+**Level:** Beginner
+
+## Usage
+
+Apply the `.shine-card` class to any card container. The sweep is a
+`::before` pseudo-element positioned off-canvas and transitioned across on
+`:hover` — no JS needed.
+
+## Accessibility
+
+- Purely decorative hover effect; doesn't touch card content or its
+  reading/tab order.
+- `prefers-reduced-motion` removes the transition and hides the sweep layer,
+  leaving a static card.
+- Hover-only in this demo; if cards are also focusable/interactive elements,
+  consider mirroring the effect on `:focus-visible` for keyboard parity.
+
+## Notes
+
+- The skewed gradient sweep travels from `-75%` to `125%` of the card's
+  width so it fully clears both edges without any visible pop-in/out.
+- `overflow: hidden` on `.shine-card` keeps the sweep clipped to each card.

--- a/submissions/examples/ease-card-shine-sweep-sap/demo.html
+++ b/submissions/examples/ease-card-shine-sweep-sap/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Card Shine Sweep</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="wrap">
+    <h1>Card Shine Sweep</h1>
+
+    <div class="shine-grid">
+      <div class="shine-card">
+        <h2>Premium</h2>
+        <p>Hover for a light sweep across the surface.</p>
+      </div>
+      <div class="shine-card">
+        <h2>Gold Tier</h2>
+        <p>Same effect, reusable on any card.</p>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-card-shine-sweep-sap/style.css
+++ b/submissions/examples/ease-card-shine-sweep-sap/style.css
@@ -1,0 +1,76 @@
+* { box-sizing: border-box; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+}
+
+.wrap { text-align: center; }
+
+h1 {
+  font-size: 1.25rem;
+  margin-bottom: 1.5rem;
+  color: #94a3b8;
+  font-weight: 600;
+}
+
+.shine-grid {
+  display: flex;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.shine-card {
+  position: relative;
+  width: 220px;
+  padding: 1.75rem 1.5rem;
+  border-radius: 16px;
+  background: linear-gradient(160deg, #1e293b, #0f172a);
+  border: 1px solid #334155;
+  overflow: hidden;
+  text-align: left;
+}
+
+.shine-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -75%;
+  width: 50%;
+  height: 100%;
+  background: linear-gradient(
+    100deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.16) 50%,
+    transparent 100%
+  );
+  transform: skewX(-20deg);
+  transition: left 0.75s ease;
+}
+
+.shine-card:hover::before {
+  left: 125%;
+}
+
+.shine-card h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.1rem;
+  color: #f8fafc;
+}
+
+.shine-card p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #94a3b8;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .shine-card::before { transition: none; display: none; }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-card-shine-sweep-sap`, a diagonal light-sweep hover effect for cards.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-card-shine-sweep-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Sweep is a single `::before` pseudo-element skewed gradient, transitioned
  via `left`, no JS required.
- README notes that interactive/focusable cards should mirror the effect on
  `:focus-visible` for keyboard parity, since this demo is hover-only.

## Feature Description

Adds a reusable CSS-only card shine-sweep hover effect.

Level: Beginner

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.