### PR TITLE
Add ease-basketball-scorecard component

### DIFF
--- a/submissions/examples/basketball-scorecard-ij/README.md
+++ b/submissions/examples/basketball-scorecard-ij/README.md
@@ -1,0 +1,11 @@
+# ease-basketball-scorecard
+
+A basketball scorecard where the team scores flip, the game clock ticks, and the lead badge pulses.
+
+## Run
+Open `demo.html` directly in a browser to watch the scoreboard animate.
+
+## Notes
+- The score digits flip like a real arena board.
+- The game clock ticks down in the middle.
+- The shot badge pulses with the home lead.

--- a/submissions/examples/basketball-scorecard-ij/demo.html
+++ b/submissions/examples/basketball-scorecard-ij/demo.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-basketball-scorecard</title>
+</head>
+<body>
+<main class="bsc-card">
+  <div class="bsc-top">
+    <span class="bsc-venue">NBA Finals</span>
+    <span class="bsc-period">Q4</span>
+  </div>
+  <div class="bsc-board">
+    <div class="bsc-team bsc-team-away">
+      <span class="bsc-team-name">NOVA</span>
+      <span class="bsc-score bsc-score-away">87</span>
+    </div>
+    <span class="bsc-versus">vs</span>
+    <div class="bsc-team bsc-team-home">
+      <span class="bsc-team-name">PHNX</span>
+      <span class="bsc-score bsc-score-home">91</span>
+    </div>
+  </div>
+  <div class="bsc-clock">
+    <span class="bsc-clock-value">0:24</span>
+    <span class="bsc-shot">shot</span>
+  </div>
+  <div class="bsc-dots">
+    <span class="bsc-dot bsc-dot-1"></span>
+    <span class="bsc-dot bsc-dot-2"></span>
+    <span class="bsc-dot bsc-dot-3"></span>
+    <span class="bsc-dot bsc-dot-4"></span>
+  </div>
+</main>
+</body>
+</html>

--- a/submissions/examples/basketball-scorecard-ij/style.css
+++ b/submissions/examples/basketball-scorecard-ij/style.css
@@ -1,0 +1,24 @@
+*,*::before,*::after{box-sizing:border-box}
+body{min-height:100vh;display:grid;place-items:center;background:#131a2b;font-family:Verdana,system-ui,sans-serif}
+.bsc-card{width:340px;background:#0d1322;border:2px solid #27334f;border-radius:20px;padding:18px;box-shadow:0 18px 34px rgba(0,0,0,.65);display:flex;flex-direction:column;gap:14px}
+.bsc-top{display:flex;align-items:center;justify-content:space-between}
+.bsc-venue{font-size:12px;letter-spacing:2px;color:#8296ba;text-transform:uppercase}
+.bsc-period{font-size:12px;font-weight:700;color:#ffd166;background:#242f4d;border-radius:6px;padding:3px 10px;animation:bsc-period-blink-basketball-scorecard 1.2s steps(2) infinite}
+.bsc-board{display:grid;grid-template-columns:1fr auto 1fr;align-items:center;gap:10px;background:#182240;border-radius:14px;padding:18px 12px}
+.bsc-team{display:flex;flex-direction:column;align-items:center;gap:10px}
+.bsc-team-name{font-size:13px;letter-spacing:3px;color:#c4d2ea}
+.bsc-score{font-size:46px;font-weight:900;line-height:1;font-family:Impact,Haettenschweiler,sans-serif;color:#eaf2ff}
+.bsc-score-away{animation:bsc-score-flip-basketball-scorecard 2.4s ease-in-out infinite}
+.bsc-score-home{animation:bsc-score-flip-basketball-scorecard 2.4s ease-in-out .5s infinite;color:#ffd166}
+.bsc-versus{font-size:12px;color:#52668d}
+.bsc-clock{display:flex;align-items:center;gap:10px;justify-content:center}
+.bsc-clock-value{font-size:28px;font-weight:700;color:#ffb84d;font-family:Consolas,monospace;animation:bsc-clock-tick-basketball-scorecard 1s steps(10) infinite}
+.bsc-shot{font-size:10px;color:#ff6b6b;border:1px solid #ff6b6b;border-radius:12px;padding:3px 9px;animation:bsc-lead-pulse-basketball-scorecard 1.6s ease-in-out infinite}
+.bsc-dots{display:flex;justify-content:center;gap:6px}
+.bsc-dot{width:9px;height:9px;border-radius:50%;background:#3a4a6c}
+.bsc-dot-1{background:#ff6b6b;animation:bsc-lead-pulse-basketball-scorecard 1s ease-in-out infinite}
+.bsc-dot-2,.bsc-dot-3,.bsc-dot-4{background:#ffd166}
+@keyframes bsc-score-flip-basketball-scorecard{0%,100%{transform:rotateX(0)}40%{transform:rotateX(90deg)}60%{transform:rotateX(-90deg)}}
+@keyframes bsc-clock-tick-basketball-scorecard{0%{transform:translateY(0)}25%{transform:translateY(-2px)}75%{transform:translateY(1px)}100%{transform:translateY(0)}}
+@keyframes bsc-lead-pulse-basketball-scorecard{0%,100%{opacity:1}50%{opacity:.35}}
+@keyframes bsc-period-blink-basketball-scorecard{0%,100%{opacity:1}50%{opacity:.4}}


### PR DESCRIPTION
## Component: ease-basketball-scorecard — scores flip, clock ticks, and lead pulses

**Closes #72721**

### What this adds
A basketball scorecard where the team scores flip, the game clock ticks, and the lead badge pulses.

### Acceptance Criteria covered
- Team scores flip
- Game clock ticks
- Lead badge pulses

### Files
- `submissions/examples/basketball-scorecard-ij/demo.html`
- `submissions/examples/basketball-scorecard-ij/style.css`
- `submissions/examples/basketball-scorecard-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the scores flip, the clock tick, and the lead pulse.