### PR TITLE
Add ease-sudoku-grid-puzzle component

### DIFF
--- a/submissions/examples/sudoku-grid-puzzle-ij/README.md
+++ b/submissions/examples/sudoku-grid-puzzle-ij/README.md
@@ -1,0 +1,11 @@
+# ease-sudoku-grid-puzzle
+
+A sudoku grid puzzle where the cells fill in, the active line highlights sweep, and the pencil notes pulse.
+
+## Run
+Open `demo.html` directly in a browser to watch the grid settle.
+
+## Notes
+- Given cells pop into the board.
+- Row five sweeps a soft highlight.
+- Pencil notes pulse in the empty cells.

--- a/submissions/examples/sudoku-grid-puzzle-ij/demo.html
+++ b/submissions/examples/sudoku-grid-puzzle-ij/demo.html
@@ -1,0 +1,118 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-sudoku-grid-puzzle</title>
+</head>
+<body>
+<main class="sud-card">
+  <div class="sud-head">
+    <span class="sud-title">Daily Puzzle</span>
+    <span class="sud-difficulty">medium</span>
+  </div>
+  <div class="sud-board">
+    <div class="sud-row">
+      <span class="sud-cell sud-given">5</span>
+      <span class="sud-cell sud-given">3</span>
+      <span class="sud-cell sud-empty">2</span>
+      <span class="sud-cell"></span>
+      <span class="sud-cell sud-given">7</span>
+      <span class="sud-cell"></span>
+      <span class="sud-cell"></span>
+      <span class="sud-cell"></span>
+      <span class="sud-cell"></span>
+    </div>
+    <div class="sud-row">
+      <span class="sud-cell sud-given">6</span>
+      <span class="sud-cell sud-empty">5</span>
+      <span class="sud-cell"></span>
+      <span class="sud-cell sud-given">1</span>
+      <span class="sud-cell sud-given">9</span>
+      <span class="sud-cell sud-given">5</span>
+      <span class="sud-cell"></span>
+      <span class="sud-cell"></span>
+      <span class="sud-cell"></span>
+    </div>
+    <div class="sud-row">
+      <span class="sud-cell sud-empty">4</span>
+      <span class="sud-cell sud-given">9</span>
+      <span class="sud-cell sud-given">8</span>
+      <span class="sud-cell"></span>
+      <span class="sud-cell"></span>
+      <span class="sud-cell"></span>
+      <span class="sud-cell"></span>
+      <span class="sud-cell sud-given">6</span>
+      <span class="sud-cell"></span>
+    </div>
+    <div class="sud-row">
+      <span class="sud-cell sud-given">8</span>
+      <span class="sud-cell"></span>
+      <span class="sud-cell"></span>
+      <span class="sud-cell"></span>
+      <span class="sud-cell sud-given">6</span>
+      <span class="sud-cell"></span>
+      <span class="sud-cell"></span>
+      <span class="sud-cell"></span>
+      <span class="sud-cell sud-given">3</span>
+    </div>
+    <div class="sud-row">
+      <span class="sud-cell sud-hl sud-given">4</span>
+      <span class="sud-cell sud-hl"></span>
+      <span class="sud-cell sud-hl"></span>
+      <span class="sud-cell sud-hl sud-given">8</span>
+      <span class="sud-cell sud-hl"></span>
+      <span class="sud-cell sud-hl sud-given">3</span>
+      <span class="sud-cell sud-hl"></span>
+      <span class="sud-cell sud-hl"></span>
+      <span class="sud-cell sud-hl sud-given">1</span>
+    </div>
+    <div class="sud-row">
+      <span class="sud-cell sud-given">7</span>
+      <span class="sud-cell"></span>
+      <span class="sud-cell"></span>
+      <span class="sud-cell"></span>
+      <span class="sud-cell sud-given">2</span>
+      <span class="sud-cell"></span>
+      <span class="sud-cell"></span>
+      <span class="sud-cell"></span>
+      <span class="sud-cell sud-given">6</span>
+    </div>
+    <div class="sud-row">
+      <span class="sud-cell"></span>
+      <span class="sud-cell sud-given">6</span>
+      <span class="sud-cell"></span>
+      <span class="sud-cell"></span>
+      <span class="sud-cell"></span>
+      <span class="sud-cell"></span>
+      <span class="sud-cell sud-given">2</span>
+      <span class="sud-cell sud-given">8</span>
+      <span class="sud-cell"></span>
+    </div>
+    <div class="sud-row">
+      <span class="sud-cell"></span>
+      <span class="sud-cell"></span>
+      <span class="sud-cell"></span>
+      <span class="sud-cell sud-given">4</span>
+      <span class="sud-cell sud-given">1</span>
+      <span class="sud-cell sud-given">9</span>
+      <span class="sud-cell"></span>
+      <span class="sud-cell"></span>
+      <span class="sud-cell sud-given">5</span>
+    </div>
+    <div class="sud-row">
+      <span class="sud-cell"></span>
+      <span class="sud-cell"></span>
+      <span class="sud-cell"></span>
+      <span class="sud-cell"></span>
+      <span class="sud-cell sud-given">8</span>
+      <span class="sud-cell"></span>
+      <span class="sud-cell"></span>
+      <span class="sud-cell sud-given">7</span>
+      <span class="sud-cell sud-given">9</span>
+    </div>
+  </div>
+  <p class="sud-note">Row five is highlighted</p>
+</main>
+</body>
+</html>

