### PR TITLE
feat: add ease-glitch-text — CSS-only glitch text animation (glitch-text-ak)

### DIFF
--- a/submissions/examples/glitch-text-ak/README.md
+++ b/submissions/examples/glitch-text-ak/README.md
@@ -1,0 +1,17 @@
+# glitch-text-ak
+
+CSS-only glitch/corrupt text animation. No JavaScript required.
+
+## How to use
+
+```html
+<!-- data-text must match the text content exactly -->
+<h1 class="ease-glitch-text" data-text="GLITCH">GLITCH</h1>
+
+<!-- Colour variants -->
+<h1 class="ease-glitch-text ease-glitch-text--fire"   data-text="FIRE">FIRE</h1>
+<h1 class="ease-glitch-text ease-glitch-text--matrix" data-text="MATRIX">MATRIX</h1>
+<h1 class="ease-glitch-text ease-glitch-text--mono"   data-text="MONO">MONO</h1>
+
+<!-- Hover only -->
+<h1 class="ease-glitch-text ease-glitch-text--hover"  data-text="HOVER">HOVER</h1>

--- a/submissions/examples/glitch-text-ak/demo.html
+++ b/submissions/examples/glitch-text-ak/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Glitch Text — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <p class="label">Default — cyan / magenta</p>
+  <h1 class="ease-glitch-text" data-text="GLITCH">GLITCH</h1>
+
+  <p class="label">--fire</p>
+  <h2 class="ease-glitch-text ease-glitch-text--fire" data-text="EASEFIRE">EASEFIRE</h2>
+
+  <p class="label">--matrix</p>
+  <h2 class="ease-glitch-text ease-glitch-text--matrix" data-text="MATRIX">MATRIX</h2>
+
+  <p class="label">--mono</p>
+  <h2 class="ease-glitch-text ease-glitch-text--mono" data-text="SYSTEM">SYSTEM</h2>
+
+  <p class="label">--hover (glitch only on hover)</p>
+  <h2 class="ease-glitch-text ease-glitch-text--hover" data-text="HOVER ME">HOVER ME</h2>
+
+</body>
+</html>

--- a/submissions/examples/glitch-text-ak/style.css
+++ b/submissions/examples/glitch-text-ak/style.css
@@ -1,0 +1,134 @@
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 3.5rem;
+  background: #0f0e17;
+  font-family: system-ui, sans-serif;
+  padding: 3rem 1.5rem;
+}
+
+.label {
+  color: rgba(255,255,255,0.25);
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  text-align: center;
+  margin-bottom: -2.5rem;
+}
+
+/* ── Keyframes ───────────────────────────────────────────── */
+@keyframes ease-glitch-clip {
+  0%,100% { clip-path: inset(0 0 98% 0); transform: translate(-4px, 0); }
+  20%      { clip-path: inset(30% 0 50% 0); transform: translate(4px, 0); }
+  40%      { clip-path: inset(60% 0 20% 0); transform: translate(-3px, 0); }
+  60%      { clip-path: inset(80% 0 5%  0); transform: translate(3px, 0); }
+  80%      { clip-path: inset(10% 0 70% 0); transform: translate(-4px, 0); }
+}
+
+@keyframes ease-glitch-clip2 {
+  0%,100% { clip-path: inset(50% 0 30% 0); transform: translate(4px, 0); }
+  25%      { clip-path: inset(10% 0 80% 0); transform: translate(-4px, 0); }
+  50%      { clip-path: inset(70% 0 10% 0); transform: translate(3px, 0); }
+  75%      { clip-path: inset(20% 0 60% 0); transform: translate(-3px, 0); }
+}
+
+@keyframes ease-glitch-shake {
+  0%,100% { transform: translate(0, 0); }
+  10%      { transform: translate(-2px, 1px); }
+  20%      { transform: translate(2px, -1px); }
+  30%      { transform: translate(-1px, 2px); }
+  40%      { transform: translate(1px, -2px); }
+  50%      { transform: translate(-2px, 0); }
+  60%      { transform: translate(2px, 1px); }
+  70%      { transform: translate(0, -1px); }
+  80%      { transform: translate(-1px, 0); }
+  90%      { transform: translate(1px, 1px); }
+}
+
+/* ── Base class ──────────────────────────────────────────── */
+.ease-glitch-text {
+  position: relative;
+  display: inline-block;
+  font-size: clamp(2.5rem, 7vw, 4.5rem);
+  font-weight: 900;
+  letter-spacing: -0.03em;
+  color: #fff;
+  text-transform: uppercase;
+  animation: ease-glitch-shake 3s infinite;
+}
+
+/* Cyan ghost — before */
+.ease-glitch-text::before {
+  content: attr(data-text);
+  position: absolute;
+  inset: 0;
+  color: #0ff;
+  animation: ease-glitch-clip 2.5s infinite linear;
+  opacity: 0.8;
+}
+
+/* Magenta ghost — after */
+.ease-glitch-text::after {
+  content: attr(data-text);
+  position: absolute;
+  inset: 0;
+  color: #f0f;
+  animation: ease-glitch-clip2 2s infinite linear;
+  opacity: 0.8;
+}
+
+/* ── Colour variants ─────────────────────────────────────── */
+
+/* Red/Yellow */
+.ease-glitch-text--fire::before { color: #ff4500; }
+.ease-glitch-text--fire::after  { color: #ffd700; }
+
+/* Green/Blue (matrix) */
+.ease-glitch-text--matrix { color: #0f0; }
+.ease-glitch-text--matrix::before { color: #0ff; }
+.ease-glitch-text--matrix::after  { color: #00f; }
+
+/* White/Grey (mono) */
+.ease-glitch-text--mono { color: #e2e8f0; }
+.ease-glitch-text--mono::before { color: #94a3b8; opacity: 0.5; }
+.ease-glitch-text--mono::after  { color: #fff; opacity: 0.5; }
+
+/* ── Speed modifiers ─────────────────────────────────────── */
+.ease-glitch-text--fast::before { animation-duration: 1s; }
+.ease-glitch-text--fast::after  { animation-duration: 0.8s; }
+.ease-glitch-text--fast         { animation-duration: 1.5s; }
+
+.ease-glitch-text--slow::before { animation-duration: 5s; }
+.ease-glitch-text--slow::after  { animation-duration: 4s; }
+.ease-glitch-text--slow         { animation-duration: 6s; }
+
+/* ── Hover-only variant ──────────────────────────────────── */
+.ease-glitch-text--hover::before,
+.ease-glitch-text--hover::after {
+  animation: none;
+}
+.ease-glitch-text--hover { animation: none; }
+
+.ease-glitch-text--hover:hover {
+  animation: ease-glitch-shake 0.4s infinite;
+}
+.ease-glitch-text--hover:hover::before {
+  animation: ease-glitch-clip 0.5s infinite linear;
+}
+.ease-glitch-text--hover:hover::after {
+  animation: ease-glitch-clip2 0.4s infinite linear;
+}
+
+/* ── Reduced motion ──────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-glitch-text,
+  .ease-glitch-text::before,
+  .ease-glitch-text::after {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## What
CSS-only chromatic aberration glitch effect for text using
clip-path animation on ::before and ::after pseudo-elements.
Colour variants + hover-only mode. Zero JS.

## How to review
Open submissions/examples/glitch-text-ak/demo.html in browser.

## Checklist
- [x] Only files under submissions/examples/glitch-text-ak/
- [x] demo.html works without a server
- [x] No CDN or external JS
- [x] Unique suffix -ak