### PR TITLE
Add ease-flight-status-board component

### DIFF
--- a/submissions/examples/flight-status-board-ij/README.md
+++ b/submissions/examples/flight-status-board-ij/README.md
@@ -1,0 +1,11 @@
+# ease-flight-status-board
+
+A departure board where the rows flicker, the flight codes tick, and the status blinks.
+
+## Run
+Open `demo.html` directly in a browser to watch the board update.
+
+## Notes
+- The flight rows flicker like a live screen.
+- The flight codes tick in the first column.
+- The status labels blink in turn.

--- a/submissions/examples/flight-status-board-ij/demo.html
+++ b/submissions/examples/flight-status-board-ij/demo.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-flight-status-board demo</title>
+</head>
+<body>
+<div class="fsb-board">
+  <div class="fsb-header">
+    <span>FLIGHT</span><span>DEST</span><span>GATE</span><span>STATUS</span>
+  </div>
+  <div class="fsb-row"><b class="fsb-code">EK 507</b><span class="fsb-dest">DUBAI</span><span class="fsb-gate">B12</span><em class="fsb-status">BOARDING</em></div>
+  <div class="fsb-row"><b class="fsb-code">QF 10</b><span class="fsb-dest">SYDNEY</span><span class="fsb-gate">A4</span><em class="fsb-status">ON TIME</em></div>
+  <div class="fsb-row"><b class="fsb-code">UA 88</b><span class="fsb-dest">TOKYO</span><span class="fsb-gate">C7</span><em class="fsb-status">DELAYED</em></div>
+  <div class="fsb-row"><b class="fsb-code">LH 402</b><span class="fsb-dest">FRANKFURT</span><span class="fsb-gate">D3</span><em class="fsb-status">LANDED</em></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/flight-status-board-ij/style.css
+++ b/submissions/examples/flight-status-board-ij/style.css
@@ -1,0 +1,14 @@
+.fsb-board{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:340px;background:linear-gradient(180deg,#0c1420,#060b12);border:2px solid #1e2f42;border-radius:14px;padding:16px;display:flex;flex-direction:column;gap:8px}
+.fsb-header{display:grid;grid-template-columns:1.2fr 1.4fr 1fr 1.2fr;gap:6px;padding:8px 10px;background:#0a0f17;border-radius:8px}
+.fsb-header span{font-size:9px;font-weight:800;letter-spacing:2px;color:#5c6b7c}
+.fsb-row{display:grid;grid-template-columns:1.2fr 1.4fr 1fr 1.2fr;gap:6px;align-items:center;background:#0d1520;border-radius:8px;padding:10px;border:1px solid #16222f;animation:fsb-row-flicker-flight-status-board 3s ease-in-out infinite}
+.fsb-row:nth-child(3){animation-delay:.6s}
+.fsb-row:nth-child(4){animation-delay:1.2s}
+.fsb-row:nth-child(5){animation-delay:1.8s}
+.fsb-code{font-size:11px;font-weight:800;color:#ffd76a;font-family:'Courier New',monospace;animation:fsb-code-tick-flight-status-board 2s steps(3) infinite}
+.fsb-dest{font-size:10px;font-weight:700;color:#c7d6e8}
+.fsb-gate{font-size:10px;font-weight:800;color:#5ce1e6}
+.fsb-status{font-size:9px;font-weight:800;letter-spacing:1px;color:#7cebb0;animation:fsb-status-blink-flight-status-board 1.2s ease-in-out infinite}
+@keyframes fsb-row-flicker-flight-status-board{0%,100%{opacity:1}50%{opacity:.6}}
+@keyframes fsb-code-tick-flight-status-board{0%{opacity:1}50%{opacity:.35}100%{opacity:1}}
+@keyframes fsb-status-blink-flight-status-board{0%,100%{opacity:1}50%{opacity:.25}}


### PR DESCRIPTION
## Component: ease-flight-status-board — rows flicker, codes tick, and status blinks

**Closes #72541**

### What this adds
A departure board where the rows flicker, the flight codes tick, and the status blinks.

### Acceptance Criteria covered
- Rows flicker
- Flight codes tick
- Status blinks

### Files
- `submissions/examples/flight-status-board-ij/demo.html`
- `submissions/examples/flight-status-board-ij/style.css`
- `submissions/examples/flight-status-board-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the rows flicker, the codes tick, and the status blink.