### PR TITLE
feat: add pendulum loader example

### DIFF
--- a/submissions/examples/pendulum-loader-vk/README.md
+++ b/submissions/examples/pendulum-loader-vk/README.md
@@ -1,0 +1,235 @@
+# CSS Pendulum Loader
+
+A pure CSS Newton's cradle-inspired loading animation where the two end balls swing outward and return continuously around three stationary balls in the middle.
+
+## Features
+
+- Pure HTML and CSS
+- No JavaScript
+- Newton's cradle-inspired pendulum animation
+- Two alternating swinging end balls
+- Three stationary middle balls
+- Smooth continuous motion
+- Small and large size variants
+- Customizable ball size and swing angle
+- Responsive design
+- Accessible loading status
+- `prefers-reduced-motion` support
+
+## Usage
+
+Include the stylesheet:
+
+```html
+<link rel="stylesheet" href="style.css">
+```
+
+Then add the loader markup:
+
+```html
+<div
+    class="cradle-loader"
+    role="status"
+    aria-live="polite"
+    aria-label="Loading, please wait"
+>
+    <span class="cradle-rail"></span>
+
+    <span class="cradle-ball cradle-ball--end-left"></span>
+
+    <span class="cradle-ball"></span>
+
+    <span class="cradle-ball"></span>
+
+    <span class="cradle-ball"></span>
+
+    <span class="cradle-ball cradle-ball--end-right"></span>
+
+    <span class="visually-hidden">
+        Loading…
+    </span>
+</div>
+```
+
+Place the loader inside your desired container.
+
+## Size Variants
+
+A smaller version can be created using:
+
+```html
+<div class="cradle-loader cradle-loader--sm">
+    ...
+</div>
+```
+
+A larger version can be created using:
+
+```html
+<div class="cradle-loader cradle-loader--lg">
+    ...
+</div>
+```
+
+## Customization
+
+Change the ball size:
+
+```css
+.cradle-loader {
+    --ball-d: clamp(1.5rem, 4vw, 2.1rem);
+}
+```
+
+Change the swing angle:
+
+```css
+.cradle-loader {
+    --swing-angle: 42deg;
+}
+```
+
+Change the animation speed:
+
+```css
+.cradle-loader {
+    --duration: 1.8s;
+}
+```
+
+Change the rail appearance:
+
+```css
+.cradle-loader {
+    --rail-color: linear-gradient(180deg, #94a3b8, #475569);
+}
+```
+
+Change the string color:
+
+```css
+.cradle-loader {
+    --string-color: rgba(148, 163, 184, 0.85);
+}
+```
+
+## How It Works
+
+Each pendulum is represented by a `.cradle-ball` element containing a CSS-generated string and ball.
+
+The pendulum uses:
+
+```css
+transform-origin: top center;
+```
+
+so the rotation occurs from the top of the string, creating a realistic hanging-pendulum motion.
+
+The two end balls use separate keyframe animations:
+
+```css
+.cradle-ball--end-left {
+    animation: cradle-swing-left var(--duration) ease-in-out infinite;
+}
+
+.cradle-ball--end-right {
+    animation:
+        cradle-swing-right
+        var(--duration)
+        ease-in-out
+        infinite;
+    animation-delay: calc(var(--duration) * -0.5);
+}
+```
+
+The half-duration animation delay causes the two end balls to swing in alternating phases.
+
+The three middle balls remain stationary, creating the visual effect of a Newton's cradle.
+
+No JavaScript or external libraries are required.
+
+## Accessibility
+
+The loader uses:
+
+```html
+role="status"
+aria-live="polite"
+aria-label="Loading, please wait"
+```
+
+This communicates the loading state to assistive technologies.
+
+The visible animation is decorative, while the visually hidden text provides additional loading information.
+
+The visually hidden text uses:
+
+```css
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+```
+
+## Reduced Motion
+
+When `prefers-reduced-motion: reduce` is enabled, the swinging animation is replaced with a subtle brightness pulse on the end balls.
+
+```css
+@media (prefers-reduced-motion: reduce) {
+    .cradle-ball--end-left,
+    .cradle-ball--end-right {
+        animation: cradle-pulse 1.6s ease-in-out infinite;
+        transform: rotate(0deg);
+    }
+}
+```
+
+This preserves the loading-state feedback while reducing large positional movement.
+
+## Demo
+
+Open `demo.html` directly in a browser.
+
+No server or JavaScript is required.
+
+The demo includes:
+
+- Default loader
+- Small loader variant
+- Large loader variant
+
+## Browser Testing
+
+- Microsoft Edge
+
+## Why It Fits EaseMotion CSS
+
+This example demonstrates how CSS transforms, keyframes, transform origins, pseudo-elements, gradients, custom properties, and animation delays can create a physics-inspired loading animation without JavaScript.
+
+The component can be used for:
+
+- Loading screens
+- Data fetching states
+- Progress indicators
+- Dashboard interfaces
+- Web applications
+- Minimal UI designs
+- Interactive loading states
+
+## Files
+
+- `demo.html` — Demo page with loader variants
+- `style.css` — Pendulum styling, animation, and responsive behavior
+- `README.md` — Documentation
+
+## License
+
+This example is part of the EaseMotion CSS project.

