### PR TITLE
Add ease-keyboard-press-visualizer component

### DIFF
--- a/submissions/examples/keyboard-press-visualizer-ij/README.md
+++ b/submissions/examples/keyboard-press-visualizer-ij/README.md
@@ -1,0 +1,11 @@
+# ease-keyboard-press-visualizer
+
+A keyboard visualizer where the keys press in sequence, ripples spread outward, and the hint blinks.
+
+## Run
+Open `demo.html` directly in a browser to watch the keys strike.
+
+## Notes
+- The keys press one after another.
+- Ripples spread from each key.
+- The hint label blinks underneath.

--- a/submissions/examples/keyboard-press-visualizer-ij/demo.html
+++ b/submissions/examples/keyboard-press-visualizer-ij/demo.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-keyboard-press-visualizer demo</title>
+</head>
+<body>
+<div class="kpv-panel">
+  <div class="kpv-keys">
+    <kbd class="kpv-key">A</kbd>
+    <kbd class="kpv-key">S</kbd>
+    <kbd class="kpv-key">D</kbd>
+    <kbd class="kpv-key kpv-space">SPACE</kbd>
+  </div>
+  <span class="kpv-hint">PRESS KEYS TO RIPPLE</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/keyboard-press-visualizer-ij/style.css
+++ b/submissions/examples/keyboard-press-visualizer-ij/style.css
@@ -1,0 +1,12 @@
+.kpv-panel{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:320px;background:linear-gradient(180deg,#202a1e,#101610);border:2px solid #38522f;border-radius:16px;padding:22px;display:flex;flex-direction:column;gap:18px;align-items:center}
+.kpv-keys{display:flex;gap:10px}
+.kpv-key{width:56px;height:56px;border-radius:10px;background:#151d12;border:2px solid #3c5c30;border-bottom-width:6px;color:#7cebb0;font-size:18px;font-weight:800;font-family:'Courier New',monospace;display:flex;align-items:center;justify-content:center;position:relative;animation:kpv-key-press-keyboard-press-visualizer 2s ease-in-out infinite}
+.kpv-key:nth-child(2){animation-delay:.4s}
+.kpv-key:nth-child(3){animation-delay:.8s}
+.kpv-key:nth-child(4){animation-delay:1.2s}
+.kpv-space{width:110px;font-size:11px;letter-spacing:2px}
+.kpv-key::after{content:"";position:absolute;inset:-6px;border-radius:14px;border:2px solid rgba(124,235,176,0);animation:kpv-ripple-spread-keyboard-press-visualizer 2s ease-in-out infinite}
+.kpv-hint{font-size:10px;font-weight:800;letter-spacing:3px;color:#8b9bad;animation:kpv-hint-blink-keyboard-press-visualizer 1.5s ease-in-out infinite}
+@keyframes kpv-key-press-keyboard-press-visualizer{0%,100%{transform:translateY(0);border-bottom-width:6px}50%{transform:translateY(5px);border-bottom-width:2px}}
+@keyframes kpv-ripple-spread-keyboard-press-visualizer{0%{opacity:0;transform:scale(1)}50%{opacity:1}100%{opacity:0;transform:scale(1.4)}}
+@keyframes kpv-hint-blink-keyboard-press-visualizer{0%,100%{opacity:1}50%{opacity:.3}}


### PR DESCRIPTION
## Component: ease-keyboard-press-visualizer — keys press, ripples spread, and hint blinks

**Closes #72586**

### What this adds
A keyboard visualizer where the keys press in sequence, ripples spread outward, and the hint blinks.

### Acceptance Criteria covered
- Keys press in sequence
- Ripples spread outward
- Hint label blinks

### Files
- `submissions/examples/keyboard-press-visualizer-ij/demo.html`
- `submissions/examples/keyboard-press-visualizer-ij/style.css`
- `submissions/examples/keyboard-press-visualizer-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the keys press, the ripples spread, and the hint blink.