### PR TITLE
Add ease-server-uptime-meter component

### DIFF
--- a/submissions/examples/server-uptime-meter-ij/README.md
+++ b/submissions/examples/server-uptime-meter-ij/README.md
@@ -1,0 +1,11 @@
+# ease-server-uptime-meter
+
+A server status meter where the uptime readout ticks, the status dot pulses, and the load bars fill.
+
+## Run
+Open `demo.html` directly in a browser to watch the server health card.
+
+## Notes
+- The uptime value bobs on each second.
+- The status dot pulses with a green halo.
+- CPU, memory and disk bars fill in turn.

--- a/submissions/examples/server-uptime-meter-ij/demo.html
+++ b/submissions/examples/server-uptime-meter-ij/demo.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-server-uptime-meter</title>
+</head>
+<body>
+<main class="sum-card">
+  <div class="sum-head">
+    <span class="sum-host">web-01</span>
+    <span class="sum-tag">production</span>
+    <div class="sum-status">
+      <span class="sum-dot"></span>
+      <span class="sum-dot-text">Operational</span>
+    </div>
+  </div>
+  <div class="sum-uptime">
+    <span class="sum-uptime-value">99.982%</span>
+    <span class="sum-uptime-label">uptime this month</span>
+  </div>
+  <div class="sum-loads">
+    <div class="sum-row">
+      <span class="sum-row-name">CPU</span>
+      <div class="sum-row-track"><span class="sum-row-fill sum-row-fill-1"></span></div>
+      <span class="sum-row-val">61%</span>
+    </div>
+    <div class="sum-row">
+      <span class="sum-row-name">Memory</span>
+      <div class="sum-row-track"><span class="sum-row-fill sum-row-fill-2"></span></div>
+      <span class="sum-row-val">37%</span>
+    </div>
+    <div class="sum-row">
+      <span class="sum-row-name">Disk</span>
+      <div class="sum-row-track"><span class="sum-row-fill sum-row-fill-3"></span></div>
+      <span class="sum-row-val">24%</span>
+    </div>
+  </div>
+</main>
+</body>
+</html>

--- a/submissions/examples/server-uptime-meter-ij/style.css
+++ b/submissions/examples/server-uptime-meter-ij/style.css
@@ -1,0 +1,24 @@
+*{margin:0;padding:0;box-sizing:border-box}
+body{min-height:100vh;display:grid;place-items:center;background:#e9eef3;font-family:Verdana,sans-serif}
+.sum-card{width:340px;background:#ffffff;border-radius:16px;padding:18px;box-shadow:0 12px 26px rgba(50,70,90,.22);display:flex;flex-direction:column;gap:14px}
+.sum-head{display:flex;align-items:center;gap:10px}
+.sum-host{font-size:15px;font-weight:700;color:#2c3e50}
+.sum-tag{font-size:11px;background:#e2e9f1;color:#5d7390;border-radius:6px;padding:3px 8px}
+.sum-status{display:flex;align-items:center;gap:8px;margin-left:auto}
+.sum-dot{width:13px;height:13px;border-radius:50%;background:#27ae60;animation:sum-status-pulse-server-uptime-meter 1.6s ease-in-out infinite}
+.sum-dot-text{font-size:12px;color:#27ae60;font-weight:600}
+.sum-uptime{display:flex;flex-direction:column;align-items:center;padding:10px 0;border:1px dashed #cfdae6;border-radius:12px}
+.sum-uptime-value{font-size:30px;font-weight:800;color:#1f6f8b;animation:sum-uptime-tick-server-uptime-meter 1s steps(12) infinite}
+.sum-uptime-label{font-size:11px;color:#7a8fa6}
+.sum-loads{display:flex;flex-direction:column;gap:10px}
+.sum-row{display:flex;align-items:center;gap:10px}
+.sum-row-name{width:56px;font-size:12px;color:#52667c}
+.sum-row-track{flex:1;height:10px;background:#e3eaf2;border-radius:6px;overflow:hidden}
+.sum-row-fill{display:block;height:100%;border-radius:6px;transform-origin:left;animation:sum-bar-fill-server-uptime-meter 2.4s ease-in-out infinite}
+.sum-row-fill-1{background:#4f9fd8;width:61%}
+.sum-row-fill-2{background:#e67e22;width:37%}
+.sum-row-fill-3{background:#9b59b6;width:24%}
+.sum-row-val{width:38px;font-size:12px;color:#52667c;text-align:right}
+@keyframes sum-uptime-tick-server-uptime-meter{0%{transform:translateY(0)}25%{transform:translateY(-2px)}75%{transform:translateY(1px)}100%{transform:translateY(0)}}
+@keyframes sum-status-pulse-server-uptime-meter{0%,100%{box-shadow:0 0 0 0 rgba(39,174,96,.5)}50%{box-shadow:0 0 0 8px rgba(39,174,96,0)}}
+@keyframes sum-bar-fill-server-uptime-meter{0%{transform:scaleX(.2)}50%{transform:scaleX(1)}100%{transform:scaleX(.2)}}


### PR DESCRIPTION
## Component: ease-server-uptime-meter — uptime ticks, status pulses, and bars fill

**Closes #72671**

### What this adds
A server status meter where the uptime readout ticks, the status dot pulses, and the load bars fill.

### Acceptance Criteria covered
- Uptime readout ticks
- Status dot pulses
- Load bars fill

### Files
- `submissions/examples/server-uptime-meter-ij/demo.html`
- `submissions/examples/server-uptime-meter-ij/style.css`
- `submissions/examples/server-uptime-meter-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the uptime tick, the dot pulse, and the bars fill.