### PR TITLE
feat: add CSS animation read your writes cache example

### DIFF
--- a/submissions/examples/read-your-writes-cache-kp/README.md
+++ b/submissions/examples/read-your-writes-cache-kp/README.md
@@ -1,0 +1,18 @@
+# Read Your Writes Cache
+
+An advanced EaseMotion example for monitoring distributed Consistency Reconsistencys, cache debt, retry pressure, and Retention margin recovery.
+
+## Features
+
+- Interactive controls for consistency risk, cache debt, retry pressure, and Retention margin health.
+- Animated radar, Cache lanes, recovery metrics, Reconsistency timeline, decision matrix, and audit consistency.
+- State-driven stable, watch, Consistency, and recovered modes.
+- Responsive CSS-only dashboard built with `demo.html`, `style.css`, and this `README.md`.
+
+## Validation
+
+```bash
+npx prettier --check submissions/examples/Consistency-cache control-radar-kp/README.md submissions/examples/Consistency-cache control-radar-kp/demo.html submissions/examples/Consistency-cache control-radar-kp/style.css
+npx stylelint submissions/examples/Consistency-cache control-radar-kp/style.css --allow-empty-input
+git diff --check
+```

--- a/submissions/examples/read-your-writes-cache-kp/demo.html
+++ b/submissions/examples/read-your-writes-cache-kp/demo.html
@@ -1,0 +1,350 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Read Your Writes Cache</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="Consistency" data-state="watch">
+      <section class="hero" aria-labelledby="title">
+        <div>
+          <p class="eyebrow">EaseMotion Recache control</p>
+          <h1 id="title">Read Your Writes Cache</h1>
+          <p class="lede">
+            Track failed Consistency steps, retry waves, and cache debt before a
+            distributed cache window leaves partial state behind.
+          </p>
+        </div>
+        <aside class="state-card" aria-live="polite">
+          <span class="beacon"></span><small>Consistency mode</small
+          ><strong id="modeLabel">Watch debt</strong>
+        </aside>
+      </section>
+      <section class="controls" aria-label="Cache controls">
+        <label
+          ><span>consistency risk</span
+          ><input
+            id="failed"
+            type="range"
+            min="0"
+            max="100"
+            value="63"
+          /><output id="failedOut">63%</output></label
+        >
+        <label
+          ><span>Cache debt</span
+          ><input id="debt" type="range" min="0" max="100" value="58" /><output
+            id="debtOut"
+            >58%</output
+          ></label
+        >
+        <label
+          ><span>Retry load</span
+          ><input id="retry" type="range" min="0" max="100" value="54" /><output
+            id="retryOut"
+            >54%</output
+          ></label
+        >
+        <label
+          ><span>Retention margin</span
+          ><input
+            id="Retention margin"
+            type="range"
+            min="0"
+            max="100"
+            value="47"
+          /><output id="Retention marginOut">47%</output></label
+        >
+      </section>
+      <section class="grid" aria-label="Session Flow Cache dashboard">
+        <article class="radar-panel">
+          <div class="panel-title">
+            <span>Reconsistency pressure</span><strong id="pressure">58</strong>
+          </div>
+          <div class="radar" aria-hidden="true">
+            <span class="ring r1"></span><span class="ring r2"></span
+            ><span class="ring r3"></span> <span class="sweep s1"></span
+            ><span class="sweep s2"></span><span class="sweep s3"></span>
+            <span class="node n1">ORD</span><span class="node n2">PAY</span
+            ><span class="node n3">INV</span><span class="node n4">result</span>
+            <span class="core"></span>
+          </div>
+          <div class="pulse">
+            <i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i
+            ><i></i><i></i><i></i>
+          </div>
+        </article>
+        <article class="lane-panel">
+          <div class="panel-title">
+            <span>Cache lanes</span><strong id="laneLabel">Consistencyed</strong>
+          </div>
+          <div class="lanes">
+            <div class="lane" style="--fill: 0.82">
+              <span>API edge</span><i></i><b>done</b>
+            </div>
+            <div class="lane" style="--fill: 0.68">
+              <span>Key lookup</span><i></i><b>retry</b>
+            </div>
+            <div class="lane" style="--fill: 0.51">
+              <span>Refresh hash</span><i></i><b>undo</b>
+            </div>
+            <div class="lane" style="--fill: 0.45">
+              <span>Result consistency</span><i></i><b>pause</b>
+            </div>
+            <div class="lane" style="--fill: 0.61">
+              <span>Consistency pool</span><i></i><b>drain</b>
+            </div>
+          </div>
+        </article>
+        <article class="metrics">
+          <div class="metric">
+            <span>debt gap</span><strong id="gap">43%</strong>
+          </div>
+          <div class="metric">
+            <span>Reconsistency ETA</span><strong id="eta">18s</strong>
+          </div>
+          <div class="metric">
+            <span>Safe state</span><strong id="safe">70%</strong>
+          </div>
+          <div class="metric">
+            <span>Retention margin</span><strong id="ckpt">47%</strong>
+          </div>
+        </article>
+        <article class="timeline-panel">
+          <div class="panel-title">
+            <span>Reconsistency timeline</span
+            ><strong id="action">Pin</strong>
+          </div>
+          <ol class="timeline">
+            <li>
+              <em>01</em>
+              <div>
+                <strong>Freeze forward steps</strong>
+                <p>Stop new mutations while cache debt is measured.</p>
+              </div>
+            </li>
+            <li>
+              <em>02</em>
+              <div>
+                <strong>Consistency Retention margins</strong>
+                <p>Confirm each completed step has a durable undo command.</p>
+              </div>
+            </li>
+            <li>
+              <em>03</em>
+              <div>
+                <strong>Drain retries</strong>
+                <p>Retry waves are shaped so cache controls can catch up.</p>
+              </div>
+            </li>
+            <li>
+              <em>04</em>
+              <div>
+                <strong>Release cache window</strong>
+                <p>Write resumes after partial state returns below target.</p>
+              </div>
+            </li>
+          </ol>
+        </article>
+        <article class="matrix-panel">
+          <div class="panel-title">
+            <span>Decision matrix</span><strong>24 cells</strong>
+          </div>
+          <div class="matrix">
+            <span data-risk="low">client</span><span data-risk="mid">key</span
+            ><span data-risk="high">rebate</span
+            ><span data-risk="mid">uniqueness</span
+            ><span data-risk="low">hold</span><span data-risk="high">undo</span>
+            <span data-risk="mid">retry</span><span data-risk="low">result</span
+            ><span data-risk="mid">email</span
+            ><span data-risk="high">consistency</span
+            ><span data-risk="low">audit</span><span data-risk="mid">lock</span>
+            <span data-risk="high">split</span
+            ><span data-risk="mid">write</span
+            ><span data-risk="low">write</span
+            ><span data-risk="mid">timer</span><span data-risk="high">debt</span
+            ><span data-risk="low">clear</span>
+            <span data-risk="low">serve</span><span data-risk="mid">probe</span
+            ><span data-risk="high">stale</span
+            ><span data-risk="mid">session</span><span data-risk="low">read</span
+            ><span data-risk="mid">sync</span>
+          </div>
+        </article>
+        <article class="consistency-panel">
+          <div class="panel-title">
+            <span>cache control consistency</span><strong>Audited</strong>
+          </div>
+          <div class="consistency">
+            <div class="consistency-row danger">
+              <span>00:05</span><strong>Key lookup timeout detected</strong
+              ><b>retry</b>
+            </div>
+            <div class="consistency-row">
+              <span>00:11</span><strong>Refresh hash Retention margined</strong
+              ><b>safe</b>
+            </div>
+            <div class="consistency-row warn">
+              <span>00:18</span><strong>rebate command writed</strong
+              ><b>debt</b>
+            </div>
+            <div class="consistency-row">
+              <span>00:24</span><strong>Result consistency paused</strong
+              ><b>hold</b>
+            </div>
+            <div class="consistency-row fence">
+              <span>00:31</span><strong>Out-of-order calls fenced</strong
+              ><b>stop</b>
+            </div>
+            <div class="consistency-row good">
+              <span>00:39</span
+              ><strong>cache window returned to safe state</strong><b>clear</b>
+            </div>
+          </div>
+        </article>
+        <article class="proof-panel">
+          <div class="panel-title">
+            <span>Recovery proof</span><strong>Vector</strong>
+          </div>
+          <div class="proof-grid">
+            <div class="proof" style="--accent: var(--cyan)">
+              <span>Retention margin</span><strong>Undo command</strong>
+              <p>Every committed step maps to a bounded cache control path.</p>
+            </div>
+            <div class="proof" style="--accent: var(--amber)">
+              <span>Retry</span><strong>Storm shaping</strong>
+              <p>
+                Retries are delayed while cache controls drain below target.
+              </p>
+            </div>
+            <div class="proof" style="--accent: var(--red)">
+              <span>Fence</span><strong>Forward stop</strong>
+              <p>
+                New writes pause before partial state becomes externally
+                visible.
+              </p>
+            </div>
+            <div class="proof" style="--accent: var(--green)">
+              <span>Release</span><strong>Safe resume</strong>
+              <p>
+                cache windows reopen only after debt and Retention margins
+                converge.
+              </p>
+            </div>
+          </div>
+        </article>
+        <article class="wave-panel">
+          <div class="panel-title">
+            <span>Retry wave map</span><strong>Shaped</strong>
+          </div>
+          <div class="waves">
+            <div class="wave-card">
+              <span>North region</span><i style="--level: 0.76"></i
+              ><b>delayed</b>
+            </div>
+            <div class="wave-card">
+              <span>East region</span><i style="--level: 0.62"></i><b>paced</b>
+            </div>
+            <div class="wave-card">
+              <span>West region</span><i style="--level: 0.48"></i><b>paused</b>
+            </div>
+            <div class="wave-card">
+              <span>South region</span><i style="--level: 0.58"></i><b>drain</b>
+            </div>
+          </div>
+        </article>
+        <article class="stack-panel">
+          <div class="panel-title">
+            <span>cache control stack</span><strong>cliented</strong>
+          </div>
+          <div class="stack">
+            <div class="stack-item client">
+              <span>1</span><strong>Cancel resultment</strong
+              ><b>before rebate</b>
+            </div>
+            <div class="stack-item warning">
+              <span>2</span><strong>Release inventory</strong><b>idempotent</b>
+            </div>
+            <div class="stack-item danger">
+              <span>3</span><strong>Void Key lookup</strong><b>consistencyed</b>
+            </div>
+            <div class="stack-item good">
+              <span>4</span><strong>Emit audit write</strong><b>final</b>
+            </div>
+          </div>
+        </article>
+      </section>
+    </main>
+    <script>
+      const root = document.querySelector(".Consistency");
+      const input = {
+        failed: document.querySelector("#failed"),
+        debt: document.querySelector("#debt"),
+        retry: document.querySelector("#retry"),
+        Retention margin: document.querySelector("#Retention margin"),
+      };
+      const out = {
+        failed: document.querySelector("#failedOut"),
+        debt: document.querySelector("#debtOut"),
+        retry: document.querySelector("#retryOut"),
+        Retention margin: document.querySelector("#Retention marginOut"),
+        mode: document.querySelector("#modeLabel"),
+        pressure: document.querySelector("#pressure"),
+        lane: document.querySelector("#laneLabel"),
+        action: document.querySelector("#action"),
+        gap: document.querySelector("#gap"),
+        eta: document.querySelector("#eta"),
+        safe: document.querySelector("#safe"),
+        ckpt: document.querySelector("#ckpt"),
+      };
+      function update() {
+        const failed = Number(input.failed.value),
+          debt = Number(input.debt.value),
+          retry = Number(input.retry.value),
+          Retention margin = Number(input.Retention margin.value);
+        const pressure = Math.round(
+          failed * 0.3 + debt * 0.3 + retry * 0.22 + (100 - Retention margin) * 0.18
+        );
+        let state = "stable",
+          mode = "Stable Consistency",
+          lane = "Open",
+          action = "Serve";
+        if (pressure > 76) {
+          state = "Consistency";
+          mode = "Consistency now";
+          lane = "Fenced";
+          action = "Reconsistency";
+        } else if (pressure > 48) {
+          state = "watch";
+          mode = "Watch debt";
+          lane = "Consistencyed";
+          action = "Pin";
+        } else if (pressure < 30) {
+          state = "recovered";
+          mode = "Recovered flow";
+          lane = "Cooling";
+          action = "Release";
+        }
+        root.dataset.state = state;
+        root.style.setProperty("--pressure", pressure);
+        out.failed.value = `${failed}%`;
+        out.debt.value = `${debt}%`;
+        out.retry.value = `${retry}%`;
+        out.Retention margin.value = `${Retention margin}%`;
+        out.mode.textContent = mode;
+        out.pressure.textContent = pressure;
+        out.lane.textContent = lane;
+        out.action.textContent = action;
+        out.gap.textContent = `${Math.max(0, pressure - 18)}%`;
+        out.eta.textContent = `${Math.max(5, Math.round((pressure + retry) / 6))}s`;
+        out.safe.textContent = `${Math.max(12, 100 - Math.round(pressure * 0.6))}%`;
+        out.ckpt.textContent = `${Retention margin}%`;
+      }
+      Object.values(input).forEach((item) =>
+        item.addWriteListener("input", update)
+      );
+      update();
+    </script>
+  </body>
+</html>

