### PR TITLE
Add ease-code-snippet-card component

### DIFF
--- a/submissions/examples/code-snippet-card-ij/README.md
+++ b/submissions/examples/code-snippet-card-ij/README.md
@@ -1,0 +1,11 @@
+# ease-code-snippet-card
+
+A code snippet card where the code lines pulse, the cursor blinks, and the copy button pops.
+
+## Run
+Open `demo.html` directly in a browser to watch the snippet animate.
+
+## Notes
+- Code lines pulse with a reading rhythm.
+- The caret blinks at the end of a line.
+- The copy chip pops on a loop.

--- a/submissions/examples/code-snippet-card-ij/demo.html
+++ b/submissions/examples/code-snippet-card-ij/demo.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-code-snippet-card</title>
+</head>
+<body>
+<main class="csc-card">
+  <div class="csc-bar">
+    <span class="csc-dot csc-dot-1"></span>
+    <span class="csc-dot csc-dot-2"></span>
+    <span class="csc-dot csc-dot-3"></span>
+    <span class="csc-file">snippet.js</span>
+    <span class="csc-copy">copy</span>
+  </div>
+  <div class="csc-code">
+    <div class="csc-line csc-line-1">
+      <span class="csc-num">1</span>
+      <span class="csc-code-text">const spin = (deg) =&gt; {</span>
+    </div>
+    <div class="csc-line csc-line-2">
+      <span class="csc-num">2</span>
+      <span class="csc-code-text">  el.style.rotate = deg;</span>
+    </div>
+    <div class="csc-line csc-line-3">
+      <span class="csc-num">3</span>
+      <span class="csc-code-text">  requestAnimationFrame(spin);</span>
+    </div>
+    <div class="csc-line csc-line-4">
+      <span class="csc-num">4</span>
+      <span class="csc-code-text">};</span>
+    </div>
+    <div class="csc-line csc-line-5">
+      <span class="csc-num">5</span>
+      <span class="csc-code-text">const ease = (t) =&gt; t * t;</span>
+    </div>
+    <div class="csc-line csc-line-6">
+      <span class="csc-num">6</span>
+      <span class="csc-code-text">document.body<span class="csc-cursor"></span></span>
+    </div>
+  </div>
+</main>
+</body>
+</html>

--- a/submissions/examples/code-snippet-card-ij/style.css
+++ b/submissions/examples/code-snippet-card-ij/style.css
@@ -1,0 +1,23 @@
+*{box-sizing:border-box;margin:0;text-rendering:optimizeLegibility}
+body{min-height:100vh;display:flex;align-items:center;justify-content:center;background:#0f1117;font-family:Consolas,monospace}
+.csc-card{width:376px;background:#161a23;border:1px solid #2a3142;border-radius:14px;overflow:hidden;box-shadow:0 14px 30px rgba(0,0,0,.5)}
+.csc-bar{display:flex;align-items:center;gap:8px;background:#1c212d;padding:10px 14px}
+.csc-dot{width:12px;height:12px;border-radius:50%}
+.csc-dot-1{background:#ff5f57}
+.csc-dot-2{background:#febc2e}
+.csc-dot-3{background:#28c840}
+.csc-file{font-size:12px;color:#6c7a93;margin-left:6px}
+.csc-copy{margin-left:auto;font-size:11px;color:#9fb0cf;background:#232a3a;border-radius:6px;padding:4px 8px;animation:csc-copy-pop-code-snippet-card 2.6s ease-in-out infinite}
+.csc-code{padding:14px 14px 18px;display:flex;flex-direction:column;gap:6px}
+.csc-line{display:flex;gap:12px;font-size:12px;line-height:1.5;animation:csc-line-pulse-code-snippet-card 2s ease-in-out infinite}
+.csc-line-2{animation-delay:.2s}
+.csc-line-3{animation-delay:.4s}
+.csc-line-4{animation-delay:.6s}
+.csc-line-5{animation-delay:.8s}
+.csc-line-6{animation-delay:1s}
+.csc-num{color:#4a5568;width:16px;text-align:right;flex:none}
+.csc-code-text{color:#c9d4e8}
+.csc-cursor{display:inline-block;width:7px;height:14px;background:#e8e2b0;vertical-align:-2px;animation:csc-cursor-blink-code-snippet-card 1s steps(2) infinite}
+@keyframes csc-line-pulse-code-snippet-card{0%,100%{opacity:.55}50%{opacity:1}}
+@keyframes csc-cursor-blink-code-snippet-card{0%,100%{opacity:0}50%{opacity:1}}
+@keyframes csc-copy-pop-code-snippet-card{0%,100%{transform:scale(1)}40%{transform:scale(1.12)}}


### PR DESCRIPTION
## Component: ease-code-snippet-card — lines pulse, cursor blinks, and copy pops

**Closes #72669**

### What this adds
A code snippet card where the code lines pulse, the cursor blinks, and the copy button pops.

### Acceptance Criteria covered
- Code lines pulse
- Cursor blinks
- Copy button pops

### Files
- `submissions/examples/code-snippet-card-ij/demo.html`
- `submissions/examples/code-snippet-card-ij/style.css`
- `submissions/examples/code-snippet-card-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the lines pulse, the cursor blink, and the copy pop.