--- a/submissions/examples/pendulum-loader-vk/demo.html
+++ b/submissions/examples/pendulum-loader-vk/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>CSS Pendulum Loader — Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="demo-page">
+    <h1>CSS Pendulum Loader</h1>
+    <p>A pure-CSS Newton's cradle: the two end balls swing and appear to pass momentum through the still balls in the middle — used as a loading indicator.</p>
+
+    <section class="demo-stage demo-stage--dark">
+      <div class="cradle-loader" role="status" aria-live="polite" aria-label="Loading, please wait">
+        <span class="cradle-rail"></span>
+        <span class="cradle-ball cradle-ball--end-left"></span>
+        <span class="cradle-ball"></span>
+        <span class="cradle-ball"></span>
+        <span class="cradle-ball"></span>
+        <span class="cradle-ball cradle-ball--end-right"></span>
+        <span class="visually-hidden">Loading…</span>
+      </div>
+    </section>
+
+    <section class="demo-stage demo-stage--row">
+      <div class="cradle-loader cradle-loader--sm" role="status" aria-live="polite" aria-label="Loading, please wait">
+        <span class="cradle-rail"></span>
+        <span class="cradle-ball cradle-ball--end-left"></span>
+        <span class="cradle-ball"></span>
+        <span class="cradle-ball"></span>
+        <span class="cradle-ball"></span>
+        <span class="cradle-ball cradle-ball--end-right"></span>
+        <span class="visually-hidden">Loading…</span>
+      </div>
+
+      <div class="cradle-loader cradle-loader--lg" role="status" aria-live="polite" aria-label="Loading, please wait">
+        <span class="cradle-rail"></span>
+        <span class="cradle-ball cradle-ball--end-left"></span>
+        <span class="cradle-ball"></span>
+        <span class="cradle-ball"></span>
+        <span class="cradle-ball"></span>
+        <span class="cradle-ball cradle-ball--end-right"></span>
+        <span class="visually-hidden">Loading…</span>
+      </div>
+    </section>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/pendulum-loader-vk/style.css
+++ b/submissions/examples/pendulum-loader-vk/style.css
@@ -1,0 +1,166 @@
+/* =========================================================
+   CSS Pendulum Loader — Newton's Cradle
+   Pure CSS, no JS. The two end balls swing OUTWARD from rest
+   and fall back in, appearing to pass momentum through the
+   three still balls in between.
+   ========================================================= */
+
+* { box-sizing: border-box; }
+
+/* ---------- demo page chrome (not required for integration) ---------- */
+
+.demo-page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 3rem 1.5rem;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #1e293b;
+  background: #f8fafc;
+  text-align: center;
+}
+
+.demo-page p { max-width: 34rem; color: #475569; margin-bottom: 1rem; }
+
+.demo-stage {
+  width: 100%;
+  max-width: 40rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4rem;
+  padding: 3.5rem 1.5rem;
+  border-radius: 1rem;
+}
+
+.demo-stage--dark {
+  background: radial-gradient(circle at 50% 0%, #1e293b, #0f172a 70%);
+}
+
+.demo-stage--row { background: #eef2f7; flex-wrap: wrap; }
+
+/* ---------- component ---------- */
+
+.cradle-loader {
+  --ball-d: clamp(1.5rem, 4vw, 2.1rem);
+  --string-len: calc(var(--ball-d) * 2.3);
+  --swing-angle: 42deg;
+  --duration: 1.8s;
+  --rail-color: linear-gradient(180deg, #94a3b8, #475569);
+  --string-color: rgba(148, 163, 184, 0.85);
+  --ball-highlight: #f8fafc;
+  --ball-mid: #cbd5e1;
+  --ball-shade: #64748b;
+
+  position: relative;
+  display: flex;
+  width: calc(var(--ball-d) * 5);
+  height: calc(var(--string-len) + var(--ball-d));
+  margin: 0 auto;
+}
+
+.cradle-loader--sm { --ball-d: clamp(1rem, 3vw, 1.4rem); }
+.cradle-loader--lg { --ball-d: clamp(2.2rem, 6vw, 3rem); }
+
+/* supporting rail the strings hang from */
+.cradle-rail {
+  position: absolute;
+  top: 0;
+  left: -2%;
+  width: 104%;
+  height: calc(var(--ball-d) * 0.14);
+  min-height: 2px;
+  background: var(--rail-color);
+  border-radius: 999px;
+  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.35);
+}
+
+/* each string + ball unit; rotation pivots at the top, i.e. the rail */
+.cradle-ball {
+  position: relative;
+  width: var(--ball-d);
+  height: 100%;
+  transform-origin: top center;
+}
+
+.cradle-ball::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 1px;
+  height: calc(100% - var(--ball-d));
+  background: var(--string-color);
+  transform: translateX(-50%);
+}
+
+.cradle-ball::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: var(--ball-d);
+  height: var(--ball-d);
+  border-radius: 50%;
+  transform: translateX(-50%);
+  background: radial-gradient(circle at 32% 28%, var(--ball-highlight), var(--ball-mid) 55%, var(--ball-shade) 100%);
+  box-shadow:
+    inset -2px -3px 4px rgba(15, 23, 42, 0.35),
+    0 3px 6px rgba(15, 23, 42, 0.3);
+}
+
+/* the two end balls do the swinging; the middle three stay put.
+   NOTE ON DIRECTION: CSS rotate() on a downward-hanging pendulum
+   is left-handed — positive (clockwise) angles swing it to the
+   LEFT, negative angles swing it to the RIGHT. So the LEFT ball
+   (which needs to swing further left, outward) uses a POSITIVE
+   angle, and the RIGHT ball uses a NEGATIVE angle. */
+.cradle-ball--end-left {
+  animation: cradle-swing-left var(--duration) ease-in-out infinite;
+}
+
+.cradle-ball--end-right {
+  animation: cradle-swing-right var(--duration) ease-in-out infinite;
+  animation-delay: calc(var(--duration) * -0.5);
+}
+
+@keyframes cradle-swing-left {
+  0%, 100% { transform: rotate(0deg); }                 /* resting against the stack */
+  50%      { transform: rotate(var(--swing-angle)); }   /* lifted outward, to the left */
+}
+
+@keyframes cradle-swing-right {
+  0%, 100% { transform: rotate(0deg); }                          /* resting against the stack */
+  50%      { transform: rotate(calc(var(--swing-angle) * -1)); } /* lifted outward, to the right */
+}
+
+/* screen-reader-only text, visually hidden but announced */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* respect users who've asked for less motion: swap the swing
+   for a gentle glow pulse on the end balls instead of freezing
+   outright, so the loading state is still communicated */
+@media (prefers-reduced-motion: reduce) {
+  .cradle-ball--end-left,
+  .cradle-ball--end-right {
+    animation: cradle-pulse 1.6s ease-in-out infinite;
+    transform: rotate(0deg);
+  }
+}
+
+@keyframes cradle-pulse {
+  0%, 100% { filter: brightness(1); }
+  50%      { filter: brightness(1.35); }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pure CSS Newton's cradle-inspired pendulum loader where the two end balls swing outward and return continuously around three stationary balls.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A pure CSS Newton's cradle-inspired loading animation featuring two alternating swinging end balls and three stationary balls in the middle.

**How does a developer use it?**

```html
<div
    class="cradle-loader"
    role="status"
    aria-live="polite"
    aria-label="Loading, please wait"
>
    <span class="cradle-rail"></span>

    <span class="cradle-ball cradle-ball--end-left"></span>

    <span class="cradle-ball"></span>
    <span class="cradle-ball"></span>
    <span class="cradle-ball"></span>

    <span class="cradle-ball cradle-ball--end-right"></span>

    <span class="visually-hidden">
        Loading…
    </span>
</div>
```

**Why does it fit EaseMotion CSS?**

It demonstrates how CSS transforms, keyframes, transform origins, animation delays, gradients, pseudo-elements, and custom properties can create a physics-inspired loading animation without JavaScript or external libraries.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Edge

---

## Notes for Maintainer

The implementation uses pure HTML and CSS with no JavaScript or external libraries. The two end pendulums swing in alternating phases while the three middle balls remain stationary to create a Newton's cradle-inspired loading effect.

The component includes small and large size variants, responsive sizing, accessible loading status markup, and `prefers-reduced-motion` support.

Closes #70675