### PR TITLE
feat: add CSS split button menu

### DIFF
--- a/submissions/examples/css-split-button-menu/README.md
+++ b/submissions/examples/css-split-button-menu/README.md
@@ -1,0 +1,26 @@
+# CSS Split Button Menu
+
+A polished, responsive split button component built with pure HTML and CSS for EaseMotion CSS.
+
+## ✨ Features
+
+- Pure CSS dropdown interaction
+- No JavaScript dependency
+- Semantic `<details>` and `<summary>` interaction
+- Responsive layout
+- Keyboard-friendly native interaction
+- Accessible focus states
+- Smooth dropdown animation
+- Hover and active states
+- Reduced-motion support
+- Mobile-friendly design
+- Modern CSS custom properties
+- Clean and reusable structure
+
+## 📁 Files
+
+```text
+css-split-button-menu/
+├── demo.html
+├── style.css
+└── README.md

--- a/submissions/examples/css-split-button-menu/demo.html
+++ b/submissions/examples/css-split-button-menu/demo.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta
+    name="description"
+    content="Accessible CSS-only split button menu demonstration"
+  >
+  <title>CSS Split Button Menu | EaseMotion</title>
+
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+  <main class="page">
+    <section class="demo-card" aria-labelledby="demo-title">
+
+      <div class="demo-header">
+        <span class="eyebrow">EaseMotion CSS</span>
+        <h1 id="demo-title">Split Button Menu</h1>
+        <p>
+          A responsive CSS-only action button with an attached dropdown menu.
+        </p>
+      </div>
+
+      <div class="demo-stage">
+
+        <div class="split-button">
+
+          <a
+            class="split-button__primary"
+            href="#download"
+            aria-label="Download project"
+          >
+            <svg
+              aria-hidden="true"
+              viewBox="0 0 24 24"
+              focusable="false"
+            >
+              <path d="M12 3v11m0 0 4-4m-4 4-4-4M5 20h14"/>
+            </svg>
+
+            <span>Download</span>
+          </a>
+
+          <details class="split-button__menu">
+            <summary
+              class="split-button__toggle"
+              aria-label="More download options"
+            >
+              <svg
+                aria-hidden="true"
+                viewBox="0 0 24 24"
+                focusable="false"
+              >
+                <path d="m7 10 5 5 5-5"/>
+              </svg>
+            </summary>
+
+            <div class="menu-panel" role="menu">
+
+              <a href="#source" role="menuitem">
+                <span class="menu-icon" aria-hidden="true">⌘</span>
+                <span>
+                  <strong>Source Code</strong>
+                  <small>Download source files</small>
+                </span>
+              </a>
+
+              <a href="#zip" role="menuitem">
+                <span class="menu-icon" aria-hidden="true">↓</span>
+                <span>
+                  <strong>ZIP Archive</strong>
+                  <small>Download as compressed file</small>
+                </span>
+              </a>
+
+              <a href="#docs" role="menuitem">
+                <span class="menu-icon" aria-hidden="true">?</span>
+                <span>
+                  <strong>Documentation</strong>
+                  <small>Read implementation details</small>
+                </span>
+              </a>
+
+            </div>
+          </details>
+
+        </div>
+
+      </div>
+
+      <div class="feature-grid">
+
+        <article class="feature">
+          <span>01</span>
+          <h2>CSS Only</h2>
+          <p>No JavaScript is required for the dropdown interaction.</p>
+        </article>
+
+        <article class="feature">
+          <span>02</span>
+          <h2>Responsive</h2>
+          <p>Adapts naturally to smaller screens and touch devices.</p>
+        </article>
+
+        <article class="feature">
+          <span>03</span>
+          <h2>Accessible</h2>
+          <p>Uses semantic links, details and summary controls.</p>
+        </article>
+
+      </div>
+
+    </section>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/css-split-button-menu/style.css
+++ b/submissions/examples/css-split-button-menu/style.css
@@ -1,0 +1,498 @@
+/* =========================================================
+   EaseMotion CSS
+   Component: Split Button Menu
+   ========================================================= */
+
+   :root {
+    --page-bg: #f4f7fb;
+    --surface: #ffffff;
+    --surface-soft: #f8fafc;
+  
+    --text-primary: #172033;
+    --text-secondary: #64748b;
+    --text-muted: #94a3b8;
+  
+    --accent: #4f46e5;
+    --accent-dark: #3730a3;
+    --accent-soft: #eef2ff;
+  
+    --border: #e2e8f0;
+    --border-strong: #cbd5e1;
+  
+    --shadow-sm:
+      0 2px 6px rgba(15, 23, 42, 0.06);
+  
+    --shadow-lg:
+      0 18px 45px rgba(15, 23, 42, 0.12);
+  
+    --radius-sm: 8px;
+    --radius-md: 12px;
+    --radius-lg: 20px;
+  
+    --transition:
+      180ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  }
+  
+  /* ---------- Reset ---------- */
+  
+  * {
+    box-sizing: border-box;
+  }
+  
+  html {
+    scroll-behavior: smooth;
+  }
+  
+  body {
+    min-height: 100vh;
+    margin: 0;
+  
+    font-family:
+      Inter,
+      ui-sans-serif,
+      system-ui,
+      -apple-system,
+      BlinkMacSystemFont,
+      "Segoe UI",
+      sans-serif;
+  
+    color: var(--text-primary);
+    background:
+      radial-gradient(
+        circle at top,
+        #ffffff 0,
+        var(--page-bg) 48%,
+        #edf2f7 100%
+      );
+  
+    -webkit-font-smoothing: antialiased;
+  }
+  
+  /* ---------- Page ---------- */
+  
+  .page {
+    width: min(1100px, calc(100% - 32px));
+    min-height: 100vh;
+    margin-inline: auto;
+  
+    display: grid;
+    place-items: center;
+  
+    padding-block: 64px;
+  }
+  
+  /* ---------- Main Card ---------- */
+  
+  .demo-card {
+    width: 100%;
+    overflow: visible;
+  
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+  
+    box-shadow: var(--shadow-lg);
+  }
+  
+  /* ---------- Header ---------- */
+  
+  .demo-header {
+    padding: 42px 42px 30px;
+  
+    border-bottom: 1px solid var(--border);
+  }
+  
+  .eyebrow {
+    display: inline-flex;
+    align-items: center;
+  
+    margin-bottom: 10px;
+  
+    color: var(--accent);
+    font-size: 0.75rem;
+    font-weight: 800;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+  
+  .demo-header h1 {
+    margin: 0;
+  
+    font-size: clamp(1.8rem, 4vw, 2.7rem);
+    line-height: 1.1;
+    letter-spacing: -0.04em;
+  }
+  
+  .demo-header p {
+    max-width: 620px;
+    margin: 14px 0 0;
+  
+    color: var(--text-secondary);
+    font-size: 1rem;
+    line-height: 1.7;
+  }
+  
+  /* ---------- Demo Stage ---------- */
+  
+  .demo-stage {
+    min-height: 330px;
+  
+    display: grid;
+    place-items: center;
+  
+    padding: 70px 24px;
+  
+    background:
+      linear-gradient(
+        135deg,
+        rgba(79, 70, 229, 0.035),
+        transparent 55%
+      );
+  }
+  
+  /* =========================================================
+     Split Button
+     ========================================================= */
+  
+  .split-button {
+    position: relative;
+  
+    display: inline-flex;
+    align-items: stretch;
+  
+    border-radius: var(--radius-md);
+  
+    box-shadow:
+      0 8px 20px rgba(79, 70, 229, 0.18);
+  
+    isolation: isolate;
+  }
+  
+  /* ---------- Primary Action ---------- */
+  
+  .split-button__primary {
+    min-height: 52px;
+  
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+  
+    padding: 0 22px;
+  
+    color: #ffffff;
+    background: var(--accent);
+  
+    border: 1px solid var(--accent);
+    border-right: 1px solid rgba(255, 255, 255, 0.25);
+    border-radius: var(--radius-md) 0 0 var(--radius-md);
+  
+    font-size: 0.95rem;
+    font-weight: 750;
+    text-decoration: none;
+  
+    transition:
+      background var(--transition),
+      transform var(--transition),
+      box-shadow var(--transition);
+  }
+  
+  .split-button__primary:hover {
+    background: var(--accent-dark);
+  }
+  
+  .split-button__primary:active {
+    transform: translateY(1px);
+  }
+  
+  .split-button__primary:focus-visible,
+  .split-button__toggle:focus-visible,
+  .menu-panel a:focus-visible {
+    outline: 3px solid rgba(79, 70, 229, 0.28);
+    outline-offset: 3px;
+  }
+  
+  .split-button__primary svg {
+    width: 18px;
+    height: 18px;
+  
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+  
+  /* =========================================================
+     Dropdown Control
+     ========================================================= */
+  
+  .split-button__menu {
+    position: relative;
+  }
+  
+  .split-button__toggle {
+    width: 50px;
+    min-height: 52px;
+  
+    display: grid;
+    place-items: center;
+  
+    color: #ffffff;
+    background: var(--accent);
+  
+    border: 1px solid var(--accent);
+    border-radius: 0 var(--radius-md) var(--radius-md) 0;
+  
+    cursor: pointer;
+    list-style: none;
+  
+    transition:
+      background var(--transition),
+      transform var(--transition);
+  }
+  
+  .split-button__toggle::-webkit-details-marker {
+    display: none;
+  }
+  
+  .split-button__toggle:hover {
+    background: var(--accent-dark);
+  }
+  
+  .split-button__toggle svg {
+    width: 18px;
+    height: 18px;
+  
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  
+    transition: transform var(--transition);
+  }
+  
+  .split-button__menu[open] .split-button__toggle svg {
+    transform: rotate(180deg);
+  }
+  
+  /* =========================================================
+     Menu Panel
+     ========================================================= */
+  
+  .menu-panel {
+    position: absolute;
+    z-index: 20;
+  
+    top: calc(100% + 10px);
+    right: 0;
+  
+    width: 280px;
+  
+    padding: 8px;
+  
+    background: var(--surface);
+  
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+  
+    box-shadow:
+      0 18px 45px rgba(15, 23, 42, 0.16),
+      0 4px 10px rgba(15, 23, 42, 0.06);
+  
+    transform-origin: top right;
+  
+    animation:
+      menu-enter 180ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  }
+  
+  @keyframes menu-enter {
+    from {
+      opacity: 0;
+      transform: translateY(-6px) scale(0.97);
+    }
+  
+    to {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
+  }
+  
+  /* ---------- Menu Items ---------- */
+  
+  .menu-panel a {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  
+    padding: 12px;
+  
+    color: var(--text-primary);
+    border-radius: var(--radius-sm);
+  
+    text-decoration: none;
+  
+    transition:
+      background var(--transition),
+      transform var(--transition);
+  }
+  
+  .menu-panel a:hover {
+    background: var(--surface-soft);
+    transform: translateX(2px);
+  }
+  
+  .menu-panel a:active {
+    transform: translateX(2px) scale(0.99);
+  }
+  
+  .menu-panel a + a {
+    margin-top: 2px;
+  }
+  
+  .menu-panel strong,
+  .menu-panel small {
+    display: block;
+  }
+  
+  .menu-panel strong {
+    font-size: 0.9rem;
+    font-weight: 750;
+  }
+  
+  .menu-panel small {
+    margin-top: 3px;
+  
+    color: var(--text-secondary);
+    font-size: 0.76rem;
+    line-height: 1.35;
+  }
+  
+  /* ---------- Menu Icon ---------- */
+  
+  .menu-icon {
+    width: 36px;
+    height: 36px;
+    flex: 0 0 36px;
+  
+    display: grid;
+    place-items: center;
+  
+    color: var(--accent);
+    background: var(--accent-soft);
+  
+    border-radius: 9px;
+  
+    font-size: 0.95rem;
+    font-weight: 800;
+  }
+  
+  /* =========================================================
+     Feature Grid
+     ========================================================= */
+  
+  .feature-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+  
+    border-top: 1px solid var(--border);
+  }
+  
+  .feature {
+    padding: 28px 30px;
+  }
+  
+  .feature + .feature {
+    border-left: 1px solid var(--border);
+  }
+  
+  .feature > span {
+    color: var(--accent);
+  
+    font-size: 0.72rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+  }
+  
+  .feature h2 {
+    margin: 8px 0 7px;
+  
+    font-size: 1rem;
+    letter-spacing: -0.015em;
+  }
+  
+  .feature p {
+    margin: 0;
+  
+    color: var(--text-secondary);
+  
+    font-size: 0.85rem;
+    line-height: 1.6;
+  }
+  
+  /* =========================================================
+     Responsive
+     ========================================================= */
+  
+  @media (max-width: 700px) {
+    .page {
+      width: min(100% - 20px, 600px);
+      padding-block: 20px;
+    }
+  
+    .demo-header {
+      padding: 30px 24px 24px;
+    }
+  
+    .demo-stage {
+      min-height: 280px;
+      padding: 55px 16px;
+    }
+  
+    .feature-grid {
+      grid-template-columns: 1fr;
+    }
+  
+    .feature + .feature {
+      border-top: 1px solid var(--border);
+      border-left: 0;
+    }
+  }
+  
+  @media (max-width: 420px) {
+    .split-button__primary {
+      padding-inline: 16px;
+    }
+  
+    .split-button__primary span {
+      display: none;
+    }
+  
+    .split-button__primary {
+      width: 52px;
+    }
+  
+    .menu-panel {
+      right: -4px;
+      width: min(280px, calc(100vw - 40px));
+    }
+  }
+  
+  /* =========================================================
+     Reduced Motion
+     ========================================================= */
+  
+  @media (prefers-reduced-motion: reduce) {
+    html {
+      scroll-behavior: auto;
+    }
+  
+    *,
+    *::before,
+    *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+    }
+  }


### PR DESCRIPTION
## ✨ Description

Implemented the **CSS Split Button Menu** for EaseMotion CSS.

### What was added

* Responsive split button component
* Pure HTML and CSS implementation
* Native `<details>` / `<summary>` dropdown interaction
* Smooth menu entrance animation
* Hover, active, and focus states
* Responsive mobile layout
* Accessible labels and semantic structure
* `prefers-reduced-motion` support
* Component documentation

### Files

* `submissions/examples/css-split-button-menu/demo.html`
* `submissions/examples/css-split-button-menu/style.css`
* `submissions/examples/css-split-button-menu/README.md`

### Testing

* Tested desktop layout
* Tested responsive/mobile layout
* Tested dropdown interaction
* Tested keyboard focus behavior
* Verified no JavaScript dependency
* Verified reduced-motion behavior

Closes #70658
