### PR TITLE
Add ease-equalizer-spectrum-bars component

### DIFF
--- a/submissions/examples/equalizer-spectrum-bars-ij/README.md
+++ b/submissions/examples/equalizer-spectrum-bars-ij/README.md
@@ -1,0 +1,11 @@
+# ease-equalizer-spectrum-bars
+
+An equalizer where the spectrum bars ripple, the note chip floats, and the frequencies label.
+
+## Run
+Open `demo.html` directly in a browser to watch the spectrum.
+
+## Notes
+- Bars dance at their own rhythm.
+- The now-playing note floats softly.
+- Frequency labels mark the band edges.

--- a/submissions/examples/equalizer-spectrum-bars-ij/demo.html
+++ b/submissions/examples/equalizer-spectrum-bars-ij/demo.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-equalizer-spectrum-bars</title>
+</head>
+<body>
+<main class="esb-card">
+  <header class="esb-head">
+    <h1 class="esb-title">Equalizer</h1>
+    <span class="esb-mode">Stereo</span>
+  </header>
+  <section class="esb-spectrum" aria-label="frequency bars">
+    <span class="esb-bar esb-bar-1"></span>
+    <span class="esb-bar esb-bar-2"></span>
+    <span class="esb-bar esb-bar-3"></span>
+    <span class="esb-bar esb-bar-4"></span>
+    <span class="esb-bar esb-bar-5"></span>
+    <span class="esb-bar esb-bar-6"></span>
+    <span class="esb-bar esb-bar-7"></span>
+    <span class="esb-bar esb-bar-8"></span>
+    <span class="esb-bar esb-bar-9"></span>
+    <span class="esb-bar esb-bar-10"></span>
+  </section>
+  <section class="esb-labels">
+    <span class="esb-freq">62</span>
+    <span class="esb-freq">250</span>
+    <span class="esb-freq">1K</span>
+    <span class="esb-freq">4K</span>
+    <span class="esb-freq">16K</span>
+  </section>
+  <footer class="esb-foot">
+    <span class="esb-note">Now playing</span>
+    <span class="esb-track">Pulse</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/equalizer-spectrum-bars-ij/style.css
+++ b/submissions/examples/equalizer-spectrum-bars-ij/style.css
@@ -1,0 +1,25 @@
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0;list-style:none}
+body{min-height:100vh;display:flex;align-items:center;justify-content:center;background:#1a1220;font-family:'Segoe UI',sans-serif}
+.esb-card{width:390px;border-radius:16px;padding:20px;background:linear-gradient(165deg,#2a1c33,#170f1d);color:#efe6f7;box-shadow:0 18px 46px rgba(0,0,0,.5)}
+.esb-head{display:flex;justify-content:space-between;align-items:center;margin-bottom:16px}
+.esb-title{font-size:17px;letter-spacing:2px;color:#d5c3e8}
+.esb-mode{font-size:11px;color:#b78ce8;border:1px solid #b78ce8;border-radius:999px;padding:3px 10px}
+.esb-spectrum{display:flex;align-items:flex-end;justify-content:space-between;gap:6px;height:150px;margin-bottom:8px;background:#0f0b14;border-radius:10px;padding:10px;box-shadow:inset 0 2px 10px rgba(0,0,0,.5)}
+.esb-bar{flex:1;border-radius:4px 4px 0 0;background:linear-gradient(180deg,#ff6bd6,#7a3ff2);transform-origin:bottom;animation:esb-bar-ripple-equalizer-spectrum-bars 1.2s ease-in-out infinite}
+@keyframes esb-bar-ripple-equalizer-spectrum-bars{0%,100%{transform:scaleY(.28)}50%{transform:scaleY(1)}}
+.esb-bar-1{height:100%;animation-duration:.8s}
+.esb-bar-2{height:100%;animation-duration:1s}
+.esb-bar-3{height:100%;animation-duration:.7s}
+.esb-bar-4{height:100%;animation-duration:1.2s}
+.esb-bar-5{height:100%;animation-duration:.9s}
+.esb-bar-6{height:100%;animation-duration:1.1s}
+.esb-bar-7{height:100%;animation-duration:.75s}
+.esb-bar-8{height:100%;animation-duration:1.05s}
+.esb-bar-9{height:100%;animation-duration:.85s}
+.esb-bar-10{height:100%;animation-duration:.95s}
+.esb-labels{display:flex;justify-content:space-between;padding:0 8px;margin-bottom:12px}
+.esb-freq{font-size:9px;color:#8a7599}
+.esb-foot{display:flex;justify-content:space-between;align-items:center;border-top:1px solid rgba(255,255,255,.14);padding-top:10px}
+.esb-note{font-size:12px;color:#d5c3e8;animation:esb-note-float-equalizer-spectrum-bars 2s ease-in-out infinite}
+@keyframes esb-note-float-equalizer-spectrum-bars{0%,100%{transform:translateY(0)}50%{transform:translateY(-3px)}}
+.esb-track{font-size:12px;font-weight:bold;color:#b78ce8}


### PR DESCRIPTION
## Component: ease-equalizer-spectrum-bars — bars ripple, notes float, and frequencies label

**Closes #72804**

### What this adds
An equalizer where the spectrum bars ripple, the note chip floats, and the frequencies label.

### Acceptance Criteria covered
- Spectrum bars ripple
- Note chip floats
- Frequencies label

### Files
- `submissions/examples/equalizer-spectrum-bars-ij/demo.html`
- `submissions/examples/equalizer-spectrum-bars-ij/style.css`
- `submissions/examples/equalizer-spectrum-bars-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the bars ripple, the note float, and the labels sit.