### PR TITLE
feat: add animated determinate progress bar (#69378)

### DIFF
--- a/submissions/examples/animated-progress-bar-aaniya22/README.md
+++ b/submissions/examples/animated-progress-bar-aaniya22/README.md
@@ -1,0 +1,59 @@
+# Animated Progress Bar (Determinate)
+
+A pure CSS/HTML animated progress bar that smoothly fills from `0%` to a
+target percentage on load, with a continuously animated diagonal-stripe
+gradient to simulate ongoing activity.
+
+## Files
+
+- `demo.html` — usage examples with several target percentages and color variants
+- `style.css` — all styles and animations
+- `README.md` — this file
+
+## How it works
+
+The component uses two nested elements:
+
+- **`.progress-track`** — the outer container (the "track"). It holds the
+  target percentage as a CSS custom property, `--progress`, set inline.
+- **`.progress-fill`** — the inner child element (the "fill"). Its width is
+  animated from `0%` to `var(--progress)` via a `@keyframes` rule
+  (`fill-progress`). A second, infinitely-looping keyframe animation
+  (`stripe-move`) shifts a repeating diagonal-stripe gradient across the
+  fill to give it a sense of continuous activity.
+
+## Usage
+
+Set the desired percentage using the `--progress` CSS variable on the
+inline `style` attribute of `.progress-track`:
+
+```html
+<div class="progress-track" style="--progress: 75%;">
+  <div class="progress-fill"></div>
+</div>
+```
+
+No JavaScript is required — just change the `--progress` value per
+instance, and optionally add a label above it.
+
+### Color variants (optional)
+
+Add one of these classes to `.progress-track` to change the fill color:
+
+- `success` — green
+- `warning` — amber
+- `danger` — red
+
+### Accessibility / reduced motion
+
+Users with `prefers-reduced-motion: reduce` enabled will see the fill jump
+straight to its target width instead of animating, while still keeping the
+correct final value.
+
+## Notes
+
+- No existing files were modified — this is a strictly additive
+  contribution living entirely in
+  `submissions/examples/animated-progress-bar-aaniya22/`.
+- No JavaScript is used; the fill width and stripe animation are both
+  driven by CSS `@keyframes` and the `--progress` custom property.

--- a/submissions/examples/animated-progress-bar-aaniya22/demo.html
+++ b/submissions/examples/animated-progress-bar-aaniya22/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Progress Bar (Determinate) — EaseMotion-css</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <p class="demo-heading">Animated Progress Bar</p>
+
+  <div class="progress-wrapper">
+    <div class="progress-label">
+      <span>Uploading files</span>
+      <span>40%</span>
+    </div>
+    <div class="progress-track" style="--progress: 40%;">
+      <div class="progress-fill"></div>
+    </div>
+  </div>
+
+  <div class="progress-wrapper">
+    <div class="progress-label">
+      <span>Profile completion</span>
+      <span>75%</span>
+    </div>
+    <div class="progress-track" style="--progress: 75%;">
+      <div class="progress-fill"></div>
+    </div>
+  </div>
+
+  <div class="progress-wrapper">
+    <div class="progress-label">
+      <span>Storage used</span>
+      <span>92%</span>
+    </div>
+    <div class="progress-track danger" style="--progress: 92%;">
+      <div class="progress-fill"></div>
+    </div>
+  </div>
+
+  <div class="progress-wrapper">
+    <div class="progress-label">
+      <span>Setup complete</span>
+      <span>100%</span>
+    </div>
+    <div class="progress-track success" style="--progress: 100%;">
+      <div class="progress-fill"></div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/animated-progress-bar-aaniya22/style.css
+++ b/submissions/examples/animated-progress-bar-aaniya22/style.css
@@ -1,0 +1,106 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #0f1117;
+  color: #e6e6e6;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 20px;
+  gap: 36px;
+}
+
+.demo-heading {
+  font-size: 1.1rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: #9aa4b2;
+  text-transform: uppercase;
+}
+
+.progress-wrapper {
+  width: 100%;
+  max-width: 420px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.progress-label {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  color: #9aa4b2;
+}
+
+.progress-track {
+  --progress: 0%;
+  width: 100%;
+  height: 18px;
+  border-radius: 999px;
+  background: #1c2028;
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+  position: relative;
+}
+
+.progress-fill {
+  height: 100%;
+  width: 0%;
+  border-radius: 999px;
+  background-color: #4f8cff;
+  background-image: linear-gradient(
+    45deg,
+    rgba(255, 255, 255, 0.18) 25%,
+    transparent 25%,
+    transparent 50%,
+    rgba(255, 255, 255, 0.18) 50%,
+    rgba(255, 255, 255, 0.18) 75%,
+    transparent 75%,
+    transparent
+  );
+  background-size: 32px 32px;
+  animation:
+    fill-progress 1.4s ease-out forwards,
+    stripe-move 1s linear infinite;
+}
+
+.progress-track.success .progress-fill {
+  background-color: #2ecc71;
+}
+.progress-track.warning .progress-fill {
+  background-color: #f5a623;
+}
+.progress-track.danger .progress-fill {
+  background-color: #ff5c5c;
+}
+
+@keyframes fill-progress {
+  from {
+    width: 0%;
+  }
+  to {
+    width: var(--progress);
+  }
+}
+
+@keyframes stripe-move {
+  from {
+    background-position: 0 0;
+  }
+  to {
+    background-position: 32px 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .progress-fill {
+    animation: fill-progress 0s forwards;
+  }
+}


### PR DESCRIPTION
closes #69378
## Pull Request Description
Adds a pure CSS/HTML animated determinate progress bar component, as requested in issue #69378. The bar fills from 0% to a target percentage set via a CSS custom property, with a continuously animated striped gradient to convey ongoing activity.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/animated-progress-bar-aaniya22/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A determinate progress bar with a track/fill structure that animates its width from 0% to a developer-defined target percentage on load, plus a looping striped gradient on the fill to simulate activity.

**How does a developer use it?**
```html
<div class="progress-track" style="--progress: 75%;">
  <div class="progress-fill"></div>
</div>
```

**Why does it fit EaseMotion CSS?**
It's pure CSS/HTML, driven entirely by a single readable custom property (`--progress`), with no JavaScript required — consistent with the repo's human-readable, animation-first, additive-only philosophy. It also respects `prefers-reduced-motion`.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Included optional color variant classes (`success`, `warning`, `danger`) and a `prefers-reduced-motion` fallback beyond the base spec — happy to strip these out if you'd rather keep the submission minimal and spec-only.