### PR TITLE
Add ease-battery-charging-bolt component

### DIFF
--- a/submissions/examples/battery-charging-bolt-ij/README.md
+++ b/submissions/examples/battery-charging-bolt-ij/README.md
@@ -1,0 +1,11 @@
+# ease-battery-charging-bolt
+
+A battery where the charge fill rises, the bolt flashes, and the percent ticks.
+
+## Run
+Open `demo.html` directly in a browser to watch the battery charge.
+
+## Notes
+- The charge fill rises inside the cell.
+- The bolt flashes over the fill.
+- The percent readout ticks below.

--- a/submissions/examples/battery-charging-bolt-ij/demo.html
+++ b/submissions/examples/battery-charging-bolt-ij/demo.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-battery-charging-bolt demo</title>
+</head>
+<body>
+<div class="bcb-panel">
+  <div class="bcb-battery">
+    <div class="bcb-cell"><em class="bcb-fill"></em><b class="bcb-bolt">&#9889;</b></div>
+    <span class="bcb-tip"></span>
+  </div>
+  <div class="bcb-read">
+    <span class="bcb-tag">CHARGING</span>
+    <b class="bcb-pct">74%</b>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/battery-charging-bolt-ij/style.css
+++ b/submissions/examples/battery-charging-bolt-ij/style.css
@@ -1,0 +1,13 @@
+.bcb-panel{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:290px;background:linear-gradient(180deg,#1e2a24,#111a15);border:2px solid #31493a;border-radius:16px;padding:20px;display:flex;flex-direction:column;align-items:center;gap:16px}
+.bcb-battery{display:flex;align-items:center;gap:6px}
+.bcb-cell{position:relative;width:160px;height:64px;background:#0f1a13;border:4px solid #4a6b52;border-radius:12px;overflow:hidden}
+.bcb-tip{width:12px;height:28px;background:#4a6b52;border-radius:0 6px 6px 0}
+.bcb-fill{position:absolute;left:6px;right:6px;top:6px;bottom:6px;width:64%;background:linear-gradient(90deg,#7cebb0,#5ce1e6);border-radius:6px;animation:bcb-fill-rise-battery-charging-bolt 4s ease-in-out infinite}
+.bcb-bolt{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);font-size:28px;color:#ffd76a;animation:bcb-bolt-flash-battery-charging-bolt 1s ease-in-out infinite}
+.bcb-read{display:flex;justify-content:space-between;align-items:center;width:100%}
+.bcb-tag{font-size:10px;font-weight:800;letter-spacing:3px;color:#7cebb0;animation:bcb-tag-blink-battery-charging-bolt 1.4s ease-in-out infinite}
+.bcb-pct{font-size:22px;font-weight:800;color:#ffd76a;font-family:'Courier New',monospace;animation:bcb-pct-tick-battery-charging-bolt 2s steps(4) infinite}
+@keyframes bcb-fill-rise-battery-charging-bolt{0%,100%{width:22%}50%{width:86%}}
+@keyframes bcb-bolt-flash-battery-charging-bolt{0%,100%{opacity:1}50%{opacity:.2}}
+@keyframes bcb-tag-blink-battery-charging-bolt{0%,100%{opacity:1}50%{opacity:.3}}
+@keyframes bcb-pct-tick-battery-charging-bolt{0%{opacity:1}50%{opacity:.3}}


### PR DESCRIPTION
## Component: ease-battery-charging-bolt — fill rises, bolt flashes, and pct ticks

**Closes #72527**

### What this adds
A battery where the charge fill rises, the bolt flashes, and the percent ticks.

### Acceptance Criteria covered
- Charge fill rises
- Bolt flashes
- Percent ticks

### Files
- `submissions/examples/battery-charging-bolt-ij/demo.html`
- `submissions/examples/battery-charging-bolt-ij/style.css`
- `submissions/examples/battery-charging-bolt-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the fill rise, the bolt flash, and the pct tick.