### PR TITLE
feat: add CSS GIF message preview card (#70130)

### DIFF
--- a/submissions/examples/css-gif-message-preview/README.md
+++ b/submissions/examples/css-gif-message-preview/README.md
@@ -1,0 +1,64 @@
+# CSS GIF Message Preview
+
+An animated GIF-style preview card designed to sit inside a chat message
+thread, built with pure CSS/HTML — no JavaScript, no actual GIF file
+required. The looping motion is simulated with CSS `@keyframes`
+(a shifting gradient plus two drifting blurred orbs), giving the
+impression of a playing GIF.
+
+## Files
+
+- `demo.html` — a sample chat thread with GIF preview cards mixed in with
+  regular text bubbles
+- `style.css` — all styles and animations
+- `README.md` — this file
+
+## How it works
+
+`.gif-preview-card` is a fixed-size card with an animated gradient
+background (`gif-loop-shift`) and two pseudo-elements (`::before`,
+`::after`) that drift around using their own `@keyframes` animations,
+simulating the look of a small looping video/GIF. A `.gif-badge` label
+sits in the top-left corner, matching how GIFs are commonly marked in
+chat UIs.
+
+## Usage
+
+```html
+<div
+  class="gif-preview-card"
+  role="button"
+  tabindex="0"
+  aria-label="Animated GIF preview, press Enter to play"
+>
+  <span class="gif-badge">GIF</span>
+</div>
+```
+
+### Accessibility
+
+- `role="button"` and `tabindex="0"` make the card focusable and
+  keyboard-navigable.
+- `aria-label` describes the card's purpose for screen readers.
+- A visible `:focus-visible` outline is included for keyboard users.
+- `prefers-reduced-motion: reduce` disables all looping animations.
+
+### Responsive behavior
+
+On narrow viewports (≤420px), the chat thread and GIF card scale down to
+fit the available width.
+
+## Why it fits EaseMotion CSS
+
+Pure CSS/HTML, no JavaScript or external GIF assets, simple readable
+`@keyframes` for the looping motion, and follows accessible, responsive
+patterns consistent with the rest of the library.
+
+## Notes
+
+- No existing files were modified — this is a strictly additive
+  contribution living entirely in
+  `submissions/examples/css-gif-message-preview/`.
+- The "GIF" itself is a CSS-only illusion (animated gradient + drifting
+  orbs) rather than an actual image file, keeping the demo fully
+  self-contained.

--- a/submissions/examples/css-gif-message-preview/demo.html
+++ b/submissions/examples/css-gif-message-preview/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS GIF Message Preview — EaseMotion-css</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <p class="demo-heading">CSS GIF Message Preview</p>
+
+  <div class="chat-thread">
+
+    <div class="chat-message incoming">
+      <div class="chat-bubble-text">Check this out 👀</div>
+    </div>
+
+    <div class="chat-message incoming">
+      <div
+        class="gif-preview-card"
+        role="button"
+        tabindex="0"
+        aria-label="Animated GIF preview, press Enter to play"
+      >
+        <span class="gif-badge">GIF</span>
+      </div>
+      <span class="gif-caption">sent a GIF</span>
+    </div>
+
+    <div class="chat-message outgoing">
+      <div class="chat-bubble-text">Haha love it 😂</div>
+    </div>
+
+    <div class="chat-message outgoing">
+      <div
+        class="gif-preview-card"
+        role="button"
+        tabindex="0"
+        aria-label="Animated GIF preview, press Enter to play"
+      >
+        <span class="gif-badge">GIF</span>
+      </div>
+      <span class="gif-caption">sent a GIF</span>
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/css-gif-message-preview/style.css
+++ b/submissions/examples/css-gif-message-preview/style.css
@@ -1,0 +1,182 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #0b0f14;
+  color: #e6e6e6;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 20px;
+  gap: 28px;
+}
+
+.demo-heading {
+  font-size: 1.1rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: #9aa4b2;
+  text-transform: uppercase;
+}
+
+.chat-thread {
+  width: 100%;
+  max-width: 380px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.chat-message {
+  display: flex;
+  flex-direction: column;
+  max-width: 78%;
+}
+
+.chat-message.incoming {
+  align-self: flex-start;
+}
+
+.chat-message.outgoing {
+  align-self: flex-end;
+}
+
+.chat-bubble-text {
+  background: #1c2028;
+  color: #e6e6e6;
+  padding: 10px 14px;
+  border-radius: 16px;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.chat-message.outgoing .chat-bubble-text {
+  background: #4f8cff;
+  color: #fff;
+}
+
+.gif-preview-card {
+  position: relative;
+  width: 220px;
+  height: 150px;
+  border-radius: 14px;
+  overflow: hidden;
+  background: linear-gradient(
+    135deg,
+    #3a2f6b 0%,
+    #6f3faa 30%,
+    #d3487a 60%,
+    #ff8a4c 100%
+  );
+  background-size: 300% 300%;
+  animation: gif-loop-shift 3s ease-in-out infinite;
+  cursor: pointer;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
+}
+
+.gif-preview-card::before,
+.gif-preview-card::after {
+  content: "";
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(2px);
+  opacity: 0.55;
+}
+
+.gif-preview-card::before {
+  width: 90px;
+  height: 90px;
+  background: rgba(255, 255, 255, 0.35);
+  top: -20px;
+  left: -20px;
+  animation: gif-orb-drift-a 3s ease-in-out infinite;
+}
+
+.gif-preview-card::after {
+  width: 60px;
+  height: 60px;
+  background: rgba(255, 255, 255, 0.25);
+  bottom: -10px;
+  right: -10px;
+  animation: gif-orb-drift-b 3s ease-in-out infinite;
+}
+
+@keyframes gif-loop-shift {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}
+
+@keyframes gif-orb-drift-a {
+  0%,
+  100% {
+    transform: translate(0, 0);
+  }
+  50% {
+    transform: translate(30px, 20px);
+  }
+}
+
+@keyframes gif-orb-drift-b {
+  0%,
+  100% {
+    transform: translate(0, 0);
+  }
+  50% {
+    transform: translate(-25px, -15px);
+  }
+}
+
+.gif-badge {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  background: rgba(0, 0, 0, 0.65);
+  color: #fff;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  padding: 2px 6px;
+  border-radius: 4px;
+  z-index: 2;
+}
+
+.gif-caption {
+  margin-top: 6px;
+  font-size: 0.75rem;
+  color: #9aa4b2;
+}
+
+.gif-preview-card:focus-visible {
+  outline: 3px solid #4f8cff;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .gif-preview-card,
+  .gif-preview-card::before,
+  .gif-preview-card::after {
+    animation: none;
+  }
+}
+
+@media (max-width: 420px) {
+  .chat-thread {
+    max-width: 100%;
+  }
+  .gif-preview-card {
+    width: 100%;
+    max-width: 220px;
+  }
+}


### PR DESCRIPTION
closes #70130
## Pull Request Description
Adds a "CSS GIF Message Preview" component, as requested in issue #70130. A looping, GIF-style animated preview card designed to sit inside a chat message thread — no actual GIF asset required, the motion is fully CSS-driven.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/css-gif-message-preview/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
An animated GIF-style preview card for chat message bubbles, with a looping gradient + drifting-orb animation that simulates the look of a playing GIF, plus a "GIF" badge.

**How does a developer use it?**
```html
<div
  class="gif-preview-card"
  role="button"
  tabindex="0"
  aria-label="Animated GIF preview, press Enter to play"
>
  <span class="gif-badge">GIF</span>
</div>
```

**Why does it fit EaseMotion CSS?**
It's pure CSS/HTML with no JavaScript and no external GIF file, uses readable `@keyframes` for the looping motion, is fully responsive, and includes accessibility support (`role`, `tabindex`, `aria-label`, `:focus-visible`, and `prefers-reduced-motion`) — matching the repo's animation-first, accessible-by-default philosophy.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
The "GIF" is simulated entirely with CSS (animated gradient + drifting blurred pseudo-elements) rather than an actual image file, so the demo stays fully self-contained. Happy to swap in a real `<img>`-based approach if you'd prefer that over the CSS-only illusion.