### PR TITLE
feat: add CSS sold out overlay #70693

### DIFF
--- a/submissions/examples/r-sold-out-overlay-70693/README.md
+++ b/submissions/examples/r-sold-out-overlay-70693/README.md
@@ -1,0 +1,68 @@
+# CSS Sold Out Overlay
+
+A responsive pure CSS product card with an animated "SOLD OUT" overlay.
+
+## Issue
+
+#70693 — CSS Sold Out Overlay
+
+## Description
+
+This component demonstrates a product card that displays a prominent sold-out state using a CSS overlay.
+
+The overlay appears on hover and keyboard focus, adding a blurred dark layer and animated status badge without JavaScript.
+
+## Features
+
+- Pure HTML and CSS
+- No JavaScript
+- Animated sold-out overlay
+- CSS-created product illustration
+- Hover interaction
+- Keyboard focus support
+- Responsive design
+- Accessible button state
+- `prefers-reduced-motion` support
+- No external dependencies
+
+## Files
+
+- `demo.html` — Component markup
+- `style.css` — Component styles and animations
+- `README.md` — Documentation
+
+## How to Use
+
+Open `demo.html` in a modern browser.
+
+## Interaction
+
+Hover over the product card to reveal the sold-out overlay.
+
+The card also responds to keyboard focus.
+
+## Accessibility
+
+The product card includes an accessible description and the disabled purchase button communicates that the product is unavailable.
+
+The animation is reduced when the user has enabled reduced-motion preferences.
+
+## CSS Techniques
+
+- CSS gradients
+- Pseudo-elements
+- `backdrop-filter`
+- CSS transitions
+- CSS transforms
+- `box-shadow`
+- Responsive media queries
+- CSS custom properties
+- `prefers-reduced-motion`
+
+## Browser Support
+
+Works in modern browsers supporting standard CSS properties and animations.
+
+## Credits
+
+Created as a contribution to EaseMotion CSS for GSSoC 2026.

