### PR TITLE
Add ease-podcast-episode-list component

### DIFF
--- a/submissions/examples/podcast-episode-list-ij/README.md
+++ b/submissions/examples/podcast-episode-list-ij/README.md
@@ -1,0 +1,11 @@
+# ease-podcast-episode-list
+
+A podcast episode list where the episode cards load in, the progress bars draw, and the mic icon blinks.
+
+## Run
+Open `demo.html` directly in a browser to watch the episodes load.
+
+## Notes
+- Episode cards scale into place in turn.
+- Progress bars draw across each row.
+- The mic icon blinks in the header.

--- a/submissions/examples/podcast-episode-list-ij/demo.html
+++ b/submissions/examples/podcast-episode-list-ij/demo.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-podcast-episode-list</title>
+</head>
+<body>
+<main class="pel-card">
+  <div class="pel-head">
+    <div class="pel-mic">●</div>
+    <div>
+      <p class="pel-brand">The Daily Byte</p>
+      <p class="pel-series">Episode feed</p>
+    </div>
+  </div>
+  <div class="pel-ep pel-ep-1">
+    <div class="pel-ep-cover">▷</div>
+    <div class="pel-ep-body">
+      <p class="pel-ep-title">Why Runtimes Matter</p>
+      <p class="pel-ep-meta">24 min</p>
+      <div class="pel-bar"><span class="pel-bar-fill pel-bar-fill-1"></span></div>
+    </div>
+  </div>
+  <div class="pel-ep pel-ep-2">
+    <div class="pel-ep-cover">▷</div>
+    <div class="pel-ep-body">
+      <p class="pel-ep-title">The Proxy Explained</p>
+      <p class="pel-ep-meta">18 min</p>
+      <div class="pel-bar"><span class="pel-bar-fill pel-bar-fill-2"></span></div>
+    </div>
+  </div>
+  <div class="pel-ep pel-ep-3">
+    <div class="pel-ep-cover">▷</div>
+    <div class="pel-ep-body">
+      <p class="pel-ep-title">Cache Every Layer</p>
+      <p class="pel-ep-meta">31 min</p>
+      <div class="pel-bar"><span class="pel-bar-fill pel-bar-fill-3"></span></div>
+    </div>
+  </div>
+  <div class="pel-ep pel-ep-4">
+    <div class="pel-ep-cover">▷</div>
+    <div class="pel-ep-body">
+      <p class="pel-ep-title">Shipping on Time</p>
+      <p class="pel-ep-meta">12 min</p>
+      <div class="pel-bar"><span class="pel-bar-fill pel-bar-fill-4"></span></div>
+    </div>
+  </div>
+</main>
+</body>
+</html>

--- a/submissions/examples/podcast-episode-list-ij/style.css
+++ b/submissions/examples/podcast-episode-list-ij/style.css
@@ -1,0 +1,25 @@
+*{box-sizing:border-box;padding:0;margin:0}
+body{min-height:100vh;display:flex;align-items:center;justify-content:center;background:#f6efe6;font-family:Georgia,serif}
+.pel-card{width:360px;background:#fffdf8;border-radius:18px;padding:20px;box-shadow:0 10px 22px rgba(120,90,60,.25);display:flex;flex-direction:column;gap:12px}
+.pel-head{display:flex;align-items:center;gap:10px;border-bottom:2px solid #e8d9c4;padding-bottom:10px}
+.pel-mic{width:36px;height:36px;border-radius:10px;background:#b87333;color:#fff7ec;display:flex;align-items:center;justify-content:center;font-size:18px;animation:pel-mic-blink-podcast-episode-list 1.4s ease-in-out infinite}
+.pel-brand{font-size:15px;font-weight:700;color:#6b4a2a}
+.pel-series{font-size:12px;color:#a58766}
+.pel-ep{display:flex;gap:10px;align-items:flex-start;background:#f4ead9;border-radius:12px;padding:10px}
+.pel-ep-1{animation:pel-card-load-podcast-episode-list .6s ease-out .0s both}
+.pel-ep-2{animation:pel-card-load-podcast-episode-list .6s ease-out .2s both}
+.pel-ep-3{animation:pel-card-load-podcast-episode-list .6s ease-out .4s both}
+.pel-ep-4{animation:pel-card-load-podcast-episode-list .6s ease-out .6s both}
+.pel-ep-cover{width:40px;height:40px;border-radius:9px;background:#e2cdb2;flex:none;display:flex;align-items:center;justify-content:center;font-size:17px}
+.pel-ep-body{flex:1}
+.pel-ep-title{font-size:13px;font-weight:600;color:#5c4026}
+.pel-ep-meta{font-size:11px;color:#a58766}
+.pel-bar{height:5px;background:#d9c3a4;border-radius:4px;margin-top:6px;overflow:hidden}
+.pel-bar-fill{display:block;height:100%;background:linear-gradient(90deg,#c98d4a,#b87333);transform-origin:left;animation:pel-bar-draw-podcast-episode-list 2.4s ease-in-out infinite}
+.pel-bar-fill-1{width:62%;animation-delay:.0s}
+.pel-bar-fill-2{width:45%;animation-delay:.5s}
+.pel-bar-fill-3{width:78%;animation-delay:1s}
+.pel-bar-fill-4{width:34%;animation-delay:1.5s}
+@keyframes pel-card-load-podcast-episode-list{from{transform:scale(.96);opacity:0}to{transform:scale(1);opacity:1}}
+@keyframes pel-bar-draw-podcast-episode-list{0%{transform:scaleX(.1)}50%{transform:scaleX(1)}100%{transform:scaleX(.1)}}
+@keyframes pel-mic-blink-podcast-episode-list{0%,100%{opacity:1}50%{opacity:.45}}


### PR DESCRIPTION
## Component: ease-podcast-episode-list — episodes load, bars draw, and mic blinks

**Closes #72664**

### What this adds
A podcast episode list where the episode cards load in, the progress bars draw, and the mic icon blinks.

### Acceptance Criteria covered
- Episode cards load
- Progress bars draw
- Mic icon blinks

### Files
- `submissions/examples/podcast-episode-list-ij/demo.html`
- `submissions/examples/podcast-episode-list-ij/style.css`
- `submissions/examples/podcast-episode-list-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the episodes load, the bars draw, and the mic blink.