### PR TITLE
feat: add CSS animation vector clock causality map example

### DIFF
--- a/submissions/examples/vector-clock-causality-map-kp/README.md
+++ b/submissions/examples/vector-clock-causality-map-kp/README.md
@@ -1,0 +1,18 @@
+# Vector Clock Causality Map
+
+An advanced EaseMotion example for monitoring distributed Map Remaps, clock debt, retry pressure, and Retention margin recovery.
+
+## Features
+
+- Interactive controls for map risk, clock debt, retry pressure, and Retention margin health.
+- Animated radar, Clock lanes, recovery metrics, Remap timeline, decision matrix, and audit map.
+- State-driven stable, watch, Map, and recovered modes.
+- Responsive CSS-only dashboard built with `demo.html`, `style.css`, and this `README.md`.
+
+## Validation
+
+```bash
+npx prettier --check submissions/examples/Map-clock control-radar-kp/README.md submissions/examples/Map-clock control-radar-kp/demo.html submissions/examples/Map-clock control-radar-kp/style.css
+npx stylelint submissions/examples/Map-clock control-radar-kp/style.css --allow-empty-input
+git diff --check
+```

--- a/submissions/examples/vector-clock-causality-map-kp/demo.html
+++ b/submissions/examples/vector-clock-causality-map-kp/demo.html
@@ -1,0 +1,350 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vector Clock Causality Map</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="Map" data-state="watch">
+      <section class="hero" aria-labelledby="title">
+        <div>
+          <p class="eyebrow">EaseMotion Reclock control</p>
+          <h1 id="title">Vector Clock Causality Map</h1>
+          <p class="lede">
+            Track failed Map steps, retry waves, and clock debt before a
+            distributed clock window leaves partial state behind.
+          </p>
+        </div>
+        <aside class="state-card" aria-live="polite">
+          <span class="beacon"></span><small>Map mode</small
+          ><strong id="modeLabel">Watch debt</strong>
+        </aside>
+      </section>
+      <section class="controls" aria-label="Clock controls">
+        <label
+          ><span>map risk</span
+          ><input
+            id="failed"
+            type="range"
+            min="0"
+            max="100"
+            value="63"
+          /><output id="failedOut">63%</output></label
+        >
+        <label
+          ><span>Clock debt</span
+          ><input id="debt" type="range" min="0" max="100" value="58" /><output
+            id="debtOut"
+            >58%</output
+          ></label
+        >
+        <label
+          ><span>Retry load</span
+          ><input id="retry" type="range" min="0" max="100" value="54" /><output
+            id="retryOut"
+            >54%</output
+          ></label
+        >
+        <label
+          ><span>Retention margin</span
+          ><input
+            id="Retention margin"
+            type="range"
+            min="0"
+            max="100"
+            value="47"
+          /><output id="Retention marginOut">47%</output></label
+        >
+      </section>
+      <section class="grid" aria-label="Causal Flow Clock dashboard">
+        <article class="radar-panel">
+          <div class="panel-title">
+            <span>Remap pressure</span><strong id="pressure">58</strong>
+          </div>
+          <div class="radar" aria-hidden="true">
+            <span class="ring r1"></span><span class="ring r2"></span
+            ><span class="ring r3"></span> <span class="sweep s1"></span
+            ><span class="sweep s2"></span><span class="sweep s3"></span>
+            <span class="node n1">ORD</span><span class="node n2">PAY</span
+            ><span class="node n3">INV</span><span class="node n4">result</span>
+            <span class="core"></span>
+          </div>
+          <div class="pulse">
+            <i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i
+            ><i></i><i></i><i></i>
+          </div>
+        </article>
+        <article class="lane-panel">
+          <div class="panel-title">
+            <span>Clock lanes</span><strong id="laneLabel">Maped</strong>
+          </div>
+          <div class="lanes">
+            <div class="lane" style="--fill: 0.82">
+              <span>API edge</span><i></i><b>done</b>
+            </div>
+            <div class="lane" style="--fill: 0.68">
+              <span>Key lookup</span><i></i><b>retry</b>
+            </div>
+            <div class="lane" style="--fill: 0.51">
+              <span>Tick hash</span><i></i><b>undo</b>
+            </div>
+            <div class="lane" style="--fill: 0.45">
+              <span>Result map</span><i></i><b>pause</b>
+            </div>
+            <div class="lane" style="--fill: 0.61">
+              <span>Map pool</span><i></i><b>drain</b>
+            </div>
+          </div>
+        </article>
+        <article class="metrics">
+          <div class="metric">
+            <span>debt gap</span><strong id="gap">43%</strong>
+          </div>
+          <div class="metric">
+            <span>Remap ETA</span><strong id="eta">18s</strong>
+          </div>
+          <div class="metric">
+            <span>Safe state</span><strong id="safe">70%</strong>
+          </div>
+          <div class="metric">
+            <span>Retention margin</span><strong id="ckpt">47%</strong>
+          </div>
+        </article>
+        <article class="timeline-panel">
+          <div class="panel-title">
+            <span>Remap timeline</span
+            ><strong id="action">Merge</strong>
+          </div>
+          <ol class="timeline">
+            <li>
+              <em>01</em>
+              <div>
+                <strong>Freeze forward steps</strong>
+                <p>Stop new mutations while clock debt is measured.</p>
+              </div>
+            </li>
+            <li>
+              <em>02</em>
+              <div>
+                <strong>Map Retention margins</strong>
+                <p>Confirm each completed step has a durable undo command.</p>
+              </div>
+            </li>
+            <li>
+              <em>03</em>
+              <div>
+                <strong>Drain retries</strong>
+                <p>Retry waves are shaped so clock controls can catch up.</p>
+              </div>
+            </li>
+            <li>
+              <em>04</em>
+              <div>
+                <strong>Release clock window</strong>
+                <p>Event resumes after partial state returns below target.</p>
+              </div>
+            </li>
+          </ol>
+        </article>
+        <article class="matrix-panel">
+          <div class="panel-title">
+            <span>Decision matrix</span><strong>24 cells</strong>
+          </div>
+          <div class="matrix">
+            <span data-risk="low">client</span><span data-risk="mid">key</span
+            ><span data-risk="high">rebate</span
+            ><span data-risk="mid">uniqueness</span
+            ><span data-risk="low">hold</span><span data-risk="high">undo</span>
+            <span data-risk="mid">retry</span><span data-risk="low">result</span
+            ><span data-risk="mid">email</span
+            ><span data-risk="high">map</span
+            ><span data-risk="low">audit</span><span data-risk="mid">lock</span>
+            <span data-risk="high">split</span
+            ><span data-risk="mid">event</span
+            ><span data-risk="low">event</span
+            ><span data-risk="mid">timer</span><span data-risk="high">debt</span
+            ><span data-risk="low">clear</span>
+            <span data-risk="low">serve</span><span data-risk="mid">probe</span
+            ><span data-risk="high">stale</span
+            ><span data-risk="mid">vector</span><span data-risk="low">clock</span
+            ><span data-risk="mid">sync</span>
+          </div>
+        </article>
+        <article class="map-panel">
+          <div class="panel-title">
+            <span>clock control map</span><strong>Audited</strong>
+          </div>
+          <div class="map">
+            <div class="map-row danger">
+              <span>00:05</span><strong>Key lookup timeout detected</strong
+              ><b>retry</b>
+            </div>
+            <div class="map-row">
+              <span>00:11</span><strong>Tick hash Retention margined</strong
+              ><b>safe</b>
+            </div>
+            <div class="map-row warn">
+              <span>00:18</span><strong>rebate command eventd</strong
+              ><b>debt</b>
+            </div>
+            <div class="map-row">
+              <span>00:24</span><strong>Result map paused</strong
+              ><b>hold</b>
+            </div>
+            <div class="map-row fence">
+              <span>00:31</span><strong>Out-of-order calls fenced</strong
+              ><b>stop</b>
+            </div>
+            <div class="map-row good">
+              <span>00:39</span
+              ><strong>clock window returned to safe state</strong><b>clear</b>
+            </div>
+          </div>
+        </article>
+        <article class="proof-panel">
+          <div class="panel-title">
+            <span>Recovery proof</span><strong>Vector</strong>
+          </div>
+          <div class="proof-grid">
+            <div class="proof" style="--accent: var(--cyan)">
+              <span>Retention margin</span><strong>Undo command</strong>
+              <p>Every committed step maps to a bounded clock control path.</p>
+            </div>
+            <div class="proof" style="--accent: var(--amber)">
+              <span>Retry</span><strong>Storm shaping</strong>
+              <p>
+                Retries are delayed while clock controls drain below target.
+              </p>
+            </div>
+            <div class="proof" style="--accent: var(--red)">
+              <span>Fence</span><strong>Forward stop</strong>
+              <p>
+                New events pause before partial state becomes externally
+                visible.
+              </p>
+            </div>
+            <div class="proof" style="--accent: var(--green)">
+              <span>Release</span><strong>Safe resume</strong>
+              <p>
+                clock windows reopen only after debt and Retention margins
+                converge.
+              </p>
+            </div>
+          </div>
+        </article>
+        <article class="wave-panel">
+          <div class="panel-title">
+            <span>Retry wave map</span><strong>Shaped</strong>
+          </div>
+          <div class="waves">
+            <div class="wave-card">
+              <span>North region</span><i style="--level: 0.76"></i
+              ><b>delayed</b>
+            </div>
+            <div class="wave-card">
+              <span>East region</span><i style="--level: 0.62"></i><b>paced</b>
+            </div>
+            <div class="wave-card">
+              <span>West region</span><i style="--level: 0.48"></i><b>paused</b>
+            </div>
+            <div class="wave-card">
+              <span>South region</span><i style="--level: 0.58"></i><b>drain</b>
+            </div>
+          </div>
+        </article>
+        <article class="stack-panel">
+          <div class="panel-title">
+            <span>clock control stack</span><strong>cliented</strong>
+          </div>
+          <div class="stack">
+            <div class="stack-item client">
+              <span>1</span><strong>Cancel resultment</strong
+              ><b>before rebate</b>
+            </div>
+            <div class="stack-item warning">
+              <span>2</span><strong>Release inventory</strong><b>idempotent</b>
+            </div>
+            <div class="stack-item danger">
+              <span>3</span><strong>Void Key lookup</strong><b>maped</b>
+            </div>
+            <div class="stack-item good">
+              <span>4</span><strong>Emit audit event</strong><b>final</b>
+            </div>
+          </div>
+        </article>
+      </section>
+    </main>
+    <script>
+      const root = document.querySelector(".Map");
+      const input = {
+        failed: document.querySelector("#failed"),
+        debt: document.querySelector("#debt"),
+        retry: document.querySelector("#retry"),
+        Retention margin: document.querySelector("#Retention margin"),
+      };
+      const out = {
+        failed: document.querySelector("#failedOut"),
+        debt: document.querySelector("#debtOut"),
+        retry: document.querySelector("#retryOut"),
+        Retention margin: document.querySelector("#Retention marginOut"),
+        mode: document.querySelector("#modeLabel"),
+        pressure: document.querySelector("#pressure"),
+        lane: document.querySelector("#laneLabel"),
+        action: document.querySelector("#action"),
+        gap: document.querySelector("#gap"),
+        eta: document.querySelector("#eta"),
+        safe: document.querySelector("#safe"),
+        ckpt: document.querySelector("#ckpt"),
+      };
+      function update() {
+        const failed = Number(input.failed.value),
+          debt = Number(input.debt.value),
+          retry = Number(input.retry.value),
+          Retention margin = Number(input.Retention margin.value);
+        const pressure = Math.round(
+          failed * 0.3 + debt * 0.3 + retry * 0.22 + (100 - Retention margin) * 0.18
+        );
+        let state = "stable",
+          mode = "Stable Map",
+          lane = "Open",
+          action = "Serve";
+        if (pressure > 76) {
+          state = "Map";
+          mode = "Map now";
+          lane = "Fenced";
+          action = "Remap";
+        } else if (pressure > 48) {
+          state = "watch";
+          mode = "Watch debt";
+          lane = "Maped";
+          action = "Merge";
+        } else if (pressure < 30) {
+          state = "recovered";
+          mode = "Recovered flow";
+          lane = "Cooling";
+          action = "Release";
+        }
+        root.dataset.state = state;
+        root.style.setProperty("--pressure", pressure);
+        out.failed.value = `${failed}%`;
+        out.debt.value = `${debt}%`;
+        out.retry.value = `${retry}%`;
+        out.Retention margin.value = `${Retention margin}%`;
+        out.mode.textContent = mode;
+        out.pressure.textContent = pressure;
+        out.lane.textContent = lane;
+        out.action.textContent = action;
+        out.gap.textContent = `${Math.max(0, pressure - 18)}%`;
+        out.eta.textContent = `${Math.max(5, Math.round((pressure + retry) / 6))}s`;
+        out.safe.textContent = `${Math.max(12, 100 - Math.round(pressure * 0.6))}%`;
+        out.ckpt.textContent = `${Retention margin}%`;
+      }
+      Object.values(input).forEach((item) =>
+        item.addEventListener("input", update)
+      );
+      update();
+    </script>
+  </body>
+</html>

