### PR TITLE
fix: load easemotion.css entry point in demo.html

### DIFF
--- a/examples/demo.html
+++ b/examples/demo.html
@@ -21,15 +21,8 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
 
-  <!-- EaseMotion CSS -->
-  <link rel="stylesheet" href="../core/variables.css" />
-  <link rel="stylesheet" href="../core/base.css" />
-  <link rel="stylesheet" href="../core/animations.css" />
-  <link rel="stylesheet" href="../core/utilities.css" />
-  <link rel="stylesheet" href="../components/buttons.css" />
-  <link rel="stylesheet" href="../components/cards.css" />
-  <link rel="stylesheet" href="../components/navbar.css" />
-  <link rel="stylesheet" href="../components/scroll-progress.css" />
+  <!-- EaseMotion CSS — single entry point preserves @layer order -->
+  <link rel="stylesheet" href="../easemotion.css" />
 
   <style>
     /* ── Theme Definitions ────────────────────────────────── */


### PR DESCRIPTION
## Problem
demo.html loaded 8 individual CSS files, bypassing easemotion.css.
This broke the @layer cascade ordering and left 22+ components unloaded.

## Fix
Replaced all individual imports with a single `../easemotion.css` link,
restoring correct layer ordering and full component coverage.

## Testing
Open examples/demo.html in browser — all buttons, cards, navbar,
and scroll-progress should render correctly with no console errors.