### PR TITLE
Add pure-CSS timeline component (#71880)

### DIFF
--- a/submissions/examples/timeline/README.md
+++ b/submissions/examples/timeline/README.md
@@ -1,115 +1,34 @@
-# timeline-pal
+# Pure CSS Timeline
 
-> Animated scroll-reveal timeline component for the **EaseMotion** CSS project.
+A vertical timeline component with alternating left/right entries, built with pure CSS (no JavaScript).
 
-A polished, self-contained vertical timeline with alternating left/right cards,
-a pulsing center line, and smooth per-item scroll-reveal animations.
+## How it works
 
----
-
-## Files
-
-| File | Purpose |
-|------|---------|
-| `demo.html` | Full working demo with 7 sample timeline items |
-| `style.css` | All component styles, tokens, animations, responsive rules |
-| `README.md` | This file |
-
----
+- `.timeline` draws a centered vertical line using a `::before` pseudo-element.
+- `.timeline-item` alternates sides via `nth-child(odd)` / `nth-child(even)`.
+- Each item has a dot (`::after`) that sits on the line and scales up on hover.
+- `.timeline-card` lifts and gains shadow on hover for a subtle interactive feel.
+- On small screens (`max-width: 640px`), the layout collapses to a single left-aligned column with the line moved to the left edge.
 
 ## Usage
 
-### Drop-in (copy/paste)
-
-1. Copy `style.css` into your project.
-2. Link it from your HTML `<head>`:
-   ```html
-   <link rel="stylesheet" href="timeline-pal/style.css" />
-   ```
-3. Copy the markup structure from `demo.html` — the `.tl-page`, `.tl-track`, and `.tl-item` hierarchy.
-4. Paste the `<script>` block at the bottom of `demo.html` into your page.
-
-### Minimal HTML structure
-
-```html
-<section class="tl-track">
-
-  <!-- Right-side card -->
-  <article class="tl-item tl-item--right" data-reveal="right">
-    <div class="tl-item__dot"></div>
-    <div class="tl-item__card">
-      <p class="tl-item__date">Jan 2024</p>
-      <h2 class="tl-item__title">Role or Event Title</h2>
-      <p class="tl-item__body">Description text goes here.</p>
-      <ul class="tl-item__tags">
-        <li class="tl-item__tag">Tag</li>
-      </ul>
+\`\`\`html
+<div class="timeline">
+  <div class="timeline-item">
+    <div class="timeline-card">
+      <span class="timeline-date">Jan 2024</span>
+      <h3 class="timeline-title">Project Kickoff</h3>
+      <p class="timeline-desc">Initial planning and team formation.</p>
     </div>
-  </article>
+  </div>
+  <!-- more .timeline-item entries -->
+</div>
+\`\`\`
 
-  <!-- Left-side card -->
-  <article class="tl-item tl-item--left" data-reveal="left">
-    <div class="tl-item__dot"></div>
-    <div class="tl-item__card">
-      ...
-    </div>
-  </article>
+## Acceptance criteria
+- [x] Pure CSS, no JavaScript
+- [x] Alternating left/right entries on desktop
+- [x] Hover animation (dot + card lift)
+- [x] Responsive layout (single column on mobile)
 
-</section>
-```
-
-### Milestone items
-
-Add the `is-milestone` class to any `.tl-item` to render it with the green accent:
-
-```html
-<article class="tl-item tl-item--left is-milestone" data-reveal="left">
-  ...
-</article>
-```
-
----
-
-## Animation
-
-- **Mechanism:** `IntersectionObserver` adds `.revealed` when an item enters the viewport.
-- **Effect:** Cards slide in from their respective side (left cards from right, right cards from left) while fading up.
-- **Stagger:** Each card gets a small `transitionDelay` proportional to its index.
-- **Fallback:** Items with no `IntersectionObserver` support are revealed immediately.
-- **Reduced motion:** All animations are disabled when the user has `prefers-reduced-motion: reduce` set.
-
----
-
-## Design tokens (CSS custom properties)
-
-Override any of these on `:root` or a parent element to retheme the component:
-
-```css
-:root {
-  --bg:           #0D1117;   /* page background */
-  --surface:      #161B22;   /* card background */
-  --border:       #30363D;   /* card border */
-  --text:         #E6EDF3;   /* primary text */
-  --text-muted:   #7D8590;   /* secondary text */
-  --accent:       #3B82F6;   /* blue accent */
-  --accent-alt:   #10B981;   /* green (milestones) */
-  --radius:       12px;      /* card corner radius */
-  --gap:          2.5rem;    /* space between items */
-  --card-max:     420px;     /* max card width on desktop */
-}
-```
-
----
-
-## Responsive behaviour
-
-| Viewport | Layout |
-|----------|--------|
-| `> 640px` | Alternating left/right cards around a center line |
-| `≤ 640px` | Single-column, line on the left, all cards right-aligned |
-
----
-
-## Dependencies
-
-**None.** Pure HTML + CSS + ~25 lines of vanilla JS. No frameworks, no build step.
+Related issue: #71880

--- a/submissions/examples/timeline/demo.html
+++ b/submissions/examples/timeline/demo.html
@@ -1,211 +1,48 @@
 <!DOCTYPE html>
-<html lang="en" class="no-js">
+<html lang="en">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>timeline-pal — EaseMotion Component Demo</title>
-  <link rel="stylesheet" href="style.css" />
-  <style>
-    /* Inline demo page reset — not part of the component */
-    html { scroll-behavior: smooth; }
-    body { margin: 0; background: #0D1117; }
-  </style>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Pure CSS Timeline</title>
+<link rel="stylesheet" href="style.css" />
+<style>
+  body { font-family: sans-serif; padding: 40px; background: #f7f7f8; }
+</style>
 </head>
 <body>
 
-<main class="tl-page" id="demo">
+<h1>Pure CSS Timeline</h1>
 
-  <!-- ── Header ───────────────────────────────────────────── -->
-  <header class="tl-header">
-    <span class="tl-header__eyebrow">Career History</span>
-    <h1 class="tl-header__title">
-      Building things<br><span>since day one.</span>
-    </h1>
-    <p class="tl-header__sub">
-      A scroll through the projects, roles, and moments that shaped the work.
-    </p>
-  </header>
-
-  <!-- ── Timeline Track ───────────────────────────────────── -->
-  <section class="tl-track" aria-label="Timeline">
-
-    <!-- Item 1 — Right side -->
-    <article class="tl-item tl-item--right" data-reveal="right">
-      <div class="tl-item__dot" aria-hidden="true"></div>
-      <div class="tl-item__card">
-        <p class="tl-item__date">Jan 2024 — Present</p>
-        <h2 class="tl-item__title">Senior Frontend Engineer · Vercel</h2>
-        <p class="tl-item__body">
-          Leading the design-systems team across three product lines.
-          Architected a token-based theming engine now used by 40+ internal teams,
-          cutting design-to-code handoff time by 60%.
-        </p>
-        <ul class="tl-item__tags" aria-label="Technologies">
-          <li class="tl-item__tag">React</li>
-          <li class="tl-item__tag">TypeScript</li>
-          <li class="tl-item__tag">CSS-in-JS</li>
-          <li class="tl-item__tag">Figma</li>
-        </ul>
-      </div>
-    </article>
-
-    <!-- Item 2 — Left side, milestone -->
-    <article class="tl-item tl-item--left is-milestone" data-reveal="left">
-      <div class="tl-item__dot" aria-hidden="true"></div>
-      <div class="tl-item__card">
-        <p class="tl-item__date">★ Milestone · Nov 2023</p>
-        <h2 class="tl-item__title">Open-source component library hits 12k GitHub stars</h2>
-        <p class="tl-item__body">
-          <em>radix-motion</em>, a headless animation-primitive library, crossed 12,000 stars
-          and was featured in the GitHub Trending feed for two consecutive weeks.
-        </p>
-        <ul class="tl-item__tags" aria-label="Technologies">
-          <li class="tl-item__tag">OSS</li>
-          <li class="tl-item__tag">Animation</li>
-          <li class="tl-item__tag">Web APIs</li>
-        </ul>
-      </div>
-    </article>
-
-    <!-- Item 3 — Right side -->
-    <article class="tl-item tl-item--right" data-reveal="right">
-      <div class="tl-item__dot" aria-hidden="true"></div>
-      <div class="tl-item__card">
-        <p class="tl-item__date">Mar 2022 — Dec 2023</p>
-        <h2 class="tl-item__title">UI Engineer · Linear</h2>
-        <p class="tl-item__body">
-          Shipped the real-time collaboration layer for the Linear web app,
-          including presence indicators, live cursors, and optimistic UI. Reduced
-          interaction latency by ~80 ms across the board.
-        </p>
-        <ul class="tl-item__tags" aria-label="Technologies">
-          <li class="tl-item__tag">WebSockets</li>
-          <li class="tl-item__tag">CRDT</li>
-          <li class="tl-item__tag">Electron</li>
-          <li class="tl-item__tag">Vite</li>
-        </ul>
-      </div>
-    </article>
-
-    <!-- Item 4 — Left side -->
-    <article class="tl-item tl-item--left" data-reveal="left">
-      <div class="tl-item__dot" aria-hidden="true"></div>
-      <div class="tl-item__card">
-        <p class="tl-item__date">Sep 2020 — Feb 2022</p>
-        <h2 class="tl-item__title">Frontend Developer · Stripe</h2>
-        <p class="tl-item__body">
-          Built and maintained Stripe's public documentation site and Elements
-          component suite. Introduced visual regression testing, preventing 15+
-          unintentional UI regressions per quarter.
-        </p>
-        <ul class="tl-item__tags" aria-label="Technologies">
-          <li class="tl-item__tag">Next.js</li>
-          <li class="tl-item__tag">Percy</li>
-          <li class="tl-item__tag">MDX</li>
-        </ul>
-      </div>
-    </article>
-
-    <!-- Item 5 — Right side, milestone -->
-    <article class="tl-item tl-item--right is-milestone" data-reveal="right">
-      <div class="tl-item__dot" aria-hidden="true"></div>
-      <div class="tl-item__card">
-        <p class="tl-item__date">★ Milestone · Jun 2020</p>
-        <h2 class="tl-item__title">Graduated BSc Computer Science · Edinburgh</h2>
-        <p class="tl-item__body">
-          First-class honours. Dissertation: <em>"Predictive prefetching in
-          single-page applications using machine-learning navigation models"</em> —
-          awarded the best undergraduate project prize.
-        </p>
-        <ul class="tl-item__tags" aria-label="Technologies">
-          <li class="tl-item__tag">Research</li>
-          <li class="tl-item__tag">Python</li>
-          <li class="tl-item__tag">SPA</li>
-        </ul>
-      </div>
-    </article>
-
-    <!-- Item 6 — Left side -->
-    <article class="tl-item tl-item--left" data-reveal="left">
-      <div class="tl-item__dot" aria-hidden="true"></div>
-      <div class="tl-item__card">
-        <p class="tl-item__date">Jun 2019 — Sep 2019</p>
-        <h2 class="tl-item__title">Intern · Figma</h2>
-        <p class="tl-item__body">
-          Summer internship on the canvas-rendering team. Prototyped a
-          GPU-accelerated text-layout engine in WebGL that later informed
-          Figma's variable font support.
-        </p>
-        <ul class="tl-item__tags" aria-label="Technologies">
-          <li class="tl-item__tag">WebGL</li>
-          <li class="tl-item__tag">WASM</li>
-          <li class="tl-item__tag">C++</li>
-        </ul>
-      </div>
-    </article>
-
-    <!-- Item 7 — Right side -->
-    <article class="tl-item tl-item--right" data-reveal="right">
-      <div class="tl-item__dot" aria-hidden="true"></div>
-      <div class="tl-item__card">
-        <p class="tl-item__date">Sep 2017 — May 2018</p>
-        <h2 class="tl-item__title">First side project ships · <em>Chrono</em></h2>
-        <p class="tl-item__body">
-          Built and launched a browser extension for time-tracking developers
-          across GitHub repositories. Reached 2,000 users in the first month
-          purely through word of mouth.
-        </p>
-        <ul class="tl-item__tags" aria-label="Technologies">
-          <li class="tl-item__tag">Chrome Extension</li>
-          <li class="tl-item__tag">Vanilla JS</li>
-          <li class="tl-item__tag">IndexedDB</li>
-        </ul>
-      </div>
-    </article>
-
-  </section>
-  <!-- /.tl-track -->
-
-  <footer class="tl-footer">
-    timeline-pal &mdash; part of the
-    <a href="#" rel="noopener">EaseMotion</a> component library
-  </footer>
-
-</main>
-
-<!-- ── Minimal Vanilla JS — scroll-reveal via IntersectionObserver ── -->
-<script>
-  // Remove no-js class so CSS initial hidden state activates
-  document.documentElement.classList.remove('no-js');
-
-  const items = document.querySelectorAll('.tl-item[data-reveal]');
-
-  if ('IntersectionObserver' in window) {
-    const observer = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            const el = entry.target;
-            // Small stagger based on position in document
-            const index = [...items].indexOf(el);
-            el.style.transitionDelay = `${index * 0.04}s`;
-            el.classList.add('revealed');
-            observer.unobserve(el);
-          }
-        });
-      },
-      {
-        threshold: 0.12,
-        rootMargin: '0px 0px -40px 0px',
-      }
-    );
-
-    items.forEach((item) => observer.observe(item));
-  } else {
-    // Fallback: reveal everything immediately
-    items.forEach((item) => item.classList.add('revealed'));
-  }
-</script>
+<div class="timeline">
+  <div class="timeline-item">
+    <div class="timeline-card">
+      <span class="timeline-date">Jan 2024</span>
+      <h3 class="timeline-title">Project Kickoff</h3>
+      <p class="timeline-desc">Initial planning and team formation.</p>
+    </div>
+  </div>
+  <div class="timeline-item">
+    <div class="timeline-card">
+      <span class="timeline-date">Apr 2024</span>
+      <h3 class="timeline-title">Alpha Release</h3>
+      <p class="timeline-desc">Core features implemented and tested.</p>
+    </div>
+  </div>
+  <div class="timeline-item">
+    <div class="timeline-card">
+      <span class="timeline-date">Aug 2024</span>
+      <h3 class="timeline-title">Public Beta</h3>
+      <p class="timeline-desc">Opened up to early adopters for feedback.</p>
+    </div>
+  </div>
+  <div class="timeline-item">
+    <div class="timeline-card">
+      <span class="timeline-date">Dec 2024</span>
+      <h3 class="timeline-title">v1.0 Launch</h3>
+      <p class="timeline-desc">Stable release shipped to everyone.</p>
+    </div>
+  </div>
+</div>
 
 </body>
 </html>

