### PR TITLE
Add ease-git-commit-history component

### DIFF
--- a/submissions/examples/git-commit-history-ij/README.md
+++ b/submissions/examples/git-commit-history-ij/README.md
@@ -1,0 +1,11 @@
+# ease-git-commit-history
+
+A git commit history where the commit nodes pop in, the branch line draws, and the hashes flicker.
+
+## Run
+Open `demo.html` directly in a browser to watch the history build.
+
+## Notes
+- Commit nodes pop into their rows.
+- The branch line pulses along the rail.
+- Short hashes flicker beside each commit.

--- a/submissions/examples/git-commit-history-ij/demo.html
+++ b/submissions/examples/git-commit-history-ij/demo.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-git-commit-history</title>
+</head>
+<body>
+<main class="gch-card">
+  <h1 class="gch-title">Commit History</h1>
+  <div class="gch-list">
+    <div class="gch-item gch-item-1">
+      <span class="gch-node gch-node-1"></span>
+      <span class="gch-msg">fix: clamp glow bounds</span>
+      <span class="gch-meta">2 hours ago</span>
+      <span class="gch-hash">a3f9c1</span>
+    </div>
+    <div class="gch-item gch-item-2">
+      <span class="gch-node gch-node-2"></span>
+      <span class="gch-msg">feat: add pulse easing</span>
+      <span class="gch-meta">4 hours ago</span>
+      <span class="gch-hash">b27e0d</span>
+    </div>
+    <div class="gch-item gch-item-3">
+      <span class="gch-node gch-node-3"></span>
+      <span class="gch-msg">refactor: split themes</span>
+      <span class="gch-meta">yesterday</span>
+      <span class="gch-hash">c9d2fa</span>
+    </div>
+    <div class="gch-item gch-item-4">
+      <span class="gch-node gch-node-4"></span>
+      <span class="gch-msg">docs: tune keyframes</span>
+      <span class="gch-meta">2 days ago</span>
+      <span class="gch-hash">e8b7a3</span>
+    </div>
+    <div class="gch-item gch-item-5">
+      <span class="gch-node gch-node-5"></span>
+      <span class="gch-msg">chore: tidy folders</span>
+      <span class="gch-meta">3 days ago</span>
+      <span class="gch-hash">f1c4e6</span>
+    </div>
+  </div>
+</main>
+</body>
+</html>

--- a/submissions/examples/git-commit-history-ij/style.css
+++ b/submissions/examples/git-commit-history-ij/style.css
@@ -1,0 +1,24 @@
+*{box-sizing:border-box;margin:0;font-family:system-ui}
+body{min-height:100vh;display:flex;align-items:center;justify-content:center;background:#f4f1ec;font-family:Helvetica Neue,sans-serif}
+.gch-card{width:360px;background:#ffffff;border:1px solid #e2dccf;border-radius:18px;padding:18px;box-shadow:0 10px 24px rgba(80,60,30,.16)}
+.gch-title{font-size:15px;font-weight:700;color:#3a3226;margin-bottom:14px}
+.gch-list{position:relative;padding-left:26px}
+.gch-list::before{content:"";position:absolute;left:9px;top:4px;bottom:4px;width:2px;background:#d8cfc0;animation:gch-line-draw-git-commit-history 3s ease-in-out infinite}
+.gch-item{position:relative;padding:8px 0;display:flex;flex-direction:column;gap:2px}
+.gch-item-1{animation:gch-node-pop-git-commit-history .5s ease-out .0s both}
+.gch-item-2{animation:gch-node-pop-git-commit-history .5s ease-out .25s both}
+.gch-item-3{animation:gch-node-pop-git-commit-history .5s ease-out .5s both}
+.gch-item-4{animation:gch-node-pop-git-commit-history .5s ease-out .75s both}
+.gch-item-5{animation:gch-node-pop-git-commit-history .5s ease-out 1s both}
+.gch-node{position:absolute;left:-23px;top:10px;width:14px;height:14px;border-radius:50%;background:#ffffff;border:3px solid #c0784a}
+.gch-node-1{border-color:#c0784a}
+.gch-node-2{border-color:#8e44ad}
+.gch-node-3{border-color:#2980b9}
+.gch-node-4{border-color:#16a085}
+.gch-node-5{border-color:#d35400}
+.gch-msg{font-size:13px;color:#3a3226;font-weight:600}
+.gch-meta{font-size:11px;color:#9a8f7c}
+.gch-hash{font-size:11px;color:#b0835a;font-family:Consolas,monospace;animation:gch-hash-flicker-git-commit-history 2s steps(2) infinite}
+@keyframes gch-node-pop-git-commit-history{from{transform:scale(.4);opacity:0}to{transform:scale(1);opacity:1}}
+@keyframes gch-line-draw-git-commit-history{0%{transform:scaleY(.2)}50%{transform:scaleY(1)}100%{transform:scaleY(.35)}}
+@keyframes gch-hash-flicker-git-commit-history{0%,100%{opacity:.55}50%{opacity:1}}


### PR DESCRIPTION
## Component: ease-git-commit-history — nodes pop, branch draws, and hashes flicker

**Closes #72673**

### What this adds
A git commit history where the commit nodes pop in, the branch line draws, and the hashes flicker.

### Acceptance Criteria covered
- Commit nodes pop
- Branch line draws
- Hashes flicker

### Files
- `submissions/examples/git-commit-history-ij/demo.html`
- `submissions/examples/git-commit-history-ij/style.css`
- `submissions/examples/git-commit-history-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the nodes pop, the line draw, and the hashes flicker.