### PR TITLE
Add ease-pomodoro-timer-card component

### DIFF
--- a/submissions/examples/pomodoro-timer-card-ij/README.md
+++ b/submissions/examples/pomodoro-timer-card-ij/README.md
@@ -1,0 +1,11 @@
+# ease-pomodoro-timer-card
+
+A pomodoro timer card where the focus ring drains, the time ticks, and the session dots glow.
+
+## Run
+Open `demo.html` directly in a browser to watch the timer run a session.
+
+## Notes
+- The outer ring drains as time passes.
+- The time readout pulses on each tick.
+- Completed session dots glow at the base.

--- a/submissions/examples/pomodoro-timer-card-ij/demo.html
+++ b/submissions/examples/pomodoro-timer-card-ij/demo.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-pomodoro-timer-card</title>
+</head>
+<body>
+<main class="pom-card">
+  <div class="pom-ring">
+    <div class="pom-ring-inner">
+      <span class="pom-time">24:59</span>
+      <span class="pom-phase">focus</span>
+    </div>
+  </div>
+  <div class="pom-controls">
+    <span class="pom-btn pom-btn-1">focus</span>
+    <span class="pom-btn">short</span>
+    <span class="pom-btn">long</span>
+  </div>
+  <div class="pom-sessions">
+    <span class="pom-dot pom-dot-1"></span>
+    <span class="pom-dot pom-dot-2"></span>
+    <span class="pom-dot pom-dot-3"></span>
+  </div>
+  <p class="pom-note">Round 2 of 4</p>
+</main>
+</body>
+</html>

--- a/submissions/examples/pomodoro-timer-card-ij/style.css
+++ b/submissions/examples/pomodoro-timer-card-ij/style.css
@@ -1,0 +1,18 @@
+*,*::before{box-sizing:border-box;margin:0}
+body{min-height:100vh;display:flex;align-items:center;justify-content:center;background:#f6e9e9;font-family:Georgia,serif}
+.pom-card{width:300px;background:#fff8f8;border-radius:24px;padding:24px;box-shadow:0 16px 34px rgba(160,70,70,.22);display:flex;flex-direction:column;align-items:center;gap:16px}
+.pom-ring{width:190px;height:190px;border-radius:50%;background:conic-gradient(#ff7b7b 0deg,#ff7b7b 240deg,#f0d9d9 240deg);display:flex;align-items:center;justify-content:center;animation:pom-ring-drain-pomodoro-timer-card 4s linear infinite}
+.pom-ring-inner{width:158px;height:158px;border-radius:50%;background:#fff8f8;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:2px}
+.pom-time{font-size:34px;font-weight:800;color:#b3403c;font-family:Consolas,monospace;animation:pom-time-tick-pomodoro-timer-card 1s steps(60) infinite}
+.pom-phase{font-size:12px;letter-spacing:2px;color:#c98a86;text-transform:uppercase}
+.pom-controls{display:flex;gap:8px}
+.pom-btn{font-size:11px;color:#a8504c;border:1px solid #e5c2c0;border-radius:14px;padding:6px 12px}
+.pom-btn-1{background:#ff7b7b;color:#ffffff;border-color:#ff7b7b;animation:pom-session-glow-pomodoro-timer-card 2s ease-in-out infinite}
+.pom-sessions{display:flex;gap:8px}
+.pom-dot{width:10px;height:10px;border-radius:50%;background:#eccfcf}
+.pom-dot-1,.pom-dot-2{background:#ff7b7b;animation:pom-session-glow-pomodoro-timer-card 1.4s ease-in-out infinite}
+.pom-dot-3{background:#ffb3a7}
+.pom-note{font-size:12px;color:#b3807c}
+@keyframes pom-ring-drain-pomodoro-timer-card{from{background:conic-gradient(#ff7b7b 0deg,#ff7b7b 360deg,#f0d9d9 360deg)}to{background:conic-gradient(#ff7b7b 0deg,#ff7b7b 0deg,#f0d9d9 0deg)}}
+@keyframes pom-time-tick-pomodoro-timer-card{0%{transform:scale(1)}25%{transform:scale(.97)}75%{transform:scale(1.02)}100%{transform:scale(1)}}
+@keyframes pom-session-glow-pomodoro-timer-card{0%,100%{box-shadow:0 0 0 0 rgba(255,123,123,.5)}50%{box-shadow:0 0 0 8px rgba(255,123,123,0)}}


### PR DESCRIPTION
## Component: ease-pomodoro-timer-card — ring drains, time ticks, and sessions glow

**Closes #72736**

### What this adds
A pomodoro timer card where the focus ring drains, the time ticks, and the session dots glow.

### Acceptance Criteria covered
- Focus ring drains
- Time ticks
- Session dots glow

### Files
- `submissions/examples/pomodoro-timer-card-ij/demo.html`
- `submissions/examples/pomodoro-timer-card-ij/style.css`
- `submissions/examples/pomodoro-timer-card-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the ring drain, the time tick, and the dots glow.