### PR TITLE
feat: add ease-typewriter-code-block-sap

### DIFF
--- a/submissions/examples/ease-typewriter-code-block-sap/README.md
+++ b/submissions/examples/ease-typewriter-code-block-sap/README.md
@@ -1,0 +1,29 @@
+# Typewriter Code Block
+
+A code-editor-styled window where a code snippet types itself out character
+by character with a blinking caret, mimicking a live-coding demo.
+
+**Level:** Intermediate
+
+## Usage
+
+Set `snippet` in the script to any code string. `typeNext()` reveals it one
+character at a time via `setTimeout`; a CSS-animated `.caret` blinks after
+the currently-revealed text.
+
+## Accessibility
+
+- Checks `prefers-reduced-motion` in JS before typing: reduced-motion users
+  get the full snippet rendered instantly instead of the character-by-
+  character animation, and the caret's blink animation is also disabled via CSS.
+- An `aria-live="polite"` region (visually hidden via `.sr-only`, not
+  `display:none`) announces completion so screen reader users aren't stuck
+  listening to nothing during/after typing, without narrating every character.
+- The animated caret is `aria-hidden="true"` since it's purely decorative.
+
+## Notes
+
+- Typing speed is 18ms/character in this demo; tune via the `setTimeout`
+  delay in `typeNext()`.
+- Uses `textContent` (not `innerHTML`) when revealing the snippet, so no
+  markup injection risk even with special characters in the code sample.

--- a/submissions/examples/ease-typewriter-code-block-sap/demo.html
+++ b/submissions/examples/ease-typewriter-code-block-sap/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Typewriter Code Block</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="wrap">
+    <h1>Typewriter Code Block</h1>
+
+    <div class="code-window">
+      <div class="code-titlebar">
+        <span class="dot dot-r"></span><span class="dot dot-y"></span><span class="dot dot-g"></span>
+        <span class="code-filename">app.js</span>
+      </div>
+      <pre class="code-body"><code id="codeOutput"></code><span class="caret" aria-hidden="true"></span></pre>
+    </div>
+
+    <p class="sr-only" id="codeAnnounce" aria-live="polite"></p>
+  </main>
+
+  <script>
+    const snippet = `function greet(name) {
+  return \`Hello, \${name}!\`;
+}
+
+console.log(greet("world"));`;
+
+    const output = document.getElementById('codeOutput');
+    const announce = document.getElementById('codeAnnounce');
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    if (reduceMotion) {
+      output.textContent = snippet;
+      announce.textContent = 'Code snippet loaded.';
+    } else {
+      let i = 0;
+      function typeNext() {
+        if (i <= snippet.length) {
+          output.textContent = snippet.slice(0, i);
+          i++;
+          setTimeout(typeNext, 18);
+        } else {
+          announce.textContent = 'Code snippet finished typing.';
+        }
+      }
+      typeNext();
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-typewriter-code-block-sap/style.css
+++ b/submissions/examples/ease-typewriter-code-block-sap/style.css
@@ -1,0 +1,86 @@
+* { box-sizing: border-box; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+}
+
+.wrap { width: min(520px, 92vw); text-align: center; }
+
+h1 {
+  font-size: 1.25rem;
+  margin-bottom: 1.5rem;
+  color: #94a3b8;
+  font-weight: 600;
+}
+
+.code-window {
+  border-radius: 12px;
+  overflow: hidden;
+  background: #1e1e2e;
+  box-shadow: 0 20px 50px rgba(0,0,0,0.4);
+  text-align: left;
+}
+
+.code-titlebar {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.6rem 0.9rem;
+  background: #181825;
+}
+
+.dot { width: 11px; height: 11px; border-radius: 50%; }
+.dot-r { background: #f87171; }
+.dot-y { background: #fbbf24; }
+.dot-g { background: #4ade80; }
+
+.code-filename {
+  margin-left: 0.75rem;
+  font-size: 0.75rem;
+  color: #6c7086;
+}
+
+.code-body {
+  margin: 0;
+  padding: 1.25rem 1.5rem;
+  font-family: "SF Mono", "Fira Code", Consolas, monospace;
+  font-size: 0.85rem;
+  line-height: 1.6;
+  color: #cdd6f4;
+  min-height: 140px;
+  white-space: pre-wrap;
+}
+
+.caret {
+  display: inline-block;
+  width: 8px;
+  height: 1em;
+  background: #a6e3a1;
+  vertical-align: text-bottom;
+  animation: caret-blink 0.9s steps(1) infinite;
+}
+
+@keyframes caret-blink {
+  0%, 49% { opacity: 1; }
+  50%, 100% { opacity: 0; }
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .caret { animation: none; opacity: 1; }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-typewriter-code-block-sap`, a code window with a self-typing typewriter effect.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-typewriter-code-block-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- JS checks `prefers-reduced-motion` before starting the animation: reduced-
  motion users get the snippet rendered instantly rather than skipped or stuck.
- Completion is announced via a visually-hidden `aria-live="polite"` region
  so screen reader users get a single end-of-typing cue instead of silence
  or per-character noise.

## Feature Description

Adds a reusable typewriter-effect code block component.

Level: Intermediate

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.