### PR TITLE
Add ease-database-storage-meter component

### DIFF
--- a/submissions/examples/database-storage-meter-ij/README.md
+++ b/submissions/examples/database-storage-meter-ij/README.md
@@ -1,0 +1,11 @@
+# ease-database-storage-meter
+
+A database storage meter where the capacity gauge fills, the database cylinder glows, and the stats tick.
+
+## Run
+Open `demo.html` directly in a browser to watch the storage card animate.
+
+## Notes
+- The capacity gauge sweeps across its track.
+- The database cylinder brightens in a cycle.
+- Stats chips bob at their own offsets.

--- a/submissions/examples/database-storage-meter-ij/demo.html
+++ b/submissions/examples/database-storage-meter-ij/demo.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-database-storage-meter</title>
+</head>
+<body>
+<main class="dbs-card">
+  <div class="dbs-head">
+    <span class="dbs-crown">PROD CLUSTER</span>
+    <span class="dbs-name">orders_db</span>
+  </div>
+  <div class="dbs-cylinder"></div>
+  <div class="dbs-gauge">
+    <span class="dbs-gauge-label"><span>Storage used</span><span>341 GB / 512 GB</span></span>
+    <div class="dbs-gauge-track"><span class="dbs-gauge-fill"></span></div>
+  </div>
+  <div class="dbs-stats">
+    <div class="dbs-stat dbs-stat-1">
+      <span class="dbs-stat-value">42</span>
+      <span class="dbs-stat-name">tables</span>
+    </div>
+    <div class="dbs-stat dbs-stat-2">
+      <span class="dbs-stat-value">1.8M</span>
+      <span class="dbs-stat-name">rows</span>
+    </div>
+    <div class="dbs-stat dbs-stat-3">
+      <span class="dbs-stat-value">128</span>
+      <span class="dbs-stat-name">indexes</span>
+    </div>
+  </div>
+</main>
+</body>
+</html>

--- a/submissions/examples/database-storage-meter-ij/style.css
+++ b/submissions/examples/database-storage-meter-ij/style.css
@@ -1,0 +1,21 @@
+*,*::before,*::after{box-sizing:border-box;padding:0;margin:0}
+body{min-height:100vh;display:flex;align-items:center;justify-content:center;background:#eef2f6;font-family:Optima,sans-serif}
+.dbs-card{width:340px;background:#ffffff;border-radius:22px;padding:22px;box-shadow:0 16px 32px rgba(40,60,80,.22);display:flex;flex-direction:column;gap:16px}
+.dbs-head{display:flex;align-items:center;gap:12px}
+.dbs-crown{font-size:12px;color:#5b7f95;background:#e8f0f5;border-radius:8px;padding:4px 10px}
+.dbs-name{font-size:17px;font-weight:800;color:#264a5c}
+.dbs-cylinder{width:74px;height:92px;margin:0 auto;background:#e9f4fa;border:4px solid #4d94b8;border-radius:50%/14px;position:relative;animation:dbs-cylinder-glow-database-storage-meter 2.8s ease-in-out infinite}
+.dbs-cylinder::before{content:"";position:absolute;left:-4px;right:-4px;top:20px;height:4px;background:#4d94b8}
+.dbs-gauge{display:flex;flex-direction:column;gap:6px}
+.dbs-gauge-label{display:flex;justify-content:space-between;font-size:12px;color:#5b7f95}
+.dbs-gauge-track{height:14px;background:#e3ecf2;border-radius:9px;overflow:hidden}
+.dbs-gauge-fill{display:block;height:100%;background:linear-gradient(90deg,#4d94b8,#7fd0e8);transform-origin:left;animation:dbs-gauge-fill-database-storage-meter 3s ease-in-out infinite}
+.dbs-stats{display:grid;grid-template-columns:repeat(3,1fr);gap:10px}
+.dbs-stat{background:#f2f7fb;border-radius:12px;padding:10px;text-align:center;animation:dbs-stat-tick-database-storage-meter 1.6s ease-in-out infinite}
+.dbs-stat-2{animation-delay:.2s}
+.dbs-stat-3{animation-delay:.4s}
+.dbs-stat-value{display:block;font-size:18px;font-weight:800;color:#264a5c}
+.dbs-stat-name{display:block;font-size:10px;color:#6f90a6;margin-top:3px}
+@keyframes dbs-gauge-fill-database-storage-meter{0%{transform:scaleX(.1)}50%{transform:scaleX(.86)}100%{transform:scaleX(.1)}}
+@keyframes dbs-cylinder-glow-database-storage-meter{0%,100%{filter:brightness(1)}50%{filter:brightness(1.5)}}
+@keyframes dbs-stat-tick-database-storage-meter{0%,100%{transform:translateY(0)}50%{transform:translateY(-4px)}}


### PR DESCRIPTION
## Component: ease-database-storage-meter — gauge fills, cylinder glows, and stats tick

**Closes #72675**

### What this adds
A database storage meter where the capacity gauge fills, the database cylinder glows, and the stats tick.

### Acceptance Criteria covered
- Capacity gauge fills
- Cylinder glows
- Stats tick

### Files
- `submissions/examples/database-storage-meter-ij/demo.html`
- `submissions/examples/database-storage-meter-ij/style.css`
- `submissions/examples/database-storage-meter-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the gauge fill, the cylinder glow, and the stats tick.