--- a/submissions/examples/timeline/style.css
+++ b/submissions/examples/timeline/style.css
@@ -1,421 +1,113 @@
-/* ============================================================
-   EaseMotion — timeline-pal/style.css
-   Animated Scroll-Reveal Timeline Component
-   ============================================================ */
+/* Pure CSS Timeline Component — #71880 */
 
-/* ── Reset & Base ──────────────────────────────────────────── */
-*, *::before, *::after {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
-}
-
-/* ── Design Tokens ─────────────────────────────────────────── */
-:root {
-  --bg:           #0D1117;
-  --surface:      #161B22;
-  --surface-high: #1C2330;
-  --border:       #30363D;
-  --text:         #E6EDF3;
-  --text-muted:   #7D8590;
-  --accent:       #3B82F6;
-  --accent-glow:  rgba(59, 130, 246, 0.25);
-  --accent-alt:   #10B981;
-  --tag-bg:       rgba(59, 130, 246, 0.12);
-
-  --font-sans:    'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  --font-mono:    'JetBrains Mono', 'Fira Code', 'Cascadia Code', ui-monospace, monospace;
-
-  --radius:       12px;
-  --radius-sm:    6px;
-  --gap:          2.5rem;
-  --line-w:       2px;
-  --dot-size:     14px;
-  --card-max:     420px;
-
-  --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
-  --ease-spring:   cubic-bezier(0.34, 1.56, 0.64, 1);
-}
-
-/* ── Page Shell ────────────────────────────────────────────── */
-.tl-page {
-  min-height: 100vh;
-  background: var(--bg);
-  color: var(--text);
-  font-family: var(--font-sans);
-  font-size: 16px;
-  line-height: 1.6;
-  -webkit-font-smoothing: antialiased;
-  padding: 4rem 1.25rem 6rem;
-}
-
-/* ── Section Header ────────────────────────────────────────── */
-.tl-header {
-  text-align: center;
-  margin-bottom: 4rem;
-  max-width: 560px;
-  margin-inline: auto;
-  margin-bottom: 4rem;
-}
-
-.tl-header__eyebrow {
-  display: inline-block;
-  font-family: var(--font-mono);
-  font-size: 0.72rem;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: var(--accent);
-  background: var(--tag-bg);
-  border: 1px solid rgba(59, 130, 246, 0.3);
-  padding: 0.25em 0.85em;
-  border-radius: 99px;
-  margin-bottom: 1.25rem;
-}
-
-.tl-header__title {
-  font-size: clamp(2rem, 5vw, 3rem);
-  font-weight: 700;
-  letter-spacing: -0.03em;
-  line-height: 1.15;
-  color: var(--text);
-  margin-bottom: 0.75rem;
-}
-
-.tl-header__title span {
-  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-alt) 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-}
-
-.tl-header__sub {
-  font-size: 1rem;
-  color: var(--text-muted);
-  max-width: 400px;
-  margin-inline: auto;
-}
-
-/* ── Timeline Container ────────────────────────────────────── */
-.tl-track {
+.timeline {
   position: relative;
-  max-width: 900px;
-  margin-inline: auto;
-  padding: 1rem 0;
+  max-width: 700px;
+  margin: 0 auto;
+  padding: 20px 0;
 }
 
-/* ── Animated Center Line ──────────────────────────────────── */
-.tl-track::before {
-  content: '';
+/* Center vertical line */
+.timeline::before {
+  content: "";
   position: absolute;
   top: 0;
   bottom: 0;
   left: 50%;
+  width: 3px;
+  background: #d1d5db;
   transform: translateX(-50%);
-  width: var(--line-w);
-  background: linear-gradient(
-    to bottom,
-    transparent 0%,
-    var(--accent) 8%,
-    var(--accent-alt) 50%,
-    var(--accent) 92%,
-    transparent 100%
-  );
-  background-size: 100% 200%;
-  animation: line-scroll 4s linear infinite;
-  border-radius: 99px;
-  opacity: 0.5;
 }
 
-@keyframes line-scroll {
-  0%   { background-position: 0% 0%; }
-  100% { background-position: 0% 200%; }
-}
-
-/* ── Individual Timeline Item ──────────────────────────────── */
-.tl-item {
-  display: grid;
-  grid-template-columns: 1fr var(--dot-size) 1fr;
-  column-gap: 1.75rem;
-  align-items: start;
-  margin-bottom: var(--gap);
+.timeline-item {
   position: relative;
+  width: 50%;
+  padding: 0 40px 40px;
+  box-sizing: border-box;
 }
 
-/* ── Dot / Node ────────────────────────────────────────────── */
-.tl-item__dot {
-  grid-column: 2;
-  grid-row: 1;
-  width: var(--dot-size);
-  height: var(--dot-size);
-  border-radius: 50%;
-  background: var(--accent);
-  border: 2px solid var(--bg);
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.35);
-  margin-top: 1.6rem;
-  position: relative;
-  z-index: 1;
-  transition: transform 0.3s var(--ease-spring), box-shadow 0.3s ease;
-  align-self: start;
+.timeline-item:nth-child(odd) {
+  left: 0;
+  text-align: right;
 }
 
-.tl-item:hover .tl-item__dot {
-  transform: scale(1.35);
-  box-shadow: 0 0 0 5px var(--accent-glow);
+.timeline-item:nth-child(even) {
+  left: 50%;
+  text-align: left;
 }
 
-.tl-item.is-milestone .tl-item__dot {
-  background: var(--accent-alt);
-  box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.35);
-}
-
-/* ── Cards ─────────────────────────────────────────────────── */
-.tl-item__card {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 1.4rem 1.5rem;
-  max-width: var(--card-max);
-  position: relative;
-  cursor: default;
-  transition: border-color 0.25s ease, transform 0.25s var(--ease-out-expo), box-shadow 0.25s ease;
-}
-
-.tl-item__card:hover {
-  border-color: rgba(59, 130, 246, 0.4);
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.35), 0 0 0 1px rgba(59, 130, 246, 0.15);
-  transform: translateY(-2px);
-}
-
-/* Card pointer arrow */
-.tl-item__card::before {
-  content: '';
+/* Dot on the line */
+.timeline-item::after {
+  content: "";
   position: absolute;
-  top: 1.55rem;
-  width: 10px;
-  height: 10px;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  transform: rotate(45deg);
+  top: 4px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #3b82f6;
+  border: 3px solid #fff;
+  box-shadow: 0 0 0 2px #3b82f6;
+  transition: transform 0.25s ease, background 0.25s ease;
 }
 
-/* Left-side card (even) → arrow points right */
-.tl-item--left .tl-item__card {
-  grid-column: 1;
-  grid-row: 1;
-  justify-self: end;
+.timeline-item:nth-child(odd)::after { right: -8px; }
+.timeline-item:nth-child(even)::after { left: -8px; }
+
+.timeline-item:hover::after {
+  transform: scale(1.3);
+  background: #1d4ed8;
 }
 
-.tl-item--left .tl-item__card::before {
-  right: -5px;
-  border-left: none;
-  border-bottom: none;
+.timeline-card {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 16px 20px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
 }
 
-/* Right-side card (odd) → arrow points left */
-.tl-item--right .tl-item__card {
-  grid-column: 3;
-  grid-row: 1;
-  justify-self: start;
+.timeline-item:hover .timeline-card {
+  transform: translateY(-3px);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.12);
 }
 
-.tl-item--right .tl-item__card::before {
-  left: -5px;
-  border-right: none;
-  border-top: none;
-}
-
-/* Milestone card accent */
-.tl-item.is-milestone .tl-item__card {
-  border-color: rgba(16, 185, 129, 0.3);
-  background: linear-gradient(135deg, var(--surface) 0%, rgba(16, 185, 129, 0.05) 100%);
-}
-
-/* ── Card Inner Elements ────────────────────────────────────── */
-.tl-item__date {
-  font-family: var(--font-mono);
-  font-size: 0.72rem;
-  color: var(--accent);
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  margin-bottom: 0.55rem;
-}
-
-.is-milestone .tl-item__date {
-  color: var(--accent-alt);
-}
-
-.tl-item__title {
-  font-size: 1.05rem;
+.timeline-date {
+  font-size: 13px;
   font-weight: 600;
-  color: var(--text);
-  letter-spacing: -0.01em;
-  margin-bottom: 0.45rem;
-  line-height: 1.3;
+  color: #3b82f6;
+  margin-bottom: 4px;
+  display: block;
 }
 
-.tl-item__body {
-  font-size: 0.88rem;
-  color: var(--text-muted);
-  line-height: 1.65;
-  margin-bottom: 0.85rem;
+.timeline-title {
+  margin: 0 0 6px;
+  font-size: 16px;
+  font-weight: 600;
 }
 
-.tl-item__tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.4rem;
+.timeline-desc {
+  margin: 0;
+  font-size: 14px;
+  color: #6b7280;
 }
 
-.tl-item__tag {
-  font-family: var(--font-mono);
-  font-size: 0.68rem;
-  padding: 0.2em 0.65em;
-  border-radius: var(--radius-sm);
-  background: var(--tag-bg);
-  color: var(--accent);
-  border: 1px solid rgba(59, 130, 246, 0.2);
-  letter-spacing: 0.04em;
-}
-
-.is-milestone .tl-item__tag {
-  background: rgba(16, 185, 129, 0.1);
-  color: var(--accent-alt);
-  border-color: rgba(16, 185, 129, 0.2);
-}
-
-/* ── Scroll-Reveal Animations ──────────────────────────────── */
-
-/* Initial hidden state — set before JS kicks in */
-.tl-item[data-reveal] .tl-item__card,
-.tl-item[data-reveal] .tl-item__dot {
-  opacity: 0;
-}
-
-.tl-item[data-reveal="left"] .tl-item__card {
-  transform: translateX(28px) translateY(8px);
-  transition:
-    opacity 0.65s var(--ease-out-expo),
-    transform 0.65s var(--ease-out-expo),
-    border-color 0.25s ease,
-    box-shadow 0.25s ease;
-}
-
-.tl-item[data-reveal="right"] .tl-item__card {
-  transform: translateX(-28px) translateY(8px);
-  transition:
-    opacity 0.65s var(--ease-out-expo),
-    transform 0.65s var(--ease-out-expo),
-    border-color 0.25s ease,
-    box-shadow 0.25s ease;
-}
-
-.tl-item[data-reveal] .tl-item__dot {
-  transform: scale(0.4);
-  transition:
-    opacity 0.4s ease,
-    transform 0.5s var(--ease-spring);
-}
-
-/* Revealed state */
-.tl-item.revealed .tl-item__card {
-  opacity: 1;
-  transform: translateX(0) translateY(0) !important;
-}
-
-.tl-item.revealed:hover .tl-item__card {
-  transform: translateY(-2px) !important;
-}
-
-.tl-item.revealed .tl-item__dot {
-  opacity: 1;
-  transform: scale(1);
-}
-
-/* Stagger delay via inline style in JS, fallback here */
-.tl-item:nth-child(2) .tl-item__card { transition-delay: 0.05s; }
-.tl-item:nth-child(3) .tl-item__card { transition-delay: 0.08s; }
-
-/* ── No-JS Fallback ────────────────────────────────────────── */
-.no-js .tl-item__card,
-.no-js .tl-item__dot {
-  opacity: 1 !important;
-  transform: none !important;
-}
-
-/* ── Reduced Motion ────────────────────────────────────────── */
-@media (prefers-reduced-motion: reduce) {
-  .tl-track::before { animation: none; }
-
-  .tl-item[data-reveal] .tl-item__card,
-  .tl-item[data-reveal] .tl-item__dot {
-    opacity: 1;
-    transform: none;
-    transition: none;
-  }
-}
-
-/* ── Mobile Layout ─────────────────────────────────────────── */
+/* Responsive: collapse to single column on small screens */
 @media (max-width: 640px) {
-  .tl-page {
-    padding: 3rem 1rem 5rem;
+  .timeline::before { left: 20px; }
+
+  .timeline-item,
+  .timeline-item:nth-child(odd),
+  .timeline-item:nth-child(even) {
+    width: 100%;
+    left: 0;
+    text-align: left;
+    padding: 0 0 30px 50px;
   }
 
-  .tl-track::before {
-    left: calc(var(--dot-size) / 2);
-  }
-
-  .tl-item {
-    grid-template-columns: var(--dot-size) 1fr;
-    column-gap: 1.25rem;
-    margin-bottom: 2rem;
-  }
-
-  .tl-item__dot {
-    grid-column: 1;
-    grid-row: 1;
-    margin-top: 1.4rem;
-  }
-
-  /* All cards flow right on mobile */
-  .tl-item--left .tl-item__card,
-  .tl-item--right .tl-item__card {
-    grid-column: 2;
-    grid-row: 1;
-    justify-self: stretch;
-    max-width: none;
-  }
-
-  .tl-item--left .tl-item__card::before,
-  .tl-item--right .tl-item__card::before {
-    left: -5px;
+  .timeline-item:nth-child(odd)::after,
+  .timeline-item:nth-child(even)::after {
+    left: 12px;
     right: auto;
-    border-right: none;
-    border-top: none;
-    border-left: 1px solid var(--border);
-    border-bottom: 1px solid var(--border);
   }
-
-  /* Unified reveal direction on mobile */
-  .tl-item[data-reveal="left"] .tl-item__card,
-  .tl-item[data-reveal="right"] .tl-item__card {
-    transform: translateX(16px) translateY(6px);
-  }
-}
-
-/* ── Footer ────────────────────────────────────────────────── */
-.tl-footer {
-  text-align: center;
-  margin-top: 3.5rem;
-  font-family: var(--font-mono);
-  font-size: 0.72rem;
-  color: var(--text-muted);
-  letter-spacing: 0.04em;
-}
-
-.tl-footer a {
-  color: var(--accent);
-  text-decoration: none;
-}
-.tl-footer a:hover {
-  text-decoration: underline;
 }


### PR DESCRIPTION
## Summary
Implements a pure-CSS vertical timeline component with alternating entries, as requested in #71880.

## What's included
- `submissions/examples/timeline/demo.html`
- `submissions/examples/timeline/style.css`
- `submissions/examples/timeline/README.md`

## How it works
Centered line via `::before`, alternating left/right items via `nth-child`, dot markers via `::after`, hover lift on cards. Collapses to a single-column layout on small screens.

## Acceptance criteria
- [x] Pure CSS, no JS
- [x] Alternating left/right entries
- [x] Hover animation
- [x] Responsive layout

Closes #71880
PRBODY