### PR TITLE
Add ease-chess-board-display component

### DIFF
--- a/submissions/examples/chess-board-display-ij/README.md
+++ b/submissions/examples/chess-board-display-ij/README.md
@@ -1,0 +1,11 @@
+# ease-chess-board-display
+
+A chess board display where the pieces glide, the active square glows, and the move clock ticks.
+
+## Run
+Open `demo.html` directly in a browser to watch the board animate.
+
+## Notes
+- Pieces bob gently in their squares.
+- The king square glows on the last rank.
+- The move clock ticks beside the title.

--- a/submissions/examples/chess-board-display-ij/demo.html
+++ b/submissions/examples/chess-board-display-ij/demo.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-chess-board-display</title>
+</head>
+<body>
+<main class="chb-card">
+  <div class="chb-head">
+    <span class="chb-title">Classic Board</span>
+    <span class="chb-clock">09:41</span>
+  </div>
+  <div class="chb-board">
+    <span class="chb-cell chb-dark chb-piece">&#9820;</span>
+    <span class="chb-cell chb-light chb-piece">&#9822;</span>
+    <span class="chb-cell chb-dark chb-piece">&#9821;</span>
+    <span class="chb-cell chb-light chb-piece">&#9819;</span>
+    <span class="chb-cell chb-dark chb-piece">&#9818;</span>
+    <span class="chb-cell chb-light chb-piece">&#9821;</span>
+    <span class="chb-cell chb-dark chb-piece">&#9822;</span>
+    <span class="chb-cell chb-light chb-piece">&#9820;</span>
+    <span class="chb-cell chb-light chb-piece">&#9823;</span>
+    <span class="chb-cell chb-dark chb-piece">&#9823;</span>
+    <span class="chb-cell chb-light chb-piece">&#9823;</span>
+    <span class="chb-cell chb-dark chb-piece">&#9823;</span>
+    <span class="chb-cell chb-light chb-piece">&#9823;</span>
+    <span class="chb-cell chb-dark chb-piece">&#9823;</span>
+    <span class="chb-cell chb-light chb-piece">&#9823;</span>
+    <span class="chb-cell chb-dark chb-piece">&#9823;</span>
+    <span class="chb-cell chb-dark"></span>
+    <span class="chb-cell chb-light"></span>
+    <span class="chb-cell chb-dark"></span>
+    <span class="chb-cell chb-light"></span>
+    <span class="chb-cell chb-dark"></span>
+    <span class="chb-cell chb-light"></span>
+    <span class="chb-cell chb-dark"></span>
+    <span class="chb-cell chb-light"></span>
+    <span class="chb-cell chb-light"></span>
+    <span class="chb-cell chb-dark"></span>
+    <span class="chb-cell chb-light"></span>
+    <span class="chb-cell chb-dark"></span>
+    <span class="chb-cell chb-light"></span>
+    <span class="chb-cell chb-dark"></span>
+    <span class="chb-cell chb-light"></span>
+    <span class="chb-cell chb-dark"></span>
+    <span class="chb-cell chb-dark"></span>
+    <span class="chb-cell chb-light"></span>
+    <span class="chb-cell chb-dark"></span>
+    <span class="chb-cell chb-light"></span>
+    <span class="chb-cell chb-dark"></span>
+    <span class="chb-cell chb-light"></span>
+    <span class="chb-cell chb-dark"></span>
+    <span class="chb-cell chb-light"></span>
+    <span class="chb-cell chb-light"></span>
+    <span class="chb-cell chb-dark"></span>
+    <span class="chb-cell chb-light"></span>
+    <span class="chb-cell chb-dark"></span>
+    <span class="chb-cell chb-light"></span>
+    <span class="chb-cell chb-dark"></span>
+    <span class="chb-cell chb-light"></span>
+    <span class="chb-cell chb-dark"></span>
+    <span class="chb-cell chb-dark chb-piece">&#9817;</span>
+    <span class="chb-cell chb-light chb-piece">&#9817;</span>
+    <span class="chb-cell chb-dark chb-piece">&#9817;</span>
+    <span class="chb-cell chb-light chb-piece">&#9817;</span>
+    <span class="chb-cell chb-dark chb-piece">&#9817;</span>
+    <span class="chb-cell chb-light chb-piece">&#9817;</span>
+    <span class="chb-cell chb-dark chb-piece">&#9817;</span>
+    <span class="chb-cell chb-light chb-piece">&#9817;</span>
+    <span class="chb-cell chb-light chb-glow chb-piece">&#9814;</span>
+    <span class="chb-cell chb-dark chb-piece">&#9816;</span>
+    <span class="chb-cell chb-light chb-piece">&#9815;</span>
+    <span class="chb-cell chb-dark chb-piece">&#9813;</span>
+    <span class="chb-cell chb-light chb-piece">&#9812;</span>
+    <span class="chb-cell chb-dark chb-piece">&#9815;</span>
+    <span class="chb-cell chb-light chb-piece">&#9816;</span>
+    <span class="chb-cell chb-dark chb-piece">&#9814;</span>
+  </div>
+  <p class="chb-note">White to move</p>
+</main>
+</body>
+</html>

