### PR TITLE
fix: move ease-marquee.css import into components section

### DIFF
--- a/easemotion.css
+++ b/easemotion.css
@@ -26,9 +26,10 @@
 @import "./core/base.css";
 @import "./core/animations.css";
 @import "./core/utilities.css";
-@import "./components/ease-marquee.css";
 
 /* ── Components (tree-shakeable in future versions) ──────── */
+@import "./components/ease-marquee.css";
+@import "./components/buttons.css";
 @import "./components/buttons.css";
 @import "./components/cards.css";
 @import "./components/navbar.css";


### PR DESCRIPTION
## Problem
`ease-marquee.css` was imported inside the Core block in `easemotion.css`,
before the Components comment, despite living in `./components/`.

## Fix
Moved the import to the top of the Components block where it belongs,
restoring correct cascade layer ordering.

## Testing
Open any page that uses `.ease-marquee` alongside other components
and verify no visual regressions in stacking/transition order.

closed #72763