### PR TITLE
Add ease-sleep-tracker-stats component

### DIFF
--- a/submissions/examples/sleep-tracker-stats-ij/README.md
+++ b/submissions/examples/sleep-tracker-stats-ij/README.md
@@ -1,0 +1,11 @@
+# ease-sleep-tracker-stats
+
+A sleep dashboard where the week bars climb, the hours readout ticks, and the quality badge pulses.
+
+## Run
+Open `demo.html` directly in a browser to watch the week stack up.
+
+## Notes
+- The seven day bars climb the chart.
+- The hours readout ticks in the hero.
+- The quality badge pulses in the readout bar.

--- a/submissions/examples/sleep-tracker-stats-ij/demo.html
+++ b/submissions/examples/sleep-tracker-stats-ij/demo.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-sleep-tracker-stats demo</title>
+</head>
+<body>
+<div class="sts-panel">
+  <div class="sts-hero">
+    <b class="sts-hours">7.5</b>
+    <span class="sts-unit">HRS</span>
+  </div>
+  <div class="sts-chart">
+    <i class="sts-bar"></i>
+    <i class="sts-bar"></i>
+    <i class="sts-bar"></i>
+    <i class="sts-bar"></i>
+    <i class="sts-bar"></i>
+    <i class="sts-bar"></i>
+    <i class="sts-bar"></i>
+  </div>
+  <div class="sts-days">
+    <span class="sts-day">S</span>
+    <span class="sts-day">M</span>
+    <span class="sts-day">T</span>
+    <span class="sts-day">W</span>
+    <span class="sts-day">T</span>
+    <span class="sts-day">F</span>
+    <span class="sts-day">S</span>
+  </div>
+  <div class="sts-read">
+    <span class="sts-tag">DEEP</span>
+    <b class="sts-quality">GOOD</b>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/sleep-tracker-stats-ij/style.css
+++ b/submissions/examples/sleep-tracker-stats-ij/style.css
@@ -1,0 +1,21 @@
+.sts-panel{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:300px;background:linear-gradient(180deg,#1a1f3a,#0e1123);border:2px solid #2e3a66;border-radius:16px;padding:20px;display:flex;flex-direction:column;gap:14px}
+.sts-hero{display:flex;align-items:baseline;gap:8px;justify-content:center}
+.sts-hours{font-size:38px;font-weight:800;color:#a78bfa;font-family:'Courier New',monospace;animation:sts-hours-tick-sleep-tracker-stats 1.8s steps(3) infinite}
+.sts-unit{font-size:12px;font-weight:800;letter-spacing:2px;color:#8b9bad}
+.sts-chart{display:flex;align-items:flex-end;gap:8px;height:110px;background:#0d1030;border-radius:10px;padding:12px;border:1px solid #232b52}
+.sts-bar{flex:1;height:30px;background:linear-gradient(180deg,#a78bfa,#5ce1e6);border-radius:3px;transform-origin:bottom;animation:sts-bar-rise-sleep-tracker-stats 2.2s ease-in-out infinite}
+.sts-bar:nth-child(2){height:48px;animation-delay:.3s}
+.sts-bar:nth-child(3){height:66px;animation-delay:.6s}
+.sts-bar:nth-child(4){height:40px;animation-delay:.9s}
+.sts-bar:nth-child(5){height:74px;animation-delay:1.2s}
+.sts-bar:nth-child(6){height:54px;animation-delay:1.5s}
+.sts-bar:nth-child(7){height:62px;animation-delay:1.8s}
+.sts-days{display:flex;gap:8px}
+.sts-day{flex:1;text-align:center;font-size:9px;font-weight:800;color:#8b9bad;letter-spacing:1px}
+.sts-read{display:flex;justify-content:space-between;align-items:center;background:#0d1030;border-radius:8px;padding:10px 14px;border:1px solid #232b52}
+.sts-tag{font-size:10px;font-weight:800;letter-spacing:2px;color:#5ce1e6;animation:sts-tag-blink-sleep-tracker-stats 1.4s ease-in-out infinite}
+.sts-quality{font-size:14px;font-weight:800;color:#a78bfa;animation:sts-quality-pulse-sleep-tracker-stats 2s ease-in-out infinite}
+@keyframes sts-hours-tick-sleep-tracker-stats{0%{opacity:1}50%{opacity:.35}100%{opacity:1}}
+@keyframes sts-bar-rise-sleep-tracker-stats{0%,100%{transform:scaleY(.5)}50%{transform:scaleY(1)}}
+@keyframes sts-tag-blink-sleep-tracker-stats{0%,100%{opacity:1}50%{opacity:.3}}
+@keyframes sts-quality-pulse-sleep-tracker-stats{0%,100%{opacity:1}50%{opacity:.45}}


### PR DESCRIPTION
## Component: ease-sleep-tracker-stats — bars climb, hours tick, and quality pulses

**Closes #72515**

### What this adds
A sleep dashboard where the week bars climb, the hours readout ticks, and the quality badge pulses.

### Acceptance Criteria covered
- Week bars climb
- Hours readout ticks
- Quality badge pulses

### Files
- `submissions/examples/sleep-tracker-stats-ij/demo.html`
- `submissions/examples/sleep-tracker-stats-ij/style.css`
- `submissions/examples/sleep-tracker-stats-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the bars climb, the hours tick, and the quality pulse.