--- a/submissions/examples/r-sold-out-overlay-70693/demo.html
+++ b/submissions/examples/r-sold-out-overlay-70693/demo.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta
+    name="description"
+    content="CSS sold out overlay product card demonstration."
+  >
+  <title>CSS Sold Out Overlay</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <section class="demo" aria-labelledby="demo-title">
+      <p class="eyebrow">EASEMOTION CSS</p>
+      <h1 id="demo-title">Sold Out Overlay</h1>
+      <p class="intro">
+        A pure CSS product overlay for unavailable items.
+      </p>
+
+      <article class="product-card" aria-label="Urban Runner shoes, sold out">
+        <div class="product-image">
+          <div class="shoe" aria-hidden="true">
+            <span class="shoe-lace lace-1"></span>
+            <span class="shoe-lace lace-2"></span>
+            <span class="shoe-lace lace-3"></span>
+            <span class="shoe-lace lace-4"></span>
+          </div>
+
+          <div class="sold-out-overlay" aria-hidden="true">
+            <span class="sold-out-badge">SOLD OUT</span>
+          </div>
+        </div>
+
+        <div class="product-info">
+          <div>
+            <p class="product-category">Running Collection</p>
+            <h2>Urban Runner</h2>
+          </div>
+
+          <p class="price">$89</p>
+
+          <button
+            class="buy-button"
+            type="button"
+            disabled
+            aria-label="Urban Runner is sold out"
+          >
+            Sold Out
+          </button>
+        </div>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/r-sold-out-overlay-70693/style.css
+++ b/submissions/examples/r-sold-out-overlay-70693/style.css
@@ -1,0 +1,637 @@
+:root {
+  --bg: #080b12;
+  --card: #111827;
+  --card-light: #182235;
+  --text: #f8fafc;
+  --muted: #94a3b8;
+  --accent: #ff4d67;
+  --accent-dark: #d93650;
+  --white: #ffffff;
+  --border: rgba(255, 255, 255, 0.1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(
+      circle at 50% 0%,
+      rgba(255, 77, 103, 0.12),
+      transparent 34%
+    ),
+    var(--bg);
+}
+
+.page {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 48px 20px;
+}
+
+.demo {
+  width: min(100%, 460px);
+  text-align: center;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.2em;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 7vw, 3rem);
+  letter-spacing: -0.04em;
+}
+
+.intro {
+  margin: 12px auto 30px;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+/* Product card */
+
+.product-card {
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  background: var(--card);
+  text-align: left;
+  box-shadow:
+    0 25px 70px rgba(0, 0, 0, 0.4),
+    0 0 0 1px rgba(255, 255, 255, 0.02);
+  transition:
+    transform 300ms ease,
+    box-shadow 300ms ease;
+}
+
+.product-card:hover {
+  transform: translateY(-6px);
+  box-shadow:
+    0 32px 80px rgba(0, 0, 0, 0.5),
+    0 0 35px rgba(255, 77, 103, 0.08);
+}
+
+/* Image */
+
+.product-image {
+  position: relative;
+  min-height: 300px;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  background:
+    radial-gradient(
+      circle at 50% 40%,
+      rgba(255, 255, 255, 0.12),
+      transparent 35%
+    ),
+    linear-gradient(145deg, #243149, #0f172a);
+}
+
+/* Decorative shoe created with CSS */
+
+.shoe {
+  position: relative;
+  width: 245px;
+  height: 125px;
+  border-radius: 45% 55% 20% 25%;
+  transform: rotate(-7deg);
+  background:
+    linear-gradient(
+      165deg,
+      #f8fafc 0%,
+      #dbe4ef 50%,
+      #94a3b8 100%
+    );
+  box-shadow:
+    0 22px 25px rgba(0, 0, 0, 0.3),
+    inset -12px -10px 18px rgba(15, 23, 42, 0.2);
+}
+
+.shoe::before {
+  content: "";
+  position: absolute;
+  top: -28px;
+  left: 80px;
+  width: 105px;
+  height: 75px;
+  border-radius: 50% 60% 10% 30%;
+  background: linear-gradient(145deg, #f8fafc, #cbd5e1);
+  transform: rotate(8deg);
+}
+
+.shoe::after {
+  content: "";
+  position: absolute;
+  right: -8px;
+  bottom: 5px;
+  width: 205px;
+  height: 20px;
+  border-radius: 50%;
+  background: #334155;
+  box-shadow: inset 0 5px 0 rgba(255, 255, 255, 0.15);
+}
+
+.shoe-lace {
+  position: absolute;
+  z-index: 2;
+  left: 102px;
+  width: 65px;
+  height: 5px;
+  border-radius: 999px;
+  background: #64748b;
+  transform: rotate(10deg);
+}
+
+.lace-1 {
+  top: 32px;
+}
+
+.lace-2 {
+  top: 43px;
+}
+
+.lace-3 {
+  top: 54px;
+}
+
+.lace-4 {
+  top: 65px;
+}
+
+/* Sold out overlay */
+
+.sold-out-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 5;
+  display: grid;
+  place-items: center;
+  background:
+    linear-gradient(
+      135deg,
+      rgba(3, 7, 18, 0.48),
+      rgba(3, 7, 18, 0.76)
+    );
+  opacity: 0;
+  transition:
+    opacity 300ms ease,
+    backdrop-filter 300ms ease;
+  backdrop-filter: blur(0);
+}
+
+.product-card:hover .sold-out-overlay,
+.product-card:focus-within .sold-out-overlay {
+  opacity: 1;
+  backdrop-filter: blur(3px);
+}
+
+.sold-out-badge {
+  position: relative;
+  display: inline-block;
+  padding: 13px 25px;
+  color: var(--white);
+  border: 2px solid var(--accent);
+  border-radius: 8px;
+  background: rgba(217, 54, 80, 0.88);
+  box-shadow:
+    0 0 0 5px rgba(255, 77, 103, 0.1),
+    0 0 28px rgba(255, 77, 103, 0.35);
+  font-size: 1.05rem;
+  font-weight: 900;
+  letter-spacing: 0.15em;
+  transform: rotate(-8deg) scale(0.85);
+  transition: transform 350ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.product-card:hover .sold-out-badge,
+.product-card:focus-within .sold-out-badge {
+  transform: rotate(-8deg) scale(1);
+}
+
+/* Product details */
+
+.product-info {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 14px;
+  padding: 24px;
+}
+
+.product-category {
+  margin: 0 0 5px;
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.product-info h2 {
+  margin: 0;
+  font-size: 1.45rem;
+}
+
+.price {
+  margin: 0;
+  align-self: center;
+  color: var(--text);
+  font-size: 1.3rem;
+  font-weight: 800;
+}
+
+.buy-button {
+  grid-column: 1 / -1;
+  width: 100%;
+  min-height: 48px;
+  border: 0;
+  border-radius: 12px;
+  color: #94a3b8;
+  background: #273244;
+  font: inherit;
+  font-weight: 700;
+  cursor: not-allowed;
+  opacity: 0.75;
+}
+
+/* Keyboard accessibility */
+
+.product-card:focus-within {
+  outline: 3px solid rgba(255, 77, 103, 0.5);
+  outline-offset: 5px;
+}
+
+/* Responsive */
+
+@media (max-width: 520px) {
+  .page {
+    padding: 30px 16px;
+  }
+
+  .product-image {
+    min-height: 250px;
+  }
+
+  .shoe {
+    transform: scale(0.8) rotate(-7deg);
+  }
+
+  .product-info {
+    padding: 20px;
+  }
+}
+
+/* Reduced motion */
+
+@media (prefers-reduced-motion: reduce) {
+  .product-card,
+  .sold-out-overlay,
+  .sold-out-badge {
+    transition: none;
+  }
+
+  .product-card:hover {
+    transform: none;
+  }
+}:root {
+  --bg: #080b12;
+  --card: #111827;
+  --card-light: #182235;
+  --text: #f8fafc;
+  --muted: #94a3b8;
+  --accent: #ff4d67;
+  --accent-dark: #d93650;
+  --white: #ffffff;
+  --border: rgba(255, 255, 255, 0.1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(
+      circle at 50% 0%,
+      rgba(255, 77, 103, 0.12),
+      transparent 34%
+    ),
+    var(--bg);
+}
+
+.page {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 48px 20px;
+}
+
+.demo {
+  width: min(100%, 460px);
+  text-align: center;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.2em;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 7vw, 3rem);
+  letter-spacing: -0.04em;
+}
+
+.intro {
+  margin: 12px auto 30px;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+/* Product card */
+
+.product-card {
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  background: var(--card);
+  text-align: left;
+  box-shadow:
+    0 25px 70px rgba(0, 0, 0, 0.4),
+    0 0 0 1px rgba(255, 255, 255, 0.02);
+  transition:
+    transform 300ms ease,
+    box-shadow 300ms ease;
+}
+
+.product-card:hover {
+  transform: translateY(-6px);
+  box-shadow:
+    0 32px 80px rgba(0, 0, 0, 0.5),
+    0 0 35px rgba(255, 77, 103, 0.08);
+}
+
+/* Image */
+
+.product-image {
+  position: relative;
+  min-height: 300px;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  background:
+    radial-gradient(
+      circle at 50% 40%,
+      rgba(255, 255, 255, 0.12),
+      transparent 35%
+    ),
+    linear-gradient(145deg, #243149, #0f172a);
+}
+
+/* Decorative shoe created with CSS */
+
+.shoe {
+  position: relative;
+  width: 245px;
+  height: 125px;
+  border-radius: 45% 55% 20% 25%;
+  transform: rotate(-7deg);
+  background:
+    linear-gradient(
+      165deg,
+      #f8fafc 0%,
+      #dbe4ef 50%,
+      #94a3b8 100%
+    );
+  box-shadow:
+    0 22px 25px rgba(0, 0, 0, 0.3),
+    inset -12px -10px 18px rgba(15, 23, 42, 0.2);
+}
+
+.shoe::before {
+  content: "";
+  position: absolute;
+  top: -28px;
+  left: 80px;
+  width: 105px;
+  height: 75px;
+  border-radius: 50% 60% 10% 30%;
+  background: linear-gradient(145deg, #f8fafc, #cbd5e1);
+  transform: rotate(8deg);
+}
+
+.shoe::after {
+  content: "";
+  position: absolute;
+  right: -8px;
+  bottom: 5px;
+  width: 205px;
+  height: 20px;
+  border-radius: 50%;
+  background: #334155;
+  box-shadow: inset 0 5px 0 rgba(255, 255, 255, 0.15);
+}
+
+.shoe-lace {
+  position: absolute;
+  z-index: 2;
+  left: 102px;
+  width: 65px;
+  height: 5px;
+  border-radius: 999px;
+  background: #64748b;
+  transform: rotate(10deg);
+}
+
+.lace-1 {
+  top: 32px;
+}
+
+.lace-2 {
+  top: 43px;
+}
+
+.lace-3 {
+  top: 54px;
+}
+
+.lace-4 {
+  top: 65px;
+}
+
+/* Sold out overlay */
+
+.sold-out-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 5;
+  display: grid;
+  place-items: center;
+  background:
+    linear-gradient(
+      135deg,
+      rgba(3, 7, 18, 0.48),
+      rgba(3, 7, 18, 0.76)
+    );
+  opacity: 0;
+  transition:
+    opacity 300ms ease,
+    backdrop-filter 300ms ease;
+  backdrop-filter: blur(0);
+}
+
+.product-card:hover .sold-out-overlay,
+.product-card:focus-within .sold-out-overlay {
+  opacity: 1;
+  backdrop-filter: blur(3px);
+}
+
+.sold-out-badge {
+  position: relative;
+  display: inline-block;
+  padding: 13px 25px;
+  color: var(--white);
+  border: 2px solid var(--accent);
+  border-radius: 8px;
+  background: rgba(217, 54, 80, 0.88);
+  box-shadow:
+    0 0 0 5px rgba(255, 77, 103, 0.1),
+    0 0 28px rgba(255, 77, 103, 0.35);
+  font-size: 1.05rem;
+  font-weight: 900;
+  letter-spacing: 0.15em;
+  transform: rotate(-8deg) scale(0.85);
+  transition: transform 350ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.product-card:hover .sold-out-badge,
+.product-card:focus-within .sold-out-badge {
+  transform: rotate(-8deg) scale(1);
+}
+
+/* Product details */
+
+.product-info {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 14px;
+  padding: 24px;
+}
+
+.product-category {
+  margin: 0 0 5px;
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.product-info h2 {
+  margin: 0;
+  font-size: 1.45rem;
+}
+
+.price {
+  margin: 0;
+  align-self: center;
+  color: var(--text);
+  font-size: 1.3rem;
+  font-weight: 800;
+}
+
+.buy-button {
+  grid-column: 1 / -1;
+  width: 100%;
+  min-height: 48px;
+  border: 0;
+  border-radius: 12px;
+  color: #94a3b8;
+  background: #273244;
+  font: inherit;
+  font-weight: 700;
+  cursor: not-allowed;
+  opacity: 0.75;
+}
+
+/* Keyboard accessibility */
+
+.product-card:focus-within {
+  outline: 3px solid rgba(255, 77, 103, 0.5);
+  outline-offset: 5px;
+}
+
+/* Responsive */
+
+@media (max-width: 520px) {
+  .page {
+    padding: 30px 16px;
+  }
+
+  .product-image {
+    min-height: 250px;
+  }
+
+  .shoe {
+    transform: scale(0.8) rotate(-7deg);
+  }
+
+  .product-info {
+    padding: 20px;
+  }
+}
+
+/* Reduced motion */
+
+@media (prefers-reduced-motion: reduce) {
+  .product-card,
+  .sold-out-overlay,
+  .sold-out-badge {
+    transition: none;
+  }
+
+  .product-card:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Description

Implemented the CSS Sold Out Overlay component for issue #70693.

### Changes

* Added a responsive product card.
* Added a pure CSS sold-out overlay.
* Added hover and keyboard-focus interactions.
* Added an animated `SOLD OUT` badge.
* Added a CSS-created product illustration.
* Added accessible disabled purchase state.
* Added responsive styling.
* Added `prefers-reduced-motion` support.
* Added the required documentation.

### Files Added

* `submissions/examples/r-sold-out-overlay-70693/demo.html`
* `submissions/examples/r-sold-out-overlay-70693/style.css`
* `submissions/examples/r-sold-out-overlay-70693/README.md`

### Issue

Closes #70693