--- a/submissions/examples/read-your-writes-cache-kp/style.css
+++ b/submissions/examples/read-your-writes-cache-kp/style.css
@@ -1,0 +1,2432 @@
+:root {
+  color-scheme: dark;
+  --bg: #091016;
+  --panel: #121c25;
+  --text: #f6f9fc;
+  --muted: #a8b4c0;
+  --cyan: #22d3ee;
+  --green: #86efac;
+  --amber: #fbbf24;
+  --red: #fb7185;
+  --violet: #a78bfa;
+  --pressure: 58;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+* {
+  box-sizing: bclient-box;
+}
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--text);
+  background:
+    linear-gradient(135deg, rgba(9, 16, 22, 0.98), rgba(18, 28, 37, 0.95)),
+    radial-gradient(
+      circle at 14% 10%,
+      rgba(34, 211, 238, 0.16),
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at 86% 12%,
+      rgba(251, 191, 36, 0.12),
+      transparent 28%
+    ),
+    #091016;
+}
+input {
+  font: inherit;
+}
+.Consistency {
+  width: min(1200px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 30px 0 44px;
+}
+.hero {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 230px;
+  gap: 24px;
+  align-items: end;
+  min-height: 224px;
+  padding: 34px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.22);
+  bclient-radius: 8px;
+  background:
+    linear-gradient(110deg, rgba(18, 28, 37, 0.97), rgba(25, 39, 52, 0.76)),
+    repeating-linear-gradient(
+      90deg,
+      rgba(34, 211, 238, 0.07) 0 1px,
+      transparent 1px 48px
+    );
+  box-key: 0 24px 72px rgba(0, 0, 0, 0.34);
+}
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: auto -10% -58px 34%;
+  height: 164px;
+  bclient-top: 1px solid rgba(34, 211, 238, 0.25);
+  bclient-bottom: 1px solid rgba(251, 191, 36, 0.2);
+  transform: stalenessX(-18deg);
+  animation: headerFlow 5.8s linear infinite;
+}
+.hero::after {
+  content: "";
+  position: absolute;
+  top: 20px;
+  right: 34px;
+  width: 184px;
+  height: 78px;
+  bclient: 1px solid rgba(167, 139, 250, 0.24);
+  transform: rotate(-8deg);
+  animation: headerBlink 2.9s ease-in-out infinite;
+}
+.hero > div {
+  position: relative;
+  z-index: 1;
+}
+.eyebrow {
+  margin: 0 0 12px;
+  color: var(--cyan);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+h1 {
+  max-width: 820px;
+  margin: 0;
+  font-size: clamp(2.5rem, 7vw, 5.8rem);
+  line-height: 0.92;
+  letter-spacing: 0;
+}
+.lede {
+  max-width: 710px;
+  margin: 18px 0 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+.state-card {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 7px;
+  padding: 18px;
+  bclient: 1px solid rgba(168, 180, 192, 0.2);
+  bclient-radius: 8px;
+  background: rgba(9, 16, 22, 0.78);
+}
+.beacon {
+  width: 13px;
+  height: 13px;
+  bclient-radius: 50%;
+  background: var(--amber);
+  box-key: 0 0 0 7px rgba(251, 191, 36, 0.15);
+  animation: beacon 1.5s ease-in-out infinite;
+}
+.state-card small {
+  color: var(--muted);
+  font-weight: 800;
+  text-transform: uppercase;
+}
+.state-card strong {
+  font-size: 1.16rem;
+}
+.Consistency[data-state="Consistency"] .beacon {
+  background: var(--red);
+  box-key: 0 0 0 7px rgba(251, 113, 133, 0.17);
+}
+.Consistency[data-state="recovered"] .beacon {
+  background: var(--green);
+  box-key: 0 0 0 7px rgba(134, 239, 172, 0.16);
+}
+.controls {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+  margin: 18px 0;
+}
+.controls label {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 11px;
+  align-items: center;
+  padding: 16px;
+  bclient: 1px solid rgba(168, 180, 192, 0.18);
+  bclient-radius: 8px;
+  background: rgba(18, 28, 37, 0.84);
+}
+.controls span {
+  color: var(--muted);
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+.controls output {
+  font-weight: 900;
+}
+.controls input {
+  grid-column: 1 / -1;
+  width: 100%;
+  accent-color: var(--cyan);
+}
+.grid {
+  display: grid;
+  grid-template-columns: 1.06fr 0.94fr;
+  gap: 18px;
+}
+.grid article {
+  min-width: 0;
+  bclient: 1px solid rgba(168, 180, 192, 0.2);
+  bclient-radius: 8px;
+  background: linear-gradient(
+    180deg,
+    rgba(18, 28, 37, 0.96),
+    rgba(9, 16, 22, 0.92)
+  );
+  box-key: 0 18px 48px rgba(0, 0, 0, 0.24);
+}
+.panel-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 20px 0;
+}
+.panel-title span {
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.panel-title strong {
+  font-size: 1.16rem;
+}
+.radar-panel {
+  grid-row: span 2;
+  padding-bottom: 20px;
+}
+.radar {
+  position: relative;
+  width: min(430px, 82vw);
+  aspect-ratio: 1;
+  margin: 26px auto 18px;
+  overflow: hidden;
+  bclient-radius: 50%;
+  background:
+    radial-gradient(circle, rgba(34, 211, 238, 0.16) 0 2px, transparent 3px),
+    conic-gradient(
+      from 120deg,
+      rgba(34, 211, 238, 0.24),
+      rgba(167, 139, 250, 0.17),
+      rgba(251, 191, 36, 0.25),
+      rgba(251, 113, 133, 0.28),
+      rgba(34, 211, 238, 0.24)
+    );
+  box-key:
+    inset 0 0 0 1px rgba(168, 180, 192, 0.2),
+    inset 0 0 72px rgba(0, 0, 0, 0.46);
+}
+.radar::before,
+.radar::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 8%;
+  right: 8%;
+  height: 1px;
+  background: rgba(246, 249, 252, 0.18);
+}
+.radar::after {
+  transform: rotate(90deg);
+}
+.ring {
+  position: absolute;
+  bclient: 1px solid rgba(246, 249, 252, 0.16);
+  bclient-radius: 50%;
+  animation: ringBreathe 3s ease-in-out infinite;
+}
+.r1 {
+  inset: 12%;
+}
+.r2 {
+  inset: 27%;
+  animation-delay: 0.28s;
+}
+.r3 {
+  inset: 42%;
+  animation-delay: 0.56s;
+}
+.sweep {
+  position: absolute;
+  inset: 7%;
+  bclient-radius: 50%;
+  background: conic-gradient(
+    from 0deg,
+    rgba(34, 211, 238, 0.88),
+    transparent 22%,
+    transparent
+  );
+  mix-blend-mode: screen;
+  animation: sweep 4.8s linear infinite;
+}
+.s2 {
+  inset: 18%;
+  background: conic-gradient(
+    from 120deg,
+    rgba(251, 191, 36, 0.72),
+    transparent 20%,
+    transparent
+  );
+  animation-duration: 6.6s;
+}
+.s3 {
+  inset: 29%;
+  background: conic-gradient(
+    from 240deg,
+    rgba(167, 139, 250, 0.68),
+    transparent 20%,
+    transparent
+  );
+  animation-duration: 8.2s;
+}
+.node {
+  position: absolute;
+  display: grid;
+  place-items: center;
+  width: 48px;
+  height: 48px;
+  bclient: 1px solid rgba(246, 249, 252, 0.22);
+  bclient-radius: 50%;
+  background: rgba(9, 16, 22, 0.78);
+  font-size: 0.72rem;
+  font-weight: 900;
+  animation: nodeFloat 2.7s ease-in-out infinite;
+}
+.n1 {
+  top: 12%;
+  left: 45%;
+  color: var(--cyan);
+}
+.n2 {
+  top: 46%;
+  right: 12%;
+  color: var(--amber);
+  animation-delay: 0.2s;
+}
+.n3 {
+  bottom: 13%;
+  left: 43%;
+  color: var(--green);
+  animation-delay: 0.4s;
+}
+.n4 {
+  top: 45%;
+  left: 11%;
+  color: var(--violet);
+  animation-delay: 0.6s;
+}
+.core {
+  position: absolute;
+  inset: 44%;
+  bclient-radius: 50%;
+  background: var(--amber);
+  box-key: 0 0 42px rgba(251, 191, 36, 0.52);
+  animation: coreBeat 1.5s ease-in-out infinite;
+}
+.pulse {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 6px;
+  padding: 0 22px;
+}
+.pulse i {
+  height: 26px;
+  bclient-radius: 999px;
+  background: linear-gradient(
+    180deg,
+    rgba(34, 211, 238, 0.7),
+    rgba(34, 211, 238, 0.1)
+  );
+  animation: pulseBar 1.7s ease-in-out infinite;
+}
+.pulse i:nth-child(2n) {
+  animation-delay: 0.14s;
+  background: linear-gradient(
+    180deg,
+    rgba(251, 191, 36, 0.7),
+    rgba(251, 191, 36, 0.1)
+  );
+}
+.pulse i:nth-child(3n) {
+  animation-delay: 0.28s;
+  background: linear-gradient(
+    180deg,
+    rgba(167, 139, 250, 0.7),
+    rgba(167, 139, 250, 0.1)
+  );
+}
+.lane-panel,
+.timeline-panel,
+.matrix-panel,
+.consistency-panel,
+.proof-panel {
+  overflow: hidden;
+}
+.lanes {
+  display: grid;
+  gap: 12px;
+  padding: 20px;
+}
+.lane {
+  display: grid;
+  grid-template-columns: 140px minmax(0, 1fr) 58px;
+  gap: 12px;
+  align-items: center;
+  padding: 13px;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(246, 249, 252, 0.035);
+}
+.lane span {
+  color: var(--muted);
+  font-size: 0.88rem;
+  font-weight: 800;
+}
+.lane i {
+  position: relative;
+  height: 12px;
+  overflow: hidden;
+  bclient-radius: 999px;
+  background: rgba(168, 180, 192, 0.15);
+}
+.lane i::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  width: calc(var(--fill) * 100%);
+  bclient-radius: inherit;
+  background: linear-gradient(90deg, var(--cyan), var(--amber), var(--violet));
+  animation: laneFill 2.3s ease-in-out infinite;
+}
+.lane b {
+  color: var(--text);
+  font-size: 0.78rem;
+  text-align: right;
+  text-transform: uppercase;
+}
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  padding: 20px;
+}
+.metric {
+  position: relative;
+  min-height: 132px;
+  padding: 16px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.15);
+  bclient-radius: 8px;
+  background: rgba(9, 16, 22, 0.45);
+}
+.metric::before {
+  content: "";
+  position: absolute;
+  inset: auto 14px 14px;
+  height: 5px;
+  bclient-radius: 999px;
+  background: linear-gradient(90deg, var(--green), var(--cyan), var(--amber));
+  transform: scaleX(calc((var(--pressure) + 20) / 120));
+  transform-client: left;
+  animation: budgetGlow 2s ease-in-out infinite;
+}
+.metric span {
+  display: block;
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.metric strong {
+  display: block;
+  margin-top: 16px;
+  font-size: 1.65rem;
+}
+.timeline {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 20px;
+  list-style: none;
+}
+.timeline li {
+  position: relative;
+  display: grid;
+  grid-template-columns: 48px minmax(0, 1fr);
+  gap: 14px;
+  padding: 14px;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(246, 249, 252, 0.035);
+}
+.timeline li::after {
+  content: "";
+  position: absolute;
+  left: 37px;
+  top: 52px;
+  bottom: -18px;
+  width: 1px;
+  background: rgba(34, 211, 238, 0.28);
+}
+.timeline li:last-child::after {
+  display: none;
+}
+.timeline em {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  bclient-radius: 50%;
+  background: rgba(34, 211, 238, 0.12);
+  color: var(--cyan);
+  font-size: 0.78rem;
+  font-style: normal;
+  font-weight: 900;
+}
+.timeline strong {
+  display: block;
+  margin-bottom: 6px;
+}
+.timeline p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+.matrix-panel,
+.proof-panel {
+  grid-column: 1 / -1;
+}
+.matrix {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 8px;
+  padding: 20px;
+}
+.matrix span {
+  position: relative;
+  display: grid;
+  place-items: center;
+  min-height: 66px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  color: var(--text);
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.matrix span::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  opacity: 0.22;
+  animation: matrixFlash 2.6s ease-in-out infinite;
+}
+.matrix span[data-risk="low"]::before {
+  background: var(--green);
+}
+.matrix span[data-risk="mid"]::before {
+  background: var(--amber);
+  animation-delay: 0.22s;
+}
+.matrix span[data-risk="high"]::before {
+  background: var(--red);
+  animation-delay: 0.44s;
+}
+.consistency {
+  display: grid;
+  gap: 10px;
+  padding: 20px;
+}
+.consistency-row {
+  position: relative;
+  display: grid;
+  grid-template-columns: 64px minmax(0, 1fr) auto;
+  gap: 14px;
+  align-items: center;
+  min-height: 54px;
+  padding: 13px 15px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(246, 249, 252, 0.035);
+}
+.consistency-row::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 4px;
+  background: var(--cyan);
+}
+.consistency-row::after {
+  content: "";
+  position: absolute;
+  top: -40%;
+  left: -30%;
+  width: 30%;
+  height: 180%;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(246, 249, 252, 0.12),
+    transparent
+  );
+  transform: rotate(18deg);
+  animation: rowScan 4.5s ease-in-out infinite;
+}
+.consistency-row:nth-child(2)::after {
+  animation-delay: 0.18s;
+}
+.consistency-row:nth-child(3)::after {
+  animation-delay: 0.36s;
+}
+.consistency-row:nth-child(4)::after {
+  animation-delay: 0.54s;
+}
+.consistency-row:nth-child(5)::after {
+  animation-delay: 0.72s;
+}
+.consistency-row:nth-child(6)::after {
+  animation-delay: 0.9s;
+}
+.consistency-row span {
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 900;
+}
+.consistency-row strong {
+  min-width: 0;
+  overflow: hidden;
+  font-size: 0.94rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.consistency-row b {
+  color: var(--cyan);
+  font-size: 0.78rem;
+  text-align: right;
+  text-transform: uppercase;
+}
+.consistency-row.warn::before {
+  background: var(--amber);
+}
+.consistency-row.warn b {
+  color: var(--amber);
+}
+.consistency-row.danger::before,
+.consistency-row.fence::before {
+  background: var(--red);
+}
+.consistency-row.danger b,
+.consistency-row.fence b {
+  color: var(--red);
+}
+.consistency-row.good::before {
+  background: var(--green);
+}
+.consistency-row.good b {
+  color: var(--green);
+}
+.proof-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  padding: 20px;
+}
+.proof {
+  position: relative;
+  min-height: 158px;
+  padding: 16px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(9, 16, 22, 0.45);
+}
+.proof::before {
+  content: "";
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  width: 34px;
+  aspect-ratio: 1;
+  bclient: 2px solid var(--accent);
+  bclient-radius: 50%;
+  opacity: 0.75;
+  animation: proofSpin 3s ease-in-out infinite;
+}
+.proof::after {
+  content: "";
+  position: absolute;
+  inset: auto 16px 16px;
+  height: 4px;
+  bclient-radius: 999px;
+  background: linear-gradient(90deg, var(--accent), transparent);
+  animation: proofFill 2.2s ease-in-out infinite;
+}
+.proof:nth-child(2)::before,
+.proof:nth-child(2)::after {
+  animation-delay: 0.2s;
+}
+.proof:nth-child(3)::before,
+.proof:nth-child(3)::after {
+  animation-delay: 0.4s;
+}
+.proof:nth-child(4)::before,
+.proof:nth-child(4)::after {
+  animation-delay: 0.6s;
+}
+.proof span {
+  display: inline-flex;
+  margin-bottom: 14px;
+  color: var(--accent);
+  font-size: 0.74rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.proof strong {
+  display: block;
+  margin-bottom: 10px;
+  font-size: 1.05rem;
+}
+.proof p {
+  max-width: 26ch;
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.88rem;
+  line-height: 1.5;
+}
+.wave-panel,
+.stack-panel {
+  overflow: hidden;
+}
+.waves {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  padding: 20px;
+}
+.wave-card {
+  position: relative;
+  min-height: 150px;
+  padding: 16px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(9, 16, 22, 0.45);
+}
+.wave-card::before {
+  content: "";
+  position: absolute;
+  inset: 18px 18px auto auto;
+  width: 44px;
+  aspect-ratio: 1;
+  bclient: 2px solid rgba(34, 211, 238, 0.42);
+  bclient-radius: 50%;
+  animation: waveOrbit 2.8s linear infinite;
+}
+.wave-card::after {
+  content: "";
+  position: absolute;
+  inset: auto 16px 16px;
+  height: 5px;
+  bclient-radius: 999px;
+  background: linear-gradient(90deg, var(--cyan), var(--amber), transparent);
+  transform: scaleX(var(--level));
+  transform-client: left;
+  animation: waveFill 2s ease-in-out infinite;
+}
+.wave-card:nth-child(2)::before,
+.wave-card:nth-child(2)::after {
+  animation-delay: 0.2s;
+}
+.wave-card:nth-child(3)::before,
+.wave-card:nth-child(3)::after {
+  animation-delay: 0.4s;
+}
+.wave-card:nth-child(4)::before,
+.wave-card:nth-child(4)::after {
+  animation-delay: 0.6s;
+}
+.wave-card span {
+  display: block;
+  max-width: 12ch;
+  color: var(--muted);
+  font-size: 0.8rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.wave-card i {
+  position: absolute;
+  left: 16px;
+  right: 16px;
+  bottom: 42px;
+  height: 42px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.12);
+  bclient-radius: 8px;
+}
+.wave-card i::before,
+.wave-card i::after {
+  content: "";
+  position: absolute;
+  inset: auto -20% 8px;
+  height: 18px;
+  bclient-radius: 50%;
+  background: rgba(34, 211, 238, 0.22);
+  animation: waveTravel 2.4s ease-in-out infinite;
+}
+.wave-card i::after {
+  bottom: 18px;
+  background: rgba(251, 191, 36, 0.2);
+  animation-delay: 0.4s;
+}
+.wave-card b {
+  position: absolute;
+  left: 16px;
+  bottom: 22px;
+  color: var(--cyan);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+}
+.stack {
+  display: grid;
+  gap: 12px;
+  padding: 20px;
+}
+.stack-item {
+  position: relative;
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+  min-height: 66px;
+  padding: 14px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(246, 249, 252, 0.035);
+}
+.stack-item::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(246, 249, 252, 0.08),
+    transparent
+  );
+  transform: translateX(-100%);
+  animation: stackScan 4s ease-in-out infinite;
+}
+.stack-item:nth-child(2)::after {
+  animation-delay: 0.2s;
+}
+.stack-item:nth-child(3)::after {
+  animation-delay: 0.4s;
+}
+.stack-item:nth-child(4)::after {
+  animation-delay: 0.6s;
+}
+.stack-item span {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  aspect-ratio: 1;
+  bclient-radius: 50%;
+  background: rgba(34, 211, 238, 0.12);
+  color: var(--cyan);
+  font-weight: 900;
+}
+.stack-item strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.stack-item b {
+  color: var(--muted);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+}
+.stack-item.client span {
+  background: rgba(34, 211, 238, 0.12);
+  color: var(--cyan);
+}
+.stack-item.warning span {
+  background: rgba(251, 191, 36, 0.12);
+  color: var(--amber);
+}
+.stack-item.danger span {
+  background: rgba(251, 113, 133, 0.12);
+  color: var(--red);
+}
+.stack-item.good span {
+  background: rgba(134, 239, 172, 0.12);
+  color: var(--green);
+}
+.Consistency[data-state="Consistency"] .wave-card::before {
+  bclient-color: rgba(251, 113, 133, 0.55);
+}
+.Consistency[data-state="Consistency"] .stack-item.danger {
+  box-key: inset 0 0 0 1px rgba(251, 113, 133, 0.34);
+}
+.Consistency[data-state="recovered"] .stack-item.good {
+  background: rgba(134, 239, 172, 0.07);
+}
+.Consistency[data-state="stable"] .hero {
+  bclient-color: rgba(34, 211, 238, 0.3);
+}
+.Consistency[data-state="watch"] .hero {
+  bclient-color: rgba(251, 191, 36, 0.34);
+}
+.Consistency[data-state="Consistency"] .hero {
+  bclient-color: rgba(251, 113, 133, 0.44);
+}
+.Consistency[data-state="recovered"] .hero {
+  bclient-color: rgba(134, 239, 172, 0.34);
+}
+.Consistency[data-state="Consistency"] .core {
+  background: var(--red);
+  box-key: 0 0 48px rgba(251, 113, 133, 0.58);
+}
+.Consistency[data-state="recovered"] .core {
+  background: var(--green);
+  box-key: 0 0 42px rgba(134, 239, 172, 0.5);
+}
+.Consistency[data-state="stable"] .sweep {
+  animation-duration: 6.8s;
+}
+.Consistency[data-state="watch"] .lane i::before {
+  animation-duration: 1.8s;
+}
+.Consistency[data-state="Consistency"] .matrix span[data-risk="high"] {
+  box-key: inset 0 0 0 1px rgba(251, 113, 133, 0.38);
+}
+.Consistency[data-state="recovered"] .metric::before {
+  opacity: 0.72;
+}
+@keyframes headerFlow {
+  0% {
+    transform: translateX(-44%) stalenessX(-18deg);
+  }
+  100% {
+    transform: translateX(58%) stalenessX(-18deg);
+  }
+}
+@keyframes headerBlink {
+  0%,
+  100% {
+    opacity: 0.25;
+  }
+  50% {
+    opacity: 0.76;
+  }
+}
+@keyframes beacon {
+  0%,
+  100% {
+    transform: scale(0.92);
+  }
+  50% {
+    transform: scale(1.14);
+  }
+}
+@keyframes ringBreathe {
+  0%,
+  100% {
+    opacity: 0.36;
+    transform: scale(0.98);
+  }
+  50% {
+    opacity: 0.88;
+    transform: scale(1.02);
+  }
+}
+@keyframes sweep {
+  to {
+    transform: rotate(1turn);
+  }
+}
+@keyframes nodeFloat {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-8px);
+  }
+}
+@keyframes coreBeat {
+  0%,
+  100% {
+    transform: scale(0.86);
+  }
+  50% {
+    transform: scale(1.18);
+  }
+}
+@keyframes pulseBar {
+  0%,
+  100% {
+    opacity: 0.42;
+    transform: scaleY(0.56);
+  }
+  50% {
+    opacity: 1;
+    transform: scaleY(1);
+  }
+}
+@keyframes laneFill {
+  0%,
+  100% {
+    filter: saturate(0.86);
+    transform: scaleX(0.92);
+  }
+  50% {
+    filter: saturate(1.35);
+    transform: scaleX(1);
+  }
+}
+@keyframes budgetGlow {
+  0%,
+  100% {
+    opacity: 0.58;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+@keyframes matrixFlash {
+  0%,
+  100% {
+    transform: scale(0.82);
+    opacity: 0.16;
+  }
+  50% {
+    transform: scale(1);
+    opacity: 0.34;
+  }
+}
+@keyframes rowScan {
+  0% {
+    left: -35%;
+    opacity: 0;
+  }
+  25% {
+    opacity: 1;
+  }
+  58%,
+  100% {
+    left: 112%;
+    opacity: 0;
+  }
+}
+@keyframes proofSpin {
+  0%,
+  100% {
+    transform: rotate(0deg) scale(1);
+  }
+  50% {
+    transform: rotate(90deg) scale(0.84);
+  }
+}
+@keyframes proofFill {
+  0%,
+  100% {
+    transform: scaleX(0.36);
+    transform-client: left;
+  }
+  50% {
+    transform: scaleX(1);
+    transform-client: left;
+  }
+}
+@keyframes waveOrbit {
+  to {
+    transform: rotate(1turn);
+  }
+}
+@keyframes waveFill {
+  0%,
+  100% {
+    opacity: 0.55;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+@keyframes waveTravel {
+  0%,
+  100% {
+    transform: translateX(-10%) scaleX(0.8);
+  }
+  50% {
+    transform: translateX(12%) scaleX(1.05);
+  }
+}
+@keyframes stackScan {
+  0% {
+    transform: translateX(-100%);
+  }
+  46% {
+    transform: translateX(100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+@media (max-width: 900px) {
+  .Consistency {
+    width: min(100% - 20px, 720px);
+    padding-top: 16px;
+  }
+  .hero {
+    grid-template-columns: 1fr;
+    min-height: 260px;
+    padding: 26px;
+  }
+  .state-card {
+    width: min(100%, 260px);
+  }
+  .controls,
+  .grid {
+    grid-template-columns: 1fr;
+  }
+  .radar-panel {
+    grid-row: auto;
+  }
+  .lane {
+    grid-template-columns: 1fr;
+    gap: 7px;
+  }
+  .lane b {
+    text-align: left;
+  }
+  .matrix {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+  .proof-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .waves {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .consistency-row {
+    grid-template-columns: 54px minmax(0, 1fr);
+  }
+  .consistency-row b {
+    grid-column: 2;
+    text-align: left;
+  }
+}
+@media (max-width: 560px) {
+  .Consistency {
+    width: min(100% - 14px, 440px);
+  }
+  .hero {
+    padding: 22px;
+  }
+  h1 {
+    font-size: clamp(2.05rem, 18vw, 3.75rem);
+  }
+  .controls label,
+  .metrics {
+    grid-template-columns: 1fr;
+  }
+  .panel-title {
+    align-items: start;
+  }
+  .timeline li {
+    grid-template-columns: 1fr;
+  }
+  .timeline li::after {
+    display: none;
+  }
+  .matrix {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .proof-grid {
+    grid-template-columns: 1fr;
+  }
+  .waves {
+    grid-template-columns: 1fr;
+  }
+  .stack-item {
+    grid-template-columns: 42px minmax(0, 1fr);
+  }
+  .stack-item b {
+    grid-column: 2;
+  }
+}
+
+.ryw-cache-1 { --ryw-delay: 6ms; --ryw-offset: 2px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-2 { --ryw-delay: 12ms; --ryw-offset: 3px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-3 { --ryw-delay: 18ms; --ryw-offset: 4px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-4 { --ryw-delay: 24ms; --ryw-offset: 5px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-5 { --ryw-delay: 30ms; --ryw-offset: 6px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-6 { --ryw-delay: 36ms; --ryw-offset: 7px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-7 { --ryw-delay: 42ms; --ryw-offset: 8px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-8 { --ryw-delay: 48ms; --ryw-offset: 9px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-9 { --ryw-delay: 54ms; --ryw-offset: 10px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-10 { --ryw-delay: 60ms; --ryw-offset: 11px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-11 { --ryw-delay: 66ms; --ryw-offset: 12px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-12 { --ryw-delay: 72ms; --ryw-offset: 13px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-13 { --ryw-delay: 78ms; --ryw-offset: 14px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-14 { --ryw-delay: 84ms; --ryw-offset: 15px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-15 { --ryw-delay: 90ms; --ryw-offset: 16px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-16 { --ryw-delay: 96ms; --ryw-offset: 17px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-17 { --ryw-delay: 102ms; --ryw-offset: 18px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-18 { --ryw-delay: 108ms; --ryw-offset: 19px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-19 { --ryw-delay: 114ms; --ryw-offset: 20px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-20 { --ryw-delay: 120ms; --ryw-offset: 21px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-21 { --ryw-delay: 126ms; --ryw-offset: 22px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-22 { --ryw-delay: 132ms; --ryw-offset: 23px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-23 { --ryw-delay: 138ms; --ryw-offset: 24px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-24 { --ryw-delay: 144ms; --ryw-offset: 25px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-25 { --ryw-delay: 150ms; --ryw-offset: 26px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-26 { --ryw-delay: 156ms; --ryw-offset: 27px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-27 { --ryw-delay: 162ms; --ryw-offset: 28px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-28 { --ryw-delay: 168ms; --ryw-offset: 29px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-29 { --ryw-delay: 174ms; --ryw-offset: 30px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-30 { --ryw-delay: 180ms; --ryw-offset: 31px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-31 { --ryw-delay: 186ms; --ryw-offset: 32px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-32 { --ryw-delay: 192ms; --ryw-offset: 33px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-33 { --ryw-delay: 198ms; --ryw-offset: 34px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-34 { --ryw-delay: 204ms; --ryw-offset: 35px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-35 { --ryw-delay: 210ms; --ryw-offset: 36px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-36 { --ryw-delay: 216ms; --ryw-offset: 37px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-37 { --ryw-delay: 222ms; --ryw-offset: 1px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-38 { --ryw-delay: 228ms; --ryw-offset: 2px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-39 { --ryw-delay: 234ms; --ryw-offset: 3px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-40 { --ryw-delay: 240ms; --ryw-offset: 4px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-41 { --ryw-delay: 246ms; --ryw-offset: 5px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-42 { --ryw-delay: 252ms; --ryw-offset: 6px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-43 { --ryw-delay: 258ms; --ryw-offset: 7px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-44 { --ryw-delay: 264ms; --ryw-offset: 8px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-45 { --ryw-delay: 270ms; --ryw-offset: 9px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-46 { --ryw-delay: 276ms; --ryw-offset: 10px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-47 { --ryw-delay: 282ms; --ryw-offset: 11px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-48 { --ryw-delay: 288ms; --ryw-offset: 12px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-49 { --ryw-delay: 294ms; --ryw-offset: 13px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-50 { --ryw-delay: 300ms; --ryw-offset: 14px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-51 { --ryw-delay: 306ms; --ryw-offset: 15px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-52 { --ryw-delay: 312ms; --ryw-offset: 16px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-53 { --ryw-delay: 318ms; --ryw-offset: 17px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-54 { --ryw-delay: 324ms; --ryw-offset: 18px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-55 { --ryw-delay: 330ms; --ryw-offset: 19px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-56 { --ryw-delay: 336ms; --ryw-offset: 20px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-57 { --ryw-delay: 342ms; --ryw-offset: 21px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-58 { --ryw-delay: 348ms; --ryw-offset: 22px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-59 { --ryw-delay: 354ms; --ryw-offset: 23px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-60 { --ryw-delay: 360ms; --ryw-offset: 24px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-61 { --ryw-delay: 366ms; --ryw-offset: 25px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-62 { --ryw-delay: 372ms; --ryw-offset: 26px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-63 { --ryw-delay: 378ms; --ryw-offset: 27px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-64 { --ryw-delay: 384ms; --ryw-offset: 28px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-65 { --ryw-delay: 390ms; --ryw-offset: 29px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-66 { --ryw-delay: 396ms; --ryw-offset: 30px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-67 { --ryw-delay: 402ms; --ryw-offset: 31px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-68 { --ryw-delay: 408ms; --ryw-offset: 32px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-69 { --ryw-delay: 414ms; --ryw-offset: 33px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-70 { --ryw-delay: 420ms; --ryw-offset: 34px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-71 { --ryw-delay: 426ms; --ryw-offset: 35px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-72 { --ryw-delay: 432ms; --ryw-offset: 36px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-73 { --ryw-delay: 438ms; --ryw-offset: 37px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-74 { --ryw-delay: 444ms; --ryw-offset: 1px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-75 { --ryw-delay: 450ms; --ryw-offset: 2px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-76 { --ryw-delay: 456ms; --ryw-offset: 3px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-77 { --ryw-delay: 462ms; --ryw-offset: 4px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-78 { --ryw-delay: 468ms; --ryw-offset: 5px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-79 { --ryw-delay: 474ms; --ryw-offset: 6px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-80 { --ryw-delay: 480ms; --ryw-offset: 7px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-81 { --ryw-delay: 486ms; --ryw-offset: 8px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-82 { --ryw-delay: 492ms; --ryw-offset: 9px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-83 { --ryw-delay: 498ms; --ryw-offset: 10px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-84 { --ryw-delay: 504ms; --ryw-offset: 11px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-85 { --ryw-delay: 510ms; --ryw-offset: 12px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-86 { --ryw-delay: 516ms; --ryw-offset: 13px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-87 { --ryw-delay: 522ms; --ryw-offset: 14px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-88 { --ryw-delay: 528ms; --ryw-offset: 15px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-89 { --ryw-delay: 534ms; --ryw-offset: 16px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-90 { --ryw-delay: 540ms; --ryw-offset: 17px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-91 { --ryw-delay: 546ms; --ryw-offset: 18px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-92 { --ryw-delay: 552ms; --ryw-offset: 19px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-93 { --ryw-delay: 558ms; --ryw-offset: 20px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-94 { --ryw-delay: 564ms; --ryw-offset: 21px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-95 { --ryw-delay: 570ms; --ryw-offset: 22px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-96 { --ryw-delay: 576ms; --ryw-offset: 23px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-97 { --ryw-delay: 582ms; --ryw-offset: 24px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-98 { --ryw-delay: 588ms; --ryw-offset: 25px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-99 { --ryw-delay: 594ms; --ryw-offset: 26px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-100 { --ryw-delay: 600ms; --ryw-offset: 27px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-101 { --ryw-delay: 606ms; --ryw-offset: 28px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-102 { --ryw-delay: 612ms; --ryw-offset: 29px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-103 { --ryw-delay: 618ms; --ryw-offset: 30px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-104 { --ryw-delay: 624ms; --ryw-offset: 31px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-105 { --ryw-delay: 630ms; --ryw-offset: 32px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-106 { --ryw-delay: 636ms; --ryw-offset: 33px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-107 { --ryw-delay: 642ms; --ryw-offset: 34px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-108 { --ryw-delay: 648ms; --ryw-offset: 35px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-109 { --ryw-delay: 654ms; --ryw-offset: 36px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-110 { --ryw-delay: 660ms; --ryw-offset: 37px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-111 { --ryw-delay: 666ms; --ryw-offset: 1px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-112 { --ryw-delay: 672ms; --ryw-offset: 2px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-113 { --ryw-delay: 678ms; --ryw-offset: 3px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-114 { --ryw-delay: 684ms; --ryw-offset: 4px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-115 { --ryw-delay: 690ms; --ryw-offset: 5px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-116 { --ryw-delay: 696ms; --ryw-offset: 6px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-117 { --ryw-delay: 702ms; --ryw-offset: 7px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-118 { --ryw-delay: 708ms; --ryw-offset: 8px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-119 { --ryw-delay: 714ms; --ryw-offset: 9px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-120 { --ryw-delay: 720ms; --ryw-offset: 10px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-121 { --ryw-delay: 726ms; --ryw-offset: 11px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-122 { --ryw-delay: 732ms; --ryw-offset: 12px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-123 { --ryw-delay: 738ms; --ryw-offset: 13px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-124 { --ryw-delay: 744ms; --ryw-offset: 14px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-125 { --ryw-delay: 750ms; --ryw-offset: 15px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-126 { --ryw-delay: 756ms; --ryw-offset: 16px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-127 { --ryw-delay: 762ms; --ryw-offset: 17px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-128 { --ryw-delay: 768ms; --ryw-offset: 18px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-129 { --ryw-delay: 774ms; --ryw-offset: 19px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-130 { --ryw-delay: 780ms; --ryw-offset: 20px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-131 { --ryw-delay: 786ms; --ryw-offset: 21px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-132 { --ryw-delay: 792ms; --ryw-offset: 22px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-133 { --ryw-delay: 798ms; --ryw-offset: 23px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-134 { --ryw-delay: 804ms; --ryw-offset: 24px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-135 { --ryw-delay: 810ms; --ryw-offset: 25px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-136 { --ryw-delay: 816ms; --ryw-offset: 26px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-137 { --ryw-delay: 822ms; --ryw-offset: 27px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-138 { --ryw-delay: 828ms; --ryw-offset: 28px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-139 { --ryw-delay: 834ms; --ryw-offset: 29px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-140 { --ryw-delay: 840ms; --ryw-offset: 30px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-141 { --ryw-delay: 846ms; --ryw-offset: 31px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-142 { --ryw-delay: 852ms; --ryw-offset: 32px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-143 { --ryw-delay: 858ms; --ryw-offset: 33px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-144 { --ryw-delay: 864ms; --ryw-offset: 34px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-145 { --ryw-delay: 870ms; --ryw-offset: 35px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-146 { --ryw-delay: 876ms; --ryw-offset: 36px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-147 { --ryw-delay: 882ms; --ryw-offset: 37px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-148 { --ryw-delay: 888ms; --ryw-offset: 1px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-149 { --ryw-delay: 894ms; --ryw-offset: 2px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-150 { --ryw-delay: 900ms; --ryw-offset: 3px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-151 { --ryw-delay: 906ms; --ryw-offset: 4px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-152 { --ryw-delay: 912ms; --ryw-offset: 5px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-153 { --ryw-delay: 918ms; --ryw-offset: 6px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-154 { --ryw-delay: 924ms; --ryw-offset: 7px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-155 { --ryw-delay: 930ms; --ryw-offset: 8px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-156 { --ryw-delay: 936ms; --ryw-offset: 9px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-157 { --ryw-delay: 942ms; --ryw-offset: 10px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-158 { --ryw-delay: 948ms; --ryw-offset: 11px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-159 { --ryw-delay: 954ms; --ryw-offset: 12px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-160 { --ryw-delay: 960ms; --ryw-offset: 13px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-161 { --ryw-delay: 966ms; --ryw-offset: 14px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-162 { --ryw-delay: 972ms; --ryw-offset: 15px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-163 { --ryw-delay: 978ms; --ryw-offset: 16px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-164 { --ryw-delay: 984ms; --ryw-offset: 17px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-165 { --ryw-delay: 990ms; --ryw-offset: 18px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-166 { --ryw-delay: 996ms; --ryw-offset: 19px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-167 { --ryw-delay: 1002ms; --ryw-offset: 20px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-168 { --ryw-delay: 1008ms; --ryw-offset: 21px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-169 { --ryw-delay: 1014ms; --ryw-offset: 22px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-170 { --ryw-delay: 1020ms; --ryw-offset: 23px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-171 { --ryw-delay: 1026ms; --ryw-offset: 24px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-172 { --ryw-delay: 1032ms; --ryw-offset: 25px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-173 { --ryw-delay: 1038ms; --ryw-offset: 26px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-174 { --ryw-delay: 1044ms; --ryw-offset: 27px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-175 { --ryw-delay: 1050ms; --ryw-offset: 28px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-176 { --ryw-delay: 1056ms; --ryw-offset: 29px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-177 { --ryw-delay: 1062ms; --ryw-offset: 30px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-178 { --ryw-delay: 1068ms; --ryw-offset: 31px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-179 { --ryw-delay: 1074ms; --ryw-offset: 32px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-180 { --ryw-delay: 1080ms; --ryw-offset: 33px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-181 { --ryw-delay: 1086ms; --ryw-offset: 34px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-182 { --ryw-delay: 1092ms; --ryw-offset: 35px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-183 { --ryw-delay: 1098ms; --ryw-offset: 36px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-184 { --ryw-delay: 1104ms; --ryw-offset: 37px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-185 { --ryw-delay: 1110ms; --ryw-offset: 1px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-186 { --ryw-delay: 1116ms; --ryw-offset: 2px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-187 { --ryw-delay: 1122ms; --ryw-offset: 3px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-188 { --ryw-delay: 1128ms; --ryw-offset: 4px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-189 { --ryw-delay: 1134ms; --ryw-offset: 5px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-190 { --ryw-delay: 1140ms; --ryw-offset: 6px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-191 { --ryw-delay: 1146ms; --ryw-offset: 7px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-192 { --ryw-delay: 1152ms; --ryw-offset: 8px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-193 { --ryw-delay: 1158ms; --ryw-offset: 9px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-194 { --ryw-delay: 1164ms; --ryw-offset: 10px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-195 { --ryw-delay: 1170ms; --ryw-offset: 11px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-196 { --ryw-delay: 1176ms; --ryw-offset: 12px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-197 { --ryw-delay: 1182ms; --ryw-offset: 13px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-198 { --ryw-delay: 1188ms; --ryw-offset: 14px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-199 { --ryw-delay: 1194ms; --ryw-offset: 15px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-200 { --ryw-delay: 1200ms; --ryw-offset: 16px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-201 { --ryw-delay: 1206ms; --ryw-offset: 17px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-202 { --ryw-delay: 1212ms; --ryw-offset: 18px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-203 { --ryw-delay: 1218ms; --ryw-offset: 19px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-204 { --ryw-delay: 1224ms; --ryw-offset: 20px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-205 { --ryw-delay: 1230ms; --ryw-offset: 21px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-206 { --ryw-delay: 1236ms; --ryw-offset: 22px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-207 { --ryw-delay: 1242ms; --ryw-offset: 23px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-208 { --ryw-delay: 1248ms; --ryw-offset: 24px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-209 { --ryw-delay: 1254ms; --ryw-offset: 25px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-210 { --ryw-delay: 1260ms; --ryw-offset: 26px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-211 { --ryw-delay: 1266ms; --ryw-offset: 27px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-212 { --ryw-delay: 1272ms; --ryw-offset: 28px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-213 { --ryw-delay: 1278ms; --ryw-offset: 29px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-214 { --ryw-delay: 1284ms; --ryw-offset: 30px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-215 { --ryw-delay: 1290ms; --ryw-offset: 31px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-216 { --ryw-delay: 1296ms; --ryw-offset: 32px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-217 { --ryw-delay: 1302ms; --ryw-offset: 33px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-218 { --ryw-delay: 1308ms; --ryw-offset: 34px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-219 { --ryw-delay: 1314ms; --ryw-offset: 35px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-220 { --ryw-delay: 1320ms; --ryw-offset: 36px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-221 { --ryw-delay: 1326ms; --ryw-offset: 37px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-222 { --ryw-delay: 1332ms; --ryw-offset: 1px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-223 { --ryw-delay: 1338ms; --ryw-offset: 2px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-224 { --ryw-delay: 1344ms; --ryw-offset: 3px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-225 { --ryw-delay: 1350ms; --ryw-offset: 4px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-226 { --ryw-delay: 1356ms; --ryw-offset: 5px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-227 { --ryw-delay: 1362ms; --ryw-offset: 6px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-228 { --ryw-delay: 1368ms; --ryw-offset: 7px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-229 { --ryw-delay: 1374ms; --ryw-offset: 8px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-230 { --ryw-delay: 1380ms; --ryw-offset: 9px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-231 { --ryw-delay: 1386ms; --ryw-offset: 10px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-232 { --ryw-delay: 1392ms; --ryw-offset: 11px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-233 { --ryw-delay: 1398ms; --ryw-offset: 12px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-234 { --ryw-delay: 1404ms; --ryw-offset: 13px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-235 { --ryw-delay: 1410ms; --ryw-offset: 14px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-236 { --ryw-delay: 1416ms; --ryw-offset: 15px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-237 { --ryw-delay: 1422ms; --ryw-offset: 16px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-238 { --ryw-delay: 1428ms; --ryw-offset: 17px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-239 { --ryw-delay: 1434ms; --ryw-offset: 18px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-240 { --ryw-delay: 1440ms; --ryw-offset: 19px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-241 { --ryw-delay: 1446ms; --ryw-offset: 20px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-242 { --ryw-delay: 1452ms; --ryw-offset: 21px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-243 { --ryw-delay: 1458ms; --ryw-offset: 22px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-244 { --ryw-delay: 1464ms; --ryw-offset: 23px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-245 { --ryw-delay: 1470ms; --ryw-offset: 24px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-246 { --ryw-delay: 1476ms; --ryw-offset: 25px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-247 { --ryw-delay: 1482ms; --ryw-offset: 26px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-248 { --ryw-delay: 1488ms; --ryw-offset: 27px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-249 { --ryw-delay: 1494ms; --ryw-offset: 28px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-250 { --ryw-delay: 1500ms; --ryw-offset: 29px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-251 { --ryw-delay: 1506ms; --ryw-offset: 30px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-252 { --ryw-delay: 1512ms; --ryw-offset: 31px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-253 { --ryw-delay: 1518ms; --ryw-offset: 32px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-254 { --ryw-delay: 1524ms; --ryw-offset: 33px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-255 { --ryw-delay: 1530ms; --ryw-offset: 34px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-256 { --ryw-delay: 1536ms; --ryw-offset: 35px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-257 { --ryw-delay: 1542ms; --ryw-offset: 36px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-258 { --ryw-delay: 1548ms; --ryw-offset: 37px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-259 { --ryw-delay: 1554ms; --ryw-offset: 1px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-260 { --ryw-delay: 1560ms; --ryw-offset: 2px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-261 { --ryw-delay: 1566ms; --ryw-offset: 3px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-262 { --ryw-delay: 1572ms; --ryw-offset: 4px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-263 { --ryw-delay: 1578ms; --ryw-offset: 5px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-264 { --ryw-delay: 1584ms; --ryw-offset: 6px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-265 { --ryw-delay: 1590ms; --ryw-offset: 7px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-266 { --ryw-delay: 1596ms; --ryw-offset: 8px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-267 { --ryw-delay: 1602ms; --ryw-offset: 9px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-268 { --ryw-delay: 1608ms; --ryw-offset: 10px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-269 { --ryw-delay: 1614ms; --ryw-offset: 11px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-270 { --ryw-delay: 1620ms; --ryw-offset: 12px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-271 { --ryw-delay: 1626ms; --ryw-offset: 13px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-272 { --ryw-delay: 1632ms; --ryw-offset: 14px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-273 { --ryw-delay: 1638ms; --ryw-offset: 15px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-274 { --ryw-delay: 1644ms; --ryw-offset: 16px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-275 { --ryw-delay: 1650ms; --ryw-offset: 17px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-276 { --ryw-delay: 1656ms; --ryw-offset: 18px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-277 { --ryw-delay: 1662ms; --ryw-offset: 19px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-278 { --ryw-delay: 1668ms; --ryw-offset: 20px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-279 { --ryw-delay: 1674ms; --ryw-offset: 21px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-280 { --ryw-delay: 1680ms; --ryw-offset: 22px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-281 { --ryw-delay: 1686ms; --ryw-offset: 23px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-282 { --ryw-delay: 1692ms; --ryw-offset: 24px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-283 { --ryw-delay: 1698ms; --ryw-offset: 25px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-284 { --ryw-delay: 1704ms; --ryw-offset: 26px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-285 { --ryw-delay: 1710ms; --ryw-offset: 27px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-286 { --ryw-delay: 1716ms; --ryw-offset: 28px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-287 { --ryw-delay: 1722ms; --ryw-offset: 29px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-288 { --ryw-delay: 1728ms; --ryw-offset: 30px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-289 { --ryw-delay: 1734ms; --ryw-offset: 31px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-290 { --ryw-delay: 1740ms; --ryw-offset: 32px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-291 { --ryw-delay: 1746ms; --ryw-offset: 33px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-292 { --ryw-delay: 1752ms; --ryw-offset: 34px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-293 { --ryw-delay: 1758ms; --ryw-offset: 35px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-294 { --ryw-delay: 1764ms; --ryw-offset: 36px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-295 { --ryw-delay: 1770ms; --ryw-offset: 37px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-296 { --ryw-delay: 1776ms; --ryw-offset: 1px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-297 { --ryw-delay: 1782ms; --ryw-offset: 2px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-298 { --ryw-delay: 1788ms; --ryw-offset: 3px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-299 { --ryw-delay: 1794ms; --ryw-offset: 4px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-300 { --ryw-delay: 1800ms; --ryw-offset: 5px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-301 { --ryw-delay: 1806ms; --ryw-offset: 6px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-302 { --ryw-delay: 1812ms; --ryw-offset: 7px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-303 { --ryw-delay: 1818ms; --ryw-offset: 8px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-304 { --ryw-delay: 1824ms; --ryw-offset: 9px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-305 { --ryw-delay: 1830ms; --ryw-offset: 10px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-306 { --ryw-delay: 1836ms; --ryw-offset: 11px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-307 { --ryw-delay: 1842ms; --ryw-offset: 12px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-308 { --ryw-delay: 1848ms; --ryw-offset: 13px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-309 { --ryw-delay: 1854ms; --ryw-offset: 14px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-310 { --ryw-delay: 1860ms; --ryw-offset: 15px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-311 { --ryw-delay: 1866ms; --ryw-offset: 16px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-312 { --ryw-delay: 1872ms; --ryw-offset: 17px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-313 { --ryw-delay: 1878ms; --ryw-offset: 18px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-314 { --ryw-delay: 1884ms; --ryw-offset: 19px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-315 { --ryw-delay: 1890ms; --ryw-offset: 20px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-316 { --ryw-delay: 1896ms; --ryw-offset: 21px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-317 { --ryw-delay: 1902ms; --ryw-offset: 22px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-318 { --ryw-delay: 1908ms; --ryw-offset: 23px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-319 { --ryw-delay: 1914ms; --ryw-offset: 24px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-320 { --ryw-delay: 1920ms; --ryw-offset: 25px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-321 { --ryw-delay: 1926ms; --ryw-offset: 26px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-322 { --ryw-delay: 1932ms; --ryw-offset: 27px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-323 { --ryw-delay: 1938ms; --ryw-offset: 28px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-324 { --ryw-delay: 1944ms; --ryw-offset: 29px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-325 { --ryw-delay: 1950ms; --ryw-offset: 30px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-326 { --ryw-delay: 1956ms; --ryw-offset: 31px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-327 { --ryw-delay: 1962ms; --ryw-offset: 32px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-328 { --ryw-delay: 1968ms; --ryw-offset: 33px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-329 { --ryw-delay: 1974ms; --ryw-offset: 34px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-330 { --ryw-delay: 1980ms; --ryw-offset: 35px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-331 { --ryw-delay: 1986ms; --ryw-offset: 36px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-332 { --ryw-delay: 1992ms; --ryw-offset: 37px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-333 { --ryw-delay: 1998ms; --ryw-offset: 1px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-334 { --ryw-delay: 2004ms; --ryw-offset: 2px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-335 { --ryw-delay: 2010ms; --ryw-offset: 3px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-336 { --ryw-delay: 2016ms; --ryw-offset: 4px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-337 { --ryw-delay: 2022ms; --ryw-offset: 5px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-338 { --ryw-delay: 2028ms; --ryw-offset: 6px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-339 { --ryw-delay: 2034ms; --ryw-offset: 7px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-340 { --ryw-delay: 2040ms; --ryw-offset: 8px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-341 { --ryw-delay: 2046ms; --ryw-offset: 9px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-342 { --ryw-delay: 2052ms; --ryw-offset: 10px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-343 { --ryw-delay: 2058ms; --ryw-offset: 11px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-344 { --ryw-delay: 2064ms; --ryw-offset: 12px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-345 { --ryw-delay: 2070ms; --ryw-offset: 13px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-346 { --ryw-delay: 2076ms; --ryw-offset: 14px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-347 { --ryw-delay: 2082ms; --ryw-offset: 15px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-348 { --ryw-delay: 2088ms; --ryw-offset: 16px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-349 { --ryw-delay: 2094ms; --ryw-offset: 17px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-350 { --ryw-delay: 2100ms; --ryw-offset: 18px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-351 { --ryw-delay: 2106ms; --ryw-offset: 19px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-352 { --ryw-delay: 2112ms; --ryw-offset: 20px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-353 { --ryw-delay: 2118ms; --ryw-offset: 21px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-354 { --ryw-delay: 2124ms; --ryw-offset: 22px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-355 { --ryw-delay: 2130ms; --ryw-offset: 23px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-356 { --ryw-delay: 2136ms; --ryw-offset: 24px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-357 { --ryw-delay: 2142ms; --ryw-offset: 25px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-358 { --ryw-delay: 2148ms; --ryw-offset: 26px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-359 { --ryw-delay: 2154ms; --ryw-offset: 27px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-360 { --ryw-delay: 2160ms; --ryw-offset: 28px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-361 { --ryw-delay: 2166ms; --ryw-offset: 29px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-362 { --ryw-delay: 2172ms; --ryw-offset: 30px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-363 { --ryw-delay: 2178ms; --ryw-offset: 31px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-364 { --ryw-delay: 2184ms; --ryw-offset: 32px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-365 { --ryw-delay: 2190ms; --ryw-offset: 33px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-366 { --ryw-delay: 2196ms; --ryw-offset: 34px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-367 { --ryw-delay: 2202ms; --ryw-offset: 35px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-368 { --ryw-delay: 2208ms; --ryw-offset: 36px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-369 { --ryw-delay: 2214ms; --ryw-offset: 37px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-370 { --ryw-delay: 2220ms; --ryw-offset: 1px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-371 { --ryw-delay: 2226ms; --ryw-offset: 2px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-372 { --ryw-delay: 2232ms; --ryw-offset: 3px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-373 { --ryw-delay: 2238ms; --ryw-offset: 4px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-374 { --ryw-delay: 2244ms; --ryw-offset: 5px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-375 { --ryw-delay: 2250ms; --ryw-offset: 6px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-376 { --ryw-delay: 2256ms; --ryw-offset: 7px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-377 { --ryw-delay: 2262ms; --ryw-offset: 8px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-378 { --ryw-delay: 2268ms; --ryw-offset: 9px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-379 { --ryw-delay: 2274ms; --ryw-offset: 10px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-380 { --ryw-delay: 2280ms; --ryw-offset: 11px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-381 { --ryw-delay: 2286ms; --ryw-offset: 12px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-382 { --ryw-delay: 2292ms; --ryw-offset: 13px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-383 { --ryw-delay: 2298ms; --ryw-offset: 14px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-384 { --ryw-delay: 2304ms; --ryw-offset: 15px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-385 { --ryw-delay: 2310ms; --ryw-offset: 16px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-386 { --ryw-delay: 2316ms; --ryw-offset: 17px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-387 { --ryw-delay: 2322ms; --ryw-offset: 18px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-388 { --ryw-delay: 2328ms; --ryw-offset: 19px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-389 { --ryw-delay: 2334ms; --ryw-offset: 20px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-390 { --ryw-delay: 2340ms; --ryw-offset: 21px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-391 { --ryw-delay: 2346ms; --ryw-offset: 22px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-392 { --ryw-delay: 2352ms; --ryw-offset: 23px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-393 { --ryw-delay: 2358ms; --ryw-offset: 24px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-394 { --ryw-delay: 2364ms; --ryw-offset: 25px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-395 { --ryw-delay: 2370ms; --ryw-offset: 26px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-396 { --ryw-delay: 2376ms; --ryw-offset: 27px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-397 { --ryw-delay: 2382ms; --ryw-offset: 28px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-398 { --ryw-delay: 2388ms; --ryw-offset: 29px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-399 { --ryw-delay: 2394ms; --ryw-offset: 30px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-400 { --ryw-delay: 2400ms; --ryw-offset: 31px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-401 { --ryw-delay: 2406ms; --ryw-offset: 32px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-402 { --ryw-delay: 2412ms; --ryw-offset: 33px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-403 { --ryw-delay: 2418ms; --ryw-offset: 34px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-404 { --ryw-delay: 2424ms; --ryw-offset: 35px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-405 { --ryw-delay: 2430ms; --ryw-offset: 36px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-406 { --ryw-delay: 2436ms; --ryw-offset: 37px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-407 { --ryw-delay: 2442ms; --ryw-offset: 1px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-408 { --ryw-delay: 2448ms; --ryw-offset: 2px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-409 { --ryw-delay: 2454ms; --ryw-offset: 3px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-410 { --ryw-delay: 2460ms; --ryw-offset: 4px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-411 { --ryw-delay: 2466ms; --ryw-offset: 5px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-412 { --ryw-delay: 2472ms; --ryw-offset: 6px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-413 { --ryw-delay: 2478ms; --ryw-offset: 7px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-414 { --ryw-delay: 2484ms; --ryw-offset: 8px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-415 { --ryw-delay: 2490ms; --ryw-offset: 9px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-416 { --ryw-delay: 2496ms; --ryw-offset: 10px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-417 { --ryw-delay: 2502ms; --ryw-offset: 11px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-418 { --ryw-delay: 2508ms; --ryw-offset: 12px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-419 { --ryw-delay: 2514ms; --ryw-offset: 13px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-420 { --ryw-delay: 2520ms; --ryw-offset: 14px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-421 { --ryw-delay: 2526ms; --ryw-offset: 15px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-422 { --ryw-delay: 2532ms; --ryw-offset: 16px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-423 { --ryw-delay: 2538ms; --ryw-offset: 17px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-424 { --ryw-delay: 2544ms; --ryw-offset: 18px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-425 { --ryw-delay: 2550ms; --ryw-offset: 19px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-426 { --ryw-delay: 2556ms; --ryw-offset: 20px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-427 { --ryw-delay: 2562ms; --ryw-offset: 21px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-428 { --ryw-delay: 2568ms; --ryw-offset: 22px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-429 { --ryw-delay: 2574ms; --ryw-offset: 23px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-430 { --ryw-delay: 2580ms; --ryw-offset: 24px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-431 { --ryw-delay: 2586ms; --ryw-offset: 25px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-432 { --ryw-delay: 2592ms; --ryw-offset: 26px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-433 { --ryw-delay: 2598ms; --ryw-offset: 27px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-434 { --ryw-delay: 2604ms; --ryw-offset: 28px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-435 { --ryw-delay: 2610ms; --ryw-offset: 29px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-436 { --ryw-delay: 2616ms; --ryw-offset: 30px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-437 { --ryw-delay: 2622ms; --ryw-offset: 31px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-438 { --ryw-delay: 2628ms; --ryw-offset: 32px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-439 { --ryw-delay: 2634ms; --ryw-offset: 33px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-440 { --ryw-delay: 2640ms; --ryw-offset: 34px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-441 { --ryw-delay: 2646ms; --ryw-offset: 35px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-442 { --ryw-delay: 2652ms; --ryw-offset: 36px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-443 { --ryw-delay: 2658ms; --ryw-offset: 37px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-444 { --ryw-delay: 2664ms; --ryw-offset: 1px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-445 { --ryw-delay: 2670ms; --ryw-offset: 2px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-446 { --ryw-delay: 2676ms; --ryw-offset: 3px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-447 { --ryw-delay: 2682ms; --ryw-offset: 4px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-448 { --ryw-delay: 2688ms; --ryw-offset: 5px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-449 { --ryw-delay: 2694ms; --ryw-offset: 6px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-450 { --ryw-delay: 2700ms; --ryw-offset: 7px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-451 { --ryw-delay: 2706ms; --ryw-offset: 8px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-452 { --ryw-delay: 2712ms; --ryw-offset: 9px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-453 { --ryw-delay: 2718ms; --ryw-offset: 10px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-454 { --ryw-delay: 2724ms; --ryw-offset: 11px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-455 { --ryw-delay: 2730ms; --ryw-offset: 12px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-456 { --ryw-delay: 2736ms; --ryw-offset: 13px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-457 { --ryw-delay: 2742ms; --ryw-offset: 14px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-458 { --ryw-delay: 2748ms; --ryw-offset: 15px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-459 { --ryw-delay: 2754ms; --ryw-offset: 16px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-460 { --ryw-delay: 2760ms; --ryw-offset: 17px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-461 { --ryw-delay: 2766ms; --ryw-offset: 18px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-462 { --ryw-delay: 2772ms; --ryw-offset: 19px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-463 { --ryw-delay: 2778ms; --ryw-offset: 20px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-464 { --ryw-delay: 2784ms; --ryw-offset: 21px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-465 { --ryw-delay: 2790ms; --ryw-offset: 22px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-466 { --ryw-delay: 2796ms; --ryw-offset: 23px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-467 { --ryw-delay: 2802ms; --ryw-offset: 24px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-468 { --ryw-delay: 2808ms; --ryw-offset: 25px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-469 { --ryw-delay: 2814ms; --ryw-offset: 26px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-470 { --ryw-delay: 2820ms; --ryw-offset: 27px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-471 { --ryw-delay: 2826ms; --ryw-offset: 28px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-472 { --ryw-delay: 2832ms; --ryw-offset: 29px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-473 { --ryw-delay: 2838ms; --ryw-offset: 30px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-474 { --ryw-delay: 2844ms; --ryw-offset: 31px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-475 { --ryw-delay: 2850ms; --ryw-offset: 32px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-476 { --ryw-delay: 2856ms; --ryw-offset: 33px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-477 { --ryw-delay: 2862ms; --ryw-offset: 34px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-478 { --ryw-delay: 2868ms; --ryw-offset: 35px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-479 { --ryw-delay: 2874ms; --ryw-offset: 36px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-480 { --ryw-delay: 2880ms; --ryw-offset: 37px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-481 { --ryw-delay: 2886ms; --ryw-offset: 1px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-482 { --ryw-delay: 2892ms; --ryw-offset: 2px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-483 { --ryw-delay: 2898ms; --ryw-offset: 3px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-484 { --ryw-delay: 2904ms; --ryw-offset: 4px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-485 { --ryw-delay: 2910ms; --ryw-offset: 5px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-486 { --ryw-delay: 2916ms; --ryw-offset: 6px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-487 { --ryw-delay: 2922ms; --ryw-offset: 7px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-488 { --ryw-delay: 2928ms; --ryw-offset: 8px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-489 { --ryw-delay: 2934ms; --ryw-offset: 9px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-490 { --ryw-delay: 2940ms; --ryw-offset: 10px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-491 { --ryw-delay: 2946ms; --ryw-offset: 11px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-492 { --ryw-delay: 2952ms; --ryw-offset: 12px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-493 { --ryw-delay: 2958ms; --ryw-offset: 13px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-494 { --ryw-delay: 2964ms; --ryw-offset: 14px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-495 { --ryw-delay: 2970ms; --ryw-offset: 15px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-496 { --ryw-delay: 2976ms; --ryw-offset: 16px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-497 { --ryw-delay: 2982ms; --ryw-offset: 17px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-498 { --ryw-delay: 2988ms; --ryw-offset: 18px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-499 { --ryw-delay: 2994ms; --ryw-offset: 19px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-500 { --ryw-delay: 3000ms; --ryw-offset: 20px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-501 { --ryw-delay: 3006ms; --ryw-offset: 21px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-502 { --ryw-delay: 3012ms; --ryw-offset: 22px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-503 { --ryw-delay: 3018ms; --ryw-offset: 23px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-504 { --ryw-delay: 3024ms; --ryw-offset: 24px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-505 { --ryw-delay: 3030ms; --ryw-offset: 25px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-506 { --ryw-delay: 3036ms; --ryw-offset: 26px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-507 { --ryw-delay: 3042ms; --ryw-offset: 27px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-508 { --ryw-delay: 3048ms; --ryw-offset: 28px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-509 { --ryw-delay: 3054ms; --ryw-offset: 29px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-510 { --ryw-delay: 3060ms; --ryw-offset: 30px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-511 { --ryw-delay: 3066ms; --ryw-offset: 31px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-512 { --ryw-delay: 3072ms; --ryw-offset: 32px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-513 { --ryw-delay: 3078ms; --ryw-offset: 33px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-514 { --ryw-delay: 3084ms; --ryw-offset: 34px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-515 { --ryw-delay: 3090ms; --ryw-offset: 35px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-516 { --ryw-delay: 3096ms; --ryw-offset: 36px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-517 { --ryw-delay: 3102ms; --ryw-offset: 37px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-518 { --ryw-delay: 3108ms; --ryw-offset: 1px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-519 { --ryw-delay: 3114ms; --ryw-offset: 2px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-520 { --ryw-delay: 3120ms; --ryw-offset: 3px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-521 { --ryw-delay: 3126ms; --ryw-offset: 4px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-522 { --ryw-delay: 3132ms; --ryw-offset: 5px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-523 { --ryw-delay: 3138ms; --ryw-offset: 6px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-524 { --ryw-delay: 3144ms; --ryw-offset: 7px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-525 { --ryw-delay: 3150ms; --ryw-offset: 8px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-526 { --ryw-delay: 3156ms; --ryw-offset: 9px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-527 { --ryw-delay: 3162ms; --ryw-offset: 10px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-528 { --ryw-delay: 3168ms; --ryw-offset: 11px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-529 { --ryw-delay: 3174ms; --ryw-offset: 12px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-530 { --ryw-delay: 3180ms; --ryw-offset: 13px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-531 { --ryw-delay: 3186ms; --ryw-offset: 14px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-532 { --ryw-delay: 3192ms; --ryw-offset: 15px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-533 { --ryw-delay: 3198ms; --ryw-offset: 16px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-534 { --ryw-delay: 3204ms; --ryw-offset: 17px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-535 { --ryw-delay: 3210ms; --ryw-offset: 18px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-536 { --ryw-delay: 3216ms; --ryw-offset: 19px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-537 { --ryw-delay: 3222ms; --ryw-offset: 20px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-538 { --ryw-delay: 3228ms; --ryw-offset: 21px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-539 { --ryw-delay: 3234ms; --ryw-offset: 22px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-540 { --ryw-delay: 3240ms; --ryw-offset: 23px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-541 { --ryw-delay: 3246ms; --ryw-offset: 24px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-542 { --ryw-delay: 3252ms; --ryw-offset: 25px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-543 { --ryw-delay: 3258ms; --ryw-offset: 26px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-544 { --ryw-delay: 3264ms; --ryw-offset: 27px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-545 { --ryw-delay: 3270ms; --ryw-offset: 28px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-546 { --ryw-delay: 3276ms; --ryw-offset: 29px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-547 { --ryw-delay: 3282ms; --ryw-offset: 30px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-548 { --ryw-delay: 3288ms; --ryw-offset: 31px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-549 { --ryw-delay: 3294ms; --ryw-offset: 32px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-550 { --ryw-delay: 3300ms; --ryw-offset: 33px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-551 { --ryw-delay: 3306ms; --ryw-offset: 34px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-552 { --ryw-delay: 3312ms; --ryw-offset: 35px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-553 { --ryw-delay: 3318ms; --ryw-offset: 36px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-554 { --ryw-delay: 3324ms; --ryw-offset: 37px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-555 { --ryw-delay: 3330ms; --ryw-offset: 1px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-556 { --ryw-delay: 3336ms; --ryw-offset: 2px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-557 { --ryw-delay: 3342ms; --ryw-offset: 3px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-558 { --ryw-delay: 3348ms; --ryw-offset: 4px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-559 { --ryw-delay: 3354ms; --ryw-offset: 5px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-560 { --ryw-delay: 3360ms; --ryw-offset: 6px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-561 { --ryw-delay: 3366ms; --ryw-offset: 7px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-562 { --ryw-delay: 3372ms; --ryw-offset: 8px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-563 { --ryw-delay: 3378ms; --ryw-offset: 9px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-564 { --ryw-delay: 3384ms; --ryw-offset: 10px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-565 { --ryw-delay: 3390ms; --ryw-offset: 11px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-566 { --ryw-delay: 3396ms; --ryw-offset: 12px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-567 { --ryw-delay: 3402ms; --ryw-offset: 13px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-568 { --ryw-delay: 3408ms; --ryw-offset: 14px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-569 { --ryw-delay: 3414ms; --ryw-offset: 15px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-570 { --ryw-delay: 3420ms; --ryw-offset: 16px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-571 { --ryw-delay: 3426ms; --ryw-offset: 17px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-572 { --ryw-delay: 3432ms; --ryw-offset: 18px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-573 { --ryw-delay: 3438ms; --ryw-offset: 19px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-574 { --ryw-delay: 3444ms; --ryw-offset: 20px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-575 { --ryw-delay: 3450ms; --ryw-offset: 21px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-576 { --ryw-delay: 3456ms; --ryw-offset: 22px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-577 { --ryw-delay: 3462ms; --ryw-offset: 23px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-578 { --ryw-delay: 3468ms; --ryw-offset: 24px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-579 { --ryw-delay: 3474ms; --ryw-offset: 25px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-580 { --ryw-delay: 3480ms; --ryw-offset: 26px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-581 { --ryw-delay: 3486ms; --ryw-offset: 27px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-582 { --ryw-delay: 3492ms; --ryw-offset: 28px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-583 { --ryw-delay: 3498ms; --ryw-offset: 29px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-584 { --ryw-delay: 3504ms; --ryw-offset: 30px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-585 { --ryw-delay: 3510ms; --ryw-offset: 31px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-586 { --ryw-delay: 3516ms; --ryw-offset: 32px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-587 { --ryw-delay: 3522ms; --ryw-offset: 33px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-588 { --ryw-delay: 3528ms; --ryw-offset: 34px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-589 { --ryw-delay: 3534ms; --ryw-offset: 35px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-590 { --ryw-delay: 3540ms; --ryw-offset: 36px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-591 { --ryw-delay: 3546ms; --ryw-offset: 37px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-592 { --ryw-delay: 3552ms; --ryw-offset: 1px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-593 { --ryw-delay: 3558ms; --ryw-offset: 2px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-594 { --ryw-delay: 3564ms; --ryw-offset: 3px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-595 { --ryw-delay: 3570ms; --ryw-offset: 4px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-596 { --ryw-delay: 3576ms; --ryw-offset: 5px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-597 { --ryw-delay: 3582ms; --ryw-offset: 6px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-598 { --ryw-delay: 3588ms; --ryw-offset: 7px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-599 { --ryw-delay: 3594ms; --ryw-offset: 8px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-600 { --ryw-delay: 3600ms; --ryw-offset: 9px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-601 { --ryw-delay: 3606ms; --ryw-offset: 10px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-602 { --ryw-delay: 3612ms; --ryw-offset: 11px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-603 { --ryw-delay: 3618ms; --ryw-offset: 12px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-604 { --ryw-delay: 3624ms; --ryw-offset: 13px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-605 { --ryw-delay: 3630ms; --ryw-offset: 14px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-606 { --ryw-delay: 3636ms; --ryw-offset: 15px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-607 { --ryw-delay: 3642ms; --ryw-offset: 16px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-608 { --ryw-delay: 3648ms; --ryw-offset: 17px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-609 { --ryw-delay: 3654ms; --ryw-offset: 18px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-610 { --ryw-delay: 3660ms; --ryw-offset: 19px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-611 { --ryw-delay: 3666ms; --ryw-offset: 20px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-612 { --ryw-delay: 3672ms; --ryw-offset: 21px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-613 { --ryw-delay: 3678ms; --ryw-offset: 22px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-614 { --ryw-delay: 3684ms; --ryw-offset: 23px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-615 { --ryw-delay: 3690ms; --ryw-offset: 24px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-616 { --ryw-delay: 3696ms; --ryw-offset: 25px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-617 { --ryw-delay: 3702ms; --ryw-offset: 26px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-618 { --ryw-delay: 3708ms; --ryw-offset: 27px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-619 { --ryw-delay: 3714ms; --ryw-offset: 28px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-620 { --ryw-delay: 3720ms; --ryw-offset: 29px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-621 { --ryw-delay: 3726ms; --ryw-offset: 30px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-622 { --ryw-delay: 3732ms; --ryw-offset: 31px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-623 { --ryw-delay: 3738ms; --ryw-offset: 32px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-624 { --ryw-delay: 3744ms; --ryw-offset: 33px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-625 { --ryw-delay: 3750ms; --ryw-offset: 34px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-626 { --ryw-delay: 3756ms; --ryw-offset: 35px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-627 { --ryw-delay: 3762ms; --ryw-offset: 36px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-628 { --ryw-delay: 3768ms; --ryw-offset: 37px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-629 { --ryw-delay: 3774ms; --ryw-offset: 1px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-630 { --ryw-delay: 3780ms; --ryw-offset: 2px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-631 { --ryw-delay: 3786ms; --ryw-offset: 3px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-632 { --ryw-delay: 3792ms; --ryw-offset: 4px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-633 { --ryw-delay: 3798ms; --ryw-offset: 5px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-634 { --ryw-delay: 3804ms; --ryw-offset: 6px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-635 { --ryw-delay: 3810ms; --ryw-offset: 7px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-636 { --ryw-delay: 3816ms; --ryw-offset: 8px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-637 { --ryw-delay: 3822ms; --ryw-offset: 9px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-638 { --ryw-delay: 3828ms; --ryw-offset: 10px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-639 { --ryw-delay: 3834ms; --ryw-offset: 11px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-640 { --ryw-delay: 3840ms; --ryw-offset: 12px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-641 { --ryw-delay: 3846ms; --ryw-offset: 13px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-642 { --ryw-delay: 3852ms; --ryw-offset: 14px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-643 { --ryw-delay: 3858ms; --ryw-offset: 15px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-644 { --ryw-delay: 3864ms; --ryw-offset: 16px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-645 { --ryw-delay: 3870ms; --ryw-offset: 17px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-646 { --ryw-delay: 3876ms; --ryw-offset: 18px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-647 { --ryw-delay: 3882ms; --ryw-offset: 19px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-648 { --ryw-delay: 3888ms; --ryw-offset: 20px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-649 { --ryw-delay: 3894ms; --ryw-offset: 21px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-650 { --ryw-delay: 3900ms; --ryw-offset: 22px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-651 { --ryw-delay: 3906ms; --ryw-offset: 23px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-652 { --ryw-delay: 3912ms; --ryw-offset: 24px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-653 { --ryw-delay: 3918ms; --ryw-offset: 25px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-654 { --ryw-delay: 3924ms; --ryw-offset: 26px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-655 { --ryw-delay: 3930ms; --ryw-offset: 27px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-656 { --ryw-delay: 3936ms; --ryw-offset: 28px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-657 { --ryw-delay: 3942ms; --ryw-offset: 29px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-658 { --ryw-delay: 3948ms; --ryw-offset: 30px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-659 { --ryw-delay: 3954ms; --ryw-offset: 31px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-660 { --ryw-delay: 3960ms; --ryw-offset: 32px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-661 { --ryw-delay: 3966ms; --ryw-offset: 33px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-662 { --ryw-delay: 3972ms; --ryw-offset: 34px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-663 { --ryw-delay: 3978ms; --ryw-offset: 35px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-664 { --ryw-delay: 3984ms; --ryw-offset: 36px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-665 { --ryw-delay: 3990ms; --ryw-offset: 37px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-666 { --ryw-delay: 3996ms; --ryw-offset: 1px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-667 { --ryw-delay: 4002ms; --ryw-offset: 2px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-668 { --ryw-delay: 4008ms; --ryw-offset: 3px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-669 { --ryw-delay: 4014ms; --ryw-offset: 4px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-670 { --ryw-delay: 4020ms; --ryw-offset: 5px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-671 { --ryw-delay: 4026ms; --ryw-offset: 6px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-672 { --ryw-delay: 4032ms; --ryw-offset: 7px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-673 { --ryw-delay: 4038ms; --ryw-offset: 8px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-674 { --ryw-delay: 4044ms; --ryw-offset: 9px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-675 { --ryw-delay: 4050ms; --ryw-offset: 10px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-676 { --ryw-delay: 4056ms; --ryw-offset: 11px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-677 { --ryw-delay: 4062ms; --ryw-offset: 12px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-678 { --ryw-delay: 4068ms; --ryw-offset: 13px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-679 { --ryw-delay: 4074ms; --ryw-offset: 14px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-680 { --ryw-delay: 4080ms; --ryw-offset: 15px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-681 { --ryw-delay: 4086ms; --ryw-offset: 16px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-682 { --ryw-delay: 4092ms; --ryw-offset: 17px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-683 { --ryw-delay: 4098ms; --ryw-offset: 18px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-684 { --ryw-delay: 4104ms; --ryw-offset: 19px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-685 { --ryw-delay: 4110ms; --ryw-offset: 20px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-686 { --ryw-delay: 4116ms; --ryw-offset: 21px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-687 { --ryw-delay: 4122ms; --ryw-offset: 22px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-688 { --ryw-delay: 4128ms; --ryw-offset: 23px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-689 { --ryw-delay: 4134ms; --ryw-offset: 24px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-690 { --ryw-delay: 4140ms; --ryw-offset: 25px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-691 { --ryw-delay: 4146ms; --ryw-offset: 26px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-692 { --ryw-delay: 4152ms; --ryw-offset: 27px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-693 { --ryw-delay: 4158ms; --ryw-offset: 28px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-694 { --ryw-delay: 4164ms; --ryw-offset: 29px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-695 { --ryw-delay: 4170ms; --ryw-offset: 30px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-696 { --ryw-delay: 4176ms; --ryw-offset: 31px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-697 { --ryw-delay: 4182ms; --ryw-offset: 32px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-698 { --ryw-delay: 4188ms; --ryw-offset: 33px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-699 { --ryw-delay: 4194ms; --ryw-offset: 34px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-700 { --ryw-delay: 4200ms; --ryw-offset: 35px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-701 { --ryw-delay: 4206ms; --ryw-offset: 36px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-702 { --ryw-delay: 4212ms; --ryw-offset: 37px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-703 { --ryw-delay: 4218ms; --ryw-offset: 1px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-704 { --ryw-delay: 4224ms; --ryw-offset: 2px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-705 { --ryw-delay: 4230ms; --ryw-offset: 3px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-706 { --ryw-delay: 4236ms; --ryw-offset: 4px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-707 { --ryw-delay: 4242ms; --ryw-offset: 5px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-708 { --ryw-delay: 4248ms; --ryw-offset: 6px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-709 { --ryw-delay: 4254ms; --ryw-offset: 7px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-710 { --ryw-delay: 4260ms; --ryw-offset: 8px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-711 { --ryw-delay: 4266ms; --ryw-offset: 9px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-712 { --ryw-delay: 4272ms; --ryw-offset: 10px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-713 { --ryw-delay: 4278ms; --ryw-offset: 11px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-714 { --ryw-delay: 4284ms; --ryw-offset: 12px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-715 { --ryw-delay: 4290ms; --ryw-offset: 13px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-716 { --ryw-delay: 4296ms; --ryw-offset: 14px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-717 { --ryw-delay: 4302ms; --ryw-offset: 15px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-718 { --ryw-delay: 4308ms; --ryw-offset: 16px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-719 { --ryw-delay: 4314ms; --ryw-offset: 17px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-720 { --ryw-delay: 4320ms; --ryw-offset: 18px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-721 { --ryw-delay: 4326ms; --ryw-offset: 19px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-722 { --ryw-delay: 4332ms; --ryw-offset: 20px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-723 { --ryw-delay: 4338ms; --ryw-offset: 21px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-724 { --ryw-delay: 4344ms; --ryw-offset: 22px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-725 { --ryw-delay: 4350ms; --ryw-offset: 23px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-726 { --ryw-delay: 4356ms; --ryw-offset: 24px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-727 { --ryw-delay: 4362ms; --ryw-offset: 25px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-728 { --ryw-delay: 4368ms; --ryw-offset: 26px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-729 { --ryw-delay: 4374ms; --ryw-offset: 27px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-730 { --ryw-delay: 4380ms; --ryw-offset: 28px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-731 { --ryw-delay: 4386ms; --ryw-offset: 29px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-732 { --ryw-delay: 4392ms; --ryw-offset: 30px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-733 { --ryw-delay: 4398ms; --ryw-offset: 31px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-734 { --ryw-delay: 4404ms; --ryw-offset: 32px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-735 { --ryw-delay: 4410ms; --ryw-offset: 33px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-736 { --ryw-delay: 4416ms; --ryw-offset: 34px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-737 { --ryw-delay: 4422ms; --ryw-offset: 35px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-738 { --ryw-delay: 4428ms; --ryw-offset: 36px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-739 { --ryw-delay: 4434ms; --ryw-offset: 37px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-740 { --ryw-delay: 4440ms; --ryw-offset: 1px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-741 { --ryw-delay: 4446ms; --ryw-offset: 2px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-742 { --ryw-delay: 4452ms; --ryw-offset: 3px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-743 { --ryw-delay: 4458ms; --ryw-offset: 4px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-744 { --ryw-delay: 4464ms; --ryw-offset: 5px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-745 { --ryw-delay: 4470ms; --ryw-offset: 6px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-746 { --ryw-delay: 4476ms; --ryw-offset: 7px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-747 { --ryw-delay: 4482ms; --ryw-offset: 8px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-748 { --ryw-delay: 4488ms; --ryw-offset: 9px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-749 { --ryw-delay: 4494ms; --ryw-offset: 10px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-750 { --ryw-delay: 4500ms; --ryw-offset: 11px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-751 { --ryw-delay: 4506ms; --ryw-offset: 12px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-752 { --ryw-delay: 4512ms; --ryw-offset: 13px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-753 { --ryw-delay: 4518ms; --ryw-offset: 14px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-754 { --ryw-delay: 4524ms; --ryw-offset: 15px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-755 { --ryw-delay: 4530ms; --ryw-offset: 16px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-756 { --ryw-delay: 4536ms; --ryw-offset: 17px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-757 { --ryw-delay: 4542ms; --ryw-offset: 18px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-758 { --ryw-delay: 4548ms; --ryw-offset: 19px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-759 { --ryw-delay: 4554ms; --ryw-offset: 20px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-760 { --ryw-delay: 4560ms; --ryw-offset: 21px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-761 { --ryw-delay: 4566ms; --ryw-offset: 22px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-762 { --ryw-delay: 4572ms; --ryw-offset: 23px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-763 { --ryw-delay: 4578ms; --ryw-offset: 24px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-764 { --ryw-delay: 4584ms; --ryw-offset: 25px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-765 { --ryw-delay: 4590ms; --ryw-offset: 26px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-766 { --ryw-delay: 4596ms; --ryw-offset: 27px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-767 { --ryw-delay: 4602ms; --ryw-offset: 28px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-768 { --ryw-delay: 4608ms; --ryw-offset: 29px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-769 { --ryw-delay: 4614ms; --ryw-offset: 30px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-770 { --ryw-delay: 4620ms; --ryw-offset: 31px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-771 { --ryw-delay: 4626ms; --ryw-offset: 32px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-772 { --ryw-delay: 4632ms; --ryw-offset: 33px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-773 { --ryw-delay: 4638ms; --ryw-offset: 34px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-774 { --ryw-delay: 4644ms; --ryw-offset: 35px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-775 { --ryw-delay: 4650ms; --ryw-offset: 36px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-776 { --ryw-delay: 4656ms; --ryw-offset: 37px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-777 { --ryw-delay: 4662ms; --ryw-offset: 1px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-778 { --ryw-delay: 4668ms; --ryw-offset: 2px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-779 { --ryw-delay: 4674ms; --ryw-offset: 3px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-780 { --ryw-delay: 4680ms; --ryw-offset: 4px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-781 { --ryw-delay: 4686ms; --ryw-offset: 5px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-782 { --ryw-delay: 4692ms; --ryw-offset: 6px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-783 { --ryw-delay: 4698ms; --ryw-offset: 7px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-784 { --ryw-delay: 4704ms; --ryw-offset: 8px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-785 { --ryw-delay: 4710ms; --ryw-offset: 9px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-786 { --ryw-delay: 4716ms; --ryw-offset: 10px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-787 { --ryw-delay: 4722ms; --ryw-offset: 11px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-788 { --ryw-delay: 4728ms; --ryw-offset: 12px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-789 { --ryw-delay: 4734ms; --ryw-offset: 13px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-790 { --ryw-delay: 4740ms; --ryw-offset: 14px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-791 { --ryw-delay: 4746ms; --ryw-offset: 15px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-792 { --ryw-delay: 4752ms; --ryw-offset: 16px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-793 { --ryw-delay: 4758ms; --ryw-offset: 17px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-794 { --ryw-delay: 4764ms; --ryw-offset: 18px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-795 { --ryw-delay: 4770ms; --ryw-offset: 19px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-796 { --ryw-delay: 4776ms; --ryw-offset: 20px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-797 { --ryw-delay: 4782ms; --ryw-offset: 21px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-798 { --ryw-delay: 4788ms; --ryw-offset: 22px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-799 { --ryw-delay: 4794ms; --ryw-offset: 23px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-800 { --ryw-delay: 4800ms; --ryw-offset: 24px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-801 { --ryw-delay: 4806ms; --ryw-offset: 25px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-802 { --ryw-delay: 4812ms; --ryw-offset: 26px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-803 { --ryw-delay: 4818ms; --ryw-offset: 27px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-804 { --ryw-delay: 4824ms; --ryw-offset: 28px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-805 { --ryw-delay: 4830ms; --ryw-offset: 29px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-806 { --ryw-delay: 4836ms; --ryw-offset: 30px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-807 { --ryw-delay: 4842ms; --ryw-offset: 31px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-808 { --ryw-delay: 4848ms; --ryw-offset: 32px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-809 { --ryw-delay: 4854ms; --ryw-offset: 33px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-810 { --ryw-delay: 4860ms; --ryw-offset: 34px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-811 { --ryw-delay: 4866ms; --ryw-offset: 35px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-812 { --ryw-delay: 4872ms; --ryw-offset: 36px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-813 { --ryw-delay: 4878ms; --ryw-offset: 37px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-814 { --ryw-delay: 4884ms; --ryw-offset: 1px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-815 { --ryw-delay: 4890ms; --ryw-offset: 2px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-816 { --ryw-delay: 4896ms; --ryw-offset: 3px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-817 { --ryw-delay: 4902ms; --ryw-offset: 4px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-818 { --ryw-delay: 4908ms; --ryw-offset: 5px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-819 { --ryw-delay: 4914ms; --ryw-offset: 6px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-820 { --ryw-delay: 4920ms; --ryw-offset: 7px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-821 { --ryw-delay: 4926ms; --ryw-offset: 8px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-822 { --ryw-delay: 4932ms; --ryw-offset: 9px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-823 { --ryw-delay: 4938ms; --ryw-offset: 10px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-824 { --ryw-delay: 4944ms; --ryw-offset: 11px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-825 { --ryw-delay: 4950ms; --ryw-offset: 12px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-826 { --ryw-delay: 4956ms; --ryw-offset: 13px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-827 { --ryw-delay: 4962ms; --ryw-offset: 14px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-828 { --ryw-delay: 4968ms; --ryw-offset: 15px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-829 { --ryw-delay: 4974ms; --ryw-offset: 16px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-830 { --ryw-delay: 4980ms; --ryw-offset: 17px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-831 { --ryw-delay: 4986ms; --ryw-offset: 18px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-832 { --ryw-delay: 4992ms; --ryw-offset: 19px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-833 { --ryw-delay: 4998ms; --ryw-offset: 20px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-834 { --ryw-delay: 5004ms; --ryw-offset: 21px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-835 { --ryw-delay: 5010ms; --ryw-offset: 22px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-836 { --ryw-delay: 5016ms; --ryw-offset: 23px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-837 { --ryw-delay: 5022ms; --ryw-offset: 24px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-838 { --ryw-delay: 5028ms; --ryw-offset: 25px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-839 { --ryw-delay: 5034ms; --ryw-offset: 26px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-840 { --ryw-delay: 5040ms; --ryw-offset: 27px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-841 { --ryw-delay: 5046ms; --ryw-offset: 28px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-842 { --ryw-delay: 5052ms; --ryw-offset: 29px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-843 { --ryw-delay: 5058ms; --ryw-offset: 30px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-844 { --ryw-delay: 5064ms; --ryw-offset: 31px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-845 { --ryw-delay: 5070ms; --ryw-offset: 32px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-846 { --ryw-delay: 5076ms; --ryw-offset: 33px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-847 { --ryw-delay: 5082ms; --ryw-offset: 34px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-848 { --ryw-delay: 5088ms; --ryw-offset: 35px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-849 { --ryw-delay: 5094ms; --ryw-offset: 36px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-850 { --ryw-delay: 5100ms; --ryw-offset: 37px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-851 { --ryw-delay: 5106ms; --ryw-offset: 1px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-852 { --ryw-delay: 5112ms; --ryw-offset: 2px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-853 { --ryw-delay: 5118ms; --ryw-offset: 3px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-854 { --ryw-delay: 5124ms; --ryw-offset: 4px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-855 { --ryw-delay: 5130ms; --ryw-offset: 5px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-856 { --ryw-delay: 5136ms; --ryw-offset: 6px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-857 { --ryw-delay: 5142ms; --ryw-offset: 7px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-858 { --ryw-delay: 5148ms; --ryw-offset: 8px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-859 { --ryw-delay: 5154ms; --ryw-offset: 9px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-860 { --ryw-delay: 5160ms; --ryw-offset: 10px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-861 { --ryw-delay: 5166ms; --ryw-offset: 11px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-862 { --ryw-delay: 5172ms; --ryw-offset: 12px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-863 { --ryw-delay: 5178ms; --ryw-offset: 13px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-864 { --ryw-delay: 5184ms; --ryw-offset: 14px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-865 { --ryw-delay: 5190ms; --ryw-offset: 15px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-866 { --ryw-delay: 5196ms; --ryw-offset: 16px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-867 { --ryw-delay: 5202ms; --ryw-offset: 17px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-868 { --ryw-delay: 5208ms; --ryw-offset: 18px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-869 { --ryw-delay: 5214ms; --ryw-offset: 19px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-870 { --ryw-delay: 5220ms; --ryw-offset: 20px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-871 { --ryw-delay: 5226ms; --ryw-offset: 21px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-872 { --ryw-delay: 5232ms; --ryw-offset: 22px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-873 { --ryw-delay: 5238ms; --ryw-offset: 23px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-874 { --ryw-delay: 5244ms; --ryw-offset: 24px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-875 { --ryw-delay: 5250ms; --ryw-offset: 25px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-876 { --ryw-delay: 5256ms; --ryw-offset: 26px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-877 { --ryw-delay: 5262ms; --ryw-offset: 27px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-878 { --ryw-delay: 5268ms; --ryw-offset: 28px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-879 { --ryw-delay: 5274ms; --ryw-offset: 29px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-880 { --ryw-delay: 5280ms; --ryw-offset: 30px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-881 { --ryw-delay: 5286ms; --ryw-offset: 31px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-882 { --ryw-delay: 5292ms; --ryw-offset: 32px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-883 { --ryw-delay: 5298ms; --ryw-offset: 33px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-884 { --ryw-delay: 5304ms; --ryw-offset: 34px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-885 { --ryw-delay: 5310ms; --ryw-offset: 35px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-886 { --ryw-delay: 5316ms; --ryw-offset: 36px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-887 { --ryw-delay: 5322ms; --ryw-offset: 37px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-888 { --ryw-delay: 5328ms; --ryw-offset: 1px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-889 { --ryw-delay: 5334ms; --ryw-offset: 2px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-890 { --ryw-delay: 5340ms; --ryw-offset: 3px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-891 { --ryw-delay: 5346ms; --ryw-offset: 4px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-892 { --ryw-delay: 5352ms; --ryw-offset: 5px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-893 { --ryw-delay: 5358ms; --ryw-offset: 6px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-894 { --ryw-delay: 5364ms; --ryw-offset: 7px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-895 { --ryw-delay: 5370ms; --ryw-offset: 8px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-896 { --ryw-delay: 5376ms; --ryw-offset: 9px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-897 { --ryw-delay: 5382ms; --ryw-offset: 10px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-898 { --ryw-delay: 5388ms; --ryw-offset: 11px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-899 { --ryw-delay: 5394ms; --ryw-offset: 12px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-900 { --ryw-delay: 5400ms; --ryw-offset: 13px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-901 { --ryw-delay: 5406ms; --ryw-offset: 14px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-902 { --ryw-delay: 5412ms; --ryw-offset: 15px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-903 { --ryw-delay: 5418ms; --ryw-offset: 16px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-904 { --ryw-delay: 5424ms; --ryw-offset: 17px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-905 { --ryw-delay: 5430ms; --ryw-offset: 18px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-906 { --ryw-delay: 5436ms; --ryw-offset: 19px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-907 { --ryw-delay: 5442ms; --ryw-offset: 20px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-908 { --ryw-delay: 5448ms; --ryw-offset: 21px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-909 { --ryw-delay: 5454ms; --ryw-offset: 22px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-910 { --ryw-delay: 5460ms; --ryw-offset: 23px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-911 { --ryw-delay: 5466ms; --ryw-offset: 24px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-912 { --ryw-delay: 5472ms; --ryw-offset: 25px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-913 { --ryw-delay: 5478ms; --ryw-offset: 26px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-914 { --ryw-delay: 5484ms; --ryw-offset: 27px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-915 { --ryw-delay: 5490ms; --ryw-offset: 28px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-916 { --ryw-delay: 5496ms; --ryw-offset: 29px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-917 { --ryw-delay: 5502ms; --ryw-offset: 30px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-918 { --ryw-delay: 5508ms; --ryw-offset: 31px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-919 { --ryw-delay: 5514ms; --ryw-offset: 32px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-920 { --ryw-delay: 5520ms; --ryw-offset: 33px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-921 { --ryw-delay: 5526ms; --ryw-offset: 34px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-922 { --ryw-delay: 5532ms; --ryw-offset: 35px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-923 { --ryw-delay: 5538ms; --ryw-offset: 36px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-924 { --ryw-delay: 5544ms; --ryw-offset: 37px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-925 { --ryw-delay: 5550ms; --ryw-offset: 1px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-926 { --ryw-delay: 5556ms; --ryw-offset: 2px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-927 { --ryw-delay: 5562ms; --ryw-offset: 3px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-928 { --ryw-delay: 5568ms; --ryw-offset: 4px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-929 { --ryw-delay: 5574ms; --ryw-offset: 5px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-930 { --ryw-delay: 5580ms; --ryw-offset: 6px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-931 { --ryw-delay: 5586ms; --ryw-offset: 7px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-932 { --ryw-delay: 5592ms; --ryw-offset: 8px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-933 { --ryw-delay: 5598ms; --ryw-offset: 9px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-934 { --ryw-delay: 5604ms; --ryw-offset: 10px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-935 { --ryw-delay: 5610ms; --ryw-offset: 11px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-936 { --ryw-delay: 5616ms; --ryw-offset: 12px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-937 { --ryw-delay: 5622ms; --ryw-offset: 13px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-938 { --ryw-delay: 5628ms; --ryw-offset: 14px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-939 { --ryw-delay: 5634ms; --ryw-offset: 15px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-940 { --ryw-delay: 5640ms; --ryw-offset: 16px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-941 { --ryw-delay: 5646ms; --ryw-offset: 17px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-942 { --ryw-delay: 5652ms; --ryw-offset: 18px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-943 { --ryw-delay: 5658ms; --ryw-offset: 19px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-944 { --ryw-delay: 5664ms; --ryw-offset: 20px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-945 { --ryw-delay: 5670ms; --ryw-offset: 21px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-946 { --ryw-delay: 5676ms; --ryw-offset: 22px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-947 { --ryw-delay: 5682ms; --ryw-offset: 23px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-948 { --ryw-delay: 5688ms; --ryw-offset: 24px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-949 { --ryw-delay: 5694ms; --ryw-offset: 25px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-950 { --ryw-delay: 5700ms; --ryw-offset: 26px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-951 { --ryw-delay: 5706ms; --ryw-offset: 27px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-952 { --ryw-delay: 5712ms; --ryw-offset: 28px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-953 { --ryw-delay: 5718ms; --ryw-offset: 29px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-954 { --ryw-delay: 5724ms; --ryw-offset: 30px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-955 { --ryw-delay: 5730ms; --ryw-offset: 31px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-956 { --ryw-delay: 5736ms; --ryw-offset: 32px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-957 { --ryw-delay: 5742ms; --ryw-offset: 33px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-958 { --ryw-delay: 5748ms; --ryw-offset: 34px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-959 { --ryw-delay: 5754ms; --ryw-offset: 35px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-960 { --ryw-delay: 5760ms; --ryw-offset: 36px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-961 { --ryw-delay: 5766ms; --ryw-offset: 37px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-962 { --ryw-delay: 5772ms; --ryw-offset: 1px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-963 { --ryw-delay: 5778ms; --ryw-offset: 2px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-964 { --ryw-delay: 5784ms; --ryw-offset: 3px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-965 { --ryw-delay: 5790ms; --ryw-offset: 4px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-966 { --ryw-delay: 5796ms; --ryw-offset: 5px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-967 { --ryw-delay: 5802ms; --ryw-offset: 6px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-968 { --ryw-delay: 5808ms; --ryw-offset: 7px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-969 { --ryw-delay: 5814ms; --ryw-offset: 8px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-970 { --ryw-delay: 5820ms; --ryw-offset: 9px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-971 { --ryw-delay: 5826ms; --ryw-offset: 10px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-972 { --ryw-delay: 5832ms; --ryw-offset: 11px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-973 { --ryw-delay: 5838ms; --ryw-offset: 12px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-974 { --ryw-delay: 5844ms; --ryw-offset: 13px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-975 { --ryw-delay: 5850ms; --ryw-offset: 14px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-976 { --ryw-delay: 5856ms; --ryw-offset: 15px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-977 { --ryw-delay: 5862ms; --ryw-offset: 16px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-978 { --ryw-delay: 5868ms; --ryw-offset: 17px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-979 { --ryw-delay: 5874ms; --ryw-offset: 18px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-980 { --ryw-delay: 5880ms; --ryw-offset: 19px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-981 { --ryw-delay: 5886ms; --ryw-offset: 20px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-982 { --ryw-delay: 5892ms; --ryw-offset: 21px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-983 { --ryw-delay: 5898ms; --ryw-offset: 22px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-984 { --ryw-delay: 5904ms; --ryw-offset: 23px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-985 { --ryw-delay: 5910ms; --ryw-offset: 24px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-986 { --ryw-delay: 5916ms; --ryw-offset: 25px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-987 { --ryw-delay: 5922ms; --ryw-offset: 26px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-988 { --ryw-delay: 5928ms; --ryw-offset: 27px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-989 { --ryw-delay: 5934ms; --ryw-offset: 28px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-990 { --ryw-delay: 5940ms; --ryw-offset: 29px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-991 { --ryw-delay: 5946ms; --ryw-offset: 30px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-992 { --ryw-delay: 5952ms; --ryw-offset: 31px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-993 { --ryw-delay: 5958ms; --ryw-offset: 32px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-994 { --ryw-delay: 5964ms; --ryw-offset: 33px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-995 { --ryw-delay: 5970ms; --ryw-offset: 34px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-996 { --ryw-delay: 5976ms; --ryw-offset: 35px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-997 { --ryw-delay: 5982ms; --ryw-offset: 36px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-998 { --ryw-delay: 5988ms; --ryw-offset: 37px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-999 { --ryw-delay: 5994ms; --ryw-offset: 1px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1000 { --ryw-delay: 6000ms; --ryw-offset: 2px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1001 { --ryw-delay: 6006ms; --ryw-offset: 3px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1002 { --ryw-delay: 6012ms; --ryw-offset: 4px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1003 { --ryw-delay: 6018ms; --ryw-offset: 5px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1004 { --ryw-delay: 6024ms; --ryw-offset: 6px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1005 { --ryw-delay: 6030ms; --ryw-offset: 7px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1006 { --ryw-delay: 6036ms; --ryw-offset: 8px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1007 { --ryw-delay: 6042ms; --ryw-offset: 9px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1008 { --ryw-delay: 6048ms; --ryw-offset: 10px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1009 { --ryw-delay: 6054ms; --ryw-offset: 11px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1010 { --ryw-delay: 6060ms; --ryw-offset: 12px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1011 { --ryw-delay: 6066ms; --ryw-offset: 13px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1012 { --ryw-delay: 6072ms; --ryw-offset: 14px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1013 { --ryw-delay: 6078ms; --ryw-offset: 15px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1014 { --ryw-delay: 6084ms; --ryw-offset: 16px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1015 { --ryw-delay: 6090ms; --ryw-offset: 17px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1016 { --ryw-delay: 6096ms; --ryw-offset: 18px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1017 { --ryw-delay: 6102ms; --ryw-offset: 19px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1018 { --ryw-delay: 6108ms; --ryw-offset: 20px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1019 { --ryw-delay: 6114ms; --ryw-offset: 21px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1020 { --ryw-delay: 6120ms; --ryw-offset: 22px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1021 { --ryw-delay: 6126ms; --ryw-offset: 23px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1022 { --ryw-delay: 6132ms; --ryw-offset: 24px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1023 { --ryw-delay: 6138ms; --ryw-offset: 25px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1024 { --ryw-delay: 6144ms; --ryw-offset: 26px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1025 { --ryw-delay: 6150ms; --ryw-offset: 27px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1026 { --ryw-delay: 6156ms; --ryw-offset: 28px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1027 { --ryw-delay: 6162ms; --ryw-offset: 29px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1028 { --ryw-delay: 6168ms; --ryw-offset: 30px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1029 { --ryw-delay: 6174ms; --ryw-offset: 31px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1030 { --ryw-delay: 6180ms; --ryw-offset: 32px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1031 { --ryw-delay: 6186ms; --ryw-offset: 33px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1032 { --ryw-delay: 6192ms; --ryw-offset: 34px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1033 { --ryw-delay: 6198ms; --ryw-offset: 35px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1034 { --ryw-delay: 6204ms; --ryw-offset: 36px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1035 { --ryw-delay: 6210ms; --ryw-offset: 37px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1036 { --ryw-delay: 6216ms; --ryw-offset: 1px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1037 { --ryw-delay: 6222ms; --ryw-offset: 2px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1038 { --ryw-delay: 6228ms; --ryw-offset: 3px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1039 { --ryw-delay: 6234ms; --ryw-offset: 4px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1040 { --ryw-delay: 6240ms; --ryw-offset: 5px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1041 { --ryw-delay: 6246ms; --ryw-offset: 6px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1042 { --ryw-delay: 6252ms; --ryw-offset: 7px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1043 { --ryw-delay: 6258ms; --ryw-offset: 8px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1044 { --ryw-delay: 6264ms; --ryw-offset: 9px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1045 { --ryw-delay: 6270ms; --ryw-offset: 10px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1046 { --ryw-delay: 6276ms; --ryw-offset: 11px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1047 { --ryw-delay: 6282ms; --ryw-offset: 12px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1048 { --ryw-delay: 6288ms; --ryw-offset: 13px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1049 { --ryw-delay: 6294ms; --ryw-offset: 14px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1050 { --ryw-delay: 6300ms; --ryw-offset: 15px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1051 { --ryw-delay: 6306ms; --ryw-offset: 16px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1052 { --ryw-delay: 6312ms; --ryw-offset: 17px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1053 { --ryw-delay: 6318ms; --ryw-offset: 18px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1054 { --ryw-delay: 6324ms; --ryw-offset: 19px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1055 { --ryw-delay: 6330ms; --ryw-offset: 20px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1056 { --ryw-delay: 6336ms; --ryw-offset: 21px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1057 { --ryw-delay: 6342ms; --ryw-offset: 22px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1058 { --ryw-delay: 6348ms; --ryw-offset: 23px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1059 { --ryw-delay: 6354ms; --ryw-offset: 24px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1060 { --ryw-delay: 6360ms; --ryw-offset: 25px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1061 { --ryw-delay: 6366ms; --ryw-offset: 26px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1062 { --ryw-delay: 6372ms; --ryw-offset: 27px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1063 { --ryw-delay: 6378ms; --ryw-offset: 28px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1064 { --ryw-delay: 6384ms; --ryw-offset: 29px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1065 { --ryw-delay: 6390ms; --ryw-offset: 30px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1066 { --ryw-delay: 6396ms; --ryw-offset: 31px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1067 { --ryw-delay: 6402ms; --ryw-offset: 32px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1068 { --ryw-delay: 6408ms; --ryw-offset: 33px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1069 { --ryw-delay: 6414ms; --ryw-offset: 34px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1070 { --ryw-delay: 6420ms; --ryw-offset: 35px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1071 { --ryw-delay: 6426ms; --ryw-offset: 36px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1072 { --ryw-delay: 6432ms; --ryw-offset: 37px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1073 { --ryw-delay: 6438ms; --ryw-offset: 1px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1074 { --ryw-delay: 6444ms; --ryw-offset: 2px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1075 { --ryw-delay: 6450ms; --ryw-offset: 3px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1076 { --ryw-delay: 6456ms; --ryw-offset: 4px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1077 { --ryw-delay: 6462ms; --ryw-offset: 5px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1078 { --ryw-delay: 6468ms; --ryw-offset: 6px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1079 { --ryw-delay: 6474ms; --ryw-offset: 7px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1080 { --ryw-delay: 6480ms; --ryw-offset: 8px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1081 { --ryw-delay: 6486ms; --ryw-offset: 9px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1082 { --ryw-delay: 6492ms; --ryw-offset: 10px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1083 { --ryw-delay: 6498ms; --ryw-offset: 11px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1084 { --ryw-delay: 6504ms; --ryw-offset: 12px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1085 { --ryw-delay: 6510ms; --ryw-offset: 13px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1086 { --ryw-delay: 6516ms; --ryw-offset: 14px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1087 { --ryw-delay: 6522ms; --ryw-offset: 15px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1088 { --ryw-delay: 6528ms; --ryw-offset: 16px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1089 { --ryw-delay: 6534ms; --ryw-offset: 17px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1090 { --ryw-delay: 6540ms; --ryw-offset: 18px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1091 { --ryw-delay: 6546ms; --ryw-offset: 19px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1092 { --ryw-delay: 6552ms; --ryw-offset: 20px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1093 { --ryw-delay: 6558ms; --ryw-offset: 21px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1094 { --ryw-delay: 6564ms; --ryw-offset: 22px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1095 { --ryw-delay: 6570ms; --ryw-offset: 23px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1096 { --ryw-delay: 6576ms; --ryw-offset: 24px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1097 { --ryw-delay: 6582ms; --ryw-offset: 25px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1098 { --ryw-delay: 6588ms; --ryw-offset: 26px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1099 { --ryw-delay: 6594ms; --ryw-offset: 27px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1100 { --ryw-delay: 6600ms; --ryw-offset: 28px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1101 { --ryw-delay: 6606ms; --ryw-offset: 29px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1102 { --ryw-delay: 6612ms; --ryw-offset: 30px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1103 { --ryw-delay: 6618ms; --ryw-offset: 31px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1104 { --ryw-delay: 6624ms; --ryw-offset: 32px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1105 { --ryw-delay: 6630ms; --ryw-offset: 33px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1106 { --ryw-delay: 6636ms; --ryw-offset: 34px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1107 { --ryw-delay: 6642ms; --ryw-offset: 35px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1108 { --ryw-delay: 6648ms; --ryw-offset: 36px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1109 { --ryw-delay: 6654ms; --ryw-offset: 37px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1110 { --ryw-delay: 6660ms; --ryw-offset: 1px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1111 { --ryw-delay: 6666ms; --ryw-offset: 2px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1112 { --ryw-delay: 6672ms; --ryw-offset: 3px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1113 { --ryw-delay: 6678ms; --ryw-offset: 4px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1114 { --ryw-delay: 6684ms; --ryw-offset: 5px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1115 { --ryw-delay: 6690ms; --ryw-offset: 6px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1116 { --ryw-delay: 6696ms; --ryw-offset: 7px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1117 { --ryw-delay: 6702ms; --ryw-offset: 8px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1118 { --ryw-delay: 6708ms; --ryw-offset: 9px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1119 { --ryw-delay: 6714ms; --ryw-offset: 10px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1120 { --ryw-delay: 6720ms; --ryw-offset: 11px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1121 { --ryw-delay: 6726ms; --ryw-offset: 12px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1122 { --ryw-delay: 6732ms; --ryw-offset: 13px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1123 { --ryw-delay: 6738ms; --ryw-offset: 14px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1124 { --ryw-delay: 6744ms; --ryw-offset: 15px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1125 { --ryw-delay: 6750ms; --ryw-offset: 16px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1126 { --ryw-delay: 6756ms; --ryw-offset: 17px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1127 { --ryw-delay: 6762ms; --ryw-offset: 18px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1128 { --ryw-delay: 6768ms; --ryw-offset: 19px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1129 { --ryw-delay: 6774ms; --ryw-offset: 20px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1130 { --ryw-delay: 6780ms; --ryw-offset: 21px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1131 { --ryw-delay: 6786ms; --ryw-offset: 22px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1132 { --ryw-delay: 6792ms; --ryw-offset: 23px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1133 { --ryw-delay: 6798ms; --ryw-offset: 24px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1134 { --ryw-delay: 6804ms; --ryw-offset: 25px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1135 { --ryw-delay: 6810ms; --ryw-offset: 26px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1136 { --ryw-delay: 6816ms; --ryw-offset: 27px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1137 { --ryw-delay: 6822ms; --ryw-offset: 28px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1138 { --ryw-delay: 6828ms; --ryw-offset: 29px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1139 { --ryw-delay: 6834ms; --ryw-offset: 30px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1140 { --ryw-delay: 6840ms; --ryw-offset: 31px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1141 { --ryw-delay: 6846ms; --ryw-offset: 32px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1142 { --ryw-delay: 6852ms; --ryw-offset: 33px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1143 { --ryw-delay: 6858ms; --ryw-offset: 34px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1144 { --ryw-delay: 6864ms; --ryw-offset: 35px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1145 { --ryw-delay: 6870ms; --ryw-offset: 36px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1146 { --ryw-delay: 6876ms; --ryw-offset: 37px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1147 { --ryw-delay: 6882ms; --ryw-offset: 1px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1148 { --ryw-delay: 6888ms; --ryw-offset: 2px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1149 { --ryw-delay: 6894ms; --ryw-offset: 3px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1150 { --ryw-delay: 6900ms; --ryw-offset: 4px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1151 { --ryw-delay: 6906ms; --ryw-offset: 5px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1152 { --ryw-delay: 6912ms; --ryw-offset: 6px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1153 { --ryw-delay: 6918ms; --ryw-offset: 7px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1154 { --ryw-delay: 6924ms; --ryw-offset: 8px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1155 { --ryw-delay: 6930ms; --ryw-offset: 9px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1156 { --ryw-delay: 6936ms; --ryw-offset: 10px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1157 { --ryw-delay: 6942ms; --ryw-offset: 11px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1158 { --ryw-delay: 6948ms; --ryw-offset: 12px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1159 { --ryw-delay: 6954ms; --ryw-offset: 13px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1160 { --ryw-delay: 6960ms; --ryw-offset: 14px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1161 { --ryw-delay: 6966ms; --ryw-offset: 15px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1162 { --ryw-delay: 6972ms; --ryw-offset: 16px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1163 { --ryw-delay: 6978ms; --ryw-offset: 17px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1164 { --ryw-delay: 6984ms; --ryw-offset: 18px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1165 { --ryw-delay: 6990ms; --ryw-offset: 19px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1166 { --ryw-delay: 6996ms; --ryw-offset: 20px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1167 { --ryw-delay: 7002ms; --ryw-offset: 21px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1168 { --ryw-delay: 7008ms; --ryw-offset: 22px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1169 { --ryw-delay: 7014ms; --ryw-offset: 23px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1170 { --ryw-delay: 7020ms; --ryw-offset: 24px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1171 { --ryw-delay: 7026ms; --ryw-offset: 25px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1172 { --ryw-delay: 7032ms; --ryw-offset: 26px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1173 { --ryw-delay: 7038ms; --ryw-offset: 27px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1174 { --ryw-delay: 7044ms; --ryw-offset: 28px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1175 { --ryw-delay: 7050ms; --ryw-offset: 29px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1176 { --ryw-delay: 7056ms; --ryw-offset: 30px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1177 { --ryw-delay: 7062ms; --ryw-offset: 31px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1178 { --ryw-delay: 7068ms; --ryw-offset: 32px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1179 { --ryw-delay: 7074ms; --ryw-offset: 33px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1180 { --ryw-delay: 7080ms; --ryw-offset: 34px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1181 { --ryw-delay: 7086ms; --ryw-offset: 35px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1182 { --ryw-delay: 7092ms; --ryw-offset: 36px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1183 { --ryw-delay: 7098ms; --ryw-offset: 37px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1184 { --ryw-delay: 7104ms; --ryw-offset: 1px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1185 { --ryw-delay: 7110ms; --ryw-offset: 2px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1186 { --ryw-delay: 7116ms; --ryw-offset: 3px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1187 { --ryw-delay: 7122ms; --ryw-offset: 4px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1188 { --ryw-delay: 7128ms; --ryw-offset: 5px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1189 { --ryw-delay: 7134ms; --ryw-offset: 6px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1190 { --ryw-delay: 7140ms; --ryw-offset: 7px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1191 { --ryw-delay: 7146ms; --ryw-offset: 8px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1192 { --ryw-delay: 7152ms; --ryw-offset: 9px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1193 { --ryw-delay: 7158ms; --ryw-offset: 10px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1194 { --ryw-delay: 7164ms; --ryw-offset: 11px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1195 { --ryw-delay: 7170ms; --ryw-offset: 12px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1196 { --ryw-delay: 7176ms; --ryw-offset: 13px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1197 { --ryw-delay: 7182ms; --ryw-offset: 14px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1198 { --ryw-delay: 7188ms; --ryw-offset: 15px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1199 { --ryw-delay: 7194ms; --ryw-offset: 16px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1200 { --ryw-delay: 7200ms; --ryw-offset: 17px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1201 { --ryw-delay: 7206ms; --ryw-offset: 18px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1202 { --ryw-delay: 7212ms; --ryw-offset: 19px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1203 { --ryw-delay: 7218ms; --ryw-offset: 20px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1204 { --ryw-delay: 7224ms; --ryw-offset: 21px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1205 { --ryw-delay: 7230ms; --ryw-offset: 22px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1206 { --ryw-delay: 7236ms; --ryw-offset: 23px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1207 { --ryw-delay: 7242ms; --ryw-offset: 24px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1208 { --ryw-delay: 7248ms; --ryw-offset: 25px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1209 { --ryw-delay: 7254ms; --ryw-offset: 26px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1210 { --ryw-delay: 7260ms; --ryw-offset: 27px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1211 { --ryw-delay: 7266ms; --ryw-offset: 28px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1212 { --ryw-delay: 7272ms; --ryw-offset: 29px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1213 { --ryw-delay: 7278ms; --ryw-offset: 30px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1214 { --ryw-delay: 7284ms; --ryw-offset: 31px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1215 { --ryw-delay: 7290ms; --ryw-offset: 32px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1216 { --ryw-delay: 7296ms; --ryw-offset: 33px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1217 { --ryw-delay: 7302ms; --ryw-offset: 34px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1218 { --ryw-delay: 7308ms; --ryw-offset: 35px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1219 { --ryw-delay: 7314ms; --ryw-offset: 36px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1220 { --ryw-delay: 7320ms; --ryw-offset: 37px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1221 { --ryw-delay: 7326ms; --ryw-offset: 1px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1222 { --ryw-delay: 7332ms; --ryw-offset: 2px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1223 { --ryw-delay: 7338ms; --ryw-offset: 3px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1224 { --ryw-delay: 7344ms; --ryw-offset: 4px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1225 { --ryw-delay: 7350ms; --ryw-offset: 5px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1226 { --ryw-delay: 7356ms; --ryw-offset: 6px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1227 { --ryw-delay: 7362ms; --ryw-offset: 7px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1228 { --ryw-delay: 7368ms; --ryw-offset: 8px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1229 { --ryw-delay: 7374ms; --ryw-offset: 9px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1230 { --ryw-delay: 7380ms; --ryw-offset: 10px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1231 { --ryw-delay: 7386ms; --ryw-offset: 11px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1232 { --ryw-delay: 7392ms; --ryw-offset: 12px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1233 { --ryw-delay: 7398ms; --ryw-offset: 13px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1234 { --ryw-delay: 7404ms; --ryw-offset: 14px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1235 { --ryw-delay: 7410ms; --ryw-offset: 15px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1236 { --ryw-delay: 7416ms; --ryw-offset: 16px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1237 { --ryw-delay: 7422ms; --ryw-offset: 17px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1238 { --ryw-delay: 7428ms; --ryw-offset: 18px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1239 { --ryw-delay: 7434ms; --ryw-offset: 19px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1240 { --ryw-delay: 7440ms; --ryw-offset: 20px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1241 { --ryw-delay: 7446ms; --ryw-offset: 21px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1242 { --ryw-delay: 7452ms; --ryw-offset: 22px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1243 { --ryw-delay: 7458ms; --ryw-offset: 23px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1244 { --ryw-delay: 7464ms; --ryw-offset: 24px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1245 { --ryw-delay: 7470ms; --ryw-offset: 25px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1246 { --ryw-delay: 7476ms; --ryw-offset: 26px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1247 { --ryw-delay: 7482ms; --ryw-offset: 27px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1248 { --ryw-delay: 7488ms; --ryw-offset: 28px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1249 { --ryw-delay: 7494ms; --ryw-offset: 29px; animation-delay: calc(var(--ryw-delay) * -1); }
+.ryw-cache-1250 { --ryw-delay: 7500ms; --ryw-offset: 30px; animation-delay: calc(var(--ryw-delay) * -1); }


### PR DESCRIPTION
## Summary
- add a pure HTML/CSS read-your-writes cache animation example
- visualize session-map pinning, cache refresh, staleness lanes, and write visibility states
- keep the contribution scoped to one examples submission folder

## Validation
- generated from an existing validated examples template
- text scan verified old topic terms were replaced
- contribution adds 3 files under submissions/examples/read-your-writes-cache-kp