### PR TITLE
Add ease-typing-speed-test component

### DIFF
--- a/submissions/examples/typing-speed-test-ij/README.md
+++ b/submissions/examples/typing-speed-test-ij/README.md
@@ -1,0 +1,11 @@
+# ease-typing-speed-test
+
+A typing speed test where the sample text types out, the caret blinks, and the live stats tick.
+
+## Run
+Open `demo.html` directly in a browser to watch the test in action.
+
+## Notes
+- Words pop in one after another.
+- The caret blinks at the end of the sample.
+- WPM, accuracy and timer stats tick in turn.

--- a/submissions/examples/typing-speed-test-ij/demo.html
+++ b/submissions/examples/typing-speed-test-ij/demo.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-typing-speed-test</title>
+</head>
+<body>
+<main class="tst-card">
+  <div class="tst-head">
+    <span class="tst-label">Typing Test</span>
+    <span class="tst-mode">hard</span>
+  </div>
+  <div class="tst-text">
+    <span class="tst-word">the</span> <span class="tst-word">quick</span> <span class="tst-word">brown</span> <span class="tst-word">fox</span> <span class="tst-word">jumps</span> <span class="tst-word">over</span> <span class="tst-word">the</span> <span class="tst-word">lazy</span> <span class="tst-caret"></span>
+  </div>
+  <div class="tst-stats">
+    <div class="tst-stat">
+      <span class="tst-stat-value">42</span>
+      <span class="tst-stat-name">wpm</span>
+    </div>
+    <div class="tst-stat">
+      <span class="tst-stat-value">96%</span>
+      <span class="tst-stat-name">acc</span>
+    </div>
+    <div class="tst-stat">
+      <span class="tst-stat-value">2</span>
+      <span class="tst-stat-name">err</span>
+    </div>
+    <div class="tst-stat">
+      <span class="tst-stat-value">0:37</span>
+      <span class="tst-stat-name">time</span>
+    </div>
+  </div>
+  <div class="tst-progress"><span class="tst-progress-fill"></span></div>
+</main>
+</body>
+</html>

--- a/submissions/examples/typing-speed-test-ij/style.css
+++ b/submissions/examples/typing-speed-test-ij/style.css
@@ -1,0 +1,26 @@
+*{margin:0;padding:0;box-sizing:border-box}
+body{min-height:100vh;display:flex;align-items:center;justify-content:center;background:#0e1524;font-family:Courier New,monospace}
+.tst-card{width:400px;background:#161f33;border:1px solid #26324d;border-radius:18px;padding:22px;box-shadow:0 16px 32px rgba(0,0,0,.55);display:flex;flex-direction:column;gap:16px}
+.tst-head{display:flex;align-items:center;justify-content:space-between}
+.tst-label{font-size:14px;letter-spacing:2px;color:#7f94b8;text-transform:uppercase}
+.tst-mode{font-size:11px;color:#ffd166;background:#232f4c;border-radius:8px;padding:3px 9px}
+.tst-text{font-size:16px;line-height:1.9;color:#c9d6ee;background:#0f182b;border-radius:12px;padding:14px 16px;letter-spacing:.5px}
+.tst-word{animation:tst-char-pop-typing-speed-test .45s ease-out both}
+.tst-word:nth-child(2){animation-delay:.15s}
+.tst-word:nth-child(3){animation-delay:.3s}
+.tst-word:nth-child(4){animation-delay:.45s}
+.tst-word:nth-child(5){animation-delay:.6s}
+.tst-word:nth-child(6){animation-delay:.75s}
+.tst-word:nth-child(7){animation-delay:.9s}
+.tst-word:nth-child(8){animation-delay:1.05s}
+.tst-caret{display:inline-block;width:9px;height:19px;background:#ffd166;vertical-align:-3px;margin-left:4px;animation:tst-caret-blink-typing-speed-test 1s steps(2) infinite}
+.tst-stats{display:grid;grid-template-columns:repeat(4,1fr);gap:10px}
+.tst-stat{background:#101a2e;border-radius:12px;padding:10px 4px;text-align:center}
+.tst-stat-value{display:block;font-size:20px;font-weight:700;color:#4fd2a8;animation:tst-stat-tick-typing-speed-test 1.2s steps(8) infinite}
+.tst-stat-name{display:block;font-size:10px;color:#6f86ad;margin-top:4px}
+.tst-progress{height:10px;background:#1a2740;border-radius:6px;overflow:hidden}
+.tst-progress-fill{display:block;height:100%;width:64%;background:linear-gradient(90deg,#3b82f6,#4fd2a8);animation:tst-progress-fill-typing-speed-test 2.6s ease-in-out infinite}
+@keyframes tst-char-pop-typing-speed-test{from{opacity:0;transform:translateY(6px)}to{opacity:1;transform:translateY(0)}}
+@keyframes tst-caret-blink-typing-speed-test{0%,100%{opacity:0}50%{opacity:1}}
+@keyframes tst-stat-tick-typing-speed-test{0%,100%{transform:translateY(0)}50%{transform:translateY(-3px)}}
+@keyframes tst-progress-fill-typing-speed-test{0%{width:20%}50%{width:86%}100%{width:64%}}


### PR DESCRIPTION
## Component: ease-typing-speed-test — text types, caret blinks, and stats tick

**Closes #72727**

### What this adds
A typing speed test where the sample text types out, the caret blinks, and the live stats tick.

### Acceptance Criteria covered
- Sample text types
- Caret blinks
- Live stats tick

### Files
- `submissions/examples/typing-speed-test-ij/demo.html`
- `submissions/examples/typing-speed-test-ij/style.css`
- `submissions/examples/typing-speed-test-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the text type, the caret blink, and the stats tick.