### PR TITLE
feat: add ease-ripple-btn — CSS-only ripple press effect (ripple-press-ak)

### DIFF
--- a/submissions/examples/ripple-press-ak/README.md
+++ b/submissions/examples/ripple-press-ak/README.md
@@ -1,0 +1,54 @@
+# ripple-press-ak
+
+A pure CSS ripple press animation for buttons — no JavaScript required.
+
+## What it does
+
+Adds a smooth radial ripple that expands from the centre of the button on `:active`, combined with a subtle press-down scale and hover lift. Works on both `<button>` and `<a>` elements.
+
+## How to use
+
+```html
+<!-- Default (primary colour) -->
+<button class="ease-ripple-btn">Click me</button>
+
+<!-- Colour variants -->
+<button class="ease-ripple-btn ease-ripple-btn--secondary">Secondary</button>
+<button class="ease-ripple-btn ease-ripple-btn--success">Success</button>
+<button class="ease-ripple-btn ease-ripple-btn--danger">Danger</button>
+<button class="ease-ripple-btn ease-ripple-btn--ghost">Ghost</button>
+
+<!-- Size variants -->
+<button class="ease-ripple-btn ease-ripple-btn--sm">Small</button>
+<button class="ease-ripple-btn ease-ripple-btn--lg">Large</button>
+
+<!-- Works on anchor tags too -->
+<a href="#" class="ease-ripple-btn">Link button</a>
+```
+
+## How to review
+
+1. Open `demo.html` directly in a browser (no server needed)
+2. Click any button — you should see a white ripple spread from centre
+3. Hover — button lifts with a purple glow shadow
+4. Press and hold — button scales down slightly (press feedback)
+5. Tab to any button and press Space/Enter — focus ring should be visible
+
+## Classes
+
+| Class | Description |
+|---|---|
+| `ease-ripple-btn` | Base class — required |
+| `ease-ripple-btn--secondary` | Purple variant |
+| `ease-ripple-btn--success` | Green variant |
+| `ease-ripple-btn--danger` | Red variant |
+| `ease-ripple-btn--ghost` | Outline/ghost variant |
+| `ease-ripple-btn--sm` | Small size |
+| `ease-ripple-btn--lg` | Large size |
+
+## Implementation notes
+
+- Ripple uses `::after` pseudo-element scaled via `:active` — zero JS
+- Respects `prefers-reduced-motion` (transition durations collapse to near-zero via the framework's global media query in `easemotion.css`)
+- Design tokens mirror EaseMotion's `--ease-color-*`, `--ease-speed-*`, and `--ease-ease` variables
+- `overflow: hidden` on the button clips the ripple to the button's border-radius

--- a/submissions/examples/ripple-press-ak/demo.html
+++ b/submissions/examples/ripple-press-ak/demo.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ripple Press Button — EaseMotion CSS</title>
+  <meta name="description" content="CSS-only ripple press effect using the ease-ripple-btn class. No JavaScript required." />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <h1>✦ Ripple Press Effect</h1>
+  <p class="subtitle">Pure CSS · No JavaScript · Click any button to see the ripple</p>
+
+  <!-- Row 1: Sizes -->
+  <div class="demo-row">
+    <div style="display:flex;flex-direction:column;align-items:center;gap:0.5rem">
+      <button class="ease-ripple-btn ease-ripple-btn--sm">Small</button>
+      <span class="btn-label">--sm</span>
+    </div>
+
+    <div style="display:flex;flex-direction:column;align-items:center;gap:0.5rem">
+      <button class="ease-ripple-btn">Default</button>
+      <span class="btn-label">default</span>
+    </div>
+
+    <div style="display:flex;flex-direction:column;align-items:center;gap:0.5rem">
+      <button class="ease-ripple-btn ease-ripple-btn--lg">Large</button>
+      <span class="btn-label">--lg</span>
+    </div>
+  </div>
+
+  <!-- Row 2: Colours -->
+  <div class="demo-row">
+    <div style="display:flex;flex-direction:column;align-items:center;gap:0.5rem">
+      <button class="ease-ripple-btn">Primary</button>
+      <span class="btn-label">primary</span>
+    </div>
+
+    <div style="display:flex;flex-direction:column;align-items:center;gap:0.5rem">
+      <button class="ease-ripple-btn ease-ripple-btn--secondary">Secondary</button>
+      <span class="btn-label">--secondary</span>
+    </div>
+
+    <div style="display:flex;flex-direction:column;align-items:center;gap:0.5rem">
+      <button class="ease-ripple-btn ease-ripple-btn--success">Success</button>
+      <span class="btn-label">--success</span>
+    </div>
+
+    <div style="display:flex;flex-direction:column;align-items:center;gap:0.5rem">
+      <button class="ease-ripple-btn ease-ripple-btn--danger">Danger</button>
+      <span class="btn-label">--danger</span>
+    </div>
+
+    <div style="display:flex;flex-direction:column;align-items:center;gap:0.5rem">
+      <button class="ease-ripple-btn ease-ripple-btn--ghost">Ghost</button>
+      <span class="btn-label">--ghost</span>
+    </div>
+  </div>
+
+  <!-- Row 3: As anchor tag -->
+  <div class="demo-row">
+    <div style="display:flex;flex-direction:column;align-items:center;gap:0.5rem">
+      <a href="#" class="ease-ripple-btn">Works on &lt;a&gt; too</a>
+      <span class="btn-label">anchor tag</span>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ripple-press-ak/style.css
+++ b/submissions/examples/ripple-press-ak/style.css
@@ -1,0 +1,210 @@
+/* ============================================================
+   ripple-press-ak — CSS-only Ripple Press Effect
+   Author: akhilmodi29 (ak)
+   Track: Standard (HTML/CSS)
+   ============================================================ */
+
+/* ── Base Reset ──────────────────────────────────────────── */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+/* ── Design Tokens (mirrors EaseMotion variables) ────────── */
+:root {
+  --ease-color-primary:      #6c63ff;
+  --ease-color-primary-dark: #4b44cc;
+  --ease-color-secondary:    #8b5cf6;
+  --ease-speed-fast:         150ms;
+  --ease-speed-medium:       300ms;
+  --ease-ease:               cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-ease-out:           cubic-bezier(0, 0, 0.2, 1);
+  --ease-radius-full:        9999px;
+}
+
+/* ── Page Shell ──────────────────────────────────────────── */
+body {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2.5rem;
+  background: #0f0e17;
+  font-family: system-ui, sans-serif;
+  padding: 3rem 1rem;
+}
+
+h1 {
+  color: #fff;
+  font-size: 1.5rem;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  text-align: center;
+}
+
+p.subtitle {
+  color: rgba(255, 255, 255, 0.45);
+  font-size: 0.875rem;
+  text-align: center;
+  margin-top: -1.5rem;
+}
+
+.demo-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  align-items: center;
+  justify-content: center;
+}
+
+/* ── .ease-ripple-btn — the reusable class ───────────────── */
+.ease-ripple-btn {
+  position: relative;
+  overflow: hidden;
+
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+
+  padding: 0.75rem 1.75rem;
+  border: none;
+  border-radius: var(--ease-radius-full);
+  cursor: pointer;
+
+  font-size: 0.9375rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  text-decoration: none;
+
+  /* default colour — override with modifier classes */
+  background: var(--ease-color-primary);
+  color: #fff;
+
+  transition:
+    transform       var(--ease-speed-fast)   var(--ease-ease),
+    box-shadow      var(--ease-speed-medium) var(--ease-ease),
+    background      var(--ease-speed-medium) var(--ease-ease);
+}
+
+/* Ripple pseudo-element — scales from center on :active */
+.ease-ripple-btn::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  margin: auto;
+
+  /* start as a tiny circle */
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+
+  background: rgba(255, 255, 255, 0.35);
+
+  /* idle: invisible, not scaled */
+  opacity: 0;
+  transform: scale(0);
+
+  transition:
+    transform var(--ease-speed-medium) var(--ease-ease-out),
+    opacity   var(--ease-speed-fast)   var(--ease-ease);
+}
+
+/* Trigger ripple on press */
+.ease-ripple-btn:active::after {
+  /* expand to cover the whole button (button is ~300px wide max → 150× scale) */
+  transform: scale(150);
+  opacity: 1;
+
+  transition:
+    transform 0.45s   var(--ease-ease-out),
+    opacity   0.01ms  var(--ease-ease);
+}
+
+/* Press-down feedback */
+.ease-ripple-btn:active {
+  transform: scale(0.96);
+}
+
+/* Hover lift */
+.ease-ripple-btn:hover {
+  box-shadow: 0 8px 24px rgba(108, 99, 255, 0.35);
+  transform: translateY(-2px);
+}
+
+.ease-ripple-btn:hover:active {
+  transform: scale(0.96);
+}
+
+/* Focus ring for keyboard users */
+.ease-ripple-btn:focus-visible {
+  outline: 2px solid var(--ease-color-primary);
+  outline-offset: 3px;
+}
+
+/* ── Colour Modifiers ────────────────────────────────────── */
+
+/* Secondary (purple) */
+.ease-ripple-btn--secondary {
+  background: var(--ease-color-secondary);
+}
+.ease-ripple-btn--secondary:hover {
+  box-shadow: 0 8px 24px rgba(139, 92, 246, 0.35);
+}
+
+/* Success (green) */
+.ease-ripple-btn--success {
+  background: #15803d;
+}
+.ease-ripple-btn--success::after {
+  background: rgba(255, 255, 255, 0.3);
+}
+.ease-ripple-btn--success:hover {
+  box-shadow: 0 8px 24px rgba(21, 128, 61, 0.4);
+}
+
+/* Danger (red) */
+.ease-ripple-btn--danger {
+  background: #b91c1c;
+}
+.ease-ripple-btn--danger:hover {
+  box-shadow: 0 8px 24px rgba(185, 28, 28, 0.4);
+}
+
+/* Ghost (outline) */
+.ease-ripple-btn--ghost {
+  background: transparent;
+  border: 1.5px solid rgba(108, 99, 255, 0.5);
+  color: #a09af8;
+}
+.ease-ripple-btn--ghost::after {
+  background: rgba(108, 99, 255, 0.15);
+}
+.ease-ripple-btn--ghost:hover {
+  background: rgba(108, 99, 255, 0.08);
+  border-color: var(--ease-color-primary);
+  box-shadow: 0 8px 24px rgba(108, 99, 255, 0.2);
+}
+
+/* ── Size Modifiers ──────────────────────────────────────── */
+.ease-ripple-btn--sm {
+  padding: 0.5rem 1.1rem;
+  font-size: 0.8125rem;
+}
+
+.ease-ripple-btn--lg {
+  padding: 1rem 2.25rem;
+  font-size: 1.0625rem;
+}
+
+/* ── Label below each button ─────────────────────────────── */
+.btn-label {
+  color: rgba(255, 255, 255, 0.3);
+  font-size: 0.75rem;
+  text-align: center;
+  margin-top: -0.5rem;
+}


### PR DESCRIPTION
## What
Adds a pure CSS ripple press animation via `.ease-ripple-btn` class.
No JavaScript. Works on <button> and <a> elements.

## How to review
Open `submissions/examples/ripple-press-ak/demo.html` directly in browser and click any button.

## Checklist
- [x] Files only under submissions/examples/ripple-press-ak/
- [x] demo.html opens without a server
- [x] No CDN links or external JS
- [x] Naming includes unique suffix -ak