### PR TITLE
Add ease-drone-hud-display component

### DIFF
--- a/submissions/examples/drone-hud-display-ij/README.md
+++ b/submissions/examples/drone-hud-display-ij/README.md
@@ -1,0 +1,11 @@
+# ease-drone-hud-display
+
+A drone HUD display where the retical pulses, the altitude readout ticks, and the horizon levels.
+
+## Run
+Open `demo.html` directly in a browser to watch the HUD.
+
+## Notes
+- The retical breathes around the center.
+- The altitude value blinks on a rhythm.
+- The horizon strip stays level on screen.

--- a/submissions/examples/drone-hud-display-ij/demo.html
+++ b/submissions/examples/drone-hud-display-ij/demo.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-drone-hud-display</title>
+</head>
+<body>
+<main class="dhd-card">
+  <header class="dhd-head">
+    <h1 class="dhd-title">Drone HUD</h1>
+    <span class="dhd-gps">GPS LOCK</span>
+  </header>
+  <section class="dhd-view" aria-label="hud view">
+    <span class="dhd-retical"></span>
+    <span class="dhd-axis dhd-axis-h"></span>
+    <span class="dhd-axis dhd-axis-v"></span>
+    <span class="dhd-horizon"></span>
+    <span class="dhd-alt-box">
+      <span class="dhd-alt-label">ALT</span>
+      <strong class="dhd-alt-value">84</strong>
+    </span>
+    <span class="dhd-spd-box">
+      <span class="dhd-spd-label">SPD</span>
+      <strong class="dhd-spd-value">22</strong>
+    </span>
+  </section>
+  <section class="dhd-bars">
+    <span class="dhd-batt-label">Batt</span>
+    <div class="dhd-batt-track"><div class="dhd-batt-fill"></div></div>
+    <span class="dhd-batt-value">72%</span>
+  </section>
+  <footer class="dhd-foot">
+    <span class="dhd-home">HOME 034</span>
+    <span class="dhd-signal">RSSI -48</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/drone-hud-display-ij/style.css
+++ b/submissions/examples/drone-hud-display-ij/style.css
@@ -1,0 +1,28 @@
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0;word-wrap:normal}
+body{min-height:100vh;display:flex;align-items:center;justify-content:center;background:#071a12;font-family:'Segoe UI',sans-serif}
+.dhd-card{width:430px;border-radius:16px;padding:20px;background:linear-gradient(165deg,#0d2b1e,#05130c);color:#bff5d8;box-shadow:0 18px 46px rgba(0,0,0,.55)}
+.dhd-head{display:flex;justify-content:space-between;align-items:center;margin-bottom:14px}
+.dhd-title{font-size:16px;letter-spacing:3px;color:#8fd8b2}
+.dhd-gps{font-size:11px;color:#05130c;background:#4dff9d;border-radius:999px;padding:3px 10px;font-weight:bold}
+.dhd-view{position:relative;height:220px;margin-bottom:12px;background:radial-gradient(circle at 50% 50%,#103a28,#04170e 78%);border-radius:10px;overflow:hidden;border:1px solid #1b4a33}
+.dhd-retical{position:absolute;top:50%;left:50%;width:120px;height:120px;margin:-60px 0 0 -60px;border:2px solid #4dff9d;border-radius:50%;box-shadow:0 0 0 1px rgba(77,255,157,.25);animation:dhd-retical-pulse-drone-hud-display 2.4s ease-in-out infinite}
+@keyframes dhd-retical-pulse-drone-hud-display{0%,100%{transform:scale(1);opacity:.9}50%{transform:scale(1.06);opacity:1}}
+.dhd-axis{position:absolute;background:rgba(77,255,157,.5)}
+.dhd-axis-h{top:50%;left:0;right:0;height:1px}
+.dhd-axis-v{left:50%;top:0;bottom:0;width:1px}
+.dhd-horizon{position:absolute;top:64%;left:8%;right:8%;height:2px;background:rgba(255,209,102,.6)}
+.dhd-alt-box{position:absolute;left:12px;top:14px;text-align:left}
+.dhd-alt-label{display:block;font-size:10px;color:#8fd8b2;letter-spacing:2px}
+.dhd-alt-value{font-size:24px;color:#4dff9d;animation:dhd-altitude-read-drone-hud-display 2s ease-in-out infinite}
+@keyframes dhd-altitude-read-drone-hud-display{0%,100%{opacity:1}50%{opacity:.4}}
+.dhd-spd-box{position:absolute;right:12px;top:14px;text-align:right}
+.dhd-spd-label{display:block;font-size:10px;color:#8fd8b2;letter-spacing:2px}
+.dhd-spd-value{font-size:24px;color:#ffd166}
+.dhd-bars{display:flex;align-items:center;gap:10px;margin-bottom:12px}
+.dhd-batt-label{font-size:11px;color:#8fd8b2}
+.dhd-batt-track{flex:1;height:9px;border-radius:999px;background:#082117;overflow:hidden}
+.dhd-batt-fill{height:100%;width:72%;border-radius:999px;background:linear-gradient(90deg,#4dff9d,#a3ffc9)}
+.dhd-batt-value{font-size:11px;color:#4dff9d}
+.dhd-foot{display:flex;justify-content:space-between;border-top:1px solid rgba(255,255,255,.14);padding-top:10px}
+.dhd-home{font-size:11px;color:#8fd8b2}
+.dhd-signal{font-size:11px;color:#ffd166}


### PR DESCRIPTION
## Component: ease-drone-hud-display — retical pulses, altitude ticks, and horizon levels

**Closes #72800**

### What this adds
A drone HUD display where the retical pulses, the altitude readout ticks, and the horizon levels.

### Acceptance Criteria covered
- Retical pulses
- Altitude readout ticks
- Horizon levels

### Files
- `submissions/examples/drone-hud-display-ij/demo.html`
- `submissions/examples/drone-hud-display-ij/style.css`
- `submissions/examples/drone-hud-display-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the retical pulse, the altitude tick, and the horizon level.