### PR TITLE
Add ease-accordion-faq-list component

### DIFF
--- a/submissions/examples/accordion-faq-list-ij/README.md
+++ b/submissions/examples/accordion-faq-list-ij/README.md
@@ -1,0 +1,11 @@
+# ease-accordion-faq-list
+
+An FAQ accordion where the panels expand, the chevrons flip, and the answers fade in.
+
+## Run
+Open `demo.html` directly in a browser to watch the accordion cycle.
+
+## Notes
+- The panels highlight in sequence.
+- The chevrons flip between states.
+- The answers fade in below each question.

--- a/submissions/examples/accordion-faq-list-ij/demo.html
+++ b/submissions/examples/accordion-faq-list-ij/demo.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-accordion-faq-list demo</title>
+</head>
+<body>
+<div class="afl-list">
+  <div class="afl-item"><span class="afl-q">HOW DO I OPEN IT?</span><span class="afl-chev">&#9660;</span><p class="afl-a">Open demo.html in any modern browser.</p></div>
+  <div class="afl-item"><span class="afl-q">DOES IT NEED A SERVER?</span><span class="afl-chev">&#9660;</span><p class="afl-a">No. It runs straight from the file.</p></div>
+  <div class="afl-item"><span class="afl-q">CAN I EDIT THE COLORS?</span><span class="afl-chev">&#9660;</span><p class="afl-a">Yes. Change the palette in style.css.</p></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/accordion-faq-list-ij/style.css
+++ b/submissions/examples/accordion-faq-list-ij/style.css
@@ -1,0 +1,10 @@
+.afl-list{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:320px;background:linear-gradient(180deg,#20243a,#121425);border:2px solid #373e6a;border-radius:14px;padding:16px;display:flex;flex-direction:column;gap:10px}
+.afl-item{background:#181b2e;border:1px solid #2c3152;border-radius:10px;padding:12px 14px;display:flex;flex-wrap:wrap;gap:8px;align-items:center;animation:afl-panel-expand-accordion-faq-list 3s ease-in-out infinite}
+.afl-item:nth-child(2){animation-delay:1s}
+.afl-item:nth-child(3){animation-delay:2s}
+.afl-q{flex:1;font-size:11px;font-weight:800;letter-spacing:1px;color:#c7d6e8}
+.afl-chev{font-size:10px;color:#a78bfa;animation:afl-chevron-flip-accordion-faq-list 1.6s ease-in-out infinite}
+.afl-a{width:100%;font-size:10px;line-height:1.6;color:#8b9bad;margin:0;animation:afl-answer-fade-accordion-faq-list 3s ease-in-out infinite}
+@keyframes afl-panel-expand-accordion-faq-list{0%,100%{opacity:.45}50%{opacity:1}}
+@keyframes afl-chevron-flip-accordion-faq-list{0%,100%{transform:rotate(0deg)}50%{transform:rotate(180deg)}}
+@keyframes afl-answer-fade-accordion-faq-list{0%,100%{opacity:.5}50%{opacity:1}}


### PR DESCRIPTION
## Component: ease-accordion-faq-list — panels expand, chevrons flip, and answers fade

**Closes #72560**

### What this adds
An FAQ accordion where the panels expand, the chevrons flip, and the answers fade in.

### Acceptance Criteria covered
- Panels expand in turn
- Chevrons flip direction
- Answers fade in

### Files
- `submissions/examples/accordion-faq-list-ij/demo.html`
- `submissions/examples/accordion-faq-list-ij/style.css`
- `submissions/examples/accordion-faq-list-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the panels expand, the chevrons flip, and the answers fade.