--- a/submissions/examples/chess-board-display-ij/style.css
+++ b/submissions/examples/chess-board-display-ij/style.css
@@ -1,0 +1,16 @@
+*,*::after,*::before{box-sizing:border-box;padding:0;margin:0}
+body{min-height:100vh;display:flex;align-items:center;justify-content:center;background:#2c2a33;font-family:Segoe UI,system-ui,sans-serif}
+.chb-card{width:370px;background:#3a3a46;border:3px solid #23232d;border-radius:16px;padding:16px;box-shadow:0 20px 40px rgba(0,0,0,.6);display:flex;flex-direction:column;gap:12px;align-items:center}
+.chb-head{display:flex;align-items:center;justify-content:space-between;width:100%}
+.chb-title{font-size:15px;font-weight:700;color:#e8e6f0}
+.chb-clock{font-size:15px;font-weight:700;color:#ffb84d;font-family:Consolas,monospace;animation:chb-clock-tick-chess-board-display 1s steps(10) infinite}
+.chb-board{display:grid;grid-template-columns:repeat(8,1fr);width:100%;border:3px solid #1d1d26}
+.chb-cell{aspect-ratio:1;display:flex;align-items:center;justify-content:center;font-size:26px;line-height:1}
+.chb-dark{background:#8b7355}
+.chb-light{background:#f2e3c8}
+.chb-cell.chb-glow{animation:chb-square-glow-chess-board-display 2s ease-in-out infinite}
+.chb-piece{animation:chb-piece-glide-chess-board-display 1.6s ease-in-out infinite}
+.chb-note{font-size:12px;color:#b9b3c6}
+@keyframes chb-piece-glide-chess-board-display{0%,100%{transform:translateY(0)}50%{transform:translateY(-6px)}}
+@keyframes chb-square-glow-chess-board-display{0%,100%{filter:brightness(1)}50%{filter:brightness(1.5)}}
+@keyframes chb-clock-tick-chess-board-display{0%{transform:translateY(0)}25%{transform:translateY(-2px)}75%{transform:translateY(1px)}100%{transform:translateY(0)}}


### PR DESCRIPTION
## Component: ease-chess-board-display — pieces glide, squares glow, and clock ticks

**Closes #72730**

### What this adds
A chess board display where the pieces glide, the active square glows, and the move clock ticks.

### Acceptance Criteria covered
- Pieces glide
- Active square glows
- Move clock ticks

### Files
- `submissions/examples/chess-board-display-ij/demo.html`
- `submissions/examples/chess-board-display-ij/style.css`
- `submissions/examples/chess-board-display-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the pieces glide, the square glow, and the clock tick.