### PR TITLE
Add ease-seismograph-readout component

### DIFF
--- a/submissions/examples/seismograph-readout-ij/README.md
+++ b/submissions/examples/seismograph-readout-ij/README.md
@@ -1,0 +1,11 @@
+# ease-seismograph-readout
+
+A seismograph where the trace draws, the drum spins, and the magnitude spikes pulse.
+
+## Run
+Open `demo.html` directly in a browser to watch the drum record.
+
+## Notes
+- The trace line scrolls across the drum.
+- The drum cap rotates with the reel.
+- Magnitude spikes pump in the strip.

--- a/submissions/examples/seismograph-readout-ij/demo.html
+++ b/submissions/examples/seismograph-readout-ij/demo.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-seismograph-readout</title>
+</head>
+<body>
+<main class="sgs-card">
+  <header class="sgs-head">
+    <h1 class="sgs-title">Seismograph</h1>
+    <span class="sgs-station">SMO-01</span>
+  </header>
+  <section class="sgs-stage" aria-label="seismic drum">
+    <span class="sgs-grid-v"></span>
+    <span class="sgs-grid-h"></span>
+    <div class="sgs-trace"><span class="sgs-line"></span></div>
+    <span class="sgs-pen"></span>
+    <span class="sgs-drum"></span>
+  </section>
+  <div class="sgs-readout">
+    <span class="sgs-label">Magnitude</span>
+    <strong class="sgs-mag">4.2</strong>
+  </div>
+  <section class="sgs-strip" aria-label="magnitude strip">
+    <span class="sgs-spike sgs-spike-1"></span>
+    <span class="sgs-spike sgs-spike-2"></span>
+    <span class="sgs-spike sgs-spike-3"></span>
+  </section>
+  <footer class="sgs-foot">
+    <span class="sgs-time">14:32:08 UTC</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/seismograph-readout-ij/style.css
+++ b/submissions/examples/seismograph-readout-ij/style.css
@@ -1,0 +1,26 @@
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0;font-weight:inherit}
+body{min-height:100vh;display:flex;align-items:center;justify-content:center;background:#0f1217;font-family:'Courier New',monospace}
+.sgs-card{width:470px;border-radius:14px;padding:20px;background:linear-gradient(160deg,#1c2129,#10141b);color:#dce4ef;box-shadow:0 18px 44px rgba(0,0,0,.6)}
+.sgs-head{display:flex;justify-content:space-between;align-items:center;margin-bottom:14px}
+.sgs-title{font-size:16px;letter-spacing:3px;color:#aeb9c7}
+.sgs-station{font-size:12px;color:#6ee7a0}
+.sgs-stage{position:relative;height:150px;margin-bottom:12px;background:#0b0e13;border-radius:8px;overflow:hidden;border:1px solid #2a313c}
+.sgs-grid-v{position:absolute;top:0;bottom:0;left:25%;border-left:1px dashed #26303d}
+.sgs-grid-h{position:absolute;top:0;bottom:0;left:50%;border-left:1px dashed #26303d}
+.sgs-trace{position:absolute;top:0;left:0;right:0;bottom:0;overflow:hidden}
+.sgs-line{position:absolute;left:0;top:60px;width:200%;height:3px;background:repeating-linear-gradient(90deg,#6ee7a0 0 18px,transparent 18px 22px,#6ee7a0 22px 46px,transparent 46px 52px,#6ee7a0 52px 74px,transparent 74px 120px,#6ee7a0 120px 140px,transparent 140px 200px,#6ee7a0 200px 230px,transparent 230px 300px);animation:sgs-trace-draw-seismograph-readout 4s linear infinite}
+@keyframes sgs-trace-draw-seismograph-readout{from{transform:translateX(0)}to{transform:translateX(-150px)}}
+.sgs-pen{position:absolute;left:58%;top:52px;width:3px;height:18px;background:#ffd166;border-radius:2px}
+.sgs-drum{position:absolute;right:12px;top:12px;width:34px;height:34px;border:4px solid #38424f;border-radius:50%;border-top-color:#6ee7a0;animation:sgs-drum-rotate-seismograph-readout 1.4s linear infinite}
+@keyframes sgs-drum-rotate-seismograph-readout{to{transform:rotate(360deg)}}
+.sgs-readout{display:flex;align-items:baseline;justify-content:space-between;margin-bottom:10px}
+.sgs-label{font-size:12px;color:#9aa7b5}
+.sgs-mag{font-size:30px;color:#ffd166}
+.sgs-strip{display:flex;align-items:flex-end;gap:6px;height:44px;margin-bottom:12px}
+.sgs-spike{flex:1;background:linear-gradient(180deg,#6ee7a0,#1f7a4d);border-radius:2px 2px 0 0;animation:sgs-spike-pulse-seismograph-readout .9s ease-in-out infinite}
+@keyframes sgs-spike-pulse-seismograph-readout{0%,100%{transform:scaleY(1)}50%{transform:scaleY(.6)}}
+.sgs-spike-1{height:22%;animation-delay:.1s}
+.sgs-spike-2{height:74%;animation-delay:.3s}
+.sgs-spike-3{height:38%;animation-delay:.5s}
+.sgs-foot{display:flex;justify-content:flex-end;border-top:1px solid #232a34;padding-top:8px}
+.sgs-time{font-size:11px;color:#7c8a99}


### PR DESCRIPTION
## Component: ease-seismograph-readout — trace draws, drum spins, and spikes pulse

**Closes #72769**

### What this adds
A seismograph readout where the trace draws, the drum spins, and the magnitude spikes pulse.

### Acceptance Criteria covered
- Trace line draws
- Drum spins
- Spikes pulse

### Files
- `submissions/examples/seismograph-readout-ij/demo.html`
- `submissions/examples/seismograph-readout-ij/style.css`
- `submissions/examples/seismograph-readout-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the trace draw, the drum spin, and the spikes pulse.