### PR TITLE
feat: add CSS neumorphic press button

### DIFF
--- a/submissions/examples/css-neumorphic-press-button/README.md
+++ b/submissions/examples/css-neumorphic-press-button/README.md
@@ -1,0 +1,29 @@
+# CSS Neumorphic Press Button
+
+A pure CSS neumorphic button with a soft raised appearance and an inward
+pressed effect.
+
+## Features
+
+- Pure HTML and CSS
+- No JavaScript required
+- Soft neumorphic design
+- Pressed/inset animation
+- Hover interaction
+- Keyboard accessible
+- Visible keyboard focus state
+- Responsive design
+- Supports `prefers-reduced-motion`
+- Works on desktop and mobile devices
+
+## Files
+
+- `demo.html` - Demonstration page
+- `style.css` - Component styles
+
+## Usage
+
+Include the stylesheet:
+
+```html
+<link rel="stylesheet" href="style.css">

--- a/submissions/examples/css-neumorphic-press-button/demo.html
+++ b/submissions/examples/css-neumorphic-press-button/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta
+    name="description"
+    content="Accessible CSS neumorphic press button demonstration"
+  >
+  <title>CSS Neumorphic Press Button</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+  <main class="demo">
+    <section class="component" aria-labelledby="demo-title">
+      <h1 id="demo-title">Neumorphic Press Button</h1>
+
+      <p class="description">
+        A soft neumorphic button that visually sinks inward when pressed or focused.
+      </p>
+
+      <button
+        class="neumorphic-button"
+        type="button"
+        aria-label="Activate neumorphic press button"
+      >
+        Press Me
+      </button>
+
+      <p class="hint">
+        Click, tap, or use the keyboard to interact.
+      </p>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/css-neumorphic-press-button/style.css
+++ b/submissions/examples/css-neumorphic-press-button/style.css
@@ -1,0 +1,133 @@
+:root {
+    --bg: #e6e9ef;
+    --text: #30343b;
+    --shadow-light: rgba(255, 255, 255, 0.9);
+    --shadow-dark: rgba(163, 177, 198, 0.65);
+    --focus: #315efb;
+  }
+  
+  * {
+    box-sizing: border-box;
+  }
+  
+  html {
+    min-height: 100%;
+  }
+  
+  body {
+    min-height: 100vh;
+    margin: 0;
+    font-family:
+      Inter,
+      system-ui,
+      -apple-system,
+      BlinkMacSystemFont,
+      "Segoe UI",
+      sans-serif;
+    background: var(--bg);
+    color: var(--text);
+  }
+  
+  .demo {
+    min-height: 100vh;
+    display: grid;
+    place-items: center;
+    padding: 2rem;
+  }
+  
+  .component {
+    width: min(100%, 42rem);
+    padding: clamp(2rem, 6vw, 4rem);
+    text-align: center;
+  }
+  
+  .component h1 {
+    margin: 0 0 0.75rem;
+    font-size: clamp(1.7rem, 5vw, 2.5rem);
+  }
+  
+  .description {
+    max-width: 34rem;
+    margin: 0 auto 2.5rem;
+    line-height: 1.6;
+  }
+  
+  .neumorphic-button {
+    appearance: none;
+    border: 0;
+    border-radius: 1.25rem;
+    padding: 1.1rem 2.5rem;
+  
+    background: var(--bg);
+    color: var(--text);
+  
+    font: inherit;
+    font-size: 1.05rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+  
+    cursor: pointer;
+  
+    box-shadow:
+      10px 10px 20px var(--shadow-dark),
+      -10px -10px 20px var(--shadow-light);
+  
+    transition:
+      box-shadow 160ms ease,
+      transform 160ms ease;
+  }
+  
+  .neumorphic-button:hover {
+    transform: translateY(-2px);
+  }
+  
+  .neumorphic-button:active {
+    transform: translateY(1px);
+  
+    box-shadow:
+      inset 6px 6px 12px var(--shadow-dark),
+      inset -6px -6px 12px var(--shadow-light);
+  }
+  
+  .neumorphic-button:focus-visible {
+    outline: 3px solid var(--focus);
+    outline-offset: 5px;
+  }
+  
+  .neumorphic-button:focus:not(:focus-visible) {
+    outline: none;
+  }
+  
+  .hint {
+    margin: 1.75rem 0 0;
+    font-size: 0.9rem;
+    opacity: 0.75;
+  }
+  
+  /* Responsive behavior */
+  @media (max-width: 480px) {
+    .demo {
+      padding: 1rem;
+    }
+  
+    .component {
+      padding: 2rem 1rem;
+    }
+  
+    .neumorphic-button {
+      width: min(100%, 18rem);
+      padding: 1rem 2rem;
+    }
+  }
+  
+  /* Respect users who prefer reduced motion */
+  @media (prefers-reduced-motion: reduce) {
+    .neumorphic-button {
+      transition: none;
+    }
+  
+    .neumorphic-button:hover,
+    .neumorphic-button:active {
+      transform: none;
+    }
+  }


### PR DESCRIPTION
## Description

Implemented the CSS Neumorphic Press Button for #70734.

### Changes

- Added pure HTML/CSS neumorphic button
- Added raised and pressed states
- Added hover interaction
- Added keyboard focus support
- Added responsive styling
- Added prefers-reduced-motion support
- Added documentation

### Files Added

- `submissions/examples/css-neumorphic-press-button/demo.html`
- `submissions/examples/css-neumorphic-press-button/style.css`
- `submissions/examples/css-neumorphic-press-button/README.md`

### Testing

- Tested button interaction in a modern browser
- Tested keyboard focus
- Tested responsive layout
- Tested reduced-motion behavior

Closes #70734