### PR TITLE
feat: add CSS unit converter widget (#70067)

### DIFF
--- a/submissions/examples/css-unit-converter-widget/README.md
+++ b/submissions/examples/css-unit-converter-widget/README.md
@@ -1,0 +1,74 @@
+# CSS Unit Converter Widget
+
+A tabbed unit-converter display built with pure CSS/HTML — no JavaScript.
+It switches between **Length**, **Weight**, and **Temperature** panels
+using the "checked radio" CSS trick, with an animated fade/slide-in
+transition whenever the active tab changes.
+
+## Files
+
+- `demo.html` — the widget with three conversion tabs
+- `style.css` — all styles and animations
+- `README.md` — this file
+
+## How it works
+
+Three visually-hidden radio inputs sit before their corresponding
+`<label>` tab buttons and `.unit-panel` panels in the DOM. CSS sibling
+selectors (`:checked ~ ...`) show the active tab's styling and reveal
+the matching panel. Each panel plays a short `panel-fade-in`
+`@keyframes` animation whenever it becomes visible.
+
+## Usage
+
+```html
+<div class="unit-converter" role="group" aria-label="Unit converter">
+  <input type="radio" name="unit-tab" id="tab-length" checked />
+  <input type="radio" name="unit-tab" id="tab-weight" />
+
+  <div class="unit-tabs">
+    <label for="tab-length">Length</label>
+    <label for="tab-weight">Weight</label>
+  </div>
+
+  <div class="unit-panels">
+    <div class="unit-panel length">
+      <div class="value-row">
+        <span class="value-label">10 cm</span>
+        <span class="value-number">3.94 in</span>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+### Why fixed reference values, not a live input?
+
+This is a pure CSS component, and CSS cannot read a typed number and
+compute a converted result — that requires JavaScript. To stay within
+the "no JavaScript" spec, this widget shows a small set of pre-computed
+reference conversions per category instead, animated in on tab switch.
+
+### Accessibility
+
+- Tab labels are focusable and keyboard-operable via native
+  `<label for>` behavior tied to the radio group.
+- `role="group"` and `aria-label` identify the widget for screen readers.
+- Each panel has an `aria-label` describing its category.
+- Visible focus outline on keyboard navigation.
+- `prefers-reduced-motion: reduce` disables the panel animation.
+
+### Responsive behavior
+
+Fluid `max-width` and vertically-stacked rows adapt naturally to narrow
+viewports.
+
+## Why it fits EaseMotion CSS
+
+Pure CSS/HTML, no JavaScript, readable `@keyframes` transition, and
+accessible, responsive markup.
+
+## Notes
+
+- No existing files were modified — strictly additive, living entirely
+  in `submissions/examples/css-unit-converter-widget/`.

--- a/submissions/examples/css-unit-converter-widget/demo.html
+++ b/submissions/examples/css-unit-converter-widget/demo.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Unit Converter Widget — EaseMotion-css</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <p class="demo-heading">CSS Unit Converter Widget</p>
+
+  <div class="unit-converter" role="group" aria-label="Unit converter">
+
+    <input type="radio" name="unit-tab" id="tab-length" checked />
+    <input type="radio" name="unit-tab" id="tab-weight" />
+    <input type="radio" name="unit-tab" id="tab-temp" />
+
+    <div class="unit-tabs">
+      <label for="tab-length" tabindex="0">Length</label>
+      <label for="tab-weight" tabindex="0">Weight</label>
+      <label for="tab-temp" tabindex="0">Temp</label>
+    </div>
+
+    <div class="unit-panels">
+
+      <div class="unit-panel length" aria-label="Length conversions">
+        <div class="value-row">
+          <span class="value-label">10 cm</span>
+          <span class="conversion-arrow">→</span>
+          <span class="value-number">3.94 in</span>
+        </div>
+        <div class="value-row">
+          <span class="value-label">1 m</span>
+          <span class="conversion-arrow">→</span>
+          <span class="value-number">3.28 ft</span>
+        </div>
+        <div class="value-row">
+          <span class="value-label">5 km</span>
+          <span class="conversion-arrow">→</span>
+          <span class="value-number">3.11 mi</span>
+        </div>
+      </div>
+
+      <div class="unit-panel weight" aria-label="Weight conversions">
+        <div class="value-row">
+          <span class="value-label">5 kg</span>
+          <span class="conversion-arrow">→</span>
+          <span class="value-number">11.02 lb</span>
+        </div>
+        <div class="value-row">
+          <span class="value-label">1 lb</span>
+          <span class="conversion-arrow">→</span>
+          <span class="value-number">453.6 g</span>
+        </div>
+        <div class="value-row">
+          <span class="value-label">1 oz</span>
+          <span class="conversion-arrow">→</span>
+          <span class="value-number">28.35 g</span>
+        </div>
+      </div>
+
+      <div class="unit-panel temp" aria-label="Temperature conversions">
+        <div class="value-row">
+          <span class="value-label">0°C</span>
+          <span class="conversion-arrow">→</span>
+          <span class="value-number">32°F</span>
+        </div>
+        <div class="value-row">
+          <span class="value-label">25°C</span>
+          <span class="conversion-arrow">→</span>
+          <span class="value-number">77°F</span>
+        </div>
+        <div class="value-row">
+          <span class="value-label">100°C</span>
+          <span class="conversion-arrow">→</span>
+          <span class="value-number">212°F</span>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/css-unit-converter-widget/style.css
+++ b/submissions/examples/css-unit-converter-widget/style.css
@@ -1,0 +1,134 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #0b0f14;
+  color: #e6e6e6;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 20px;
+  gap: 28px;
+}
+
+.demo-heading {
+  font-size: 1.1rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: #9aa4b2;
+  text-transform: uppercase;
+}
+
+.unit-converter {
+  width: 100%;
+  max-width: 360px;
+  background: #161a22;
+  border-radius: 16px;
+  padding: 20px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
+}
+
+.unit-converter input[type="radio"] {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.unit-tabs {
+  display: flex;
+  gap: 6px;
+  background: #1c2028;
+  border-radius: 10px;
+  padding: 4px;
+  margin-bottom: 18px;
+}
+
+.unit-tabs label {
+  flex: 1;
+  text-align: center;
+  padding: 8px 10px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #9aa4b2;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background-color 0.25s ease, color 0.25s ease;
+}
+
+.unit-tabs label:hover {
+  color: #e6e6e6;
+}
+
+.unit-converter input[type="radio"]:focus-visible + label {
+  outline: 2px solid #4f8cff;
+  outline-offset: 2px;
+}
+
+.unit-panel {
+  display: none;
+  animation: panel-fade-in 0.35s ease both;
+}
+
+.unit-panel .value-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 0;
+  border-bottom: 1px solid #232833;
+}
+
+.unit-panel .value-row:last-child {
+  border-bottom: none;
+}
+
+.unit-panel .value-label {
+  font-size: 0.85rem;
+  color: #9aa4b2;
+}
+
+.unit-panel .value-number {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: #e6e6e6;
+}
+
+.unit-panel .conversion-arrow {
+  font-size: 0.9rem;
+  color: #4f8cff;
+  margin: 0 10px;
+}
+
+@keyframes panel-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+#tab-length:checked ~ .unit-tabs label[for="tab-length"],
+#tab-weight:checked ~ .unit-tabs label[for="tab-weight"],
+#tab-temp:checked ~ .unit-tabs label[for="tab-temp"] {
+  background: #4f8cff;
+  color: #fff;
+}
+
+#tab-length:checked ~ .unit-panels .unit-panel.length,
+#tab-weight:checked ~ .unit-panels .unit-panel.weight,
+#tab-temp:checked ~ .unit-panels .unit-panel.temp {
+  display: block;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .unit-panel {
+    animation: none;
+  }
+}


### PR DESCRIPTION
closes #70067
## Pull Request Description
Adds a "CSS Unit Converter Widget" component, as requested in issue #70067. A tabbed, pure-CSS unit converter that switches between Length, Weight, and Temperature reference values using the checked-radio technique, with an animated fade/slide-in transition on tab change.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/css-unit-converter-widget/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A tabbed unit-converter display showing preset Length, Weight, and Temperature conversions, with each panel animating in on tab switch.

**How does a developer use it?**
```html
<div class="unit-converter" role="group" aria-label="Unit converter">
  <input type="radio" name="unit-tab" id="tab-length" checked />
  <input type="radio" name="unit-tab" id="tab-weight" />
  <div class="unit-tabs">
    <label for="tab-length">Length</label>
    <label for="tab-weight">Weight</label>
  </div>
  <div class="unit-panels">
    <div class="unit-panel length">
      <div class="value-row">
        <span class="value-label">10 cm</span>
        <span class="value-number">3.94 in</span>
      </div>
    </div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
Pure CSS/HTML with no JavaScript, uses the checked-radio sibling-selector pattern for tab switching, a readable `panel-fade-in` `@keyframes` transition, and accessible/responsive markup (`role`, `aria-label`, keyboard-operable labels, `:focus-visible`, `prefers-reduced-motion`) — matching the repo's animation-first, accessible-by-default philosophy.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Since this is a strict "no JavaScript" CSS-only component, it can't take arbitrary user input and compute a live conversion — CSS has no math/input-reading capability for that. I built it as a tabbed reference-value display instead (preset Length/Weight/Temp conversions, animated on tab switch) and flagged this trade-off explicitly so it's not a surprise in review. Happy to adjust the value set or add more categories if useful.