### PR TITLE
Add ease-quiz-score-board component

### DIFF
--- a/submissions/examples/quiz-score-board-ij/README.md
+++ b/submissions/examples/quiz-score-board-ij/README.md
@@ -1,0 +1,11 @@
+# ease-quiz-score-board
+
+A quiz scoreboard where the player scores count up, the answer tag flashes, and the podium pops.
+
+## Run
+Open `demo.html` directly in a browser to watch the round tally.
+
+## Notes
+- Player columns pop into the podium.
+- Scores bob as they climb.
+- The correct answer tag flashes in the panel.

--- a/submissions/examples/quiz-score-board-ij/demo.html
+++ b/submissions/examples/quiz-score-board-ij/demo.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-quiz-score-board</title>
+</head>
+<body>
+<main class="qsb-card">
+  <div class="qsb-head">
+    <span class="qsb-title">Round Scoreboard</span>
+    <span class="qsb-question">Q7</span>
+  </div>
+  <div class="qsb-players">
+    <div class="qsb-player qsb-player-1">
+      <span class="qsb-name">Alex</span>
+      <span class="qsb-score">320</span>
+    </div>
+    <div class="qsb-player qsb-player-2">
+      <span class="qsb-name">Mina</span>
+      <span class="qsb-score">275</span>
+    </div>
+    <div class="qsb-player qsb-player-3">
+      <span class="qsb-name">Ravi</span>
+      <span class="qsb-score">210</span>
+    </div>
+  </div>
+  <div class="qsb-answer">
+    <span class="qsb-answer-tag">correct</span>
+    <span class="qsb-answer-text">Mount Fuji</span>
+  </div>
+</main>
+</body>
+</html>

--- a/submissions/examples/quiz-score-board-ij/style.css
+++ b/submissions/examples/quiz-score-board-ij/style.css
@@ -1,0 +1,20 @@
+*{margin:0;box-sizing:border-box}
+body{min-height:100vh;display:flex;align-items:center;justify-content:center;background:#241e3d;font-family:Candara,sans-serif}
+.qsb-card{width:310px;background:#2d2650;border:1px solid #443b74;border-radius:22px;padding:20px;box-shadow:0 18px 36px rgba(15,10,40,.6);display:flex;flex-direction:column;gap:16px}
+.qsb-head{display:flex;align-items:center;justify-content:space-between}
+.qsb-title{font-size:15px;font-weight:700;color:#c9bfea}
+.qsb-question{font-size:13px;font-weight:700;color:#2d2650;background:#ffd166;border-radius:8px;padding:3px 10px}
+.qsb-players{display:grid;grid-template-columns:repeat(3,1fr);gap:10px}
+.qsb-player{background:#241f42;border-radius:14px;padding:14px 6px;text-align:center;animation:qsb-podium-pop-quiz-score-board .5s ease-out both}
+.qsb-player-1{animation-delay:.1s}
+.qsb-player-2{animation-delay:.3s}
+.qsb-player-3{animation-delay:.5s}
+.qsb-name{display:block;font-size:13px;font-weight:700;color:#d8cff2}
+.qsb-score{display:block;font-size:26px;font-weight:900;color:#8b7fe0;margin-top:6px;animation:qsb-score-count-quiz-score-board 1.4s ease-in-out infinite}
+.qsb-player-1 .qsb-score{color:#ffd166}
+.qsb-answer{display:flex;align-items:center;gap:10px;background:#241f42;border-radius:12px;padding:10px 12px}
+.qsb-answer-tag{font-size:11px;font-weight:700;color:#ffffff;background:#2e9e63;border-radius:8px;padding:3px 9px;animation:qsb-answer-flash-quiz-score-board 1.8s steps(2) infinite}
+.qsb-answer-text{font-size:13px;color:#d8cff2}
+@keyframes qsb-score-count-quiz-score-board{0%,100%{transform:translateY(0)}50%{transform:translateY(-4px)}}
+@keyframes qsb-answer-flash-quiz-score-board{0%,100%{opacity:1}50%{opacity:.4}}
+@keyframes qsb-podium-pop-quiz-score-board{from{transform:scale(.6);opacity:0}to{transform:scale(1);opacity:1}}


### PR DESCRIPTION
## Component: ease-quiz-score-board — scores count, answers flash, and podium pops

**Closes #72746**

### What this adds
A quiz scoreboard where the player scores count up, the answer tag flashes, and the podium pops.

### Acceptance Criteria covered
- Scores count up
- Answer tag flashes
- Podium pops

### Files
- `submissions/examples/quiz-score-board-ij/demo.html`
- `submissions/examples/quiz-score-board-ij/style.css`
- `submissions/examples/quiz-score-board-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the scores count, the answer flash, and the podium pop.