--- a/submissions/examples/sudoku-grid-puzzle-ij/style.css
+++ b/submissions/examples/sudoku-grid-puzzle-ij/style.css
@@ -1,0 +1,20 @@
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+body{min-height:100vh;display:grid;place-items:center;background:#eef1f6;font-family:Aptos,sans-serif}
+.sud-card{width:320px;background:#ffffff;border-radius:20px;padding:20px;box-shadow:0 14px 30px rgba(60,80,110,.22);display:flex;flex-direction:column;gap:14px;align-items:center}
+.sud-head{display:flex;align-items:center;justify-content:space-between;width:100%}
+.sud-title{font-size:16px;font-weight:800;color:#2c3e63}
+.sud-difficulty{font-size:11px;color:#ffffff;background:#e67e22;border-radius:8px;padding:3px 9px}
+.sud-board{display:flex;flex-direction:column;border:2px solid #2c3e63;border-radius:8px;overflow:hidden}
+.sud-row{display:grid;grid-template-columns:repeat(9,1fr)}
+.sud-row:nth-child(3n){border-bottom:2px solid #2c3e63}
+.sud-row:last-child{border-bottom:none}
+.sud-cell{aspect-ratio:1;border:1px solid #d5deea;display:flex;align-items:center;justify-content:center;font-size:17px;font-weight:600;color:#33475f}
+.sud-row .sud-cell:nth-child(3n){border-right:2px solid #2c3e63}
+.sud-row .sud-cell:last-child{border-right:none}
+.sud-cell.sud-given{color:#0f1b30;font-weight:800;animation:sud-cell-fill-sudoku-grid-puzzle .5s ease-out both}
+.sud-cell.sud-hl{background:#fff3d6;animation:sud-highlight-sweep-sudoku-grid-puzzle 2.2s ease-in-out infinite}
+.sud-cell.sud-empty{color:#9fb2c9;font-size:13px;animation:sud-note-pulse-sudoku-grid-puzzle 1.8s ease-in-out infinite}
+.sud-note{font-size:12px;color:#7e91ad}
+@keyframes sud-highlight-sweep-sudoku-grid-puzzle{0%,100%{background:#fff3d6}50%{background:#ffe9a8}}
+@keyframes sud-note-pulse-sudoku-grid-puzzle{0%,100%{opacity:.55}50%{opacity:1}}
+@keyframes sud-cell-fill-sudoku-grid-puzzle{from{transform:scale(.6);opacity:0}to{transform:scale(1);opacity:1}}


### PR DESCRIPTION
## Component: ease-sudoku-grid-puzzle — cells fill, highlights sweep, and notes pulse

**Closes #72733**

### What this adds
A sudoku grid puzzle where the cells fill in, the active line highlights sweep, and the pencil notes pulse.

### Acceptance Criteria covered
- Cells fill in
- Active line sweeps
- Pencil notes pulse

### Files
- `submissions/examples/sudoku-grid-puzzle-ij/demo.html`
- `submissions/examples/sudoku-grid-puzzle-ij/style.css`
- `submissions/examples/sudoku-grid-puzzle-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the cells fill, the line sweep, and the notes pulse.