### PR TITLE
Add pure-CSS password visibility toggle (#71874)

### DIFF
--- a/submissions/examples/password-toggle/README.md
+++ b/submissions/examples/password-toggle/README.md
@@ -1,0 +1,32 @@
+# Pure CSS Password Visibility Toggle
+
+A password visibility toggle built with **zero JavaScript**, using the checkbox hack combined with `-webkit-text-security` for masking.
+
+## How it works
+
+- A hidden `<input type="checkbox">` sits alongside a normal `<input type="text">`.
+- The text input is masked by default via `-webkit-text-security: disc`, which visually renders characters as dots without needing `type="password"`.
+- The eye icon is a `<label>` bound to the checkbox — clicking it toggles `:checked`.
+- CSS sibling selectors swap `-webkit-text-security` between `disc` and `none`, and swap the eye/eye-off icons, based on checkbox state.
+
+## Browser support
+
+`-webkit-text-security` is supported in Chrome, Edge, Safari, and Opera (WebKit/Blink). It is **not supported in Firefox** — Firefox users will see the password in plain text at all times, since there's no native CSS-only way to mask text in that engine. This is a known limitation of pure-CSS approaches; a JS-based fallback (toggling `type="password"`/`type="text"`) is more portable, but not "pure CSS."
+
+## Usage
+
+\`\`\`html
+<label class="pw-toggle-wrap">
+  <input type="checkbox" class="pw-toggle-checkbox" />
+  <input type="text" class="pw-toggle-input" placeholder="Enter password" />
+  <span class="pw-toggle-label"><!-- eye / eye-off SVGs --></span>
+</label>
+\`\`\`
+
+## Acceptance criteria
+- [x] Pure CSS — no JavaScript
+- [x] Toggle button with eye / eye-off icon states
+- [x] Masked-by-default input
+- [x] Documented browser limitation (WebKit-only masking)
+
+Related issue: #71874

--- a/submissions/examples/password-toggle/demo.html
+++ b/submissions/examples/password-toggle/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Pure CSS Password Visibility Toggle</title>
+<link rel="stylesheet" href="style.css" />
+<style>
+  body { font-family: sans-serif; padding: 40px; background: #f7f7f8; }
+</style>
+</head>
+<body>
+
+<h1>Pure CSS Password Visibility Toggle</h1>
+<p>No JavaScript — toggled entirely with the checkbox hack and <code>-webkit-text-security</code>.</p>
+
+<label class="pw-toggle-wrap">
+  <input type="checkbox" class="pw-toggle-checkbox" />
+  <input type="text" class="pw-toggle-input" placeholder="Enter password" autocomplete="off" />
+  <span class="pw-toggle-label">
+    <svg class="icon-eye" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"/>
+      <circle cx="12" cy="12" r="3"/>
+    </svg>
+    <svg class="icon-eye-off" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <path d="M17.94 17.94A10.94 10.94 0 0 1 12 20c-7 0-11-8-11-8a20.3 20.3 0 0 1 5.06-6.06M9.9 4.24A10.94 10.94 0 0 1 12 4c7 0 11 8 11 8a20.3 20.3 0 0 1-3.22 4.45M14.12 14.12a3 3 0 1 1-4.24-4.24"/>
+      <line x1="1" y1="1" x2="23" y2="23"/>
+    </svg>
+  </span>
+</label>
+
+</body>
+</html>

--- a/submissions/examples/password-toggle/style.css
+++ b/submissions/examples/password-toggle/style.css
@@ -1,0 +1,70 @@
+/* Pure CSS Password Visibility Toggle — #71874 */
+/* Uses the checkbox hack + -webkit-text-security (no JS required) */
+
+.pw-toggle-wrap {
+  position: relative;
+  display: inline-block;
+  width: 260px;
+}
+
+/* Hide the real checkbox */
+.pw-toggle-checkbox {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.pw-toggle-input {
+  width: 100%;
+  padding: 10px 44px 10px 12px;
+  font-size: 15px;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  outline: none;
+  box-sizing: border-box;
+  transition: border-color 0.2s ease;
+  /* Masked by default, like type="password" */
+  -webkit-text-security: disc;
+}
+
+.pw-toggle-input:focus {
+  border-color: #3b82f6;
+}
+
+/* Eye icon label/button */
+.pw-toggle-label {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 22px;
+  height: 22px;
+  cursor: pointer;
+  color: #6b7280;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.2s ease, transform 0.2s ease;
+}
+
+.pw-toggle-label:hover {
+  color: #374151;
+  transform: translateY(-50%) scale(1.1);
+}
+
+.pw-toggle-label svg { width: 100%; height: 100%; }
+.pw-toggle-label .icon-eye-off { display: none; }
+
+/* When checked: reveal the text and swap the icon */
+.pw-toggle-checkbox:checked ~ .pw-toggle-input {
+  -webkit-text-security: none;
+}
+
+.pw-toggle-checkbox:checked ~ .pw-toggle-label .icon-eye { display: none; }
+.pw-toggle-checkbox:checked ~ .pw-toggle-label .icon-eye-off { display: block; }
+
+/* Responsive */
+@media (max-width: 480px) {
+  .pw-toggle-wrap { width: 100%; }
+}


### PR DESCRIPTION
## Summary
Implements a password visibility toggle using only CSS (checkbox hack + `-webkit-text-security`), as requested in #71874.

## What's included
- `submissions/examples/password-toggle/demo.html`
- `submissions/examples/password-toggle/style.css`
- `submissions/examples/password-toggle/README.md`

## How it works
A hidden checkbox + label (eye icon) toggles `-webkit-text-security` on a sibling text input via CSS sibling selectors — no JS involved.

## Known limitation
`-webkit-text-security` is WebKit/Blink-only (Chrome, Edge, Safari, Opera). Firefox has no CSS-only equivalent, so the input remains unmasked there. Documented in the submission's README.

## Acceptance criteria
- [x] Pure CSS, no JS
- [x] Eye / eye-off icon toggle
- [x] Masked-by-default input
- [x] Browser support caveat documented

Closes #71874
PRBODY
