### PR TITLE
Add ease-air-quality-index component

### DIFF
--- a/submissions/examples/air-quality-index-ij/README.md
+++ b/submissions/examples/air-quality-index-ij/README.md
@@ -1,0 +1,11 @@
+# ease-air-quality-index
+
+An air quality index where the gauge needle shifts, the pollutant chips rise, and the level label blinks.
+
+## Run
+Open `demo.html` directly in a browser to watch the index settle.
+
+## Notes
+- The needle drifts across the colored scale.
+- Pollutant chips rise into place in turn.
+- The level label blinks above the gauge.

--- a/submissions/examples/air-quality-index-ij/demo.html
+++ b/submissions/examples/air-quality-index-ij/demo.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-air-quality-index</title>
+</head>
+<body>
+<main class="aqi-card">
+  <div class="aqi-head">
+    <span class="aqi-title">Air Quality</span>
+    <span class="aqi-label">moderate</span>
+  </div>
+  <div class="aqi-gauge">
+    <span class="aqi-seg aqi-seg-1"></span>
+    <span class="aqi-seg aqi-seg-2"></span>
+    <span class="aqi-seg aqi-seg-3"></span>
+    <span class="aqi-seg aqi-seg-4"></span>
+    <span class="aqi-seg aqi-seg-5"></span>
+    <span class="aqi-needle"></span>
+  </div>
+  <div class="aqi-chips">
+    <span class="aqi-chip aqi-chip-1">PM2.5 <b>58</b></span>
+    <span class="aqi-chip aqi-chip-2">O3 <b>74</b></span>
+    <span class="aqi-chip aqi-chip-3">NO2 <b>31</b></span>
+    <span class="aqi-chip aqi-chip-4">CO <b>0.9</b></span>
+  </div>
+  <p class="aqi-note">Sensitive groups advised</p>
+</main>
+</body>
+</html>

--- a/submissions/examples/air-quality-index-ij/style.css
+++ b/submissions/examples/air-quality-index-ij/style.css
@@ -1,0 +1,24 @@
+*{box-sizing:border-box;margin:0;font-family:inherit}
+body{min-height:100vh;display:grid;place-items:center;background:#eef4f2;font-family:Trebuchet MS,sans-serif}
+.aqi-card{width:330px;background:#ffffff;border-radius:20px;padding:20px;box-shadow:0 14px 30px rgba(60,95,80,.2);display:flex;flex-direction:column;gap:14px}
+.aqi-head{display:flex;align-items:center;justify-content:space-between}
+.aqi-title{font-size:16px;font-weight:800;color:#2c4038}
+.aqi-label{font-size:12px;font-weight:700;color:#d9822b;background:#fdf0dd;border-radius:10px;padding:4px 11px;animation:aqi-label-blink-air-quality-index 1.6s steps(2) infinite}
+.aqi-gauge{position:relative;height:14px;background:#e6efe9;border-radius:9px;overflow:hidden;display:flex}
+.aqi-seg{flex:1;border-right:2px solid #ffffff}
+.aqi-seg-1{background:#2e9e63}
+.aqi-seg-2{background:#7fbf3a}
+.aqi-seg-3{background:#f2c033}
+.aqi-seg-4{background:#f28c33}
+.aqi-seg-5{background:#d94f4f}
+.aqi-needle{position:absolute;top:-4px;bottom:-4px;left:0;width:4px;background:#2c4038;border-radius:3px;animation:aqi-gauge-shift-air-quality-index 3.2s ease-in-out infinite}
+.aqi-chips{display:grid;grid-template-columns:1fr 1fr;gap:8px}
+.aqi-chip{background:#f3f8f5;border-radius:12px;padding:8px 10px;font-size:12px;color:#4a6257;animation:aqi-chip-rise-air-quality-index .5s ease-out both}
+.aqi-chip b{float:right;color:#2c4038}
+.aqi-chip-2{animation-delay:.15s}
+.aqi-chip-3{animation-delay:.3s}
+.aqi-chip-4{animation-delay:.45s}
+.aqi-note{font-size:12px;color:#6f8a7e;border-top:1px dashed #d6e4dd;padding-top:10px;text-align:center}
+@keyframes aqi-gauge-shift-air-quality-index{0%{left:6%}25%{left:28%}50%{left:54%}75%{left:34%}100%{left:6%}}
+@keyframes aqi-chip-rise-air-quality-index{from{transform:translateY(10px);opacity:0}to{transform:translateY(0);opacity:1}}
+@keyframes aqi-label-blink-air-quality-index{0%,100%{opacity:1}50%{opacity:.45}}


### PR DESCRIPTION
## Component: ease-air-quality-index — gauge shifts, chips rise, and label blinks

**Closes #72743**

### What this adds
An air quality index where the gauge needle shifts, the pollutant chips rise, and the level label blinks.

### Acceptance Criteria covered
- Gauge needle shifts
- Pollutant chips rise
- Level label blinks

### Files
- `submissions/examples/air-quality-index-ij/demo.html`
- `submissions/examples/air-quality-index-ij/style.css`
- `submissions/examples/air-quality-index-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the needle shift, the chips rise, and the label blink.