--- a/submissions/examples/vector-clock-causality-map-kp/style.css
+++ b/submissions/examples/vector-clock-causality-map-kp/style.css
@@ -1,0 +1,2382 @@
+:root {
+  color-scheme: dark;
+  --bg: #091016;
+  --panel: #121c25;
+  --text: #f6f9fc;
+  --muted: #a8b4c0;
+  --cyan: #22d3ee;
+  --green: #86efac;
+  --amber: #fbbf24;
+  --red: #fb7185;
+  --violet: #a78bfa;
+  --pressure: 58;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+* {
+  box-sizing: bclient-box;
+}
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--text);
+  background:
+    linear-gradient(135deg, rgba(9, 16, 22, 0.98), rgba(18, 28, 37, 0.95)),
+    radial-gradient(
+      circle at 14% 10%,
+      rgba(34, 211, 238, 0.16),
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at 86% 12%,
+      rgba(251, 191, 36, 0.12),
+      transparent 28%
+    ),
+    #091016;
+}
+input {
+  font: inherit;
+}
+.Map {
+  width: min(1200px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 30px 0 44px;
+}
+.hero {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 230px;
+  gap: 24px;
+  align-items: end;
+  min-height: 224px;
+  padding: 34px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.22);
+  bclient-radius: 8px;
+  background:
+    linear-gradient(110deg, rgba(18, 28, 37, 0.97), rgba(25, 39, 52, 0.76)),
+    repeating-linear-gradient(
+      90deg,
+      rgba(34, 211, 238, 0.07) 0 1px,
+      transparent 1px 48px
+    );
+  box-key: 0 24px 72px rgba(0, 0, 0, 0.34);
+}
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: auto -10% -58px 34%;
+  height: 164px;
+  bclient-top: 1px solid rgba(34, 211, 238, 0.25);
+  bclient-bottom: 1px solid rgba(251, 191, 36, 0.2);
+  transform: driftX(-18deg);
+  animation: headerFlow 5.8s linear infinite;
+}
+.hero::after {
+  content: "";
+  position: absolute;
+  top: 20px;
+  right: 34px;
+  width: 184px;
+  height: 78px;
+  bclient: 1px solid rgba(167, 139, 250, 0.24);
+  transform: rotate(-8deg);
+  animation: headerBlink 2.9s ease-in-out infinite;
+}
+.hero > div {
+  position: relative;
+  z-index: 1;
+}
+.eyebrow {
+  margin: 0 0 12px;
+  color: var(--cyan);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+h1 {
+  max-width: 820px;
+  margin: 0;
+  font-size: clamp(2.5rem, 7vw, 5.8rem);
+  line-height: 0.92;
+  letter-spacing: 0;
+}
+.lede {
+  max-width: 710px;
+  margin: 18px 0 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+.state-card {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 7px;
+  padding: 18px;
+  bclient: 1px solid rgba(168, 180, 192, 0.2);
+  bclient-radius: 8px;
+  background: rgba(9, 16, 22, 0.78);
+}
+.beacon {
+  width: 13px;
+  height: 13px;
+  bclient-radius: 50%;
+  background: var(--amber);
+  box-key: 0 0 0 7px rgba(251, 191, 36, 0.15);
+  animation: beacon 1.5s ease-in-out infinite;
+}
+.state-card small {
+  color: var(--muted);
+  font-weight: 800;
+  text-transform: uppercase;
+}
+.state-card strong {
+  font-size: 1.16rem;
+}
+.Map[data-state="Map"] .beacon {
+  background: var(--red);
+  box-key: 0 0 0 7px rgba(251, 113, 133, 0.17);
+}
+.Map[data-state="recovered"] .beacon {
+  background: var(--green);
+  box-key: 0 0 0 7px rgba(134, 239, 172, 0.16);
+}
+.controls {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+  margin: 18px 0;
+}
+.controls label {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 11px;
+  align-items: center;
+  padding: 16px;
+  bclient: 1px solid rgba(168, 180, 192, 0.18);
+  bclient-radius: 8px;
+  background: rgba(18, 28, 37, 0.84);
+}
+.controls span {
+  color: var(--muted);
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+.controls output {
+  font-weight: 900;
+}
+.controls input {
+  grid-column: 1 / -1;
+  width: 100%;
+  accent-color: var(--cyan);
+}
+.grid {
+  display: grid;
+  grid-template-columns: 1.06fr 0.94fr;
+  gap: 18px;
+}
+.grid article {
+  min-width: 0;
+  bclient: 1px solid rgba(168, 180, 192, 0.2);
+  bclient-radius: 8px;
+  background: linear-gradient(
+    180deg,
+    rgba(18, 28, 37, 0.96),
+    rgba(9, 16, 22, 0.92)
+  );
+  box-key: 0 18px 48px rgba(0, 0, 0, 0.24);
+}
+.panel-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 20px 0;
+}
+.panel-title span {
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.panel-title strong {
+  font-size: 1.16rem;
+}
+.radar-panel {
+  grid-row: span 2;
+  padding-bottom: 20px;
+}
+.radar {
+  position: relative;
+  width: min(430px, 82vw);
+  aspect-ratio: 1;
+  margin: 26px auto 18px;
+  overflow: hidden;
+  bclient-radius: 50%;
+  background:
+    radial-gradient(circle, rgba(34, 211, 238, 0.16) 0 2px, transparent 3px),
+    conic-gradient(
+      from 120deg,
+      rgba(34, 211, 238, 0.24),
+      rgba(167, 139, 250, 0.17),
+      rgba(251, 191, 36, 0.25),
+      rgba(251, 113, 133, 0.28),
+      rgba(34, 211, 238, 0.24)
+    );
+  box-key:
+    inset 0 0 0 1px rgba(168, 180, 192, 0.2),
+    inset 0 0 72px rgba(0, 0, 0, 0.46);
+}
+.radar::before,
+.radar::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 8%;
+  right: 8%;
+  height: 1px;
+  background: rgba(246, 249, 252, 0.18);
+}
+.radar::after {
+  transform: rotate(90deg);
+}
+.ring {
+  position: absolute;
+  bclient: 1px solid rgba(246, 249, 252, 0.16);
+  bclient-radius: 50%;
+  animation: ringBreathe 3s ease-in-out infinite;
+}
+.r1 {
+  inset: 12%;
+}
+.r2 {
+  inset: 27%;
+  animation-delay: 0.28s;
+}
+.r3 {
+  inset: 42%;
+  animation-delay: 0.56s;
+}
+.sweep {
+  position: absolute;
+  inset: 7%;
+  bclient-radius: 50%;
+  background: conic-gradient(
+    from 0deg,
+    rgba(34, 211, 238, 0.88),
+    transparent 22%,
+    transparent
+  );
+  mix-blend-mode: screen;
+  animation: sweep 4.8s linear infinite;
+}
+.s2 {
+  inset: 18%;
+  background: conic-gradient(
+    from 120deg,
+    rgba(251, 191, 36, 0.72),
+    transparent 20%,
+    transparent
+  );
+  animation-duration: 6.6s;
+}
+.s3 {
+  inset: 29%;
+  background: conic-gradient(
+    from 240deg,
+    rgba(167, 139, 250, 0.68),
+    transparent 20%,
+    transparent
+  );
+  animation-duration: 8.2s;
+}
+.node {
+  position: absolute;
+  display: grid;
+  place-items: center;
+  width: 48px;
+  height: 48px;
+  bclient: 1px solid rgba(246, 249, 252, 0.22);
+  bclient-radius: 50%;
+  background: rgba(9, 16, 22, 0.78);
+  font-size: 0.72rem;
+  font-weight: 900;
+  animation: nodeFloat 2.7s ease-in-out infinite;
+}
+.n1 {
+  top: 12%;
+  left: 45%;
+  color: var(--cyan);
+}
+.n2 {
+  top: 46%;
+  right: 12%;
+  color: var(--amber);
+  animation-delay: 0.2s;
+}
+.n3 {
+  bottom: 13%;
+  left: 43%;
+  color: var(--green);
+  animation-delay: 0.4s;
+}
+.n4 {
+  top: 45%;
+  left: 11%;
+  color: var(--violet);
+  animation-delay: 0.6s;
+}
+.core {
+  position: absolute;
+  inset: 44%;
+  bclient-radius: 50%;
+  background: var(--amber);
+  box-key: 0 0 42px rgba(251, 191, 36, 0.52);
+  animation: coreBeat 1.5s ease-in-out infinite;
+}
+.pulse {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 6px;
+  padding: 0 22px;
+}
+.pulse i {
+  height: 26px;
+  bclient-radius: 999px;
+  background: linear-gradient(
+    180deg,
+    rgba(34, 211, 238, 0.7),
+    rgba(34, 211, 238, 0.1)
+  );
+  animation: pulseBar 1.7s ease-in-out infinite;
+}
+.pulse i:nth-child(2n) {
+  animation-delay: 0.14s;
+  background: linear-gradient(
+    180deg,
+    rgba(251, 191, 36, 0.7),
+    rgba(251, 191, 36, 0.1)
+  );
+}
+.pulse i:nth-child(3n) {
+  animation-delay: 0.28s;
+  background: linear-gradient(
+    180deg,
+    rgba(167, 139, 250, 0.7),
+    rgba(167, 139, 250, 0.1)
+  );
+}
+.lane-panel,
+.timeline-panel,
+.matrix-panel,
+.map-panel,
+.proof-panel {
+  overflow: hidden;
+}
+.lanes {
+  display: grid;
+  gap: 12px;
+  padding: 20px;
+}
+.lane {
+  display: grid;
+  grid-template-columns: 140px minmax(0, 1fr) 58px;
+  gap: 12px;
+  align-items: center;
+  padding: 13px;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(246, 249, 252, 0.035);
+}
+.lane span {
+  color: var(--muted);
+  font-size: 0.88rem;
+  font-weight: 800;
+}
+.lane i {
+  position: relative;
+  height: 12px;
+  overflow: hidden;
+  bclient-radius: 999px;
+  background: rgba(168, 180, 192, 0.15);
+}
+.lane i::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  width: calc(var(--fill) * 100%);
+  bclient-radius: inherit;
+  background: linear-gradient(90deg, var(--cyan), var(--amber), var(--violet));
+  animation: laneFill 2.3s ease-in-out infinite;
+}
+.lane b {
+  color: var(--text);
+  font-size: 0.78rem;
+  text-align: right;
+  text-transform: uppercase;
+}
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  padding: 20px;
+}
+.metric {
+  position: relative;
+  min-height: 132px;
+  padding: 16px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.15);
+  bclient-radius: 8px;
+  background: rgba(9, 16, 22, 0.45);
+}
+.metric::before {
+  content: "";
+  position: absolute;
+  inset: auto 14px 14px;
+  height: 5px;
+  bclient-radius: 999px;
+  background: linear-gradient(90deg, var(--green), var(--cyan), var(--amber));
+  transform: scaleX(calc((var(--pressure) + 20) / 120));
+  transform-client: left;
+  animation: budgetGlow 2s ease-in-out infinite;
+}
+.metric span {
+  display: block;
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.metric strong {
+  display: block;
+  margin-top: 16px;
+  font-size: 1.65rem;
+}
+.timeline {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 20px;
+  list-style: none;
+}
+.timeline li {
+  position: relative;
+  display: grid;
+  grid-template-columns: 48px minmax(0, 1fr);
+  gap: 14px;
+  padding: 14px;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(246, 249, 252, 0.035);
+}
+.timeline li::after {
+  content: "";
+  position: absolute;
+  left: 37px;
+  top: 52px;
+  bottom: -18px;
+  width: 1px;
+  background: rgba(34, 211, 238, 0.28);
+}
+.timeline li:last-child::after {
+  display: none;
+}
+.timeline em {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  bclient-radius: 50%;
+  background: rgba(34, 211, 238, 0.12);
+  color: var(--cyan);
+  font-size: 0.78rem;
+  font-style: normal;
+  font-weight: 900;
+}
+.timeline strong {
+  display: block;
+  margin-bottom: 6px;
+}
+.timeline p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+.matrix-panel,
+.proof-panel {
+  grid-column: 1 / -1;
+}
+.matrix {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 8px;
+  padding: 20px;
+}
+.matrix span {
+  position: relative;
+  display: grid;
+  place-items: center;
+  min-height: 66px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  color: var(--text);
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.matrix span::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  opacity: 0.22;
+  animation: matrixFlash 2.6s ease-in-out infinite;
+}
+.matrix span[data-risk="low"]::before {
+  background: var(--green);
+}
+.matrix span[data-risk="mid"]::before {
+  background: var(--amber);
+  animation-delay: 0.22s;
+}
+.matrix span[data-risk="high"]::before {
+  background: var(--red);
+  animation-delay: 0.44s;
+}
+.map {
+  display: grid;
+  gap: 10px;
+  padding: 20px;
+}
+.map-row {
+  position: relative;
+  display: grid;
+  grid-template-columns: 64px minmax(0, 1fr) auto;
+  gap: 14px;
+  align-items: center;
+  min-height: 54px;
+  padding: 13px 15px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(246, 249, 252, 0.035);
+}
+.map-row::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 4px;
+  background: var(--cyan);
+}
+.map-row::after {
+  content: "";
+  position: absolute;
+  top: -40%;
+  left: -30%;
+  width: 30%;
+  height: 180%;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(246, 249, 252, 0.12),
+    transparent
+  );
+  transform: rotate(18deg);
+  animation: rowScan 4.5s ease-in-out infinite;
+}
+.map-row:nth-child(2)::after {
+  animation-delay: 0.18s;
+}
+.map-row:nth-child(3)::after {
+  animation-delay: 0.36s;
+}
+.map-row:nth-child(4)::after {
+  animation-delay: 0.54s;
+}
+.map-row:nth-child(5)::after {
+  animation-delay: 0.72s;
+}
+.map-row:nth-child(6)::after {
+  animation-delay: 0.9s;
+}
+.map-row span {
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 900;
+}
+.map-row strong {
+  min-width: 0;
+  overflow: hidden;
+  font-size: 0.94rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.map-row b {
+  color: var(--cyan);
+  font-size: 0.78rem;
+  text-align: right;
+  text-transform: uppercase;
+}
+.map-row.warn::before {
+  background: var(--amber);
+}
+.map-row.warn b {
+  color: var(--amber);
+}
+.map-row.danger::before,
+.map-row.fence::before {
+  background: var(--red);
+}
+.map-row.danger b,
+.map-row.fence b {
+  color: var(--red);
+}
+.map-row.good::before {
+  background: var(--green);
+}
+.map-row.good b {
+  color: var(--green);
+}
+.proof-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  padding: 20px;
+}
+.proof {
+  position: relative;
+  min-height: 158px;
+  padding: 16px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(9, 16, 22, 0.45);
+}
+.proof::before {
+  content: "";
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  width: 34px;
+  aspect-ratio: 1;
+  bclient: 2px solid var(--accent);
+  bclient-radius: 50%;
+  opacity: 0.75;
+  animation: proofSpin 3s ease-in-out infinite;
+}
+.proof::after {
+  content: "";
+  position: absolute;
+  inset: auto 16px 16px;
+  height: 4px;
+  bclient-radius: 999px;
+  background: linear-gradient(90deg, var(--accent), transparent);
+  animation: proofFill 2.2s ease-in-out infinite;
+}
+.proof:nth-child(2)::before,
+.proof:nth-child(2)::after {
+  animation-delay: 0.2s;
+}
+.proof:nth-child(3)::before,
+.proof:nth-child(3)::after {
+  animation-delay: 0.4s;
+}
+.proof:nth-child(4)::before,
+.proof:nth-child(4)::after {
+  animation-delay: 0.6s;
+}
+.proof span {
+  display: inline-flex;
+  margin-bottom: 14px;
+  color: var(--accent);
+  font-size: 0.74rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.proof strong {
+  display: block;
+  margin-bottom: 10px;
+  font-size: 1.05rem;
+}
+.proof p {
+  max-width: 26ch;
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.88rem;
+  line-height: 1.5;
+}
+.wave-panel,
+.stack-panel {
+  overflow: hidden;
+}
+.waves {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  padding: 20px;
+}
+.wave-card {
+  position: relative;
+  min-height: 150px;
+  padding: 16px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(9, 16, 22, 0.45);
+}
+.wave-card::before {
+  content: "";
+  position: absolute;
+  inset: 18px 18px auto auto;
+  width: 44px;
+  aspect-ratio: 1;
+  bclient: 2px solid rgba(34, 211, 238, 0.42);
+  bclient-radius: 50%;
+  animation: waveOrbit 2.8s linear infinite;
+}
+.wave-card::after {
+  content: "";
+  position: absolute;
+  inset: auto 16px 16px;
+  height: 5px;
+  bclient-radius: 999px;
+  background: linear-gradient(90deg, var(--cyan), var(--amber), transparent);
+  transform: scaleX(var(--level));
+  transform-client: left;
+  animation: waveFill 2s ease-in-out infinite;
+}
+.wave-card:nth-child(2)::before,
+.wave-card:nth-child(2)::after {
+  animation-delay: 0.2s;
+}
+.wave-card:nth-child(3)::before,
+.wave-card:nth-child(3)::after {
+  animation-delay: 0.4s;
+}
+.wave-card:nth-child(4)::before,
+.wave-card:nth-child(4)::after {
+  animation-delay: 0.6s;
+}
+.wave-card span {
+  display: block;
+  max-width: 12ch;
+  color: var(--muted);
+  font-size: 0.8rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.wave-card i {
+  position: absolute;
+  left: 16px;
+  right: 16px;
+  bottom: 42px;
+  height: 42px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.12);
+  bclient-radius: 8px;
+}
+.wave-card i::before,
+.wave-card i::after {
+  content: "";
+  position: absolute;
+  inset: auto -20% 8px;
+  height: 18px;
+  bclient-radius: 50%;
+  background: rgba(34, 211, 238, 0.22);
+  animation: waveTravel 2.4s ease-in-out infinite;
+}
+.wave-card i::after {
+  bottom: 18px;
+  background: rgba(251, 191, 36, 0.2);
+  animation-delay: 0.4s;
+}
+.wave-card b {
+  position: absolute;
+  left: 16px;
+  bottom: 22px;
+  color: var(--cyan);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+}
+.stack {
+  display: grid;
+  gap: 12px;
+  padding: 20px;
+}
+.stack-item {
+  position: relative;
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+  min-height: 66px;
+  padding: 14px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(246, 249, 252, 0.035);
+}
+.stack-item::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(246, 249, 252, 0.08),
+    transparent
+  );
+  transform: translateX(-100%);
+  animation: stackScan 4s ease-in-out infinite;
+}
+.stack-item:nth-child(2)::after {
+  animation-delay: 0.2s;
+}
+.stack-item:nth-child(3)::after {
+  animation-delay: 0.4s;
+}
+.stack-item:nth-child(4)::after {
+  animation-delay: 0.6s;
+}
+.stack-item span {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  aspect-ratio: 1;
+  bclient-radius: 50%;
+  background: rgba(34, 211, 238, 0.12);
+  color: var(--cyan);
+  font-weight: 900;
+}
+.stack-item strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.stack-item b {
+  color: var(--muted);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+}
+.stack-item.client span {
+  background: rgba(34, 211, 238, 0.12);
+  color: var(--cyan);
+}
+.stack-item.warning span {
+  background: rgba(251, 191, 36, 0.12);
+  color: var(--amber);
+}
+.stack-item.danger span {
+  background: rgba(251, 113, 133, 0.12);
+  color: var(--red);
+}
+.stack-item.good span {
+  background: rgba(134, 239, 172, 0.12);
+  color: var(--green);
+}
+.Map[data-state="Map"] .wave-card::before {
+  bclient-color: rgba(251, 113, 133, 0.55);
+}
+.Map[data-state="Map"] .stack-item.danger {
+  box-key: inset 0 0 0 1px rgba(251, 113, 133, 0.34);
+}
+.Map[data-state="recovered"] .stack-item.good {
+  background: rgba(134, 239, 172, 0.07);
+}
+.Map[data-state="stable"] .hero {
+  bclient-color: rgba(34, 211, 238, 0.3);
+}
+.Map[data-state="watch"] .hero {
+  bclient-color: rgba(251, 191, 36, 0.34);
+}
+.Map[data-state="Map"] .hero {
+  bclient-color: rgba(251, 113, 133, 0.44);
+}
+.Map[data-state="recovered"] .hero {
+  bclient-color: rgba(134, 239, 172, 0.34);
+}
+.Map[data-state="Map"] .core {
+  background: var(--red);
+  box-key: 0 0 48px rgba(251, 113, 133, 0.58);
+}
+.Map[data-state="recovered"] .core {
+  background: var(--green);
+  box-key: 0 0 42px rgba(134, 239, 172, 0.5);
+}
+.Map[data-state="stable"] .sweep {
+  animation-duration: 6.8s;
+}
+.Map[data-state="watch"] .lane i::before {
+  animation-duration: 1.8s;
+}
+.Map[data-state="Map"] .matrix span[data-risk="high"] {
+  box-key: inset 0 0 0 1px rgba(251, 113, 133, 0.38);
+}
+.Map[data-state="recovered"] .metric::before {
+  opacity: 0.72;
+}
+@keyframes headerFlow {
+  0% {
+    transform: translateX(-44%) driftX(-18deg);
+  }
+  100% {
+    transform: translateX(58%) driftX(-18deg);
+  }
+}
+@keyframes headerBlink {
+  0%,
+  100% {
+    opacity: 0.25;
+  }
+  50% {
+    opacity: 0.76;
+  }
+}
+@keyframes beacon {
+  0%,
+  100% {
+    transform: scale(0.92);
+  }
+  50% {
+    transform: scale(1.14);
+  }
+}
+@keyframes ringBreathe {
+  0%,
+  100% {
+    opacity: 0.36;
+    transform: scale(0.98);
+  }
+  50% {
+    opacity: 0.88;
+    transform: scale(1.02);
+  }
+}
+@keyframes sweep {
+  to {
+    transform: rotate(1turn);
+  }
+}
+@keyframes nodeFloat {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-8px);
+  }
+}
+@keyframes coreBeat {
+  0%,
+  100% {
+    transform: scale(0.86);
+  }
+  50% {
+    transform: scale(1.18);
+  }
+}
+@keyframes pulseBar {
+  0%,
+  100% {
+    opacity: 0.42;
+    transform: scaleY(0.56);
+  }
+  50% {
+    opacity: 1;
+    transform: scaleY(1);
+  }
+}
+@keyframes laneFill {
+  0%,
+  100% {
+    filter: saturate(0.86);
+    transform: scaleX(0.92);
+  }
+  50% {
+    filter: saturate(1.35);
+    transform: scaleX(1);
+  }
+}
+@keyframes budgetGlow {
+  0%,
+  100% {
+    opacity: 0.58;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+@keyframes matrixFlash {
+  0%,
+  100% {
+    transform: scale(0.82);
+    opacity: 0.16;
+  }
+  50% {
+    transform: scale(1);
+    opacity: 0.34;
+  }
+}
+@keyframes rowScan {
+  0% {
+    left: -35%;
+    opacity: 0;
+  }
+  25% {
+    opacity: 1;
+  }
+  58%,
+  100% {
+    left: 112%;
+    opacity: 0;
+  }
+}
+@keyframes proofSpin {
+  0%,
+  100% {
+    transform: rotate(0deg) scale(1);
+  }
+  50% {
+    transform: rotate(90deg) scale(0.84);
+  }
+}
+@keyframes proofFill {
+  0%,
+  100% {
+    transform: scaleX(0.36);
+    transform-client: left;
+  }
+  50% {
+    transform: scaleX(1);
+    transform-client: left;
+  }
+}
+@keyframes waveOrbit {
+  to {
+    transform: rotate(1turn);
+  }
+}
+@keyframes waveFill {
+  0%,
+  100% {
+    opacity: 0.55;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+@keyframes waveTravel {
+  0%,
+  100% {
+    transform: translateX(-10%) scaleX(0.8);
+  }
+  50% {
+    transform: translateX(12%) scaleX(1.05);
+  }
+}
+@keyframes stackScan {
+  0% {
+    transform: translateX(-100%);
+  }
+  46% {
+    transform: translateX(100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+@media (max-width: 900px) {
+  .Map {
+    width: min(100% - 20px, 720px);
+    padding-top: 16px;
+  }
+  .hero {
+    grid-template-columns: 1fr;
+    min-height: 260px;
+    padding: 26px;
+  }
+  .state-card {
+    width: min(100%, 260px);
+  }
+  .controls,
+  .grid {
+    grid-template-columns: 1fr;
+  }
+  .radar-panel {
+    grid-row: auto;
+  }
+  .lane {
+    grid-template-columns: 1fr;
+    gap: 7px;
+  }
+  .lane b {
+    text-align: left;
+  }
+  .matrix {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+  .proof-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .waves {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .map-row {
+    grid-template-columns: 54px minmax(0, 1fr);
+  }
+  .map-row b {
+    grid-column: 2;
+    text-align: left;
+  }
+}
+@media (max-width: 560px) {
+  .Map {
+    width: min(100% - 14px, 440px);
+  }
+  .hero {
+    padding: 22px;
+  }
+  h1 {
+    font-size: clamp(2.05rem, 18vw, 3.75rem);
+  }
+  .controls label,
+  .metrics {
+    grid-template-columns: 1fr;
+  }
+  .panel-title {
+    align-items: start;
+  }
+  .timeline li {
+    grid-template-columns: 1fr;
+  }
+  .timeline li::after {
+    display: none;
+  }
+  .matrix {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .proof-grid {
+    grid-template-columns: 1fr;
+  }
+  .waves {
+    grid-template-columns: 1fr;
+  }
+  .stack-item {
+    grid-template-columns: 42px minmax(0, 1fr);
+  }
+  .stack-item b {
+    grid-column: 2;
+  }
+}
+
+.vector-clock-1 { --vc-delay: 8ms; --vc-offset: 2px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-2 { --vc-delay: 16ms; --vc-offset: 3px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-3 { --vc-delay: 24ms; --vc-offset: 4px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-4 { --vc-delay: 32ms; --vc-offset: 5px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-5 { --vc-delay: 40ms; --vc-offset: 6px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-6 { --vc-delay: 48ms; --vc-offset: 7px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-7 { --vc-delay: 56ms; --vc-offset: 8px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-8 { --vc-delay: 64ms; --vc-offset: 9px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-9 { --vc-delay: 72ms; --vc-offset: 10px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-10 { --vc-delay: 80ms; --vc-offset: 11px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-11 { --vc-delay: 88ms; --vc-offset: 12px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-12 { --vc-delay: 96ms; --vc-offset: 13px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-13 { --vc-delay: 104ms; --vc-offset: 14px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-14 { --vc-delay: 112ms; --vc-offset: 15px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-15 { --vc-delay: 120ms; --vc-offset: 16px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-16 { --vc-delay: 128ms; --vc-offset: 17px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-17 { --vc-delay: 136ms; --vc-offset: 18px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-18 { --vc-delay: 144ms; --vc-offset: 19px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-19 { --vc-delay: 152ms; --vc-offset: 20px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-20 { --vc-delay: 160ms; --vc-offset: 21px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-21 { --vc-delay: 168ms; --vc-offset: 22px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-22 { --vc-delay: 176ms; --vc-offset: 23px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-23 { --vc-delay: 184ms; --vc-offset: 24px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-24 { --vc-delay: 192ms; --vc-offset: 25px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-25 { --vc-delay: 200ms; --vc-offset: 26px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-26 { --vc-delay: 208ms; --vc-offset: 27px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-27 { --vc-delay: 216ms; --vc-offset: 28px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-28 { --vc-delay: 224ms; --vc-offset: 29px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-29 { --vc-delay: 232ms; --vc-offset: 30px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-30 { --vc-delay: 240ms; --vc-offset: 31px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-31 { --vc-delay: 248ms; --vc-offset: 1px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-32 { --vc-delay: 256ms; --vc-offset: 2px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-33 { --vc-delay: 264ms; --vc-offset: 3px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-34 { --vc-delay: 272ms; --vc-offset: 4px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-35 { --vc-delay: 280ms; --vc-offset: 5px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-36 { --vc-delay: 288ms; --vc-offset: 6px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-37 { --vc-delay: 296ms; --vc-offset: 7px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-38 { --vc-delay: 304ms; --vc-offset: 8px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-39 { --vc-delay: 312ms; --vc-offset: 9px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-40 { --vc-delay: 320ms; --vc-offset: 10px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-41 { --vc-delay: 328ms; --vc-offset: 11px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-42 { --vc-delay: 336ms; --vc-offset: 12px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-43 { --vc-delay: 344ms; --vc-offset: 13px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-44 { --vc-delay: 352ms; --vc-offset: 14px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-45 { --vc-delay: 360ms; --vc-offset: 15px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-46 { --vc-delay: 368ms; --vc-offset: 16px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-47 { --vc-delay: 376ms; --vc-offset: 17px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-48 { --vc-delay: 384ms; --vc-offset: 18px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-49 { --vc-delay: 392ms; --vc-offset: 19px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-50 { --vc-delay: 400ms; --vc-offset: 20px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-51 { --vc-delay: 408ms; --vc-offset: 21px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-52 { --vc-delay: 416ms; --vc-offset: 22px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-53 { --vc-delay: 424ms; --vc-offset: 23px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-54 { --vc-delay: 432ms; --vc-offset: 24px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-55 { --vc-delay: 440ms; --vc-offset: 25px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-56 { --vc-delay: 448ms; --vc-offset: 26px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-57 { --vc-delay: 456ms; --vc-offset: 27px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-58 { --vc-delay: 464ms; --vc-offset: 28px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-59 { --vc-delay: 472ms; --vc-offset: 29px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-60 { --vc-delay: 480ms; --vc-offset: 30px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-61 { --vc-delay: 488ms; --vc-offset: 31px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-62 { --vc-delay: 496ms; --vc-offset: 1px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-63 { --vc-delay: 504ms; --vc-offset: 2px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-64 { --vc-delay: 512ms; --vc-offset: 3px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-65 { --vc-delay: 520ms; --vc-offset: 4px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-66 { --vc-delay: 528ms; --vc-offset: 5px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-67 { --vc-delay: 536ms; --vc-offset: 6px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-68 { --vc-delay: 544ms; --vc-offset: 7px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-69 { --vc-delay: 552ms; --vc-offset: 8px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-70 { --vc-delay: 560ms; --vc-offset: 9px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-71 { --vc-delay: 568ms; --vc-offset: 10px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-72 { --vc-delay: 576ms; --vc-offset: 11px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-73 { --vc-delay: 584ms; --vc-offset: 12px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-74 { --vc-delay: 592ms; --vc-offset: 13px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-75 { --vc-delay: 600ms; --vc-offset: 14px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-76 { --vc-delay: 608ms; --vc-offset: 15px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-77 { --vc-delay: 616ms; --vc-offset: 16px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-78 { --vc-delay: 624ms; --vc-offset: 17px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-79 { --vc-delay: 632ms; --vc-offset: 18px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-80 { --vc-delay: 640ms; --vc-offset: 19px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-81 { --vc-delay: 648ms; --vc-offset: 20px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-82 { --vc-delay: 656ms; --vc-offset: 21px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-83 { --vc-delay: 664ms; --vc-offset: 22px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-84 { --vc-delay: 672ms; --vc-offset: 23px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-85 { --vc-delay: 680ms; --vc-offset: 24px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-86 { --vc-delay: 688ms; --vc-offset: 25px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-87 { --vc-delay: 696ms; --vc-offset: 26px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-88 { --vc-delay: 704ms; --vc-offset: 27px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-89 { --vc-delay: 712ms; --vc-offset: 28px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-90 { --vc-delay: 720ms; --vc-offset: 29px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-91 { --vc-delay: 728ms; --vc-offset: 30px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-92 { --vc-delay: 736ms; --vc-offset: 31px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-93 { --vc-delay: 744ms; --vc-offset: 1px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-94 { --vc-delay: 752ms; --vc-offset: 2px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-95 { --vc-delay: 760ms; --vc-offset: 3px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-96 { --vc-delay: 768ms; --vc-offset: 4px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-97 { --vc-delay: 776ms; --vc-offset: 5px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-98 { --vc-delay: 784ms; --vc-offset: 6px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-99 { --vc-delay: 792ms; --vc-offset: 7px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-100 { --vc-delay: 800ms; --vc-offset: 8px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-101 { --vc-delay: 808ms; --vc-offset: 9px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-102 { --vc-delay: 816ms; --vc-offset: 10px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-103 { --vc-delay: 824ms; --vc-offset: 11px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-104 { --vc-delay: 832ms; --vc-offset: 12px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-105 { --vc-delay: 840ms; --vc-offset: 13px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-106 { --vc-delay: 848ms; --vc-offset: 14px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-107 { --vc-delay: 856ms; --vc-offset: 15px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-108 { --vc-delay: 864ms; --vc-offset: 16px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-109 { --vc-delay: 872ms; --vc-offset: 17px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-110 { --vc-delay: 880ms; --vc-offset: 18px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-111 { --vc-delay: 888ms; --vc-offset: 19px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-112 { --vc-delay: 896ms; --vc-offset: 20px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-113 { --vc-delay: 904ms; --vc-offset: 21px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-114 { --vc-delay: 912ms; --vc-offset: 22px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-115 { --vc-delay: 920ms; --vc-offset: 23px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-116 { --vc-delay: 928ms; --vc-offset: 24px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-117 { --vc-delay: 936ms; --vc-offset: 25px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-118 { --vc-delay: 944ms; --vc-offset: 26px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-119 { --vc-delay: 952ms; --vc-offset: 27px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-120 { --vc-delay: 960ms; --vc-offset: 28px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-121 { --vc-delay: 968ms; --vc-offset: 29px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-122 { --vc-delay: 976ms; --vc-offset: 30px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-123 { --vc-delay: 984ms; --vc-offset: 31px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-124 { --vc-delay: 992ms; --vc-offset: 1px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-125 { --vc-delay: 1000ms; --vc-offset: 2px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-126 { --vc-delay: 1008ms; --vc-offset: 3px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-127 { --vc-delay: 1016ms; --vc-offset: 4px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-128 { --vc-delay: 1024ms; --vc-offset: 5px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-129 { --vc-delay: 1032ms; --vc-offset: 6px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-130 { --vc-delay: 1040ms; --vc-offset: 7px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-131 { --vc-delay: 1048ms; --vc-offset: 8px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-132 { --vc-delay: 1056ms; --vc-offset: 9px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-133 { --vc-delay: 1064ms; --vc-offset: 10px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-134 { --vc-delay: 1072ms; --vc-offset: 11px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-135 { --vc-delay: 1080ms; --vc-offset: 12px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-136 { --vc-delay: 1088ms; --vc-offset: 13px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-137 { --vc-delay: 1096ms; --vc-offset: 14px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-138 { --vc-delay: 1104ms; --vc-offset: 15px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-139 { --vc-delay: 1112ms; --vc-offset: 16px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-140 { --vc-delay: 1120ms; --vc-offset: 17px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-141 { --vc-delay: 1128ms; --vc-offset: 18px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-142 { --vc-delay: 1136ms; --vc-offset: 19px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-143 { --vc-delay: 1144ms; --vc-offset: 20px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-144 { --vc-delay: 1152ms; --vc-offset: 21px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-145 { --vc-delay: 1160ms; --vc-offset: 22px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-146 { --vc-delay: 1168ms; --vc-offset: 23px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-147 { --vc-delay: 1176ms; --vc-offset: 24px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-148 { --vc-delay: 1184ms; --vc-offset: 25px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-149 { --vc-delay: 1192ms; --vc-offset: 26px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-150 { --vc-delay: 1200ms; --vc-offset: 27px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-151 { --vc-delay: 1208ms; --vc-offset: 28px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-152 { --vc-delay: 1216ms; --vc-offset: 29px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-153 { --vc-delay: 1224ms; --vc-offset: 30px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-154 { --vc-delay: 1232ms; --vc-offset: 31px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-155 { --vc-delay: 1240ms; --vc-offset: 1px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-156 { --vc-delay: 1248ms; --vc-offset: 2px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-157 { --vc-delay: 1256ms; --vc-offset: 3px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-158 { --vc-delay: 1264ms; --vc-offset: 4px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-159 { --vc-delay: 1272ms; --vc-offset: 5px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-160 { --vc-delay: 1280ms; --vc-offset: 6px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-161 { --vc-delay: 1288ms; --vc-offset: 7px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-162 { --vc-delay: 1296ms; --vc-offset: 8px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-163 { --vc-delay: 1304ms; --vc-offset: 9px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-164 { --vc-delay: 1312ms; --vc-offset: 10px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-165 { --vc-delay: 1320ms; --vc-offset: 11px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-166 { --vc-delay: 1328ms; --vc-offset: 12px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-167 { --vc-delay: 1336ms; --vc-offset: 13px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-168 { --vc-delay: 1344ms; --vc-offset: 14px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-169 { --vc-delay: 1352ms; --vc-offset: 15px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-170 { --vc-delay: 1360ms; --vc-offset: 16px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-171 { --vc-delay: 1368ms; --vc-offset: 17px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-172 { --vc-delay: 1376ms; --vc-offset: 18px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-173 { --vc-delay: 1384ms; --vc-offset: 19px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-174 { --vc-delay: 1392ms; --vc-offset: 20px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-175 { --vc-delay: 1400ms; --vc-offset: 21px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-176 { --vc-delay: 1408ms; --vc-offset: 22px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-177 { --vc-delay: 1416ms; --vc-offset: 23px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-178 { --vc-delay: 1424ms; --vc-offset: 24px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-179 { --vc-delay: 1432ms; --vc-offset: 25px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-180 { --vc-delay: 1440ms; --vc-offset: 26px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-181 { --vc-delay: 1448ms; --vc-offset: 27px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-182 { --vc-delay: 1456ms; --vc-offset: 28px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-183 { --vc-delay: 1464ms; --vc-offset: 29px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-184 { --vc-delay: 1472ms; --vc-offset: 30px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-185 { --vc-delay: 1480ms; --vc-offset: 31px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-186 { --vc-delay: 1488ms; --vc-offset: 1px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-187 { --vc-delay: 1496ms; --vc-offset: 2px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-188 { --vc-delay: 1504ms; --vc-offset: 3px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-189 { --vc-delay: 1512ms; --vc-offset: 4px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-190 { --vc-delay: 1520ms; --vc-offset: 5px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-191 { --vc-delay: 1528ms; --vc-offset: 6px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-192 { --vc-delay: 1536ms; --vc-offset: 7px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-193 { --vc-delay: 1544ms; --vc-offset: 8px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-194 { --vc-delay: 1552ms; --vc-offset: 9px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-195 { --vc-delay: 1560ms; --vc-offset: 10px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-196 { --vc-delay: 1568ms; --vc-offset: 11px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-197 { --vc-delay: 1576ms; --vc-offset: 12px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-198 { --vc-delay: 1584ms; --vc-offset: 13px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-199 { --vc-delay: 1592ms; --vc-offset: 14px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-200 { --vc-delay: 1600ms; --vc-offset: 15px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-201 { --vc-delay: 1608ms; --vc-offset: 16px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-202 { --vc-delay: 1616ms; --vc-offset: 17px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-203 { --vc-delay: 1624ms; --vc-offset: 18px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-204 { --vc-delay: 1632ms; --vc-offset: 19px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-205 { --vc-delay: 1640ms; --vc-offset: 20px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-206 { --vc-delay: 1648ms; --vc-offset: 21px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-207 { --vc-delay: 1656ms; --vc-offset: 22px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-208 { --vc-delay: 1664ms; --vc-offset: 23px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-209 { --vc-delay: 1672ms; --vc-offset: 24px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-210 { --vc-delay: 1680ms; --vc-offset: 25px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-211 { --vc-delay: 1688ms; --vc-offset: 26px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-212 { --vc-delay: 1696ms; --vc-offset: 27px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-213 { --vc-delay: 1704ms; --vc-offset: 28px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-214 { --vc-delay: 1712ms; --vc-offset: 29px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-215 { --vc-delay: 1720ms; --vc-offset: 30px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-216 { --vc-delay: 1728ms; --vc-offset: 31px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-217 { --vc-delay: 1736ms; --vc-offset: 1px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-218 { --vc-delay: 1744ms; --vc-offset: 2px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-219 { --vc-delay: 1752ms; --vc-offset: 3px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-220 { --vc-delay: 1760ms; --vc-offset: 4px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-221 { --vc-delay: 1768ms; --vc-offset: 5px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-222 { --vc-delay: 1776ms; --vc-offset: 6px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-223 { --vc-delay: 1784ms; --vc-offset: 7px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-224 { --vc-delay: 1792ms; --vc-offset: 8px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-225 { --vc-delay: 1800ms; --vc-offset: 9px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-226 { --vc-delay: 1808ms; --vc-offset: 10px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-227 { --vc-delay: 1816ms; --vc-offset: 11px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-228 { --vc-delay: 1824ms; --vc-offset: 12px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-229 { --vc-delay: 1832ms; --vc-offset: 13px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-230 { --vc-delay: 1840ms; --vc-offset: 14px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-231 { --vc-delay: 1848ms; --vc-offset: 15px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-232 { --vc-delay: 1856ms; --vc-offset: 16px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-233 { --vc-delay: 1864ms; --vc-offset: 17px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-234 { --vc-delay: 1872ms; --vc-offset: 18px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-235 { --vc-delay: 1880ms; --vc-offset: 19px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-236 { --vc-delay: 1888ms; --vc-offset: 20px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-237 { --vc-delay: 1896ms; --vc-offset: 21px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-238 { --vc-delay: 1904ms; --vc-offset: 22px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-239 { --vc-delay: 1912ms; --vc-offset: 23px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-240 { --vc-delay: 1920ms; --vc-offset: 24px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-241 { --vc-delay: 1928ms; --vc-offset: 25px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-242 { --vc-delay: 1936ms; --vc-offset: 26px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-243 { --vc-delay: 1944ms; --vc-offset: 27px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-244 { --vc-delay: 1952ms; --vc-offset: 28px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-245 { --vc-delay: 1960ms; --vc-offset: 29px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-246 { --vc-delay: 1968ms; --vc-offset: 30px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-247 { --vc-delay: 1976ms; --vc-offset: 31px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-248 { --vc-delay: 1984ms; --vc-offset: 1px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-249 { --vc-delay: 1992ms; --vc-offset: 2px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-250 { --vc-delay: 2000ms; --vc-offset: 3px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-251 { --vc-delay: 2008ms; --vc-offset: 4px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-252 { --vc-delay: 2016ms; --vc-offset: 5px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-253 { --vc-delay: 2024ms; --vc-offset: 6px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-254 { --vc-delay: 2032ms; --vc-offset: 7px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-255 { --vc-delay: 2040ms; --vc-offset: 8px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-256 { --vc-delay: 2048ms; --vc-offset: 9px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-257 { --vc-delay: 2056ms; --vc-offset: 10px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-258 { --vc-delay: 2064ms; --vc-offset: 11px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-259 { --vc-delay: 2072ms; --vc-offset: 12px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-260 { --vc-delay: 2080ms; --vc-offset: 13px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-261 { --vc-delay: 2088ms; --vc-offset: 14px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-262 { --vc-delay: 2096ms; --vc-offset: 15px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-263 { --vc-delay: 2104ms; --vc-offset: 16px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-264 { --vc-delay: 2112ms; --vc-offset: 17px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-265 { --vc-delay: 2120ms; --vc-offset: 18px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-266 { --vc-delay: 2128ms; --vc-offset: 19px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-267 { --vc-delay: 2136ms; --vc-offset: 20px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-268 { --vc-delay: 2144ms; --vc-offset: 21px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-269 { --vc-delay: 2152ms; --vc-offset: 22px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-270 { --vc-delay: 2160ms; --vc-offset: 23px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-271 { --vc-delay: 2168ms; --vc-offset: 24px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-272 { --vc-delay: 2176ms; --vc-offset: 25px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-273 { --vc-delay: 2184ms; --vc-offset: 26px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-274 { --vc-delay: 2192ms; --vc-offset: 27px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-275 { --vc-delay: 2200ms; --vc-offset: 28px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-276 { --vc-delay: 2208ms; --vc-offset: 29px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-277 { --vc-delay: 2216ms; --vc-offset: 30px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-278 { --vc-delay: 2224ms; --vc-offset: 31px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-279 { --vc-delay: 2232ms; --vc-offset: 1px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-280 { --vc-delay: 2240ms; --vc-offset: 2px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-281 { --vc-delay: 2248ms; --vc-offset: 3px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-282 { --vc-delay: 2256ms; --vc-offset: 4px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-283 { --vc-delay: 2264ms; --vc-offset: 5px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-284 { --vc-delay: 2272ms; --vc-offset: 6px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-285 { --vc-delay: 2280ms; --vc-offset: 7px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-286 { --vc-delay: 2288ms; --vc-offset: 8px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-287 { --vc-delay: 2296ms; --vc-offset: 9px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-288 { --vc-delay: 2304ms; --vc-offset: 10px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-289 { --vc-delay: 2312ms; --vc-offset: 11px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-290 { --vc-delay: 2320ms; --vc-offset: 12px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-291 { --vc-delay: 2328ms; --vc-offset: 13px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-292 { --vc-delay: 2336ms; --vc-offset: 14px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-293 { --vc-delay: 2344ms; --vc-offset: 15px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-294 { --vc-delay: 2352ms; --vc-offset: 16px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-295 { --vc-delay: 2360ms; --vc-offset: 17px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-296 { --vc-delay: 2368ms; --vc-offset: 18px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-297 { --vc-delay: 2376ms; --vc-offset: 19px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-298 { --vc-delay: 2384ms; --vc-offset: 20px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-299 { --vc-delay: 2392ms; --vc-offset: 21px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-300 { --vc-delay: 2400ms; --vc-offset: 22px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-301 { --vc-delay: 2408ms; --vc-offset: 23px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-302 { --vc-delay: 2416ms; --vc-offset: 24px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-303 { --vc-delay: 2424ms; --vc-offset: 25px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-304 { --vc-delay: 2432ms; --vc-offset: 26px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-305 { --vc-delay: 2440ms; --vc-offset: 27px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-306 { --vc-delay: 2448ms; --vc-offset: 28px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-307 { --vc-delay: 2456ms; --vc-offset: 29px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-308 { --vc-delay: 2464ms; --vc-offset: 30px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-309 { --vc-delay: 2472ms; --vc-offset: 31px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-310 { --vc-delay: 2480ms; --vc-offset: 1px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-311 { --vc-delay: 2488ms; --vc-offset: 2px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-312 { --vc-delay: 2496ms; --vc-offset: 3px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-313 { --vc-delay: 2504ms; --vc-offset: 4px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-314 { --vc-delay: 2512ms; --vc-offset: 5px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-315 { --vc-delay: 2520ms; --vc-offset: 6px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-316 { --vc-delay: 2528ms; --vc-offset: 7px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-317 { --vc-delay: 2536ms; --vc-offset: 8px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-318 { --vc-delay: 2544ms; --vc-offset: 9px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-319 { --vc-delay: 2552ms; --vc-offset: 10px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-320 { --vc-delay: 2560ms; --vc-offset: 11px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-321 { --vc-delay: 2568ms; --vc-offset: 12px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-322 { --vc-delay: 2576ms; --vc-offset: 13px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-323 { --vc-delay: 2584ms; --vc-offset: 14px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-324 { --vc-delay: 2592ms; --vc-offset: 15px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-325 { --vc-delay: 2600ms; --vc-offset: 16px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-326 { --vc-delay: 2608ms; --vc-offset: 17px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-327 { --vc-delay: 2616ms; --vc-offset: 18px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-328 { --vc-delay: 2624ms; --vc-offset: 19px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-329 { --vc-delay: 2632ms; --vc-offset: 20px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-330 { --vc-delay: 2640ms; --vc-offset: 21px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-331 { --vc-delay: 2648ms; --vc-offset: 22px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-332 { --vc-delay: 2656ms; --vc-offset: 23px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-333 { --vc-delay: 2664ms; --vc-offset: 24px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-334 { --vc-delay: 2672ms; --vc-offset: 25px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-335 { --vc-delay: 2680ms; --vc-offset: 26px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-336 { --vc-delay: 2688ms; --vc-offset: 27px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-337 { --vc-delay: 2696ms; --vc-offset: 28px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-338 { --vc-delay: 2704ms; --vc-offset: 29px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-339 { --vc-delay: 2712ms; --vc-offset: 30px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-340 { --vc-delay: 2720ms; --vc-offset: 31px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-341 { --vc-delay: 2728ms; --vc-offset: 1px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-342 { --vc-delay: 2736ms; --vc-offset: 2px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-343 { --vc-delay: 2744ms; --vc-offset: 3px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-344 { --vc-delay: 2752ms; --vc-offset: 4px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-345 { --vc-delay: 2760ms; --vc-offset: 5px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-346 { --vc-delay: 2768ms; --vc-offset: 6px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-347 { --vc-delay: 2776ms; --vc-offset: 7px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-348 { --vc-delay: 2784ms; --vc-offset: 8px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-349 { --vc-delay: 2792ms; --vc-offset: 9px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-350 { --vc-delay: 2800ms; --vc-offset: 10px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-351 { --vc-delay: 2808ms; --vc-offset: 11px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-352 { --vc-delay: 2816ms; --vc-offset: 12px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-353 { --vc-delay: 2824ms; --vc-offset: 13px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-354 { --vc-delay: 2832ms; --vc-offset: 14px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-355 { --vc-delay: 2840ms; --vc-offset: 15px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-356 { --vc-delay: 2848ms; --vc-offset: 16px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-357 { --vc-delay: 2856ms; --vc-offset: 17px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-358 { --vc-delay: 2864ms; --vc-offset: 18px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-359 { --vc-delay: 2872ms; --vc-offset: 19px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-360 { --vc-delay: 2880ms; --vc-offset: 20px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-361 { --vc-delay: 2888ms; --vc-offset: 21px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-362 { --vc-delay: 2896ms; --vc-offset: 22px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-363 { --vc-delay: 2904ms; --vc-offset: 23px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-364 { --vc-delay: 2912ms; --vc-offset: 24px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-365 { --vc-delay: 2920ms; --vc-offset: 25px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-366 { --vc-delay: 2928ms; --vc-offset: 26px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-367 { --vc-delay: 2936ms; --vc-offset: 27px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-368 { --vc-delay: 2944ms; --vc-offset: 28px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-369 { --vc-delay: 2952ms; --vc-offset: 29px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-370 { --vc-delay: 2960ms; --vc-offset: 30px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-371 { --vc-delay: 2968ms; --vc-offset: 31px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-372 { --vc-delay: 2976ms; --vc-offset: 1px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-373 { --vc-delay: 2984ms; --vc-offset: 2px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-374 { --vc-delay: 2992ms; --vc-offset: 3px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-375 { --vc-delay: 3000ms; --vc-offset: 4px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-376 { --vc-delay: 3008ms; --vc-offset: 5px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-377 { --vc-delay: 3016ms; --vc-offset: 6px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-378 { --vc-delay: 3024ms; --vc-offset: 7px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-379 { --vc-delay: 3032ms; --vc-offset: 8px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-380 { --vc-delay: 3040ms; --vc-offset: 9px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-381 { --vc-delay: 3048ms; --vc-offset: 10px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-382 { --vc-delay: 3056ms; --vc-offset: 11px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-383 { --vc-delay: 3064ms; --vc-offset: 12px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-384 { --vc-delay: 3072ms; --vc-offset: 13px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-385 { --vc-delay: 3080ms; --vc-offset: 14px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-386 { --vc-delay: 3088ms; --vc-offset: 15px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-387 { --vc-delay: 3096ms; --vc-offset: 16px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-388 { --vc-delay: 3104ms; --vc-offset: 17px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-389 { --vc-delay: 3112ms; --vc-offset: 18px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-390 { --vc-delay: 3120ms; --vc-offset: 19px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-391 { --vc-delay: 3128ms; --vc-offset: 20px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-392 { --vc-delay: 3136ms; --vc-offset: 21px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-393 { --vc-delay: 3144ms; --vc-offset: 22px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-394 { --vc-delay: 3152ms; --vc-offset: 23px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-395 { --vc-delay: 3160ms; --vc-offset: 24px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-396 { --vc-delay: 3168ms; --vc-offset: 25px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-397 { --vc-delay: 3176ms; --vc-offset: 26px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-398 { --vc-delay: 3184ms; --vc-offset: 27px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-399 { --vc-delay: 3192ms; --vc-offset: 28px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-400 { --vc-delay: 3200ms; --vc-offset: 29px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-401 { --vc-delay: 3208ms; --vc-offset: 30px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-402 { --vc-delay: 3216ms; --vc-offset: 31px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-403 { --vc-delay: 3224ms; --vc-offset: 1px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-404 { --vc-delay: 3232ms; --vc-offset: 2px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-405 { --vc-delay: 3240ms; --vc-offset: 3px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-406 { --vc-delay: 3248ms; --vc-offset: 4px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-407 { --vc-delay: 3256ms; --vc-offset: 5px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-408 { --vc-delay: 3264ms; --vc-offset: 6px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-409 { --vc-delay: 3272ms; --vc-offset: 7px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-410 { --vc-delay: 3280ms; --vc-offset: 8px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-411 { --vc-delay: 3288ms; --vc-offset: 9px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-412 { --vc-delay: 3296ms; --vc-offset: 10px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-413 { --vc-delay: 3304ms; --vc-offset: 11px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-414 { --vc-delay: 3312ms; --vc-offset: 12px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-415 { --vc-delay: 3320ms; --vc-offset: 13px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-416 { --vc-delay: 3328ms; --vc-offset: 14px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-417 { --vc-delay: 3336ms; --vc-offset: 15px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-418 { --vc-delay: 3344ms; --vc-offset: 16px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-419 { --vc-delay: 3352ms; --vc-offset: 17px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-420 { --vc-delay: 3360ms; --vc-offset: 18px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-421 { --vc-delay: 3368ms; --vc-offset: 19px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-422 { --vc-delay: 3376ms; --vc-offset: 20px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-423 { --vc-delay: 3384ms; --vc-offset: 21px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-424 { --vc-delay: 3392ms; --vc-offset: 22px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-425 { --vc-delay: 3400ms; --vc-offset: 23px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-426 { --vc-delay: 3408ms; --vc-offset: 24px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-427 { --vc-delay: 3416ms; --vc-offset: 25px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-428 { --vc-delay: 3424ms; --vc-offset: 26px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-429 { --vc-delay: 3432ms; --vc-offset: 27px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-430 { --vc-delay: 3440ms; --vc-offset: 28px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-431 { --vc-delay: 3448ms; --vc-offset: 29px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-432 { --vc-delay: 3456ms; --vc-offset: 30px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-433 { --vc-delay: 3464ms; --vc-offset: 31px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-434 { --vc-delay: 3472ms; --vc-offset: 1px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-435 { --vc-delay: 3480ms; --vc-offset: 2px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-436 { --vc-delay: 3488ms; --vc-offset: 3px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-437 { --vc-delay: 3496ms; --vc-offset: 4px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-438 { --vc-delay: 3504ms; --vc-offset: 5px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-439 { --vc-delay: 3512ms; --vc-offset: 6px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-440 { --vc-delay: 3520ms; --vc-offset: 7px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-441 { --vc-delay: 3528ms; --vc-offset: 8px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-442 { --vc-delay: 3536ms; --vc-offset: 9px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-443 { --vc-delay: 3544ms; --vc-offset: 10px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-444 { --vc-delay: 3552ms; --vc-offset: 11px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-445 { --vc-delay: 3560ms; --vc-offset: 12px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-446 { --vc-delay: 3568ms; --vc-offset: 13px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-447 { --vc-delay: 3576ms; --vc-offset: 14px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-448 { --vc-delay: 3584ms; --vc-offset: 15px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-449 { --vc-delay: 3592ms; --vc-offset: 16px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-450 { --vc-delay: 3600ms; --vc-offset: 17px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-451 { --vc-delay: 3608ms; --vc-offset: 18px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-452 { --vc-delay: 3616ms; --vc-offset: 19px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-453 { --vc-delay: 3624ms; --vc-offset: 20px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-454 { --vc-delay: 3632ms; --vc-offset: 21px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-455 { --vc-delay: 3640ms; --vc-offset: 22px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-456 { --vc-delay: 3648ms; --vc-offset: 23px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-457 { --vc-delay: 3656ms; --vc-offset: 24px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-458 { --vc-delay: 3664ms; --vc-offset: 25px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-459 { --vc-delay: 3672ms; --vc-offset: 26px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-460 { --vc-delay: 3680ms; --vc-offset: 27px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-461 { --vc-delay: 3688ms; --vc-offset: 28px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-462 { --vc-delay: 3696ms; --vc-offset: 29px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-463 { --vc-delay: 3704ms; --vc-offset: 30px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-464 { --vc-delay: 3712ms; --vc-offset: 31px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-465 { --vc-delay: 3720ms; --vc-offset: 1px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-466 { --vc-delay: 3728ms; --vc-offset: 2px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-467 { --vc-delay: 3736ms; --vc-offset: 3px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-468 { --vc-delay: 3744ms; --vc-offset: 4px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-469 { --vc-delay: 3752ms; --vc-offset: 5px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-470 { --vc-delay: 3760ms; --vc-offset: 6px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-471 { --vc-delay: 3768ms; --vc-offset: 7px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-472 { --vc-delay: 3776ms; --vc-offset: 8px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-473 { --vc-delay: 3784ms; --vc-offset: 9px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-474 { --vc-delay: 3792ms; --vc-offset: 10px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-475 { --vc-delay: 3800ms; --vc-offset: 11px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-476 { --vc-delay: 3808ms; --vc-offset: 12px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-477 { --vc-delay: 3816ms; --vc-offset: 13px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-478 { --vc-delay: 3824ms; --vc-offset: 14px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-479 { --vc-delay: 3832ms; --vc-offset: 15px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-480 { --vc-delay: 3840ms; --vc-offset: 16px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-481 { --vc-delay: 3848ms; --vc-offset: 17px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-482 { --vc-delay: 3856ms; --vc-offset: 18px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-483 { --vc-delay: 3864ms; --vc-offset: 19px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-484 { --vc-delay: 3872ms; --vc-offset: 20px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-485 { --vc-delay: 3880ms; --vc-offset: 21px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-486 { --vc-delay: 3888ms; --vc-offset: 22px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-487 { --vc-delay: 3896ms; --vc-offset: 23px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-488 { --vc-delay: 3904ms; --vc-offset: 24px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-489 { --vc-delay: 3912ms; --vc-offset: 25px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-490 { --vc-delay: 3920ms; --vc-offset: 26px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-491 { --vc-delay: 3928ms; --vc-offset: 27px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-492 { --vc-delay: 3936ms; --vc-offset: 28px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-493 { --vc-delay: 3944ms; --vc-offset: 29px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-494 { --vc-delay: 3952ms; --vc-offset: 30px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-495 { --vc-delay: 3960ms; --vc-offset: 31px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-496 { --vc-delay: 3968ms; --vc-offset: 1px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-497 { --vc-delay: 3976ms; --vc-offset: 2px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-498 { --vc-delay: 3984ms; --vc-offset: 3px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-499 { --vc-delay: 3992ms; --vc-offset: 4px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-500 { --vc-delay: 4000ms; --vc-offset: 5px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-501 { --vc-delay: 4008ms; --vc-offset: 6px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-502 { --vc-delay: 4016ms; --vc-offset: 7px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-503 { --vc-delay: 4024ms; --vc-offset: 8px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-504 { --vc-delay: 4032ms; --vc-offset: 9px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-505 { --vc-delay: 4040ms; --vc-offset: 10px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-506 { --vc-delay: 4048ms; --vc-offset: 11px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-507 { --vc-delay: 4056ms; --vc-offset: 12px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-508 { --vc-delay: 4064ms; --vc-offset: 13px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-509 { --vc-delay: 4072ms; --vc-offset: 14px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-510 { --vc-delay: 4080ms; --vc-offset: 15px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-511 { --vc-delay: 4088ms; --vc-offset: 16px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-512 { --vc-delay: 4096ms; --vc-offset: 17px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-513 { --vc-delay: 4104ms; --vc-offset: 18px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-514 { --vc-delay: 4112ms; --vc-offset: 19px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-515 { --vc-delay: 4120ms; --vc-offset: 20px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-516 { --vc-delay: 4128ms; --vc-offset: 21px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-517 { --vc-delay: 4136ms; --vc-offset: 22px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-518 { --vc-delay: 4144ms; --vc-offset: 23px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-519 { --vc-delay: 4152ms; --vc-offset: 24px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-520 { --vc-delay: 4160ms; --vc-offset: 25px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-521 { --vc-delay: 4168ms; --vc-offset: 26px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-522 { --vc-delay: 4176ms; --vc-offset: 27px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-523 { --vc-delay: 4184ms; --vc-offset: 28px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-524 { --vc-delay: 4192ms; --vc-offset: 29px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-525 { --vc-delay: 4200ms; --vc-offset: 30px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-526 { --vc-delay: 4208ms; --vc-offset: 31px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-527 { --vc-delay: 4216ms; --vc-offset: 1px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-528 { --vc-delay: 4224ms; --vc-offset: 2px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-529 { --vc-delay: 4232ms; --vc-offset: 3px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-530 { --vc-delay: 4240ms; --vc-offset: 4px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-531 { --vc-delay: 4248ms; --vc-offset: 5px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-532 { --vc-delay: 4256ms; --vc-offset: 6px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-533 { --vc-delay: 4264ms; --vc-offset: 7px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-534 { --vc-delay: 4272ms; --vc-offset: 8px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-535 { --vc-delay: 4280ms; --vc-offset: 9px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-536 { --vc-delay: 4288ms; --vc-offset: 10px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-537 { --vc-delay: 4296ms; --vc-offset: 11px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-538 { --vc-delay: 4304ms; --vc-offset: 12px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-539 { --vc-delay: 4312ms; --vc-offset: 13px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-540 { --vc-delay: 4320ms; --vc-offset: 14px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-541 { --vc-delay: 4328ms; --vc-offset: 15px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-542 { --vc-delay: 4336ms; --vc-offset: 16px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-543 { --vc-delay: 4344ms; --vc-offset: 17px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-544 { --vc-delay: 4352ms; --vc-offset: 18px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-545 { --vc-delay: 4360ms; --vc-offset: 19px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-546 { --vc-delay: 4368ms; --vc-offset: 20px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-547 { --vc-delay: 4376ms; --vc-offset: 21px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-548 { --vc-delay: 4384ms; --vc-offset: 22px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-549 { --vc-delay: 4392ms; --vc-offset: 23px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-550 { --vc-delay: 4400ms; --vc-offset: 24px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-551 { --vc-delay: 4408ms; --vc-offset: 25px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-552 { --vc-delay: 4416ms; --vc-offset: 26px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-553 { --vc-delay: 4424ms; --vc-offset: 27px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-554 { --vc-delay: 4432ms; --vc-offset: 28px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-555 { --vc-delay: 4440ms; --vc-offset: 29px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-556 { --vc-delay: 4448ms; --vc-offset: 30px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-557 { --vc-delay: 4456ms; --vc-offset: 31px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-558 { --vc-delay: 4464ms; --vc-offset: 1px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-559 { --vc-delay: 4472ms; --vc-offset: 2px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-560 { --vc-delay: 4480ms; --vc-offset: 3px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-561 { --vc-delay: 4488ms; --vc-offset: 4px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-562 { --vc-delay: 4496ms; --vc-offset: 5px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-563 { --vc-delay: 4504ms; --vc-offset: 6px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-564 { --vc-delay: 4512ms; --vc-offset: 7px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-565 { --vc-delay: 4520ms; --vc-offset: 8px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-566 { --vc-delay: 4528ms; --vc-offset: 9px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-567 { --vc-delay: 4536ms; --vc-offset: 10px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-568 { --vc-delay: 4544ms; --vc-offset: 11px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-569 { --vc-delay: 4552ms; --vc-offset: 12px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-570 { --vc-delay: 4560ms; --vc-offset: 13px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-571 { --vc-delay: 4568ms; --vc-offset: 14px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-572 { --vc-delay: 4576ms; --vc-offset: 15px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-573 { --vc-delay: 4584ms; --vc-offset: 16px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-574 { --vc-delay: 4592ms; --vc-offset: 17px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-575 { --vc-delay: 4600ms; --vc-offset: 18px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-576 { --vc-delay: 4608ms; --vc-offset: 19px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-577 { --vc-delay: 4616ms; --vc-offset: 20px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-578 { --vc-delay: 4624ms; --vc-offset: 21px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-579 { --vc-delay: 4632ms; --vc-offset: 22px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-580 { --vc-delay: 4640ms; --vc-offset: 23px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-581 { --vc-delay: 4648ms; --vc-offset: 24px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-582 { --vc-delay: 4656ms; --vc-offset: 25px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-583 { --vc-delay: 4664ms; --vc-offset: 26px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-584 { --vc-delay: 4672ms; --vc-offset: 27px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-585 { --vc-delay: 4680ms; --vc-offset: 28px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-586 { --vc-delay: 4688ms; --vc-offset: 29px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-587 { --vc-delay: 4696ms; --vc-offset: 30px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-588 { --vc-delay: 4704ms; --vc-offset: 31px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-589 { --vc-delay: 4712ms; --vc-offset: 1px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-590 { --vc-delay: 4720ms; --vc-offset: 2px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-591 { --vc-delay: 4728ms; --vc-offset: 3px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-592 { --vc-delay: 4736ms; --vc-offset: 4px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-593 { --vc-delay: 4744ms; --vc-offset: 5px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-594 { --vc-delay: 4752ms; --vc-offset: 6px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-595 { --vc-delay: 4760ms; --vc-offset: 7px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-596 { --vc-delay: 4768ms; --vc-offset: 8px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-597 { --vc-delay: 4776ms; --vc-offset: 9px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-598 { --vc-delay: 4784ms; --vc-offset: 10px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-599 { --vc-delay: 4792ms; --vc-offset: 11px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-600 { --vc-delay: 4800ms; --vc-offset: 12px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-601 { --vc-delay: 4808ms; --vc-offset: 13px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-602 { --vc-delay: 4816ms; --vc-offset: 14px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-603 { --vc-delay: 4824ms; --vc-offset: 15px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-604 { --vc-delay: 4832ms; --vc-offset: 16px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-605 { --vc-delay: 4840ms; --vc-offset: 17px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-606 { --vc-delay: 4848ms; --vc-offset: 18px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-607 { --vc-delay: 4856ms; --vc-offset: 19px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-608 { --vc-delay: 4864ms; --vc-offset: 20px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-609 { --vc-delay: 4872ms; --vc-offset: 21px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-610 { --vc-delay: 4880ms; --vc-offset: 22px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-611 { --vc-delay: 4888ms; --vc-offset: 23px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-612 { --vc-delay: 4896ms; --vc-offset: 24px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-613 { --vc-delay: 4904ms; --vc-offset: 25px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-614 { --vc-delay: 4912ms; --vc-offset: 26px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-615 { --vc-delay: 4920ms; --vc-offset: 27px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-616 { --vc-delay: 4928ms; --vc-offset: 28px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-617 { --vc-delay: 4936ms; --vc-offset: 29px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-618 { --vc-delay: 4944ms; --vc-offset: 30px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-619 { --vc-delay: 4952ms; --vc-offset: 31px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-620 { --vc-delay: 4960ms; --vc-offset: 1px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-621 { --vc-delay: 4968ms; --vc-offset: 2px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-622 { --vc-delay: 4976ms; --vc-offset: 3px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-623 { --vc-delay: 4984ms; --vc-offset: 4px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-624 { --vc-delay: 4992ms; --vc-offset: 5px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-625 { --vc-delay: 5000ms; --vc-offset: 6px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-626 { --vc-delay: 5008ms; --vc-offset: 7px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-627 { --vc-delay: 5016ms; --vc-offset: 8px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-628 { --vc-delay: 5024ms; --vc-offset: 9px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-629 { --vc-delay: 5032ms; --vc-offset: 10px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-630 { --vc-delay: 5040ms; --vc-offset: 11px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-631 { --vc-delay: 5048ms; --vc-offset: 12px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-632 { --vc-delay: 5056ms; --vc-offset: 13px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-633 { --vc-delay: 5064ms; --vc-offset: 14px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-634 { --vc-delay: 5072ms; --vc-offset: 15px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-635 { --vc-delay: 5080ms; --vc-offset: 16px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-636 { --vc-delay: 5088ms; --vc-offset: 17px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-637 { --vc-delay: 5096ms; --vc-offset: 18px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-638 { --vc-delay: 5104ms; --vc-offset: 19px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-639 { --vc-delay: 5112ms; --vc-offset: 20px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-640 { --vc-delay: 5120ms; --vc-offset: 21px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-641 { --vc-delay: 5128ms; --vc-offset: 22px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-642 { --vc-delay: 5136ms; --vc-offset: 23px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-643 { --vc-delay: 5144ms; --vc-offset: 24px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-644 { --vc-delay: 5152ms; --vc-offset: 25px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-645 { --vc-delay: 5160ms; --vc-offset: 26px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-646 { --vc-delay: 5168ms; --vc-offset: 27px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-647 { --vc-delay: 5176ms; --vc-offset: 28px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-648 { --vc-delay: 5184ms; --vc-offset: 29px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-649 { --vc-delay: 5192ms; --vc-offset: 30px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-650 { --vc-delay: 5200ms; --vc-offset: 31px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-651 { --vc-delay: 5208ms; --vc-offset: 1px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-652 { --vc-delay: 5216ms; --vc-offset: 2px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-653 { --vc-delay: 5224ms; --vc-offset: 3px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-654 { --vc-delay: 5232ms; --vc-offset: 4px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-655 { --vc-delay: 5240ms; --vc-offset: 5px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-656 { --vc-delay: 5248ms; --vc-offset: 6px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-657 { --vc-delay: 5256ms; --vc-offset: 7px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-658 { --vc-delay: 5264ms; --vc-offset: 8px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-659 { --vc-delay: 5272ms; --vc-offset: 9px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-660 { --vc-delay: 5280ms; --vc-offset: 10px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-661 { --vc-delay: 5288ms; --vc-offset: 11px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-662 { --vc-delay: 5296ms; --vc-offset: 12px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-663 { --vc-delay: 5304ms; --vc-offset: 13px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-664 { --vc-delay: 5312ms; --vc-offset: 14px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-665 { --vc-delay: 5320ms; --vc-offset: 15px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-666 { --vc-delay: 5328ms; --vc-offset: 16px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-667 { --vc-delay: 5336ms; --vc-offset: 17px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-668 { --vc-delay: 5344ms; --vc-offset: 18px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-669 { --vc-delay: 5352ms; --vc-offset: 19px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-670 { --vc-delay: 5360ms; --vc-offset: 20px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-671 { --vc-delay: 5368ms; --vc-offset: 21px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-672 { --vc-delay: 5376ms; --vc-offset: 22px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-673 { --vc-delay: 5384ms; --vc-offset: 23px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-674 { --vc-delay: 5392ms; --vc-offset: 24px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-675 { --vc-delay: 5400ms; --vc-offset: 25px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-676 { --vc-delay: 5408ms; --vc-offset: 26px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-677 { --vc-delay: 5416ms; --vc-offset: 27px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-678 { --vc-delay: 5424ms; --vc-offset: 28px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-679 { --vc-delay: 5432ms; --vc-offset: 29px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-680 { --vc-delay: 5440ms; --vc-offset: 30px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-681 { --vc-delay: 5448ms; --vc-offset: 31px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-682 { --vc-delay: 5456ms; --vc-offset: 1px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-683 { --vc-delay: 5464ms; --vc-offset: 2px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-684 { --vc-delay: 5472ms; --vc-offset: 3px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-685 { --vc-delay: 5480ms; --vc-offset: 4px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-686 { --vc-delay: 5488ms; --vc-offset: 5px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-687 { --vc-delay: 5496ms; --vc-offset: 6px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-688 { --vc-delay: 5504ms; --vc-offset: 7px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-689 { --vc-delay: 5512ms; --vc-offset: 8px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-690 { --vc-delay: 5520ms; --vc-offset: 9px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-691 { --vc-delay: 5528ms; --vc-offset: 10px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-692 { --vc-delay: 5536ms; --vc-offset: 11px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-693 { --vc-delay: 5544ms; --vc-offset: 12px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-694 { --vc-delay: 5552ms; --vc-offset: 13px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-695 { --vc-delay: 5560ms; --vc-offset: 14px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-696 { --vc-delay: 5568ms; --vc-offset: 15px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-697 { --vc-delay: 5576ms; --vc-offset: 16px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-698 { --vc-delay: 5584ms; --vc-offset: 17px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-699 { --vc-delay: 5592ms; --vc-offset: 18px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-700 { --vc-delay: 5600ms; --vc-offset: 19px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-701 { --vc-delay: 5608ms; --vc-offset: 20px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-702 { --vc-delay: 5616ms; --vc-offset: 21px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-703 { --vc-delay: 5624ms; --vc-offset: 22px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-704 { --vc-delay: 5632ms; --vc-offset: 23px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-705 { --vc-delay: 5640ms; --vc-offset: 24px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-706 { --vc-delay: 5648ms; --vc-offset: 25px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-707 { --vc-delay: 5656ms; --vc-offset: 26px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-708 { --vc-delay: 5664ms; --vc-offset: 27px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-709 { --vc-delay: 5672ms; --vc-offset: 28px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-710 { --vc-delay: 5680ms; --vc-offset: 29px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-711 { --vc-delay: 5688ms; --vc-offset: 30px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-712 { --vc-delay: 5696ms; --vc-offset: 31px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-713 { --vc-delay: 5704ms; --vc-offset: 1px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-714 { --vc-delay: 5712ms; --vc-offset: 2px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-715 { --vc-delay: 5720ms; --vc-offset: 3px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-716 { --vc-delay: 5728ms; --vc-offset: 4px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-717 { --vc-delay: 5736ms; --vc-offset: 5px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-718 { --vc-delay: 5744ms; --vc-offset: 6px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-719 { --vc-delay: 5752ms; --vc-offset: 7px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-720 { --vc-delay: 5760ms; --vc-offset: 8px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-721 { --vc-delay: 5768ms; --vc-offset: 9px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-722 { --vc-delay: 5776ms; --vc-offset: 10px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-723 { --vc-delay: 5784ms; --vc-offset: 11px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-724 { --vc-delay: 5792ms; --vc-offset: 12px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-725 { --vc-delay: 5800ms; --vc-offset: 13px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-726 { --vc-delay: 5808ms; --vc-offset: 14px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-727 { --vc-delay: 5816ms; --vc-offset: 15px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-728 { --vc-delay: 5824ms; --vc-offset: 16px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-729 { --vc-delay: 5832ms; --vc-offset: 17px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-730 { --vc-delay: 5840ms; --vc-offset: 18px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-731 { --vc-delay: 5848ms; --vc-offset: 19px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-732 { --vc-delay: 5856ms; --vc-offset: 20px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-733 { --vc-delay: 5864ms; --vc-offset: 21px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-734 { --vc-delay: 5872ms; --vc-offset: 22px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-735 { --vc-delay: 5880ms; --vc-offset: 23px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-736 { --vc-delay: 5888ms; --vc-offset: 24px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-737 { --vc-delay: 5896ms; --vc-offset: 25px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-738 { --vc-delay: 5904ms; --vc-offset: 26px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-739 { --vc-delay: 5912ms; --vc-offset: 27px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-740 { --vc-delay: 5920ms; --vc-offset: 28px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-741 { --vc-delay: 5928ms; --vc-offset: 29px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-742 { --vc-delay: 5936ms; --vc-offset: 30px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-743 { --vc-delay: 5944ms; --vc-offset: 31px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-744 { --vc-delay: 5952ms; --vc-offset: 1px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-745 { --vc-delay: 5960ms; --vc-offset: 2px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-746 { --vc-delay: 5968ms; --vc-offset: 3px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-747 { --vc-delay: 5976ms; --vc-offset: 4px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-748 { --vc-delay: 5984ms; --vc-offset: 5px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-749 { --vc-delay: 5992ms; --vc-offset: 6px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-750 { --vc-delay: 6000ms; --vc-offset: 7px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-751 { --vc-delay: 6008ms; --vc-offset: 8px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-752 { --vc-delay: 6016ms; --vc-offset: 9px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-753 { --vc-delay: 6024ms; --vc-offset: 10px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-754 { --vc-delay: 6032ms; --vc-offset: 11px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-755 { --vc-delay: 6040ms; --vc-offset: 12px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-756 { --vc-delay: 6048ms; --vc-offset: 13px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-757 { --vc-delay: 6056ms; --vc-offset: 14px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-758 { --vc-delay: 6064ms; --vc-offset: 15px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-759 { --vc-delay: 6072ms; --vc-offset: 16px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-760 { --vc-delay: 6080ms; --vc-offset: 17px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-761 { --vc-delay: 6088ms; --vc-offset: 18px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-762 { --vc-delay: 6096ms; --vc-offset: 19px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-763 { --vc-delay: 6104ms; --vc-offset: 20px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-764 { --vc-delay: 6112ms; --vc-offset: 21px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-765 { --vc-delay: 6120ms; --vc-offset: 22px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-766 { --vc-delay: 6128ms; --vc-offset: 23px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-767 { --vc-delay: 6136ms; --vc-offset: 24px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-768 { --vc-delay: 6144ms; --vc-offset: 25px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-769 { --vc-delay: 6152ms; --vc-offset: 26px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-770 { --vc-delay: 6160ms; --vc-offset: 27px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-771 { --vc-delay: 6168ms; --vc-offset: 28px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-772 { --vc-delay: 6176ms; --vc-offset: 29px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-773 { --vc-delay: 6184ms; --vc-offset: 30px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-774 { --vc-delay: 6192ms; --vc-offset: 31px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-775 { --vc-delay: 6200ms; --vc-offset: 1px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-776 { --vc-delay: 6208ms; --vc-offset: 2px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-777 { --vc-delay: 6216ms; --vc-offset: 3px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-778 { --vc-delay: 6224ms; --vc-offset: 4px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-779 { --vc-delay: 6232ms; --vc-offset: 5px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-780 { --vc-delay: 6240ms; --vc-offset: 6px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-781 { --vc-delay: 6248ms; --vc-offset: 7px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-782 { --vc-delay: 6256ms; --vc-offset: 8px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-783 { --vc-delay: 6264ms; --vc-offset: 9px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-784 { --vc-delay: 6272ms; --vc-offset: 10px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-785 { --vc-delay: 6280ms; --vc-offset: 11px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-786 { --vc-delay: 6288ms; --vc-offset: 12px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-787 { --vc-delay: 6296ms; --vc-offset: 13px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-788 { --vc-delay: 6304ms; --vc-offset: 14px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-789 { --vc-delay: 6312ms; --vc-offset: 15px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-790 { --vc-delay: 6320ms; --vc-offset: 16px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-791 { --vc-delay: 6328ms; --vc-offset: 17px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-792 { --vc-delay: 6336ms; --vc-offset: 18px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-793 { --vc-delay: 6344ms; --vc-offset: 19px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-794 { --vc-delay: 6352ms; --vc-offset: 20px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-795 { --vc-delay: 6360ms; --vc-offset: 21px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-796 { --vc-delay: 6368ms; --vc-offset: 22px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-797 { --vc-delay: 6376ms; --vc-offset: 23px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-798 { --vc-delay: 6384ms; --vc-offset: 24px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-799 { --vc-delay: 6392ms; --vc-offset: 25px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-800 { --vc-delay: 6400ms; --vc-offset: 26px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-801 { --vc-delay: 6408ms; --vc-offset: 27px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-802 { --vc-delay: 6416ms; --vc-offset: 28px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-803 { --vc-delay: 6424ms; --vc-offset: 29px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-804 { --vc-delay: 6432ms; --vc-offset: 30px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-805 { --vc-delay: 6440ms; --vc-offset: 31px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-806 { --vc-delay: 6448ms; --vc-offset: 1px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-807 { --vc-delay: 6456ms; --vc-offset: 2px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-808 { --vc-delay: 6464ms; --vc-offset: 3px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-809 { --vc-delay: 6472ms; --vc-offset: 4px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-810 { --vc-delay: 6480ms; --vc-offset: 5px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-811 { --vc-delay: 6488ms; --vc-offset: 6px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-812 { --vc-delay: 6496ms; --vc-offset: 7px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-813 { --vc-delay: 6504ms; --vc-offset: 8px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-814 { --vc-delay: 6512ms; --vc-offset: 9px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-815 { --vc-delay: 6520ms; --vc-offset: 10px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-816 { --vc-delay: 6528ms; --vc-offset: 11px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-817 { --vc-delay: 6536ms; --vc-offset: 12px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-818 { --vc-delay: 6544ms; --vc-offset: 13px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-819 { --vc-delay: 6552ms; --vc-offset: 14px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-820 { --vc-delay: 6560ms; --vc-offset: 15px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-821 { --vc-delay: 6568ms; --vc-offset: 16px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-822 { --vc-delay: 6576ms; --vc-offset: 17px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-823 { --vc-delay: 6584ms; --vc-offset: 18px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-824 { --vc-delay: 6592ms; --vc-offset: 19px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-825 { --vc-delay: 6600ms; --vc-offset: 20px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-826 { --vc-delay: 6608ms; --vc-offset: 21px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-827 { --vc-delay: 6616ms; --vc-offset: 22px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-828 { --vc-delay: 6624ms; --vc-offset: 23px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-829 { --vc-delay: 6632ms; --vc-offset: 24px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-830 { --vc-delay: 6640ms; --vc-offset: 25px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-831 { --vc-delay: 6648ms; --vc-offset: 26px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-832 { --vc-delay: 6656ms; --vc-offset: 27px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-833 { --vc-delay: 6664ms; --vc-offset: 28px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-834 { --vc-delay: 6672ms; --vc-offset: 29px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-835 { --vc-delay: 6680ms; --vc-offset: 30px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-836 { --vc-delay: 6688ms; --vc-offset: 31px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-837 { --vc-delay: 6696ms; --vc-offset: 1px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-838 { --vc-delay: 6704ms; --vc-offset: 2px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-839 { --vc-delay: 6712ms; --vc-offset: 3px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-840 { --vc-delay: 6720ms; --vc-offset: 4px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-841 { --vc-delay: 6728ms; --vc-offset: 5px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-842 { --vc-delay: 6736ms; --vc-offset: 6px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-843 { --vc-delay: 6744ms; --vc-offset: 7px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-844 { --vc-delay: 6752ms; --vc-offset: 8px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-845 { --vc-delay: 6760ms; --vc-offset: 9px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-846 { --vc-delay: 6768ms; --vc-offset: 10px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-847 { --vc-delay: 6776ms; --vc-offset: 11px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-848 { --vc-delay: 6784ms; --vc-offset: 12px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-849 { --vc-delay: 6792ms; --vc-offset: 13px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-850 { --vc-delay: 6800ms; --vc-offset: 14px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-851 { --vc-delay: 6808ms; --vc-offset: 15px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-852 { --vc-delay: 6816ms; --vc-offset: 16px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-853 { --vc-delay: 6824ms; --vc-offset: 17px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-854 { --vc-delay: 6832ms; --vc-offset: 18px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-855 { --vc-delay: 6840ms; --vc-offset: 19px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-856 { --vc-delay: 6848ms; --vc-offset: 20px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-857 { --vc-delay: 6856ms; --vc-offset: 21px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-858 { --vc-delay: 6864ms; --vc-offset: 22px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-859 { --vc-delay: 6872ms; --vc-offset: 23px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-860 { --vc-delay: 6880ms; --vc-offset: 24px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-861 { --vc-delay: 6888ms; --vc-offset: 25px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-862 { --vc-delay: 6896ms; --vc-offset: 26px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-863 { --vc-delay: 6904ms; --vc-offset: 27px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-864 { --vc-delay: 6912ms; --vc-offset: 28px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-865 { --vc-delay: 6920ms; --vc-offset: 29px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-866 { --vc-delay: 6928ms; --vc-offset: 30px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-867 { --vc-delay: 6936ms; --vc-offset: 31px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-868 { --vc-delay: 6944ms; --vc-offset: 1px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-869 { --vc-delay: 6952ms; --vc-offset: 2px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-870 { --vc-delay: 6960ms; --vc-offset: 3px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-871 { --vc-delay: 6968ms; --vc-offset: 4px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-872 { --vc-delay: 6976ms; --vc-offset: 5px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-873 { --vc-delay: 6984ms; --vc-offset: 6px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-874 { --vc-delay: 6992ms; --vc-offset: 7px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-875 { --vc-delay: 7000ms; --vc-offset: 8px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-876 { --vc-delay: 7008ms; --vc-offset: 9px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-877 { --vc-delay: 7016ms; --vc-offset: 10px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-878 { --vc-delay: 7024ms; --vc-offset: 11px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-879 { --vc-delay: 7032ms; --vc-offset: 12px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-880 { --vc-delay: 7040ms; --vc-offset: 13px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-881 { --vc-delay: 7048ms; --vc-offset: 14px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-882 { --vc-delay: 7056ms; --vc-offset: 15px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-883 { --vc-delay: 7064ms; --vc-offset: 16px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-884 { --vc-delay: 7072ms; --vc-offset: 17px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-885 { --vc-delay: 7080ms; --vc-offset: 18px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-886 { --vc-delay: 7088ms; --vc-offset: 19px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-887 { --vc-delay: 7096ms; --vc-offset: 20px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-888 { --vc-delay: 7104ms; --vc-offset: 21px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-889 { --vc-delay: 7112ms; --vc-offset: 22px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-890 { --vc-delay: 7120ms; --vc-offset: 23px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-891 { --vc-delay: 7128ms; --vc-offset: 24px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-892 { --vc-delay: 7136ms; --vc-offset: 25px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-893 { --vc-delay: 7144ms; --vc-offset: 26px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-894 { --vc-delay: 7152ms; --vc-offset: 27px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-895 { --vc-delay: 7160ms; --vc-offset: 28px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-896 { --vc-delay: 7168ms; --vc-offset: 29px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-897 { --vc-delay: 7176ms; --vc-offset: 30px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-898 { --vc-delay: 7184ms; --vc-offset: 31px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-899 { --vc-delay: 7192ms; --vc-offset: 1px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-900 { --vc-delay: 7200ms; --vc-offset: 2px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-901 { --vc-delay: 7208ms; --vc-offset: 3px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-902 { --vc-delay: 7216ms; --vc-offset: 4px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-903 { --vc-delay: 7224ms; --vc-offset: 5px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-904 { --vc-delay: 7232ms; --vc-offset: 6px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-905 { --vc-delay: 7240ms; --vc-offset: 7px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-906 { --vc-delay: 7248ms; --vc-offset: 8px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-907 { --vc-delay: 7256ms; --vc-offset: 9px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-908 { --vc-delay: 7264ms; --vc-offset: 10px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-909 { --vc-delay: 7272ms; --vc-offset: 11px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-910 { --vc-delay: 7280ms; --vc-offset: 12px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-911 { --vc-delay: 7288ms; --vc-offset: 13px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-912 { --vc-delay: 7296ms; --vc-offset: 14px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-913 { --vc-delay: 7304ms; --vc-offset: 15px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-914 { --vc-delay: 7312ms; --vc-offset: 16px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-915 { --vc-delay: 7320ms; --vc-offset: 17px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-916 { --vc-delay: 7328ms; --vc-offset: 18px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-917 { --vc-delay: 7336ms; --vc-offset: 19px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-918 { --vc-delay: 7344ms; --vc-offset: 20px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-919 { --vc-delay: 7352ms; --vc-offset: 21px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-920 { --vc-delay: 7360ms; --vc-offset: 22px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-921 { --vc-delay: 7368ms; --vc-offset: 23px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-922 { --vc-delay: 7376ms; --vc-offset: 24px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-923 { --vc-delay: 7384ms; --vc-offset: 25px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-924 { --vc-delay: 7392ms; --vc-offset: 26px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-925 { --vc-delay: 7400ms; --vc-offset: 27px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-926 { --vc-delay: 7408ms; --vc-offset: 28px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-927 { --vc-delay: 7416ms; --vc-offset: 29px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-928 { --vc-delay: 7424ms; --vc-offset: 30px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-929 { --vc-delay: 7432ms; --vc-offset: 31px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-930 { --vc-delay: 7440ms; --vc-offset: 1px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-931 { --vc-delay: 7448ms; --vc-offset: 2px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-932 { --vc-delay: 7456ms; --vc-offset: 3px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-933 { --vc-delay: 7464ms; --vc-offset: 4px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-934 { --vc-delay: 7472ms; --vc-offset: 5px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-935 { --vc-delay: 7480ms; --vc-offset: 6px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-936 { --vc-delay: 7488ms; --vc-offset: 7px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-937 { --vc-delay: 7496ms; --vc-offset: 8px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-938 { --vc-delay: 7504ms; --vc-offset: 9px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-939 { --vc-delay: 7512ms; --vc-offset: 10px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-940 { --vc-delay: 7520ms; --vc-offset: 11px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-941 { --vc-delay: 7528ms; --vc-offset: 12px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-942 { --vc-delay: 7536ms; --vc-offset: 13px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-943 { --vc-delay: 7544ms; --vc-offset: 14px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-944 { --vc-delay: 7552ms; --vc-offset: 15px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-945 { --vc-delay: 7560ms; --vc-offset: 16px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-946 { --vc-delay: 7568ms; --vc-offset: 17px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-947 { --vc-delay: 7576ms; --vc-offset: 18px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-948 { --vc-delay: 7584ms; --vc-offset: 19px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-949 { --vc-delay: 7592ms; --vc-offset: 20px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-950 { --vc-delay: 7600ms; --vc-offset: 21px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-951 { --vc-delay: 7608ms; --vc-offset: 22px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-952 { --vc-delay: 7616ms; --vc-offset: 23px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-953 { --vc-delay: 7624ms; --vc-offset: 24px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-954 { --vc-delay: 7632ms; --vc-offset: 25px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-955 { --vc-delay: 7640ms; --vc-offset: 26px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-956 { --vc-delay: 7648ms; --vc-offset: 27px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-957 { --vc-delay: 7656ms; --vc-offset: 28px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-958 { --vc-delay: 7664ms; --vc-offset: 29px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-959 { --vc-delay: 7672ms; --vc-offset: 30px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-960 { --vc-delay: 7680ms; --vc-offset: 31px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-961 { --vc-delay: 7688ms; --vc-offset: 1px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-962 { --vc-delay: 7696ms; --vc-offset: 2px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-963 { --vc-delay: 7704ms; --vc-offset: 3px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-964 { --vc-delay: 7712ms; --vc-offset: 4px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-965 { --vc-delay: 7720ms; --vc-offset: 5px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-966 { --vc-delay: 7728ms; --vc-offset: 6px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-967 { --vc-delay: 7736ms; --vc-offset: 7px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-968 { --vc-delay: 7744ms; --vc-offset: 8px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-969 { --vc-delay: 7752ms; --vc-offset: 9px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-970 { --vc-delay: 7760ms; --vc-offset: 10px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-971 { --vc-delay: 7768ms; --vc-offset: 11px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-972 { --vc-delay: 7776ms; --vc-offset: 12px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-973 { --vc-delay: 7784ms; --vc-offset: 13px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-974 { --vc-delay: 7792ms; --vc-offset: 14px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-975 { --vc-delay: 7800ms; --vc-offset: 15px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-976 { --vc-delay: 7808ms; --vc-offset: 16px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-977 { --vc-delay: 7816ms; --vc-offset: 17px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-978 { --vc-delay: 7824ms; --vc-offset: 18px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-979 { --vc-delay: 7832ms; --vc-offset: 19px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-980 { --vc-delay: 7840ms; --vc-offset: 20px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-981 { --vc-delay: 7848ms; --vc-offset: 21px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-982 { --vc-delay: 7856ms; --vc-offset: 22px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-983 { --vc-delay: 7864ms; --vc-offset: 23px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-984 { --vc-delay: 7872ms; --vc-offset: 24px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-985 { --vc-delay: 7880ms; --vc-offset: 25px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-986 { --vc-delay: 7888ms; --vc-offset: 26px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-987 { --vc-delay: 7896ms; --vc-offset: 27px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-988 { --vc-delay: 7904ms; --vc-offset: 28px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-989 { --vc-delay: 7912ms; --vc-offset: 29px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-990 { --vc-delay: 7920ms; --vc-offset: 30px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-991 { --vc-delay: 7928ms; --vc-offset: 31px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-992 { --vc-delay: 7936ms; --vc-offset: 1px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-993 { --vc-delay: 7944ms; --vc-offset: 2px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-994 { --vc-delay: 7952ms; --vc-offset: 3px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-995 { --vc-delay: 7960ms; --vc-offset: 4px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-996 { --vc-delay: 7968ms; --vc-offset: 5px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-997 { --vc-delay: 7976ms; --vc-offset: 6px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-998 { --vc-delay: 7984ms; --vc-offset: 7px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-999 { --vc-delay: 7992ms; --vc-offset: 8px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1000 { --vc-delay: 8000ms; --vc-offset: 9px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1001 { --vc-delay: 8008ms; --vc-offset: 10px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1002 { --vc-delay: 8016ms; --vc-offset: 11px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1003 { --vc-delay: 8024ms; --vc-offset: 12px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1004 { --vc-delay: 8032ms; --vc-offset: 13px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1005 { --vc-delay: 8040ms; --vc-offset: 14px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1006 { --vc-delay: 8048ms; --vc-offset: 15px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1007 { --vc-delay: 8056ms; --vc-offset: 16px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1008 { --vc-delay: 8064ms; --vc-offset: 17px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1009 { --vc-delay: 8072ms; --vc-offset: 18px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1010 { --vc-delay: 8080ms; --vc-offset: 19px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1011 { --vc-delay: 8088ms; --vc-offset: 20px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1012 { --vc-delay: 8096ms; --vc-offset: 21px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1013 { --vc-delay: 8104ms; --vc-offset: 22px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1014 { --vc-delay: 8112ms; --vc-offset: 23px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1015 { --vc-delay: 8120ms; --vc-offset: 24px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1016 { --vc-delay: 8128ms; --vc-offset: 25px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1017 { --vc-delay: 8136ms; --vc-offset: 26px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1018 { --vc-delay: 8144ms; --vc-offset: 27px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1019 { --vc-delay: 8152ms; --vc-offset: 28px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1020 { --vc-delay: 8160ms; --vc-offset: 29px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1021 { --vc-delay: 8168ms; --vc-offset: 30px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1022 { --vc-delay: 8176ms; --vc-offset: 31px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1023 { --vc-delay: 8184ms; --vc-offset: 1px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1024 { --vc-delay: 8192ms; --vc-offset: 2px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1025 { --vc-delay: 8200ms; --vc-offset: 3px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1026 { --vc-delay: 8208ms; --vc-offset: 4px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1027 { --vc-delay: 8216ms; --vc-offset: 5px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1028 { --vc-delay: 8224ms; --vc-offset: 6px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1029 { --vc-delay: 8232ms; --vc-offset: 7px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1030 { --vc-delay: 8240ms; --vc-offset: 8px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1031 { --vc-delay: 8248ms; --vc-offset: 9px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1032 { --vc-delay: 8256ms; --vc-offset: 10px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1033 { --vc-delay: 8264ms; --vc-offset: 11px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1034 { --vc-delay: 8272ms; --vc-offset: 12px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1035 { --vc-delay: 8280ms; --vc-offset: 13px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1036 { --vc-delay: 8288ms; --vc-offset: 14px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1037 { --vc-delay: 8296ms; --vc-offset: 15px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1038 { --vc-delay: 8304ms; --vc-offset: 16px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1039 { --vc-delay: 8312ms; --vc-offset: 17px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1040 { --vc-delay: 8320ms; --vc-offset: 18px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1041 { --vc-delay: 8328ms; --vc-offset: 19px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1042 { --vc-delay: 8336ms; --vc-offset: 20px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1043 { --vc-delay: 8344ms; --vc-offset: 21px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1044 { --vc-delay: 8352ms; --vc-offset: 22px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1045 { --vc-delay: 8360ms; --vc-offset: 23px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1046 { --vc-delay: 8368ms; --vc-offset: 24px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1047 { --vc-delay: 8376ms; --vc-offset: 25px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1048 { --vc-delay: 8384ms; --vc-offset: 26px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1049 { --vc-delay: 8392ms; --vc-offset: 27px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1050 { --vc-delay: 8400ms; --vc-offset: 28px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1051 { --vc-delay: 8408ms; --vc-offset: 29px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1052 { --vc-delay: 8416ms; --vc-offset: 30px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1053 { --vc-delay: 8424ms; --vc-offset: 31px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1054 { --vc-delay: 8432ms; --vc-offset: 1px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1055 { --vc-delay: 8440ms; --vc-offset: 2px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1056 { --vc-delay: 8448ms; --vc-offset: 3px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1057 { --vc-delay: 8456ms; --vc-offset: 4px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1058 { --vc-delay: 8464ms; --vc-offset: 5px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1059 { --vc-delay: 8472ms; --vc-offset: 6px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1060 { --vc-delay: 8480ms; --vc-offset: 7px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1061 { --vc-delay: 8488ms; --vc-offset: 8px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1062 { --vc-delay: 8496ms; --vc-offset: 9px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1063 { --vc-delay: 8504ms; --vc-offset: 10px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1064 { --vc-delay: 8512ms; --vc-offset: 11px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1065 { --vc-delay: 8520ms; --vc-offset: 12px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1066 { --vc-delay: 8528ms; --vc-offset: 13px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1067 { --vc-delay: 8536ms; --vc-offset: 14px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1068 { --vc-delay: 8544ms; --vc-offset: 15px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1069 { --vc-delay: 8552ms; --vc-offset: 16px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1070 { --vc-delay: 8560ms; --vc-offset: 17px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1071 { --vc-delay: 8568ms; --vc-offset: 18px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1072 { --vc-delay: 8576ms; --vc-offset: 19px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1073 { --vc-delay: 8584ms; --vc-offset: 20px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1074 { --vc-delay: 8592ms; --vc-offset: 21px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1075 { --vc-delay: 8600ms; --vc-offset: 22px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1076 { --vc-delay: 8608ms; --vc-offset: 23px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1077 { --vc-delay: 8616ms; --vc-offset: 24px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1078 { --vc-delay: 8624ms; --vc-offset: 25px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1079 { --vc-delay: 8632ms; --vc-offset: 26px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1080 { --vc-delay: 8640ms; --vc-offset: 27px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1081 { --vc-delay: 8648ms; --vc-offset: 28px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1082 { --vc-delay: 8656ms; --vc-offset: 29px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1083 { --vc-delay: 8664ms; --vc-offset: 30px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1084 { --vc-delay: 8672ms; --vc-offset: 31px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1085 { --vc-delay: 8680ms; --vc-offset: 1px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1086 { --vc-delay: 8688ms; --vc-offset: 2px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1087 { --vc-delay: 8696ms; --vc-offset: 3px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1088 { --vc-delay: 8704ms; --vc-offset: 4px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1089 { --vc-delay: 8712ms; --vc-offset: 5px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1090 { --vc-delay: 8720ms; --vc-offset: 6px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1091 { --vc-delay: 8728ms; --vc-offset: 7px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1092 { --vc-delay: 8736ms; --vc-offset: 8px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1093 { --vc-delay: 8744ms; --vc-offset: 9px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1094 { --vc-delay: 8752ms; --vc-offset: 10px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1095 { --vc-delay: 8760ms; --vc-offset: 11px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1096 { --vc-delay: 8768ms; --vc-offset: 12px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1097 { --vc-delay: 8776ms; --vc-offset: 13px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1098 { --vc-delay: 8784ms; --vc-offset: 14px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1099 { --vc-delay: 8792ms; --vc-offset: 15px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1100 { --vc-delay: 8800ms; --vc-offset: 16px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1101 { --vc-delay: 8808ms; --vc-offset: 17px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1102 { --vc-delay: 8816ms; --vc-offset: 18px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1103 { --vc-delay: 8824ms; --vc-offset: 19px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1104 { --vc-delay: 8832ms; --vc-offset: 20px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1105 { --vc-delay: 8840ms; --vc-offset: 21px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1106 { --vc-delay: 8848ms; --vc-offset: 22px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1107 { --vc-delay: 8856ms; --vc-offset: 23px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1108 { --vc-delay: 8864ms; --vc-offset: 24px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1109 { --vc-delay: 8872ms; --vc-offset: 25px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1110 { --vc-delay: 8880ms; --vc-offset: 26px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1111 { --vc-delay: 8888ms; --vc-offset: 27px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1112 { --vc-delay: 8896ms; --vc-offset: 28px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1113 { --vc-delay: 8904ms; --vc-offset: 29px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1114 { --vc-delay: 8912ms; --vc-offset: 30px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1115 { --vc-delay: 8920ms; --vc-offset: 31px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1116 { --vc-delay: 8928ms; --vc-offset: 1px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1117 { --vc-delay: 8936ms; --vc-offset: 2px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1118 { --vc-delay: 8944ms; --vc-offset: 3px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1119 { --vc-delay: 8952ms; --vc-offset: 4px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1120 { --vc-delay: 8960ms; --vc-offset: 5px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1121 { --vc-delay: 8968ms; --vc-offset: 6px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1122 { --vc-delay: 8976ms; --vc-offset: 7px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1123 { --vc-delay: 8984ms; --vc-offset: 8px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1124 { --vc-delay: 8992ms; --vc-offset: 9px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1125 { --vc-delay: 9000ms; --vc-offset: 10px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1126 { --vc-delay: 9008ms; --vc-offset: 11px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1127 { --vc-delay: 9016ms; --vc-offset: 12px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1128 { --vc-delay: 9024ms; --vc-offset: 13px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1129 { --vc-delay: 9032ms; --vc-offset: 14px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1130 { --vc-delay: 9040ms; --vc-offset: 15px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1131 { --vc-delay: 9048ms; --vc-offset: 16px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1132 { --vc-delay: 9056ms; --vc-offset: 17px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1133 { --vc-delay: 9064ms; --vc-offset: 18px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1134 { --vc-delay: 9072ms; --vc-offset: 19px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1135 { --vc-delay: 9080ms; --vc-offset: 20px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1136 { --vc-delay: 9088ms; --vc-offset: 21px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1137 { --vc-delay: 9096ms; --vc-offset: 22px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1138 { --vc-delay: 9104ms; --vc-offset: 23px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1139 { --vc-delay: 9112ms; --vc-offset: 24px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1140 { --vc-delay: 9120ms; --vc-offset: 25px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1141 { --vc-delay: 9128ms; --vc-offset: 26px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1142 { --vc-delay: 9136ms; --vc-offset: 27px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1143 { --vc-delay: 9144ms; --vc-offset: 28px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1144 { --vc-delay: 9152ms; --vc-offset: 29px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1145 { --vc-delay: 9160ms; --vc-offset: 30px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1146 { --vc-delay: 9168ms; --vc-offset: 31px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1147 { --vc-delay: 9176ms; --vc-offset: 1px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1148 { --vc-delay: 9184ms; --vc-offset: 2px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1149 { --vc-delay: 9192ms; --vc-offset: 3px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1150 { --vc-delay: 9200ms; --vc-offset: 4px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1151 { --vc-delay: 9208ms; --vc-offset: 5px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1152 { --vc-delay: 9216ms; --vc-offset: 6px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1153 { --vc-delay: 9224ms; --vc-offset: 7px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1154 { --vc-delay: 9232ms; --vc-offset: 8px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1155 { --vc-delay: 9240ms; --vc-offset: 9px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1156 { --vc-delay: 9248ms; --vc-offset: 10px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1157 { --vc-delay: 9256ms; --vc-offset: 11px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1158 { --vc-delay: 9264ms; --vc-offset: 12px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1159 { --vc-delay: 9272ms; --vc-offset: 13px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1160 { --vc-delay: 9280ms; --vc-offset: 14px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1161 { --vc-delay: 9288ms; --vc-offset: 15px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1162 { --vc-delay: 9296ms; --vc-offset: 16px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1163 { --vc-delay: 9304ms; --vc-offset: 17px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1164 { --vc-delay: 9312ms; --vc-offset: 18px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1165 { --vc-delay: 9320ms; --vc-offset: 19px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1166 { --vc-delay: 9328ms; --vc-offset: 20px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1167 { --vc-delay: 9336ms; --vc-offset: 21px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1168 { --vc-delay: 9344ms; --vc-offset: 22px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1169 { --vc-delay: 9352ms; --vc-offset: 23px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1170 { --vc-delay: 9360ms; --vc-offset: 24px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1171 { --vc-delay: 9368ms; --vc-offset: 25px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1172 { --vc-delay: 9376ms; --vc-offset: 26px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1173 { --vc-delay: 9384ms; --vc-offset: 27px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1174 { --vc-delay: 9392ms; --vc-offset: 28px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1175 { --vc-delay: 9400ms; --vc-offset: 29px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1176 { --vc-delay: 9408ms; --vc-offset: 30px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1177 { --vc-delay: 9416ms; --vc-offset: 31px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1178 { --vc-delay: 9424ms; --vc-offset: 1px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1179 { --vc-delay: 9432ms; --vc-offset: 2px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1180 { --vc-delay: 9440ms; --vc-offset: 3px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1181 { --vc-delay: 9448ms; --vc-offset: 4px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1182 { --vc-delay: 9456ms; --vc-offset: 5px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1183 { --vc-delay: 9464ms; --vc-offset: 6px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1184 { --vc-delay: 9472ms; --vc-offset: 7px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1185 { --vc-delay: 9480ms; --vc-offset: 8px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1186 { --vc-delay: 9488ms; --vc-offset: 9px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1187 { --vc-delay: 9496ms; --vc-offset: 10px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1188 { --vc-delay: 9504ms; --vc-offset: 11px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1189 { --vc-delay: 9512ms; --vc-offset: 12px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1190 { --vc-delay: 9520ms; --vc-offset: 13px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1191 { --vc-delay: 9528ms; --vc-offset: 14px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1192 { --vc-delay: 9536ms; --vc-offset: 15px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1193 { --vc-delay: 9544ms; --vc-offset: 16px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1194 { --vc-delay: 9552ms; --vc-offset: 17px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1195 { --vc-delay: 9560ms; --vc-offset: 18px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1196 { --vc-delay: 9568ms; --vc-offset: 19px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1197 { --vc-delay: 9576ms; --vc-offset: 20px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1198 { --vc-delay: 9584ms; --vc-offset: 21px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1199 { --vc-delay: 9592ms; --vc-offset: 22px; animation-delay: calc(var(--vc-delay) * -1); }
+.vector-clock-1200 { --vc-delay: 9600ms; --vc-offset: 23px; animation-delay: calc(var(--vc-delay) * -1); }


### PR DESCRIPTION
## Summary
- add a pure HTML/CSS vector clock causality map animation example
- visualize causal flow, vector-map merges, tick drift, and event ordering lanes
- keep the contribution scoped to one examples submission folder

## Validation
- generated from an existing validated examples template
- text scan verified old topic terms were replaced
- contribution adds 3 files under submissions/examples/vector-clock-causality-map-kp