### PR TITLE
Add ease-skill-progress-bars component

### DIFF
--- a/submissions/examples/skill-progress-bars-ij/README.md
+++ b/submissions/examples/skill-progress-bars-ij/README.md
@@ -1,0 +1,11 @@
+# ease-skill-progress-bars
+
+A skill meter where the bars fill, the skill labels tick, and the percentages pulse.
+
+## Run
+Open `demo.html` directly in a browser to watch the skills grow.
+
+## Notes
+- The bars fill toward their skill level.
+- The skill labels tick in sequence.
+- The percentages pulse on the right.

--- a/submissions/examples/skill-progress-bars-ij/demo.html
+++ b/submissions/examples/skill-progress-bars-ij/demo.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-skill-progress-bars demo</title>
+</head>
+<body>
+<div class="spb-panel">
+  <div class="spb-row"><span class="spb-skill">HTML</span><span class="spb-bar"><em class="spb-fill"></em></span><b class="spb-pct">92%</b></div>
+  <div class="spb-row"><span class="spb-skill">CSS</span><span class="spb-bar"><em class="spb-fill"></em></span><b class="spb-pct">84%</b></div>
+  <div class="spb-row"><span class="spb-skill">JS</span><span class="spb-bar"><em class="spb-fill"></em></span><b class="spb-pct">68%</b></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/skill-progress-bars-ij/style.css
+++ b/submissions/examples/skill-progress-bars-ij/style.css
@@ -1,0 +1,11 @@
+.spb-panel{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:320px;background:linear-gradient(180deg,#1f2a26,#121815);border:2px solid #33503f;border-radius:14px;padding:20px;display:flex;flex-direction:column;gap:16px}
+.spb-row{display:grid;grid-template-columns:48px 1fr 44px;gap:10px;align-items:center}
+.spb-skill{font-size:10px;font-weight:800;letter-spacing:2px;color:#c7d6e8;animation:spb-label-tick-skill-progress-bars 1.8s steps(3) infinite}
+.spb-bar{height:10px;background:#0d120f;border-radius:5px;border:1px solid #274a32;overflow:hidden}
+.spb-fill{display:block;height:100%;width:92%;background:linear-gradient(90deg,#7cebb0,#ffd76a);border-radius:5px;animation:spb-fill-skill-progress-bars 4s ease-in-out infinite}
+.spb-row:nth-child(2) .spb-fill{width:84%;animation-delay:.4s}
+.spb-row:nth-child(3) .spb-fill{width:68%;animation-delay:.8s}
+.spb-pct{font-size:12px;font-weight:800;color:#ffd76a;font-family:'Courier New',monospace;animation:spb-pct-pulse-skill-progress-bars 1.6s ease-in-out infinite}
+@keyframes spb-fill-skill-progress-bars{0%,100%{width:14%}50%{width:96%}}
+@keyframes spb-label-tick-skill-progress-bars{0%{opacity:1}50%{opacity:.35}100%{opacity:1}}
+@keyframes spb-pct-pulse-skill-progress-bars{0%,100%{opacity:1}50%{opacity:.4}}


### PR DESCRIPTION
## Component: ease-skill-progress-bars — bars fill, labels tick, and pcts pulse

**Closes #72564**

### What this adds
A skill meter where the bars fill, the skill labels tick, and the percentages pulse.

### Acceptance Criteria covered
- Bars fill to their level
- Skill labels tick
- Percentages pulse

### Files
- `submissions/examples/skill-progress-bars-ij/demo.html`
- `submissions/examples/skill-progress-bars-ij/style.css`
- `submissions/examples/skill-progress-bars-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the bars fill, the labels tick, and the pcts pulse.